### PR TITLE
refactor(analysis): deduplicate keep.js literal in scope coverage tests

### DIFF
--- a/internal/analysis/scope_cov_more_runtime_test.go
+++ b/internal/analysis/scope_cov_more_runtime_test.go
@@ -8,17 +8,19 @@ import (
 	"testing"
 )
 
+const scopeKeepJS = "keep.js"
+
 func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 	repo := t.TempDir()
 	scopedRoot := t.TempDir()
-	sourcePath := filepath.Join(repo, "src", "keep.js")
+	sourcePath := filepath.Join(repo, "src", scopeKeepJS)
 	writeScopeFile(t, sourcePath, "export const keep = true\n")
 
-	targetDir := filepath.Join(scopedRoot, "src", "keep.js")
+	targetDir := filepath.Join(scopedRoot, "src", scopeKeepJS)
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		t.Fatalf("mkdir target dir: %v", err)
 	}
-	if err := copyFile(repo, scopedRoot, filepath.Join("src", "keep.js")); err == nil {
+	if err := copyFile(repo, scopedRoot, filepath.Join("src", scopeKeepJS)); err == nil {
 		t.Fatalf("expected copyFile to fail when target path is a directory")
 	}
 


### PR DESCRIPTION
## Issue

SonarCloud reported `AZ0BjrSPMG8n_2J2mo9n` in `internal/analysis/scope_cov_more_runtime_test.go:14` for repeated `keep.js` literals.

## Cause

The test repeated the same path segment in three places, which triggered Sonar rule `go:S1192`.

## Fix

Introduce a package-level `scopeKeepJS` constant and use it for the source path, target path, and failing `copyFile` call.

## Validation

- `go test ./internal/analysis`
- Pre-commit hooks ran `make fmt`, `make ci`, `go test ./...`, `go test -race ./...`, and the repo memory benchmark delta checks.

Closes #386
