### PR TITLE
fix(vscode-lopper): select workflow-tagged managed binary assets

### DIFF
--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -402,15 +402,15 @@ export function selectReleaseAsset(release: GitHubRelease, host: HostPlatform): 
 }
 
 function assetNameCandidates(releaseTag: string, host: HostPlatform): string[] {
-  const expectedName = assetNameForRelease(releaseTag, host);
-  const normalizedTag = normalizeReleaseTag(releaseTag);
-  if (!normalizedTag) {
-    return [expectedName];
-  }
+	const normalizedTag = normalizeReleaseTag(releaseTag);
+	if (!normalizedTag) {
+		throw new Error("release tag is required");
+	}
+	const expectedName = assetNameForRelease(normalizedTag, host);
 
-  if (!normalizedTag.startsWith("v")) {
-    return [expectedName];
-  }
+	if (!normalizedTag.startsWith("v")) {
+		return [expectedName];
+	}
 
   return [expectedName, assetNameForRelease(normalizedTag.substring(1), host)];
 }

--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -384,18 +384,35 @@ export function assetNameForRelease(releaseTag: string, host: HostPlatform): str
   if (!normalizedTag) {
     throw new Error("release tag is required");
   }
-  const version = normalizedTag.replace(/^v/, "");
   const extension = host.platform === "win32" ? "zip" : "tar.gz";
-  return `lopper_${version}_${platformSegment(host.platform)}_${archSegment(host.arch)}.${extension}`;
+  return `lopper_${normalizedTag}_${platformSegment(host.platform)}_${archSegment(host.arch)}.${extension}`;
 }
 
 export function selectReleaseAsset(release: GitHubRelease, host: HostPlatform): GitHubReleaseAsset {
-  const expectedName = assetNameForRelease(release.tag_name, host);
-  const asset = release.assets.find((item) => item.name === expectedName);
-  if (!asset) {
-    throw new Error(`release ${release.tag_name} does not contain asset ${expectedName}`);
+  const expectedNames = Array.from(new Set(assetNameCandidates(release.tag_name, host)));
+  for (const expectedName of expectedNames) {
+    const asset = release.assets.find((item) => item.name === expectedName);
+    if (asset) {
+      return asset;
+    }
   }
-  return asset;
+
+  const rendered = expectedNames.length === 1 ? expectedNames[0] : `${expectedNames.join(" or ")}`;
+  throw new Error(`release ${release.tag_name} does not contain expected asset ${rendered}`);
+}
+
+function assetNameCandidates(releaseTag: string, host: HostPlatform): string[] {
+  const expectedName = assetNameForRelease(releaseTag, host);
+  const normalizedTag = normalizeReleaseTag(releaseTag);
+  if (!normalizedTag) {
+    return [expectedName];
+  }
+
+  if (!normalizedTag.startsWith("v")) {
+    return [expectedName];
+  }
+
+  return [expectedName, assetNameForRelease(normalizedTag.substring(1), host)];
 }
 
 function normalizeReleaseTag(releaseTag?: string): string | undefined {

--- a/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
@@ -13,17 +13,77 @@ import {
   LopperBinaryLifecycleManager,
   ManagedBinaryInstaller,
   type GitHubRelease,
+  selectReleaseAsset,
 } from "../../managedBinary";
 
 suite("managed binary installer", () => {
   test("builds expected release asset names", () => {
     assert.equal(
       assetNameForRelease("v1.2.3", { platform: "linux", arch: "x64" }),
+      "lopper_v1.2.3_linux_amd64.tar.gz",
+    );
+    assert.equal(
+      assetNameForRelease("1.2.3", { platform: "linux", arch: "x64" }),
       "lopper_1.2.3_linux_amd64.tar.gz",
     );
     assert.equal(
       assetNameForRelease("v1.2.3", { platform: "win32", arch: "arm64" }),
+      "lopper_v1.2.3_windows_arm64.zip",
+    );
+    assert.equal(
+      assetNameForRelease("1.2.3", { platform: "win32", arch: "arm64" }),
       "lopper_1.2.3_windows_arm64.zip",
+    );
+  });
+
+  test("selects tagged release asset names produced by release builds", () => {
+    const host = { platform: "linux" as const, arch: "x64" };
+    const release: GitHubRelease = {
+      tag_name: "v9.8.7",
+      assets: [
+        {
+          name: "other.zip",
+          browser_download_url: "file://other",
+        },
+        {
+          name: assetNameForRelease("v9.8.7", host),
+          browser_download_url: "file://release-asset",
+        },
+      ],
+    };
+
+    const asset = selectReleaseAsset(release, host);
+    assert.equal(asset.name, assetNameForRelease("v9.8.7", host));
+  });
+
+  test("falls back to legacy non-prefixed assets for compatibility", () => {
+    const host = { platform: "linux" as const, arch: "x64" };
+    const release: GitHubRelease = {
+      tag_name: "v9.8.7",
+      assets: [
+        {
+          name: assetNameForRelease("9.8.7", host),
+          browser_download_url: "file://legacy-asset",
+        },
+      ],
+    };
+
+    const asset = selectReleaseAsset(release, host);
+    assert.equal(asset.name, assetNameForRelease("9.8.7", host));
+  });
+
+  test("fails when release assets do not include expected candidates", () => {
+    const host = { platform: "linux" as const, arch: "x64" };
+    const release: GitHubRelease = {
+      tag_name: "v9.8.7",
+      assets: [{ name: "lopper_9.8.7_other_linux_amd64.tar.gz", browser_download_url: "file://not-matching" }],
+    };
+
+    assert.throws(
+      () => selectReleaseAsset(release, host),
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message.includes("release v9.8.7 does not contain expected asset"),
     );
   });
 
@@ -303,7 +363,7 @@ async function createTarballFixture(
   const archiveDir = path.join(tempRoot, "tar-source");
   const rootDir = path.join(
     archiveDir,
-    `lopper_${releaseTag.replace(/^v/, "")}_${host.platform}_${host.arch === "x64" ? "amd64" : "arm64"}`,
+    `lopper_${releaseTag}_${host.platform}_${host.arch === "x64" ? "amd64" : "arm64"}`,
   );
   await mkdir(rootDir, { recursive: true });
   await writeFile(path.join(rootDir, "lopper"), contents);
@@ -321,7 +381,7 @@ async function createZipFixture(
   binaryRelativePath = "lopper.exe",
 ): Promise<string> {
   const zip = new AdmZip();
-  const rootDir = `lopper_${releaseTag.replace(/^v/, "")}_windows_${host.arch === "x64" ? "amd64" : "arm64"}`;
+  const rootDir = `lopper_${releaseTag}_windows_${host.arch === "x64" ? "amd64" : "arm64"}`;
   zip.addFile(`${rootDir}/${binaryRelativePath}`, Buffer.from(contents, "utf8"));
 
   const archivePath = path.join(tempRoot, assetNameForRelease(releaseTag, host));

--- a/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
@@ -87,6 +87,19 @@ suite("managed binary installer", () => {
     );
   });
 
+  test("fails when the release tag is blank", () => {
+    const host = { platform: "linux" as const, arch: "x64" };
+    const release: GitHubRelease = {
+      tag_name: "   ",
+      assets: [],
+    };
+
+    assert.throws(
+      () => selectReleaseAsset(release, host),
+      (error: unknown) => error instanceof Error && error.message.includes("release tag is required"),
+    );
+  });
+
   test("installs tar.gz managed binaries into cache", async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-binary-test-"));
     try {


### PR DESCRIPTION
## Summary
The VS Code extension was deriving managed binary asset names by dropping a leading `v` from release tags, then requiring an exact filename match. That prevented auto-download on tagged releases because this repo’s release pipeline publishes assets with full tags (for example `lopper_v9.8.7_linux_amd64.tar.gz`).

## Root cause
`assetNameForRelease()` stripped `v` from release tags, and `selectReleaseAsset()` only matched that exact legacy filename.

## Fix
- Build asset names using the tag as published by release workflow (keeps `v` prefix if present).
- Update release asset selection to accept both tagged and legacy non-`v` names for compatibility.
- Add regression tests covering:
  - tagged asset name generation,
  - selecting workflow-style tagged assets,
  - legacy fallback,
  - and mismatch error path.

## Validation
- Ran `npm run compile` in `extensions/vscode-lopper`.
- Ran focused test: `npx mocha out/test/suite/managedBinary.test.js`.

Closes #615
