### PR TITLE
Sonar(ruby): Inline provenance source check

### DIFF
--- a/internal/lang/ruby/adapter_test.go
+++ b/internal/lang/ruby/adapter_test.go
@@ -276,8 +276,8 @@ UNKNOWN
 	if _, ok := out["ignored-gem"]; ok {
 		t.Fatalf("expected unknown section to be ignored, got %#v", out)
 	}
-	if got := rubyDependencyProvenanceSource(sources[privateGemDependency]); got != rubyDependencySourceGit {
-		t.Fatalf("expected git provenance, got %#v", sources[privateGemDependency])
+	if rubyDependencyProvenanceSource(sources[privateGemDependency]) != rubyDependencySourceGit {
+		t.Fatalf("expected git provenance, got %#v", rubyDependencyProvenanceSource(sources[privateGemDependency]))
 	}
 }
 

--- a/internal/lang/ruby/adapter_test.go
+++ b/internal/lang/ruby/adapter_test.go
@@ -276,8 +276,8 @@ UNKNOWN
 	if _, ok := out["ignored-gem"]; ok {
 		t.Fatalf("expected unknown section to be ignored, got %#v", out)
 	}
-	if rubyDependencyProvenanceSource(sources[privateGemDependency]) != rubyDependencySourceGit {
-		t.Fatalf("expected git provenance, got %#v", rubyDependencyProvenanceSource(sources[privateGemDependency]))
+	if got := rubyDependencyProvenanceSource(sources[privateGemDependency]); got != rubyDependencySourceGit {
+		t.Fatalf("expected git provenance, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Closes #572

- Remove unnecessary variable declaration at internal/lang/ruby/adapter_test.go:279.
- Use condition expression directly in the if condition while preserving existing behavior.
- Target milestone: v1.3.3
