### PR TITLE
fix(release): allow reusable workflow callers to read checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.should_release == 'true' }}
     permissions:
+      checks: read
       contents: read
       packages: write
     uses: ./.github/workflows/release-orchestration.yml

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -37,6 +37,7 @@ jobs:
     needs:
       - prepare-rolling
     permissions:
+      checks: read
       contents: read
       packages: write
     uses: ./.github/workflows/release-orchestration.yml


### PR DESCRIPTION
## Summary
- add `checks: read` to the `release.yml` reusable workflow caller
- add `checks: read` to the `rolling.yml` reusable workflow caller
- unblock the new `confirm-validated-source` job in stable and rolling promotions

## Validation
- pre-commit hook passed locally (`make ci`)
