### PR TITLE
[feat] add sonarqube review comments action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,14 +273,16 @@ jobs:
             }
 
       - name: Post SonarQube review comments (PR)
-        if: ${{ github.event_name == 'pull_request' && !env.ACT && secrets.SONAR_TOKEN != '' && steps.sonar_scan.outcome == 'success' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: ${{ github.event_name == 'pull_request' && !env.ACT && env.SONAR_TOKEN != '' && steps.sonar_scan.outcome == 'success' }}
         continue-on-error: true
         uses: RishabhTayal/sonarqube-review-comments-action@ec6510452a09e32cd45238308151a3e817182ee2
         with:
           sonar_project_key: ben-ranford_lopper
           sonar_host_url: https://sonarcloud.io
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          sonar_token: ${{ secrets.SONAR_TOKEN }}
+          sonar_token: ${{ env.SONAR_TOKEN }}
 
       - name: Run coverage gate
         id: cov


### PR DESCRIPTION
## Issue
Pull requests did not surface SonarCloud findings directly in the review conversation, so static-analysis issues were easy to miss during normal code review.

## Cause And User Impact
The CI workflow had no Sonar scan/commenting steps tied to PR execution. As a result, reviewers had to leave GitHub and inspect SonarCloud manually, which reduced feedback loop speed and made remediation less actionable.

## Root Cause
`.github/workflows/ci.yml` lacked:
- a PR Sonar scan step in the `verify` job
- a follow-up step to translate Sonar findings into PR comments

## Fix
Updated `/Users/benranford/Projects/lopper-sonarqube/.github/workflows/ci.yml` to:
- add `SonarSource/sonarqube-scan-action@v7` for pull requests
- pass SonarCloud configuration (`sonar.organization=ben-ranford`, `sonar.projectKey=ben-ranford_lopper`)
- add `RishabhTayal/sonarqube-review-comments-action@v1` to post Sonar issues as actionable PR feedback
- guard both steps for PR-only runs, skip `act`, and require `SONAR_TOKEN`
- gate comment posting on successful Sonar scan outcome

## Validation
- Local workflow syntax validation: YAML parse of `ci.yml` succeeded.
- Repo checks passed locally: `make ci` (including lint, gosec, tests) and pre-commit coverage gate.
