### PR TITLE
refactor(ruby): split bundler parsing and provenance seams

### DIFF
--- a/internal/lang/ruby/bundler_declarations.go
+++ b/internal/lang/ruby/bundler_declarations.go
@@ -1,0 +1,226 @@
+package ruby
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+type bundlerDeclaration struct {
+	dependency string
+	kind       string
+	signal     string
+}
+
+func loadBundlerDependencies(repoPath string, out map[string]struct{}) error {
+	return loadBundlerDependenciesWithSources(repoPath, out, nil)
+}
+
+func loadBundlerDependenciesWithSources(repoPath string, out map[string]struct{}, sources map[string]rubyDependencySource) error {
+	if err := loadGemfileDependencies(repoPath, out, sources); err != nil {
+		return err
+	}
+	return loadGemfileLockDependencies(repoPath, out, sources)
+}
+
+func loadGemfileDependencies(repoPath string, out map[string]struct{}, sources map[string]rubyDependencySource) error {
+	content, err := readBundlerFile(repoPath, gemfileName)
+	if err != nil {
+		return err
+	}
+	if len(content) == 0 {
+		return nil
+	}
+	applyBundlerDeclarations(out, sources, parseGemfileDeclarations(content))
+	return nil
+}
+
+func loadGemfileLockDependencies(repoPath string, out map[string]struct{}, sources map[string]rubyDependencySource) error {
+	content, err := readBundlerFile(repoPath, gemfileLockName)
+	if err != nil {
+		return err
+	}
+	if len(content) == 0 {
+		return nil
+	}
+	for _, dependency := range parseGemfileLockDeclarations(content) {
+		out[dependency] = struct{}{}
+	}
+	parseGemfileLockSourceAttribution(content, out, sources)
+	return nil
+}
+
+func parseGemfileDeclarations(content []byte) []bundlerDeclaration {
+	declarations := make([]bundlerDeclaration, 0)
+	for _, line := range strings.Split(string(content), "\n") {
+		dependency, kind, ok := parseGemfileDependencyLine(line)
+		if !ok {
+			continue
+		}
+		declarations = append(declarations, bundlerDeclaration{
+			dependency: dependency,
+			kind:       kind,
+			signal:     gemfileName,
+		})
+	}
+	return declarations
+}
+
+func parseGemfileLockDeclarations(content []byte) []string {
+	dependencies := make([]string, 0)
+	for _, line := range strings.Split(string(content), "\n") {
+		matches := gemSpecPattern.FindStringSubmatch(line)
+		if len(matches) != 2 {
+			continue
+		}
+		if dependency := normalizeDependencyID(matches[1]); dependency != "" {
+			dependencies = append(dependencies, dependency)
+		}
+	}
+	return dependencies
+}
+
+func applyBundlerDeclarations(out map[string]struct{}, sources map[string]rubyDependencySource, declarations []bundlerDeclaration) {
+	for _, declaration := range declarations {
+		addRubyDependency(out, sources, declaration.dependency, declaration.kind, declaration.signal)
+	}
+}
+
+func parseGemfileDependencyLine(line string) (string, string, bool) {
+	line = shared.StripLineComment(line, "#")
+	matches := gemDeclarationPattern.FindStringSubmatch(line)
+	if len(matches) != 2 {
+		return "", "", false
+	}
+	dependency := normalizeDependencyID(matches[1])
+	if dependency == "" {
+		return "", "", false
+	}
+	kind := rubyDependencySourceRubygems
+	switch {
+	case gemPathOptionPattern.MatchString(line):
+		kind = rubyDependencySourcePath
+	case gemGitOptionPattern.MatchString(line):
+		kind = rubyDependencySourceGit
+	}
+	return dependency, kind, true
+}
+
+func parseGemfileLockSourceAttribution(content []byte, out map[string]struct{}, sources map[string]rubyDependencySource) {
+	if sources == nil || len(content) == 0 {
+		return
+	}
+	applyBundlerDeclarations(out, sources, parseGemfileLockSourceDeclarations(content))
+}
+
+func parseGemfileLockSourceDeclarations(content []byte) []bundlerDeclaration {
+	state := gemfileLockSourceAttributionState{}
+	for _, rawLine := range strings.Split(string(content), "\n") {
+		applyGemfileLockSourceAttributionLine(rawLine, &state)
+	}
+	return state.declarations
+}
+
+type gemfileLockSourceAttributionState struct {
+	currentKind  string
+	inSpecs      bool
+	declarations []bundlerDeclaration
+}
+
+func applyGemfileLockSourceAttributionLine(rawLine string, state *gemfileLockSourceAttributionState) {
+	line := strings.TrimRight(rawLine, "\r")
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return
+	}
+	if !isGemfileLockTopLevelLine(line) {
+		applyGemfileLockDependencyEntry(line, state)
+		return
+	}
+
+	state.currentKind = parseGemfileLockSection(trimmed)
+	state.inSpecs = false
+}
+
+func isGemfileLockTopLevelLine(line string) bool {
+	return !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t")
+}
+
+func parseGemfileLockSection(line string) string {
+	switch line {
+	case rubyGemfileSectionGem:
+		return rubyDependencySourceRubygems
+	case rubyGemfileSectionGit:
+		return rubyDependencySourceGit
+	case rubyGemfileSectionPath:
+		return rubyDependencySourcePath
+	default:
+		return ""
+	}
+}
+
+func applyGemfileLockDependencyEntry(line string, state *gemfileLockSourceAttributionState) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == rubyGemfileSpecsSection {
+		state.inSpecs = state.currentKind != ""
+		return
+	}
+	if !state.inSpecs {
+		return
+	}
+	matches := gemTopLevelSpecPattern.FindStringSubmatch(line)
+	if len(matches) != 2 {
+		return
+	}
+	state.declarations = append(state.declarations, bundlerDeclaration{
+		dependency: normalizeDependencyID(matches[1]),
+		kind:       state.currentKind,
+		signal:     gemfileLockName,
+	})
+}
+
+func addRubyDependency(out map[string]struct{}, sources map[string]rubyDependencySource, dependency, kind, signal string) {
+	if dependency == "" {
+		return
+	}
+	if out != nil {
+		out[dependency] = struct{}{}
+	}
+	if sources == nil {
+		return
+	}
+	info := sources[dependency]
+	switch kind {
+	case rubyDependencySourceRubygems:
+		info.Rubygems = true
+	case rubyDependencySourceGit:
+		info.Git = true
+	case rubyDependencySourcePath:
+		info.Path = true
+	}
+	switch signal {
+	case gemfileName:
+		info.DeclaredGemfile = true
+	case gemfileLockName:
+		info.DeclaredLock = true
+	}
+	sources[dependency] = info
+}
+
+func readBundlerFile(repoPath, filename string) ([]byte, error) {
+	targetPath := filepath.Join(repoPath, filename)
+	content, err := safeio.ReadFileUnder(repoPath, targetPath)
+	switch {
+	case err == nil:
+		return content, nil
+	case errors.Is(err, os.ErrNotExist):
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("read %s: %w", filename, err)
+	}
+}

--- a/internal/lang/ruby/bundler_declarations.go
+++ b/internal/lang/ruby/bundler_declarations.go
@@ -48,9 +48,7 @@ func loadGemfileLockDependencies(repoPath string, out map[string]struct{}, sourc
 	if len(content) == 0 {
 		return nil
 	}
-	for _, dependency := range parseGemfileLockDeclarations(content) {
-		out[dependency] = struct{}{}
-	}
+	applyGemfileLockDeclarations(content, out)
 	parseGemfileLockSourceAttribution(content, out, sources)
 	return nil
 }
@@ -74,15 +72,35 @@ func parseGemfileDeclarations(content []byte) []bundlerDeclaration {
 func parseGemfileLockDeclarations(content []byte) []string {
 	dependencies := make([]string, 0)
 	for _, line := range strings.Split(string(content), "\n") {
-		matches := gemSpecPattern.FindStringSubmatch(line)
-		if len(matches) != 2 {
+		dependency, ok := parseGemfileLockDeclarationLine(line)
+		if !ok {
 			continue
 		}
-		if dependency := normalizeDependencyID(matches[1]); dependency != "" {
-			dependencies = append(dependencies, dependency)
-		}
+		dependencies = append(dependencies, dependency)
 	}
 	return dependencies
+}
+
+func applyGemfileLockDeclarations(content []byte, out map[string]struct{}) {
+	for _, line := range strings.Split(string(content), "\n") {
+		dependency, ok := parseGemfileLockDeclarationLine(line)
+		if !ok {
+			continue
+		}
+		out[dependency] = struct{}{}
+	}
+}
+
+func parseGemfileLockDeclarationLine(line string) (string, bool) {
+	matches := gemSpecPattern.FindStringSubmatch(line)
+	if len(matches) != 2 {
+		return "", false
+	}
+	dependency := normalizeDependencyID(matches[1])
+	if dependency == "" {
+		return "", false
+	}
+	return dependency, true
 }
 
 func applyBundlerDeclarations(out map[string]struct{}, sources map[string]rubyDependencySource, declarations []bundlerDeclaration) {

--- a/internal/lang/ruby/bundler_declarations_seams_test.go
+++ b/internal/lang/ruby/bundler_declarations_seams_test.go
@@ -43,6 +43,23 @@ GEM
 	}
 }
 
+func TestRubyApplyGemfileLockDeclarationsSeam(t *testing.T) {
+	content := []byte(`GEM
+  specs:
+    httparty (0.22.0)
+      json (>= 2.0)
+    rack (3.1.0)
+`)
+
+	out := map[string]struct{}{}
+	applyGemfileLockDeclarations(content, out)
+	got := sortedMapKeys(out)
+	want := []string{"httparty", "json", "rack"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("applyGemfileLockDeclarations()=%#v want %#v", got, want)
+	}
+}
+
 func TestRubyParseGemfileLockSourceDeclarationsSeam(t *testing.T) {
 	content := []byte(`GIT
   specs:
@@ -112,5 +129,14 @@ func declarationTuples(declarations []bundlerDeclaration) []string {
 	for _, declaration := range declarations {
 		out = append(out, declaration.dependency+"|"+declaration.kind+"|"+declaration.signal)
 	}
+	return out
+}
+
+func sortedMapKeys(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	slices.Sort(out)
 	return out
 }

--- a/internal/lang/ruby/bundler_declarations_seams_test.go
+++ b/internal/lang/ruby/bundler_declarations_seams_test.go
@@ -1,0 +1,116 @@
+package ruby
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestRubyParseGemfileDeclarationsSeam(t *testing.T) {
+	content := []byte(`source 'https://rubygems.org'
+gem 'rack'
+gem 'private_gem', git: 'https://example.test/private_gem.git'
+gem 'local_gem', :path => 'vendor/local_gem'
+gem ''
+`)
+
+	declarations := parseGemfileDeclarations(content)
+	got := declarationTuples(declarations)
+	want := []string{
+		"rack|rubygems|Gemfile",
+		"private-gem|git|Gemfile",
+		"local-gem|path|Gemfile",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("parseGemfileDeclarations()=%#v want %#v", got, want)
+	}
+}
+
+func TestRubyParseGemfileLockDeclarationsSeam(t *testing.T) {
+	content := []byte(`GIT
+  specs:
+    private_gem (1.0.0)
+      rack (>= 2.0)
+
+GEM
+  specs:
+    httparty (0.22.0)
+`)
+
+	got := parseGemfileLockDeclarations(content)
+	want := []string{"private-gem", "rack", "httparty"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("parseGemfileLockDeclarations()=%#v want %#v", got, want)
+	}
+}
+
+func TestRubyParseGemfileLockSourceDeclarationsSeam(t *testing.T) {
+	content := []byte(`GIT
+  specs:
+    private_gem (1.0.0)
+      rack (>= 2.0)
+
+PATH
+  specs:
+    local_gem (0.1.0)
+
+UNKNOWN
+  specs:
+    ignored_gem (0.1.0)
+
+GEM
+  specs:
+    httparty (0.22.0)
+`)
+
+	declarations := parseGemfileLockSourceDeclarations(content)
+	got := declarationTuples(declarations)
+	want := []string{
+		"private-gem|git|Gemfile.lock",
+		"local-gem|path|Gemfile.lock",
+		"httparty|rubygems|Gemfile.lock",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("parseGemfileLockSourceDeclarations()=%#v want %#v", got, want)
+	}
+}
+
+func TestRubyApplyBundlerDeclarationsSeam(t *testing.T) {
+	out := map[string]struct{}{}
+	sources := map[string]rubyDependencySource{}
+	applyBundlerDeclarations(out, sources, []bundlerDeclaration{{
+		dependency: "rack",
+		kind:       rubyDependencySourceRubygems,
+		signal:     gemfileName,
+	}, {
+		dependency: "rack",
+		kind:       rubyDependencySourceRubygems,
+		signal:     gemfileLockName,
+	}, {
+		dependency: "private-gem",
+		kind:       rubyDependencySourceGit,
+		signal:     gemfileName,
+	}})
+
+	if _, ok := out["rack"]; !ok {
+		t.Fatalf("expected rack dependency in output set, got %#v", out)
+	}
+	if _, ok := out["private-gem"]; !ok {
+		t.Fatalf("expected private-gem dependency in output set, got %#v", out)
+	}
+	rackInfo := sources["rack"]
+	if !rackInfo.Rubygems || !rackInfo.DeclaredGemfile || !rackInfo.DeclaredLock {
+		t.Fatalf("unexpected rack source attribution: %#v", rackInfo)
+	}
+	privateInfo := sources["private-gem"]
+	if !privateInfo.Git || !privateInfo.DeclaredGemfile || privateInfo.DeclaredLock {
+		t.Fatalf("unexpected private-gem source attribution: %#v", privateInfo)
+	}
+}
+
+func declarationTuples(declarations []bundlerDeclaration) []string {
+	out := make([]string, 0, len(declarations))
+	for _, declaration := range declarations {
+		out = append(out, declaration.dependency+"|"+declaration.kind+"|"+declaration.signal)
+	}
+	return out
+}

--- a/internal/lang/ruby/catalog.go
+++ b/internal/lang/ruby/catalog.go
@@ -2,10 +2,8 @@ package ruby
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -13,185 +11,11 @@ import (
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
-func loadBundlerDependencies(repoPath string, out map[string]struct{}) error {
-	return loadBundlerDependenciesWithSources(repoPath, out, nil)
-}
-
-func loadBundlerDependenciesWithSources(repoPath string, out map[string]struct{}, sources map[string]rubyDependencySource) error {
-	if err := loadGemfileDependencies(repoPath, out, sources); err != nil {
-		return err
-	}
-	return loadGemfileLockDependencies(repoPath, out, sources)
-}
-
 func loadDeclaredDependencies(ctx context.Context, repoPath string, out map[string]struct{}, sources map[string]rubyDependencySource) ([]string, error) {
 	if err := loadBundlerDependenciesWithSources(repoPath, out, sources); err != nil {
 		return nil, err
 	}
 	return loadGemspecDependencies(ctx, repoPath, out)
-}
-
-func loadGemfileDependencies(repoPath string, out map[string]struct{}, sources map[string]rubyDependencySource) error {
-	content, err := readBundlerFile(repoPath, gemfileName)
-	if err != nil {
-		return err
-	}
-	if len(content) == 0 {
-		return nil
-	}
-	for _, line := range strings.Split(string(content), "\n") {
-		dependency, kind, ok := parseGemfileDependencyLine(line)
-		if !ok {
-			continue
-		}
-		addRubyDependency(out, sources, dependency, kind, gemfileName)
-	}
-	return nil
-}
-
-func loadGemfileLockDependencies(repoPath string, out map[string]struct{}, sources map[string]rubyDependencySource) error {
-	content, err := readBundlerFile(repoPath, gemfileLockName)
-	if err != nil {
-		return err
-	}
-	if len(content) == 0 {
-		return nil
-	}
-	for _, line := range strings.Split(string(content), "\n") {
-		matches := gemSpecPattern.FindStringSubmatch(line)
-		if len(matches) != 2 {
-			continue
-		}
-		if dependency := normalizeDependencyID(matches[1]); dependency != "" {
-			out[dependency] = struct{}{}
-		}
-	}
-	parseGemfileLockSourceAttribution(content, out, sources)
-	return nil
-}
-
-func parseGemfileDependencyLine(line string) (string, string, bool) {
-	line = shared.StripLineComment(line, "#")
-	matches := gemDeclarationPattern.FindStringSubmatch(line)
-	if len(matches) != 2 {
-		return "", "", false
-	}
-	dependency := normalizeDependencyID(matches[1])
-	if dependency == "" {
-		return "", "", false
-	}
-	kind := rubyDependencySourceRubygems
-	switch {
-	case gemPathOptionPattern.MatchString(line):
-		kind = rubyDependencySourcePath
-	case gemGitOptionPattern.MatchString(line):
-		kind = rubyDependencySourceGit
-	}
-	return dependency, kind, true
-}
-
-func parseGemfileLockSourceAttribution(content []byte, out map[string]struct{}, sources map[string]rubyDependencySource) {
-	if sources == nil || len(content) == 0 {
-		return
-	}
-	state := gemfileLockSourceAttributionState{}
-	for _, rawLine := range strings.Split(string(content), "\n") {
-		applyGemfileLockSourceAttributionLine(rawLine, &state, out, sources)
-	}
-}
-
-type gemfileLockSourceAttributionState struct {
-	currentKind string
-	inSpecs     bool
-}
-
-func applyGemfileLockSourceAttributionLine(rawLine string, state *gemfileLockSourceAttributionState, out map[string]struct{}, sources map[string]rubyDependencySource) {
-	line := strings.TrimRight(rawLine, "\r")
-	trimmed := strings.TrimSpace(line)
-	if trimmed == "" {
-		return
-	}
-	if !isGemfileLockTopLevelLine(line) {
-		applyGemfileLockDependencyEntry(line, state, out, sources)
-		return
-	}
-
-	state.currentKind = parseGemfileLockSection(trimmed)
-	state.inSpecs = false
-}
-
-func isGemfileLockTopLevelLine(line string) bool {
-	return !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t")
-}
-
-func parseGemfileLockSection(line string) string {
-	switch line {
-	case rubyGemfileSectionGem:
-		return rubyDependencySourceRubygems
-	case rubyGemfileSectionGit:
-		return rubyDependencySourceGit
-	case rubyGemfileSectionPath:
-		return rubyDependencySourcePath
-	default:
-		return ""
-	}
-}
-
-func applyGemfileLockDependencyEntry(line string, state *gemfileLockSourceAttributionState, out map[string]struct{}, sources map[string]rubyDependencySource) {
-	trimmed := strings.TrimSpace(line)
-	if trimmed == rubyGemfileSpecsSection {
-		state.inSpecs = state.currentKind != ""
-		return
-	}
-	if !state.inSpecs {
-		return
-	}
-	matches := gemTopLevelSpecPattern.FindStringSubmatch(line)
-	if len(matches) != 2 {
-		return
-	}
-	addRubyDependency(out, sources, normalizeDependencyID(matches[1]), state.currentKind, gemfileLockName)
-}
-
-func addRubyDependency(out map[string]struct{}, sources map[string]rubyDependencySource, dependency, kind, signal string) {
-	if dependency == "" {
-		return
-	}
-	if out != nil {
-		out[dependency] = struct{}{}
-	}
-	if sources == nil {
-		return
-	}
-	info := sources[dependency]
-	switch kind {
-	case rubyDependencySourceRubygems:
-		info.Rubygems = true
-	case rubyDependencySourceGit:
-		info.Git = true
-	case rubyDependencySourcePath:
-		info.Path = true
-	}
-	switch signal {
-	case gemfileName:
-		info.DeclaredGemfile = true
-	case gemfileLockName:
-		info.DeclaredLock = true
-	}
-	sources[dependency] = info
-}
-
-func readBundlerFile(repoPath, filename string) ([]byte, error) {
-	targetPath := filepath.Join(repoPath, filename)
-	content, err := safeio.ReadFileUnder(repoPath, targetPath)
-	switch {
-	case err == nil:
-		return content, nil
-	case errors.Is(err, os.ErrNotExist):
-		return nil, nil
-	default:
-		return nil, fmt.Errorf("read %s: %w", filename, err)
-	}
 }
 
 func loadGemspecDependencies(ctx context.Context, repoPath string, out map[string]struct{}) ([]string, error) {

--- a/internal/lang/ruby/provenance.go
+++ b/internal/lang/ruby/provenance.go
@@ -1,0 +1,73 @@
+package ruby
+
+import "github.com/ben-ranford/lopper/internal/report"
+
+func buildRubyDependencyProvenance(info rubyDependencySource) *report.DependencyProvenance {
+	source := rubyDependencyProvenanceSource(info)
+	if source == "" {
+		return nil
+	}
+	return &report.DependencyProvenance{
+		Source:     source,
+		Confidence: rubyDependencyProvenanceConfidence(info),
+		Signals:    rubyDependencyProvenanceSignals(info),
+	}
+}
+
+func rubyDependencyProvenanceSource(info rubyDependencySource) string {
+	kinds := 0
+	source := ""
+	if info.Rubygems {
+		kinds++
+		source = rubyDependencySourceRubygems
+	}
+	if info.Git {
+		kinds++
+		source = rubyDependencySourceGit
+	}
+	if info.Path {
+		kinds++
+		source = rubyDependencySourcePath
+	}
+	switch kinds {
+	case 0:
+		return ""
+	case 1:
+		return source
+	default:
+		return rubyDependencySourceBundler
+	}
+}
+
+func rubyDependencyProvenanceConfidence(info rubyDependencySource) string {
+	switch {
+	case info.DeclaredLock || info.Git || info.Path:
+		return "high"
+	case info.Rubygems:
+		return "medium"
+	default:
+		return ""
+	}
+}
+
+func rubyDependencyProvenanceSignals(info rubyDependencySource) []string {
+	signals := make([]string, 0, 4)
+	if rubyDependencyProvenanceSource(info) == rubyDependencySourceBundler {
+		if info.Git {
+			signals = append(signals, rubyDependencySourceGit)
+		}
+		if info.Path {
+			signals = append(signals, rubyDependencySourcePath)
+		}
+		if info.Rubygems {
+			signals = append(signals, rubyDependencySourceRubygems)
+		}
+	}
+	if info.DeclaredGemfile {
+		signals = append(signals, gemfileName)
+	}
+	if info.DeclaredLock {
+		signals = append(signals, gemfileLockName)
+	}
+	return signals
+}

--- a/internal/lang/ruby/report.go
+++ b/internal/lang/ruby/report.go
@@ -1,8 +1,6 @@
 package ruby
 
 import (
-	"fmt"
-
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
@@ -21,51 +19,19 @@ func buildTopRubyDependencies(topN int, scan scanResult, weights report.RemovalC
 }
 
 func buildDependencyReport(dependency string, scan scanResult) (report.DependencyReport, []string) {
+	stats := collectRubyDependencyStats(dependency, scan.Files)
+	return shapeRubyDependencyReport(dependency, stats, scan.DeclaredSources[dependency])
+}
+
+func collectRubyDependencyStats(dependency string, files []fileScan) shared.DependencyStats {
 	importsOf := func(file fileScan) []shared.ImportRecord {
 		return file.Imports
 	}
 	usageOf := func(file fileScan) map[string]int {
 		return file.Usage
 	}
-	fileUsages := shared.MapFileUsages(scan.Files, importsOf, usageOf)
-	stats := shared.BuildDependencyStats(dependency, fileUsages, normalizeDependencyID)
-
-	dependencyReport := shared.BuildDependencyReportFromStats(dependency, "ruby", stats)
-	dependencyReport.Provenance = buildRubyDependencyProvenance(scan.DeclaredSources[dependency])
-	if stats.WildcardImports > 0 {
-		dependencyReport.RiskCues = append(dependencyReport.RiskCues, report.RiskCue{
-			Code:     "dynamic-require",
-			Severity: "medium",
-			Message:  fmt.Sprintf("found %d runtime require signal(s) for this gem", stats.WildcardImports),
-		})
-	}
-	dependencyReport.Recommendations = buildRecommendations(dependencyReport)
-
-	if stats.HasImports {
-		return dependencyReport, nil
-	}
-	return dependencyReport, []string{fmt.Sprintf("no requires found for dependency %q", dependency)}
-}
-
-func buildRecommendations(dep report.DependencyReport) []report.Recommendation {
-	recs := make([]report.Recommendation, 0, 2)
-	if len(dep.UsedImports) == 0 && len(dep.UnusedImports) > 0 {
-		recs = append(recs, report.Recommendation{
-			Code:      "remove-unused-gem",
-			Priority:  "high",
-			Message:   fmt.Sprintf("No require usage was detected for %q; consider removing it.", dep.Name),
-			Rationale: "Unused gems add maintenance and security overhead.",
-		})
-	}
-	if len(dep.RiskCues) > 0 {
-		recs = append(recs, report.Recommendation{
-			Code:      "review-runtime-requires",
-			Priority:  "medium",
-			Message:   "Runtime require signals were detected; manually verify usage before removal.",
-			Rationale: "Runtime require loading can hide usage from static analysis.",
-		})
-	}
-	return recs
+	fileUsages := shared.MapFileUsages(files, importsOf, usageOf)
+	return shared.BuildDependencyStats(dependency, fileUsages, normalizeDependencyID)
 }
 
 func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
@@ -83,74 +49,4 @@ func sortedDependencyUnion(values ...map[string]struct{}) []string {
 		}
 	}
 	return shared.SortedKeys(set)
-}
-
-func buildRubyDependencyProvenance(info rubyDependencySource) *report.DependencyProvenance {
-	source := rubyDependencyProvenanceSource(info)
-	if source == "" {
-		return nil
-	}
-	return &report.DependencyProvenance{
-		Source:     source,
-		Confidence: rubyDependencyProvenanceConfidence(info),
-		Signals:    rubyDependencyProvenanceSignals(info),
-	}
-}
-
-func rubyDependencyProvenanceSource(info rubyDependencySource) string {
-	kinds := 0
-	source := ""
-	if info.Rubygems {
-		kinds++
-		source = rubyDependencySourceRubygems
-	}
-	if info.Git {
-		kinds++
-		source = rubyDependencySourceGit
-	}
-	if info.Path {
-		kinds++
-		source = rubyDependencySourcePath
-	}
-	switch kinds {
-	case 0:
-		return ""
-	case 1:
-		return source
-	default:
-		return rubyDependencySourceBundler
-	}
-}
-
-func rubyDependencyProvenanceConfidence(info rubyDependencySource) string {
-	switch {
-	case info.DeclaredLock || info.Git || info.Path:
-		return "high"
-	case info.Rubygems:
-		return "medium"
-	default:
-		return ""
-	}
-}
-
-func rubyDependencyProvenanceSignals(info rubyDependencySource) []string {
-	signals := make([]string, 0, 4)
-	if rubyDependencyProvenanceSource(info) == rubyDependencySourceBundler {
-		if info.Git {
-			signals = append(signals, rubyDependencySourceGit)
-		}
-		if info.Path {
-			signals = append(signals, rubyDependencySourcePath)
-		}
-		if info.Rubygems {
-			signals = append(signals, rubyDependencySourceRubygems)
-		}
-	}
-	if info.DeclaredGemfile {
-		signals = append(signals, gemfileName)
-	}
-	if info.DeclaredLock {
-		signals = append(signals, gemfileLockName)
-	}
-	return signals
 }

--- a/internal/lang/ruby/report_shaping.go
+++ b/internal/lang/ruby/report_shaping.go
@@ -1,0 +1,55 @@
+package ruby
+
+import (
+	"fmt"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func shapeRubyDependencyReport(dependency string, stats shared.DependencyStats, source rubyDependencySource) (report.DependencyReport, []string) {
+	dependencyReport := shared.BuildDependencyReportFromStats(dependency, "ruby", stats)
+	dependencyReport.Provenance = buildRubyDependencyProvenance(source)
+	appendRuntimeRequireRiskCue(&dependencyReport, stats.WildcardImports)
+	dependencyReport.Recommendations = buildRecommendations(dependencyReport)
+	return dependencyReport, shapeRubyDependencyWarnings(dependency, stats)
+}
+
+func appendRuntimeRequireRiskCue(dep *report.DependencyReport, wildcardImports int) {
+	if wildcardImports == 0 {
+		return
+	}
+	dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+		Code:     "dynamic-require",
+		Severity: "medium",
+		Message:  fmt.Sprintf("found %d runtime require signal(s) for this gem", wildcardImports),
+	})
+}
+
+func shapeRubyDependencyWarnings(dependency string, stats shared.DependencyStats) []string {
+	if stats.HasImports {
+		return nil
+	}
+	return []string{fmt.Sprintf("no requires found for dependency %q", dependency)}
+}
+
+func buildRecommendations(dep report.DependencyReport) []report.Recommendation {
+	recs := make([]report.Recommendation, 0, 2)
+	if len(dep.UsedImports) == 0 && len(dep.UnusedImports) > 0 {
+		recs = append(recs, report.Recommendation{
+			Code:      "remove-unused-gem",
+			Priority:  "high",
+			Message:   fmt.Sprintf("No require usage was detected for %q; consider removing it.", dep.Name),
+			Rationale: "Unused gems add maintenance and security overhead.",
+		})
+	}
+	if len(dep.RiskCues) > 0 {
+		recs = append(recs, report.Recommendation{
+			Code:      "review-runtime-requires",
+			Priority:  "medium",
+			Message:   "Runtime require signals were detected; manually verify usage before removal.",
+			Rationale: "Runtime require loading can hide usage from static analysis.",
+		})
+	}
+	return recs
+}

--- a/internal/lang/ruby/report_shaping_seams_test.go
+++ b/internal/lang/ruby/report_shaping_seams_test.go
@@ -1,0 +1,46 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestRubyShapeDependencyReportSeam(t *testing.T) {
+	stats := shared.DependencyStats{
+		HasImports:      true,
+		UsedCount:       1,
+		TotalCount:      1,
+		UsedPercent:     100,
+		UsedImports:     []report.ImportUse{{Name: "private_gem", Module: "private_gem"}},
+		WildcardImports: 1,
+	}
+	info := rubyDependencySource{Git: true, DeclaredGemfile: true}
+
+	dep, warnings := shapeRubyDependencyReport("private-gem", stats, info)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", warnings)
+	}
+	if dep.Provenance == nil || dep.Provenance.Source != rubyDependencySourceGit {
+		t.Fatalf("expected git provenance, got %#v", dep.Provenance)
+	}
+	if len(dep.RiskCues) != 1 || dep.RiskCues[0].Code != "dynamic-require" {
+		t.Fatalf("expected dynamic-require risk cue, got %#v", dep.RiskCues)
+	}
+	if len(dep.Recommendations) != 1 || dep.Recommendations[0].Code != "review-runtime-requires" {
+		t.Fatalf("expected runtime review recommendation, got %#v", dep.Recommendations)
+	}
+}
+
+func TestRubyShapeDependencyWarningsSeam(t *testing.T) {
+	warnings := shapeRubyDependencyWarnings("rack", shared.DependencyStats{})
+	if len(warnings) != 1 || warnings[0] != `no requires found for dependency "rack"` {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+
+	warnings = shapeRubyDependencyWarnings("rack", shared.DependencyStats{HasImports: true})
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings when imports exist, got %#v", warnings)
+	}
+}


### PR DESCRIPTION
## Summary
- split Bundler declaration parsing and loading seams into a dedicated module
- separate Ruby provenance interpretation from dependency report assembly
- separate warning/report shaping from stats collection and add seam-focused tests

## Validation
- go test ./internal/lang/ruby
- go test ./...

Closes #632