### PR TITLE
fix(cpp): fall back when compile db sources escape repo

### DIFF
--- a/internal/lang/cpp/adapter_helpers_test.go
+++ b/internal/lang/cpp/adapter_helpers_test.go
@@ -14,7 +14,9 @@ import (
 
 const (
 	testMainCPPFileName = "main.cpp"
-	fmtCoreIncludeLine  = "#include <fmt/core.h>\n"
+	systemIncludeDir    = "/usr/include"
+	fmtCoreHeader       = "fmt/core.h"
+	fmtCoreIncludeLine  = "#include <" + fmtCoreHeader + ">\n"
 )
 
 func TestDetectCanceledContext(t *testing.T) {
@@ -77,7 +79,7 @@ func TestCompileContextCollectorStagesCompileDatabaseData(t *testing.T) {
 	if !ctx.HasCompileDatabase {
 		t.Fatalf("expected compile database to be recorded")
 	}
-	wantIncludeDirs := []string{"/usr/include", filepath.Join(repo, "include")}
+	wantIncludeDirs := []string{systemIncludeDir, filepath.Join(repo, "include")}
 	slices.Sort(wantIncludeDirs)
 	if !slices.Equal(ctx.IncludeDirs, wantIncludeDirs) {
 		t.Fatalf("unexpected include dirs: %#v", ctx.IncludeDirs)
@@ -121,14 +123,14 @@ func TestResolveCompilePathAndDirectory(t *testing.T) {
 }
 
 func TestExtractIncludeDirsAndAddDedup(t *testing.T) {
-	dirs := extractIncludeDirs([]string{"-I", "include", "-Ivendor/include", "-isystem", "/usr/include", "-iquote", "headers", "-isystem/opt/include", "-iquotequoted", "-Ivendor/include", "-I", ""}, "/repo")
+	dirs := extractIncludeDirs([]string{"-I", "include", "-Ivendor/include", "-isystem", systemIncludeDir, "-iquote", "headers", "-isystem/opt/include", "-iquotequoted", "-Ivendor/include", "-I", ""}, "/repo")
 	want := []string{
 		"/opt/include",
 		"/repo/headers",
 		"/repo/include",
 		"/repo/quoted",
 		"/repo/vendor/include",
-		"/usr/include",
+		systemIncludeDir,
 	}
 	if !slices.Equal(dirs, want) {
 		t.Fatalf("unexpected include dirs: got %#v want %#v", dirs, want)
@@ -136,7 +138,7 @@ func TestExtractIncludeDirsAndAddDedup(t *testing.T) {
 }
 
 func TestParseIncludesBranches(t *testing.T) {
-	content := []byte(`#include <fmt/core.h>
+	content := []byte(`#include <` + fmtCoreHeader + `>
 #include "local/header.hpp"
 #include SOME_MACRO_HEADER
 #include <broken
@@ -233,8 +235,8 @@ func TestCollectDependencyUsageSummaryApply(t *testing.T) {
 	summary := collectDependencyUsage("fmt", []fileScan{{
 		Path: testMainCPPFileName,
 		Includes: []includeRecord{
-			{Dependency: "fmt", Header: "fmt/core.h", Location: report.Location{File: testMainCPPFileName, Line: 1, Column: 1}},
-			{Dependency: "FMT", Header: "fmt/core.h", Location: report.Location{File: testMainCPPFileName, Line: 2, Column: 1}},
+			{Dependency: "fmt", Header: fmtCoreHeader, Location: report.Location{File: testMainCPPFileName, Line: 1, Column: 1}},
+			{Dependency: "FMT", Header: fmtCoreHeader, Location: report.Location{File: testMainCPPFileName, Line: 2, Column: 1}},
 			{Dependency: "fmt", Header: "fmt/format.h", Location: report.Location{File: testMainCPPFileName, Line: 3, Column: 1}},
 		},
 	}})
@@ -245,10 +247,10 @@ func TestCollectDependencyUsageSummaryApply(t *testing.T) {
 	if dep.TotalExportsCount != 2 || dep.UsedExportsCount != 2 || dep.UsedPercent != 100 {
 		t.Fatalf("unexpected dependency usage summary: %#v", dep)
 	}
-	if len(dep.TopUsedSymbols) != 2 || dep.TopUsedSymbols[0].Name != "fmt/core.h" || dep.TopUsedSymbols[0].Count != 2 {
+	if len(dep.TopUsedSymbols) != 2 || dep.TopUsedSymbols[0].Name != fmtCoreHeader || dep.TopUsedSymbols[0].Count != 2 {
 		t.Fatalf("unexpected top used symbols: %#v", dep.TopUsedSymbols)
 	}
-	if len(dep.UsedImports) != 2 || dep.UsedImports[0].Name != "fmt/core.h" || len(dep.UsedImports[0].Locations) != 2 {
+	if len(dep.UsedImports) != 2 || dep.UsedImports[0].Name != fmtCoreHeader || len(dep.UsedImports[0].Locations) != 2 {
 		t.Fatalf("unexpected flattened usage imports: %#v", dep.UsedImports)
 	}
 }
@@ -287,6 +289,26 @@ func TestScanRepoWithOutsideCompileSourceWarning(t *testing.T) {
 	if !hasWarning(result.Warnings, "outside repo boundary") {
 		t.Fatalf("expected outside repo warning, got %#v", result.Warnings)
 	}
+	if !hasWarning(result.Warnings, "falling back to repo scan") {
+		t.Fatalf("expected fallback warning, got %#v", result.Warnings)
+	}
+}
+
+func TestScanRepoFallsBackWhenCompileSourcesEscapeRepo(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", testMainCPPFileName), fmtCoreIncludeLine+"int main() { return 0; }\n")
+	compileInfo := compileContext{
+		HasCompileDatabase: true,
+		SourceFiles:        []string{"/tmp/not-in-repo.cpp"},
+	}
+
+	result, err := scanRepo(context.Background(), repo, compileInfo, newDependencyCatalog())
+	if err != nil {
+		t.Fatalf("scan repo: %v", err)
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != filepath.Join("src", testMainCPPFileName) {
+		t.Fatalf("expected repo source fallback to scan in-repo file, got %#v", result.Files)
+	}
 }
 
 func TestScanRepoCanceledAndMissingFileErrors(t *testing.T) {
@@ -304,9 +326,15 @@ func TestScanRepoCanceledAndMissingFileErrors(t *testing.T) {
 	missingSource := compileContext{
 		SourceFiles: []string{filepath.Join(repo, "src", "missing.cpp")},
 	}
-	_, err = scanRepo(context.Background(), repo, missingSource, newDependencyCatalog())
-	if err == nil {
-		t.Fatalf("expected missing source file error from scanRepo")
+	result, err := scanRepo(context.Background(), repo, missingSource, newDependencyCatalog())
+	if err != nil {
+		t.Fatalf("expected missing compile-db source to fall back, got err=%v", err)
+	}
+	if !hasWarning(result.Warnings, "missing from repo") {
+		t.Fatalf("expected missing compile-db warning, got %#v", result.Warnings)
+	}
+	if !hasWarning(result.Warnings, "falling back to repo scan") {
+		t.Fatalf("expected fallback warning, got %#v", result.Warnings)
 	}
 }
 

--- a/internal/lang/cpp/adapter_test.go
+++ b/internal/lang/cpp/adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
@@ -37,6 +38,29 @@ int main() { return 0; }
 	dep := reportData.Dependencies[0]
 	if dep.Name != "fmt" || dep.UsedExportsCount != 2 || dep.TotalExportsCount != 2 || dep.UsedPercent != 100 {
 		t.Fatalf("unexpected dependency report: %#v", dep)
+	}
+}
+
+func TestAnalyseFallsBackWhenCompileDatabaseEscapesRepo(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "compile_commands.json"), `[
+  {"directory":".","file":"../escape/outside.cpp","command":"c++ -Iinclude -c ../escape/outside.cpp"}
+]`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "main.cpp"), `#include <fmt/core.h>
+int main() { return 0; }
+`)
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, Dependency: "fmt"})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if len(reportData.Dependencies) != 1 || reportData.Dependencies[0].UsedExportsCount != 1 {
+		t.Fatalf("expected fmt usage from repo fallback, got %#v", reportData.Dependencies)
+	}
+	if !slices.ContainsFunc(reportData.Warnings, func(warning string) bool {
+		return strings.Contains(strings.ToLower(warning), "falling back to repo scan")
+	}) {
+		t.Fatalf("expected compile-db fallback warning, got %#v", reportData.Warnings)
 	}
 }
 

--- a/internal/lang/cpp/include_resolution.go
+++ b/internal/lang/cpp/include_resolution.go
@@ -66,10 +66,11 @@ func scanRepo(ctx context.Context, repoPath string, compileInfo compileContext, 
 		result: scanResult{Catalog: catalog},
 	}
 
-	files, err := resolveScanFiles(ctx, repoPath, compileInfo)
+	files, warnings, err := resolveScanFiles(ctx, repoPath, compileInfo)
 	if err != nil {
 		return stage.result, err
 	}
+	stage.result.Warnings = append(stage.result.Warnings, warnings...)
 	if len(files) == 0 {
 		stage.result.Warnings = append(stage.result.Warnings, "no C/C++ source files found for analysis")
 		return stage.result, nil
@@ -84,11 +85,56 @@ func scanRepo(ctx context.Context, repoPath string, compileInfo compileContext, 
 	return stage.result, nil
 }
 
-func resolveScanFiles(ctx context.Context, repoPath string, compileInfo compileContext) ([]string, error) {
+func resolveScanFiles(ctx context.Context, repoPath string, compileInfo compileContext) ([]string, []string, error) {
 	if len(compileInfo.SourceFiles) > 0 {
-		return compileInfo.SourceFiles, nil
+		files, warnings, err := filterCompileSourceHints(repoPath, compileInfo.SourceFiles)
+		if err != nil {
+			return nil, warnings, err
+		}
+		if len(files) > 0 {
+			return files, warnings, nil
+		}
+		warnings = append(warnings, "compile database did not yield valid in-repo source files; falling back to repo scan")
+		files, err = walkCPPFiles(ctx, repoPath)
+		return files, warnings, err
 	}
-	return walkCPPFiles(ctx, repoPath)
+	files, err := walkCPPFiles(ctx, repoPath)
+	return files, nil, err
+}
+
+func filterCompileSourceHints(repoPath string, sourceFiles []string) ([]string, []string, error) {
+	files := make([]string, 0, len(sourceFiles))
+	warnings := make([]string, 0)
+	seen := make(map[string]struct{}, len(sourceFiles))
+
+	for _, sourcePath := range sourceFiles {
+		sourcePath = filepath.Clean(sourcePath)
+		if !shared.IsPathWithin(repoPath, sourcePath) {
+			warnings = append(warnings, fmt.Sprintf("skipping compile database file outside repo boundary: %s", sourcePath))
+			continue
+		}
+
+		info, err := os.Stat(sourcePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				warnings = append(warnings, fmt.Sprintf("skipping compile database file missing from repo: %s", relOrBase(repoPath, sourcePath)))
+				continue
+			}
+			return nil, warnings, err
+		}
+		if info.IsDir() {
+			warnings = append(warnings, fmt.Sprintf("skipping compile database path that is not a file: %s", relOrBase(repoPath, sourcePath)))
+			continue
+		}
+		if _, ok := seen[sourcePath]; ok {
+			continue
+		}
+		seen[sourcePath] = struct{}{}
+		files = append(files, sourcePath)
+	}
+
+	sort.Strings(files)
+	return files, warnings, nil
 }
 
 func (s *scanStage) process(ctx context.Context, path string) error {


### PR DESCRIPTION
## Issue
- `compile_commands.json` entries could point only outside the repository, causing C++ analysis to skip real in-repo translation units.
- Sonar also flagged duplicated test literals in `internal/lang/cpp/adapter_helpers_test.go`.
- Closes #508
- Closes #567
- Closes #568

## Cause and User Impact
- A hostile or stale compile database could suppress dependency findings for actual repository sources.
- Users would see false negatives because the scanner trusted compile-db source paths as the complete scan universe.
- The duplicated test literals kept the helper test file red under Sonar critical duplication rules.

## Root Cause
- `resolveScanFiles` returned compile-db source paths directly whenever any were present, without validating that they still pointed to usable in-repo files.
- The helper tests repeated `/usr/include` and `fmt/core.h` across multiple cases instead of centralizing them.

## Fix
- Filter compile-db source paths before scanning, keeping only existing files that stay within the repo boundary.
- Fall back to walking repository C/C++ sources when the compile database yields no valid in-repo translation units, while preserving compile-db behavior when valid translation units exist.
- Add regression coverage for the escape-path false negative and for fallback on missing compile-db sources.
- Replace the duplicated test literals with shared constants without changing test behavior.

## Validation
- `go test ./internal/lang/cpp`
- `make ci` via pre-commit hook during `git commit`
