### PR TITLE
fix(thresholds): block remote packs from discovered config

### DIFF
--- a/docs/threshold-tuning.md
+++ b/docs/threshold-tuning.md
@@ -87,7 +87,7 @@ thresholds:
   fail_on_increase_percent: 2
 ```
 
-Remote policy packs are supported when pinned by SHA-256 in the URL fragment:
+Remote policy packs are supported when pinned by SHA-256 in the URL fragment and loaded from an explicit trusted config path (`--config ...`):
 
 ```yaml
 policy:

--- a/internal/thresholds/config.go
+++ b/internal/thresholds/config.go
@@ -52,7 +52,7 @@ func LoadWithPolicy(repoPath, explicitPath string) (LoadResult, error) {
 		}, nil
 	}
 
-	resolver := newPackResolver(repoAbs)
+	resolver := newPackResolver(repoAbs, explicitProvided)
 	mergeResult, err := resolver.resolveFile(configPath, explicitProvided)
 	if err != nil {
 		return LoadResult{}, err

--- a/internal/thresholds/config_cov_more_http_test.go
+++ b/internal/thresholds/config_cov_more_http_test.go
@@ -44,7 +44,7 @@ func (r *errReadCloser) Close() error {
 
 func TestThresholdConfigAdditionalRemotePolicyBranches(t *testing.T) {
 	t.Run("resolver surfaces canonical location failures", func(t *testing.T) {
-		if _, err := newPackResolver(t.TempDir()).resolveFile("https://example.com/policy.yml#bad-pin", true); err == nil {
+		if _, err := newPackResolver(t.TempDir(), true).resolveFile("https://example.com/policy.yml#bad-pin", true); err == nil {
 			t.Fatalf("expected resolveFile to reject invalid canonical policy locations")
 		}
 	})

--- a/internal/thresholds/config_packs.go
+++ b/internal/thresholds/config_packs.go
@@ -8,8 +8,9 @@ import (
 )
 
 type packResolver struct {
-	repoPath string
-	stack    []string
+	repoPath    string
+	allowRemote bool
+	stack       []string
 }
 
 type resolveMergeResult struct {
@@ -33,10 +34,11 @@ func (r *resolveMergeResult) policySourcesHighToLow() []string {
 	return sources
 }
 
-func newPackResolver(repoPath string) *packResolver {
+func newPackResolver(repoPath string, allowRemote bool) *packResolver {
 	return &packResolver{
-		repoPath: repoPath,
-		stack:    make([]string, 0, 8),
+		repoPath:    repoPath,
+		allowRemote: allowRemote,
+		stack:       make([]string, 0, 8),
 	}
 }
 
@@ -67,6 +69,9 @@ func (r *packResolver) resolveFile(path string, explicitProvided bool) (resolveM
 		resolvedRef, err := resolvePackRef(canonical, packRef)
 		if err != nil {
 			return resolveMergeResult{}, fmt.Errorf("parse config file %s: invalid policy.packs[%d]: %w", canonical, idx, err)
+		}
+		if _, remote := parseRemoteURL(resolvedRef); remote && !r.allowRemote {
+			return resolveMergeResult{}, fmt.Errorf("parse config file %s: invalid policy.packs[%d]: remote policy packs require an explicit config path", canonical, idx)
 		}
 		packResult, err := r.resolveFile(resolvedRef, true)
 		if err != nil {

--- a/internal/thresholds/config_test.go
+++ b/internal/thresholds/config_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -586,7 +587,48 @@ func TestLoadWithPolicyRejectsRemotePackWithoutPin(t *testing.T) {
 	}
 }
 
-func TestLoadWithPolicyRemotePackWithPin(t *testing.T) {
+func TestLoadWithPolicyRepoDiscoveredConfigRejectsRemotePackWithoutFetching(t *testing.T) {
+	repo := t.TempDir()
+	packBody := `thresholds:
+  low_confidence_warning_percent: 19
+  removal_candidate_weight_usage: 0.6
+  removal_candidate_weight_impact: 0.2
+  removal_candidate_weight_confidence: 0.2
+`
+	sum := sha256.Sum256([]byte(packBody))
+	pin := hex.EncodeToString(sum[:])
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		if r.URL.Path != "/org.yml" {
+			http.NotFound(w, r)
+			return
+		}
+		if _, err := w.Write([]byte(packBody)); err != nil {
+			t.Fatalf("write remote pack response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	testutil.MustWriteFile(t, filepath.Join(repo, "packs", "org.yml"), fmt.Sprintf("policy:\n  packs:\n    - %s/org.yml#sha256=%s\n", server.URL, pin))
+	testutil.MustWriteFile(t, filepath.Join(repo, lopperYMLName), "policy:\n  packs:\n    - packs/org.yml\n")
+
+	result, err := LoadWithPolicy(repo, "")
+	if err == nil {
+		t.Fatalf("expected repo-discovered config to reject remote pack")
+	}
+	if !strings.Contains(err.Error(), "remote policy packs require an explicit config path") {
+		t.Fatalf("unexpected repo-discovered remote pack error: %v", err)
+	}
+	if result.ConfigPath != "" || len(result.PolicySources) != 0 {
+		t.Fatalf("expected empty result on rejected remote pack, got %#v", result)
+	}
+	if got := atomic.LoadInt32(&requests); got != 0 {
+		t.Fatalf("expected no remote fetches for repo-discovered config, got %d", got)
+	}
+}
+
+func TestLoadWithPolicyRemotePackWithPinFromExplicitConfig(t *testing.T) {
 	repo := t.TempDir()
 	packBody := `thresholds:
   low_confidence_warning_percent: 19
@@ -608,10 +650,10 @@ func TestLoadWithPolicyRemotePackWithPin(t *testing.T) {
 	defer server.Close()
 
 	policy := fmt.Sprintf("policy:\n  packs:\n    - %s/org.yml#sha256=%s\nthresholds:\n  fail_on_increase_percent: 3\n", server.URL, pin)
-	testutil.MustWriteFile(t, filepath.Join(repo, lopperYMLName), policy)
-	result, err := LoadWithPolicy(repo, "")
+	testutil.MustWriteFile(t, filepath.Join(repo, customConfigName), policy)
+	result, err := LoadWithPolicy(repo, customConfigName)
 	if err != nil {
-		t.Fatalf("load with pinned remote pack: %v", err)
+		t.Fatalf("load explicit config with pinned remote pack: %v", err)
 	}
 	if result.Resolved.FailOnIncreasePercent != 3 {
 		t.Fatalf("expected repo override, got %d", result.Resolved.FailOnIncreasePercent)
@@ -624,7 +666,7 @@ func TestLoadWithPolicyRemotePackWithPin(t *testing.T) {
 	}
 }
 
-func TestLoadWithPolicyRemotePackPinMismatch(t *testing.T) {
+func TestLoadWithPolicyRemotePackPinMismatchFromExplicitConfig(t *testing.T) {
 	repo := t.TempDir()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if _, err := w.Write([]byte("thresholds:\n  low_confidence_warning_percent: 12\n")); err != nil {
@@ -632,9 +674,9 @@ func TestLoadWithPolicyRemotePackPinMismatch(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	testutil.MustWriteFile(t, filepath.Join(repo, lopperYMLName), fmt.Sprintf("policy:\n  packs:\n    - %s/org.yml#sha256=%s\n", server.URL, strings.Repeat("a", 64)))
+	testutil.MustWriteFile(t, filepath.Join(repo, customConfigName), fmt.Sprintf("policy:\n  packs:\n    - %s/org.yml#sha256=%s\n", server.URL, strings.Repeat("a", 64)))
 
-	_, err := LoadWithPolicy(repo, "")
+	_, err := LoadWithPolicy(repo, customConfigName)
 	if err == nil {
 		t.Fatalf("expected remote pin mismatch error")
 	}


### PR DESCRIPTION
## Issue
Closes #504.

A repo-discovered `.lopper.yml` could point `policy.packs` at pinned remote URLs, which triggered outbound GET requests during config resolution before the user had explicitly trusted that config source.

## Root Cause
Remote policy pack resolution only distinguished pinned versus unpinned URLs. It did not distinguish explicit trusted config paths from auto-discovered repo config.

## Fix
Thread an `allowRemote` trust decision from the root config load into pack resolution. Auto-discovered repo config now rejects remote packs before any HTTP request is made, while explicit trusted config paths still allow pinned remote policy packs.

## Validation
- `go test ./internal/thresholds/...`
- `go test ./internal/cli -run TestParseArgsAnalysePolicySources -count=1`
