### PR TITLE
fix(python): expand stdlib allowlist coverage

### DIFF
--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -458,10 +458,14 @@ func pythonFileUsages(scan scanResult) []shared.FileUsage {
 }
 
 var pythonStdlib = map[string]bool{
-	"abc": true, "argparse": true, "asyncio": true, "collections": true, "contextlib": true, "copy": true,
-	"csv": true, "dataclasses": true, "datetime": true, "functools": true, "hashlib": true, "http": true,
-	"importlib": true, "itertools": true, "json": true, "logging": true, "math": true, "os": true,
-	"pathlib": true, "queue": true, "random": true, "re": true, "socket": true, "sqlite3": true,
-	"ssl": true, "statistics": true, "string": true, "subprocess": true, "sys": true, "threading": true,
-	"time": true, "typing": true, "unittest": true, "urllib": true, "uuid": true, "xml": true, "zipfile": true,
+	"abc": true, "argparse": true, "ast": true, "asyncio": true, "codecs": true, "collections": true,
+	"concurrent": true, "contextlib": true, "copy": true, "csv": true, "dataclasses": true, "datetime": true,
+	"decimal": true, "dis": true, "enum": true, "fractions": true, "functools": true, "gc": true,
+	"glob": true, "hashlib": true, "http": true, "importlib": true, "inspect": true, "io": true,
+	"itertools": true, "json": true, "keyword": true, "logging": true, "math": true, "multiprocessing": true,
+	"operator": true, "os": true, "pathlib": true, "platform": true, "pprint": true, "queue": true,
+	"random": true, "re": true, "shutil": true, "signal": true, "socket": true, "sqlite3": true,
+	"ssl": true, "statistics": true, "string": true, "struct": true, "subprocess": true, "sys": true,
+	"tempfile": true, "textwrap": true, "threading": true, "time": true, "traceback": true, "typing": true,
+	"unittest": true, "urllib": true, "uuid": true, "warnings": true, "weakref": true, "xml": true, "zipfile": true,
 }

--- a/internal/lang/python/helpers_test.go
+++ b/internal/lang/python/helpers_test.go
@@ -81,6 +81,42 @@ func TestPythonModuleResolutionHelpers(t *testing.T) {
 	}
 }
 
+func TestPythonDependencyFromModuleStdlibCoverage(t *testing.T) {
+	repo := t.TempDir()
+	modules := []string{
+		"io",
+		"enum",
+		"struct",
+		"ast",
+		"inspect",
+		"shutil",
+		"glob",
+		"tempfile",
+		"traceback",
+		"warnings",
+		"weakref",
+		"platform",
+		"signal",
+		"pprint",
+		"decimal",
+		"fractions",
+		"codecs",
+		"textwrap",
+		"operator",
+		"gc",
+		"dis",
+		"keyword",
+		"multiprocessing",
+		"concurrent",
+		"concurrent.futures",
+	}
+	for _, module := range modules {
+		if dependency := dependencyFromModule(repo, module); dependency != "" {
+			t.Fatalf("expected stdlib module %q to be ignored, got dependency %q", module, dependency)
+		}
+	}
+}
+
 func TestPythonDirectoryAndRecommendationsHelpers(t *testing.T) {
 	if !shouldSkipDir(".git") || !shouldSkipDir(".venv") || shouldSkipDir("src") {
 		t.Fatalf("unexpected shouldSkipDir behavior")


### PR DESCRIPTION
## Issue
Fixes #392. The Python adapter treated several standard library imports as third-party dependencies because `pythonStdlib` did not include a number of common stdlib roots.

## Cause and user impact
When repositories imported modules like `io`, `enum`, `inspect`, `tempfile`, `multiprocessing`, or `concurrent.futures`, lopper reported them as external dependencies. That inflated dependency reports with false positives and made Python analysis less trustworthy.

## Root cause
`internal/lang/python/adapter.go` hard-coded a partial stdlib allowlist. The missing roots were not filtered before dependency classification.

## Fix
Expanded `pythonStdlib` to include the missing stdlib roots called out in the issue, including `concurrent` so dotted imports like `concurrent.futures` resolve through the stdlib path. Added focused regression coverage in `internal/lang/python/helpers_test.go` to assert those modules are ignored by `dependencyFromModule`.

## Validation
Not run locally in this session.
