### PR TITLE
fix(vscode): trust-gate workspace binaries

### DIFF
--- a/extensions/vscode-lopper/README.md
+++ b/extensions/vscode-lopper/README.md
@@ -23,9 +23,10 @@ The extension uses the same adapter IDs as the `lopper` CLI.
 The extension shells out to `lopper`.
 
 - If `lopper` is already on your `PATH`, the extension will use it automatically.
-- If your repo contains `bin/lopper`, the extension will use that first.
+- If your repo contains `bin/lopper`, the extension will use that first after you trust the workspace.
 - If no local binary is available, the extension can download a matching GitHub release into extension-managed storage.
 - You can always override detection with `lopper.binaryPath` or `LOPPER_BINARY_PATH`.
+- Workspace-local binaries, including `bin/lopper` and `lopper.binaryPath` values inside the repo, are blocked until the workspace is trusted.
 
 ## Install
 

--- a/extensions/vscode-lopper/package.json
+++ b/extensions/vscode-lopper/package.json
@@ -17,6 +17,12 @@
   "engines": {
     "vscode": "^1.90.0"
   },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Lopper does not execute workspace-local binaries until the workspace is trusted."
+    }
+  },
   "categories": [
     "Linters",
     "Other"

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -76,6 +76,16 @@ class LopperController implements vscode.Disposable, vscode.HoverProvider, vscod
           }, 400),
         );
       }),
+      vscode.workspace.onDidGrantWorkspaceTrust(async () => {
+        const folder = this.primaryWorkspaceFolder();
+        if (!folder) {
+          return;
+        }
+        if (!vscode.workspace.getConfiguration("lopper", folder.uri).get<boolean>("autoRefresh", true)) {
+          return;
+        }
+        await this.refreshWorkspace(folder, false, this.activeDocumentForFolder(folder));
+      }),
     );
   }
 

--- a/extensions/vscode-lopper/src/lopperRunner.ts
+++ b/extensions/vscode-lopper/src/lopperRunner.ts
@@ -106,13 +106,16 @@ export class LopperRunner {
     }
   }
 
-  async resolveBinaryPath(folder: vscode.WorkspaceFolder): Promise<string> {
-    const configuredBinaryPath = await this.resolveConfiguredBinaryPath(folder);
+  async resolveBinaryPath(
+    folder: vscode.WorkspaceFolder,
+    workspaceTrusted = vscode.workspace.isTrusted,
+  ): Promise<string> {
+    const configuredBinaryPath = await this.resolveConfiguredBinaryPath(folder, workspaceTrusted);
     if (configuredBinaryPath) {
       return configuredBinaryPath;
     }
 
-    const localBinaryPath = await this.resolveLocalBinaryPath(folder);
+    const localBinaryPath = await this.resolveLocalBinaryPath(folder, workspaceTrusted);
     if (localBinaryPath) {
       return localBinaryPath;
     }
@@ -120,10 +123,15 @@ export class LopperRunner {
     return this.resolveManagedBinaryPath(folder);
   }
 
-  private async resolveConfiguredBinaryPath(folder: vscode.WorkspaceFolder): Promise<string | undefined> {
+  private async resolveConfiguredBinaryPath(
+    folder: vscode.WorkspaceFolder,
+    workspaceTrusted: boolean,
+  ): Promise<string | undefined> {
     const envBinaryPath = process.env.LOPPER_BINARY_PATH?.trim();
     if (envBinaryPath) {
-      return this.ensureConfiguredBinaryExists(envBinaryPath, "LOPPER_BINARY_PATH");
+      const binaryPath = await this.ensureConfiguredBinaryExists(envBinaryPath, "LOPPER_BINARY_PATH");
+      this.ensureWorkspaceTrustedForBinary(binaryPath, folder, "LOPPER_BINARY_PATH", workspaceTrusted);
+      return binaryPath;
     }
 
     const configuredBinaryPath = vscode.workspace
@@ -137,10 +145,15 @@ export class LopperRunner {
     const resolvedPath = path.isAbsolute(configuredBinaryPath)
       ? configuredBinaryPath
       : path.join(folder.uri.fsPath, configuredBinaryPath);
-    return this.ensureConfiguredBinaryExists(resolvedPath, "lopper.binaryPath");
+    const binaryPath = await this.ensureConfiguredBinaryExists(resolvedPath, "lopper.binaryPath");
+    this.ensureWorkspaceTrustedForBinary(binaryPath, folder, "lopper.binaryPath", workspaceTrusted);
+    return binaryPath;
   }
 
-  private async resolveLocalBinaryPath(folder: vscode.WorkspaceFolder): Promise<string | undefined> {
+  private async resolveLocalBinaryPath(
+    folder: vscode.WorkspaceFolder,
+    workspaceTrusted: boolean,
+  ): Promise<string | undefined> {
     const localBinary = path.join(folder.uri.fsPath, "bin", lopperBinaryName());
     try {
       const fileStat = await stat(localBinary);
@@ -153,6 +166,10 @@ export class LopperRunner {
       } else {
         // On POSIX, ensure the file is executable.
         await access(localBinary, fsConstants.X_OK);
+      }
+      if (!workspaceTrusted) {
+        this.output.appendLine(`skipping workspace-local lopper binary in untrusted workspace: ${localBinary}`);
+        return findExecutableInPath(lopperBinaryName());
       }
       return localBinary;
     } catch {
@@ -228,6 +245,21 @@ export class LopperRunner {
     }
   }
 
+  private ensureWorkspaceTrustedForBinary(
+    binaryPath: string,
+    folder: vscode.WorkspaceFolder,
+    source: string,
+    workspaceTrusted: boolean,
+  ): void {
+    if (workspaceTrusted || !isPathInsideWorkspace(binaryPath, folder.uri.fsPath)) {
+      return;
+    }
+
+    throw new BinaryResolutionError(
+      `${source} points to a workspace-local binary in an untrusted workspace. Trust this workspace or use a binary outside the workspace.`,
+    );
+  }
+
   private async runReport(binaryPath: string, args: string[], cwd: string): Promise<LopperReport> {
     this.output.appendLine(`running: ${binaryPath} ${args.join(" ")}`);
     try {
@@ -279,4 +311,9 @@ function shouldFetchCodemod(dependency: LopperDependencyReport, requestedLanguag
 
 function lopperBinaryName(platform = process.platform): string {
   return platform === "win32" ? "lopper.exe" : "lopper";
+}
+
+function isPathInsideWorkspace(candidatePath: string, workspaceRoot: string): boolean {
+  const relativePath = path.relative(path.resolve(workspaceRoot), path.resolve(candidatePath));
+  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }

--- a/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "node:assert/strict";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { suite, test } from "mocha";
@@ -53,6 +53,54 @@ suite("lopper runner", () => {
       await rm(tempRoot, { recursive: true, force: true });
     }
   });
+
+  test("rejects workspace-local configured binaries in untrusted workspaces", async () => {
+    const folder = workspaceFolder();
+    const tempRoot = await mkdtemp(path.join(folder.uri.fsPath, ".lopper-untrusted-configured-"));
+    const binaryPath = path.join(tempRoot, "lopper");
+    const previousPath = process.env.LOPPER_BINARY_PATH;
+
+    try {
+      await writeExecutable(binaryPath);
+      process.env.LOPPER_BINARY_PATH = binaryPath;
+
+      const runner = createRunner(tempRoot);
+      await assert.rejects(
+        runner.resolveBinaryPath(folder, false),
+        (error: unknown) =>
+          error instanceof BinaryResolutionError &&
+          error.message.includes("workspace-local binary in an untrusted workspace"),
+      );
+    } finally {
+      restoreEnv("LOPPER_BINARY_PATH", previousPath);
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("skips workspace-local bin/lopper in untrusted workspaces", async function () {
+    const folder = workspaceFolder();
+    const workspaceBinary = path.join(folder.uri.fsPath, "bin", platformBinaryName());
+    const pathRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-runner-path-"));
+    const fallbackBinary = path.join(pathRoot, platformBinaryName());
+    const previousBinaryPath = process.env.LOPPER_BINARY_PATH;
+    const previousPathEnv = process.env.PATH;
+
+    try {
+      delete process.env.LOPPER_BINARY_PATH;
+      await writeExecutable(workspaceBinary);
+      await writeExecutable(fallbackBinary);
+      process.env.PATH = joinPathEntries([pathRoot, previousPathEnv]);
+
+      const runner = createRunner(pathRoot);
+      const resolvedPath = await runner.resolveBinaryPath(folder, false);
+      assert.equal(resolvedPath, fallbackBinary);
+    } finally {
+      restoreEnv("LOPPER_BINARY_PATH", previousBinaryPath);
+      restoreEnv("PATH", previousPathEnv);
+      await rm(workspaceBinary, { force: true });
+      await rm(pathRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 function workspaceFolder(): vscode.WorkspaceFolder {
@@ -64,6 +112,24 @@ function workspaceFolder(): vscode.WorkspaceFolder {
 function createRunner(storageRoot: string): LopperRunner {
   const context = { globalStorageUri: vscode.Uri.file(storageRoot) } as vscode.ExtensionContext;
   return new LopperRunner({ appendLine: () => undefined }, context);
+}
+
+async function writeExecutable(binaryPath: string): Promise<void> {
+  await mkdir(path.dirname(binaryPath), { recursive: true });
+  await writeFile(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
+  if (process.platform !== "win32") {
+    await chmod(binaryPath, 0o755);
+  }
+}
+
+function joinPathEntries(entries: Array<string | undefined>): string {
+  return entries
+    .filter((entry): entry is string => entry !== undefined && entry.length > 0)
+    .join(path.delimiter);
+}
+
+function platformBinaryName(): string {
+  return process.platform === "win32" ? "lopper.exe" : "lopper";
 }
 
 function restoreEnv(name: string, value: string | undefined): void {


### PR DESCRIPTION
## Issue
Closes #507.

The VS Code extension could resolve and run workspace-controlled binaries from `bin/lopper` or workspace-relative `lopper.binaryPath` settings without gating that behavior on workspace trust.

## Root Cause
Binary resolution preferred workspace-local executables, but the extension did not declare limited untrusted-workspace support or defer those workspace-local execution paths until trust was granted.

## Fix
Declare limited untrusted-workspace support, block workspace-local binaries until the workspace is trusted, and rerun the auto-refresh path when trust is granted. Added runner coverage for untrusted-workspace binary resolution and documented the trust requirement.

## Validation
- `make build`
- `make vscode-extension-install`
- `make vscode-extension-test`
