### PR TITLE
[bug] Reduce SonarQube complexity and harden analysis paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 concurrency:
   group: release-main
   cancel-in-progress: false
@@ -34,13 +31,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        if: ${{ !env.ACT }}
+        if: ${{ github.actor != 'nektos/act' }}
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Setup Go (act)
-        if: ${{ env.ACT }}
+        if: ${{ github.actor == 'nektos/act' }}
         run: |
           if ! command -v go >/dev/null 2>&1; then
             apt-get update
@@ -49,13 +46,13 @@ jobs:
           go version
 
       - name: Setup Zig
-        if: ${{ !env.ACT }}
+        if: ${{ github.actor != 'nektos/act' }}
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
 
       - name: Setup Zig (act)
-        if: ${{ env.ACT }}
+        if: ${{ github.actor == 'nektos/act' }}
         run: |
           if ! command -v zig >/dev/null 2>&1; then
             urls=(
@@ -99,7 +96,7 @@ jobs:
             PLATFORMS="linux/amd64 linux/arm64 windows/amd64 windows/arm64"
 
       - name: Upload Linux/Windows artifacts
-        if: ${{ !env.ACT }}
+        if: ${{ github.actor != 'nektos/act' }}
         uses: actions/upload-artifact@v4
         with:
           name: release-linux-windows
@@ -108,11 +105,11 @@ jobs:
             dist/*.zip
 
       - name: Mock Linux/Windows artifact upload (act)
-        if: ${{ env.ACT }}
+        if: ${{ github.actor == 'nektos/act' }}
         run: ls -lh dist/*
 
   build-darwin:
-    if: ${{ !env.ACT }}
+    if: ${{ github.actor != 'nektos/act' }}
     needs: prepare
     runs-on: macos-latest
     steps:
@@ -149,7 +146,7 @@ jobs:
             dist/*.zip
 
   build-darwin-act:
-    if: ${{ env.ACT }}
+    if: ${{ github.actor == 'nektos/act' }}
     needs: prepare
     runs-on: ubuntu-latest
     steps:
@@ -157,13 +154,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        if: ${{ !env.ACT }}
+        if: ${{ github.actor != 'nektos/act' }}
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Setup Go (act)
-        if: ${{ env.ACT }}
+        if: ${{ github.actor == 'nektos/act' }}
         run: |
           if ! command -v go >/dev/null 2>&1; then
             apt-get update
@@ -184,13 +181,15 @@ jobs:
         run: ls -lh dist/*
 
   publish:
-    if: ${{ !env.ACT && always() && needs.prepare.result == 'success' && needs.build-linux-windows.result == 'success' && needs.build-darwin.result == 'success' && (needs.build-darwin-act.result == 'success' || needs.build-darwin-act.result == 'skipped') }}
+    if: ${{ github.actor != 'nektos/act' && always() && needs.prepare.result == 'success' && needs.build-linux-windows.result == 'success' && needs.build-darwin.result == 'success' && (needs.build-darwin-act.result == 'success' || needs.build-darwin-act.result == 'skipped') }}
     needs:
       - prepare
       - build-linux-windows
       - build-darwin
       - build-darwin-act
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout (for changelog generation)
         uses: actions/checkout@v4
@@ -198,7 +197,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download release artifacts
-        if: ${{ !env.ACT }}
+        if: ${{ github.actor != 'nektos/act' }}
         uses: actions/download-artifact@v4
         with:
           pattern: release-*
@@ -251,7 +250,7 @@ jobs:
             dist/*.zip
 
   publish-act:
-    if: ${{ env.ACT && always() && needs.prepare.result == 'success' && needs.build-linux-windows.result == 'success' && needs.build-darwin-act.result == 'success' }}
+    if: ${{ github.actor == 'nektos/act' && always() && needs.prepare.result == 'success' && needs.build-linux-windows.result == 'success' && needs.build-darwin-act.result == 'success' }}
     needs:
       - prepare
       - build-linux-windows

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -74,10 +74,10 @@ func TestMergeRecommendationsPriorityOrder(t *testing.T) {
 
 func writeFile(t *testing.T, path string, content string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		t.Fatalf("mkdir %s: %v", path, err)
 	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -36,61 +36,84 @@ func New(out io.Writer, in io.Reader) *App {
 func (a *App) Execute(ctx context.Context, req Request) (string, error) {
 	switch req.Mode {
 	case ModeTUI:
-		opts := ui.Options{
-			RepoPath: req.RepoPath,
-			Language: req.TUI.Language,
-			TopN:     req.TUI.TopN,
-			Filter:   req.TUI.Filter,
-			Sort:     req.TUI.Sort,
-			PageSize: req.TUI.PageSize,
-		}
-		if req.TUI.SnapshotPath != "" {
-			return "", a.TUI.Snapshot(ctx, opts, req.TUI.SnapshotPath)
-		}
-		return "", a.TUI.Start(ctx, opts)
+		return a.executeTUI(ctx, req)
 	case ModeAnalyse:
-		reportData, err := a.Analyzer.Analyse(ctx, analysis.Request{
-			RepoPath:         req.RepoPath,
-			Dependency:       req.Analyse.Dependency,
-			TopN:             req.Analyse.TopN,
-			Language:         req.Analyse.Language,
-			RuntimeTracePath: req.Analyse.RuntimeTracePath,
-		})
-		if err != nil {
-			return "", err
-		}
-
-		formatted, err := a.Formatter.Format(reportData, req.Analyse.Format)
-		if err != nil {
-			return "", err
-		}
-
-		if req.Analyse.BaselinePath != "" {
-			baseline, err := report.Load(req.Analyse.BaselinePath)
-			if err != nil {
-				return formatted, err
-			}
-			reportData, err = report.ApplyBaseline(reportData, baseline)
-			if err != nil {
-				return formatted, err
-			}
-			formatted, err = a.Formatter.Format(reportData, req.Analyse.Format)
-			if err != nil {
-				return "", err
-			}
-		}
-
-		if req.Analyse.FailOnIncrease > 0 {
-			if reportData.WasteIncreasePercent == nil {
-				return formatted, ErrBaselineRequired
-			}
-			if *reportData.WasteIncreasePercent > float64(req.Analyse.FailOnIncrease) {
-				return formatted, ErrFailOnIncrease
-			}
-		}
-
-		return formatted, nil
+		return a.executeAnalyse(ctx, req)
 	default:
 		return "", ErrUnknownMode
 	}
+}
+
+func (a *App) executeTUI(ctx context.Context, req Request) (string, error) {
+	opts := ui.Options{
+		RepoPath: req.RepoPath,
+		Language: req.TUI.Language,
+		TopN:     req.TUI.TopN,
+		Filter:   req.TUI.Filter,
+		Sort:     req.TUI.Sort,
+		PageSize: req.TUI.PageSize,
+	}
+	if req.TUI.SnapshotPath != "" {
+		return "", a.TUI.Snapshot(ctx, opts, req.TUI.SnapshotPath)
+	}
+	return "", a.TUI.Start(ctx, opts)
+}
+
+func (a *App) executeAnalyse(ctx context.Context, req Request) (string, error) {
+	reportData, err := a.Analyzer.Analyse(ctx, analysis.Request{
+		RepoPath:         req.RepoPath,
+		Dependency:       req.Analyse.Dependency,
+		TopN:             req.Analyse.TopN,
+		Language:         req.Analyse.Language,
+		RuntimeTracePath: req.Analyse.RuntimeTracePath,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	reportData, formatted, err := a.applyBaselineIfNeeded(reportData, req.Analyse)
+	if err != nil {
+		return formatted, err
+	}
+	if err := validateFailOnIncrease(reportData, req.Analyse.FailOnIncrease); err != nil {
+		return formatted, err
+	}
+	return formatted, nil
+}
+
+func (a *App) applyBaselineIfNeeded(reportData report.Report, req AnalyseRequest) (report.Report, string, error) {
+	formatted, err := a.Formatter.Format(reportData, req.Format)
+	if err != nil {
+		return report.Report{}, "", err
+	}
+	if req.BaselinePath == "" {
+		return reportData, formatted, nil
+	}
+
+	baseline, err := report.Load(req.BaselinePath)
+	if err != nil {
+		return reportData, formatted, err
+	}
+	reportData, err = report.ApplyBaseline(reportData, baseline)
+	if err != nil {
+		return reportData, formatted, err
+	}
+	formatted, err = a.Formatter.Format(reportData, req.Format)
+	if err != nil {
+		return report.Report{}, "", err
+	}
+	return reportData, formatted, nil
+}
+
+func validateFailOnIncrease(reportData report.Report, threshold int) error {
+	if threshold <= 0 {
+		return nil
+	}
+	if reportData.WasteIncreasePercent == nil {
+		return ErrBaselineRequired
+	}
+	if *reportData.WasteIncreasePercent > float64(threshold) {
+		return ErrFailOnIncrease
+	}
+	return nil
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -32,28 +32,28 @@ func (c *CLI) Run(ctx context.Context, args []string) int {
 	req, err := ParseArgs(args)
 	if err != nil {
 		if errors.Is(err, ErrHelpRequested) {
-			fmt.Fprint(c.Out, Usage())
+			_, _ = fmt.Fprint(c.Out, Usage())
 			return 0
 		}
-		fmt.Fprintf(c.Err, "error: %v\n\n", err)
-		fmt.Fprint(c.Err, Usage())
+		_, _ = fmt.Fprintf(c.Err, "error: %v\n\n", err)
+		_, _ = fmt.Fprint(c.Err, Usage())
 		return 2
 	}
 
 	output, runErr := c.Runner.Execute(ctx, req)
 	if output != "" {
-		fmt.Fprint(c.Out, output)
+		_, _ = fmt.Fprint(c.Out, output)
 		if !strings.HasSuffix(output, "\n") {
-			fmt.Fprintln(c.Out)
+			_, _ = fmt.Fprintln(c.Out)
 		}
 	}
 
 	if runErr != nil {
 		if errors.Is(runErr, app.ErrFailOnIncrease) {
-			fmt.Fprintln(c.Err, runErr.Error())
+			_, _ = fmt.Fprintln(c.Err, runErr.Error())
 			return 3
 		}
-		fmt.Fprintln(c.Err, runErr.Error())
+		_, _ = fmt.Fprintln(c.Err, runErr.Error())
 		return 1
 	}
 

--- a/internal/lang/js/scan_test.go
+++ b/internal/lang/js/scan_test.go
@@ -24,18 +24,21 @@ func TestScanRepoFixtures(t *testing.T) {
 				t.Fatalf("scan repo: %v", err)
 			}
 
-			found := false
-			for _, file := range result.Files {
-				for _, imp := range file.Imports {
-					if imp.Module == tc.module {
-						found = true
-						break
-					}
-				}
-			}
+			found := containsModuleImport(result, tc.module)
 			if !found {
 				t.Fatalf("expected to find module %q", tc.module)
 			}
 		})
 	}
+}
+
+func containsModuleImport(result ScanResult, module string) bool {
+	for _, file := range result.Files {
+		for _, imp := range file.Imports {
+			if imp.Module == module {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/lang/shared/dependency_usage.go
+++ b/internal/lang/shared/dependency_usage.go
@@ -1,0 +1,323 @@
+package shared
+
+import (
+	"regexp"
+	"sort"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+type ImportRecord struct {
+	Dependency string
+	Module     string
+	Name       string
+	Local      string
+	Location   report.Location
+	Wildcard   bool
+}
+
+type FileUsage struct {
+	Imports []ImportRecord
+	Usage   map[string]int
+}
+
+type DependencyStats struct {
+	HasImports      bool
+	UsedCount       int
+	TotalCount      int
+	UsedPercent     float64
+	TopSymbols      []report.SymbolUsage
+	UsedImports     []report.ImportUse
+	UnusedImports   []report.ImportUse
+	WildcardImports int
+}
+
+func FirstContentColumn(line string) int {
+	for i := 0; i < len(line); i++ {
+		if line[i] != ' ' && line[i] != '\t' {
+			return i + 1
+		}
+	}
+	return 1
+}
+
+func MapSlice[T any, R any](items []T, mapper func(T) R) []R {
+	mapped := make([]R, 0, len(items))
+	for _, item := range items {
+		mapped = append(mapped, mapper(item))
+	}
+	return mapped
+}
+
+func MapFileUsages[T any](
+	files []T,
+	importsOf func(T) []ImportRecord,
+	usageOf func(T) map[string]int,
+) []FileUsage {
+	return MapSlice(files, func(file T) FileUsage {
+		return FileUsage{
+			Imports: importsOf(file),
+			Usage:   usageOf(file),
+		}
+	})
+}
+
+func CountUsage(content []byte, imports []ImportRecord) map[string]int {
+	importCount := make(map[string]int)
+	for _, imported := range imports {
+		if imported.Wildcard || imported.Local == "" {
+			continue
+		}
+		importCount[imported.Local]++
+	}
+
+	usage := make(map[string]int, len(importCount))
+	text := string(content)
+	for local, count := range importCount {
+		pattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(local) + `\b`)
+		occurrences := len(pattern.FindAllStringIndex(text, -1)) - count
+		if occurrences < 0 {
+			occurrences = 0
+		}
+		usage[local] = occurrences
+	}
+	return usage
+}
+
+func BuildDependencyStats(dependency string, files []FileUsage, normalize func(string) string) DependencyStats {
+	acc := newStatsAccumulator()
+	for _, file := range files {
+		acc.collectForFile(dependency, file, normalize)
+	}
+	return acc.build()
+}
+
+type statsAccumulator struct {
+	usedImports     map[string]*report.ImportUse
+	unusedImports   map[string]*report.ImportUse
+	usedSymbols     map[string]struct{}
+	allSymbols      map[string]struct{}
+	symbolCounts    map[string]int
+	wildcardImports int
+}
+
+func newStatsAccumulator() *statsAccumulator {
+	return &statsAccumulator{
+		usedImports:   make(map[string]*report.ImportUse),
+		unusedImports: make(map[string]*report.ImportUse),
+		usedSymbols:   make(map[string]struct{}),
+		allSymbols:    make(map[string]struct{}),
+		symbolCounts:  make(map[string]int),
+	}
+}
+
+func (acc *statsAccumulator) collectForFile(dependency string, file FileUsage, normalize func(string) string) {
+	for _, imported := range file.Imports {
+		if normalize(imported.Dependency) != dependency {
+			continue
+		}
+		acc.collectImport(file, imported)
+	}
+}
+
+func (acc *statsAccumulator) collectImport(file FileUsage, imported ImportRecord) {
+	acc.allSymbols[imported.Name] = struct{}{}
+	entry := report.ImportUse{
+		Name:      imported.Name,
+		Module:    imported.Module,
+		Locations: []report.Location{imported.Location},
+	}
+	if isImportUsed(file, imported) {
+		acc.addUsedImport(file, imported, entry)
+	} else {
+		addImport(acc.unusedImports, entry)
+	}
+	if imported.Wildcard {
+		acc.wildcardImports++
+	}
+}
+
+func isImportUsed(file FileUsage, imported ImportRecord) bool {
+	return imported.Wildcard || file.Usage[imported.Local] > 0
+}
+
+func (acc *statsAccumulator) addUsedImport(file FileUsage, imported ImportRecord, entry report.ImportUse) {
+	acc.usedSymbols[imported.Name] = struct{}{}
+	count := effectiveUsageCount(file, imported)
+	if count > 0 {
+		acc.symbolCounts[imported.Name] += count
+	}
+	addImport(acc.usedImports, entry)
+}
+
+func effectiveUsageCount(file FileUsage, imported ImportRecord) int {
+	count := file.Usage[imported.Local]
+	if imported.Wildcard && count == 0 {
+		return 1
+	}
+	return count
+}
+
+func (acc *statsAccumulator) build() DependencyStats {
+	usedCount := len(acc.usedSymbols)
+	totalCount := len(acc.allSymbols)
+	usedPercent := calculateUsedPercent(usedCount, totalCount)
+	topSymbols := buildTopSymbols(acc.symbolCounts)
+	used := flattenImports(acc.usedImports)
+	unused := dedupeUnused(flattenImports(acc.unusedImports), used)
+	return DependencyStats{
+		HasImports:      totalCount > 0,
+		UsedCount:       usedCount,
+		TotalCount:      totalCount,
+		UsedPercent:     usedPercent,
+		TopSymbols:      topSymbols,
+		UsedImports:     used,
+		UnusedImports:   unused,
+		WildcardImports: acc.wildcardImports,
+	}
+}
+
+func calculateUsedPercent(usedCount, totalCount int) float64 {
+	if totalCount == 0 {
+		return 0
+	}
+	return (float64(usedCount) / float64(totalCount)) * 100
+}
+
+func buildTopSymbols(symbolCounts map[string]int) []report.SymbolUsage {
+	topSymbols := make([]report.SymbolUsage, 0, len(symbolCounts))
+	for name, count := range symbolCounts {
+		topSymbols = append(topSymbols, report.SymbolUsage{Name: name, Count: count})
+	}
+	sort.Slice(topSymbols, func(i, j int) bool {
+		if topSymbols[i].Count == topSymbols[j].Count {
+			return topSymbols[i].Name < topSymbols[j].Name
+		}
+		return topSymbols[i].Count > topSymbols[j].Count
+	})
+	if len(topSymbols) > 5 {
+		topSymbols = topSymbols[:5]
+	}
+	return topSymbols
+}
+
+func ListDependencies(files []FileUsage, normalize func(string) string) []string {
+	set := make(map[string]struct{})
+	for _, file := range files {
+		for _, imported := range file.Imports {
+			if imported.Dependency == "" {
+				continue
+			}
+			set[normalize(imported.Dependency)] = struct{}{}
+		}
+	}
+	items := make([]string, 0, len(set))
+	for item := range set {
+		items = append(items, item)
+	}
+	sort.Strings(items)
+	return items
+}
+
+func BuildTopReports(
+	topN int,
+	dependencies []string,
+	buildReport func(string) (report.DependencyReport, []string),
+) ([]report.DependencyReport, []string) {
+	reports := make([]report.DependencyReport, 0, len(dependencies))
+	warnings := make([]string, 0)
+	for _, dependency := range dependencies {
+		depReport, depWarnings := buildReport(dependency)
+		reports = append(reports, depReport)
+		warnings = append(warnings, depWarnings...)
+	}
+	SortReportsByWaste(reports)
+	if topN > 0 && topN < len(reports) {
+		reports = reports[:topN]
+	}
+	if len(reports) == 0 {
+		warnings = append(warnings, "no dependency data available for top-N ranking")
+	}
+	return reports, warnings
+}
+
+func SortReportsByWaste(reports []report.DependencyReport) {
+	sort.Slice(reports, func(i, j int) bool {
+		iScore, iKnown := WasteScore(reports[i])
+		jScore, jKnown := WasteScore(reports[j])
+		if iKnown != jKnown {
+			return iKnown
+		}
+		if iScore == jScore {
+			return reports[i].Name < reports[j].Name
+		}
+		return iScore > jScore
+	})
+}
+
+func WasteScore(dep report.DependencyReport) (float64, bool) {
+	if dep.TotalExportsCount == 0 {
+		return -1, false
+	}
+	return 100 - dep.UsedPercent, true
+}
+
+func SortedKeys(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	items := make([]string, 0, len(values))
+	for value := range values {
+		items = append(items, value)
+	}
+	sort.Strings(items)
+	return items
+}
+
+func HasWildcardImport(imports []report.ImportUse) bool {
+	for _, imported := range imports {
+		if imported.Name == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func addImport(dest map[string]*report.ImportUse, entry report.ImportUse) {
+	key := entry.Module + ":" + entry.Name
+	if current, ok := dest[key]; ok {
+		current.Locations = append(current.Locations, entry.Locations...)
+		return
+	}
+	copyEntry := entry
+	dest[key] = &copyEntry
+}
+
+func flattenImports(source map[string]*report.ImportUse) []report.ImportUse {
+	items := make([]report.ImportUse, 0, len(source))
+	for _, entry := range source {
+		items = append(items, *entry)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Module == items[j].Module {
+			return items[i].Name < items[j].Name
+		}
+		return items[i].Module < items[j].Module
+	})
+	return items
+}
+
+func dedupeUnused(unused, used []report.ImportUse) []report.ImportUse {
+	usedKeys := make(map[string]struct{}, len(used))
+	for _, entry := range used {
+		usedKeys[entry.Module+":"+entry.Name] = struct{}{}
+	}
+	filtered := make([]report.ImportUse, 0, len(unused))
+	for _, entry := range unused {
+		if _, ok := usedKeys[entry.Module+":"+entry.Name]; ok {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}


### PR DESCRIPTION
## Summary

This change tackles SonarQube complexity findings across the analysis pipeline and language adapters, while tightening a few workflow and CLI edges that were surfaced during refactoring.

## Changes

- Refactored high-complexity paths in analysis/service, app orchestration, and UI summary rendering to simplify control flow and reduce branching.
- Reworked JS, JVM, and Python adapter internals to keep behaviour the same while breaking large methods into clearer units.
- Tightened JS risk/scan/recommendation and export handling to remove repeated logic and improve readability.
- Updated CLI and selected tests to align with the refactored execution paths and cleaner literals.
- Made a small workflow adjustment in the release pipeline for consistency with the updated code paths.

## Validation

Commands and checks run:

```bash
go test ./...
```

Additional manual validation:

- Reviewed language-specific adapter output shape for parity with current expectations.
- Spot-checked summary and recommendation flows after refactor-focused changes.

## Risk and compatibility

- Breaking changes: None intended.
- Migration required: No.
- Performance impact: Expected to be neutral; this is primarily a structural refactor to satisfy quality gates.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] No unrelated changes included
- [x] Ready for review
