### PR TITLE
fix(ci): expand inline suppression guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ make demos-check
 ```
 
 `make ci` includes goroutine leak detection and the curated memory benchmark delta gate against `origin/main`.
+It also blocks newly introduced inline suppression markers in source files, so fix the underlying finding instead of adding `nosonar`, `nosec`, `nolint`, `noqa`, `eslint-disable`, `ts-ignore`, `ts-expect-error`, or coverage-bypass comments.
 If a change intentionally increases the tracked memory benchmarks beyond the configured thresholds, note that in the PR and ask a maintainer to apply the `memory-approved` label.
 
 ## VS Code Extension

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -67,7 +67,7 @@ When running locally with `act`, target the Linux-backed jobs explicitly (for ex
 - `make mod-check`: enforce `go mod tidy -diff` and `go mod verify`
 - `make dup-check`: fail when **new/changed Go lines** exceed duplication max percentage versus base ref (defaults: `DUPLICATION_MAX=3`, `DUPLICATION_TOKEN_THRESHOLD=55`, `DUPLICATION_BASE=origin/main`)
 - Dup checker is pinned to immutable revision `DUPL_VERSION=f008fcf5e62793d38bda510ee37aab8b0c68e76c`.
-- `make suppression-check`: fail when staged changes or branch-added lines introduce inline suppression markers
+- `make suppression-check`: fail when staged, working-tree, or branch-added source lines introduce inline suppression markers such as `nosonar`, `nosec`, `nolint`, `noqa`, `eslint-disable`, `ts-ignore`, `ts-expect-error`, and coverage-bypass comments
 - `make format-check`: fail if `gofmt` changes are needed
 - `make security`: run `gosec`
 - `make vuln-check`: run `govulncheck`

--- a/scripts/check-inline-suppressions.sh
+++ b/scripts/check-inline-suppressions.sh
@@ -5,9 +5,13 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 requested_base_ref="${SUPPRESSION_BASE:-origin/main}"
-marker_prefix="no"
+marker_no_prefix="no"
+marker_ts_prefix="ts"
+marker_eslint_prefix="eslint"
+marker_coverage_prefix="coverage"
 # Build marker names from pieces so this gate does not match its own source.
-marker_pattern="(^|[^[:alnum:]_])(${marker_prefix}sec|${marker_prefix}sonar)([^[:alnum:]_]|$)"
+marker_pattern="(^|[[:space:]])((//|/\\*+|#)[[:space:]]*(@?(${marker_no_prefix}(sec|sonar|lint|qa)|${marker_eslint_prefix}-disable(-next-line|-line)?|${marker_ts_prefix}-(ignore|expect-error)|pragma:[[:space:]]*${marker_no_prefix}[[:space:]]+cover|${marker_coverage_prefix}:[[:space:]]*ignore)))([^[:alnum:]_-]|$)"
+source_file_pattern="(^\\.githooks/|.*\\.(go|sh|bash|zsh|ksh|py|rb|php|js|jsx|cjs|mjs|ts|tsx|java|kt|kts|swift|rs|c|cc|cpp|cxx|h|hpp|hh|cs|ya?ml)$)"
 diff_scope=""
 
 create_temp_file() {
@@ -27,7 +31,13 @@ create_temp_file() {
 	return 1
 }
 
-if git diff --cached --quiet --exit-code -- .; then
+if ! git diff --cached --quiet --exit-code -- .; then
+	diff_scope="staged changes"
+	diff_args=(git diff --cached --unified=0 --no-color --diff-filter=AM --relative --)
+elif ! git diff --quiet --exit-code -- .; then
+	diff_scope="working tree changes"
+	diff_args=(git diff --unified=0 --no-color --diff-filter=AM --relative --)
+else
 	base_ref="$requested_base_ref"
 	used_fallback=0
 	if ! git rev-parse --verify -q "$base_ref^{commit}" >/dev/null; then
@@ -49,24 +59,23 @@ if git diff --cached --quiet --exit-code -- .; then
 		diff_scope="branch changes vs $base_ref"
 	fi
 	diff_args=(git diff --unified=0 --no-color --diff-filter=AM --relative "$base_commit..HEAD" --)
-else
-	diff_scope="staged changes"
-	diff_args=(git diff --cached --unified=0 --no-color --diff-filter=AM --relative --)
 fi
 
 tmp_matches="$(create_temp_file)"
 trap 'rm -f "$tmp_matches"' EXIT INT TERM
 
 set +e
-"${diff_args[@]}" | awk -v pattern="$marker_pattern" '
+"${diff_args[@]}" | awk -v pattern="$marker_pattern" -v file_pattern="$source_file_pattern" '
 BEGIN {
 	IGNORECASE = 1
 	file = ""
 	line = 0
 	found = 0
+	check_file = 0
 }
 /^\+\+\+ b\// {
 	file = substr($0, 7)
+	check_file = (file ~ file_pattern)
 	next
 }
 /^@@ / {
@@ -79,7 +88,7 @@ BEGIN {
 }
 /^\+/ && $0 !~ /^\+\+\+/ {
 	content = substr($0, 2)
-	if (content ~ pattern) {
+	if (check_file && content ~ pattern) {
 		printf "%s:%d:%s\n", file, line, content
 		found = 1
 	}

--- a/scripts/check_inline_suppressions_test.go
+++ b/scripts/check_inline_suppressions_test.go
@@ -153,7 +153,7 @@ func newInlineSuppressionRepo(t *testing.T) string {
 }
 
 func runSuppressionCheck(repoDir string) (string, error) {
-	cmd := exec.Command("bash", "scripts/check-inline-suppressions.sh")
+	cmd := exec.Command(filepath.Join(repoDir, "scripts", "check-inline-suppressions.sh"))
 	cmd.Dir = repoDir
 	output, err := cmd.CombinedOutput()
 	return string(output), err

--- a/scripts/check_inline_suppressions_test.go
+++ b/scripts/check_inline_suppressions_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+const mainGoPath = "main.go"
+
 func TestInlineSuppressionCheckRejectsStagedMarkers(t *testing.T) {
 	t.Parallel()
 
@@ -19,14 +21,14 @@ func TestInlineSuppressionCheckRejectsStagedMarkers(t *testing.T) {
 	}{
 		{
 			name:    "nosec",
-			path:    "main.go",
-			content: "package main\n\nfunc main() {\n\t_ = 1 //" + "nosec G404\n}\n",
+			path:    mainGoPath,
+			content: mainGoWithComment("nosec G404"),
 			want:    "//" + "nosec",
 		},
 		{
 			name:    "nolint",
-			path:    "main.go",
-			content: "package main\n\nfunc main() {\n\t_ = 1 //" + "nolint:staticcheck\n}\n",
+			path:    mainGoPath,
+			content: mainGoWithComment("nolint:staticcheck"),
 			want:    "//" + "nolint",
 		},
 		{
@@ -64,11 +66,11 @@ func TestInlineSuppressionCheckRejectsWorkingTreeMarkers(t *testing.T) {
 	t.Parallel()
 
 	repoDir := newInlineSuppressionRepo(t)
-	writeFile(t, filepath.Join(repoDir, "main.go"), "package main\n\nfunc main() {\n\t_ = 1\n}\n")
-	runCommand(t, repoDir, "git", "add", "main.go")
+	writeFile(t, filepath.Join(repoDir, mainGoPath), mainGoWithoutComment())
+	runCommand(t, repoDir, "git", "add", mainGoPath)
 	runCommand(t, repoDir, "git", "commit", "-m", "add source file")
 
-	writeFile(t, filepath.Join(repoDir, "main.go"), "package main\n\nfunc main() {\n\t_ = 1 //"+"nolint:staticcheck\n}\n")
+	writeFile(t, filepath.Join(repoDir, mainGoPath), mainGoWithComment("nolint:staticcheck"))
 
 	output, err := runSuppressionCheck(repoDir)
 	if err == nil {
@@ -101,8 +103,8 @@ func TestInlineSuppressionCheckIgnoresQuotedMarkersInSource(t *testing.T) {
 
 	repoDir := newInlineSuppressionRepo(t)
 	source := "package main\n\nconst marker = \"" + "//" + "nosec" + "\"\n"
-	writeFile(t, filepath.Join(repoDir, "main.go"), source)
-	runCommand(t, repoDir, "git", "add", "main.go")
+	writeFile(t, filepath.Join(repoDir, mainGoPath), source)
+	runCommand(t, repoDir, "git", "add", mainGoPath)
 
 	output, err := runSuppressionCheck(repoDir)
 	if err != nil {
@@ -111,6 +113,14 @@ func TestInlineSuppressionCheckIgnoresQuotedMarkersInSource(t *testing.T) {
 	if !strings.Contains(output, "Inline suppression check passed (staged changes)") {
 		t.Fatalf("expected pass message, got:\n%s", output)
 	}
+}
+
+func mainGoWithoutComment() string {
+	return "package main\n\nfunc main() {\n\t_ = 1\n}\n"
+}
+
+func mainGoWithComment(comment string) string {
+	return "package main\n\nfunc main() {\n\t_ = 1 //" + comment + "\n}\n"
 }
 
 func newInlineSuppressionRepo(t *testing.T) string {

--- a/scripts/check_inline_suppressions_test.go
+++ b/scripts/check_inline_suppressions_test.go
@@ -1,0 +1,178 @@
+package scripts
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInlineSuppressionCheckRejectsStagedMarkers(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		path    string
+		content string
+		want    string
+	}{
+		{
+			name:    "nosec",
+			path:    "main.go",
+			content: "package main\n\nfunc main() {\n\t_ = 1 //" + "nosec G404\n}\n",
+			want:    "//" + "nosec",
+		},
+		{
+			name:    "nolint",
+			path:    "main.go",
+			content: "package main\n\nfunc main() {\n\t_ = 1 //" + "nolint:staticcheck\n}\n",
+			want:    "//" + "nolint",
+		},
+		{
+			name:    "ts-ignore",
+			path:    "main.ts",
+			content: "const value = 1;\n// @" + "ts-ignore\nconsole.log(value as string);\n",
+			want:    "@" + "ts-ignore",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repoDir := newInlineSuppressionRepo(t)
+			writeFile(t, filepath.Join(repoDir, tc.path), tc.content)
+			runCommand(t, repoDir, "git", "add", tc.path)
+
+			output, err := runSuppressionCheck(repoDir)
+			if err == nil {
+				t.Fatalf("expected suppression check to fail for %s, output:\n%s", tc.name, output)
+			}
+			if !strings.Contains(output, tc.want) {
+				t.Fatalf("expected output to mention %q, got:\n%s", tc.want, output)
+			}
+			if !strings.Contains(output, "Inline suppression markers are not allowed in staged changes.") {
+				t.Fatalf("expected staged change failure message, got:\n%s", output)
+			}
+		})
+	}
+}
+
+func TestInlineSuppressionCheckRejectsWorkingTreeMarkers(t *testing.T) {
+	t.Parallel()
+
+	repoDir := newInlineSuppressionRepo(t)
+	writeFile(t, filepath.Join(repoDir, "main.go"), "package main\n\nfunc main() {\n\t_ = 1\n}\n")
+	runCommand(t, repoDir, "git", "add", "main.go")
+	runCommand(t, repoDir, "git", "commit", "-m", "add source file")
+
+	writeFile(t, filepath.Join(repoDir, "main.go"), "package main\n\nfunc main() {\n\t_ = 1 //"+"nolint:staticcheck\n}\n")
+
+	output, err := runSuppressionCheck(repoDir)
+	if err == nil {
+		t.Fatalf("expected working tree suppression check to fail, output:\n%s", output)
+	}
+	if !strings.Contains(output, "Inline suppression markers are not allowed in working tree changes.") {
+		t.Fatalf("expected working tree failure message, got:\n%s", output)
+	}
+}
+
+func TestInlineSuppressionCheckAllowsDocumentationMentions(t *testing.T) {
+	t.Parallel()
+
+	repoDir := newInlineSuppressionRepo(t)
+	docContent := "# Policy\n\nDo not add `" + "//" + "nolint` or `" + "//" + "nosec` markers in source files.\n"
+	writeFile(t, filepath.Join(repoDir, "docs", "policy.md"), docContent)
+	runCommand(t, repoDir, "git", "add", "docs/policy.md")
+
+	output, err := runSuppressionCheck(repoDir)
+	if err != nil {
+		t.Fatalf("expected documentation mention to pass, output:\n%s", output)
+	}
+	if !strings.Contains(output, "Inline suppression check passed (staged changes)") {
+		t.Fatalf("expected pass message, got:\n%s", output)
+	}
+}
+
+func TestInlineSuppressionCheckIgnoresQuotedMarkersInSource(t *testing.T) {
+	t.Parallel()
+
+	repoDir := newInlineSuppressionRepo(t)
+	source := "package main\n\nconst marker = \"" + "//" + "nosec" + "\"\n"
+	writeFile(t, filepath.Join(repoDir, "main.go"), source)
+	runCommand(t, repoDir, "git", "add", "main.go")
+
+	output, err := runSuppressionCheck(repoDir)
+	if err != nil {
+		t.Fatalf("expected quoted marker to pass, output:\n%s", output)
+	}
+	if !strings.Contains(output, "Inline suppression check passed (staged changes)") {
+		t.Fatalf("expected pass message, got:\n%s", output)
+	}
+}
+
+func newInlineSuppressionRepo(t *testing.T) string {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	scriptDir := filepath.Join(repoDir, "scripts")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir scripts: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	scriptPath := filepath.Join(cwd, "check-inline-suppressions.sh")
+	scriptData, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	writeFileMode(t, filepath.Join(scriptDir, "check-inline-suppressions.sh"), string(scriptData), 0o755)
+
+	runCommand(t, repoDir, "git", "init", "-b", "main")
+	runCommand(t, repoDir, "git", "config", "user.name", "Test User")
+	runCommand(t, repoDir, "git", "config", "user.email", "test@example.com")
+	runCommand(t, repoDir, "git", "add", "scripts/check-inline-suppressions.sh")
+	runCommand(t, repoDir, "git", "commit", "-m", "baseline")
+
+	return repoDir
+}
+
+func runSuppressionCheck(repoDir string) (string, error) {
+	cmd := exec.Command("bash", "scripts/check-inline-suppressions.sh")
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func runCommand(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	writeFileMode(t, path, content, 0o644)
+}
+
+func writeFileMode(t *testing.T, path string, content string, mode os.FileMode) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Closes #639.

## Issue
PR CI already blocked `nosonar` and `nosec`, but it did not cover other common inline suppression markers such as `nolint`, `noqa`, `eslint-disable`, `ts-ignore`, `ts-expect-error`, or coverage-bypass comments.

## Cause and User Impact
That gap made it possible for agent-written changes to silence findings instead of addressing them, which weakens the value of the quality gates and makes review less trustworthy.

## Root Cause
The inline suppression check only matched two marker families and treated any matching token anywhere on a changed line as a violation, which left bypass paths open and risked false positives in legitimate test strings.

## Fix
The suppression gate now covers the wider set of inline suppression markers, scans staged changes, unstaged working-tree changes, and committed branch deltas, restricts detection to source and hook files, and matches actual comment syntax so quoted marker strings in tests do not trip the guard.

I also added regression coverage around the check itself and updated contributor/CI docs to document the expanded policy and local behavior.

## Validation
- `go test ./scripts`
- `shellcheck scripts/check-inline-suppressions.sh`
- `make suppression-check`
- `make ci`
- `make demos-check`
