### PR TITLE
fix(elixir): ignore commented apps_path in umbrella detection

### DIFF
--- a/internal/lang/elixir/adapter.go
+++ b/internal/lang/elixir/adapter.go
@@ -116,7 +116,7 @@ func detectFromRootFiles(repoPath string, detection *language.Detection, roots m
 }
 
 func detectUmbrellaAppsPath(content []byte) (bool, string) {
-	raw := string(content)
+	raw := stripElixirComments(content)
 	if !strings.Contains(raw, "apps_path:") {
 		return false, ""
 	}
@@ -128,6 +128,55 @@ func detectUmbrellaAppsPath(content []byte) (bool, string) {
 		}
 	}
 	return true, "apps"
+}
+
+func stripElixirComments(content []byte) string {
+	var stripped strings.Builder
+	stripped.Grow(len(content))
+
+	inSingleQuote := false
+	inDoubleQuote := false
+	escaped := false
+
+	for i := 0; i < len(content); i++ {
+		ch := content[i]
+		if escaped {
+			stripped.WriteByte(ch)
+			escaped = false
+			continue
+		}
+		if ch == '\\' && (inSingleQuote || inDoubleQuote) {
+			stripped.WriteByte(ch)
+			escaped = true
+			continue
+		}
+		switch ch {
+		case '"':
+			if !inSingleQuote {
+				inDoubleQuote = !inDoubleQuote
+			}
+			stripped.WriteByte(ch)
+		case '\'':
+			if !inDoubleQuote {
+				inSingleQuote = !inSingleQuote
+			}
+			stripped.WriteByte(ch)
+		case '#':
+			if inSingleQuote || inDoubleQuote {
+				stripped.WriteByte(ch)
+				continue
+			}
+			for i < len(content) && content[i] != '\n' {
+				i++
+			}
+			if i < len(content) {
+				stripped.WriteByte('\n')
+			}
+		default:
+			stripped.WriteByte(ch)
+		}
+	}
+	return stripped.String()
 }
 
 func addUmbrellaRoots(repoPath string, appsPath string, roots map[string]struct{}) error {

--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -137,6 +137,13 @@ func TestDetectWithConfidenceUmbrellaCustomAppsPath(t *testing.T) {
 	assertDetectionFixture(t, repo, filepath.Join("services", "api"), filepath.Base(repo))
 }
 
+func TestDetectWithConfidenceIgnoresCommentedAppsPath(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  # apps_path: \"services\"\n  def project, do: []\nend\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "services", "api", mixExsName), "defmodule Api.MixProject do\n  use Mix.Project\nend\n")
+	assertDetectionFixture(t, repo, filepath.Base(repo), "")
+}
+
 func TestParseImportsAliasAsSetsLocalName(t *testing.T) {
 	content := []byte("defmodule Demo do\n  alias Foo.Bar, as: Baz\n  Baz.run()\nend\n")
 	declared := map[string]struct{}{"foo": {}}
@@ -164,6 +171,9 @@ func TestResolveWeights(t *testing.T) {
 func TestDetectUmbrellaAppsPathBranches(t *testing.T) {
 	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("def project, do: []\n")); umbrella || appsPath != "" {
 		t.Fatalf("expected non-umbrella config without apps_path, got umbrella=%v appsPath=%q", umbrella, appsPath)
+	}
+	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("# apps_path: \"services\"\ndef project, do: []\n")); umbrella || appsPath != "" {
+		t.Fatalf("expected commented apps_path to be ignored, got umbrella=%v appsPath=%q", umbrella, appsPath)
 	}
 	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("def project, do: [apps_path: \"   \"]\n")); !umbrella || appsPath != "apps" {
 		t.Fatalf("expected blank apps_path to fall back to apps, got umbrella=%v appsPath=%q", umbrella, appsPath)


### PR DESCRIPTION
## Issue
Elixir umbrella detection was treating commented `apps_path:` text in `mix.exs` as real umbrella configuration. In repos that had a nested Mix app plus a commented example like `# apps_path: "services"`, detection dropped the repository root from the detected roots.

## Cause and user impact
That caused the adapter to classify a normal Mix repo as an umbrella app and only keep nested app roots. Users would get incomplete Elixir detection for repos that merely mentioned `apps_path:` in comments.

## Root cause
`detectUmbrellaAppsPath` scanned the raw `mix.exs` content and matched `apps_path:` before accounting for Elixir comments.

## Fix
Strip Elixir line comments before checking for `apps_path:` and add regressions for both the low-level parser branch and `DetectWithConfidence` so a commented `apps_path:` no longer triggers umbrella-only detection.

## Validation
- `go test ./internal/lang/elixir -run 'TestDetectWithConfidenceIgnoresCommentedAppsPath|TestDetectUmbrellaAppsPathBranches'`
- `go test ./internal/lang/elixir`
- `go test ./internal/analysis -run 'TestAnalyse(ElixirFixture|FixtureDependencyAndTopN)?|TestAnalyseElixir'`

Closes #424
