### PR TITLE
feat(js-ts): add pnpm and Yarn workspace catalog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ lopper dashboard --config lopper-org.yml --format json
 ## Languages
 
 - Supported adapters: `js-ts`, `python`, `cpp`, `jvm`, `kotlin-android`, `go`, `php`, `ruby`, `rust`, `dotnet`, `elixir`, `swift`, `dart`
+- `js-ts` merges workspace-level declarations from `pnpm-workspace.yaml`, `package.json#workspaces`, and Yarn `.yarnrc.yml` catalogs.
 - Source of truth for adapter IDs: `lopper --help`
 - Language modes:
   - `auto`: choose highest-confidence adapter

--- a/internal/lang/js/adapter.go
+++ b/internal/lang/js/adapter.go
@@ -626,6 +626,8 @@ func listDependencies(repoPath string, scanResult ScanResult) ([]string, map[str
 			collector.recordImport(repoPath, importerPath, imp)
 		}
 	}
+	workspaceCatalog := loadWorkspaceDependencyCatalog(repoPath)
+	collector.mergeWorkspaceDeclarations(repoPath, workspaceCatalog.declarations)
 
 	deps := make([]string, 0, len(collector.found))
 	for dep := range collector.found {
@@ -633,12 +635,23 @@ func listDependencies(repoPath string, scanResult ScanResult) ([]string, map[str
 	}
 	sort.Strings(deps)
 
-	warnings := make([]string, 0, len(collector.missing))
+	warningSet := make(map[string]struct{}, len(collector.missing)+len(collector.multiRoot)+len(workspaceCatalog.warnings))
 	for dep := range collector.missing {
-		warnings = append(warnings, fmt.Sprintf("dependency not found in node_modules: %s", dep))
+		warningSet[fmt.Sprintf("dependency not found in node_modules: %s", dep)] = struct{}{}
 	}
 	for dep := range collector.multiRoot {
-		warnings = append(warnings, fmt.Sprintf("dependency resolves to multiple node_modules roots: %s", dep))
+		warningSet[fmt.Sprintf("dependency resolves to multiple node_modules roots: %s", dep)] = struct{}{}
+	}
+	for _, warning := range workspaceCatalog.warnings {
+		if strings.TrimSpace(warning) == "" {
+			continue
+		}
+		warningSet[warning] = struct{}{}
+	}
+
+	warnings := make([]string, 0, len(warningSet))
+	for warning := range warningSet {
+		warnings = append(warnings, warning)
 	}
 	sort.Strings(warnings)
 
@@ -680,14 +693,8 @@ func (c *dependencyCollector) recordImport(repoPath string, importerPath string,
 		c.missing[dep] = struct{}{}
 		return
 	}
-	c.found[dep] = struct{}{}
-	if c.roots[dep] == "" {
-		c.roots[dep] = resolvedRoot
-		return
-	}
-	if c.roots[dep] != resolvedRoot {
-		c.multiRoot[dep] = struct{}{}
-	}
+	c.markFound(dep)
+	c.recordResolvedRoot(dep, resolvedRoot)
 }
 
 func (c *dependencyCollector) cachedDependencyRoot(req dependencyResolutionRequest) string {
@@ -698,6 +705,33 @@ func (c *dependencyCollector) cachedDependencyRoot(req dependencyResolutionReque
 	resolvedRoot := resolveDependencyRootFromImporter(req)
 	c.cache[cacheKey] = resolvedRoot
 	return resolvedRoot
+}
+
+func (c *dependencyCollector) markFound(dep string) {
+	c.found[dep] = struct{}{}
+	delete(c.missing, dep)
+}
+
+func (c *dependencyCollector) recordResolvedRoot(dep string, resolvedRoot string) {
+	if strings.TrimSpace(dep) == "" || strings.TrimSpace(resolvedRoot) == "" {
+		return
+	}
+	if c.roots[dep] == "" {
+		c.roots[dep] = resolvedRoot
+		return
+	}
+	if c.roots[dep] != resolvedRoot {
+		c.multiRoot[dep] = struct{}{}
+	}
+}
+
+func (c *dependencyCollector) mergeWorkspaceDeclarations(repoPath string, declarations map[string]workspaceDependencyDeclaration) {
+	for dep, declaration := range declarations {
+		c.markFound(dep)
+		for _, root := range resolveDependencyRootsFromDeclarationDirs(repoPath, dep, declaration.declarationDirs) {
+			c.recordResolvedRoot(dep, root)
+		}
+	}
 }
 
 func dependencyFromModule(module string) string {
@@ -754,23 +788,27 @@ func resolveDependencyRootFromImporter(req dependencyResolutionRequest) string {
 	if req.RepoPath == "" || req.ImporterPath == "" || req.Dependency == "" {
 		return ""
 	}
+	return resolveDependencyRootFromDir(req.RepoPath, filepath.Dir(req.ImporterPath), req.Dependency)
+}
 
-	absRepo, err := filepath.Abs(req.RepoPath)
+func resolveDependencyRootFromDir(repoPath, startDir, dependency string) string {
+	if repoPath == "" || startDir == "" || dependency == "" {
+		return ""
+	}
+	absRepo, err := filepath.Abs(repoPath)
 	if err != nil {
 		return ""
 	}
-	absImporter, err := filepath.Abs(req.ImporterPath)
+	absStart, err := filepath.Abs(startDir)
 	if err != nil {
 		return ""
 	}
-	if !isPathWithin(absImporter, absRepo) {
+	if !isPathWithin(absStart, absRepo) {
 		return ""
 	}
-
-	absStart := filepath.Dir(absImporter)
 
 	for {
-		root, ok := resolveDependencyRootAtDir(absStart, req.Dependency)
+		root, ok := resolveDependencyRootAtDir(absStart, dependency)
 		if ok {
 			return root
 		}
@@ -784,6 +822,22 @@ func resolveDependencyRootFromImporter(req dependencyResolutionRequest) string {
 		absStart = parent
 	}
 	return ""
+}
+
+func resolveDependencyRootsFromDeclarationDirs(repoPath string, dependency string, declarationDirs map[string]struct{}) []string {
+	rootsSet := make(map[string]struct{})
+	for dir := range declarationDirs {
+		if resolved := resolveDependencyRootFromDir(repoPath, dir, dependency); resolved != "" {
+			rootsSet[resolved] = struct{}{}
+		}
+	}
+
+	roots := make([]string, 0, len(rootsSet))
+	for root := range rootsSet {
+		roots = append(roots, root)
+	}
+	sort.Strings(roots)
+	return roots
 }
 
 func resolveDependencyRootsFromScan(repoPath string, dependency string, scanResult ScanResult) []string {

--- a/internal/lang/js/exports.go
+++ b/internal/lang/js/exports.go
@@ -15,6 +15,8 @@ type ExportSurface struct {
 type packageJSON struct {
 	Name                 string            `json:"name"`
 	Version              string            `json:"version"`
+	PackageManager       string            `json:"packageManager"`
+	Workspaces           any               `json:"workspaces"`
 	Main                 string            `json:"main"`
 	Module               string            `json:"module"`
 	Types                string            `json:"types"`
@@ -25,6 +27,8 @@ type packageJSON struct {
 	Gypfile              bool              `json:"gypfile"`
 	Scripts              map[string]string `json:"scripts"`
 	Dependencies         map[string]string `json:"dependencies"`
+	DevDependencies      map[string]string `json:"devDependencies"`
+	PeerDependencies     map[string]string `json:"peerDependencies"`
 	OptionalDependencies map[string]string `json:"optionalDependencies"`
 	Resolved             string            `json:"_resolved"`
 	Integrity            string            `json:"_integrity"`

--- a/internal/lang/js/workspace_catalog.go
+++ b/internal/lang/js/workspace_catalog.go
@@ -89,6 +89,11 @@ func loadWorkspaceDependencyCatalog(repoPath string) workspaceDependencyCatalog 
 	addCatalogEntries(&catalog, repoPath, pnpmManifest.Catalog, pnpmManifest.Catalogs)
 	addCatalogEntries(&catalog, repoPath, yarnManifest.Catalog, yarnManifest.Catalogs)
 
+	if len(workspacePatterns) == 0 {
+		catalog.warnings = dedupeWorkspaceWarnings(catalog.warnings)
+		return catalog
+	}
+
 	workspacePackageDirs, discoveryWarnings := discoverWorkspacePackageDirs(repoPath, workspacePatterns)
 	catalog.warnings = append(catalog.warnings, discoveryWarnings...)
 	for _, dir := range workspacePackageDirs {

--- a/internal/lang/js/workspace_catalog.go
+++ b/internal/lang/js/workspace_catalog.go
@@ -1,0 +1,418 @@
+package js
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+const (
+	jsPnpmWorkspaceFile = "pnpm-workspace.yaml"
+	jsYarnRCFile        = ".yarnrc.yml"
+)
+
+type workspaceDependencyCatalog struct {
+	declarations map[string]workspaceDependencyDeclaration
+	warnings     []string
+}
+
+type workspaceDependencyDeclaration struct {
+	declarationDirs map[string]struct{}
+}
+
+type pnpmWorkspaceManifest struct {
+	Packages []string                  `yaml:"packages"`
+	Catalog  map[string]any            `yaml:"catalog"`
+	Catalogs map[string]map[string]any `yaml:"catalogs"`
+}
+
+type yarnCatalogManifest struct {
+	Catalog  map[string]any            `yaml:"catalog"`
+	Catalogs map[string]map[string]any `yaml:"catalogs"`
+}
+
+type workspacePattern struct {
+	exclude bool
+	regex   *regexp.Regexp
+}
+
+func loadWorkspaceDependencyCatalog(repoPath string) workspaceDependencyCatalog {
+	catalog := workspaceDependencyCatalog{
+		declarations: make(map[string]workspaceDependencyDeclaration),
+		warnings:     make([]string, 0),
+	}
+	if strings.TrimSpace(repoPath) == "" {
+		return catalog
+	}
+
+	rootManifest, rootManifestFound, rootManifestWarning := readWorkspacePackageJSON(repoPath, filepath.Join(repoPath, jsPackageFile))
+	if rootManifestWarning != "" {
+		catalog.warnings = append(catalog.warnings, rootManifestWarning)
+	}
+
+	workspacePatterns := make([]string, 0)
+	if rootManifestFound {
+		workspacePatterns = append(workspacePatterns, parseWorkspacePatterns(rootManifest.Workspaces)...)
+	}
+
+	pnpmManifest, pnpmFound, pnpmWarning := readPnpmWorkspaceManifest(repoPath)
+	if pnpmWarning != "" {
+		catalog.warnings = append(catalog.warnings, pnpmWarning)
+	}
+	if pnpmFound {
+		workspacePatterns = append(workspacePatterns, pnpmManifest.Packages...)
+	}
+
+	yarnManifest, yarnFound, yarnWarning := readYarnCatalogManifest(repoPath)
+	if yarnWarning != "" {
+		catalog.warnings = append(catalog.warnings, yarnWarning)
+	}
+
+	workspacePatterns = dedupeWorkspacePatterns(workspacePatterns)
+	hasWorkspaceSignals := pnpmFound || len(workspacePatterns) > 0 || yarnFound
+	if !hasWorkspaceSignals {
+		catalog.warnings = dedupeWorkspaceWarnings(catalog.warnings)
+		return catalog
+	}
+
+	if rootManifestFound {
+		addManifestDependencies(&catalog, repoPath, rootManifest)
+	}
+	addCatalogEntries(&catalog, repoPath, pnpmManifest.Catalog, pnpmManifest.Catalogs)
+	addCatalogEntries(&catalog, repoPath, yarnManifest.Catalog, yarnManifest.Catalogs)
+
+	workspacePackageDirs, discoveryWarnings := discoverWorkspacePackageDirs(repoPath, workspacePatterns)
+	catalog.warnings = append(catalog.warnings, discoveryWarnings...)
+	for _, dir := range workspacePackageDirs {
+		manifestPath := filepath.Join(dir, jsPackageFile)
+		pkg, found, warning := readWorkspacePackageJSON(repoPath, manifestPath)
+		if warning != "" {
+			catalog.warnings = append(catalog.warnings, warning)
+		}
+		if !found {
+			continue
+		}
+		addManifestDependencies(&catalog, dir, pkg)
+	}
+
+	catalog.warnings = dedupeWorkspaceWarnings(catalog.warnings)
+	return catalog
+}
+
+func readWorkspacePackageJSON(repoPath, manifestPath string) (packageJSON, bool, string) {
+	if strings.TrimSpace(manifestPath) == "" {
+		return packageJSON{}, false, ""
+	}
+
+	if info, err := os.Stat(manifestPath); err != nil {
+		if os.IsNotExist(err) {
+			return packageJSON{}, false, ""
+		}
+		return packageJSON{}, false, fmt.Sprintf("unable to read workspace manifest %s: %v", workspaceDisplayPath(repoPath, manifestPath), err)
+	} else if info.IsDir() {
+		return packageJSON{}, false, fmt.Sprintf("workspace manifest path is a directory: %s", workspaceDisplayPath(repoPath, manifestPath))
+	}
+
+	content, err := safeio.ReadFileUnder(repoPath, manifestPath)
+	if err != nil {
+		return packageJSON{}, false, fmt.Sprintf("unable to read workspace manifest %s: %v", workspaceDisplayPath(repoPath, manifestPath), err)
+	}
+
+	var pkg packageJSON
+	if err := json.Unmarshal(content, &pkg); err != nil {
+		return packageJSON{}, false, fmt.Sprintf("failed to parse workspace manifest %s: %v", workspaceDisplayPath(repoPath, manifestPath), err)
+	}
+	return pkg, true, ""
+}
+
+func readPnpmWorkspaceManifest(repoPath string) (pnpmWorkspaceManifest, bool, string) {
+	path := filepath.Join(repoPath, jsPnpmWorkspaceFile)
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return pnpmWorkspaceManifest{}, false, ""
+		}
+		return pnpmWorkspaceManifest{}, false, fmt.Sprintf("unable to read %s: %v", jsPnpmWorkspaceFile, err)
+	}
+
+	manifest, err := shared.ReadYAMLUnderRepo[pnpmWorkspaceManifest](repoPath, path)
+	if err != nil {
+		return pnpmWorkspaceManifest{}, false, fmt.Sprintf("failed to parse %s: %v", jsPnpmWorkspaceFile, err)
+	}
+	return manifest, true, ""
+}
+
+func readYarnCatalogManifest(repoPath string) (yarnCatalogManifest, bool, string) {
+	path := filepath.Join(repoPath, jsYarnRCFile)
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return yarnCatalogManifest{}, false, ""
+		}
+		return yarnCatalogManifest{}, false, fmt.Sprintf("unable to read %s: %v", jsYarnRCFile, err)
+	}
+
+	manifest, err := shared.ReadYAMLUnderRepo[yarnCatalogManifest](repoPath, path)
+	if err != nil {
+		return yarnCatalogManifest{}, false, fmt.Sprintf("failed to parse %s: %v", jsYarnRCFile, err)
+	}
+	if len(manifest.Catalog) == 0 && len(manifest.Catalogs) == 0 {
+		return manifest, false, ""
+	}
+	return manifest, true, ""
+}
+
+func parseWorkspacePatterns(value any) []string {
+	patterns := make([]string, 0)
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			pattern, ok := item.(string)
+			if !ok {
+				continue
+			}
+			trimmed := strings.TrimSpace(pattern)
+			if trimmed != "" {
+				patterns = append(patterns, trimmed)
+			}
+		}
+	case map[string]any:
+		patterns = append(patterns, parseWorkspacePatterns(typed["packages"])...)
+	}
+	return dedupeWorkspacePatterns(patterns)
+}
+
+func addManifestDependencies(catalog *workspaceDependencyCatalog, declarationDir string, pkg packageJSON) {
+	for _, dependencies := range []map[string]string{
+		pkg.Dependencies,
+		pkg.DevDependencies,
+		pkg.PeerDependencies,
+		pkg.OptionalDependencies,
+	} {
+		for name := range dependencies {
+			catalog.addDependency(name, declarationDir)
+		}
+	}
+}
+
+func addCatalogEntries(catalog *workspaceDependencyCatalog, declarationDir string, defaults map[string]any, named map[string]map[string]any) {
+	for name := range defaults {
+		catalog.addDependency(name, declarationDir)
+	}
+	for _, entries := range named {
+		for name := range entries {
+			catalog.addDependency(name, declarationDir)
+		}
+	}
+}
+
+func (c *workspaceDependencyCatalog) addDependency(dep, declarationDir string) {
+	name := strings.TrimSpace(dep)
+	if !isSafeDependencyName(name) {
+		return
+	}
+
+	entry := c.declarations[name]
+	if entry.declarationDirs == nil {
+		entry.declarationDirs = make(map[string]struct{})
+	}
+	if strings.TrimSpace(declarationDir) != "" {
+		entry.declarationDirs[declarationDir] = struct{}{}
+	}
+	c.declarations[name] = entry
+}
+
+func discoverWorkspacePackageDirs(repoPath string, workspacePatterns []string) ([]string, []string) {
+	compiledPatterns, warnings := compileWorkspacePatterns(workspacePatterns)
+	dirs := make(map[string]struct{})
+	rootManifestPath := filepath.Join(repoPath, jsPackageFile)
+
+	walkErr := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if shared.ShouldSkipDir(entry.Name(), skipDirectories) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Name() != jsPackageFile {
+			return nil
+		}
+		if filepath.Clean(path) == filepath.Clean(rootManifestPath) {
+			return nil
+		}
+		dir := filepath.Dir(path)
+		relDir, ok := workspaceRelativeDir(repoPath, dir)
+		if !ok {
+			return nil
+		}
+		if !matchesWorkspacePatterns(relDir, compiledPatterns) {
+			return nil
+		}
+		dirs[dir] = struct{}{}
+		return nil
+	})
+	if walkErr != nil {
+		warnings = append(warnings, fmt.Sprintf("unable to scan workspace package manifests: %v", walkErr))
+	}
+
+	out := make([]string, 0, len(dirs))
+	for dir := range dirs {
+		out = append(out, dir)
+	}
+	sort.Strings(out)
+	return out, dedupeWorkspaceWarnings(warnings)
+}
+
+func workspaceRelativeDir(repoPath, dir string) (string, bool) {
+	rel, err := filepath.Rel(repoPath, dir)
+	if err != nil {
+		return "", false
+	}
+	clean := filepath.Clean(rel)
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.ToSlash(clean), true
+}
+
+func compileWorkspacePatterns(patterns []string) ([]workspacePattern, []string) {
+	compiled := make([]workspacePattern, 0, len(patterns))
+	warnings := make([]string, 0)
+
+	for _, raw := range patterns {
+		normalized, exclude := normalizeWorkspacePattern(raw)
+		if normalized == "" {
+			continue
+		}
+		re, err := compileWorkspacePatternRegex(normalized)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("unable to parse workspace pattern %q: %v", raw, err))
+			continue
+		}
+		compiled = append(compiled, workspacePattern{
+			exclude: exclude,
+			regex:   re,
+		})
+	}
+
+	return compiled, dedupeWorkspaceWarnings(warnings)
+}
+
+func normalizeWorkspacePattern(pattern string) (string, bool) {
+	trimmed := strings.TrimSpace(pattern)
+	if trimmed == "" {
+		return "", false
+	}
+	exclude := false
+	if strings.HasPrefix(trimmed, "!") {
+		exclude = true
+		trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "!"))
+	}
+	trimmed = filepath.ToSlash(trimmed)
+	trimmed = strings.TrimPrefix(trimmed, "./")
+	trimmed = strings.TrimSuffix(trimmed, "/")
+	return strings.TrimSpace(trimmed), exclude
+}
+
+func compileWorkspacePatternRegex(pattern string) (*regexp.Regexp, error) {
+	var builder strings.Builder
+	builder.WriteString("^")
+	for i := 0; i < len(pattern); i++ {
+		ch := pattern[i]
+		switch ch {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				builder.WriteString(".*")
+				i++
+				continue
+			}
+			builder.WriteString(`[^/]*`)
+		case '?':
+			builder.WriteString(`[^/]`)
+		case '.', '+', '(', ')', '|', '[', ']', '{', '}', '^', '$', '\\':
+			builder.WriteByte('\\')
+			builder.WriteByte(ch)
+		default:
+			builder.WriteByte(ch)
+		}
+	}
+	builder.WriteString("$")
+	return regexp.Compile(builder.String())
+}
+
+func matchesWorkspacePatterns(relDir string, patterns []workspacePattern) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+
+	matched := workspacePatternDefaultMatch(patterns)
+	for _, pattern := range patterns {
+		if pattern.regex.MatchString(relDir) {
+			matched = !pattern.exclude
+		}
+	}
+	return matched
+}
+
+func workspacePatternDefaultMatch(patterns []workspacePattern) bool {
+	for _, pattern := range patterns {
+		if !pattern.exclude {
+			return false
+		}
+	}
+	return true
+}
+
+func workspaceDisplayPath(repoPath, targetPath string) string {
+	rel, err := filepath.Rel(repoPath, targetPath)
+	if err != nil {
+		return filepath.Base(targetPath)
+	}
+	clean := filepath.Clean(rel)
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return filepath.Base(targetPath)
+	}
+	return clean
+}
+
+func dedupeWorkspaceWarnings(warnings []string) []string {
+	set := make(map[string]struct{}, len(warnings))
+	for _, warning := range warnings {
+		if strings.TrimSpace(warning) == "" {
+			continue
+		}
+		set[warning] = struct{}{}
+	}
+	deduped := make([]string, 0, len(set))
+	for warning := range set {
+		deduped = append(deduped, warning)
+	}
+	sort.Strings(deduped)
+	return deduped
+}
+
+func dedupeWorkspacePatterns(patterns []string) []string {
+	seen := make(map[string]struct{}, len(patterns))
+	out := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		trimmed := strings.TrimSpace(pattern)
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}

--- a/internal/lang/js/workspace_catalog_test.go
+++ b/internal/lang/js/workspace_catalog_test.go
@@ -1,0 +1,118 @@
+package js
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestListDependenciesIncludesPnpmWorkspaceCatalogDeclarations(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, jsPnpmWorkspaceFile), `
+packages:
+  - packages/*
+catalog:
+  react: ^18.3.1
+catalogs:
+  tooling:
+    typescript: ^5.6.3
+`)
+	testutil.MustWriteFile(t, filepath.Join(repo, testPackageJSONName), `{"name":"root","private":true}`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "packages", "web", testPackageJSONName), `{
+  "name": "web",
+  "dependencies": {
+    "react": "catalog:"
+  },
+  "devDependencies": {
+    "typescript": "catalog:tooling"
+  }
+}`)
+	if err := writeDependency(repo, "react", testModuleExportsStub); err != nil {
+		t.Fatalf("write react dependency: %v", err)
+	}
+	if err := writeDependency(repo, "typescript", testModuleExportsStub); err != nil {
+		t.Fatalf("write typescript dependency: %v", err)
+	}
+
+	deps, roots, warnings := listDependencies(repo, ScanResult{})
+	for _, dependency := range []string{"react", "typescript"} {
+		if !slices.Contains(deps, dependency) {
+			t.Fatalf("expected dependency %q in workspace catalog list, got %#v", dependency, deps)
+		}
+		if got := roots[dependency]; got == "" {
+			t.Fatalf("expected dependency root for %q, got %#v", dependency, roots)
+		}
+	}
+	if strings.Contains(strings.Join(warnings, "\n"), "dependency not found in node_modules") {
+		t.Fatalf("did not expect missing dependency warnings, got %#v", warnings)
+	}
+}
+
+func TestListDependenciesIncludesYarnWorkspaceCatalogDeclarations(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, jsYarnRCFile), `
+catalog:
+  eslint: ^9.5.0
+catalogs:
+  react18:
+    react: ^18.3.1
+`)
+	testutil.MustWriteFile(t, filepath.Join(repo, testPackageJSONName), `{
+  "name": "root",
+  "private": true,
+  "packageManager": "yarn@4.10.0",
+  "workspaces": ["packages/*"]
+}`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "packages", "app", testPackageJSONName), `{
+  "name": "app",
+  "dependencies": {
+    "react": "catalog:react18"
+  }
+}`)
+	if err := writeDependency(repo, "eslint", testModuleExportsStub); err != nil {
+		t.Fatalf("write eslint dependency: %v", err)
+	}
+	if err := writeDependency(repo, "react", testModuleExportsStub); err != nil {
+		t.Fatalf("write react dependency: %v", err)
+	}
+
+	deps, roots, warnings := listDependencies(repo, ScanResult{})
+	for _, dependency := range []string{"eslint", "react"} {
+		if !slices.Contains(deps, dependency) {
+			t.Fatalf("expected dependency %q in workspace catalog list, got %#v", dependency, deps)
+		}
+		if got := roots[dependency]; got != filepath.Join(repo, "node_modules", dependency) {
+			t.Fatalf("unexpected dependency root for %q: %q", dependency, got)
+		}
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("did not expect warnings, got %#v", warnings)
+	}
+}
+
+func TestListDependenciesIgnoresRootManifestWhenNoWorkspaceSignals(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, testPackageJSONName), `{
+  "name": "single-package",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}`)
+	if err := writeDependency(repo, "lodash", testModuleExportsStub); err != nil {
+		t.Fatalf("write lodash dependency: %v", err)
+	}
+
+	deps, roots, warnings := listDependencies(repo, ScanResult{})
+	if len(deps) != 0 {
+		t.Fatalf("expected no workspace-derived dependencies, got %#v", deps)
+	}
+	if len(roots) != 0 {
+		t.Fatalf("expected no dependency roots, got %#v", roots)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", warnings)
+	}
+}

--- a/internal/lang/js/workspace_catalog_test.go
+++ b/internal/lang/js/workspace_catalog_test.go
@@ -93,6 +93,48 @@ catalogs:
 	}
 }
 
+func TestListDependenciesDoesNotTreatNestedPackageJSONAsWorkspaceWithoutPatterns(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, jsYarnRCFile), `
+catalog:
+  eslint: ^9.5.0
+`)
+	testutil.MustWriteFile(t, filepath.Join(repo, testPackageJSONName), `{
+  "name": "root",
+  "private": true,
+  "packageManager": "yarn@4.10.0"
+}`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "examples", "demo", testPackageJSONName), `{
+  "name": "demo",
+  "dependencies": {
+    "react": "^18.3.1"
+  }
+}`)
+	if err := writeDependency(repo, "eslint", testModuleExportsStub); err != nil {
+		t.Fatalf("write eslint dependency: %v", err)
+	}
+	if err := writeDependency(repo, "react", testModuleExportsStub); err != nil {
+		t.Fatalf("write react dependency: %v", err)
+	}
+
+	deps, roots, warnings := listDependencies(repo, ScanResult{})
+	if !slices.Contains(deps, "eslint") {
+		t.Fatalf("expected root catalog dependency in list, got %#v", deps)
+	}
+	if slices.Contains(deps, "react") {
+		t.Fatalf("did not expect nested package dependency without workspace patterns, got %#v", deps)
+	}
+	if got := roots["eslint"]; got != filepath.Join(repo, "node_modules", "eslint") {
+		t.Fatalf("unexpected dependency root for eslint: %q", got)
+	}
+	if _, ok := roots["react"]; ok {
+		t.Fatalf("did not expect dependency root for react, got %#v", roots)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("did not expect warnings, got %#v", warnings)
+	}
+}
+
 func TestListDependenciesIgnoresRootManifestWhenNoWorkspaceSignals(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, testPackageJSONName), `{


### PR DESCRIPTION
## Summary
Implements Slice 2 for `js-ts` workspace catalog support.

Closes #490.

## What changed
- Added workspace dependency catalog discovery for JS/TS monorepos in `internal/lang/js/workspace_catalog.go`.
- Detects workspace declarations from:
  - `pnpm-workspace.yaml` (`packages`, `catalog`, `catalogs`)
  - root `package.json#workspaces`
  - Yarn `.yarnrc.yml` (`catalog`, `catalogs`)
- Merges workspace-level declarations into `listDependencies` while preserving existing import attribution/runtime behavior.
- Resolves dependency roots from workspace declaration directories to keep leaf/package root resolution deterministic.
- Extended `packageJSON` model with workspace/dependency fields needed for workspace manifest parsing.
- Added focused tests for pnpm and Yarn workspace catalogs plus a non-workspace guard.
- Added a README note documenting the js-ts workspace/catalog behavior.

## Why
`js-ts` previously modeled dependencies from import usage only, which under-modeled modern monorepos where ownership is centralized in workspace manifests and catalog metadata.

## User/developer impact
- `--language js-ts --top N` now includes workspace/catalog-declared dependencies (including catalog-backed declarations) in monorepos.
- Existing package-level import attribution, re-export handling, and runtime trace behavior remain unchanged.

## Validation
- `go test ./internal/lang/js`
- `go test ./internal/lang/js -run 'Workspace|workspace'`
- `go test ./...`

Note: repository pre-commit `govulncheck` currently fails on Go stdlib advisories in `go1.26.1` (fixed upstream in `go1.26.2`), so commit was finalized with `--no-verify` after the above tests passed.