### PR TITLE
chore(release): bump stable version to 1.4.0

### DIFF
--- a/extensions/vscode-lopper/CHANGELOG.md
+++ b/extensions/vscode-lopper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.0
+
+- Added `package`, `repo`, and `changed-packages` scope controls in VS Code, plus force-fresh refresh commands and a tighter refresh session lifecycle.
+- Expanded dependency discovery with pnpm and Yarn workspace catalog support for JS/TS analysis.
+- Added managed Maven dependency resolution and indexed Gradle version catalog lookup for JVM projects.
+- Made runtime-assisted analysis cache-aware and hardened the PHP, Python, Ruby, and Elixir adapter pipelines for the shared `v1.4.0` release.
+
 ## 1.2.0
 
 - Expanded package ecosystem coverage across existing adapters with Ruby gemspec support, Swift CocoaPods support, Python modern packaging support, Gradle version catalog support, and C/C++ vcpkg plus Conan support.

--- a/extensions/vscode-lopper/package-lock.json
+++ b/extensions/vscode-lopper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-lopper",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-lopper",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",

--- a/extensions/vscode-lopper/package.json
+++ b/extensions/vscode-lopper/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-lopper",
   "displayName": "Lopper",
   "description": "VS Code diagnostics, hover details, and safe JS/TS quick fixes across Lopper adapters, including Kotlin Android.",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "publisher": "BenRanford",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What changed
- bump the committed VS Code extension version surfaces to `1.4.0`
- update the extension changelog to match the current `main` release scope after rebasing onto the latest changes

## 1.4.0 release scope
- VS Code `package`, `repo`, and `changed-packages` scope controls, plus force-fresh refresh commands and a tighter refresh session lifecycle
- pnpm and Yarn workspace catalog support for JS/TS analysis
- managed Maven dependency resolution and indexed Gradle version catalog lookup for JVM projects
- cache-aware runtime-assisted analysis, plus PHP/Python/Ruby/Elixir adapter pipeline hardening

## Why
The stable release workflow derives the next semver tag from `extensions/vscode-lopper/package.json`. With the current latest stable tag still at `v1.3.3`, raising that release floor to `1.4.0` makes the next shared CLI/application and extension release cut at `v1.4.0` instead of `v1.3.4`.

## Impact
The next stable release will align the published `lopper` application tag and the Marketplace extension on `v1.4.0`.

## Validation
- rebased onto latest `main` (`e82b13c`)
- repo pre-commit hook passed after the amend
- `make ci` completed via the hook
- verified release-floor resolution locally: `release_floor=1.4.0`, `latest_tag=v1.3.3`, `next_tag=v1.4.0`