### PR TITLE
feat(jvm): add managed Maven deps and index Gradle catalog lookup

### DIFF
--- a/internal/lang/jvm/adapter.go
+++ b/internal/lang/jvm/adapter.go
@@ -2,7 +2,9 @@ package jvm
 
 import (
 	"context"
+	"encoding/xml"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -287,8 +289,9 @@ func isSourceFile(path string) bool {
 }
 
 var (
-	packagePattern = regexp.MustCompile(`(?m)^\s*package\s+([A-Za-z_][A-Za-z0-9_\.]*)\s*;?\s*$`)
-	importPattern  = regexp.MustCompile(`(?m)^\s*import\s+(?:static\s+)?([A-Za-z_][A-Za-z0-9_\.]*)(\.\*)?(?:\s+as\s+([A-Za-z_][A-Za-z0-9_]*))?\s*;?\s*$`)
+	packagePattern          = regexp.MustCompile(`(?m)^\s*package\s+([A-Za-z_][A-Za-z0-9_\.]*)\s*;?\s*$`)
+	importPattern           = regexp.MustCompile(`(?m)^\s*import\s+(?:static\s+)?([A-Za-z_][A-Za-z0-9_\.]*)(\.\*)?(?:\s+as\s+([A-Za-z_][A-Za-z0-9_]*))?\s*;?\s*$`)
+	pomPropertyTokenPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
 )
 
 const importPatternMatchGroups = 4
@@ -500,14 +503,56 @@ type dependencyDescriptor struct {
 	Artifact string
 }
 
+type pomProjectModel struct {
+	GroupID              string               `xml:"groupId"`
+	ArtifactID           string               `xml:"artifactId"`
+	Version              string               `xml:"version"`
+	Parent               pomParentModel       `xml:"parent"`
+	Properties           pomPropertiesModel   `xml:"properties"`
+	Dependencies         []pomDependencyModel `xml:"dependencies>dependency"`
+	DependencyManagement struct {
+		Dependencies []pomDependencyModel `xml:"dependencies>dependency"`
+	} `xml:"dependencyManagement"`
+}
+
+type pomParentModel struct {
+	GroupID string `xml:"groupId"`
+	Version string `xml:"version"`
+}
+
+type pomPropertiesModel struct {
+	Properties []pomPropertyModel `xml:",any"`
+}
+
+type pomPropertyModel struct {
+	XMLName xml.Name
+	Value   string `xml:",chardata"`
+}
+
+type pomDependencyModel struct {
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+	Version    string `xml:"version"`
+	Type       string `xml:"type"`
+	Scope      string `xml:"scope"`
+}
+
+type pomDependencyKind int
+
+const (
+	pomDependencyDirect pomDependencyKind = iota
+	pomDependencyManaged
+)
+
 func collectDeclaredDependencies(repoPath string) ([]dependencyDescriptor, map[string]string, map[string]string, []string) {
 	descriptors := make([]dependencyDescriptor, 0)
 	warnings := make([]string, 0)
 
-	pomDescriptors := parsePomDependencies(repoPath)
+	pomDescriptors, pomWarnings := parsePomDependenciesWithWarnings(repoPath)
 	gradleDescriptors, gradleWarnings := parseGradleDependenciesWithWarnings(repoPath)
 	descriptors = append(descriptors, pomDescriptors...)
 	descriptors = append(descriptors, gradleDescriptors...)
+	warnings = append(warnings, pomWarnings...)
 	warnings = append(warnings, gradleWarnings...)
 
 	descriptors = dedupeAndSortDescriptors(descriptors)
@@ -599,10 +644,171 @@ func artifactLookupStrategy(group, artifact string) ([]string, []string) {
 }
 
 func parsePomDependencies(repoPath string) []dependencyDescriptor {
-	pattern := regexp.MustCompile(`(?s)<dependency>\s*.*?<groupId>\s*([^<\s]+)\s*</groupId>\s*.*?<artifactId>\s*([^<\s]+)\s*</artifactId>.*?</dependency>`)
-	return parseBuildFiles(repoPath, pomXMLName, func(content string) []dependencyDescriptor {
-		return parseDependencyDescriptorsFromMatches(pattern.FindAllStringSubmatch(content, -1))
-	})
+	descriptors, _ := parsePomDependenciesWithWarnings(repoPath)
+	return descriptors
+}
+
+func parsePomDependenciesWithWarnings(repoPath string) ([]dependencyDescriptor, []string) {
+	pomParser := func(path, content string) ([]dependencyDescriptor, []string) {
+		return parsePomDependencyContent(relativeBuildFilePath(repoPath, path), content)
+	}
+	return parseBuildFilesWithWarnings(repoPath, pomParser, pomXMLName)
+}
+
+func parsePomDependencyContent(relativePath, content string) ([]dependencyDescriptor, []string) {
+	var project pomProjectModel
+	if err := xml.Unmarshal([]byte(content), &project); err != nil {
+		return nil, []string{fmt.Sprintf("unable to parse Maven pom.xml %s: %v", relativePath, err)}
+	}
+
+	propertyMap := buildPomPropertyMap(project)
+	directDescriptors, directWarnings := parsePomDependencyList(project.Dependencies, propertyMap, pomDependencyDirect, relativePath)
+	managedDescriptors, managedWarnings := parsePomDependencyList(project.DependencyManagement.Dependencies, propertyMap, pomDependencyManaged, relativePath)
+
+	descriptors := make([]dependencyDescriptor, 0, len(directDescriptors)+len(managedDescriptors))
+	descriptors = append(descriptors, directDescriptors...)
+	descriptors = append(descriptors, managedDescriptors...)
+
+	warnings := make([]string, 0, len(directWarnings)+len(managedWarnings))
+	warnings = append(warnings, directWarnings...)
+	warnings = append(warnings, managedWarnings...)
+
+	return dedupeAndSortDescriptors(descriptors), shared.DedupeWarnings(warnings)
+}
+
+func parsePomDependencyList(dependencies []pomDependencyModel, propertyMap map[string]string, kind pomDependencyKind, relativePath string) ([]dependencyDescriptor, []string) {
+	descriptors := make([]dependencyDescriptor, 0, len(dependencies))
+	warnings := make([]string, 0)
+	for _, dependency := range dependencies {
+		descriptor, warning := parsePomDependency(dependency, propertyMap, kind, relativePath)
+		if descriptor.Group != "" && descriptor.Artifact != "" {
+			descriptors = append(descriptors, descriptor)
+		}
+		if warning != "" {
+			warnings = append(warnings, warning)
+		}
+	}
+	return descriptors, warnings
+}
+
+func parsePomDependency(dependency pomDependencyModel, propertyMap map[string]string, kind pomDependencyKind, relativePath string) (dependencyDescriptor, string) {
+	group, unresolvedGroup := resolvePomPropertyValue(dependency.GroupID, propertyMap)
+	artifact, unresolvedArtifact := resolvePomPropertyValue(dependency.ArtifactID, propertyMap)
+	if unresolvedGroup || unresolvedArtifact || group == "" || artifact == "" {
+		return dependencyDescriptor{}, ""
+	}
+
+	descriptor := dependencyDescriptor{
+		Name:     artifact,
+		Group:    group,
+		Artifact: artifact,
+	}
+	if kind != pomDependencyManaged {
+		return descriptor, ""
+	}
+
+	version, unresolvedVersion := resolvePomPropertyValue(dependency.Version, propertyMap)
+	if !isPomImportedBOM(dependency) {
+		if version == "" || unresolvedVersion {
+			return descriptor, fmt.Sprintf("unable to resolve managed Maven version for %s:%s in %s", group, artifact, relativePath)
+		}
+		return descriptor, ""
+	}
+
+	if version == "" || unresolvedVersion {
+		return descriptor, fmt.Sprintf("unable to resolve imported Maven BOM version for %s:%s in %s", group, artifact, relativePath)
+	}
+	return descriptor, ""
+}
+
+func isPomImportedBOM(dependency pomDependencyModel) bool {
+	return strings.EqualFold(strings.TrimSpace(dependency.Type), "pom") &&
+		strings.EqualFold(strings.TrimSpace(dependency.Scope), "import")
+}
+
+func buildPomPropertyMap(project pomProjectModel) map[string]string {
+	properties := make(map[string]string)
+	for _, property := range project.Properties.Properties {
+		key := strings.TrimSpace(property.XMLName.Local)
+		value := strings.TrimSpace(property.Value)
+		if key == "" || value == "" {
+			continue
+		}
+		properties[key] = value
+	}
+
+	groupID := strings.TrimSpace(project.GroupID)
+	if groupID == "" {
+		groupID = strings.TrimSpace(project.Parent.GroupID)
+	}
+	version := strings.TrimSpace(project.Version)
+	if version == "" {
+		version = strings.TrimSpace(project.Parent.Version)
+	}
+	artifactID := strings.TrimSpace(project.ArtifactID)
+
+	setPomPropertyValue(properties, "project.groupId", groupID)
+	setPomPropertyValue(properties, "pom.groupId", groupID)
+	setPomPropertyValue(properties, "groupId", groupID)
+
+	setPomPropertyValue(properties, "project.version", version)
+	setPomPropertyValue(properties, "pom.version", version)
+	setPomPropertyValue(properties, "version", version)
+
+	setPomPropertyValue(properties, "project.artifactId", artifactID)
+	setPomPropertyValue(properties, "pom.artifactId", artifactID)
+	setPomPropertyValue(properties, "artifactId", artifactID)
+
+	setPomPropertyValue(properties, "project.parent.groupId", strings.TrimSpace(project.Parent.GroupID))
+	setPomPropertyValue(properties, "project.parent.version", strings.TrimSpace(project.Parent.Version))
+	return properties
+}
+
+func setPomPropertyValue(properties map[string]string, key, value string) {
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" || value == "" {
+		return
+	}
+	properties[key] = value
+}
+
+func resolvePomPropertyValue(value string, properties map[string]string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", false
+	}
+	unresolved := false
+	for iteration := 0; iteration < 8; iteration++ {
+		matches := pomPropertyTokenPattern.FindAllStringSubmatch(value, -1)
+		if len(matches) == 0 {
+			break
+		}
+		updated := value
+		replaced := false
+		for _, match := range matches {
+			if len(match) != 2 {
+				continue
+			}
+			token := match[0]
+			key := strings.TrimSpace(match[1])
+			replacement, ok := properties[key]
+			if !ok || strings.TrimSpace(replacement) == "" {
+				unresolved = true
+				continue
+			}
+			updated = strings.ReplaceAll(updated, token, strings.TrimSpace(replacement))
+			replaced = true
+		}
+		value = updated
+		if !replaced {
+			break
+		}
+	}
+	if pomPropertyTokenPattern.MatchString(value) {
+		unresolved = true
+	}
+	return strings.TrimSpace(value), unresolved
 }
 
 func parseGradleDependencies(repoPath string) []dependencyDescriptor {
@@ -753,11 +959,15 @@ func (c *buildFileWarningCollector) visit(path string, entry fs.DirEntry, err er
 }
 
 func formatBuildFileReadWarning(repoPath, path string, err error) string {
+	return "unable to read " + relativeBuildFilePath(repoPath, path) + ": " + err.Error()
+}
+
+func relativeBuildFilePath(repoPath, path string) string {
 	relPath := path
 	if rel, relErr := filepath.Rel(repoPath, path); relErr == nil {
 		relPath = rel
 	}
-	return "unable to read " + filepath.ToSlash(relPath) + ": " + err.Error()
+	return filepath.ToSlash(relPath)
 }
 
 func matchesBuildFile(fileName string, names []string) bool {

--- a/internal/lang/jvm/adapter_test.go
+++ b/internal/lang/jvm/adapter_test.go
@@ -82,6 +82,58 @@ class ExampleTest {
 	}
 }
 
+func TestAdapterAnalyseDependencyFromMavenDependencyManagement(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, testFilePomXML), `
+<project>
+  <properties>
+    <junit.version>5.10.2</junit.version>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>3.4.5</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "test", "java", "ManagedExampleTest.java"), `
+import org.junit.jupiter.api.Test;
+
+class ManagedExampleTest {
+  @Test
+  void runs() {}
+}
+`)
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath:   repo,
+		Dependency: "junit-jupiter-api",
+	})
+	if err != nil {
+		t.Fatalf(errAnalyseFmt, err)
+	}
+	if len(reportData.Dependencies) != 1 {
+		t.Fatalf("expected one dependency report, got %d", len(reportData.Dependencies))
+	}
+	if reportData.Dependencies[0].UsedExportsCount == 0 {
+		t.Fatalf("expected managed Maven dependency usage to be recorded")
+	}
+	if strings.Contains(strings.Join(reportData.Warnings, "\n"), "unable to resolve managed Maven version") {
+		t.Fatalf("did not expect managed-version warning, got %#v", reportData.Warnings)
+	}
+}
+
 func TestAdapterAnalyseTopN(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, testFileBuildGradleKTS), `

--- a/internal/lang/jvm/helpers_test.go
+++ b/internal/lang/jvm/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
@@ -124,7 +125,16 @@ func TestJVMDescriptorAndBuildFileHelpers(t *testing.T) {
 	}
 
 	repo := t.TempDir()
-	testutil.MustWriteFile(t, filepath.Join(repo, "pom.xml"), `<dependency><groupId>org.junit</groupId><artifactId>junit</artifactId></dependency>`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "pom.xml"), `
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+</project>
+`)
 	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), `implementation 'com.squareup.okhttp3:okhttp:4.12.0'`)
 	poms := parsePomDependencies(repo)
 	gradle := parseGradleDependencies(repo)
@@ -138,6 +148,86 @@ func TestJVMDescriptorAndBuildFileHelpers(t *testing.T) {
 	}
 	if !slices.Contains(names, "junit") || !slices.Contains(names, "okhttp") {
 		t.Fatalf("expected declared dependencies from build files, got %#v", names)
+	}
+}
+
+func TestJVMParsePomDependenciesIncludesManagedAndBOMEntries(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "pom.xml"), `
+<project>
+  <properties>
+    <junit.version>5.10.2</junit.version>
+    <spring.boot.version>3.4.5</spring.boot.version>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+`)
+	descriptors, warnings := parsePomDependenciesWithWarnings(repo)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for resolvable managed dependencies, got %#v", warnings)
+	}
+
+	names := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		names = append(names, descriptor.Name)
+	}
+	for _, name := range []string{"junit-jupiter-api", "spring-boot-dependencies"} {
+		if !slices.Contains(names, name) {
+			t.Fatalf("expected managed Maven dependency %q in %#v", name, descriptors)
+		}
+	}
+}
+
+func TestJVMParsePomDependenciesWarnsForUnresolvedManagedVersions(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "pom.xml"), `
+<project>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${missing.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+`)
+
+	descriptors, warnings := parsePomDependenciesWithWarnings(repo)
+	if len(descriptors) != 2 {
+		t.Fatalf("expected managed dependencies to remain surfaced, got %#v", descriptors)
+	}
+
+	joined := strings.Join(warnings, "\n")
+	for _, expected := range []string{
+		"unable to resolve managed Maven version for org.junit.jupiter:junit-jupiter-api in pom.xml",
+		"unable to resolve imported Maven BOM version for org.springframework.boot:spring-boot-dependencies in pom.xml",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("expected warning %q in %q", expected, joined)
+		}
 	}
 }
 

--- a/internal/lang/shared/gradle_catalog.go
+++ b/internal/lang/shared/gradle_catalog.go
@@ -36,12 +36,19 @@ type GradleCatalogLibrary struct {
 type GradleCatalogResolver struct {
 	knownCatalogs map[string]struct{}
 	scopes        []gradleCatalogScope
+	lookup        gradleCatalogLookupIndex
 }
 
 type gradleCatalogScope struct {
 	root      string
 	libraries map[string]GradleCatalogLibrary
 	bundles   map[string][]GradleCatalogLibrary
+}
+
+type gradleCatalogLookupIndex struct {
+	scopesByRoot    map[string]*gradleCatalogScope
+	cachedScopes    map[string]*gradleCatalogScope
+	cachedUnmatched map[string]struct{}
 }
 
 type gradleCatalogSource struct {
@@ -222,23 +229,34 @@ func (r *gradleCatalogRegistry) trackKnownCatalog(name string) {
 }
 
 func (r *gradleCatalogRegistry) buildResolver() GradleCatalogResolver {
+	r.parseSources()
+	scopes := r.sortedScopes()
+	resolver := GradleCatalogResolver{
+		knownCatalogs: r.knownCatalogs,
+		scopes:        scopes,
+	}
+	resolver.lookup = newGradleCatalogLookupIndex(resolver.scopes)
+	return resolver
+}
+
+func (r *gradleCatalogRegistry) parseSources() {
 	for _, source := range r.sources {
 		r.loadSource(source)
 	}
-	resolver := GradleCatalogResolver{
-		knownCatalogs: r.knownCatalogs,
-		scopes:        make([]gradleCatalogScope, 0, len(r.scopesByRoot)),
-	}
+}
+
+func (r *gradleCatalogRegistry) sortedScopes() []gradleCatalogScope {
+	scopes := make([]gradleCatalogScope, 0, len(r.scopesByRoot))
 	for _, scope := range r.scopesByRoot {
-		resolver.scopes = append(resolver.scopes, *scope)
+		scopes = append(scopes, *scope)
 	}
-	sort.Slice(resolver.scopes, func(i, j int) bool {
-		if len(resolver.scopes[i].root) == len(resolver.scopes[j].root) {
-			return resolver.scopes[i].root < resolver.scopes[j].root
+	sort.Slice(scopes, func(i, j int) bool {
+		if len(scopes[i].root) == len(scopes[j].root) {
+			return scopes[i].root < scopes[j].root
 		}
-		return len(resolver.scopes[i].root) > len(resolver.scopes[j].root)
+		return len(scopes[i].root) > len(scopes[j].root)
 	})
-	return resolver
+	return scopes
 }
 
 func (r *gradleCatalogRegistry) loadSource(source gradleCatalogSource) {
@@ -458,13 +476,55 @@ func (r *GradleCatalogResolver) resolveBundleReference(buildFilePath, catalogNam
 }
 
 func (r *GradleCatalogResolver) scopeForBuildFile(buildFilePath string) *gradleCatalogScope {
+	r.ensureLookupIndex()
+	return r.lookup.resolve(buildFilePath)
+}
+
+func (r *GradleCatalogResolver) ensureLookupIndex() {
+	if r.lookup.scopesByRoot != nil {
+		return
+	}
+	r.lookup = newGradleCatalogLookupIndex(r.scopes)
+}
+
+func newGradleCatalogLookupIndex(scopes []gradleCatalogScope) gradleCatalogLookupIndex {
+	index := gradleCatalogLookupIndex{
+		scopesByRoot:    make(map[string]*gradleCatalogScope, len(scopes)),
+		cachedScopes:    make(map[string]*gradleCatalogScope),
+		cachedUnmatched: make(map[string]struct{}),
+	}
+	for i := range scopes {
+		scope := &scopes[i]
+		index.scopesByRoot[filepath.Clean(scope.root)] = scope
+	}
+	return index
+}
+
+func (i *gradleCatalogLookupIndex) resolve(buildFilePath string) *gradleCatalogScope {
+	if i == nil || len(i.scopesByRoot) == 0 {
+		return nil
+	}
 	cleanPath := filepath.Clean(buildFilePath)
-	for index := range r.scopes {
-		scope := &r.scopes[index]
-		if isGradleCatalogSubPath(scope.root, cleanPath) {
+	if scope, ok := i.cachedScopes[cleanPath]; ok {
+		return scope
+	}
+	if _, ok := i.cachedUnmatched[cleanPath]; ok {
+		return nil
+	}
+
+	candidate := cleanPath
+	for {
+		if scope, ok := i.scopesByRoot[candidate]; ok {
+			i.cachedScopes[cleanPath] = scope
 			return scope
 		}
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			break
+		}
+		candidate = parent
 	}
+	i.cachedUnmatched[cleanPath] = struct{}{}
 	return nil
 }
 

--- a/internal/lang/shared/gradle_catalog_internal_test.go
+++ b/internal/lang/shared/gradle_catalog_internal_test.go
@@ -485,6 +485,32 @@ func TestGradleCatalogPathAndWarningHelpers(t *testing.T) {
 	}
 }
 
+func TestGradleCatalogLookupIndexCachesScopeMatches(t *testing.T) {
+	resolver := GradleCatalogResolver{
+		scopes: []gradleCatalogScope{
+			{root: filepath.Clean(testAppRoot)},
+		},
+	}
+	if resolver.lookup.scopesByRoot != nil {
+		t.Fatalf("expected zero-value resolver lookup index to be uninitialized")
+	}
+
+	scope := resolver.scopeForBuildFile(testBuildFile)
+	if scope == nil || scope.root != filepath.Clean(testAppRoot) {
+		t.Fatalf("expected build file to resolve against app scope, got %#v", scope)
+	}
+	if resolver.lookup.scopesByRoot == nil || resolver.lookup.cachedScopes[filepath.Clean(testBuildFile)] == nil {
+		t.Fatalf("expected lookup index and cache to be initialized, got %#v", resolver.lookup)
+	}
+
+	if unresolved := resolver.scopeForBuildFile(testOtherBuildFile); unresolved != nil {
+		t.Fatalf("expected non-matching build file to stay unresolved, got %#v", unresolved)
+	}
+	if _, ok := resolver.lookup.cachedUnmatched[filepath.Clean(testOtherBuildFile)]; !ok {
+		t.Fatalf("expected unmatched lookup to be cached, got %#v", resolver.lookup.cachedUnmatched)
+	}
+}
+
 func TestGradleCatalogReferenceCollectorIgnoresUnknownInputs(t *testing.T) {
 	resolver := GradleCatalogResolver{knownCatalogs: map[string]struct{}{gradleCatalogName: {}}}
 	collector := newGradleCatalogReferenceCollector(&resolver, testBuildFile)


### PR DESCRIPTION
## Summary
- add structured Maven `pom.xml` parsing in the JVM adapter for both direct dependencies and `dependencyManagement` entries
- surface imported BOM coordinates (`type=pom`, `scope=import`) as declared dependencies
- add conservative warnings when managed Maven/BOM versions are missing or unresolved
- refactor shared Gradle catalog resolver into explicit source-parse/scope-build stages and add indexed/cached scope lookup to avoid repeated linear scope scans
- add regression coverage for managed Maven/BOM parsing and Gradle catalog indexed lookup behavior

## Why
Slice 3 requires complete managed Maven surface support (`#491`) and cleaner/faster shared Gradle catalog lookup seams (`#536`) used by JVM and Kotlin Android adapters.

## Validation
- `go test ./internal/lang/jvm`
- `go test ./internal/lang/shared`
- `go test ./internal/lang/kotlinandroid`
- `env -u GIT_DIR -u GIT_WORK_TREE GOTOOLCHAIN=go1.26.2 go test ./scripts`
- `GO_TOOLCHAIN=go1.26.2 make vuln-check`

## Issues
Closes #491
Closes #536