### PR TITLE
chore: sync extension version to v1.3.0

### DIFF
--- a/extensions/vscode-lopper/package-lock.json
+++ b/extensions/vscode-lopper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-lopper",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-lopper",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",

--- a/extensions/vscode-lopper/package.json
+++ b/extensions/vscode-lopper/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-lopper",
   "displayName": "Lopper",
   "description": "VS Code diagnostics, hover details, and safe JS/TS quick fixes across Lopper adapters, including Kotlin Android.",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "publisher": "BenRanford",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bumps the committed VS Code extension release floor to 1.3.0 so the stable release workflow cuts v1.3.0.