### PR TITLE
fix(language): guard nil registry receiver

### DIFF
--- a/internal/language/registry.go
+++ b/internal/language/registry.go
@@ -24,6 +24,10 @@ func NewRegistry() *Registry {
 }
 
 func (r *Registry) Register(adapter Adapter) error {
+	if r == nil {
+		return errors.New("language registry is nil")
+	}
+
 	if adapter == nil {
 		return errors.New("adapter is nil")
 	}

--- a/internal/language/registry_test.go
+++ b/internal/language/registry_test.go
@@ -126,6 +126,9 @@ func TestResolveAutoTieReturnsError(t *testing.T) {
 
 func TestRegisterValidationAndIDs(t *testing.T) {
 	registry := NewRegistry()
+	if (*Registry)(nil).Register(&testAdapter{id: "nil", detection: Detection{Matched: true}}) == nil {
+		t.Fatalf("expected nil registry register error")
+	}
 	if registry.Register(nil) == nil {
 		t.Fatalf("expected nil adapter error")
 	}


### PR DESCRIPTION
## Issue
`language.Registry.Register` panicked when called on a nil receiver instead of returning a normal error. That made the public registry API inconsistent with `Resolve` and `IDs`, which already treat a nil registry receiver as an error or empty result.

## Cause and Impact
The method accessed `r.adapters` before checking whether `r` itself was nil. Any caller holding a nil `*language.Registry` could trigger a runtime panic instead of getting a recoverable error.

## Root Cause
`Register` validated only the adapter argument. Unlike the other nil-safe registry methods, it had no receiver guard before dereferencing internal state.

## Fix
Add an early nil-receiver check in `Register` that returns `language registry is nil`, and extend the existing registry validation test to assert that nil receiver behavior.

## Validation
- `go test ./internal/language -run '^TestRegisterValidationAndIDs$' -count=1`
- `go test ./internal/language -count=1`

Closes #422
