### PR TITLE
test(swift): reduce test cognitive complexity

### DIFF
--- a/internal/lang/swift/adapter_cov_branch_followup_test.go
+++ b/internal/lang/swift/adapter_cov_branch_followup_test.go
@@ -25,14 +25,7 @@ func TestSwiftScannerWalkFollowupBranches(t *testing.T) {
 	if err := os.WriteFile(ignoredPath, []byte("struct Ignored {}\n"), 0o644); err != nil {
 		t.Fatalf("write ignored swift file: %v", err)
 	}
-	entries, err := os.ReadDir(repo)
-	if err != nil {
-		t.Fatalf("read repo dir: %v", err)
-	}
-	entriesByName := make(map[string]os.DirEntry, len(entries))
-	for _, entry := range entries {
-		entriesByName[entry.Name()] = entry
-	}
+	entriesByName := mustReadDirEntriesByName(t, repo)
 	if err := scanner.walk(ctx, ignoredPath, entriesByName["ignored.swift"], nil); err == nil {
 		t.Fatalf("expected canceled context error from scanner walk")
 	}
@@ -41,14 +34,7 @@ func TestSwiftScannerWalkFollowupBranches(t *testing.T) {
 	if err := os.Mkdir(sourceDir, 0o755); err != nil {
 		t.Fatalf("mkdir Sources dir: %v", err)
 	}
-	entries, err = os.ReadDir(repo)
-	if err != nil {
-		t.Fatalf("read repo dir after creating Sources: %v", err)
-	}
-	entriesByName = make(map[string]os.DirEntry, len(entries))
-	for _, entry := range entries {
-		entriesByName[entry.Name()] = entry
-	}
+	entriesByName = mustReadDirEntriesByName(t, repo)
 	if err := scanner.walk(context.Background(), sourceDir, entriesByName["Sources"], nil); err != nil {
 		t.Fatalf("expected regular directory walk to continue, got %v", err)
 	}
@@ -57,14 +43,7 @@ func TestSwiftScannerWalkFollowupBranches(t *testing.T) {
 	if err := os.WriteFile(readmePath, []byte("# docs\n"), 0o644); err != nil {
 		t.Fatalf("write readme: %v", err)
 	}
-	entries, err = os.ReadDir(repo)
-	if err != nil {
-		t.Fatalf("read repo dir after creating README.md: %v", err)
-	}
-	entriesByName = make(map[string]os.DirEntry, len(entries))
-	for _, entry := range entries {
-		entriesByName[entry.Name()] = entry
-	}
+	entriesByName = mustReadDirEntriesByName(t, repo)
 	if err := scanner.walk(context.Background(), readmePath, entriesByName["README.md"], nil); err != nil {
 		t.Fatalf("expected non-swift file walk to be ignored, got %v", err)
 	}
@@ -73,14 +52,7 @@ func TestSwiftScannerWalkFollowupBranches(t *testing.T) {
 	if err := os.WriteFile(swiftPath, []byte("struct Example {}\n"), 0o644); err != nil {
 		t.Fatalf("write swift file: %v", err)
 	}
-	entries, err = os.ReadDir(repo)
-	if err != nil {
-		t.Fatalf("read repo dir after creating main.swift: %v", err)
-	}
-	entriesByName = make(map[string]os.DirEntry, len(entries))
-	for _, entry := range entries {
-		entriesByName[entry.Name()] = entry
-	}
+	entriesByName = mustReadDirEntriesByName(t, repo)
 	if err := scanner.walk(context.Background(), swiftPath, entriesByName["main.swift"], nil); err != nil {
 		t.Fatalf("expected swift file walk to scan successfully, got %v", err)
 	}

--- a/internal/lang/swift/adapter_cov_extra_test.go
+++ b/internal/lang/swift/adapter_cov_extra_test.go
@@ -187,10 +187,16 @@ func TestSwiftThresholdAndNormalizationHelpers(t *testing.T) {
 }
 
 func TestSwiftScanAndRecommendationBranches(t *testing.T) {
+	t.Run("catalog and scan", testSwiftScanAndRecommendationCatalogAndScan)
+	t.Run("report branches", testSwiftScanAndRecommendationReportBranches)
+	t.Run("top dependency ranking", testSwiftScanAndRecommendationTopRanking)
+}
+
+func testSwiftScanAndRecommendationCatalogAndScan(t *testing.T) {
+	t.Helper()
+
 	repo := t.TempDir()
-	dependencies := []swiftFixtureDependency{
-		alamofireFixtureDependency(),
-	}
+	dependencies := []swiftFixtureDependency{alamofireFixtureDependency()}
 	mainContent := `import Alamofire
 import MysteryKit
 func run() {
@@ -224,9 +230,14 @@ func run() {
 	if _, err := scanRepo(testutil.CanceledContext(), repo, catalog); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected canceled scan to fail with context.Canceled, got %v", err)
 	}
+}
 
-	meta := dependencyMeta{Declared: true, Source: packageResolvedName}
-	catalog.Dependencies["alamofire"] = meta
+func testSwiftScanAndRecommendationReportBranches(t *testing.T) {
+	t.Helper()
+
+	catalog := dependencyCatalog{
+		Dependencies: map[string]dependencyMeta{"alamofire": {Declared: true, Source: packageResolvedName}},
+	}
 	file := fileScan{
 		Path: filepath.Join("Sources", "Demo", swiftMainFileName),
 		Imports: []importBinding{{
@@ -246,7 +257,7 @@ func run() {
 	if len(reportWarnings) != 0 {
 		t.Fatalf("expected import-backed report to avoid warnings, got %#v", reportWarnings)
 	}
-	if len(buildDependencyRiskCues(meta)) != 1 {
+	if len(buildDependencyRiskCues(catalog.Dependencies["alamofire"])) != 1 {
 		t.Fatalf("expected unresolved dependency risk cue")
 	}
 	if len(reportData.Recommendations) != 3 {
@@ -255,6 +266,10 @@ func run() {
 	if reportData.Provenance == nil || reportData.Provenance.Signals[0] != packageResolvedName {
 		t.Fatalf("expected provenance from lockfile source, got %#v", reportData.Provenance)
 	}
+}
+
+func testSwiftScanAndRecommendationTopRanking(t *testing.T) {
+	t.Helper()
 
 	topReports, topWarnings := buildTopSwiftDependencies(scanResult{}, dependencyCatalog{}, 50)(5, scanResult{}, report.DefaultRemovalCandidateWeights())
 	if len(topReports) != 0 || len(topWarnings) != 1 {
@@ -422,9 +437,22 @@ func testSwiftResolvedPinAndIgnoredSymbolFallbacks(t *testing.T) {
 }
 
 func TestSwiftUsageHeuristicBranches(t *testing.T) {
+	t.Run("empty imports preserve usage", testSwiftUsageHeuristicPreservesExistingUsage)
+	t.Run("multiple dependencies avoid attribution", testSwiftUsageHeuristicAvoidsAttributionWithMultipleDeps)
+	t.Run("single dependency handles usage heuristics", testSwiftUsageHeuristicSingleDependencyBranches)
+	t.Run("symbol collection detects local declarations", testSwiftUsageHeuristicCollectsLocalSymbols)
+}
+
+func testSwiftUsageHeuristicPreservesExistingUsage(t *testing.T) {
+	t.Helper()
+
 	if got := applyUnqualifiedUsageHeuristic(nil, nil, map[string]int{"Session": 2}); got["Session"] != 2 {
 		t.Fatalf("expected empty import heuristic to preserve usage, got %#v", got)
 	}
+}
+
+func testSwiftUsageHeuristicAvoidsAttributionWithMultipleDeps(t *testing.T) {
+	t.Helper()
 
 	multipleDeps := []importBinding{
 		{Dependency: "alamofire", Module: "Alamofire", Local: "Session"},
@@ -433,6 +461,10 @@ func TestSwiftUsageHeuristicBranches(t *testing.T) {
 	if got := applyUnqualifiedUsageHeuristic([]byte("let value = Session.default"), multipleDeps, map[string]int{}); len(got) != 0 {
 		t.Fatalf("expected multiple dependency heuristic to avoid attribution, got %#v", got)
 	}
+}
+
+func testSwiftUsageHeuristicSingleDependencyBranches(t *testing.T) {
+	t.Helper()
 
 	singleDep := []importBinding{{Dependency: "alamofire", Module: "Alamofire", Local: "Session"}}
 	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\n_ = Session.default"), singleDep, map[string]int{"Session": 3}); got["Session"] != 3 {
@@ -460,6 +492,10 @@ func TestSwiftUsageHeuristicBranches(t *testing.T) {
 	if !hasPotentialUnqualifiedSymbolUsage([]byte("import Alamofire\nlet value = NetworkSession()"), singleDep) {
 		t.Fatalf("expected non-standard symbol usage to be detected")
 	}
+}
+
+func testSwiftUsageHeuristicCollectsLocalSymbols(t *testing.T) {
+	t.Helper()
 
 	symbols := collectLocalDeclaredSymbols([]byte("struct Demo {}\nprotocol Runner {}\nimport Alamofire\n"))
 	if _, ok := symbols[lookupKey("Demo")]; !ok {
@@ -556,6 +592,20 @@ let package = Package(
 }
 
 func TestSwiftRemainingBranchCoverage(t *testing.T) {
+	t.Run("skip dir and reference resolution", testSwiftRemainingSkipDirAndReferenceResolution)
+	t.Run("dot-call helpers", testSwiftRemainingDotCallHelpers)
+	t.Run("string field parsing", testSwiftRemainingStringFieldParsing)
+	t.Run("detection and scan fallbacks", testSwiftRemainingDetectionAndScanFallbacks)
+}
+
+func TestSwiftFinalHelperBranches(t *testing.T) {
+	t.Run("lookup and unresolved import branches", testSwiftFinalLookupBranches)
+	t.Run("import parsing and skipped dir detection", testSwiftFinalImportParsingAndSkippedDirDetection)
+}
+
+func testSwiftRemainingSkipDirAndReferenceResolution(t *testing.T) {
+	t.Helper()
+
 	if !shouldSkipDir(".git") {
 		t.Fatalf("expected common git dir to be skipped")
 	}
@@ -569,6 +619,10 @@ func TestSwiftRemainingBranchCoverage(t *testing.T) {
 	if got := resolveDependencyReference(aliasOnlyCatalog, "LegacyKit"); got != "legacy" {
 		t.Fatalf("expected alias-based dependency resolution, got %q", got)
 	}
+}
+
+func testSwiftRemainingDotCallHelpers(t *testing.T) {
+	t.Helper()
 
 	if args := extractDotCallArguments(".target name: \"ignored\"", "target", 5); len(args) != 0 {
 		t.Fatalf("expected malformed target call to be ignored, got %#v", args)
@@ -580,11 +634,19 @@ func TestSwiftRemainingBranchCoverage(t *testing.T) {
 	if !ok || next <= 0 || !strings.Contains(inner, `quoted`) {
 		t.Fatalf("expected escaped string paren capture, got inner=%q next=%d ok=%v", inner, next, ok)
 	}
+}
+
+func testSwiftRemainingStringFieldParsing(t *testing.T) {
+	t.Helper()
 
 	rawFields := parseStringFields(`note: "\q"`)
 	if rawFields["note"] != `\q` {
 		t.Fatalf("expected raw field preservation on unquote failure, got %#v", rawFields)
 	}
+}
+
+func testSwiftRemainingDetectionAndScanFallbacks(t *testing.T) {
+	t.Helper()
 
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, "Sources", "App", swiftMainFileName), "import Foundation\n")
@@ -612,7 +674,9 @@ func TestSwiftRemainingBranchCoverage(t *testing.T) {
 	}
 }
 
-func TestSwiftFinalHelperBranches(t *testing.T) {
+func testSwiftFinalLookupBranches(t *testing.T) {
+	t.Helper()
+
 	lookup := map[string]string{}
 	setLookup(lookup, "", "alamofire")
 	setLookup(lookup, lookupKey("Alamofire"), "")
@@ -637,6 +701,10 @@ func TestSwiftFinalHelperBranches(t *testing.T) {
 	if shouldTrackUnresolvedImport("", catalog) {
 		t.Fatalf("expected empty unresolved import to be ignored")
 	}
+}
+
+func testSwiftFinalImportParsingAndSkippedDirDetection(t *testing.T) {
+	t.Helper()
 
 	imports := parseSwiftImports([]byte("// comment only\nimport \n@testable import Alamofire // trailing comment\n"), swiftMainFileName)
 	if len(imports) != 1 || imports[0].Module != "Alamofire" {
@@ -708,35 +776,6 @@ func assertSwiftStringStart(t *testing.T, content []byte, index int, wantHashCou
 	if hashCount != wantHashCount || nextIndex != wantNextIndex || multiline != wantMultiline || ok != wantOK {
 		t.Fatalf("unexpected string start detection: got hashCount=%d nextIndex=%d multiline=%v ok=%v", hashCount, nextIndex, multiline, ok)
 	}
-}
-
-func mustReadSwiftDetectionEntries(t *testing.T) (string, fs.DirEntry, fs.DirEntry) {
-	t.Helper()
-
-	repo := t.TempDir()
-	testutil.MustWriteFile(t, filepath.Join(repo, swiftBuildDirName, swiftMainFileName), "import Foundation\n")
-	testutil.MustWriteFile(t, filepath.Join(repo, packageManifestName), "// manifest\n")
-
-	entries, err := os.ReadDir(repo)
-	if err != nil {
-		t.Fatalf("read dir: %v", err)
-	}
-
-	var buildEntry fs.DirEntry
-	var manifestEntry fs.DirEntry
-	for _, entry := range entries {
-		switch entry.Name() {
-		case swiftBuildDirName:
-			buildEntry = entry
-		case packageManifestName:
-			manifestEntry = entry
-		}
-	}
-	if buildEntry == nil || manifestEntry == nil {
-		t.Fatalf("expected build and manifest entries, got %#v", entries)
-	}
-
-	return repo, buildEntry, manifestEntry
 }
 
 func TestSwiftMissingFileAndNoMatchBranches(t *testing.T) {

--- a/internal/lang/swift/adapter_cov_helpers_test.go
+++ b/internal/lang/swift/adapter_cov_helpers_test.go
@@ -1,0 +1,55 @@
+package swift
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func mustReadDirEntriesByName(t *testing.T, dir string) map[string]os.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read repo dir: %v", err)
+	}
+
+	entriesByName := make(map[string]os.DirEntry, len(entries))
+	for _, entry := range entries {
+		entriesByName[entry.Name()] = entry
+	}
+	return entriesByName
+}
+
+func mustReadSwiftDirEntry(t *testing.T, dir, name string) os.DirEntry {
+	t.Helper()
+
+	entriesByName := mustReadDirEntriesByName(t, dir)
+	entry, ok := entriesByName[name]
+	if !ok {
+		t.Fatalf("expected %s dir entry", name)
+	}
+	return entry
+}
+
+func mustReadSwiftDetectionEntries(t *testing.T) (string, os.DirEntry, os.DirEntry) {
+	t.Helper()
+
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, swiftBuildDirName, swiftMainFileName), "import Foundation\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, packageManifestName), "// manifest\n")
+
+	entriesByName := mustReadDirEntriesByName(t, repo)
+	buildEntry, ok := entriesByName[swiftBuildDirName]
+	if !ok {
+		t.Fatalf("expected build entry, got %#v", entriesByName)
+	}
+	manifestEntry, ok := entriesByName[packageManifestName]
+	if !ok {
+		t.Fatalf("expected manifest entry, got %#v", entriesByName)
+	}
+
+	return repo, buildEntry, manifestEntry
+}

--- a/internal/lang/swift/adapter_cov_more_branches_test.go
+++ b/internal/lang/swift/adapter_cov_more_branches_test.go
@@ -40,11 +40,11 @@ func testSwiftDetectionHelpers(t *testing.T) {
 }
 
 func testSwiftManifestAndResolvedLoaders(t *testing.T) {
-	testSwiftManifestDirectoryFailure(t)
-	testSwiftResolvedLoaderEmptyPins(t)
-	testSwiftManifestLoaderSkipsIncompleteDeclarations(t)
-	testSwiftResolvedLoaderSkipsBlankPins(t)
-	testSwiftCollectLocalModulesIgnoresBlankNames(t)
+	t.Run("manifest directory failure", testSwiftManifestDirectoryFailure)
+	t.Run("resolved loader empty pins", testSwiftResolvedLoaderEmptyPins)
+	t.Run("manifest loader skips incomplete declarations", testSwiftManifestLoaderSkipsIncompleteDeclarations)
+	t.Run("resolved loader skips blank pins", testSwiftResolvedLoaderSkipsBlankPins)
+	t.Run("collect local modules ignores blank names", testSwiftCollectLocalModulesIgnoresBlankNames)
 }
 
 func testSwiftManifestDirectoryFailure(t *testing.T) {
@@ -358,20 +358,4 @@ func newTestSwiftCatalog() dependencyCatalog {
 		ModuleToDependency: map[string]string{},
 		LocalModules:       map[string]struct{}{},
 	}
-}
-
-func mustReadSwiftDirEntry(t *testing.T, dir, name string) fs.DirEntry {
-	t.Helper()
-
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read repo dir: %v", err)
-	}
-	for _, entry := range entries {
-		if entry.Name() == name {
-			return entry
-		}
-	}
-	t.Fatalf("expected %s dir entry", name)
-	return nil
 }


### PR DESCRIPTION
# Issue
Issue #468 tracks Swift test cognitive complexity in the coverage test suite.

# Cause and user impact
The Swift coverage tests had grown into long, deeply nested test functions. That made the suite harder to read, harder to extend, and more expensive to review. The immediate user impact was maintenance friction: small coverage changes required editing dense test bodies instead of working with focused helpers and subtests.

# Root cause
The coverage test file accumulated multiple branching scenarios in the same functions. Shared setup and repeated assertions were inline, which pushed the cognitive complexity up as more cases were added.

# Fix
I decomposed the Swift coverage tests into smaller helpers and subtests. The shared setup and assertions now live in `internal/lang/swift/adapter_cov_helpers_test.go`, and the scenario-specific coverage work is split across smaller test files:

- `internal/lang/swift/adapter_cov_branch_followup_test.go`
- `internal/lang/swift/adapter_cov_extra_test.go`
- `internal/lang/swift/adapter_cov_more_branches_test.go`

This keeps each test focused on one behavior while preserving the same coverage intent.

Closes #468

# Tests
- `go test ./internal/lang/swift`
