### PR TITLE
fix(report): escape multiline warnings in table output

### DIFF
--- a/internal/report/format_table_sections.go
+++ b/internal/report/format_table_sections.go
@@ -198,9 +198,13 @@ func appendWarnings(buffer *bytes.Buffer, report Report) {
 	buffer.WriteString("\nWarnings:\n")
 	for _, warning := range report.Warnings {
 		buffer.WriteString("- ")
-		buffer.WriteString(warning)
+		buffer.WriteString(escapeTableWarning(warning))
 		buffer.WriteString("\n")
 	}
+}
+
+func escapeTableWarning(warning string) string {
+	return strings.NewReplacer("\r\n", "\\n", "\r", "\\n", "\n", "\\n", "\t", "\\t").Replace(warning)
 }
 
 func topWasteDeltas(deltas []DependencyDelta, limit int) []DependencyDelta {

--- a/internal/report/format_table_sections.go
+++ b/internal/report/format_table_sections.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+var tableWarningReplacer = strings.NewReplacer("\r\n", "\\n", "\r", "\\n", "\n", "\\n", "\t", "\\t")
+
 func appendSummary(buffer *bytes.Buffer, summary *Summary) {
 	if summary == nil {
 		return
@@ -204,7 +206,7 @@ func appendWarnings(buffer *bytes.Buffer, report Report) {
 }
 
 func escapeTableWarning(warning string) string {
-	return strings.NewReplacer("\r\n", "\\n", "\r", "\\n", "\n", "\\n", "\t", "\\t").Replace(warning)
+	return tableWarningReplacer.Replace(warning)
 }
 
 func topWasteDeltas(deltas []DependencyDelta, limit int) []DependencyDelta {

--- a/internal/report/format_test.go
+++ b/internal/report/format_test.go
@@ -282,6 +282,21 @@ func TestFormatEmptyAndWarnings(t *testing.T) {
 	assertOutputContains(t, output, "No dependencies to report.", "Scope:", "mode: repo", "Warnings:", "fail_on_increase_percent", "Effective policy:")
 }
 
+func TestFormatTableEscapesMultilineWarnings(t *testing.T) {
+	reportData := Report{
+		Warnings: []string{"warning-line-1\nwarning-line-2", "warning-line-3\r\nwarning-line-4", "warning\twith\ttab"},
+	}
+	output, err := NewFormatter().Format(reportData, FormatTable)
+	if err != nil {
+		t.Fatalf(unexpectedErrFmt, err)
+	}
+	assertOutputContains(t, output,
+		"- warning-line-1\\nwarning-line-2",
+		"- warning-line-3\\nwarning-line-4",
+		"- warning\\twith\\ttab",
+	)
+}
+
 func TestFormattingHelpersBytesAndSymbols(t *testing.T) {
 	if got := formatBytes(0); got != "0 B" {
 		t.Fatalf("unexpected 0-byte format: %q", got)


### PR DESCRIPTION
## Summary
- Fixes an issue where table output warnings with embedded newlines or tabs were rendered across multiple lines and could break plain-text parsing/readability.
- Escapes multiline warning content in table output so report consumers receive a single-line warning entry per item.

## Cause
- Warning messages in report data were forwarded directly to the table formatter without normalization.
- If a warning contained `\n`, `\r`, or tabs, it expanded outside the intended bullet item format.

## Fix
- Added `escapeTableWarning` in `internal/report/format_table_sections.go` to normalize newlines (`\r\n`, `\r`, `\n`) to `\\n` and tabs to `\\t` before rendering warnings.
- Added a focused regression test in `internal/report/format_test.go` to validate multiline and tab-containing warning entries are escaped in table output.

## Validation
- `go test ./internal/report -run TestFormat`
- `go test ./internal/report -run TestFormatEmptyAndWarnings|TestFormatTableEscapesMultilineWarnings|TestFormatTable|TestFormatUses`

Closes #475
