### PR TITLE
fix(thresholds): reject trailing YAML documents

### DIFF
--- a/internal/thresholds/config_parse.go
+++ b/internal/thresholds/config_parse.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -26,6 +27,11 @@ func parseConfig(path string, data []byte) (rawConfig, error) {
 		decoder := yaml.NewDecoder(bytes.NewReader(data))
 		decoder.KnownFields(true)
 		if err := decoder.Decode(&cfg); err != nil {
+			return rawConfig{}, fmt.Errorf("invalid YAML config: %w", err)
+		}
+		if err := decoder.Decode(&struct{}{}); err == nil {
+			return rawConfig{}, fmt.Errorf("invalid YAML config: multiple YAML documents")
+		} else if err != io.EOF {
 			return rawConfig{}, fmt.Errorf("invalid YAML config: %w", err)
 		}
 	}

--- a/internal/thresholds/config_parse.go
+++ b/internal/thresholds/config_parse.go
@@ -29,7 +29,8 @@ func parseConfig(path string, data []byte) (rawConfig, error) {
 		if err := decoder.Decode(&cfg); err != nil {
 			return rawConfig{}, fmt.Errorf("invalid YAML config: %w", err)
 		}
-		if err := decoder.Decode(&struct{}{}); err == nil {
+		var extra any
+		if err := decoder.Decode(&extra); err == nil {
 			return rawConfig{}, fmt.Errorf("invalid YAML config: multiple YAML documents")
 		} else if err != io.EOF {
 			return rawConfig{}, fmt.Errorf("invalid YAML config: %w", err)

--- a/internal/thresholds/config_test.go
+++ b/internal/thresholds/config_test.go
@@ -286,6 +286,20 @@ func TestLoadConfigInvalidJSONMultipleValues(t *testing.T) {
 	}
 }
 
+func TestLoadConfigInvalidYAMLMultipleDocuments(t *testing.T) {
+	repo := t.TempDir()
+	cfg := "thresholds:\n  fail_on_increase_percent: 1\n---\nthresholds:\n  fail_on_increase_percent: 2\n"
+	testutil.MustWriteFile(t, filepath.Join(repo, lopperYAMLName), cfg)
+
+	_, _, err := Load(repo, "")
+	if err == nil {
+		t.Fatalf("expected invalid YAML multiple document error")
+	}
+	if !strings.Contains(err.Error(), "multiple YAML documents") {
+		t.Fatalf(unexpectedErrFmt, err)
+	}
+}
+
 func TestLoadConfigInvalidYAML(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, lopperYAMLName), "thresholds: [\n")
@@ -453,6 +467,9 @@ func TestParseConfigInvalidYAMLMultipleDocuments(t *testing.T) {
 	_, err := parseConfig(lopperYAMLName, []byte("thresholds:\n  fail_on_increase_percent: 1\n---\nthresholds:\n  fail_on_increase_percent: 2\n"))
 	if err == nil {
 		t.Fatalf("expected invalid YAML multiple document error")
+	}
+	if !strings.Contains(err.Error(), "multiple YAML documents") {
+		t.Fatalf(unexpectedErrFmt, err)
 	}
 }
 

--- a/internal/thresholds/config_test.go
+++ b/internal/thresholds/config_test.go
@@ -449,6 +449,13 @@ func TestParseConfigInvalidJSONDecodeError(t *testing.T) {
 	}
 }
 
+func TestParseConfigInvalidYAMLMultipleDocuments(t *testing.T) {
+	_, err := parseConfig(lopperYAMLName, []byte("thresholds:\n  fail_on_increase_percent: 1\n---\nthresholds:\n  fail_on_increase_percent: 2\n"))
+	if err == nil {
+		t.Fatalf("expected invalid YAML multiple document error")
+	}
+}
+
 func TestConfigExtensionSupportsPinnedRemoteURLs(t *testing.T) {
 	got := configExtension("https://example.com/policies/base.JSON#sha256=" + strings.Repeat("a", 64))
 	if got != ".json" {


### PR DESCRIPTION
## Issue
- Fixes issue [#486](https://github.com/ben-ranford/lopper/issues/486).

## Cause
The YAML config parser used `yaml.Decoder` to decode exactly one document and then returned success without checking whether additional YAML documents existed in the same stream.

## Impact
A `.lopper.yaml`/policy file containing trailing YAML documents was silently accepted, with later documents ignored, which violated expected strict single-document behavior.

## Fix
In `internal/thresholds/config_parse.go`, after decoding the first document, the parser now checks the decoder for additional documents. If any extra non-EOF content exists, parsing fails with `invalid YAML config: multiple YAML documents`.

## Validation
- `go test ./internal/thresholds -run 'TestParseConfigInvalidYAMLMultipleDocuments|TestLoadConfigInvalidYAML|TestParseConfigInvalidJSONDecodeError' -count=1`

Closes #486
