### PR TITLE
fix(lang): scan go.work workspace members without root module

### DIFF
--- a/internal/lang/golang/adapter.go
+++ b/internal/lang/golang/adapter.go
@@ -130,16 +130,12 @@ func applyGoRootSignals(repoPath string, detection *language.Detection, roots ma
 }
 
 func addGoWorkRoots(repoPath string, roots map[string]struct{}) error {
-	useEntries, err := readGoWorkUseEntries(repoPath)
+	moduleDirs, err := goWorkModuleDirs(repoPath)
 	if err != nil {
 		return err
 	}
-	for _, rel := range useEntries {
-		resolved, ok := resolveRepoBoundedPath(repoPath, rel)
-		if !ok {
-			continue
-		}
-		roots[resolved] = struct{}{}
+	for dir := range moduleDirs {
+		roots[dir] = struct{}{}
 	}
 	return nil
 }
@@ -385,6 +381,10 @@ func workspaceRootModuleDirs(repoPath string, moduleInfo moduleInfo) (map[string
 		return nil, nil
 	}
 
+	return goWorkModuleDirs(repoPath)
+}
+
+func goWorkModuleDirs(repoPath string) (map[string]struct{}, error) {
 	useEntries, err := readGoWorkUseEntries(repoPath)
 	if err != nil {
 		return nil, err

--- a/internal/lang/golang/adapter.go
+++ b/internal/lang/golang/adapter.go
@@ -244,7 +244,11 @@ func scanRepo(ctx context.Context, repoPath string, moduleInfo moduleInfo) (scan
 	if repoPath == "" {
 		return result, fs.ErrInvalid
 	}
-	nestedModules, err := nestedModuleDirs(repoPath)
+	workspaceMemberDirs, err := workspaceRootModuleDirs(repoPath, moduleInfo)
+	if err != nil {
+		return result, err
+	}
+	nestedModules, err := nestedModuleDirs(repoPath, workspaceMemberDirs)
 	if err != nil {
 		return result, err
 	}
@@ -376,7 +380,31 @@ func scanGoSourceFile(repoPath, path string, moduleInfo moduleInfo, result *scan
 	return nil
 }
 
-func nestedModuleDirs(repoPath string) (map[string]struct{}, error) {
+func workspaceRootModuleDirs(repoPath string, moduleInfo moduleInfo) (map[string]struct{}, error) {
+	if moduleInfo.ModulePath != "" {
+		return nil, nil
+	}
+
+	useEntries, err := readGoWorkUseEntries(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(useEntries) == 0 {
+		return nil, nil
+	}
+
+	workspaceRoots := make(map[string]struct{}, len(useEntries))
+	for _, rel := range useEntries {
+		resolved, ok := resolveRepoBoundedPath(repoPath, rel)
+		if !ok {
+			continue
+		}
+		workspaceRoots[resolved] = struct{}{}
+	}
+	return workspaceRoots, nil
+}
+
+func nestedModuleDirs(repoPath string, workspaceModuleDirs map[string]struct{}) (map[string]struct{}, error) {
 	dirs := make(map[string]struct{})
 	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
@@ -396,6 +424,9 @@ func nestedModuleDirs(repoPath string) (map[string]struct{}, error) {
 			return err
 		}
 		if exists {
+			if _, ok := workspaceModuleDirs[path]; ok {
+				return nil
+			}
 			dirs[path] = struct{}{}
 			return filepath.SkipDir
 		}
@@ -408,7 +439,7 @@ func nestedModuleDirs(repoPath string) (map[string]struct{}, error) {
 }
 
 func discoverNestedModules(repoPath string) ([]string, []string, map[string]string, error) {
-	nestedDirs, err := nestedModuleDirs(repoPath)
+	nestedDirs, err := nestedModuleDirs(repoPath, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/lang/golang/adapter.go
+++ b/internal/lang/golang/adapter.go
@@ -423,14 +423,14 @@ func nestedModuleDirs(repoPath string, workspaceModuleDirs map[string]struct{}) 
 		if err != nil {
 			return err
 		}
-		if exists {
-			if _, ok := workspaceModuleDirs[path]; ok {
-				return nil
-			}
-			dirs[path] = struct{}{}
-			return filepath.SkipDir
+		if !exists {
+			return nil
 		}
-		return nil
+		if _, ok := workspaceModuleDirs[path]; ok {
+			return nil
+		}
+		dirs[path] = struct{}{}
+		return filepath.SkipDir
 	})
 	if err != nil {
 		return nil, err

--- a/internal/lang/golang/adapter_cov_more_branches_test.go
+++ b/internal/lang/golang/adapter_cov_more_branches_test.go
@@ -49,7 +49,7 @@ func testGoHelperGuardBranches(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
 		t.Fatalf("mkdir .git dir: %v", err)
 	}
-	nested, err := nestedModuleDirs(repo)
+	nested, err := nestedModuleDirs(repo, nil)
 	if err != nil {
 		t.Fatalf("nestedModuleDirs: %v", err)
 	}

--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -413,6 +413,26 @@ func TestAdapterAnalyseSkipsNestedModulesFromRootScan(t *testing.T) {
 	}
 }
 
+func TestAdapterAnalyseWorkspaceGoWorkScansMembers(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, fileGoWork), go125Line+"\n\nuse ./svc/a\n")
+	writeFile(t, filepath.Join(repo, "svc", "a", fileGoMod), goModDemoWithUUID)
+	writeFile(t, filepath.Join(repo, "svc", "a", fileMainGo), mainUUIDNoopProgram)
+
+	reportData := analyseReport(t, language.Request{
+		RepoPath: repo,
+		TopN:     10,
+	})
+	if !slices.Contains(dependencyNames(reportData.Dependencies), depUUID) {
+		t.Fatalf("expected workspace dependency %s in %#v", depUUID, dependencyNames(reportData.Dependencies))
+	}
+
+	warningsText := strings.ToLower(strings.Join(reportData.Warnings, "\n"))
+	if strings.Contains(warningsText, "nested module directories") || strings.Contains(warningsText, "no go source files found") {
+		t.Fatalf("did not expect workspace member skip warnings, got %#v", reportData.Warnings)
+	}
+}
+
 func TestBuildRequestedGoDependenciesNoInputWarning(t *testing.T) {
 	deps, warnings := buildRequestedGoDependencies(language.Request{}, scanResult{})
 	if len(deps) != 0 {
@@ -885,7 +905,7 @@ func TestNestedModuleDiscoveryAndSkipDir(t *testing.T) {
 	writeFile(t, filepath.Join(repo, fileGoMod), modulePrefix+"example.com/root"+go125Block)
 	writeFile(t, filepath.Join(repo, "sub", fileGoMod), "module example.com/sub\n\nrequire "+depUUID+" v1.6.0\n")
 
-	dirs, err := nestedModuleDirs(repo)
+	dirs, err := nestedModuleDirs(repo, nil)
 	if err != nil {
 		t.Fatalf("nested module dirs: %v", err)
 	}
@@ -1246,7 +1266,7 @@ func TestDiscoverNestedModulesIgnoresGoModDirectory(t *testing.T) {
 		t.Fatalf("mkdir sub/go.mod dir: %v", err)
 	}
 
-	nested, err := nestedModuleDirs(repo)
+	nested, err := nestedModuleDirs(repo, nil)
 	if err != nil {
 		t.Fatalf("nested module dirs: %v", err)
 	}


### PR DESCRIPTION
## Summary

This resolves a scan regression for Go workspaces where the repository root has `go.work` but no root `go.mod`.

## Problem
`scanRepo` skipped every nested `go.mod` directory, so workspace member modules listed in `go.work` were treated as nested modules and never scanned. Analysis returned empty file results and misleading nested-module warnings even when dependencies were used in workspace members.

## Fix
When the repo is workspace-only (no root module path in `moduleInfo`), `scanRepo` now builds an exclusion map from bounded `go.work` `use` entries and passes it into nested-module discovery during scan.

- Added `workspaceRootModuleDirs` to resolve workspace member directories only for workspace-rooted repos.
- Updated `nestedModuleDirs` to avoid skipping those workspace member directories.
- Added regression coverage to verify a `go.work`-only workspace with `./svc/a` is scanned and dependency usage is attributed.

## Testing
- `go test ./internal/lang/golang -run "TestAdapterAnalyseSkipsNestedModulesFromRootScan|TestAdapterAnalyseWorkspaceGoWorkScansMembers|TestNestedModuleDiscoveryAndSkipDir|TestLoadGoWorkLocalModulesHappyPathAndInvalidEntries"`

Closes #623
