### PR TITLE
chore(release): bump stable version to 1.2.0

### DIFF
--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -110,7 +110,7 @@ For Darwin artifacts, build on a macOS runner with native architecture.
 To build multiple platforms:
 
 ```bash
-make release VERSION=v1.0.2 PLATFORMS="linux/amd64 darwin/arm64 windows/amd64"
+make release VERSION=v1.2.0 PLATFORMS="linux/amd64 darwin/arm64 windows/amd64"
 ```
 
 Install toolchain support with:

--- a/extensions/vscode-lopper/CHANGELOG.md
+++ b/extensions/vscode-lopper/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+- Expanded package ecosystem coverage across existing adapters with Ruby gemspec support, Swift CocoaPods support, Python modern packaging support, Gradle version catalog support, and C/C++ vcpkg plus Conan support.
+- Landed the supporting correctness and refactor batch that hardened release readiness across lockfile drift, reporting, runtime cancellation, registry safety, and the release workflow smoke path.
+
 ## 1.0.2
 
 - Republished the Marketplace package at a new patch version to supersede the earlier `1.0.1` and `1.0.0` extension builds.

--- a/extensions/vscode-lopper/package-lock.json
+++ b/extensions/vscode-lopper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-lopper",
-  "version": "1.0.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-lopper",
-      "version": "1.0.2",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",

--- a/extensions/vscode-lopper/package.json
+++ b/extensions/vscode-lopper/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-lopper",
   "displayName": "Lopper",
   "description": "VS Code diagnostics, hover details, and safe JS/TS quick fixes across Lopper adapters, including Kotlin Android.",
-  "version": "1.0.2",
+  "version": "1.2.0",
   "publisher": "BenRanford",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Issue
The v1.2 feature batch is merged, but the stable release surface still reports `1.0.2` in the VS Code extension package metadata and changelog.

## Cause and user impact
The release workflow derives the stable semver tag from `extensions/vscode-lopper/package.json`. If that version stays at `1.0.2`, a manual release cut will not promote the stable tag to `v1.2.0`, and the Marketplace-facing changelog/version story stays out of sync with the shipped feature set.

## Root cause
The repo accumulated the full v1.2 substance across merged milestones and fixes, but no dedicated release-cut PR updated the extension version surface and release documentation example.

## Fix
This PR bumps the VS Code extension package version to `1.2.0`, updates the lockfile root metadata to match, adds a `1.2.0` changelog entry summarizing the release contents, and refreshes the release command example in `docs/ci-usage.md`.

## Validation
- `make vscode-extension-install`
- `cd extensions/vscode-lopper && npm run compile`
