### PR TITLE
refactor(elixir): simplify stripElixirComments

### DIFF
--- a/internal/lang/elixir/adapter.go
+++ b/internal/lang/elixir/adapter.go
@@ -134,49 +134,91 @@ func stripElixirComments(content []byte) string {
 	var stripped strings.Builder
 	stripped.Grow(len(content))
 
-	inSingleQuote := false
-	inDoubleQuote := false
-	escaped := false
+	state := elixirCommentState{}
 
 	for i := 0; i < len(content); i++ {
 		ch := content[i]
-		if escaped {
-			stripped.WriteByte(ch)
-			escaped = false
+
+		if state.writeEscaped(&stripped, ch) {
 			continue
 		}
-		if ch == '\\' && (inSingleQuote || inDoubleQuote) {
-			stripped.WriteByte(ch)
-			escaped = true
+
+		if state.writeEscape(&stripped, ch) {
 			continue
 		}
-		switch ch {
-		case '"':
-			if !inSingleQuote {
-				inDoubleQuote = !inDoubleQuote
-			}
-			stripped.WriteByte(ch)
-		case '\'':
-			if !inDoubleQuote {
-				inSingleQuote = !inSingleQuote
-			}
-			stripped.WriteByte(ch)
-		case '#':
-			if inSingleQuote || inDoubleQuote {
+
+		if state.writeQuote(&stripped, ch) {
+			continue
+		}
+
+		if ch == '#' {
+			if state.inQuotedString() {
 				stripped.WriteByte(ch)
 				continue
 			}
-			for i < len(content) && content[i] != '\n' {
-				i++
-			}
-			if i < len(content) {
-				stripped.WriteByte('\n')
-			}
-		default:
-			stripped.WriteByte(ch)
+			i = skipElixirComment(content, i, &stripped)
+			continue
 		}
+
+		stripped.WriteByte(ch)
 	}
 	return stripped.String()
+}
+
+type elixirCommentState struct {
+	inSingleQuote bool
+	inDoubleQuote bool
+	escaped       bool
+}
+
+func (s *elixirCommentState) inQuotedString() bool {
+	return s.inSingleQuote || s.inDoubleQuote
+}
+
+func (s *elixirCommentState) writeEscaped(out *strings.Builder, ch byte) bool {
+	if !s.escaped {
+		return false
+	}
+	out.WriteByte(ch)
+	s.escaped = false
+	return true
+}
+
+func (s *elixirCommentState) writeEscape(out *strings.Builder, ch byte) bool {
+	if ch != '\\' || !s.inQuotedString() {
+		return false
+	}
+	out.WriteByte(ch)
+	s.escaped = true
+	return true
+}
+
+func (s *elixirCommentState) writeQuote(out *strings.Builder, ch byte) bool {
+	switch ch {
+	case '"':
+		if !s.inSingleQuote {
+			s.inDoubleQuote = !s.inDoubleQuote
+		}
+	case '\'':
+		if !s.inDoubleQuote {
+			s.inSingleQuote = !s.inSingleQuote
+		}
+	default:
+		return false
+	}
+	out.WriteByte(ch)
+	return true
+}
+
+func skipElixirComment(content []byte, start int, out *strings.Builder) int {
+	i := start
+	for i < len(content) && content[i] != '\n' {
+		i++
+	}
+	if i < len(content) {
+		out.WriteByte('\n')
+	}
+	return i
 }
 
 func addUmbrellaRoots(repoPath string, appsPath string, roots map[string]struct{}) error {

--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -166,6 +166,38 @@ func TestDetectWithConfidenceIgnoresCommentedAppsPath(t *testing.T) {
 	assertDetectionFixture(t, repo, filepath.Base(repo), "")
 }
 
+func TestStripElixirCommentsPreservesQuotedAndEscapedContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "double quoted hash stays",
+			input: "def project, do: [apps_path: \"ser#vices\"]\n# comment\n",
+			want:  "def project, do: [apps_path: \"ser#vices\"]\n\n",
+		},
+		{
+			name:  "escaped quote and hash stay",
+			input: "def project, do: [apps_path: \"ser\\\"vices\\#x\"]\n# comment\n",
+			want:  "def project, do: [apps_path: \"ser\\\"vices\\#x\"]\n\n",
+		},
+		{
+			name:  "single quoted hash stays",
+			input: "value = 'foo#bar'\n# comment\n",
+			want:  "value = 'foo#bar'\n\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripElixirComments([]byte(tc.input)); got != tc.want {
+				t.Fatalf("unexpected stripped output:\nwant: %q\ngot:  %q", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestParseImportsAliasAsSetsLocalName(t *testing.T) {
 	content := []byte("defmodule Demo do\n  alias Foo.Bar, as: Baz\n  Baz.run()\nend\n")
 	declared := map[string]struct{}{"foo": {}}


### PR DESCRIPTION
# Issue
`stripElixirComments` was handling quotes and escape state inline, which made the Elixir comment stripping logic harder to read and reason about.

# Root cause
The parser kept all state in a single loop with nested conditionals, so quote tracking, escape handling, and comment skipping were tightly coupled.

# Fix
I split the comment-stripping state machine in [`internal/lang/elixir/adapter.go`](/Users/benranford/Projects/lopper/.worktrees/bug-v1-3-issue-470-elixir-comment-complexity/internal/lang/elixir/adapter.go) into small helpers for quote handling, escape handling, and comment skipping, and added coverage in [`internal/lang/elixir/adapter_test.go`](/Users/benranford/Projects/lopper/.worktrees/bug-v1-3-issue-470-elixir-comment-complexity/internal/lang/elixir/adapter_test.go) for quoted and escaped hashes.

# Validation
- `make ci`
