### PR TITLE
fix(analysis): include worktree changes in changed scope

### DIFF
--- a/internal/analysis/pipeline_cov_more_runtime_test.go
+++ b/internal/analysis/pipeline_cov_more_runtime_test.go
@@ -37,12 +37,13 @@ func TestScopedCandidateRootsChangedPackagesSuccessBranch(t *testing.T) {
 	writeFile(t, filepath.Join(rootA, "a.txt"), "a2\n")
 	testutil.RunGit(t, repoRoot, "add", ".")
 	testutil.RunGit(t, repoRoot, "commit", "-m", "change package a")
+	writeFile(t, filepath.Join(rootB, "b-dirty.txt"), "dirty\n")
 
 	roots, warnings := scopedCandidateRoots(ScopeModeChangedPackages, []string{rootA, rootB}, repoRoot)
 	if len(warnings) != 0 {
 		t.Fatalf("expected changed-packages resolution without warnings, got %#v", warnings)
 	}
-	if len(roots) != 1 || roots[0] != rootA {
-		t.Fatalf("expected changed-packages scope to keep the changed package root, got %#v", roots)
+	if len(roots) != 2 || roots[0] != rootA || roots[1] != rootB {
+		t.Fatalf("expected changed-packages scope to include changed and dirty package roots, got %#v", roots)
 	}
 }

--- a/internal/workspace/changed_files.go
+++ b/internal/workspace/changed_files.go
@@ -29,9 +29,11 @@ func ChangedFiles(repoPath string) ([]string, error) {
 		return parseChangedFileLines(diffOutput), nil
 	}
 
-	changed := make([]string, 0, len(diffOutput)+len(statusOutput))
-	changed = append(changed, parseChangedFileLines(diffOutput)...)
-	changed = append(changed, parsePorcelainChangedFiles(statusOutput)...)
+	diffFiles := parseChangedFileLines(diffOutput)
+	statusFiles := parsePorcelainChangedFiles(statusOutput)
+	changed := make([]string, 0, len(diffFiles)+len(statusFiles))
+	changed = append(changed, diffFiles...)
+	changed = append(changed, statusFiles...)
 	return collectUniquePaths(changed, func(v string) string { return v }), nil
 }
 

--- a/internal/workspace/changed_files.go
+++ b/internal/workspace/changed_files.go
@@ -15,15 +15,24 @@ func ChangedFiles(repoPath string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	diffOutput, diffErr := runGit(gitPath, normalized, "diff", "--no-ext-diff", "--no-textconv", "--name-only", "--diff-filter=ACMRD", "HEAD~1..HEAD")
-	if diffErr == nil {
-		return parseChangedFileLines(diffOutput), nil
-	}
 	statusOutput, statusErr := runGit(gitPath, normalized, "status", "--porcelain")
-	if statusErr != nil {
+
+	if statusErr != nil && diffErr != nil {
 		return nil, errors.Join(diffErr, statusErr)
 	}
-	return parsePorcelainChangedFiles(statusOutput), nil
+	if diffErr != nil {
+		return parsePorcelainChangedFiles(statusOutput), nil
+	}
+	if statusErr != nil {
+		return parseChangedFileLines(diffOutput), nil
+	}
+
+	changed := make([]string, 0, len(diffOutput)+len(statusOutput))
+	changed = append(changed, parseChangedFileLines(diffOutput)...)
+	changed = append(changed, parsePorcelainChangedFiles(statusOutput)...)
+	return collectUniquePaths(changed, func(v string) string { return v }), nil
 }
 
 func parseChangedFileLines(output []byte) []string {

--- a/internal/workspace/workspace_changed_files_test.go
+++ b/internal/workspace/workspace_changed_files_test.go
@@ -52,6 +52,11 @@ func TestChangedFilesParsesDiffAndStatusFallback(t *testing.T) {
 			script: "#!/bin/sh\nif [ \"$3\" = \"diff\" ]; then\n  echo \"diff fail\" >&2\n  exit 2\nfi\nif [ \"$3\" = \"status\" ]; then\n  echo \"M  pkg/a.go\"\n  echo \"R  old.go -> pkg/b.go\"\n  exit 0\nfi\nexit 1\n",
 			want:   []string{"pkg/a.go", "pkg/b.go"},
 		},
+		{
+			name:   "diff_and_status_union",
+			script: "#!/bin/sh\nif [ \"$3\" = \"diff\" ]; then\n  printf '%s\\n' \"packages/a/committed.go\" \"packages/a/kept.go\"\n  exit 0\nfi\nif [ \"$3\" = \"status\" ]; then\n  echo \"M  packages/a/committed.go\"\n  echo \"?? packages/b/new.go\"\n  exit 0\nfi\nexit 1\n",
+			want:   []string{"packages/a/committed.go", "packages/a/kept.go", "packages/b/new.go"},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
- Fixed `workspace.ChangedFiles` to include both committed diffs (`git diff --name-only HEAD~1..HEAD`) and working-tree changes (`git status --porcelain`) in the same result set.
- This is now returned as a deduplicated union so `--scope-mode changed-packages` can include packages with uncommitted edits or untracked files.

## Cause
`ChangedFiles` returned early whenever `git diff` succeeded, so status output was skipped entirely.

## Impact
After the first commit, dirty worktree changes were silently omitted from changed-package scope selection, producing stale package targets during local analysis and CI runs.

## Validation
- `go test ./internal/workspace ./internal/analysis -run 'TestChangedFiles|TestScopedCandidateRootsChangedPackagesSuccessBranch'`

Closes #620
