### PR TITLE
feat(featureflags): add registry and resolver

### DIFF
--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -1,0 +1,331 @@
+package featureflags
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewRegistryValidatesEntries(t *testing.T) {
+	_, err := NewRegistry([]Flag{{Code: "", Name: "alpha", Lifecycle: LifecyclePreview}})
+	if err == nil || !strings.Contains(err.Error(), "feature code is required") {
+		t.Fatalf("expected missing code error, got %v", err)
+	}
+	_, err = NewRegistry([]Flag{{Code: "BAD-0001", Name: "alpha", Lifecycle: LifecyclePreview}})
+	if err == nil || !strings.Contains(err.Error(), "invalid feature code") {
+		t.Fatalf("expected invalid code error, got %v", err)
+	}
+	_, err = NewRegistry([]Flag{{Code: "LOP-FEAT-0001", Name: "Alpha", Lifecycle: LifecyclePreview}})
+	if err == nil || !strings.Contains(err.Error(), "invalid feature name") {
+		t.Fatalf("expected invalid name error, got %v", err)
+	}
+	_, err = NewRegistry([]Flag{{Code: "LOP-FEAT-001", Name: "alpha", Lifecycle: LifecyclePreview}})
+	if err == nil || !strings.Contains(err.Error(), "must use LOP-FEAT-NNNN") {
+		t.Fatalf("expected short code error, got %v", err)
+	}
+	_, err = NewRegistry([]Flag{{Code: "LOP-FEAT-00A1", Name: "alpha", Lifecycle: LifecyclePreview}})
+	if err == nil || !strings.Contains(err.Error(), "suffix must be numeric") {
+		t.Fatalf("expected nonnumeric code error, got %v", err)
+	}
+	_, err = NewRegistry([]Flag{{Code: "LOP-FEAT-0001", Name: "", Lifecycle: LifecyclePreview}})
+	if err == nil || !strings.Contains(err.Error(), "feature name is required") {
+		t.Fatalf("expected missing name error, got %v", err)
+	}
+	_, err = NewRegistry([]Flag{{Code: "LOP-FEAT-0001", Name: "alpha", Lifecycle: "unknown"}})
+	if err == nil || !strings.Contains(err.Error(), "invalid feature lifecycle") {
+		t.Fatalf("expected invalid lifecycle error, got %v", err)
+	}
+}
+
+func TestDefaultRegistryAndLookup(t *testing.T) {
+	if got := DefaultRegistry().Flags(); len(got) != 0 {
+		t.Fatalf("expected empty default registry, got %#v", got)
+	}
+	if flags := (*Registry)(nil).Flags(); len(flags) != 0 {
+		t.Fatalf("expected nil registry flags to be empty, got %#v", flags)
+	}
+	if _, ok := (*Registry)(nil).Lookup("anything"); ok {
+		t.Fatalf("expected nil registry lookup to miss")
+	}
+
+	registry := testRegistry(t)
+	if _, ok := registry.Lookup("   "); ok {
+		t.Fatalf("expected blank lookup to miss")
+	}
+	if got, ok := registry.Lookup("stable-flag"); !ok || got.Code != "LOP-FEAT-0002" {
+		t.Fatalf("expected name lookup to find stable flag, got %#v ok=%v", got, ok)
+	}
+	flags := registry.Flags()
+	flags[0].Name = "mutated"
+	if got, _ := registry.Lookup("LOP-FEAT-0001"); got.Name != "preview-flag" {
+		t.Fatalf("expected Flags to return a defensive copy, got %#v", got)
+	}
+}
+
+func TestNewRegistryRejectsDuplicates(t *testing.T) {
+	_, err := NewRegistry([]Flag{
+		{Code: "LOP-FEAT-0001", Name: "alpha", Lifecycle: LifecyclePreview},
+		{Code: "LOP-FEAT-0001", Name: "beta", Lifecycle: LifecyclePreview},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate feature code") {
+		t.Fatalf("expected duplicate code error, got %v", err)
+	}
+
+	_, err = NewRegistry([]Flag{
+		{Code: "LOP-FEAT-0001", Name: "alpha", Lifecycle: LifecyclePreview},
+		{Code: "LOP-FEAT-0002", Name: "alpha", Lifecycle: LifecyclePreview},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate feature name") {
+		t.Fatalf("expected duplicate name error, got %v", err)
+	}
+}
+
+func TestNextCodeAllocatesGeneratedCodes(t *testing.T) {
+	if code, err := DefaultRegistry().NextCode(); err != nil || code != "LOP-FEAT-0001" {
+		t.Fatalf("expected empty registry to allocate first code, got %q err=%v", code, err)
+	}
+	if code, err := (*Registry)(nil).NextCode(); err != nil || code != "LOP-FEAT-0001" {
+		t.Fatalf("expected nil registry to allocate first code, got %q err=%v", code, err)
+	}
+
+	registry, err := NewRegistry([]Flag{
+		{Code: "LOP-FEAT-0007", Name: "later", Lifecycle: LifecyclePreview},
+		{Code: "LOP-FEAT-0002", Name: "earlier", Lifecycle: LifecycleStable},
+	})
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	if code, err := registry.NextCode(); err != nil || code != "LOP-FEAT-0008" {
+		t.Fatalf("expected next generated code, got %q err=%v", code, err)
+	}
+
+	full, err := NewRegistry([]Flag{{Code: "LOP-FEAT-9999", Name: "last", Lifecycle: LifecyclePreview}})
+	if err != nil {
+		t.Fatalf("new full registry: %v", err)
+	}
+	if code, err := full.NextCode(); err == nil || code != "" {
+		t.Fatalf("expected exhausted code space, got %q err=%v", code, err)
+	}
+}
+
+func TestLifecycleAndChannelAliases(t *testing.T) {
+	if got, err := NormalizeLifecycle("experimental"); err != nil || got != LifecyclePreview {
+		t.Fatalf("expected experimental alias to normalize to preview, got %q err=%v", got, err)
+	}
+	if got, err := NormalizeLifecycle("done"); err != nil || got != LifecycleStable {
+		t.Fatalf("expected done alias to normalize to stable, got %q err=%v", got, err)
+	}
+	if got, err := NormalizeChannel(""); err != nil || got != ChannelDev {
+		t.Fatalf("expected blank channel to normalize to dev, got %q err=%v", got, err)
+	}
+	if got, err := NormalizeChannel("rolling"); err != nil || got != ChannelRolling {
+		t.Fatalf("expected rolling channel, got %q err=%v", got, err)
+	}
+	if got, err := NormalizeChannel("release"); err != nil || got != ChannelRelease {
+		t.Fatalf("expected release channel, got %q err=%v", got, err)
+	}
+	if _, err := NormalizeChannel("bad"); err == nil {
+		t.Fatalf("expected invalid channel to fail")
+	}
+}
+
+func TestResolveChannelDefaults(t *testing.T) {
+	registry := testRegistry(t)
+
+	dev, err := registry.Resolve(ResolveOptions{Channel: ChannelDev})
+	if err != nil {
+		t.Fatalf("resolve dev: %v", err)
+	}
+	if dev.Enabled("preview-flag") {
+		t.Fatalf("expected preview flag default-off in dev")
+	}
+	if !dev.Enabled("stable-flag") {
+		t.Fatalf("expected stable flag default-on in dev")
+	}
+
+	release, err := registry.Resolve(ResolveOptions{Channel: ChannelRelease})
+	if err != nil {
+		t.Fatalf("resolve release: %v", err)
+	}
+	if release.Enabled("preview-flag") {
+		t.Fatalf("expected preview flag default-off in release")
+	}
+	if !release.Enabled("stable-flag") {
+		t.Fatalf("expected stable flag default-on in release")
+	}
+
+	rolling, err := registry.Resolve(ResolveOptions{Channel: ChannelRolling})
+	if err != nil {
+		t.Fatalf("resolve rolling: %v", err)
+	}
+	if !rolling.Enabled("preview-flag") || !rolling.Enabled("stable-flag") {
+		t.Fatalf("expected rolling to enable all flags")
+	}
+}
+
+func TestResolveReleaseLockAndExplicitOverrides(t *testing.T) {
+	registry := testRegistry(t)
+	lock := &ReleaseLock{Release: "v1.4.2", DefaultOn: []string{"LOP-FEAT-0001"}}
+
+	resolved, err := registry.Resolve(ResolveOptions{
+		Channel: ChannelRelease,
+		Lock:    lock,
+		Disable: []string{"stable-flag"},
+	})
+	if err != nil {
+		t.Fatalf("resolve release lock: %v", err)
+	}
+	if !resolved.Enabled("preview-flag") {
+		t.Fatalf("expected release lock to enable preview flag")
+	}
+	if resolved.Enabled("stable-flag") {
+		t.Fatalf("expected explicit disable to win over stable default")
+	}
+
+	resolved, err = registry.Resolve(ResolveOptions{
+		Channel: ChannelRelease,
+		Enable:  []string{"preview-flag"},
+		Disable: []string{"preview-flag"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "both enabled and disabled") {
+		t.Fatalf("expected enable/disable conflict, got resolved=%v err=%v", resolved, err)
+	}
+}
+
+func TestResolveRejectsUnknownReferences(t *testing.T) {
+	registry := testRegistry(t)
+	if _, err := registry.Resolve(ResolveOptions{Channel: "bad"}); err == nil {
+		t.Fatalf("expected invalid channel to fail")
+	}
+	if _, err := registry.Resolve(ResolveOptions{Enable: []string{"missing"}}); err == nil {
+		t.Fatalf("expected unknown explicit enable to fail")
+	}
+	if _, err := registry.Resolve(ResolveOptions{Disable: []string{"missing"}}); err == nil {
+		t.Fatalf("expected unknown explicit disable to fail")
+	}
+	if _, err := registry.Resolve(ResolveOptions{
+		Channel: ChannelRelease,
+		Lock:    &ReleaseLock{Release: "v1.4.2", DefaultOn: []string{"missing"}},
+	}); err == nil {
+		t.Fatalf("expected unknown release lock ref to fail")
+	}
+	if resolved, err := (*Registry)(nil).Resolve(ResolveOptions{}); err != nil || resolved.Enabled("anything") {
+		t.Fatalf("expected nil registry to resolve against empty defaults, resolved=%#v err=%v", resolved, err)
+	}
+}
+
+func TestParseReleaseLock(t *testing.T) {
+	lock, err := ParseReleaseLock([]byte(`{
+		"release": " v1.4.2 ",
+		"defaultOn": [" LOP-FEAT-0001 ", ""],
+		"notes": {" LOP-FEAT-0001 ": " preview on "}
+	}`))
+	if err != nil {
+		t.Fatalf("parse release lock: %v", err)
+	}
+	if lock.Release != "v1.4.2" {
+		t.Fatalf("expected release to be trimmed, got %q", lock.Release)
+	}
+	if len(lock.DefaultOn) != 1 || lock.DefaultOn[0] != "LOP-FEAT-0001" {
+		t.Fatalf("expected normalized defaultOn refs, got %#v", lock.DefaultOn)
+	}
+	if got := lock.Notes["LOP-FEAT-0001"]; got != "preview on" {
+		t.Fatalf("expected normalized note, got %q", got)
+	}
+
+	if _, err := ParseReleaseLock([]byte(`{"release":""}`)); err == nil {
+		t.Fatalf("expected blank release to fail")
+	}
+	if _, err := ParseReleaseLock([]byte(`{"release":"v1","unknown":true}`)); err == nil {
+		t.Fatalf("expected unknown field to fail")
+	}
+	if _, err := ParseReleaseLock([]byte(`{"release":"v1"} {"release":"v2"}`)); err == nil {
+		t.Fatalf("expected multiple JSON values to fail")
+	}
+}
+
+func TestValidateReleaseLockRejectsDuplicatesAndUnknownNotes(t *testing.T) {
+	registry := testRegistry(t)
+	if err := registry.ValidateReleaseLock(nil); err != nil {
+		t.Fatalf("expected nil lock to be valid, got %v", err)
+	}
+	if err := registry.ValidateReleaseLock(&ReleaseLock{}); err == nil || !strings.Contains(err.Error(), "release is required") {
+		t.Fatalf("expected blank release to fail, got %v", err)
+	}
+	if err := registry.ValidateReleaseLock(&ReleaseLock{
+		Release:   "v1.4.2",
+		DefaultOn: []string{"LOP-FEAT-0001", "preview-flag"},
+	}); err == nil || !strings.Contains(err.Error(), "duplicate feature") {
+		t.Fatalf("expected duplicate lock refs to fail, got %v", err)
+	}
+	if err := registry.ValidateReleaseLock(&ReleaseLock{
+		Release: "v1.4.2",
+		Notes:   map[string]string{"missing": "note"},
+	}); err == nil || !strings.Contains(err.Error(), "unknown feature note") {
+		t.Fatalf("expected unknown note ref to fail, got %v", err)
+	}
+}
+
+func TestManifestReportsDefaults(t *testing.T) {
+	registry := testRegistry(t)
+	manifest, err := registry.Manifest(ResolveOptions{
+		Channel: ChannelRelease,
+		Lock:    &ReleaseLock{Release: "v1.4.2", DefaultOn: []string{"preview-flag"}},
+	})
+	if err != nil {
+		t.Fatalf("manifest: %v", err)
+	}
+	if len(manifest) != 2 {
+		t.Fatalf("expected two manifest entries, got %#v", manifest)
+	}
+	if manifest[0].Code != "LOP-FEAT-0001" || !manifest[0].EnabledByDefault {
+		t.Fatalf("expected preview flag lock default-on, got %#v", manifest[0])
+	}
+	if manifest[1].Code != "LOP-FEAT-0002" || !manifest[1].EnabledByDefault {
+		t.Fatalf("expected stable flag default-on, got %#v", manifest[1])
+	}
+	if _, err := registry.Manifest(ResolveOptions{Enable: []string{"missing"}}); err == nil {
+		t.Fatalf("expected manifest to return resolver errors")
+	}
+	if manifest, err := (*Registry)(nil).Manifest(ResolveOptions{}); err != nil || len(manifest) != 0 {
+		t.Fatalf("expected nil registry manifest to be empty, manifest=%#v err=%v", manifest, err)
+	}
+}
+
+func TestEnabledFlag(t *testing.T) {
+	resolved, err := testRegistry(t).Resolve(ResolveOptions{Channel: ChannelRolling})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if enabled, err := resolved.EnabledFlag(" preview-flag "); err != nil || !enabled {
+		t.Fatalf("expected preview flag enabled in rolling, enabled=%v err=%v", enabled, err)
+	}
+	if enabled, err := resolved.EnabledFlag("missing"); err == nil || enabled {
+		t.Fatalf("expected unknown feature error, enabled=%v err=%v", enabled, err)
+	}
+	var empty *Set
+	if empty.Enabled("preview-flag") {
+		t.Fatalf("expected nil set to report disabled")
+	}
+}
+
+func testRegistry(t *testing.T) *Registry {
+	t.Helper()
+	registry, err := NewRegistry([]Flag{
+		{
+			Code:        "LOP-FEAT-0001",
+			Name:        "preview-flag",
+			Description: "Preview behavior",
+			Lifecycle:   LifecyclePreview,
+		},
+		{
+			Code:        "LOP-FEAT-0002",
+			Name:        "stable-flag",
+			Description: "Stable behavior",
+			Lifecycle:   LifecycleStable,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	return registry
+}

--- a/internal/featureflags/lock.go
+++ b/internal/featureflags/lock.go
@@ -1,0 +1,86 @@
+package featureflags
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type ReleaseLock struct {
+	Release   string            `json:"release"`
+	DefaultOn []string          `json:"defaultOn"`
+	Notes     map[string]string `json:"notes,omitempty"`
+}
+
+func ParseReleaseLock(data []byte) (*ReleaseLock, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var lock ReleaseLock
+	if err := decoder.Decode(&lock); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return nil, fmt.Errorf("invalid JSON: multiple JSON values")
+	}
+	lock.Release = strings.TrimSpace(lock.Release)
+	lock.DefaultOn = normalizeRefs(lock.DefaultOn)
+	lock.Notes = normalizeNotes(lock.Notes)
+	if lock.Release == "" {
+		return nil, fmt.Errorf("release is required")
+	}
+	return &lock, nil
+}
+
+func (r *Registry) ValidateReleaseLock(lock *ReleaseLock) error {
+	if lock == nil {
+		return nil
+	}
+	if strings.TrimSpace(lock.Release) == "" {
+		return fmt.Errorf("release is required")
+	}
+	seen := map[string]struct{}{}
+	for _, ref := range lock.DefaultOn {
+		flag, ok := r.Lookup(ref)
+		if !ok {
+			return fmt.Errorf("unknown feature in release lock: %s", ref)
+		}
+		if _, exists := seen[flag.Code]; exists {
+			return fmt.Errorf("duplicate feature in release lock: %s", ref)
+		}
+		seen[flag.Code] = struct{}{}
+	}
+	for ref := range lock.Notes {
+		if _, ok := r.Lookup(ref); !ok {
+			return fmt.Errorf("unknown feature note in release lock: %s", ref)
+		}
+	}
+	return nil
+}
+
+func normalizeRefs(refs []string) []string {
+	normalized := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		trimmed := strings.TrimSpace(ref)
+		if trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	return normalized
+}
+
+func normalizeNotes(notes map[string]string) map[string]string {
+	if len(notes) == 0 {
+		return nil
+	}
+	normalized := make(map[string]string, len(notes))
+	for key, value := range notes {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			continue
+		}
+		normalized[trimmedKey] = strings.TrimSpace(value)
+	}
+	return normalized
+}

--- a/internal/featureflags/registry.go
+++ b/internal/featureflags/registry.go
@@ -1,0 +1,200 @@
+package featureflags
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const featureCodePrefix = "LOP-FEAT-"
+const maxFeatureCode = 9999
+
+type Lifecycle string
+
+const (
+	LifecyclePreview Lifecycle = "preview"
+	LifecycleStable  Lifecycle = "stable"
+)
+
+type Channel string
+
+const (
+	ChannelDev     Channel = "dev"
+	ChannelRolling Channel = "rolling"
+	ChannelRelease Channel = "release"
+)
+
+type Flag struct {
+	Code        string
+	Name        string
+	Description string
+	Lifecycle   Lifecycle
+}
+
+type Registry struct {
+	flags  []Flag
+	byCode map[string]Flag
+	byName map[string]Flag
+}
+
+var defaultRegistry = &Registry{
+	flags:  []Flag{},
+	byCode: map[string]Flag{},
+	byName: map[string]Flag{},
+}
+
+func DefaultRegistry() *Registry {
+	return defaultRegistry
+}
+
+func NewRegistry(flags []Flag) (*Registry, error) {
+	registry := &Registry{
+		flags:  make([]Flag, 0, len(flags)),
+		byCode: make(map[string]Flag, len(flags)),
+		byName: make(map[string]Flag, len(flags)),
+	}
+	for _, flag := range flags {
+		normalized, err := normalizeFlag(flag)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := registry.byCode[normalized.Code]; exists {
+			return nil, fmt.Errorf("duplicate feature code: %s", normalized.Code)
+		}
+		if _, exists := registry.byName[normalized.Name]; exists {
+			return nil, fmt.Errorf("duplicate feature name: %s", normalized.Name)
+		}
+		registry.flags = append(registry.flags, normalized)
+		registry.byCode[normalized.Code] = normalized
+		registry.byName[normalized.Name] = normalized
+	}
+	sort.Slice(registry.flags, func(i, j int) bool {
+		return registry.flags[i].Code < registry.flags[j].Code
+	})
+	return registry, nil
+}
+
+func (r *Registry) Flags() []Flag {
+	if r == nil {
+		return nil
+	}
+	flags := make([]Flag, len(r.flags))
+	copy(flags, r.flags)
+	return flags
+}
+
+func (r *Registry) Lookup(ref string) (Flag, bool) {
+	if r == nil {
+		return Flag{}, false
+	}
+	normalized := strings.TrimSpace(ref)
+	if normalized == "" {
+		return Flag{}, false
+	}
+	if flag, ok := r.byCode[normalized]; ok {
+		return flag, true
+	}
+	flag, ok := r.byName[normalized]
+	return flag, ok
+}
+
+func (r *Registry) NextCode() (string, error) {
+	if r == nil {
+		r = DefaultRegistry()
+	}
+	highest := 0
+	for _, flag := range r.flags {
+		value, err := featureCodeNumber(flag.Code)
+		if err != nil {
+			return "", err
+		}
+		if value > highest {
+			highest = value
+		}
+	}
+	if highest >= maxFeatureCode {
+		return "", fmt.Errorf("feature code space exhausted")
+	}
+	return fmt.Sprintf("%s%04d", featureCodePrefix, highest+1), nil
+}
+
+func NormalizeLifecycle(value string) (Lifecycle, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(LifecyclePreview), "experimental":
+		return LifecyclePreview, nil
+	case string(LifecycleStable), "done":
+		return LifecycleStable, nil
+	default:
+		return "", fmt.Errorf("invalid feature lifecycle: %q", value)
+	}
+}
+
+func NormalizeChannel(value string) (Channel, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", string(ChannelDev):
+		return ChannelDev, nil
+	case string(ChannelRolling):
+		return ChannelRolling, nil
+	case string(ChannelRelease):
+		return ChannelRelease, nil
+	default:
+		return "", fmt.Errorf("invalid feature build channel: %q", value)
+	}
+}
+
+func normalizeFlag(flag Flag) (Flag, error) {
+	flag.Code = strings.TrimSpace(flag.Code)
+	flag.Name = strings.TrimSpace(flag.Name)
+	flag.Description = strings.TrimSpace(flag.Description)
+	if err := validateFeatureCode(flag.Code); err != nil {
+		return Flag{}, err
+	}
+	if err := validateFeatureName(flag.Name); err != nil {
+		return Flag{}, err
+	}
+	lifecycle, err := NormalizeLifecycle(string(flag.Lifecycle))
+	if err != nil {
+		return Flag{}, fmt.Errorf("feature %s: %w", flag.Code, err)
+	}
+	flag.Lifecycle = lifecycle
+	return flag, nil
+}
+
+func validateFeatureCode(code string) error {
+	_, err := featureCodeNumber(code)
+	return err
+}
+
+func featureCodeNumber(code string) (int, error) {
+	if code == "" {
+		return 0, fmt.Errorf("feature code is required")
+	}
+	if !strings.HasPrefix(code, featureCodePrefix) {
+		return 0, fmt.Errorf("invalid feature code %q: must use %sNNNN", code, featureCodePrefix)
+	}
+	suffix := strings.TrimPrefix(code, featureCodePrefix)
+	if len(suffix) != 4 {
+		return 0, fmt.Errorf("invalid feature code %q: must use %sNNNN", code, featureCodePrefix)
+	}
+	value := 0
+	for _, r := range suffix {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("invalid feature code %q: suffix must be numeric", code)
+		}
+		value = value*10 + int(r-'0')
+	}
+	return value, nil
+}
+
+func validateFeatureName(name string) error {
+	if name == "" {
+		return fmt.Errorf("feature name is required")
+	}
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			continue
+		}
+		return fmt.Errorf("invalid feature name %q: use lowercase letters, digits, and hyphens", name)
+	}
+	return nil
+}

--- a/internal/featureflags/resolver.go
+++ b/internal/featureflags/resolver.go
@@ -1,0 +1,165 @@
+package featureflags
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type ResolveOptions struct {
+	Channel Channel
+	Lock    *ReleaseLock
+	Enable  []string
+	Disable []string
+}
+
+type Set struct {
+	enabled map[string]bool
+	byCode  map[string]Flag
+	byName  map[string]Flag
+}
+
+type ManifestEntry struct {
+	Code             string    `json:"code"`
+	Name             string    `json:"name"`
+	Description      string    `json:"description,omitempty"`
+	Lifecycle        Lifecycle `json:"lifecycle"`
+	EnabledByDefault bool      `json:"enabledByDefault"`
+}
+
+func (r *Registry) Resolve(opts ResolveOptions) (Set, error) {
+	if r == nil {
+		r = DefaultRegistry()
+	}
+	channel, err := NormalizeChannel(string(opts.Channel))
+	if err != nil {
+		return Set{}, err
+	}
+	if err := r.ValidateReleaseLock(opts.Lock); err != nil {
+		return Set{}, err
+	}
+
+	enabled := r.channelDefaults(channel)
+	r.applyReleaseLockDefaults(channel, opts.Lock, enabled)
+	if err := r.applyExplicitOverrides(enabled, opts.Enable, opts.Disable); err != nil {
+		return Set{}, err
+	}
+
+	return Set{
+		enabled: enabled,
+		byCode:  copyFlagMap(r.byCode),
+		byName:  copyFlagMap(r.byName),
+	}, nil
+}
+
+func (r *Registry) channelDefaults(channel Channel) map[string]bool {
+	enabled := make(map[string]bool, len(r.flags))
+	enableAll := channel == ChannelRolling
+	for _, flag := range r.flags {
+		enabled[flag.Code] = enableAll || flag.Lifecycle == LifecycleStable
+	}
+	return enabled
+}
+
+func (r *Registry) applyReleaseLockDefaults(channel Channel, lock *ReleaseLock, enabled map[string]bool) {
+	if channel != ChannelRelease || lock == nil {
+		return
+	}
+	for _, ref := range lock.DefaultOn {
+		flag, _ := r.Lookup(ref)
+		enabled[flag.Code] = true
+	}
+}
+
+func (r *Registry) applyExplicitOverrides(enabled map[string]bool, enable []string, disable []string) error {
+	explicitEnable, err := r.resolveRefs(enable)
+	if err != nil {
+		return err
+	}
+	explicitDisable, err := r.resolveRefs(disable)
+	if err != nil {
+		return err
+	}
+	for code := range explicitEnable {
+		if _, disabled := explicitDisable[code]; disabled {
+			return fmt.Errorf("feature %s is both enabled and disabled", code)
+		}
+		enabled[code] = true
+	}
+	for code := range explicitDisable {
+		enabled[code] = false
+	}
+	return nil
+}
+
+func (r *Registry) Manifest(opts ResolveOptions) ([]ManifestEntry, error) {
+	if r == nil {
+		r = DefaultRegistry()
+	}
+	resolved, err := r.Resolve(opts)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]ManifestEntry, 0, len(r.flags))
+	for _, flag := range r.flags {
+		entries = append(entries, ManifestEntry{
+			Code:             flag.Code,
+			Name:             flag.Name,
+			Description:      flag.Description,
+			Lifecycle:        flag.Lifecycle,
+			EnabledByDefault: resolved.Enabled(flag.Code),
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Code < entries[j].Code
+	})
+	return entries, nil
+}
+
+func (s *Set) Enabled(ref string) bool {
+	flag, ok := s.lookup(ref)
+	if !ok {
+		return false
+	}
+	return s.enabled[flag.Code]
+}
+
+func (s *Set) EnabledFlag(ref string) (bool, error) {
+	flag, ok := s.lookup(ref)
+	if !ok {
+		return false, fmt.Errorf("unknown feature: %s", ref)
+	}
+	return s.enabled[flag.Code], nil
+}
+
+func (s *Set) lookup(ref string) (Flag, bool) {
+	ref = strings.TrimSpace(ref)
+	if s == nil {
+		return Flag{}, false
+	}
+	if flag, ok := s.byCode[ref]; ok {
+		return flag, true
+	}
+	flag, ok := s.byName[ref]
+	return flag, ok
+}
+
+func (r *Registry) resolveRefs(refs []string) (map[string]struct{}, error) {
+	resolved := map[string]struct{}{}
+	for _, ref := range normalizeRefs(refs) {
+		flag, ok := r.Lookup(ref)
+		if !ok {
+			return nil, fmt.Errorf("unknown feature: %s", ref)
+		}
+		resolved[flag.Code] = struct{}{}
+	}
+	return resolved, nil
+}
+
+func copyFlagMap(source map[string]Flag) map[string]Flag {
+	copied := make(map[string]Flag, len(source))
+	for key, value := range source {
+		copied[key] = value
+	}
+	return copied
+}


### PR DESCRIPTION
## Issue

Closes #725. Part of the feature flagging umbrella in #721.

## Cause and impact

The feature flagging rollout needs a single typed model before CLI, config, release, and documentation work can build on it. Without that model, feature gates would drift into ad hoc string checks, release-channel defaults would be hard to reason about, and merging a PR could be confused with graduating a feature to stable.

## Root cause

Lopper did not have a central registry or resolver for feature metadata, immutable feature codes, lifecycle state, release-channel defaults, release lock overrides, or explicit user opt-in/opt-out precedence.

## Fix

- Added `internal/featureflags` with typed `Flag`, `Registry`, lifecycle, and channel models.
- Added immutable feature-code validation for `LOP-FEAT-NNNN` values and `Registry.NextCode()` so the #728 helper can allocate the next generated code without duplicating numbering logic.
- Added resolver behavior for `dev`, `rolling`, and `release` channels.
- Kept rolling builds default-on for every registered feature while dev/release default stable features on and preview features off.
- Added release lock parsing and validation so stable releases can deliberately default preview flags on without marking them stable.
- Added explicit enable/disable handling with conflict detection and opt-out precedence.
- Added manifest entries that report code, name, description, lifecycle, and default state.

## Validation

- `GOTOOLCHAIN=go1.26.2 go test ./internal/featureflags`
- `make ci`
- Pre-commit `make ci`

The local and hook gates both passed, including lint, style, actionlint, inline suppression checks, `gosec` with 0 issues, `govulncheck`, unit tests, goleak tests, race tests, memory benchmark gate, build, and coverage.
