### PR TITLE
feat(dart): improve dependency source attribution behind preview flag

### DIFF
--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -47,6 +47,9 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 	if req.LowConfidenceWarningPercent != nil {
 		baseKey["lowConfidenceWarningPercent"] = *req.LowConfidenceWarningPercent
 	}
+	if enabledFeatures := req.Features.EnabledCodes(); len(enabledFeatures) > 0 {
+		baseKey["enabledFeatures"] = enabledFeatures
+	}
 	if len(req.LicenseDenyList) > 0 {
 		baseKey["licenseDeny"] = req.LicenseDenyList
 	}

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -173,6 +174,35 @@ func TestAnalysisCachePrepareEntryIncludesLicensePolicyInputs(t *testing.T) {
 	}
 }
 
+func TestAnalysisCachePrepareEntryIncludesEnabledFeatures(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "console.log('hello')\n")
+	request := Request{
+		RepoPath: repo,
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    filepath.Join(repo, cacheTestDirectoryName),
+		},
+	}
+	cache := newAnalysisCache(request, repo)
+
+	baseReq := Request{RepoPath: repo, TopN: 1}
+	entryA, err := cache.prepareEntry(baseReq, "cachelang", repo)
+	if err != nil {
+		t.Fatalf("prepare entry A: %v", err)
+	}
+
+	withFeature := baseReq
+	withFeature.Features = mustEnabledFeatureSet(t, "dart-source-attribution-preview")
+	entryB, err := cache.prepareEntry(withFeature, "cachelang", repo)
+	if err != nil {
+		t.Fatalf("prepare entry B: %v", err)
+	}
+	if entryA.KeyDigest == entryB.KeyDigest {
+		t.Fatalf("expected different cache keys when enabled feature set changes")
+	}
+}
+
 func TestAnalysisCacheWarnTakeWarningsAndSnapshot(t *testing.T) {
 	cache := &analysisCache{
 		metadata: report.CacheMetadata{
@@ -295,6 +325,26 @@ func assertLookupMissWithReason(t *testing.T, cache *analysisCache, entry cacheE
 	if len(cache.metadata.Invalidations) == 0 || cache.metadata.Invalidations[len(cache.metadata.Invalidations)-1].Reason != expectedReason {
 		t.Fatalf("expected %s invalidation, got %#v", expectedReason, cache.metadata.Invalidations)
 	}
+}
+
+func mustEnabledFeatureSet(t *testing.T, name string) featureflags.Set {
+	t.Helper()
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
+		Code:      "LOP-FEAT-0001",
+		Name:      name,
+		Lifecycle: featureflags.LifecyclePreview,
+	}})
+	if err != nil {
+		t.Fatalf("new feature registry: %v", err)
+	}
+	resolved, err := registry.Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  []string{name},
+	})
+	if err != nil {
+		t.Fatalf("resolve feature set: %v", err)
+	}
+	return resolved
 }
 
 func TestAnalysisCacheLookupInvalidationBranches(t *testing.T) {

--- a/internal/analysis/execution.go
+++ b/internal/analysis/execution.go
@@ -64,6 +64,7 @@ func (s *Service) runCandidateOnRoots(ctx context.Context, req Request, repoPath
 			TopN:                              req.TopN,
 			SuggestOnly:                       req.SuggestOnly,
 			RuntimeProfile:                    req.RuntimeProfile,
+			Features:                          req.Features,
 			MinUsagePercentForRecommendations: req.MinUsagePercentForRecommendations,
 			RemovalCandidateWeights:           req.RemovalCandidateWeights,
 			IncludeRegistryProvenance:         req.IncludeRegistryProvenance,

--- a/internal/analysis/request.go
+++ b/internal/analysis/request.go
@@ -1,6 +1,9 @@
 package analysis
 
-import "github.com/ben-ranford/lopper/internal/report"
+import (
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/report"
+)
 
 const (
 	ScopeModeRepo            = "repo"
@@ -28,6 +31,7 @@ type Request struct {
 	RuntimeTestCommand                string
 	IncludePatterns                   []string
 	ExcludePatterns                   []string
+	Features                          featureflags.Set
 	LowConfidenceWarningPercent       *int
 	MinUsagePercentForRecommendations *int
 	RemovalCandidateWeights           *report.RemovalCandidateWeights

--- a/internal/app/analyse_prepare.go
+++ b/internal/app/analyse_prepare.go
@@ -56,6 +56,7 @@ func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseE
 			RuntimeTestCommand:                strings.TrimSpace(req.Analyse.RuntimeTestCommand),
 			IncludePatterns:                   req.Analyse.IncludePatterns,
 			ExcludePatterns:                   req.Analyse.ExcludePatterns,
+			Features:                          req.Analyse.Features,
 			LowConfidenceWarningPercent:       &lowConfidence,
 			MinUsagePercentForRecommendations: &minUsage,
 			RemovalCandidateWeights:           &weights,

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -33,6 +33,7 @@ func TestExecuteAnalyseEmitsEffectiveThresholds(t *testing.T) {
 	req.Analyse.CacheEnabled = false
 	req.Analyse.CachePath = "/tmp/lopper-cache"
 	req.Analyse.CacheReadOnly = true
+	req.Analyse.Features = mustEnabledPreviewFeatureSet(t)
 	req.Analyse.PolicySources = []string{"cli", "defaults"}
 	req.Analyse.Thresholds = thresholds.Values{
 		FailOnIncreasePercent:             0,

--- a/internal/app/app_test_helpers_test.go
+++ b/internal/app/app_test_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ben-ranford/lopper/internal/analysis"
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/notify"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/ui"
@@ -90,6 +91,7 @@ func assertForwardedAnalyseRequest(t *testing.T, got analysis.Request) {
 		{"runtime profile", got.RuntimeProfile == "browser-import"},
 		{"scope mode", got.ScopeMode == ScopeModeChangedPackages},
 		{"cache options", got.Cache != nil && !got.Cache.Enabled && got.Cache.Path == "/tmp/lopper-cache" && got.Cache.ReadOnly},
+		{"features", got.Features.Enabled("dart-source-attribution-preview")},
 		{"suggest only", got.SuggestOnly},
 		{"removal candidate weights", got.RemovalCandidateWeights != nil && got.RemovalCandidateWeights.Usage == 0.6 && got.RemovalCandidateWeights.Impact == 0.2 && got.RemovalCandidateWeights.Confidence == 0.2},
 	}
@@ -102,4 +104,24 @@ func assertForwardedAnalyseRequest(t *testing.T, got analysis.Request) {
 
 func testTime() time.Time {
 	return time.Date(2026, time.February, 22, 15, 0, 0, 0, time.UTC)
+}
+
+func mustEnabledPreviewFeatureSet(t *testing.T) featureflags.Set {
+	t.Helper()
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
+		Code:      "LOP-FEAT-0001",
+		Name:      "dart-source-attribution-preview",
+		Lifecycle: featureflags.LifecyclePreview,
+	}})
+	if err != nil {
+		t.Fatalf("new feature registry: %v", err)
+	}
+	features, err := registry.Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  []string{"dart-source-attribution-preview"},
+	})
+	if err != nil {
+		t.Fatalf("resolve feature set: %v", err)
+	}
+	return features
 }

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -62,8 +62,8 @@ func TestExecuteFeaturesReleaseChannelAndEmptyRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute empty features: %v", err)
 	}
-	if emptyOutput != "No feature flags registered.\n" {
-		t.Fatalf("expected empty feature table, got %q", emptyOutput)
+	if !strings.Contains(emptyOutput, "dart-source-attribution-preview") || !strings.Contains(emptyOutput, "false") {
+		t.Fatalf("expected default feature table to include dart-source-attribution-preview disabled by default, got %q", emptyOutput)
 	}
 }
 

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -59,6 +59,8 @@ func TestExecuteFeaturesReleaseChannelAndEmptyRegistry(t *testing.T) {
 
 	emptyReq := DefaultRequest()
 	emptyReq.Mode = ModeFeatures
+	// Keep this assertion stable across CI lanes that set BUILD_CHANNEL=rolling.
+	emptyReq.Features.Channel = "dev"
 	emptyOutput, err := (&App{}).Execute(context.Background(), emptyReq)
 	if err != nil {
 		t.Fatalf("execute empty features: %v", err)

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -40,8 +40,12 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 	if err := ValidateDefaultRegistry(); err != nil {
 		t.Fatalf("expected embedded default registry to be valid, got %v", err)
 	}
-	if got := DefaultRegistry().Flags(); len(got) != 0 {
-		t.Fatalf("expected empty default registry, got %#v", got)
+	defaultFlags := DefaultRegistry().Flags()
+	if len(defaultFlags) == 0 {
+		t.Fatalf("expected embedded default registry to contain feature flags")
+	}
+	if got, ok := DefaultRegistry().Lookup("dart-source-attribution-preview"); !ok || got.Code != "LOP-FEAT-0001" {
+		t.Fatalf("expected dart source attribution preview flag in default registry, got %#v ok=%v", got, ok)
 	}
 	if flags := (*Registry)(nil).Flags(); len(flags) != 0 {
 		t.Fatalf("expected nil registry flags to be empty, got %#v", flags)
@@ -146,11 +150,11 @@ func TestNewRegistryRejectsDuplicates(t *testing.T) {
 }
 
 func TestNextCodeAllocatesGeneratedCodes(t *testing.T) {
-	if code, err := DefaultRegistry().NextCode(); err != nil || code != "LOP-FEAT-0001" {
-		t.Fatalf("expected empty registry to allocate first code, got %q err=%v", code, err)
+	if code, err := DefaultRegistry().NextCode(); err != nil || code != "LOP-FEAT-0002" {
+		t.Fatalf("expected default registry to allocate next code, got %q err=%v", code, err)
 	}
-	if code, err := (*Registry)(nil).NextCode(); err != nil || code != "LOP-FEAT-0001" {
-		t.Fatalf("expected nil registry to allocate first code, got %q err=%v", code, err)
+	if code, err := (*Registry)(nil).NextCode(); err != nil || code != "LOP-FEAT-0002" {
+		t.Fatalf("expected nil registry to allocate next default code, got %q err=%v", code, err)
 	}
 
 	registry, err := NewRegistry([]Flag{
@@ -489,8 +493,10 @@ func TestManifestReportsDefaults(t *testing.T) {
 	if _, err := registry.Manifest(ResolveOptions{Enable: []string{"missing"}}); err == nil {
 		t.Fatalf("expected manifest to return resolver errors")
 	}
-	if manifest, err := (*Registry)(nil).Manifest(ResolveOptions{}); err != nil || len(manifest) != 0 {
-		t.Fatalf("expected nil registry manifest to be empty, manifest=%#v err=%v", manifest, err)
+	if manifest, err := (*Registry)(nil).Manifest(ResolveOptions{}); err != nil || len(manifest) == 0 {
+		t.Fatalf("expected nil registry manifest to defer to defaults, manifest=%#v err=%v", manifest, err)
+	} else if manifest[0].Name != "dart-source-attribution-preview" {
+		t.Fatalf("expected default manifest entry for dart-source-attribution-preview, got %#v", manifest[0])
 	}
 }
 
@@ -510,6 +516,9 @@ func TestEnabledFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
+	if got := resolved.EnabledCodes(); len(got) != 2 || got[0] != "LOP-FEAT-0001" || got[1] != "LOP-FEAT-0002" {
+		t.Fatalf("expected enabled codes for rolling defaults, got %#v", got)
+	}
 	if enabled, err := resolved.EnabledFlag(" preview-flag "); err != nil || !enabled {
 		t.Fatalf("expected preview flag enabled in rolling, enabled=%v err=%v", enabled, err)
 	}
@@ -519,6 +528,39 @@ func TestEnabledFlag(t *testing.T) {
 	var empty *Set
 	if empty.Enabled("preview-flag") {
 		t.Fatalf("expected nil set to report disabled")
+	}
+	if got := empty.EnabledCodes(); len(got) != 0 {
+		t.Fatalf("expected nil set enabled codes to be empty, got %#v", got)
+	}
+}
+
+func TestDefaultRegistryDartSourceAttributionPreviewDefaultsAndOptIn(t *testing.T) {
+	registry := DefaultRegistry()
+	dev, err := registry.Resolve(ResolveOptions{Channel: ChannelDev})
+	if err != nil {
+		t.Fatalf("resolve dev defaults: %v", err)
+	}
+	if dev.Enabled("dart-source-attribution-preview") {
+		t.Fatalf("expected dart-source-attribution-preview default-off in dev channel")
+	}
+
+	release, err := registry.Resolve(ResolveOptions{Channel: ChannelRelease})
+	if err != nil {
+		t.Fatalf("resolve release defaults: %v", err)
+	}
+	if release.Enabled("dart-source-attribution-preview") {
+		t.Fatalf("expected dart-source-attribution-preview default-off in release channel")
+	}
+
+	optIn, err := registry.Resolve(ResolveOptions{
+		Channel: ChannelDev,
+		Enable:  []string{"dart-source-attribution-preview"},
+	})
+	if err != nil {
+		t.Fatalf("resolve explicit opt-in: %v", err)
+	}
+	if !optIn.Enabled("dart-source-attribution-preview") {
+		t.Fatalf("expected explicit opt-in to enable dart-source-attribution-preview")
 	}
 }
 

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -1,1 +1,8 @@
-[]
+[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "dart-source-attribution-preview",
+    "description": "Enable richer Dart and Flutter dependency source attribution and federated plugin relationship reporting.",
+    "lifecycle": "preview"
+  }
+]

--- a/internal/featureflags/resolver.go
+++ b/internal/featureflags/resolver.go
@@ -133,6 +133,20 @@ func (s *Set) Enabled(ref string) bool {
 	return s.enabled[flag.Code]
 }
 
+func (s *Set) EnabledCodes() []string {
+	if s == nil || len(s.enabled) == 0 {
+		return nil
+	}
+	codes := make([]string, 0, len(s.enabled))
+	for code, enabled := range s.enabled {
+		if enabled {
+			codes = append(codes, code)
+		}
+	}
+	sort.Strings(codes)
+	return codes
+}
+
 func (s *Set) EnabledFlag(ref string) (bool, error) {
 	flag, ok := s.lookup(ref)
 	if !ok {

--- a/internal/lang/dart/adapter_branches_extra_test.go
+++ b/internal/lang/dart/adapter_branches_extra_test.go
@@ -268,6 +268,43 @@ flutter:
 	assertDeclaredLockResolution(t, manifest.Dependencies)
 }
 
+func TestAnnotateFederatedPluginDependenciesFromLockMetadata(t *testing.T) {
+	deps := map[string]dependencyInfo{
+		"url_launcher": {},
+		"http":         {},
+	}
+	lockPackages := map[string]pubspecLockPackage{
+		"url_launcher": {
+			Description: map[string]any{"name": "url_launcher"},
+		},
+		"url_launcher_android": {
+			Description: map[string]any{"name": "url_launcher_android"},
+		},
+		"url_launcher_platform_interface": {
+			Description: map[string]any{"name": "url_launcher_platform_interface"},
+		},
+	}
+
+	annotateFederatedPluginDependencies(deps, lockPackages)
+
+	info := deps["url_launcher"]
+	if !info.FederatedPlugin {
+		t.Fatalf("expected url_launcher to be marked as federated plugin")
+	}
+	if info.FederatedFamily != "url_launcher" {
+		t.Fatalf("expected federated family url_launcher, got %#v", info)
+	}
+	if info.FederatedRole != federatedRoleApp {
+		t.Fatalf("expected federated app role, got %#v", info)
+	}
+	if !slices.Equal(info.FederatedMembers, []string{"url_launcher_android", "url_launcher_platform_interface"}) {
+		t.Fatalf("unexpected federated members: %#v", info.FederatedMembers)
+	}
+	if deps["http"].FederatedPlugin {
+		t.Fatalf("did not expect unrelated dependency to be marked federated")
+	}
+}
+
 func TestScanBranchesAndWarnings(t *testing.T) {
 	repo := t.TempDir()
 	manifestPath := filepath.Join(repo, pubspecYAMLName)
@@ -591,11 +628,17 @@ func assertLoadedManifest(t *testing.T, manifest packageManifest, warnings []str
 	if !manifest.Dependencies["flutter"].FlutterSDK {
 		t.Fatalf("expected flutter dependency to be marked as sdk")
 	}
+	if manifest.Dependencies["flutter"].Source != dependencySourceSDK {
+		t.Fatalf("expected flutter dependency source sdk, got %#v", manifest.Dependencies["flutter"])
+	}
 	if !manifest.Dependencies["url_launcher_android"].PluginLike {
 		t.Fatalf("expected plugin package classification from lock/manifest metadata")
 	}
 	if !manifest.Dependencies["local_pkg"].LocalPath {
 		t.Fatalf("expected path dependency to be marked as local")
+	}
+	if manifest.Dependencies["local_pkg"].Source != dependencySourcePath {
+		t.Fatalf("expected local dependency source path, got %#v", manifest.Dependencies["local_pkg"])
 	}
 }
 

--- a/internal/lang/dart/adapter_cov_more_branches_test.go
+++ b/internal/lang/dart/adapter_cov_more_branches_test.go
@@ -249,16 +249,17 @@ func testDartImportParsingAndDependencySelection(t *testing.T) {
 	if got := parseShowSymbols("show "); len(got) != 0 {
 		t.Fatalf("expected empty show clause to be ignored, got %#v", got)
 	}
-	if got := allDependencies(scanResult{
+	scan := scanResult{
 		DeclaredDependencies: map[string]dependencyInfo{
 			"local_pkg": {LocalPath: true},
 			"http":      {},
 		},
-	}); len(got) != 1 || got[0] != "http" {
+	}
+	if got := allDependencies(scan, false); len(got) != 1 || got[0] != "http" {
 		t.Fatalf("expected local path dependencies to be excluded, got %#v", got)
 	}
 
-	reportData, warnings := buildDependencyReport("http", scanResult{DeclaredDependencies: map[string]dependencyInfo{"http": {}}, Files: []fileScan{{Imports: []importBinding{{Dependency: "http", Module: "package:http/http.dart", Name: "Client", Local: "Client"}, {Dependency: "http", Module: "package:http/http.dart", Name: "Request", Local: "Request"}}, Usage: map[string]int{"Client": 1}}}}, 90)
+	reportData, warnings := buildDependencyReport("http", scanResult{DeclaredDependencies: map[string]dependencyInfo{"http": {}}, Files: []fileScan{{Imports: []importBinding{{Dependency: "http", Module: "package:http/http.dart", Name: "Client", Local: "Client"}, {Dependency: "http", Module: "package:http/http.dart", Name: "Request", Local: "Request"}}, Usage: map[string]int{"Client": 1}}}}, 90, false)
 	if len(warnings) != 0 || len(reportData.Recommendations) == 0 {
 		t.Fatalf("expected low-usage dependency recommendation, report=%#v warnings=%#v", reportData, warnings)
 	}

--- a/internal/lang/dart/adapter_test.go
+++ b/internal/lang/dart/adapter_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -265,6 +266,218 @@ void main() {
 	}
 }
 
+func TestDartSourceAttributionPreviewFlagOffKeepsLegacyBehavior(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, pubspecYAMLName), `name: app
+dependencies:
+  http: ^1.2.0
+  git_pkg:
+    git:
+      url: https://github.com/example/git_pkg.git
+      ref: v1.0.0
+  local_pkg:
+    path: ../local_pkg
+  flutter:
+    sdk: flutter
+  url_launcher: ^6.0.0
+dependency_overrides:
+  git_pkg:
+    git:
+      url: https://github.com/example/git_pkg.git
+      ref: v1.0.1
+flutter:
+  uses-material-design: true
+`)
+	writeFile(t, filepath.Join(repo, pubspecLockName), `packages:
+  http:
+    dependency: "direct main"
+    description: {name: http, url: "https://pub.dev"}
+    source: hosted
+    version: "1.2.0"
+  git_pkg:
+    dependency: "direct overridden"
+    description: {url: "https://github.com/example/git_pkg.git", ref: "v1.0.1"}
+    source: git
+    version: "1.0.1"
+  local_pkg:
+    dependency: "direct main"
+    description: {path: ../local_pkg}
+    source: path
+    version: "0.0.1"
+  flutter:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  url_launcher:
+    dependency: "direct main"
+    description: {name: url_launcher, url: "https://pub.dev"}
+    source: hosted
+    version: "6.0.0"
+  url_launcher_android:
+    dependency: transitive
+    description: {name: url_launcher_android, url: "https://pub.dev"}
+    source: hosted
+    version: "6.0.0"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description: {name: url_launcher_platform_interface, url: "https://pub.dev"}
+    source: hosted
+    version: "2.0.0"
+`)
+	writeFile(t, filepath.Join(repo, "lib", mainDartFileName), `import 'package:http/http.dart' as http;
+import 'package:url_launcher/url_launcher.dart' as launcher;
+
+void main() {
+  http.Client();
+  launcher.launchUrl(Uri.parse('https://example.com'));
+}
+`)
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath: repo,
+		TopN:     25,
+	})
+	if err != nil {
+		t.Fatalf(analyseErrorFormat, err)
+	}
+
+	if _, ok := findDependency(reportData.Dependencies, "local_pkg"); ok {
+		t.Fatalf("expected local path dependency to remain excluded with preview flag off")
+	}
+	gitDep, ok := findDependency(reportData.Dependencies, "git_pkg")
+	if !ok {
+		t.Fatalf("expected git_pkg dependency in top report")
+	}
+	if gitDep.Provenance != nil {
+		t.Fatalf("expected no provenance with preview flag off, got %#v", gitDep.Provenance)
+	}
+	urlLauncher, ok := findDependency(reportData.Dependencies, "url_launcher")
+	if !ok {
+		t.Fatalf("expected url_launcher dependency in top report")
+	}
+	if hasRiskCueCode(urlLauncher, "flutter-federated-plugin-family") {
+		t.Fatalf("expected no federated plugin cue with preview flag off")
+	}
+}
+
+func TestDartSourceAttributionPreviewFlagOnAddsSourceAndFederatedAttribution(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, pubspecYAMLName), `name: app
+dependencies:
+  http: ^1.2.0
+  git_pkg:
+    git:
+      url: https://github.com/example/git_pkg.git
+      ref: v1.0.0
+  local_pkg:
+    path: ../local_pkg
+  flutter:
+    sdk: flutter
+  url_launcher: ^6.0.0
+dependency_overrides:
+  git_pkg:
+    git:
+      url: https://github.com/example/git_pkg.git
+      ref: v1.0.1
+flutter:
+  uses-material-design: true
+`)
+	writeFile(t, filepath.Join(repo, pubspecLockName), `packages:
+  http:
+    dependency: "direct main"
+    description: {name: http, url: "https://pub.dev"}
+    source: hosted
+    version: "1.2.0"
+  git_pkg:
+    dependency: "direct overridden"
+    description: {url: "https://github.com/example/git_pkg.git", ref: "v1.0.1"}
+    source: git
+    version: "1.0.1"
+  local_pkg:
+    dependency: "direct main"
+    description: {path: ../local_pkg}
+    source: path
+    version: "0.0.1"
+  flutter:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  url_launcher:
+    dependency: "direct main"
+    description: {name: url_launcher, url: "https://pub.dev"}
+    source: hosted
+    version: "6.0.0"
+  url_launcher_android:
+    dependency: transitive
+    description: {name: url_launcher_android, url: "https://pub.dev"}
+    source: hosted
+    version: "6.0.0"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description: {name: url_launcher_platform_interface, url: "https://pub.dev"}
+    source: hosted
+    version: "2.0.0"
+`)
+	writeFile(t, filepath.Join(repo, "lib", mainDartFileName), `import 'package:http/http.dart' as http;
+import 'package:url_launcher/url_launcher.dart' as launcher;
+
+void main() {
+  http.Client();
+  launcher.launchUrl(Uri.parse('https://example.com'));
+}
+`)
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath:   repo,
+		TopN:       25,
+		Features:   mustDartPreviewFeatureSet(t, true),
+		Dependency: "",
+	})
+	if err != nil {
+		t.Fatalf(analyseErrorFormat, err)
+	}
+
+	assertProvenanceSource(t, reportData.Dependencies, "http", dependencySourceHosted)
+	assertProvenanceSource(t, reportData.Dependencies, "git_pkg", dependencySourceGit)
+	assertProvenanceSource(t, reportData.Dependencies, "local_pkg", dependencySourcePath)
+	assertProvenanceSource(t, reportData.Dependencies, "flutter", dependencySourceSDK)
+
+	localDep, ok := findDependency(reportData.Dependencies, "local_pkg")
+	if !ok {
+		t.Fatalf("expected local_pkg dependency when preview flag is enabled")
+	}
+	if !hasRiskCueCode(localDep, "local-path-dependency") {
+		t.Fatalf("expected local path cue, got %#v", localDep.RiskCues)
+	}
+	if hasRecommendationCode(localDep, "remove-unused-dependency") {
+		t.Fatalf("expected local path dependency to skip remove-unused recommendation under preview")
+	}
+
+	gitDep, ok := findDependency(reportData.Dependencies, "git_pkg")
+	if !ok {
+		t.Fatalf("expected git_pkg dependency in report")
+	}
+	if !hasRiskCueCode(gitDep, "git-dependency-source") {
+		t.Fatalf("expected git dependency source cue, got %#v", gitDep.RiskCues)
+	}
+	if !containsRecommendationMessage(gitDep, "review-dependency-override", "git dependency") {
+		t.Fatalf("expected override recommendation context for git dependency, got %#v", gitDep.Recommendations)
+	}
+
+	urlLauncher, ok := findDependency(reportData.Dependencies, "url_launcher")
+	if !ok {
+		t.Fatalf("expected url_launcher dependency in report")
+	}
+	if !hasRiskCueCode(urlLauncher, "flutter-federated-plugin-family") {
+		t.Fatalf("expected federated plugin risk cue, got %#v", urlLauncher.RiskCues)
+	}
+	if urlLauncher.Provenance == nil || !slices.Contains(urlLauncher.Provenance.Signals, "federated:url_launcher") {
+		t.Fatalf("expected federated provenance signal, got %#v", urlLauncher.Provenance)
+	}
+}
+
 func findDependency(dependencies []report.DependencyReport, name string) (report.DependencyReport, bool) {
 	for _, dependency := range dependencies {
 		if dependency.Name == name {
@@ -290,6 +503,50 @@ func hasRecommendationCode(dep report.DependencyReport, code string) bool {
 		}
 	}
 	return false
+}
+
+func containsRecommendationMessage(dep report.DependencyReport, code string, needle string) bool {
+	for _, rec := range dep.Recommendations {
+		if rec.Code == code && strings.Contains(strings.ToLower(rec.Message), strings.ToLower(needle)) {
+			return true
+		}
+	}
+	return false
+}
+
+func assertProvenanceSource(t *testing.T, dependencies []report.DependencyReport, name string, expected string) {
+	t.Helper()
+	dep, ok := findDependency(dependencies, name)
+	if !ok {
+		t.Fatalf("expected dependency %q in report", name)
+	}
+	if dep.Provenance == nil {
+		t.Fatalf("expected provenance for dependency %q", name)
+	}
+	if dep.Provenance.Source != expected {
+		t.Fatalf("expected provenance source %q for %q, got %#v", expected, name, dep.Provenance)
+	}
+}
+
+func mustDartPreviewFeatureSet(t *testing.T, enabled bool) featureflags.Set {
+	t.Helper()
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
+		Code:      "LOP-FEAT-0001",
+		Name:      dartSourceAttributionPreviewFeature,
+		Lifecycle: featureflags.LifecyclePreview,
+	}})
+	if err != nil {
+		t.Fatalf("new feature registry: %v", err)
+	}
+	opts := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
+	if enabled {
+		opts.Enable = []string{dartSourceAttributionPreviewFeature}
+	}
+	features, err := registry.Resolve(opts)
+	if err != nil {
+		t.Fatalf("resolve feature set: %v", err)
+	}
+	return features
 }
 
 func containsWarning(warnings []string, needle string) bool {

--- a/internal/lang/dart/coverage_helper_test.go
+++ b/internal/lang/dart/coverage_helper_test.go
@@ -2,7 +2,6 @@ package dart
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -11,25 +10,8 @@ import (
 )
 
 func TestDartCoverageAnalysePathNormalizationFailure(t *testing.T) {
-	originalWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	tempWD := t.TempDir()
-	if err := os.Chdir(tempWD); err != nil {
-		t.Fatalf("chdir temp: %v", err)
-	}
-	t.Cleanup(func() {
-		if chdirErr := os.Chdir(originalWD); chdirErr != nil {
-			t.Fatalf("restore working directory: %v", chdirErr)
-		}
-	})
-	if err := os.RemoveAll(tempWD); err != nil {
-		t.Fatalf("remove temp wd: %v", err)
-	}
-
-	if _, analyseErr := NewAdapter().Analyse(context.Background(), language.Request{}); analyseErr == nil {
-		t.Fatalf("expected analyse to fail when working directory can no longer be resolved")
+	if _, analyseErr := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: string([]byte{0})}); analyseErr == nil {
+		t.Fatalf("expected analyse to fail when repository path cannot be normalized")
 	}
 }
 

--- a/internal/lang/dart/coverage_helper_test.go
+++ b/internal/lang/dart/coverage_helper_test.go
@@ -10,154 +10,177 @@ import (
 	"github.com/ben-ranford/lopper/internal/report"
 )
 
-func TestDartCoverageErrorAndSourceBranches(t *testing.T) {
-	t.Run("analyse path normalization failure", func(t *testing.T) {
-		originalWD, err := os.Getwd()
-		if err != nil {
-			t.Fatalf("getwd: %v", err)
-		}
-		tempWD := t.TempDir()
-		if err := os.Chdir(tempWD); err != nil {
-			t.Fatalf("chdir temp: %v", err)
-		}
-		t.Cleanup(func() {
-			if chdirErr := os.Chdir(originalWD); chdirErr != nil {
-				t.Fatalf("restore working directory: %v", chdirErr)
-			}
-		})
-		if err := os.RemoveAll(tempWD); err != nil {
-			t.Fatalf("remove temp wd: %v", err)
-		}
-
-		_, analyseErr := NewAdapter().Analyse(context.Background(), language.Request{})
-		if analyseErr == nil {
-			t.Fatalf("expected analyse to fail when working directory can no longer be resolved")
+func TestDartCoverageAnalysePathNormalizationFailure(t *testing.T) {
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	tempWD := t.TempDir()
+	if err := os.Chdir(tempWD); err != nil {
+		t.Fatalf("chdir temp: %v", err)
+	}
+	t.Cleanup(func() {
+		if chdirErr := os.Chdir(originalWD); chdirErr != nil {
+			t.Fatalf("restore working directory: %v", chdirErr)
 		}
 	})
+	if err := os.RemoveAll(tempWD); err != nil {
+		t.Fatalf("remove temp wd: %v", err)
+	}
 
-	t.Run("scan cancellation returns adapter scan error", func(t *testing.T) {
-		repo := t.TempDir()
-		writeFile(t, filepath.Join(repo, pubspecYAMLName), "name: app\ndependencies:\n  http: ^1.0.0\n")
-		writeFile(t, filepath.Join(repo, "lib", "main.dart"), "import 'package:http/http.dart';\n")
+	if _, analyseErr := NewAdapter().Analyse(context.Background(), language.Request{}); analyseErr == nil {
+		t.Fatalf("expected analyse to fail when working directory can no longer be resolved")
+	}
+}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
+func TestDartCoverageScanCancellationReturnsAdapterScanError(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, pubspecYAMLName), "name: app\ndependencies:\n  http: ^1.0.0\n")
+	writeFile(t, filepath.Join(repo, "lib", "main.dart"), "import 'package:http/http.dart';\n")
 
-		var out report.Report
-		_, err := NewAdapter().scanRepo(ctx, repo, &out)
-		if err == nil {
-			t.Fatalf("expected canceled context to fail scan")
-		}
-	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-	t.Run("manifest merge + source helpers", func(t *testing.T) {
-		dest := map[string]dependencyInfo{
-			"git_dep": {
-				Source:       dependencySourceGit,
-				SourceDetail: "",
-			},
-			"federated_app": {
-				FederatedFamily: "",
-				FederatedRole:   "",
-			},
-		}
-		mergeDependencyInfo(dest, "git_dep", dependencyInfo{
+	var out report.Report
+	if _, err := NewAdapter().scanRepo(ctx, repo, &out); err == nil {
+		t.Fatalf("expected canceled context to fail scan")
+	}
+}
+
+func TestMergeDependencyInfoMergesSourceAndFederatedMembers(t *testing.T) {
+	dest := map[string]dependencyInfo{
+		"git_dep": {
 			Source:       dependencySourceGit,
-			SourceDetail: "https://example.com/repo.git",
-		})
-		mergeDependencyInfo(dest, "federated_app", dependencyInfo{
-			FederatedMembers: []string{"federated_android", "federated_ios"},
-		})
-		if dest["git_dep"].SourceDetail == "" {
-			t.Fatalf("expected mergeDependencyInfo to fill missing source detail")
-		}
-		if len(dest["federated_app"].FederatedMembers) != 2 {
-			t.Fatalf("expected mergeDependencyInfo to merge federated members, got %#v", dest["federated_app"].FederatedMembers)
-		}
-
-		if got := dependencySourceDetail(map[string]any{"ignored": "value"}, "url"); got != "" {
-			t.Fatalf("expected empty source detail when preferred keys are absent, got %q", got)
-		}
-		if got := dependencySourceDetail(" https://example.com/pkg ", "url"); got != "https://example.com/pkg" {
-			t.Fatalf("expected scalar source detail trim, got %q", got)
-		}
-
-		if got := dependencySourcePriority("unknown"); got != 0 {
-			t.Fatalf("expected unknown source priority 0, got %d", got)
-		}
-
-		assignDependencySource(nil, dependencySourceHosted, "x")
-		info := dependencyInfo{}
-		assignDependencySource(&info, "", "x")
-		if info.Source != "" {
-			t.Fatalf("expected empty source assignment to be ignored, got %#v", info)
-		}
-		assignDependencySource(&info, dependencySourceHosted, "")
-		assignDependencySource(&info, dependencySourcePath, "/tmp/local")
-		assignDependencySource(&info, dependencySourcePath, "filled")
-		if info.Source != dependencySourcePath || info.SourceDetail == "" {
-			t.Fatalf("expected source priority/detail assignment, got %#v", info)
-		}
-
-		specInfo := dependencyInfoFromSpec("pkg", map[string]any{"hosted": map[string]any{"url": "https://pub.dev"}, "version": "^1.2.3"}, nil)
-		if specInfo.Source != dependencySourceHosted {
-			t.Fatalf("expected hosted source from spec, got %#v", specInfo)
-		}
-
-		if _, _, ok := federatedFamilyRole("  "); ok {
-			t.Fatalf("expected blank dependency not to produce federated family role")
-		}
-
-		sourceMeta := dependencyInfo{LocalPath: true}
-		if got := dependencySource(sourceMeta); got != dependencySourcePath {
-			t.Fatalf("expected local-path fallback source, got %q", got)
-		}
-		sourceMeta = dependencyInfo{FlutterSDK: true}
-		if got := dependencySource(sourceMeta); got != dependencySourceSDK {
-			t.Fatalf("expected flutter-sdk fallback source, got %q", got)
-		}
-		if label := dependencySourceLabel(dependencyInfo{Source: dependencySourceGit}); label != "git" {
-			t.Fatalf("expected git source label, got %q", label)
-		}
-		if label := dependencySourceLabel(dependencyInfo{Source: dependencySourceHosted}); label != "hosted" {
-			t.Fatalf("expected hosted source label, got %q", label)
-		}
-		if label := dependencySourceLabel(dependencyInfo{Source: dependencySourceSDK}); label != "SDK" {
-			t.Fatalf("expected non-flutter sdk label, got %q", label)
-		}
-		if message := dependencyOverrideMessage(dependencyInfo{}, true); message != "dependency is marked in dependency_overrides" {
-			t.Fatalf("unexpected override message for unknown source: %q", message)
-		}
-		if message := dependencyOverrideRecommendation(dependencyInfo{}, true); message != "Review dependency_overrides usage and limit overrides to active blockers." {
-			t.Fatalf("unexpected override recommendation for unknown source: %q", message)
-		}
-		if message := federatedPluginMessage(dependencyInfo{}); message != "dependency participates in a Flutter federated plugin family" {
-			t.Fatalf("unexpected federated message without family: %q", message)
-		}
-		if message := federatedPluginMessage(dependencyInfo{FederatedFamily: "foo"}); message != `dependency participates in the "foo" Flutter federated plugin family` {
-			t.Fatalf("unexpected federated message without members: %q", message)
-		}
-		if prov := buildDartDependencyProvenance(dependencyInfo{}); prov != nil {
-			t.Fatalf("expected no provenance without source, got %#v", prov)
-		}
-		prov := buildDartDependencyProvenance(dependencyInfo{
-			Source:             dependencySourceHosted,
-			DeclaredInManifest: true,
-		})
-		if prov == nil || prov.Confidence != "medium" {
-			t.Fatalf("expected medium-confidence manifest provenance, got %#v", prov)
-		}
+			SourceDetail: "",
+		},
+		"federated_app": {
+			FederatedFamily: "",
+			FederatedRole:   "",
+		},
+	}
+	mergeDependencyInfo(dest, "git_dep", dependencyInfo{
+		Source:       dependencySourceGit,
+		SourceDetail: "https://example.com/repo.git",
+	})
+	mergeDependencyInfo(dest, "federated_app", dependencyInfo{
+		FederatedMembers: []string{"federated_android", "federated_ios"},
 	})
 
-	t.Run("directive parser edge branches", func(t *testing.T) {
-		if kind, mod, clause, ok := parseImportDirective(`part "x.dart";`); ok || kind != "" || mod != "" || clause != "" {
-			t.Fatalf("expected non-directive line to fail parse")
-		}
-		if _, _, _, ok := parseImportDirective(`using "x.dart";`); ok {
-			t.Fatalf("expected unsupported directive kind to fail parse")
-		}
-		if symbols := parseShowSymbols("show hide Foo"); len(symbols) != 0 {
-			t.Fatalf("expected empty show list after hide trim, got %#v", symbols)
-		}
+	if dest["git_dep"].SourceDetail == "" {
+		t.Fatalf("expected mergeDependencyInfo to fill missing source detail")
+	}
+	if len(dest["federated_app"].FederatedMembers) != 2 {
+		t.Fatalf("expected mergeDependencyInfo to merge federated members, got %#v", dest["federated_app"].FederatedMembers)
+	}
+}
+
+func TestDependencySourceDetailScalarAndMapFallbacks(t *testing.T) {
+	if got := dependencySourceDetail(map[string]any{"ignored": "value"}, "url"); got != "" {
+		t.Fatalf("expected empty source detail when preferred keys are absent, got %q", got)
+	}
+	if got := dependencySourceDetail(" https://example.com/pkg ", "url"); got != "https://example.com/pkg" {
+		t.Fatalf("expected scalar source detail trim, got %q", got)
+	}
+}
+
+func TestDependencySourcePriorityUnknown(t *testing.T) {
+	if got := dependencySourcePriority("unknown"); got != 0 {
+		t.Fatalf("expected unknown source priority 0, got %d", got)
+	}
+}
+
+func TestAssignDependencySourceBranchCoverage(t *testing.T) {
+	assignDependencySource(nil, dependencySourceHosted, "x")
+
+	info := dependencyInfo{}
+	assignDependencySource(&info, "", "x")
+	if info.Source != "" {
+		t.Fatalf("expected empty source assignment to be ignored, got %#v", info)
+	}
+
+	assignDependencySource(&info, dependencySourceHosted, "")
+	assignDependencySource(&info, dependencySourcePath, "/tmp/local")
+	assignDependencySource(&info, dependencySourcePath, "filled")
+	if info.Source != dependencySourcePath || info.SourceDetail == "" {
+		t.Fatalf("expected source priority/detail assignment, got %#v", info)
+	}
+}
+
+func TestDependencyInfoFromSpecHostedSource(t *testing.T) {
+	spec := map[string]any{
+		"hosted":  map[string]any{"url": "https://pub.dev"},
+		"version": "^1.2.3",
+	}
+	specInfo := dependencyInfoFromSpec("pkg", spec, nil)
+	if specInfo.Source != dependencySourceHosted {
+		t.Fatalf("expected hosted source from spec, got %#v", specInfo)
+	}
+}
+
+func TestFederatedFamilyRoleBlankDependency(t *testing.T) {
+	if _, _, ok := federatedFamilyRole("  "); ok {
+		t.Fatalf("expected blank dependency not to produce federated family role")
+	}
+}
+
+func TestDependencySourceFallbacksAndLabels(t *testing.T) {
+	sourceMeta := dependencyInfo{LocalPath: true}
+	if got := dependencySource(sourceMeta); got != dependencySourcePath {
+		t.Fatalf("expected local-path fallback source, got %q", got)
+	}
+
+	sourceMeta = dependencyInfo{FlutterSDK: true}
+	if got := dependencySource(sourceMeta); got != dependencySourceSDK {
+		t.Fatalf("expected flutter-sdk fallback source, got %q", got)
+	}
+
+	if label := dependencySourceLabel(dependencyInfo{Source: dependencySourceGit}); label != "git" {
+		t.Fatalf("expected git source label, got %q", label)
+	}
+	if label := dependencySourceLabel(dependencyInfo{Source: dependencySourceHosted}); label != "hosted" {
+		t.Fatalf("expected hosted source label, got %q", label)
+	}
+	if label := dependencySourceLabel(dependencyInfo{Source: dependencySourceSDK}); label != "SDK" {
+		t.Fatalf("expected non-flutter sdk label, got %q", label)
+	}
+}
+
+func TestDependencyOverrideAndFederatedMessages(t *testing.T) {
+	if message := dependencyOverrideMessage(dependencyInfo{}, true); message != "dependency is marked in dependency_overrides" {
+		t.Fatalf("unexpected override message for unknown source: %q", message)
+	}
+	if message := dependencyOverrideRecommendation(dependencyInfo{}, true); message != "Review dependency_overrides usage and limit overrides to active blockers." {
+		t.Fatalf("unexpected override recommendation for unknown source: %q", message)
+	}
+	if message := federatedPluginMessage(dependencyInfo{}); message != "dependency participates in a Flutter federated plugin family" {
+		t.Fatalf("unexpected federated message without family: %q", message)
+	}
+	if message := federatedPluginMessage(dependencyInfo{FederatedFamily: "foo"}); message != `dependency participates in the "foo" Flutter federated plugin family` {
+		t.Fatalf("unexpected federated message without members: %q", message)
+	}
+}
+
+func TestBuildDartDependencyProvenanceCoverage(t *testing.T) {
+	if prov := buildDartDependencyProvenance(dependencyInfo{}); prov != nil {
+		t.Fatalf("expected no provenance without source, got %#v", prov)
+	}
+	prov := buildDartDependencyProvenance(dependencyInfo{
+		Source:             dependencySourceHosted,
+		DeclaredInManifest: true,
 	})
+	if prov == nil || prov.Confidence != "medium" {
+		t.Fatalf("expected medium-confidence manifest provenance, got %#v", prov)
+	}
+}
+
+func TestDartDirectiveParserEdgeBranches(t *testing.T) {
+	if kind, mod, clause, ok := parseImportDirective(`part "x.dart";`); ok || kind != "" || mod != "" || clause != "" {
+		t.Fatalf("expected non-directive line to fail parse")
+	}
+	if _, _, _, ok := parseImportDirective(`using "x.dart";`); ok {
+		t.Fatalf("expected unsupported directive kind to fail parse")
+	}
+	if symbols := parseShowSymbols("show hide Foo"); len(symbols) != 0 {
+		t.Fatalf("expected empty show list after hide trim, got %#v", symbols)
+	}
 }

--- a/internal/lang/dart/coverage_helper_test.go
+++ b/internal/lang/dart/coverage_helper_test.go
@@ -1,0 +1,163 @@
+package dart
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestDartCoverageErrorAndSourceBranches(t *testing.T) {
+	t.Run("analyse path normalization failure", func(t *testing.T) {
+		originalWD, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("getwd: %v", err)
+		}
+		tempWD := t.TempDir()
+		if err := os.Chdir(tempWD); err != nil {
+			t.Fatalf("chdir temp: %v", err)
+		}
+		t.Cleanup(func() {
+			if chdirErr := os.Chdir(originalWD); chdirErr != nil {
+				t.Fatalf("restore working directory: %v", chdirErr)
+			}
+		})
+		if err := os.RemoveAll(tempWD); err != nil {
+			t.Fatalf("remove temp wd: %v", err)
+		}
+
+		_, analyseErr := NewAdapter().Analyse(context.Background(), language.Request{})
+		if analyseErr == nil {
+			t.Fatalf("expected analyse to fail when working directory can no longer be resolved")
+		}
+	})
+
+	t.Run("scan cancellation returns adapter scan error", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, pubspecYAMLName), "name: app\ndependencies:\n  http: ^1.0.0\n")
+		writeFile(t, filepath.Join(repo, "lib", "main.dart"), "import 'package:http/http.dart';\n")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var out report.Report
+		_, err := NewAdapter().scanRepo(ctx, repo, &out)
+		if err == nil {
+			t.Fatalf("expected canceled context to fail scan")
+		}
+	})
+
+	t.Run("manifest merge + source helpers", func(t *testing.T) {
+		dest := map[string]dependencyInfo{
+			"git_dep": {
+				Source:       dependencySourceGit,
+				SourceDetail: "",
+			},
+			"federated_app": {
+				FederatedFamily: "",
+				FederatedRole:   "",
+			},
+		}
+		mergeDependencyInfo(dest, "git_dep", dependencyInfo{
+			Source:       dependencySourceGit,
+			SourceDetail: "https://example.com/repo.git",
+		})
+		mergeDependencyInfo(dest, "federated_app", dependencyInfo{
+			FederatedMembers: []string{"federated_android", "federated_ios"},
+		})
+		if dest["git_dep"].SourceDetail == "" {
+			t.Fatalf("expected mergeDependencyInfo to fill missing source detail")
+		}
+		if len(dest["federated_app"].FederatedMembers) != 2 {
+			t.Fatalf("expected mergeDependencyInfo to merge federated members, got %#v", dest["federated_app"].FederatedMembers)
+		}
+
+		if got := dependencySourceDetail(map[string]any{"ignored": "value"}, "url"); got != "" {
+			t.Fatalf("expected empty source detail when preferred keys are absent, got %q", got)
+		}
+		if got := dependencySourceDetail(" https://example.com/pkg ", "url"); got != "https://example.com/pkg" {
+			t.Fatalf("expected scalar source detail trim, got %q", got)
+		}
+
+		if got := dependencySourcePriority("unknown"); got != 0 {
+			t.Fatalf("expected unknown source priority 0, got %d", got)
+		}
+
+		assignDependencySource(nil, dependencySourceHosted, "x")
+		info := dependencyInfo{}
+		assignDependencySource(&info, "", "x")
+		if info.Source != "" {
+			t.Fatalf("expected empty source assignment to be ignored, got %#v", info)
+		}
+		assignDependencySource(&info, dependencySourceHosted, "")
+		assignDependencySource(&info, dependencySourcePath, "/tmp/local")
+		assignDependencySource(&info, dependencySourcePath, "filled")
+		if info.Source != dependencySourcePath || info.SourceDetail == "" {
+			t.Fatalf("expected source priority/detail assignment, got %#v", info)
+		}
+
+		specInfo := dependencyInfoFromSpec("pkg", map[string]any{"hosted": map[string]any{"url": "https://pub.dev"}, "version": "^1.2.3"}, nil)
+		if specInfo.Source != dependencySourceHosted {
+			t.Fatalf("expected hosted source from spec, got %#v", specInfo)
+		}
+
+		if _, _, ok := federatedFamilyRole("  "); ok {
+			t.Fatalf("expected blank dependency not to produce federated family role")
+		}
+
+		sourceMeta := dependencyInfo{LocalPath: true}
+		if got := dependencySource(sourceMeta); got != dependencySourcePath {
+			t.Fatalf("expected local-path fallback source, got %q", got)
+		}
+		sourceMeta = dependencyInfo{FlutterSDK: true}
+		if got := dependencySource(sourceMeta); got != dependencySourceSDK {
+			t.Fatalf("expected flutter-sdk fallback source, got %q", got)
+		}
+		if label := dependencySourceLabel(dependencyInfo{Source: dependencySourceGit}); label != "git" {
+			t.Fatalf("expected git source label, got %q", label)
+		}
+		if label := dependencySourceLabel(dependencyInfo{Source: dependencySourceHosted}); label != "hosted" {
+			t.Fatalf("expected hosted source label, got %q", label)
+		}
+		if label := dependencySourceLabel(dependencyInfo{Source: dependencySourceSDK}); label != "SDK" {
+			t.Fatalf("expected non-flutter sdk label, got %q", label)
+		}
+		if message := dependencyOverrideMessage(dependencyInfo{}, true); message != "dependency is marked in dependency_overrides" {
+			t.Fatalf("unexpected override message for unknown source: %q", message)
+		}
+		if message := dependencyOverrideRecommendation(dependencyInfo{}, true); message != "Review dependency_overrides usage and limit overrides to active blockers." {
+			t.Fatalf("unexpected override recommendation for unknown source: %q", message)
+		}
+		if message := federatedPluginMessage(dependencyInfo{}); message != "dependency participates in a Flutter federated plugin family" {
+			t.Fatalf("unexpected federated message without family: %q", message)
+		}
+		if message := federatedPluginMessage(dependencyInfo{FederatedFamily: "foo"}); message != `dependency participates in the "foo" Flutter federated plugin family` {
+			t.Fatalf("unexpected federated message without members: %q", message)
+		}
+		if prov := buildDartDependencyProvenance(dependencyInfo{}); prov != nil {
+			t.Fatalf("expected no provenance without source, got %#v", prov)
+		}
+		prov := buildDartDependencyProvenance(dependencyInfo{
+			Source:             dependencySourceHosted,
+			DeclaredInManifest: true,
+		})
+		if prov == nil || prov.Confidence != "medium" {
+			t.Fatalf("expected medium-confidence manifest provenance, got %#v", prov)
+		}
+	})
+
+	t.Run("directive parser edge branches", func(t *testing.T) {
+		if kind, mod, clause, ok := parseImportDirective(`part "x.dart";`); ok || kind != "" || mod != "" || clause != "" {
+			t.Fatalf("expected non-directive line to fail parse")
+		}
+		if _, _, _, ok := parseImportDirective(`using "x.dart";`); ok {
+			t.Fatalf("expected unsupported directive kind to fail parse")
+		}
+		if symbols := parseShowSymbols("show hide Foo"); len(symbols) != 0 {
+			t.Fatalf("expected empty show list after hide trim, got %#v", symbols)
+		}
+	})
+}

--- a/internal/lang/dart/manifest.go
+++ b/internal/lang/dart/manifest.go
@@ -80,9 +80,9 @@ func loadPackageManifest(repoPath, manifestPath string) (packageManifest, []stri
 	root := filepath.Dir(manifestPath)
 
 	if len(overrideDeps) > 0 {
-		relManifest, relErr := filepath.Rel(repoPath, manifestPath)
-		if relErr != nil {
-			relManifest = manifestPath
+		relManifest := manifestPath
+		if relative, relErr := filepath.Rel(repoPath, manifestPath); relErr == nil && strings.TrimSpace(relative) != "" {
+			relManifest = relative
 		}
 		warnings = append(warnings, fmt.Sprintf("dependency_overrides declared in %s: %s", relManifest, strings.Join(overrideDeps, ", ")))
 	}
@@ -96,12 +96,14 @@ func loadPackageManifest(repoPath, manifestPath string) (packageManifest, []stri
 			return packageManifest{}, nil, lockErr
 		}
 		mergeLockDependencyData(dependencies, lockData.Packages, &hasPluginMetadata)
+		annotateFederatedPluginDependencies(dependencies, lockData.Packages)
 	} else if os.IsNotExist(statErr) {
-		relRoot, relErr := filepath.Rel(repoPath, root)
-		if relErr != nil || relRoot == "" {
-			relRoot = "."
+		relRoot := "."
+		if relative, relErr := filepath.Rel(repoPath, root); relErr == nil && strings.TrimSpace(relative) != "" {
+			relRoot = relative
 		}
 		warnings = append(warnings, fmt.Sprintf("pubspec.lock not found in %s; resolved package metadata may be partial", relRoot))
+		annotateFederatedPluginDependencies(dependencies, nil)
 	} else {
 		return packageManifest{}, nil, statErr
 	}
@@ -170,15 +172,18 @@ func mergeLockDependencyData(dest map[string]dependencyInfo, packages map[string
 			continue
 		}
 		classification := strings.ToLower(strings.TrimSpace(item.Dependency))
+		source := normalizeDependencySource(item.Source)
 		info := dependencyInfo{
-			Runtime:    strings.Contains(classification, "main"),
-			Dev:        strings.Contains(classification, "dev"),
-			Override:   strings.Contains(classification, "overrid"),
-			FlutterSDK: strings.EqualFold(strings.TrimSpace(item.Source), "sdk") && lockDescriptionTargetsFlutter(item.Description),
-			LocalPath:  strings.EqualFold(strings.TrimSpace(item.Source), "path"),
-			PluginLike: isLikelyFlutterPluginPackage(dependency),
-			Source:     strings.TrimSpace(item.Source),
-			Version:    strings.TrimSpace(item.Version),
+			Runtime:        strings.Contains(classification, "main"),
+			Dev:            strings.Contains(classification, "dev"),
+			Override:       strings.Contains(classification, "overrid"),
+			ResolvedInLock: true,
+			FlutterSDK:     source == dependencySourceSDK && lockDescriptionTargetsFlutter(item.Description),
+			LocalPath:      source == dependencySourcePath,
+			PluginLike:     isLikelyFlutterPluginPackage(dependency),
+			Source:         source,
+			SourceDetail:   dependencySourceDetail(item.Description, "path", "url", "sdk", "name"),
+			Version:        strings.TrimSpace(item.Version),
 		}
 		if hasPluginMetadataValue(item.Description) {
 			info.PluginLike = true
@@ -243,11 +248,30 @@ func mergeDependencyInfo(dest map[string]dependencyInfo, dependency string, inco
 	current.LocalPath = current.LocalPath || incoming.LocalPath
 	current.FlutterSDK = current.FlutterSDK || incoming.FlutterSDK
 	current.PluginLike = current.PluginLike || incoming.PluginLike
-	if current.Source == "" {
+	current.DeclaredInManifest = current.DeclaredInManifest || incoming.DeclaredInManifest
+	hadResolvedInLock := current.ResolvedInLock
+	current.ResolvedInLock = current.ResolvedInLock || incoming.ResolvedInLock
+	current.FederatedPlugin = current.FederatedPlugin || incoming.FederatedPlugin
+	if current.Source == "" || (!hadResolvedInLock && incoming.ResolvedInLock) {
 		current.Source = incoming.Source
+		if incoming.SourceDetail != "" {
+			current.SourceDetail = incoming.SourceDetail
+		}
+	} else if current.Source == incoming.Source && current.SourceDetail == "" {
+		current.SourceDetail = incoming.SourceDetail
 	}
-	if current.Version == "" {
+	if current.Version == "" || (!hadResolvedInLock && incoming.ResolvedInLock) {
 		current.Version = incoming.Version
+	}
+	if current.FederatedFamily == "" {
+		current.FederatedFamily = incoming.FederatedFamily
+	}
+	if current.FederatedRole == "" {
+		current.FederatedRole = incoming.FederatedRole
+	}
+	if len(incoming.FederatedMembers) > 0 {
+		current.FederatedMembers = dedupeStrings(append(current.FederatedMembers, incoming.FederatedMembers...))
+		sort.Strings(current.FederatedMembers)
 	}
 	dest[dependency] = current
 }

--- a/internal/lang/dart/manifest.go
+++ b/internal/lang/dart/manifest.go
@@ -242,6 +242,14 @@ func mergeDependencyInfo(dest map[string]dependencyInfo, dependency string, inco
 		dest[dependency] = incoming
 		return
 	}
+	hadResolvedInLock := current.ResolvedInLock
+	mergeDependencyFlags(&current, incoming)
+	mergeDependencySourceAndVersion(&current, incoming, hadResolvedInLock)
+	mergeDependencyFederatedMetadata(&current, incoming)
+	dest[dependency] = current
+}
+
+func mergeDependencyFlags(current *dependencyInfo, incoming dependencyInfo) {
 	current.Runtime = current.Runtime || incoming.Runtime
 	current.Dev = current.Dev || incoming.Dev
 	current.Override = current.Override || incoming.Override
@@ -249,10 +257,13 @@ func mergeDependencyInfo(dest map[string]dependencyInfo, dependency string, inco
 	current.FlutterSDK = current.FlutterSDK || incoming.FlutterSDK
 	current.PluginLike = current.PluginLike || incoming.PluginLike
 	current.DeclaredInManifest = current.DeclaredInManifest || incoming.DeclaredInManifest
-	hadResolvedInLock := current.ResolvedInLock
 	current.ResolvedInLock = current.ResolvedInLock || incoming.ResolvedInLock
 	current.FederatedPlugin = current.FederatedPlugin || incoming.FederatedPlugin
-	if current.Source == "" || (!hadResolvedInLock && incoming.ResolvedInLock) {
+}
+
+func mergeDependencySourceAndVersion(current *dependencyInfo, incoming dependencyInfo, hadResolvedInLock bool) {
+	preferIncomingLockMetadata := !hadResolvedInLock && incoming.ResolvedInLock
+	if current.Source == "" || preferIncomingLockMetadata {
 		current.Source = incoming.Source
 		if incoming.SourceDetail != "" {
 			current.SourceDetail = incoming.SourceDetail
@@ -260,18 +271,21 @@ func mergeDependencyInfo(dest map[string]dependencyInfo, dependency string, inco
 	} else if current.Source == incoming.Source && current.SourceDetail == "" {
 		current.SourceDetail = incoming.SourceDetail
 	}
-	if current.Version == "" || (!hadResolvedInLock && incoming.ResolvedInLock) {
+	if current.Version == "" || preferIncomingLockMetadata {
 		current.Version = incoming.Version
 	}
+}
+
+func mergeDependencyFederatedMetadata(current *dependencyInfo, incoming dependencyInfo) {
 	if current.FederatedFamily == "" {
 		current.FederatedFamily = incoming.FederatedFamily
 	}
 	if current.FederatedRole == "" {
 		current.FederatedRole = incoming.FederatedRole
 	}
-	if len(incoming.FederatedMembers) > 0 {
-		current.FederatedMembers = dedupeStrings(append(current.FederatedMembers, incoming.FederatedMembers...))
-		sort.Strings(current.FederatedMembers)
+	if len(incoming.FederatedMembers) == 0 {
+		return
 	}
-	dest[dependency] = current
+	current.FederatedMembers = dedupeStrings(append(current.FederatedMembers, incoming.FederatedMembers...))
+	sort.Strings(current.FederatedMembers)
 }

--- a/internal/lang/dart/plugin_heuristics.go
+++ b/internal/lang/dart/plugin_heuristics.go
@@ -2,23 +2,51 @@ package dart
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
+const federatedPlatformInterfaceSuffix = "_platform_interface"
+
+var federatedPlatformSuffixes = []string{"_android", "_ios", "_macos", "_linux", "_windows", "_web"}
+
 func dependencyInfoFromSpec(dependency string, value any, hasPluginMetadata *bool) dependencyInfo {
 	info := dependencyInfo{
-		PluginLike: isLikelyFlutterPluginPackage(dependency),
+		PluginLike:         isLikelyFlutterPluginPackage(dependency),
+		DeclaredInManifest: true,
 	}
 	fields, ok := toStringMap(value)
 	if !ok {
+		if strings.TrimSpace(asString(value)) != "" {
+			assignDependencySource(&info, dependencySourceHosted, "")
+		}
 		return info
 	}
-	if asString(fields["path"]) != "" {
+
+	if pathValue := strings.TrimSpace(asString(fields["path"])); pathValue != "" {
 		info.LocalPath = true
+		assignDependencySource(&info, dependencySourcePath, pathValue)
 	}
-	if sdkValue := asString(fields["sdk"]); strings.EqualFold(sdkValue, "flutter") {
-		info.FlutterSDK = true
+
+	if gitValue, exists := fields["git"]; exists && gitValue != nil {
+		assignDependencySource(&info, dependencySourceGit, dependencySourceDetail(gitValue, "url", "ref", "path"))
 	}
+
+	if sdkValue := strings.TrimSpace(asString(fields["sdk"])); sdkValue != "" {
+		if strings.EqualFold(sdkValue, "flutter") {
+			info.FlutterSDK = true
+		}
+		assignDependencySource(&info, dependencySourceSDK, sdkValue)
+	}
+
+	if hostedValue, exists := fields["hosted"]; exists && hostedValue != nil {
+		assignDependencySource(&info, dependencySourceHosted, dependencySourceDetail(hostedValue, "url", "name"))
+	}
+
+	if versionValue := strings.TrimSpace(asString(fields["version"])); versionValue != "" {
+		assignDependencySource(&info, dependencySourceHosted, "")
+	}
+
 	if hasPluginMetadataValue(fields) {
 		info.PluginLike = true
 		if hasPluginMetadata != nil {
@@ -26,6 +54,184 @@ func dependencyInfoFromSpec(dependency string, value any, hasPluginMetadata *boo
 		}
 	}
 	return info
+}
+
+func dependencySourceDetail(value any, preferredKeys ...string) string {
+	if fields, ok := toStringMap(value); ok {
+		for _, key := range preferredKeys {
+			if detail := strings.TrimSpace(asString(fields[key])); detail != "" {
+				return detail
+			}
+		}
+		return ""
+	}
+	return strings.TrimSpace(asString(value))
+}
+
+func normalizeDependencySource(source string) string {
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case dependencySourceHosted:
+		return dependencySourceHosted
+	case dependencySourceGit:
+		return dependencySourceGit
+	case dependencySourcePath:
+		return dependencySourcePath
+	case dependencySourceSDK:
+		return dependencySourceSDK
+	default:
+		return strings.ToLower(strings.TrimSpace(source))
+	}
+}
+
+func dependencySourcePriority(source string) int {
+	switch normalizeDependencySource(source) {
+	case dependencySourcePath:
+		return 4
+	case dependencySourceGit:
+		return 3
+	case dependencySourceSDK:
+		return 2
+	case dependencySourceHosted:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func assignDependencySource(info *dependencyInfo, source, detail string) {
+	if info == nil {
+		return
+	}
+	source = normalizeDependencySource(source)
+	detail = strings.TrimSpace(detail)
+	if source == "" {
+		return
+	}
+	if info.Source == "" || dependencySourcePriority(source) > dependencySourcePriority(info.Source) {
+		info.Source = source
+		if detail != "" {
+			info.SourceDetail = detail
+		}
+		return
+	}
+	if info.Source == source && info.SourceDetail == "" {
+		info.SourceDetail = detail
+	}
+}
+
+func annotateFederatedPluginDependencies(dependencies map[string]dependencyInfo, lockPackages map[string]pubspecLockPackage) {
+	if len(dependencies) == 0 {
+		return
+	}
+
+	candidates := collectDependencyCandidates(dependencies, lockPackages)
+	if len(candidates) == 0 {
+		return
+	}
+
+	families := make(map[string]map[string]string)
+	for candidate := range candidates {
+		family, role, ok := federatedFamilyRole(candidate)
+		if !ok {
+			continue
+		}
+		if _, exists := families[family]; !exists {
+			families[family] = make(map[string]string)
+		}
+		families[family][candidate] = role
+	}
+
+	for dependency, info := range dependencies {
+		dependency = normalizeDependencyID(dependency)
+		if dependency == "" {
+			continue
+		}
+
+		family := dependency
+		role := federatedRoleApp
+		if parsedFamily, parsedRole, ok := federatedFamilyRole(dependency); ok {
+			family = parsedFamily
+			role = parsedRole
+		}
+
+		familyMembers := families[family]
+		if len(familyMembers) == 0 {
+			continue
+		}
+
+		members := make([]string, 0, len(familyMembers)+1)
+		if _, hasRoot := candidates[family]; hasRoot {
+			members = append(members, family)
+		}
+		for member := range familyMembers {
+			members = append(members, member)
+		}
+		members = dedupeStrings(members)
+		slices.Sort(members)
+		if len(members) < 2 {
+			continue
+		}
+
+		related := make([]string, 0, len(members)-1)
+		for _, member := range members {
+			if member != dependency {
+				related = append(related, member)
+			}
+		}
+		if len(related) == 0 {
+			continue
+		}
+
+		info.FederatedPlugin = true
+		info.FederatedFamily = family
+		info.FederatedRole = role
+		if dependency == family {
+			info.FederatedRole = federatedRoleApp
+		}
+		info.FederatedMembers = related
+		dependencies[dependency] = info
+	}
+}
+
+func collectDependencyCandidates(dependencies map[string]dependencyInfo, lockPackages map[string]pubspecLockPackage) map[string]struct{} {
+	candidates := make(map[string]struct{}, len(dependencies)+len(lockPackages))
+	for dependency := range dependencies {
+		normalized := normalizeDependencyID(dependency)
+		if normalized != "" {
+			candidates[normalized] = struct{}{}
+		}
+	}
+	for rawName, item := range lockPackages {
+		if dependency := normalizeDependencyID(rawName); dependency != "" {
+			candidates[dependency] = struct{}{}
+		}
+		if dependency := lockPackageName(item.Description); dependency != "" {
+			candidates[dependency] = struct{}{}
+		}
+	}
+	return candidates
+}
+
+func federatedFamilyRole(dependency string) (string, string, bool) {
+	dependency = normalizeDependencyID(dependency)
+	if dependency == "" {
+		return "", "", false
+	}
+	if strings.HasSuffix(dependency, federatedPlatformInterfaceSuffix) {
+		family := strings.TrimSuffix(dependency, federatedPlatformInterfaceSuffix)
+		if family != "" {
+			return family, federatedRolePlatformInterface, true
+		}
+	}
+	for _, suffix := range federatedPlatformSuffixes {
+		if strings.HasSuffix(dependency, suffix) {
+			family := strings.TrimSuffix(dependency, suffix)
+			if family != "" {
+				return family, federatedRolePlatform, true
+			}
+		}
+	}
+	return "", "", false
 }
 
 func hasPluginMetadataValue(value any) bool {
@@ -85,7 +291,7 @@ func isLikelyFlutterPluginPackage(dependency string) bool {
 		strings.HasSuffix(dependency, "_linux"),
 		strings.HasSuffix(dependency, "_windows"),
 		strings.HasSuffix(dependency, "_web"),
-		strings.Contains(dependency, "_platform_interface"):
+		strings.Contains(dependency, federatedPlatformInterfaceSuffix):
 		return true
 	default:
 		return false

--- a/internal/lang/dart/plugin_heuristics.go
+++ b/internal/lang/dart/plugin_heuristics.go
@@ -43,7 +43,7 @@ func dependencyInfoFromSpec(dependency string, value any, hasPluginMetadata *boo
 		assignDependencySource(&info, dependencySourceHosted, dependencySourceDetail(hostedValue, "url", "name"))
 	}
 
-	if versionValue := strings.TrimSpace(asString(fields["version"])); versionValue != "" {
+	if strings.TrimSpace(asString(fields["version"])) != "" {
 		assignDependencySource(&info, dependencySourceHosted, "")
 	}
 
@@ -129,6 +129,22 @@ func annotateFederatedPluginDependencies(dependencies map[string]dependencyInfo,
 		return
 	}
 
+	families := collectFederatedFamilies(candidates)
+	for rawDependency, info := range dependencies {
+		dependency := normalizeDependencyID(rawDependency)
+		if dependency == "" {
+			continue
+		}
+		family, role := resolvedFederatedFamilyRole(dependency)
+		related := relatedFederatedMembers(dependency, family, families[family], candidates)
+		if len(related) == 0 {
+			continue
+		}
+		dependencies[dependency] = applyFederatedMetadata(info, dependency, family, role, related)
+	}
+}
+
+func collectFederatedFamilies(candidates map[string]struct{}) map[string]map[string]string {
 	families := make(map[string]map[string]string)
 	for candidate := range candidates {
 		family, role, ok := federatedFamilyRole(candidate)
@@ -140,57 +156,50 @@ func annotateFederatedPluginDependencies(dependencies map[string]dependencyInfo,
 		}
 		families[family][candidate] = role
 	}
+	return families
+}
 
-	for dependency, info := range dependencies {
-		dependency = normalizeDependencyID(dependency)
-		if dependency == "" {
-			continue
-		}
-
-		family := dependency
-		role := federatedRoleApp
-		if parsedFamily, parsedRole, ok := federatedFamilyRole(dependency); ok {
-			family = parsedFamily
-			role = parsedRole
-		}
-
-		familyMembers := families[family]
-		if len(familyMembers) == 0 {
-			continue
-		}
-
-		members := make([]string, 0, len(familyMembers)+1)
-		if _, hasRoot := candidates[family]; hasRoot {
-			members = append(members, family)
-		}
-		for member := range familyMembers {
-			members = append(members, member)
-		}
-		members = dedupeStrings(members)
-		slices.Sort(members)
-		if len(members) < 2 {
-			continue
-		}
-
-		related := make([]string, 0, len(members)-1)
-		for _, member := range members {
-			if member != dependency {
-				related = append(related, member)
-			}
-		}
-		if len(related) == 0 {
-			continue
-		}
-
-		info.FederatedPlugin = true
-		info.FederatedFamily = family
-		info.FederatedRole = role
-		if dependency == family {
-			info.FederatedRole = federatedRoleApp
-		}
-		info.FederatedMembers = related
-		dependencies[dependency] = info
+func resolvedFederatedFamilyRole(dependency string) (string, string) {
+	if family, role, ok := federatedFamilyRole(dependency); ok {
+		return family, role
 	}
+	return dependency, federatedRoleApp
+}
+
+func relatedFederatedMembers(dependency string, family string, familyMembers map[string]string, candidates map[string]struct{}) []string {
+	if len(familyMembers) == 0 {
+		return nil
+	}
+	members := make([]string, 0, len(familyMembers)+1)
+	if _, hasRoot := candidates[family]; hasRoot {
+		members = append(members, family)
+	}
+	for member := range familyMembers {
+		members = append(members, member)
+	}
+	members = dedupeStrings(members)
+	slices.Sort(members)
+	if len(members) < 2 {
+		return nil
+	}
+	related := make([]string, 0, len(members)-1)
+	for _, member := range members {
+		if member != dependency {
+			related = append(related, member)
+		}
+	}
+	return related
+}
+
+func applyFederatedMetadata(info dependencyInfo, dependency string, family string, role string, related []string) dependencyInfo {
+	info.FederatedPlugin = true
+	info.FederatedFamily = family
+	info.FederatedRole = role
+	if dependency == family {
+		info.FederatedRole = federatedRoleApp
+	}
+	info.FederatedMembers = related
+	return info
 }
 
 func collectDependencyCandidates(dependencies map[string]dependencyInfo, lockPackages map[string]pubspecLockPackage) map[string]struct{} {

--- a/internal/lang/dart/report.go
+++ b/internal/lang/dart/report.go
@@ -2,6 +2,7 @@ package dart
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
@@ -10,29 +11,30 @@ import (
 
 func buildRequestedDartDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
 	minUsageThreshold := resolveMinUsageRecommendationThreshold(req.MinUsagePercentForRecommendations)
+	previewEnabled := req.Features.Enabled(dartSourceAttributionPreviewFeature)
 	switch {
 	case req.Dependency != "":
 		dependency := normalizeDependencyID(req.Dependency)
-		depReport, warnings := buildDependencyReport(dependency, scan, minUsageThreshold)
+		depReport, warnings := buildDependencyReport(dependency, scan, minUsageThreshold, previewEnabled)
 		return []report.DependencyReport{depReport}, warnings
 	case req.TopN > 0:
-		return buildTopDartDependencies(req.TopN, scan, minUsageThreshold)
+		return buildTopDartDependencies(req.TopN, scan, minUsageThreshold, previewEnabled)
 	default:
 		return nil, []string{"no dependency or top-N target provided"}
 	}
 }
 
-func buildTopDartDependencies(topN int, scan scanResult, minUsageThreshold int) ([]report.DependencyReport, []string) {
-	dependencies := allDependencies(scan)
+func buildTopDartDependencies(topN int, scan scanResult, minUsageThreshold int, previewEnabled bool) ([]report.DependencyReport, []string) {
+	dependencies := allDependencies(scan, previewEnabled)
 	return shared.BuildTopReports(topN, dependencies, func(dependency string) (report.DependencyReport, []string) {
-		return buildDependencyReport(dependency, scan, minUsageThreshold)
+		return buildDependencyReport(dependency, scan, minUsageThreshold, previewEnabled)
 	})
 }
 
-func allDependencies(scan scanResult) []string {
+func allDependencies(scan scanResult, previewEnabled bool) []string {
 	set := make(map[string]struct{})
 	for dependency, info := range scan.DeclaredDependencies {
-		if info.LocalPath {
+		if info.LocalPath && !previewEnabled {
 			continue
 		}
 		set[dependency] = struct{}{}
@@ -45,7 +47,7 @@ func allDependencies(scan scanResult) []string {
 	return shared.SortedKeys(set)
 }
 
-func buildDependencyReport(dependency string, scan scanResult, minUsageThreshold int) (report.DependencyReport, []string) {
+func buildDependencyReport(dependency string, scan scanResult, minUsageThreshold int, previewEnabled bool) (report.DependencyReport, []string) {
 	stats := shared.BuildDependencyStats(dependency, dartFileUsages(scan), normalizeDependencyID)
 	meta, declared := scan.DeclaredDependencies[dependency]
 
@@ -79,20 +81,55 @@ func buildDependencyReport(dependency string, scan scanResult, minUsageThreshold
 			Rationale: "Undeclared dependencies can break reproducible builds and reviews.",
 		})
 	}
+
 	if declared {
+		if previewEnabled {
+			dep.Provenance = buildDartDependencyProvenance(meta)
+		}
 		if meta.Override {
 			dep.RiskCues = append(dep.RiskCues, report.RiskCue{
 				Code:     "dependency-override",
 				Severity: "medium",
-				Message:  "dependency is marked in dependency_overrides",
+				Message:  dependencyOverrideMessage(meta, previewEnabled),
 			})
 			dep.Recommendations = append(dep.Recommendations, report.Recommendation{
 				Code:      "review-dependency-override",
 				Priority:  "medium",
-				Message:   "Review dependency_overrides usage and limit overrides to active blockers.",
+				Message:   dependencyOverrideRecommendation(meta, previewEnabled),
 				Rationale: "Overrides can hide upstream changes and create drift over time.",
 			})
 		}
+
+		source := dependencySource(meta)
+		if previewEnabled {
+			switch source {
+			case dependencySourcePath:
+				dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+					Code:     "local-path-dependency",
+					Severity: "low",
+					Message:  "dependency is sourced from a local path",
+				})
+				dep.Recommendations = append(dep.Recommendations, report.Recommendation{
+					Code:      "review-local-path-dependency",
+					Priority:  "medium",
+					Message:   "Treat local path dependencies as internal package edges before removal decisions.",
+					Rationale: "Local package links are often workspace-internal and not ordinary third-party surface.",
+				})
+			case dependencySourceGit:
+				dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+					Code:     "git-dependency-source",
+					Severity: "medium",
+					Message:  "dependency resolves from a git source",
+				})
+				dep.Recommendations = append(dep.Recommendations, report.Recommendation{
+					Code:      "pin-git-dependency",
+					Priority:  "medium",
+					Message:   "Pin git dependencies to reviewed refs and monitor upstream revision drift.",
+					Rationale: "Git-sourced dependencies can move outside normal hosted package release workflows.",
+				})
+			}
+		}
+
 		if meta.FlutterSDK {
 			dep.RiskCues = append(dep.RiskCues, report.RiskCue{
 				Code:     "flutter-sdk-dependency",
@@ -100,20 +137,31 @@ func buildDependencyReport(dependency string, scan scanResult, minUsageThreshold
 				Message:  "dependency is provided by the Flutter SDK",
 			})
 		}
-		if meta.PluginLike {
+
+		pluginLike := meta.PluginLike || (previewEnabled && meta.FederatedPlugin)
+		if pluginLike {
 			dep.RiskCues = append(dep.RiskCues, report.RiskCue{
 				Code:     "flutter-plugin-dependency",
 				Severity: "medium",
-				Message:  "dependency appears to be a Flutter plugin package with platform bindings",
+				Message:  pluginDependencyMessage(meta, previewEnabled),
 			})
 			dep.Recommendations = append(dep.Recommendations, report.Recommendation{
 				Code:      "audit-plugin-removal",
 				Priority:  "medium",
-				Message:   "Audit native platform impact before removing this Flutter plugin dependency.",
+				Message:   pluginRemovalRecommendation(meta, previewEnabled),
 				Rationale: "Plugin dependencies can bind Android/iOS platform code beyond Dart call sites.",
 			})
 		}
+
+		if previewEnabled && meta.FederatedPlugin {
+			dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+				Code:     "flutter-federated-plugin-family",
+				Severity: "medium",
+				Message:  federatedPluginMessage(meta),
+			})
+		}
 	}
+
 	if stats.WildcardImports > 0 {
 		dep.RiskCues = append(dep.RiskCues, report.RiskCue{
 			Code:     "broad-imports",
@@ -135,7 +183,7 @@ func buildDependencyReport(dependency string, scan scanResult, minUsageThreshold
 			Rationale: "Low observed usage can indicate avoidable dependency surface area.",
 		})
 	}
-	if declared && stats.TotalCount == 0 {
+	if declared && stats.TotalCount == 0 && (!previewEnabled || !meta.LocalPath) {
 		dep.Recommendations = append(dep.Recommendations, report.Recommendation{
 			Code:      "remove-unused-dependency",
 			Priority:  "high",
@@ -148,6 +196,120 @@ func buildDependencyReport(dependency string, scan scanResult, minUsageThreshold
 	shared.SortRecommendations(dep.Recommendations, recommendationPriorityRank)
 
 	return dep, warnings
+}
+
+func dependencySource(meta dependencyInfo) string {
+	source := normalizeDependencySource(meta.Source)
+	if source != "" {
+		return source
+	}
+	if meta.LocalPath {
+		return dependencySourcePath
+	}
+	if meta.FlutterSDK {
+		return dependencySourceSDK
+	}
+	return ""
+}
+
+func dependencySourceLabel(meta dependencyInfo) string {
+	switch dependencySource(meta) {
+	case dependencySourcePath:
+		return "local path"
+	case dependencySourceGit:
+		return "git"
+	case dependencySourceHosted:
+		return "hosted"
+	case dependencySourceSDK:
+		if meta.FlutterSDK {
+			return "Flutter SDK"
+		}
+		return "SDK"
+	default:
+		return ""
+	}
+}
+
+func dependencyOverrideMessage(meta dependencyInfo, previewEnabled bool) string {
+	if !previewEnabled {
+		return "dependency is marked in dependency_overrides"
+	}
+	if label := dependencySourceLabel(meta); label != "" {
+		return fmt.Sprintf("dependency is marked in dependency_overrides (%s source)", label)
+	}
+	return "dependency is marked in dependency_overrides"
+}
+
+func dependencyOverrideRecommendation(meta dependencyInfo, previewEnabled bool) string {
+	if !previewEnabled {
+		return "Review dependency_overrides usage and limit overrides to active blockers."
+	}
+	if label := dependencySourceLabel(meta); label != "" {
+		return fmt.Sprintf("Review dependency_overrides usage for this %s dependency and limit overrides to active blockers.", label)
+	}
+	return "Review dependency_overrides usage and limit overrides to active blockers."
+}
+
+func pluginDependencyMessage(meta dependencyInfo, previewEnabled bool) string {
+	if !previewEnabled || !meta.FederatedPlugin || meta.FederatedFamily == "" {
+		return "dependency appears to be a Flutter plugin package with platform bindings"
+	}
+	return fmt.Sprintf("dependency is part of Flutter federated plugin family %q with platform bindings", meta.FederatedFamily)
+}
+
+func pluginRemovalRecommendation(meta dependencyInfo, previewEnabled bool) string {
+	if !previewEnabled || !meta.FederatedPlugin || meta.FederatedFamily == "" {
+		return "Audit native platform impact before removing this Flutter plugin dependency."
+	}
+	return fmt.Sprintf("Audit platform impact across the %q federated plugin family before removing this dependency.", meta.FederatedFamily)
+}
+
+func federatedPluginMessage(meta dependencyInfo) string {
+	if meta.FederatedFamily == "" {
+		return "dependency participates in a Flutter federated plugin family"
+	}
+	if len(meta.FederatedMembers) == 0 {
+		return fmt.Sprintf("dependency participates in the %q Flutter federated plugin family", meta.FederatedFamily)
+	}
+	return fmt.Sprintf("dependency participates in the %q Flutter federated plugin family with related packages: %s", meta.FederatedFamily, strings.Join(meta.FederatedMembers, ", "))
+}
+
+func buildDartDependencyProvenance(meta dependencyInfo) *report.DependencyProvenance {
+	source := dependencySource(meta)
+	if source == "" {
+		return nil
+	}
+	signals := make([]string, 0, 6)
+	if meta.DeclaredInManifest {
+		signals = append(signals, pubspecYAMLName)
+	}
+	if meta.ResolvedInLock {
+		signals = append(signals, pubspecLockName)
+	}
+	if meta.SourceDetail != "" {
+		signals = append(signals, meta.SourceDetail)
+	}
+	if meta.Override {
+		signals = append(signals, "dependency_overrides")
+	}
+	if meta.FederatedPlugin && meta.FederatedFamily != "" {
+		signals = append(signals, "federated:"+meta.FederatedFamily)
+	}
+	signals = dedupeStrings(signals)
+
+	confidence := ""
+	switch {
+	case meta.ResolvedInLock:
+		confidence = "high"
+	case meta.DeclaredInManifest:
+		confidence = "medium"
+	}
+
+	return &report.DependencyProvenance{
+		Source:     source,
+		Confidence: confidence,
+		Signals:    signals,
+	}
 }
 
 func dartFileUsages(scan scanResult) []shared.FileUsage {

--- a/internal/lang/dart/report.go
+++ b/internal/lang/dart/report.go
@@ -69,133 +69,159 @@ func buildDependencyReport(dependency string, scan scanResult, minUsageThreshold
 	}
 
 	if !declared && stats.HasImports {
-		dep.RiskCues = append(dep.RiskCues, report.RiskCue{
-			Code:     "undeclared-package-import",
-			Severity: "medium",
-			Message:  "package import was detected but the dependency is not declared in pubspec",
-		})
-		dep.Recommendations = append(dep.Recommendations, report.Recommendation{
-			Code:      "declare-missing-dependency",
-			Priority:  "high",
-			Message:   fmt.Sprintf("Add %q to pubspec dependencies or remove the import.", dependency),
-			Rationale: "Undeclared dependencies can break reproducible builds and reviews.",
-		})
+		addUndeclaredDependencySignals(&dep, dependency)
 	}
 
 	if declared {
-		if previewEnabled {
-			dep.Provenance = buildDartDependencyProvenance(meta)
-		}
-		if meta.Override {
-			dep.RiskCues = append(dep.RiskCues, report.RiskCue{
-				Code:     "dependency-override",
-				Severity: "medium",
-				Message:  dependencyOverrideMessage(meta, previewEnabled),
-			})
-			dep.Recommendations = append(dep.Recommendations, report.Recommendation{
-				Code:      "review-dependency-override",
-				Priority:  "medium",
-				Message:   dependencyOverrideRecommendation(meta, previewEnabled),
-				Rationale: "Overrides can hide upstream changes and create drift over time.",
-			})
-		}
-
-		source := dependencySource(meta)
-		if previewEnabled {
-			switch source {
-			case dependencySourcePath:
-				dep.RiskCues = append(dep.RiskCues, report.RiskCue{
-					Code:     "local-path-dependency",
-					Severity: "low",
-					Message:  "dependency is sourced from a local path",
-				})
-				dep.Recommendations = append(dep.Recommendations, report.Recommendation{
-					Code:      "review-local-path-dependency",
-					Priority:  "medium",
-					Message:   "Treat local path dependencies as internal package edges before removal decisions.",
-					Rationale: "Local package links are often workspace-internal and not ordinary third-party surface.",
-				})
-			case dependencySourceGit:
-				dep.RiskCues = append(dep.RiskCues, report.RiskCue{
-					Code:     "git-dependency-source",
-					Severity: "medium",
-					Message:  "dependency resolves from a git source",
-				})
-				dep.Recommendations = append(dep.Recommendations, report.Recommendation{
-					Code:      "pin-git-dependency",
-					Priority:  "medium",
-					Message:   "Pin git dependencies to reviewed refs and monitor upstream revision drift.",
-					Rationale: "Git-sourced dependencies can move outside normal hosted package release workflows.",
-				})
-			}
-		}
-
-		if meta.FlutterSDK {
-			dep.RiskCues = append(dep.RiskCues, report.RiskCue{
-				Code:     "flutter-sdk-dependency",
-				Severity: "low",
-				Message:  "dependency is provided by the Flutter SDK",
-			})
-		}
-
-		pluginLike := meta.PluginLike || (previewEnabled && meta.FederatedPlugin)
-		if pluginLike {
-			dep.RiskCues = append(dep.RiskCues, report.RiskCue{
-				Code:     "flutter-plugin-dependency",
-				Severity: "medium",
-				Message:  pluginDependencyMessage(meta, previewEnabled),
-			})
-			dep.Recommendations = append(dep.Recommendations, report.Recommendation{
-				Code:      "audit-plugin-removal",
-				Priority:  "medium",
-				Message:   pluginRemovalRecommendation(meta, previewEnabled),
-				Rationale: "Plugin dependencies can bind Android/iOS platform code beyond Dart call sites.",
-			})
-		}
-
-		if previewEnabled && meta.FederatedPlugin {
-			dep.RiskCues = append(dep.RiskCues, report.RiskCue{
-				Code:     "flutter-federated-plugin-family",
-				Severity: "medium",
-				Message:  federatedPluginMessage(meta),
-			})
-		}
+		applyDeclaredDependencySignals(&dep, meta, previewEnabled)
 	}
 
 	if stats.WildcardImports > 0 {
-		dep.RiskCues = append(dep.RiskCues, report.RiskCue{
-			Code:     "broad-imports",
-			Severity: "low",
-			Message:  "broad import/export directives may reduce static attribution precision",
-		})
-		dep.Recommendations = append(dep.Recommendations, report.Recommendation{
-			Code:      "prefer-explicit-imports",
-			Priority:  "low",
-			Message:   "Prefer explicit imports (`show`) or prefixes (`as`) for tighter attribution.",
-			Rationale: "Explicit import surfaces improve confidence in static usage analysis.",
-		})
+		addBroadImportSignals(&dep)
 	}
 	if dep.TotalExportsCount > 0 && dep.UsedPercent > 0 && dep.UsedPercent < float64(minUsageThreshold) {
-		dep.Recommendations = append(dep.Recommendations, report.Recommendation{
-			Code:      "reduce-dart-surface-area",
-			Priority:  "low",
-			Message:   fmt.Sprintf("Only %.1f%% of %q imports appear used; review if a leaner package would suffice.", dep.UsedPercent, dependency),
-			Rationale: "Low observed usage can indicate avoidable dependency surface area.",
-		})
+		addLowUsageRecommendation(&dep, dependency)
 	}
 	if declared && stats.TotalCount == 0 && (!previewEnabled || !meta.LocalPath) {
-		dep.Recommendations = append(dep.Recommendations, report.Recommendation{
-			Code:      "remove-unused-dependency",
-			Priority:  "high",
-			Message:   "No imports were detected for this declared dependency; consider removing it.",
-			Rationale: "Unused dependencies increase attack and maintenance surface.",
-		})
+		addUnusedDeclaredDependencyRecommendation(&dep)
 	}
 
 	shared.SortRiskCues(dep.RiskCues)
 	shared.SortRecommendations(dep.Recommendations, recommendationPriorityRank)
 
 	return dep, warnings
+}
+
+func addUndeclaredDependencySignals(dep *report.DependencyReport, dependency string) {
+	dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+		Code:     "undeclared-package-import",
+		Severity: "medium",
+		Message:  "package import was detected but the dependency is not declared in pubspec",
+	})
+	dep.Recommendations = append(dep.Recommendations, report.Recommendation{
+		Code:      "declare-missing-dependency",
+		Priority:  "high",
+		Message:   fmt.Sprintf("Add %q to pubspec dependencies or remove the import.", dependency),
+		Rationale: "Undeclared dependencies can break reproducible builds and reviews.",
+	})
+}
+
+func applyDeclaredDependencySignals(dep *report.DependencyReport, meta dependencyInfo, previewEnabled bool) {
+	if previewEnabled {
+		dep.Provenance = buildDartDependencyProvenance(meta)
+	}
+	if meta.Override {
+		addOverrideSignals(dep, meta, previewEnabled)
+	}
+	if previewEnabled {
+		addPreviewDependencySourceSignals(dep, meta)
+	}
+	if meta.FlutterSDK {
+		dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+			Code:     "flutter-sdk-dependency",
+			Severity: "low",
+			Message:  "dependency is provided by the Flutter SDK",
+		})
+	}
+	if meta.PluginLike || (previewEnabled && meta.FederatedPlugin) {
+		addPluginSignals(dep, meta, previewEnabled)
+	}
+	if previewEnabled && meta.FederatedPlugin {
+		dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+			Code:     "flutter-federated-plugin-family",
+			Severity: "medium",
+			Message:  federatedPluginMessage(meta),
+		})
+	}
+}
+
+func addOverrideSignals(dep *report.DependencyReport, meta dependencyInfo, previewEnabled bool) {
+	dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+		Code:     "dependency-override",
+		Severity: "medium",
+		Message:  dependencyOverrideMessage(meta, previewEnabled),
+	})
+	dep.Recommendations = append(dep.Recommendations, report.Recommendation{
+		Code:      "review-dependency-override",
+		Priority:  "medium",
+		Message:   dependencyOverrideRecommendation(meta, previewEnabled),
+		Rationale: "Overrides can hide upstream changes and create drift over time.",
+	})
+}
+
+func addPreviewDependencySourceSignals(dep *report.DependencyReport, meta dependencyInfo) {
+	switch dependencySource(meta) {
+	case dependencySourcePath:
+		dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+			Code:     "local-path-dependency",
+			Severity: "low",
+			Message:  "dependency is sourced from a local path",
+		})
+		dep.Recommendations = append(dep.Recommendations, report.Recommendation{
+			Code:      "review-local-path-dependency",
+			Priority:  "medium",
+			Message:   "Treat local path dependencies as internal package edges before removal decisions.",
+			Rationale: "Local package links are often workspace-internal and not ordinary third-party surface.",
+		})
+	case dependencySourceGit:
+		dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+			Code:     "git-dependency-source",
+			Severity: "medium",
+			Message:  "dependency resolves from a git source",
+		})
+		dep.Recommendations = append(dep.Recommendations, report.Recommendation{
+			Code:      "pin-git-dependency",
+			Priority:  "medium",
+			Message:   "Pin git dependencies to reviewed refs and monitor upstream revision drift.",
+			Rationale: "Git-sourced dependencies can move outside normal hosted package release workflows.",
+		})
+	}
+}
+
+func addPluginSignals(dep *report.DependencyReport, meta dependencyInfo, previewEnabled bool) {
+	dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+		Code:     "flutter-plugin-dependency",
+		Severity: "medium",
+		Message:  pluginDependencyMessage(meta, previewEnabled),
+	})
+	dep.Recommendations = append(dep.Recommendations, report.Recommendation{
+		Code:      "audit-plugin-removal",
+		Priority:  "medium",
+		Message:   pluginRemovalRecommendation(meta, previewEnabled),
+		Rationale: "Plugin dependencies can bind Android/iOS platform code beyond Dart call sites.",
+	})
+}
+
+func addBroadImportSignals(dep *report.DependencyReport) {
+	dep.RiskCues = append(dep.RiskCues, report.RiskCue{
+		Code:     "broad-imports",
+		Severity: "low",
+		Message:  "broad import/export directives may reduce static attribution precision",
+	})
+	dep.Recommendations = append(dep.Recommendations, report.Recommendation{
+		Code:      "prefer-explicit-imports",
+		Priority:  "low",
+		Message:   "Prefer explicit imports (`show`) or prefixes (`as`) for tighter attribution.",
+		Rationale: "Explicit import surfaces improve confidence in static usage analysis.",
+	})
+}
+
+func addLowUsageRecommendation(dep *report.DependencyReport, dependency string) {
+	dep.Recommendations = append(dep.Recommendations, report.Recommendation{
+		Code:      "reduce-dart-surface-area",
+		Priority:  "low",
+		Message:   fmt.Sprintf("Only %.1f%% of %q imports appear used; review if a leaner package would suffice.", dep.UsedPercent, dependency),
+		Rationale: "Low observed usage can indicate avoidable dependency surface area.",
+	})
+}
+
+func addUnusedDeclaredDependencyRecommendation(dep *report.DependencyReport) {
+	dep.Recommendations = append(dep.Recommendations, report.Recommendation{
+		Code:      "remove-unused-dependency",
+		Priority:  "high",
+		Message:   "No imports were detected for this declared dependency; consider removing it.",
+		Rationale: "Unused dependencies increase attack and maintenance surface.",
+	})
 }
 
 func dependencySource(meta dependencyInfo) string {

--- a/internal/lang/dart/scan.go
+++ b/internal/lang/dart/scan.go
@@ -74,9 +74,6 @@ func collectManifestRoots(manifests []packageManifest) map[string]struct{} {
 	roots := make(map[string]struct{}, len(manifests))
 	for _, manifest := range manifests {
 		root := filepath.Clean(strings.TrimSpace(manifest.Root))
-		if root == "" {
-			continue
-		}
 		roots[root] = struct{}{}
 	}
 	return roots
@@ -177,9 +174,9 @@ func scanDartSourceFile(repoPath, path string, depLookup map[string]dependencyIn
 	if err != nil {
 		return err
 	}
-	relativePath, relErr := filepath.Rel(repoPath, path)
-	if relErr != nil {
-		relativePath = path
+	relativePath := path
+	if relative, relErr := filepath.Rel(repoPath, path); relErr == nil && strings.TrimSpace(relative) != "" {
+		relativePath = relative
 	}
 	imports := parseDartImports(content, relativePath, depLookup, result.UnresolvedImports)
 	result.Files = append(result.Files, fileScan{
@@ -220,9 +217,6 @@ func parseImportDirective(line string) (string, string, string, bool) {
 	kind := strings.TrimSpace(strings.ToLower(match[1]))
 	module := strings.TrimSpace(match[2])
 	clause := strings.TrimSpace(match[3])
-	if kind != "import" && kind != "export" {
-		return "", "", "", false
-	}
 	return kind, module, clause, true
 }
 
@@ -282,11 +276,7 @@ func extractAlias(clause string) string {
 	if len(match) != 2 {
 		return ""
 	}
-	alias := strings.TrimSpace(match[1])
-	if !identPattern.MatchString(alias) {
-		return ""
-	}
-	return alias
+	return strings.TrimSpace(match[1])
 }
 
 func parseShowSymbols(clause string) []string {

--- a/internal/lang/dart/types.go
+++ b/internal/lang/dart/types.go
@@ -12,14 +12,28 @@ type Adapter struct {
 }
 
 const (
-	pubspecYAMLName      = "pubspec.yaml"
-	pubspecYMLName       = "pubspec.yml"
-	pubspecLockName      = "pubspec.lock"
-	maxDetectionEntries  = 2048
-	maxManifestCount     = 256
-	maxScanFiles         = 4096
-	maxScannableDartFile = 2 * 1024 * 1024
-	maxWarningSamples    = 5
+	pubspecYAMLName                     = "pubspec.yaml"
+	pubspecYMLName                      = "pubspec.yml"
+	pubspecLockName                     = "pubspec.lock"
+	dartSourceAttributionPreviewFeature = "dart-source-attribution-preview"
+	maxDetectionEntries                 = 2048
+	maxManifestCount                    = 256
+	maxScanFiles                        = 4096
+	maxScannableDartFile                = 2 * 1024 * 1024
+	maxWarningSamples                   = 5
+)
+
+const (
+	dependencySourceHosted = "hosted"
+	dependencySourceGit    = "git"
+	dependencySourcePath   = "path"
+	dependencySourceSDK    = "sdk"
+)
+
+const (
+	federatedRoleApp               = "app"
+	federatedRolePlatform          = "platform"
+	federatedRolePlatformInterface = "platform-interface"
 )
 
 var dartRootSignals = []shared.RootSignal{
@@ -29,14 +43,21 @@ var dartRootSignals = []shared.RootSignal{
 }
 
 type dependencyInfo struct {
-	Runtime    bool
-	Dev        bool
-	Override   bool
-	LocalPath  bool
-	FlutterSDK bool
-	PluginLike bool
-	Source     string
-	Version    string
+	Runtime            bool
+	Dev                bool
+	Override           bool
+	LocalPath          bool
+	FlutterSDK         bool
+	PluginLike         bool
+	Source             string
+	SourceDetail       string
+	Version            string
+	DeclaredInManifest bool
+	ResolvedInLock     bool
+	FederatedPlugin    bool
+	FederatedFamily    string
+	FederatedRole      string
+	FederatedMembers   []string
 }
 
 type packageManifest struct {

--- a/internal/language/adapter.go
+++ b/internal/language/adapter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/report"
 )
 
@@ -17,6 +18,7 @@ type Request struct {
 	TopN                              int
 	SuggestOnly                       bool
 	RuntimeProfile                    string
+	Features                          featureflags.Set
 	MinUsagePercentForRecommendations *int
 	RemovalCandidateWeights           *report.RemovalCandidateWeights
 	IncludeRegistryProvenance         bool

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -326,8 +326,11 @@ func TestManifestEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("release manifest: %v", err)
 	}
-	if len(manifest) != 0 {
-		t.Fatalf("expected empty embedded manifest, got %#v", manifest)
+	if len(manifest) == 0 {
+		t.Fatalf("expected embedded manifest entries, got %#v", manifest)
+	}
+	if manifest[0].Name != "dart-source-attribution-preview" || manifest[0].EnabledByDefault {
+		t.Fatalf("expected dart-source-attribution-preview default-off in release channel, got %#v", manifest[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add preview-gated Dart/Flutter dependency source attribution for hosted, git, path, and SDK-backed dependencies
- improve federated plugin-family attribution and dependency_overrides messaging under preview mode
- wire preview feature flag plumbing through analysis/app layers and update feature tooling expectations

## Testing
- go test ./internal/lang/dart ./internal/featureflags ./internal/app ./internal/analysis ./tools/featureflag
- go test ./...
- pre-commit make ci gate (lint/security/vuln/test/race/coverage/memory benchmark/build)

Closes #450