### PR TITLE
fix(shared): reject symlink escapes in IsPathWithin

### DIFF
--- a/internal/lang/shared/adapter_scaffold.go
+++ b/internal/lang/shared/adapter_scaffold.go
@@ -114,9 +114,50 @@ func IsPathWithin(root, candidate string) bool {
 	if err != nil {
 		return false
 	}
-	rel, err := filepath.Rel(absRoot, absCandidate)
+	if !pathWithin(absRoot, absCandidate) {
+		return false
+	}
+
+	resolvedRoot, err := resolvePathWithMissingLeaf(absRoot)
+	if err != nil {
+		return false
+	}
+	resolvedCandidate, err := resolvePathWithMissingLeaf(absCandidate)
+	if err != nil {
+		return false
+	}
+
+	return pathWithin(resolvedRoot, resolvedCandidate)
+}
+
+func pathWithin(root, candidate string) bool {
+	rel, err := filepath.Rel(root, candidate)
 	if err != nil {
 		return false
 	}
 	return rel == "." || (!strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && rel != "..")
+}
+
+func resolvePathWithMissingLeaf(path string) (string, error) {
+	cleanPath := filepath.Clean(path)
+
+	_, err := os.Lstat(cleanPath)
+	if err == nil {
+		return filepath.EvalSymlinks(cleanPath)
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	parent := filepath.Dir(cleanPath)
+	if parent == cleanPath {
+		return cleanPath, nil
+	}
+
+	resolvedParent, err := resolvePathWithMissingLeaf(parent)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(resolvedParent, filepath.Base(cleanPath)), nil
 }

--- a/internal/lang/shared/dependency_usage_test.go
+++ b/internal/lang/shared/dependency_usage_test.go
@@ -610,3 +610,20 @@ func TestIsPathWithin(t *testing.T) {
 		t.Fatalf("expected invalid candidate to return false")
 	}
 }
+
+func TestIsPathWithinRejectsSymlinkEscape(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	escape := filepath.Join(repo, "escape")
+
+	if err := os.Symlink(outside, escape); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	if IsPathWithin(repo, escape) {
+		t.Fatalf("expected symlink that resolves outside repo to be rejected")
+	}
+	if IsPathWithin(repo, filepath.Join(escape, "nested.txt")) {
+		t.Fatalf("expected path through escaping symlink to be rejected")
+	}
+}


### PR DESCRIPTION
## Issue
Closes #483

## Cause and user impact
Boundary checks treated lexical in-repo symlink paths as safe even when the symlink target resolved outside the repository, which let callers accept escaping paths as if they were inside the repo.

## Root cause
`IsPathWithin` only compared absolute path strings via `filepath.Rel` and never rechecked the resolved symlink target.

## Fix
Added a symlink-aware resolution pass that still tolerates missing leaf paths, then revalidated the resolved root and candidate paths before returning true. Added regression coverage for direct and nested escape paths through an in-repo symlink.

## Validation
- go test ./internal/lang/shared
