### PR TITLE
fix(ci): authenticate sync-version push with PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,11 +252,21 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Validate sync token
+        env:
+          MAIN_SYNC_PAT: ${{ secrets.MAIN_SYNC_PAT }}
+        run: |
+          if [ -z "${MAIN_SYNC_PAT}" ]; then
+            echo "::error::MAIN_SYNC_PAT is required for sync-release-version direct pushes to protected main."
+            exit 1
+          fi
+
       - name: Checkout release branch
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
+          token: ${{ secrets.MAIN_SYNC_PAT }}
 
       - name: Sync committed extension version
         env:


### PR DESCRIPTION
## Issue
The release workflow's `sync-release-version` job needs to write back version metadata after a stable release. With `main` protected by a required-PR ruleset, direct pushes from the default workflow token are rejected.

## Cause and Impact
`sync-release-version` used `GITHUB_TOKEN` credentials via default checkout/push behavior. `GITHUB_TOKEN` is evaluated as `github-actions[bot]` and does not satisfy the protected-branch pull-request rule, so the sync step fails and leaves committed version surfaces unsynced.

## Root Cause
Authentication for the post-release push path was coupled to `GITHUB_TOKEN`, while repository policy requires a credential that can bypass the protected-branch pull-request requirement.

## Fix
- require `MAIN_SYNC_PAT` in `sync-release-version`
- fail fast with a clear error when `MAIN_SYNC_PAT` is missing
- use `MAIN_SYNC_PAT` for checkout so subsequent git operations authenticate with that token
- keep existing sync commit/rebase/push retry logic unchanged

## Validation
- `make actionlint`
- repository pre-commit hook `make ci` (triggered on commit)
