### PR TITLE
refactor: split adapter capability contracts

### DIFF
--- a/internal/language/adapter.go
+++ b/internal/language/adapter.go
@@ -85,19 +85,36 @@ func DetectMatched(ctx context.Context, repoPath string, detectWithConfidence De
 	return detection.Matched, nil
 }
 
-type Adapter interface {
+type AdapterIdentity interface {
 	ID() string
 	Aliases() []string
+}
+
+type Detector interface {
 	Detect(ctx context.Context, repoPath string) (bool, error)
-	Analyse(ctx context.Context, req Request) (report.Report, error)
 }
 
 type ConfidenceProvider interface {
-	Detect(ctx context.Context, repoPath string) (bool, error)
+	Detector
 	DetectWithConfidence(ctx context.Context, repoPath string) (Detection, error)
 }
 
+type Analyser interface {
+	Analyse(ctx context.Context, req Request) (report.Report, error)
+}
+
+type Adapter interface {
+	AdapterIdentity
+	Detector
+	Analyser
+}
+
+type CandidateAdapter interface {
+	ID() string
+	Analyser
+}
+
 type Candidate struct {
-	Adapter   Adapter
+	Adapter   CandidateAdapter
 	Detection Detection
 }

--- a/internal/language/registry.go
+++ b/internal/language/registry.go
@@ -50,7 +50,7 @@ func (r *Registry) Register(adapter Adapter) error {
 	return nil
 }
 
-func (r *Registry) Select(ctx context.Context, repoPath string, languageID string) (Adapter, error) {
+func (r *Registry) Select(ctx context.Context, repoPath string, languageID string) (CandidateAdapter, error) {
 	candidates, err := r.Resolve(ctx, repoPath, languageID)
 	if err != nil {
 		return nil, err
@@ -171,7 +171,7 @@ func (r *Registry) detectMatches(ctx context.Context, repoPath string) ([]Candid
 	return matches, nil
 }
 
-func detectAdapter(ctx context.Context, adapter Adapter, repoPath string) (Detection, error) {
+func detectAdapter(ctx context.Context, adapter Detector, repoPath string) (Detection, error) {
 	if detector, ok := adapter.(ConfidenceProvider); ok {
 		detection, err := detector.DetectWithConfidence(ctx, repoPath)
 		if err != nil {

--- a/internal/language/registry_test.go
+++ b/internal/language/registry_test.go
@@ -23,19 +23,13 @@ type testAdapter struct {
 	detectErr error
 }
 
-type simpleAdapter struct {
-	id      string
+type simpleDetector struct {
 	matched bool
 	err     error
 }
 
-func (a *simpleAdapter) ID() string        { return a.id }
-func (a *simpleAdapter) Aliases() []string { return nil }
-func (a *simpleAdapter) Detect(context.Context, string) (bool, error) {
-	return a.matched, a.err
-}
-func (a *simpleAdapter) Analyse(context.Context, Request) (report.Report, error) {
-	return report.Report{}, nil
+func (d *simpleDetector) Detect(context.Context, string) (bool, error) {
+	return d.matched, d.err
 }
 
 func (a *testAdapter) ID() string {
@@ -200,14 +194,14 @@ func TestNormalizeDetectionAndClamp(t *testing.T) {
 }
 
 func TestDetectAdapterFallbackPath(t *testing.T) {
-	detection, err := detectAdapter(context.Background(), &simpleAdapter{id: "simple", matched: true}, ".")
+	detection, err := detectAdapter(context.Background(), &simpleDetector{matched: true}, ".")
 	if err != nil {
 		t.Fatalf("detect adapter fallback: %v", err)
 	}
 	if !detection.Matched || detection.Confidence != 60 {
 		t.Fatalf("unexpected fallback detection: %#v", detection)
 	}
-	if _, err := detectAdapter(context.Background(), &simpleAdapter{id: "simple", err: errors.New("boom")}, "."); err == nil {
+	if _, err := detectAdapter(context.Background(), &simpleDetector{err: errors.New("boom")}, "."); err == nil {
 		t.Fatalf("expected detect error from fallback adapter")
 	}
 }
@@ -299,7 +293,7 @@ func TestDetectMatchesAndFallbackDetectorBranches(t *testing.T) {
 		t.Fatalf("expected de-duped matches, got %#v", matches)
 	}
 
-	detection, err := detectAdapter(context.Background(), &simpleAdapter{id: "simple", matched: false}, ".")
+	detection, err := detectAdapter(context.Background(), &simpleDetector{matched: false}, ".")
 	if err != nil {
 		t.Fatalf("detect adapter fallback unmatched: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Split the language adapter surface into identity, detection, confidence detection, and analysis capability interfaces.
- Narrowed candidate and detection helper signatures where they only need analysis or detection capabilities.
- Kept AdapterLifecycle and Clock behavior intact.

Closes #628

## Tests
- go test ./internal/language ./internal/analysis ./internal/lang/...
- pre-commit make ci hook passed during commit (fmt, lint/style, security/vuln checks, full tests, goleak, race, memory delta, build, coverage)