### PR TITLE
[bug] clarify identifier usage logic and remove dead branch

### DIFF
--- a/internal/lang/js/scan.go
+++ b/internal/lang/js/scan.go
@@ -295,10 +295,13 @@ func isIdentifierUsage(node *sitter.Node) bool {
 	case "object_pattern", "array_pattern":
 		return false
 	case "member_expression", "subscript_expression":
-		// Don't count the object in member/subscript expressions as direct usage
-		// since these are tracked separately as namespace property access
+		// The object side (e.g. `util` in `util.map`) is tracked via namespace
+		// property access, so only non-object identifiers count as direct usage.
 		objectNode := parent.ChildByFieldName("object")
-		return objectNode == nil || objectNode.ID() != node.ID()
+		if objectNode != nil && objectNode.ID() == node.ID() {
+			return false
+		}
+		return true
 	default:
 		return true
 	}

--- a/internal/runtime/trace.go
+++ b/internal/runtime/trace.go
@@ -122,9 +122,6 @@ func dependencyFromResolvedPath(value string) string {
 		return ""
 	}
 	parts := strings.Split(rest, "/")
-	if len(parts) == 0 {
-		return ""
-	}
 	if strings.HasPrefix(parts[0], "@") {
 		if len(parts) < 2 {
 			return ""


### PR DESCRIPTION
## Summary

This change addresses two code-quality findings.

In `internal/runtime/trace.go`, `strings.Split(rest, "/")` can never return a zero-length slice, so the `len(parts) == 0` branch was unreachable dead code.

In `internal/lang/js/scan.go`, the `member_expression` / `subscript_expression` branch in `isIdentifierUsage` was correct in behaviour but implemented as an inverted boolean expression that did not line up cleanly with the comment. The branch is now written as an explicit early-return check so the implementation matches intent and is easier to maintain.

## Changes

- Removed unreachable `len(parts) == 0` guard after `strings.Split` in `dependencyFromResolvedPath`.
- Rewrote member/subscript handling in `isIdentifierUsage` to explicit object-node exclusion logic with clearer comment text.
- Left behaviour unchanged while making control flow and intent clearer.

## Validation

Commands and checks run:

```bash
go test ./...
```

Additional manual validation:

- Pre-commit hooks passed (`make fmt`, `make ci`, `make cov`) during commit.

## Risk and compatibility

- Breaking changes: None expected.
- Migration required: None.
- Performance impact: None expected; logic is equivalent with dead code removed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] No unrelated changes included
- [x] Ready for review
