### PR TITLE
fix(ui): sanitize tui detail output

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -348,13 +348,51 @@ func writeLines(out io.Writer, lines []string) error {
 }
 
 func writef(out io.Writer, format string, args ...any) error {
-	_, err := fmt.Fprintf(out, format, args...)
+	_, err := fmt.Fprintf(out, format, sanitizeOutputArgs(args)...)
 	return err
 }
 
 func writeln(out io.Writer, args ...any) error {
-	_, err := fmt.Fprintln(out, args...)
+	_, err := fmt.Fprintln(out, sanitizeOutputArgs(args)...)
 	return err
+}
+
+func sanitizeOutputArgs(args []any) []any {
+	sanitizedArgs := make([]any, len(args))
+	for i, arg := range args {
+		switch value := arg.(type) {
+		case string:
+			sanitizedArgs[i] = sanitizeTerminalString(value)
+		default:
+			sanitizedArgs[i] = arg
+		}
+	}
+	return sanitizedArgs
+}
+
+func sanitizeTerminalString(value string) string {
+	if value == "" {
+		return value
+	}
+	isControlByte := func(b byte) bool {
+		return b < 0x20 || b == 0x7f || (b >= 0x80 && b <= 0x9f)
+	}
+
+	const hex = "0123456789abcdef"
+	var output strings.Builder
+	output.Grow(len(value))
+	for i := 0; i < len(value); i++ {
+		b := value[i]
+		if !isControlByte(b) {
+			output.WriteByte(b)
+			continue
+		}
+		output.WriteByte('\\')
+		output.WriteByte('x')
+		output.WriteByte(hex[b>>4])
+		output.WriteByte(hex[b&0x0f])
+	}
+	return output.String()
 }
 
 func formatRuntimeModules(modules []detailRuntimeModuleView) string {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ben-ranford/lopper/internal/analysis"
 )
@@ -374,25 +375,43 @@ func sanitizeTerminalString(value string) string {
 	if value == "" {
 		return value
 	}
-	isControlByte := func(b byte) bool {
-		return b < 0x20 || b == 0x7f || (b >= 0x80 && b <= 0x9f)
-	}
 
 	const hex = "0123456789abcdef"
 	var output strings.Builder
 	output.Grow(len(value))
-	for i := 0; i < len(value); i++ {
-		b := value[i]
-		if !isControlByte(b) {
-			output.WriteByte(b)
+	for i := 0; i < len(value); {
+		r, size := utf8.DecodeRuneInString(value[i:])
+		if r == utf8.RuneError && size == 1 {
+			b := value[i]
+			if !isTerminalControlRune(rune(b)) {
+				output.WriteByte(b)
+				i++
+				continue
+			}
+			writeEscapedByte(&output, b, hex)
+			i++
 			continue
 		}
-		output.WriteByte('\\')
-		output.WriteByte('x')
-		output.WriteByte(hex[b>>4])
-		output.WriteByte(hex[b&0x0f])
+		if !isTerminalControlRune(r) {
+			output.WriteRune(r)
+			i += size
+			continue
+		}
+		writeEscapedByte(&output, byte(r), hex)
+		i += size
 	}
 	return output.String()
+}
+
+func isTerminalControlRune(r rune) bool {
+	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
+}
+
+func writeEscapedByte(output *strings.Builder, b byte, hex string) {
+	output.WriteByte('\\')
+	output.WriteByte('x')
+	output.WriteByte(hex[b>>4])
+	output.WriteByte(hex[b&0x0f])
 }
 
 func formatRuntimeModules(modules []detailRuntimeModuleView) string {

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -15,7 +15,12 @@ const (
 	showDetailErrFmt = "show detail: %v"
 	indexJSFile      = "index.js"
 	depMapModule     = "dep/map"
+	depMapProvenance = " -> dep#map"
 	maliciousPath    = "src/\x1b[]0;PWN\x07.js"
+	unicodePath      = "src/Ā.js"
+	namespaceImport  = "namespace-import"
+	suggestOnlyMode  = "suggest-only"
+	usedImportsLabel = "Used imports"
 )
 
 func TestDetailShowsRiskCues(t *testing.T) {
@@ -44,12 +49,12 @@ func TestDetailShowsRiskCues(t *testing.T) {
 						{Code: "prefer-subpath-imports", Priority: "medium", Message: "Prefer subpath imports."},
 					},
 					Codemod: &report.CodemodReport{
-						Mode: "suggest-only",
+						Mode: suggestOnlyMode,
 						Suggestions: []report.CodemodSuggestion{
 							{File: indexJSFile, Line: 1, FromModule: "risky", ToModule: "risky/map"},
 						},
 						Skips: []report.CodemodSkip{
-							{File: indexJSFile, Line: 2, ReasonCode: "namespace-import", Message: "namespace imports are not safe to rewrite automatically"},
+							{File: indexJSFile, Line: 2, ReasonCode: namespaceImport, Message: "namespace imports are not safe to rewrite automatically"},
 						},
 					},
 				},
@@ -85,10 +90,10 @@ func TestDetailShowsRiskCues(t *testing.T) {
 	if !strings.Contains(output, "[MEDIUM] prefer-subpath-imports") {
 		t.Fatalf("expected recommendation entry, got: %s", output)
 	}
-	if !strings.Contains(output, "Codemod preview") || !strings.Contains(output, "mode: suggest-only") {
+	if !strings.Contains(output, "Codemod preview") || !strings.Contains(output, "mode: "+suggestOnlyMode) {
 		t.Fatalf("expected codemod section, got: %s", output)
 	}
-	if !strings.Contains(output, "[namespace-import]") {
+	if !strings.Contains(output, "["+namespaceImport+"]") {
 		t.Fatalf("expected codemod skip reason code in output, got: %s", output)
 	}
 }
@@ -139,10 +144,10 @@ func TestDetailRejectsEmptyDependency(t *testing.T) {
 func TestDetailPrintHelpers(t *testing.T) {
 	var out bytes.Buffer
 	out.Reset()
-	if err := printImportList(&out, "Used imports", nil); err != nil {
+	if err := printImportList(&out, usedImportsLabel, nil); err != nil {
 		t.Fatalf("print empty import list: %v", err)
 	}
-	if err := printImportList(&out, "Used imports", []detailImportView{{
+	if err := printImportList(&out, usedImportsLabel, []detailImportView{{
 		Name:       "map",
 		Module:     "lodash",
 		Locations:  []detailLocationView{{File: indexJSFile, Line: 2}},
@@ -408,16 +413,16 @@ func TestDetailWriteErrorPropagation(t *testing.T) {
 					{Code: "prefer-subpath-imports", Priority: "medium", Message: "prefer map", Rationale: "smaller bundle"},
 				},
 				Codemod: &report.CodemodReport{
-					Mode: "suggest-only",
+					Mode: suggestOnlyMode,
 					Suggestions: []report.CodemodSuggestion{
 						{File: indexJSFile, Line: 1, FromModule: "dep", ToModule: depMapModule},
 					},
 					Skips: []report.CodemodSkip{
-						{File: indexJSFile, Line: 2, ReasonCode: "namespace-import", Message: "unsafe"},
+						{File: indexJSFile, Line: 2, ReasonCode: namespaceImport, Message: "unsafe"},
 					},
 				},
 				UsedImports: []report.ImportUse{
-					{Name: "map", Module: "dep", Locations: []report.Location{{File: indexJSFile, Line: 1}}, Provenance: []string{indexJSFile + " -> dep#map"}},
+					{Name: "map", Module: "dep", Locations: []report.Location{{File: indexJSFile, Line: 1}}, Provenance: []string{indexJSFile + depMapProvenance}},
 				},
 				UnusedImports: []report.ImportUse{
 					{Name: "filter", Module: "dep", Locations: []report.Location{{File: indexJSFile, Line: 2}}},
@@ -456,6 +461,9 @@ func TestSanitizeTerminalStringEscapesControlBytes(t *testing.T) {
 	if got := sanitizeTerminalString("safe/path.js"); got != "safe/path.js" {
 		t.Fatalf("expected normal text to remain unchanged, got %q", got)
 	}
+	if got := sanitizeTerminalString(unicodePath); got != unicodePath {
+		t.Fatalf("expected unicode text to remain unchanged, got %q", got)
+	}
 	if got := sanitizeTerminalString("line1\nline2"); got != "line1\\x0aline2" {
 		t.Fatalf("expected newline to be escaped, got %q", got)
 	}
@@ -464,11 +472,11 @@ func TestSanitizeTerminalStringEscapesControlBytes(t *testing.T) {
 func TestPrintImportListSanitizesPathOutput(t *testing.T) {
 	t.Parallel()
 	var out bytes.Buffer
-	if err := printImportList(&out, "Used imports", []detailImportView{{
+	if err := printImportList(&out, usedImportsLabel, []detailImportView{{
 		Name:       "map",
 		Module:     "dep",
 		Locations:  []detailLocationView{{File: maliciousPath, Line: 1}},
-		Provenance: []string{maliciousPath + " -> dep#map"},
+		Provenance: []string{maliciousPath + depMapProvenance},
 	}}); err != nil {
 		t.Fatalf("print import list: %v", err)
 	}
@@ -481,7 +489,7 @@ func TestPrintImportListSanitizesPathOutput(t *testing.T) {
 	if !strings.Contains(output, sanitizedPath) {
 		t.Fatalf("expected sanitized import path in output, got %q", output)
 	}
-	if !strings.Contains(output, "provenance: "+sanitizedPath+" -> dep#map") {
+	if !strings.Contains(output, "provenance: "+sanitizedPath+depMapProvenance) {
 		t.Fatalf("expected provenance path to be sanitized, got %q", output)
 	}
 }
@@ -490,9 +498,9 @@ func TestPrintCodemodSanitizesPathOutput(t *testing.T) {
 	t.Parallel()
 	var out bytes.Buffer
 	if err := printCodemod(&out, &detailCodemodView{
-		Mode:        "suggest-only",
+		Mode:        suggestOnlyMode,
 		Suggestions: []detailCodemodSuggestionView{{File: maliciousPath, Line: 1, FromModule: "dep", ToModule: "dep/map"}},
-		Skips:       []detailCodemodSkipView{{File: maliciousPath, Line: 2, ReasonCode: "namespace-import", Message: "unsafe"}},
+		Skips:       []detailCodemodSkipView{{File: maliciousPath, Line: 2, ReasonCode: namespaceImport, Message: "unsafe"}},
 	}); err != nil {
 		t.Fatalf("print codemod: %v", err)
 	}

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -15,6 +15,7 @@ const (
 	showDetailErrFmt = "show detail: %v"
 	indexJSFile      = "index.js"
 	depMapModule     = "dep/map"
+	maliciousPath    = "src/\x1b[]0;PWN\x07.js"
 )
 
 func TestDetailShowsRiskCues(t *testing.T) {
@@ -443,5 +444,65 @@ func TestDetailWriteErrorPropagation(t *testing.T) {
 	}
 	if !sawSuccess {
 		t.Fatalf("expected one successful render when failAt exceeds write count")
+	}
+}
+
+func TestSanitizeTerminalStringEscapesControlBytes(t *testing.T) {
+	t.Parallel()
+	normalized := sanitizeTerminalString(maliciousPath)
+	if normalized != "src/\\x1b[]0;PWN\\x07.js" {
+		t.Fatalf("expected control bytes to be hex-escaped, got %q", normalized)
+	}
+	if got := sanitizeTerminalString("safe/path.js"); got != "safe/path.js" {
+		t.Fatalf("expected normal text to remain unchanged, got %q", got)
+	}
+	if got := sanitizeTerminalString("line1\nline2"); got != "line1\\x0aline2" {
+		t.Fatalf("expected newline to be escaped, got %q", got)
+	}
+}
+
+func TestPrintImportListSanitizesPathOutput(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	if err := printImportList(&out, "Used imports", []detailImportView{{
+		Name:       "map",
+		Module:     "dep",
+		Locations:  []detailLocationView{{File: maliciousPath, Line: 1}},
+		Provenance: []string{maliciousPath + " -> dep#map"},
+	}}); err != nil {
+		t.Fatalf("print import list: %v", err)
+	}
+
+	output := out.String()
+	sanitizedPath := sanitizeTerminalString(maliciousPath)
+	if strings.Contains(output, maliciousPath) {
+		t.Fatalf("expected raw control bytes to be sanitized, got %q", output)
+	}
+	if !strings.Contains(output, sanitizedPath) {
+		t.Fatalf("expected sanitized import path in output, got %q", output)
+	}
+	if !strings.Contains(output, "provenance: "+sanitizedPath+" -> dep#map") {
+		t.Fatalf("expected provenance path to be sanitized, got %q", output)
+	}
+}
+
+func TestPrintCodemodSanitizesPathOutput(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	if err := printCodemod(&out, &detailCodemodView{
+		Mode:        "suggest-only",
+		Suggestions: []detailCodemodSuggestionView{{File: maliciousPath, Line: 1, FromModule: "dep", ToModule: "dep/map"}},
+		Skips:       []detailCodemodSkipView{{File: maliciousPath, Line: 2, ReasonCode: "namespace-import", Message: "unsafe"}},
+	}); err != nil {
+		t.Fatalf("print codemod: %v", err)
+	}
+
+	output := out.String()
+	sanitizedPath := sanitizeTerminalString(maliciousPath)
+	if strings.Contains(output, maliciousPath) {
+		t.Fatalf("expected raw control bytes to be sanitized, got %q", output)
+	}
+	if !strings.Contains(output, sanitizedPath) {
+		t.Fatalf("expected sanitized codemod paths in output, got %q", output)
 	}
 }


### PR DESCRIPTION
## Summary
Fix terminal control-sequence injection in TUI detail output by sanitizing repository-derived strings before printing. Detail views now escape non-printable terminal-control bytes in displayed strings so malicious file paths cannot inject ANSI/control sequences.

## Cause
`internal/ui/detail.go` rendered repository path-like fields (import locations, codemod files, provenance, warnings, and other detail strings) directly to stdout with `fmt.Fprintf/Fprintln`, so control bytes embedded in repository data could be interpreted by terminals.

## Fix
- Added terminal output sanitization helpers in `internal/ui/detail.go`.
- Centralized safe escaping for `writef`/`writeln` to apply to all string values in detail output paths.
- Added focused regression tests for control-byte escape behavior in import and codemod path rendering.

## Validation
- `go test ./internal/ui -run "TestSanitizeTerminalStringEscapesControlBytes|TestPrintImportListSanitizesPathOutput|TestPrintCodemodSanitizesPathOutput"`
- `go test ./internal/ui -run '^TestDetail'`

Closes #618
