### PR TITLE
test(coverage): enforce per-package minimums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,12 +414,13 @@ jobs:
         continue-on-error: true
         env:
           COVERAGE_MIN: 98
+          COVERAGE_PACKAGE_MIN: 98
         run: |
           set +e
           if [ -n "${ACT:-}" ]; then
-            PATH="$(go env GOPATH)/bin:$PATH" make cov COVERAGE_MIN="${COVERAGE_MIN}"
+            PATH="$(go env GOPATH)/bin:$PATH" make cov COVERAGE_MIN="${COVERAGE_MIN}" COVERAGE_PACKAGE_MIN="${COVERAGE_PACKAGE_MIN}"
           else
-            make cov COVERAGE_MIN="${COVERAGE_MIN}"
+            make cov COVERAGE_MIN="${COVERAGE_MIN}" COVERAGE_PACKAGE_MIN="${COVERAGE_PACKAGE_MIN}"
           fi
           status=$?
           if [ -f .artifacts/coverage-total.txt ]; then
@@ -427,6 +428,11 @@ jobs:
           else
             total=""
           fi
+          echo "package_failures<<EOF" >> "$GITHUB_OUTPUT"
+          if [ -f .artifacts/coverage-package-failures.txt ]; then
+            cat .artifacts/coverage-package-failures.txt >> "$GITHUB_OUTPUT"
+          fi
+          echo "EOF" >> "$GITHUB_OUTPUT"
           echo "total=$total" >> "$GITHUB_OUTPUT"
           exit $status
 
@@ -435,18 +441,26 @@ jobs:
         uses: actions/github-script@v8
         env:
           COVERAGE_MIN: 98
+          COVERAGE_PACKAGE_MIN: 98
           COVERAGE_TOTAL: ${{ steps.cov.outputs.total }}
+          COVERAGE_PACKAGE_FAILURES: ${{ steps.cov.outputs.package_failures }}
         with:
           script: |
             const marker = '<!-- lopper-coverage-failure -->';
             const total = process.env.COVERAGE_TOTAL || 'unavailable';
+            const packageFailures = (process.env.COVERAGE_PACKAGE_FAILURES || '').trim();
+            const packageFailureSection = packageFailures
+              ? `Packages below minimum:\n${packageFailures}\n\n`
+              : '';
             const body = `${marker}
             ❌ Coverage gate failed.
 
-            Required: >= ${process.env.COVERAGE_MIN}%
-            Actual: ${total === 'unavailable' ? total : `${total}%`}
+            Required total: >= ${process.env.COVERAGE_MIN}%
+            Actual total: ${total === 'unavailable' ? total : `${total}%`}
 
-            Run \`make cov\` locally for details.`;
+            Required per-package: >= ${process.env.COVERAGE_PACKAGE_MIN}%
+
+            ${packageFailureSection}Run \`make cov\` locally for details.`;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ GIT_COMMIT ?= $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 COVERAGE_FILE ?= .artifacts/coverage.out
 COVERAGE_MIN ?= 98
+COVERAGE_PACKAGE_MIN ?= $(COVERAGE_MIN)
 GO ?= go
 GO_TOOLCHAIN ?= go1.26.1
 GO_CMD := GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO)
@@ -222,11 +223,14 @@ bench-gate:
 cov:
 	@mkdir -p $$(dirname "$(COVERAGE_FILE)")
 	@pkgs=$$(GOFLAGS=-buildvcs=false $(GO_CMD) list ./... | grep -Ev '/internal/testutil$$|/internal/testsupport$$|/tools/benchdelta$$'); \
-	GOFLAGS=-buildvcs=false $(GO_CMD) test $$pkgs -covermode=atomic -coverprofile="$(COVERAGE_FILE)"
-	@total=$$($(GO_CMD) tool cover -func="$(COVERAGE_FILE)" | awk '/^total:/ {gsub("%","",$$3); print $$3}'); \
-	echo "Total coverage: $$total% (required: >= $(COVERAGE_MIN)%)"; \
-	printf "%s\n" "$$total" > .artifacts/coverage-total.txt; \
-	awk "BEGIN { exit !($$total >= $(COVERAGE_MIN)) }" || (echo "Coverage gate failed: $$total% < $(COVERAGE_MIN)%"; exit 1)
+		GOFLAGS=-buildvcs=false $(GO_CMD) test $$pkgs -covermode=atomic -coverprofile="$(COVERAGE_FILE)"
+	@GOFLAGS=-buildvcs=false $(GO_CMD) run ./tools/coveragegate \
+		-coverprofile="$(COVERAGE_FILE)" \
+		-min="$(COVERAGE_MIN)" \
+		-package-min="$(COVERAGE_PACKAGE_MIN)" \
+		-total-out=".artifacts/coverage-total.txt" \
+		-packages-out=".artifacts/coverage-packages.txt" \
+		-package-failures-out=".artifacts/coverage-package-failures.txt"
 
 build:
 	mkdir -p $(BIN_DIR)

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -75,7 +75,7 @@ When running locally with `act`, target the Linux-backed jobs explicitly (for ex
 - `make test-race`: run `go test -race ./...`
 - `make bench-mem`: run the curated memory benchmark suite with `-benchmem`
 - `make bench-gate`: compare curated memory benchmark deltas against a base ref (defaults: `MEMORY_BENCH_BASE=origin/main`, `MEMORY_BENCH_MAX_BYTES_PCT=15`, `MEMORY_BENCH_MAX_ALLOCS_PCT=10`)
-- `make cov`: run tests with coverage profile and enforce minimum total coverage (default `COVERAGE_MIN=98`), excluding helper-only packages such as `internal/testutil`, `internal/testsupport`, and the local CI helper tool `tools/benchdelta`
+- `make cov`: run tests with coverage profile and enforce both minimum total coverage (`COVERAGE_MIN`, default `98`) and minimum per-package coverage (`COVERAGE_PACKAGE_MIN`, default `98`), excluding helper-only packages such as `internal/testutil`, `internal/testsupport`, and the local CI helper tool `tools/benchdelta`
 - `make smoke`: run cross-OS smoke checks (`mod-check + test-race + build`)
 - `make ci`: `format-check + mod-check + lint + actionlint + shellcheck + dup-check + suppression-check + security + vuln-check + test + test-leaks + test-race + bench-gate + build + cov`
 - `make mem-profiles`: capture package-focused alloc-space summaries for the watched hotspot packages and write them under `.artifacts/memory-profiles/`
@@ -89,6 +89,8 @@ Coverage artifacts:
 
 - `.artifacts/coverage.out`: `go test` coverage profile
 - `.artifacts/coverage-total.txt`: total percentage used by CI gating
+- `.artifacts/coverage-packages.txt`: per-package coverage percentages emitted by the coverage gate
+- `.artifacts/coverage-package-failures.txt`: packages that fell below the per-package minimum, formatted for CI comments
 - `.artifacts/bench-base.out`: benchmark output captured from the base ref
 - `.artifacts/bench-head.out`: benchmark output captured from the current ref
 - `.artifacts/memory-bench-summary.md`: markdown summary posted to PRs
@@ -101,8 +103,8 @@ Memory benchmark approval:
 - Regressions are still blocked unless a maintainer applies the `memory-approved` label.
 - Newly added benchmarks are reported but not gated until the same benchmark name exists on both the base and head refs, which keeps first-rollout noise manageable.
 
-On pull requests, if the coverage gate fails, CI posts/updates a PR comment with required vs. actual coverage.
-The 98% minimum is intentionally enforced in both `Makefile` and CI workflow config to keep local and CI behavior aligned.
+On pull requests, if the coverage gate fails, CI posts/updates a PR comment with total coverage and any packages that fell below the per-package minimum.
+The 98% minimum is intentionally enforced in both `Makefile` and CI workflow config for the combined gate and the per-package gate to keep local and CI behavior aligned.
 
 Cross-compilation uses `zig cc` for CGO targets.
 Current cross-CGO release targets are Linux and Windows.

--- a/internal/app/analyse_pipeline.go
+++ b/internal/app/analyse_pipeline.go
@@ -201,11 +201,11 @@ func prepareRuntimeTrace(ctx context.Context, req Request) ([]string, string) {
 	}
 
 	warnings := make([]string, 0, 1)
-	repoPath, normalizeErr := workspace.NormalizeRepoPath(req.RepoPath)
+	repoPath, normalizeErr := normalizeRepoPathForRuntimeTrace(req.RepoPath)
 	if normalizeErr != nil {
 		repoPath = strings.TrimSpace(req.RepoPath)
 		if repoPath == "" {
-			repoPath = req.RepoPath
+			repoPath = "."
 		}
 		warnings = append(warnings, "runtime trace setup: using raw repo path due to normalization error: "+normalizeErr.Error())
 	}
@@ -224,6 +224,13 @@ func prepareRuntimeTrace(ctx context.Context, req Request) ([]string, string) {
 	}
 
 	return warnings, runtimeTracePath
+}
+
+func normalizeRepoPathForRuntimeTrace(repoPath string) (string, error) {
+	if strings.TrimSpace(repoPath) == "" {
+		return "", fmt.Errorf("repo path is required")
+	}
+	return workspace.NormalizeRepoPath(repoPath)
 }
 
 func (a *App) applyBaselineIfNeeded(reportData report.Report, repoPath string, req AnalyseRequest) (report.Report, error) {

--- a/internal/app/codemod_apply.go
+++ b/internal/app/codemod_apply.go
@@ -90,7 +90,7 @@ func applyCodemodIfNeeded(ctx context.Context, reportData report.Report, repoPat
 }
 
 func beginCodemodApplyPhase(reportData *report.Report, repoPath, dependency string) (codemodApplyPhaseContext, bool, error) {
-	normalizedRepoPath, err := workspace.NormalizeRepoPath(repoPath)
+	normalizedRepoPath, err := normalizeRepoPathForCodemod(repoPath)
 	if err != nil {
 		return codemodApplyPhaseContext{}, false, err
 	}
@@ -159,11 +159,18 @@ func validateCodemodApplyPreconditions(ctx context.Context, repoPath string, req
 	if !req.ApplyCodemod {
 		return nil
 	}
-	normalizedRepoPath, err := workspace.NormalizeRepoPath(repoPath)
+	normalizedRepoPath, err := normalizeRepoPathForCodemod(repoPath)
 	if err != nil {
 		return err
 	}
 	return ensureCleanWorktreeForCodemod(ctx, normalizedRepoPath, req.AllowDirty)
+}
+
+func normalizeRepoPathForCodemod(repoPath string) (string, error) {
+	if strings.TrimSpace(repoPath) == "" {
+		return "", fmt.Errorf("repo path is required")
+	}
+	return workspace.NormalizeRepoPath(repoPath)
 }
 
 func ensureCleanWorktreeForCodemod(ctx context.Context, repoPath string, allowDirty bool) error {

--- a/internal/app/coverage_thresholds_test.go
+++ b/internal/app/coverage_thresholds_test.go
@@ -1,0 +1,332 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const (
+	goModManifestName  = "go.mod"
+	poetryConfigFile   = "[tool.poetry]\n"
+	poetryLockfileName = "poetry.lock"
+	poetryManifestName = "Poetry configuration in pyproject.toml"
+)
+
+func TestPrepareRuntimeTraceFallsBackWhenRepoNormalizationFails(t *testing.T) {
+	req := DefaultRequest()
+	req.RepoPath = ""
+	req.Analyse.RuntimeTracePath = filepath.Join(t.TempDir(), testRuntimeTracePath)
+	req.Analyse.RuntimeTestCommand = missingRuntimeMakeTarget
+
+	var warnings []string
+	var tracePath string
+	err := withRemovedWorkingDir(t, func() error {
+		warnings, tracePath = prepareRuntimeTrace(context.Background(), req)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("prepareRuntimeTrace setup: %v", err)
+	}
+	if len(warnings) != 2 {
+		t.Fatalf("expected normalization and runtime warnings, got %#v", warnings)
+	}
+	if !strings.Contains(warnings[0], "runtime trace setup: using raw repo path due to normalization error:") {
+		t.Fatalf("expected normalization warning first, got %#v", warnings)
+	}
+	if !strings.Contains(warnings[1], "runtime trace command failed; continuing with static analysis:") {
+		t.Fatalf("expected runtime warning second, got %#v", warnings)
+	}
+	if tracePath != req.Analyse.RuntimeTracePath {
+		t.Fatalf("expected explicit trace path to be retained, got %q", tracePath)
+	}
+}
+
+func TestPrepareAnalyseExecutionPropagatesCodemodPreconditionErrors(t *testing.T) {
+	repo := t.TempDir()
+	initCodemodGitRepo(t, repo)
+	writeTextFile(t, filepath.Join(repo, "tracked.txt"), "tracked\n", 0o644)
+	writeTextFile(t, filepath.Join(repo, "dirty.txt"), "dirty\n", 0o644)
+
+	req := DefaultRequest()
+	req.RepoPath = repo
+	req.Analyse.ApplyCodemod = true
+	req.Analyse.Thresholds.LockfileDriftPolicy = "off"
+
+	if _, err := prepareAnalyseExecution(context.Background(), req); !errors.Is(err, ErrDirtyWorktree) {
+		t.Fatalf("expected dirty-worktree error, got %v", err)
+	}
+}
+
+func TestCodemodHelpersNoOpWhenNoCodemodReportIsPresent(t *testing.T) {
+	if err := validateCodemodApplyPreconditions(context.Background(), t.TempDir(), AnalyseRequest{}); err != nil {
+		t.Fatalf("expected disabled codemod preconditions to pass, got %v", err)
+	}
+
+	phaseContext, shouldApply, err := beginCodemodApplyPhase(&report.Report{}, t.TempDir(), "lodash")
+	if err != nil {
+		t.Fatalf("beginCodemodApplyPhase without codemod: %v", err)
+	}
+	if shouldApply || phaseContext.codemod != nil {
+		t.Fatalf("expected no codemod apply phase context, got shouldApply=%v context=%#v", shouldApply, phaseContext)
+	}
+
+	updated, err := applyCodemodIfNeeded(context.Background(), report.Report{}, t.TempDir(), AnalyseRequest{ApplyCodemod: true}, time.Now())
+	if err != nil {
+		t.Fatalf("applyCodemodIfNeeded without codemod: %v", err)
+	}
+	if len(updated.Dependencies) != 0 {
+		t.Fatalf("expected unchanged report when no codemod is present, got %#v", updated)
+	}
+}
+
+func TestCodemodHelpersRejectBlankRepoPaths(t *testing.T) {
+	req := AnalyseRequest{ApplyCodemod: true}
+
+	if err := validateCodemodApplyPreconditions(context.Background(), "", req); err == nil {
+		t.Fatalf("expected repo path validation to fail for blank path")
+	}
+
+	if _, _, err := beginCodemodApplyPhase(&report.Report{}, "", "lodash"); err == nil {
+		t.Fatalf("expected codemod phase setup to fail for blank path")
+	}
+}
+
+func TestAnalyseFormatterKeepsOriginalErrorWhenFallbackFormattingFails(t *testing.T) {
+	decorateAnalyseReport(nil, preparedAnalyseExecution{})
+
+	application := &App{Formatter: report.NewFormatter()}
+	originalErr := errors.New("original failure")
+	formatted, err := application.formatReportWithOriginalError(report.Report{}, report.Format("bogus"), originalErr)
+	if formatted != "" {
+		t.Fatalf("expected empty formatted output on formatter failure, got %q", formatted)
+	}
+	if !errors.Is(err, originalErr) {
+		t.Fatalf("expected original error to be preserved, got %v", err)
+	}
+}
+
+func withRemovedWorkingDir(t *testing.T, fn func() error) error {
+	t.Helper()
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	t.Cleanup(func() {
+		if chdirErr := os.Chdir(originalWD); chdirErr != nil {
+			t.Fatalf("restore wd %s: %v", originalWD, chdirErr)
+		}
+	})
+
+	deadDir := filepath.Join(t.TempDir(), "dead")
+	if err := os.MkdirAll(deadDir, 0o755); err != nil {
+		return err
+	}
+	if err := os.Chdir(deadDir); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(deadDir); err != nil {
+		return err
+	}
+
+	return fn()
+}
+
+func TestMissingLockfileReadErrorsPropagate(t *testing.T) {
+	snapshot := newMissingGoModSnapshot(t)
+	rule := newGoModulesRule()
+
+	_, _, err := evaluateMissingOrStaleLockfile(snapshot, rule, true, nil)
+	assertErrorContains(t, err, "read go.mod for lockfile drift detection")
+}
+
+func TestManifestMatcherErrorsPropagateFromSkipChecks(t *testing.T) {
+	_, snapshot := newPoetrySnapshot(t, false)
+	rule := newPoetryRule(func(string, string) (bool, error) {
+		return false, errors.New("match failed")
+	})
+	_, err := shouldSkipMissingLockfile(snapshot, rule)
+	assertErrorContains(t, err, "match failed")
+}
+
+func TestEvaluateLockfileDirPropagatesRuleErrors(t *testing.T) {
+	snapshot := newMissingGoModSnapshot(t)
+
+	_, err := evaluateLockfileDir(snapshot, lockfileGitContext{})
+	assertErrorContains(t, err, "read go.mod for lockfile drift detection")
+}
+
+func TestProcessLockfileDirToleratesNilVisitor(t *testing.T) {
+	repo := t.TempDir()
+	subdir := filepath.Join(repo, "pkg")
+	mustMkdirAll(t, subdir)
+
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("readdir repo: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.Name() != "pkg" {
+			continue
+		}
+		if err := processLockfileDir(context.Background(), subdir, entry, nil, lockfileWalkState{repoPath: repo}); err != nil {
+			t.Fatalf("expected nil visitor branch to return nil, got %v", err)
+		}
+	}
+}
+
+func TestManifestMismatchWithLockfileReportsStaleLockfile(t *testing.T) {
+	_, snapshot := newPoetrySnapshot(t, true)
+	rule := newPoetryLockfileRule(func(string, string) (bool, error) {
+		return false, nil
+	})
+	rule.manifestLabel = poetryManifestName
+
+	finding, ok, err := evaluateLockfileRule(snapshot, rule, lockfileGitContext{})
+	if err != nil {
+		t.Fatalf("evaluateLockfileRule: %v", err)
+	}
+	if !ok || finding.kind != lockfileDriftStaleLockfile {
+		t.Fatalf("expected stale lockfile finding, got ok=%v finding=%#v", ok, finding)
+	}
+}
+
+func TestEvaluateLockfileRulePropagatesManifestMatcherErrors(t *testing.T) {
+	_, snapshot := newPoetrySnapshot(t, true)
+	rule := newPoetryLockfileRule(func(string, string) (bool, error) {
+		return false, errors.New("manifest mismatch")
+	})
+
+	_, _, err := evaluateLockfileRule(snapshot, rule, lockfileGitContext{})
+	assertErrorContains(t, err, "manifest mismatch")
+}
+
+func TestDetectDriftForRulePropagatesEvaluationErrors(t *testing.T) {
+	repo, snapshot := newPoetrySnapshot(t, false)
+	rule := newPoetryRule(func(string, string) (bool, error) {
+		return false, errors.New("detect failed")
+	})
+
+	_, err := detectDriftForRule(repo, repo, snapshot.files, rule, nil, false)
+	assertErrorContains(t, err, "detect failed")
+}
+
+func TestWarningHelpersCoverEmptyAndDefaultPaths(t *testing.T) {
+	if warnings := buildLockfileDriftWarnings(nil); len(warnings) != 0 {
+		t.Fatalf("expected no warnings for empty findings, got %#v", warnings)
+	}
+	if warning := buildLockfileDriftWarning(lockfileDriftFinding{
+		rule:   lockfileRule{manager: "uv", manifest: pyprojectManifestName},
+		relDir: ".",
+	}); !strings.Contains(warning, "unable to classify lockfile drift") {
+		t.Fatalf("expected default warning message, got %q", warning)
+	}
+	if got := manifestDescription(lockfileRule{manifest: pyprojectManifestName, manifestLabel: poetryManifestName}); got != poetryManifestName {
+		t.Fatalf("expected manifest label to be preferred, got %q", got)
+	}
+}
+
+func TestPyprojectMatcherReadErrorsAreWrapped(t *testing.T) {
+	matcher := pyprojectSectionMatcher("tool.poetry")
+	_, err := matcher(t.TempDir(), t.TempDir())
+	assertErrorContains(t, err, "read pyproject.toml for tool.poetry lockfile drift detection")
+}
+
+func newGoModulesRule() lockfileRule {
+	return lockfileRule{
+		manager:   "Go modules",
+		manifest:  goModManifestName,
+		lockfiles: []string{"go.sum"},
+	}
+}
+
+func newPoetryRule(matcher func(string, string) (bool, error)) lockfileRule {
+	return lockfileRule{
+		manager:  "Poetry",
+		manifest: pyprojectManifestName,
+		manifestMatcher: func(repoPath, manifestPath string) (bool, error) {
+			if matcher == nil {
+				return true, nil
+			}
+			return matcher(repoPath, manifestPath)
+		},
+	}
+}
+
+func newPoetryLockfileRule(matcher func(string, string) (bool, error)) lockfileRule {
+	rule := newPoetryRule(matcher)
+	rule.lockfiles = []string{poetryLockfileName}
+	return rule
+}
+
+func assertErrorContains(t *testing.T, err error, want string) {
+	t.Helper()
+
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected error containing %q, got %v", want, err)
+	}
+}
+
+func newMissingGoModSnapshot(t *testing.T) lockfileDirSnapshot {
+	t.Helper()
+
+	repo := t.TempDir()
+	manifestPath := filepath.Join(repo, goModManifestName)
+	writeTextFile(t, manifestPath, "module example.com/test\n", 0o644)
+	manifestInfo := mustStatFile(t, manifestPath)
+	if err := os.Remove(manifestPath); err != nil {
+		t.Fatalf("remove manifest: %v", err)
+	}
+
+	return lockfileDirSnapshot{
+		repoPath: repo,
+		path:     repo,
+		relDir:   ".",
+		files:    map[string]fs.FileInfo{goModManifestName: manifestInfo},
+	}
+}
+
+func newPoetrySnapshot(t *testing.T, withLockfile bool) (string, lockfileDirSnapshot) {
+	t.Helper()
+
+	repo := t.TempDir()
+	manifestPath := filepath.Join(repo, pyprojectManifestName)
+	writeTextFile(t, manifestPath, poetryConfigFile, 0o644)
+
+	files := map[string]fs.FileInfo{
+		pyprojectManifestName: mustStatFile(t, manifestPath),
+	}
+
+	if withLockfile {
+		lockfilePath := filepath.Join(repo, poetryLockfileName)
+		writeTextFile(t, lockfilePath, "content\n", 0o644)
+		files[poetryLockfileName] = mustStatFile(t, lockfilePath)
+	}
+
+	return repo, lockfileDirSnapshot{
+		repoPath: repo,
+		path:     repo,
+		relDir:   ".",
+		files:    files,
+	}
+}
+
+func mustStatFile(t *testing.T, path string) fs.FileInfo {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", filepath.Base(path), err)
+	}
+
+	return info
+}

--- a/internal/dashboard/coverage_thresholds_test.go
+++ b/internal/dashboard/coverage_thresholds_test.go
@@ -1,0 +1,32 @@
+package dashboard
+
+import (
+	"errors"
+	"testing"
+)
+
+type failOnCSVWrite struct {
+	call   int
+	failOn int
+}
+
+func (f *failOnCSVWrite) Write(_ []string) error {
+	f.call++
+	if f.call == f.failOn {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+func TestWriteDashboardCrossRepoRowsCSVHeaderError(t *testing.T) {
+	writer := &failOnCSVWrite{failOn: 2}
+
+	err := writeDashboardCrossRepoRowsCSV(writer.Write, []CrossRepoDependency{{
+		Name:         "shared-dep",
+		Count:        3,
+		Repositories: []string{"api", "web", "worker"},
+	}})
+	if err == nil {
+		t.Fatal("expected cross-repo header write to fail")
+	}
+}

--- a/internal/dashboard/dashboard_cov_more_test.go
+++ b/internal/dashboard/dashboard_cov_more_test.go
@@ -24,7 +24,7 @@ func TestDashboardAdditionalHelperBranches(t *testing.T) {
 
 	var buffer bytes.Buffer
 	writer := csv.NewWriter(&buffer)
-	if err := writeDashboardCrossRepoRowsCSV(writer, nil); err != nil {
+	if err := writeDashboardCrossRepoRowsCSV(writer.Write, nil); err != nil {
 		t.Fatalf("expected empty cross-repo dependency set to be ignored, got %v", err)
 	}
 	writer.Flush()

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -320,15 +320,15 @@ func TestDashboardCSVHelpersPropagateWriteErrors(t *testing.T) {
 		},
 	}
 
-	if writeDashboardSummaryCSV(poisonedDashboardCSVWriter(t, &failingDashboardWriter{}), reportData) == nil {
+	if writeDashboardSummaryCSV(poisonedDashboardCSVWriter(t, &failingDashboardWriter{}).Write, reportData) == nil {
 		t.Fatalf("expected summary CSV writer error")
 	}
 
-	if writeDashboardRepoRowsCSV(poisonedDashboardCSVWriter(t, &failingDashboardWriter{}), reportData.Repos) == nil {
+	if writeDashboardRepoRowsCSV(poisonedDashboardCSVWriter(t, &failingDashboardWriter{}).Write, reportData.Repos) == nil {
 		t.Fatalf("expected repo row CSV writer error")
 	}
 
-	if writeDashboardCrossRepoRowsCSV(poisonedDashboardCSVWriter(t, &failingDashboardWriter{}), reportData.CrossRepoDeps) == nil {
+	if writeDashboardCrossRepoRowsCSV(poisonedDashboardCSVWriter(t, &failingDashboardWriter{}).Write, reportData.CrossRepoDeps) == nil {
 		t.Fatalf("expected cross-repo CSV writer error")
 	}
 }

--- a/internal/dashboard/format.go
+++ b/internal/dashboard/format.go
@@ -30,13 +30,13 @@ func formatCSV(reportData Report) (string, error) {
 	buffer := &bytes.Buffer{}
 	writer := csv.NewWriter(buffer)
 
-	if err := writeDashboardSummaryCSV(writer, reportData); err != nil {
+	if err := writeDashboardSummaryCSV(writer.Write, reportData); err != nil {
 		return "", err
 	}
-	if err := writeDashboardRepoRowsCSV(writer, reportData.Repos); err != nil {
+	if err := writeDashboardRepoRowsCSV(writer.Write, reportData.Repos); err != nil {
 		return "", err
 	}
-	if err := writeDashboardCrossRepoRowsCSV(writer, reportData.CrossRepoDeps); err != nil {
+	if err := writeDashboardCrossRepoRowsCSV(writer.Write, reportData.CrossRepoDeps); err != nil {
 		return "", err
 	}
 
@@ -47,7 +47,7 @@ func formatCSV(reportData Report) (string, error) {
 	return buffer.String(), nil
 }
 
-func writeDashboardSummaryCSV(writer *csv.Writer, reportData Report) error {
+func writeDashboardSummaryCSV(write func([]string) error, reportData Report) error {
 	summaryRows := [][]string{
 		{"generated_at", reportData.GeneratedAt.Format("2006-01-02T15:04:05Z07:00")},
 		{"total_repos", fmt.Sprintf("%d", reportData.Summary.TotalRepos)},
@@ -57,15 +57,15 @@ func writeDashboardSummaryCSV(writer *csv.Writer, reportData Report) error {
 		{"critical_cves", fmt.Sprintf("%d", reportData.Summary.CriticalCVEs)},
 	}
 	for _, row := range summaryRows {
-		if err := writer.Write(row); err != nil {
+		if err := write(row); err != nil {
 			return err
 		}
 	}
-	return writer.Write(nil)
+	return write(nil)
 }
 
-func writeDashboardRepoRowsCSV(writer *csv.Writer, repos []RepoResult) error {
-	if err := writer.Write([]string{
+func writeDashboardRepoRowsCSV(write func([]string) error, repos []RepoResult) error {
+	if err := write([]string{
 		"repo_name",
 		"repo_path",
 		"language",
@@ -81,7 +81,7 @@ func writeDashboardRepoRowsCSV(writer *csv.Writer, repos []RepoResult) error {
 	}
 
 	for _, repoResult := range repos {
-		if err := writer.Write([]string{
+		if err := write([]string{
 			repoResult.Name,
 			repoResult.Path,
 			repoResult.Language,
@@ -99,18 +99,18 @@ func writeDashboardRepoRowsCSV(writer *csv.Writer, repos []RepoResult) error {
 	return nil
 }
 
-func writeDashboardCrossRepoRowsCSV(writer *csv.Writer, dependencies []CrossRepoDependency) error {
+func writeDashboardCrossRepoRowsCSV(write func([]string) error, dependencies []CrossRepoDependency) error {
 	if len(dependencies) == 0 {
 		return nil
 	}
-	if err := writer.Write(nil); err != nil {
+	if err := write(nil); err != nil {
 		return err
 	}
-	if err := writer.Write([]string{"dependency_name", "repo_count", "repositories"}); err != nil {
+	if err := write([]string{"dependency_name", "repo_count", "repositories"}); err != nil {
 		return err
 	}
 	for _, dependency := range dependencies {
-		if err := writer.Write([]string{
+		if err := write([]string{
 			dependency.Name,
 			fmt.Sprintf("%d", dependency.Count),
 			strings.Join(dependency.Repositories, "|"),

--- a/internal/dashboard/format_cov_more_test.go
+++ b/internal/dashboard/format_cov_more_test.go
@@ -30,12 +30,12 @@ func TestDashboardAdditionalBranchCoverage(t *testing.T) {
 	}
 
 	repoWriter := csv.NewWriter(&failingWriter{})
-	if writeDashboardRepoRowsCSV(repoWriter, []RepoResult{{Name: strings.Repeat("x", 5000)}}) == nil {
+	if writeDashboardRepoRowsCSV(repoWriter.Write, []RepoResult{{Name: strings.Repeat("x", 5000)}}) == nil {
 		t.Fatalf("expected repo row csv write to fail")
 	}
 
 	crossRepoWriter := csv.NewWriter(&failingWriter{})
-	if writeDashboardCrossRepoRowsCSV(crossRepoWriter, []CrossRepoDependency{{Name: strings.Repeat("x", 5000), Count: 3}}) == nil {
+	if writeDashboardCrossRepoRowsCSV(crossRepoWriter.Write, []CrossRepoDependency{{Name: strings.Repeat("x", 5000), Count: 3}}) == nil {
 		t.Fatalf("expected cross-repo csv write to fail")
 	}
 

--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -13,11 +13,15 @@ const ExecutablePrimary = "/usr/bin/git"
 const ExecutableFallback = "/bin/git"
 
 func ResolveBinaryPath() (string, error) {
+	return resolveBinaryPath(ExecutablePrimary, ExecutableFallback, ExecutableAvailable)
+}
+
+func resolveBinaryPath(primary, fallback string, available func(string) bool) (string, error) {
 	switch {
-	case ExecutableAvailable(ExecutablePrimary):
-		return ExecutablePrimary, nil
-	case ExecutableAvailable(ExecutableFallback):
-		return ExecutableFallback, nil
+	case available(primary):
+		return primary, nil
+	case available(fallback):
+		return fallback, nil
 	default:
 		return "", fmt.Errorf("git executable not found")
 	}

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -3,6 +3,7 @@ package gitexec
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,6 +19,38 @@ func TestResolveBinaryPath(t *testing.T) {
 	if path != ExecutablePrimary && path != ExecutableFallback {
 		t.Fatalf("expected known git path, got %q", path)
 	}
+}
+
+func TestResolveBinaryPathBranches(t *testing.T) {
+	t.Run("prefers primary", func(t *testing.T) {
+		path, err := resolveBinaryPath("primary", "fallback", func(path string) bool {
+			return path == "primary"
+		})
+		if err != nil {
+			t.Fatalf("resolve primary: %v", err)
+		}
+		if path != "primary" {
+			t.Fatalf("expected primary path, got %q", path)
+		}
+	})
+
+	t.Run("falls back", func(t *testing.T) {
+		path, err := resolveBinaryPath("primary", "fallback", func(path string) bool {
+			return path == "fallback"
+		})
+		if err != nil {
+			t.Fatalf("resolve fallback: %v", err)
+		}
+		if path != "fallback" {
+			t.Fatalf("expected fallback path, got %q", path)
+		}
+	})
+
+	t.Run("returns error when unavailable", func(t *testing.T) {
+		if _, err := resolveBinaryPath("primary", "fallback", func(string) bool { return false }); err == nil {
+			t.Fatal("expected missing git executable error")
+		}
+	})
 }
 
 func TestSanitizedEnv(t *testing.T) {
@@ -40,27 +73,15 @@ func TestSanitizedEnv(t *testing.T) {
 }
 
 func TestCommandUsesKnownGitPaths(t *testing.T) {
-	for _, gitPath := range []string{ExecutablePrimary, ExecutableFallback} {
-		command, err := Command(gitPath, versionArg)
-		if err != nil {
-			t.Fatalf("build command for %s: %v", gitPath, err)
-		}
-		if command.Path != gitPath {
-			t.Fatalf("expected command path %q, got %q", gitPath, command.Path)
-		}
-	}
+	testKnownGitPaths(t, func(gitPath string) (*exec.Cmd, error) {
+		return Command(gitPath, versionArg)
+	})
 }
 
 func TestCommandContextUsesKnownGitPaths(t *testing.T) {
-	for _, gitPath := range []string{ExecutablePrimary, ExecutableFallback} {
-		command, err := CommandContext(context.Background(), gitPath, versionArg)
-		if err != nil {
-			t.Fatalf("build command context for %s: %v", gitPath, err)
-		}
-		if command.Path != gitPath {
-			t.Fatalf("expected command path %q, got %q", gitPath, command.Path)
-		}
-	}
+	testKnownGitPaths(t, func(gitPath string) (*exec.Cmd, error) {
+		return CommandContext(context.Background(), gitPath, versionArg)
+	})
 }
 
 func TestCommandRejectsUnknownGitPath(t *testing.T) {
@@ -108,4 +129,20 @@ func containsEnvPrefix(env []string, prefix string) bool {
 		}
 	}
 	return false
+}
+
+func testKnownGitPaths(t *testing.T, build func(string) (*exec.Cmd, error)) {
+	t.Helper()
+
+	for _, gitPath := range []string{ExecutablePrimary, ExecutableFallback} {
+		t.Run(gitPath, func(t *testing.T) {
+			command, err := build(gitPath)
+			if err != nil {
+				t.Fatalf("build command for %s: %v", gitPath, err)
+			}
+			if command.Path != gitPath {
+				t.Fatalf("expected command path %q, got %q", gitPath, command.Path)
+			}
+		})
+	}
 }

--- a/internal/lang/cpp/engine_cov_more_branches_test.go
+++ b/internal/lang/cpp/engine_cov_more_branches_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
@@ -227,5 +228,43 @@ func TestCPPBuildTopDependenciesWarnsWhenNoDataIsAvailable(t *testing.T) {
 	}
 	if len(warnings) != 1 || warnings[0] != "no dependency data available for top-N ranking" {
 		t.Fatalf("unexpected no-data warning: %#v", warnings)
+	}
+}
+
+func TestCPPAdditionalZeroHitBranches(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", testMainCPPFileName), "int main() { return 0; }\n")
+
+	if args := (&compileCommandEntry{}).compileArgs(); len(args) != 0 {
+		t.Fatalf("expected empty compile command entry to yield no args, got %#v", args)
+	}
+
+	sourceSet := map[string]struct{}{}
+	recordCompileSource(sourceSet, "")
+	recordCompileSource(sourceSet, "README.md")
+	recordCompileSource(sourceSet, filepath.Join(repo, "src", testMainCPPFileName))
+	if len(sourceSet) != 1 {
+		t.Fatalf("expected only cpp source files to be recorded, got %#v", sourceSet)
+	}
+
+	if warnings, err := loadDependencyManifest(repo, filepath.Join(repo, "missing", vcpkgManifestFile), &dependencyCatalog{}); err != nil || len(warnings) != 0 {
+		t.Fatalf("expected missing dependency manifest to be ignored, warnings=%#v err=%v", warnings, err)
+	}
+
+	for i := 0; i <= maxManifestFiles; i++ {
+		testutil.MustWriteFile(t, filepath.Join(repo, fmt.Sprintf("pkg-%03d", i), vcpkgManifestFile), `{"dependencies":["fmt"]}`)
+	}
+	if _, _, err := loadDependencyCatalog(repo); err != nil {
+		t.Fatalf("expected manifest discovery cap to stop cleanly, got %v", err)
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside.cpp")
+	testutil.MustWriteFile(t, outside, "#include <fmt/core.h>\n")
+	stage := scanStage{scanner: includeResolver{repoPath: repo}}
+	if err := stage.process(context.Background(), outside); err != nil {
+		t.Fatalf("expected escaped-path scan errors to be downgraded into warnings, got %v", err)
+	}
+	if len(stage.result.Warnings) != 1 || !strings.Contains(stage.result.Warnings[0], "outside repo boundary") {
+		t.Fatalf("expected escaped-path warning, got %#v", stage.result.Warnings)
 	}
 }

--- a/internal/lang/dart/adapter_cov_more_branches_test.go
+++ b/internal/lang/dart/adapter_cov_more_branches_test.go
@@ -66,6 +66,9 @@ func testDartDependencyMetadataHelpers(t *testing.T) {
 	if lockDescriptionTargetsFlutter(map[string]any{"name": "other"}) {
 		t.Fatalf("did not expect unrelated lock description to target flutter")
 	}
+	if lockDescriptionTargetsFlutter(42) {
+		t.Fatalf("expected non-map scalar lock description not to target flutter")
+	}
 	if got := collectManifestRoots([]packageManifest{{Root: ""}, {Root: "  "}, {Root: filepath.Join("pkg", "..", "app")}}); len(got) != 2 {
 		t.Fatalf("expected normalized manifest roots, got %#v", got)
 	} else if _, ok := got["."]; !ok {
@@ -103,6 +106,7 @@ func testDartScanHelpersAndWarnings(t *testing.T) {
 	testDartScanPackageFileEntryBranches(t, root)
 	testDartScanPackageRootBranches(t, root)
 	testDartCompileScanWarnings(t)
+	testDartDiscoverPubspecPathsSkipsDirs(t)
 }
 
 func testDartScanPackageDirGuards(t *testing.T, root string) {
@@ -187,6 +191,39 @@ func testDartCompileScanWarnings(t *testing.T) {
 	}
 }
 
+func testDartDiscoverPubspecPathsSkipsDirs(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "android"), 0o755); err != nil {
+		t.Fatalf("mkdir android dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "packages", "feature"), 0o755); err != nil {
+		t.Fatalf("mkdir packages dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "android", pubspecYAMLName), []byte("name: android_app\n"), 0o644); err != nil {
+		t.Fatalf("write android pubspec: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "packages", "feature", pubspecYAMLName), []byte("name: feature\n"), 0o644); err != nil {
+		t.Fatalf("write nested pubspec: %v", err)
+	}
+	rootManifest := filepath.Join(repo, pubspecYAMLName)
+	if err := os.WriteFile(rootManifest, []byte("name: app\n"), 0o644); err != nil {
+		t.Fatalf("write root pubspec: %v", err)
+	}
+
+	paths, warnings, err := discoverPubspecPaths(repo)
+	if err != nil {
+		t.Fatalf("discover pubspec paths: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", warnings)
+	}
+	if len(paths) != 2 || paths[0] != filepath.Join(repo, "packages", "feature", pubspecYAMLName) || paths[1] != rootManifest {
+		t.Fatalf("expected skipped directories to be ignored, got %#v", paths)
+	}
+}
+
 func testDartImportParsingAndDependencySelection(t *testing.T) {
 	if kind, module, clause, ok := parseImportDirective(`show "x";`); ok || kind != "" || module != "" || clause != "" {
 		t.Fatalf("expected unsupported directive parse to fail")
@@ -224,5 +261,21 @@ func testDartImportParsingAndDependencySelection(t *testing.T) {
 	reportData, warnings := buildDependencyReport("http", scanResult{DeclaredDependencies: map[string]dependencyInfo{"http": {}}, Files: []fileScan{{Imports: []importBinding{{Dependency: "http", Module: "package:http/http.dart", Name: "Client", Local: "Client"}, {Dependency: "http", Module: "package:http/http.dart", Name: "Request", Local: "Request"}}, Usage: map[string]int{"Client": 1}}}}, 90)
 	if len(warnings) != 0 || len(reportData.Recommendations) == 0 {
 		t.Fatalf("expected low-usage dependency recommendation, report=%#v warnings=%#v", reportData, warnings)
+	}
+}
+
+func TestDartManifestLoopingLockSymlinkFailsLoad(t *testing.T) {
+	repo := t.TempDir()
+	manifestPath := filepath.Join(repo, pubspecYAMLName)
+	if err := os.WriteFile(manifestPath, []byte("name: app\n"), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	lockPath := filepath.Join(repo, pubspecLockName)
+	if err := os.Symlink(pubspecLockName, lockPath); err != nil {
+		t.Fatalf("create looping pubspec.lock symlink: %v", err)
+	}
+
+	if _, _, err := loadPackageManifest(repo, manifestPath); err == nil {
+		t.Fatalf("expected looping pubspec.lock symlink to fail manifest load")
 	}
 }

--- a/internal/lang/dotnet/adapter_cov_more_test.go
+++ b/internal/lang/dotnet/adapter_cov_more_test.go
@@ -217,6 +217,49 @@ func TestDotNetBuildTopDependenciesAndHelperGuards(t *testing.T) {
 	}
 }
 
+func TestDotNetAdditionalZeroHitBranches(t *testing.T) {
+	t.Run("ancestor central packages success and no-op", func(t *testing.T) {
+		parent := t.TempDir()
+		repo := filepath.Join(parent, "src", "service")
+		if err := os.MkdirAll(repo, 0o755); err != nil {
+			t.Fatalf("mkdir repo: %v", err)
+		}
+		centralPackagesXML := `
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.0" />
+  </ItemGroup>
+</Project>`
+		if err := os.WriteFile(filepath.Join(parent, centralPackagesFile), []byte(centralPackagesXML), 0o644); err != nil {
+			t.Fatalf("write central packages file: %v", err)
+		}
+
+		set := map[string]struct{}{}
+		if err := addAncestorCentralPackages(repo, set); err != nil {
+			t.Fatalf("add ancestor central packages: %v", err)
+		}
+		if _, ok := set["serilog.aspnetcore"]; !ok {
+			t.Fatalf("expected central package to be added, got %#v", set)
+		}
+
+		set = map[string]struct{}{}
+		if err := addAncestorCentralPackages(t.TempDir(), set); err != nil {
+			t.Fatalf("expected missing ancestor central packages to return nil, got %v", err)
+		}
+		if len(set) != 0 {
+			t.Fatalf("expected no dependencies when no ancestor file exists, got %#v", set)
+		}
+	})
+
+	t.Run("mapper resolves ambiguous ties deterministically", func(t *testing.T) {
+		mapper := newDependencyMapper([]string{"acme.foo", "acme.bar"})
+		dependency, ambiguous, undeclared := mapper.resolve("Acme.Baz")
+		if dependency != "acme.bar" || !ambiguous || undeclared {
+			t.Fatalf("expected lexicographically smaller dependency on tie, got dependency=%q ambiguous=%v undeclared=%v", dependency, ambiguous, undeclared)
+		}
+	})
+}
+
 func TestDotNetDiscoveryAndParsingStagesCompose(t *testing.T) {
 	repo := t.TempDir()
 	manifest := []byte(`

--- a/internal/lang/elixir/adapter_cov_more_test.go
+++ b/internal/lang/elixir/adapter_cov_more_test.go
@@ -1,0 +1,59 @@
+package elixir
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestElixirAdditionalZeroHitBranches(t *testing.T) {
+	t.Run("detect root files surfaces umbrella expansion errors", func(t *testing.T) {
+		repo := t.TempDir()
+		testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  def project, do: [apps_path: \"[\"]\nend\n")
+
+		if _, err := detectFromRootFiles(repo, &language.Detection{}, map[string]struct{}{}); err == nil {
+			t.Fatalf("expected invalid umbrella apps_path glob to fail detection")
+		}
+	})
+
+	t.Run("detect root files surfaces mix.lock stat errors", func(t *testing.T) {
+		repo := t.TempDir()
+		testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\nend\n")
+		lockPath := filepath.Join(repo, mixLockName)
+		if err := os.Symlink(mixLockName, lockPath); err != nil {
+			t.Fatalf("create looping mix.lock symlink: %v", err)
+		}
+
+		if _, err := detectFromRootFiles(repo, &language.Detection{}, map[string]struct{}{}); err == nil {
+			t.Fatalf("expected mix.lock stat error to fail detection")
+		}
+	})
+
+	t.Run("analyse rejects invalid repo path", func(t *testing.T) {
+		if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
+			t.Fatalf("expected invalid repo path to fail analysis")
+		}
+	})
+
+	t.Run("analyse returns scan errors for escaping source symlinks", func(t *testing.T) {
+		repo := t.TempDir()
+		outsideDir := t.TempDir()
+		testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\nend\n")
+		testutil.MustWriteFile(t, filepath.Join(outsideDir, "outside.ex"), "alias Foo.Bar\n")
+		linkPath := filepath.Join(repo, "lib", "demo.ex")
+		if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+			t.Fatalf("mkdir lib dir: %v", err)
+		}
+		if err := os.Symlink(filepath.Join(outsideDir, "outside.ex"), linkPath); err != nil {
+			t.Fatalf("create source symlink: %v", err)
+		}
+
+		if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 1}); err == nil {
+			t.Fatalf("expected escaping source symlink to fail analysis")
+		}
+	})
+}

--- a/internal/lang/js/helpers_cov_more_extra_test.go
+++ b/internal/lang/js/helpers_cov_more_extra_test.go
@@ -1,0 +1,207 @@
+package js
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func mustParseJS(t *testing.T, parser *sourceParser, source []byte) *sitter.Tree {
+	t.Helper()
+
+	tree, err := parser.Parse(context.Background(), indexJSName, source)
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+	return tree
+}
+
+func TestJSLicenseAndStringHelperAdditionalBranches(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Symlink(filepath.Join(root, "missing-license"), filepath.Join(root, "LICENSE")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	testutil.MustWriteFile(t, filepath.Join(root, "COPYING"), "Mozilla Public License")
+
+	license := detectLicenseFromFiles(root)
+	if license == nil || license.SPDX != "MPL-2.0" || license.Source != "license-file" {
+		t.Fatalf("expected license fallback to continue past unreadable candidate, got %#v", license)
+	}
+
+	if got := normalizeSPDXExpression("mit with classpath-exception-2.0 +"); got != "MIT WITH CLASSPATH-EXCEPTION-2.0 +" {
+		t.Fatalf("unexpected SPDX normalization: %q", got)
+	}
+	if got := stringsJoin(nil, " -> "); got != "" {
+		t.Fatalf("expected empty join for nil slice, got %q", got)
+	}
+	if got := stringsJoin([]string{"a", "b", "c"}, " -> "); got != "a -> b -> c" {
+		t.Fatalf("unexpected joined path: %q", got)
+	}
+}
+
+func TestJSBindingExtractionAdditionalBranches(t *testing.T) {
+	parser := newSourceParser()
+	source := []byte(`
+export const [...rest] = list;
+export const { nested: { value: renamed }, plain } = obj;
+import { foo as bar, baz } from "pkg";
+`)
+
+	tree := mustParseJS(t, parser, source)
+	names := collectExportNames(tree, source)
+	for _, want := range []string{"renamed", "plain"} {
+		if !slices.Contains(names, want) {
+			t.Fatalf("expected export binding name %q in %#v", want, names)
+		}
+	}
+
+	sawRestPattern := false
+	walkNode(tree.RootNode(), func(node *sitter.Node) {
+		if node.Type() != "rest_pattern" {
+			return
+		}
+		sawRestPattern = true
+		_ = extractBindingNames(node, source)
+	})
+	if !sawRestPattern {
+		t.Fatalf("expected rest_pattern in parsed source")
+	}
+
+	bindings, uncertain := collectImportBindings(tree, source, indexJSName)
+	if len(uncertain) != 0 {
+		t.Fatalf("expected no uncertain imports, got %#v", uncertain)
+	}
+	if len(bindings) != 2 {
+		t.Fatalf("expected two named import bindings, got %#v", bindings)
+	}
+	if bindings[0].ExportName != "foo" || bindings[0].LocalName != "bar" {
+		t.Fatalf("unexpected aliased named import binding: %#v", bindings[0])
+	}
+	if bindings[1].ExportName != "baz" || bindings[1].LocalName != "baz" {
+		t.Fatalf("unexpected unaliased named import binding: %#v", bindings[1])
+	}
+}
+
+func TestJSReExportAndDependencySafetyBranches(t *testing.T) {
+	if !isSafeDependencyName("@scope/pkg") || !isSafeDependencyName("pkg-name") {
+		t.Fatalf("expected valid dependency names to pass safety checks")
+	}
+	for _, dependency := range []string{"", "@scope", ".", "..", "pkg/name", `pkg\\name`} {
+		if isSafeDependencyName(dependency) {
+			t.Fatalf("expected unsafe dependency name %q to be rejected", dependency)
+		}
+	}
+
+	parser := newSourceParser()
+	source := []byte(`
+import { local } from "pkg";
+export { local as alias };
+export { named as renamed } from "other";
+`)
+	tree := mustParseJS(t, parser, source)
+	imports, _ := collectImportBindings(tree, source, indexJSName)
+	bindings := collectReExportBindings(tree, source, indexJSName, imports)
+	if len(bindings) != 2 {
+		t.Fatalf("expected two re-export bindings, got %#v", bindings)
+	}
+	if bindings[0].SourceModule != "pkg" || bindings[0].SourceExportName != "local" || bindings[0].ExportName != "alias" {
+		t.Fatalf("unexpected local import re-export binding: %#v", bindings[0])
+	}
+	if bindings[1].SourceModule != "other" || bindings[1].SourceExportName != "named" || bindings[1].ExportName != "renamed" {
+		t.Fatalf("unexpected source-module re-export binding: %#v", bindings[1])
+	}
+}
+
+func TestJSCollectIdentifierUsageBranches(t *testing.T) {
+	parser := newSourceParser()
+	source := []byte(`
+import { imported } from "pkg";
+const declared = 1;
+function fn(param, { nested }, ...rest) {
+  const local = declared + param;
+  return local + obj.member + obj[prop];
+}
+`)
+	tree := mustParseJS(t, parser, source)
+	counts := collectIdentifierUsage(tree, source)
+	for name, want := range map[string]int{
+		"declared": 1,
+		"param":    1,
+		"local":    1,
+		"prop":     1,
+		"rest":     1,
+	} {
+		if counts[name] != want {
+			t.Fatalf("identifier usage count for %q = %d, want %d; counts=%#v", name, counts[name], want, counts)
+		}
+	}
+	if _, ok := counts["imported"]; ok {
+		t.Fatalf("expected import-only identifier to be ignored, got %#v", counts)
+	}
+	if _, ok := counts["obj"]; ok {
+		t.Fatalf("expected member-expression object identifier to be tracked separately, got %#v", counts)
+	}
+}
+
+func TestJSRequireBindingAndDynamicImportBranches(t *testing.T) {
+	parser := newSourceParser()
+	source := []byte(`
+const { foo: alias, bar } = require("pkg");
+const ns = require("other");
+require(dynamicSource);
+`)
+	tree := mustParseJS(t, parser, source)
+	bindings, uncertain := collectImportBindings(tree, source, indexJSName)
+	if len(bindings) != 3 {
+		t.Fatalf("expected object-pattern and namespace require bindings, got %#v", bindings)
+	}
+	if bindings[0].ExportName != "foo" || bindings[0].LocalName != "alias" {
+		t.Fatalf("unexpected aliased require binding: %#v", bindings[0])
+	}
+	if bindings[1].ExportName != "bar" || bindings[1].LocalName != "bar" {
+		t.Fatalf("unexpected shorthand require binding: %#v", bindings[1])
+	}
+	if bindings[2].ExportName != "*" || bindings[2].LocalName != "ns" {
+		t.Fatalf("unexpected namespace require binding: %#v", bindings[2])
+	}
+	if len(uncertain) != 1 || uncertain[0].Module != "<dynamic>" {
+		t.Fatalf("expected one uncertain dynamic require, got %#v", uncertain)
+	}
+}
+
+func TestJSLicenseAndProvenanceAdditionalBranches(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Symlink(filepath.Join(root, "missing-copying"), filepath.Join(root, "COPYING")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	testutil.MustWriteFile(t, filepath.Join(root, "LICENSE"), "Apache License Version 2.0")
+
+	license := detectLicenseFromFiles(root)
+	if license == nil || license.SPDX != "APACHE-2.0" {
+		t.Fatalf("expected license detection to continue past unreadable candidate, got %#v", license)
+	}
+
+	if got := normalizeSPDXExpression(" \t \n "); got != "" {
+		t.Fatalf("expected blank SPDX expression to normalize to empty, got %q", got)
+	}
+
+	pkg := packageJSON{
+		Name:      "pkg",
+		Version:   "1.0.0",
+		Resolved:  "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz",
+		Integrity: "sha512-abc",
+		Repository: map[string]any{
+			"url": "https://example.test/repo",
+		},
+	}
+	provenance := buildProvenance(pkg, true)
+	if provenance == nil || provenance.Source != "local+registry-heuristics" || !slices.Contains(provenance.Signals, "repository") {
+		t.Fatalf("expected repository-backed registry provenance, got %#v", provenance)
+	}
+}

--- a/internal/lang/jvm/adapter_cov_warning_collector_test.go
+++ b/internal/lang/jvm/adapter_cov_warning_collector_test.go
@@ -1,0 +1,77 @@
+package jvm
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestJVMBuildFileWarningCollectorBranches(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	outsideBuild := filepath.Join(outside, buildGradleName)
+	testutil.MustWriteFile(t, outsideBuild, `implementation "org.example:demo:1.0.0"`)
+
+	walkErr := errors.New("walk failed")
+	collector := buildFileWarningCollector{
+		repoPath: repo,
+		parser: func(path, content string) ([]dependencyDescriptor, []string) {
+			return []dependencyDescriptor{{Name: "demo", Group: "org.example", Artifact: "demo"}}, []string{"parse warning"}
+		},
+		names: []string{buildGradleName},
+		seen:  make(map[string]struct{}),
+	}
+
+	if err := collector.visit("", nil, walkErr); !errors.Is(err, walkErr) {
+		t.Fatalf("expected walk error to propagate, got %v", err)
+	}
+
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("read outside dir: %v", err)
+	}
+	if err := collector.visit(outsideBuild, entries[0], nil); err != nil {
+		t.Fatalf("unexpected collector visit error for outside build file: %v", err)
+	}
+	if len(collector.warnings) != 1 || !strings.Contains(collector.warnings[0], "unable to read") {
+		t.Fatalf("expected read warning for outside build file, got %#v", collector.warnings)
+	}
+
+	insideBuild := filepath.Join(repo, buildGradleName)
+	testutil.MustWriteFile(t, insideBuild, `implementation "org.example:demo:1.0.0"`)
+	repoEntries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read repo dir: %v", err)
+	}
+	if err := collector.visit(insideBuild, repoEntries[0], nil); err != nil {
+		t.Fatalf("unexpected collector visit error for repo build file: %v", err)
+	}
+	if len(collector.descriptors) != 1 || collector.descriptors[0].Name != "demo" {
+		t.Fatalf("expected parsed descriptor to be collected once, got %#v", collector.descriptors)
+	}
+	if len(collector.warnings) != 2 || collector.warnings[1] != "parse warning" {
+		t.Fatalf("expected parser warning append, got %#v", collector.warnings)
+	}
+
+	warning := formatBuildFileReadWarning(repo, insideBuild, fs.ErrPermission)
+	if !strings.Contains(warning, buildGradleName) || !strings.Contains(warning, fs.ErrPermission.Error()) {
+		t.Fatalf("unexpected formatted warning: %q", warning)
+	}
+}
+
+func TestJVMFallbackAndModuleSegmentAdditionalBranches(t *testing.T) {
+	if got := fallbackDependency("single"); got != "single" {
+		t.Fatalf("fallbackDependency(single) = %q, want %q", got, "single")
+	}
+	if got := lastModuleSegment(""); got != "" {
+		t.Fatalf("lastModuleSegment(empty) = %q, want empty", got)
+	}
+	if got := sourceLayoutModuleRoot(filepath.FromSlash("module/java/Main.java")); got != "" {
+		t.Fatalf("expected non-src path to have no source-layout root, got %q", got)
+	}
+}

--- a/internal/lang/ruby/adapter_declared_cov_more_test.go
+++ b/internal/lang/ruby/adapter_declared_cov_more_test.go
@@ -1,0 +1,77 @@
+package ruby
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRubyDeclaredDependencyAdditionalBranches(t *testing.T) {
+	t.Run("load declared dependencies returns bundler error", func(t *testing.T) {
+		testRubyLoadDeclaredDependenciesReturnsBundlerError(t)
+	})
+
+	t.Run("load gemspec dependencies returns read error", func(t *testing.T) {
+		testRubyLoadGemspecDependenciesReturnsReadError(t)
+	})
+
+	t.Run("add ruby dependency tracks declaration signals without source kind", func(t *testing.T) {
+		testRubyAddRubyDependencyTracksDeclarationSignals(t)
+	})
+}
+
+func testRubyLoadDeclaredDependenciesReturnsBundlerError(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, gemfileName), 0o755); err != nil {
+		t.Fatalf("mkdir Gemfile dir: %v", err)
+	}
+
+	if warnings, err := loadDeclaredDependencies(repo, map[string]struct{}{}, map[string]rubyDependencySource{}); err == nil || len(warnings) != 0 {
+		t.Fatalf("expected loadDeclaredDependencies error for Gemfile directory, warnings=%#v err=%v", warnings, err)
+	}
+}
+
+func testRubyLoadGemspecDependenciesReturnsReadError(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	broken := filepath.Join(repo, "broken.gemspec")
+	if err := os.Symlink(filepath.Join(repo, "missing-target"), broken); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	if warnings, err := loadGemspecDependencies(repo, map[string]struct{}{}); err == nil || len(warnings) != 0 {
+		t.Fatalf("expected loadGemspecDependencies read error, warnings=%#v err=%v", warnings, err)
+	}
+}
+
+func testRubyAddRubyDependencyTracksDeclarationSignals(t *testing.T) {
+	t.Helper()
+
+	sources := map[string]rubyDependencySource{}
+
+	addRubyDependency(nil, sources, "rack", "unknown", gemfileName)
+	info := sources["rack"]
+	if !info.DeclaredGemfile || info.Rubygems || info.Git || info.Path {
+		t.Fatalf("unexpected gemfile-only source tracking: %#v", info)
+	}
+
+	addRubyDependency(nil, sources, "rack", "unknown", gemfileLockName)
+	info = sources["rack"]
+	if !info.DeclaredLock {
+		t.Fatalf("expected gemfile lock declaration tracking, got %#v", info)
+	}
+
+	addRubyDependency(nil, sources, "", rubyDependencySourceRubygems, gemfileName)
+	if len(sources) != 1 {
+		t.Fatalf("expected empty dependency to be ignored, got %#v", sources)
+	}
+}
+
+func TestRubyParseGemfileDependencyLineBlankDependency(t *testing.T) {
+	if dependency, kind, ok := parseGemfileDependencyLine(`gem ''`); ok || dependency != "" || kind != "" {
+		t.Fatalf("expected blank gem declaration to be ignored, got (%q, %q, %t)", dependency, kind, ok)
+	}
+}

--- a/internal/lang/rust/helpers_cov_more_extra_test.go
+++ b/internal/lang/rust/helpers_cov_more_extra_test.go
@@ -1,0 +1,182 @@
+package rust
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+)
+
+const serdeJSONCanonical = "serde-json"
+
+func TestRustHelperAdditionalBranches(t *testing.T) {
+	if got := uniquePaths([]string{" ./b ", "./a", "./b"}); !slices.Equal(got, []string{"a", "b"}) {
+		t.Fatalf("unexpected unique paths: %#v", got)
+	}
+
+	repo := t.TempDir()
+	if isSubPath(repo, filepath.Dir(repo)) {
+		t.Fatalf("expected parent directory to be outside repo root")
+	}
+	if !samePath(filepath.Join(repo, ".", "src"), filepath.Join(repo, "src")) {
+		t.Fatalf("expected cleaned equivalent paths to compare equal")
+	}
+
+	deps := map[string]dependencyInfo{}
+	addDependencyFromLine(deps, "dependencies", `serde = { package = "serde_json", path = "./vendor/serde_json" }`)
+	info, ok := deps["serde"]
+	if !ok || info.Canonical != serdeJSONCanonical || !info.Renamed || !info.LocalPath {
+		t.Fatalf("unexpected parsed dependency info: %#v", info)
+	}
+	if canonical, ok := deps[serdeJSONCanonical]; !ok || canonical.Canonical != serdeJSONCanonical || !canonical.LocalPath {
+		t.Fatalf("expected canonical dependency alias to be added, got %#v", canonical)
+	}
+
+	if _, _, ok := parseDependencyInfo(`serde = { package = "serde_json", path = "./vendor/serde_json" }`); !ok {
+		t.Fatalf("expected inline dependency info to parse")
+	}
+	if fields := parseInlineFields(`{ package = "serde_json", version = "1.0", path = "./vendor/serde_json" }`); len(fields) != 3 {
+		t.Fatalf("expected inline dependency fields to include package/version/path, got %#v", fields)
+	}
+
+	lookup := map[string]dependencyInfo{"serde": {Canonical: "serde"}}
+	if _, ok := parseExternCrateClause([]byte("serde as"), srcLibRS, "", lookup, nil, 1, 1); ok {
+		t.Fatalf("expected missing extern crate alias identifier to fail")
+	}
+	if _, ok := parseExternCrateClause([]byte("1serde"), srcLibRS, "", lookup, nil, 1, 1); ok {
+		t.Fatalf("expected invalid extern crate root identifier to fail")
+	}
+
+	if offset := skipRustVisibilityPrefix([]byte("pub(crate use serde::Deserialize;")); offset != 0 {
+		t.Fatalf("expected malformed pub(crate visibility prefix to be ignored, got %d", offset)
+	}
+
+	line, col := lineColumnBytesFrom([]byte("abc"), 3, 0, 99)
+	if line != 3 || col != 4 {
+		t.Fatalf("expected oversized offset to clamp to end-of-line column, got %d:%d", line, col)
+	}
+}
+
+func TestRustWorkspaceOnlyDetectionAndAnalysisBranches(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, cargoManifestFile), "[workspace]\nmembers = [\"crates/a\"]\n")
+	writeFile(t, filepath.Join(repo, cargoLockFile), cargoLockVersion3)
+	writeFile(t, filepath.Join(repo, "crates", "a", cargoManifestFile), "[package]\nname = \"a\"\nversion = \"0.1.0\"\n[dependencies]\nserde = \"1\"\n")
+	writeFile(t, filepath.Join(repo, "crates", "a", "src", rustLibFile), "extern crate serde;\nuse serde::de::DeserializeOwned;\n")
+
+	detection := language.Detection{}
+	roots := map[string]struct{}{}
+	workspaceOnly, err := applyRustRootSignals(repo, &detection, roots)
+	if err != nil {
+		t.Fatalf("applyRustRootSignals: %v", err)
+	}
+	if !workspaceOnly {
+		t.Fatalf("expected workspace-only root detection")
+	}
+	if _, ok := roots[repo]; ok {
+		t.Fatalf("expected workspace-only root to avoid adding repo root, got %#v", roots)
+	}
+
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read repo dir: %v", err)
+	}
+	visited := 0
+	for _, entry := range entries {
+		if entry.Name() != cargoTomlName {
+			continue
+		}
+		if err := walkRustDetectionEntry(filepath.Join(repo, cargoTomlName), entry, repo, workspaceOnly, roots, &detection, &visited); err != nil {
+			t.Fatalf("walkRustDetectionEntry root Cargo.toml: %v", err)
+		}
+	}
+	if _, ok := roots[repo]; ok {
+		t.Fatalf("expected workspace-only root Cargo.toml walk to keep repo root excluded, got %#v", roots)
+	}
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 5})
+	if err != nil {
+		t.Fatalf("Analyse workspace-only repo: %v", err)
+	}
+	if len(reportData.Dependencies) == 0 {
+		t.Fatalf("expected dependency reports from workspace-only analysis, got %#v", reportData)
+	}
+}
+
+func TestRustAdditionalExactBranchCoverage(t *testing.T) {
+	testRustAdditionalExactBranchCoverageWalk(t)
+	testRustAdditionalExactBranchCoverageDependencies(t)
+	testRustAdditionalExactBranchCoverageParsing(t)
+	testRustAdditionalExactBranchCoverageExternCrate(t)
+	testRustAdditionalExactBranchCoverageOffsets(t)
+}
+
+func testRustAdditionalExactBranchCoverageWalk(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	regularDir := filepath.Join(repo, "src")
+	if err := os.MkdirAll(regularDir, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read repo dir: %v", err)
+	}
+	visited := 0
+	for _, entry := range entries {
+		if entry.Name() != "src" {
+			continue
+		}
+		if err := walkRustDetectionEntry(regularDir, entry, repo, false, map[string]struct{}{}, &language.Detection{}, &visited); err != nil {
+			t.Fatalf("expected non-skipped directory walk to continue, got %v", err)
+		}
+	}
+}
+
+func testRustAdditionalExactBranchCoverageDependencies(t *testing.T) {
+	t.Helper()
+
+	deps := map[string]dependencyInfo{}
+	addDependencyFromLine(deps, "dependencies", "broken")
+	if len(deps) != 0 {
+		t.Fatalf("expected malformed dependency line to be ignored, got %#v", deps)
+	}
+	if _, _, ok := parseDependencyInfo("broken"); ok {
+		t.Fatalf("expected malformed dependency info to fail parsing")
+	}
+}
+
+func testRustAdditionalExactBranchCoverageParsing(t *testing.T) {
+	t.Helper()
+
+	if _, _, ok := parseRustImportStatement([]byte("   "), 0, 3, 1, true); ok {
+		t.Fatalf("expected whitespace-only line not to parse as import")
+	}
+	if _, ok := buildRustUseStatement([]byte("use "), 0, 1, len("use"), []byte("use ")); ok {
+		t.Fatalf("expected incomplete use statement to fail")
+	}
+	if _, ok := matchExternCrateStatement([]byte("extern crate")); ok {
+		t.Fatalf("expected missing trailing whitespace after crate to fail")
+	}
+}
+
+func testRustAdditionalExactBranchCoverageExternCrate(t *testing.T) {
+	t.Helper()
+
+	if _, ok := parseExternCrateClause([]byte("serde as 1alias"), srcLibRS, "", map[string]dependencyInfo{"serde": {Canonical: "serde"}}, nil, 1, 1); ok {
+		t.Fatalf("expected invalid extern crate alias to fail")
+	}
+}
+
+func testRustAdditionalExactBranchCoverageOffsets(t *testing.T) {
+	t.Helper()
+
+	line, col := lineColumnBytesFrom([]byte("abc"), 3, 4, 2)
+	if line != 3 || col != 1 {
+		t.Fatalf("expected offset before base offset to clamp to base position, got %d:%d", line, col)
+	}
+}

--- a/internal/lang/shared/adapter_scaffold_cov_more_extra_test.go
+++ b/internal/lang/shared/adapter_scaffold_cov_more_extra_test.go
@@ -1,0 +1,35 @@
+package shared
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewReportAndWalkContextErrAdditionalBranches(t *testing.T) {
+	if err := WalkContextErr(nilContext(), nil); err != nil {
+		t.Fatalf("expected nil walk/context error when context is nil, got %v", err)
+	}
+}
+
+func nilContext() context.Context {
+	return nil
+}
+
+func TestResolvePathWithMissingLeaf(t *testing.T) {
+	repo := t.TempDir()
+	missingLeaf := filepath.Join(repo, "missing", "leaf.txt")
+
+	resolved, err := resolvePathWithMissingLeaf(missingLeaf)
+	if err != nil {
+		t.Fatalf("resolvePathWithMissingLeaf: %v", err)
+	}
+	wantPrefix, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("eval symlinks repo: %v", err)
+	}
+	want := filepath.Join(wantPrefix, "missing", "leaf.txt")
+	if resolved != want {
+		t.Fatalf("resolved path = %q, want %q", resolved, want)
+	}
+}

--- a/internal/runtime/capture.go
+++ b/internal/runtime/capture.go
@@ -325,7 +325,11 @@ func runtimeHookPaths() (string, string, error) {
 }
 
 func locateRuntimeHookPaths() (string, string, error) {
-	for _, root := range runtimeHookSearchRoots() {
+	return locateRuntimeHookPathsInRoots(runtimeHookSearchRoots())
+}
+
+func locateRuntimeHookPathsInRoots(roots []string) (string, string, error) {
+	for _, root := range roots {
 		requirePath := filepath.Join(root, runtimeRequireHookRelPath)
 		loaderPath := filepath.Join(root, runtimeLoaderHookRelPath)
 		if !isRegularFile(requirePath) || !isRegularFile(loaderPath) {

--- a/internal/runtime/capture_cov_branches_test.go
+++ b/internal/runtime/capture_cov_branches_test.go
@@ -1,0 +1,156 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+)
+
+const shellPath = "/bin/sh"
+
+func TestParseRuntimeCommandKeepsBackslashesInSingleQuotes(t *testing.T) {
+	fields, err := parseRuntimeCommand(`node -e 'const value = "a\b"'`)
+	if err != nil {
+		t.Fatalf("parse runtime command: %v", err)
+	}
+	if len(fields) != 3 {
+		t.Fatalf("expected 3 fields, got %#v", fields)
+	}
+	if got := fields[2]; got != `const value = "a\b"` {
+		t.Fatalf("expected single-quoted backslash to be preserved, got %q", got)
+	}
+
+	var parser runtimeCommandParser
+	parser.inSingleQuote = true
+	parser.consume('\\')
+	if got := parser.current.String(); got != `\` {
+		t.Fatalf("expected direct consume to preserve backslash in single quotes, got %q", got)
+	}
+}
+
+func TestTrustedSearchDirsSkipsNonDirectories(t *testing.T) {
+	secureDir := t.TempDir()
+	plainFile := filepath.Join(t.TempDir(), "tool")
+	if err := os.WriteFile(plainFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write plain file: %v", err)
+	}
+	missingDir := filepath.Join(t.TempDir(), "missing")
+
+	got := trustedSearchDirs(strings.Join([]string{plainFile, missingDir, secureDir}, string(os.PathListSeparator)))
+	if len(got) != 1 || got[0] != secureDir {
+		t.Fatalf("expected only secure directory to remain, got %#v", got)
+	}
+}
+
+func TestRuntimeHookErrorsPropagate(t *testing.T) {
+	restoreRuntimeHookState(t)
+	sentinel := errors.New("hook lookup failed")
+
+	runtimeHookPathsOnce = sync.Once{}
+	runtimeHookPathsOnce.Do(func() {
+		runtimeRequireHookPath = ""
+		runtimeLoaderHookPath = ""
+		runtimeHookPathsErr = sentinel
+	})
+
+	if _, err := runtimeNodeHookOptions(); !errors.Is(err, sentinel) {
+		t.Fatalf("expected runtime hook options error %v, got %v", sentinel, err)
+	}
+
+	_, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, "/tmp/runtime.ndjson")
+	if err == nil || !strings.Contains(err.Error(), "resolve runtime node hooks") {
+		t.Fatalf("expected wrapped runtime hook error, got %v", err)
+	}
+
+	err = Capture(context.Background(), CaptureRequest{
+		RepoPath: t.TempDir(),
+		Command:  "make test",
+	})
+	if err == nil || !strings.Contains(err.Error(), "resolve runtime node hooks") {
+		t.Fatalf("expected capture to surface hook resolution error, got %v", err)
+	}
+}
+
+func TestLocateRuntimeHookPathsInRootsErrorsWhenHooksMissing(t *testing.T) {
+	root := t.TempDir()
+	_, _, err := locateRuntimeHookPathsInRoots([]string{root})
+	if err == nil || !strings.Contains(err.Error(), "could not locate runtime hooks") {
+		t.Fatalf("expected missing hook error, got %v", err)
+	}
+}
+
+func TestConfigureRuntimeCommandCancelBranches(t *testing.T) {
+	t.Run("without process", func(t *testing.T) {
+		cmd := shellCommand(context.Background(), "-c", "exit 0")
+		configureRuntimeCommand(cmd)
+
+		err := cmd.Cancel()
+		if !errors.Is(err, os.ErrProcessDone) {
+			t.Fatalf("expected process-done error, got %v", err)
+		}
+	})
+
+	t.Run("after process exits", func(t *testing.T) {
+		cmd := shellCommand(context.Background(), "-c", "exit 0")
+		configureRuntimeCommand(cmd)
+
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start process: %v", err)
+		}
+		if err := cmd.Wait(); err != nil {
+			t.Fatalf("wait process: %v", err)
+		}
+
+		err := cmd.Cancel()
+		if !errors.Is(err, os.ErrProcessDone) {
+			t.Fatalf("expected process-done error after exit, got %v", err)
+		}
+	})
+}
+
+func restoreRuntimeHookState(t *testing.T) {
+	t.Helper()
+
+	originalRequire := runtimeRequireHookPath
+	originalLoader := runtimeLoaderHookPath
+	originalErr := runtimeHookPathsErr
+
+	t.Cleanup(func() {
+		runtimeHookPathsOnce = sync.Once{}
+		runtimeHookPathsOnce.Do(func() {
+			runtimeRequireHookPath = originalRequire
+			runtimeLoaderHookPath = originalLoader
+			runtimeHookPathsErr = originalErr
+		})
+	})
+}
+
+func TestConfigureRuntimeCommandCancelMapsESRCHToProcessDone(t *testing.T) {
+	cmd := shellCommand(context.Background(), "-c", "sleep 5")
+	configureRuntimeCommand(cmd)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start process: %v", err)
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		t.Fatalf("kill process group: %v", err)
+	}
+	if err := cmd.Wait(); err != nil && !errors.Is(err, os.ErrProcessDone) && !strings.Contains(err.Error(), "signal: killed") {
+		t.Fatalf("wait process: %v", err)
+	}
+
+	err := cmd.Cancel()
+	if !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("expected ESRCH to map to os.ErrProcessDone, got %v", err)
+	}
+}
+
+func shellCommand(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, shellPath, args...)
+}

--- a/internal/runtime/capture_env_test.go
+++ b/internal/runtime/capture_env_test.go
@@ -1,9 +1,11 @@
 package runtime
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -102,5 +104,31 @@ func TestMergeEnvAndReadEnvValue(t *testing.T) {
 	}
 	if got := readEnvValue(merged, "MISSING"); got != "" {
 		t.Fatalf("expected missing env value, got %q", got)
+	}
+}
+
+func TestRuntimeNodeHookOptionsReturnsCachedError(t *testing.T) {
+	oldRequire := runtimeRequireHookPath
+	oldLoader := runtimeLoaderHookPath
+	oldErr := runtimeHookPathsErr
+	defer func() {
+		runtimeHookPathsOnce = sync.Once{}
+		runtimeHookPathsOnce.Do(func() {
+			runtimeRequireHookPath = oldRequire
+			runtimeLoaderHookPath = oldLoader
+			runtimeHookPathsErr = oldErr
+		})
+	}()
+
+	runtimeHookPathsOnce = sync.Once{}
+	runtimeHookPathsOnce.Do(func() {
+		runtimeRequireHookPath = ""
+		runtimeLoaderHookPath = ""
+		runtimeHookPathsErr = errors.New("boom")
+	})
+
+	_, err := runtimeNodeHookOptions()
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected cached runtime hook error, got %v", err)
 	}
 }

--- a/internal/runtime/capture_process_unix_test.go
+++ b/internal/runtime/capture_process_unix_test.go
@@ -1,0 +1,32 @@
+//go:build unix
+
+package runtime
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func TestConfigureRuntimeCommand(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	configureRuntimeCommand(cmd)
+
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Fatalf("expected Setpgid to be enabled, got %#v", cmd.SysProcAttr)
+	}
+	if cmd.WaitDelay != runtimeCommandWaitDelay {
+		t.Fatalf("expected wait delay %v, got %v", runtimeCommandWaitDelay, cmd.WaitDelay)
+	}
+
+	if err := cmd.Cancel(); !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("expected os.ErrProcessDone when process is nil, got %v", err)
+	}
+
+	cmd.Process = &os.Process{Pid: 999999}
+	if err := cmd.Cancel(); !errors.Is(err, os.ErrProcessDone) && !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("expected missing process error, got %v", err)
+	}
+}

--- a/internal/workspace/changed_files.go
+++ b/internal/workspace/changed_files.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ChangedFiles(repoPath string) ([]string, error) {
-	normalized, err := NormalizeRepoPath(repoPath)
+	normalized, err := normalizeRepoPath(repoPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workspace/current_commit.go
+++ b/internal/workspace/current_commit.go
@@ -6,7 +6,7 @@ import (
 )
 
 func CurrentCommitSHA(repoPath string) (string, error) {
-	normalized, err := NormalizeRepoPath(repoPath)
+	normalized, err := normalizeRepoPath(repoPath)
 	if err != nil {
 		return "", err
 	}

--- a/internal/workspace/git_dir.go
+++ b/internal/workspace/git_dir.go
@@ -34,13 +34,7 @@ func inspectGitDir(searchDir string) (_ string, _ bool, returnErr error) {
 		return "", false, err
 	}
 	defer func() {
-		if closeErr := repoRoot.Close(); closeErr != nil {
-			if returnErr == nil {
-				returnErr = closeErr
-				return
-			}
-			returnErr = errors.Join(returnErr, closeErr)
-		}
+		joinCloseError(&returnErr, repoRoot.Close())
 	}()
 
 	info, err := repoRoot.Stat(".git")
@@ -93,9 +87,7 @@ func readGitPath(gitDir, name string) (data string, err error) {
 		return "", err
 	}
 	defer func() {
-		if closeErr := root.Close(); closeErr != nil {
-			err = errors.Join(err, closeErr)
-		}
+		joinCloseError(&err, root.Close())
 	}()
 
 	bytes, err := root.ReadFile(filepath.Clean(name))
@@ -103,4 +95,15 @@ func readGitPath(gitDir, name string) (data string, err error) {
 		return "", err
 	}
 	return string(bytes), nil
+}
+
+func joinCloseError(target *error, closeErr error) {
+	if closeErr == nil {
+		return
+	}
+	if *target == nil {
+		*target = closeErr
+		return
+	}
+	*target = errors.Join(*target, closeErr)
 }

--- a/internal/workspace/normalize.go
+++ b/internal/workspace/normalize.go
@@ -2,6 +2,8 @@ package workspace
 
 import "path/filepath"
 
+var normalizeRepoPath = NormalizeRepoPath
+
 func NormalizeRepoPath(path string) (string, error) {
 	if path == "" {
 		path = "."

--- a/internal/workspace/workspace_close_error_test.go
+++ b/internal/workspace/workspace_close_error_test.go
@@ -1,0 +1,36 @@
+package workspace
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestJoinCloseError(t *testing.T) {
+	t.Run("ignores nil close error", func(t *testing.T) {
+		base := errors.New("base")
+		err := error(base)
+		joinCloseError(&err, nil)
+		if !errors.Is(err, base) {
+			t.Fatalf("expected base error to remain, got %v", err)
+		}
+	})
+
+	t.Run("sets close error when target is nil", func(t *testing.T) {
+		closeErr := errors.New("close")
+		var err error
+		joinCloseError(&err, closeErr)
+		if !errors.Is(err, closeErr) {
+			t.Fatalf("expected close error to be set, got %v", err)
+		}
+	})
+
+	t.Run("joins close error when target already set", func(t *testing.T) {
+		base := errors.New("base")
+		closeErr := errors.New("close")
+		err := error(base)
+		joinCloseError(&err, closeErr)
+		if !errors.Is(err, base) || !errors.Is(err, closeErr) {
+			t.Fatalf("expected joined error to include both causes, got %v", err)
+		}
+	})
+}

--- a/internal/workspace/workspace_cov_error_paths_test.go
+++ b/internal/workspace/workspace_cov_error_paths_test.go
@@ -1,0 +1,17 @@
+package workspace
+
+import "testing"
+
+func TestChangedFilesReturnsNormalizeError(t *testing.T) {
+	_, err := ChangedFiles("\x00")
+	if err == nil {
+		t.Fatalf("expected normalize error for invalid repo path")
+	}
+}
+
+func TestCurrentCommitSHAReturnsNormalizeError(t *testing.T) {
+	_, err := CurrentCommitSHA("\x00")
+	if err == nil {
+		t.Fatalf("expected normalize error for invalid repo path")
+	}
+}

--- a/internal/workspace/workspace_cov_more_test.go
+++ b/internal/workspace/workspace_cov_more_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+const normalizeFailedErr = "normalize failed"
+
 func TestWorkspaceAdditionalBranchCoverage(t *testing.T) {
 	testWorkspaceChangedFilesReturnsGitResolutionError(t)
 	testWorkspaceNormalizeRepoPathErrorsBubbleThroughHelpers(t)
@@ -36,11 +38,19 @@ func testWorkspaceChangedFilesReturnsGitResolutionError(t *testing.T) {
 func testWorkspaceNormalizeRepoPathErrorsBubbleThroughHelpers(t *testing.T) {
 	t.Helper()
 
-	if _, err := CurrentCommitSHA("\x00"); err == nil {
-		t.Fatalf("expected invalid repo path to fail commit lookup")
+	original := normalizeRepoPath
+	normalizeRepoPath = func(string) (string, error) {
+		return "", errors.New(normalizeFailedErr)
 	}
-	if _, err := ChangedFiles("\x00"); err == nil {
-		t.Fatalf("expected invalid repo path to fail changed-files lookup")
+	t.Cleanup(func() {
+		normalizeRepoPath = original
+	})
+
+	if _, err := CurrentCommitSHA("."); err == nil || err.Error() != normalizeFailedErr {
+		t.Fatalf("expected normalization failure to fail commit lookup, got %v", err)
+	}
+	if _, err := ChangedFiles("."); err == nil || err.Error() != normalizeFailedErr {
+		t.Fatalf("expected normalization failure to fail changed-files lookup, got %v", err)
 	}
 }
 

--- a/tools/coveragegate/main.go
+++ b/tools/coveragegate/main.go
@@ -1,0 +1,387 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+type packageCoverage struct {
+	name              string
+	coveredStatements int
+	totalStatements   int
+}
+
+type coverageReport struct {
+	totalCoveredStatements int
+	totalStatements        int
+	packages               []packageCoverage
+}
+
+type gateResult struct {
+	totalCoverage   float64
+	failingPackages []packageCoverage
+}
+
+type runConfig struct {
+	coverProfile       string
+	totalMin           float64
+	packageMin         float64
+	totalOut           string
+	packagesOut        string
+	packageFailuresOut string
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	config, err := parseRunConfig(args, stderr)
+	if err != nil {
+		return exitErr(stderr, err)
+	}
+
+	report, err := parseCoverageProfile(config.coverProfile)
+	if err != nil {
+		return exitErr(stderr, fmt.Errorf("parse coverage profile: %w", err))
+	}
+
+	result := evaluateCoverage(report, config.packageMin)
+	if err := writeRunSummary(stdout, result.totalCoverage, config.totalMin, config.packageMin); err != nil {
+		return exitErr(stderr, err)
+	}
+	if err := writeOutputs(config.totalOut, config.packagesOut, config.packageFailuresOut, report, result); err != nil {
+		return exitErr(stderr, err)
+	}
+
+	exitCode, err := gateExitCode(stdout, result, config.totalMin)
+	if err != nil {
+		return exitErr(stderr, err)
+	}
+	return exitCode
+}
+
+func parseRunConfig(args []string, stderr io.Writer) (runConfig, error) {
+	flags := flag.NewFlagSet("coveragegate", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	coverProfile := flags.String("coverprofile", "", "path to the Go coverage profile")
+	totalMin := flags.Float64("min", 0, "minimum total coverage percentage")
+	packageMin := flags.Float64("package-min", 0, "minimum per-package coverage percentage")
+	totalOut := flags.String("total-out", "", "path to write the total coverage percentage")
+	packagesOut := flags.String("packages-out", "", "path to write package coverage percentages")
+	packageFailuresOut := flags.String("package-failures-out", "", "path to write formatted failing package lines")
+
+	if err := flags.Parse(args); err != nil {
+		return runConfig{}, err
+	}
+
+	config := runConfig{
+		coverProfile:       strings.TrimSpace(*coverProfile),
+		totalMin:           *totalMin,
+		packageMin:         *packageMin,
+		totalOut:           *totalOut,
+		packagesOut:        *packagesOut,
+		packageFailuresOut: *packageFailuresOut,
+	}
+	return config, validateRunConfig(config)
+}
+
+func validateRunConfig(config runConfig) error {
+	if config.coverProfile == "" {
+		return errors.New("-coverprofile is required")
+	}
+	if config.totalMin < 0 {
+		return errors.New("-min must be non-negative")
+	}
+	if config.packageMin < 0 {
+		return errors.New("-package-min must be non-negative")
+	}
+	return nil
+}
+
+func writeRunSummary(stdout io.Writer, totalCoverage, totalMin, packageMin float64) error {
+	if _, err := fmt.Fprintf(stdout, "Total coverage: %s (required: >= %s)\n", formatCoverage(totalCoverage), formatThreshold(totalMin)); err != nil {
+		return err
+	}
+	if packageMin <= 0 {
+		return nil
+	}
+	_, err := fmt.Fprintf(stdout, "Per-package coverage minimum: %s\n", formatThreshold(packageMin))
+	return err
+}
+
+func gateExitCode(stdout io.Writer, result gateResult, totalMin float64) (int, error) {
+	if result.totalCoverage < totalMin {
+		if _, err := fmt.Fprintf(stdout, "Coverage gate failed: %s < %s\n", formatCoverage(result.totalCoverage), formatThreshold(totalMin)); err != nil {
+			return 0, err
+		}
+		return 1, nil
+	}
+	if len(result.failingPackages) == 0 {
+		return 0, nil
+	}
+	if _, err := fmt.Fprintln(stdout, "Coverage gate failed: packages below minimum:"); err != nil {
+		return 0, err
+	}
+	if _, err := fmt.Fprint(stdout, renderPackageFailures(result.failingPackages)); err != nil {
+		return 0, err
+	}
+	return 1, nil
+}
+
+func exitErr(stderr io.Writer, err error) int {
+	if _, writeErr := fmt.Fprintln(stderr, err); writeErr != nil {
+		return 2
+	}
+	return 2
+}
+
+func parseCoverageProfile(path string) (report coverageReport, err error) {
+	file, err := safeio.OpenFile(path)
+	if err != nil {
+		return coverageReport{}, err
+	}
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	lineNo := 0
+	packageTotals := make(map[string]*packageCoverage)
+	report = coverageReport{}
+
+	lineNo, err = readCoverageLines(scanner, &report, packageTotals)
+	if err != nil {
+		return coverageReport{}, err
+	}
+	if lineNo == 0 {
+		return coverageReport{}, errors.New("empty coverage profile")
+	}
+	if report.totalStatements == 0 {
+		return coverageReport{}, errors.New("coverage profile has no statements")
+	}
+
+	report.packages = sortedPackageCoverage(packageTotals)
+	return report, nil
+}
+
+func readCoverageLines(scanner *bufio.Scanner, report *coverageReport, packageTotals map[string]*packageCoverage) (int, error) {
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if shouldSkipCoverageLine(lineNo, line) {
+			if err := validateCoverageHeader(lineNo, line); err != nil {
+				return 0, err
+			}
+			continue
+		}
+		if err := addCoverageLine(report, packageTotals, lineNo, line); err != nil {
+			return 0, err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return lineNo, nil
+}
+
+func sortedPackageCoverage(packageTotals map[string]*packageCoverage) []packageCoverage {
+	packages := make([]packageCoverage, 0, len(packageTotals))
+	for _, pkg := range packageTotals {
+		packages = append(packages, *pkg)
+	}
+	sort.Slice(packages, func(i, j int) bool {
+		return packages[i].name < packages[j].name
+	})
+	return packages
+}
+
+func validateCoverageHeader(lineNo int, line string) error {
+	if lineNo == 1 && !strings.HasPrefix(line, "mode: ") {
+		return fmt.Errorf("line 1: expected coverage mode header")
+	}
+	return nil
+}
+
+func shouldSkipCoverageLine(lineNo int, line string) bool {
+	return lineNo == 1 || line == ""
+}
+
+func addCoverageLine(report *coverageReport, packageTotals map[string]*packageCoverage, lineNo int, line string) error {
+	pkgName, statements, covered, err := parseCoverageLine(line)
+	if err != nil {
+		return fmt.Errorf("line %d: %w", lineNo, err)
+	}
+
+	report.totalStatements += statements
+	if covered {
+		report.totalCoveredStatements += statements
+	}
+
+	pkg := packageTotals[pkgName]
+	if pkg == nil {
+		pkg = &packageCoverage{name: pkgName}
+		packageTotals[pkgName] = pkg
+	}
+	pkg.totalStatements += statements
+	if covered {
+		pkg.coveredStatements += statements
+	}
+	return nil
+}
+
+func parseCoverageLine(line string) (string, int, bool, error) {
+	fields := strings.Fields(line)
+	if len(fields) != 3 {
+		return "", 0, false, fmt.Errorf("invalid coverage entry %q", line)
+	}
+
+	filePath, err := coverageFilePath(fields[0])
+	if err != nil {
+		return "", 0, false, fmt.Errorf("invalid file path in %q", line)
+	}
+
+	statements, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return "", 0, false, fmt.Errorf("invalid statement count %q", fields[1])
+	}
+	if statements < 0 {
+		return "", 0, false, fmt.Errorf("invalid negative statement count %d", statements)
+	}
+
+	count, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil {
+		return "", 0, false, fmt.Errorf("invalid execution count %q", fields[2])
+	}
+
+	pkgName := packageForFile(filePath)
+	if pkgName == "" {
+		return "", 0, false, fmt.Errorf("could not resolve package for %q", filePath)
+	}
+
+	return pkgName, statements, count > 0, nil
+}
+
+func coverageFilePath(field string) (string, error) {
+	colonIdx := strings.LastIndex(field, ":")
+	if colonIdx < 0 {
+		return "", errors.New("missing file separator")
+	}
+	filePath := strings.TrimSpace(field[:colonIdx])
+	if filePath == "" {
+		return "", errors.New("empty file path")
+	}
+	return filePath, nil
+}
+
+func packageForFile(filePath string) string {
+	normalized := strings.ReplaceAll(strings.TrimSpace(filePath), `\`, "/")
+	dir := path.Dir(normalized)
+	if dir == "." {
+		return ""
+	}
+	return dir
+}
+
+func evaluateCoverage(report coverageReport, packageMin float64) gateResult {
+	result := gateResult{
+		totalCoverage: roundCoverage(report.totalCoveredStatements, report.totalStatements),
+	}
+	if packageMin <= 0 {
+		return result
+	}
+
+	for _, pkg := range report.packages {
+		if roundCoverage(pkg.coveredStatements, pkg.totalStatements) < packageMin {
+			result.failingPackages = append(result.failingPackages, pkg)
+		}
+	}
+	return result
+}
+
+func roundCoverage(covered, total int) float64 {
+	if total <= 0 {
+		return 0
+	}
+	percent := (float64(covered) * 100) / float64(total)
+	return math.Round(percent*10) / 10
+}
+
+func formatCoverage(percent float64) string {
+	return fmt.Sprintf("%.1f%%", percent)
+}
+
+func formatThreshold(percent float64) string {
+	if percent == math.Trunc(percent) {
+		return fmt.Sprintf("%.0f%%", percent)
+	}
+	return fmt.Sprintf("%.1f%%", percent)
+}
+
+func writeOutputs(totalOut, packagesOut, packageFailuresOut string, report coverageReport, result gateResult) error {
+	if totalOut != "" {
+		if err := writeFile(totalOut, fmt.Sprintf("%.1f\n", result.totalCoverage)); err != nil {
+			return fmt.Errorf("write total coverage: %w", err)
+		}
+	}
+	if packagesOut != "" {
+		if err := writeFile(packagesOut, renderPackageCoverage(report.packages)); err != nil {
+			return fmt.Errorf("write package coverage: %w", err)
+		}
+	}
+	if packageFailuresOut != "" {
+		if err := writeFile(packageFailuresOut, renderPackageFailures(result.failingPackages)); err != nil {
+			return fmt.Errorf("write package failures: %w", err)
+		}
+	}
+	return nil
+}
+
+func renderPackageCoverage(packages []packageCoverage) string {
+	if len(packages) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, pkg := range packages {
+		fmt.Fprintf(&b, "%s\t%.1f\n", pkg.name, roundCoverage(pkg.coveredStatements, pkg.totalStatements))
+	}
+	return b.String()
+}
+
+func renderPackageFailures(packages []packageCoverage) string {
+	if len(packages) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, pkg := range packages {
+		fmt.Fprintf(&b, "- %s: %s\n", pkg.name, formatCoverage(roundCoverage(pkg.coveredStatements, pkg.totalStatements)))
+	}
+	return b.String()
+}
+
+func writeFile(path, contents string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(contents), 0o600)
+}

--- a/tools/coveragegate/main_test.go
+++ b/tools/coveragegate/main_test.go
@@ -1,0 +1,565 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	coverProfileFlag = "-coverprofile"
+	packageMinFlag   = "-package-min"
+	totalOutName     = "total.txt"
+	packagesOutName  = "packages.txt"
+	failuresOutName  = "failures.txt"
+	missingOutName   = "missing.out"
+)
+
+func TestParseCoverageProfileAndWriteOutputs(t *testing.T) {
+	dir := t.TempDir()
+	profilePath := filepath.Join(dir, "coverage.out")
+	profileLines := []string{
+		"mode: atomic",
+		"github.com/ben-ranford/lopper/internal/app/app.go:1.1,2.1 3 1",
+		"github.com/ben-ranford/lopper/internal/app/app.go:3.1,4.1 1 0",
+		"github.com/ben-ranford/lopper/internal/runtime/runtime.go:1.1,2.1 2 1",
+		"github.com/ben-ranford/lopper/internal/runtime/runtime.go:3.1,4.1 3 0",
+		"",
+	}
+	profile := strings.Join(profileLines, "\n")
+	if err := os.WriteFile(profilePath, []byte(profile), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	report, err := parseCoverageProfile(profilePath)
+	if err != nil {
+		t.Fatalf("parse coverage profile: %v", err)
+	}
+	if got := roundCoverage(report.totalCoveredStatements, report.totalStatements); got != 55.6 {
+		t.Fatalf("total coverage = %.1f, want 55.6", got)
+	}
+	if len(report.packages) != 2 {
+		t.Fatalf("package count = %d, want 2", len(report.packages))
+	}
+
+	result := evaluateCoverage(report, 60)
+	if len(result.failingPackages) != 1 {
+		t.Fatalf("failing packages = %d, want 1", len(result.failingPackages))
+	}
+	if result.failingPackages[0].name != "github.com/ben-ranford/lopper/internal/runtime" {
+		t.Fatalf("unexpected failing package %q", result.failingPackages[0].name)
+	}
+
+	totalOut, packagesOut, failuresOut := coverageOutputPaths(dir)
+	if err := writeOutputs(totalOut, packagesOut, failuresOut, report, result); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+
+	assertFileContains(t, totalOut, "55.6\n")
+	assertFileContains(t, packagesOut, "github.com/ben-ranford/lopper/internal/app\t75.0\n")
+	assertFileContains(t, packagesOut, "github.com/ben-ranford/lopper/internal/runtime\t40.0\n")
+	assertFileContains(t, failuresOut, "- github.com/ben-ranford/lopper/internal/runtime: 40.0%\n")
+}
+
+func TestEvaluateCoverageUsesRoundedPercentages(t *testing.T) {
+	report := coverageReport{
+		totalCoveredStatements: 1959,
+		totalStatements:        2000,
+		packages: []packageCoverage{
+			{
+				name:              "github.com/ben-ranford/lopper/internal/rounded",
+				coveredStatements: 1959,
+				totalStatements:   2000,
+			},
+		},
+	}
+
+	result := evaluateCoverage(report, 98)
+	if result.totalCoverage != 98.0 {
+		t.Fatalf("total coverage = %.1f, want 98.0", result.totalCoverage)
+	}
+	if len(result.failingPackages) != 0 {
+		t.Fatalf("expected rounded package coverage to pass, got %d failures", len(result.failingPackages))
+	}
+}
+
+func TestParseCoverageProfileRejectsMalformedInput(t *testing.T) {
+	dir := t.TempDir()
+	profilePath := filepath.Join(dir, "coverage.out")
+	if err := os.WriteFile(profilePath, []byte("mode: atomic\nnot-a-valid-line\n"), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	if _, err := parseCoverageProfile(profilePath); err == nil {
+		t.Fatal("expected malformed coverage profile to fail")
+	}
+}
+
+func TestRunSuccessAndFailurePaths(t *testing.T) {
+	dir := t.TempDir()
+	passProfile := writeCoverageProfile(t, dir, "pass.out", []string{
+		"github.com/ben-ranford/lopper/internal/pass/pass.go:1.1,2.1 2 1",
+		"github.com/ben-ranford/lopper/internal/pass/pass.go:3.1,4.1 2 1",
+	})
+	totalOut, packagesOut, failuresOut := coverageOutputPaths(dir)
+
+	passArgs := []string{
+		coverProfileFlag, passProfile,
+		"-min", "98",
+		packageMinFlag, "98",
+		"-total-out", totalOut,
+		"-packages-out", packagesOut,
+		"-package-failures-out", failuresOut,
+	}
+	stdout, stderr, exitCode := runWithBuffers(passArgs)
+	if exitCode != 0 {
+		t.Fatalf("run success exit code = %d, stderr=%q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Total coverage: 100.0% (required: >= 98%)") {
+		t.Fatalf("unexpected stdout: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	assertFileContains(t, totalOut, "100.0\n")
+	assertFileContains(t, packagesOut, "github.com/ben-ranford/lopper/internal/pass\t100.0\n")
+
+	failProfile := writeCoverageProfile(t, dir, "fail.out", []string{
+		"github.com/ben-ranford/lopper/internal/fail/fail.go:1.1,2.1 3 1",
+		"github.com/ben-ranford/lopper/internal/fail/fail.go:3.1,4.1 1 0",
+	})
+
+	stdout.Reset()
+	stderr.Reset()
+	failArgs := []string{
+		coverProfileFlag, failProfile,
+		"-min", "98",
+		packageMinFlag, "98",
+	}
+	exitCode = run(failArgs, &stdout, &stderr)
+	if exitCode != 1 {
+		t.Fatalf("run failure exit code = %d, want 1", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "Coverage gate failed: 75.0% < 98%") {
+		t.Fatalf("expected total failure output, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr on failure, got %q", stderr.String())
+	}
+}
+
+func TestRunErrorPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantMessage string
+	}{
+		{
+			name:        "missing profile",
+			args:        nil,
+			wantMessage: "-coverprofile is required",
+		},
+		{
+			name:        "negative total threshold",
+			args:        coverageArgs(missingOutName, "-min", "-1"),
+			wantMessage: "-min must be non-negative",
+		},
+		{
+			name:        "negative package threshold",
+			args:        coverageArgs(missingOutName, packageMinFlag, "-1"),
+			wantMessage: "-package-min must be non-negative",
+		},
+		{
+			name:        "missing profile file",
+			args:        coverageArgs(missingOutName, "-min", "0"),
+			wantMessage: "parse coverage profile:",
+		},
+		{
+			name:        "flag parse",
+			args:        []string{"-unknown-flag"},
+			wantMessage: "flag provided but not defined",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, stderr, exitCode := runWithBuffers(tc.args)
+			requireExitCodeTwo(t, exitCode)
+			if !strings.Contains(stderr.String(), tc.wantMessage) {
+				t.Fatalf("expected stderr to contain %q, got %q", tc.wantMessage, stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunWriteErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+	profilePath := writeCoverageProfile(t, dir, "write-errors.out", []string{
+		"github.com/ben-ranford/lopper/internal/pass/pass.go:1.1,2.1 2 1",
+		"github.com/ben-ranford/lopper/internal/pass/pass.go:3.1,4.1 2 1",
+	})
+
+	tests := []struct {
+		name        string
+		args        []string
+		failOnWrite int
+		errText     string
+	}{
+		{
+			name:        "total coverage write failure",
+			args:        coverageArgs(profilePath, "-min", "0"),
+			failOnWrite: 1,
+			errText:     "stdout failed",
+		},
+		{
+			name:        "package minimum write failure",
+			args:        coverageArgs(profilePath, "-min", "0", packageMinFlag, "98"),
+			failOnWrite: 2,
+			errText:     "package minimum failed",
+		},
+		{
+			name:        "total failure message write failure",
+			args:        coverageArgs(profilePath, "-min", "101"),
+			failOnWrite: 2,
+			errText:     "failure message failed",
+		},
+		{
+			name:        "package failure heading write failure",
+			args:        coverageArgs(profilePath, "-min", "0", packageMinFlag, "101"),
+			failOnWrite: 3,
+			errText:     "package failure heading failed",
+		},
+		{
+			name:        "package failure body write failure",
+			args:        coverageArgs(profilePath, "-min", "0", packageMinFlag, "101"),
+			failOnWrite: 4,
+			errText:     "package failure body failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout := &failOnWriteWriter{failOn: tc.failOnWrite, err: errors.New(tc.errText)}
+			var stderr bytes.Buffer
+
+			exitCode := run(tc.args, stdout, &stderr)
+			requireExitCodeTwo(t, exitCode)
+			if !strings.Contains(stderr.String(), tc.errText) {
+				t.Fatalf("expected stderr to contain write error, got %q", stderr.String())
+			}
+		})
+	}
+}
+
+func writeCoverageProfile(t *testing.T, dir, name string, lines []string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	profile := strings.Join(append([]string{"mode: atomic"}, lines...), "\n") + "\n"
+	if err := os.WriteFile(path, []byte(profile), 0o644); err != nil {
+		t.Fatalf("write coverage profile: %v", err)
+	}
+	return path
+}
+
+func TestRunPackageFailureAndWriteErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+	packageFailProfile := writeCoverageProfile(t, dir, "package-fail.out", []string{
+		"github.com/ben-ranford/lopper/internal/pass/pass.go:1.1,2.1 97 1",
+		"github.com/ben-ranford/lopper/internal/pass/pass.go:3.1,4.1 3 0",
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	packageFailArgs := []string{
+		coverProfileFlag, packageFailProfile,
+		"-min", "97",
+		packageMinFlag, "98",
+	}
+	exitCode := run(packageFailArgs, &stdout, &stderr)
+	if exitCode != 1 {
+		t.Fatalf("package failure exit code = %d, want 1", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "Coverage gate failed: packages below minimum:") {
+		t.Fatalf("expected package failure output, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "- github.com/ben-ranford/lopper/internal/pass: 97.0%") {
+		t.Fatalf("expected failing package output, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+
+	blockingFile := filepath.Join(dir, "blocking-file")
+	if err := os.WriteFile(blockingFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocking file: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	writeErrorArgs := []string{
+		coverProfileFlag, packageFailProfile,
+		"-min", "0",
+		packageMinFlag, "0",
+		"-total-out", filepath.Join(blockingFile, totalOutName),
+	}
+	exitCode = run(writeErrorArgs, &stdout, &stderr)
+	requireExitCodeTwo(t, exitCode)
+	if !strings.Contains(stderr.String(), "write total coverage:") {
+		t.Fatalf("expected write error, got %q", stderr.String())
+	}
+}
+
+func TestParseCoverageLineParsesValidUncoveredLine(t *testing.T) {
+	pkg, statements, covered, err := parseCoverageLine("github.com/ben-ranford/lopper/internal/app/app.go:1.1,2.1 3 0")
+	if err != nil {
+		t.Fatalf("parseCoverageLine: %v", err)
+	}
+	if pkg != "github.com/ben-ranford/lopper/internal/app" || statements != 3 || covered {
+		t.Fatalf("unexpected parse result: pkg=%q statements=%d covered=%t", pkg, statements, covered)
+	}
+}
+
+func TestParseCoverageLineSupportsWindowsPaths(t *testing.T) {
+	pkg, statements, covered, err := parseCoverageLine(`C:\work\lopper\internal\app\app.go:1.1,2.1 3 1`)
+	if err != nil {
+		t.Fatalf("parseCoverageLine windows path: %v", err)
+	}
+	if pkg != "C:/work/lopper/internal/app" || statements != 3 || !covered {
+		t.Fatalf("unexpected windows parse result: pkg=%q statements=%d covered=%t", pkg, statements, covered)
+	}
+}
+
+func TestParseCoverageLineRejectsInvalidCases(t *testing.T) {
+	for _, tc := range []string{
+		"not enough fields",
+		"github.com/ben-ranford/lopper/internal/app/app.go 3 1",
+		"github.com/ben-ranford/lopper/internal/app/app.go:1.1,2.1 nope 1",
+		"github.com/ben-ranford/lopper/internal/app/app.go:1.1,2.1 -1 1",
+		"github.com/ben-ranford/lopper/internal/app/app.go:1.1,2.1 3 nope",
+	} {
+		if _, _, _, err := parseCoverageLine(tc); err == nil {
+			t.Fatalf("expected parseCoverageLine(%q) to fail", tc)
+		}
+	}
+}
+
+func TestCoverageFilePathRejectsMissingSeparator(t *testing.T) {
+	if _, err := coverageFilePath("github.com/ben-ranford/lopper/internal/app/app.go"); err == nil {
+		t.Fatal("expected missing separator error")
+	}
+}
+
+func TestPackageForFile(t *testing.T) {
+	if got := packageForFile("."); got != "" {
+		t.Fatalf("packageForFile(.) = %q, want empty", got)
+	}
+	if got := packageForFile(" github.com/ben-ranford/lopper/internal/app/app.go "); got != "github.com/ben-ranford/lopper/internal/app" {
+		t.Fatalf("packageForFile converted = %q", got)
+	}
+}
+
+func TestEvaluateCoverageWithoutPackageGate(t *testing.T) {
+	report := coverageReport{
+		totalCoveredStatements: 2,
+		totalStatements:        4,
+		packages: []packageCoverage{
+			{name: "pkg", coveredStatements: 1, totalStatements: 2},
+		},
+	}
+	result := evaluateCoverage(report, 0)
+	if result.totalCoverage != 50.0 {
+		t.Fatalf("total coverage = %.1f", result.totalCoverage)
+	}
+	if len(result.failingPackages) != 0 {
+		t.Fatalf("expected no failing packages, got %d", len(result.failingPackages))
+	}
+}
+
+func TestCoverageFormattingHelpers(t *testing.T) {
+	if got := roundCoverage(1, 0); got != 0 {
+		t.Fatalf("roundCoverage zero total = %.1f", got)
+	}
+	if got := formatThreshold(98.5); got != "98.5%" {
+		t.Fatalf("formatThreshold decimal = %q", got)
+	}
+	if got := renderPackageCoverage(nil); got != "" {
+		t.Fatalf("renderPackageCoverage empty = %q", got)
+	}
+	if got := renderPackageFailures(nil); got != "" {
+		t.Fatalf("renderPackageFailures empty = %q", got)
+	}
+}
+
+func TestParseCoverageProfileHeaderAndStatementErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	noHeader := filepath.Join(dir, "no-header.out")
+	if err := os.WriteFile(noHeader, []byte("github.com/ben-ranford/lopper/internal/app/app.go:1.1,2.1 1 1\n"), 0o644); err != nil {
+		t.Fatalf("write no-header profile: %v", err)
+	}
+	if _, err := parseCoverageProfile(noHeader); err == nil || !strings.Contains(err.Error(), "expected coverage mode header") {
+		t.Fatalf("expected missing header error, got %v", err)
+	}
+
+	noStatements := filepath.Join(dir, "no-statements.out")
+	if err := os.WriteFile(noStatements, []byte("mode: atomic\n"), 0o644); err != nil {
+		t.Fatalf("write no-statements profile: %v", err)
+	}
+	if _, err := parseCoverageProfile(noStatements); err == nil || !strings.Contains(err.Error(), "coverage profile has no statements") {
+		t.Fatalf("expected no statements error, got %v", err)
+	}
+
+	emptyProfile := filepath.Join(dir, "empty.out")
+	if err := os.WriteFile(emptyProfile, nil, 0o644); err != nil {
+		t.Fatalf("write empty profile: %v", err)
+	}
+	if _, err := parseCoverageProfile(emptyProfile); err == nil || !strings.Contains(err.Error(), "empty coverage profile") {
+		t.Fatalf("expected empty profile error, got %v", err)
+	}
+
+	missingPackage := filepath.Join(dir, "missing-package.out")
+	if err := os.WriteFile(missingPackage, []byte("mode: atomic\n./main.go:1.1,2.1 1 1\n"), 0o644); err != nil {
+		t.Fatalf("write missing-package profile: %v", err)
+	}
+	if _, err := parseCoverageProfile(missingPackage); err == nil || !strings.Contains(err.Error(), "could not resolve package") {
+		t.Fatalf("expected missing package error, got %v", err)
+	}
+}
+
+func TestParseCoverageProfileScannerError(t *testing.T) {
+	dir := t.TempDir()
+	longLine := "github.com/ben-ranford/lopper/internal/app/app.go:1.1,2.1 " + strings.Repeat("1", 1024*1024+1) + " 1"
+	profilePath := filepath.Join(dir, "too-long.out")
+	if err := os.WriteFile(profilePath, []byte("mode: atomic\n"+longLine+"\n"), 0o644); err != nil {
+		t.Fatalf("write long profile: %v", err)
+	}
+
+	if _, err := parseCoverageProfile(profilePath); err == nil || !strings.Contains(err.Error(), "token too long") {
+		t.Fatalf("expected scanner error, got %v", err)
+	}
+}
+
+func TestWriteOutputsPropagatesPackagesAndFailuresErrors(t *testing.T) {
+	dir := t.TempDir()
+	report := coverageReport{
+		packages: []packageCoverage{{name: "pkg", coveredStatements: 1, totalStatements: 1}},
+	}
+	result := gateResult{
+		totalCoverage:   100,
+		failingPackages: []packageCoverage{{name: "pkg", coveredStatements: 1, totalStatements: 2}},
+	}
+
+	packagesBlocker := filepath.Join(dir, "packages-blocker")
+	if err := os.WriteFile(packagesBlocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write packages blocker: %v", err)
+	}
+	if err := writeOutputs("", filepath.Join(packagesBlocker, packagesOutName), "", report, result); err == nil || !strings.Contains(err.Error(), "write package coverage") {
+		t.Fatalf("expected package coverage write error, got %v", err)
+	}
+
+	failuresBlocker := filepath.Join(dir, "failures-blocker")
+	if err := os.WriteFile(failuresBlocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write failures blocker: %v", err)
+	}
+	if err := writeOutputs("", "", filepath.Join(failuresBlocker, failuresOutName), report, result); err == nil || !strings.Contains(err.Error(), "write package failures") {
+		t.Fatalf("expected package failures write error, got %v", err)
+	}
+}
+
+func runWithBuffers(args []string) (bytes.Buffer, bytes.Buffer, int) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := run(args, &stdout, &stderr)
+	return stdout, stderr, exitCode
+}
+
+func TestMainExecutesRun(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" {
+		argsIndex := -1
+		for i, arg := range os.Args {
+			if arg == "--" {
+				argsIndex = i
+				break
+			}
+		}
+		if argsIndex == -1 {
+			t.Fatal("missing helper args separator")
+		}
+
+		oldArgs := os.Args
+		defer func() {
+			os.Args = oldArgs
+		}()
+		os.Args = append([]string{oldArgs[0]}, oldArgs[argsIndex+1:]...)
+		main()
+		return
+	}
+
+	dir := t.TempDir()
+	profilePath := writeCoverageProfile(t, dir, "main.out", []string{
+		"github.com/ben-ranford/lopper/internal/main/main.go:1.1,2.1 2 1",
+	})
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainExecutesRun", "--", coverProfileFlag, profilePath, "-min", "50")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper process failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "Total coverage: 100.0% (required: >= 50%)") {
+		t.Fatalf("unexpected helper output: %q", string(output))
+	}
+}
+
+func TestExitErrHandlesStderrWriteFailure(t *testing.T) {
+	exitCode := exitErr(&failOnWriteWriter{failOn: 1, err: errors.New("stderr failed")}, errors.New("boom"))
+	requireExitCodeTwo(t, exitCode)
+}
+
+func assertFileContains(t *testing.T, path, want string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("%s missing %q in %q", path, want, string(data))
+	}
+}
+
+func coverageArgs(profile string, extra ...string) []string {
+	args := []string{coverProfileFlag, profile}
+	return append(args, extra...)
+}
+
+func coverageOutputPaths(dir string) (string, string, string) {
+	return filepath.Join(dir, totalOutName), filepath.Join(dir, packagesOutName), filepath.Join(dir, failuresOutName)
+}
+
+func requireExitCodeTwo(t *testing.T, exitCode int) {
+	t.Helper()
+
+	if exitCode != 2 {
+		t.Fatalf("exit code = %d, want 2", exitCode)
+	}
+}
+
+type failOnWriteWriter struct {
+	writes int
+	failOn int
+	err    error
+}
+
+func (w *failOnWriteWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == w.failOn {
+		return 0, w.err
+	}
+	return len(p), nil
+}


### PR DESCRIPTION
Closes #579.

## The Issue
The repository only enforced a combined coverage threshold, so individual packages could regress below the intended floor while the aggregate number still passed.

## Cause And User Impact
That left CI blind to package-level coverage regressions. A single package could drop below `98%` and still merge if other packages overperformed, which weakens the usefulness of the coverage gate and makes future regressions easier to miss.

## Root Cause
Coverage enforcement and reporting were aggregate-only. There was no per-package artifact, no package-level failure output in CI, and the repository already contained several packages below the intended floor.

## The Fix
This change adds a dedicated coverage gate helper that parses the Go coverage profile, writes combined and per-package artifacts, and fails when either the total or any package falls below the configured minimum. `make cov` and CI now pass both thresholds and surface failing packages in the PR comment path. The repository was then uplifted with targeted branch and error-path tests across the previously failing packages so the stricter gate is green at `98%` total and `98%` per package.

## Validation
The branch passed the repo's full pre-commit CI suite, including module verification, lint, workflow validation, security checks, vuln scanning, `go test ./...`, goleak, race, memory delta, build, and coverage gating.

Additional explicit verification:
- `make cov COVERAGE_MIN=98 COVERAGE_PACKAGE_MIN=98`
