### PR TITLE
fix(report): escape newlines in pr-comment formatter

### DIFF
--- a/internal/report/format_pr_comment.go
+++ b/internal/report/format_pr_comment.go
@@ -113,5 +113,5 @@ func signedBytes(value int64) string {
 }
 
 func escapeMarkdownTable(value string) string {
-	return strings.NewReplacer("|", "\\|", "`", "'").Replace(value)
+	return strings.NewReplacer("|", "\\|", "`", "'", "\n", "\\n", "\r", "\\r").Replace(value)
 }

--- a/internal/report/format_test.go
+++ b/internal/report/format_test.go
@@ -192,6 +192,35 @@ func TestFormatPRComment(t *testing.T) {
 	assertOutputContains(t, output, "## Lopper (Delta)", "| Dependency count | +2 |", "| Estimated unused bytes | +1.0 KB |", "### Dependency deltas", "`lodash`", "+512.0 B")
 }
 
+func TestFormatPRCommentEscapesDependencyNameNewlines(t *testing.T) {
+	reportData := Report{
+		BaselineComparison: &BaselineComparison{
+			SummaryDelta: SummaryDelta{
+				DependencyCountDelta: 1,
+				UsedPercentDelta:     0,
+			},
+			Dependencies: []DependencyDelta{
+				{
+					Kind:                  DependencyDeltaAdded,
+					Name:                  "safe`name\nwith`new-line",
+					Language:              "js-ts",
+					UsedPercentDelta:      0.1,
+					UsedExportsCountDelta: 0,
+				},
+			},
+		},
+	}
+	output, err := NewFormatter().Format(reportData, FormatPRComment)
+	if err != nil {
+		t.Fatalf("format pr-comment escapes newlines: %v", err)
+	}
+
+	assertOutputContains(t, output, "`safe'name\\nwith'new-line`")
+	if strings.Contains(output, "`safe'name\nwith'new-line`") {
+		t.Fatalf("expected dependency name newline to be escaped as literal")
+	}
+}
+
 func TestFormatPRCommentNoBaseline(t *testing.T) {
 	output, err := NewFormatter().Format(Report{}, FormatPRComment)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Escapes newline and carriage-return characters in PR comment table cells via the shared markdown table sanitizer used by PR comment rendering.
- Prevents dependency names containing line breaks from breaking Markdown table formatting or injecting extra rows in PR comments.
- Adds a focused regression test for newline handling in dependency names.

## Validation

- `go test ./internal/report`

Closes #474
