### PR TITLE
[feat] restore brew install docs and demo table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,25 @@ It compares imported dependencies to actual usage and reports waste, risk cues, 
 
 ## Install
 
-Install from GitHub Releases:
+macOS/Linux (Homebrew tap, stable):
 
 ```bash
-# Open latest release page and download the asset for your platform.
+brew tap ben-ranford/tap
+brew install lopper
+```
+
+macOS/Linux (Homebrew tap, rolling):
+
+```bash
+brew install ben-ranford/tap/lopper-rolling
+```
+
+`lopper-rolling` tracks `main` and is not a stable semver release.
+
+Windows (GitHub Releases):
+
+```bash
+# Open latest release page and download the Windows asset for your platform.
 gh release view --repo ben-ranford/lopper --web
 ```
 
@@ -59,6 +74,20 @@ lopper analyse --top 20 \
   --score-weight-impact 0.30 \
   --score-weight-confidence 0.20
 ```
+
+## Terminal demos
+
+Regenerate all demo assets from source tapes:
+
+```bash
+make demos
+```
+
+| Demo | What it demonstrates | GIF preview |
+| --- | --- | --- |
+| Quick start ranking | End-to-end `--top` workflow and waste-ranked dependency table for fast triage. | ![Quick start top ranking demo](docs/demos/assets/quickstart-top.gif) |
+| Single dependency deep dive | Focused analysis of one dependency with detailed usage signal and recommendation context. | ![Single dependency demo](docs/demos/assets/single-dependency.gif) |
+| Baseline gate in CI flow | Baseline comparison and increase gating to catch regression risk in automated checks. | ![Baseline gating demo](docs/demos/assets/baseline-gate.gif) |
 
 ## Languages
 


### PR DESCRIPTION
## Issue
The README install section regressed and no longer documented Homebrew tap installation, so macOS/Linux users were directed to a generic GitHub Releases flow instead of the primary package channel.

## Cause and User Impact
A previous docs simplification removed tap-focused install instructions and the terminal demo section. This reduced clarity for users choosing stable vs rolling builds and removed quick visual context for common workflows.

## Root Cause
The install section was condensed around a single GitHub Releases command, and subsequent README edits did not restore the Homebrew guidance or demo coverage.

## Fix
- Restored Homebrew tap instructions as the primary install path for macOS/Linux stable builds.
- Added explicit rolling channel install command.
- Clarified that `lopper-rolling` tracks `main` and is not a stable semver release.
- Kept GitHub Releases instructions, but scoped them to Windows.
- Reintroduced terminal demos in a table with:
  - demo name
  - what each demo demonstrates
  - inline GIF preview

## Validation
Pre-commit hooks ran and passed during commit creation:
- `make fmt`
- `make ci` (lint, duplication gate, gosec, test, build)
- `make cov` (total coverage 95.9%, threshold >= 95%)
