### PR TITLE
feat(vscode): surface dependency license and provenance in hovers

### DIFF
--- a/extensions/vscode-lopper/README.md
+++ b/extensions/vscode-lopper/README.md
@@ -6,7 +6,7 @@ Lopper brings dependency-surface analysis into VS Code with inline diagnostics a
 ## What it does
 
 - Flags unused dependency imports directly in editors covered by supported Lopper adapters.
-- Shows dependency usage, risk cues, and recommendation context in hovers.
+- Shows dependency usage, license, provenance, risk cues, and recommendation context in hovers.
 - Offers deterministic quick fixes for safe `--suggest-only` JS/TS subpath rewrites.
 - Keeps a status-bar summary and a manual `Lopper: Refresh Diagnostics` command.
 

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -9,6 +9,8 @@ import {
   type WorkspaceAnalysisRunner,
 } from "./lopperRunner";
 import type {
+  LopperDependencyLicense,
+  LopperDependencyProvenance,
   LopperCodemodSuggestion,
   LopperDependencyReport,
   LopperImportUse,
@@ -200,6 +202,16 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       if (recommendation) {
         markdown.appendMarkdown(`\n\nRecommendation: `);
         markdown.appendText(recommendation.message);
+      }
+      const licenseSummary = formatDependencyLicense(item.dependency.license);
+      if (licenseSummary) {
+        markdown.appendMarkdown(`\n\nLicense: `);
+        markdown.appendText(licenseSummary);
+      }
+      const provenanceSummary = formatDependencyProvenance(item.dependency.provenance);
+      if (provenanceSummary) {
+        markdown.appendMarkdown(`\n\nProvenance: `);
+        markdown.appendText(provenanceSummary);
       }
       return markdown;
     });
@@ -447,6 +459,64 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     this.statusBar.text = text;
     this.statusBar.tooltip = tooltip;
   }
+}
+
+function formatDependencyLicense(license?: LopperDependencyLicense): string | undefined {
+  if (!license) {
+    return undefined;
+  }
+
+  const segments: string[] = [];
+  if (license.denied) {
+    segments.push("DENIED");
+  } else if (license.unknown) {
+    segments.push("Unknown");
+  }
+
+  if (license.spdx) {
+    segments.push(license.spdx);
+  } else if (license.raw) {
+    segments.push(license.raw);
+  } else if (license.unknown || license.denied) {
+    segments.push("unresolved");
+  } else {
+    segments.push("missing");
+  }
+
+  if (license.source) {
+    segments.push(`source: ${license.source}`);
+  }
+  if (license.confidence) {
+    segments.push(`confidence: ${license.confidence}`);
+  }
+  const evidence = license.evidence ?? [];
+  if (evidence.length > 0) {
+    segments.push(`evidence: ${evidence.join(", ")}`);
+  }
+
+  return segments.join(" • ");
+}
+
+function formatDependencyProvenance(provenance?: LopperDependencyProvenance): string | undefined {
+  if (!provenance) {
+    return undefined;
+  }
+
+  const segments: string[] = [];
+  if (provenance.source) {
+    segments.push(`source: ${provenance.source}`);
+  }
+  if (provenance.confidence) {
+    segments.push(`confidence: ${provenance.confidence}`);
+  }
+  const signals = provenance.signals ?? [];
+  if (signals.length > 0) {
+    segments.push(`signals: ${signals.join(", ")}`);
+  }
+  if (segments.length === 0) {
+    return "unresolved";
+  }
+  return segments.join(" • ");
 }
 
 class LopperExtensionBootstrap implements vscode.Disposable {

--- a/extensions/vscode-lopper/src/test/suite/smoke.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/smoke.test.ts
@@ -44,6 +44,9 @@ suite("vscode-lopper smoke", () => {
       .replaceAll("&nbsp;", " ");
     assert.match(normalizedHoverText, /scope-lib/);
     assert.match(normalizedHoverText, /Used exports:/);
+    assert.match(normalizedHoverText, /License:/);
+    assert.match(normalizedHoverText, /Provenance:/);
+    assert.match(normalizedHoverText, /unknown/i);
 
     const quickFixes = await vscode.commands.executeCommand<
       (vscode.CodeAction | vscode.Command)[]

--- a/extensions/vscode-lopper/src/types.ts
+++ b/extensions/vscode-lopper/src/types.ts
@@ -20,6 +20,24 @@ export interface LopperDependencyReport {
   usedImports?: LopperImportUse[];
   unusedImports?: LopperImportUse[];
   codemod?: LopperCodemodReport;
+  license?: LopperDependencyLicense;
+  provenance?: LopperDependencyProvenance;
+}
+
+export interface LopperDependencyLicense {
+  spdx?: string;
+  raw?: string;
+  source?: string;
+  confidence?: string;
+  unknown?: boolean;
+  denied?: boolean;
+  evidence?: string[];
+}
+
+export interface LopperDependencyProvenance {
+  source?: string;
+  confidence?: string;
+  signals?: string[];
 }
 
 export interface LopperRiskCue {


### PR DESCRIPTION
## Summary
Closes #608

## Why
The VS Code extension consumed dependency rows from `lopper analyse --format json` but only rendered usage/risk/recommendation fields in hover output. As a result, existing license and provenance metadata never reached editor triage workflows even when available.

## Fix
- Extended `extensions/vscode-lopper/src/types.ts` dependency models with `license` and `provenance` surfaces from the report schema.
- Added hover renderers in `extensions/vscode-lopper/src/extension.ts` to always show concise License and Provenance sections for any dependency row that includes them.
- Added explicit formatting for denied and unknown license states so those status outcomes remain visible instead of being dropped.
- Updated `extensions/vscode-lopper/src/test/suite/smoke.test.ts` to verify new hover content for License/Provenance.
- Updated README feature list to document the new hover data surfaces.

## Validation
- `npm run compile` in `extensions/vscode-lopper`
- `LOPPER_BINARY_PATH=/tmp/lopper-vscode-license npm run test:e2e` in `extensions/vscode-lopper`
