### PR TITLE
fix(ci): stop rerunning CI on main after PR close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: ci
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   extension-changes:

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -2,7 +2,7 @@
 
 This repository includes five GitHub Actions workflows:
 
-- `.github/workflows/ci.yml`: runs checks on pull requests and pushes to `main`
+- `.github/workflows/ci.yml`: runs checks on pull requests
 - `.github/workflows/release.yml`: scheduled weekly (Saturday 12:00 UTC) semver release workflow that runs when changes exist since the previous stable tag or when version alignment needs to promote the stable CLI tag to the VS Code extension version, then runs CI and publishes a GitHub release with:
   - Linux/Windows artifacts from Ubuntu (cross-compiled with `zig`)
   - Darwin artifact from macOS (native arch)


### PR DESCRIPTION
Closes #501

## The issue

Closing or merging a pull request triggered `ci.yml` a second time on `main`, even though the repository already has merge-specific automation for post-merge work.

## Cause and user impact

A merged PR produced two separate post-review workflow effects: the intended rolling workflow on PR close/merge, and an unnecessary `ci` workflow run from the `push` to `main`. That consumed extra runner time and cluttered the status history on `main`.

## Root cause

`.github/workflows/ci.yml` subscribed to both `pull_request` and `push` on `main`, so every merge commit to `main` retriggered the full CI workflow.

## The fix

The PR removes the `push` trigger from `ci.yml` so CI stays PR-scoped, and updates the CI documentation to match the actual trigger behavior.

## Validation

- `make actionlint`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml: ok"'`
- `git diff --check`
