### PR TITLE
refactor(ci): extract shared smoke bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,10 +511,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout
+      - &ci_smoke_checkout
+        name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Go
+      - &ci_smoke_setup_go
+        name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -536,13 +538,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - *ci_smoke_checkout
 
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
+      - *ci_smoke_setup_go
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
Closes #411

## Issue
`os-smoke` and `vscode-smoke` in `.github/workflows/ci.yml` each defined the same smoke-job bootstrap for repository checkout and Go setup.

## Root cause
The workflow kept each smoke job self-contained, so the common bootstrap steps drifted into duplicated inline step definitions inside a large CI file.

## Fix
Refactored the smoke bootstrap into shared YAML-anchored step mappings inside `ci.yml`. `os-smoke` now defines the canonical `Checkout` and `Setup Go` steps, and `vscode-smoke` reuses those exact mappings before its job-specific Node and VS Code test steps. This keeps behavior unchanged while centralizing the duplicated bootstrap.

## Validation
- Parsed `.github/workflows/ci.yml` locally with Ruby `Psych.safe_load(..., aliases: true)` to verify YAML syntax and anchor resolution.
- Confirmed the resolved smoke-job steps still point to `actions/checkout@v6` and `actions/setup-go@v6` with `go-version-file: go.mod`.
- `actionlint` is not installed in this environment, so no workflow-specific linter run was available locally.
