### PR TITLE
fix(ui): accept eof-terminated tui commands

### DIFF
--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -83,6 +84,9 @@ func (s *Summary) renderSummaryOutput(reportView summaryReportView, state summar
 func readSummaryInput(reader *bufio.Reader) (string, error) {
 	input, err := reader.ReadString('\n')
 	if err != nil {
+		if errors.Is(err, io.EOF) && input != "" {
+			return strings.TrimSpace(input), nil
+		}
 		return "", err
 	}
 	return strings.TrimSpace(input), nil

--- a/internal/ui/summary_commands_test.go
+++ b/internal/ui/summary_commands_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ben-ranford/lopper/internal/report"
 )
 
+const openDepCommand = "open dep"
+
 func newSummaryCommandState() *summaryState {
 	return &summaryState{page: 2, pageSize: 10, sortMode: sortByWaste}
 }
@@ -333,12 +335,12 @@ func TestReadSummaryInputEOFWithoutNewline(t *testing.T) {
 		t.Fatalf("expected input q, got %q", input)
 	}
 
-	reader = bufio.NewReader(strings.NewReader("open dep"))
+	reader = bufio.NewReader(strings.NewReader(openDepCommand))
 	input, err = readSummaryInput(reader)
 	if err != nil {
 		t.Fatalf("expected readSummaryInput to treat EOF with partial command as command, got %v", err)
 	}
-	if input != "open dep" {
+	if input != openDepCommand {
 		t.Fatalf("expected multi-word input, got %q", input)
 	}
 }
@@ -491,7 +493,7 @@ func TestSummaryCommandValidationBranches(t *testing.T) {
 func TestSummaryHandleDetailErrorBranch(t *testing.T) {
 	summary := NewSummary(io.Discard, strings.NewReader(""), &errorAnalyzer{err: errors.New("detail failed")}, report.NewFormatter())
 	state := summaryState{}
-	_, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: ".", Language: "auto"}, &state, "open dep")
+	_, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: ".", Language: "auto"}, &state, openDepCommand)
 	if err == nil {
 		t.Fatalf("expected detail error to propagate")
 	}
@@ -532,7 +534,7 @@ func TestSummaryStartErrorBranches(t *testing.T) {
 
 	// handleSummaryInput failure path via open detail command.
 	seqAnalyzer := &sequenceErrorAnalyzer{}
-	summary = NewSummary(io.Discard, strings.NewReader("open dep\n"), seqAnalyzer, report.NewFormatter())
+	summary = NewSummary(io.Discard, strings.NewReader(openDepCommand+"\n"), seqAnalyzer, report.NewFormatter())
 	if summary.Start(context.Background(), Options{RepoPath: ".", TopN: 1, PageSize: 1, Language: "auto"}) == nil {
 		t.Fatalf("expected detail-open error from handleSummaryInput")
 	}

--- a/internal/ui/summary_commands_test.go
+++ b/internal/ui/summary_commands_test.go
@@ -323,6 +323,26 @@ func TestReadSummaryInputError(t *testing.T) {
 	}
 }
 
+func TestReadSummaryInputEOFWithoutNewline(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("q"))
+	input, err := readSummaryInput(reader)
+	if err != nil {
+		t.Fatalf("expected readSummaryInput to treat EOF with partial input as command, got %v", err)
+	}
+	if input != "q" {
+		t.Fatalf("expected input q, got %q", input)
+	}
+
+	reader = bufio.NewReader(strings.NewReader("open dep"))
+	input, err = readSummaryInput(reader)
+	if err != nil {
+		t.Fatalf("expected readSummaryInput to treat EOF with partial command as command, got %v", err)
+	}
+	if input != "open dep" {
+		t.Fatalf("expected multi-word input, got %q", input)
+	}
+}
+
 type errorAnalyzer struct {
 	err error
 }
@@ -515,6 +535,14 @@ func TestSummaryStartErrorBranches(t *testing.T) {
 	summary = NewSummary(io.Discard, strings.NewReader("open dep\n"), seqAnalyzer, report.NewFormatter())
 	if summary.Start(context.Background(), Options{RepoPath: ".", TopN: 1, PageSize: 1, Language: "auto"}) == nil {
 		t.Fatalf("expected detail-open error from handleSummaryInput")
+	}
+}
+
+func TestSummaryStartEOFWithoutNewline(t *testing.T) {
+	rep := report.Report{Dependencies: []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}}}
+	summary := NewSummary(io.Discard, strings.NewReader("q"), &stubAnalyzer{report: rep}, report.NewFormatter())
+	if err := summary.Start(context.Background(), Options{RepoPath: "."}); err != nil {
+		t.Fatalf("expected EOF-terminated command to be processed as quit, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes TUI input handling so commands typed without a trailing newline (e.g. `q` followed by EOF) are still processed.

## Cause and impact
`readSummaryInput` returned an error on `io.EOF` even when buffered input existed without a trailing `\n`, so the TUI loop treated that as hard EOF and exited prematurely.

## Root cause
`bufio.Reader.ReadString('\n')` can return `(partialInput, io.EOF)` when stdin is terminated without newline. The previous implementation dropped `partialInput` and returned the error directly.

## Fix
- If `ReadString('\n')` returns `io.EOF` with non-empty `input`, return trimmed input and continue processing.
- Preserve existing behavior for true empty input by still returning `io.EOF` when no bytes are read.
- Add regression coverage for `readSummaryInput` handling of EOF-without-newline commands and `Summary.Start` accepting `q` in that scenario.

## Checks
- `go test ./internal/ui -run 'Test(ReadSummaryInput|TestSummaryStart)'`

Closes #485
