### PR TITLE
refactor(elixir): isolate sanitizer state machine from parser

### DIFF
--- a/internal/lang/elixir/detection.go
+++ b/internal/lang/elixir/detection.go
@@ -100,7 +100,7 @@ func detectUmbrellaAppsPath(content []byte) (bool, string) {
 }
 
 func stripElixirComments(content []byte) string {
-	masked := maskElixirImportSource(content)
+	masked := sanitizeElixirSource(content)
 
 	var stripped strings.Builder
 	stripped.Grow(len(content))

--- a/internal/lang/elixir/import_parser.go
+++ b/internal/lang/elixir/import_parser.go
@@ -14,6 +14,9 @@ func parseImports(content []byte, filePath string, declared map[string]struct{})
 }
 
 func parseImportsFromSanitized(content []byte, sanitized []byte, filePath string, declared map[string]struct{}) []shared.ImportRecord {
+	if len(sanitized) != len(content) {
+		return nil
+	}
 	matches := importPattern.FindAllSubmatchIndex(sanitized, -1)
 	records := make([]shared.ImportRecord, 0, len(matches))
 	for _, idx := range matches {

--- a/internal/lang/elixir/import_parser.go
+++ b/internal/lang/elixir/import_parser.go
@@ -1,0 +1,97 @@
+package elixir
+
+import (
+	"bytes"
+	"strings"
+	"unicode"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func parseImports(content []byte, filePath string, declared map[string]struct{}) []shared.ImportRecord {
+	return parseImportsFromSanitized(content, sanitizeElixirSource(content), filePath, declared)
+}
+
+func parseImportsFromSanitized(content []byte, sanitized []byte, filePath string, declared map[string]struct{}) []shared.ImportRecord {
+	matches := importPattern.FindAllSubmatchIndex(sanitized, -1)
+	records := make([]shared.ImportRecord, 0, len(matches))
+	for _, idx := range matches {
+		keywordStart := idx[2]
+		keyword := strings.TrimSpace(string(content[idx[2]:idx[3]]))
+		module := strings.TrimSpace(string(content[idx[4]:idx[5]]))
+		dependency := dependencyFromModule(module, declared)
+		if dependency == "" {
+			continue
+		}
+		line := 1 + strings.Count(string(content[:keywordStart]), "\n")
+		local := module
+		if parts := strings.Split(module, "."); len(parts) > 0 {
+			local = parts[len(parts)-1]
+		}
+		if keyword == "alias" {
+			if aliasLocal := parseAliasLocal(lineBytes(content, keywordStart)); aliasLocal != "" {
+				local = aliasLocal
+			}
+		}
+		records = append(records, shared.ImportRecord{
+			Dependency: dependency,
+			Module:     module,
+			Name:       module,
+			Local:      local,
+			Location:   report.Location{File: filePath, Line: line, Column: 1},
+		})
+	}
+	return records
+}
+
+func lineBytes(content []byte, start int) []byte {
+	if start < 0 || start >= len(content) {
+		return nil
+	}
+	line := content[start:]
+	if i := bytes.IndexByte(line, '\n'); i >= 0 {
+		return line[:i]
+	}
+	return line
+}
+
+func parseAliasLocal(line []byte) string {
+	matches := aliasAsPattern.FindSubmatch(line)
+	if len(matches) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(string(matches[1]))
+}
+
+func dependencyFromModule(module string, declared map[string]struct{}) string {
+	root := strings.Split(module, ".")[0]
+	normalized := normalizeDependencyID(camelToSnake(root))
+	if normalized == "" {
+		return ""
+	}
+	if _, ok := declared[normalized]; ok {
+		return normalized
+	}
+	alt := strings.ReplaceAll(normalized, "_", "-")
+	if _, ok := declared[alt]; ok {
+		return alt
+	}
+	return ""
+}
+
+func normalizeDependencyID(value string) string {
+	return strings.ReplaceAll(shared.NormalizeDependencyID(value), "_", "-")
+}
+
+func camelToSnake(value string) string {
+	var b strings.Builder
+	runes := []rune(value)
+	for i, r := range runes {
+		if unicode.IsUpper(r) && i > 0 && (unicode.IsLower(runes[i-1]) || (i+1 < len(runes) && unicode.IsLower(runes[i+1]))) {
+			b.WriteByte('_')
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}

--- a/internal/lang/elixir/import_parser_test.go
+++ b/internal/lang/elixir/import_parser_test.go
@@ -8,26 +8,30 @@ import (
 
 func TestParseImportsFromSanitizedSeparatesSourceSanitizer(t *testing.T) {
 	content := []byte("defmodule Demo do\n  message = \"\"\"\n  alias Foo.Bar\n  \"\"\"\n  alias Foo.Bar, as: Baz\nend\n")
-	sanitized := append([]byte(nil), content...)
+	sanitized := sanitizeElixirSource(content)
 
-	heredocAlias := []byte("alias Foo.Bar")
-	index := bytes.Index(content, heredocAlias)
+	realAlias := []byte("alias Foo.Bar, as: Baz")
+	index := bytes.Index(content, realAlias)
 	if index < 0 {
-		t.Fatalf("expected fixture to contain heredoc alias text")
+		t.Fatalf("expected fixture to contain non-heredoc alias text")
 	}
-	for i := index; i < index+len(heredocAlias); i++ {
+	for i := index; i < index+len(realAlias); i++ {
 		sanitized[i] = ' '
 	}
 
 	imports := parseImportsFromSanitized(content, sanitized, "lib/demo.ex", map[string]struct{}{"foo": {}})
-	if len(imports) != 1 {
-		t.Fatalf("expected one import from pre-sanitized source, got %#v", imports)
+	if len(imports) != 0 {
+		t.Fatalf("expected no imports after masking non-heredoc alias in pre-sanitized source, got %#v", imports)
 	}
-	if imports[0].Local != "Baz" {
-		t.Fatalf("expected alias local Baz, got %q", imports[0].Local)
-	}
-	if imports[0].Location.Line != 5 {
-		t.Fatalf("expected import location line 5, got %d", imports[0].Location.Line)
+}
+
+func TestParseImportsFromSanitizedRejectsMismatchedBufferLengths(t *testing.T) {
+	content := []byte("defmodule Demo do\n  alias Foo.Bar\nend\n")
+	sanitized := sanitizeElixirSource(content)
+
+	imports := parseImportsFromSanitized(content, sanitized[:len(sanitized)-1], "lib/demo.ex", map[string]struct{}{"foo": {}})
+	if len(imports) != 0 {
+		t.Fatalf("expected mismatched sanitized buffer to produce no imports, got %#v", imports)
 	}
 }
 

--- a/internal/lang/elixir/import_parser_test.go
+++ b/internal/lang/elixir/import_parser_test.go
@@ -1,0 +1,44 @@
+package elixir
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestParseImportsFromSanitizedSeparatesSourceSanitizer(t *testing.T) {
+	content := []byte("defmodule Demo do\n  message = \"\"\"\n  alias Foo.Bar\n  \"\"\"\n  alias Foo.Bar, as: Baz\nend\n")
+	sanitized := append([]byte(nil), content...)
+
+	heredocAlias := []byte("alias Foo.Bar")
+	index := bytes.Index(content, heredocAlias)
+	if index < 0 {
+		t.Fatalf("expected fixture to contain heredoc alias text")
+	}
+	for i := index; i < index+len(heredocAlias); i++ {
+		sanitized[i] = ' '
+	}
+
+	imports := parseImportsFromSanitized(content, sanitized, "lib/demo.ex", map[string]struct{}{"foo": {}})
+	if len(imports) != 1 {
+		t.Fatalf("expected one import from pre-sanitized source, got %#v", imports)
+	}
+	if imports[0].Local != "Baz" {
+		t.Fatalf("expected alias local Baz, got %q", imports[0].Local)
+	}
+	if imports[0].Location.Line != 5 {
+		t.Fatalf("expected import location line 5, got %d", imports[0].Location.Line)
+	}
+}
+
+func TestParseImportsMatchesExplicitSanitizerPipeline(t *testing.T) {
+	content := []byte("defmodule Demo do\n  message = \"\"\"\n  alias Foo.Bar\n  \"\"\"\n  alias Foo.Bar, as: Baz\n  import Foo.Bar\nend\n")
+	declared := map[string]struct{}{"foo": {}}
+	filePath := "lib/demo.ex"
+
+	got := parseImports(content, filePath, declared)
+	want := parseImportsFromSanitized(content, sanitizeElixirSource(content), filePath, declared)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected wrapper parse path to match explicit sanitizer pipeline:\nwant %#v\ngot  %#v", want, got)
+	}
+}

--- a/internal/lang/elixir/scan.go
+++ b/internal/lang/elixir/scan.go
@@ -1,15 +1,12 @@
 package elixir
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode"
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
-	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
@@ -36,88 +33,4 @@ func scanElixirRepo(ctx context.Context, repoPath string, declared map[string]st
 		return nil
 	})
 	return result, err
-}
-
-func parseImports(content []byte, filePath string, declared map[string]struct{}) []shared.ImportRecord {
-	sanitized := maskElixirImportSource(content)
-	matches := importPattern.FindAllSubmatchIndex(sanitized, -1)
-	records := make([]shared.ImportRecord, 0, len(matches))
-	for _, idx := range matches {
-		keywordStart := idx[2]
-		keyword := strings.TrimSpace(string(content[idx[2]:idx[3]]))
-		module := strings.TrimSpace(string(content[idx[4]:idx[5]]))
-		dependency := dependencyFromModule(module, declared)
-		if dependency == "" {
-			continue
-		}
-		line := 1 + strings.Count(string(content[:keywordStart]), "\n")
-		local := module
-		if parts := strings.Split(module, "."); len(parts) > 0 {
-			local = parts[len(parts)-1]
-		}
-		if keyword == "alias" {
-			if aliasLocal := parseAliasLocal(lineBytes(content, keywordStart)); aliasLocal != "" {
-				local = aliasLocal
-			}
-		}
-		records = append(records, shared.ImportRecord{
-			Dependency: dependency,
-			Module:     module,
-			Name:       module,
-			Local:      local,
-			Location:   report.Location{File: filePath, Line: line, Column: 1},
-		})
-	}
-	return records
-}
-
-func lineBytes(content []byte, start int) []byte {
-	if start < 0 || start >= len(content) {
-		return nil
-	}
-	line := content[start:]
-	if i := bytes.IndexByte(line, '\n'); i >= 0 {
-		return line[:i]
-	}
-	return line
-}
-
-func parseAliasLocal(line []byte) string {
-	matches := aliasAsPattern.FindSubmatch(line)
-	if len(matches) < 2 {
-		return ""
-	}
-	return strings.TrimSpace(string(matches[1]))
-}
-
-func dependencyFromModule(module string, declared map[string]struct{}) string {
-	root := strings.Split(module, ".")[0]
-	normalized := normalizeDependencyID(camelToSnake(root))
-	if normalized == "" {
-		return ""
-	}
-	if _, ok := declared[normalized]; ok {
-		return normalized
-	}
-	alt := strings.ReplaceAll(normalized, "_", "-")
-	if _, ok := declared[alt]; ok {
-		return alt
-	}
-	return ""
-}
-
-func normalizeDependencyID(value string) string {
-	return strings.ReplaceAll(shared.NormalizeDependencyID(value), "_", "-")
-}
-
-func camelToSnake(value string) string {
-	var b strings.Builder
-	runes := []rune(value)
-	for i, r := range runes {
-		if unicode.IsUpper(r) && i > 0 && (unicode.IsLower(runes[i-1]) || (i+1 < len(runes) && unicode.IsLower(runes[i+1]))) {
-			b.WriteByte('_')
-		}
-		b.WriteRune(unicode.ToLower(r))
-	}
-	return b.String()
 }

--- a/internal/lang/elixir/source_mask.go
+++ b/internal/lang/elixir/source_mask.go
@@ -1,6 +1,6 @@
 package elixir
 
-type elixirImportMaskState struct {
+type elixirSourceMaskState struct {
 	inSingleQuote   bool
 	inDoubleQuote   bool
 	inSingleHeredoc bool
@@ -8,34 +8,34 @@ type elixirImportMaskState struct {
 	escaped         bool
 }
 
-func maskElixirImportSource(content []byte) []byte {
+func sanitizeElixirSource(content []byte) []byte {
 	sanitized := make([]byte, len(content))
 	copy(sanitized, content)
-	state := elixirImportMaskState{}
+	state := elixirSourceMaskState{}
 
 	for i := 0; i < len(content); i++ {
-		i += maskElixirSourceAt(content, sanitized, i, &state)
+		i += sanitizeElixirSourceAt(content, sanitized, i, &state)
 	}
 
 	return sanitized
 }
 
-func maskElixirSourceAt(content []byte, sanitized []byte, index int, state *elixirImportMaskState) int {
+func sanitizeElixirSourceAt(content []byte, sanitized []byte, index int, state *elixirSourceMaskState) int {
 	switch {
 	case state.inDoubleHeredoc:
-		return maskElixirHeredocByte(content, sanitized, index, state, '"')
+		return sanitizeElixirHeredocByte(content, sanitized, index, state, '"')
 	case state.inSingleHeredoc:
-		return maskElixirHeredocByte(content, sanitized, index, state, '\'')
+		return sanitizeElixirHeredocByte(content, sanitized, index, state, '\'')
 	case state.inDoubleQuote:
-		return maskElixirQuotedByte(content, sanitized, index, state, '"')
+		return sanitizeElixirQuotedByte(content, sanitized, index, state, '"')
 	case state.inSingleQuote:
-		return maskElixirQuotedByte(content, sanitized, index, state, '\'')
+		return sanitizeElixirQuotedByte(content, sanitized, index, state, '\'')
 	default:
-		return startElixirMaskedRegion(content, sanitized, index, state)
+		return startElixirSanitizedRegion(content, sanitized, index, state)
 	}
 }
 
-func maskElixirHeredocByte(content []byte, sanitized []byte, index int, state *elixirImportMaskState, quote byte) int {
+func sanitizeElixirHeredocByte(content []byte, sanitized []byte, index int, state *elixirSourceMaskState, quote byte) int {
 	maskElixirSourceByte(sanitized, index)
 	if !isElixirTripleQuote(content, index, quote) {
 		return 0
@@ -50,7 +50,7 @@ func maskElixirHeredocByte(content []byte, sanitized []byte, index int, state *e
 	return 2
 }
 
-func maskElixirQuotedByte(content []byte, sanitized []byte, index int, state *elixirImportMaskState, quote byte) int {
+func sanitizeElixirQuotedByte(content []byte, sanitized []byte, index int, state *elixirSourceMaskState, quote byte) int {
 	maskElixirSourceByte(sanitized, index)
 	if state.escaped {
 		state.escaped = false
@@ -70,7 +70,7 @@ func maskElixirQuotedByte(content []byte, sanitized []byte, index int, state *el
 	return 0
 }
 
-func startElixirMaskedRegion(content []byte, sanitized []byte, index int, state *elixirImportMaskState) int {
+func startElixirSanitizedRegion(content []byte, sanitized []byte, index int, state *elixirSourceMaskState) int {
 	if isElixirTripleQuote(content, index, '"') {
 		maskElixirSourceByte(sanitized, index)
 		maskElixirSourceByte(sanitized, index+1)


### PR DESCRIPTION
## Summary
- split Elixir import parsing to consume a pre-sanitized source buffer via parseImportsFromSanitized
- keep parseImports as a wrapper composing parser + sanitizer to preserve behavior
- rename source sanitizer internals to source-focused naming and update comment stripping to use the same sanitizer
- add parser/sanitizer separation and wrapper parity tests for regression safety

## Testing
- go test ./internal/lang/elixir
- go test ./...

Closes #633