### PR TITLE
fix(boundary): harden repo-local path handling

### DIFF
--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -37,6 +37,13 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 		cache.cacheable = false
 		return cache
 	}
+	if req.Cache == nil || strings.TrimSpace(req.Cache.Path) == "" {
+		if cachePathEscapesRepo(options.Path, repoPath) {
+			cache.cacheable = false
+			cache.warn("analysis cache unavailable: cache path escapes repository root")
+			return cache
+		}
+	}
 	if err := os.MkdirAll(filepath.Join(options.Path, "keys"), 0o750); err != nil {
 		cache.cacheable = false
 		cache.warn("analysis cache unavailable: " + err.Error())
@@ -49,6 +56,22 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 	}
 	cache.cacheable = true
 	return cache
+}
+
+func cachePathEscapesRepo(cachePath, repoPath string) bool {
+	resolvedCachePath, err := filepath.EvalSymlinks(cachePath)
+	if err != nil {
+		return false
+	}
+	resolvedRepoPath, err := filepath.EvalSymlinks(repoPath)
+	if err != nil {
+		resolvedRepoPath = filepath.Clean(repoPath)
+	}
+	rel, err := filepath.Rel(resolvedRepoPath, resolvedCachePath)
+	if err != nil {
+		return true
+	}
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func resolveCacheOptions(req *CacheOptions, repoPath string) resolvedCacheOptions {

--- a/internal/analysis/cache_extra_test.go
+++ b/internal/analysis/cache_extra_test.go
@@ -99,6 +99,30 @@ func TestNewAnalysisCacheObjectsDirInitFailureAddsWarning(t *testing.T) {
 	}
 }
 
+func TestNewAnalysisCacheRejectsSymlinkedDefaultPathOutsideRepo(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	symlinkPath := filepath.Join(repo, cacheDirName)
+	if err := os.Symlink(outside, symlinkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cache := newAnalysisCache(Request{}, repo)
+	if cache.cacheable {
+		t.Fatalf("expected symlinked default cache path to be rejected")
+	}
+	warnings := cache.takeWarnings()
+	if len(warnings) == 0 || !strings.Contains(warnings[0], "cache path escapes repository root") {
+		t.Fatalf("expected symlink escape warning, got %#v", warnings)
+	}
+	if _, err := os.Stat(filepath.Join(outside, cacheKeysDirName)); !os.IsNotExist(err) {
+		t.Fatalf("expected no keys dir to be created outside repo, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, cacheObjectsDirName)); !os.IsNotExist(err) {
+		t.Fatalf("expected no objects dir to be created outside repo, stat err=%v", err)
+	}
+}
+
 func TestLockOrConfigFileRecognizesGradleVersionCatalogs(t *testing.T) {
 	if !lockOrConfigFile("libs.versions.toml") {
 		t.Fatalf("expected Gradle version catalogs to participate in cache invalidation")

--- a/internal/lang/dotnet/adapter.go
+++ b/internal/lang/dotnet/adapter.go
@@ -378,9 +378,6 @@ func collectDeclaredDependencies(repoPath string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := addAncestorCentralPackages(repoPath, set); err != nil {
-		return nil, err
-	}
 	return sortedDependencies(set), nil
 }
 

--- a/internal/lang/dotnet/adapter_branches_extra_test.go
+++ b/internal/lang/dotnet/adapter_branches_extra_test.go
@@ -83,7 +83,7 @@ func TestScanRepoAndReadSourceBranches(t *testing.T) {
 	}
 }
 
-func TestCollectDeclaredDependenciesAncestorFallback(t *testing.T) {
+func TestCollectDeclaredDependenciesIgnoresAncestorCentralPackages(t *testing.T) {
 	parent := t.TempDir()
 	repo := filepath.Join(parent, "src", "service")
 	testutil.MustWriteFile(t, filepath.Join(parent, "Directory.Packages.props"), `
@@ -95,8 +95,11 @@ func TestCollectDeclaredDependenciesAncestorFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("collect dependencies: %v", err)
 	}
-	if !slices.Contains(deps, "acme.platform") || !slices.Contains(deps, "dapper") {
-		t.Fatalf("expected ancestor and local dependencies, got %#v", deps)
+	if slices.Contains(deps, "acme.platform") {
+		t.Fatalf("expected ancestor central package manifest to be ignored, got %#v", deps)
+	}
+	if !slices.Contains(deps, "dapper") {
+		t.Fatalf("expected local dependency to remain visible, got %#v", deps)
 	}
 }
 

--- a/internal/lang/elixir/adapter.go
+++ b/internal/lang/elixir/adapter.go
@@ -180,7 +180,11 @@ func stripElixirComments(content []byte) string {
 }
 
 func addUmbrellaRoots(repoPath string, appsPath string, roots map[string]struct{}) error {
-	apps, err := filepath.Glob(filepath.Join(repoPath, appsPath, "*"))
+	appsRoot := filepath.Join(repoPath, appsPath)
+	if !shared.IsPathWithin(repoPath, appsRoot) {
+		return nil
+	}
+	apps, err := filepath.Glob(filepath.Join(appsRoot, "*"))
 	if err != nil {
 		return err
 	}

--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -137,6 +137,26 @@ func TestDetectWithConfidenceUmbrellaCustomAppsPath(t *testing.T) {
 	assertDetectionFixture(t, repo, filepath.Join("services", "api"), filepath.Base(repo))
 }
 
+func TestDetectWithConfidenceIgnoresEscapingAppsPath(t *testing.T) {
+	repo := t.TempDir()
+	outsideApps := filepath.Join(filepath.Dir(repo), "outside", "apps")
+	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  def project, do: [apps_path: \"../outside/apps\"]\nend\n")
+	testutil.MustWriteFile(t, filepath.Join(outsideApps, "api", mixExsName), "defmodule Api.MixProject do\n  use Mix.Project\nend\n")
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	for _, root := range detection.Roots {
+		if strings.Contains(root, filepath.Join("outside", "apps")) {
+			t.Fatalf("did not expect escaped apps_path root, got %#v", detection.Roots)
+		}
+	}
+	if !containsSuffix(detection.Roots, filepath.Base(repo)) {
+		t.Fatalf("expected repo root fallback, got %#v", detection.Roots)
+	}
+}
+
 func TestDetectWithConfidenceIgnoresCommentedAppsPath(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  # apps_path: \"services\"\n  def project, do: []\nend\n")

--- a/internal/report/baseline_snapshot.go
+++ b/internal/report/baseline_snapshot.go
@@ -75,6 +75,10 @@ func SaveSnapshot(dir string, key string, rep Report, now time.Time) (path strin
 		return "", fmt.Errorf("baseline key is required")
 	}
 
+	if info, statErr := os.Lstat(trimmedDir); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("baseline store directory must not be a symlink: %s", trimmedDir)
+	}
+
 	if err := os.MkdirAll(trimmedDir, 0o750); err != nil {
 		return "", err
 	}

--- a/internal/report/baseline_snapshot_test.go
+++ b/internal/report/baseline_snapshot_test.go
@@ -184,6 +184,29 @@ func TestSaveSnapshotMkdirFailure(t *testing.T) {
 	}
 }
 
+func TestSaveSnapshotRejectsSymlinkedStoreDir(t *testing.T) {
+	now := time.Date(2026, time.February, 22, 10, 0, 0, 0, time.UTC)
+	root := t.TempDir()
+	target := filepath.Join(root, "actual-store")
+	if err := os.MkdirAll(target, 0o750); err != nil {
+		t.Fatalf("create target store: %v", err)
+	}
+	link := filepath.Join(root, "store-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if _, err := SaveSnapshot(link, "label:x", Report{}, now); err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+
+	if entries, err := os.ReadDir(target); err != nil {
+		t.Fatalf("read target store: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("expected no snapshot files written via symlinked store dir, got %d entries", len(entries))
+	}
+}
+
 func TestSaveSnapshotSortsDependenciesDeterministically(t *testing.T) {
 	now := time.Date(2026, time.February, 22, 10, 0, 0, 0, time.UTC)
 	reportData := Report{


### PR DESCRIPTION
This draft batches #505, #506, #509, and #510 into the `v1.2.2` security patch line.

Do not land or release this batch until the `v1.2.1` release has completed successfully.

## Issue

Several repo-local code paths still crossed the intended repository boundary:

- the default analysis cache root could follow a symlinked `.lopper-cache` outside the repo
- baseline snapshot saves could write through a symlinked store directory
- .NET dependency collection could read ancestor `Directory.Packages.props` files above the repo
- Elixir umbrella discovery could follow `apps_path` values like `../outside/apps`

That meant untrusted repository contents could influence reads and writes outside the requested repo root.

## Cause And User Impact

The affected paths trusted literal filesystem joins or ancestor walking before enforcing a repo-local boundary. In practice that let a malicious or surprising workspace layout redirect writes into other writable locations, or pull dependency metadata from parent directories that were never meant to be part of the scan.

## Root Cause

The codebase already uses guarded reads in many places, but these four paths either:

- initialized repo-owned roots without validating where symlinks resolved
- accepted a store root that was itself a symlink
- intentionally walked to ancestor manifests outside `repoPath`
- treated umbrella `apps_path` values as trusted without checking that they stayed under the repo

## Fix

This batch keeps the changes narrow and patch-safe:

- reject the default repo-local analysis cache when `.lopper-cache` resolves outside the repo and surface the cache as unavailable instead of creating `keys/` and `objects/` outside the boundary
- reject a symlinked baseline snapshot store directory before `MkdirAll` and `OpenRoot`
- stop adding ancestor `Directory.Packages.props` manifests when collecting .NET declared dependencies
- ignore Elixir umbrella `apps_path` values that resolve outside `repoPath` while preserving the existing commented and blank `apps_path` behavior

## Validation

- `go test ./internal/analysis`
- `go test ./internal/report`
- `go test ./internal/lang/dotnet`
- `go test ./internal/lang/elixir`
- `go test ./...`

Closes #505
Closes #506
Closes #509
Closes #510
