### PR TITLE
fix(release): allow VS Code packaging when version already matches tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,8 +262,11 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           version="${RELEASE_TAG#v}"
+          current_version="$(python3 scripts/read_package_version.py extensions/vscode-lopper/package.json)"
           cd extensions/vscode-lopper
-          npm version "$version" --no-git-tag-version
+          if [ "$current_version" != "$version" ]; then
+            npm version "$version" --no-git-tag-version
+          fi
           npx @vscode/vsce package --out "../../dist/lopper-vscode-${version}.vsix"
 
       - name: Upload VS Code extension artifact


### PR DESCRIPTION
## Issue
The `release` workflow currently fails in `build-vscode-extension` during the `Package VS Code extension` step.

## Impact
Manual stable release runs on `main` stop before publishing the VSIX artifact, which blocks the VS Code extension from being included in the release.

## Root Cause
The packaging step always runs `npm version "$version" --no-git-tag-version`. When the checked-in extension version already matches the release tag, npm exits with `Version not changed` and the job fails.

## Fix
Make the version bump conditional. The workflow now reads the current extension version first and only calls `npm version` when the release tag differs from the checked-in package version.

## Validation
- Observed failing GitHub job: `release` run `23080437142`, `build-vscode-extension`, `Package VS Code extension`
- Local reproduction of the failure before the fix: `npm version 1.0.2 --no-git-tag-version` failed with `Version not changed`
- Node 24 container validation of the fixed packaging path for `RELEASE_TAG=v1.0.2`
- pre-commit hooks
- `make ci`
