### PR TITLE
[bug] fix tui in-place refresh behavior

### DIFF
--- a/internal/ui/summary_commands_test.go
+++ b/internal/ui/summary_commands_test.go
@@ -22,8 +22,8 @@ func TestSummaryCommandHandlersHelpAndFiltering(t *testing.T) {
 	if !applySummaryCommand(state, "help", &out) || !state.showHelp {
 		t.Fatalf("expected help command to set help flag")
 	}
-	if !strings.Contains(out.String(), "Commands:") {
-		t.Fatalf("expected help text output")
+	if out.Len() != 0 {
+		t.Fatalf("expected help command to rely on re-render instead of direct output")
 	}
 	if !applySummaryCommand(state, "filter lodash", io.Discard) || state.filter != "lodash" || state.page != 1 {
 		t.Fatalf("expected filter command to set filter and reset page")


### PR DESCRIPTION
## Issue
The TUI command loop rendered by appending new output blocks on each interaction, which caused the screen to grow with repeated summaries and made normal command usage hard to follow.

## Cause and user impact
Command handling mixed two output paths:
- `help` printed directly from the command handler.
- The loop then rendered the full summary again on the next iteration.

Additionally, the loop did not clear terminal output before re-rendering. In interactive sessions this looked like a fresh full scan printed for every command.

## Root cause
In `/internal/ui/summary.go`, the command handler for `help` wrote immediate output instead of updating state only, and `Start` always printed renders without terminal-aware screen refresh.

## Fix
- Added terminal detection (`supportsScreenRefresh`) to enable in-place redraw only for character-device output.
- Added `clearSummaryScreen` and invoked it at the start of each render loop iteration in interactive mode.
- Changed `handleHelpCommand` to update state (`showHelp`) without direct output, so rendering is centralized.
- Updated test expectation in `/internal/ui/summary_commands_test.go` to assert no direct help-print side effect.

## Validation
- `go test ./internal/ui/...`
- `go test ./...`
- Pre-commit checks (`make fmt`, `make ci`, `make cov`) passed during commit.

Closes #124
