### PR TITLE
feat(swift): add carthage support behind preview flag

### DIFF
--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -47,8 +47,8 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 	if req.LowConfidenceWarningPercent != nil {
 		baseKey["lowConfidenceWarningPercent"] = *req.LowConfidenceWarningPercent
 	}
-	if enabledFeatures := req.Features.EnabledCodes(); len(enabledFeatures) > 0 {
-		baseKey["enabledFeatures"] = enabledFeatures
+	if featureSnapshot := req.Features.Snapshot(); len(featureSnapshot) > 0 {
+		baseKey["features"] = featureSnapshot
 	}
 	if len(req.LicenseDenyList) > 0 {
 		baseKey["licenseDeny"] = req.LicenseDenyList

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -174,33 +174,45 @@ func TestAnalysisCachePrepareEntryIncludesLicensePolicyInputs(t *testing.T) {
 	}
 }
 
-func TestAnalysisCachePrepareEntryIncludesEnabledFeatures(t *testing.T) {
+func TestAnalysisCachePrepareEntryIncludesFeatureFlags(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "console.log('hello')\n")
-	request := Request{
+	req := Request{
 		RepoPath: repo,
 		Cache: &CacheOptions{
 			Enabled: true,
 			Path:    filepath.Join(repo, cacheTestDirectoryName),
 		},
 	}
-	cache := newAnalysisCache(request, repo)
+	cache := newAnalysisCache(req, repo)
 
-	baseReq := Request{RepoPath: repo, TopN: 1}
-	entryA, err := cache.prepareEntry(baseReq, "cachelang", repo)
-	if err != nil {
-		t.Fatalf("prepare entry A: %v", err)
-	}
+	disabledSet := mustResolveFeatureSet(t, false)
+	enabledSet := mustResolveFeatureSet(t, true)
 
-	withFeature := baseReq
-	withFeature.Features = mustEnabledFeatureSet(t, "dart-source-attribution-preview")
-	entryB, err := cache.prepareEntry(withFeature, "cachelang", repo)
+	entryDisabled, err := cache.prepareEntry(Request{RepoPath: repo, TopN: 1, Features: disabledSet}, "cachelang", repo)
 	if err != nil {
-		t.Fatalf("prepare entry B: %v", err)
+		t.Fatalf("prepare disabled feature entry: %v", err)
 	}
-	if entryA.KeyDigest == entryB.KeyDigest {
-		t.Fatalf("expected different cache keys when enabled feature set changes")
+	entryEnabled, err := cache.prepareEntry(Request{RepoPath: repo, TopN: 1, Features: enabledSet}, "cachelang", repo)
+	if err != nil {
+		t.Fatalf("prepare enabled feature entry: %v", err)
 	}
+	if entryDisabled.KeyDigest == entryEnabled.KeyDigest {
+		t.Fatalf("expected different cache keys when feature flag state changes")
+	}
+}
+
+func mustResolveFeatureSet(t *testing.T, enabled bool) featureflags.Set {
+	t.Helper()
+	options := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
+	if enabled {
+		options.Enable = []string{"swift-carthage-preview"}
+	}
+	resolved, err := featureflags.DefaultRegistry().Resolve(options)
+	if err != nil {
+		t.Fatalf("resolve feature set: %v", err)
+	}
+	return resolved
 }
 
 func TestAnalysisCacheWarnTakeWarningsAndSnapshot(t *testing.T) {
@@ -325,26 +337,6 @@ func assertLookupMissWithReason(t *testing.T, cache *analysisCache, entry cacheE
 	if len(cache.metadata.Invalidations) == 0 || cache.metadata.Invalidations[len(cache.metadata.Invalidations)-1].Reason != expectedReason {
 		t.Fatalf("expected %s invalidation, got %#v", expectedReason, cache.metadata.Invalidations)
 	}
-}
-
-func mustEnabledFeatureSet(t *testing.T, name string) featureflags.Set {
-	t.Helper()
-	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
-		Code:      "LOP-FEAT-0001",
-		Name:      name,
-		Lifecycle: featureflags.LifecyclePreview,
-	}})
-	if err != nil {
-		t.Fatalf("new feature registry: %v", err)
-	}
-	resolved, err := registry.Resolve(featureflags.ResolveOptions{
-		Channel: featureflags.ChannelDev,
-		Enable:  []string{name},
-	})
-	if err != nil {
-		t.Fatalf("resolve feature set: %v", err)
-	}
-	return resolved
 }
 
 func TestAnalysisCacheLookupInvalidationBranches(t *testing.T) {

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 )
@@ -246,6 +247,104 @@ func TestServiceAnalyseSwiftCocoaPodsAutoAndAllModes(t *testing.T) {
 			t.Fatalf("expected js-ts results in all-mode report, got %#v", reportData.Dependencies)
 		}
 	})
+}
+
+func TestServiceAnalyseSwiftCarthageAutoModeBehindPreviewFlag(t *testing.T) {
+	repo := t.TempDir()
+	writeSwiftCarthageAnalysisFixture(t, repo)
+	service := NewService()
+
+	withoutFlag, err := service.Analyse(context.Background(), Request{
+		RepoPath:   repo,
+		Dependency: "rxswift",
+		Language:   "auto",
+	})
+	if err != nil {
+		t.Fatalf("analyse swift Carthage auto without flag: %v", err)
+	}
+	if dep := singleDependencyReport(t, withoutFlag); dep.TotalExportsCount != 0 {
+		t.Fatalf("expected preview-off analysis to avoid Carthage attribution, got %#v", dep)
+	}
+
+	reportData, err := service.Analyse(context.Background(), Request{
+		RepoPath:   repo,
+		Dependency: "rxswift",
+		Language:   "auto",
+		Features:   mustResolveSwiftCarthagePreviewSet(t, true),
+	})
+	if err != nil {
+		t.Fatalf("analyse swift Carthage auto with flag: %v", err)
+	}
+	dep := singleDependencyReport(t, reportData)
+	if dep.Language != "swift" || dep.TotalExportsCount == 0 {
+		t.Fatalf("expected Carthage-attributed swift dependency in auto mode, got %#v", dep)
+	}
+}
+
+func TestServiceAnalyseSwiftCarthageAllModeBehindPreviewFlag(t *testing.T) {
+	repo := t.TempDir()
+	writeJSFixture(t, repo)
+	writeSwiftCarthageAnalysisFixture(t, repo)
+
+	reportData, err := NewService().Analyse(context.Background(), Request{
+		RepoPath: repo,
+		TopN:     10,
+		Language: "all",
+		Features: mustResolveSwiftCarthagePreviewSet(t, true),
+	})
+	if err != nil {
+		t.Fatalf("analyse all mixed Swift Carthage repo: %v", err)
+	}
+	assertReportLanguages(t, reportData.Dependencies, "swift", "js-ts")
+}
+
+func writeSwiftCarthageAnalysisFixture(t *testing.T, repo string) {
+	t.Helper()
+	writeFile(t, filepath.Join(repo, "Cartfile"), "github \"ReactiveX/RxSwift\" ~> 6.0\n")
+	writeFile(t, filepath.Join(repo, "Cartfile.resolved"), "github \"ReactiveX/RxSwift\" \"6.8.0\"\n")
+	writeFile(t, filepath.Join(repo, "Sources", "App", "main.swift"), "import RxSwift\nlet value = DisposeBag()\n")
+}
+
+func writeJSFixture(t *testing.T, repo string) {
+	t.Helper()
+	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
+	writeFile(t, filepath.Join(repo, indexJSFileName), lodashMapUsageJS)
+	writeFile(t, filepath.Join(repo, "node_modules", "lodash", packageJSONFileName), nodeMainPackageJSON)
+	writeFile(t, filepath.Join(repo, "node_modules", "lodash", indexJSFileName), mapExportJSContent)
+}
+
+func singleDependencyReport(t *testing.T, reportData report.Report) report.DependencyReport {
+	t.Helper()
+	if len(reportData.Dependencies) != 1 {
+		t.Fatalf(expectedOneDependencyText, len(reportData.Dependencies))
+	}
+	return reportData.Dependencies[0]
+}
+
+func assertReportLanguages(t *testing.T, dependencies []report.DependencyReport, expected ...string) {
+	t.Helper()
+	languages := make([]string, 0, len(dependencies))
+	for _, dep := range dependencies {
+		languages = append(languages, dep.Language)
+	}
+	for _, languageID := range expected {
+		if !slices.Contains(languages, languageID) {
+			t.Fatalf("expected language %q in dependencies, got %#v", languageID, languages)
+		}
+	}
+}
+
+func mustResolveSwiftCarthagePreviewSet(t *testing.T, enabled bool) featureflags.Set {
+	t.Helper()
+	options := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
+	if enabled {
+		options.Enable = []string{"swift-carthage-preview"}
+	}
+	resolved, err := featureflags.DefaultRegistry().Resolve(options)
+	if err != nil {
+		t.Fatalf("resolve swift Carthage preview feature set: %v", err)
+	}
+	return resolved
 }
 
 func TestServiceAnalyseRuntimeCorrelationIntegration(t *testing.T) {

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/thresholds"
 )
@@ -94,6 +95,46 @@ func TestExecuteAnalyseForwardsRustRecommendationThreshold(t *testing.T) {
 	}
 	if analyzer.lastReq.MinUsagePercentForRecommendations == nil || *analyzer.lastReq.MinUsagePercentForRecommendations != 70 {
 		t.Fatalf("expected min-usage threshold to be forwarded for rust analysis, got %#v", analyzer.lastReq.MinUsagePercentForRecommendations)
+	}
+}
+
+func TestExecuteAnalyseForwardsFeatureFlags(t *testing.T) {
+	analyzer := &fakeAnalyzer{
+		report: report.Report{
+			RepoPath:      ".",
+			Dependencies:  []report.DependencyReport{{Name: "rxswift", Language: "swift"}},
+			SchemaVersion: "0.1.0",
+		},
+	}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
+		Code:      "LOP-FEAT-0001",
+		Name:      "swift-carthage-preview",
+		Lifecycle: featureflags.LifecyclePreview,
+	}})
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	resolved, err := registry.Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  []string{"swift-carthage-preview"},
+	})
+	if err != nil {
+		t.Fatalf("resolve feature set: %v", err)
+	}
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.Analyse.TopN = 1
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.Features = resolved
+
+	if _, err := application.Execute(context.Background(), req); err != nil {
+		t.Fatalf(executeAnalyseErrFmt, err)
+	}
+	if !analyzer.lastReq.Features.Enabled("swift-carthage-preview") {
+		t.Fatalf("expected analyse request features to be forwarded, got %#v", analyzer.lastReq.Features)
 	}
 }
 

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -67,6 +67,7 @@ func TestExecuteFeaturesReleaseChannelAndEmptyRegistry(t *testing.T) {
 	}
 	if !strings.Contains(emptyOutput, "dart-source-attribution-preview") ||
 		!strings.Contains(emptyOutput, "lockfile-drift-ecosystem-expansion-preview") ||
+		!strings.Contains(emptyOutput, "swift-carthage-preview") ||
 		!strings.Contains(emptyOutput, "false") {
 		t.Fatalf("expected default feature table to include embedded preview flags disabled by default, got %q", emptyOutput)
 	}

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -41,14 +41,17 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 		t.Fatalf("expected embedded default registry to be valid, got %v", err)
 	}
 	defaultFlags := DefaultRegistry().Flags()
-	if len(defaultFlags) != 2 {
-		t.Fatalf("expected embedded default registry to contain two feature flags, got %#v", defaultFlags)
+	if len(defaultFlags) != 3 {
+		t.Fatalf("expected embedded default registry to contain three feature flags, got %#v", defaultFlags)
 	}
 	if got, ok := DefaultRegistry().Lookup("dart-source-attribution-preview"); !ok || got.Code != "LOP-FEAT-0001" {
 		t.Fatalf("expected dart source attribution preview flag in default registry, got %#v ok=%v", got, ok)
 	}
 	if got, ok := DefaultRegistry().Lookup("lockfile-drift-ecosystem-expansion-preview"); !ok || got.Code != "LOP-FEAT-0002" {
 		t.Fatalf("expected lockfile drift ecosystem preview flag in default registry, got %#v ok=%v", got, ok)
+	}
+	if got, ok := DefaultRegistry().Lookup("swift-carthage-preview"); !ok || got.Code != "LOP-FEAT-0003" {
+		t.Fatalf("expected swift Carthage preview flag in default registry, got %#v ok=%v", got, ok)
 	}
 	if flags := (*Registry)(nil).Flags(); len(flags) != 0 {
 		t.Fatalf("expected nil registry flags to be empty, got %#v", flags)
@@ -64,8 +67,8 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 	if got, ok := registry.Lookup("stable-flag"); !ok || got.Code != "LOP-FEAT-0002" {
 		t.Fatalf("expected name lookup to find stable flag, got %#v ok=%v", got, ok)
 	}
-	flags := registry.Flags()
-	flags[0].Name = "mutated"
+	copiedFlags := registry.Flags()
+	copiedFlags[0].Name = "mutated"
 	if got, _ := registry.Lookup("LOP-FEAT-0001"); got.Name != "preview-flag" {
 		t.Fatalf("expected Flags to return a defensive copy, got %#v", got)
 	}
@@ -153,10 +156,10 @@ func TestNewRegistryRejectsDuplicates(t *testing.T) {
 }
 
 func TestNextCodeAllocatesGeneratedCodes(t *testing.T) {
-	if code, err := DefaultRegistry().NextCode(); err != nil || code != "LOP-FEAT-0003" {
+	if code, err := DefaultRegistry().NextCode(); err != nil || code != "LOP-FEAT-0004" {
 		t.Fatalf("expected embedded registry to allocate next code, got %q err=%v", code, err)
 	}
-	if code, err := (*Registry)(nil).NextCode(); err != nil || code != "LOP-FEAT-0003" {
+	if code, err := (*Registry)(nil).NextCode(); err != nil || code != "LOP-FEAT-0004" {
 		t.Fatalf("expected nil registry to allocate next code from defaults, got %q err=%v", code, err)
 	}
 
@@ -496,12 +499,18 @@ func TestManifestReportsDefaults(t *testing.T) {
 	if _, err := registry.Manifest(ResolveOptions{Enable: []string{"missing"}}); err == nil {
 		t.Fatalf("expected manifest to return resolver errors")
 	}
-	if manifest, err := (*Registry)(nil).Manifest(ResolveOptions{}); err != nil || len(manifest) != 2 {
+	manifest, err = (*Registry)(nil).Manifest(ResolveOptions{})
+	if err != nil || len(manifest) != 3 {
 		t.Fatalf("expected nil registry manifest to defer to defaults, manifest=%#v err=%v", manifest, err)
-	} else if manifest[0].Name != "dart-source-attribution-preview" {
-		t.Fatalf("expected default manifest entry for dart-source-attribution-preview, got %#v", manifest[0])
-	} else if manifest[1].Name != "lockfile-drift-ecosystem-expansion-preview" {
-		t.Fatalf("expected default manifest entry for lockfile drift preview, got %#v", manifest[1])
+	}
+	for index, expectedName := range []string{
+		"dart-source-attribution-preview",
+		"lockfile-drift-ecosystem-expansion-preview",
+		"swift-carthage-preview",
+	} {
+		if manifest[index].Name != expectedName {
+			t.Fatalf("expected default manifest entry %d to be %s, got %#v", index, expectedName, manifest[index])
+		}
 	}
 }
 
@@ -530,6 +539,10 @@ func TestEnabledFlag(t *testing.T) {
 	if enabled, err := resolved.EnabledFlag("missing"); err == nil || enabled {
 		t.Fatalf("expected unknown feature error, enabled=%v err=%v", enabled, err)
 	}
+	snapshot := resolved.Snapshot()
+	if len(snapshot) != 2 || !snapshot["LOP-FEAT-0001"] || !snapshot["LOP-FEAT-0002"] {
+		t.Fatalf("unexpected feature snapshot: %#v", snapshot)
+	}
 	var empty *Set
 	if empty.Enabled("preview-flag") {
 		t.Fatalf("expected nil set to report disabled")
@@ -537,35 +550,50 @@ func TestEnabledFlag(t *testing.T) {
 	if got := empty.EnabledCodes(); len(got) != 0 {
 		t.Fatalf("expected nil set enabled codes to be empty, got %#v", got)
 	}
+	if snapshot := empty.Snapshot(); len(snapshot) != 0 {
+		t.Fatalf("expected nil set snapshot to be empty, got %#v", snapshot)
+	}
 }
 
-func TestDefaultRegistryDartSourceAttributionPreviewDefaultsAndOptIn(t *testing.T) {
+func TestDefaultRegistryPreviewDefaultsAndOptIn(t *testing.T) {
 	registry := DefaultRegistry()
 	dev, err := registry.Resolve(ResolveOptions{Channel: ChannelDev})
 	if err != nil {
 		t.Fatalf("resolve dev defaults: %v", err)
 	}
-	if dev.Enabled("dart-source-attribution-preview") {
-		t.Fatalf("expected dart-source-attribution-preview default-off in dev channel")
+	for _, name := range []string{
+		"dart-source-attribution-preview",
+		"lockfile-drift-ecosystem-expansion-preview",
+		"swift-carthage-preview",
+	} {
+		if dev.Enabled(name) {
+			t.Fatalf("expected %s default-off in dev channel", name)
+		}
 	}
 
 	release, err := registry.Resolve(ResolveOptions{Channel: ChannelRelease})
 	if err != nil {
 		t.Fatalf("resolve release defaults: %v", err)
 	}
-	if release.Enabled("dart-source-attribution-preview") {
-		t.Fatalf("expected dart-source-attribution-preview default-off in release channel")
+	for _, name := range []string{
+		"dart-source-attribution-preview",
+		"lockfile-drift-ecosystem-expansion-preview",
+		"swift-carthage-preview",
+	} {
+		if release.Enabled(name) {
+			t.Fatalf("expected %s default-off in release channel", name)
+		}
 	}
 
 	optIn, err := registry.Resolve(ResolveOptions{
 		Channel: ChannelDev,
-		Enable:  []string{"dart-source-attribution-preview"},
+		Enable:  []string{"swift-carthage-preview"},
 	})
 	if err != nil {
 		t.Fatalf("resolve explicit opt-in: %v", err)
 	}
-	if !optIn.Enabled("dart-source-attribution-preview") {
-		t.Fatalf("expected explicit opt-in to enable dart-source-attribution-preview")
+	if !optIn.Enabled("swift-carthage-preview") {
+		t.Fatalf("expected explicit opt-in to enable swift-carthage-preview")
 	}
 }
 

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -10,5 +10,11 @@
     "name": "lockfile-drift-ecosystem-expansion-preview",
     "description": "Preview expansion of shared lockfile drift checks for .NET, Dart, Elixir, and SwiftPM ecosystems.",
     "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0003",
+    "name": "swift-carthage-preview",
+    "description": "Enable Carthage dependency parsing for the Swift adapter.",
+    "lifecycle": "preview"
   }
 ]

--- a/internal/featureflags/resolver.go
+++ b/internal/featureflags/resolver.go
@@ -155,6 +155,17 @@ func (s *Set) EnabledFlag(ref string) (bool, error) {
 	return s.enabled[flag.Code], nil
 }
 
+func (s *Set) Snapshot() map[string]bool {
+	if s == nil || len(s.enabled) == 0 {
+		return nil
+	}
+	snapshot := make(map[string]bool, len(s.enabled))
+	for code, enabled := range s.enabled {
+		snapshot[code] = enabled
+	}
+	return snapshot
+}
+
 func (s *Set) lookup(ref string) (Flag, bool) {
 	ref = strings.TrimSpace(ref)
 	if s == nil {

--- a/internal/lang/swift/adapter.go
+++ b/internal/lang/swift/adapter.go
@@ -24,7 +24,10 @@ func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Rep
 		return report.Report{}, err
 	}
 
-	catalog, catalogWarnings, err := buildDependencyCatalog(repoPath)
+	catalogOptions := dependencyCatalogOptions{
+		EnableCarthage: req.Features.Enabled(swiftCarthagePreviewFlagName),
+	}
+	catalog, catalogWarnings, err := buildDependencyCatalogWithOptions(repoPath, catalogOptions)
 	if err != nil {
 		return report.Report{}, err
 	}

--- a/internal/lang/swift/adapter_test_helpers_test.go
+++ b/internal/lang/swift/adapter_test_helpers_test.go
@@ -26,6 +26,12 @@ type swiftFixturePodDependency struct {
 	version string
 }
 
+type swiftFixtureCarthageDependency struct {
+	kind      string
+	source    string
+	reference string
+}
+
 func alamofireFixtureDependency() swiftFixtureDependency {
 	return swiftFixtureDependency{
 		identity:    "alamofire",
@@ -49,6 +55,14 @@ func alamofirePodFixtureDependency() swiftFixturePodDependency {
 	return swiftFixturePodDependency{
 		name:    "Alamofire",
 		version: "5.8.1",
+	}
+}
+
+func rxSwiftCarthageFixtureDependency() swiftFixtureCarthageDependency {
+	return swiftFixtureCarthageDependency{
+		kind:      "github",
+		source:    "ReactiveX/RxSwift",
+		reference: "6.8.0",
 	}
 }
 
@@ -86,6 +100,13 @@ func writeSwiftDemoCocoaPodsProject(t *testing.T, repo string, dependencies []sw
 	writeSwiftDemoSourceFile(t, repo, mainContent)
 }
 
+func writeSwiftDemoCarthageProject(t *testing.T, repo string, dependencies []swiftFixtureCarthageDependency, mainContent string) {
+	t.Helper()
+	testutil.MustWriteFile(t, filepath.Join(repo, carthageManifestName), buildCartfileContent(dependencies))
+	testutil.MustWriteFile(t, filepath.Join(repo, carthageResolvedName), buildCartfileResolvedContent(dependencies))
+	writeSwiftDemoSourceFile(t, repo, mainContent)
+}
+
 func writeSwiftDemoSourceFile(t *testing.T, repo string, mainContent string) {
 	t.Helper()
 	testutil.MustWriteFile(t, filepath.Join(repo, "Sources", "Demo", swiftMainFileName), mainContent)
@@ -113,5 +134,33 @@ func buildPodLockContent(dependencies []swiftFixturePodDependency) string {
 		lines = append(lines, "  - "+dependency.name+" ("+dependency.version+")")
 	}
 	lines = append(lines, `COCOAPODS: 1.13.0`)
+	return strings.Join(lines, "\n")
+}
+
+func buildCartfileContent(dependencies []swiftFixtureCarthageDependency) string {
+	lines := make([]string, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		kind := strings.TrimSpace(dependency.kind)
+		if kind == "" {
+			kind = "github"
+		}
+		lines = append(lines, kind+` "`+dependency.source+`" "`+dependency.reference+`"`)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func buildCartfileResolvedContent(dependencies []swiftFixtureCarthageDependency) string {
+	lines := make([]string, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		kind := strings.TrimSpace(dependency.kind)
+		if kind == "" {
+			kind = "github"
+		}
+		reference := strings.TrimSpace(dependency.reference)
+		if reference == "" {
+			reference = "1.0.0"
+		}
+		lines = append(lines, kind+` "`+dependency.source+`" "`+reference+`"`)
+	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/lang/swift/carthage.go
+++ b/internal/lang/swift/carthage.go
@@ -1,0 +1,310 @@
+package swift
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+func loadCarthageManifestData(repoPath string, catalog *dependencyCatalog) (bool, []string, error) {
+	manifestPath := filepath.Join(repoPath, carthageManifestName)
+	content, err := safeio.ReadFileUnder(repoPath, manifestPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil, nil
+		}
+		return false, nil, fmt.Errorf("read %s: %w", carthageManifestName, err)
+	}
+
+	entries := parseCarthageManifestDependencies(content)
+	warnings := make([]string, 0, 2)
+	ambiguousModules := make(map[string]struct{})
+	for _, entry := range entries {
+		depID := normalizeDependencyID(entry.Dependency)
+		if depID == "" {
+			continue
+		}
+		ensureDeclaredDependencyForManager(catalog, depID, carthageManager)
+		addCarthageMappings(catalog, depID, entry, ambiguousModules)
+	}
+	if len(entries) == 0 {
+		warnings = append(warnings, "no Carthage declarations found in Cartfile")
+	}
+	if warning := carthageAmbiguityWarning(ambiguousModules); warning != "" {
+		warnings = append(warnings, warning)
+	}
+	return true, warnings, nil
+}
+
+func loadCarthageResolvedData(repoPath string, catalog *dependencyCatalog) (bool, []string, error) {
+	resolvedPath := filepath.Join(repoPath, carthageResolvedName)
+	content, err := safeio.ReadFileUnder(repoPath, resolvedPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil, nil
+		}
+		return false, nil, fmt.Errorf("read %s: %w", carthageResolvedName, err)
+	}
+
+	entries := parseCarthageResolvedDependencies(content)
+	warnings := make([]string, 0, 2)
+	ambiguousModules := make(map[string]struct{})
+	if len(entries) == 0 {
+		warnings = append(warnings, "no Carthage entries found in Cartfile.resolved")
+	}
+	for _, entry := range entries {
+		depID := normalizeDependencyID(entry.Dependency)
+		if depID == "" {
+			continue
+		}
+		source := strings.TrimSpace(entry.Source)
+		if source == "" {
+			source = carthageResolvedName
+		}
+		version, revision := classifyCarthageReference(entry.Reference)
+		ensureResolvedDependencyForManager(catalog, depID, version, revision, source, carthageManager)
+		addCarthageMappings(catalog, depID, entry, ambiguousModules)
+	}
+	if warning := carthageAmbiguityWarning(ambiguousModules); warning != "" {
+		warnings = append(warnings, warning)
+	}
+	return true, warnings, nil
+}
+
+func parseCarthageManifestDependencies(content []byte) []carthageDependency {
+	return parseCarthageDependencies(content, false)
+}
+
+func parseCarthageResolvedDependencies(content []byte) []carthageDependency {
+	return parseCarthageDependencies(content, true)
+}
+
+func parseCarthageDependencies(content []byte, requireReference bool) []carthageDependency {
+	lines := strings.Split(string(content), "\n")
+	entries := make([]carthageDependency, 0, len(lines))
+	for _, line := range lines {
+		entry, ok := parseCarthageLine(line, requireReference)
+		if !ok {
+			continue
+		}
+		entries = append(entries, entry)
+		if len(entries) >= maxCarthageDeclarations {
+			break
+		}
+	}
+	return dedupeCarthageDependencies(entries)
+}
+
+func parseCarthageLine(line string, requireReference bool) (carthageDependency, bool) {
+	line = strings.TrimSpace(shared.StripLineComment(line, "#"))
+	if line == "" {
+		return carthageDependency{}, false
+	}
+	kind, rest, ok := splitCarthageLinePrefix(line)
+	if !ok {
+		return carthageDependency{}, false
+	}
+	if kind != "github" && kind != "git" && kind != "binary" {
+		return carthageDependency{}, false
+	}
+
+	source, rest, ok := readQuotedValue(rest)
+	if !ok {
+		return carthageDependency{}, false
+	}
+	reference, _, hasReference := readQuotedValue(rest)
+	if requireReference && !hasReference {
+		return carthageDependency{}, false
+	}
+	depID := deriveCarthageDependencyID(kind, source)
+	if depID == "" {
+		return carthageDependency{}, false
+	}
+	return carthageDependency{
+		Kind:       kind,
+		Source:     strings.TrimSpace(source),
+		Reference:  strings.TrimSpace(reference),
+		Dependency: depID,
+	}, true
+}
+
+func splitCarthageLinePrefix(line string) (string, string, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return "", "", false
+	}
+	prefix := strings.ToLower(strings.TrimSpace(fields[0]))
+	if prefix == "" {
+		return "", "", false
+	}
+	rest := strings.TrimSpace(line[len(fields[0]):])
+	if rest == "" {
+		return "", "", false
+	}
+	return prefix, rest, true
+}
+
+func readQuotedValue(input string) (string, string, bool) {
+	input = strings.TrimSpace(input)
+	if !strings.HasPrefix(input, `"`) {
+		return "", input, false
+	}
+	escaped := false
+	for i := 1; i < len(input); i++ {
+		ch := input[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch != '"' {
+			continue
+		}
+
+		raw := input[1:i]
+		if unquoted, err := strconv.Unquote(`"` + raw + `"`); err == nil {
+			raw = unquoted
+		}
+		return strings.TrimSpace(raw), strings.TrimSpace(input[i+1:]), true
+	}
+	return "", input, false
+}
+
+func deriveCarthageDependencyID(kind, source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return ""
+	}
+	if kind == "github" {
+		cleaned := strings.Trim(source, "/")
+		parts := strings.Split(cleaned, "/")
+		if len(parts) >= 2 {
+			return normalizeDependencyID(strings.TrimSuffix(parts[len(parts)-1], ".git"))
+		}
+	}
+	identity := derivePackageIdentity(source)
+	if kind == "binary" {
+		identity = strings.TrimSuffix(identity, path.Ext(identity))
+	}
+	if depID := normalizeDependencyID(identity); depID != "" {
+		return depID
+	}
+	return normalizeDependencyID(source)
+}
+
+func addCarthageMappings(catalog *dependencyCatalog, depID string, entry carthageDependency, ambiguousModules map[string]struct{}) {
+	mapAlias(catalog, depID, depID)
+	for _, alias := range carthageAliasCandidates(entry, depID) {
+		mapAlias(catalog, alias, depID)
+	}
+	for _, module := range carthageModuleCandidates(entry, depID) {
+		if setLookupWithStatus(catalog.ModuleToDependency, lookupKey(module), depID) {
+			ambiguousModules[module] = struct{}{}
+		}
+	}
+}
+
+func carthageAliasCandidates(entry carthageDependency, depID string) []string {
+	candidates := []string{depID, entry.Dependency, entry.Source, derivePackageIdentity(entry.Source)}
+	if entry.Kind == "github" {
+		parts := strings.Split(strings.Trim(entry.Source, "/"), "/")
+		if len(parts) >= 2 {
+			candidates = append(candidates, parts[len(parts)-2], parts[len(parts)-1])
+		}
+	}
+	if entry.Kind == "binary" {
+		base := derivePackageIdentity(entry.Source)
+		candidates = append(candidates, strings.TrimSuffix(base, path.Ext(base)))
+	}
+	return dedupeStrings(candidates)
+}
+
+func carthageModuleCandidates(entry carthageDependency, depID string) []string {
+	candidates := append([]string{depID, entry.Dependency}, carthageAliasCandidates(entry, depID)...)
+	for _, candidate := range append([]string{}, candidates...) {
+		tokens := carthageModuleTokens(candidate)
+		if len(tokens) > 1 {
+			candidates = append(candidates, strings.Join(tokens, ""))
+		}
+	}
+	return dedupeStrings(candidates)
+}
+
+func carthageModuleTokens(value string) []string {
+	return strings.FieldsFunc(strings.TrimSpace(value), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+}
+
+func dedupeCarthageDependencies(entries []carthageDependency) []carthageDependency {
+	if len(entries) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(entries))
+	result := make([]carthageDependency, 0, len(entries))
+	for _, entry := range entries {
+		depID := normalizeDependencyID(entry.Dependency)
+		if depID == "" {
+			continue
+		}
+		if _, ok := seen[depID]; ok {
+			continue
+		}
+		seen[depID] = struct{}{}
+		entry.Dependency = depID
+		result = append(result, entry)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Dependency < result[j].Dependency
+	})
+	return result
+}
+
+func carthageAmbiguityWarning(ambiguousModules map[string]struct{}) string {
+	return formatAmbiguousModuleWarning("Carthage", ambiguousModules)
+}
+
+func classifyCarthageReference(value string) (string, string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", ""
+	}
+	if isLikelyCarthageVersion(value) {
+		return value, ""
+	}
+	return "", value
+}
+
+func isLikelyCarthageVersion(value string) bool {
+	trimmed := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(value), "v"))
+	if trimmed == "" {
+		return false
+	}
+	if !unicode.IsDigit(rune(trimmed[0])) {
+		return false
+	}
+	hasDot := false
+	for _, r := range trimmed {
+		switch {
+		case unicode.IsDigit(r):
+		case r == '.':
+			hasDot = true
+		case r == '-' || r == '+':
+		default:
+			return false
+		}
+	}
+	return hasDot
+}

--- a/internal/lang/swift/carthage_coverage_test.go
+++ b/internal/lang/swift/carthage_coverage_test.go
@@ -1,0 +1,185 @@
+package swift
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestSwiftCarthageLoadersHandleMissingMalformedAndEmptyFiles(t *testing.T) {
+	catalog := newSwiftCoverageCatalog()
+	repo := t.TempDir()
+	assertMissingCarthageLoader(t, repo, &catalog, loadCarthageManifestData)
+	assertCarthageLoaderRejectsDirectory(t, repo, carthageManifestName, &catalog, loadCarthageManifestData)
+
+	manifestPath := filepath.Join(repo, carthageManifestName)
+	testutil.MustWriteFile(t, manifestPath, "\n# comment only\n")
+	found, warnings, err := loadCarthageManifestData(repo, &catalog)
+	if err != nil || !found || len(warnings) == 0 || !strings.Contains(warnings[0], "no Carthage declarations") {
+		t.Fatalf("expected empty Cartfile warning, found=%v warnings=%#v err=%v", found, warnings, err)
+	}
+
+	assertMissingCarthageLoader(t, repo, &catalog, loadCarthageResolvedData)
+	assertCarthageLoaderRejectsDirectory(t, repo, carthageResolvedName, &catalog, loadCarthageResolvedData)
+	resolvedPath := filepath.Join(repo, carthageResolvedName)
+	testutil.MustWriteFile(t, resolvedPath, "github \"ReactiveX/RxSwift\"\n")
+	found, warnings, err = loadCarthageResolvedData(repo, &catalog)
+	if err != nil || !found || len(warnings) == 0 || !strings.Contains(warnings[0], "no Carthage entries") {
+		t.Fatalf("expected unresolved Cartfile.resolved warning, found=%v warnings=%#v err=%v", found, warnings, err)
+	}
+}
+
+func TestSwiftCarthageParserRejectsMalformedLines(t *testing.T) {
+	if _, _, ok := splitCarthageLinePrefix("github"); ok {
+		t.Fatalf("expected splitCarthageLinePrefix to reject lines without quoted source")
+	}
+	if _, _, ok := splitCarthageLinePrefix("  "); ok {
+		t.Fatalf("expected splitCarthageLinePrefix to reject blank lines")
+	}
+	if _, _, ok := readQuotedValue(`plain`); ok {
+		t.Fatalf("expected unquoted value parse to fail")
+	}
+	if _, _, ok := readQuotedValue(`"unterminated`); ok {
+		t.Fatalf("expected unterminated quote parse to fail")
+	}
+	if _, ok := parseCarthageLine(`unknown "owner/repo" "1.0.0"`, false); ok {
+		t.Fatalf("expected unsupported Carthage kind to be ignored")
+	}
+	if _, ok := parseCarthageLine(`github owner/repo "1.0.0"`, false); ok {
+		t.Fatalf("expected unquoted source to be ignored")
+	}
+	if _, ok := parseCarthageLine(`github "owner/repo"`, true); ok {
+		t.Fatalf("expected missing required reference to be ignored")
+	}
+}
+
+func TestSwiftCarthageParserHandlesEscapesAndDependencies(t *testing.T) {
+	if value, _, ok := readQuotedValue(`"value\"with\"escapes" trailing`); !ok || value != `value"with"escapes` {
+		t.Fatalf("expected quoted value with escapes to parse, got value=%q ok=%v", value, ok)
+	}
+	if entry, ok := parseCarthageLine(`binary "https://example.com/FancyKit.json" "1.2.3"`, true); !ok || entry.Dependency != "fancykit" {
+		t.Fatalf("expected binary Carthage entry to parse with normalized dependency, got %#v ok=%v", entry, ok)
+	}
+	if got := deriveCarthageDependencyID("github", ""); got != "" {
+		t.Fatalf("expected empty github source to produce empty dependency id, got %q", got)
+	}
+	if got := deriveCarthageDependencyID("github", "owner/repo.git"); got != "repo" {
+		t.Fatalf("expected github source dependency id from repo name, got %q", got)
+	}
+	if got := deriveCarthageDependencyID("binary", "https://example.com/FancyKit.json"); got != "fancykit" {
+		t.Fatalf("expected binary source dependency id without extension, got %q", got)
+	}
+}
+
+func TestSwiftCarthageDedupeCandidatesAndReferences(t *testing.T) {
+	dependencies := parseCarthageDependencies([]byte(strings.Repeat(`github "owner/repo" "1.0.0"`+"\n", maxCarthageDeclarations+5)), false)
+	if len(dependencies) != 1 {
+		t.Fatalf("expected dedupe + max declaration cap to return one dependency, got %#v", dependencies)
+	}
+	if got := dedupeCarthageDependencies(nil); len(got) != 0 {
+		t.Fatalf("expected nil entries to dedupe as empty result, got %#v", got)
+	}
+	deduped := dedupeCarthageDependencies([]carthageDependency{{Dependency: ""}, {Dependency: "Repo"}, {Dependency: "repo"}})
+	if len(deduped) != 1 || deduped[0].Dependency != "repo" {
+		t.Fatalf("expected dedupe to skip empties and normalize duplicates, got %#v", deduped)
+	}
+	if aliases := carthageAliasCandidates(carthageDependency{Kind: "binary", Source: "https://example.com/FancyKit.json"}, "fancykit"); len(aliases) == 0 {
+		t.Fatalf("expected binary alias candidates")
+	}
+	if classifyVersion, classifyRevision := classifyCarthageReference(""); classifyVersion != "" || classifyRevision != "" {
+		t.Fatalf("expected empty reference to classify as empty, got version=%q revision=%q", classifyVersion, classifyRevision)
+	}
+	if isLikelyCarthageVersion("abcdef") {
+		t.Fatalf("expected non-numeric reference not to classify as version")
+	}
+	if !isLikelyCarthageVersion("1.2.3-1+1") {
+		t.Fatalf("expected semver-like reference to classify as version")
+	}
+}
+
+func TestSwiftCarthageCatalogOptionsAndAnalyseErrorBranches(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, packageManifestName), "let package = Package(name: \"Demo\")\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, packageResolvedName), "{\"pins\":[]}\n")
+	assertCarthageSourceCount(t, dependencyCatalogOptions{}, 4)
+	assertCarthageSourceCount(t, dependencyCatalogOptions{EnableCarthage: true}, 6)
+
+	catalog := newSwiftCoverageCatalog()
+	ensureDeclaredDependencyForManager(&catalog, "", carthageManager)
+	ensureResolvedDependencyForManager(&catalog, "", "1.0.0", "", "source", carthageManager)
+
+	_, analyseErr := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath: string([]byte{0}),
+		TopN:     1,
+		Features: mustResolveCarthagePreviewFeatures(t),
+	})
+	if analyseErr == nil {
+		t.Fatalf("expected analyse to fail on invalid repo path")
+	}
+}
+
+type carthageLoader func(string, *dependencyCatalog) (bool, []string, error)
+
+func assertMissingCarthageLoader(t *testing.T, repo string, catalog *dependencyCatalog, loader carthageLoader) {
+	t.Helper()
+	found, warnings, err := loader(repo, catalog)
+	if err != nil || found || len(warnings) != 0 {
+		t.Fatalf("expected missing Carthage file to be ignored, found=%v warnings=%#v err=%v", found, warnings, err)
+	}
+}
+
+func assertCarthageLoaderRejectsDirectory(t *testing.T, repo, name string, catalog *dependencyCatalog, loader carthageLoader) {
+	t.Helper()
+	path := filepath.Join(repo, name)
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s path: %v", name, err)
+	}
+	if _, _, err := loader(repo, catalog); err == nil {
+		t.Fatalf("expected %s read error for directory path", name)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove %s dir: %v", name, err)
+	}
+}
+
+func assertCarthageSourceCount(t *testing.T, options dependencyCatalogOptions, expected int) {
+	t.Helper()
+	if sources := discoveredSwiftCatalogSources(options); len(sources) != expected {
+		t.Fatalf("expected source list length %d, got %#v", expected, sources)
+	}
+}
+
+func mustResolveCarthagePreviewFeatures(t *testing.T) featureflags.Set {
+	t.Helper()
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
+		Code:      "LOP-FEAT-9998",
+		Name:      swiftCarthagePreviewFlagName,
+		Lifecycle: featureflags.LifecyclePreview,
+	}})
+	if err != nil {
+		t.Fatalf("new feature registry: %v", err)
+	}
+	features, err := registry.Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  []string{swiftCarthagePreviewFlagName},
+	})
+	if err != nil {
+		t.Fatalf("resolve feature set: %v", err)
+	}
+	return features
+}
+
+func newSwiftCoverageCatalog() dependencyCatalog {
+	return dependencyCatalog{
+		Dependencies:       make(map[string]dependencyMeta),
+		AliasToDependency:  make(map[string]string),
+		ModuleToDependency: make(map[string]string),
+		LocalModules:       make(map[string]struct{}),
+	}
+}

--- a/internal/lang/swift/carthage_test.go
+++ b/internal/lang/swift/carthage_test.go
@@ -1,0 +1,170 @@
+package swift
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestSwiftAdapterDetectWithCarthageRoots(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, carthageManifestName), buildCartfileContent([]swiftFixtureCarthageDependency{rxSwiftCarthageFixtureDependency()}))
+	testutil.MustWriteFile(t, filepath.Join(repo, "Sources", "App", swiftMainFileName), "import RxSwift\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "Packages", "Feature", carthageResolvedName), buildCartfileResolvedContent([]swiftFixtureCarthageDependency{{kind: "github", source: "SnapKit/SnapKit", reference: "5.7.0"}}))
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if !detection.Matched {
+		t.Fatalf("expected swift detection to match")
+	}
+	if !slices.Contains(detection.Roots, repo) {
+		t.Fatalf("expected repo root in detection roots, got %#v", detection.Roots)
+	}
+	nested := filepath.Join(repo, "Packages", "Feature")
+	if !slices.Contains(detection.Roots, nested) {
+		t.Fatalf("expected nested Carthage root in detection roots, got %#v", detection.Roots)
+	}
+}
+
+func TestSwiftBuildDependencyCatalogGatesCarthageByFeatureFlag(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, carthageManifestName), buildCartfileContent([]swiftFixtureCarthageDependency{rxSwiftCarthageFixtureDependency()}))
+	testutil.MustWriteFile(t, filepath.Join(repo, carthageResolvedName), buildCartfileResolvedContent([]swiftFixtureCarthageDependency{rxSwiftCarthageFixtureDependency()}))
+
+	catalog, _, err := buildDependencyCatalog(repo)
+	if err != nil {
+		t.Fatalf("build dependency catalog (default): %v", err)
+	}
+	if catalog.HasCarthage || len(catalog.Dependencies) != 0 {
+		t.Fatalf("expected default catalog to ignore Carthage, got %#v", catalog)
+	}
+
+	catalog, warnings, err := buildDependencyCatalogWithOptions(repo, dependencyCatalogOptions{EnableCarthage: true})
+	if err != nil {
+		t.Fatalf("build dependency catalog (carthage enabled): %v", err)
+	}
+	if !catalog.HasCarthage {
+		t.Fatalf("expected Carthage catalog state to be active")
+	}
+	if _, ok := catalog.Dependencies["rxswift"]; !ok {
+		t.Fatalf("expected rxswift dependency in Carthage-enabled catalog, got %#v", catalog.Dependencies)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for complete Carthage catalog, got %#v", warnings)
+	}
+}
+
+func TestSwiftAdapterCarthageFlagControlsDependencyAttribution(t *testing.T) {
+	repo := t.TempDir()
+	writeSwiftDemoCarthageProject(t, repo, []swiftFixtureCarthageDependency{rxSwiftCarthageFixtureDependency()}, `import RxSwift
+let value = DisposeBag()`)
+
+	disabled := mustSingleSwiftDependencyReport(t, language.Request{RepoPath: repo, Dependency: "rxswift"})
+	if disabled.TotalExportsCount != 0 {
+		t.Fatalf("expected no Carthage attribution when preview flag is disabled, got %#v", disabled)
+	}
+
+	enabled := mustSingleSwiftDependencyReport(t, language.Request{
+		RepoPath:   repo,
+		Dependency: "rxswift",
+		Features:   mustResolveSwiftCarthageFeatureSet(t, true),
+	})
+	if enabled.TotalExportsCount == 0 {
+		t.Fatalf("expected Carthage attribution when preview flag is enabled, got %#v", enabled)
+	}
+	if enabled.Provenance == nil || len(enabled.Provenance.Signals) == 0 || enabled.Provenance.Signals[0] != "ReactiveX/RxSwift" {
+		t.Fatalf("expected Carthage provenance signal, got %#v", enabled.Provenance)
+	}
+}
+
+func TestSwiftAdapterCarthageMissingResolvedRiskCue(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, carthageManifestName), buildCartfileContent([]swiftFixtureCarthageDependency{rxSwiftCarthageFixtureDependency()}))
+	writeSwiftDemoSourceFile(t, repo, `import RxSwift
+let value = DisposeBag()`)
+
+	reportData := mustAnalyseSwiftRequest(t, language.Request{
+		RepoPath:   repo,
+		Dependency: "rxswift",
+		Features:   mustResolveSwiftCarthageFeatureSet(t, true),
+	})
+	if len(reportData.Dependencies) != 1 {
+		t.Fatalf(expectedOneDependencyReport, len(reportData.Dependencies))
+	}
+	dep := reportData.Dependencies[0]
+	if !hasRiskCueCode(dep, "missing-carthage-lock-resolution") {
+		t.Fatalf("expected Cartfile.resolved risk cue, got %#v", dep.RiskCues)
+	}
+	if !hasRecommendationCode(dep, "refresh-cartfile-resolved") {
+		t.Fatalf("expected Cartfile.resolved recommendation, got %#v", dep.Recommendations)
+	}
+	assertWarningContains(t, reportData.Warnings, carthageResolvedName+" not found")
+}
+
+func TestSwiftAdapterWarnsOnAmbiguousCarthageModuleMappings(t *testing.T) {
+	repo := t.TempDir()
+	dependencies := []swiftFixtureCarthageDependency{
+		{kind: "github", source: "Acme/Firebase-Analytics", reference: "1.0.0"},
+		{kind: "github", source: "Acme/FirebaseAnalytics", reference: "1.0.0"},
+	}
+	writeSwiftDemoCarthageProject(t, repo, dependencies, `import FirebaseAnalytics
+let value = Analytics.self`)
+
+	reportData := mustAnalyseSwiftRequest(t, language.Request{
+		RepoPath: repo,
+		TopN:     5,
+		Features: mustResolveSwiftCarthageFeatureSet(t, true),
+	})
+	assertWarningContains(t, reportData.Warnings, "ambiguous Carthage module mapping")
+}
+
+func TestSwiftParseCarthageDependencies(t *testing.T) {
+	manifest := parseCarthageManifestDependencies([]byte(`# comment
+
+github "ReactiveX/RxSwift" ~> 6.0
+git "https://github.com/Quick/Quick.git" "7.0.0"
+binary "https://example.com/FancyKit.json" == 1.2.0
+`))
+	if len(manifest) != 3 {
+		t.Fatalf("expected 3 Cartfile dependencies, got %#v", manifest)
+	}
+	if manifest[0].Dependency != "fancykit" || manifest[1].Dependency != "quick" || manifest[2].Dependency != "rxswift" {
+		t.Fatalf("unexpected normalized Cartfile dependencies: %#v", manifest)
+	}
+
+	resolved := parseCarthageResolvedDependencies([]byte(`github "ReactiveX/RxSwift" "6.8.0"
+git "https://github.com/Quick/Quick.git" "7.0.0"
+git "https://example.com/internal-kit.git" "abcdef123456"
+`))
+	if len(resolved) != 3 {
+		t.Fatalf("expected 3 Cartfile.resolved dependencies, got %#v", resolved)
+	}
+	version, revision := classifyCarthageReference("6.8.0")
+	if version != "6.8.0" || revision != "" {
+		t.Fatalf("expected semver reference classification, got version=%q revision=%q", version, revision)
+	}
+	version, revision = classifyCarthageReference("abcdef123456")
+	if version != "" || revision == "" {
+		t.Fatalf("expected revision reference classification, got version=%q revision=%q", version, revision)
+	}
+}
+
+func mustResolveSwiftCarthageFeatureSet(t *testing.T, enabled bool) featureflags.Set {
+	t.Helper()
+	opts := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
+	if enabled {
+		opts.Enable = []string{swiftCarthagePreviewFlagName}
+	}
+	resolved, err := featureflags.DefaultRegistry().Resolve(opts)
+	if err != nil {
+		t.Fatalf("resolve feature set: %v", err)
+	}
+	return resolved
+}

--- a/internal/lang/swift/catalog.go
+++ b/internal/lang/swift/catalog.go
@@ -16,6 +16,14 @@ import (
 )
 
 func buildDependencyCatalog(repoPath string) (dependencyCatalog, []string, error) {
+	return buildDependencyCatalogWithOptions(repoPath, dependencyCatalogOptions{})
+}
+
+type dependencyCatalogOptions struct {
+	EnableCarthage bool
+}
+
+func buildDependencyCatalogWithOptions(repoPath string, opts dependencyCatalogOptions) (dependencyCatalog, []string, error) {
 	catalog := dependencyCatalog{
 		Dependencies:       make(map[string]dependencyMeta),
 		AliasToDependency:  make(map[string]string),
@@ -36,12 +44,23 @@ func buildDependencyCatalog(repoPath string) (dependencyCatalog, []string, error
 	}
 	warnings = append(warnings, podWarnings...)
 
+	carthage := packageManagerCatalogState{}
+	if opts.EnableCarthage {
+		carthageWarnings := []string(nil)
+		carthage, carthageWarnings, err = loadPackageManagerCatalog(repoPath, &catalog, loadCarthageManifestData, loadCarthageResolvedData)
+		if err != nil {
+			return dependencyCatalog{}, nil, err
+		}
+		warnings = append(warnings, carthageWarnings...)
+	}
+
 	catalog.HasSwiftPM = swiftPM.Active()
 	catalog.HasCocoaPods = cocoaPods.Active()
-	warnings = append(warnings, missingCatalogWarnings(swiftPM, cocoaPods)...)
+	catalog.HasCarthage = opts.EnableCarthage && carthage.Active()
+	warnings = append(warnings, missingCatalogWarnings(swiftPM, cocoaPods, carthage, opts.EnableCarthage)...)
 
 	if len(catalog.Dependencies) == 0 {
-		warnings = append(warnings, "no Swift dependencies were discovered from Package.swift, Package.resolved, Podfile, or Podfile.lock")
+		warnings = append(warnings, "no Swift dependencies were discovered from "+strings.Join(discoveredSwiftCatalogSources(opts), ", "))
 	}
 	return catalog, dedupeWarnings(warnings), nil
 }
@@ -75,12 +94,26 @@ func loadPackageManagerCatalog(repoPath string, catalog *dependencyCatalog, mani
 	}, append(manifestWarnings, lockWarnings...), nil
 }
 
-func missingCatalogWarnings(swiftPM, cocoaPods packageManagerCatalogState) []string {
+func missingCatalogWarnings(swiftPM, cocoaPods, carthage packageManagerCatalogState, includeCarthage bool) []string {
 	warnings := make([]string, 0, 4)
-	switch {
-	case !swiftPM.Active() && !cocoaPods.Active():
+	activeManagers := 0
+	for _, state := range []packageManagerCatalogState{swiftPM, cocoaPods} {
+		if state.Active() {
+			activeManagers++
+		}
+	}
+	if includeCarthage && carthage.Active() {
+		activeManagers++
+	}
+
+	switch activeManagers {
+	case 0:
 		warnings = append(warnings, packageManifestName+" not found; dependency declaration mapping may be incomplete")
 		warnings = append(warnings, packageResolvedName+" not found; version/resolution mapping may be incomplete")
+		if includeCarthage {
+			warnings = append(warnings, carthageManifestName+" not found; Carthage declaration mapping may be incomplete")
+			warnings = append(warnings, carthageResolvedName+" not found; Carthage version/resolution mapping may be incomplete")
+		}
 	default:
 		if swiftPM.Active() {
 			warnings = append(warnings, managerMissingWarnings(swiftPM, packageManifestName+" not found; dependency declaration mapping may be incomplete", packageResolvedName+" not found; version/resolution mapping may be incomplete")...)
@@ -88,8 +121,19 @@ func missingCatalogWarnings(swiftPM, cocoaPods packageManagerCatalogState) []str
 		if cocoaPods.Active() {
 			warnings = append(warnings, managerMissingWarnings(cocoaPods, podManifestName+" not found; CocoaPods declaration mapping may be incomplete", podLockName+" not found; CocoaPods version/resolution mapping may be incomplete")...)
 		}
+		if includeCarthage && carthage.Active() {
+			warnings = append(warnings, managerMissingWarnings(carthage, carthageManifestName+" not found; Carthage declaration mapping may be incomplete", carthageResolvedName+" not found; Carthage version/resolution mapping may be incomplete")...)
+		}
 	}
 	return warnings
+}
+
+func discoveredSwiftCatalogSources(opts dependencyCatalogOptions) []string {
+	sources := []string{packageManifestName, packageResolvedName, podManifestName, podLockName}
+	if opts.EnableCarthage {
+		sources = append(sources, carthageManifestName, carthageResolvedName)
+	}
+	return sources
 }
 
 func managerMissingWarnings(state packageManagerCatalogState, manifestWarning string, lockWarning string) []string {
@@ -463,6 +507,8 @@ func ensureDeclaredDependencyForManager(catalog *dependencyCatalog, depID string
 		meta.DeclaredViaSwiftPM = true
 	case cocoaPodsManager:
 		meta.DeclaredViaCocoaPods = true
+	case carthageManager:
+		meta.DeclaredViaCarthage = true
 	}
 	catalog.Dependencies[depID] = meta
 }
@@ -480,6 +526,8 @@ func ensureResolvedDependencyForManager(catalog *dependencyCatalog, depID string
 		meta.ResolvedViaSwiftPM = true
 	case cocoaPodsManager:
 		meta.ResolvedViaCocoaPods = true
+	case carthageManager:
+		meta.ResolvedViaCarthage = true
 	}
 	catalog.Dependencies[depID] = meta
 }

--- a/internal/lang/swift/cocoapods.go
+++ b/internal/lang/swift/cocoapods.go
@@ -307,6 +307,10 @@ func dedupePodLockEntries(entries []podLockEntry) []podLockEntry {
 }
 
 func cocoaPodsAmbiguityWarning(ambiguousModules map[string]struct{}) string {
+	return formatAmbiguousModuleWarning("CocoaPods", ambiguousModules)
+}
+
+func formatAmbiguousModuleWarning(manager string, ambiguousModules map[string]struct{}) string {
 	aliases := shared.SortedKeys(ambiguousModules)
 	if len(aliases) == 0 {
 		return ""
@@ -315,7 +319,7 @@ func cocoaPodsAmbiguityWarning(ambiguousModules map[string]struct{}) string {
 	if len(samples) > maxWarningSamples {
 		samples = samples[:maxWarningSamples]
 	}
-	message := "ambiguous CocoaPods module mapping for inferred aliases: " + strings.Join(samples, ", ")
+	message := "ambiguous " + manager + " module mapping for inferred aliases: " + strings.Join(samples, ", ")
 	if len(aliases) > maxWarningSamples {
 		message += fmt.Sprintf(", +%d more", len(aliases)-maxWarningSamples)
 	}

--- a/internal/lang/swift/detect.go
+++ b/internal/lang/swift/detect.go
@@ -19,6 +19,8 @@ func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (la
 		{Name: packageResolvedName, Confidence: 25},
 		{Name: podManifestName, Confidence: 60},
 		{Name: podLockName, Confidence: 25},
+		{Name: carthageManifestName, Confidence: 60},
+		{Name: carthageResolvedName, Confidence: 25},
 	}
 	if err := shared.ApplyRootSignals(repoPath, rootSignals, &detection, roots); err != nil {
 		return language.Detection{}, err
@@ -54,7 +56,7 @@ func detectSwiftEntry(ctx context.Context, path string, entry fs.DirEntry, detec
 
 func recordSwiftDetectionEntry(path string, name string, detection *language.Detection, roots map[string]struct{}) error {
 	switch strings.ToLower(name) {
-	case strings.ToLower(packageManifestName), strings.ToLower(packageResolvedName), strings.ToLower(podManifestName), strings.ToLower(podLockName):
+	case strings.ToLower(packageManifestName), strings.ToLower(packageResolvedName), strings.ToLower(podManifestName), strings.ToLower(podLockName), strings.ToLower(carthageManifestName), strings.ToLower(carthageResolvedName):
 		detection.Matched = true
 		detection.Confidence += 10
 		roots[filepath.Dir(path)] = struct{}{}

--- a/internal/lang/swift/report.go
+++ b/internal/lang/swift/report.go
@@ -149,6 +149,16 @@ func dependencyLockfileIssues(meta dependencyMeta) []dependencyLockfileIssue {
 			Rationale:          "Keeping Podfile.lock aligned improves reproducibility and pod-to-module attribution fidelity.",
 		})
 	}
+	if meta.DeclaredViaCarthage && !meta.ResolvedViaCarthage {
+		issues = append(issues, dependencyLockfileIssue{
+			Code:               "missing-carthage-lock-resolution",
+			RecommendationCode: "refresh-cartfile-resolved",
+			Manifest:           carthageManifestName,
+			Lockfile:           carthageResolvedName,
+			Message:            "dependency is declared in Cartfile but missing from Cartfile.resolved",
+			Rationale:          "Keeping Cartfile.resolved aligned improves reproducibility and Carthage framework attribution fidelity.",
+		})
+	}
 	if usesManagerSpecificMetadata(meta) {
 		return issues
 	}
@@ -166,7 +176,7 @@ func dependencyLockfileIssues(meta dependencyMeta) []dependencyLockfileIssue {
 }
 
 func usesManagerSpecificMetadata(meta dependencyMeta) bool {
-	return meta.DeclaredViaSwiftPM || meta.ResolvedViaSwiftPM || meta.DeclaredViaCocoaPods || meta.ResolvedViaCocoaPods
+	return meta.DeclaredViaSwiftPM || meta.ResolvedViaSwiftPM || meta.DeclaredViaCocoaPods || meta.ResolvedViaCocoaPods || meta.DeclaredViaCarthage || meta.ResolvedViaCarthage
 }
 
 func resolveMinUsageRecommendationThreshold(value *int) int {

--- a/internal/lang/swift/types.go
+++ b/internal/lang/swift/types.go
@@ -3,20 +3,25 @@ package swift
 import "github.com/ben-ranford/lopper/internal/lang/shared"
 
 const (
-	swiftAdapterID          = "swift"
-	packageManifestName     = "Package.swift"
-	packageResolvedName     = "Package.resolved"
-	podManifestName         = "Podfile"
-	podLockName             = "Podfile.lock"
-	maxDetectFiles          = 2048
-	maxScanFiles            = 4096
-	maxScannableSwiftFile   = 2 * 1024 * 1024
-	maxManifestDeclarations = 512
-	maxPodDeclarations      = 512
-	maxWarningSamples       = 5
-	ambiguousDependencyKey  = "\x00"
-	swiftPackageManager     = "swiftpm"
-	cocoaPodsManager        = "cocoapods"
+	swiftAdapterID               = "swift"
+	swiftCarthagePreviewFlagName = "swift-carthage-preview"
+	packageManifestName          = "Package.swift"
+	packageResolvedName          = "Package.resolved"
+	podManifestName              = "Podfile"
+	podLockName                  = "Podfile.lock"
+	carthageManifestName         = "Cartfile"
+	carthageResolvedName         = "Cartfile.resolved"
+	maxDetectFiles               = 2048
+	maxScanFiles                 = 4096
+	maxScannableSwiftFile        = 2 * 1024 * 1024
+	maxManifestDeclarations      = 512
+	maxPodDeclarations           = 512
+	maxCarthageDeclarations      = 512
+	maxWarningSamples            = 5
+	ambiguousDependencyKey       = "\x00"
+	swiftPackageManager          = "swiftpm"
+	cocoaPodsManager             = "cocoapods"
+	carthageManager              = "carthage"
 )
 
 type importBinding = shared.ImportRecord
@@ -37,6 +42,8 @@ type dependencyMeta struct {
 	ResolvedViaSwiftPM   bool
 	DeclaredViaCocoaPods bool
 	ResolvedViaCocoaPods bool
+	DeclaredViaCarthage  bool
+	ResolvedViaCarthage  bool
 }
 
 type dependencyCatalog struct {
@@ -46,6 +53,7 @@ type dependencyCatalog struct {
 	LocalModules       map[string]struct{}
 	HasSwiftPM         bool
 	HasCocoaPods       bool
+	HasCarthage        bool
 }
 
 type scanResult struct {
@@ -102,4 +110,11 @@ type podLockEntry struct {
 	Name    string
 	Version string
 	Source  string
+}
+
+type carthageDependency struct {
+	Kind       string
+	Source     string
+	Reference  string
+	Dependency string
 }

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -332,7 +332,7 @@ func TestManifestEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("release manifest: %v", err)
 	}
-	if len(manifest) != 2 {
+	if len(manifest) != 3 {
 		t.Fatalf("expected embedded manifest entries, got %#v", manifest)
 	}
 	if manifest[0].Name != "dart-source-attribution-preview" || manifest[0].EnabledByDefault {
@@ -340,6 +340,9 @@ func TestManifestEntries(t *testing.T) {
 	}
 	if manifest[1].Name != "lockfile-drift-ecosystem-expansion-preview" || manifest[1].EnabledByDefault {
 		t.Fatalf("expected lockfile drift preview default-off in release channel, got %#v", manifest[1])
+	}
+	if manifest[2].Name != "swift-carthage-preview" || manifest[2].EnabledByDefault {
+		t.Fatalf("expected swift Carthage preview default-off in release channel, got %#v", manifest[2])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated Carthage parser path in the Swift adapter (`Cartfile` + `Cartfile.resolved`) and merge Carthage declarations/resolution metadata into the existing Swift dependency catalog
- preserve existing SwiftPM behavior while supporting Carthage-only and mixed-manager repositories under `--language swift`
- gate Carthage parsing behind a preview feature path with focused tests and coverage fixtures

## Problem
Swift analysis previously covered SwiftPM only. Repositories using Carthage had no first-class declared dependency inventory, and resolved Carthage metadata was not surfaced in reports.

## Root Cause
The Swift catalog pipeline only read SwiftPM manifests/locks and had no Carthage parser seam.

## Fix
A new Carthage parsing module now reads `Cartfile` and `Cartfile.resolved`, normalizes dependency metadata, and merges it into the existing Swift dependency report flow without changing source scanning behavior.

## Validation
- `go test ./internal/lang/swift`
- pre-commit hook suite during commit (`go test ./...`, lint, formatting, shellcheck, markdown lint)

Closes #454
