### PR TITLE
fix(runtime): unblock v1.3.1 release

### DIFF
--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -365,6 +365,7 @@ func TestMergeCodemodReport(t *testing.T) {
 	merged := mergeCodemodReport(left, right)
 	if merged == nil {
 		t.Fatalf("expected merged codemod report")
+		return
 	}
 	if merged.Mode != "suggest-only" {
 		t.Fatalf("expected mode suggest-only, got %q", merged.Mode)

--- a/internal/analysis/service_usage_uncertainty_test.go
+++ b/internal/analysis/service_usage_uncertainty_test.go
@@ -60,6 +60,7 @@ func TestMergeUsageUncertaintyCombinesAndCapsSamples(t *testing.T) {
 	got := mergeUsageUncertainty(left, right)
 	if got == nil {
 		t.Fatalf("expected merge result")
+		return
 	}
 	if got.ConfirmedImportUses != 7 || got.UncertainImportUses != 7 {
 		t.Fatalf("unexpected aggregate counts: %#v", got)

--- a/internal/lang/js/adapter_helpers_extra_test.go
+++ b/internal/lang/js/adapter_helpers_extra_test.go
@@ -216,6 +216,7 @@ func TestSummarizeUsageUncertainty(t *testing.T) {
 	})
 	if summary == nil {
 		t.Fatalf("expected usage uncertainty summary")
+		return
 	}
 	if summary.ConfirmedImportUses != 1 || summary.UncertainImportUses != 1 {
 		t.Fatalf("unexpected uncertainty summary counts: %#v", summary)

--- a/internal/lang/js/codemod_test.go
+++ b/internal/lang/js/codemod_test.go
@@ -30,6 +30,7 @@ func TestAdapterAnalyseSuggestOnlyCodemodPreview(t *testing.T) {
 	codemod := reportData.Dependencies[0].Codemod
 	if codemod == nil {
 		t.Fatalf("expected codemod report")
+		return
 	}
 	if codemod.Mode != codemodModeSuggestOnly {
 		t.Fatalf("expected codemod mode %q, got %q", codemodModeSuggestOnly, codemod.Mode)
@@ -67,6 +68,7 @@ func TestAdapterAnalyseSuggestOnlySkipsUnsafeTransforms(t *testing.T) {
 	codemod := reportData.Dependencies[0].Codemod
 	if codemod == nil {
 		t.Fatalf("expected codemod report")
+		return
 	}
 	if len(codemod.Suggestions) != 0 {
 		t.Fatalf("expected no safe suggestions, got %#v", codemod.Suggestions)

--- a/internal/lang/ruby/adapter_test.go
+++ b/internal/lang/ruby/adapter_test.go
@@ -320,6 +320,7 @@ func assertRubyDependencyProvenanceSignalData(t *testing.T, info rubyDependencyS
 	}
 	if provenance == nil {
 		t.Fatalf("expected provenance for %#v", info)
+		return
 	}
 	if provenance.Source != wantSource || provenance.Confidence != wantConfidence || !slices.Equal(provenance.Signals, wantSignals) {
 		t.Fatalf("unexpected provenance: %#v", provenance)
@@ -447,6 +448,7 @@ func assertRubyDependencyProvenance(t *testing.T, repo, dependency, wantSource s
 	provenance := reportData.Dependencies[0].Provenance
 	if provenance == nil {
 		t.Fatalf("expected provenance for %s", dependency)
+		return
 	}
 	if provenance.Source != wantSource {
 		t.Fatalf("expected %s provenance source %q, got %#v", dependency, wantSource, provenance)

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -320,6 +320,7 @@ func TestDependencyAnchorLocationBranches(t *testing.T) {
 	anchor := dependencyAnchorLocation(dep)
 	if anchor == nil {
 		t.Fatalf("expected non-nil anchor")
+		return
 	}
 	if anchor.PhysicalLocation.ArtifactLocation.URI != testAFileGo {
 		t.Fatalf("expected sorted anchor path, got %#v", anchor)

--- a/internal/report/scoring_test.go
+++ b/internal/report/scoring_test.go
@@ -43,6 +43,7 @@ func TestAnnotateRemovalCandidateScoresConfidenceRationale(t *testing.T) {
 	candidate := deps[0].RemovalCandidate
 	if candidate == nil {
 		t.Fatalf("expected candidate score")
+		return
 	}
 	if candidate.Confidence >= 50 {
 		t.Fatalf("expected confidence reduction for wildcard/risk/runtime-only cues, got %f", candidate.Confidence)
@@ -72,6 +73,7 @@ func TestAnnotateReachabilityConfidenceAddsPerDependencyArtifact(t *testing.T) {
 	confidence := reportData.Dependencies[0].ReachabilityConfidence
 	if confidence == nil {
 		t.Fatalf("expected reachability confidence artifact")
+		return
 	}
 	if confidence.Model != reachabilityConfidenceModelV2 {
 		t.Fatalf("expected reachability confidence model %q, got %q", reachabilityConfidenceModelV2, confidence.Model)

--- a/internal/report/summary_test.go
+++ b/internal/report/summary_test.go
@@ -51,6 +51,7 @@ func TestComputeSummaryCountsUnknownDeniedLicense(t *testing.T) {
 
 	if summary == nil {
 		t.Fatal("expected summary")
+		return
 	}
 	if summary.UnknownLicenseCount != 1 {
 		t.Fatalf("expected one unknown license, got %#v", summary)

--- a/internal/runtime/capture_process_unix.go
+++ b/internal/runtime/capture_process_unix.go
@@ -19,6 +19,12 @@ func configureRuntimeCommand(cmd *exec.Cmd) {
 		if cmd.Process == nil {
 			return os.ErrProcessDone
 		}
+		if err := cmd.Process.Signal(syscall.Signal(0)); err != nil {
+			if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
 		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
 			if errors.Is(err, syscall.ESRCH) {
 				return os.ErrProcessDone

--- a/internal/runtime/capture_process_unix_test.go
+++ b/internal/runtime/capture_process_unix_test.go
@@ -3,9 +3,11 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -28,5 +30,20 @@ func TestConfigureRuntimeCommand(t *testing.T) {
 	cmd.Process = &os.Process{Pid: 999999}
 	if err := cmd.Cancel(); !errors.Is(err, os.ErrProcessDone) && !errors.Is(err, syscall.ESRCH) {
 		t.Fatalf("expected missing process error, got %v", err)
+	}
+}
+
+func TestConfigureRuntimeCommandCancelRunningProcess(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", "sleep 5")
+	configureRuntimeCommand(cmd)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start process: %v", err)
+	}
+	if err := cmd.Cancel(); err != nil {
+		t.Fatalf("cancel running process: %v", err)
+	}
+	if err := cmd.Wait(); err != nil && !errors.Is(err, os.ErrProcessDone) && !strings.Contains(err.Error(), "signal: killed") {
+		t.Fatalf("wait process: %v", err)
 	}
 }

--- a/internal/ui/ui_cov_more_test.go
+++ b/internal/ui/ui_cov_more_test.go
@@ -239,6 +239,7 @@ func testUIReachabilityMapping(t *testing.T) {
 	got := mapDetailReachabilityConfidence(confidence)
 	if got == nil {
 		t.Fatalf("expected mapped reachability confidence")
+		return
 	}
 	if got.Model != confidence.Model || got.Score != confidence.Score || got.Summary != confidence.Summary {
 		t.Fatalf("unexpected mapped confidence: %#v", got)


### PR DESCRIPTION
## Summary
- map cancel attempts on already-finished processes to `os.ErrProcessDone`
- add runtime coverage for cancelling a running process
- add minimal nil-guard returns in tests so current `main` satisfies staticcheck during release validation

## Release impact
This unblocks the failed `v1.3.1` release workflow.

Fixes #585
