### PR TITLE
fix(release): stop using secrets in workflow guards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      VSCE_PUBLISH: ${{ secrets.VSCE_PUBLISH }}
     steps:
       - name: Download release artifacts
         uses: actions/download-artifact@v8
@@ -319,7 +321,7 @@ jobs:
             dist/*.vsix
 
       - name: Setup Node
-        if: ${{ needs.prepare.outputs.is_stable_release == 'true' && secrets.VSCE_PUBLISH != '' }}
+        if: ${{ needs.prepare.outputs.is_stable_release == 'true' && env.VSCE_PUBLISH != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -327,13 +329,13 @@ jobs:
           cache-dependency-path: extensions/vscode-lopper/package-lock.json
 
       - name: Install extension dependencies for publish
-        if: ${{ needs.prepare.outputs.is_stable_release == 'true' && secrets.VSCE_PUBLISH != '' }}
+        if: ${{ needs.prepare.outputs.is_stable_release == 'true' && env.VSCE_PUBLISH != '' }}
         run: make vscode-extension-install
 
       - name: Publish VS Code extension to Marketplace
-        if: ${{ needs.prepare.outputs.is_stable_release == 'true' && secrets.VSCE_PUBLISH != '' }}
+        if: ${{ needs.prepare.outputs.is_stable_release == 'true' && env.VSCE_PUBLISH != '' }}
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PUBLISH }}
+          VSCE_PAT: ${{ env.VSCE_PUBLISH }}
         run: |
           set -euo pipefail
           vsix_path="$(find dist -maxdepth 1 -name 'lopper-vscode-*.vsix' | head -n1)"


### PR DESCRIPTION
## Issue
Pushes to `main` were failing the `release.yml` workflow immediately during workflow validation, so the release pipeline could not even start.

## Cause and user impact
The release workflow added VS Code Marketplace publish steps guarded with `if:` expressions that referenced `secrets.VSCE_PUBLISH` directly. GitHub Actions rejects direct secret references inside `if:` conditionals, which makes the workflow invalid at parse time and causes instant 0-second failures.

## Root cause
The workflow mixed two different expression rules:
- secrets are valid in `env:` assignments
- secrets are not valid in `if:` guards

That left the new stable-release publish path syntactically invalid even though the surrounding YAML structure was otherwise fine.

## Fix
The publish job now lifts `VSCE_PUBLISH` into job-level `env`, and all publish-related `if:` guards check `env.VSCE_PUBLISH != ''` instead of referencing the secret directly. The marketplace publish step also consumes the lifted env value for `VSCE_PAT`, keeping the behavior the same while making the workflow valid.

## Validation
I validated this change with:
- `act workflow_dispatch -j prepare -W .github/workflows/release.yml -P ubuntu-latest=act-node-git:local --container-architecture linux/arm64 --pull=false` in a normal temp checkout with the patched workflow overlaid, which completed the `prepare` job successfully.
- The repository pre-commit gate triggered by `git commit`, which ran `make fmt` and `make ci` successfully.
