### PR TITLE
fix(runtime): resolve node hooks from lopper root

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,12 @@ Capture a runtime trace:
 
 ```bash
 export LOPPER_RUNTIME_TRACE=.artifacts/lopper-runtime.ndjson
-export NODE_OPTIONS="--require ./scripts/runtime/require-hook.cjs --loader ./scripts/runtime/loader.mjs"
+export LOPPER_ROOT=/path/to/lopper
+export NODE_OPTIONS="--require ${LOPPER_ROOT}/scripts/runtime/require-hook.cjs --loader ${LOPPER_ROOT}/scripts/runtime/loader.mjs"
 npm test
 ```
+
+Use the hook files from the lopper checkout or install tree. Relative hook paths resolve from the repo running `npm test`, not from lopper itself.
 
 Or let Lopper run the test command and capture the trace automatically:
 

--- a/internal/runtime/capture.go
+++ b/internal/runtime/capture.go
@@ -6,13 +6,17 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
+	"sync"
 	"unicode"
 )
 
 const defaultTraceRelPath = ".artifacts/lopper-runtime.ndjson"
 const runtimeBinDirsEnvKey = "LOPPER_RUNTIME_BIN_DIRS"
 const defaultTrustedRuntimeBinDirs = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"
+const runtimeRequireHookRelPath = "scripts/runtime/require-hook.cjs"
+const runtimeLoaderHookRelPath = "scripts/runtime/loader.mjs"
 
 var runtimeExecutableAllowlist = map[string]struct{}{
 	"npm":    {},
@@ -28,6 +32,13 @@ var runtimeExecutableAllowlist = map[string]struct{}{
 	"deno":   {},
 	"make":   {},
 }
+
+var (
+	runtimeHookPathsOnce   sync.Once
+	runtimeRequireHookPath string
+	runtimeLoaderHookPath  string
+	runtimeHookPathsErr    error
+)
 
 type CaptureRequest struct {
 	RepoPath  string
@@ -65,7 +76,10 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 		return err
 	}
 	cmd.Dir = repoPath
-	cmd.Env = withRuntimeTraceEnv(os.Environ(), tracePath)
+	cmd.Env, err = withRuntimeTraceEnv(os.Environ(), tracePath)
+	if err != nil {
+		return err
+	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		trimmed := strings.TrimSpace(string(output))
@@ -244,19 +258,23 @@ func trustedSearchDirs(dirListValue string) []string {
 	return dirs
 }
 
-func withRuntimeTraceEnv(base []string, tracePath string) []string {
+func withRuntimeTraceEnv(base []string, tracePath string) ([]string, error) {
+	required, err := runtimeNodeHookOptions()
+	if err != nil {
+		return nil, fmt.Errorf("resolve runtime node hooks: %w", err)
+	}
+
 	existing := readEnvValue(base, "NODE_OPTIONS")
 	updates := map[string]string{
 		"LOPPER_RUNTIME_TRACE": tracePath,
 	}
 	nodeOptions := strings.TrimSpace(existing)
-	required := "--require=./scripts/runtime/require-hook.cjs --loader=./scripts/runtime/loader.mjs"
 	if nodeOptions == "" {
 		updates["NODE_OPTIONS"] = required
 	} else {
 		updates["NODE_OPTIONS"] = nodeOptions + " " + required
 	}
-	return mergeEnv(base, updates)
+	return mergeEnv(base, updates), nil
 }
 
 func mergeEnv(base []string, updates map[string]string) []string {
@@ -289,4 +307,74 @@ func readEnvValue(env []string, key string) string {
 		}
 	}
 	return ""
+}
+
+func runtimeNodeHookOptions() (string, error) {
+	requirePath, loaderPath, err := runtimeHookPaths()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("--require=%s --loader=%s", requirePath, loaderPath), nil
+}
+
+func runtimeHookPaths() (string, string, error) {
+	runtimeHookPathsOnce.Do(func() {
+		runtimeRequireHookPath, runtimeLoaderHookPath, runtimeHookPathsErr = locateRuntimeHookPaths()
+	})
+	return runtimeRequireHookPath, runtimeLoaderHookPath, runtimeHookPathsErr
+}
+
+func locateRuntimeHookPaths() (string, string, error) {
+	for _, root := range runtimeHookSearchRoots() {
+		requirePath := filepath.Join(root, runtimeRequireHookRelPath)
+		loaderPath := filepath.Join(root, runtimeLoaderHookRelPath)
+		if !isRegularFile(requirePath) || !isRegularFile(loaderPath) {
+			continue
+		}
+		return requirePath, loaderPath, nil
+	}
+
+	return "", "", fmt.Errorf("could not locate runtime hooks %q and %q", runtimeRequireHookRelPath, runtimeLoaderHookRelPath)
+}
+
+func runtimeHookSearchRoots() []string {
+	seen := make(map[string]struct{})
+	roots := make([]string, 0)
+	addSearchPath := func(path string) {
+		if path == "" {
+			return
+		}
+		for dir := filepath.Clean(path); ; dir = filepath.Dir(dir) {
+			if !filepath.IsAbs(dir) {
+				break
+			}
+			if _, ok := seen[dir]; !ok {
+				seen[dir] = struct{}{}
+				roots = append(roots, dir)
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+		}
+	}
+
+	if executablePath, err := os.Executable(); err == nil {
+		executableDir := filepath.Dir(executablePath)
+		addSearchPath(executableDir)
+		addSearchPath(filepath.Join(executableDir, "..", "share", "lopper"))
+	}
+	if _, filename, _, ok := goruntime.Caller(0); ok {
+		addSearchPath(filepath.Dir(filename))
+	}
+
+	return roots
+}
+
+func isRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
 }

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -33,6 +33,41 @@ func TestCapture(t *testing.T) {
 	}
 }
 
+func TestCaptureUsesAbsoluteNodeHookPaths(t *testing.T) {
+	repo := t.TempDir()
+	nodeOptionsPath := filepath.Join(repo, "node-options.txt")
+	t.Setenv("LOPPER_CAPTURE_NODE_OPTIONS", nodeOptionsPath)
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "npm", "#!/bin/sh\nprintf '%s' \"$NODE_OPTIONS\" > \"$LOPPER_CAPTURE_NODE_OPTIONS\"\n"))
+
+	err := Capture(context.Background(), CaptureRequest{
+		RepoPath: repo,
+		Command:  npmTestCommand,
+	})
+	if err != nil {
+		t.Fatalf("capture runtime trace: %v", err)
+	}
+
+	gotBytes, err := os.ReadFile(nodeOptionsPath)
+	if err != nil {
+		t.Fatalf("read node options: %v", err)
+	}
+	got := string(gotBytes)
+	if strings.Contains(got, "./scripts/runtime/") {
+		t.Fatalf("expected node hook paths to resolve from lopper, got %q", got)
+	}
+
+	requirePath, loaderPath, err := runtimeHookPaths()
+	if err != nil {
+		t.Fatalf("runtime hook paths: %v", err)
+	}
+	if !strings.Contains(got, "--require="+requirePath) {
+		t.Fatalf("expected absolute require hook path, got %q", got)
+	}
+	if !strings.Contains(got, "--loader="+loaderPath) {
+		t.Fatalf("expected absolute loader hook path, got %q", got)
+	}
+}
+
 func TestCaptureCommandFailure(t *testing.T) {
 	repo := t.TempDir()
 	assertCaptureErrorContains(t, CaptureRequest{RepoPath: repo, Command: "make __missing_target__"}, "runtime test command failed")

--- a/internal/runtime/capture_env_test.go
+++ b/internal/runtime/capture_env_test.go
@@ -9,7 +9,15 @@ import (
 
 func TestWithRuntimeTraceEnv(t *testing.T) {
 	tracePath := "/tmp/runtime.ndjson"
-	env := withRuntimeTraceEnv([]string{"NODE_OPTIONS=--max-old-space-size=4096", "PATH=/usr/bin"}, tracePath)
+	requirePath, loaderPath, err := runtimeHookPaths()
+	if err != nil {
+		t.Fatalf("runtime hook paths: %v", err)
+	}
+
+	env, err := withRuntimeTraceEnv([]string{"NODE_OPTIONS=--max-old-space-size=4096", "PATH=/usr/bin"}, tracePath)
+	if err != nil {
+		t.Fatalf("with runtime trace env: %v", err)
+	}
 
 	var hasTrace bool
 	var hasNodeOptions bool
@@ -22,7 +30,13 @@ func TestWithRuntimeTraceEnv(t *testing.T) {
 			if !strings.Contains(entry, "--max-old-space-size=4096") {
 				t.Fatalf("expected existing NODE_OPTIONS to be preserved: %q", entry)
 			}
-			if !strings.Contains(entry, "--loader=./scripts/runtime/loader.mjs") {
+			if strings.Contains(entry, "./scripts/runtime/") {
+				t.Fatalf("expected absolute runtime hook paths, got %q", entry)
+			}
+			if !strings.Contains(entry, "--require="+requirePath) {
+				t.Fatalf("expected require hook to be included: %q", entry)
+			}
+			if !strings.Contains(entry, "--loader="+loaderPath) {
 				t.Fatalf("expected loader hook to be included: %q", entry)
 			}
 		}

--- a/internal/runtime/runtime_cov_more_test.go
+++ b/internal/runtime/runtime_cov_more_test.go
@@ -8,7 +8,10 @@ import (
 
 func TestRuntimeAdditionalHelperBranches(t *testing.T) {
 	tracePath := "/tmp/runtime.ndjson"
-	env := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, tracePath)
+	env, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, tracePath)
+	if err != nil {
+		t.Fatalf("with runtime trace env: %v", err)
+	}
 	if readEnvValue(env, "NODE_OPTIONS") == "" {
 		t.Fatalf("expected NODE_OPTIONS to be injected when absent")
 	}


### PR DESCRIPTION
## Issue
Closes #476

## Cause and user impact
Runtime trace capture injected Node hook paths relative to the analyzed repo, so `npm test` or similar commands resolved the hooks from the target repository instead of the lopper checkout or install tree.

## Root cause
`withRuntimeTraceEnv` appended `./scripts/runtime/...` directly into `NODE_OPTIONS`, while `Capture` executes the runtime command with `cmd.Dir` set to the analyzed repo.

## Fix
Resolved the runtime hook files to absolute paths from the lopper tree, updated capture env helpers to surface resolution errors, added regression coverage for absolute hook injection, and clarified the README example.

## Validation
- go test ./internal/runtime ./internal/app
