### PR TITLE
fix(security): sanitize csv exports against formula injection

### DIFF
--- a/internal/csvsanitize/sanitize.go
+++ b/internal/csvsanitize/sanitize.go
@@ -1,0 +1,22 @@
+package csvsanitize
+
+func EscapeLeadingFormula(value string) string {
+	if value == "" {
+		return value
+	}
+
+	switch value[0] {
+	case '=', '+', '-', '@':
+		return "'" + value
+	default:
+		return value
+	}
+}
+
+func EscapeLeadingFormulaRow(values []string) []string {
+	sanitized := make([]string, len(values))
+	for i, value := range values {
+		sanitized[i] = EscapeLeadingFormula(value)
+	}
+	return sanitized
+}

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -196,6 +196,65 @@ func TestFormatReportCSVIncludesCrossRepoRows(t *testing.T) {
 	}
 }
 
+func TestFormatReportCSVSanitizesCrossRepoAndRepoFormulaPrefixes(t *testing.T) {
+	reportData := Report{
+		GeneratedAt: time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC),
+		Repos: []RepoResult{
+			{
+				Name:                  "+repo",
+				Path:                  "@path",
+				Language:              "go",
+				DependencyCount:       1,
+				WasteCandidateCount:   0,
+				WasteCandidatePercent: 0,
+			},
+		},
+		Summary: Summary{
+			TotalRepos:           1,
+			TotalDeps:            1,
+			TotalWasteCandidates: 0,
+			CrossRepoDuplicates:  1,
+			CriticalCVEs:         0,
+		},
+		CrossRepoDeps: []CrossRepoDependency{
+			{
+				Name:         "-shared",
+				Count:        3,
+				Repositories: []string{"repo-a", "-repo-b", "@repo-c"},
+			},
+		},
+	}
+
+	csvOutput, err := FormatReport(reportData, FormatCSV)
+	if err != nil {
+		t.Fatalf("format csv with formula-like values: %v", err)
+	}
+
+	reader := csv.NewReader(strings.NewReader(csvOutput))
+	reader.FieldsPerRecord = -1
+	rows, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read csv output: %v", err)
+	}
+
+	var repoRow, crossRepoRow []string
+	for i, row := range rows {
+		if len(row) > 0 && row[0] == "repo_name" && i+1 < len(rows) {
+			repoRow = rows[i+1]
+		}
+		if len(row) > 0 && row[0] == "dependency_name" && i+1 < len(rows) {
+			crossRepoRow = rows[i+1]
+		}
+	}
+
+	if len(repoRow) != 10 || repoRow[0] != "'+repo" || repoRow[1] != "'@path" {
+		t.Fatalf("expected sanitized repo csv row, got %#v", repoRow)
+	}
+	if len(crossRepoRow) != 3 || crossRepoRow[0] != "'-shared" || crossRepoRow[2] != "repo-a|'-repo-b|'@repo-c" {
+		t.Fatalf("expected sanitized cross-repo csv row, got %#v", crossRepoRow)
+	}
+}
+
 func TestFormatReportUnknownFormat(t *testing.T) {
 	_, err := FormatReport(Report{}, Format("xml"))
 	if err == nil || !errors.Is(err, ErrUnknownFormat) {

--- a/internal/dashboard/format.go
+++ b/internal/dashboard/format.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"github.com/ben-ranford/lopper/internal/csvsanitize"
 	"html"
 	"strings"
 )
@@ -57,7 +58,7 @@ func writeDashboardSummaryCSV(write func([]string) error, reportData Report) err
 		{"critical_cves", fmt.Sprintf("%d", reportData.Summary.CriticalCVEs)},
 	}
 	for _, row := range summaryRows {
-		if err := write(row); err != nil {
+		if err := write(csvsanitize.EscapeLeadingFormulaRow(row)); err != nil {
 			return err
 		}
 	}
@@ -65,7 +66,7 @@ func writeDashboardSummaryCSV(write func([]string) error, reportData Report) err
 }
 
 func writeDashboardRepoRowsCSV(write func([]string) error, repos []RepoResult) error {
-	if err := write([]string{
+	if err := write(csvsanitize.EscapeLeadingFormulaRow([]string{
 		"repo_name",
 		"repo_path",
 		"language",
@@ -76,12 +77,12 @@ func writeDashboardRepoRowsCSV(write func([]string) error, repos []RepoResult) e
 		"critical_cves",
 		"denied_license_count",
 		"error",
-	}); err != nil {
+	})); err != nil {
 		return err
 	}
 
 	for _, repoResult := range repos {
-		if err := write([]string{
+		if err := write(csvsanitize.EscapeLeadingFormulaRow([]string{
 			repoResult.Name,
 			repoResult.Path,
 			repoResult.Language,
@@ -92,7 +93,7 @@ func writeDashboardRepoRowsCSV(write func([]string) error, repos []RepoResult) e
 			fmt.Sprintf("%d", repoResult.CriticalCVEs),
 			fmt.Sprintf("%d", repoResult.DeniedLicenseCount),
 			repoResult.Error,
-		}); err != nil {
+		})); err != nil {
 			return err
 		}
 	}
@@ -106,15 +107,19 @@ func writeDashboardCrossRepoRowsCSV(write func([]string) error, dependencies []C
 	if err := write(nil); err != nil {
 		return err
 	}
-	if err := write([]string{"dependency_name", "repo_count", "repositories"}); err != nil {
+	if err := write(csvsanitize.EscapeLeadingFormulaRow([]string{"dependency_name", "repo_count", "repositories"})); err != nil {
 		return err
 	}
 	for _, dependency := range dependencies {
-		if err := write([]string{
+		repositories := make([]string, len(dependency.Repositories))
+		for i, repo := range dependency.Repositories {
+			repositories[i] = csvsanitize.EscapeLeadingFormula(repo)
+		}
+		if err := write(csvsanitize.EscapeLeadingFormulaRow([]string{
 			dependency.Name,
 			fmt.Sprintf("%d", dependency.Count),
-			strings.Join(dependency.Repositories, "|"),
-		}); err != nil {
+			strings.Join(repositories, "|"),
+		})); err != nil {
 			return err
 		}
 	}

--- a/internal/dashboard/format.go
+++ b/internal/dashboard/format.go
@@ -5,9 +5,10 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"github.com/ben-ranford/lopper/internal/csvsanitize"
 	"html"
 	"strings"
+
+	"github.com/ben-ranford/lopper/internal/csvsanitize"
 )
 
 func FormatReport(reportData Report, format Format) (string, error) {

--- a/internal/report/format_csv.go
+++ b/internal/report/format_csv.go
@@ -3,6 +3,7 @@ package report
 import (
 	"bytes"
 	"encoding/csv"
+	"github.com/ben-ranford/lopper/internal/csvsanitize"
 	"sort"
 	"strconv"
 	"strings"
@@ -62,7 +63,7 @@ func formatCSV(reportData Report) (string, error) {
 		return "", err
 	}
 	for _, dep := range sortedDependenciesForCSV(reportData.Dependencies) {
-		if err := writer.Write(formatDependencyCSVRow(reportData, dep)); err != nil {
+		if err := writer.Write(csvsanitize.EscapeLeadingFormulaRow(formatDependencyCSVRow(reportData, dep))); err != nil {
 			return "", err
 		}
 	}

--- a/internal/report/format_csv_test.go
+++ b/internal/report/format_csv_test.go
@@ -148,6 +148,43 @@ func TestFormatCSV(t *testing.T) {
 	})
 }
 
+func TestFormatCSVDependencyNamesSanitizeFormulaPrefixes(t *testing.T) {
+	reportData := Report{
+		SchemaVersion: SchemaVersion,
+		GeneratedAt:   time.Date(2026, time.March, 30, 12, 34, 56, 0, time.UTC),
+		Dependencies: []DependencyReport{
+			{Name: "=2+3", Language: "go"},
+			{Name: "+cmd", Language: "go"},
+			{Name: "-cmd", Language: "go"},
+			{Name: "@cmd", Language: "go"},
+		},
+	}
+
+	output, err := NewFormatter().Format(reportData, FormatCSV)
+	if err != nil {
+		t.Fatalf("format csv: %v", err)
+	}
+
+	rows := readCSVRows(t, output)
+	if len(rows) != 5 {
+		t.Fatalf("expected header and four dependency rows, got %d rows", len(rows))
+	}
+
+	rowByName := map[string]map[string]string{}
+	for _, row := range rows[1:] {
+		decoded := csvRowMap(rows[0], row)
+		rowByName[decoded["dependency_name"]] = decoded
+	}
+
+	for _, name := range []string{"=2+3", "+cmd", "-cmd", "@cmd"} {
+		if got, ok := rowByName["'"+name]; !ok {
+			t.Fatalf("expected sanitized dependency name %q in csv rows, got %#v", "'"+name, rowByName)
+		} else if got["dependency_name"] != "'"+name {
+			t.Fatalf("expected dependency_name %q, got %q", "'"+name, got["dependency_name"])
+		}
+	}
+}
+
 func TestFormatCSVEmptyReport(t *testing.T) {
 	output, err := NewFormatter().Format(Report{}, FormatCSV)
 	if err != nil {


### PR DESCRIPTION
## Context
Closes #617

## Root cause
`internal/report/format_csv.go` and `internal/dashboard/format.go` wrote dependency and repository data directly into CSV fields without escaping spreadsheet formula prefixes.

## Impact
A dependency name beginning with `=`, `+`, `-`, or `@` can be interpreted as a formula when a maintainer opens CSV output in spreadsheet software.

## Fix
Added a dedicated CSV formula-escaping helper in `internal/csvsanitize` that neutralizes leading formula prefixes.
Applied it in both CSV exporters so string cells are consistently escaped before writing, including cross-repo repository list values.

## Validation
- `go test ./internal/report ./internal/dashboard`
