### PR TITLE
feat(flags): add assisted graduation workflow

### DIFF
--- a/.github/workflows/graduate-feature.yml
+++ b/.github/workflows/graduate-feature.yml
@@ -1,0 +1,129 @@
+name: graduate feature
+
+on:
+  workflow_dispatch:
+    inputs:
+      feature:
+        description: Feature code or name to graduate
+        required: true
+        type: string
+      evidence:
+        description: Evidence supporting stable defaults
+        required: true
+        type: string
+      compatibility_notes:
+        description: Compatibility and rollback notes
+        required: true
+        type: string
+      release_lock_notes:
+        description: Release locks to remove, keep, or preserve
+        required: false
+        default: None.
+        type: string
+      issue:
+        description: Issue number to close or reference
+        required: false
+        default: "721"
+        type: string
+      milestone:
+        description: Milestone to assign to the graduation PR
+        required: false
+        default: "v1.4.2"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  graduate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    env:
+      COMPATIBILITY_NOTES: ${{ inputs.compatibility_notes }}
+      EVIDENCE: ${{ inputs.evidence }}
+      FEATURE: ${{ inputs.feature }}
+      GH_TOKEN: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
+      ISSUE_NUMBER: ${{ inputs.issue }}
+      MILESTONE: ${{ inputs.milestone }}
+      RELEASE_LOCK_NOTES: ${{ inputs.release_lock_notes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Graduate feature and open PR
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          slug="$(printf '%s' "${FEATURE}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')"
+          if [ -z "${slug}" ]; then
+            slug="feature"
+          fi
+          branch="feat/graduate-${slug}-$(date -u +%Y%m%d%H%M%S)"
+          git checkout -b "${branch}"
+
+          go run ./tools/featureflag graduate --feature "${FEATURE}"
+          go run ./tools/featureflag validate
+
+          git add internal/featureflags/features.json
+          if git diff --cached --quiet; then
+            echo "No feature flag catalog change was produced."
+            exit 1
+          fi
+          git commit -m "feat(flags): graduate ${FEATURE} to stable"
+          git push origin "${branch}"
+
+          issue_line=""
+          if [ -n "${ISSUE_NUMBER}" ]; then
+            issue_line="Closes #${ISSUE_NUMBER}."
+          fi
+
+          mkdir -p .artifacts
+          cat > .artifacts/graduate-feature-pr.md <<PR_BODY
+          ${issue_line}
+
+          ## Graduation evidence
+
+          ${EVIDENCE}
+
+          ## Compatibility and rollback
+
+          ${COMPATIBILITY_NOTES}
+
+          ## Release lock notes
+
+          ${RELEASE_LOCK_NOTES}
+
+          ## Validation
+
+          - \`go run ./tools/featureflag graduate --feature ${FEATURE}\`
+          - \`go run ./tools/featureflag validate\`
+          PR_BODY
+
+          pr_args=(
+            --base main
+            --head "${branch}"
+            --title "feat(flags): graduate ${FEATURE} to stable"
+            --body-file .artifacts/graduate-feature-pr.md
+            --label enhancement
+            --label target-series:1.4.x
+          )
+          if [ -n "${MILESTONE}" ]; then
+            pr_args+=(--milestone "${MILESTONE}")
+          fi
+
+          pr_url="$(gh pr create "${pr_args[@]}")"
+          echo "Opened ${pr_url}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ Contributor rules:
 - Stable release builds enable `stable` flags by default and may enable specific `preview` flags through `internal/featureflags/release_locks.json`.
 - Release locks are release-specific default-on decisions; they do not change the lifecycle to `stable`.
 - Graduation requires a separate PR that changes the registry lifecycle to `stable` and states the rollout evidence.
+- Use `make feature-flag-graduate FEATURE=...` locally, or run `graduate-feature.yml`, to prepare a graduation PR.
 - PRs that add, lock, or graduate a feature flag must run `go run ./tools/featureflag validate`.
 
 Reviewers should ask for a flag when the change changes default user behavior but lacks enough evidence for immediate stable rollout.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format fmt format-check gostyle lint actionlint shellcheck mod-check feature-flag feature-flag-check dup-check suppression-check security vuln-check test test-leaks test-race bench-mem bench-delta bench-gate cov build manpage ci smoke demos demos-check mem-profiles release clean toolchain-check toolchain-install toolchain-install-macos toolchain-install-linux tools-install setup hooks-install hooks-uninstall sync-version vscode-extension-install vscode-extension-compile vscode-extension-test vscode-extension-package
+.PHONY: format fmt format-check gostyle lint actionlint shellcheck mod-check feature-flag feature-flag-graduate feature-flag-check dup-check suppression-check security vuln-check test test-leaks test-race bench-mem bench-delta bench-gate cov build manpage ci smoke demos demos-check mem-profiles release clean toolchain-check toolchain-install toolchain-install-macos toolchain-install-linux tools-install setup hooks-install hooks-uninstall sync-version vscode-extension-install vscode-extension-compile vscode-extension-test vscode-extension-package
 
 BINARY_NAME ?= lopper
 CMD_PATH ?= ./cmd/lopper
@@ -91,6 +91,9 @@ mod-check:
 
 feature-flag:
 	$(GO_CMD) run ./tools/featureflag add --name "$(NAME)" --description "$(DESCRIPTION)"
+
+feature-flag-graduate:
+	$(GO_CMD) run ./tools/featureflag graduate --feature "$(FEATURE)"
 
 feature-flag-check:
 	$(GO_CMD) run ./tools/featureflag validate

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -181,6 +181,32 @@ Minimum evidence for graduation:
 - no open Sonar, Copilot, or review issues remain for the feature
 - release notes or PR notes identify whether any release lock should be removed or kept for historical release reporting
 
+Use the local helper when preparing a graduation change by hand:
+
+```bash
+make feature-flag-graduate FEATURE=LOP-FEAT-0001
+```
+
+or:
+
+```bash
+go run ./tools/featureflag graduate --feature example-preview
+```
+
+Maintainers can also use the assisted workflow to open a graduation PR with the required evidence already in the body:
+
+```bash
+gh workflow run graduate-feature.yml \
+  -f feature=LOP-FEAT-0001 \
+  -f evidence="Rolling builds have shipped this enabled, tests cover the stable path, and docs are updated." \
+  -f compatibility_notes="No breaking config changes; disable with --disable-feature if rollback is needed." \
+  -f release_lock_notes="Remove future locks for this feature after the PR merges."
+```
+
+The workflow changes only the registry lifecycle and opens a PR.
+It does not merge the PR, remove release locks automatically, or infer stability from release-please.
+Use the optional `issue` and `milestone` inputs when the graduation belongs somewhere other than the current feature flagging rollout issue.
+
 After graduation, future release builds enable the feature by default through `lifecycle: "stable"`.
 Remove release locks for future releases when they are no longer needed.
 
@@ -192,5 +218,5 @@ Remove release locks for future releases when they are no longer needed.
 4. Implement the behavior so `preview` is default-off in release builds but default-on in rolling builds.
 5. Add CLI/config examples or docs when users can opt in.
 6. Use release locks only when a stable release should turn on a preview feature before graduation.
-7. Graduate in a later PR when the evidence is strong enough for stable defaults.
+7. Graduate in a later PR with `make feature-flag-graduate` or the `graduate-feature.yml` workflow when the evidence is strong enough for stable defaults.
 8. Clean up obsolete preview code paths, release locks, and docs after graduation.

--- a/tools/featureflag/main.go
+++ b/tools/featureflag/main.go
@@ -11,7 +11,10 @@ import (
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
-const catalogPath = "internal/featureflags/features.json"
+const (
+	catalogPath                  = "internal/featureflags/features.json"
+	resolveWorkingDirectoryError = "resolve working directory: %w"
+)
 
 var (
 	exitFunc                      = os.Exit
@@ -35,11 +38,13 @@ func main() {
 
 func run(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: featureflag add|validate|manifest|report")
+		return fmt.Errorf("usage: featureflag add|graduate|validate|manifest|report")
 	}
 	switch args[0] {
 	case "add":
 		return runAdd(args[1:])
+	case "graduate":
+		return runGraduate(args[1:])
 	case "validate":
 		return runValidate()
 	case "manifest":
@@ -68,7 +73,7 @@ func runAdd(args []string) error {
 
 	root, err := getwdFn()
 	if err != nil {
-		return fmt.Errorf("resolve working directory: %w", err)
+		return fmt.Errorf(resolveWorkingDirectoryError, err)
 	}
 	flags, err := readCatalog(root)
 	if err != nil {
@@ -96,6 +101,62 @@ func runAdd(args []string) error {
 		return fmt.Errorf("write feature catalog: %w", err)
 	}
 	_, err = fmt.Fprintf(os.Stdout, "added %s %s\n", code, strings.TrimSpace(*name))
+	return err
+}
+
+func runGraduate(args []string) error {
+	fs := flag.NewFlagSet("graduate", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	feature := fs.String("feature", strings.TrimSpace(os.Getenv("FEATURE")), "feature code or name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if len(fs.Args()) > 0 {
+		return fmt.Errorf("too many arguments for featureflag graduate")
+	}
+	ref := strings.TrimSpace(*feature)
+	if ref == "" {
+		return fmt.Errorf("feature code or name is required")
+	}
+
+	root, err := getwdFn()
+	if err != nil {
+		return fmt.Errorf(resolveWorkingDirectoryError, err)
+	}
+	flags, err := readCatalog(root)
+	if err != nil {
+		return err
+	}
+	registry, err := newRegistryFn(flags)
+	if err != nil {
+		return err
+	}
+	target, ok := registry.Lookup(ref)
+	if !ok {
+		return fmt.Errorf("unknown feature: %s", ref)
+	}
+	if target.Lifecycle == featureflags.LifecycleStable {
+		return fmt.Errorf("feature %s is already stable", target.Code)
+	}
+	updated := false
+	for i := range flags {
+		if flags[i].Code == target.Code {
+			flags[i].Lifecycle = featureflags.LifecycleStable
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		return fmt.Errorf("feature %s is missing from the catalog", target.Code)
+	}
+	data, err := featureflags.FormatCatalog(flags)
+	if err != nil {
+		return err
+	}
+	if err := writeFileUnderFn(root, filepath.Join(root, catalogPath), data, 0o644); err != nil {
+		return fmt.Errorf("write feature catalog: %w", err)
+	}
+	_, err = fmt.Fprintf(os.Stdout, "graduated %s %s to stable\n", target.Code, target.Name)
 	return err
 }
 
@@ -202,7 +263,7 @@ func readPreviousCatalog(path string) ([]featureflags.Flag, bool, error) {
 	}
 	root, err := getwdFn()
 	if err != nil {
-		return nil, false, fmt.Errorf("resolve working directory: %w", err)
+		return nil, false, fmt.Errorf(resolveWorkingDirectoryError, err)
 	}
 	data, err := safeio.ReadFileUnder(root, filepath.Join(root, path))
 	if err != nil {

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -12,6 +12,21 @@ import (
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
+const graduateFeatureCatalog = `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "preview-flag",
+    "description": "Preview behavior",
+    "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0002",
+    "name": "stable-flag",
+    "description": "Stable behavior",
+    "lifecycle": "stable"
+  }
+]`
+
 func TestRunAddFeatureFlag(t *testing.T) {
 	root := t.TempDir()
 	catalogDir := filepath.Join(root, "internal", "featureflags")
@@ -44,30 +59,87 @@ func TestRunAddFeatureFlag(t *testing.T) {
 	}
 }
 
+func TestRunGraduateFeatureFlag(t *testing.T) {
+	for _, ref := range []string{"preview-flag", "LOP-FEAT-0001"} {
+		assertGraduateFeature(t, ref)
+	}
+}
+
 func TestRunFeatureFlagErrors(t *testing.T) {
-	if err := run(nil); err == nil || !strings.Contains(err.Error(), "usage") {
-		t.Fatalf("expected usage error, got %v", err)
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing command", args: nil, want: "usage"},
+		{name: "unknown command", args: []string{"nope"}, want: "unknown"},
+		{name: "missing add name", args: []string{"add"}, want: "name is required"},
+		{name: "extra add argument", args: []string{"add", "--name", "new-flag", "extra"}, want: "too many arguments"},
+		{name: "missing graduate feature", args: []string{"graduate"}, want: "feature code or name is required"},
+		{name: "extra graduate argument", args: []string{"graduate", "--feature", "preview-flag", "extra"}, want: "too many arguments"},
+	} {
+		assertRunErrorContains(t, tc.name, tc.args, tc.want)
 	}
-	if err := run([]string{"nope"}); err == nil || !strings.Contains(err.Error(), "unknown") {
-		t.Fatalf("expected unknown command error, got %v", err)
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "bad add flag", args: []string{"add", "--definitely-not-a-flag"}},
+		{name: "bad graduate flag", args: []string{"graduate", "--definitely-not-a-flag"}},
+	} {
+		assertRunError(t, tc.name, tc.args)
 	}
-	if err := run([]string{"add"}); err == nil || !strings.Contains(err.Error(), "name is required") {
-		t.Fatalf("expected missing name error, got %v", err)
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "validate", args: []string{"validate"}},
+		{name: "manifest", args: []string{"manifest"}},
+		{name: "report", args: []string{"report"}},
+	} {
+		assertRunOK(t, tc.name, tc.args)
 	}
-	if err := run([]string{"add", "--name", "new-flag", "extra"}); err == nil || !strings.Contains(err.Error(), "too many arguments") {
-		t.Fatalf("expected extra argument error, got %v", err)
+}
+
+func TestRunGraduateFeatureFlagRejectsBadState(t *testing.T) {
+	root := t.TempDir()
+	writeFeatureCatalog(t, root, graduateFeatureCatalog)
+	t.Chdir(root)
+
+	if err := run([]string{"graduate", "--feature", "missing-flag"}); err == nil || !strings.Contains(err.Error(), "unknown feature") {
+		t.Fatalf("expected unknown feature error, got %v", err)
 	}
-	if err := run([]string{"add", "--definitely-not-a-flag"}); err == nil {
-		t.Fatalf("expected flag parse error")
+	if err := run([]string{"graduate", "--feature", "stable-flag"}); err == nil || !strings.Contains(err.Error(), "already stable") {
+		t.Fatalf("expected already stable error, got %v", err)
 	}
-	if err := run([]string{"validate"}); err != nil {
-		t.Fatalf("expected embedded registry validation to pass, got %v", err)
+}
+
+func TestRunGraduateFeatureFlagRejectsBadCatalogState(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := run([]string{"graduate", "--feature", "preview-flag"}); err == nil || !strings.Contains(err.Error(), "read feature catalog") {
+		t.Fatalf("expected missing catalog error, got %v", err)
 	}
-	if err := run([]string{"manifest"}); err != nil {
-		t.Fatalf("expected embedded manifest to render, got %v", err)
+
+	root := t.TempDir()
+	writeFeatureCatalog(t, root, `[]`)
+	t.Chdir(root)
+
+	oldNewRegistry := newRegistryFn
+	t.Cleanup(func() { newRegistryFn = oldNewRegistry })
+	newRegistryFn = func([]featureflags.Flag) (*featureflags.Registry, error) {
+		return nil, errors.New("registry failed")
 	}
-	if err := run([]string{"report"}); err != nil {
-		t.Fatalf("expected embedded report to render, got %v", err)
+	if err := run([]string{"graduate", "--feature", "preview-flag"}); err == nil || !strings.Contains(err.Error(), "registry failed") {
+		t.Fatalf("expected injected registry error, got %v", err)
+	}
+
+	newRegistryFn = func([]featureflags.Flag) (*featureflags.Registry, error) {
+		return featureflags.NewRegistry([]featureflags.Flag{
+			{Code: "LOP-FEAT-0001", Name: "preview-flag", Lifecycle: featureflags.LifecyclePreview},
+		})
+	}
+	if err := run([]string{"graduate", "--feature", "preview-flag"}); err == nil || !strings.Contains(err.Error(), "missing from the catalog") {
+		t.Fatalf("expected missing catalog target error, got %v", err)
 	}
 }
 
@@ -142,6 +214,38 @@ func TestRunAddFeatureFlagGetwdAndWriteErrors(t *testing.T) {
 		writeFileUnderFn = oldWrite
 	})
 	if err := run([]string{"add", "--name", "new-flag"}); err == nil || !strings.Contains(err.Error(), "write feature catalog") {
+		t.Fatalf("expected write error, got %v", err)
+	}
+}
+
+func TestRunGraduateFeatureFlagGetwdAndWriteErrors(t *testing.T) {
+	oldGetwd := getwdFn
+	getwdFn = func() (string, error) { return "", errors.New("cwd failed") }
+	if err := run([]string{"graduate", "--feature", "preview-flag"}); err == nil || !strings.Contains(err.Error(), "resolve working directory") {
+		t.Fatalf("expected getwd error, got %v", err)
+	}
+	getwdFn = oldGetwd
+
+	root := t.TempDir()
+	writeFeatureCatalog(t, root, `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "preview-flag",
+    "description": "Preview behavior",
+    "lifecycle": "preview"
+  }
+]`)
+	t.Chdir(root)
+
+	oldWrite := writeFileUnderFn
+	writeFileUnderFn = func(string, string, []byte, os.FileMode) error {
+		return errors.New("write failed")
+	}
+	t.Cleanup(func() {
+		getwdFn = oldGetwd
+		writeFileUnderFn = oldWrite
+	})
+	if err := run([]string{"graduate", "--feature", "preview-flag"}); err == nil || !strings.Contains(err.Error(), "write feature catalog") {
 		t.Fatalf("expected write error, got %v", err)
 	}
 }
@@ -268,6 +372,16 @@ func TestRunManifestAndReportUseChannels(t *testing.T) {
 			t.Fatalf("expected report to contain %q, got %s", want, reportOutput)
 		}
 	}
+
+	rollingReport, err := captureStdout(t, func() error {
+		return run([]string{"report", "--channel", "rolling"})
+	})
+	if err != nil {
+		t.Fatalf("run rolling report: %v", err)
+	}
+	if !strings.Contains(rollingReport, "Preview enabled by rolling channel") {
+		t.Fatalf("expected rolling report preview section, got %s", rollingReport)
+	}
 }
 
 func TestRunManifestAndReportRejectBadInputs(t *testing.T) {
@@ -280,6 +394,9 @@ func TestRunManifestAndReportRejectBadInputs(t *testing.T) {
 	}
 	if err := run([]string{"manifest", "extra"}); err == nil || !strings.Contains(err.Error(), "too many arguments") {
 		t.Fatalf("expected manifest extra argument error, got %v", err)
+	}
+	if err := run([]string{"report", "--channel"}); err == nil {
+		t.Fatalf("expected report flag parse error")
 	}
 	if err := run([]string{"report", "--previous-catalog", filepath.Join(t.TempDir(), "missing.json")}); err == nil || !strings.Contains(err.Error(), "read previous feature catalog") {
 		t.Fatalf("expected missing previous catalog error, got %v", err)
@@ -420,6 +537,80 @@ func testRegistry(t *testing.T) *featureflags.Registry {
 		t.Fatalf("new registry: %v", err)
 	}
 	return registry
+}
+
+func assertGraduateFeature(t *testing.T, ref string) {
+	t.Helper()
+	t.Run(ref, func(t *testing.T) {
+		root := t.TempDir()
+		catalogDir := writeFeatureCatalog(t, root, graduateFeatureCatalog)
+		t.Chdir(root)
+
+		output, err := captureStdout(t, func() error {
+			return run([]string{"graduate", "--feature", ref})
+		})
+		if err != nil {
+			t.Fatalf("run graduate: %v", err)
+		}
+		flags := readFeatureCatalog(t, catalogDir)
+		if flags[0].Code != "LOP-FEAT-0001" || flags[0].Lifecycle != featureflags.LifecycleStable {
+			t.Fatalf("expected preview flag to graduate, got %#v", flags[0])
+		}
+		if !strings.Contains(output, "graduated LOP-FEAT-0001 preview-flag to stable") {
+			t.Fatalf("expected graduation output, got %q", output)
+		}
+	})
+}
+
+func assertRunErrorContains(t *testing.T, name string, args []string, want string) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		err := run(args)
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error containing %q, got %v", want, err)
+		}
+	})
+}
+
+func assertRunError(t *testing.T, name string, args []string) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		if err := run(args); err == nil {
+			t.Fatalf("expected run error")
+		}
+	})
+}
+
+func assertRunOK(t *testing.T, name string, args []string) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		if err := run(args); err != nil {
+			t.Fatalf("run %s: %v", name, err)
+		}
+	})
+}
+
+func readFeatureCatalog(t *testing.T, catalogDir string) []featureflags.Flag {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(catalogDir, "features.json"))
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	flags, err := featureflags.ParseCatalog(data)
+	if err != nil {
+		t.Fatalf("parse catalog: %v", err)
+	}
+	return flags
+}
+
+func writeFeatureCatalog(t *testing.T, root, content string) string {
+	t.Helper()
+	catalogDir := filepath.Join(root, "internal", "featureflags")
+	if err := os.MkdirAll(catalogDir, 0o755); err != nil {
+		t.Fatalf("mkdir catalog dir: %v", err)
+	}
+	testutil.MustWriteFile(t, filepath.Join(catalogDir, "features.json"), content)
+	return catalogDir
 }
 
 func captureStdout(t *testing.T, fn func() error) (string, error) {


### PR DESCRIPTION
## Summary

- add `featureflag graduate` and `make feature-flag-graduate` so maintainers can move preview flags to stable by code or name
- add a manual `graduate-feature.yml` workflow that opens an evidence-filled graduation PR instead of auto-graduating on merge
- document the graduation path in `docs/feature-flags.md` and `CONTRIBUTING.md`

## Validation

- `GOTOOLCHAIN=go1.26.2 go test ./tools/featureflag -cover`
- `GOTOOLCHAIN=go1.26.2 make ci`
- pre-commit `make ci` gate

Closes #721