### PR TITLE
fix: keep skipped-name repo roots walkable

### DIFF
--- a/internal/lang/shared/adapter_scaffold.go
+++ b/internal/lang/shared/adapter_scaffold.go
@@ -55,6 +55,7 @@ func WalkRepoFiles(ctx context.Context, repoPath string, maxFiles int, skipDir f
 	}
 
 	walker := repoWalker{
+		rootPath: filepath.Clean(repoPath),
 		maxFiles: maxFiles,
 		skipDir:  skipDir,
 		visit:    visit,
@@ -79,6 +80,7 @@ func WalkContextErr(ctx context.Context, walkErr error) error {
 }
 
 type repoWalker struct {
+	rootPath string
 	maxFiles int
 	skipDir  func(string) bool
 	visit    func(path string, entry fs.DirEntry) error
@@ -93,7 +95,7 @@ func (w *repoWalker) handle(ctx context.Context, path string, entry fs.DirEntry,
 		return ctx.Err()
 	}
 	if entry.IsDir() {
-		if w.skipDir(entry.Name()) {
+		if filepath.Clean(path) != w.rootPath && w.skipDir(entry.Name()) {
 			return filepath.SkipDir
 		}
 		return nil

--- a/internal/lang/shared/dependency_usage_test.go
+++ b/internal/lang/shared/dependency_usage_test.go
@@ -698,6 +698,32 @@ func TestWalkRepoFiles(t *testing.T) {
 	}
 }
 
+func TestWalkRepoFilesRootNamedSkippedDir(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "build")
+	if err := os.MkdirAll(filepath.Join(repo, "vendor"), 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "vendor", "ignored.go"), []byte("package ignored\n"), 0o600); err != nil {
+		t.Fatalf("write ignored.go: %v", err)
+	}
+
+	var visited []string
+	err := WalkRepoFiles(context.Background(), repo, 0, ShouldSkipCommonDir, func(path string, entry fs.DirEntry) error {
+		visited = append(visited, filepath.ToSlash(path[len(repo)+1:]))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo files: %v", err)
+	}
+	if !slices.Equal(visited, []string{"main.go"}) {
+		t.Fatalf("expected root named build to be walked while descendants stay skipped, got %#v", visited)
+	}
+}
+
 func TestWalkRepoFilesCanceled(t *testing.T) {
 	repo := t.TempDir()
 	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("a"), 0o600); err != nil {


### PR DESCRIPTION
Closes #621

Summary:
- Keep WalkRepoFiles from applying skipped-directory basename rules to the starting repo root.
- Add regression coverage for a repo rooted at build while preserving skipped descendant traversal behavior.

Tests:
- go test ./internal/lang/shared -run 'TestWalkRepoFiles|TestWalkRepoFilesRootNamedSkippedDir'
- go test ./internal/lang/shared
- pre-commit make ci suite during commit