### PR TITLE
test(version): restore release coverage headroom

### DIFF
--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -42,3 +42,21 @@ func TestStringOmitsUnknownMetadata(t *testing.T) {
 		t.Fatalf("expected compact dev version string, got %q", got)
 	}
 }
+
+func TestInfoStringIncludesMetadata(t *testing.T) {
+	info := Info{
+		Version:   "1.2.2",
+		Commit:    "abc1234",
+		BuildDate: "2026-03-30T08:44:43Z",
+	}
+
+	if got := info.String(); got != "lopper 1.2.2 (commit abc1234, built 2026-03-30T08:44:43Z)" {
+		t.Fatalf("expected formatted metadata string, got %q", got)
+	}
+}
+
+func TestNormalizeVersionDefaultsBlankToDev(t *testing.T) {
+	if got := normalizeVersion("  \t  "); got != "dev" {
+		t.Fatalf("expected blank version to normalize to dev, got %q", got)
+	}
+}


### PR DESCRIPTION
## Issue

The manually triggered `v1.2.2` release workflow on `main` failed in `orchestrate-release / build-darwin` during the validation phase, so the stable release was not published.

## Cause and User Impact

The Darwin release job enforces the repository coverage gate at `>= 98%`. On commit `da22089b72bf44f6c6649791280b165c5ab2ae4d`, total coverage on the Darwin runner fell to `97.9%`, which blocked release artifact generation and prevented creation of `v1.2.2`.

## Root Cause

`internal/version` had low statement coverage for two simple branches:

- the metadata-bearing `Info.String()` formatting path
- the blank-version fallback path in `normalizeVersion`

That small package-level gap was enough to drag the aggregate coverage just under the release threshold on Darwin.

## Fix

Add two focused tests in `internal/version/version_test.go` to cover:

- formatting a fully populated `Info`
- normalizing a blank version string back to `dev`

No production code changes are included.

## Validation

- `go test -cover ./internal/version`
- `go test -coverprofile=/tmp/lopper-version-fixed.cov ./internal/version && go tool cover -func=/tmp/lopper-version-fixed.cov`
- `make cov COVERAGE_MIN=98`
- repository pre-commit `make ci` hook during commit
