### PR TITLE
[bug] trim manual release notes section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,11 +211,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout (for changelog generation)
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
       - name: Download release artifacts
         uses: actions/download-artifact@v7
         with:
@@ -227,7 +222,6 @@ jobs:
         run: |
           set -euo pipefail
           current_tag="${{ needs.prepare.outputs.tag }}"
-          previous_tag="${{ needs.prepare.outputs.previous_tag }}"
           ghcr_owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           ghcr_ref="ghcr.io/${ghcr_owner}/lopper:${current_tag}"
           ghcr_package_url="https://github.com/${GITHUB_REPOSITORY}/pkgs/container/lopper"
@@ -242,18 +236,6 @@ jobs:
             echo
             echo "- Tagged image: \`${ghcr_ref}\`"
             echo "- Package: [GHCR lopper package](${ghcr_package_url})"
-            echo "- Pull command: \`docker pull ${ghcr_ref}\`"
-            echo
-            if [ -n "${previous_tag}" ]; then
-              echo "Changes since \`${previous_tag}\`:"
-              echo
-              git log --reverse --pretty=format:'- %h %s (%an)' "${previous_tag}..${GITHUB_SHA}"
-            else
-              echo "All commits up to \`${current_tag}\`:"
-              echo
-              git log --reverse --pretty=format:'- %h %s (%an)' "${GITHUB_SHA}"
-            fi
-            echo
             echo
             echo "---"
             echo


### PR DESCRIPTION
## Issue
Release notes were duplicating commit history in two places: a manually generated "Changes since ..." section and GitHub's auto-generated release notes.

## Cause and Impact
The release workflow generated a custom commit log with `git log` and also enabled `generate_release_notes: true` in the release action.
This produced redundant history in published release notes and made the generated notes noisier than necessary.

## Root Cause
The `publish` job in `/Users/benranford/Projects/lopper/.github/workflows/release.yml` still contained legacy changelog code:
- checkout + full git history fetch for changelog generation
- previous tag lookup
- manual commit range output
- explicit docker pull command line in the body

## Fix
Updated `/Users/benranford/Projects/lopper/.github/workflows/release.yml` to simplify the static preface and defer commit history to GitHub auto-generation:
- removed manual "Changes since" / "All commits up to" section
- removed the `Pull command` line from the container image section
- removed now-unused checkout step and previous-tag lookup
- kept `generate_release_notes: true` to let GitHub append commit/PR details

## Validation
- Parsed workflow YAML successfully:
  - `ruby -ryaml -e "YAML.load_file('.github/workflows/release.yml'); puts 'YAML OK'"`
- Verified no whitespace/diff formatting issues in changed file:
  - `git diff --check -- .github/workflows/release.yml`
