### PR TITLE
fix(release): remove weekly semver preface from notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,8 +198,6 @@ jobs:
           ghcr_package_url="https://github.com/${GITHUB_REPOSITORY}/pkgs/container/lopper"
 
           {
-            echo "## Weekly semver release"
-            echo
             echo "- Tag: \`${current_tag}\`"
             echo
             echo "## Container image"


### PR DESCRIPTION
## Issue
Weekly semver releases prepend `## Weekly semver release` at the top of the generated release notes.

## Cause and user impact/effect
The changelog generation step in the release workflow hardcodes this heading before the actual release content. It adds repetitive noise at the top of every weekly release note.

## Root cause
`.github/workflows/release.yml` writes the heading in the `Generate changelog` step before writing the tag and artifact sections.

## Fix
Removed the `## Weekly semver release` heading and extra spacer line from the generated changelog preamble. Release notes now start directly with the tag and then continue with the existing container and VS Code extension sections.

## Tests/checks used to validate
- `make actionlint`
