### PR TITLE
fix(workspace): preserve deleted and spaced changed files

### DIFF
--- a/internal/workspace/changed_files.go
+++ b/internal/workspace/changed_files.go
@@ -15,7 +15,7 @@ func ChangedFiles(repoPath string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	diffOutput, diffErr := runGit(gitPath, normalized, "diff", "--name-only", "--diff-filter=ACMR", "HEAD~1..HEAD")
+	diffOutput, diffErr := runGit(gitPath, normalized, "diff", "--name-only", "--diff-filter=ACMRD", "HEAD~1..HEAD")
 	if diffErr == nil {
 		return parseChangedFileLines(diffOutput), nil
 	}
@@ -27,8 +27,8 @@ func ChangedFiles(repoPath string) ([]string, error) {
 }
 
 func parseChangedFileLines(output []byte) []string {
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	return collectUniquePaths(lines, strings.TrimSpace)
+	lines := strings.Split(strings.TrimRight(string(output), "\r\n"), "\n")
+	return collectUniquePaths(lines, func(line string) string { return line })
 }
 
 func collectUniquePaths(lines []string, extractor func(string) string) []string {
@@ -50,15 +50,14 @@ func collectUniquePaths(lines []string, extractor func(string) string) []string 
 }
 
 func parsePorcelainChangedFiles(output []byte) []string {
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	lines := strings.Split(strings.TrimRight(string(output), "\r\n"), "\n")
 	return collectUniquePaths(lines, func(line string) string {
-		line = strings.TrimSpace(line)
 		if len(line) < 4 {
 			return ""
 		}
-		path := strings.TrimSpace(line[3:])
+		path := line[3:]
 		if idx := strings.LastIndex(path, " -> "); idx >= 0 {
-			path = strings.TrimSpace(path[idx+4:])
+			path = path[idx+4:]
 		}
 		return path
 	})

--- a/internal/workspace/workspace_changed_files_test.go
+++ b/internal/workspace/workspace_changed_files_test.go
@@ -38,14 +38,17 @@ func TestChangedFilesParsesDiffAndStatusFallback(t *testing.T) {
 	tests := []struct {
 		name   string
 		script string
+		want   []string
 	}{
 		{
 			name:   "diff_success",
-			script: "#!/bin/sh\nif [ \"$3\" = \"diff\" ]; then\n  echo \"pkg/a.go\"\n  echo \"pkg/b.go\"\n  exit 0\nfi\nexit 1\n",
+			script: "#!/bin/sh\nif [ \"$3\" = \"diff\" ]; then\n  case \"$*\" in\n    *\"--diff-filter=ACMRD\"*) ;;\n    *)\n      echo \"missing deleted-files diff filter\" >&2\n      exit 4\n      ;;\n  esac\n  printf '%s\\n' \"  pkg/spaced.go\" \"pkg/deleted.go\"\n  exit 0\nfi\nexit 1\n",
+			want:   []string{"  pkg/spaced.go", "pkg/deleted.go"},
 		},
 		{
 			name:   "status_fallback",
 			script: "#!/bin/sh\nif [ \"$3\" = \"diff\" ]; then\n  echo \"diff fail\" >&2\n  exit 2\nfi\nif [ \"$3\" = \"status\" ]; then\n  echo \"M  pkg/a.go\"\n  echo \"R  old.go -> pkg/b.go\"\n  exit 0\nfi\nexit 1\n",
+			want:   []string{"pkg/a.go", "pkg/b.go"},
 		},
 	}
 
@@ -57,8 +60,13 @@ func TestChangedFilesParsesDiffAndStatusFallback(t *testing.T) {
 			if err != nil {
 				t.Fatalf("changed files lookup failed: %v", err)
 			}
-			if len(changed) != 2 || changed[0] != "pkg/a.go" || changed[1] != "pkg/b.go" {
-				t.Fatalf("expected parsed changed names, got %#v", changed)
+			if len(changed) != len(tc.want) {
+				t.Fatalf("expected %d changed names, got %#v", len(tc.want), changed)
+			}
+			for i := range tc.want {
+				if changed[i] != tc.want[i] {
+					t.Fatalf("expected parsed changed names %#v, got %#v", tc.want, changed)
+				}
 			}
 		})
 	}
@@ -77,13 +85,13 @@ func TestChangedFilesReturnsJoinedGitErrors(t *testing.T) {
 }
 
 func TestParseChangedFileHelpers(t *testing.T) {
-	changed := parseChangedFileLines([]byte("packages/a/file.ts\npackages/a/file.ts\n"))
-	if len(changed) != 1 || changed[0] != "packages/a/file.ts" {
+	changed := parseChangedFileLines([]byte("  packages/a/file.ts\n  packages/a/file.ts\n"))
+	if len(changed) != 1 || changed[0] != "  packages/a/file.ts" {
 		t.Fatalf("expected deduped changed lines, got %#v", changed)
 	}
 
-	porcelain := parsePorcelainChangedFiles([]byte("M  packages/a/file.ts\nR  old.ts -> packages/b/new.ts\n"))
-	if len(porcelain) != 2 || porcelain[0] != "packages/a/file.ts" || porcelain[1] != "packages/b/new.ts" {
+	porcelain := parsePorcelainChangedFiles([]byte("M   packages/a/file.ts\nR  old.ts ->  packages/b/new.ts\n"))
+	if len(porcelain) != 2 || porcelain[0] != " packages/a/file.ts" || porcelain[1] != " packages/b/new.ts" {
 		t.Fatalf("expected parsed porcelain paths, got %#v", porcelain)
 	}
 


### PR DESCRIPTION
## Issue
Closes #472
Closes #473

## Cause and user impact
Changed-files collection trimmed path output too aggressively and filtered deletions out of the last-commit diff path, so deleted files vanished from reports and filenames that intentionally began with whitespace were corrupted.

## Root cause
The last-commit diff used `--diff-filter=ACMR`, and both the diff parser and porcelain parser trimmed full path payloads instead of only removing trailing line endings.

## Fix
Switched the diff path to include deletions, preserved leading whitespace in changed-file parsing, and expanded regression coverage for spaced filenames and deleted-file detection.

## Validation
- go test ./internal/workspace ./internal/analysis ./internal/app
