### PR TITLE
fix(release): retry Homebrew tap push races

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,9 @@ jobs:
       - sync-release-version
     if: ${{ needs.prepare.outputs.should_release == 'true' }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: homebrew-tap-main
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:
@@ -334,6 +337,7 @@ jobs:
           repository: ben-ranford/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
+          fetch-depth: 0
 
       - name: Update lopper formula
         if: ${{ steps.tap_token.outputs.available == 'true' }}
@@ -406,7 +410,18 @@ jobs:
           fi
 
           git commit -m "lopper ${{ needs.prepare.outputs.tag }}"
-          git push origin HEAD:main
+          for attempt in 1 2 3; do
+            echo "Push attempt ${attempt} for Homebrew formula"
+            git fetch origin main:refs/remotes/origin/main
+            git rebase origin/main
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Failed to push Homebrew formula after retries" >&2
+          exit 1
 
       - name: Skip tap update when token is missing
         if: ${{ steps.tap_token.outputs.available != 'true' }}

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -136,6 +136,9 @@ jobs:
       - prepare-rolling
       - publish-rolling
     runs-on: ubuntu-latest
+    concurrency:
+      group: homebrew-tap-main
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:
@@ -161,6 +164,7 @@ jobs:
           repository: ben-ranford/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
+          fetch-depth: 0
 
       - name: Update lopper-rolling formula
         if: ${{ steps.tap_token.outputs.available == 'true' }}
@@ -234,7 +238,18 @@ jobs:
           fi
 
           git commit -m "lopper-rolling ${{ needs.prepare-rolling.outputs.tag }}"
-          git push origin HEAD:main
+          for attempt in 1 2 3; do
+            echo "Push attempt ${attempt} for rolling Homebrew formula"
+            git fetch origin main:refs/remotes/origin/main
+            git rebase origin/main
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Failed to push rolling Homebrew formula after retries" >&2
+          exit 1
 
       - name: Skip rolling tap update when token is missing
         if: ${{ steps.tap_token.outputs.available != 'true' }}


### PR DESCRIPTION
## Issue

The stable release workflow and rolling release workflow both update `ben-ranford/homebrew-tap` on `main`. The tap checkout could become stale while the job spent time validating the formula, so a later `git push origin HEAD:main` sometimes failed with a non-fast-forward rejection.

## Cause and Impact

The tap update jobs checked out the tap repository, generated and validated a formula, then pushed without refreshing from the remote branch. If another tap writer landed during that validation window, the release job failed after the GitHub release, VSIX publish, and image publish had already succeeded. The release was usable, but the workflow status was red and the stable Homebrew formula could lag until a rerun.

## Root Cause

Stable and rolling tap updates wrote to the same external repository branch without a shared serialization point or a fetch/rebase retry before pushing.

## Fix

- Add a shared `homebrew-tap-main` concurrency group to the stable and rolling tap update jobs.
- Fetch the full tap history so rebasing is available.
- Replace the single push with a three-attempt fetch, rebase, and push loop.

## Validation

- `actionlint .github/workflows/release.yml .github/workflows/rolling.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); YAML.load_file('.github/workflows/rolling.yml')"`
- `git diff --check`
- pre-commit `make ci` gate: lint, actionlint, inline suppression check, gosec, govulncheck, tests, goleak tests, race tests, memory benchmark gate, build, coverage gate
