### PR TITLE
chore(vscode): sync extension version to 1.2.2

### DIFF
--- a/extensions/vscode-lopper/package-lock.json
+++ b/extensions/vscode-lopper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-lopper",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-lopper",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",

--- a/extensions/vscode-lopper/package.json
+++ b/extensions/vscode-lopper/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-lopper",
   "displayName": "Lopper",
   "description": "VS Code diagnostics, hover details, and safe JS/TS quick fixes across Lopper adapters, including Kotlin Android.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "publisher": "BenRanford",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Sync the committed VS Code extension version surfaces to `1.2.2` after the `v1.2.2` release published.

## Why
The `release` workflow successfully published `v1.2.2`, but its post-release `sync-release-version` job tried to push directly to `main` and was blocked by repository rules that require PRs.

## Changes
- bump `extensions/vscode-lopper/package.json` to `1.2.2`
- bump `extensions/vscode-lopper/package-lock.json` to `1.2.2`

## Validation
- release workflow run `23737079162` published [v1.2.2](https://github.com/ben-ranford/lopper/releases/tag/v1.2.2)
- no code-path changes; PR CI will validate the metadata sync under normal branch protections
