### PR TITLE
test(kotlin-android): dedupe alpha-core literal

### DIFF
--- a/internal/lang/kotlinandroid/gradle_lookup_stages_test.go
+++ b/internal/lang/kotlinandroid/gradle_lookup_stages_test.go
@@ -92,14 +92,16 @@ func TestGradleLockfileDiscoveryAndParsingStages(t *testing.T) {
 }
 
 func TestBuildDependencyLookupIndexStage(t *testing.T) {
+	const alphaCore = "alpha-core"
+
 	lookups := buildDependencyLookupIndex([]dependencyDescriptor{
-		{Name: "alpha-core", Group: "com.example.alpha", Artifact: "alpha-core"},
+		{Name: alphaCore, Group: "com.example.alpha", Artifact: alphaCore},
 		{Name: "alpha-runtime", Group: "org.sample.alpha", Artifact: "alpha-runtime"},
 	})
-	if got := lookups.Prefixes["com.example.alpha"]; got != "alpha-core" {
+	if got := lookups.Prefixes["com.example.alpha"]; got != alphaCore {
 		t.Fatalf("expected group prefix lookup for alpha-core, got %q", got)
 	}
-	if got := lookups.Aliases["alpha.core"]; got != "alpha-core" {
+	if got := lookups.Aliases["alpha.core"]; got != alphaCore {
 		t.Fatalf("expected artifact alias lookup for alpha-core, got %q", got)
 	}
 	if _, ok := lookups.Ambiguous["alpha"]; !ok {


### PR DESCRIPTION
## Issue
Sonar flagged duplicated `alpha-core` string literals in `internal/lang/kotlinandroid/gradle_lookup_stages_test.go`.

## Cause and User Impact
The test repeated the same literal in the fixture setup and in the assertions. This is harmless at runtime, but it creates avoidable duplication noise in the test file and triggers the Sonar duplication rule.

## Root Cause
`alpha-core` was written inline in multiple places instead of being named once for the test.

## Fix
Introduced a local `alphaCore` constant inside `TestBuildDependencyLookupIndexStage` and reused it for the fixture and expectations.

## Validation
- `go test ./internal/lang/kotlinandroid`
- Repository pre-commit checks ran during commit, including `go test ./...`, `go test -race ./...`, memory benchmark delta, and coverage gates.

Closes #569