### PR TITLE
chore(release): make docs/refactor commits releasable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,21 @@ make mem-profiles
 3. Keep commits focused and descriptive.
 4. Open a pull request with clear context, scope, and validation steps.
 
+## Commit style and releases
+
+Stable releases are prepared by release-please from Conventional Commits merged to `main`.
+Use these commit types for changes that should appear in release notes:
+
+- `fix(scope): summary` for patch releases.
+- `docs(scope): summary` for documentation-only patch releases.
+- `refactor(scope): summary` for refactoring patch releases.
+- `perf(scope): summary` for performance patch releases.
+- `feat(scope): summary` for minor releases.
+- `type(scope)!: summary` or a `BREAKING CHANGE:` footer for major releases.
+
+Use non-release types such as `test`, `ci`, `build`, or `chore` when the change should not by itself create a release PR.
+Good scopes include `release`, `ci`, `vscode`, `js`, `jvm`, `go`, `report`, `ui`, `runtime`, and `homebrew`.
+
 ## Adapter docs checklist
 
 If you add a new language adapter, update the contributor-facing docs and user-facing metadata in the same change:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,32 @@
     ".": {
       "release-type": "go",
       "changelog-path": "extensions/vscode-lopper/CHANGELOG.md",
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        }
+      ],
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Issue

The initial release-please setup documented the basic Conventional Commit release behavior, but `docs:` and `refactor:` commits were still hidden by release-please's default changelog sections. Hidden commit types do not become user-facing release notes, so they would not reliably create a patch release PR by themselves.

## Cause and impact

Release-please defaults hide `docs` and `refactor` sections. That conflicts with the desired repo policy where documentation-only and refactoring changes should be patch-producing release-note entries.

## Root cause

The manifest config did not override `changelog-sections`, and the contributor guide did not yet document the repo-specific commit types that are expected to drive releases.

## Fix

- Makes `docs` and `refactor` visible release-please changelog sections.
- Keeps `feat` as minor and `fix`/`perf` as patch-producing sections.
- Documents the repo commit policy in `CONTRIBUTING.md`, including non-release types for changes that should not create a release PR.

## Tests and checks

- JSON parse for `release-please-config.json`
- `npx --yes ajv-cli validate --strict=false -s /Users/benranford/.npm/_npx/57c4e8d2d77e9874/node_modules/release-please/schemas/config.json -d release-please-config.json`
- `git diff --check`
- Full pre-commit `make ci` gate, including lint, actionlint, shellcheck, security, vuln check, tests, goleak, race tests, memory benchmark gate, build, and coverage
