### PR TITLE
[feat] re-export and barrel attribution

### DIFF
--- a/docs/report-schema.json
+++ b/docs/report-schema.json
@@ -119,6 +119,10 @@
         "locations": {
           "type": "array",
           "items": { "$ref": "#/$defs/location" }
+        },
+        "provenance": {
+          "type": "array",
+          "items": { "type": "string" }
         }
       }
     },

--- a/docs/report-schema.md
+++ b/docs/report-schema.md
@@ -20,6 +20,7 @@ Validate with your JSON Schema tooling against `docs/report-schema.json`.
 - `dependencies[].riskCues`: heuristic risk signals.
 - `dependencies[].recommendations`: actionable follow-up suggestions.
 - `dependencies[].runtimeUsage`: runtime load annotations (when `--runtime-trace` is used).
+- `dependencies[].usedImports[].provenance`: optional attribution chain for barrel/re-export resolution in detailed views.
 - `wasteIncreasePercent`: present when `--baseline` was supplied and compared.
 
 ## Notes

--- a/internal/lang/js/reexport_attribution_test.go
+++ b/internal/lang/js/reexport_attribution_test.go
@@ -1,0 +1,95 @@
+package js
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+)
+
+func TestAdapterAnalyseReExportAttributionNestedAlias(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "src", "index.ts"), strings.Join([]string{
+		`import { mapAlias as m } from "./barrel"`,
+		`m([1], (x) => x)`,
+		"",
+	}, "\n"))
+	mustWriteFile(t, filepath.Join(repo, "src", "barrel.ts"), `export { remap as mapAlias } from "./leaf"`)
+	mustWriteFile(t, filepath.Join(repo, "src", "leaf.ts"), `export { map as remap } from "lodash"`)
+
+	lodashDir := filepath.Join(repo, "node_modules", "lodash")
+	mustWriteFile(t, filepath.Join(lodashDir, "package.json"), testPackageJSONMain)
+	mustWriteFile(t, filepath.Join(lodashDir, "index.js"), "export function map() {}\nexport function filter() {}\n")
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath:   repo,
+		Dependency: "lodash",
+	})
+	if err != nil {
+		t.Fatalf(testAnalyseErrFmt, err)
+	}
+	if len(reportData.Dependencies) != 1 {
+		t.Fatalf(testExpectedOneDepFmt, len(reportData.Dependencies))
+	}
+
+	dep := reportData.Dependencies[0]
+	if dep.UsedExportsCount != 1 {
+		t.Fatalf("expected one used export from attribution chain, got %d", dep.UsedExportsCount)
+	}
+	if len(dep.UsedImports) != 1 {
+		t.Fatalf("expected one used import, got %#v", dep.UsedImports)
+	}
+	if dep.UsedImports[0].Name != "map" {
+		t.Fatalf("expected barrel attribution to map to lodash export map, got %#v", dep.UsedImports[0])
+	}
+	if len(dep.UsedImports[0].Provenance) == 0 {
+		t.Fatalf("expected provenance details on used import, got %#v", dep.UsedImports[0])
+	}
+	if !strings.Contains(dep.UsedImports[0].Provenance[0], "src/index.ts") ||
+		!strings.Contains(dep.UsedImports[0].Provenance[0], "src/barrel.ts") ||
+		!strings.Contains(dep.UsedImports[0].Provenance[0], "src/leaf.ts") ||
+		!strings.Contains(dep.UsedImports[0].Provenance[0], "lodash#map") {
+		t.Fatalf("unexpected provenance chain: %#v", dep.UsedImports[0].Provenance)
+	}
+}
+
+func TestAdapterAnalyseReExportCycleWarning(t *testing.T) {
+	repo := t.TempDir()
+	mustWriteFile(t, filepath.Join(repo, "src", "index.ts"), strings.Join([]string{
+		`import { x } from "./a"`,
+		`console.log(x)`,
+		"",
+	}, "\n"))
+	mustWriteFile(t, filepath.Join(repo, "src", "a.ts"), `export { x } from "./b"`)
+	mustWriteFile(t, filepath.Join(repo, "src", "b.ts"), `export { x } from "./a"`)
+
+	lodashDir := filepath.Join(repo, "node_modules", "lodash")
+	mustWriteFile(t, filepath.Join(lodashDir, "package.json"), testPackageJSONMain)
+	mustWriteFile(t, filepath.Join(lodashDir, "index.js"), "export function map() {}\n")
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath:   repo,
+		Dependency: "lodash",
+	})
+	if err != nil {
+		t.Fatalf(testAnalyseErrFmt, err)
+	}
+
+	warnings := strings.Join(reportData.Warnings, "\n")
+	if !strings.Contains(warnings, "re-export attribution cycle") {
+		t.Fatalf("expected re-export cycle warning, got %#v", reportData.Warnings)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/lang/js/reexport_resolver.go
+++ b/internal/lang/js/reexport_resolver.go
@@ -1,0 +1,277 @@
+package js
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+type reExportResolver struct {
+	filesByPath  map[string]FileScan
+	resolveCache map[string]string
+	warningSet   map[string]struct{}
+}
+
+type resolvedAttribution struct {
+	Module     string
+	ExportName string
+	Provenance string
+}
+
+func newReExportResolver(scanResult ScanResult) *reExportResolver {
+	filesByPath := make(map[string]FileScan, len(scanResult.Files))
+	for _, file := range scanResult.Files {
+		filesByPath[normalizeModulePath(file.Path)] = file
+	}
+	return &reExportResolver{
+		filesByPath:  filesByPath,
+		resolveCache: make(map[string]string),
+		warningSet:   make(map[string]struct{}),
+	}
+}
+
+func (r *reExportResolver) warnings() []string {
+	warnings := make([]string, 0, len(r.warningSet))
+	for warning := range r.warningSet {
+		warnings = append(warnings, warning)
+	}
+	slices.Sort(warnings)
+	return warnings
+}
+
+func (r *reExportResolver) resolveImportAttribution(importerPath string, imp ImportBinding, dependency string) (resolvedAttribution, bool) {
+	if !isLocalModuleSpecifier(imp.Module) {
+		return resolvedAttribution{}, false
+	}
+	if imp.Kind != ImportNamed && imp.Kind != ImportDefault {
+		return resolvedAttribution{}, false
+	}
+
+	resolvedModule, ok := r.resolveLocalModule(importerPath, imp.Module)
+	if !ok {
+		return resolvedAttribution{}, false
+	}
+
+	requestedExport := imp.ExportName
+	if imp.Kind == ImportDefault {
+		requestedExport = "default"
+	}
+
+	origin, ok := r.resolveExportOrigin(resolveExportRequest{
+		importerPath:    normalizeModulePath(importerPath),
+		currentFilePath: resolvedModule,
+		requestedExport: requestedExport,
+		dependency:      dependency,
+		visited:         map[string]struct{}{},
+		localTrail:      []string{},
+	})
+	if !ok {
+		return resolvedAttribution{}, false
+	}
+
+	path := make([]string, 0, len(origin.localTrail)+2)
+	path = append(path, normalizeModulePath(importerPath))
+	path = append(path, origin.localTrail...)
+	path = append(path, fmt.Sprintf("%s#%s", origin.dependencyModule, origin.dependencyExport))
+
+	return resolvedAttribution{
+		Module:     origin.dependencyModule,
+		ExportName: origin.dependencyExport,
+		Provenance: strings.Join(path, " -> "),
+	}, true
+}
+
+type resolveExportRequest struct {
+	importerPath    string
+	currentFilePath string
+	requestedExport string
+	dependency      string
+	visited         map[string]struct{}
+	localTrail      []string
+}
+
+type exportOrigin struct {
+	dependencyModule string
+	dependencyExport string
+	localTrail       []string
+}
+
+func (r *reExportResolver) resolveExportOrigin(req resolveExportRequest) (exportOrigin, bool) {
+	if r.hasResolutionCycle(req) {
+		return exportOrigin{}, false
+	}
+
+	file, visited, ok := r.prepareExportResolution(req)
+	if !ok {
+		return exportOrigin{}, false
+	}
+
+	for _, binding := range selectReExportCandidates(file.ReExports, req.requestedExport) {
+		origin, ok := r.resolveExportCandidate(req, binding, visited)
+		if ok {
+			return origin, true
+		}
+	}
+
+	return exportOrigin{}, false
+}
+
+func (r *reExportResolver) hasResolutionCycle(req resolveExportRequest) bool {
+	key := req.currentFilePath + "|" + req.requestedExport
+	if _, seen := req.visited[key]; !seen {
+		return false
+	}
+	path := append([]string{}, req.localTrail...)
+	path = append(path, req.currentFilePath)
+	warning := fmt.Sprintf(
+		"re-export attribution cycle while resolving %q from %s: %s",
+		req.requestedExport,
+		req.importerPath,
+		strings.Join(path, " -> "),
+	)
+	r.warningSet[warning] = struct{}{}
+	return true
+}
+
+func (r *reExportResolver) prepareExportResolution(req resolveExportRequest) (FileScan, map[string]struct{}, bool) {
+	file, ok := r.filesByPath[req.currentFilePath]
+	if !ok {
+		return FileScan{}, nil, false
+	}
+	visited := cloneVisitedSet(req.visited)
+	visited[req.currentFilePath+"|"+req.requestedExport] = struct{}{}
+	return file, visited, true
+}
+
+func selectReExportCandidates(bindings []ReExportBinding, requestedExport string) []ReExportBinding {
+	candidates := make([]ReExportBinding, 0)
+	for _, binding := range bindings {
+		if binding.ExportName == requestedExport {
+			candidates = append(candidates, binding)
+		}
+	}
+	if len(candidates) > 0 {
+		return candidates
+	}
+	for _, binding := range bindings {
+		if binding.ExportName == "*" {
+			candidates = append(candidates, binding)
+		}
+	}
+	return candidates
+}
+
+func (r *reExportResolver) resolveExportCandidate(
+	req resolveExportRequest,
+	binding ReExportBinding,
+	visited map[string]struct{},
+) (exportOrigin, bool) {
+	nextExport := normalizeRequestedExport(binding.SourceExportName, req.requestedExport)
+	if matchesDependency(binding.SourceModule, req.dependency) {
+		return r.dependencyExportOrigin(req, binding.SourceModule, nextExport), true
+	}
+	if !isLocalModuleSpecifier(binding.SourceModule) {
+		return exportOrigin{}, false
+	}
+
+	nextPath, ok := r.resolveLocalModule(req.currentFilePath, binding.SourceModule)
+	if !ok {
+		return exportOrigin{}, false
+	}
+	return r.resolveExportOrigin(resolveExportRequest{
+		importerPath:    req.importerPath,
+		currentFilePath: nextPath,
+		requestedExport: nextExport,
+		dependency:      req.dependency,
+		visited:         visited,
+		localTrail:      appendTrail(req.localTrail, req.currentFilePath),
+	})
+}
+
+func normalizeRequestedExport(sourceExport string, requestedExport string) string {
+	if sourceExport == "*" {
+		return requestedExport
+	}
+	return sourceExport
+}
+
+func appendTrail(trail []string, current string) []string {
+	next := append([]string{}, trail...)
+	next = append(next, current)
+	return next
+}
+
+func (r *reExportResolver) dependencyExportOrigin(req resolveExportRequest, module string, exportName string) exportOrigin {
+	return exportOrigin{
+		dependencyModule: module,
+		dependencyExport: exportName,
+		localTrail:       appendTrail(req.localTrail, req.currentFilePath),
+	}
+}
+
+func cloneVisitedSet(src map[string]struct{}) map[string]struct{} {
+	cloned := make(map[string]struct{}, len(src))
+	for key := range src {
+		cloned[key] = struct{}{}
+	}
+	return cloned
+}
+
+func isLocalModuleSpecifier(module string) bool {
+	return strings.HasPrefix(module, ".")
+}
+
+func (r *reExportResolver) resolveLocalModule(importerPath string, module string) (string, bool) {
+	key := normalizeModulePath(importerPath) + "\x00" + module
+	if value, ok := r.resolveCache[key]; ok {
+		if value == "" {
+			return "", false
+		}
+		return value, true
+	}
+
+	base := filepath.Dir(normalizeModulePath(importerPath))
+	target := normalizeModulePath(filepath.Join(base, module))
+	for _, candidate := range localModuleCandidates(target) {
+		if _, ok := r.filesByPath[candidate]; ok {
+			r.resolveCache[key] = candidate
+			return candidate, true
+		}
+	}
+
+	r.resolveCache[key] = ""
+	return "", false
+}
+
+func localModuleCandidates(path string) []string {
+	normalized := normalizeModulePath(path)
+	candidates := make([]string, 0, 24)
+	candidates = append(candidates, normalized)
+	base := strings.TrimSuffix(normalized, filepath.Ext(normalized))
+	if base != normalized {
+		candidates = append(candidates, base)
+	}
+
+	extensions := []string{".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"}
+	for _, ext := range extensions {
+		candidates = append(candidates, base+ext)
+		candidates = append(candidates, filepath.Join(base, "index"+ext))
+	}
+
+	unique := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		normalizedCandidate := normalizeModulePath(candidate)
+		if _, ok := seen[normalizedCandidate]; ok {
+			continue
+		}
+		seen[normalizedCandidate] = struct{}{}
+		unique = append(unique, normalizedCandidate)
+	}
+	return unique
+}
+
+func normalizeModulePath(path string) string {
+	return filepath.ToSlash(filepath.Clean(path))
+}

--- a/internal/lang/js/reexport_resolver_helpers_test.go
+++ b/internal/lang/js/reexport_resolver_helpers_test.go
@@ -1,0 +1,191 @@
+package js
+
+import "testing"
+
+func TestReExportResolverHelperFunctions(t *testing.T) {
+	t.Run("selectReExportCandidates prefers exact", func(t *testing.T) {
+		bindings := []ReExportBinding{
+			{ExportName: "*", SourceModule: "./all"},
+			{ExportName: "mapAlias", SourceModule: "./map"},
+		}
+		candidates := selectReExportCandidates(bindings, "mapAlias")
+		if len(candidates) != 1 || candidates[0].SourceModule != "./map" {
+			t.Fatalf("expected exact candidate first, got %#v", candidates)
+		}
+	})
+
+	t.Run("selectReExportCandidates falls back to wildcard", func(t *testing.T) {
+		bindings := []ReExportBinding{
+			{ExportName: "*", SourceModule: "./all"},
+			{ExportName: "named", SourceModule: "./named"},
+		}
+		candidates := selectReExportCandidates(bindings, "missing")
+		if len(candidates) != 1 || candidates[0].ExportName != "*" {
+			t.Fatalf("expected wildcard fallback candidate, got %#v", candidates)
+		}
+	})
+
+	t.Run("normalizeRequestedExport", func(t *testing.T) {
+		if got := normalizeRequestedExport("*", "map"); got != "map" {
+			t.Fatalf("expected wildcard source to map to requested export, got %q", got)
+		}
+		if got := normalizeRequestedExport("filter", "map"); got != "filter" {
+			t.Fatalf("expected explicit source export to be preserved, got %q", got)
+		}
+	})
+
+	t.Run("appendTrail clones input", func(t *testing.T) {
+		orig := []string{"a"}
+		next := appendTrail(orig, "b")
+		if len(orig) != 1 || orig[0] != "a" {
+			t.Fatalf("expected original trail unchanged, got %#v", orig)
+		}
+		if len(next) != 2 || next[1] != "b" {
+			t.Fatalf("expected appended trail, got %#v", next)
+		}
+	})
+}
+
+func TestReExportResolverCoverageBranches(t *testing.T) {
+	resolver := &reExportResolver{
+		filesByPath:  map[string]FileScan{},
+		resolveCache: map[string]string{},
+		warningSet:   map[string]struct{}{},
+	}
+
+	req := resolveExportRequest{
+		importerPath:    "src/index.ts",
+		currentFilePath: "src/a.ts",
+		requestedExport: "x",
+		visited:         map[string]struct{}{},
+		localTrail:      []string{},
+	}
+
+	if _, _, ok := resolver.prepareExportResolution(req); ok {
+		t.Fatalf("expected missing file path to fail preparation")
+	}
+
+	req.visited = map[string]struct{}{"src/a.ts|x": {}}
+	if !resolver.hasResolutionCycle(req) {
+		t.Fatalf("expected cycle to be detected")
+	}
+	if len(resolver.warningSet) == 0 {
+		t.Fatalf("expected cycle warning to be recorded")
+	}
+
+	req.localTrail = []string{"src/index.ts"}
+	origin := resolver.dependencyExportOrigin(req, "lodash", "map")
+	if origin.dependencyModule != "lodash" || origin.dependencyExport != "map" {
+		t.Fatalf("unexpected dependency export origin: %#v", origin)
+	}
+	if len(origin.localTrail) != 2 || origin.localTrail[1] != "src/a.ts" {
+		t.Fatalf("expected local trail append, got %#v", origin.localTrail)
+	}
+}
+
+func TestReExportResolverResolveLocalAndAttributionBranches(t *testing.T) {
+	resolver := &reExportResolver{
+		filesByPath: map[string]FileScan{
+			"src/barrel.ts":      {Path: "src/barrel.ts"},
+			"src/utils/index.ts": {Path: "src/utils/index.ts"},
+		},
+		resolveCache: map[string]string{},
+		warningSet:   map[string]struct{}{},
+	}
+
+	if path, ok := resolver.resolveLocalModule("src/main.ts", "./barrel"); !ok || path != "src/barrel.ts" {
+		t.Fatalf("expected direct extension resolution, got path=%q ok=%v", path, ok)
+	}
+	if path, ok := resolver.resolveLocalModule("src/main.ts", "./utils"); !ok || path != "src/utils/index.ts" {
+		t.Fatalf("expected index file resolution, got path=%q ok=%v", path, ok)
+	}
+	if path, ok := resolver.resolveLocalModule("src/main.ts", "./missing"); ok || path != "" {
+		t.Fatalf("expected unresolved local module, got path=%q ok=%v", path, ok)
+	}
+	// hit negative cache path
+	if path, ok := resolver.resolveLocalModule("src/main.ts", "./missing"); ok || path != "" {
+		t.Fatalf("expected unresolved local module from cache, got path=%q ok=%v", path, ok)
+	}
+
+	if _, ok := resolver.resolveImportAttribution("src/main.ts", ImportBinding{
+		Module:     "lodash",
+		ExportName: "map",
+		LocalName:  "map",
+		Kind:       ImportNamed,
+	}, "lodash"); ok {
+		t.Fatalf("expected non-local import to skip resolver")
+	}
+	if _, ok := resolver.resolveImportAttribution("src/main.ts", ImportBinding{
+		Module:     "./barrel",
+		ExportName: "*",
+		LocalName:  "ns",
+		Kind:       ImportNamespace,
+	}, "lodash"); ok {
+		t.Fatalf("expected namespace local import to skip resolver")
+	}
+}
+
+func TestReExportResolverResolveExportCandidateBranches(t *testing.T) {
+	resolver := &reExportResolver{
+		filesByPath: map[string]FileScan{
+			"src/a.ts": {
+				Path: "src/a.ts",
+				ReExports: []ReExportBinding{
+					{SourceModule: "lodash", SourceExportName: "map", ExportName: "mapAlias"},
+					{SourceModule: "./b", SourceExportName: "filter", ExportName: "filterAlias"},
+				},
+			},
+			"src/b.ts": {
+				Path: "src/b.ts",
+				ReExports: []ReExportBinding{
+					{SourceModule: "lodash", SourceExportName: "filter", ExportName: "filter"},
+				},
+			},
+		},
+		resolveCache: map[string]string{},
+		warningSet:   map[string]struct{}{},
+	}
+
+	req := resolveExportRequest{
+		importerPath:    "src/index.ts",
+		currentFilePath: "src/a.ts",
+		requestedExport: "mapAlias",
+		dependency:      "lodash",
+		visited:         map[string]struct{}{},
+		localTrail:      []string{},
+	}
+
+	origin, ok := resolver.resolveExportCandidate(req, ReExportBinding{
+		SourceModule:     "lodash",
+		SourceExportName: "map",
+		ExportName:       "mapAlias",
+	}, map[string]struct{}{})
+	if !ok || origin.dependencyModule != "lodash" || origin.dependencyExport != "map" {
+		t.Fatalf("expected direct dependency origin, got origin=%#v ok=%v", origin, ok)
+	}
+
+	origin, ok = resolver.resolveExportCandidate(req, ReExportBinding{
+		SourceModule:     "./b",
+		SourceExportName: "filter",
+		ExportName:       "filterAlias",
+	}, map[string]struct{}{})
+	if !ok || origin.dependencyModule != "lodash" || origin.dependencyExport != "filter" {
+		t.Fatalf("expected local chain resolution to dependency origin, got origin=%#v ok=%v", origin, ok)
+	}
+
+	if _, ok = resolver.resolveExportCandidate(req, ReExportBinding{
+		SourceModule:     "react",
+		SourceExportName: "default",
+		ExportName:       "reactAlias",
+	}, map[string]struct{}{}); ok {
+		t.Fatalf("expected non-local non-target dependency source to be skipped")
+	}
+
+	if _, ok = resolver.resolveExportCandidate(req, ReExportBinding{
+		SourceModule:     "./missing",
+		SourceExportName: "x",
+		ExportName:       "x",
+	}, map[string]struct{}{}); ok {
+		t.Fatalf("expected unresolved local source to be skipped")
+	}
+}

--- a/internal/lang/js/scan.go
+++ b/internal/lang/js/scan.go
@@ -33,9 +33,17 @@ type ImportBinding struct {
 	Location   report.Location
 }
 
+type ReExportBinding struct {
+	SourceModule     string
+	SourceExportName string
+	ExportName       string
+	Location         report.Location
+}
+
 type FileScan struct {
 	Path            string
 	Imports         []ImportBinding
+	ReExports       []ReExportBinding
 	IdentifierUsage map[string]int
 	NamespaceUsage  map[string]map[string]int
 }
@@ -176,12 +184,14 @@ func appendParseErrorFile(parseErrorFiles *[]string, relPath string) {
 
 func analyzeFile(tree *sitter.Tree, content []byte, relPath string) FileScan {
 	imports := collectImportBindings(tree, content, relPath)
+	reExports := collectReExportBindings(tree, content, relPath, imports)
 	identifierUsage := collectIdentifierUsage(tree, content)
 	namespaceUsage := collectNamespaceUsage(tree, content)
 
 	return FileScan{
 		Path:            relPath,
 		Imports:         imports,
+		ReExports:       reExports,
 		IdentifierUsage: identifierUsage,
 		NamespaceUsage:  namespaceUsage,
 	}
@@ -245,6 +255,120 @@ func collectImportBindings(tree *sitter.Tree, content []byte, relPath string) []
 	})
 
 	return bindings
+}
+
+func collectReExportBindings(tree *sitter.Tree, content []byte, relPath string, imports []ImportBinding) []ReExportBinding {
+	importsByLocal := make(map[string][]ImportBinding)
+	for _, imp := range imports {
+		if imp.LocalName == "" {
+			continue
+		}
+		importsByLocal[imp.LocalName] = append(importsByLocal[imp.LocalName], imp)
+	}
+
+	root := tree.RootNode()
+	bindings := make([]ReExportBinding, 0)
+	walkNode(root, func(node *sitter.Node) {
+		if node.Type() != "export_statement" {
+			return
+		}
+		bindings = append(bindings, parseReExportStatement(node, content, relPath, importsByLocal)...)
+	})
+	return bindings
+}
+
+func parseReExportStatement(
+	node *sitter.Node,
+	content []byte,
+	relPath string,
+	importsByLocal map[string][]ImportBinding,
+) []ReExportBinding {
+	sourceNode := node.ChildByFieldName("source")
+	sourceModule, hasSource := extractStringLiteral(sourceNode, content)
+
+	namespaceExport := firstNamedChildOfType(node, "namespace_export")
+	if namespaceExport != nil && hasSource {
+		nameNode := firstNamedChildOfType(namespaceExport, "identifier", "property_identifier")
+		exportName := nodeText(nameNode, content)
+		if exportName != "" {
+			return []ReExportBinding{makeReExportBinding(sourceModule, "*", exportName, relPath, namespaceExport)}
+		}
+	}
+
+	clause := node.ChildByFieldName("export_clause")
+	if clause == nil {
+		clause = firstNamedChildOfType(node, "export_clause")
+	}
+	if clause != nil {
+		return parseReExportClause(clause, content, relPath, hasSource, sourceModule, importsByLocal)
+	}
+
+	if hasSource {
+		return []ReExportBinding{makeReExportBinding(sourceModule, "*", "*", relPath, node)}
+	}
+	return nil
+}
+
+func parseReExportClause(
+	node *sitter.Node,
+	content []byte,
+	relPath string,
+	hasSource bool,
+	sourceModule string,
+	importsByLocal map[string][]ImportBinding,
+) []ReExportBinding {
+	bindings := make([]ReExportBinding, 0)
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(i)
+		if child.Type() != "export_specifier" {
+			continue
+		}
+
+		nameNode := child.ChildByFieldName("name")
+		if nameNode == nil {
+			nameNode = firstNamedChildOfType(child, "identifier", "property_identifier")
+		}
+		aliasNode := child.ChildByFieldName("alias")
+		if aliasNode == nil {
+			aliasNode = nameNode
+		}
+
+		sourceExportName := nodeText(nameNode, content)
+		exportName := nodeText(aliasNode, content)
+		if sourceExportName == "" {
+			continue
+		}
+		if exportName == "" {
+			exportName = sourceExportName
+		}
+
+		if hasSource {
+			bindings = append(bindings, makeReExportBinding(sourceModule, sourceExportName, exportName, relPath, child))
+			continue
+		}
+
+		for _, imp := range importsByLocal[sourceExportName] {
+			bindings = append(
+				bindings,
+				makeReExportBinding(imp.Module, imp.ExportName, exportName, relPath, child),
+			)
+		}
+	}
+	return bindings
+}
+
+func makeReExportBinding(sourceModule string, sourceExportName string, exportName string, relPath string, node *sitter.Node) ReExportBinding {
+	location := report.Location{
+		File:   relPath,
+		Line:   int(node.StartPoint().Row) + 1,
+		Column: int(node.StartPoint().Column) + 1,
+	}
+	return ReExportBinding{
+		SourceModule:     sourceModule,
+		SourceExportName: sourceExportName,
+		ExportName:       exportName,
+		Location:         location,
+	}
 }
 
 func collectIdentifierUsage(tree *sitter.Tree, content []byte) map[string]int {

--- a/internal/lang/js/scan_unit_extra_test.go
+++ b/internal/lang/js/scan_unit_extra_test.go
@@ -3,6 +3,7 @@ package js
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -114,5 +115,52 @@ func TestParseRequireBindingNoDeclarator(t *testing.T) {
 	bindings := parseRequireBinding(call, source, "leftpad", unitIndexJS)
 	if len(bindings) != 0 {
 		t.Fatalf("expected no require bindings without variable declarator, got %#v", bindings)
+	}
+}
+
+func TestCollectReExportBindings(t *testing.T) {
+	source := []byte(strings.Join([]string{
+		`import { map as remap } from "lodash"`,
+		`export { remap as mapAlias }`,
+		`export { filter as keep } from "lodash"`,
+		`export * as api from "./ns"`,
+		`export * from "./other"`,
+		"",
+	}, "\n"))
+
+	tree, err := newSourceParser().Parse(context.Background(), unitIndexJS, source)
+	if err != nil {
+		t.Fatalf(parseSourceErrFmt, err)
+	}
+
+	imports := collectImportBindings(tree, source, unitIndexJS)
+	reExports := collectReExportBindings(tree, source, unitIndexJS, imports)
+	if len(reExports) < 3 {
+		t.Fatalf("expected re-export bindings, got %#v", reExports)
+	}
+
+	found := map[string]bool{
+		"mapAlias": false,
+		"keep":     false,
+		"api":      false,
+		"*":        false,
+	}
+	for _, item := range reExports {
+		switch {
+		case item.ExportName == "mapAlias" && item.SourceModule == "lodash" && item.SourceExportName == "map":
+			found["mapAlias"] = true
+		case item.ExportName == "keep" && item.SourceModule == "lodash" && item.SourceExportName == "filter":
+			found["keep"] = true
+		case item.ExportName == "api" && item.SourceModule == "./ns" && item.SourceExportName == "*":
+			found["api"] = true
+		case item.ExportName == "*" && item.SourceModule == "./other" && item.SourceExportName == "*":
+			found["*"] = true
+		}
+	}
+
+	for key, ok := range found {
+		if !ok {
+			t.Fatalf("expected re-export %q in %#v", key, reExports)
+		}
 	}
 }

--- a/internal/lang/js/usage_test.go
+++ b/internal/lang/js/usage_test.go
@@ -301,7 +301,7 @@ func TestCollectDependencyImportUsageWildcardWarning(t *testing.T) {
 			usedImports := make(map[string]*report.ImportUse)
 			unusedImports := make(map[string]*report.ImportUse)
 
-			hasAmbiguous := collectDependencyImportUsage(
+			hasAmbiguous, warnings := collectDependencyImportUsage(
 				tt.scanResult,
 				tt.dependency,
 				usedExports,
@@ -312,6 +312,9 @@ func TestCollectDependencyImportUsageWildcardWarning(t *testing.T) {
 
 			if hasAmbiguous != tt.expectAmbiguousFlag {
 				t.Errorf("%s: hasAmbiguous = %v, want %v", tt.description, hasAmbiguous, tt.expectAmbiguousFlag)
+			}
+			if len(warnings) != 0 {
+				t.Errorf("expected no attribution warnings, got %#v", warnings)
 			}
 		})
 	}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -103,9 +103,10 @@ type SymbolUsage struct {
 }
 
 type ImportUse struct {
-	Name      string     `json:"name"`
-	Module    string     `json:"module"`
-	Locations []Location `json:"locations,omitempty"`
+	Name       string     `json:"name"`
+	Module     string     `json:"module"`
+	Locations  []Location `json:"locations,omitempty"`
+	Provenance []string   `json:"provenance,omitempty"`
 }
 
 type SymbolRef struct {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -96,6 +96,9 @@ func printImportList(out io.Writer, title string, imports []report.ImportUse) {
 			locationHint = fmt.Sprintf(" (%s:%d)", imp.Locations[0].File, imp.Locations[0].Line)
 		}
 		_, _ = fmt.Fprintf(out, "  - %s from %s%s\n", imp.Name, imp.Module, locationHint)
+		for _, provenance := range imp.Provenance {
+			_, _ = fmt.Fprintf(out, "    provenance: %s\n", provenance)
+		}
 	}
 	_, _ = fmt.Fprintln(out, "")
 }

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -104,7 +104,12 @@ func TestDetailHelpersAndErrors(t *testing.T) {
 
 	out.Reset()
 	printImportList(&out, "Used imports", nil)
-	printImportList(&out, "Used imports", []report.ImportUse{{Name: "map", Module: "lodash", Locations: []report.Location{{File: "index.js", Line: 2}}}})
+	printImportList(&out, "Used imports", []report.ImportUse{{
+		Name:       "map",
+		Module:     "lodash",
+		Locations:  []report.Location{{File: "index.js", Line: 2}},
+		Provenance: []string{"index.js -> barrel.js -> lodash#map"},
+	}})
 	printExportsList(&out, "Unused exports", nil)
 	printExportsList(&out, "Unused exports", []report.SymbolRef{{Name: "mystery"}})
 	printRiskCues(&out, nil)
@@ -115,6 +120,9 @@ func TestDetailHelpersAndErrors(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "(unknown)") {
 		t.Fatalf("expected unknown module label for empty module exports")
+	}
+	if !strings.Contains(out.String(), "provenance: index.js -> barrel.js -> lodash#map") {
+		t.Fatalf("expected provenance detail in import list output")
 	}
 
 	if dep, ok := isDetailCommand("open lodash"); !ok || dep != "lodash" {


### PR DESCRIPTION
## Issue
Closes #62.

Symbol attribution missed usage routed through local re-export/barrel files. This produced false negatives in dependency usage reporting when code imported from local wrappers instead of direct dependency entrypoints.

## Cause and user impact
The JS/TS analyzer only matched imports that directly referenced the target dependency module. Imports from local barrel files were treated as local-only, so used exports and used-import details were underreported for real dependency origins.

## Root cause
`ScanRepo` captured imports and identifier usage, but did not build a re-export graph (`export { ... } from`, `export * from`, and local alias re-exports). Attribution in `collectDependencyImportUsage` therefore had no chain resolution from local modules to dependency exports.

## Fix
- Added re-export graph extraction to JS/TS scanning:
  - new `ReExportBinding` model.
  - per-file `ReExports` captured during AST walk.
- Added cycle-safe local re-export resolver:
  - resolves local module specifiers to scanned files.
  - follows nested/aliased chains to dependency origins.
  - emits explicit cycle warnings instead of crashing.
- Integrated resolver into dependency attribution:
  - local imports can now attribute to dependency export origins.
  - used/unused import entries include provenance chains.
- Exposed provenance in outputs:
  - `report.ImportUse` now has `provenance`.
  - detail view prints provenance lines.
  - report schema/docs updated.
- Reduced cognitive complexity to satisfy Sonar rule `go:S3776` via helper extraction in resolver/adapter paths.

## Validation
- `make ci`
- `make cov` (meets gate: `95.0%`)
- `go test ./...`
- Local SonarQube Community scan via Docker against `lopper-local` (no unresolved issues)

## Tests added/updated
- Re-export attribution integration tests (nested alias + cycle warning)
- Resolver helper/branch tests (module resolution, candidate selection, attribution branches)
- Scan re-export extraction tests (including namespace re-export)
- UI detail tests for provenance rendering
