### PR TITLE
fix(python): parse requirements.txt declarations

### DIFF
--- a/internal/lang/python/adapter_test.go
+++ b/internal/lang/python/adapter_test.go
@@ -60,6 +60,35 @@ func TestAdapterAnalyseDependency(t *testing.T) {
 	}
 }
 
+func TestAdapterAnalyseTopNRequiresRequirementsDependencies(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "requirements.txt"), "requests==2.32.0\n")
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath: repo,
+		TopN:     5,
+	})
+	if err != nil {
+		t.Fatalf("analyse requirements.txt repo: %v", err)
+	}
+
+	found := false
+	for _, dep := range reportData.Dependencies {
+		if dep.Name == "requests" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected declared dependency from requirements.txt in topN report, got %#v", dependencyNames(reportData))
+	}
+	for _, warning := range reportData.Warnings {
+		if warning == "no dependency data available for top-N ranking" {
+			t.Fatalf("unexpected top-N ranking warning: %#v", reportData.Warnings)
+		}
+	}
+}
+
 func TestAdapterAnalyseTopN(t *testing.T) {
 	repo := t.TempDir()
 	source := "import requests\nimport numpy as np\nnp.array([1])\n"

--- a/internal/lang/python/packaging.go
+++ b/internal/lang/python/packaging.go
@@ -1,6 +1,7 @@
 package python
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -23,6 +24,7 @@ const (
 	pythonPipfileLockName = "Pipfile.lock"
 	pythonPoetryLockName  = "poetry.lock"
 	pythonUVLockName      = "uv.lock"
+	pythonRequirementsTxt = "requirements.txt"
 )
 
 var pythonRequirementNamePattern = regexp.MustCompile(`^\s*([A-Za-z0-9][A-Za-z0-9._-]*)`)
@@ -120,7 +122,7 @@ func pythonPackagingFiles(dir string) (map[string]struct{}, error) {
 }
 
 func hasRelevantPythonPackagingFile(files map[string]struct{}) bool {
-	for _, name := range []string{pythonPyprojectFile, pythonPipfileName, pythonPipfileLockName, pythonPoetryLockName, pythonUVLockName} {
+	for _, name := range []string{pythonPyprojectFile, pythonPipfileName, pythonPipfileLockName, pythonPoetryLockName, pythonUVLockName, pythonRequirementsTxt} {
 		if hasFile(files, name) {
 			return true
 		}
@@ -138,6 +140,7 @@ func collectManifestDependencies(repoPath, dir string, files map[string]struct{}
 	}{
 		{name: pythonPyprojectFile, parser: parsePyprojectDependencies},
 		{name: pythonPipfileName, parser: parsePipfileDependencies},
+		{name: pythonRequirementsTxt, parser: parseRequirementsDependencies},
 	} {
 		if !hasFile(files, source.name) {
 			continue
@@ -231,6 +234,44 @@ func parsePipfileDependencies(repoPath, path string) (map[string]struct{}, []str
 	addDependencyKeys(dependencies, nestedMap(document, "packages"), pathLabel+" [packages]")
 	addDependencyKeys(dependencies, nestedMap(document, "dev-packages"), pathLabel+" [dev-packages]")
 
+	return dependencies, warnings, nil
+}
+
+func parseRequirementsDependencies(repoPath, path string) (map[string]struct{}, []string, error) {
+	content, err := safeio.ReadFileUnder(repoPath, path)
+	switch {
+	case err == nil:
+	case errors.Is(err, os.ErrNotExist):
+		return make(map[string]struct{}), nil, nil
+	default:
+		return nil, nil, fmt.Errorf("read %s: %w", relativePackagingPath(repoPath, path), err)
+	}
+
+	dependencies := make(map[string]struct{})
+	warnings := make([]string, 0)
+	skipped := 0
+	pathLabel := relativePackagingPath(repoPath, path)
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case line == "" || strings.HasPrefix(line, "#"):
+			continue
+		case strings.HasPrefix(line, "-"):
+			continue
+		}
+		if dependency := dependencyNameFromRequirement(line); dependency != "" {
+			dependencies[dependency] = struct{}{}
+			continue
+		}
+		skipped++
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, nil, fmt.Errorf("scan %s: %w", pathLabel, err)
+	}
+	if skipped > 0 {
+		warnings = append(warnings, fmt.Sprintf("%s: skipped %d requirements entries with unsupported format", pathLabel, skipped))
+	}
 	return dependencies, warnings, nil
 }
 

--- a/internal/lang/python/packaging.go
+++ b/internal/lang/python/packaging.go
@@ -25,6 +25,7 @@ const (
 	pythonPoetryLockName  = "poetry.lock"
 	pythonUVLockName      = "uv.lock"
 	pythonRequirementsTxt = "requirements.txt"
+	readPackagingErrFmt   = "read %s: %w"
 )
 
 var pythonRequirementNamePattern = regexp.MustCompile(`^\s*([A-Za-z0-9][A-Za-z0-9._-]*)`)
@@ -244,7 +245,7 @@ func parseRequirementsDependencies(repoPath, path string) (map[string]struct{}, 
 	case errors.Is(err, os.ErrNotExist):
 		return make(map[string]struct{}), nil, nil
 	default:
-		return nil, nil, fmt.Errorf("read %s: %w", relativePackagingPath(repoPath, path), err)
+		return nil, nil, fmt.Errorf(readPackagingErrFmt, relativePackagingPath(repoPath, path), err)
 	}
 
 	dependencies := make(map[string]struct{})
@@ -252,12 +253,14 @@ func parseRequirementsDependencies(repoPath, path string) (map[string]struct{}, 
 	skipped := 0
 	pathLabel := relativePackagingPath(repoPath, path)
 	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	scanner.Buffer(make([]byte, 0, 64*1024), len(content))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		switch {
 		case line == "" || strings.HasPrefix(line, "#"):
 			continue
 		case strings.HasPrefix(line, "-"):
+			skipped++
 			continue
 		}
 		if dependency := dependencyNameFromRequirement(line); dependency != "" {
@@ -326,7 +329,7 @@ func parsePipfileLockDependencies(repoPath, path string) (map[string]struct{}, [
 	case errors.Is(err, os.ErrNotExist):
 		return make(map[string]struct{}), nil, nil
 	default:
-		return nil, nil, fmt.Errorf("read %s: %w", relativePackagingPath(repoPath, path), err)
+		return nil, nil, fmt.Errorf(readPackagingErrFmt, relativePackagingPath(repoPath, path), err)
 	}
 
 	document := make(map[string]any)
@@ -349,7 +352,7 @@ func readOptionalTOMLDocument(repoPath, path string) (map[string]any, []string, 
 	case errors.Is(err, os.ErrNotExist):
 		return nil, nil, nil
 	default:
-		return nil, nil, fmt.Errorf("read %s: %w", relativePackagingPath(repoPath, path), err)
+		return nil, nil, fmt.Errorf(readPackagingErrFmt, relativePackagingPath(repoPath, path), err)
 	}
 
 	document := make(map[string]any)

--- a/internal/lang/python/packaging_test.go
+++ b/internal/lang/python/packaging_test.go
@@ -98,6 +98,51 @@ pytest = "*"
 	}
 }
 
+func TestParseRequirementsDependencies(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, pythonRequirementsTxt)
+	testutil.MustWriteFile(t, path, `
+# comment
+requests==2.32.0
+urllib3>=2.2.3
+
+`)
+
+	dependencies, warnings, err := parseRequirementsDependencies(repo, path)
+	if err != nil {
+		t.Fatalf("parse requirements dependencies: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no requirements warnings, got %#v", warnings)
+	}
+	for _, want := range []string{"requests", "urllib3"} {
+		if _, ok := dependencies[want]; !ok {
+			t.Fatalf(expectedDependencyInSetFmt, want, dependencies)
+		}
+	}
+}
+
+func TestCollectDirectoryDeclaredDependenciesFromRequirementsTxt(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, pythonRequirementsTxt), `
+requests==2.32.0
+urllib3>=2.2.3
+`)
+
+	dependencies, warnings, err := collectDirectoryDeclaredDependencies(repo, repo)
+	if err != nil {
+		t.Fatalf(collectDirectoryErrFmt, err)
+	}
+	for _, want := range []string{"requests", "urllib3"} {
+		if _, ok := dependencies[want]; !ok {
+			t.Fatalf(expectedDependencyInSetFmt, want, dependencies)
+		}
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", warnings)
+	}
+}
+
 func TestPythonAnalyseTopNIncludesPoetryDependencies(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, pythonPyprojectFile), `

--- a/internal/lang/python/packaging_test.go
+++ b/internal/lang/python/packaging_test.go
@@ -122,6 +122,49 @@ urllib3>=2.2.3
 	}
 }
 
+func TestParseRequirementsDependenciesWarnsForUnsupportedOptionLines(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, pythonRequirementsTxt)
+	testutil.MustWriteFile(t, path, `
+-r base.txt
+-c constraints.txt
+-e git+https://example.test/demo.git#egg=demo
+requests==2.32.0
+`)
+
+	dependencies, warnings, err := parseRequirementsDependencies(repo, path)
+	if err != nil {
+		t.Fatalf("parse requirements dependencies: %v", err)
+	}
+	if _, ok := dependencies["requests"]; !ok {
+		t.Fatalf(expectedDependencyInSetFmt, "requests", dependencies)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected one unsupported-format warning, got %#v", warnings)
+	}
+	if !strings.Contains(warnings[0], "skipped 3 requirements entries with unsupported format") {
+		t.Fatalf(expectedWarningFmt, "skipped 3 requirements entries with unsupported format", warnings)
+	}
+}
+
+func TestParseRequirementsDependenciesAcceptsLongLines(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, pythonRequirementsTxt)
+	longRequirement := "requests==2.32.0" + strings.Repeat(" --hash=sha256:abcdef0123456789", 3000)
+	testutil.MustWriteFile(t, path, longRequirement+"\n")
+
+	dependencies, warnings, err := parseRequirementsDependencies(repo, path)
+	if err != nil {
+		t.Fatalf("parse requirements dependencies: %v", err)
+	}
+	if _, ok := dependencies["requests"]; !ok {
+		t.Fatalf(expectedDependencyInSetFmt, "requests", dependencies)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", warnings)
+	}
+}
+
 func TestCollectDirectoryDeclaredDependenciesFromRequirementsTxt(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, pythonRequirementsTxt), `

--- a/internal/lang/python/packaging_test.go
+++ b/internal/lang/python/packaging_test.go
@@ -19,6 +19,7 @@ const (
 	expectedNoDependenciesFmt  = "expected no dependencies, got %#v"
 	expectedWarningFmt         = "expected warning containing %q, got %#v"
 	collectDirectoryErrFmt     = "collect directory declared dependencies: %v"
+	parseRequirementsErrFmt    = "parse requirements dependencies: %v"
 	packagingTestDirMode       = 0o700
 	packagingBlockedDirMode    = 0o000
 )
@@ -110,7 +111,7 @@ urllib3>=2.2.3
 
 	dependencies, warnings, err := parseRequirementsDependencies(repo, path)
 	if err != nil {
-		t.Fatalf("parse requirements dependencies: %v", err)
+		t.Fatalf(parseRequirementsErrFmt, err)
 	}
 	if len(warnings) != 0 {
 		t.Fatalf("expected no requirements warnings, got %#v", warnings)
@@ -134,7 +135,7 @@ requests==2.32.0
 
 	dependencies, warnings, err := parseRequirementsDependencies(repo, path)
 	if err != nil {
-		t.Fatalf("parse requirements dependencies: %v", err)
+		t.Fatalf(parseRequirementsErrFmt, err)
 	}
 	if _, ok := dependencies["requests"]; !ok {
 		t.Fatalf(expectedDependencyInSetFmt, "requests", dependencies)
@@ -155,7 +156,7 @@ func TestParseRequirementsDependenciesAcceptsLongLines(t *testing.T) {
 
 	dependencies, warnings, err := parseRequirementsDependencies(repo, path)
 	if err != nil {
-		t.Fatalf("parse requirements dependencies: %v", err)
+		t.Fatalf(parseRequirementsErrFmt, err)
 	}
 	if _, ok := dependencies["requests"]; !ok {
 		t.Fatalf(expectedDependencyInSetFmt, "requests", dependencies)


### PR DESCRIPTION
## Summary
- Parse `requirements.txt` as a supported Python packaging manifest so dependency declarations are collected for declared-dependency reporting.
- Preserve existing manifest priority order (pyproject/Pipfile remain first, requirements now participates before lockfile fallback).
- Add focused regression tests for direct requirements parser, directory collection, and `Analyse(...TopN)` behavior.

## Details
`collectDeclaredDependencies` never reached requirements parsing because `requirements.txt` was excluded from `hasRelevantPythonPackagingFile`, so repositories with only `requirements.txt` produced empty declared dependencies and surfaced a top-N warning despite having declared requirements.

The fix now:
- adds `requirements.txt` as a recognized packaging file,
- adds a lightweight requirements parser in `internal/lang/python/packaging.go`, and
- collects declared dependencies from that parser in the manifest collection path.

Checks:
- `go test ./internal/lang/python -run 'TestParseRequirementsDependencies|TestCollectDirectoryDeclaredDependenciesFromRequirementsTxt|TestAdapterAnalyseTopNRequiresRequirementsDependencies'`

Closes #622
