### PR TITLE
fix(release): handle tap rebase retry failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,8 +412,17 @@ jobs:
           git commit -m "lopper ${{ needs.prepare.outputs.tag }}"
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} for Homebrew formula"
-            git fetch origin main:refs/remotes/origin/main
-            git rebase origin/main
+            if ! git fetch origin main:refs/remotes/origin/main; then
+              echo "git fetch failed on attempt ${attempt}" >&2
+              sleep 2
+              continue
+            fi
+            if ! git rebase origin/main; then
+              echo "git rebase failed on attempt ${attempt}; aborting rebase and retrying" >&2
+              git rebase --abort || true
+              sleep 2
+              continue
+            fi
             if git push origin HEAD:main; then
               exit 0
             fi

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -240,8 +240,17 @@ jobs:
           git commit -m "lopper-rolling ${{ needs.prepare-rolling.outputs.tag }}"
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} for rolling Homebrew formula"
-            git fetch origin main:refs/remotes/origin/main
-            git rebase origin/main
+            if ! git fetch origin main:refs/remotes/origin/main; then
+              echo "git fetch failed on attempt ${attempt}" >&2
+              sleep 2
+              continue
+            fi
+            if ! git rebase origin/main; then
+              echo "git rebase failed on attempt ${attempt}; aborting rebase and retrying" >&2
+              git rebase --abort || true
+              sleep 2
+              continue
+            fi
             if git push origin HEAD:main; then
               exit 0
             fi


### PR DESCRIPTION
## Issue

Copilot review on #709 correctly pointed out that the new Homebrew tap retry loops did not explicitly handle `git fetch` or `git rebase` failures while `set -euo pipefail` is active.

## Cause and Impact

If `git rebase origin/main` failed, the shell would exit immediately instead of continuing to the next retry attempt. That weakened the intended protection against transient tap update races and could leave the checkout in a rebase state.

## Root Cause

The retry loop handled push failures but left fetch and rebase as unguarded commands under `set -e`.

## Fix

- Wrap `git fetch` in an explicit failure branch that sleeps and retries.
- Wrap `git rebase` in an explicit failure branch that aborts any partial rebase, sleeps, and retries.
- Apply the same behavior to stable and rolling Homebrew tap update jobs.

## Validation

- `actionlint .github/workflows/release.yml .github/workflows/rolling.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); YAML.load_file('.github/workflows/rolling.yml')"`
- `git diff --check`
- pre-commit `make ci` gate: lint, actionlint, inline suppression check, gosec, govulncheck, tests, goleak tests, race tests, memory benchmark gate, build, coverage gate

## Follow-up

Addresses Copilot review threads from #709:
- https://github.com/ben-ranford/lopper/pull/709#discussion_r3122855751
- https://github.com/ben-ranford/lopper/pull/709#discussion_r3122855800
