### PR TITLE
feat(policy): expand lockfile drift checks behind preview flag

### DIFF
--- a/internal/app/analyse_prepare.go
+++ b/internal/app/analyse_prepare.go
@@ -18,7 +18,7 @@ type preparedAnalyseExecution struct {
 }
 
 func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseExecution, error) {
-	lockfileWarnings, err := evaluateLockfileDriftPolicy(ctx, req.RepoPath, req.Analyse.Thresholds.LockfileDriftPolicy)
+	lockfileWarnings, err := evaluateLockfileDriftPolicyWithFeatures(ctx, req.RepoPath, req.Analyse.Thresholds.LockfileDriftPolicy, req.Analyse.Features)
 	if err != nil {
 		return preparedAnalyseExecution{}, err
 	}

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -65,8 +65,10 @@ func TestExecuteFeaturesReleaseChannelAndEmptyRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute empty features: %v", err)
 	}
-	if !strings.Contains(emptyOutput, "dart-source-attribution-preview") || !strings.Contains(emptyOutput, "false") {
-		t.Fatalf("expected default feature table to include dart-source-attribution-preview disabled by default, got %q", emptyOutput)
+	if !strings.Contains(emptyOutput, "dart-source-attribution-preview") ||
+		!strings.Contains(emptyOutput, "lockfile-drift-ecosystem-expansion-preview") ||
+		!strings.Contains(emptyOutput, "false") {
+		t.Fatalf("expected default feature table to include embedded preview flags disabled by default, got %q", emptyOutput)
 	}
 }
 
@@ -93,6 +95,25 @@ func TestExecuteFeaturesTableAndInvalidFormat(t *testing.T) {
 	req.Features.Channel = "bad"
 	if _, err := application.Execute(context.Background(), req); err == nil {
 		t.Fatalf("expected invalid features channel error")
+	}
+}
+
+func TestExecuteFeaturesExplicitEmptyRegistry(t *testing.T) {
+	emptyRegistry, err := featureflags.NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("new empty feature registry: %v", err)
+	}
+	application := &App{Features: emptyRegistry}
+	req := DefaultRequest()
+	req.Mode = ModeFeatures
+	req.Features.Channel = "dev"
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute empty features: %v", err)
+	}
+	if output != "No feature flags registered.\n" {
+		t.Fatalf("unexpected empty feature output: %q", output)
 	}
 }
 

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/gitexec"
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/safeio"
@@ -17,20 +19,25 @@ import (
 )
 
 const (
-	lockfileDriftWarningPrefix = "lockfile drift detected: "
-	pyprojectManifestName      = "pyproject.toml"
+	lockfileDriftWarningPrefix                     = "lockfile drift detected: "
+	pyprojectManifestName                          = "pyproject.toml"
+	lockfileDriftEcosystemExpansionPreviewFlagName = "lockfile-drift-ecosystem-expansion-preview"
 )
 
 var resolveGitBinaryPathFn = gitexec.ResolveBinaryPath
 var execGitCommandContextFn = gitexec.CommandContext
 
 type lockfileRule struct {
-	manager         string
-	manifest        string
-	manifestLabel   string
-	lockfiles       []string
-	remedy          string
-	manifestMatcher func(repoPath, dir string) (bool, error)
+	manager             string
+	manifest            string
+	manifestNames       []string
+	manifestExts        []string
+	manifestLabel       string
+	lockfiles           []string
+	remedy              string
+	skipMissingLockfile bool
+	previewFeatureFlag  string
+	manifestMatcher     func(repoPath, dir string) (bool, error)
 }
 
 type lockfileGitContext struct {
@@ -56,6 +63,7 @@ const (
 type lockfileDriftFinding struct {
 	kind      lockfileDriftKind
 	rule      lockfileRule
+	manifest  string
 	relDir    string
 	lockfiles []presentLockfile
 }
@@ -69,15 +77,54 @@ var lockfileRules = []lockfileRule{
 	{manager: "Pipenv", manifest: "Pipfile", lockfiles: []string{"Pipfile.lock"}, remedy: "run pipenv lock and commit the updated files"},
 	{manager: "Poetry", manifest: pyprojectManifestName, manifestLabel: "Poetry configuration in pyproject.toml", lockfiles: []string{"poetry.lock"}, remedy: "run poetry lock and commit the updated files", manifestMatcher: pyprojectSectionMatcher("tool.poetry")},
 	{manager: "uv", manifest: pyprojectManifestName, manifestLabel: "uv configuration in pyproject.toml", lockfiles: []string{"uv.lock"}, remedy: "run uv lock and commit the updated files", manifestMatcher: pyprojectSectionMatcher("tool.uv")},
+	{
+		manager:             ".NET",
+		manifest:            "Directory.Packages.props",
+		manifestExts:        []string{".csproj", ".fsproj"},
+		manifestLabel:       ".NET project manifest (*.csproj, *.fsproj) or Directory.Packages.props",
+		lockfiles:           []string{"packages.lock.json"},
+		remedy:              "run dotnet restore --use-lock-file (or dotnet restore for existing lock mode) and commit the updated files",
+		skipMissingLockfile: true,
+		previewFeatureFlag:  lockfileDriftEcosystemExpansionPreviewFlagName,
+	},
+	{
+		manager:             "Dart",
+		manifest:            "pubspec.yaml",
+		manifestNames:       []string{"pubspec.yml"},
+		lockfiles:           []string{"pubspec.lock"},
+		remedy:              "run dart pub get (or flutter pub get) and commit the updated files",
+		skipMissingLockfile: true,
+		previewFeatureFlag:  lockfileDriftEcosystemExpansionPreviewFlagName,
+	},
+	{
+		manager:             "Elixir",
+		manifest:            "mix.exs",
+		lockfiles:           []string{"mix.lock"},
+		remedy:              "run mix deps.get and commit the updated files",
+		skipMissingLockfile: true,
+		previewFeatureFlag:  lockfileDriftEcosystemExpansionPreviewFlagName,
+	},
+	{
+		manager:             "SwiftPM",
+		manifest:            "Package.swift",
+		lockfiles:           []string{"Package.resolved"},
+		remedy:              "run swift package resolve and commit the updated files",
+		skipMissingLockfile: true,
+		previewFeatureFlag:  lockfileDriftEcosystemExpansionPreviewFlagName,
+	},
 }
 
 func evaluateLockfileDriftPolicy(ctx context.Context, repoPath, policy string) ([]string, error) {
+	return evaluateLockfileDriftPolicyWithFeatures(ctx, repoPath, policy, featureflags.Set{})
+}
+
+func evaluateLockfileDriftPolicyWithFeatures(ctx context.Context, repoPath, policy string, features featureflags.Set) ([]string, error) {
 	normalizedPolicy := strings.TrimSpace(policy)
 	if normalizedPolicy == "off" {
 		return nil, nil
 	}
 	failMode := normalizedPolicy == "fail"
-	driftWarnings, err := detectLockfileDrift(ctx, repoPath, failMode)
+	driftWarnings, err := detectLockfileDriftWithFeatures(ctx, repoPath, failMode, features)
 	if err != nil || len(driftWarnings) == 0 {
 		return driftWarnings, err
 	}
@@ -88,6 +135,10 @@ func evaluateLockfileDriftPolicy(ctx context.Context, repoPath, policy string) (
 }
 
 func detectLockfileDrift(ctx context.Context, repoPath string, stopOnFirst bool) ([]string, error) {
+	return detectLockfileDriftWithFeatures(ctx, repoPath, stopOnFirst, featureflags.Set{})
+}
+
+func detectLockfileDriftWithFeatures(ctx context.Context, repoPath string, stopOnFirst bool, features featureflags.Set) ([]string, error) {
 	normalizedPath, err := workspace.NormalizeRepoPath(repoPath)
 	if err != nil {
 		return nil, err
@@ -96,7 +147,19 @@ func detectLockfileDrift(ctx context.Context, repoPath string, stopOnFirst bool)
 	if err != nil {
 		return nil, err
 	}
-	return scanLockfileDrift(ctx, normalizedPath, gitContext, stopOnFirst)
+	return scanLockfileDrift(ctx, normalizedPath, gitContext, stopOnFirst, activeLockfileRules(features))
+}
+
+func activeLockfileRules(features featureflags.Set) []lockfileRule {
+	active := make([]lockfileRule, 0, len(lockfileRules))
+	for _, rule := range lockfileRules {
+		previewFlag := strings.TrimSpace(rule.previewFeatureFlag)
+		if previewFlag != "" && !features.Enabled(previewFlag) {
+			continue
+		}
+		active = append(active, rule)
+	}
+	return active
 }
 
 func collectLockfileGitContext(ctx context.Context, repoPath string) (lockfileGitContext, error) {
@@ -110,12 +173,12 @@ func collectLockfileGitContext(ctx context.Context, repoPath string) (lockfileGi
 	}, nil
 }
 
-func scanLockfileDrift(ctx context.Context, repoPath string, gitContext lockfileGitContext, stopOnFirst bool) ([]string, error) {
-	warnings := make([]string, 0, len(lockfileRules))
+func scanLockfileDrift(ctx context.Context, repoPath string, gitContext lockfileGitContext, stopOnFirst bool, rules []lockfileRule) ([]string, error) {
+	warnings := make([]string, 0, len(rules))
 	state := lockfileWalkState{
 		repoPath: repoPath,
 		visit: func(snapshot lockfileDirSnapshot) error {
-			findings, err := evaluateLockfileDir(snapshot, gitContext)
+			findings, err := evaluateLockfileDirWithRules(snapshot, gitContext, rules)
 			if err != nil {
 				return err
 			}
@@ -208,9 +271,18 @@ func readLockfileDirSnapshot(repoPath, dir string) (lockfileDirSnapshot, error) 
 }
 
 func shouldSkipMissingLockfile(snapshot lockfileDirSnapshot, rule lockfileRule) (bool, error) {
-	content, err := safeio.ReadFileUnder(snapshot.repoPath, filepath.Join(snapshot.path, rule.manifest))
+	manifestNames := findRuleManifests(snapshot.files, rule)
+	manifestName := rule.manifest
+	if len(manifestNames) > 0 {
+		manifestName = manifestNames[0]
+	}
+	return shouldSkipMissingLockfileForManifest(snapshot, rule, manifestName)
+}
+
+func shouldSkipMissingLockfileForManifest(snapshot lockfileDirSnapshot, rule lockfileRule, manifestName string) (bool, error) {
+	content, err := safeio.ReadFileUnder(snapshot.repoPath, filepath.Join(snapshot.path, manifestName))
 	if err != nil {
-		return false, fmt.Errorf("read %s for lockfile drift detection: %w", rule.manifest, err)
+		return false, fmt.Errorf("read %s for lockfile drift detection: %w", manifestName, err)
 	}
 	if rule.manifestMatcher != nil {
 		matched, matchErr := rule.manifestMatcher(snapshot.repoPath, snapshot.path)
@@ -221,8 +293,11 @@ func shouldSkipMissingLockfile(snapshot lockfileDirSnapshot, rule lockfileRule) 
 			return true, nil
 		}
 	}
+	if rule.skipMissingLockfile {
+		return true, nil
+	}
 	text := string(content)
-	switch rule.manifest {
+	switch manifestName {
 	case "go.mod":
 		// go.sum is only generated when a module has external dependencies.
 		// A stdlib-only module has go.mod but no go.sum and that is valid.
@@ -241,8 +316,12 @@ func shouldSkipMissingLockfile(snapshot lockfileDirSnapshot, rule lockfileRule) 
 }
 
 func evaluateLockfileDir(snapshot lockfileDirSnapshot, gitContext lockfileGitContext) ([]lockfileDriftFinding, error) {
-	findings := make([]lockfileDriftFinding, 0, len(lockfileRules))
-	for _, rule := range lockfileRules {
+	return evaluateLockfileDirWithRules(snapshot, gitContext, activeLockfileRules(featureflags.Set{}))
+}
+
+func evaluateLockfileDirWithRules(snapshot lockfileDirSnapshot, gitContext lockfileGitContext, rules []lockfileRule) ([]lockfileDriftFinding, error) {
+	findings := make([]lockfileDriftFinding, 0, len(rules))
+	for _, rule := range rules {
 		finding, ok, err := evaluateLockfileRule(snapshot, rule, gitContext)
 		if err != nil {
 			return nil, err
@@ -256,10 +335,15 @@ func evaluateLockfileDir(snapshot lockfileDirSnapshot, gitContext lockfileGitCon
 }
 
 func evaluateLockfileRule(snapshot lockfileDirSnapshot, rule lockfileRule, gitContext lockfileGitContext) (lockfileDriftFinding, bool, error) {
-	_, hasManifest := snapshot.files[rule.manifest]
+	manifests := findRuleManifests(snapshot.files, rule)
+	hasManifest := len(manifests) > 0
+	manifestName := rule.manifest
+	if hasManifest {
+		manifestName = manifests[0]
+	}
 	lockfiles := findRuleLockfiles(snapshot.files, rule.lockfiles)
 
-	finding, handled, err := evaluateMissingOrStaleLockfile(snapshot, rule, hasManifest, lockfiles)
+	finding, handled, err := evaluateMissingOrStaleLockfileWithManifest(snapshot, rule, hasManifest, manifestName, lockfiles)
 	if handled || err != nil {
 		return finding, handled, err
 	}
@@ -281,13 +365,22 @@ func evaluateLockfileRule(snapshot lockfileDirSnapshot, rule lockfileRule, gitCo
 	if !gitContext.hasGitContext || len(gitContext.changedFiles) == 0 {
 		return lockfileDriftFinding{}, false, nil
 	}
-	return evaluateManifestChangeFinding(snapshot, rule, gitContext, lockfiles)
+	return evaluateManifestChangeFinding(snapshot, rule, gitContext, lockfiles, manifests)
 }
 
 func evaluateMissingOrStaleLockfile(snapshot lockfileDirSnapshot, rule lockfileRule, hasManifest bool, lockfiles []presentLockfile) (lockfileDriftFinding, bool, error) {
+	manifestNames := findRuleManifests(snapshot.files, rule)
+	manifestName := rule.manifest
+	if hasManifest && len(manifestNames) > 0 {
+		manifestName = manifestNames[0]
+	}
+	return evaluateMissingOrStaleLockfileWithManifest(snapshot, rule, hasManifest, manifestName, lockfiles)
+}
+
+func evaluateMissingOrStaleLockfileWithManifest(snapshot lockfileDirSnapshot, rule lockfileRule, hasManifest bool, manifestName string, lockfiles []presentLockfile) (lockfileDriftFinding, bool, error) {
 	switch {
 	case hasManifest && len(lockfiles) == 0:
-		skip, err := shouldSkipMissingLockfile(snapshot, rule)
+		skip, err := shouldSkipMissingLockfileForManifest(snapshot, rule, manifestName)
 		if err != nil {
 			return lockfileDriftFinding{}, false, err
 		}
@@ -295,9 +388,10 @@ func evaluateMissingOrStaleLockfile(snapshot lockfileDirSnapshot, rule lockfileR
 			return lockfileDriftFinding{}, false, nil
 		}
 		return lockfileDriftFinding{
-			kind:   lockfileDriftMissingLockfile,
-			rule:   rule,
-			relDir: snapshot.relDir,
+			kind:     lockfileDriftMissingLockfile,
+			rule:     rule,
+			manifest: manifestName,
+			relDir:   snapshot.relDir,
 		}, true, nil
 	case !hasManifest && len(lockfiles) > 0:
 		return staleLockfileFinding(snapshot, rule, lockfiles), true, nil
@@ -322,9 +416,16 @@ func staleLockfileFinding(snapshot lockfileDirSnapshot, rule lockfileRule, lockf
 	}
 }
 
-func evaluateManifestChangeFinding(snapshot lockfileDirSnapshot, rule lockfileRule, gitContext lockfileGitContext, lockfiles []presentLockfile) (lockfileDriftFinding, bool, error) {
-	manifestPath := relativeFilePath(snapshot.repoPath, snapshot.path, rule.manifest)
-	if !isPathChanged(gitContext.changedFiles, manifestPath) {
+func evaluateManifestChangeFinding(snapshot lockfileDirSnapshot, rule lockfileRule, gitContext lockfileGitContext, lockfiles []presentLockfile, manifests []string) (lockfileDriftFinding, bool, error) {
+	changedManifest := ""
+	for _, manifestName := range manifests {
+		manifestPath := relativeFilePath(snapshot.repoPath, snapshot.path, manifestName)
+		if isPathChanged(gitContext.changedFiles, manifestPath) {
+			changedManifest = manifestName
+			break
+		}
+	}
+	if changedManifest == "" {
 		return lockfileDriftFinding{}, false, nil
 	}
 	for _, lockfile := range lockfiles {
@@ -334,9 +435,10 @@ func evaluateManifestChangeFinding(snapshot lockfileDirSnapshot, rule lockfileRu
 		}
 	}
 	return lockfileDriftFinding{
-		kind:   lockfileDriftManifestChange,
-		rule:   rule,
-		relDir: snapshot.relDir,
+		kind:     lockfileDriftManifestChange,
+		rule:     rule,
+		manifest: changedManifest,
+		relDir:   snapshot.relDir,
 	}, true, nil
 }
 
@@ -352,15 +454,16 @@ func buildLockfileDriftWarnings(findings []lockfileDriftFinding) []string {
 }
 
 func buildLockfileDriftWarning(finding lockfileDriftFinding) string {
+	manifest := manifestNameForFinding(finding)
 	switch finding.kind {
 	case lockfileDriftMissingLockfile:
-		return fmt.Sprintf("%s%s in %s: %s exists but no matching lockfile (%s) was found; %s", lockfileDriftWarningPrefix, finding.rule.manager, finding.relDir, finding.rule.manifest, strings.Join(finding.rule.lockfiles, ", "), finding.rule.remedy)
+		return fmt.Sprintf("%s%s in %s: %s exists but no matching lockfile (%s) was found; %s", lockfileDriftWarningPrefix, finding.rule.manager, finding.relDir, manifest, strings.Join(finding.rule.lockfiles, ", "), finding.rule.remedy)
 	case lockfileDriftStaleLockfile:
 		return fmt.Sprintf("%s%s in %s: %s exists without %s; remove stale lockfile or restore the manifest", lockfileDriftWarningPrefix, finding.rule.manager, finding.relDir, finding.lockfiles[0].name, manifestDescription(finding.rule))
 	case lockfileDriftManifestChange:
-		return fmt.Sprintf("%s%s in %s: %s changed while no matching lockfile changed; %s", lockfileDriftWarningPrefix, finding.rule.manager, finding.relDir, finding.rule.manifest, finding.rule.remedy)
+		return fmt.Sprintf("%s%s in %s: %s changed while no matching lockfile changed; %s", lockfileDriftWarningPrefix, finding.rule.manager, finding.relDir, manifest, finding.rule.remedy)
 	default:
-		return fmt.Sprintf("%s%s in %s: unable to classify lockfile drift for %s", lockfileDriftWarningPrefix, finding.rule.manager, finding.relDir, finding.rule.manifest)
+		return fmt.Sprintf("%s%s in %s: unable to classify lockfile drift for %s", lockfileDriftWarningPrefix, finding.rule.manager, finding.relDir, manifest)
 	}
 }
 
@@ -401,6 +504,52 @@ func findRuleLockfiles(files map[string]fs.FileInfo, names []string) []presentLo
 		lockfiles = append(lockfiles, presentLockfile{name: name, info: info})
 	}
 	return lockfiles
+}
+
+func findRuleManifests(files map[string]fs.FileInfo, rule lockfileRule) []string {
+	manifests := make([]string, 0, 1+len(rule.manifestNames))
+	seen := make(map[string]struct{})
+	appendManifest := func(name string) {
+		if _, exists := seen[name]; exists {
+			return
+		}
+		if _, exists := files[name]; !exists {
+			return
+		}
+		seen[name] = struct{}{}
+		manifests = append(manifests, name)
+	}
+
+	appendManifest(rule.manifest)
+	for _, name := range rule.manifestNames {
+		appendManifest(name)
+	}
+
+	if len(rule.manifestExts) > 0 {
+		lowerExts := make([]string, 0, len(rule.manifestExts))
+		for _, ext := range rule.manifestExts {
+			lowerExts = append(lowerExts, strings.ToLower(strings.TrimSpace(ext)))
+		}
+		for name := range files {
+			lowerName := strings.ToLower(name)
+			for _, ext := range lowerExts {
+				if ext != "" && strings.HasSuffix(lowerName, ext) {
+					appendManifest(name)
+					break
+				}
+			}
+		}
+	}
+
+	sort.Strings(manifests)
+	return manifests
+}
+
+func manifestNameForFinding(finding lockfileDriftFinding) string {
+	if strings.TrimSpace(finding.manifest) != "" {
+		return finding.manifest
+	}
+	return finding.rule.manifest
 }
 
 func manifestDescription(rule lockfileRule) string {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/gitexec"
 )
 
@@ -18,6 +19,15 @@ const (
 	lockfileName             = "package-lock.json"
 	newUntrackedFileName     = "new-untracked.txt"
 	poetryLockName           = "poetry.lock"
+	dotnetProjectManifest    = "App.csproj"
+	dotnetCentralManifest    = "Directory.Packages.props"
+	dotnetLockfileName       = "packages.lock.json"
+	dartManifestName         = "pubspec.yaml"
+	dartLockfileName         = "pubspec.lock"
+	elixirManifestName       = "mix.exs"
+	elixirLockfileName       = "mix.lock"
+	swiftManifestName        = "Package.swift"
+	swiftLockfileName        = "Package.resolved"
 	detectLockfileDriftFmt   = "detect lockfile drift: %v"
 	demoPackageJSON          = "{\n  \"name\": \"demo\"\n}\n"
 	demoPackageJSONUpdated   = "{\n  \"name\": \"demo\",\n  \"version\": \"1.0.1\"\n}\n"
@@ -68,6 +78,123 @@ func TestDetectLockfileDriftRubyManifestChangeWithoutLockfileChange(t *testing.T
 	if !strings.Contains(warnings[0], "bundle install") {
 		t.Fatalf("expected Bundler remediation text, got %q", warnings[0])
 	}
+}
+
+func TestDetectLockfileDriftPreviewEcosystemsManifestChangeWithoutLockfileChange(t *testing.T) {
+	cases := []struct {
+		name            string
+		manifest        string
+		lockfile        string
+		initialManifest string
+		initialLockfile string
+		updatedManifest string
+		wantWarning     string
+		wantRemedy      string
+	}{
+		{
+			name:            "dotnet project",
+			manifest:        dotnetProjectManifest,
+			lockfile:        dotnetLockfileName,
+			initialManifest: "<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup><PackageReference Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n",
+			initialLockfile: "{\"version\":1,\"dependencies\":{}}\n",
+			updatedManifest: "<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup><PackageReference Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /><PackageReference Include=\"Serilog\" Version=\"3.1.0\" /></ItemGroup></Project>\n",
+			wantWarning:     ".NET in .: App.csproj changed while no matching lockfile changed",
+			wantRemedy:      "dotnet restore --use-lock-file",
+		},
+		{
+			name:            "dotnet central package management",
+			manifest:        dotnetCentralManifest,
+			lockfile:        dotnetLockfileName,
+			initialManifest: "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n",
+			initialLockfile: "{\"version\":1,\"dependencies\":{}}\n",
+			updatedManifest: "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /><PackageVersion Include=\"Serilog\" Version=\"3.1.0\" /></ItemGroup></Project>\n",
+			wantWarning:     ".NET in .: Directory.Packages.props changed while no matching lockfile changed",
+			wantRemedy:      "dotnet restore --use-lock-file",
+		},
+		{
+			name:            "dart",
+			manifest:        dartManifestName,
+			lockfile:        dartLockfileName,
+			initialManifest: "name: demo\ndependencies:\n  http: ^1.2.0\n",
+			initialLockfile: "packages:\n  http:\n    version: \"1.2.0\"\n",
+			updatedManifest: "name: demo\ndependencies:\n  http: ^1.3.0\n",
+			wantWarning:     "Dart in .: pubspec.yaml changed while no matching lockfile changed",
+			wantRemedy:      "dart pub get",
+		},
+		{
+			name:            "elixir",
+			manifest:        elixirManifestName,
+			lockfile:        elixirLockfileName,
+			initialManifest: "defmodule Demo.MixProject do\n  use Mix.Project\n  def project, do: [app: :demo, version: \"0.1.0\", deps: deps()]\n  defp deps, do: [{:jason, \"~> 1.4\"}]\nend\n",
+			initialLockfile: "%{\"jason\" => {:hex, :jason, \"1.4.1\", \"checksum\", [:mix], [], \"hexpm\", \"checksum\"}}\n",
+			updatedManifest: "defmodule Demo.MixProject do\n  use Mix.Project\n  def project, do: [app: :demo, version: \"0.1.0\", deps: deps()]\n  defp deps, do: [{:jason, \"~> 1.4\"}, {:plug, \"~> 1.15\"}]\nend\n",
+			wantWarning:     "Elixir in .: mix.exs changed while no matching lockfile changed",
+			wantRemedy:      "mix deps.get",
+		},
+		{
+			name:            "swift package manager",
+			manifest:        swiftManifestName,
+			lockfile:        swiftLockfileName,
+			initialManifest: "// swift-tools-version: 5.9\nimport PackageDescription\nlet package = Package(name: \"Demo\", dependencies: [.package(url: \"https://github.com/apple/swift-argument-parser\", from: \"1.3.0\")], targets: [.target(name: \"Demo\")])\n",
+			initialLockfile: "{\"pins\":[],\"version\":2}\n",
+			updatedManifest: "// swift-tools-version: 5.9\nimport PackageDescription\nlet package = Package(name: \"Demo\", dependencies: [.package(url: \"https://github.com/apple/swift-argument-parser\", from: \"1.3.0\"), .package(url: \"https://github.com/pointfreeco/swift-dependencies\", from: \"1.3.0\")], targets: [.target(name: \"Demo\")])\n",
+			wantWarning:     "SwiftPM in .: Package.swift changed while no matching lockfile changed",
+			wantRemedy:      "swift package resolve",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, tc.manifest), tc.initialManifest)
+			writeFile(t, filepath.Join(repo, tc.lockfile), tc.initialLockfile)
+			initGitRepo(t, repo)
+
+			writeFile(t, filepath.Join(repo, tc.manifest), tc.updatedManifest)
+
+			warnings, err := detectLockfileDriftWithFeatures(context.Background(), repo, false, lockfileDriftFeatureSet(t, true))
+			assertSingleLockfileDriftWarning(t, warnings, err, tc.wantWarning, tc.wantRemedy)
+		})
+	}
+}
+
+func TestDetectLockfileDriftEcosystemExpansionPreviewDisabledPreservesCurrentBehavior(t *testing.T) {
+	t.Run("preview ecosystems stay disabled", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, dartManifestName), "name: demo\ndependencies:\n  http: ^1.2.0\n")
+		writeFile(t, filepath.Join(repo, dartLockfileName), "packages:\n  http:\n    version: \"1.2.0\"\n")
+		initGitRepo(t, repo)
+
+		writeFile(t, filepath.Join(repo, dartManifestName), "name: demo\ndependencies:\n  http: ^1.3.0\n")
+
+		warnings, err := detectLockfileDriftWithFeatures(context.Background(), repo, false, lockfileDriftFeatureSet(t, false))
+		if err != nil {
+			t.Fatalf(detectLockfileDriftFmt, err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no preview warning when feature is disabled, got %#v", warnings)
+		}
+	})
+
+	t.Run("existing ecosystems stay unchanged", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, lockfileName), demoPackageJSON)
+		initGitRepo(t, repo)
+
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+		warnings, err := detectLockfileDriftWithFeatures(context.Background(), repo, false, lockfileDriftFeatureSet(t, false))
+		if err != nil {
+			t.Fatalf(detectLockfileDriftFmt, err)
+		}
+		if len(warnings) != 1 {
+			t.Fatalf("expected existing npm warning, got %#v", warnings)
+		}
+		if !strings.Contains(warnings[0], "npm in .: package.json changed while no matching lockfile changed") {
+			t.Fatalf("unexpected warning: %q", warnings[0])
+		}
+	})
 }
 
 func TestDetectLockfileDriftSkipsLopperCache(t *testing.T) {
@@ -558,6 +685,42 @@ func containsEnvPrefix(env []string, prefix string) bool {
 		}
 	}
 	return false
+}
+
+func assertSingleLockfileDriftWarning(t *testing.T, warnings []string, err error, wantWarning, wantRemedy string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf(detectLockfileDriftFmt, err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning, got %#v", warnings)
+	}
+	if !strings.Contains(warnings[0], wantWarning) {
+		t.Fatalf("unexpected warning: %q", warnings[0])
+	}
+	if !strings.Contains(warnings[0], wantRemedy) {
+		t.Fatalf("expected remediation text %q, got %q", wantRemedy, warnings[0])
+	}
+}
+
+func lockfileDriftFeatureSet(t *testing.T, enabled bool) featureflags.Set {
+	t.Helper()
+
+	registry := featureflags.DefaultRegistry()
+	options := featureflags.ResolveOptions{
+		Channel: featureflags.ChannelRelease,
+	}
+	if enabled {
+		options.Enable = []string{lockfileDriftEcosystemExpansionPreviewFlagName}
+	} else {
+		options.Disable = []string{lockfileDriftEcosystemExpansionPreviewFlagName}
+	}
+
+	resolved, err := registry.Resolve(options)
+	if err != nil {
+		t.Fatalf("resolve feature set: %v", err)
+	}
+	return resolved
 }
 
 // TestShouldSkipMissingLockfile verifies the per-manifest heuristics that

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -41,11 +41,14 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 		t.Fatalf("expected embedded default registry to be valid, got %v", err)
 	}
 	defaultFlags := DefaultRegistry().Flags()
-	if len(defaultFlags) == 0 {
-		t.Fatalf("expected embedded default registry to contain feature flags")
+	if len(defaultFlags) != 2 {
+		t.Fatalf("expected embedded default registry to contain two feature flags, got %#v", defaultFlags)
 	}
 	if got, ok := DefaultRegistry().Lookup("dart-source-attribution-preview"); !ok || got.Code != "LOP-FEAT-0001" {
 		t.Fatalf("expected dart source attribution preview flag in default registry, got %#v ok=%v", got, ok)
+	}
+	if got, ok := DefaultRegistry().Lookup("lockfile-drift-ecosystem-expansion-preview"); !ok || got.Code != "LOP-FEAT-0002" {
+		t.Fatalf("expected lockfile drift ecosystem preview flag in default registry, got %#v ok=%v", got, ok)
 	}
 	if flags := (*Registry)(nil).Flags(); len(flags) != 0 {
 		t.Fatalf("expected nil registry flags to be empty, got %#v", flags)
@@ -150,11 +153,11 @@ func TestNewRegistryRejectsDuplicates(t *testing.T) {
 }
 
 func TestNextCodeAllocatesGeneratedCodes(t *testing.T) {
-	if code, err := DefaultRegistry().NextCode(); err != nil || code != "LOP-FEAT-0002" {
-		t.Fatalf("expected default registry to allocate next code, got %q err=%v", code, err)
+	if code, err := DefaultRegistry().NextCode(); err != nil || code != "LOP-FEAT-0003" {
+		t.Fatalf("expected embedded registry to allocate next code, got %q err=%v", code, err)
 	}
-	if code, err := (*Registry)(nil).NextCode(); err != nil || code != "LOP-FEAT-0002" {
-		t.Fatalf("expected nil registry to allocate next default code, got %q err=%v", code, err)
+	if code, err := (*Registry)(nil).NextCode(); err != nil || code != "LOP-FEAT-0003" {
+		t.Fatalf("expected nil registry to allocate next code from defaults, got %q err=%v", code, err)
 	}
 
 	registry, err := NewRegistry([]Flag{
@@ -493,10 +496,12 @@ func TestManifestReportsDefaults(t *testing.T) {
 	if _, err := registry.Manifest(ResolveOptions{Enable: []string{"missing"}}); err == nil {
 		t.Fatalf("expected manifest to return resolver errors")
 	}
-	if manifest, err := (*Registry)(nil).Manifest(ResolveOptions{}); err != nil || len(manifest) == 0 {
+	if manifest, err := (*Registry)(nil).Manifest(ResolveOptions{}); err != nil || len(manifest) != 2 {
 		t.Fatalf("expected nil registry manifest to defer to defaults, manifest=%#v err=%v", manifest, err)
 	} else if manifest[0].Name != "dart-source-attribution-preview" {
 		t.Fatalf("expected default manifest entry for dart-source-attribution-preview, got %#v", manifest[0])
+	} else if manifest[1].Name != "lockfile-drift-ecosystem-expansion-preview" {
+		t.Fatalf("expected default manifest entry for lockfile drift preview, got %#v", manifest[1])
 	}
 }
 

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -4,5 +4,11 @@
     "name": "dart-source-attribution-preview",
     "description": "Enable richer Dart and Flutter dependency source attribution and federated plugin relationship reporting.",
     "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0002",
+    "name": "lockfile-drift-ecosystem-expansion-preview",
+    "description": "Preview expansion of shared lockfile drift checks for .NET, Dart, Elixir, and SwiftPM ecosystems.",
+    "lifecycle": "preview"
   }
 ]

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -332,11 +332,14 @@ func TestManifestEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("release manifest: %v", err)
 	}
-	if len(manifest) == 0 {
+	if len(manifest) != 2 {
 		t.Fatalf("expected embedded manifest entries, got %#v", manifest)
 	}
 	if manifest[0].Name != "dart-source-attribution-preview" || manifest[0].EnabledByDefault {
 		t.Fatalf("expected dart-source-attribution-preview default-off in release channel, got %#v", manifest[0])
+	}
+	if manifest[1].Name != "lockfile-drift-ecosystem-expansion-preview" || manifest[1].EnabledByDefault {
+		t.Fatalf("expected lockfile drift preview default-off in release channel, got %#v", manifest[1])
 	}
 }
 


### PR DESCRIPTION
## Summary
- expand shared lockfile drift coverage with preview-gated rules for .NET (`packages.lock.json`), Dart (`pubspec.lock`), Elixir (`mix.lock`), and SwiftPM (`Package.resolved`)
- keep newly added ecosystem checks disabled by default behind `lockfile-drift-ecosystem-expansion-preview`
- add targeted lockfile drift tests for each new ecosystem plus regression coverage for disabled-preview behavior
- register the preview feature flag in the embedded feature catalog and update related feature-flag tooling tests

## Validation
- go test ./internal/app -run 'LockfileDrift|ExecuteFeaturesReleaseChannelAndEmptyRegistry' -count=1
- go test ./internal/featureflags -count=1
- go test ./...

Closes #451
