### PR TITLE
[feature] skip weekly release when no changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
       previous_tag: ${{ steps.tag.outputs.previous_tag }}
+      should_release: ${{ steps.tag.outputs.should_release }}
+      release_reason: ${{ steps.tag.outputs.release_reason }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -47,11 +49,35 @@ jobs:
             fi
           fi
 
+          commits_since_previous_tag="0"
+          if [ -n "${previous_tag}" ]; then
+            commits_since_previous_tag="$(git rev-list --count "${previous_tag}..HEAD")"
+          fi
+
+          should_release="true"
+          release_reason="changes_detected"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            release_reason="manual_dispatch"
+          elif [ -z "${previous_tag}" ]; then
+            release_reason="initial_release"
+          elif [ "${commits_since_previous_tag}" = "0" ]; then
+            should_release="false"
+            release_reason="no_changes"
+          fi
+
           echo "tag=$next_tag" >> "$GITHUB_OUTPUT"
           echo "previous_tag=$previous_tag" >> "$GITHUB_OUTPUT"
+          echo "should_release=$should_release" >> "$GITHUB_OUTPUT"
+          echo "release_reason=$release_reason" >> "$GITHUB_OUTPUT"
+
+      - name: Log release gate decision
+        run: |
+          echo "Release gate: should_release=${{ steps.tag.outputs.should_release }}"
+          echo "Release gate reason: ${{ steps.tag.outputs.release_reason }}"
 
   build-linux-windows:
     needs: prepare
+    if: ${{ needs.prepare.outputs.should_release == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -94,6 +120,7 @@ jobs:
 
   build-darwin:
     needs: prepare
+    if: ${{ needs.prepare.outputs.should_release == 'true' }}
     runs-on: macos-latest
     permissions:
       contents: read
@@ -132,6 +159,7 @@ jobs:
 
   build-ghcr:
     needs: prepare
+    if: ${{ needs.prepare.outputs.should_release == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -178,6 +206,7 @@ jobs:
       - build-linux-windows
       - build-darwin
       - build-ghcr
+    if: ${{ needs.prepare.outputs.should_release == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -246,6 +275,7 @@ jobs:
     needs:
       - prepare
       - publish
+    if: ${{ needs.prepare.outputs.should_release == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -342,3 +372,14 @@ jobs:
       - name: Skip tap update when token is missing
         if: ${{ steps.tap_token.outputs.available != 'true' }}
         run: echo "HOMEBREW_TAP_TOKEN not configured; skipping tap update."
+
+  skip-release:
+    needs: prepare
+    if: ${{ needs.prepare.outputs.should_release != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: No-op when no changes since last semver tag
+        run: |
+          echo "Skipping weekly release: no changes detected since previous semver tag."

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ sudo install "$(find "$tmpdir" -type f -name lopper | head -n1)" /usr/local/bin/
 
 Release channels:
 
-- Stable semver release (`vX.Y.Z`): published weekly on Saturday at 12:00 UTC
+- Stable semver release (`vX.Y.Z`): published weekly on Saturday at 12:00 UTC when changes exist since the previous stable tag
 - Rolling prerelease (`rolling-*`): published on merge to `main`, marked as non-stable
 - Rolling GitHub prerelease assets: Linux/Windows/Darwin binaries plus source bundle
 - Docker tags: `latest` = latest stable semver, `rolling` = latest rolling build

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -3,7 +3,7 @@
 This repository includes four GitHub Actions workflows:
 
 - `.github/workflows/ci.yml`: runs checks on pull requests and pushes to `main`
-- `.github/workflows/release.yml`: scheduled weekly (Saturday 12:00 UTC) semver release workflow that runs CI and publishes a GitHub release with:
+- `.github/workflows/release.yml`: scheduled weekly (Saturday 12:00 UTC) semver release workflow that runs only when changes exist since the previous stable tag, then runs CI and publishes a GitHub release with:
   - Linux/Windows artifacts from Ubuntu (cross-compiled with `zig`)
   - Darwin artifact from macOS (native arch)
   - GHCR multi-arch image (`linux/amd64`, `linux/arm64`) tagged with the release tag and `latest`


### PR DESCRIPTION
## Summary

Add a release gate so the scheduled weekly semver release only runs when there are commits since the previous stable semver tag.

## Changes

- Extended `prepare` outputs with `should_release` and `release_reason`.
- Compute commit delta from previous stable tag and set `should_release=false` when no changes are found on scheduled runs.
- Preserve manual `workflow_dispatch` as an explicit override (`should_release=true`).
- Guard build/publish/tap-update jobs behind `if: needs.prepare.outputs.should_release == 'true'`.
- Add a `skip-release` no-op job for explicit visibility when a weekly release is skipped.
- Update docs/README wording to reflect that weekly stable releases only publish when changes exist.

## Validation

Commands and checks run:

```bash
act schedule -W .github/workflows/release.yml -n
act workflow_dispatch -W .github/workflows/release.yml -n
make fmt
make ci
make cov
```

Additional manual validation:

- Verified release workflow diff to ensure all publishing jobs are gated by `should_release`.

## Risk and compatibility

- Breaking changes: No.
- Migration required: No.
- Performance impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] No unrelated changes included
- [x] Ready for review
