### PR TITLE
test(coverage): ratchet total coverage gate to 98%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
         id: cov
         continue-on-error: true
         env:
-          COVERAGE_MIN: 95
+          COVERAGE_MIN: 98
         run: |
           set +e
           if [ -n "${ACT:-}" ]; then
@@ -437,7 +437,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && steps.cov.outcome == 'failure' && !env.ACT }}
         uses: actions/github-script@v8
         env:
-          COVERAGE_MIN: 95
+          COVERAGE_MIN: 98
           COVERAGE_TOTAL: ${{ steps.cov.outputs.total }}
         with:
           script: |

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VSCODE_EXTENSION_DIR ?= extensions/vscode-lopper
 VSCODE_EXTENSION_PACKAGE_PATH ?= $(DIST_DIR)/vscode-lopper.vsix
 VERSION ?= dev
 COVERAGE_FILE ?= .artifacts/coverage.out
-COVERAGE_MIN ?= 95
+COVERAGE_MIN ?= 98
 GO ?= go
 GO_TOOLCHAIN ?= go1.26.1
 GO_CMD := GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO)

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -74,7 +74,7 @@ When running locally with `act`, target the Linux-backed jobs explicitly (for ex
 - `make test-race`: run `go test -race ./...`
 - `make bench-mem`: run the curated memory benchmark suite with `-benchmem`
 - `make bench-gate`: compare curated memory benchmark deltas against a base ref (defaults: `MEMORY_BENCH_BASE=origin/main`, `MEMORY_BENCH_MAX_BYTES_PCT=15`, `MEMORY_BENCH_MAX_ALLOCS_PCT=10`)
-- `make cov`: run tests with coverage profile and enforce minimum total coverage (default `COVERAGE_MIN=95`), excluding helper-only packages such as `internal/testutil`, `internal/testsupport`, and the local CI helper tool `tools/benchdelta`
+- `make cov`: run tests with coverage profile and enforce minimum total coverage (default `COVERAGE_MIN=98`), excluding helper-only packages such as `internal/testutil`, `internal/testsupport`, and the local CI helper tool `tools/benchdelta`
 - `make smoke`: run cross-OS smoke checks (`mod-check + test-race + build`)
 - `make ci`: `format-check + mod-check + lint + actionlint + shellcheck + dup-check + suppression-check + security + vuln-check + test + test-leaks + test-race + bench-gate + build + cov`
 - `make mem-profiles`: capture package-focused alloc-space summaries for the watched hotspot packages and write them under `.artifacts/memory-profiles/`
@@ -101,7 +101,7 @@ Memory benchmark approval:
 - Newly added benchmarks are reported but not gated until the same benchmark name exists on both the base and head refs, which keeps first-rollout noise manageable.
 
 On pull requests, if the coverage gate fails, CI posts/updates a PR comment with required vs. actual coverage.
-The 95% minimum is intentionally enforced in both `Makefile` and CI workflow config to keep local and CI behavior aligned.
+The 98% minimum is intentionally enforced in both `Makefile` and CI workflow config to keep local and CI behavior aligned.
 
 Cross-compilation uses `zig cc` for CGO targets.
 Current cross-CGO release targets are Linux and Windows.

--- a/internal/analysis/cache_cov_more_branches_test.go
+++ b/internal/analysis/cache_cov_more_branches_test.go
@@ -1,0 +1,189 @@
+package analysis
+
+import (
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+type cacheFailAfterWriter struct {
+	failOn int
+	writes int
+}
+
+type cacheStoreFailureCase struct {
+	name       string
+	blockedDir string
+	keyDigest  string
+}
+
+func (w *cacheFailAfterWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == w.failOn {
+		return 0, errors.New("write failed")
+	}
+	return len(p), nil
+}
+
+func TestAnalysisCacheAdditionalBranchCoverage(t *testing.T) {
+	repo := t.TempDir()
+	root := mustCreateRootWithGoMod(t, repo, "pkg")
+	cache := &analysisCache{options: resolvedCacheOptions{Enabled: true, Path: filepath.Join(repo, cacheDirName)}, cacheable: true}
+	req := Request{
+		Dependency: "dep",
+		RemovalCandidateWeights: &report.RemovalCandidateWeights{
+			Usage: math.NaN(),
+		},
+	}
+	if _, err := cache.prepareEntry(req, "js-ts", root); err == nil {
+		t.Fatalf("expected prepareEntry to fail when key payload cannot be marshaled")
+	}
+
+	configDir := filepath.Join(repo, "config-dir")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if _, err := cache.computeInputDigest(root, configDir); err == nil {
+		t.Fatalf("expected computeInputDigest to fail for unreadable config path")
+	}
+
+	mustMkdirCacheLayout(t, cache.options.Path)
+	entry := cacheEntryDescriptor{KeyDigest: "nan", InputDigest: "input"}
+	if cache.store(entry, report.Report{
+		Dependencies: []report.DependencyReport{{
+			Name: "dep",
+			RemovalCandidate: &report.RemovalCandidate{
+				Score: math.NaN(),
+			},
+		}},
+	}) == nil {
+		t.Fatalf("expected cache store to fail for NaN report payload")
+	}
+}
+
+func TestAnalysisCacheAdditionalAtomicWriteErrors(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	if writeFileAtomic(filepath.Join(blocker, "child.json"), []byte("x")) == nil {
+		t.Fatalf("expected atomic write to fail when parent path is a file")
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-based temp-file creation failures are not portable on windows")
+	}
+
+	readOnlyDir := filepath.Join(dir, "readonly")
+	if err := os.Mkdir(readOnlyDir, 0o500); err != nil {
+		t.Fatalf("mkdir readonly dir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(readOnlyDir, 0o700); err != nil {
+			t.Fatalf("restore readonly dir perms: %v", err)
+		}
+	})
+	if writeFileAtomic(filepath.Join(readOnlyDir, "child.json"), []byte("x")) == nil {
+		t.Fatalf("expected atomic write to fail when temp file cannot be created")
+	}
+}
+
+func TestAnalysisCacheAdditionalWriteBranches(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "tracked.txt")
+	if err := os.WriteFile(targetPath, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+
+	t.Run("writeInputDigestRecord propagates writer failures", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			failOn int
+		}{
+			{name: "sort key", failOn: 1},
+			{name: "separator", failOn: 2},
+			{name: "digest", failOn: 3},
+			{name: "newline", failOn: 4},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				if err := writeInputDigestRecord(&cacheFailAfterWriter{failOn: tc.failOn}, cacheDigestInput{sortKey: "tracked", path: targetPath}); err == nil {
+					t.Fatalf("expected writeInputDigestRecord to fail on write %d", tc.failOn)
+				}
+			})
+		}
+	})
+
+	t.Run("buildRelevantFile rejects invalid root", func(t *testing.T) {
+		if _, err := buildRelevantFile("\x00", targetPath); err == nil {
+			t.Fatalf("expected buildRelevantFile to fail for invalid root path")
+		}
+	})
+
+	t.Run("writeFileDigest bubbles file errors", func(t *testing.T) {
+		if err := writeFileDigest(&cacheFailAfterWriter{}, filepath.Join(dir, cacheMissingFileName)); err == nil {
+			t.Fatalf("expected writeFileDigest to fail for missing file")
+		}
+	})
+}
+
+func TestAnalysisCacheAdditionalStoreBranches(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-based cache write failures are not portable on windows")
+	}
+
+	for _, tc := range []cacheStoreFailureCase{
+		{name: "object write failure", blockedDir: cacheObjectsDirName, keyDigest: "object-write"},
+		{name: "pointer write failure", blockedDir: cacheKeysDirName, keyDigest: "pointer-write"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testAnalysisCacheStoreWriteFailure(t, tc)
+		})
+	}
+}
+
+func testAnalysisCacheStoreWriteFailure(t *testing.T, tc cacheStoreFailureCase) {
+	t.Helper()
+
+	cachePath := filepath.Join(t.TempDir(), cacheDirName)
+	objectsDir := filepath.Join(cachePath, cacheObjectsDirName)
+	keysDir := filepath.Join(cachePath, cacheKeysDirName)
+	for _, dir := range []string{objectsDir, keysDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	blockedPath := filepath.Join(cachePath, tc.blockedDir)
+	if err := os.Chmod(blockedPath, 0o500); err != nil {
+		t.Fatalf("chmod %s: %v", blockedPath, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(blockedPath, 0o700); err != nil {
+			t.Fatalf("restore %s perms: %v", blockedPath, err)
+		}
+	})
+
+	if err := storeTestAnalysisCache(cachePath, tc.keyDigest); err == nil {
+		t.Fatalf("expected cache store to fail when %s is not writable", tc.blockedDir)
+	}
+}
+
+func storeTestAnalysisCache(cachePath, keyDigest string) error {
+	entry := cacheEntryDescriptor{KeyDigest: keyDigest, InputDigest: "input"}
+	rep := report.Report{RepoPath: "repo"}
+	return newTestAnalysisCache(cachePath).store(entry, rep)
+}
+
+func newTestAnalysisCache(cachePath string) *analysisCache {
+	return &analysisCache{
+		options:   resolvedCacheOptions{Enabled: true, Path: cachePath},
+		cacheable: true,
+	}
+}

--- a/internal/analysis/cache_cov_more_runtime_test.go
+++ b/internal/analysis/cache_cov_more_runtime_test.go
@@ -1,0 +1,12 @@
+package analysis
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCacheCloseIfPresentReturnsUnexpectedCloseError(t *testing.T) {
+	if err := closeIfPresent(&os.File{}); err == nil {
+		t.Fatalf("expected closeIfPresent to return a non-benign close error")
+	}
+}

--- a/internal/analysis/pipeline_cov_more_runtime_test.go
+++ b/internal/analysis/pipeline_cov_more_runtime_test.go
@@ -1,0 +1,38 @@
+package analysis
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+)
+
+func TestAnalysisPipelineAdditionalSetupBranches(t *testing.T) {
+	service := &Service{Registry: language.NewRegistry()}
+	invalidPattern := string([]byte{0xff})
+
+	if _, err := service.newAnalysisPipeline(context.Background(), Request{
+		RepoPath:        ".",
+		IncludePatterns: []string{invalidPattern},
+	}); err == nil {
+		t.Fatalf("expected newAnalysisPipeline to surface applyPathScope failures")
+	}
+}
+
+func TestScopedCandidateRootsChangedPackagesSuccessBranch(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	repoRoot := filepath.Clean(filepath.Join(cwd, "..", ".."))
+
+	roots, warnings := scopedCandidateRoots(ScopeModeChangedPackages, []string{repoRoot}, repoRoot)
+	if len(warnings) != 0 {
+		t.Fatalf("expected changed-packages resolution without warnings, got %#v", warnings)
+	}
+	if len(roots) != 1 || roots[0] != repoRoot {
+		t.Fatalf("expected changed-packages scope to keep repo root, got %#v", roots)
+	}
+}

--- a/internal/analysis/scope_cov_more_paths_test.go
+++ b/internal/analysis/scope_cov_more_paths_test.go
@@ -1,0 +1,97 @@
+package analysis
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+const scopePathTextFile = "file.txt"
+
+func TestPathWithinRejectsInvalidRoot(t *testing.T) {
+	if pathWithin("\x00", filepath.Join(t.TempDir(), scopePathTextFile)) {
+		t.Fatalf("expected invalid root to be rejected")
+	}
+}
+
+func TestCopyFileAdditionalEscapeBranches(t *testing.T) {
+	if copyFile("\x00", t.TempDir(), scopePathTextFile) == nil {
+		t.Fatalf("expected invalid source root to be rejected")
+	}
+
+	repo := t.TempDir()
+	if copyFile(repo, "\x00", scopePathTextFile) == nil {
+		t.Fatalf("expected invalid target root to be rejected")
+	}
+}
+
+func TestScopeWalkerAdditionalBranches(t *testing.T) {
+	repo := t.TempDir()
+	filePath := filepath.Join(repo, scopePathTextFile)
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	fileEntry := mustScopePathEntry(t, repo, scopePathTextFile)
+
+	includePattern := compiledPattern{pattern: "**/*", regex: regexp.MustCompile(".*")}
+	walker := &scopeWalker{
+		repoPath:        "\x00",
+		scopedRoot:      t.TempDir(),
+		includePatterns: []string{"**/*"},
+		includeCompiled: []compiledPattern{includePattern},
+		stats:           newScopeStats([]string{"**/*"}, nil),
+	}
+	if walker.walk(filePath, fileEntry, nil) == nil {
+		t.Fatalf("expected invalid repo root to fail relative-path resolution")
+	}
+
+	walker = &scopeWalker{
+		repoPath:        repo,
+		scopedRoot:      "\x00",
+		includePatterns: []string{"**/*"},
+		includeCompiled: []compiledPattern{includePattern},
+		stats:           newScopeStats([]string{"**/*"}, nil),
+	}
+	if walker.walk(filePath, fileEntry, nil) == nil {
+		t.Fatalf("expected invalid scoped root to fail file copy")
+	}
+
+	gitDir := filepath.Join(repo, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("readdir repo with .git: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != ".git" {
+			continue
+		}
+		walker = &scopeWalker{}
+		if err := walker.walk(gitDir, entry, nil); !errors.Is(err, filepath.SkipDir) {
+			t.Fatalf("expected .git directory to be skipped, got %v", err)
+		}
+		return
+	}
+	t.Fatal("expected .git entry")
+}
+
+func mustScopePathEntry(t *testing.T, dir, name string) os.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return entry
+		}
+	}
+	t.Fatalf("expected %s entry", name)
+	return nil
+}

--- a/internal/analysis/scope_cov_more_runtime_test.go
+++ b/internal/analysis/scope_cov_more_runtime_test.go
@@ -1,0 +1,38 @@
+package analysis
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
+	repo := t.TempDir()
+	scopedRoot := t.TempDir()
+	sourcePath := filepath.Join(repo, "src", "keep.js")
+	writeScopeFile(t, sourcePath, "export const keep = true\n")
+
+	targetDir := filepath.Join(scopedRoot, "src", "keep.js")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := copyFile(repo, scopedRoot, filepath.Join("src", "keep.js")); err == nil {
+		t.Fatalf("expected copyFile to fail when target path is a directory")
+	}
+
+	sourceDir := filepath.Join(repo, "src", "nested")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := copyFile(repo, scopedRoot, filepath.Join("src", "nested")); err == nil {
+		t.Fatalf("expected copyFile to fail when source path is a directory")
+	}
+
+	var err error
+	joinCloseError(&err, func() error { return errors.New("close failed") })
+	if err == nil || !strings.Contains(err.Error(), "close failed") {
+		t.Fatalf("expected joinCloseError to propagate close failure, got %v", err)
+	}
+}

--- a/internal/analysis/scope_cov_more_test.go
+++ b/internal/analysis/scope_cov_more_test.go
@@ -1,0 +1,121 @@
+package analysis
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	scopeSourcePattern  = "src/*.js"
+	scopeExcludePattern = "**/*.test.js"
+)
+
+func TestScopeNoOpCleanupIsCallable(t *testing.T) {
+	noOpCleanup()
+}
+
+func TestScopeApplyPathScopeReturnsWalkErrorForMissingRepo(t *testing.T) {
+	_, _, _, err := applyPathScope(filepath.Join(t.TempDir(), "missing"), []string{scopeJSGlob}, nil)
+	if err == nil {
+		t.Fatalf("expected missing repo to fail applyPathScope")
+	}
+}
+
+func TestScopeWalkerGuardBranches(t *testing.T) {
+	repo := t.TempDir()
+	gitDir := filepath.Join(repo, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	gitEntry := mustScopeDirEntry(t, repo, ".git")
+
+	walker := &scopeWalker{repoPath: repo, scopedRoot: t.TempDir(), stats: newScopeStats(nil, nil)}
+	if walker.walk("", nil, errors.New("walk failed")) == nil {
+		t.Fatalf("expected walkErr to be returned")
+	}
+	if err := walker.walk(gitDir, gitEntry, nil); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected .git to return SkipDir, got %v", err)
+	}
+}
+
+func TestScopeSkipAccountingAndMatcherHelpers(t *testing.T) {
+	stats := newScopeStats([]string{scopeSourcePattern}, []string{scopeExcludePattern})
+	recordScopeSkip(stats, "src/app.test.js", true, scopeSourcePattern, true, scopeExcludePattern)
+	if stats.includeMatches[scopeSourcePattern] != 1 || stats.excludeMatches[scopeExcludePattern] != 1 {
+		t.Fatalf("expected include/exclude counts, got %#v %#v", stats.includeMatches, stats.excludeMatches)
+	}
+	if len(stats.skippedDiagnostics) != 1 || stats.skippedDiagnostics[0] != "src/app.test.js (matched exclude pattern **/*.test.js)" {
+		t.Fatalf("unexpected skip diagnostic: %#v", stats.skippedDiagnostics)
+	}
+
+	patterns, err := compileGlobPatterns([]string{scopeSourcePattern})
+	if err != nil {
+		t.Fatalf("compile patterns: %v", err)
+	}
+	if matched, pattern := matchFirstCompiledPattern("src/app.ts", patterns); matched || pattern != "" {
+		t.Fatalf("expected no compiled pattern match, got matched=%v pattern=%q", matched, pattern)
+	}
+	formatted := formatPatternMatches([]string{"b", "a"}, map[string]int{"a": 1, "b": 2})
+	if formatted != "a=1, b=2" {
+		t.Fatalf("expected sorted pattern summary, got %q", formatted)
+	}
+}
+
+func TestScopePatternCompileAndTempWorkspaceFailures(t *testing.T) {
+	invalidPattern := string([]byte{0xff})
+	if _, err := compileGlobPatterns([]string{invalidPattern}); err == nil {
+		t.Fatalf("expected invalid utf-8 pattern to fail compilation")
+	}
+	if _, _, _, err := applyPathScope(t.TempDir(), []string{invalidPattern}, nil); err == nil {
+		t.Fatalf("expected include pattern compile error")
+	}
+	if _, _, _, err := applyPathScope(t.TempDir(), nil, []string{invalidPattern}); err == nil {
+		t.Fatalf("expected exclude pattern compile error")
+	}
+
+	tmpRoot := t.TempDir()
+	tmpFile := filepath.Join(tmpRoot, "tmp-as-file")
+	if err := os.WriteFile(tmpFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write tmp file: %v", err)
+	}
+	t.Setenv("TMPDIR", tmpFile)
+	if _, _, _, err := applyPathScope(t.TempDir(), []string{scopeJSGlob}, nil); err == nil {
+		t.Fatalf("expected temp workspace creation to fail")
+	}
+}
+
+func TestScopeCopyFileAndRelativePathGuards(t *testing.T) {
+	repo := t.TempDir()
+	sourcePath := filepath.Join(repo, "src", "keep.js")
+	writeScopeFile(t, sourcePath, "export const keep = true\n")
+
+	if copyFile(repo, t.TempDir(), "..") == nil {
+		t.Fatalf("expected unsafe relative path to fail")
+	}
+
+	blockedRoot := filepath.Join(t.TempDir(), "scoped-root")
+	if err := os.WriteFile(blockedRoot, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocked root: %v", err)
+	}
+	if copyFile(repo, blockedRoot, filepath.Join("src", "keep.js")) == nil {
+		t.Fatalf("expected blocked scoped root to fail copy")
+	}
+}
+
+func mustScopeDirEntry(t *testing.T, dir, name string) os.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return entry
+		}
+	}
+	t.Fatalf("expected %s entry", name)
+	return nil
+}

--- a/internal/analysis/service_cov_more_branches_test.go
+++ b/internal/analysis/service_cov_more_branches_test.go
@@ -1,0 +1,102 @@
+package analysis
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestServiceAdditionalHelperBranches(t *testing.T) {
+	if rootContainsFile("\x00", "/repo/file") {
+		t.Fatalf("expected invalid root path to fail root containment")
+	}
+
+	metadata := scopeMetadata(ScopeModePackage, "/repo", []string{"/repo", "\x00"})
+	if metadata == nil || len(metadata.Packages) != 1 || metadata.Packages[0] != "." {
+		t.Fatalf("expected scope metadata to keep repo root and skip invalid roots, got %#v", metadata)
+	}
+
+	if _, err := annotateRuntimeTraceIfPresent(t.TempDir(), "js-ts", report.Report{}); err == nil {
+		t.Fatalf("expected directory runtime trace path to return error")
+	}
+
+	merged := mergeUsageUncertainty(&report.UsageUncertainty{Samples: []report.Location{{File: "a"}, {File: "b"}, {File: "c"}, {File: "d"}}}, &report.UsageUncertainty{Samples: []report.Location{{File: "e"}, {File: "f"}}})
+	if len(merged.Samples) != 5 || merged.Samples[4].File != "e" {
+		t.Fatalf("expected mergeUsageUncertainty to append only remaining sample slots, got %#v", merged.Samples)
+	}
+
+	hasStatic, hasRuntime := runtimeUsageSignals(&report.RuntimeUsage{})
+	if !hasStatic || hasRuntime {
+		t.Fatalf("expected zero-load static usage to report static-only, got static=%v runtime=%v", hasStatic, hasRuntime)
+	}
+
+	left := &report.CodemodReport{Mode: "safe", Suggestions: []report.CodemodSuggestion{{File: "a.js", Line: 1}}}
+	got := mergeCodemodReport(left, nil)
+	if got == left || got.Mode != left.Mode || len(got.Suggestions) != 1 {
+		t.Fatalf("expected mergeCodemodReport to copy left report when right is nil, got %#v", got)
+	}
+}
+
+func TestServiceAnnotateRuntimeTraceErrorBranchViaAnalyse(t *testing.T) {
+	reg := language.NewRegistry()
+	if err := reg.Register(&testServiceAdapter{
+		id:     "ok",
+		detect: language.Detection{Matched: true, Confidence: 90},
+		analyse: report.Report{
+			Dependencies: []report.DependencyReport{{Name: "dep"}},
+		},
+	}); err != nil {
+		t.Fatalf(registerAdapterFmt, err)
+	}
+
+	svc := &Service{Registry: reg}
+	traceDir := filepath.Join(t.TempDir(), "trace-dir")
+	if err := os.MkdirAll(traceDir, 0o755); err != nil {
+		t.Fatalf("mkdir trace dir: %v", err)
+	}
+	if _, err := svc.Analyse(context.Background(), Request{
+		RepoPath:         ".",
+		Language:         "all",
+		TopN:             1,
+		RuntimeTracePath: traceDir,
+	}); err == nil {
+		t.Fatalf("expected analyse to surface invalid runtime trace error")
+	}
+}
+
+func TestServiceAdditionalAnalyseBranches(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+
+	svc := &Service{Registry: language.NewRegistry()}
+	if _, err := svc.Analyse(context.Background(), Request{
+		RepoPath:        repo,
+		IncludePatterns: []string{"["},
+	}); err == nil {
+		t.Fatalf("expected invalid scope pattern to fail analysis")
+	}
+
+	traceDir := filepath.Join(t.TempDir(), "trace-dir")
+	if err := os.MkdirAll(traceDir, 0o755); err != nil {
+		t.Fatalf("mkdir trace dir: %v", err)
+	}
+	if _, err := svc.Analyse(context.Background(), Request{
+		RepoPath:         repo,
+		RuntimeTracePath: traceDir,
+	}); err == nil {
+		t.Fatalf("expected no-result analysis to surface runtime trace error")
+	}
+}
+
+func TestMergeUsageUncertaintyRemainingBranch(t *testing.T) {
+	merged := mergeUsageUncertainty(&report.UsageUncertainty{Samples: []report.Location{{File: "a"}, {File: "b"}, {File: "c"}, {File: "d"}}}, &report.UsageUncertainty{})
+	if len(merged.Samples) != 4 {
+		t.Fatalf("expected empty-right merge to preserve left samples, got %#v", merged.Samples)
+	}
+}

--- a/internal/app/codemod_apply_helpers_test.go
+++ b/internal/app/codemod_apply_helpers_test.go
@@ -380,6 +380,16 @@ func TestWriteCodemodRollbackArtifactReadonlyDir(t *testing.T) {
 	}
 }
 
+func TestWriteCodemodRollbackArtifactOpenRootError(t *testing.T) {
+	repoFile := filepath.Join(t.TempDir(), "repo-file")
+	writeTextFile(t, repoFile, "not a directory\n", 0o600)
+
+	_, err := writeCodemodRollbackArtifact(repoFile, "lodash", []preparedCodemodFile{{file: indexJSFile, original: beforeContent, mode: 0o644}}, time.Now())
+	if err == nil {
+		t.Fatal("expected rollback artifact setup to fail when repo path is not a directory")
+	}
+}
+
 func TestApplyCodemodIfNeededNoOpWhenApplyDisabled(t *testing.T) {
 	repo := t.TempDir()
 	reportData := report.Report{Dependencies: []report.DependencyReport{{Name: "lodash"}}}

--- a/internal/app/dashboard_cov_more_test.go
+++ b/internal/app/dashboard_cov_more_test.go
@@ -1,0 +1,94 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/dashboard"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestDashboardRequestAdditionalBranches(t *testing.T) {
+	_, err := resolveDashboardRequest(DashboardRequest{
+		ConfigPath: filepath.Join(t.TempDir(), "missing-dashboard.yml"),
+	})
+	if err == nil {
+		t.Fatalf("expected missing config to fail request resolution")
+	}
+
+	repos := normalizedDashboardRepos([]DashboardRepo{
+		{Path: "   "},
+		{Path: " ./api ", Language: " go "},
+	})
+	if len(repos) != 1 {
+		t.Fatalf("expected blank repo paths to be skipped, got %#v", repos)
+	}
+	if repos[0].Name != "api" || repos[0].Language != "go" {
+		t.Fatalf("expected repo name/language normalization, got %#v", repos[0])
+	}
+
+	configDir := t.TempDir()
+	fromConfig, err := reposFromDashboardConfig(dashboard.LoadedConfig{
+		ConfigDir: configDir,
+		Dashboard: dashboard.ConfigDashboard{
+			Repos: []dashboard.ConfigRepo{
+				{Path: "./worker"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("repos from config: %v", err)
+	}
+	if len(fromConfig) != 1 || fromConfig[0].Name != "worker" || fromConfig[0].Path != filepath.Join(configDir, "worker") {
+		t.Fatalf("expected config repo name inference and path resolution, got %#v", fromConfig)
+	}
+}
+
+func TestExecuteDashboardOutputPathErrors(t *testing.T) {
+	analyzer := &mapAnalyzer{
+		reports: map[string]report.Report{
+			singleRepoPath: {
+				Dependencies: []report.DependencyReport{{Name: "dep"}},
+			},
+		},
+		errs: map[string]error{},
+	}
+	application := &App{Analyzer: analyzer}
+
+	t.Run("mkdir output directory failure", func(t *testing.T) {
+		root := t.TempDir()
+		blocker := filepath.Join(root, "blocked")
+		if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write blocker: %v", err)
+		}
+
+		req := DefaultRequest()
+		req.Mode = ModeDashboard
+		req.Dashboard.Format = "csv"
+		req.Dashboard.Repos = []DashboardRepo{{Path: singleRepoPath}}
+		req.Dashboard.OutputPath = filepath.Join(blocker, "report.csv")
+
+		if _, err := application.Execute(context.Background(), req); err == nil {
+			t.Fatalf("expected executeDashboard to fail when output directory cannot be created")
+		}
+	})
+
+	t.Run("write output file failure", func(t *testing.T) {
+		outputDir := filepath.Join(t.TempDir(), "reports")
+		if err := os.MkdirAll(outputDir, 0o755); err != nil {
+			t.Fatalf("mkdir output dir: %v", err)
+		}
+
+		req := DefaultRequest()
+		req.Mode = ModeDashboard
+		req.Dashboard.Format = "csv"
+		req.Dashboard.Repos = []DashboardRepo{{Path: singleRepoPath}}
+		req.Dashboard.OutputPath = outputDir
+
+		if _, err := application.Execute(context.Background(), req); err == nil {
+			t.Fatalf("expected executeDashboard to fail when output path is a directory")
+		}
+	})
+}

--- a/internal/app/lockfile_drift_cov_more_error_test.go
+++ b/internal/app/lockfile_drift_cov_more_error_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestDetectLockfileDriftPropagatesGitContextErrors(t *testing.T) {
+	original := resolveGitBinaryPathFn
+	defer func() { resolveGitBinaryPathFn = original }()
+
+	resolveGitBinaryPathFn = func() (string, error) { return writeFakeGitBinary(t), nil }
+	useFakeGitCommandContext(t)
+
+	cases := []struct {
+		name    string
+		mode    string
+		wantSub string
+		run     func(context.Context, string) error
+	}{
+		{
+			name:    "detect lockfile drift propagates git context errors",
+			mode:    "lsfail",
+			wantSub: "ls-files",
+			run: func(ctx context.Context, repo string) error {
+				_, err := detectLockfileDrift(ctx, repo, false)
+				return err
+			},
+		},
+		{
+			name:    "git changed files propagates tracked change failures",
+			mode:    "difffail-head",
+			wantSub: "run git",
+			run: func(ctx context.Context, repo string) error {
+				_, _, err := gitChangedFiles(ctx, repo)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFakeGitMode(t, repo, tc.mode)
+			err := tc.run(context.Background(), repo)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("expected %q error, got %v", tc.wantSub, err)
+			}
+		})
+	}
+}

--- a/internal/app/lockfile_drift_cov_more_test.go
+++ b/internal/app/lockfile_drift_cov_more_test.go
@@ -1,0 +1,166 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const lockfileRunGitErr = "run git"
+
+func TestLockfileDriftAdditionalPathAndWalkBranches(t *testing.T) {
+	if _, err := detectLockfileDrift(context.Background(), "\x00", false); err == nil {
+		t.Fatalf("expected detectLockfileDrift to reject invalid repo path")
+	}
+
+	parent := t.TempDir()
+	child := filepath.Join(parent, "child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatalf("readdir parent: %v", err)
+	}
+	if err := os.RemoveAll(child); err != nil {
+		t.Fatalf("remove child: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "child" {
+			continue
+		}
+		if processLockfileDir(context.Background(), child, entry, nil, lockfileWalkState{normalizedPath: parent, warnings: &[]string{}}) == nil {
+			t.Fatalf("expected removed directory to fail when scanning lockfile drift")
+		}
+	}
+
+	if got := relativeDir("\x00", filepath.Join(parent, "pkg")); got != filepath.Join(parent, "pkg") {
+		t.Fatalf("expected relativeDir to fall back to input dir, got %q", got)
+	}
+	if got := mergeGitPaths(); len(got) != 0 {
+		t.Fatalf("expected mergeGitPaths with no groups to return nil, got %#v", got)
+	}
+}
+
+func TestLockfileDriftGitErrorBranches(t *testing.T) {
+	original := resolveGitBinaryPathFn
+	defer func() { resolveGitBinaryPathFn = original }()
+
+	repo := t.TempDir()
+	fakeGit := writeFakeGitBinary(t)
+	resolveGitBinaryPathFn = func() (string, error) { return fakeGit, nil }
+	useFakeGitCommandContext(t)
+
+	writeFakeGitMode(t, repo, "lsfail")
+	if _, _, err := gitChangedFiles(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "ls-files") {
+		t.Fatalf("expected gitChangedFiles to surface ls-files failure, got %v", err)
+	}
+
+	writeFakeGitMode(t, repo, "difffail-head")
+	if _, err := gitTrackedChanges(context.Background(), repo); err == nil || !strings.Contains(err.Error(), lockfileRunGitErr) {
+		t.Fatalf("expected gitTrackedChanges HEAD diff failure, got %v", err)
+	}
+
+	writeFakeGitMode(t, repo, "difffail-unstaged")
+	if _, err := gitTrackedChanges(context.Background(), repo); err == nil || !strings.Contains(err.Error(), lockfileRunGitErr) {
+		t.Fatalf("expected gitTrackedChanges unstaged diff failure, got %v", err)
+	}
+
+	writeFakeGitMode(t, repo, "difffail-cached")
+	if _, err := gitTrackedChanges(context.Background(), repo); err == nil || !strings.Contains(err.Error(), lockfileRunGitErr) {
+		t.Fatalf("expected gitTrackedChanges cached diff failure, got %v", err)
+	}
+
+	resolveGitBinaryPathFn = func() (string, error) { return "", context.Canceled }
+	if _, err := gitDiffNameOnly(context.Background(), repo); err == nil {
+		t.Fatalf("expected gitDiffNameOnly to surface git command creation failure")
+	}
+}
+
+func TestGitCommandContextConstructorError(t *testing.T) {
+	originalResolve := resolveGitBinaryPathFn
+	originalExec := execGitCommandContextFn
+	resolveGitBinaryPathFn = func() (string, error) { return writeFakeGitBinary(t), nil }
+	execGitCommandContextFn = func(context.Context, string, ...string) (*exec.Cmd, error) {
+		return nil, errors.New("construct git")
+	}
+	t.Cleanup(func() {
+		resolveGitBinaryPathFn = originalResolve
+		execGitCommandContextFn = originalExec
+	})
+
+	if _, err := gitCommandContext(context.Background(), t.TempDir(), "status"); err == nil || !strings.Contains(err.Error(), "construct git") {
+		t.Fatalf("expected gitCommandContext to return constructor error, got %v", err)
+	}
+}
+
+func writeFakeGitBinary(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "git")
+	script := `#!/bin/sh
+args="$*"
+mode="${FAKE_GIT_MODE}"
+if [ "$1" = "-C" ] && [ -f "$2/.fake-git-mode" ]; then
+  mode="$(cat "$2/.fake-git-mode")"
+fi
+if printf '%s' "$args" | grep -q 'rev-parse --is-inside-work-tree'; then
+  echo true
+  exit 0
+fi
+if printf '%s' "$args" | grep -q 'rev-parse --verify --quiet HEAD'; then
+  if [ "$mode" = "difffail-cached" ] || [ "$mode" = "difffail-unstaged" ]; then
+    exit 1
+  fi
+  exit 0
+fi
+if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
+  if [ "$mode" = "lsfail" ]; then
+    echo "ls-files failed" >&2
+    exit 1
+  fi
+  exit 0
+fi
+if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
+  if printf '%s' "$args" | grep -q -- '--cached'; then
+    if [ "$mode" = "difffail-cached" ]; then
+      echo "diff failed" >&2
+      exit 1
+    fi
+    exit 0
+  fi
+  if [ "$mode" = "difffail-head" ] || [ "$mode" = "difffail-unstaged" ]; then
+    echo "diff failed" >&2
+    exit 1
+  fi
+  exit 0
+fi
+exit 0
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git script: %v", err)
+	}
+	return path
+}
+
+func writeFakeGitMode(t *testing.T, repo, mode string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, ".fake-git-mode"), []byte(mode), 0o600); err != nil {
+		t.Fatalf("write fake git mode: %v", err)
+	}
+}
+
+func useFakeGitCommandContext(t *testing.T) {
+	t.Helper()
+
+	original := execGitCommandContextFn
+	execGitCommandContextFn = func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
+		return exec.CommandContext(ctx, gitPath, args...), nil
+	}
+	t.Cleanup(func() {
+		execGitCommandContextFn = original
+	})
+}

--- a/internal/cli/cli_cov_more_test.go
+++ b/internal/cli/cli_cov_more_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/app"
+)
+
+func TestWriteOutputAdditionalBranches(t *testing.T) {
+	c := New(&fakeRunner{}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err := c.writeOutput(""); err != nil {
+		t.Fatalf("expected empty output to be ignored, got %v", err)
+	}
+
+	var out bytes.Buffer
+	c = New(&fakeRunner{}, &out, &bytes.Buffer{})
+	if err := c.writeOutput("ok\n"); err != nil {
+		t.Fatalf("write output with existing newline: %v", err)
+	}
+	if out.String() != "ok\n" {
+		t.Fatalf("expected output to be left unchanged, got %q", out.String())
+	}
+
+	c = New(&fakeRunner{}, &failOnNthWrite{n: 2}, &bytes.Buffer{})
+	if c.writeOutput("ok") == nil {
+		t.Fatalf("expected newline append write to fail")
+	}
+}
+
+func TestExitCodeForDeniedLicenses(t *testing.T) {
+	if got := exitCodeForRunError(app.ErrDeniedLicenses); got != 3 {
+		t.Fatalf("expected denied-license error to use exit code 3, got %d", got)
+	}
+}
+
+func TestRunRunnerErrorWriteFailure(t *testing.T) {
+	c := New(&fakeRunner{err: app.ErrLockfileDrift}, &bytes.Buffer{}, &failWriter{})
+	if code := c.Run(context.Background(), []string{"analyse", "lodash"}); code != 1 {
+		t.Fatalf("expected err writer failure to return exit code 1, got %d", code)
+	}
+}

--- a/internal/cli/parse_analyse_overrides_cov_more_test.go
+++ b/internal/cli/parse_analyse_overrides_cov_more_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import "testing"
+
+func TestCLINotificationOverrideAdditionalBranches(t *testing.T) {
+	slackWebhook := "https://example.com/slack-hook"
+	teamsWebhook := "ftp://example.com/teams-hook"
+	values := analyseFlagValues{
+		notifySlack: &slackWebhook,
+		notifyTeams: &teamsWebhook,
+	}
+
+	overrides, err := cliNotificationOverrides(map[string]bool{"notify-slack": true}, values)
+	if err != nil {
+		t.Fatalf("resolve slack notification override: %v", err)
+	}
+	if overrides.SlackWebhookURL == nil || *overrides.SlackWebhookURL != slackWebhook {
+		t.Fatalf("expected slack webhook override to be set, got %#v", overrides)
+	}
+
+	if _, err := cliNotificationOverrides(map[string]bool{"notify-teams": true}, values); err == nil {
+		t.Fatalf("expected invalid teams webhook override to fail")
+	}
+}

--- a/internal/cli/parse_test.go
+++ b/internal/cli/parse_test.go
@@ -33,6 +33,7 @@ const (
 	scopeGoGlob                 = "src/**/*.go"
 	scopeExcludeTestGlob        = "**/*_test.go"
 	scopeVendorGlob             = "vendor/**"
+	scopeAnalyseGoGlobs         = "src/**/*.go,internal/**/*.go"
 	scopeIncludeCombined        = "src/**/*.go,internal/**/*.go,cmd/**/*.go"
 	parseConfigFileName         = ".lopper.yml"
 	repoFlagName                = "--repo"
@@ -43,6 +44,7 @@ const (
 	dashboardConfigFlagName     = "--config"
 	dashboardConfigFileName     = "lopper-org.yml"
 	dashboardReportCSVFileName  = "report.csv"
+	notifyOnFlag                = "--notify-on"
 )
 
 func mustParseArgs(t *testing.T, args []string) app.Request {
@@ -241,10 +243,10 @@ func TestParseArgsAnalyseScopeFlags(t *testing.T) {
 	req := mustParseArgs(t, []string{
 		"analyse",
 		"--top", "3",
-		includeFlagName, "src/**/*.go,internal/**/*.go",
+		includeFlagName, scopeAnalyseGoGlobs,
 		excludeFlagName, scopeExcludeTestGlob,
 	})
-	if got := strings.Join(req.Analyse.IncludePatterns, ","); got != "src/**/*.go,internal/**/*.go" {
+	if got := strings.Join(req.Analyse.IncludePatterns, ","); got != scopeAnalyseGoGlobs {
 		t.Fatalf("unexpected include patterns: %q", got)
 	}
 	if got := strings.Join(req.Analyse.ExcludePatterns, ","); got != scopeExcludeTestGlob {
@@ -305,6 +307,22 @@ func TestMergePatternsWithEmptyNextKeepsExisting(t *testing.T) {
 	merged := mergePatterns(existing, nil)
 	if strings.Join(merged, ",") != scopeGoGlob {
 		t.Fatalf("expected merge with empty next to preserve existing patterns, got %#v", merged)
+	}
+}
+
+func TestMergePatternsSkipsDuplicatesAlreadySeen(t *testing.T) {
+	merged := mergePatterns([]string{scopeGoGlob}, []string{scopeGoGlob, "internal/**/*.go"})
+	if strings.Join(merged, ",") != scopeAnalyseGoGlobs {
+		t.Fatalf("expected duplicates to be skipped, got %#v", merged)
+	}
+}
+
+func TestSplitPatternListSkipsEmptyAndDuplicateEntries(t *testing.T) {
+	if got := splitPatternList(" , " + scopeGoGlob + ", " + scopeGoGlob + " , "); !reflect.DeepEqual(got, []string{scopeGoGlob}) {
+		t.Fatalf("expected split pattern list to keep one trimmed value, got %#v", got)
+	}
+	if got := splitPatternList(" , , "); len(got) != 0 {
+		t.Fatalf("expected nil pattern list when all values are blank, got %#v", got)
 	}
 }
 
@@ -411,7 +429,7 @@ func TestParseArgsDashboardRepos(t *testing.T) {
 }
 
 func TestParseArgsDashboardRejectsBaselineStore(t *testing.T) {
-	err := expectParseArgsError(t, []string{"dashboard", "--repos", "./api", "--baseline-store", "./baselines"}, "expected dashboard baseline-store rejection")
+	err := expectParseArgsError(t, []string{"dashboard", dashboardReposFlagName, "./api", "--baseline-store", "./baselines"}, "expected dashboard baseline-store rejection")
 	if !strings.Contains(err.Error(), "flag provided but not defined") {
 		t.Fatalf("expected unknown flag error for baseline-store, got %v", err)
 	}
@@ -451,6 +469,13 @@ func TestParseArgsDashboardValidation(t *testing.T) {
 	err = expectParseArgsError(t, []string{"dashboard", dashboardConfigFlagName, dashboardConfigFileName, "--top", "0"}, "expected dashboard top validation error")
 	if !strings.Contains(err.Error(), "--top must be > 0") {
 		t.Fatalf("unexpected dashboard top validation error: %v", err)
+	}
+}
+
+func TestParseArgsDashboardRejectsUnexpectedArguments(t *testing.T) {
+	_, err := ParseArgs([]string{"dashboard", dashboardReposFlagName, "./api", "extra"})
+	if err == nil || !strings.Contains(err.Error(), "unexpected arguments for dashboard") {
+		t.Fatalf("expected dashboard positional argument error, got %v", err)
 	}
 }
 
@@ -665,7 +690,7 @@ func TestParseArgsAnalyseNotificationPrecedence(t *testing.T) {
 	req, err := ParseArgs([]string{
 		"analyse", "--top", "10",
 		"--repo", repo,
-		"--notify-on", "improvement",
+		notifyOnFlag, "improvement",
 		"--notify-teams", "https://outlook.office.com/webhook/CLI",
 	})
 	if err != nil {
@@ -687,7 +712,7 @@ func TestParseArgsAnalyseNotificationPrecedence(t *testing.T) {
 }
 
 func TestParseArgsAnalyseInvalidNotificationInputs(t *testing.T) {
-	if _, err := ParseArgs([]string{"analyse", "--top", "1", "--notify-on", "bad"}); err == nil {
+	if _, err := ParseArgs([]string{"analyse", "--top", "1", notifyOnFlag, "bad"}); err == nil {
 		t.Fatalf("expected invalid notify-on error")
 	}
 
@@ -697,6 +722,34 @@ func TestParseArgsAnalyseInvalidNotificationInputs(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "SECRET") {
 		t.Fatalf("expected parse error to redact webhook secrets, got %q", err.Error())
+	}
+}
+
+func TestResolveAnalyseNotificationsErrors(t *testing.T) {
+	t.Run("invalid config overrides", func(t *testing.T) {
+		repo := t.TempDir()
+		configPath := filepath.Join(repo, parseConfigFileName)
+		writeFile(t, configPath, "notifications:\n  slack:\n    on: definitely-not-valid\n")
+
+		_, err := resolveAnalyseNotifications(map[string]bool{}, analyseFlagValues{}, configPath)
+		if err == nil {
+			t.Fatalf("expected config notification parse error")
+		}
+	})
+
+	t.Run("invalid env overrides", func(t *testing.T) {
+		t.Setenv(notify.EnvOn, "definitely-not-valid")
+
+		_, err := resolveAnalyseNotifications(map[string]bool{}, analyseFlagValues{}, "")
+		if err == nil {
+			t.Fatalf("expected env notification parse error")
+		}
+	})
+}
+
+func TestValidateSuggestOnlyTargetRequiresDependency(t *testing.T) {
+	if validateSuggestOnlyTarget(true, "   ", 0) == nil {
+		t.Fatalf("expected suggest-only validation to require dependency")
 	}
 }
 

--- a/internal/dashboard/dashboard_cov_more_test.go
+++ b/internal/dashboard/dashboard_cov_more_test.go
@@ -1,0 +1,44 @@
+package dashboard
+
+import (
+	"bytes"
+	"encoding/csv"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestDashboardAdditionalHelperBranches(t *testing.T) {
+	if !hasWasteCandidateRecommendation([]report.Recommendation{
+		{Code: " "},
+		{Code: "low-usage-risk"},
+	}) {
+		t.Fatalf("expected low-usage recommendation code to count as waste candidate")
+	}
+	if hasWasteCandidateRecommendation([]report.Recommendation{{Code: "keep-current"}}) {
+		t.Fatalf("did not expect non-removal recommendation to count as waste candidate")
+	}
+
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+	if err := writeDashboardCrossRepoRowsCSV(writer, nil); err != nil {
+		t.Fatalf("expected empty cross-repo dependency set to be ignored, got %v", err)
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		t.Fatalf("flush empty cross-repo rows: %v", err)
+	}
+	if buffer.Len() != 0 {
+		t.Fatalf("expected no CSV output for empty cross-repo dependencies, got %q", buffer.String())
+	}
+}
+
+func TestLoadConfigMissingFile(t *testing.T) {
+	_, err := LoadConfig(filepath.Join(t.TempDir(), "missing-dashboard.yml"))
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing config file error, got %v", err)
+	}
+}

--- a/internal/dashboard/format_cov_more_test.go
+++ b/internal/dashboard/format_cov_more_test.go
@@ -1,0 +1,60 @@
+package dashboard
+
+import (
+	"encoding/csv"
+	"errors"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+type failingWriter struct{}
+
+func (f *failingWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("boom")
+}
+
+func TestDashboardAdditionalBranchCoverage(t *testing.T) {
+	reportData := Report{
+		GeneratedAt: time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC),
+		Repos: []RepoResult{
+			{Name: strings.Repeat("x", 5000), WasteCandidatePercent: math.NaN()},
+		},
+		Summary: Summary{TotalRepos: 1, TotalDeps: 1},
+	}
+	if _, err := FormatReport(reportData, FormatJSON); err == nil {
+		t.Fatalf("expected json format to fail for NaN payload")
+	}
+
+	repoWriter := csv.NewWriter(&failingWriter{})
+	if writeDashboardRepoRowsCSV(repoWriter, []RepoResult{{Name: strings.Repeat("x", 5000)}}) == nil {
+		t.Fatalf("expected repo row csv write to fail")
+	}
+
+	crossRepoWriter := csv.NewWriter(&failingWriter{})
+	if writeDashboardCrossRepoRowsCSV(crossRepoWriter, []CrossRepoDependency{{Name: strings.Repeat("x", 5000), Count: 3}}) == nil {
+		t.Fatalf("expected cross-repo csv write to fail")
+	}
+
+	if got := metricHTML(`<label>`, `<value>`); !strings.Contains(got, "&lt;label&gt;") || !strings.Contains(got, "&lt;value&gt;") {
+		t.Fatalf("expected metric html escaping, got %q", got)
+	}
+}
+
+func TestDashboardAggregateSkipsBlankDependencyNames(t *testing.T) {
+	reportData := Aggregate(time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC), []RepoAnalysis{{
+		Input: RepoInput{Name: testRepoA, Path: "./a"},
+		Report: report.Report{
+			Dependencies: []report.DependencyReport{
+				{Name: "   "},
+			},
+		},
+	}})
+
+	if len(reportData.CrossRepoDeps) != 0 {
+		t.Fatalf("expected blank dependency names to be excluded from cross-repo index, got %#v", reportData.CrossRepoDeps)
+	}
+}

--- a/internal/lang/cpp/engine_cov_more_branches_test.go
+++ b/internal/lang/cpp/engine_cov_more_branches_test.go
@@ -1,0 +1,169 @@
+package cpp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+const cppMainSourcePath = "src/main.cpp"
+
+func TestCPPDetectAndAnalyseMoreBranches(t *testing.T) {
+	repoFile := filepath.Join(t.TempDir(), "repo-file")
+	testutil.MustWriteFile(t, repoFile, "x")
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), repoFile); err == nil {
+		t.Fatalf("expected detect-with-confidence error for non-directory repo path")
+	}
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
+		t.Fatalf("expected analyse to fail on invalid repo path")
+	}
+}
+
+func TestCPPLoadCompileContextCapAndHelpers(t *testing.T) {
+	repo := t.TempDir()
+	for i := 0; i <= maxCompileDatabases; i++ {
+		dir := filepath.Join(repo, fmt.Sprintf("build-%02d", i))
+		testutil.MustWriteFile(t, filepath.Join(dir, compileCommandsFile), `[
+  {"directory":".","file":"`+cppMainSourcePath+`","command":"c++ -Iinclude -c `+cppMainSourcePath+`"}
+]`)
+	}
+
+	compileInfo, err := loadCompileContext(repo)
+	if err != nil {
+		t.Fatalf("loadCompileContext: %v", err)
+	}
+	if !compileInfo.HasCompileDatabase {
+		t.Fatalf("expected compile database discovery")
+	}
+	if len(compileInfo.IncludeDirs) == 0 || len(compileInfo.SourceFiles) == 0 {
+		t.Fatalf("expected include dirs and source files from command parsing, got %#v", compileInfo)
+	}
+
+	result := &scanResult{UnresolvedSamples: []string{"a", "b", "c", "d", "e"}}
+	appendSampleWarnings(result, []string{"f"})
+	if len(result.UnresolvedSamples) != maxWarningSamples {
+		t.Fatalf("expected unresolved sample cap to hold, got %#v", result.UnresolvedSamples)
+	}
+
+	if got := relOrBase(repo, filepath.Join(repo, "src", testMainCPPFileName)); got != filepath.Join("src", testMainCPPFileName) {
+		t.Fatalf("expected relative path from relOrBase, got %q", got)
+	}
+	if got := dependencyFromIncludePath("."); got != "" {
+		t.Fatalf("expected dot include path to map empty, got %q", got)
+	}
+	if _, ok := parseIncludeLine("#include", 1); ok {
+		t.Fatalf("expected bare include directive to be ignored")
+	}
+	if _, ok := parseIncludeLine("#include <>", 1); ok {
+		t.Fatalf("expected empty delimited include to be ignored")
+	}
+	if _, ok := parseIncludeLine("#define VALUE 1", 1); ok {
+		t.Fatalf("expected non-include preprocessor line to be ignored")
+	}
+}
+
+func TestCPPRequestedDependencyMoreBranches(t *testing.T) {
+	scan := scanResult{
+		Files: []fileScan{{
+			Path: cppMainSourcePath,
+			Includes: []includeRecord{
+				{Dependency: "fmt", Header: "fmt/core.h", Location: report.Location{File: cppMainSourcePath, Line: 1, Column: 1}},
+				{Dependency: "zlib", Header: "zlib.h", Location: report.Location{File: cppMainSourcePath, Line: 2, Column: 1}},
+			},
+		}},
+	}
+
+	dependencies, warnings := buildRequestedCPPDependencies(language.Request{Dependency: "FMT"}, scan)
+	if len(warnings) != 0 || len(dependencies) != 1 || dependencies[0].Name != "fmt" {
+		t.Fatalf("unexpected dependency selection result: deps=%#v warnings=%#v", dependencies, warnings)
+	}
+}
+
+func TestCPPAdditionalCoverageBranches(t *testing.T) {
+	t.Run("makefile detection and normalize failure", testCPPMakefileDetectionAndNormalizeFailure)
+	t.Run("compile database read errors bubble out", testCPPCompileDatabaseReadErrorsBubbleOut)
+	t.Run("include mapping fallback branches", testCPPIncludeMappingFallbackBranches)
+}
+
+func testCPPMakefileDetectionAndNormalizeFailure(t *testing.T) {
+	detection := language.Detection{}
+	roots := map[string]struct{}{}
+	makefilePath := filepath.Join(t.TempDir(), "Makefile")
+	updateDetection(makefilePath, &detection, roots)
+	if !detection.Matched || detection.Confidence == 0 || len(roots) != 1 {
+		t.Fatalf("expected Makefile detection signal, got detection=%#v roots=%#v", detection, roots)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Fatalf("restore wd %s: %v", originalWD, err)
+		}
+	})
+	deadDir := filepath.Join(t.TempDir(), "dead")
+	if err := os.MkdirAll(deadDir, 0o755); err != nil {
+		t.Fatalf("mkdir dead dir: %v", err)
+	}
+	if err := os.Chdir(deadDir); err != nil {
+		t.Fatalf("chdir dead dir: %v", err)
+	}
+	if err := os.RemoveAll(deadDir); err != nil {
+		t.Fatalf("remove dead dir: %v", err)
+	}
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{}); err == nil {
+		t.Fatalf("expected analyse to fail when cwd cannot be resolved")
+	}
+}
+
+func testCPPCompileDatabaseReadErrorsBubbleOut(t *testing.T) {
+	repo := t.TempDir()
+	compileDB := filepath.Join(repo, compileCommandsFile)
+	if err := os.WriteFile(compileDB, []byte("[]"), 0o000); err != nil {
+		t.Fatalf("write unreadable compile db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(compileDB, 0o600); err != nil {
+			t.Fatalf("restore compile db perms: %v", err)
+		}
+	})
+	if _, err := loadCompileContext(repo); err == nil {
+		t.Fatalf("expected unreadable compile database to fail load")
+	}
+	if _, err := collectCompileDatabase(compileDB, repo, map[string]struct{}{}, map[string]struct{}{}); err == nil {
+		t.Fatalf("expected unreadable compile database to fail direct collection")
+	}
+}
+
+func testCPPIncludeMappingFallbackBranches(t *testing.T) {
+	if dirs := extractIncludeDirs([]string{" ", "-I"}, "/repo"); len(dirs) != 0 {
+		t.Fatalf("expected blank args and missing include values to be ignored, got %#v", dirs)
+	}
+
+	if dep, unresolved := mapIncludeToDependency("/repo", "/repo/main.cpp", parsedInclude{Path: ".", Delimiter: '<'}, nil); dep != "" || !unresolved {
+		t.Fatalf("expected dot include to stay unresolved, got dep=%q unresolved=%v", dep, unresolved)
+	}
+	if got := dependencyFromIncludePath("./"); got != "" {
+		t.Fatalf("expected dot-slash include path to map empty, got %q", got)
+	}
+	if got := dependencyFromIncludePath(".h"); got != "" {
+		t.Fatalf("expected extension-only include path to map empty, got %q", got)
+	}
+	if isLikelyStdHeader("   ") {
+		t.Fatalf("expected blank std header candidate to be rejected")
+	}
+
+	custom := &report.RemovalCandidateWeights{Usage: 1, Impact: 2, Confidence: 3}
+	got := resolveRemovalCandidateWeights(custom)
+	if got == report.DefaultRemovalCandidateWeights() {
+		t.Fatalf("expected non-nil weights to normalize instead of using defaults")
+	}
+}

--- a/internal/lang/dart/adapter_cov_more_branches_test.go
+++ b/internal/lang/dart/adapter_cov_more_branches_test.go
@@ -1,0 +1,228 @@
+package dart
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+)
+
+func TestDartAdditionalBranchCoverage(t *testing.T) {
+	t.Run("detect and manifest loader errors", testDartDetectAndManifestLoaderErrors)
+	t.Run("dependency metadata helpers", testDartDependencyMetadataHelpers)
+	t.Run("scan helpers and warnings", testDartScanHelpersAndWarnings)
+	t.Run("import parsing and dependency selection", testDartImportParsingAndDependencySelection)
+}
+
+func testDartDetectAndManifestLoaderErrors(t *testing.T) {
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected missing repo to fail detection")
+	}
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), "\x00"); err == nil {
+		t.Fatalf("expected invalid repo path to fail detection")
+	}
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
+		t.Fatalf("expected invalid repo path to fail analysis")
+	}
+
+	repo := t.TempDir()
+	manifestPath := filepath.Join(repo, pubspecYAMLName)
+	if err := os.Mkdir(manifestPath, 0o755); err != nil {
+		t.Fatalf("mkdir pubspec dir: %v", err)
+	}
+	if _, _, err := loadPackageManifest(repo, manifestPath); err == nil {
+		t.Fatalf("expected directory manifest to fail load")
+	}
+
+	repo = t.TempDir()
+	manifestPath = filepath.Join(repo, pubspecYAMLName)
+	if err := os.WriteFile(manifestPath, []byte("name: demo\ndependencies:\n  http: ^1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write pubspec manifest: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(repo, pubspecLockName), 0o755); err != nil {
+		t.Fatalf("mkdir pubspec.lock dir: %v", err)
+	}
+	if _, _, err := loadPackageManifest(repo, manifestPath); err == nil {
+		t.Fatalf("expected pubspec.lock stat failure to bubble")
+	}
+
+	if _, _, err := collectManifestData(repo); err == nil {
+		t.Fatalf("expected manifest collection to fail when discovered manifest is unreadable")
+	}
+}
+
+func testDartDependencyMetadataHelpers(t *testing.T) {
+	if info := dependencyInfoFromSpec("http", "^1.0.0", nil); info.LocalPath || info.FlutterSDK {
+		t.Fatalf("expected scalar dependency spec to stay default, got %#v", info)
+	}
+	if got := lockPackageName("flutter"); got != "" {
+		t.Fatalf("expected scalar lock description to produce empty package name, got %q", got)
+	}
+	if lockDescriptionTargetsFlutter(map[string]any{"name": "other"}) {
+		t.Fatalf("did not expect unrelated lock description to target flutter")
+	}
+	if got := collectManifestRoots([]packageManifest{{Root: ""}, {Root: "  "}, {Root: filepath.Join("pkg", "..", "app")}}); len(got) != 2 {
+		t.Fatalf("expected normalized manifest roots, got %#v", got)
+	} else if _, ok := got["."]; !ok {
+		t.Fatalf("expected blank roots to normalize to '.', got %#v", got)
+	} else if _, ok := got["app"]; !ok {
+		t.Fatalf("expected blank roots to normalize to '.' and app root to remain, got %#v", got)
+	}
+
+	deps := map[string]dependencyInfo{}
+	addDependencySection(deps, map[string]any{"   ": "^1.0.0"}, "runtime", nil)
+	if len(deps) != 0 {
+		t.Fatalf("expected blank dependency names to be ignored, got %#v", deps)
+	}
+
+	mergeLockDependencyData(deps, map[string]pubspecLockPackage{"   ": {Description: map[string]any{"name": "   "}}}, nil)
+	if len(deps) != 0 {
+		t.Fatalf("expected blank lock dependency names to be ignored, got %#v", deps)
+	}
+
+	if hasPluginMetadataAnyMap(map[any]any{"note": "value"}) {
+		t.Fatalf("expected plain any-map values not to count as plugin metadata")
+	}
+	if hasPluginMetadataSlice([]any{"value"}) {
+		t.Fatalf("expected plain slices not to count as plugin metadata")
+	}
+}
+
+func testDartScanHelpersAndWarnings(t *testing.T) {
+	if err := walkContextErr(context.TODO(), nil); err != nil {
+		t.Fatalf("expected nil walk context error, got %v", err)
+	}
+
+	root := t.TempDir()
+	testDartScanPackageDirGuards(t, root)
+	testDartScanPackageFileEntryBranches(t, root)
+	testDartScanPackageRootBranches(t, root)
+	testDartCompileScanWarnings(t)
+}
+
+func testDartScanPackageDirGuards(t *testing.T, root string) {
+	t.Helper()
+
+	nestedRoot := filepath.Join(root, "packages", "demo")
+	if err := os.MkdirAll(nestedRoot, 0o755); err != nil {
+		t.Fatalf("mkdir nested root: %v", err)
+	}
+	if err := scanPackageDir(root, root, filepath.Base(root), map[string]struct{}{filepath.Clean(nestedRoot): {}}); err != nil {
+		t.Fatalf("expected root directory not to be skipped, got %v", err)
+	}
+	if err := scanPackageDir(root, nestedRoot, filepath.Base(nestedRoot), map[string]struct{}{filepath.Clean(nestedRoot): {}}); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected nested manifest root to be skipped, got %v", err)
+	}
+	if err := scanPackageDir(root, filepath.Join(root, "android"), "android", nil); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected android directory to be skipped, got %v", err)
+	}
+}
+
+func testDartScanPackageFileEntryBranches(t *testing.T, root string) {
+	t.Helper()
+
+	scanned := map[string]struct{}{}
+	fileCount := 0
+	result := &scanResult{}
+	dartPath := filepath.Join(root, "lib", "main.dart")
+	if err := os.MkdirAll(filepath.Dir(dartPath), 0o755); err != nil {
+		t.Fatalf("mkdir lib dir: %v", err)
+	}
+	if err := os.WriteFile(dartPath, []byte("void main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := scanPackageFileEntry(root, dartPath, map[string]dependencyInfo{}, scanned, &fileCount, result); err != nil {
+		t.Fatalf("scan package file entry: %v", err)
+	}
+	before := len(result.Files)
+	if err := scanPackageFileEntry(root, dartPath, map[string]dependencyInfo{}, scanned, &fileCount, result); err != nil {
+		t.Fatalf("duplicate scan package file entry: %v", err)
+	}
+	if len(result.Files) != before {
+		t.Fatalf("expected duplicate file scan to be ignored, got %#v", result.Files)
+	}
+	fileCount = maxScanFiles
+	if err := scanPackageFileEntry(root, filepath.Join(root, "lib", "next.dart"), map[string]dependencyInfo{}, map[string]struct{}{}, &fileCount, result); !errors.Is(err, fs.SkipAll) || !result.SkippedFilesByBound {
+		t.Fatalf("expected file bound skip, got err=%v result=%#v", err, result)
+	}
+
+	outsidePath := filepath.Join(t.TempDir(), "outside.dart")
+	if err := os.WriteFile(outsidePath, []byte("void main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write outside source: %v", err)
+	}
+	if scanDartSourceFile(root, outsidePath, map[string]dependencyInfo{}, &scanResult{}) == nil {
+		t.Fatalf("expected repo-bounded read failure for outside dart file")
+	}
+}
+
+func testDartScanPackageRootBranches(t *testing.T, root string) {
+	t.Helper()
+
+	manifest := packageManifest{Root: "", Dependencies: map[string]dependencyInfo{}}
+	if err := scanPackageRoot(context.Background(), root, manifest, map[string]struct{}{}, map[string]struct{}{}, new(int), &scanResult{}); err != nil {
+		t.Fatalf("expected blank manifest root to default to repo path, got %v", err)
+	}
+
+	if scanPackageRoot(context.Background(), root, packageManifest{Root: filepath.Join(root, "missing"), Dependencies: map[string]dependencyInfo{}}, map[string]struct{}{}, map[string]struct{}{}, new(int), &scanResult{}) == nil {
+		t.Fatalf("expected missing manifest root to fail scan")
+	}
+}
+
+func testDartCompileScanWarnings(t *testing.T) {
+	t.Helper()
+
+	warnings := compileScanWarnings(scanResult{
+		SkippedLargeFiles:   1,
+		SkippedFilesByBound: true,
+		UnresolvedImports:   map[string]int{"dio": 2},
+	})
+	joined := strings.Join(warnings, "\n")
+	if !strings.Contains(joined, "skipped 1 Dart files") || !strings.Contains(joined, "Dart source scanning capped") || !strings.Contains(joined, "dio") {
+		t.Fatalf("expected composed scan warnings, got %#v", warnings)
+	}
+}
+
+func testDartImportParsingAndDependencySelection(t *testing.T) {
+	if kind, module, clause, ok := parseImportDirective(`show "x";`); ok || kind != "" || module != "" || clause != "" {
+		t.Fatalf("expected unsupported directive parse to fail")
+	}
+	if kind, module, clause, ok := parseImportDirective(`part "x.dart";`); ok || kind != "" || module != "" || clause != "" {
+		t.Fatalf("expected non-import/export directive parse to fail")
+	}
+	if got := parseShowSymbols("show Foo, 1Bar, Foo hide Baz"); len(got) != 1 || got[0] != "Foo" {
+		t.Fatalf("expected invalid and duplicate symbols to be filtered, got %#v", got)
+	}
+	if got := extractAlias("as 123bad"); got != "" {
+		t.Fatalf("expected invalid alias to be rejected, got %q", got)
+	}
+	if got := resolveDependencyFromModule("package:", map[string]dependencyInfo{}, nil); got != "" {
+		t.Fatalf("expected empty package import to be ignored, got %q", got)
+	}
+	if got := resolveDependencyFromModule("package:/foo", map[string]dependencyInfo{}, nil); got != "" {
+		t.Fatalf("expected blank package dependency id to be ignored, got %q", got)
+	}
+	if got := resolveDependencyFromModule("http://example.com", map[string]dependencyInfo{}, nil); got != "" {
+		t.Fatalf("expected non-package import to be ignored, got %q", got)
+	}
+	if got := parseShowSymbols("show "); len(got) != 0 {
+		t.Fatalf("expected empty show clause to be ignored, got %#v", got)
+	}
+	if got := allDependencies(scanResult{
+		DeclaredDependencies: map[string]dependencyInfo{
+			"local_pkg": {LocalPath: true},
+			"http":      {},
+		},
+	}); len(got) != 1 || got[0] != "http" {
+		t.Fatalf("expected local path dependencies to be excluded, got %#v", got)
+	}
+
+	reportData, warnings := buildDependencyReport("http", scanResult{DeclaredDependencies: map[string]dependencyInfo{"http": {}}, Files: []fileScan{{Imports: []importBinding{{Dependency: "http", Module: "package:http/http.dart", Name: "Client", Local: "Client"}, {Dependency: "http", Module: "package:http/http.dart", Name: "Request", Local: "Request"}}, Usage: map[string]int{"Client": 1}}}}, 90)
+	if len(warnings) != 0 || len(reportData.Recommendations) == 0 {
+		t.Fatalf("expected low-usage dependency recommendation, report=%#v warnings=%#v", reportData, warnings)
+	}
+}

--- a/internal/lang/dotnet/adapter_cov_more_test.go
+++ b/internal/lang/dotnet/adapter_cov_more_test.go
@@ -1,0 +1,239 @@
+package dotnet
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const dotNetProgramSource = "Program.cs"
+const dotNetMkdirObjDirErrFmt = "mkdir obj dir: %v"
+
+func TestDotNetDetectWithConfidenceGuardBranches(t *testing.T) {
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected missing repo to fail detection")
+	}
+
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, "app.sln"), 0o755); err != nil {
+		t.Fatalf("mkdir solution dir: %v", err)
+	}
+	if applyRootSignals(repo, &language.Detection{}, map[string]struct{}{}) == nil {
+		t.Fatalf("expected unreadable solution entry to fail root signal application")
+	}
+
+	repo = t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, "obj"), 0o755); err != nil {
+		t.Fatalf(dotNetMkdirObjDirErrFmt, err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, dotNetProgramSource), []byte("using System;\n"), 0o644); err != nil {
+		t.Fatalf("write Program.cs: %v", err)
+	}
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil || !detection.Matched {
+		t.Fatalf("expected detection success with skipped obj dir, detection=%#v err=%v", detection, err)
+	}
+}
+
+func TestDotNetMarkDetectionZeroConfidence(t *testing.T) {
+	detection := language.Detection{}
+	roots := map[string]struct{}{}
+	markDetection(&detection, roots, 0, "repo")
+	if detection.Matched || detection.Confidence != 0 || len(roots) != 0 {
+		t.Fatalf("expected zero-confidence detection to remain unchanged, got %#v %#v", detection, roots)
+	}
+}
+
+func TestDotNetResolveRemovalCandidateWeightsNormalizes(t *testing.T) {
+	normalized := resolveRemovalCandidateWeights(&report.RemovalCandidateWeights{Usage: 2, Impact: 1, Confidence: 1})
+	if normalized.Usage <= 0 || normalized.Impact <= 0 || normalized.Confidence <= 0 {
+		t.Fatalf("expected normalized weights, got %#v", normalized)
+	}
+}
+
+func TestDotNetAddAncestorCentralPackagesParseError(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "src", "service")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(parent, centralPackagesFile), 0o755); err != nil {
+		t.Fatalf("mkdir central packages dir: %v", err)
+	}
+	if addAncestorCentralPackages(repo, map[string]struct{}{}) == nil {
+		t.Fatalf("expected ancestor central package parse error")
+	}
+}
+
+func TestDotNetCaptureMatchesIgnoresMalformedInput(t *testing.T) {
+	if !slices.Equal(captureMatches([][][]byte{{[]byte("skip")}, {[]byte(" "), []byte(" ")}}), []string{}) {
+		t.Fatalf("expected malformed/blank captureMatches input to be ignored")
+	}
+}
+
+func TestDotNetCollectorAndScannerReturnWalkErrors(t *testing.T) {
+	repo := t.TempDir()
+	collector := newDependencyCollector(repo, map[string]struct{}{})
+	if collector.walk("", nil, context.Canceled) == nil {
+		t.Fatalf("expected collector walkErr to be returned")
+	}
+
+	scanner := newRepoScanner(repo, newDependencyMapper(nil), &scanResult{
+		AmbiguousByDependency:  map[string]int{},
+		UndeclaredByDependency: map[string]int{},
+	})
+	if scanner.walk("", nil, context.Canceled) == nil {
+		t.Fatalf("expected scanner walkErr to be returned")
+	}
+}
+
+func TestDotNetScannerSkipsObjDirAndMissingSource(t *testing.T) {
+	repo := t.TempDir()
+	repoEntryPath := filepath.Join(repo, "obj")
+	if err := os.Mkdir(repoEntryPath, 0o755); err != nil {
+		t.Fatalf(dotNetMkdirObjDirErrFmt, err)
+	}
+	objEntry := mustReadDirEntry(t, repo, "obj")
+
+	scanner := newRepoScanner(repo, newDependencyMapper(nil), &scanResult{
+		AmbiguousByDependency:  map[string]int{},
+		UndeclaredByDependency: map[string]int{},
+	})
+	if err := scanner.walk(repoEntryPath, objEntry, nil); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected scanner to skip obj dir, got %v", err)
+	}
+
+	filePath := filepath.Join(repo, dotNetProgramSource)
+	if err := os.WriteFile(filePath, []byte("using Vendor.Pkg;\n"), 0o644); err != nil {
+		t.Fatalf("write Program.cs: %v", err)
+	}
+	if err := os.Remove(filePath); err != nil {
+		t.Fatalf("remove Program.cs: %v", err)
+	}
+	if scanner.scanFile(filePath) == nil {
+		t.Fatalf("expected removed source file to fail scan")
+	}
+}
+
+func TestDotNetAddMappingMetaAccumulates(t *testing.T) {
+	scanner := newRepoScanner(t.TempDir(), newDependencyMapper(nil), &scanResult{
+		AmbiguousByDependency:  map[string]int{},
+		UndeclaredByDependency: map[string]int{},
+	})
+	scanner.addMappingMeta(mappingMetadata{
+		ambiguousByDependency:  map[string]int{"dep": 1},
+		undeclaredByDependency: map[string]int{"dep": 2},
+	})
+	if scanner.result.AmbiguousByDependency["dep"] != 1 || scanner.result.UndeclaredByDependency["dep"] != 2 {
+		t.Fatalf("expected mapping metadata to accumulate, got %#v %#v", scanner.result.AmbiguousByDependency, scanner.result.UndeclaredByDependency)
+	}
+}
+
+func TestDotNetCollectorSkipsObjDir(t *testing.T) {
+	repo := t.TempDir()
+	repoEntryPath := filepath.Join(repo, "obj")
+	if err := os.Mkdir(repoEntryPath, 0o755); err != nil {
+		t.Fatalf(dotNetMkdirObjDirErrFmt, err)
+	}
+	objEntry := mustReadDirEntry(t, repo, "obj")
+	if err := newDependencyCollector(repo, map[string]struct{}{}).walk(repoEntryPath, objEntry, nil); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected collector to skip obj dir, got %v", err)
+	}
+}
+
+func TestDotNetCollectorFailsRemovedManifest(t *testing.T) {
+	repo := t.TempDir()
+	manifestPath := filepath.Join(repo, "Bad.csproj")
+	if err := os.WriteFile(manifestPath, []byte(`<Project />`), 0o644); err != nil {
+		t.Fatalf("write manifest file: %v", err)
+	}
+	manifestEntry := mustReadDirEntry(t, repo, "Bad.csproj")
+	if err := os.Remove(manifestPath); err != nil {
+		t.Fatalf("remove manifest file: %v", err)
+	}
+	if newDependencyCollector(repo, map[string]struct{}{}).walk(manifestPath, manifestEntry, nil) == nil {
+		t.Fatalf("expected manifest parse to fail for removed file")
+	}
+}
+
+func TestDotNetParseCSharpImportLineFallsBackToUndeclaredBinding(t *testing.T) {
+	mapper := newDependencyMapper(nil)
+	meta := &mappingMetadata{
+		ambiguousByDependency:  map[string]int{},
+		undeclaredByDependency: map[string]int{},
+	}
+	binding, handled := parseCSharpImportLine([]byte("using Mystery.Component;"), dotNetProgramSource, 1, 1, mapper, meta)
+	if !handled || binding == nil || binding.Dependency != "mystery.component" {
+		t.Fatalf("expected fallback undeclared binding, got handled=%v binding=%#v", handled, binding)
+	}
+	if meta.undeclaredByDependency["mystery.component"] != 1 {
+		t.Fatalf("expected undeclared dependency metadata, got %#v", meta.undeclaredByDependency)
+	}
+}
+
+func TestDotNetImportResolutionHelpers(t *testing.T) {
+	mapper := newDependencyMapper(nil)
+	meta := &mappingMetadata{
+		ambiguousByDependency:  map[string]int{},
+		undeclaredByDependency: map[string]int{},
+	}
+	if binding := parseFSharpImportLine([]byte("open System"), "Program.fs", 1, 1, mapper, meta); binding != nil {
+		t.Fatalf("expected framework namespace to be ignored, got %#v", binding)
+	}
+	if dependency, resolved := resolveImportDependency("System.Text", mapper, meta); resolved || dependency != "" {
+		t.Fatalf("expected system import to be ignored, got dependency=%q resolved=%v", dependency, resolved)
+	}
+	if deps, err := parseManifestDependenciesForEntry(t.TempDir(), filepath.Join(t.TempDir(), "README.md"), "README.md"); err != nil || len(deps) != 0 {
+		t.Fatalf("expected non-manifest entry to be ignored, got deps=%#v err=%v", deps, err)
+	}
+	if module, alias, ok := parseCSharpUsing("using ;"); ok || module != "" || alias != "" {
+		t.Fatalf("expected blank using expression to fail parse, module=%q alias=%q ok=%v", module, alias, ok)
+	}
+}
+
+func TestDotNetBuildTopDependenciesAndHelperGuards(t *testing.T) {
+	reports, warnings := buildTopDotNetDependencies(1, scanResult{DeclaredDependencies: []string{"alpha", "beta"}}, 50, report.DefaultRemovalCandidateWeights())
+	if len(reports) != 1 || len(warnings) != 0 {
+		t.Fatalf("expected top-N slicing without extra warnings, reports=%#v warnings=%#v", reports, warnings)
+	}
+
+	mapperWithScores := newDependencyMapper([]string{"vendor", "vendor.pkg"})
+	dependency, ambiguous, undeclared := mapperWithScores.resolve("Vendor.Client")
+	if dependency != "vendor" || ambiguous || undeclared {
+		t.Fatalf("expected best-score dependency match, got dependency=%q ambiguous=%v undeclared=%v", dependency, ambiguous, undeclared)
+	}
+	if shouldSkipDir("src") {
+		t.Fatalf("did not expect src to be skipped")
+	}
+	if isSourceFile("notes.txt") {
+		t.Fatalf("did not expect txt file to count as source")
+	}
+	if isRepoBoundedPath("\x00", ".") {
+		t.Fatalf("expected invalid repo path to be rejected")
+	}
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00", TopN: 1}); err == nil {
+		t.Fatalf("expected analyse to fail for invalid repo path")
+	}
+}
+
+func mustReadDirEntry(t *testing.T, dir, name string) os.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return entry
+		}
+	}
+	t.Fatalf("expected %s dir entry", name)
+	return nil
+}

--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -2,6 +2,7 @@ package elixir
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -10,6 +11,11 @@ import (
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+const (
+	elixirFooBarDependency = "foo-bar"
+	elixirAliasFooBar      = "alias Foo.Bar"
 )
 
 func fixturePath(parts ...string) string {
@@ -155,6 +161,86 @@ func TestResolveWeights(t *testing.T) {
 	}
 }
 
+func TestDetectUmbrellaAppsPathBranches(t *testing.T) {
+	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("def project, do: []\n")); umbrella || appsPath != "" {
+		t.Fatalf("expected non-umbrella config without apps_path, got umbrella=%v appsPath=%q", umbrella, appsPath)
+	}
+	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("def project, do: [apps_path: \"   \"]\n")); !umbrella || appsPath != "apps" {
+		t.Fatalf("expected blank apps_path to fall back to apps, got umbrella=%v appsPath=%q", umbrella, appsPath)
+	}
+}
+
+func TestAddUmbrellaRootsAndDependencyFallbacks(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "apps", "api", mixExsName), "defmodule Api.MixProject do\nend\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "apps", "README.md"), "not a mix app\n")
+
+	roots := map[string]struct{}{}
+	if err := addUmbrellaRoots(repo, "apps", roots); err != nil {
+		t.Fatalf("add umbrella roots: %v", err)
+	}
+	if _, ok := roots[filepath.Join(repo, "apps", "api")]; !ok {
+		t.Fatalf("expected api umbrella root, got %#v", roots)
+	}
+	if dep := dependencyFromModule("", map[string]struct{}{elixirFooBarDependency: {}}); dep != "" {
+		t.Fatalf("expected empty dependency for empty module, got %q", dep)
+	}
+	if dep := dependencyFromModule("FooBar.Client", map[string]struct{}{elixirFooBarDependency: {}}); dep != elixirFooBarDependency {
+		t.Fatalf("expected hyphenated dependency fallback, got %q", dep)
+	}
+}
+
+func TestAddUmbrellaRootsRejectsInvalidGlobPattern(t *testing.T) {
+	if addUmbrellaRoots(t.TempDir(), "[", map[string]struct{}{}) == nil {
+		t.Fatalf("expected invalid glob pattern error")
+	}
+}
+
+func TestDetectFromRootFilesReturnsStatErrorForInvalidRepoPath(t *testing.T) {
+	repoFile := filepath.Join(t.TempDir(), "not-a-dir")
+	testutil.MustWriteFile(t, repoFile, "x")
+
+	_, err := detectFromRootFiles(repoFile, &language.Detection{}, map[string]struct{}{})
+	if err == nil {
+		t.Fatalf("expected detectFromRootFiles to fail for non-directory repo path")
+	}
+}
+
+func TestLineBytesAndParseAliasLocalEdgeCases(t *testing.T) {
+	if got := lineBytes([]byte(elixirAliasFooBar+"\n"), -1); len(got) != 0 {
+		t.Fatalf("expected nil line bytes for negative start, got %q", string(got))
+	}
+	if got := lineBytes([]byte(elixirAliasFooBar), 100); len(got) != 0 {
+		t.Fatalf("expected nil line bytes for out-of-range start, got %q", string(got))
+	}
+	if got := parseAliasLocal([]byte(elixirAliasFooBar)); got != "" {
+		t.Fatalf("expected no alias local without as:, got %q", got)
+	}
+}
+
+func TestLoadDeclaredDependenciesReturnsReadErrors(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, mixLockName), 0o755); err != nil {
+		t.Fatalf("mkdir mix.lock: %v", err)
+	}
+
+	if _, err := loadDeclaredDependencies(repo); err == nil {
+		t.Fatalf("expected loadDeclaredDependencies to fail when mix.lock is a directory")
+	}
+}
+
+func TestBuildRequestedDependenciesWarnsWhenDependencyHasNoImports(t *testing.T) {
+	dependencies, warnings := buildRequestedDependencies(language.Request{Dependency: "ecto"}, scanResult{
+		declared: map[string]struct{}{"ecto": {}},
+	})
+	if len(dependencies) != 1 || dependencies[0].Name != "ecto" {
+		t.Fatalf("expected one dependency report, got %#v", dependencies)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "no imports found") {
+		t.Fatalf("expected no-import warning, got %#v", warnings)
+	}
+}
+
 func TestDetectReturnsErrorOnMissingRepo(t *testing.T) {
 	adapter := NewAdapter()
 	matched, err := adapter.Detect(context.Background(), filepath.Join(t.TempDir(), "missing"))
@@ -174,6 +260,68 @@ func TestAnalyseReturnsErrorOnMissingRepo(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatalf("expected analyse error for missing repo path")
+	}
+}
+
+func TestElixirAdditionalReachableBranches(t *testing.T) {
+	t.Run("detect root file read and walk errors", testElixirDetectRootFileReadAndWalkErrors)
+	t.Run("scan repo unreadable source and helper edges", testElixirScanRepoUnreadableSourceAndHelperEdges)
+	t.Run("declared dependency read branches", testElixirDeclaredDependencyReadBranches)
+}
+
+func testElixirDetectRootFileReadAndWalkErrors(t *testing.T) {
+	repo := t.TempDir()
+	mixExs := filepath.Join(repo, mixExsName)
+	if err := os.WriteFile(mixExs, []byte("defmodule Demo.MixProject do end\n"), 0o000); err != nil {
+		t.Fatalf("write unreadable mix.exs: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(mixExs, 0o600); err != nil {
+			t.Fatalf("restore mix.exs perms: %v", err)
+		}
+	})
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), repo); err == nil {
+		t.Fatalf("expected unreadable root mix.exs to fail detection")
+	}
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected missing repo to fail detection walk")
+	}
+}
+
+func testElixirScanRepoUnreadableSourceAndHelperEdges(t *testing.T) {
+	repo := t.TempDir()
+	unreadable := filepath.Join(repo, "lib", "demo.ex")
+	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do end\n")
+	if err := os.MkdirAll(filepath.Dir(unreadable), 0o755); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(unreadable, []byte(elixirAliasFooBar+"\n"), 0o000); err != nil {
+		t.Fatalf("write unreadable source: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(unreadable, 0o600); err != nil {
+			t.Fatalf("restore unreadable source perms: %v", err)
+		}
+	})
+
+	if _, err := scanElixirRepo(context.Background(), repo, map[string]struct{}{"foo": {}}); err == nil {
+		t.Fatalf("expected unreadable source file to fail scan")
+	}
+	if got := string(lineBytes([]byte(elixirAliasFooBar), 0)); got != elixirAliasFooBar {
+		t.Fatalf("expected lineBytes without newline to return remaining content, got %q", got)
+	}
+}
+
+func testElixirDeclaredDependencyReadBranches(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, mixExsName), 0o755); err != nil {
+		t.Fatalf("mkdir mix.exs: %v", err)
+	}
+	if _, err := loadDeclaredDependencies(repo); err == nil {
+		t.Fatalf("expected loadDeclaredDependencies to fail when mix.exs is a directory")
+	}
+	if dep := dependencyFromModule("FooBar.Client", map[string]struct{}{elixirFooBarDependency: {}}); dep != elixirFooBarDependency {
+		t.Fatalf("expected direct normalized dependency match, got %q", dep)
 	}
 }
 

--- a/internal/lang/golang/adapter_cov_more_branches_test.go
+++ b/internal/lang/golang/adapter_cov_more_branches_test.go
@@ -1,0 +1,122 @@
+package golang
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestGoAdditionalBranchCoverage(t *testing.T) {
+	t.Run("helper guard branches", testGoHelperGuardBranches)
+	t.Run("repo bounded path guards", testGoRepoBoundedPathGuards)
+	t.Run("module loading error branches", testGoModuleLoadingErrorBranches)
+	t.Run("nested replacements populate missing entries", testGoNestedReplacementImports)
+}
+
+func testGoHelperGuardBranches(t *testing.T) {
+	t.Helper()
+
+	weights := resolveRemovalCandidateWeights(&report.RemovalCandidateWeights{
+		Usage:      -1,
+		Impact:     2,
+		Confidence: 3,
+	})
+	if weights.Usage < 0 || weights.Impact > 1 || weights.Confidence > 1 {
+		t.Fatalf("expected removal weights to be normalized, got %#v", weights)
+	}
+
+	if walkGoFiles(context.Background(), filepath.Join(t.TempDir(), "missing"), nil, moduleInfo{}, &scanResult{}) == nil {
+		t.Fatalf("expected walkGoFiles to fail for missing repo")
+	}
+
+	imports, metadata := parseImports([]byte("package main\nimport \"\"\n"), "main.go", moduleInfo{})
+	if len(imports) != 0 || len(metadata) != 0 {
+		t.Fatalf("expected blank import paths to be ignored, imports=%#v metadata=%#v", imports, metadata)
+	}
+
+	goBuildExpr, plusBuildExprs := extractBuildConstraintExpressions([]byte("\n//go:build linux\npackage main\n"))
+	if goBuildExpr == nil || len(plusBuildExprs) != 0 {
+		t.Fatalf("expected go:build expression after blank lines, go=%v plus=%#v", goBuildExpr, plusBuildExprs)
+	}
+
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git dir: %v", err)
+	}
+	nested, err := nestedModuleDirs(repo)
+	if err != nil {
+		t.Fatalf("nestedModuleDirs: %v", err)
+	}
+	if len(nested) != 0 {
+		t.Fatalf("expected skipped .git directory not to count as nested module, got %#v", nested)
+	}
+}
+
+func testGoRepoBoundedPathGuards(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	outside := filepath.Join(repo, "..", "outside")
+	if _, ok := resolveRepoBoundedPath(repo, outside); ok {
+		t.Fatalf("expected outside absolute path to be rejected")
+	}
+}
+
+func testGoModuleLoadingErrorBranches(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, goModName), []byte(moduleDemoLine+"\n"), 0o600); err != nil {
+		t.Fatalf("write root go.mod: %v", err)
+	}
+
+	goWorkDir := filepath.Join(repo, goWorkName)
+	if err := os.Mkdir(goWorkDir, 0o755); err != nil {
+		t.Fatalf("mkdir go.work dir: %v", err)
+	}
+	if _, err := loadGoModuleInfo(repo); err == nil {
+		t.Fatalf("expected go.work directory to fail workspace module loading")
+	}
+	if err := os.RemoveAll(goWorkDir); err != nil {
+		t.Fatalf("remove go.work dir: %v", err)
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-based nested module errors are not portable on windows")
+	}
+
+	blockedDir := filepath.Join(repo, "blocked")
+	if err := os.Mkdir(blockedDir, 0o700); err != nil {
+		t.Fatalf("mkdir blocked dir: %v", err)
+	}
+	if err := os.Chmod(blockedDir, 0o000); err != nil {
+		t.Fatalf("chmod blocked dir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(blockedDir, 0o700); err != nil {
+			t.Fatalf("restore blocked dir perms: %v", err)
+		}
+	})
+	if _, err := loadGoModuleInfo(repo); err == nil {
+		t.Fatalf("expected unreadable nested directory to fail nested module discovery")
+	}
+}
+
+func testGoNestedReplacementImports(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "nested", "x", goModName), "module example.com/x\n\nreplace example.com/other => "+sharedForkImport+" v1.1.0\n")
+
+	info := moduleInfo{ReplacementImports: map[string]string{}}
+	if err := loadNestedModules(repo, &info); err != nil {
+		t.Fatalf("loadNestedModules: %v", err)
+	}
+	if got := info.ReplacementImports[sharedForkImport]; got != "example.com/other" {
+		t.Fatalf("expected nested replacement to be added, got %q", got)
+	}
+}

--- a/internal/lang/js/adapter_cov_more_branches_test.go
+++ b/internal/lang/js/adapter_cov_more_branches_test.go
@@ -1,0 +1,219 @@
+package js
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestJSAdapterAdditionalBranchCoverage(t *testing.T) {
+	t.Run("detect helpers return real errors", testJSDetectHelpersReturnRealErrors)
+	t.Run("detect handles eof cap and skipped dirs", testJSDetectHandlesEOFCapAndSkippedDirs)
+	t.Run("non package root signals and usage caps", testJSNonPackageRootSignalsAndUsageCaps)
+	t.Run("analyse warning and normalize branches", testJSAnalyseWarningAndNormalizeBranches)
+	t.Run("usage and export helpers", testJSUsageAndExportHelpers)
+	t.Run("dependency collector and resolution helpers", testJSDependencyCollectorAndResolutionHelpers)
+}
+
+func testJSDetectHelpersReturnRealErrors(t *testing.T) {
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected missing repo to fail detection")
+	}
+
+	repoFile := filepath.Join(t.TempDir(), "repo-file")
+	if err := os.WriteFile(repoFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+	detection := language.Detection{}
+	roots := map[string]struct{}{}
+	if addRootSignalDetection(repoFile, &detection, roots) == nil {
+		t.Fatalf("expected non-directory repo path to fail root signal detection")
+	}
+}
+
+func testJSDetectHandlesEOFCapAndSkippedDirs(t *testing.T) {
+	repo := t.TempDir()
+	for i := 0; i <= 256; i++ {
+		path := filepath.Join(repo, "pkg", fmt.Sprintf("f-%03d.js", i))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir js dir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("export const x = 1\n"), 0o644); err != nil {
+			t.Fatalf("write js file: %v", err)
+		}
+	}
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect with confidence on capped repo: %v", err)
+	}
+	if !detection.Matched || detection.Confidence == 0 {
+		t.Fatalf("expected detection to survive EOF cap normalization, got %#v", detection)
+	}
+
+	skipRepo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(skipRepo, ".next"), 0o755); err != nil {
+		t.Fatalf("mkdir skipped dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skipRepo, ".next", testIndexJS), []byte("export const x = 1\n"), 0o644); err != nil {
+		t.Fatalf("write skipped file: %v", err)
+	}
+	detection = language.Detection{}
+	if err := scanFilesForJSDetection(skipRepo, &detection, map[string]struct{}{}); err != nil {
+		t.Fatalf("scan skipped repo: %v", err)
+	}
+	if detection.Matched {
+		t.Fatalf("expected skipped detection dir not to contribute matches, got %#v", detection)
+	}
+}
+
+func testJSNonPackageRootSignalsAndUsageCaps(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "jsconfig.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write jsconfig: %v", err)
+	}
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect jsconfig repo: %v", err)
+	}
+	if !detection.Matched || detection.Confidence < 20 {
+		t.Fatalf("expected jsconfig root signal confidence, got %#v", detection)
+	}
+
+	uncertain := make([]report.ImportUse, 0, 6)
+	for i := 0; i < 6; i++ {
+		uncertain = append(uncertain, report.ImportUse{Locations: []report.Location{{File: testIndexJS, Line: i + 1}}})
+	}
+	summary := summarizeUsageUncertainty(ScanResult{Files: []FileScan{{UncertainImports: uncertain}}})
+	if summary == nil || len(summary.Samples) != 5 {
+		t.Fatalf("expected uncertainty samples to cap at five, got %#v", summary)
+	}
+}
+
+func testJSAnalyseWarningAndNormalizeBranches(t *testing.T) {
+	repo := t.TempDir()
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 3})
+	if err != nil {
+		t.Fatalf("analyse empty repo: %v", err)
+	}
+	if len(reportData.Dependencies) != 0 {
+		t.Fatalf("expected no dependencies for empty repo, got %#v", reportData.Dependencies)
+	}
+	if len(reportData.Warnings) == 0 {
+		t.Fatalf("expected no dependency data warning")
+	}
+
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: filepath.Join(t.TempDir(), "missing"), TopN: 1}); err == nil {
+		t.Fatalf("expected scan failure for missing repo path")
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Fatalf("restore wd %s: %v", originalWD, err)
+		}
+	})
+	deadDir := filepath.Join(t.TempDir(), "dead")
+	if err := os.MkdirAll(deadDir, 0o755); err != nil {
+		t.Fatalf("mkdir dead dir: %v", err)
+	}
+	if err := os.Chdir(deadDir); err != nil {
+		t.Fatalf("chdir dead dir: %v", err)
+	}
+	if err := os.RemoveAll(deadDir); err != nil {
+		t.Fatalf("remove dead dir: %v", err)
+	}
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{}); err == nil {
+		t.Fatalf("expected analyse to fail when cwd cannot be resolved")
+	}
+}
+
+func testJSUsageAndExportHelpers(t *testing.T) {
+	summary := summarizeUsageUncertainty(ScanResult{
+		Files: []FileScan{{
+			UncertainImports: []report.ImportUse{{}},
+		}},
+	})
+	if summary == nil || summary.UncertainImportUses != 1 || len(summary.Samples) != 0 {
+		t.Fatalf("expected uncertainty summary without samples, got %#v", summary)
+	}
+	if got := totalExportCount(ExportSurface{IncludesWildcard: true}); got != 0 {
+		t.Fatalf("expected wildcard surfaces to report zero total exports, got %d", got)
+	}
+	if got := exportUsedPercent(ExportSurface{Names: map[string]struct{}{}}, map[string]struct{}{"map": {}}, 0); got != 0 {
+		t.Fatalf("expected zero total exports to yield zero used percent, got %f", got)
+	}
+}
+
+func testJSDependencyCollectorAndResolutionHelpers(t *testing.T) {
+	repo := t.TempDir()
+	importer := filepath.Join(repo, "src", testIndexJS)
+	if err := os.MkdirAll(filepath.Dir(importer), 0o755); err != nil {
+		t.Fatalf("mkdir importer dir: %v", err)
+	}
+	if err := os.WriteFile(importer, []byte("import 'dep'\n"), 0o644); err != nil {
+		t.Fatalf("write importer: %v", err)
+	}
+	depRoot := filepath.Join(repo, "node_modules", "dep")
+	if err := os.MkdirAll(depRoot, 0o755); err != nil {
+		t.Fatalf("mkdir dep root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(depRoot, "package.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write dep package: %v", err)
+	}
+
+	testJSDependencyCollectorTracksResolvedDeps(t, repo, importer)
+	testJSResolveRemovalCandidateWeights(t)
+	testJSResolveDependencyRootFailures(t, repo)
+}
+
+func testJSDependencyCollectorTracksResolvedDeps(t *testing.T, repo, importer string) {
+	t.Helper()
+
+	collector := newDependencyCollector()
+	collector.recordImport(repo, importer, ImportBinding{Module: "dep"})
+	collector.recordImport(repo, filepath.Join(t.TempDir(), testIndexJS), ImportBinding{Module: "dep"})
+	if _, ok := collector.missing["dep"]; ok {
+		t.Fatalf("expected already-found dependency not to be recorded as missing")
+	}
+
+	cacheCollector := newDependencyCollector()
+	req := dependencyResolutionRequest{RepoPath: repo, ImporterPath: importer, Dependency: "dep"}
+	if cacheCollector.cachedDependencyRoot(req) == "" {
+		t.Fatalf("expected cached dependency root to resolve")
+	}
+	if second := cacheCollector.cachedDependencyRoot(req); second == "" || len(cacheCollector.cache) != 1 {
+		t.Fatalf("expected cached dependency root reuse, got second=%q cache=%#v", second, cacheCollector.cache)
+	}
+}
+
+func testJSResolveRemovalCandidateWeights(t *testing.T) {
+	t.Helper()
+
+	custom := &report.RemovalCandidateWeights{Usage: 1, Impact: 2, Confidence: 3}
+	got := resolveRemovalCandidateWeights(custom)
+	if got == report.DefaultRemovalCandidateWeights() {
+		t.Fatalf("expected non-nil weights to normalize instead of using defaults")
+	}
+}
+
+func testJSResolveDependencyRootFailures(t *testing.T, repo string) {
+	t.Helper()
+
+	testutil.ChdirRemovedDir(t)
+	if got := resolveDependencyRootFromImporter(dependencyResolutionRequest{RepoPath: ".", ImporterPath: "src/index.js", Dependency: "dep"}); got != "" {
+		t.Fatalf("expected repo abs resolution failure to return empty root, got %q", got)
+	}
+	if got := resolveDependencyRootFromImporter(dependencyResolutionRequest{RepoPath: repo, ImporterPath: "src/index.js", Dependency: "dep"}); got != "" {
+		t.Fatalf("expected importer abs resolution failure to return empty root, got %q", got)
+	}
+}

--- a/internal/lang/js/codemod_cov_more_test.go
+++ b/internal/lang/js/codemod_cov_more_test.go
@@ -1,0 +1,163 @@
+package js
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const (
+	codemodMissingSource = "missing.js"
+	codemodIndexSource   = "index.js"
+)
+
+func TestBuildCodemodForMissingSourceWarnsAndSkipsSuggestions(t *testing.T) {
+	repo := t.TempDir()
+	file := FileScan{
+		Path: codemodMissingSource,
+		Imports: []ImportBinding{{
+			Module:     "lodash",
+			ExportName: "map",
+			LocalName:  "map",
+			Kind:       ImportNamed,
+			Location:   report.Location{Line: 1},
+		}},
+		IdentifierUsage: map[string]int{"map": 1},
+	}
+	suggestions, skips, warnings := buildCodemodForFile(repo, "lodash", subpathResolver{knownSubpaths: map[string]struct{}{"map": {}}}, file, map[string][]string{})
+	if len(suggestions) != 0 || len(skips) != 0 {
+		t.Fatalf("expected missing source to avoid suggestions/skips, got %#v %#v", suggestions, skips)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "codemod preview skipped for missing.js") {
+		t.Fatalf("expected preview warning, got %#v", warnings)
+	}
+}
+
+func TestBuildCodemodForFileWithoutTargetModuleProducesSkip(t *testing.T) {
+	assertCodemodSkipReason(t, `import { map } from "lodash";`, 1, subpathResolver{}, codemodReasonNoSubpathTarget)
+}
+
+func TestBuildCodemodForFileWithOutOfRangeLineProducesSkip(t *testing.T) {
+	assertCodemodSkipReason(t, `import { map } from "lodash";`, 9, subpathResolver{knownSubpaths: map[string]struct{}{"map": {}}}, codemodReasonUnsupportedLine)
+}
+
+func TestBuildCodemodForFileWithUnsupportedSyntaxProducesSkip(t *testing.T) {
+	assertCodemodSkipReason(t, `import { map, filter } from "lodash";`, 1, subpathResolver{knownSubpaths: map[string]struct{}{"map": {}}}, codemodReasonUnsupportedLine)
+}
+
+func TestLoadSourceLinesMissingSource(t *testing.T) {
+	lines, warning, loaded := loadSourceLines(t.TempDir(), codemodMissingSource, map[string][]string{})
+	if loaded || len(lines) != 0 || !strings.Contains(warning, codemodMissingSource) {
+		t.Fatalf("expected missing source load failure, got lines=%#v warning=%q loaded=%v", lines, warning, loaded)
+	}
+}
+
+func TestLoadSourceLinesUsesCache(t *testing.T) {
+	cached := map[string][]string{codemodIndexSource: {"cached"}}
+	lines, warning, loaded := loadSourceLines(t.TempDir(), codemodIndexSource, cached)
+	if !loaded || warning != "" || len(lines) != 1 || lines[0] != "cached" {
+		t.Fatalf("expected cached source lines, got %#v %q %v", lines, warning, loaded)
+	}
+}
+
+func TestCodemodSkipReasonBranches(t *testing.T) {
+	if code, message := codemodSkipReason(ImportBinding{Kind: ImportDefault}, FileScan{}); code != codemodReasonDefaultImport || !strings.Contains(message, "default imports") {
+		t.Fatalf("unexpected default import skip: %q %q", code, message)
+	}
+	if code, message := codemodSkipReason(ImportBinding{Kind: ImportNamed, ExportName: "map", LocalName: "map"}, FileScan{}); code != codemodReasonUnusedImport || !strings.Contains(message, "unused imports") {
+		t.Fatalf("unexpected unused named-import skip: %q %q", code, message)
+	}
+	if code, message := codemodSkipReason(ImportBinding{Kind: ImportKind("other")}, FileScan{}); code != codemodReasonUnsupportedLine || !strings.Contains(message, "not supported") {
+		t.Fatalf("unexpected unsupported-kind skip: %q %q", code, message)
+	}
+}
+
+func TestRewriteImportLineGuardBranches(t *testing.T) {
+	if _, ok := rewriteImportLine(`import { map } from "lodash';`, "lodash", "map", lodashMapSubpath); ok {
+		t.Fatalf("expected mismatched quote handling to fail import rewrite")
+	}
+	if _, ok := rewriteImportLine(`const { map } = require("lodash");`, "other", "map", lodashMapSubpath); ok {
+		t.Fatalf("expected dependency mismatch to fail require rewrite")
+	}
+}
+
+func TestNewSubpathResolverIgnoresNonMapExports(t *testing.T) {
+	depRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(depRoot, "package.json"), []byte(`{"exports":"./index.js"}`), 0o644); err != nil {
+		t.Fatalf("write non-map package.json: %v", err)
+	}
+	if got := newSubpathResolver(depRoot); len(got.knownSubpaths) != 0 {
+		t.Fatalf("expected non-map exports to be ignored, got %#v", got.knownSubpaths)
+	}
+}
+
+func TestNewSubpathResolverHandlesMissingPackageSurface(t *testing.T) {
+	if got := newSubpathResolver(filepath.Join(t.TempDir(), "missing")); len(got.knownSubpaths) != 0 {
+		t.Fatalf("expected missing package surface to return empty resolver, got %#v", got.knownSubpaths)
+	}
+}
+
+func TestNewSubpathResolverTracksExplicitExports(t *testing.T) {
+	withExports := t.TempDir()
+	if err := os.WriteFile(filepath.Join(withExports, "package.json"), []byte(`{"exports":{"./":"./index.js","./map":"./map.js","./*":"./*.js"}}`), 0o644); err != nil {
+		t.Fatalf("write package exports: %v", err)
+	}
+	resolver := newSubpathResolver(withExports)
+	if _, ok := resolver.knownSubpaths["map"]; !ok {
+		t.Fatalf("expected explicit export subpath to be tracked, got %#v", resolver.knownSubpaths)
+	}
+	if _, ok := resolver.knownSubpaths[""]; ok {
+		t.Fatalf("expected blank subpath to be ignored")
+	}
+	if _, ok := resolver.knownSubpaths["*"]; ok {
+		t.Fatalf("expected wildcard subpath to be ignored")
+	}
+}
+
+func TestHasResolvableSubpathFileAdditionalBranches(t *testing.T) {
+	withExports := t.TempDir()
+	nestedDir := filepath.Join(withExports, "nested")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, codemodIndexSource), []byte("export default 1\n"), 0o644); err != nil {
+		t.Fatalf("write nested index: %v", err)
+	}
+	if !hasResolvableSubpathFile(withExports, "nested") {
+		t.Fatalf("expected nested index lookup to resolve")
+	}
+	if hasResolvableSubpathFile(withExports, "only-dir") {
+		t.Fatalf("expected pure directory candidate not to resolve")
+	}
+}
+
+func assertCodemodSkipReason(t *testing.T, sourceLine string, line int, resolver subpathResolver, wantSkip string) {
+	t.Helper()
+
+	repo := t.TempDir()
+	sourcePath := filepath.Join(repo, codemodIndexSource)
+	if err := os.WriteFile(sourcePath, []byte(sourceLine+"\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	file := FileScan{
+		Path: codemodIndexSource,
+		Imports: []ImportBinding{{
+			Module:     "lodash",
+			ExportName: "map",
+			LocalName:  "map",
+			Kind:       ImportNamed,
+			Location:   report.Location{Line: line},
+		}},
+		IdentifierUsage: map[string]int{"map": 1},
+	}
+	_, skips, warnings := buildCodemodForFile(repo, "lodash", resolver, file, map[string][]string{})
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warning, got %#v", warnings)
+	}
+	if len(skips) != 1 || skips[0].ReasonCode != wantSkip {
+		t.Fatalf("expected skip %q, got %#v", wantSkip, skips)
+	}
+}

--- a/internal/lang/js/reexport_resolver_helpers_test.go
+++ b/internal/lang/js/reexport_resolver_helpers_test.go
@@ -1,11 +1,15 @@
 package js
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 const (
 	testImporterPath = "src/index.ts"
 	testFileAPath    = "src/a.ts"
 	testBarrelPath   = "src/barrel.ts"
+	testBarrelModule = "./barrel"
 	testUtilsPath    = "src/utils/index.ts"
 	testMainPath     = "src/main.ts"
 	testMissingPath  = "./missing"
@@ -100,7 +104,7 @@ func TestReExportResolverResolveLocalModule(t *testing.T) {
 		warningSet:   map[string]struct{}{},
 	}
 
-	assertResolvedModule(t, resolver, testMainPath, "./barrel", testBarrelPath)
+	assertResolvedModule(t, resolver, testMainPath, testBarrelModule, testBarrelPath)
 	assertResolvedModule(t, resolver, testMainPath, "./utils", testUtilsPath)
 	assertUnresolvedModule(t, resolver, testMainPath, testMissingPath)
 	// Hit negative cache path.
@@ -133,7 +137,7 @@ func TestReExportResolverResolveImportAttributionSkips(t *testing.T) {
 	if _, ok := resolver.resolveImportAttribution(testMainPath, ImportBinding{Module: "lodash", ExportName: "map", LocalName: "map", Kind: ImportNamed}, "lodash"); ok {
 		t.Fatalf("expected non-local import to skip resolver")
 	}
-	if _, ok := resolver.resolveImportAttribution(testMainPath, ImportBinding{Module: "./barrel", ExportName: "*", LocalName: "ns", Kind: ImportNamespace}, "lodash"); ok {
+	if _, ok := resolver.resolveImportAttribution(testMainPath, ImportBinding{Module: testBarrelModule, ExportName: "*", LocalName: "ns", Kind: ImportNamespace}, "lodash"); ok {
 		t.Fatalf("expected namespace local import to skip resolver")
 	}
 }
@@ -184,5 +188,55 @@ func TestReExportResolverResolveExportCandidateBranches(t *testing.T) {
 
 	if _, ok = resolver.resolveExportCandidate(req, ReExportBinding{SourceModule: testMissingPath, SourceExportName: "x", ExportName: "x"}, map[string]struct{}{}); ok {
 		t.Fatalf("expected unresolved local source to be skipped")
+	}
+}
+
+func TestReExportResolverAdditionalCoverageBranches(t *testing.T) {
+	resolver := &reExportResolver{
+		filesByPath: map[string]FileScan{
+			testBarrelPath: {
+				Path: testBarrelPath,
+				ReExports: []ReExportBinding{
+					{SourceModule: "lodash", SourceExportName: "default", ExportName: "default"},
+				},
+			},
+		},
+		resolveCache: map[string]string{},
+		warningSet:   map[string]struct{}{},
+	}
+
+	if _, ok := resolver.resolveImportAttribution(testMainPath, ImportBinding{Module: testMissingPath, ExportName: "map", Kind: ImportNamed}, "lodash"); ok {
+		t.Fatalf("expected unresolved local module attribution to fail")
+	}
+
+	attr, ok := resolver.resolveImportAttribution(testMainPath, ImportBinding{Module: testBarrelModule, LocalName: "lodash", Kind: ImportDefault}, "lodash")
+	if !ok || attr.Module != "lodash" || attr.ExportName != "default" {
+		t.Fatalf("expected default import attribution to resolve, got attr=%#v ok=%v", attr, ok)
+	}
+
+	if _, ok := resolver.resolveExportOrigin(resolveExportRequest{
+		importerPath:    testImporterPath,
+		currentFilePath: "src/missing.ts",
+		requestedExport: "x",
+		visited:         map[string]struct{}{},
+	}); ok {
+		t.Fatalf("expected export origin resolution to fail for missing file metadata")
+	}
+
+	assertResolvedModule(t, resolver, testMainPath, testBarrelModule, testBarrelPath)
+	assertResolvedModule(t, resolver, testMainPath, testBarrelModule, testBarrelPath)
+
+	candidates := localModuleCandidates("src/utils.ts")
+	if !slices.Contains(candidates, "src/utils") || !slices.Contains(candidates, "src/utils/index.ts") {
+		t.Fatalf("expected extensionless and index candidates, got %#v", candidates)
+	}
+	count := 0
+	for _, candidate := range candidates {
+		if candidate == "src/utils.ts" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected local module candidates to deduplicate repeated paths, got %#v", candidates)
 	}
 }

--- a/internal/lang/js/risk_cov_more_branches_test.go
+++ b/internal/lang/js/risk_cov_more_branches_test.go
@@ -1,0 +1,88 @@
+package js
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRiskAdditionalBranches(t *testing.T) {
+	testJSDepthRiskCueAdditionalBranch(t)
+	testJSNodeBinaryScannerSkipBranch(t)
+	testJSTransitiveDepthAndDependencyHelpers(t)
+}
+
+func testJSDepthRiskCueAdditionalBranch(t *testing.T) {
+	repo := t.TempDir()
+	root := filepath.Join(repo, "node_modules", "root")
+	deps := []string{"a", "b", "c", "d", "e", "f", "g"}
+	current := root
+	if err := os.MkdirAll(current, 0o755); err != nil {
+		t.Fatalf("mkdir root dep: %v", err)
+	}
+	for i, dep := range deps {
+		nextRoot := filepath.Join(current, "node_modules", dep)
+		if err := os.MkdirAll(nextRoot, 0o755); err != nil {
+			t.Fatalf("mkdir dep %s: %v", dep, err)
+		}
+		content := `{"dependencies":{}}`
+		if i < len(deps)-1 {
+			content = `{"dependencies":{"` + deps[i+1] + `":"1.0.0"}}`
+		}
+		if err := os.WriteFile(filepath.Join(nextRoot, packageJSONFile), []byte(content), 0o600); err != nil {
+			t.Fatalf("write package.json for %s: %v", dep, err)
+		}
+		current = nextRoot
+	}
+
+	cues, warnings := appendDepthRiskCue(nil, nil, "root", repo, filepath.Join(root, "node_modules", "a"), packageJSON{
+		Dependencies: map[string]string{"b": "1.0.0"},
+	})
+	if len(warnings) != 0 || len(cues) != 1 || cues[0].Severity != "high" {
+		t.Fatalf("expected high-severity deep graph cue, got cues=%#v warnings=%#v", cues, warnings)
+	}
+}
+
+func testJSNodeBinaryScannerSkipBranch(t *testing.T) {
+	repo := t.TempDir()
+	nodeModulesDir := filepath.Join(repo, "node_modules")
+	if err := os.MkdirAll(nodeModulesDir, 0o755); err != nil {
+		t.Fatalf("mkdir node_modules: %v", err)
+	}
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("readdir repo: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "node_modules" {
+			continue
+		}
+		scanner := &nodeBinaryScanner{maxVisited: 1}
+		if err := scanner.walk(nodeModulesDir, entry, nil); !errors.Is(err, filepath.SkipDir) {
+			t.Fatalf("expected nodeBinaryScanner to skip nested node_modules dir, got %v", err)
+		}
+	}
+}
+
+func testJSTransitiveDepthAndDependencyHelpers(t *testing.T) {
+	repo := t.TempDir()
+	root := filepath.Join(repo, "node_modules", "root")
+	memo := map[string]int{"cached": 4}
+	depth, err := transitiveDepth(repo, "cached", packageJSON{}, memo, map[string]struct{}{}, 5)
+	if err != nil || depth != 4 {
+		t.Fatalf("expected memoized transitive depth, got depth=%d err=%v", depth, err)
+	}
+
+	if root, ok := resolveInstalledDependencyRoot(repo, root, "missing"); ok || root != "" {
+		t.Fatalf("expected missing dependency root lookup to fail, got root=%q ok=%v", root, ok)
+	}
+
+	names := collectDependencyNames(packageJSON{
+		Dependencies:         map[string]string{"b": "1.0.0"},
+		OptionalDependencies: map[string]string{"a": "1.0.0"},
+	})
+	if len(names) != 2 || names[0] != "a" || names[1] != "b" {
+		t.Fatalf("expected dependency names to merge and sort, got %#v", names)
+	}
+}

--- a/internal/lang/js/scan_cov_more_malformed_test.go
+++ b/internal/lang/js/scan_cov_more_malformed_test.go
@@ -1,0 +1,95 @@
+package js
+
+import (
+	"context"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+func TestJSMalformedScannerFallbackBranches(t *testing.T) {
+	source := []byte(`
+	import from;
+	import { foo as , bar, } from "pkg";
+export { as alias, bar as , baz } from "pkg";
+require();
+const = require("leftpad");
+const { :alias, qux: } = require("pkg");
+`)
+
+	tree, err := newSourceParser().Parse(context.Background(), unitIndexJS, source)
+	if err != nil {
+		t.Fatalf(parseSourceErrFmt, err)
+	}
+	importStmts, exportStmts, callExprs := collectMalformedJSNodes(tree.RootNode())
+	if len(importStmts) == 0 || len(callExprs) == 0 {
+		t.Fatalf("expected malformed source to still produce import/call nodes")
+	}
+
+	assertMalformedJSStatements(source, importStmts, exportStmts, callExprs)
+	assertMalformedJSGuardBranches(t, tree.RootNode(), source)
+	assertMalformedJSStaticLiteralGuards(t, tree.RootNode(), source)
+}
+
+func collectMalformedJSNodes(root *sitter.Node) ([]*sitter.Node, []*sitter.Node, []*sitter.Node) {
+	var importStmts []*sitter.Node
+	var exportStmts []*sitter.Node
+	var callExprs []*sitter.Node
+	walkNode(root, func(node *sitter.Node) {
+		switch node.Type() {
+		case "import_statement":
+			importStmts = append(importStmts, node)
+		case "export_statement":
+			exportStmts = append(exportStmts, node)
+		case "call_expression":
+			callExprs = append(callExprs, node)
+		}
+	})
+	return importStmts, exportStmts, callExprs
+}
+
+func assertMalformedJSStatements(source []byte, importStmts, exportStmts, callExprs []*sitter.Node) {
+	for _, stmt := range importStmts {
+		_ = parseImportStatement(stmt, source, unitIndexJS)
+	}
+	for _, stmt := range exportStmts {
+		_ = parseReExportStatement(stmt, source, unitIndexJS, map[string][]ImportBinding{})
+	}
+	for _, call := range callExprs {
+		_ = parseRequireCall(call, source, unitIndexJS)
+		_, _ = parseUncertainDynamicImport(call, source, unitIndexJS)
+		_ = parseRequireBinding(call, source, "leftpad", unitIndexJS)
+	}
+}
+
+func assertMalformedJSGuardBranches(t *testing.T, root *sitter.Node, source []byte) {
+	t.Helper()
+
+	if _, ok := parseUncertainDynamicImport(root, source, unitIndexJS); ok {
+		t.Fatalf("expected non-call nodes to skip uncertain dynamic import parsing")
+	}
+	if bindings := parseImportStatement(root, source, unitIndexJS); len(bindings) != 0 {
+		t.Fatalf("expected non-import node to produce no bindings, got %#v", bindings)
+	}
+	if bindings := parseRequireCall(root, source, unitIndexJS); len(bindings) != 0 {
+		t.Fatalf("expected non-call node to produce no require bindings, got %#v", bindings)
+	}
+	if bindings := parseRequireBinding(root, source, "leftpad", unitIndexJS); len(bindings) != 0 {
+		t.Fatalf("expected non-declarator ancestry to produce no bound imports, got %#v", bindings)
+	}
+}
+
+func assertMalformedJSStaticLiteralGuards(t *testing.T, root *sitter.Node, source []byte) {
+	t.Helper()
+
+	if value, ok := extractStaticModuleLiteral(nil, source); ok || value != "" {
+		t.Fatalf("expected nil static module literal to fail, got value=%q ok=%v", value, ok)
+	}
+	identifier := firstNodeByType(root, "identifier")
+	if identifier == nil {
+		t.Fatalf("expected identifier node in malformed source")
+	}
+	if value, ok := extractStaticModuleLiteral(identifier, source); ok || value != "" {
+		t.Fatalf("expected bare identifier not to count as static module literal, got value=%q ok=%v", value, ok)
+	}
+}

--- a/internal/lang/js/scan_cov_more_test.go
+++ b/internal/lang/js/scan_cov_more_test.go
@@ -1,0 +1,116 @@
+package js
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+func TestJSScanRepoAndReadHelpers(t *testing.T) {
+	if _, err := ScanRepo(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected missing repo to fail ScanRepo")
+	}
+
+	sourcePath := filepath.Join(t.TempDir(), "index.js")
+	if err := os.WriteFile(sourcePath, []byte("const value = 1;\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	content, tree, relPath, err := readAndParseFile(context.Background(), newSourceParser(), "", sourcePath)
+	if err != nil {
+		t.Fatalf("readAndParseFile with empty repoPath: %v", err)
+	}
+	if len(content) == 0 || tree == nil || relPath != sourcePath {
+		t.Fatalf("expected absolute path fallback, got len=%d tree=%v relPath=%q", len(content), tree != nil, relPath)
+	}
+
+	unsupportedPath := filepath.Join(t.TempDir(), "notes.txt")
+	if err := os.WriteFile(unsupportedPath, []byte("notes"), 0o644); err != nil {
+		t.Fatalf("write unsupported source: %v", err)
+	}
+	if _, _, _, err := readAndParseFile(context.Background(), newSourceParser(), "", unsupportedPath); err == nil {
+		t.Fatalf("expected unsupported extension to fail")
+	}
+}
+
+func TestJSScanEntryAndIdentifierUsageBranches(t *testing.T) {
+	repo := t.TempDir()
+	skipDir := filepath.Join(repo, ".next")
+	if err := os.MkdirAll(skipDir, 0o755); err != nil {
+		t.Fatalf("mkdir skip dir: %v", err)
+	}
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var dirEntry fs.DirEntry
+	for _, entry := range entries {
+		if entry.Name() == ".next" {
+			dirEntry = entry
+			break
+		}
+	}
+	if dirEntry == nil {
+		t.Fatalf("expected .next entry")
+	}
+
+	state := scanRepoState{parser: newSourceParser(), repoPath: repo, result: &ScanResult{}}
+	if err := scanRepoEntry(context.Background(), &state, skipDir, dirEntry); !errors.Is(err, fs.SkipDir) {
+		t.Fatalf("expected .next directory to be skipped, got %v", err)
+	}
+
+	parser := newSourceParser()
+	source := []byte(`
+function demo(param) {
+  const { key: alias } = pkg;
+  const [item] = list;
+  const list = items;
+  const first = list[index];
+  return util.map(alias) + first;
+}
+class Widget {}
+`)
+	tree, err := parser.Parse(context.Background(), "index.js", source)
+	if err != nil {
+		t.Fatalf("parse identifier branches: %v", err)
+	}
+
+	assertIdentifierUsageState(t, tree, source, "demo", "function_declaration", false)
+	assertIdentifierUsageState(t, tree, source, "param", "formal_parameters", false)
+	assertIdentifierUsageState(t, tree, source, "item", "array_pattern", false)
+	assertIdentifierUsageState(t, tree, source, "util", "member_expression", false)
+	assertIdentifierUsageState(t, tree, source, "list", "subscript_expression", false)
+	assertIdentifierUsageState(t, tree, source, "index", "subscript_expression", true)
+}
+
+func assertIdentifierUsageState(t *testing.T, tree *sitter.Tree, source []byte, name string, parentType string, want bool) {
+	t.Helper()
+	node := findIdentifierNode(tree.RootNode(), source, name, parentType)
+	if node == nil {
+		t.Fatalf("expected identifier %q under %s", name, parentType)
+	}
+	if got := isIdentifierUsage(node); got != want {
+		t.Fatalf("expected isIdentifierUsage(%q/%s)=%v, got %v", name, parentType, want, got)
+	}
+}
+
+func findIdentifierNode(root *sitter.Node, source []byte, name, parentType string) *sitter.Node {
+	var found *sitter.Node
+	walkNode(root, func(node *sitter.Node) {
+		if found != nil || node.Type() != "identifier" {
+			return
+		}
+		parent := node.Parent()
+		if parent == nil || parent.Type() != parentType {
+			return
+		}
+		if nodeText(node, source) == name {
+			found = node
+		}
+	})
+	return found
+}

--- a/internal/lang/jvm/adapter_cov_more_branches_test.go
+++ b/internal/lang/jvm/adapter_cov_more_branches_test.go
@@ -1,0 +1,81 @@
+package jvm
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestJVMAdditionalBranches(t *testing.T) {
+	if got := sourceLayoutModuleRoot(filepath.FromSlash("src/main/java/Main.java")); got != "" {
+		t.Fatalf("expected repo-level source layout to keep empty module root, got %q", got)
+	}
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
+		t.Fatalf("expected analyse to fail on invalid repo path")
+	}
+	if _, err := scanRepo(context.Background(), "", map[string]string{}, map[string]string{}); err == nil {
+		t.Fatalf("expected scanRepo to reject empty repo path")
+	}
+	if _, ok := buildImportRecord([]string{"", "", "", ""}, "", "dep"); ok {
+		t.Fatalf("expected import record build to fail for empty module")
+	}
+	if dependency := resolveDependency("com.example.deep.Type", map[string]string{"com.example": "short", "com.example.deep": "long"}, nil); dependency != "long" {
+		t.Fatalf("expected longest prefix dependency, got %q", dependency)
+	}
+	if !shouldIgnoreImport("pkg.same.Type", "pkg.same") {
+		t.Fatalf("expected same-package import to be ignored")
+	}
+}
+
+func TestJVMAdditionalReachableBranches(t *testing.T) {
+	t.Run("missing detection path and skipped dir helper", testJVMMissingDetectionPathAndSkippedDirHelper)
+	t.Run("rootless source layout and custom weights", testJVMRootlessSourceLayoutAndCustomWeights)
+}
+
+func testJVMMissingDetectionPathAndSkippedDirHelper(t *testing.T) {
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected missing repo to fail detection walk")
+	}
+
+	repo := t.TempDir()
+	skipDir := filepath.Join(repo, ".gradle")
+	if err := os.MkdirAll(skipDir, 0o755); err != nil {
+		t.Fatalf("mkdir skip dir: %v", err)
+	}
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read repo dir: %v", err)
+	}
+	var dirEntry os.DirEntry
+	for _, entry := range entries {
+		if entry.Name() == ".gradle" {
+			dirEntry = entry
+			break
+		}
+	}
+	if dirEntry == nil {
+		t.Fatalf("expected .gradle entry")
+	}
+	if err := walkJVMDetectionEntry(skipDir, dirEntry, map[string]struct{}{}, &language.Detection{}, new(int), 8); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected detection walker to skip .gradle, got %v", err)
+	}
+	if _, err := scanRepo(context.Background(), repo, nil, nil); err != nil {
+		t.Fatalf("scan empty repo: %v", err)
+	}
+}
+
+func testJVMRootlessSourceLayoutAndCustomWeights(t *testing.T) {
+	if got := sourceLayoutModuleRoot(filepath.FromSlash("/src/main/java/Main.java")); got != "" {
+		t.Fatalf("expected absolute rootless source layout to stay empty, got %q", got)
+	}
+	custom := &report.RemovalCandidateWeights{Usage: 1, Impact: 2, Confidence: 3}
+	got := resolveRemovalCandidateWeights(custom)
+	if got == report.DefaultRemovalCandidateWeights() {
+		t.Fatalf("expected non-nil removal weights to normalize instead of using defaults")
+	}
+}

--- a/internal/lang/kotlinandroid/adapter_cov_more_branches_test.go
+++ b/internal/lang/kotlinandroid/adapter_cov_more_branches_test.go
@@ -1,0 +1,130 @@
+package kotlinandroid
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestKotlinAndroidDetectionAndHelperMoreBranches(t *testing.T) {
+	repo := t.TempDir()
+	writeRepoFiles(t, repo, map[string]string{
+		buildGradleName: testEmptyDependencies,
+		filepath.Join("src", "main", "kotlin", "Main.kt"): testAppSource,
+	})
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect with confidence: %v", err)
+	}
+	if detection.Matched {
+		t.Fatalf("expected android-specific gate to clear non-android root-only detection, got %#v", detection)
+	}
+	if len(detection.Roots) != 0 {
+		t.Fatalf("expected cleared roots without android-specific signal, got %#v", detection.Roots)
+	}
+
+	if buildFileSignalsAndroidPlugin(repo, repo) {
+		t.Fatalf("expected directory read to fail closed for android plugin detection")
+	}
+	if got := androidManifestModuleRoot(filepath.FromSlash("src/main/androidmanifest.xml")); got != "" {
+		t.Fatalf("expected repo-level manifest path to resolve to empty root, got %q", got)
+	}
+	if got := sourceLayoutModuleRoot(filepath.FromSlash("src/main/resources/Main.kt")); got != "" {
+		t.Fatalf("expected unsupported source layout to return empty root, got %q", got)
+	}
+	if hasRootSourceLayout(t.TempDir()) {
+		t.Fatalf("did not expect source layout detection without a src tree")
+	}
+
+	roots := map[string]struct{}{filepath.Join(repo, "app"): {}}
+	pruneKotlinAndroidRoots(repo, roots)
+	if len(roots) != 1 {
+		t.Fatalf("expected prune to return early when repo root is absent, got %#v", roots)
+	}
+
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
+		t.Fatalf("expected analyse to fail on invalid repo path")
+	}
+	if _, _, err := readKotlinAndroidSource(repo, filepath.Join(repo, "missing.kt")); err == nil {
+		t.Fatalf("expected readKotlinAndroidSource to return missing-file error")
+	}
+}
+
+func TestKotlinAndroidLookupAndGradleMoreBranches(t *testing.T) {
+	lookups := dependencyLookups{
+		Prefixes: map[string]string{
+			"com.example":      "short",
+			"com.example.deep": "long",
+		},
+		Aliases: map[string]string{
+			"com": "root",
+		},
+		DeclaredDependencies: map[string]struct{}{},
+	}
+
+	dependency, ambiguous := resolveDependency("com.example.deep.Type", lookups)
+	if dependency != "long" || len(ambiguous) != 0 {
+		t.Fatalf("expected longest prefix match without ambiguity, got dependency=%q ambiguous=%#v", dependency, ambiguous)
+	}
+	dependency, ambiguous = resolveDependency("com.other.Type", lookups)
+	if dependency != "root" || len(ambiguous) != 0 {
+		t.Fatalf("expected alias fallback, got dependency=%q ambiguous=%#v", dependency, ambiguous)
+	}
+
+	if _, ok := buildImportRecord([]string{"", "", "", ""}, "", "dep"); ok {
+		t.Fatalf("expected empty-module import record construction to fail")
+	}
+
+	prefixes, aliases := artifactLookupStrategy("", "alpha-runtime")
+	if len(prefixes) != 0 || len(aliases) != 1 || aliases[0] != "alpha.runtime" {
+		t.Fatalf("unexpected artifact lookup strategy result: prefixes=%#v aliases=%#v", prefixes, aliases)
+	}
+
+	if descriptors := parseGradleMapDependencies(`implementation(group: "com.example")`); len(descriptors) != 0 {
+		t.Fatalf("expected incomplete map-style gradle dependency to be ignored, got %#v", descriptors)
+	}
+
+	descriptors := dedupeDescriptors([]dependencyDescriptor{
+		{Name: "alpha", Group: "z.group", Artifact: "alpha"},
+		{Name: "alpha", Group: "a.group", Artifact: "alpha"},
+	})
+	if len(descriptors) != 2 || descriptors[0].Group != "a.group" {
+		t.Fatalf("expected dedupeDescriptors to tie-break on group, got %#v", descriptors)
+	}
+}
+
+func TestKotlinAndroidAdditionalReachableBranches(t *testing.T) {
+	t.Run("detection walk and manifest helpers", testKotlinAndroidDetectionWalkAndManifestHelpers)
+	t.Run("analyse normalize error when cwd is gone", testKotlinAndroidAnalyseNormalizeErrorWhenCWDIsGone)
+}
+
+func testKotlinAndroidDetectionWalkAndManifestHelpers(t *testing.T) {
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected missing repo to fail detection walk")
+	}
+	if got := androidManifestModuleRoot(filepath.FromSlash("src/main/AndroidManifest.xml/ignored")); got != "" {
+		t.Fatalf("expected rootless manifest path to resolve empty, got %q", got)
+	}
+
+	repo := t.TempDir()
+	roots := map[string]struct{}{
+		filepath.Join(repo, "module"): {},
+		filepath.Join(repo, "other"):  {},
+	}
+	pruneKotlinAndroidRoots(repo, roots)
+	if len(roots) != 2 {
+		t.Fatalf("expected repo-absent roots to remain untouched, got %#v", roots)
+	}
+}
+
+func testKotlinAndroidAnalyseNormalizeErrorWhenCWDIsGone(t *testing.T) {
+	testutil.ChdirRemovedDir(t)
+
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{}); err == nil {
+		t.Fatalf("expected analyse to fail when cwd cannot be resolved")
+	}
+}

--- a/internal/lang/php/adapter.go
+++ b/internal/lang/php/adapter.go
@@ -581,9 +581,6 @@ func parseImports(content []byte, filePath string, resolver dependencyResolver) 
 	unresolved := 0
 
 	for _, match := range matches {
-		if len(match) < 4 {
-			continue
-		}
 		statement := strings.TrimSpace(text[match[2]:match[3]])
 		line := lineNumberAt(text, match[2])
 		bindings, groupedDeps, unresolvedCount := parseUseStatement(statement, filePath, line, resolver)
@@ -650,9 +647,6 @@ func parseNamespaceReferenceMetadata(text string, match []int) (string, int, str
 	}
 	line := lineNumberAt(text, start)
 	local := lastNamespaceSegment(module)
-	if local == "" {
-		return "", 0, "", false
-	}
 	return module, line, local, true
 }
 
@@ -790,9 +784,6 @@ func parseUsePartModuleAndLocal(part, base string) (string, string, bool) {
 	}
 	if local == "" {
 		local = lastNamespaceSegment(module)
-	}
-	if local == "" {
-		return "", "", false
 	}
 	return module, local, true
 }

--- a/internal/lang/php/adapter_cov_more_branches_test.go
+++ b/internal/lang/php/adapter_cov_more_branches_test.go
@@ -1,0 +1,146 @@
+package php
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const phpFixtureFile = "file.php"
+
+func TestPHPAdditionalBranches(t *testing.T) {
+	testPHPRootSignalsAndHelperBranches(t)
+	testPHPResolverAndUseParsingBranches(t)
+	testPHPVendorDirectoryAndDetectionBranches(t)
+	testPHPNamespaceReferenceBranches(t)
+	testPHPRemovedFileAndImportBindingBranches(t)
+}
+
+func testPHPRootSignalsAndHelperBranches(t *testing.T) {
+	repoFile := filepath.Join(t.TempDir(), "repo-file")
+	writeFile(t, repoFile, "x")
+	if applyPHPRootSignals(repoFile, &language.Detection{}, map[string]struct{}{}) == nil {
+		t.Fatalf("expected root signal stat error for non-directory repo path")
+	}
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected missing repo to fail detection")
+	}
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
+		t.Fatalf("expected analyse to fail on invalid repo path")
+	}
+
+	reports, warnings := buildTopPHPDependencies(3, scanResult{}, 50, report.DefaultRemovalCandidateWeights())
+	if len(reports) != 0 || len(warnings) == 0 {
+		t.Fatalf("expected top-N request without dependency data to warn, reports=%#v warnings=%#v", reports, warnings)
+	}
+	if hasRiskCue(nil, "missing") {
+		t.Fatalf("did not expect missing risk cue in nil list")
+	}
+	if err := contextErr(context.TODO()); err != nil {
+		t.Fatalf("expected nil context error, got %v", err)
+	}
+	weights := resolveRemovalCandidateWeights(&report.RemovalCandidateWeights{Usage: -1, Impact: 2, Confidence: 3})
+	if weights.Usage < 0 || weights.Impact > 1 || weights.Confidence > 1 {
+		t.Fatalf("expected removal candidate weights to normalize, got %#v", weights)
+	}
+}
+
+func testPHPResolverAndUseParsingBranches(t *testing.T) {
+	resolver := dependencyResolver{
+		namespaceToDep: map[string]string{
+			"Vendor":     "vendor/root",
+			`Vendor\Pkg`: helpersVendorPkgDependency,
+		},
+	}
+	if dependency := resolver.resolveWithPSR4(`Vendor\Pkg\Client`); dependency != helpersVendorPkgDependency {
+		t.Fatalf("expected longest PSR-4 prefix match, got %q", dependency)
+	}
+	if dependency, resolved := resolver.dependencyFromModule(`Missing`); dependency != "" || !resolved {
+		t.Fatalf("expected heuristic miss to report resolved-without-dependency, got dependency=%q resolved=%v", dependency, resolved)
+	}
+	if dependency, resolved := resolver.dependencyFromModule(""); dependency != "" || resolved {
+		t.Fatalf("expected blank module to resolve empty/false, got dependency=%q resolved=%v", dependency, resolved)
+	}
+	if _, _, ok, unresolved := parseUsePart("", "", "x.php", 1, dependencyResolver{}); ok || unresolved {
+		t.Fatalf("expected blank use-part parse to fail without unresolved attribution")
+	}
+	if _, _, _, ok := parseNamespaceReferenceMetadata("ignored", []int{0}); ok {
+		t.Fatalf("expected malformed match metadata to fail")
+	}
+	if _, _, _, ok := parseNamespaceReferenceMetadata(`\`, []int{0, 1}); ok {
+		t.Fatalf("expected empty namespace metadata to fail")
+	}
+	if _, _, _, ok := parseGroupedUseStatement(`Vendor\Pkg\Client`, "x.php", 1, dependencyResolver{}); ok {
+		t.Fatalf("expected non-grouped use statement parse to fail")
+	}
+}
+
+func testPHPVendorDirectoryAndDetectionBranches(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "vendor"), 0o755); err != nil {
+		t.Fatalf("mkdir vendor dir: %v", err)
+	}
+	vendorEntry := mustPHPDirEntry(t, repo, "vendor")
+	if err := walkPHPDetectionEntry(filepath.Join(repo, "vendor"), vendorEntry, map[string]struct{}{}, &language.Detection{}, new(int), maxDetectFiles); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected vendor directory to be skipped, got %v", err)
+	}
+	if err := scanDirEntry(repo, filepath.Join(repo, "vendor"), vendorEntry, &scanState{}); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected scanDirEntry to skip vendor directory, got %v", err)
+	}
+
+	visited := maxDetectFiles
+	phpFile := filepath.Join(repo, "Index.php")
+	writeFile(t, phpFile, "<?php\n")
+	phpEntry := mustPHPDirEntry(t, repo, "Index.php")
+	if err := walkPHPDetectionEntry(phpFile, phpEntry, map[string]struct{}{}, &language.Detection{}, &visited, maxDetectFiles); !errors.Is(err, filepath.SkipAll) {
+		t.Fatalf("expected detection walk to stop after max files, got %v", err)
+	}
+}
+
+func testPHPNamespaceReferenceBranches(t *testing.T) {
+	localResolver := dependencyResolver{localNamespace: map[string]struct{}{"App": {}}}
+	if binding, unresolved, ok := parseNamespaceReference(`App\Local`, []int{0, len(`App\Local`)}, phpFixtureFile, localResolver, map[string]struct{}{}); ok || unresolved != 0 || binding != (importBinding{}) {
+		t.Fatalf("expected local namespace reference to be skipped without unresolved count, binding=%#v unresolved=%d ok=%v", binding, unresolved, ok)
+	}
+	if binding, unresolved, ok := parseNamespaceReference("ignored", []int{0}, phpFixtureFile, dependencyResolver{}, map[string]struct{}{}); ok || unresolved != 0 || binding != (importBinding{}) {
+		t.Fatalf("expected malformed namespace reference to be skipped, binding=%#v unresolved=%d ok=%v", binding, unresolved, ok)
+	}
+}
+
+func testPHPRemovedFileAndImportBindingBranches(t *testing.T) {
+	repo := t.TempDir()
+	removedPath := filepath.Join(repo, "Removed.php")
+	writeFile(t, removedPath, "<?php\n")
+	if err := os.Remove(removedPath); err != nil {
+		t.Fatalf("remove php source: %v", err)
+	}
+	if scanFileEntry(repo, removedPath, dependencyResolver{}, &scanResult{}, &scanState{}) == nil {
+		t.Fatalf("expected removed PHP source file to fail scan")
+	}
+
+	binding := newImportBinding(phpFixtureFile, 3, "vendor/pkg", `Vendor\Pkg\Client`, "ClientAlias", "", false)
+	if binding.Name != "ClientAlias" || binding.Location.Column != 1 {
+		t.Fatalf("expected new import binding to fall back to local name and fixed column, got %#v", binding)
+	}
+}
+
+func mustPHPDirEntry(t *testing.T, dir, name string) os.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return entry
+		}
+	}
+	t.Fatalf("expected %s dir entry", name)
+	return nil
+}

--- a/internal/lang/python/adapter_cov_more_branches_test.go
+++ b/internal/lang/python/adapter_cov_more_branches_test.go
@@ -1,0 +1,145 @@
+package python
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestPythonAdditionalHelperBranches(t *testing.T) {
+	repoFile := filepath.Join(t.TempDir(), "repo-file")
+	if err := os.WriteFile(repoFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+	if applyPythonRootSignals(repoFile, &language.Detection{}, map[string]struct{}{}) == nil {
+		t.Fatalf("expected root signal stat error for non-directory repo path")
+	}
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
+		t.Fatalf("expected analyse to fail on invalid repo path")
+	}
+	if _, err := scanRepo(context.Background(), ""); err == nil {
+		t.Fatalf("expected scanRepo to reject empty repo path")
+	}
+
+	if module, local := parseImportPart("   "); module != "" || local != "" {
+		t.Fatalf("expected blank import part to stay empty, got module=%q local=%q", module, local)
+	}
+	if dependency := dependencyFromModule(t.TempDir(), ""); dependency != "" {
+		t.Fatalf("expected blank dependency module to resolve empty, got %q", dependency)
+	}
+
+	localRepo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(localRepo, "localpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir local package: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localRepo, "localpkg", "__init__.py"), []byte(""), 0o600); err != nil {
+		t.Fatalf("write __init__.py: %v", err)
+	}
+	if dependency := dependencyFromModule(localRepo, "localpkg.module"); dependency != "" {
+		t.Fatalf("expected local package import to resolve empty, got %q", dependency)
+	}
+}
+
+func TestPythonRequestedDependencyAndWildcardRecommendationBranches(t *testing.T) {
+	scan := scanResult{
+		Files: []fileScan{{
+			Imports: []importBinding{{
+				Dependency: "dep",
+				Module:     "dep",
+				Name:       "*",
+				Local:      "*",
+				Wildcard:   true,
+			}},
+			Usage: map[string]int{"*": 1},
+		}},
+	}
+
+	dependencies, warnings := buildRequestedPythonDependencies(language.Request{Dependency: "dep"}, scan)
+	if len(dependencies) != 1 || len(warnings) != 0 {
+		t.Fatalf("unexpected dependency report selection: deps=%#v warnings=%#v", dependencies, warnings)
+	}
+	if len(dependencies[0].RiskCues) == 0 || len(dependencies[0].Recommendations) == 0 {
+		t.Fatalf("expected wildcard risk cues and recommendations, got %#v", dependencies[0])
+	}
+}
+
+func TestPythonAdditionalDetectionAndParserBranches(t *testing.T) {
+	t.Run("detect with missing repo returns walk error", testPythonDetectWithMissingRepoReturnsWalkError)
+	t.Run("analyse empty repo path fails when cwd is gone", testPythonAnalyseEmptyRepoPathFailsWhenCWDisGone)
+	t.Run("skip dir helpers and default weights", testPythonSkipDirHelpersAndDefaultWeights)
+	t.Run("parser helper skip branches", testPythonParserHelperSkipBranches)
+}
+
+func testPythonDetectWithMissingRepoReturnsWalkError(t *testing.T) {
+	_, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing"))
+	if err == nil {
+		t.Fatalf("expected missing repo to fail detection walk")
+	}
+}
+
+func testPythonAnalyseEmptyRepoPathFailsWhenCWDisGone(t *testing.T) {
+	testutil.ChdirRemovedDir(t)
+
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{}); err == nil {
+		t.Fatalf("expected analyse to fail when cwd cannot be resolved")
+	}
+}
+
+func testPythonSkipDirHelpersAndDefaultWeights(t *testing.T) {
+	repo := t.TempDir()
+	skipDir := filepath.Join(repo, ".venv")
+	if err := os.MkdirAll(skipDir, 0o755); err != nil {
+		t.Fatalf("mkdir skip dir: %v", err)
+	}
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read repo dir: %v", err)
+	}
+	var dirEntry os.DirEntry
+	for _, entry := range entries {
+		if entry.Name() == ".venv" {
+			dirEntry = entry
+			break
+		}
+	}
+	if dirEntry == nil {
+		t.Fatalf("expected .venv entry")
+	}
+
+	if err := walkPythonDetectionEntry(skipDir, dirEntry, map[string]struct{}{}, &language.Detection{}, new(int), 8); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected python detection walker to skip .venv, got %v", err)
+	}
+	if err := scanPythonRepoEntry(repo, skipDir, dirEntry, &scanResult{}); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected python scanner to skip .venv, got %v", err)
+	}
+	if got := resolveRemovalCandidateWeights(nil); got != report.DefaultRemovalCandidateWeights() {
+		t.Fatalf("expected default weights, got %#v", got)
+	}
+	customWeights := &report.RemovalCandidateWeights{Usage: 4, Impact: 2, Confidence: 2}
+	if got := resolveRemovalCandidateWeights(customWeights); got != report.NormalizeRemovalCandidateWeights(*customWeights) {
+		t.Fatalf("expected custom weights to be normalized, got %#v", got)
+	}
+}
+
+func testPythonParserHelperSkipBranches(t *testing.T) {
+	repo := t.TempDir()
+	imports := parseImportLine("requests, numpy as np", "main.py", repo, 0, "import requests, numpy as np")
+	if len(imports) != 2 || imports[0].Local != "requests" || imports[1].Local != "np" {
+		t.Fatalf("expected import parsing to default locals and preserve aliases, got %#v", imports)
+	}
+
+	fromImports := parseFromImportLine("requests", "get", "main.py", repo, 0, "from requests import get")
+	if len(fromImports) != 1 || fromImports[0].Name != "get" || fromImports[0].Local != "get" {
+		t.Fatalf("expected from-import local to default to symbol, got %#v", fromImports)
+	}
+
+	if dependency := dependencyFromModule(repo, "."); dependency != "" {
+		t.Fatalf("expected empty root module to resolve empty, got %q", dependency)
+	}
+}

--- a/internal/lang/ruby/adapter_test.go
+++ b/internal/lang/ruby/adapter_test.go
@@ -2,14 +2,19 @@ package ruby
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
+
+const rubyAppFile = "app.rb"
 
 func TestRubyAdapterDetectBundlerProject(t *testing.T) {
 	repo := t.TempDir()
@@ -47,7 +52,7 @@ func TestRubyAdapterAnalyseDependencyAndTopN(t *testing.T) {
 	}
 	lockfileContent := strings.Join(lockfileLines, "\n")
 	testutil.MustWriteFile(t, filepath.Join(repo, "Gemfile.lock"), lockfileContent)
-	testutil.MustWriteFile(t, filepath.Join(repo, "app.rb"), "require 'httparty'\nHTTParty.get('https://example.test')\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, rubyAppFile), "require 'httparty'\nHTTParty.get('https://example.test')\n")
 
 	adapter := NewAdapter()
 	depReport, err := adapter.Analyse(context.Background(), language.Request{RepoPath: repo, Dependency: "httparty"})
@@ -74,5 +79,113 @@ func TestRubyAdapterAnalyseDependencyAndTopN(t *testing.T) {
 	}
 	if !slices.Contains(names, "nokogiri") {
 		t.Fatalf("expected Bundler gem from Gemfile in topN output, got %#v", names)
+	}
+}
+
+func TestRubyAdditionalBranches(t *testing.T) {
+	t.Run("detect and root signals return path errors", testRubyDetectAndRootSignalsReturnPathErrors)
+	t.Run("analyse empty repo path fails when cwd is gone", testRubyAnalyseEmptyRepoPathFailsWhenCWDIsGone)
+	t.Run("scan and walk helper branches", testRubyScanAndWalkHelperBranches)
+	t.Run("detect stops after max files", testRubyDetectStopsAfterMaxFiles)
+	t.Run("require parsing and risk recommendations", testRubyRequireParsingAndRiskRecommendations)
+}
+
+func testRubyDetectAndRootSignalsReturnPathErrors(t *testing.T) {
+	repoFile := filepath.Join(t.TempDir(), "repo-file")
+	if err := os.WriteFile(repoFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+	if _, err := NewAdapter().Detect(context.Background(), repoFile); err == nil {
+		t.Fatalf("expected detect to fail for non-directory repo path")
+	}
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), repoFile); err == nil {
+		t.Fatalf("expected detect-with-confidence to fail for non-directory repo path")
+	}
+}
+
+func testRubyAnalyseEmptyRepoPathFailsWhenCWDIsGone(t *testing.T) {
+	testutil.ChdirRemovedDir(t)
+
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{}); err == nil {
+		t.Fatalf("expected analyse to fail when cwd cannot be resolved")
+	}
+}
+
+func testRubyScanAndWalkHelperBranches(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, gemfileName), "source 'https://rubygems.org'\ngem 'httparty'\n")
+
+	unreadableRuby := filepath.Join(repo, rubyAppFile)
+	if err := os.WriteFile(unreadableRuby, []byte("require 'httparty'\n"), 0o000); err != nil {
+		t.Fatalf("write unreadable ruby file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(unreadableRuby, 0o600); err != nil {
+			t.Fatalf("restore unreadable ruby perms: %v", err)
+		}
+	})
+	if _, err := scanRepo(context.Background(), repo); err == nil {
+		t.Fatalf("expected unreadable ruby file to fail scan")
+	}
+
+	skipDir := filepath.Join(repo, ".bundle")
+	if err := os.MkdirAll(skipDir, 0o755); err != nil {
+		t.Fatalf("mkdir skip dir: %v", err)
+	}
+	visitedSkipDir := false
+	if err := walkRubyRepoFiles(context.Background(), repo, func(path string, entry os.DirEntry) error {
+		if strings.Contains(path, ".bundle") {
+			visitedSkipDir = true
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk ruby repo files: %v", err)
+	}
+	if visitedSkipDir {
+		t.Fatalf("expected .bundle directory to be skipped")
+	}
+}
+
+func testRubyDetectStopsAfterMaxFiles(t *testing.T) {
+	repo := t.TempDir()
+	for i := 0; i <= maxDetectFiles; i++ {
+		testutil.MustWriteFile(t, filepath.Join(repo, "lib", "f"+strconv.Itoa(i)+".rb"), "puts 'x'\n")
+	}
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect large repo: %v", err)
+	}
+	if !detection.Matched || detection.Confidence == 0 {
+		t.Fatalf("expected ruby detection in large repo, got %#v", detection)
+	}
+}
+
+func testRubyRequireParsingAndRiskRecommendations(t *testing.T) {
+	declared := map[string]struct{}{"foo": {}}
+	imports := parseRequires([]byte("require 'foo/bar'\n"), rubyAppFile, declared)
+	if len(imports) != 1 || imports[0].Name != "bar" || imports[0].Local != "bar" {
+		t.Fatalf("expected nested require to use trailing module segment, got %#v", imports)
+	}
+
+	dep, warnings := buildDependencyReport("foo", scanResult{
+		Files: []fileScan{{
+			Imports: []importBinding{{
+				Dependency: "foo",
+				Module:     "foo",
+				Name:       "*",
+				Local:      "*",
+				Wildcard:   true,
+			}},
+			Usage: map[string]int{"*": 1},
+		}},
+		DeclaredDependencies: map[string]struct{}{"foo": {}},
+		ImportedDependencies: map[string]struct{}{"foo": {}},
+	})
+	if len(warnings) != 0 || len(dep.RiskCues) == 0 || len(dep.Recommendations) == 0 {
+		t.Fatalf("expected runtime-require risk cues and recommendations, got dep=%#v warnings=%#v", dep, warnings)
+	}
+	if got := resolveRemovalCandidateWeights(nil); got != report.DefaultRemovalCandidateWeights() {
+		t.Fatalf("expected default removal weights, got %#v", got)
 	}
 }

--- a/internal/lang/rust/adapter_cov_more_branches_test.go
+++ b/internal/lang/rust/adapter_cov_more_branches_test.go
@@ -1,0 +1,128 @@
+package rust
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+)
+
+func TestRustAdditionalManifestAndScanBranches(t *testing.T) {
+	testRustDetectAndAnalysisPathErrors(t)
+	testRustManifestAndScanErrors(t)
+	testRustUseParsingAndPathHelpers(t)
+	testRustManifestDiscoveryBranches(t)
+	testRustWorkspaceMemberFileMatchBranch(t)
+}
+
+func testRustDetectAndAnalysisPathErrors(t *testing.T) {
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), "\x00"); err == nil {
+		t.Fatalf("expected invalid repo path to fail detection")
+	}
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected missing repo path to fail detection")
+	}
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
+		t.Fatalf("expected invalid repo path to fail analysis")
+	}
+}
+
+func testRustManifestAndScanErrors(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, cargoManifestFile), 0o755); err != nil {
+		t.Fatalf("mkdir Cargo.toml dir: %v", err)
+	}
+	if _, _, _, _, err := collectManifestData(repo); err == nil {
+		t.Fatalf("expected collectManifestData to fail when Cargo.toml is a directory")
+	}
+	if scanRepoRoot(context.Background(), repo, filepath.Join(repo, "missing"), map[string]dependencyInfo{}, map[string]struct{}{}, new(int), &scanResult{}) == nil {
+		t.Fatalf("expected scanRepoRoot to fail for missing root")
+	}
+	if scanRustSourceFile(repo, repo, filepath.Join(repo, "missing.rs"), map[string]dependencyInfo{}, &scanResult{}) == nil {
+		t.Fatalf("expected scanRustSourceFile to fail for missing file")
+	}
+}
+
+func testRustUseParsingAndPathHelpers(t *testing.T) {
+	repo := t.TempDir()
+	if got := resolveDependency("dep::thing", repo, map[string]dependencyInfo{"dep": {Canonical: "dep", LocalPath: true}}, &scanResult{UnresolvedImports: map[string]int{}, LocalModuleCache: map[string]bool{}}); got != "" {
+		t.Fatalf("expected local-path dependency to resolve to empty, got %q", got)
+	}
+
+	if _, _, _, ok := parseUseStatementIndex("use serde::Deserialize;", []int{0, 1, 2}); ok {
+		t.Fatalf("expected short use-statement index slice to fail")
+	}
+	name, local := normalizeUseSymbolNames(usePathEntry{Wildcard: true}, "")
+	if name != "*" || local != "" {
+		t.Fatalf("expected wildcard fallback with empty module to keep empty local, got name=%q local=%q", name, local)
+	}
+	if _, _, _, ok := parseUseStatementIndex("use serde::Deserialize;", []int{0, 1, -1, 5}); ok {
+		t.Fatalf("expected negative use-statement bounds to fail")
+	}
+
+	if isSubPath("\x00", repo) {
+		t.Fatalf("expected invalid root path to fail subpath detection")
+	}
+	if samePath(repo, "\x00") {
+		t.Fatalf("expected mismatched valid/invalid paths not to compare equal")
+	}
+}
+
+func testRustManifestDiscoveryBranches(t *testing.T) {
+	paths, warnings, err := discoverManifestsByWalk(t.TempDir())
+	if err != nil {
+		t.Fatalf("discoverManifestsByWalk empty repo: %v", err)
+	}
+	if len(paths) != 0 || len(warnings) == 0 {
+		t.Fatalf("expected missing-manifest warning for empty repo, paths=%#v warnings=%#v", paths, warnings)
+	}
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "target"), 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("docs"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	paths, warnings, err = discoverManifestsByWalk(repo)
+	if err != nil {
+		t.Fatalf("discoverManifestsByWalk skip dirs: %v", err)
+	}
+	if len(paths) != 0 || len(warnings) == 0 {
+		t.Fatalf("expected skipped directories and non-manifest files to yield no paths, got paths=%#v warnings=%#v", paths, warnings)
+	}
+}
+
+func testRustWorkspaceMemberFileMatchBranch(t *testing.T) {
+	fileMatchRepo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(fileMatchRepo, "crates"), 0o755); err != nil {
+		t.Fatalf("mkdir crates dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fileMatchRepo, "crates", "not-a-dir"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write workspace file match: %v", err)
+	}
+	if roots := resolveWorkspaceMembers(fileMatchRepo, filepath.Join("crates", "*")); len(roots) != 0 {
+		t.Fatalf("expected file glob matches to be ignored as workspace members, got %#v", roots)
+	}
+}
+
+func TestRustWorkspaceMemberOutsideRepoBranch(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	outside := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(outside, "mod"), 0o755); err != nil {
+		t.Fatalf("mkdir outside mod: %v", err)
+	}
+	writeFile(t, filepath.Join(outside, "mod", cargoManifestFile), "[package]\nname = \"outside\"\nversion = \"0.1.0\"\n")
+
+	roots := map[string]struct{}{}
+	addWorkspaceMemberRoot(repo, filepath.Join("..", "outside", "mod"), roots)
+	if len(roots) != 0 {
+		t.Fatalf("expected outside workspace member to be ignored, got %#v", roots)
+	}
+}

--- a/internal/lang/shared/adapter_scaffold_cov_more_test.go
+++ b/internal/lang/shared/adapter_scaffold_cov_more_test.go
@@ -1,0 +1,57 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"testing"
+)
+
+type stubDirEntry struct {
+	name string
+	dir  bool
+}
+
+func (s *stubDirEntry) Name() string { return s.name }
+func (s *stubDirEntry) IsDir() bool  { return s.dir }
+func (s *stubDirEntry) Type() fs.FileMode {
+	if s.dir {
+		return fs.ModeDir
+	}
+	return 0
+}
+
+func (s *stubDirEntry) Info() (fs.FileInfo, error) { return nil, nil }
+
+func TestApplyRootSignalsUnexpectedStatError(t *testing.T) {
+	err := ApplyRootSignals(t.TempDir(), []RootSignal{{Name: "bad\x00signal", Confidence: 10}}, nil, nil)
+	if err == nil {
+		t.Fatalf("expected unexpected stat error to be returned")
+	}
+}
+
+func TestRepoWalkerHandleAdditionalBranches(t *testing.T) {
+	walkErr := errors.New("walk failed")
+	walker := repoWalker{
+		maxFiles: 1,
+		skipDir:  func(string) bool { return false },
+		visit:    func(string, fs.DirEntry) error { return nil },
+	}
+
+	if err := walker.handle(context.Background(), "repo", &stubDirEntry{name: "ignored.txt"}, walkErr); !errors.Is(err, walkErr) {
+		t.Fatalf("expected walk error to be returned, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := walker.handle(ctx, "repo", &stubDirEntry{name: "ignored.txt"}, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled context error, got %v", err)
+	}
+
+	if err := walker.handle(context.Background(), "repo/a.txt", &stubDirEntry{name: "a.txt"}, nil); err != nil {
+		t.Fatalf("expected first file visit to succeed, got %v", err)
+	}
+	if err := walker.handle(context.Background(), "repo/b.txt", &stubDirEntry{name: "b.txt"}, nil); !errors.Is(err, fs.SkipAll) {
+		t.Fatalf("expected file limit to stop walking, got %v", err)
+	}
+}

--- a/internal/lang/shared/dependency_usage_cov_more_test.go
+++ b/internal/lang/shared/dependency_usage_cov_more_test.go
@@ -1,0 +1,77 @@
+package shared
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const sharedYAMLAppFile = "app.yaml"
+
+func TestSharedAdditionalHelperBranches(t *testing.T) {
+	symbols := buildTopSymbols(map[string]int{
+		"beta":  2,
+		"alpha": 2,
+	})
+	if len(symbols) != 2 || symbols[0].Name != "alpha" || symbols[1].Name != "beta" {
+		t.Fatalf("expected equal-count symbols to sort by name, got %#v", symbols)
+	}
+
+	deps := ListDependencies([]FileUsage{{Imports: []ImportRecord{{Dependency: ""}, {Dependency: "Beta"}, {Dependency: "alpha"}}}}, NormalizeDependencyID)
+	if !slices.Equal(deps, []string{"alpha", "beta"}) {
+		t.Fatalf("unexpected dependencies: %#v", deps)
+	}
+
+	reports, warnings := BuildTopReports(3, nil, func(string) (report.DependencyReport, []string) {
+		t.Fatal("did not expect report builder to run for empty dependency list")
+		return report.DependencyReport{}, nil
+	})
+	if len(reports) != 0 {
+		t.Fatalf("expected no reports for empty dependency list, got %#v", reports)
+	}
+	if !slices.Equal(warnings, []string{"no dependency data available for top-N ranking"}) {
+		t.Fatalf("unexpected warnings for empty dependency list: %#v", warnings)
+	}
+
+	items := flattenImports(map[string]*report.ImportUse{
+		"pkg:z":   {Module: "pkg", Name: "z"},
+		"pkg:a":   {Module: "pkg", Name: "a"},
+		"alpha:b": {Module: "alpha", Name: "b"},
+	})
+	gotOrder := MapSlice(items, func(item report.ImportUse) string {
+		return item.Module + ":" + item.Name
+	})
+	if !slices.Equal(gotOrder, []string{"alpha:b", "pkg:a", "pkg:z"}) {
+		t.Fatalf("unexpected flattenImports ordering: %#v", gotOrder)
+	}
+
+	filtered := dedupeUnused([]report.ImportUse{{Module: "pkg", Name: "a"}, {Module: "pkg", Name: "b"}}, []report.ImportUse{{Module: "pkg", Name: "a"}})
+	if len(filtered) != 1 || filtered[0].Name != "b" {
+		t.Fatalf("expected used imports to be removed from unused list, got %#v", filtered)
+	}
+}
+
+func TestYAMLDisplayPathAdditionalBranches(t *testing.T) {
+	repo := t.TempDir()
+	inside := filepath.Join(repo, "configs", sharedYAMLAppFile)
+	outside := filepath.Join(t.TempDir(), sharedYAMLAppFile)
+
+	if got := yamlDisplayPath(repo, filepath.Join(".", "configs", "..", "configs", sharedYAMLAppFile)); got != filepath.Join("configs", sharedYAMLAppFile) {
+		t.Fatalf("expected relative path to be cleaned, got %q", got)
+	}
+	if got := yamlDisplayPath(repo, inside); got != filepath.Join("configs", sharedYAMLAppFile) {
+		t.Fatalf("expected repo-relative display path, got %q", got)
+	}
+	if got := yamlDisplayPath(repo, outside); got != sharedYAMLAppFile {
+		t.Fatalf("expected outside absolute path to fall back to basename, got %q", got)
+	}
+}
+
+func TestFallbackDependencyEmptyModule(t *testing.T) {
+	if got := FallbackDependency("", strings.ToUpper); got != "" {
+		t.Fatalf("expected empty module fallback to stay empty, got %q", got)
+	}
+}

--- a/internal/lang/shared/dependency_usage_test.go
+++ b/internal/lang/shared/dependency_usage_test.go
@@ -606,4 +606,7 @@ func TestIsPathWithin(t *testing.T) {
 	if IsPathWithin("\x00", inside) {
 		t.Fatalf("expected invalid root to return false")
 	}
+	if IsPathWithin(repo, "\x00") {
+		t.Fatalf("expected invalid candidate to return false")
+	}
 }

--- a/internal/lang/shared/module_helpers_test.go
+++ b/internal/lang/shared/module_helpers_test.go
@@ -1,20 +1,21 @@
 package shared
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestFallbackDependency(t *testing.T) {
-	normalize := func(value string) string {
-		return "[" + value + "]"
-	}
+	normalize := strings.ToUpper
 
 	tests := []struct {
 		name   string
 		module string
 		want   string
 	}{
-		{name: "single segment", module: "androidx", want: "[androidx]"},
-		{name: "multiple segments", module: "androidx.appcompat.widget", want: "[androidx.appcompat]"},
-		{name: "empty module", module: "", want: "[]"},
+		{name: "single segment", module: "ecto", want: "ECTO"},
+		{name: "multiple segments", module: "phoenix.html.safe", want: "PHOENIX.HTML"},
+		{name: "empty module", module: "", want: ""},
 	}
 
 	for _, tc := range tests {
@@ -34,7 +35,7 @@ func TestLastModuleSegment(t *testing.T) {
 	}{
 		{name: "empty module", module: "", want: ""},
 		{name: "single segment", module: "androidx", want: "androidx"},
-		{name: "trims final segment", module: "androidx.appcompat. widget ", want: "widget"},
+		{name: "trims final segment", module: "Foo.Bar ", want: "Bar"},
 	}
 
 	for _, tc := range tests {

--- a/internal/lang/swift/adapter_cov_more_branches_test.go
+++ b/internal/lang/swift/adapter_cov_more_branches_test.go
@@ -1,0 +1,377 @@
+package swift
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const swiftCustomBuilderCall = "CustomBuilder()\n"
+
+func TestSwiftAdditionalBranchCoverage(t *testing.T) {
+	t.Run("detection helpers", testSwiftDetectionHelpers)
+	t.Run("manifest and resolved loaders", testSwiftManifestAndResolvedLoaders)
+	t.Run("catalog and import mapping helpers", testSwiftCatalogAndImportMappingHelpers)
+	t.Run("unqualified usage helpers", testSwiftUnqualifiedUsageHelpers)
+	t.Run("invalid path and helper guard branches", testSwiftInvalidPathAndHelperGuardBranches)
+	t.Run("scanner walk branches", testSwiftScannerWalkBranches)
+}
+
+func testSwiftDetectionHelpers(t *testing.T) {
+	if err := contextError(context.TODO()); err != nil {
+		t.Fatalf("expected nil context error, got %v", err)
+	}
+	if err := maybeSkipSwiftDir(swiftBuildDirName); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected swift build dir to be skipped, got %v", err)
+	}
+	if err := maybeSkipSwiftDir("Sources"); err != nil {
+		t.Fatalf("did not expect Sources to be skipped, got %v", err)
+	}
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatalf("expected missing repo to fail detection")
+	}
+}
+
+func testSwiftManifestAndResolvedLoaders(t *testing.T) {
+	testSwiftManifestDirectoryFailure(t)
+	testSwiftResolvedLoaderEmptyPins(t)
+	testSwiftManifestLoaderSkipsIncompleteDeclarations(t)
+	testSwiftResolvedLoaderSkipsBlankPins(t)
+	testSwiftCollectLocalModulesIgnoresBlankNames(t)
+}
+
+func testSwiftManifestDirectoryFailure(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, packageManifestName), 0o755); err != nil {
+		t.Fatalf("mkdir package manifest dir: %v", err)
+	}
+	catalog := newTestSwiftCatalog()
+	if _, _, err := loadManifestData(repo, &catalog); err == nil {
+		t.Fatalf("expected manifest directory to fail load")
+	}
+}
+
+func testSwiftResolvedLoaderEmptyPins(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	catalog := newTestSwiftCatalog()
+	if err := os.WriteFile(filepath.Join(repo, packageResolvedName), []byte(`{"pins":[]}`), 0o644); err != nil {
+		t.Fatalf("write empty Package.resolved: %v", err)
+	}
+	found, warnings, err := loadResolvedData(repo, &catalog)
+	if err != nil || !found {
+		t.Fatalf("expected resolved loader success, found=%v err=%v", found, err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "no pins found") {
+		t.Fatalf("expected empty pins warning, got %#v", warnings)
+	}
+	if got := resolvedPinDependencyID(resolvedPin{}); got != "" {
+		t.Fatalf("expected empty resolved pin dependency id, got %q", got)
+	}
+	if got := resolvedPinSource(resolvedPin{}); got != "" {
+		t.Fatalf("expected empty resolved pin source, got %q", got)
+	}
+}
+
+func testSwiftManifestLoaderSkipsIncompleteDeclarations(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	manifest := `import PackageDescription
+let package = Package(
+  name: "Demo",
+  dependencies: [
+    .package(url: "", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0")
+  ],
+  targets: [
+    .target(name: "Demo", dependencies: [
+      .product(name: "", package: "swift-nio"),
+      .product(name: "NIO", package: "")
+    ])
+  ]
+)`
+	if err := os.WriteFile(filepath.Join(repo, packageManifestName), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write package manifest: %v", err)
+	}
+	catalog := newTestSwiftCatalog()
+	found, warnings, err := loadManifestData(repo, &catalog)
+	if err != nil || !found {
+		t.Fatalf("expected manifest loader success, found=%v err=%v", found, err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected incomplete manifest declarations to be skipped without warnings, got %#v", warnings)
+	}
+	if _, ok := catalog.Dependencies[swiftNIOID]; !ok {
+		t.Fatalf("expected valid dependency to remain discoverable, got %#v", catalog.Dependencies)
+	}
+}
+
+func testSwiftResolvedLoaderSkipsBlankPins(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	resolved := `{"pins":[{},{"identity":"swift-nio","location":"https://github.com/apple/swift-nio.git","state":{"version":"2.0.0"}}]}`
+	if err := os.WriteFile(filepath.Join(repo, packageResolvedName), []byte(resolved), 0o644); err != nil {
+		t.Fatalf("write package resolved: %v", err)
+	}
+	catalog := newTestSwiftCatalog()
+	found, warnings, err := loadResolvedData(repo, &catalog)
+	if err != nil || !found {
+		t.Fatalf("expected resolved loader success with skipped blank pin, found=%v err=%v", found, err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for mixed pins, got %#v", warnings)
+	}
+	if _, ok := catalog.Dependencies[swiftNIOID]; !ok {
+		t.Fatalf("expected valid resolved pin to be merged, got %#v", catalog.Dependencies)
+	}
+}
+
+func testSwiftCollectLocalModulesIgnoresBlankNames(t *testing.T) {
+	t.Helper()
+
+	catalog := dependencyCatalog{LocalModules: map[string]struct{}{}}
+	collectLocalModules(`.target(name: "")`, &catalog)
+	if len(catalog.LocalModules) != 0 {
+		t.Fatalf("expected blank local module names to be ignored, got %#v", catalog.LocalModules)
+	}
+}
+
+func testSwiftCatalogAndImportMappingHelpers(t *testing.T) {
+	catalog := dependencyCatalog{
+		Dependencies:       map[string]dependencyMeta{"dep": {}},
+		AliasToDependency:  map[string]string{},
+		ModuleToDependency: map[string]string{},
+		LocalModules:       map[string]struct{}{lookupKey("Demo"): {}},
+	}
+	ensureDependency(&catalog, "", true, true, "1.0.0", "abc", "git")
+	if len(catalog.Dependencies) != 1 {
+		t.Fatalf("expected blank dependency id to be ignored, got %#v", catalog.Dependencies)
+	}
+	ensureDependency(&catalog, "dep", false, true, "1.0.0", "abc", "git")
+	ensureDependency(&catalog, "dep", true, false, "2.0.0", "def", "other")
+	meta := catalog.Dependencies["dep"]
+	if !meta.Declared || !meta.Resolved || meta.Version != "1.0.0" || meta.Revision != "abc" || meta.Source != "git" {
+		t.Fatalf("expected first non-empty dependency metadata to persist, got %#v", meta)
+	}
+
+	setLookup(catalog.AliasToDependency, "", "dep")
+	setLookup(catalog.AliasToDependency, "dep", "")
+	if len(catalog.AliasToDependency) != 0 {
+		t.Fatalf("expected blank lookup keys/values to be ignored, got %#v", catalog.AliasToDependency)
+	}
+
+	scanner := newRepoScanner(t.TempDir(), catalog)
+	imports := scanner.resolveImports([]importBinding{
+		{Module: "dep", Dependency: "", Name: "", Local: ""},
+		{Module: "MysteryKit"},
+		{Module: "Demo"},
+	})
+	if len(imports) != 1 || imports[0].Dependency != "dep" || imports[0].Name != "dep" || imports[0].Local != "dep" {
+		t.Fatalf("expected known dependency import to be normalized, got %#v", imports)
+	}
+	if scanner.unresolvedImports["MysteryKit"] != 1 {
+		t.Fatalf("expected unresolved third-party import to be tracked, got %#v", scanner.unresolvedImports)
+	}
+	if scanner.unresolvedImports["Demo"] != 0 {
+		t.Fatalf("expected local module import not to be tracked, got %#v", scanner.unresolvedImports)
+	}
+}
+
+func testSwiftUnqualifiedUsageHelpers(t *testing.T) {
+	if got := importsByDependency([]importBinding{{Dependency: ""}, {Dependency: "dep", Local: "Dep", Module: "Dep"}}); len(got) != 1 || len(got["dep"]) != 1 {
+		t.Fatalf("expected blank dependencies to be skipped, got %#v", got)
+	}
+	if lineHasPotentialUnqualifiedSymbolUsage("Dep()", map[string]struct{}{lookupKey("Dep"): {}}, map[string]struct{}{}) {
+		t.Fatalf("expected imported module symbol to be ignored")
+	}
+	if lineHasPotentialUnqualifiedSymbolUsage("LocalType()", map[string]struct{}{}, map[string]struct{}{lookupKey("LocalType"): {}}) {
+		t.Fatalf("expected local declarations to be ignored")
+	}
+	if lineHasPotentialUnqualifiedSymbolUsage("String()", nil, nil) {
+		t.Fatalf("expected standard Swift symbol to be ignored")
+	}
+	if !lineHasPotentialUnqualifiedSymbolUsage("CustomBuilder()", nil, nil) {
+		t.Fatalf("expected unknown capitalized symbol to be treated as potential usage")
+	}
+
+	baseUsage := map[string]int{"existing": 1}
+	if got := applyUnqualifiedUsageHeuristic([]byte(swiftCustomBuilderCall), nil, baseUsage); got["existing"] != 1 {
+		t.Fatalf("expected empty import heuristic to preserve usage, got %#v", got)
+	}
+
+	usage := map[string]int{"Dep": 1}
+	imports := []importBinding{{Dependency: "dep", Local: "Dep", Module: "Dep"}}
+	if got := applyUnqualifiedUsageHeuristic([]byte("Dep.make()\n"), imports, usage); got["Dep"] != 1 {
+		t.Fatalf("expected qualified usage heuristic to keep existing usage, got %#v", got)
+	}
+
+	unqualified := map[string]int{}
+	if got := applyUnqualifiedUsageHeuristic([]byte(swiftCustomBuilderCall), imports, unqualified); got["Dep"] != 1 {
+		t.Fatalf("expected unqualified usage seeding, got %#v", got)
+	}
+
+	multiDepUsage := map[string]int{}
+	multiDepImports := []importBinding{
+		{Dependency: "dep-a", Local: "DepA", Module: "DepA"},
+		{Dependency: "dep-b", Local: "DepB", Module: "DepB"},
+	}
+	if got := applyUnqualifiedUsageHeuristic([]byte(swiftCustomBuilderCall), multiDepImports, multiDepUsage); len(got) != 0 {
+		t.Fatalf("expected multi-dependency heuristic to avoid seeding, got %#v", got)
+	}
+}
+
+func testSwiftInvalidPathAndHelperGuardBranches(t *testing.T) {
+	testSwiftInvalidPathBranches(t)
+	testSwiftStringAndImportHelpers(t)
+	testSwiftDependencyReportHelpers(t)
+}
+
+func testSwiftInvalidPathBranches(t *testing.T) {
+	t.Helper()
+
+	if _, err := NewAdapter().DetectWithConfidence(context.Background(), "\x00"); err == nil {
+		t.Fatalf("expected invalid repo path to fail detection")
+	}
+	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
+		t.Fatalf("expected invalid repo path to fail analysis")
+	}
+
+	if got := derivePackageIdentity("."); got != "" {
+		t.Fatalf("expected dot path to normalize to empty package identity, got %q", got)
+	}
+	if got := dedupeStrings(nil); len(got) != 0 {
+		t.Fatalf("expected nil string dedupe result, got %#v", got)
+	}
+	if got := extractDotCallArguments(".package(", "package", 10); len(got) != 0 {
+		t.Fatalf("expected malformed dot-call input to stop without arguments, got %#v", got)
+	}
+	if _, _, ok := captureParenthesized("x", 0); ok {
+		t.Fatalf("expected non-parenthesized input to fail capture")
+	}
+	depth := 0
+	if closed, valid := advanceParenthesisDepth(')', &depth); closed || valid {
+		t.Fatalf("expected negative depth to report invalid state, closed=%v valid=%v depth=%d", closed, valid, depth)
+	}
+}
+
+func testSwiftStringAndImportHelpers(t *testing.T) {
+	t.Helper()
+
+	if imports := parseSwiftImports([]byte("import \n"), swiftMainFileName); len(imports) != 0 {
+		t.Fatalf("expected blank Swift import to be ignored, got %#v", imports)
+	}
+
+	var builder strings.Builder
+	state := swiftStringScanState{inString: true}
+	if next := consumeSwiftStringContent([]byte("\\n"), 0, &builder, &state); next != 1 || !state.escaped {
+		t.Fatalf("expected escaped string branch to mark escape state, next=%d state=%#v", next, state)
+	}
+	if matchesSwiftStringDelimiter([]byte(`"#x`), 0, 2, false) {
+		t.Fatalf("expected mismatched raw string delimiter to fail")
+	}
+
+	symbols := collectLocalDeclaredSymbols([]byte("struct _ {}\n"))
+	if len(symbols) != 0 {
+		t.Fatalf("expected non-alphanumeric local declaration names to be ignored, got %#v", symbols)
+	}
+}
+
+func testSwiftDependencyReportHelpers(t *testing.T) {
+	t.Helper()
+
+	depReport, warnings := buildDependencyReport("dep", scanResult{}, dependencyCatalog{}, 50)
+	if depReport.Name != "dep" || len(warnings) != 1 || !strings.Contains(warnings[0], "no imports found") {
+		t.Fatalf("expected missing-import dependency report warning, report=%#v warnings=%#v", depReport, warnings)
+	}
+
+	topReports, topWarnings := buildTopSwiftDependencies(scanResult{KnownDependencies: map[string]struct{}{"alpha": {}, "beta": {}}, ImportedDependencies: map[string]struct{}{}}, dependencyCatalog{}, 50)(1, scanResult{}, report.DefaultRemovalCandidateWeights())
+	if len(topReports) != 1 || len(topWarnings) != 2 {
+		t.Fatalf("expected top-N slicing with per-dependency warnings, reports=%#v warnings=%#v", topReports, topWarnings)
+	}
+}
+
+func testSwiftScannerWalkBranches(t *testing.T) {
+	testSwiftScannerWalkErrorPassthrough(t)
+	testSwiftScannerFileBoundSkip(t)
+	testSwiftScannerRemovedFile(t)
+}
+
+func testSwiftScannerWalkErrorPassthrough(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	scanner := newRepoScanner(repo, dependencyCatalog{})
+	if err := scanner.walk(context.Background(), filepath.Join(repo, "missing.swift"), nil, fs.ErrNotExist); !os.IsNotExist(err) {
+		t.Fatalf("expected walk error passthrough, got %v", err)
+	}
+}
+
+func testSwiftScannerFileBoundSkip(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	scanner := newRepoScanner(repo, dependencyCatalog{})
+	limitedPath := filepath.Join(repo, "Limited.swift")
+	if err := os.WriteFile(limitedPath, []byte("import Foundation\n"), 0o644); err != nil {
+		t.Fatalf("write limited swift file: %v", err)
+	}
+	limitedEntry := mustReadSwiftDirEntry(t, repo, "Limited.swift")
+	scanner.visited = maxScanFiles
+	if err := scanner.scanSwiftFile(limitedPath, limitedEntry); !errors.Is(err, fs.SkipAll) {
+		t.Fatalf("expected scan file bound skip, got %v", err)
+	}
+}
+
+func testSwiftScannerRemovedFile(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	missingPath := filepath.Join(repo, "Missing.swift")
+	if err := os.WriteFile(missingPath, []byte("import Foundation\n"), 0o644); err != nil {
+		t.Fatalf("write missing swift file: %v", err)
+	}
+	missingEntry := mustReadSwiftDirEntry(t, repo, "Missing.swift")
+	if err := os.Remove(missingPath); err != nil {
+		t.Fatalf("remove missing swift file: %v", err)
+	}
+	if newRepoScanner(repo, dependencyCatalog{}).scanSwiftFile(missingPath, missingEntry) == nil {
+		t.Fatalf("expected removed Swift source file to fail scan")
+	}
+}
+
+func newTestSwiftCatalog() dependencyCatalog {
+	return dependencyCatalog{
+		Dependencies:       map[string]dependencyMeta{},
+		AliasToDependency:  map[string]string{},
+		ModuleToDependency: map[string]string{},
+		LocalModules:       map[string]struct{}{},
+	}
+}
+
+func mustReadSwiftDirEntry(t *testing.T, dir, name string) fs.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read repo dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return entry
+		}
+	}
+	t.Fatalf("expected %s dir entry", name)
+	return nil
+}

--- a/internal/notify/dispatcher_test.go
+++ b/internal/notify/dispatcher_test.go
@@ -111,3 +111,10 @@ func TestSanitizeErrorMessageVariants(t *testing.T) {
 		t.Fatalf("expected encoded webhook to be redacted, got %q", got)
 	}
 }
+
+func TestDispatcherNilReceiverReturnsNilWarnings(t *testing.T) {
+	var dispatcher *Dispatcher
+	if warnings := dispatcher.Dispatch(context.Background(), DefaultConfig(), report.Report{}, Outcome{}); len(warnings) != 0 {
+		t.Fatalf("expected nil dispatcher to return nil warnings, got %#v", warnings)
+	}
+}

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -3,8 +3,10 @@ package notify
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -107,6 +109,47 @@ func TestBuildSlackPayloadIncludesThresholdStatus(t *testing.T) {
 	}
 	if !foundStatus {
 		t.Fatalf("expected threshold status field in payload, got %#v", decoded)
+	}
+}
+
+func TestSlackNotifierNotifyBuildPayloadError(t *testing.T) {
+	err := NewSlackNotifier(nil).Notify(context.Background(), Delivery{
+		Channel:    ChannelSlack,
+		WebhookURL: "https://example.com/hook",
+		Report: report.Report{
+			Summary: &report.Summary{DependencyCount: 1, TotalExportsCount: 1, UsedPercent: math.NaN()},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected notify to fail when slack payload JSON encoding fails")
+	}
+}
+
+func TestBuildSlackPayloadFallbackBranches(t *testing.T) {
+	data, err := buildSlackPayload(Delivery{
+		Channel: ChannelSlack,
+		Trigger: TriggerAlways,
+		Report: report.Report{
+			RepoPath: filepath.Clean(string(filepath.Separator)),
+			Dependencies: []report.DependencyReport{
+				{Name: "lodash", UsedExportsCount: 1, TotalExportsCount: 2},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build slack payload fallback branches: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode slack payload: %v", err)
+	}
+	if decoded["text"] != "[Lopper] Dependency analysis for /" {
+		t.Fatalf("expected root repo path to be preserved in fallback repo name, got %#v", decoded["text"])
+	}
+	blocks, ok := decoded["blocks"].([]any)
+	if !ok || len(blocks) != 3 {
+		t.Fatalf("expected payload without generated-at context or waste delta block, got %#v", decoded["blocks"])
 	}
 }
 

--- a/internal/notify/webhook_test.go
+++ b/internal/notify/webhook_test.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,6 +16,7 @@ import (
 )
 
 const decodePayloadErrFmt = "decode payload: %v"
+const exampleHookURL = "https://example.com/hook"
 
 func newPayloadCaptureServer(t *testing.T, payload *map[string]any) *httptest.Server {
 	t.Helper()
@@ -69,6 +71,19 @@ func TestWebhookNotifierNotifySuccess(t *testing.T) {
 	}
 	if payload["channel"] != string(ChannelSlack) {
 		t.Fatalf("expected channel field, got %#v", payload["channel"])
+	}
+}
+
+func TestWebhookNotifierNotifyBuildPayloadError(t *testing.T) {
+	err := NewWebhookNotifier(nil).Notify(context.Background(), Delivery{
+		Channel:    ChannelSlack,
+		WebhookURL: exampleHookURL,
+		Report: report.Report{
+			Summary: &report.Summary{DependencyCount: 1, TotalExportsCount: 1, UsedPercent: math.NaN()},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected notify to fail when webhook payload JSON encoding fails")
 	}
 }
 
@@ -148,7 +163,7 @@ func TestParseWebhookURLValidations(t *testing.T) {
 	if _, err := ParseWebhookURL(withCredentials, "source"); err == nil {
 		t.Fatalf("expected user info validation error")
 	}
-	if _, err := ParseWebhookURL("https://example.com/hook#frag", "source"); err == nil {
+	if _, err := ParseWebhookURL(exampleHookURL+"#frag", "source"); err == nil {
 		t.Fatalf("expected fragment validation error")
 	}
 	if _, err := ParseWebhookURL("https:///hook", "source"); err == nil {
@@ -274,5 +289,25 @@ func TestSummaryDependencyCountThresholdStatusAndRepoPathOrDefault(t *testing.T)
 	expected := "Waste change vs baseline: " + strconv.FormatFloat(delta, 'f', 1, 64) + "%"
 	if got != expected {
 		t.Fatalf("expected zero delta label %q, got %q", expected, got)
+	}
+}
+
+func TestWebhookHelperBranches(t *testing.T) {
+	if got := summaryUsedPercent(report.Report{Summary: &report.Summary{TotalExportsCount: 0}}); got != "n/a" {
+		t.Fatalf("expected n/a when summary has no totals, got %q", got)
+	}
+
+	if value, err := ParseWebhookURL(exampleHookURL, "source"); err != nil || value != exampleHookURL {
+		t.Fatalf("expected valid webhook URL to round-trip, value=%q err=%v", value, err)
+	}
+	if _, err := ParseWebhookURL("https://[::1", "source"); err == nil {
+		t.Fatalf("expected webhook URL parse failure to be reported")
+	}
+
+	if got := RedactWebhookURL("   "); got != "<redacted-webhook>" {
+		t.Fatalf("expected empty webhook URL to use fallback redaction, got %q", got)
+	}
+	if got := RedactWebhookURL("//hooks.slack.com/services/A/B/SECRET"); got != "https://hooks.slack.com/..." {
+		t.Fatalf("expected schemeless webhook URL to default to https, got %q", got)
 	}
 }

--- a/internal/report/baseline_diff_test.go
+++ b/internal/report/baseline_diff_test.go
@@ -168,3 +168,61 @@ func TestComputeBaselineComparisonTracksNewDeniedLicenses(t *testing.T) {
 		t.Fatalf("expected denied license count delta to be 1, got %d", comparison.SummaryDelta.DeniedLicenseCountDelta)
 	}
 }
+
+func TestBaselineDiffAdditionalBranches(t *testing.T) {
+	current := Report{
+		Dependencies: []DependencyReport{
+			{Name: "same", Language: "go", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50},
+		},
+	}
+	baseline := Report{
+		Dependencies: []DependencyReport{
+			{Name: "same", Language: "go", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50},
+		},
+	}
+
+	comparison := ComputeBaselineComparison(current, baseline)
+	if comparison.UnchangedRows != 1 {
+		t.Fatalf("expected one unchanged row, got %d", comparison.UnchangedRows)
+	}
+	if len(comparison.Dependencies) != 0 {
+		t.Fatalf("expected unchanged dependencies to be omitted, got %#v", comparison.Dependencies)
+	}
+
+	if got := wasteFromDependency(DependencyReport{}); got != 0 {
+		t.Fatalf("expected zero waste for zero exports, got %f", got)
+	}
+
+	currentDenied := map[string]DependencyReport{
+		"go/alpha": {
+			Name:     "alpha",
+			Language: "go",
+			License:  &DependencyLicense{SPDX: "GPL-3.0", Denied: true},
+		},
+		"js/beta": {
+			Name:     "beta",
+			Language: "js",
+			License:  &DependencyLicense{SPDX: "AGPL-3.0", Denied: true},
+		},
+		"py/gamma": {
+			Name:     "gamma",
+			Language: "py",
+			License:  &DependencyLicense{SPDX: "MIT", Denied: false},
+		},
+	}
+	baselineDenied := map[string]DependencyReport{
+		"js/beta": {
+			Name:     "beta",
+			Language: "js",
+			License:  &DependencyLicense{SPDX: "AGPL-3.0", Denied: true},
+		},
+	}
+
+	denied := newlyDeniedLicenses(currentDenied, baselineDenied)
+	if len(denied) != 1 {
+		t.Fatalf("expected only newly denied licenses, got %#v", denied)
+	}
+	if denied[0].Language != "go" || denied[0].Name != "alpha" || denied[0].SPDX != "GPL-3.0" {
+		t.Fatalf("unexpected denied license delta: %#v", denied[0])
+	}
+}

--- a/internal/report/baseline_snapshot_test.go
+++ b/internal/report/baseline_snapshot_test.go
@@ -126,6 +126,7 @@ func TestSanitizeBaselineKey(t *testing.T) {
 	}{
 		{name: "empty", key: "", want: "baseline"},
 		{name: "valid", key: "release-1.2_prod", want: "release-1.2_prod"},
+		{name: "uppercase", key: "Release-1.2_Prod", want: "Release-1.2_Prod"},
 		{name: "replaces invalid and trims separators", key: "../feature branch#", want: "feature_branch"},
 		{name: "all separators fallback", key: "._-", want: "baseline"},
 	}
@@ -176,5 +177,28 @@ func TestSaveSnapshotSortsDependenciesDeterministically(t *testing.T) {
 	wantOrder := []string{"go/alpha", "go/beta", "python/zeta"}
 	if !slices.Equal(gotOrder, wantOrder) {
 		t.Fatalf("unexpected dependency order: got=%v want=%v", gotOrder, wantOrder)
+	}
+}
+
+func TestLoadWithKeySnapshotComputesMissingFields(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "snapshot.json")
+	content := `{"baselineSchemaVersion":"1.0.0","key":" label:manual ","savedAt":"2026-01-01T00:00:00Z","report":{"schemaVersion":"0.1.0","generatedAt":"2026-01-01T00:00:00Z","repoPath":".","dependencies":[{"language":"js-ts","name":"dep","usedExportsCount":1,"totalExportsCount":2}]}}` + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	rep, key, err := LoadWithKey(path)
+	if err != nil {
+		t.Fatalf("load snapshot: %v", err)
+	}
+	if key != "label:manual" {
+		t.Fatalf("expected trimmed snapshot key, got %q", key)
+	}
+	if rep.Summary == nil || rep.Summary.DependencyCount != 1 {
+		t.Fatalf("expected computed summary, got %#v", rep.Summary)
+	}
+	if len(rep.LanguageBreakdown) != 1 || rep.LanguageBreakdown[0].Language != "js-ts" {
+		t.Fatalf("expected computed language breakdown, got %#v", rep.LanguageBreakdown)
 	}
 }

--- a/internal/report/format_cov_more_branches_test.go
+++ b/internal/report/format_cov_more_branches_test.go
@@ -1,0 +1,86 @@
+package report
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"text/tabwriter"
+)
+
+func TestAppendEffectivePolicyAndBaselineComparisonMoreBranches(t *testing.T) {
+	var buffer bytes.Buffer
+	appendEffectivePolicy(&buffer, Report{
+		EffectivePolicy: &EffectivePolicy{
+			Sources: []string{"repo", "defaults"},
+			Thresholds: EffectiveThresholds{
+				FailOnIncreasePercent:             1,
+				LowConfidenceWarningPercent:       35,
+				MinUsagePercentForRecommendations: 45,
+				MaxUncertainImportCount:           2,
+			},
+			RemovalCandidateWeights: RemovalCandidateWeights{
+				Usage:      0.6,
+				Impact:     0.2,
+				Confidence: 0.2,
+			},
+			License: LicensePolicy{
+				Deny:                      []string{"GPL-3.0-only"},
+				FailOnDenied:              true,
+				IncludeRegistryProvenance: true,
+			},
+		},
+	})
+	if got := buffer.String(); !strings.Contains(got, "license_deny: GPL-3.0-only") {
+		t.Fatalf("expected effective policy deny list in output, got %q", got)
+	}
+
+	buffer.Reset()
+	appendBaselineComparison(&buffer, &BaselineComparison{
+		Progressions: []DependencyDelta{
+			{Language: "go", Name: "pkg", WastePercentDelta: -2.5, UsedPercentDelta: 2.5},
+		},
+	})
+	if got := buffer.String(); !strings.Contains(got, "progression go/pkg waste -2.5% used +2.5%") {
+		t.Fatalf("expected progression summary in output, got %q", got)
+	}
+}
+
+func TestFormatRuntimeUsageAndLicenseMoreBranches(t *testing.T) {
+	if got := formatRuntimeUsage(&RuntimeUsage{LoadCount: 1}); !strings.Contains(got, "overlap (1 loads)") {
+		t.Fatalf("expected overlap fallback correlation, got %q", got)
+	}
+	if got := formatDependencyLicense(&DependencyLicense{Unknown: true}); got != "unknown" {
+		t.Fatalf("expected unknown license fallback, got %q", got)
+	}
+	if got := formatDependencyLicense(&DependencyLicense{SPDX: "MIT"}); got != "MIT" {
+		t.Fatalf("expected SPDX pass-through, got %q", got)
+	}
+}
+
+type failingReportWriter struct{}
+
+func (w *failingReportWriter) Write(_ []byte) (int, error) {
+	return 0, bytes.ErrTooLarge
+}
+
+func TestTableWriterErrorHelpers(t *testing.T) {
+	t.Run("write table line returns writer failure", func(t *testing.T) {
+		writer := tabwriter.NewWriter(&failingReportWriter{}, 0, 0, 2, ' ', 0)
+		_, err := fmt.Fprintln(writer, strings.Repeat("x", 5000))
+		if err == nil {
+			t.Fatal("expected writeTableLine to return writer failure")
+		}
+	})
+
+	t.Run("flush table writer returns flush failure", func(t *testing.T) {
+		writer := tabwriter.NewWriter(&failingReportWriter{}, 0, 0, 2, ' ', 0)
+		if _, err := writer.Write([]byte("col1\tcol2\n")); err != nil {
+			t.Fatalf("seed tabwriter: %v", err)
+		}
+		flushErr := writer.Flush()
+		if flushErr == nil {
+			t.Fatal("expected flushTableWriter to return flush failure")
+		}
+	})
+}

--- a/internal/report/license_test.go
+++ b/internal/report/license_test.go
@@ -72,3 +72,28 @@ func TestSPDXExpressionContainsDeniedTokens(t *testing.T) {
 		t.Fatalf("did not expect denied match for empty expression/denylist")
 	}
 }
+
+func TestLicenseAdditionalBranches(t *testing.T) {
+	deps := []DependencyReport{
+		{Name: "nil-license"},
+		{Name: "set", License: &DependencyLicense{Denied: true}},
+	}
+	ApplyLicensePolicy(deps, nil)
+	if deps[1].License.Denied {
+		t.Fatalf("expected deny flag to clear when deny list is empty")
+	}
+
+	if got := SortedDenyList([]string{"###"}); len(got) != 0 {
+		t.Fatalf("expected invalid deny list to normalize to nil, got %#v", got)
+	}
+
+	deny := map[string]struct{}{"GPL-2.0-ONLY": {}}
+	if !spdxExpressionContainsDenied("MIT / GPL-2.0-only", deny) {
+		t.Fatalf("expected denied token match after delimiter flush")
+	}
+
+	ApplyLicensePolicy(deps, []string{reportTestGPL30OnlyLower})
+	if deps[0].License != nil {
+		t.Fatalf("expected nil license to remain untouched when deny list is set")
+	}
+}

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -242,6 +243,45 @@ func TestSortSARIFResultsAndLocationKey(t *testing.T) {
 	}
 }
 
+func TestSARIFRuleBuilderDeduplicatesAndSorts(t *testing.T) {
+	builder := newSARIFRuleBuilder()
+	builder.add(sarifRule{ID: "b"})
+	builder.add(sarifRule{ID: "a"})
+	builder.add(sarifRule{ID: "a"})
+
+	items := builder.list()
+	if len(items) != 2 {
+		t.Fatalf("expected duplicate rules to be ignored, got %#v", items)
+	}
+	if items[0].ID != "a" || items[1].ID != "b" {
+		t.Fatalf("expected rules to be sorted by ID, got %#v", items)
+	}
+}
+
+func TestFormatSARIFMarshalError(t *testing.T) {
+	waste := math.NaN()
+	if _, err := formatSARIF(Report{WasteIncreasePercent: &waste}); err == nil {
+		t.Fatalf("expected sarif formatting to fail for NaN payload values")
+	}
+}
+
+func TestAppendUnusedImportResultsFallsBackToAnchor(t *testing.T) {
+	rules := newSARIFRuleBuilder()
+	anchor := &sarifLocation{
+		PhysicalLocation: sarifPhysicalLocation{
+			ArtifactLocation: sarifArtifactLocation{URI: "anchor.go"},
+		},
+	}
+
+	results := appendUnusedImportResults(nil, rules, DependencyReport{Name: "pkg", Language: "js-ts", UnusedImports: []ImportUse{{Name: "map", Module: "lodash"}}}, anchor)
+	if len(results) != 1 || len(results[0].Locations) != 1 {
+		t.Fatalf("expected fallback anchor location, got %#v", results)
+	}
+	if results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI != "anchor.go" {
+		t.Fatalf("expected anchor URI to be preserved, got %#v", results[0].Locations[0])
+	}
+}
+
 func TestDependencyAnchorLocationBranches(t *testing.T) {
 	if anchor := dependencyAnchorLocation(DependencyReport{}); anchor != nil {
 		t.Fatalf("expected nil anchor without locations, got %#v", anchor)
@@ -270,6 +310,25 @@ func TestDependencyAnchorLocationBranches(t *testing.T) {
 	}
 	if anchor.PhysicalLocation.ArtifactLocation.URI != testAFileGo {
 		t.Fatalf("expected sorted anchor path, got %#v", anchor)
+	}
+}
+
+func TestDependencyAnchorLocationColumnTieBreakAndNormalizeRuleFallback(t *testing.T) {
+	dep := DependencyReport{
+		UsedImports: []ImportUse{
+			{Locations: []Location{{File: "same.go", Line: 3, Column: 2}}},
+		},
+		UnusedImports: []ImportUse{
+			{Locations: []Location{{File: "same.go", Line: 3, Column: 1}}},
+		},
+	}
+	anchor := dependencyAnchorLocation(dep)
+	if anchor == nil || anchor.PhysicalLocation.Region == nil || anchor.PhysicalLocation.Region.StartColumn != 1 {
+		t.Fatalf("expected column tie-break to prefer the earliest column, got %#v", anchor)
+	}
+
+	if got := normalizeRuleToken("!!!"); got != "unknown" {
+		t.Fatalf("expected punctuation-only rule token to normalize to unknown, got %q", got)
 	}
 }
 

--- a/internal/report/scoring_test.go
+++ b/internal/report/scoring_test.go
@@ -128,6 +128,20 @@ func TestAnnotateRemovalCandidateScoresWithWeights(t *testing.T) {
 	}
 }
 
+func TestDependencyUsageSignalAndRawImpactBranches(t *testing.T) {
+	score, ok := dependencyUsageSignal(DependencyReport{
+		UsedExportsCount:  1,
+		TotalExportsCount: 4,
+	})
+	if !ok || score != 75 {
+		t.Fatalf("expected fallback usage score of 75, got score=%f ok=%v", score, ok)
+	}
+
+	if impact := rawImpact(DependencyReport{UsedExportsCount: 5, TotalExportsCount: 3}); impact != 0 {
+		t.Fatalf("expected raw impact to clamp negative unused exports, got %f", impact)
+	}
+}
+
 func TestNormalizeRemovalCandidateWeightsFallback(t *testing.T) {
 	defaults := DefaultRemovalCandidateWeights()
 	got := NormalizeRemovalCandidateWeights(RemovalCandidateWeights{Usage: -1, Impact: 0.5, Confidence: 0.5})
@@ -266,6 +280,45 @@ func TestReachabilityHelpersFallbackBranches(t *testing.T) {
 	}
 }
 
+func TestScoringAdditionalPureBranches(t *testing.T) {
+	usageSignal := usageUncertaintyConfidenceSignal(&UsageUncertainty{ConfirmedImportUses: -1, UncertainImportUses: 1})
+	if usageSignal.signal.Score != 60 || usageSignal.signal.Code != confidenceReasonRepoUsageUncertainty {
+		t.Fatalf("expected bounded repo-uncertainty signal, got %#v", usageSignal.signal)
+	}
+
+	if got := highestRiskSeverity([]RiskCue{{Severity: "low"}, {Severity: "LOW"}, {Severity: "medium"}, {Severity: "unknown"}}); got != "medium" {
+		t.Fatalf("expected highest severity to be medium, got %q", got)
+	}
+	if got := riskSeverityWeight("unexpected"); got != 0 {
+		t.Fatalf("expected unknown severity weight to be zero, got %d", got)
+	}
+
+	summary := summarizeReachabilityConfidence([]evaluatedReachabilitySignal{
+		{signal: ReachabilitySignal{Code: confidenceReasonUsageUncertaintyClear, Score: 100}, summary: "should skip"},
+		{signal: ReachabilitySignal{Code: confidenceReasonRuntimeOverlap, Score: 100}, summary: "keep overlap"},
+		{signal: ReachabilitySignal{Code: confidenceReasonRiskMedium, Score: 70}, summary: ""},
+		{signal: ReachabilitySignal{Code: confidenceReasonRepoUsageUncertainty, Score: 60}, summary: "keep uncertainty"},
+	})
+	if summary != "keep overlap; keep uncertainty" {
+		t.Fatalf("unexpected reachability summary: %q", summary)
+	}
+
+	if got := reachabilityRationale(nil); len(got) != 0 {
+		t.Fatalf("expected nil confidence rationale to be empty, got %#v", got)
+	}
+	rationale := reachabilityRationale(&ReachabilityConfidence{
+		Signals: []ReachabilitySignal{
+			{Code: confidenceReasonUsageUncertaintyClear, Score: 100, Rationale: "skip"},
+			{Code: confidenceReasonRuntimeOverlap, Score: 100, Rationale: "keep"},
+			{Code: confidenceReasonRiskMedium, Score: 60, Rationale: "keep medium"},
+			{Code: confidenceReasonRiskLow, Score: 40, Rationale: "   "},
+		},
+	})
+	if len(rationale) != 2 || rationale[0] != "keep" || rationale[1] != "keep medium" {
+		t.Fatalf("unexpected rationale list: %#v", rationale)
+	}
+}
+
 func TestClampBounds(t *testing.T) {
 	if got := clamp(-2, 0, 100); got != 0 {
 		t.Fatalf("expected clamp lower bound, got %f", got)
@@ -400,17 +453,25 @@ func TestFilterFindingsByConfidence(t *testing.T) {
 	}
 }
 
-func TestFilterFindingsByConfidenceNonPositiveNoop(t *testing.T) {
+func TestFilterFindingsByConfidenceBypassesAndKeepsMatches(t *testing.T) {
 	deps := []DependencyReport{
 		{
-			Name:          leftPadPackageName,
-			UnusedExports: []SymbolRef{{Name: "pad", Module: leftPadPackageName, ConfidenceScore: 10}},
+			UnusedExports: []SymbolRef{
+				{Name: "keep", ConfidenceScore: 90},
+				{Name: "drop", ConfidenceScore: 40},
+			},
 		},
 	}
 
 	FilterFindingsByConfidence(deps, 0)
-
-	if len(deps[0].UnusedExports) != 1 {
+	if len(deps[0].UnusedExports) != 2 {
 		t.Fatalf("expected non-positive threshold to leave findings unchanged, got %#v", deps[0].UnusedExports)
+	}
+
+	kept := filterByConfidenceScore(deps[0].UnusedExports, 50, func(item SymbolRef) float64 {
+		return item.ConfidenceScore
+	})
+	if len(kept) != 1 || kept[0].Name != "keep" {
+		t.Fatalf("expected confidence filter to keep only high-confidence items, got %#v", kept)
 	}
 }

--- a/internal/report/summary_test.go
+++ b/internal/report/summary_test.go
@@ -71,3 +71,19 @@ func TestComputeSummaryAndLanguageBreakdownEmpty(t *testing.T) {
 		t.Fatalf("expected empty language breakdown for empty dependencies, got %#v", got)
 	}
 }
+
+func TestComputeLanguageBreakdownAdditionalBranches(t *testing.T) {
+	if got := ComputeLanguageBreakdown([]DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 2}}); len(got) != 0 {
+		t.Fatalf("expected empty breakdown when all dependencies have empty language, got %#v", got)
+	}
+
+	breakdown := ComputeLanguageBreakdown([]DependencyReport{
+		{Language: "go", Name: "dep", UsedExportsCount: 1, TotalExportsCount: 0},
+	})
+	if len(breakdown) != 1 {
+		t.Fatalf("expected one language summary, got %#v", breakdown)
+	}
+	if breakdown[0].UsedPercent != 0 {
+		t.Fatalf("expected zero used percent when totals are zero, got %#v", breakdown[0])
+	}
+}

--- a/internal/runtime/capture_test.go
+++ b/internal/runtime/capture_test.go
@@ -9,7 +9,11 @@ import (
 	"testing"
 )
 
-const npmTestCommand = "npm test"
+const (
+	npmTestCommand     = "npm test"
+	runtimeTraceNDJSON = "runtime.ndjson"
+	makeVersionCommand = "make -v"
+)
 
 func TestDefaultTracePath(t *testing.T) {
 	repo := "/tmp/repo"
@@ -48,11 +52,11 @@ func TestWithRuntimeTraceEnv(t *testing.T) {
 
 func TestCapture(t *testing.T) {
 	repo := t.TempDir()
-	tracePath := filepath.Join(repo, ".artifacts", "runtime.ndjson")
+	tracePath := filepath.Join(repo, ".artifacts", runtimeTraceNDJSON)
 	err := Capture(context.Background(), CaptureRequest{
 		RepoPath:  repo,
 		TracePath: tracePath,
-		Command:   "make -v",
+		Command:   makeVersionCommand,
 	})
 	if err != nil {
 		t.Fatalf("capture runtime trace: %v", err)
@@ -257,6 +261,92 @@ func TestBuildRuntimeCommandRejectsMalformedInput(t *testing.T) {
 	}
 }
 
+func TestCaptureTracePathSetupErrors(t *testing.T) {
+	t.Run("create trace directory", func(t *testing.T) {
+		repo := t.TempDir()
+		blocker := filepath.Join(repo, "blocked")
+		if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write blocker: %v", err)
+		}
+
+		err := Capture(context.Background(), CaptureRequest{
+			RepoPath:  repo,
+			TracePath: filepath.Join(blocker, runtimeTraceNDJSON),
+			Command:   makeVersionCommand,
+		})
+		if err == nil || !strings.Contains(err.Error(), "create runtime trace directory") {
+			t.Fatalf("expected trace directory creation error, got %v", err)
+		}
+	})
+
+	t.Run("remove previous runtime trace", func(t *testing.T) {
+		repo := t.TempDir()
+		tracePath := filepath.Join(repo, "traces", runtimeTraceNDJSON)
+		if err := os.MkdirAll(tracePath, 0o750); err != nil {
+			t.Fatalf("mkdir trace path: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tracePath, "keep.txt"), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write trace child: %v", err)
+		}
+
+		err := Capture(context.Background(), CaptureRequest{
+			RepoPath:  repo,
+			TracePath: tracePath,
+			Command:   makeVersionCommand,
+		})
+		if err == nil || !strings.Contains(err.Error(), "remove previous runtime trace") {
+			t.Fatalf("expected trace cleanup error, got %v", err)
+		}
+	})
+}
+
+func TestCaptureCommandFailureWithoutOutput(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "make", "#!/bin/sh\nexit 3\n"))
+
+	err := Capture(context.Background(), CaptureRequest{
+		RepoPath: repo,
+		Command:  "make test",
+	})
+	if err == nil {
+		t.Fatalf("expected silent command failure")
+	}
+	if !strings.Contains(err.Error(), "runtime test command failed") {
+		t.Fatalf("expected runtime command failure error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "\n") {
+		t.Fatalf("expected silent failure without command output, got %v", err)
+	}
+}
+
+func TestResolveRuntimeExecutablePathSkipsNonExecutableCandidate(t *testing.T) {
+	firstDir := t.TempDir()
+	secondDir := t.TempDir()
+
+	firstPath := filepath.Join(firstDir, "npm")
+	if err := os.WriteFile(firstPath, []byte("#!/bin/sh\n"), 0o600); err != nil {
+		t.Fatalf("write non-executable tool: %v", err)
+	}
+	secondPath := filepath.Join(secondDir, "npm")
+	if err := os.WriteFile(secondPath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write executable tool: %v", err)
+	}
+
+	got, err := resolveRuntimeExecutablePath("npm", []string{firstDir, secondDir})
+	if err != nil {
+		t.Fatalf("resolve runtime executable path: %v", err)
+	}
+	if got != secondPath {
+		t.Fatalf("expected executable path %q, got %q", secondPath, got)
+	}
+}
+
+func TestNewAllowlistedRuntimeCommandRejectsUnsupportedExecutable(t *testing.T) {
+	if _, err := newAllowlistedRuntimeCommand(context.Background(), "python"); err == nil {
+		t.Fatalf("expected unsupported executable error")
+	}
+}
+
 func TestMergeEnvAndReadEnvValue(t *testing.T) {
 	base := []string{"A=1", "BADENTRY", "NODE_OPTIONS=--max-old-space-size=2048"}
 	merged := mergeEnv(base, map[string]string{"A": "2", "B": "3"})
@@ -294,6 +384,17 @@ func setupFakeRuntimeTools(t *testing.T) string {
 		if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
 			t.Fatalf("write fake runtime tool %q: %v", tool, err)
 		}
+	}
+	return toolDir
+}
+
+func setupFakeRuntimeToolScript(t *testing.T, tool string, script string) string {
+	t.Helper()
+
+	toolDir := setupFakeRuntimeTools(t)
+	path := filepath.Join(toolDir, tool)
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake runtime tool script %q: %v", tool, err)
 	}
 	return toolDir
 }

--- a/internal/runtime/runtime_cov_more_test.go
+++ b/internal/runtime/runtime_cov_more_test.go
@@ -1,0 +1,28 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestRuntimeAdditionalHelperBranches(t *testing.T) {
+	tracePath := "/tmp/runtime.ndjson"
+	env := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, tracePath)
+	if readEnvValue(env, "NODE_OPTIONS") == "" {
+		t.Fatalf("expected NODE_OPTIONS to be injected when absent")
+	}
+	if got := readEnvValue([]string{"BROKEN", "KEY=value"}, "KEY"); got != "value" {
+		t.Fatalf("expected malformed env entries to be skipped, got %q", got)
+	}
+
+	deps := []report.DependencyReport{
+		{Language: "z", Name: "b"},
+		{Language: "a", Name: "c"},
+		{Language: "a", Name: "b"},
+	}
+	sortDependencies(deps)
+	if deps[0].Language != "a" || deps[0].Name != "b" || deps[1].Name != "c" || deps[2].Language != "z" {
+		t.Fatalf("unexpected runtime dependency ordering: %#v", deps)
+	}
+}

--- a/internal/runtime/trace_test.go
+++ b/internal/runtime/trace_test.go
@@ -15,9 +15,12 @@ const (
 	scopePkgDependency         = "@scope/pkg"
 	lodashMapModule            = "lodash/map"
 	expectedGotFormat          = "%s: expected %q, got %q"
+	loadTraceErrFmt            = "load trace: %v"
 	leftPadDependency          = "left-pad"
 	leftPadModule              = "left-pad/index"
 	leftPadResolvedIndexModule = "/repo/node_modules/left-pad/index.js"
+	alphaIndexModule           = "alpha/index.js"
+	zetaIndexModule            = "zeta/index.js"
 )
 
 func loadTraceFromContent(t *testing.T, content string) (Trace, error) {
@@ -29,7 +32,7 @@ func TestLoadTrace(t *testing.T) {
 	trace, err := loadTraceFromContent(t, `{"kind":"resolve","module":"`+lodashMapModule+`","resolved":"file:///repo/node_modules/lodash/map.js"}`+"\n"+`{"kind":"require","module":"@scope/pkg/lib","resolved":"/repo/node_modules/@scope/pkg/lib/index.js"}`+"\n")
 
 	if err != nil {
-		t.Fatalf("load trace: %v", err)
+		t.Fatalf(loadTraceErrFmt, err)
 	}
 	if trace.DependencyLoads["lodash"] != 1 {
 		t.Fatalf("expected lodash load count=1, got %d", trace.DependencyLoads["lodash"])
@@ -199,7 +202,7 @@ func TestLoadTraceParseErrorIncludesLineNumber(t *testing.T) {
 func TestLoadTraceSkipsBlankLines(t *testing.T) {
 	trace, err := loadTraceFromContent(t, "\n   \n{\"module\":\""+lodashMapModule+"\"}\n")
 	if err != nil {
-		t.Fatalf("load trace: %v", err)
+		t.Fatalf(loadTraceErrFmt, err)
 	}
 	if got := trace.DependencyLoads["lodash"]; got != 1 {
 		t.Fatalf("expected lodash load count 1, got %d", got)
@@ -213,6 +216,16 @@ func TestLoadTraceMissingFileError(t *testing.T) {
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestLoadTraceSkipsEventsWithoutDependencies(t *testing.T) {
+	trace, err := loadTraceFromContent(t, "{\"module\":\"./local\"}\n{\"resolved\":\"/repo/src/index.js\"}\n")
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if len(trace.DependencyLoads) != 0 || len(trace.DependencyModules) != 0 || len(trace.DependencySymbols) != 0 {
+		t.Fatalf("expected dependency-free events to be ignored, got %#v", trace)
 	}
 }
 
@@ -258,6 +271,28 @@ func TestAnnotateAddsRuntimeOnlyDependencyRows(t *testing.T) {
 	}
 }
 
+func TestAppendRuntimeOnlyDependenciesSkipsSeenAndZeroLoads(t *testing.T) {
+	rep := report.Report{}
+	trace := Trace{
+		DependencyLoads: map[string]int{
+			"seen": 1,
+			"zero": 0,
+			"new":  2,
+		},
+		DependencyModules: map[string]map[string]int{
+			"new": {"new/index.js": 2},
+		},
+		DependencySymbols: map[string]map[string]int{
+			"new": {"new/index.js\x00index": 2},
+		},
+	}
+
+	appendRuntimeOnlyDependencies(&rep, trace, map[string]struct{}{"seen": {}})
+	if len(rep.Dependencies) != 1 || rep.Dependencies[0].Name != "new" {
+		t.Fatalf("expected only unseen runtime dependency to be appended, got %#v", rep.Dependencies)
+	}
+}
+
 func TestRuntimeModuleAndSymbolExtraction(t *testing.T) {
 	module := runtimeModuleFromEvent(Event{Resolved: "/repo/node_modules/lodash/fp/map.js"}, "lodash")
 	if module != "lodash/fp/map.js" {
@@ -291,6 +326,15 @@ func TestRuntimeModuleFromResolvedPathBranches(t *testing.T) {
 	}
 }
 
+func TestRuntimeModuleFromResolvedPathPackageRoots(t *testing.T) {
+	if got := runtimeModuleFromResolvedPath("/repo/node_modules/lodash", "lodash"); got != "lodash" {
+		t.Fatalf("expected package root module for unscoped dependency, got %q", got)
+	}
+	if got := runtimeModuleFromResolvedPath("/repo/node_modules/@scope/pkg", scopePkgDependency); got != scopePkgDependency {
+		t.Fatalf("expected package root module for scoped dependency, got %q", got)
+	}
+}
+
 func TestRuntimeSymbolFromModuleBranches(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -307,6 +351,12 @@ func TestRuntimeSymbolFromModuleBranches(t *testing.T) {
 		if got := runtimeSymbolFromModule(tc.module, tc.dependency); got != tc.want {
 			t.Fatalf(expectedGotFormat, tc.name, tc.want, got)
 		}
+	}
+}
+
+func TestRuntimeSymbolFromModuleRejectsEmptyFileNames(t *testing.T) {
+	if got := runtimeSymbolFromModule("lodash/.js", "lodash"); got != "" {
+		t.Fatalf("expected empty symbol for empty filename stem, got %q", got)
 	}
 }
 
@@ -338,6 +388,32 @@ func TestRuntimeModulesAndSymbolsFormatting(t *testing.T) {
 	}
 	if symbols[0].Symbol != "map" || symbols[0].Module != lodashMapModule {
 		t.Fatalf("expected map symbol first, got %#v", symbols[0])
+	}
+}
+
+func TestRuntimeModulesSortsTieByModuleName(t *testing.T) {
+	modules := runtimeModules(map[string]int{
+		zetaIndexModule:  1,
+		alphaIndexModule: 1,
+	})
+	if len(modules) != 2 || modules[0].Module != alphaIndexModule || modules[1].Module != zetaIndexModule {
+		t.Fatalf("expected alphabetical order for equal counts, got %#v", modules)
+	}
+}
+
+func TestRuntimeSymbolsSortsEqualSymbolsByModuleName(t *testing.T) {
+	symbols := runtimeSymbols(map[string]int{
+		zetaIndexModule + "\x00same":  1,
+		alphaIndexModule + "\x00same": 1,
+	})
+	if len(symbols) != 2 || symbols[0].Module != alphaIndexModule || symbols[1].Module != zetaIndexModule {
+		t.Fatalf("expected equal symbols to sort by module name, got %#v", symbols)
+	}
+}
+
+func TestDependencyFromResolvedPathBlankValue(t *testing.T) {
+	if got := dependencyFromResolvedPath("   "); got != "" {
+		t.Fatalf("expected blank resolved path to produce no dependency, got %q", got)
 	}
 }
 

--- a/internal/safeio/read_cov_more_runtime_test.go
+++ b/internal/safeio/read_cov_more_runtime_test.go
@@ -1,0 +1,19 @@
+package safeio
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestReadFileUnderAndOpenFileInvalidPathBranches(t *testing.T) {
+	rootDir := t.TempDir()
+	badPath := filepath.Join(rootDir, "bad\x00name")
+
+	if _, err := ReadFileUnder(rootDir, badPath); err == nil {
+		t.Fatalf("expected ReadFileUnder to fail for invalid rooted path")
+	}
+
+	if _, err := OpenFile(badPath); err == nil {
+		t.Fatalf("expected OpenFile to fail for invalid file name")
+	}
+}

--- a/internal/safeio/read_cov_more_test.go
+++ b/internal/safeio/read_cov_more_test.go
@@ -1,0 +1,46 @@
+package safeio
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSafeIOAdditionalReadBranches(t *testing.T) {
+	rootDir := t.TempDir()
+	if resolvedRoot, err := filepath.EvalSymlinks(rootDir); err == nil && resolvedRoot != "" {
+		rootDir = resolvedRoot
+	}
+	targetPath := filepath.Join(rootDir, "nested", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Fatalf("restore wd %s: %v", originalWD, err)
+		}
+	})
+	if err := os.Chdir(rootDir); err != nil {
+		t.Fatalf("chdir root dir: %v", err)
+	}
+
+	data, err := ReadFileUnder(rootDir, filepath.Join("nested", ".", "file.txt"))
+	if err != nil {
+		t.Fatalf("read file under relative path: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("unexpected relative read content: %q", string(data))
+	}
+
+	if _, err := ReadFile(rootDir); err == nil {
+		t.Fatalf("expected directory reads to fail")
+	}
+}

--- a/internal/safeio/read_test.go
+++ b/internal/safeio/read_test.go
@@ -138,6 +138,22 @@ func TestReadOpenedFileAllowsMaxInt64Limit(t *testing.T) {
 	}
 }
 
+func TestReadOpenedFileDirectoryReadError(t *testing.T) {
+	dirFile, err := os.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := dirFile.Close(); closeErr != nil {
+			t.Fatalf("close temp dir file: %v", closeErr)
+		}
+	})
+
+	if _, err := readOpenedFile(dirFile, 1); err == nil {
+		t.Fatalf("expected readOpenedFile to fail when reading a directory")
+	}
+}
+
 func TestReadFileUnderRejectsPathTraversalOutsideRoot(t *testing.T) {
 	parentDir := t.TempDir()
 	rootDir := filepath.Join(parentDir, "root")

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -2,9 +2,11 @@ package safeio
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -340,6 +342,29 @@ func TestCleanupAtomicTempFileReturnsRootRemoveError(t *testing.T) {
 	err = cleanupAtomicTempFile(root, "temp", tempFile)
 	if err == nil {
 		t.Fatal("expected root remove error after closing root")
+	}
+}
+
+func TestCleanupAtomicTempFileJoinsCloseAndRemoveErrors(t *testing.T) {
+	rootDir := t.TempDir()
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf(openRootErrFmt, err)
+	}
+	if err := root.Close(); err != nil {
+		t.Fatalf("close root: %v", err)
+	}
+
+	err = cleanupAtomicTempFile(root, "temp", &os.File{})
+	if err == nil {
+		t.Fatal("expected cleanupAtomicTempFile to join close and remove errors")
+	}
+	var closeErrno syscall.Errno
+	if !errors.Is(err, fs.ErrInvalid) && !errors.As(err, &closeErrno) {
+		t.Fatalf("expected joined cleanup error to include a stable close failure, got %v", err)
+	}
+	if !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("expected joined cleanup error to include closed root remove, got %v", err)
 	}
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -62,6 +62,30 @@ func Chdir(t *testing.T, dir string) {
 	})
 }
 
+func ChdirRemovedDir(t *testing.T) {
+	t.Helper()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Fatalf("restore wd %s: %v", originalWD, err)
+		}
+	})
+
+	deadDir := filepath.Join(t.TempDir(), "dead")
+	if err := os.MkdirAll(deadDir, 0o750); err != nil {
+		t.Fatalf("mkdir dead dir: %v", err)
+	}
+	if err := os.Chdir(deadDir); err != nil {
+		t.Fatalf("chdir dead dir: %v", err)
+	}
+	if err := os.RemoveAll(deadDir); err != nil {
+		t.Fatalf("remove dead dir: %v", err)
+	}
+}
+
 func MustFirstFileEntry(t *testing.T, dir string) fs.DirEntry {
 	t.Helper()
 	entries, err := os.ReadDir(dir)

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -8,7 +8,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/gitexec"
 )
+
+const testutilGetwdErrFmt = "getwd: %v"
 
 func TestCanceledContextIsDone(t *testing.T) {
 	ctx := CanceledContext()
@@ -121,7 +125,7 @@ func TestWriteTempFile(t *testing.T) {
 func TestChdirAndMustFirstFileEntry(t *testing.T) {
 	originalWD, err := os.Getwd()
 	if err != nil {
-		t.Fatalf("getwd: %v", err)
+		t.Fatalf(testutilGetwdErrFmt, err)
 	}
 
 	dir := t.TempDir()
@@ -155,7 +159,7 @@ func TestChdirAndMustFirstFileEntry(t *testing.T) {
 func TestChdir(t *testing.T) {
 	original, err := os.Getwd()
 	if err != nil {
-		t.Fatalf("getwd: %v", err)
+		t.Fatalf(testutilGetwdErrFmt, err)
 	}
 	dir := t.TempDir()
 	Chdir(t, dir)
@@ -182,6 +186,37 @@ func TestChdir(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestChdirRemovedDir(t *testing.T) {
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf(testutilGetwdErrFmt, err)
+	}
+
+	t.Run("removed cwd", func(t *testing.T) {
+		ChdirRemovedDir(t)
+	})
+
+	if cwd, err := os.Getwd(); err != nil {
+		t.Fatalf("getwd after cleanup: %v", err)
+	} else if cwd != originalWD {
+		t.Fatalf("expected cwd restored to %s, got %s", originalWD, cwd)
+	}
+}
+
+func TestRunGit(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo := t.TempDir()
+	RunGit(t, repo, "init")
+	RunGit(t, repo, "status", "--short")
+
+	if _, err := os.Stat(filepath.Join(repo, ".git")); err != nil {
+		t.Fatalf("expected git repository to be initialized: %v", err)
+	}
 }
 
 func TestFatalPathsViaHelperProcess(t *testing.T) {

--- a/internal/thresholds/config_cov_more_branches_test.go
+++ b/internal/thresholds/config_cov_more_branches_test.go
@@ -1,0 +1,51 @@
+package thresholds
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const packAPolicySource = "pack-a"
+
+func TestThresholdConfigAdditionalBranches(t *testing.T) {
+	if _, err := LoadWithPolicy("\x00", ""); err == nil {
+		t.Fatalf("expected LoadWithPolicy to reject invalid repo path")
+	}
+
+	if got := normalizePathPatterns([]string{" ", "\t"}); len(got) != 0 {
+		t.Fatalf("expected blank path patterns to normalize to nil, got %#v", got)
+	}
+
+	maxUncertain := 2
+	merged := mergeOverrides(Overrides{}, Overrides{MaxUncertainImportCount: &maxUncertain})
+	if merged.MaxUncertainImportCount == nil || *merged.MaxUncertainImportCount != 2 {
+		t.Fatalf("expected max_uncertain_import_count override to merge, got %#v", merged)
+	}
+
+	sources := (&resolveMergeResult{appliedSourcesLow: []string{packAPolicySource, defaultPolicySource, packAPolicySource}}).policySourcesHighToLow()
+	if !reflect.DeepEqual(sources, []string{packAPolicySource, defaultPolicySource}) {
+		t.Fatalf("unexpected policy source ordering: %#v", sources)
+	}
+
+	if _, _, err := canonicalPolicyLocation("https://example.com/policy.yml#bad-pin"); err == nil {
+		t.Fatalf("expected canonicalPolicyLocation to reject invalid remote pin")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	location := server.URL + "/policy.yml#sha256=" + strings.Repeat("a", 64)
+	if _, err := readRemotePolicyFile(location); err == nil || !strings.Contains(err.Error(), "unexpected status") {
+		t.Fatalf("expected remote status error, got %v", err)
+	}
+
+	if isPathUnderRoot("\x00", filepath.Join(t.TempDir(), "policy.yml")) {
+		t.Fatalf("expected invalid root path to fail root containment check")
+	}
+}

--- a/internal/thresholds/config_cov_more_http_test.go
+++ b/internal/thresholds/config_cov_more_http_test.go
@@ -1,0 +1,105 @@
+package thresholds
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type staticReadCloser struct {
+	data     []byte
+	offset   int
+	closeErr error
+}
+
+func (r *staticReadCloser) Read(p []byte) (int, error) {
+	if r.offset >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.offset:])
+	r.offset += n
+	return n, nil
+}
+
+func (r *staticReadCloser) Close() error {
+	return r.closeErr
+}
+
+type errReadCloser struct {
+	readErr  error
+	closeErr error
+}
+
+func (r *errReadCloser) Read([]byte) (int, error) {
+	return 0, r.readErr
+}
+
+func (r *errReadCloser) Close() error {
+	return r.closeErr
+}
+
+func TestThresholdConfigAdditionalRemotePolicyBranches(t *testing.T) {
+	t.Run("resolver surfaces canonical location failures", func(t *testing.T) {
+		if _, err := newPackResolver(t.TempDir()).resolveFile("https://example.com/policy.yml#bad-pin", true); err == nil {
+			t.Fatalf("expected resolveFile to reject invalid canonical policy locations")
+		}
+	})
+
+	t.Run("resolve remote pack ref against parent URL", func(t *testing.T) {
+		current := "https://example.com/policies/root.yml#sha256=" + strings.Repeat("a", 64)
+		got, err := resolvePackRef(current, "../shared/base.yml#sha256="+strings.Repeat("b", 64))
+		if err != nil {
+			t.Fatalf("resolve remote relative pack ref: %v", err)
+		}
+		want := "https://example.com/shared/base.yml#sha256=" + strings.Repeat("b", 64)
+		if got != want {
+			t.Fatalf("unexpected resolved remote pack ref: got %q want %q", got, want)
+		}
+	})
+
+	t.Run("read remote policy joins close errors", func(t *testing.T) {
+		body := []byte("thresholds:\n  fail_on_increase_percent: 1\n")
+		sum := sha256.Sum256(body)
+		closeErr := errors.New("close body")
+
+		originalClient := remotePolicyHTTPClient
+		t.Cleanup(func() {
+			remotePolicyHTTPClient = originalClient
+		})
+		remotePolicyHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       &staticReadCloser{data: body, closeErr: closeErr},
+			}, nil
+		})}
+
+		location := "https://example.com/policy.yml#sha256=" + hex.EncodeToString(sum[:])
+		if _, err := readRemotePolicyFile(location); err == nil || !strings.Contains(err.Error(), closeErr.Error()) {
+			t.Fatalf("expected joined remote policy close error, got %v", err)
+		}
+	})
+
+	t.Run("read remote policy surfaces body read errors", func(t *testing.T) {
+		readErr := errors.New("read body")
+
+		originalClient := remotePolicyHTTPClient
+		t.Cleanup(func() {
+			remotePolicyHTTPClient = originalClient
+		})
+		remotePolicyHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       &errReadCloser{readErr: readErr},
+			}, nil
+		})}
+
+		location := "https://example.com/policy.yml#sha256=" + strings.Repeat("a", 64)
+		if _, err := readRemotePolicyFile(location); err == nil || !strings.Contains(err.Error(), "read remote policy response") {
+			t.Fatalf("expected remote policy read error, got %v", err)
+		}
+	})
+}

--- a/internal/thresholds/config_cov_more_runtime_test.go
+++ b/internal/thresholds/config_cov_more_runtime_test.go
@@ -1,0 +1,28 @@
+package thresholds
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestThresholdConfigAdditionalRuntimeBranches(t *testing.T) {
+	if _, err := resolvePackRef("https://example.com/policy.yml", "%zz"); err == nil || !strings.Contains(err.Error(), "invalid remote pack reference") {
+		t.Fatalf("expected invalid remote pack reference error, got %v", err)
+	}
+}
+
+func TestReadRemotePolicyFileRejectsOversizedResponses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(strings.Repeat("x", maxRemotePolicyBytes+1))); err != nil {
+			t.Fatalf("write oversized response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	location := server.URL + "/policy.yml#sha256=" + strings.Repeat("a", 64)
+	if _, err := readRemotePolicyFile(location); err == nil || !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("expected oversized remote policy error, got %v", err)
+	}
+}

--- a/internal/thresholds/config_test.go
+++ b/internal/thresholds/config_test.go
@@ -772,6 +772,91 @@ func TestPackResolverPopAndPathRootHelpers(t *testing.T) {
 	}
 }
 
+func TestThresholdHelperEdgeCases(t *testing.T) {
+	maxRoot := 1
+	maxNested := 2
+	cfg := rawConfig{
+		MaxUncertainImportCount: &maxRoot,
+		Thresholds: rawThresholds{
+			MaxUncertainImportCount: &maxNested,
+		},
+	}
+	if _, err := cfg.toOverrides(); err == nil {
+		t.Fatalf("expected duplicate nested max uncertain imports error")
+	}
+
+	rootPolicy := "warn"
+	nestedPolicy := "fail"
+	cfg = rawConfig{
+		LockfileDriftPolicy: &rootPolicy,
+		Thresholds: rawThresholds{
+			LockfileDriftPolicy: &nestedPolicy,
+		},
+	}
+	if _, err := cfg.toOverrides(); err == nil {
+		t.Fatalf("expected duplicate nested lockfile drift policy error")
+	}
+
+	includeRegistry := true
+	cfg = rawConfig{
+		LicenseIncludeRegistryProvenance: &includeRegistry,
+		Thresholds: rawThresholds{
+			LicenseIncludeRegistryProvenance: &includeRegistry,
+		},
+	}
+	if _, err := cfg.toOverrides(); err == nil {
+		t.Fatalf("expected duplicate nested license registry provenance error")
+	}
+
+	if got := dedupeStable([]string{"root", "pack", "root", "defaults"}); !reflect.DeepEqual(got, []string{"root", "pack", "defaults"}) {
+		t.Fatalf("expected stable dedupe order, got %#v", got)
+	}
+}
+
+func TestRemotePolicyURLValidationAndFetchErrors(t *testing.T) {
+	if parsed, ok := parseRemoteURL("http://%zz"); ok || parsed != nil {
+		t.Fatalf("expected invalid URL parse to be rejected")
+	}
+	if parsed, ok := parseRemoteURL("https:///missing-host"); ok || parsed != nil {
+		t.Fatalf("expected hostless remote URL to be rejected")
+	}
+	if _, err := canonicalRemotePolicyURL("mailto:test@example.com"); err == nil {
+		t.Fatalf("expected invalid canonical remote URL error")
+	}
+	if _, err := readRemotePolicyFile("://bad"); err == nil {
+		t.Fatalf("expected parse remote policy URL error")
+	}
+	if _, err := readRemotePolicyFile("https://example.com/policy.yml#bad-pin"); err == nil {
+		t.Fatalf("expected invalid pin error")
+	}
+
+	originalClient := remotePolicyHTTPClient
+	t.Cleanup(func() {
+		remotePolicyHTTPClient = originalClient
+	})
+	remotePolicyHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("boom")
+	})}
+	if _, err := readRemotePolicyFile("https://example.com/policy.yml#sha256=" + strings.Repeat("a", 64)); err == nil || !strings.Contains(err.Error(), "fetch remote policy") {
+		t.Fatalf("expected fetch remote policy error, got %v", err)
+	}
+	remotePolicyHTTPClient = originalClient
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(strings.Repeat("a", maxRemotePolicyBytes+1))); err != nil {
+			t.Fatalf("write oversized body: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	sum := sha256.Sum256([]byte("tiny"))
+	location := server.URL + "/policy.yml#sha256=" + hex.EncodeToString(sum[:])
+	if _, err := readRemotePolicyFile(location); err == nil || !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("expected remote policy size limit error, got %v", err)
+	}
+}
+
 func assertLoadConfigErrorContains(t *testing.T, config string, expectedText string) {
 	t.Helper()
 	repo := t.TempDir()
@@ -783,4 +868,10 @@ func assertLoadConfigErrorContains(t *testing.T, config string, expectedText str
 	if !strings.Contains(err.Error(), expectedText) {
 		t.Fatalf(unexpectedErrFmt, err)
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }

--- a/internal/thresholds/thresholds_cov_more_test.go
+++ b/internal/thresholds/thresholds_cov_more_test.go
@@ -1,0 +1,25 @@
+package thresholds
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestValuesValidateAdditionalBranches(t *testing.T) {
+	values := Defaults()
+	values.LicenseDenyList = []string{"gpl-3.0-only", "  ", "GPL-3.0-only", "Apache-2.0"}
+	if err := values.Validate(); err != nil {
+		t.Fatalf("validate values with deny list: %v", err)
+	}
+	if !slices.Equal(values.LicenseDenyList, []string{"APACHE-2.0", "GPL-3.0-ONLY"}) {
+		t.Fatalf("unexpected deny list normalization: %#v", values.LicenseDenyList)
+	}
+
+	values = Defaults()
+	values.LockfileDriftPolicy = "broken"
+	err := values.Validate()
+	if err == nil || !strings.Contains(err.Error(), "lockfile_drift_policy") {
+		t.Fatalf("expected invalid lockfile drift policy error, got %v", err)
+	}
+}

--- a/internal/ui/ui_cov_more_runtime_test.go
+++ b/internal/ui/ui_cov_more_runtime_test.go
@@ -1,0 +1,66 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestUISummaryAdditionalErrorBranches(t *testing.T) {
+	rep := report.Report{
+		Dependencies: []report.DependencyReport{
+			{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100},
+		},
+	}
+
+	t.Run("refresh clear-screen write error", func(t *testing.T) {
+		charDevice, err := os.Open("/dev/null")
+		if err != nil {
+			t.Skipf("open char device: %v", err)
+		}
+		t.Cleanup(func() {
+			if closeErr := charDevice.Close(); closeErr != nil {
+				t.Fatalf("close char device: %v", closeErr)
+			}
+		})
+		if !supportsScreenRefresh(charDevice) {
+			t.Skip("character device refresh detection unavailable")
+		}
+
+		summary := NewSummary(charDevice, strings.NewReader("q\n"), &stubAnalyzer{report: rep}, report.NewFormatter())
+		if err := summary.Start(context.Background(), Options{RepoPath: ".", TopN: 1, PageSize: 1}); err == nil {
+			t.Fatalf("expected refresh-in-place screen clear to fail on read-only output")
+		}
+	})
+
+	t.Run("snapshot confirmation write error", func(t *testing.T) {
+		writeErr := errors.New(uiWriteFailed)
+		outputPath := filepath.Join(t.TempDir(), "snapshot.txt")
+		summary := NewSummary(&failAfterWriter{failAt: 0, err: writeErr}, strings.NewReader(""), &stubAnalyzer{report: rep}, report.NewFormatter())
+
+		if err := summary.Snapshot(context.Background(), Options{RepoPath: ".", TopN: 1, PageSize: 1}, outputPath); !errors.Is(err, writeErr) {
+			t.Fatalf("expected snapshot confirmation write error, got %v", err)
+		}
+		if _, err := os.Stat(outputPath); err != nil {
+			t.Fatalf("expected snapshot file to be written before confirmation error, got %v", err)
+		}
+	})
+}
+
+func TestUIDetailPlaceholderWriteErrorBranches(t *testing.T) {
+	writeErr := errors.New(uiWriteFailed)
+
+	if err := renderList[string](&failAfterWriter{failAt: 1, err: writeErr}, "Empty", nil, func(_ io.Writer, _ string) error { return nil }); !errors.Is(err, writeErr) {
+		t.Fatalf("expected empty-list placeholder write error, got %v", err)
+	}
+
+	if err := printCodemod(&failAfterWriter{failAt: 1, err: writeErr}, nil); !errors.Is(err, writeErr) {
+		t.Fatalf("expected nil-codemod placeholder write error, got %v", err)
+	}
+}

--- a/internal/ui/ui_cov_more_test.go
+++ b/internal/ui/ui_cov_more_test.go
@@ -1,0 +1,174 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const uiWriteFailed = "write failed"
+const runtimeOverlapCode = "runtime-overlap"
+const runtimeOverlapSummary = runtimeOverlapCode + ": score=100.0 weight=0.200 contribution=20.0"
+
+func TestUIAdditionalOutputBranches(t *testing.T) {
+	var out bytes.Buffer
+	if err := printRemovalCandidate(&out, nil); err != nil {
+		t.Fatalf("print nil removal candidate: %v", err)
+	}
+	if !strings.Contains(out.String(), noneLabel) {
+		t.Fatalf("expected nil removal candidate to render %q, got %q", noneLabel, out.String())
+	}
+
+	writeErr := errors.New(uiWriteFailed)
+	if err := writeNoneAndBlankLine(&failAfterWriter{failAt: 0, err: writeErr}); !errors.Is(err, writeErr) {
+		t.Fatalf("expected initial writer error to propagate, got %v", err)
+	}
+	if err := writeNoneAndBlankLine(&failAfterWriter{failAt: 1, err: writeErr}); !errors.Is(err, writeErr) {
+		t.Fatalf("expected blank-line writer error to propagate, got %v", err)
+	}
+}
+
+func TestRenderSummaryOutputSuccess(t *testing.T) {
+	rep := report.Report{
+		Dependencies: []report.DependencyReport{
+			{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100},
+		},
+	}
+
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{report: rep}, report.NewFormatter())
+	if err := summary.renderSummaryOutput(rep, summaryState{sortMode: sortByWaste, page: 1, pageSize: 10}); err != nil {
+		t.Fatalf("render summary output: %v", err)
+	}
+	if !strings.Contains(out.String(), "Lopper TUI (summary)") {
+		t.Fatalf("expected rendered summary frame, got %q", out.String())
+	}
+}
+
+func TestSummaryUnknownCommandWriteError(t *testing.T) {
+	writeErr := errors.New(uiWriteFailed)
+	summary := NewSummary(&failAfterWriter{failAt: 0, err: writeErr}, strings.NewReader(""), &stubAnalyzer{report: report.Report{}}, report.NewFormatter())
+	_, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, &summaryState{}, "noop")
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("expected unknown-command write failure, got %v", err)
+	}
+}
+
+func TestUIDetailAdditionalBranches(t *testing.T) {
+	t.Run("render list empty placeholder", testUIRenderListEmptyPlaceholder)
+	t.Run("print codemod nil placeholder", testUIPrintCodemodNilPlaceholder)
+	t.Run("reachability signals without rationale", testUIReachabilitySignalsWithoutRationale)
+	t.Run("reachability signals empty", testUIReachabilitySignalsEmpty)
+	t.Run("removal candidate without rationale", testUIRemovalCandidateWithoutRationale)
+}
+
+func TestUIDetailAdditionalWriteErrorBranches(t *testing.T) {
+	writeErr := errors.New(uiWriteFailed)
+
+	if err := writeLines(&failAfterWriter{failAt: 0, err: writeErr}, []string{"line"}); !errors.Is(err, writeErr) {
+		t.Fatalf("expected writeLines error, got %v", err)
+	}
+
+	if err := printReachabilitySignals(&failAfterWriter{failAt: 0, err: writeErr}, []report.ReachabilitySignal{{Code: runtimeOverlapCode}}); !errors.Is(err, writeErr) {
+		t.Fatalf("expected signals header write failure, got %v", err)
+	}
+
+	if err := printReachabilitySignals(&failAfterWriter{failAt: 1, err: writeErr}, []report.ReachabilitySignal{{Code: runtimeOverlapCode}}); !errors.Is(err, writeErr) {
+		t.Fatalf("expected signals row write failure, got %v", err)
+	}
+
+	if err := printReachabilitySignals(&failAfterWriter{failAt: 2, err: writeErr}, []report.ReachabilitySignal{{Code: runtimeOverlapCode, Rationale: "because"}}); !errors.Is(err, writeErr) {
+		t.Fatalf("expected signals rationale write failure, got %v", err)
+	}
+
+	if err := printReachabilityConfidence(&failAfterWriter{failAt: 1, err: writeErr}, &report.ReachabilityConfidence{Model: "reachability-v2", Score: 72.5}); !errors.Is(err, writeErr) {
+		t.Fatalf("expected confidence writeLines failure, got %v", err)
+	}
+
+	if err := printReachabilityConfidence(&failAfterWriter{failAt: 3, err: writeErr}, &report.ReachabilityConfidence{
+		Model:   "reachability-v2",
+		Score:   72.5,
+		Signals: []report.ReachabilitySignal{{Code: runtimeOverlapCode}},
+	}); !errors.Is(err, writeErr) {
+		t.Fatalf("expected confidence signal write failure, got %v", err)
+	}
+}
+
+func testUIRenderListEmptyPlaceholder(t *testing.T) {
+	t.Helper()
+
+	var out bytes.Buffer
+	if err := renderList[string](&out, "Empty", nil, func(_ io.Writer, _ string) error { return nil }); err != nil {
+		t.Fatalf("render empty list: %v", err)
+	}
+	text := out.String()
+	if !strings.Contains(text, "Empty (0)") || !strings.Contains(text, noneLabel) {
+		t.Fatalf("expected empty list placeholder output, got %q", text)
+	}
+}
+
+func testUIPrintCodemodNilPlaceholder(t *testing.T) {
+	t.Helper()
+
+	var out bytes.Buffer
+	if err := printCodemod(&out, nil); err != nil {
+		t.Fatalf("print nil codemod: %v", err)
+	}
+	if !strings.Contains(out.String(), noneLabel) {
+		t.Fatalf("expected nil codemod to render %q, got %q", noneLabel, out.String())
+	}
+}
+
+func testUIReachabilitySignalsWithoutRationale(t *testing.T) {
+	t.Helper()
+
+	var out bytes.Buffer
+	if err := printReachabilitySignals(&out, []report.ReachabilitySignal{{
+		Code:         runtimeOverlapCode,
+		Score:        100,
+		Weight:       0.2,
+		Contribution: 20,
+	}}); err != nil {
+		t.Fatalf("print reachability signals: %v", err)
+	}
+	text := out.String()
+	if !strings.Contains(text, runtimeOverlapSummary) {
+		t.Fatalf("expected signal output, got %q", text)
+	}
+	if strings.Contains(text, "rationale:") {
+		t.Fatalf("expected blank rationale to be omitted, got %q", text)
+	}
+}
+
+func testUIReachabilitySignalsEmpty(t *testing.T) {
+	t.Helper()
+
+	var out bytes.Buffer
+	if err := printReachabilitySignals(&out, nil); err != nil {
+		t.Fatalf("print empty reachability signals: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no output for empty signals, got %q", out.String())
+	}
+}
+
+func testUIRemovalCandidateWithoutRationale(t *testing.T) {
+	t.Helper()
+
+	var out bytes.Buffer
+	if err := printRemovalCandidate(&out, &report.RemovalCandidate{Score: 80, Usage: 70, Impact: 60, Confidence: 90}); err != nil {
+		t.Fatalf("print removal candidate without rationale: %v", err)
+	}
+	text := out.String()
+	if strings.Contains(text, "rationale:") {
+		t.Fatalf("expected rationale section to be omitted, got %q", text)
+	}
+	if !strings.Contains(text, "confidence: 90.0") {
+		t.Fatalf("expected removal candidate details, got %q", text)
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -130,7 +130,6 @@ func sanitizedGitEnv() []string {
 
 func resolveGitDir(repoPath string) (string, error) {
 	searchDir := filepath.Clean(repoPath)
-	var lastErr error
 
 	for {
 		gitDir, found, err := inspectGitDir(searchDir)
@@ -140,13 +139,9 @@ func resolveGitDir(repoPath string) (string, error) {
 		if found {
 			return gitDir, nil
 		}
-		lastErr = os.ErrNotExist
 
 		parent := filepath.Dir(searchDir)
 		if parent == searchDir {
-			if lastErr != nil {
-				return "", lastErr
-			}
 			return "", os.ErrNotExist
 		}
 		searchDir = parent

--- a/internal/workspace/workspace_cov_more_branches_test.go
+++ b/internal/workspace/workspace_cov_more_branches_test.go
@@ -1,0 +1,41 @@
+package workspace
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceAdditionalGitBranches(t *testing.T) {
+	t.Run("changed files joins diff and status failures", func(t *testing.T) {
+		setupFakeGitResolver(t, "#!/bin/sh\nif [ \"$3\" = \"diff\" ]; then\n  echo \"diff fail\" >&2\n  exit 2\nfi\nif [ \"$3\" = \"status\" ]; then\n  echo \"status fail\" >&2\n  exit 3\nfi\nexit 1\n")
+
+		_, err := ChangedFiles(t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "diff fail") || !strings.Contains(err.Error(), "status fail") {
+			t.Fatalf("expected combined diff/status failure, got %v", err)
+		}
+	})
+
+	t.Run("inspect git dir keeps absolute gitdir path", func(t *testing.T) {
+		repo := t.TempDir()
+		absoluteGitDir := filepath.Join(t.TempDir(), "git-meta")
+		mustWrite(t, filepath.Join(repo, ".git"), "gitdir: "+absoluteGitDir+"\n")
+
+		gitDir, found, err := inspectGitDir(repo)
+		if err != nil {
+			t.Fatalf("inspect absolute gitdir: %v", err)
+		}
+		if !found || gitDir != absoluteGitDir {
+			t.Fatalf("expected absolute gitdir %q, got found=%v dir=%q", absoluteGitDir, found, gitDir)
+		}
+	})
+
+	t.Run("resolve git dir returns not-exist when no git metadata is present", func(t *testing.T) {
+		_, err := resolveGitDir(t.TempDir())
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected missing git metadata error, got %v", err)
+		}
+	})
+}

--- a/internal/workspace/workspace_cov_more_runtime_test.go
+++ b/internal/workspace/workspace_cov_more_runtime_test.go
@@ -1,0 +1,18 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkspaceInspectGitDirSymlinkLoop(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Symlink(".git", filepath.Join(repo, ".git")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	if _, _, err := inspectGitDir(repo); err == nil {
+		t.Fatalf("expected inspectGitDir to fail on .git symlink loop")
+	}
+}

--- a/internal/workspace/workspace_cov_more_test.go
+++ b/internal/workspace/workspace_cov_more_test.go
@@ -1,0 +1,141 @@
+package workspace
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkspaceAdditionalBranchCoverage(t *testing.T) {
+	testWorkspaceChangedFilesReturnsGitResolutionError(t)
+	testWorkspaceNormalizeRepoPathErrorsBubbleThroughHelpers(t)
+	testWorkspaceEmptyRepoPathFailsWhenCWDCannotBeResolved(t)
+	testWorkspaceInspectGitDirBubblesReadError(t)
+	testWorkspaceRunGitConstructorError(t)
+	testWorkspaceInspectGitDirResolvesRelativeGitDir(t)
+}
+
+func testWorkspaceChangedFilesReturnsGitResolutionError(t *testing.T) {
+	t.Helper()
+
+	original := resolveGitBinaryPathFn
+	resolveGitBinaryPathFn = func() (string, error) {
+		return "", errors.New("missing git")
+	}
+	t.Cleanup(func() {
+		resolveGitBinaryPathFn = original
+	})
+
+	if _, err := ChangedFiles(t.TempDir()); err == nil || err.Error() != "missing git" {
+		t.Fatalf("expected git resolver error, got %v", err)
+	}
+}
+
+func testWorkspaceNormalizeRepoPathErrorsBubbleThroughHelpers(t *testing.T) {
+	t.Helper()
+
+	if _, err := CurrentCommitSHA("\x00"); err == nil {
+		t.Fatalf("expected invalid repo path to fail commit lookup")
+	}
+	if _, err := ChangedFiles("\x00"); err == nil {
+		t.Fatalf("expected invalid repo path to fail changed-files lookup")
+	}
+}
+
+func testWorkspaceEmptyRepoPathFailsWhenCWDCannotBeResolved(t *testing.T) {
+	t.Helper()
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Fatalf("restore wd %s: %v", originalWD, err)
+		}
+	})
+
+	deadDir := filepath.Join(t.TempDir(), "dead")
+	if err := os.MkdirAll(deadDir, 0o755); err != nil {
+		t.Fatalf("mkdir dead dir: %v", err)
+	}
+	if err := os.Chdir(deadDir); err != nil {
+		t.Fatalf("chdir dead dir: %v", err)
+	}
+	if err := os.RemoveAll(deadDir); err != nil {
+		t.Fatalf("remove dead dir: %v", err)
+	}
+
+	if _, err := CurrentCommitSHA(""); err == nil {
+		t.Fatalf("expected commit lookup to fail when cwd cannot be resolved")
+	}
+	if _, err := ChangedFiles(""); err == nil {
+		t.Fatalf("expected changed-files lookup to fail when cwd cannot be resolved")
+	}
+}
+
+func testWorkspaceInspectGitDirBubblesReadError(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	gitFile := filepath.Join(repo, ".git")
+	if err := os.WriteFile(gitFile, []byte("gitdir: somewhere\n"), 0o000); err != nil {
+		t.Fatalf("write unreadable git file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(gitFile, 0o600); err != nil {
+			t.Fatalf("restore git file perms: %v", err)
+		}
+	})
+
+	if _, _, err := inspectGitDir(repo); err == nil {
+		t.Fatalf("expected unreadable git file to fail inspection")
+	}
+}
+
+func testWorkspaceRunGitConstructorError(t *testing.T) {
+	t.Helper()
+
+	original := execGitCommandFn
+	expected := errors.New("construct git")
+	execGitCommandFn = func(string, ...string) (*exec.Cmd, error) {
+		return nil, expected
+	}
+	t.Cleanup(func() {
+		execGitCommandFn = original
+	})
+
+	if _, err := runGit("git", t.TempDir(), "status"); !errors.Is(err, expected) {
+		t.Fatalf("expected git command construction error, got %v", err)
+	}
+}
+
+func testWorkspaceInspectGitDirResolvesRelativeGitDir(t *testing.T) {
+	t.Helper()
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	actualGitDir := filepath.Join(root, "actual-git")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.MkdirAll(actualGitDir, 0o755); err != nil {
+		t.Fatalf("mkdir git dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".git"), []byte("gitdir: ../actual-git\n"), 0o600); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+
+	gitDir, found, err := inspectGitDir(repo)
+	if err != nil {
+		t.Fatalf("inspect relative gitdir: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected gitdir file to be discovered")
+	}
+	if want := filepath.Clean(filepath.Join(repo, "..", "actual-git")); gitDir != want {
+		t.Fatalf("expected resolved gitdir %q, got %q", want, gitDir)
+	}
+}


### PR DESCRIPTION
Closes #322.

## Summary
- raises the repo coverage floor from 95%% to 98%% in the local gate, CI workflow, and CI docs
- adds targeted branch-coverage tests across analysis, app, dashboard, runtime, report, threshold, UI, workspace, and language adapters
- trims a small set of redundant impossible guards where parser or workspace invariants already guarantee the shape being handled

## User Impact
- keeps the coverage ratchet moving forward instead of allowing the suite to sit near the old 95%% floor
- makes future regressions trip at 98%% in both local and CI enforcement paths

## Root Cause
Coverage enforcement had stalled at 95%% while several branch-heavy code paths still lacked direct tests, so the suite was not safely above a tighter gate.

## Validation
- `go test -buildvcs=false ./... -coverprofile=.artifacts/coverage-issue322-final.out`
  - raw total coverage: `98.0007%%`
- `GOFLAGS=-buildvcs=false make ci COVERAGE_MIN=98`
  - full hook-equivalent CI path passed
  - coverage gate result: `98.1%%`
