### PR TITLE
docs(repo): refresh docs consistency and contribution requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ make mem-profiles
 ## Workflow
 
 1. Create a branch for your change.
-2. Add or update tests for behavior changes.
+2. Add or update tests, docs, and demo assets when behavior, flags, or workflows change.
 3. Keep commits focused and descriptive.
 4. Open a pull request with clear context, scope, and validation steps.
 
@@ -82,10 +82,11 @@ If you add a new language adapter, update the contributor-facing docs and user-f
 - Problem statement and intended behavior
 - What changed and why
 - Test evidence (`make ci`, `make demos-check`, `act pull_request -W .github/workflows/ci.yml --job verify`, manual commands, fixtures)
+- Documentation updates for user-facing behavior, flags, workflow changes, and examples
 - Performance notes when memory benchmark deltas are intentional, including whether `memory-approved` is needed
 - Backward compatibility notes (if any)
 
-If your change impacts CLI behavior shown in docs, refresh demo GIFs with `make demos` and include regenerated assets.
+If your change impacts CLI behavior, flags, workflows, or documented examples, refresh the relevant docs and demo GIFs with `make demos` and include regenerated assets.
 
 Use the PR template in `.github/PULL_REQUEST_TEMPLATE.md`.
 

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -1,12 +1,13 @@
 # CI and release workflow
 
-This repository includes five GitHub Actions workflows:
+This repository includes six GitHub Actions workflows:
 
 - `.github/workflows/ci.yml`: runs checks on pull requests
 - `.github/workflows/release.yml`: scheduled weekly (Saturday 12:00 UTC) semver release workflow that runs when meaningful changes exist since the previous stable tag or when version alignment needs to promote the stable CLI tag to the VS Code extension version, then runs CI, publishes a GitHub release, and syncs the committed VS Code extension version surfaces back to the published stable version with:
   - Linux/Windows artifacts from Ubuntu (cross-compiled with `zig`)
   - Darwin artifact from macOS (native arch)
   - GHCR multi-arch image (`linux/amd64`, `linux/arm64`) tagged with the release tag and `latest`
+- `.github/workflows/release-orchestration.yml`: reusable workflow invoked by `release.yml` and `rolling.yml` to build release artifacts and publish GHCR images
 - `.github/workflows/rolling.yml`: on merge to `main`, publishes a rolling prerelease with Linux/Windows/Darwin build artifacts plus source bundle assets, updates GHCR `rolling`, and updates Homebrew tap formula `lopper-rolling`
 - `.github/workflows/docker-ghcr.yml`: manual-only fallback to build/push the GHCR image on demand
 - `.github/workflows/memory-profiles.yml`: scheduled/manual alloc-space profiling for the watched hotspot packages (`dotnet`, `rust`, `analysis`, `golang`) with uploaded artifacts and a workflow summary

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -49,7 +49,7 @@ Notes:
 - Relative `path` values are resolved relative to the config file directory.
 - `baseline_store` is reserved for future dashboard support and is not yet applied during dashboard execution.
 - `repoUrl` entries are reserved for future support and are not yet executable by `lopper dashboard`.
-- CLI flags take precedence over config (`--format`, `--language`, `--top`, `--output`).
+- CLI flags take precedence over config for `--format` and `--output`; `--language` only fills missing repo language values, and `--top` is CLI-only.
 
 ## JSON Shape
 

--- a/docs/report-schema.json
+++ b/docs/report-schema.json
@@ -9,10 +9,12 @@
     "schemaVersion": { "type": "string", "const": "0.1.0" },
     "generatedAt": { "type": "string", "format": "date-time" },
     "repoPath": { "type": "string" },
+    "scope": { "$ref": "#/$defs/scopeMetadata" },
     "dependencies": {
       "type": "array",
       "items": { "$ref": "#/$defs/dependencyReport" }
     },
+    "usageUncertainty": { "$ref": "#/$defs/usageUncertainty" },
     "summary": { "$ref": "#/$defs/summary" },
     "languageBreakdown": {
       "type": "array",
@@ -50,6 +52,31 @@
         "unknownLicenseCount": { "type": "integer", "minimum": 0 },
         "deniedLicenseCount": { "type": "integer", "minimum": 0 },
         "reachability": { "$ref": "#/$defs/reachabilityRollup" }
+      }
+    },
+    "scopeMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": { "type": "string" },
+        "packages": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "usageUncertainty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["confirmedImportUses", "uncertainImportUses"],
+      "properties": {
+        "confirmedImportUses": { "type": "integer", "minimum": 0 },
+        "uncertainImportUses": { "type": "integer", "minimum": 0 },
+        "samples": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/location" }
+        }
       }
     },
     "languageSummary": {

--- a/docs/report-schema.md
+++ b/docs/report-schema.md
@@ -14,6 +14,8 @@ Validate with your JSON Schema tooling against `docs/report-schema.json`.
 ## Key fields
 
 - `summary`: aggregated totals across all dependency rows.
+- `scope`: analysis scope metadata (`mode`, `packages`).
+- `usageUncertainty`: JS/TS usage certainty summary (`confirmedImportUses`, `uncertainImportUses`, `samples`).
 - `languageBreakdown`: aggregate totals by adapter language (`js-ts`, `python`, `cpp`, `jvm`, `kotlin-android`, `go`, `php`, `ruby`, `rust`, `dotnet`, `elixir`, `swift`, `dart`).
 - `effectiveThresholds`: resolved threshold values applied for this run.
 - `effectivePolicy`: resolved policy object, including precedence sources, scoring weights, and license policy controls (`CLI > repo config > imported policy packs > defaults`).

--- a/internal/language/adapter_test.go
+++ b/internal/language/adapter_test.go
@@ -23,6 +23,16 @@ func TestNewAdapterContractCopiesAliases(t *testing.T) {
 	}
 }
 
+func TestAdapterContractIDAndNilAliases(t *testing.T) {
+	contract := NewAdapterContract("rust")
+	if contract.ID() != "rust" {
+		t.Fatalf("expected adapter id rust, got %q", contract.ID())
+	}
+	if got := contract.Aliases(); len(got) != 0 {
+		t.Fatalf("expected no aliases when none are configured, got %#v", got)
+	}
+}
+
 func TestAdapterLifecycleDetectUsesSharedConfidenceHandler(t *testing.T) {
 	lifecycle := NewAdapterLifecycle("go", []string{"golang"}, func(ctx context.Context, repoPath string) (Detection, error) {
 		if repoPath != "/repo" {

--- a/internal/notify/types_cov_more_test.go
+++ b/internal/notify/types_cov_more_test.go
@@ -1,0 +1,44 @@
+package notify
+
+import "testing"
+
+func TestOverridesWithoutWebhookTargetsNilReceiver(t *testing.T) {
+	var overrides *Overrides
+	if got := overrides.WithoutWebhookTargets(); got != (Overrides{}) {
+		t.Fatalf("expected empty overrides for nil receiver, got %#v", got)
+	}
+}
+
+func TestOverridesWithoutWebhookTargetsClearsWebhookURLs(t *testing.T) {
+	globalTrigger := TriggerAlways
+	slackTrigger := TriggerRegression
+	teamsTrigger := TriggerImprovement
+	slackURL := "https://hooks.slack.com/services/T/B/K"
+	teamsURL := "https://example.com/teams"
+
+	overrides := Overrides{
+		GlobalTrigger:   &globalTrigger,
+		SlackWebhookURL: &slackURL,
+		SlackTrigger:    &slackTrigger,
+		TeamsWebhookURL: &teamsURL,
+		TeamsTrigger:    &teamsTrigger,
+	}
+
+	filtered := overrides.WithoutWebhookTargets()
+
+	if filtered.SlackWebhookURL != nil || filtered.TeamsWebhookURL != nil {
+		t.Fatalf("expected webhook URLs to be removed, got %#v", filtered)
+	}
+	if filtered.GlobalTrigger != overrides.GlobalTrigger {
+		t.Fatalf("expected global trigger to be preserved")
+	}
+	if filtered.SlackTrigger != overrides.SlackTrigger {
+		t.Fatalf("expected slack trigger to be preserved")
+	}
+	if filtered.TeamsTrigger != overrides.TeamsTrigger {
+		t.Fatalf("expected teams trigger to be preserved")
+	}
+	if overrides.SlackWebhookURL == nil || overrides.TeamsWebhookURL == nil {
+		t.Fatalf("expected original overrides to remain unchanged, got %#v", overrides)
+	}
+}


### PR DESCRIPTION
## Issue
Documentation in `docs/` and `CONTRIBUTING.md` had drifted from current repository behavior, especially around workflow inventory, dashboard flag precedence, and report schema fields.

## Cause and user impact/effect
Contributors and users relying on these docs could miss required workflow details (`release-orchestration`), misread dashboard behavior, and consume an incomplete JSON schema reference. `CONTRIBUTING.md` also did not clearly require docs/demo refreshes when CLI or workflow behavior changes.

## Root cause
Documentation updates were not fully kept in lockstep with recent workflow and reporting changes, and contributor guidance did not explicitly enforce doc maintenance as part of routine change workflow.

## The fix
- Updated `docs/ci-usage.md` to reflect six workflows and document `release-orchestration.yml`.
- Updated `docs/dashboard.md` to clarify that `--format`/`--output` override config, `--language` fills missing repo language values, and `--top` is CLI-only.
- Updated `docs/report-schema.md` and `docs/report-schema.json` to include `scope` and `usageUncertainty` fields and schema definitions.
- Updated `CONTRIBUTING.md` workflow and PR expectations to make docs/demo refreshes required when behavior/flags/workflows/examples change.
- Added focused test coverage uplift (`internal/language`, `internal/notify`, `internal/version`) so local/CI coverage gate remains green.

## Tests/checks used to validate
- `make ci`
- Parallel docs audit via `parallel-worker` queue (3 completed scans synthesized + direct verification)
