### PR TITLE
[bug] fix golangci-lint and gosec version pinning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for contributing to Lopper.
 Requirements:
 
 - Go `1.26.x`
-- `golangci-lint` (optional, required for `make lint`)
+- `golangci-lint` (optional for faster local runs; `make lint` will auto-run a pinned version)
 
 Install dependencies and run checks:
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ COVERAGE_MIN ?= 60
 GO ?= go
 GO_TOOLCHAIN ?= go1.26.0
 GO_CMD := GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO)
+GOLANGCI_LINT_VERSION ?= v2.9.0
+GOSEC_VERSION ?= v2.22.11
 HOST_GOOS := $(shell $(GO_CMD) env GOOS)
 HOST_GOARCH := $(shell $(GO_CMD) env GOARCH)
 PLATFORMS ?= $(HOST_GOOS)/$(HOST_GOARCH)
@@ -29,12 +31,10 @@ format-check:
 	fi
 
 lint:
-	@command -v golangci-lint >/dev/null 2>&1 || (echo "golangci-lint not found in PATH"; exit 1)
-	golangci-lint run ./...
+	$(GO_CMD) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run ./...
 
 security:
-	@command -v gosec >/dev/null 2>&1 || (echo "gosec not found in PATH"; exit 1)
-	gosec ./...
+	$(GO_CMD) run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) ./...
 
 test:
 	$(GO_CMD) test ./...


### PR DESCRIPTION
fix a bug with gosec and golangci-lint versions post 1.26 update