### PR TITLE
feat: refactor Go adapter and add vendored provenance preview (#452 #627)

### DIFF
--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -69,6 +69,7 @@ func TestExecuteFeaturesReleaseChannelAndEmptyRegistry(t *testing.T) {
 		!strings.Contains(emptyOutput, "lockfile-drift-ecosystem-expansion-preview") ||
 		!strings.Contains(emptyOutput, "swift-carthage-preview") ||
 		!strings.Contains(emptyOutput, "powershell-adapter-preview") ||
+		!strings.Contains(emptyOutput, "go-vendored-provenance-preview") ||
 		!strings.Contains(emptyOutput, "false") {
 		t.Fatalf("expected default feature table to include embedded preview flags disabled by default, got %q", emptyOutput)
 	}

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -2,6 +2,7 @@ package featureflags
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -47,6 +48,7 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 	assertDefaultFlag(t, defaultFlags, "lockfile-drift-ecosystem-expansion-preview", "LOP-FEAT-0002")
 	assertDefaultFlag(t, defaultFlags, "swift-carthage-preview", "LOP-FEAT-0003")
 	assertDefaultFlag(t, defaultFlags, "powershell-adapter-preview", "LOP-FEAT-0004")
+	assertDefaultFlag(t, defaultFlags, "go-vendored-provenance-preview", "LOP-FEAT-0005")
 	if flags := (*Registry)(nil).Flags(); len(flags) != 0 {
 		t.Fatalf("expected nil registry flags to be empty, got %#v", flags)
 	}
@@ -96,6 +98,9 @@ func TestCatalogParseAndFormat(t *testing.T) {
 	}
 	if _, err := ParseCatalog([]byte(`[] []`)); err == nil {
 		t.Fatalf("expected multiple JSON values to fail")
+	}
+	if _, err := ParseCatalog([]byte(`[{"code":"LOP-FEAT-0001","name":"bad name","lifecycle":"preview"}]`)); err == nil {
+		t.Fatalf("expected catalog entries that fail registry validation to fail")
 	}
 	if _, err := FormatCatalog([]Flag{{Code: "bad", Name: "alpha", Lifecycle: LifecyclePreview}}); err == nil {
 		t.Fatalf("expected invalid catalog flag to fail")
@@ -502,6 +507,7 @@ func TestManifestReportsDefaults(t *testing.T) {
 	assertManifestFlag(t, manifest, "lockfile-drift-ecosystem-expansion-preview", false)
 	assertManifestFlag(t, manifest, "swift-carthage-preview", false)
 	assertManifestFlag(t, manifest, "powershell-adapter-preview", false)
+	assertManifestFlag(t, manifest, "go-vendored-provenance-preview", false)
 }
 
 func TestFormatManifest(t *testing.T) {
@@ -556,6 +562,7 @@ func TestDefaultRegistryPreviewDefaultsAndOptIn(t *testing.T) {
 		"lockfile-drift-ecosystem-expansion-preview",
 		"swift-carthage-preview",
 		"powershell-adapter-preview",
+		"go-vendored-provenance-preview",
 	} {
 		if dev.Enabled(name) {
 			t.Fatalf("expected %s default-off in dev channel", name)
@@ -571,6 +578,7 @@ func TestDefaultRegistryPreviewDefaultsAndOptIn(t *testing.T) {
 		"lockfile-drift-ecosystem-expansion-preview",
 		"swift-carthage-preview",
 		"powershell-adapter-preview",
+		"go-vendored-provenance-preview",
 	} {
 		if release.Enabled(name) {
 			t.Fatalf("expected %s default-off in release channel", name)
@@ -586,6 +594,36 @@ func TestDefaultRegistryPreviewDefaultsAndOptIn(t *testing.T) {
 	}
 	if !optIn.Enabled("swift-carthage-preview") {
 		t.Fatalf("expected explicit opt-in to enable swift-carthage-preview")
+	}
+}
+
+func TestEnabledCodes(t *testing.T) {
+	registry := testRegistry(t)
+	resolved, err := registry.Resolve(ResolveOptions{
+		Channel: ChannelRelease,
+		Enable:  []string{"preview-flag"},
+	})
+	if err != nil {
+		t.Fatalf("resolve enabled codes: %v", err)
+	}
+	if got := resolved.EnabledCodes(); !reflect.DeepEqual(got, []string{"LOP-FEAT-0001", "LOP-FEAT-0002"}) {
+		t.Fatalf("expected sorted enabled feature codes, got %#v", got)
+	}
+
+	resolved, err = registry.Resolve(ResolveOptions{
+		Channel: ChannelDev,
+		Disable: []string{"stable-flag"},
+	})
+	if err != nil {
+		t.Fatalf("resolve disabled codes: %v", err)
+	}
+	if got := resolved.EnabledCodes(); len(got) != 0 {
+		t.Fatalf("expected no enabled feature codes after disable override, got %#v", got)
+	}
+
+	var empty *Set
+	if got := empty.EnabledCodes(); len(got) != 0 {
+		t.Fatalf("expected nil set enabled codes to be empty, got %#v", got)
 	}
 }
 

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -22,5 +22,11 @@
     "name": "powershell-adapter-preview",
     "description": "Enable preview support for the PowerShell language adapter.",
     "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0005",
+    "name": "go-vendored-provenance-preview",
+    "description": "Enable vendored dependency provenance for Go using vendor/modules.txt metadata.",
+    "lifecycle": "preview"
   }
 ]

--- a/internal/lang/golang/adapter.go
+++ b/internal/lang/golang/adapter.go
@@ -5,15 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
-	"go/build/constraint"
 	"go/parser"
 	"go/token"
 	"io/fs"
-	"os"
 	"path"
 	"path/filepath"
-	"runtime"
-	"sort"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
@@ -27,130 +23,10 @@ type Adapter struct {
 	language.AdapterLifecycle
 }
 
-const (
-	goModName            = "go.mod"
-	goWorkName           = "go.work"
-	maxScannableGoFile   = 2 * 1024 * 1024
-	maxGoBuildHeaderLine = 64
-)
-
-var goSkippedDirs = map[string]bool{
-	"bin":        true,
-	".artifacts": true,
-}
-
 func NewAdapter() *Adapter {
 	adapter := &Adapter{}
 	adapter.AdapterLifecycle = language.NewAdapterLifecycle("go", []string{"golang"}, adapter.DetectWithConfidence)
 	return adapter
-}
-
-func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (language.Detection, error) {
-	repoPath = shared.DefaultRepoPath(repoPath)
-
-	detection := language.Detection{}
-	roots := make(map[string]struct{})
-	if err := applyGoRootSignals(repoPath, &detection, roots); err != nil {
-		return language.Detection{}, err
-	}
-
-	const maxFiles = 1024
-	visited := 0
-	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if ctx != nil && ctx.Err() != nil {
-			return ctx.Err()
-		}
-		return walkGoDetectionEntry(path, entry, roots, &detection, &visited, maxFiles)
-	})
-	if err != nil && !errors.Is(err, fs.SkipAll) {
-		return language.Detection{}, err
-	}
-
-	return shared.FinalizeDetection(repoPath, detection, roots), nil
-}
-
-func walkGoDetectionEntry(path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection, visited *int, maxFiles int) error {
-	if entry.IsDir() {
-		if shouldSkipDir(entry.Name()) {
-			return filepath.SkipDir
-		}
-		return nil
-	}
-	(*visited)++
-	if *visited > maxFiles {
-		return fs.SkipAll
-	}
-	updateGoDetection(path, entry, roots, detection)
-	return nil
-}
-
-func manifestPathExists(path string) (bool, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	if info.IsDir() {
-		return false, nil
-	}
-	return true, nil
-}
-
-func applyGoRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
-	rootSignals := []struct {
-		name       string
-		confidence int
-	}{
-		{name: goModName, confidence: 55},
-		{name: goWorkName, confidence: 45},
-	}
-	for _, signal := range rootSignals {
-		candidate := filepath.Join(repoPath, signal.name)
-		exists, err := manifestPathExists(candidate)
-		if err != nil {
-			return err
-		}
-		if exists {
-			detection.Matched = true
-			detection.Confidence += signal.confidence
-			roots[repoPath] = struct{}{}
-			if signal.name == goWorkName {
-				if err := addGoWorkRoots(repoPath, roots); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func addGoWorkRoots(repoPath string, roots map[string]struct{}) error {
-	moduleDirs, err := goWorkModuleDirs(repoPath)
-	if err != nil {
-		return err
-	}
-	for dir := range moduleDirs {
-		roots[dir] = struct{}{}
-	}
-	return nil
-}
-
-func updateGoDetection(path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection) {
-	switch strings.ToLower(entry.Name()) {
-	case goModName, goWorkName:
-		detection.Matched = true
-		detection.Confidence += 12
-		roots[filepath.Dir(path)] = struct{}{}
-	}
-	if strings.EqualFold(filepath.Ext(path), ".go") {
-		detection.Matched = true
-		detection.Confidence += 2
-	}
 }
 
 func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
@@ -164,7 +40,9 @@ func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Rep
 		RepoPath:    repoPath,
 	}
 
-	moduleInfo, err := loadGoModuleInfo(repoPath)
+	moduleInfo, err := loadGoModuleInfo(repoPath, moduleLoadOptions{
+		EnableVendoredProvenance: req.Features.Enabled(goVendoredProvenancePreviewFeature),
+	})
 	if err != nil {
 		return report.Report{}, err
 	}
@@ -209,32 +87,6 @@ func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) repor
 	return report.NormalizeRemovalCandidateWeights(*value)
 }
 
-type importBinding = shared.ImportRecord
-
-type fileScan struct {
-	Path    string
-	Imports []importBinding
-	Usage   map[string]int
-}
-
-type scanResult struct {
-	Files                         []fileScan
-	Warnings                      []string
-	BlankImportsByDependency      map[string]int
-	UndeclaredImportsByDependency map[string]int
-	SkippedGeneratedFiles         int
-	SkippedBuildTaggedFiles       int
-	SkippedLargeFiles             int
-	SkippedNestedModuleDirs       int
-}
-
-type moduleInfo struct {
-	ModulePath           string
-	LocalModulePaths     []string
-	DeclaredDependencies []string
-	ReplacementImports   map[string]string
-}
-
 func scanRepo(ctx context.Context, repoPath string, moduleInfo moduleInfo) (scanResult, error) {
 	result := newScanResult()
 	if repoPath == "" {
@@ -260,6 +112,7 @@ func scanRepo(ctx context.Context, repoPath string, moduleInfo moduleInfo) (scan
 func newScanResult() scanResult {
 	return scanResult{
 		BlankImportsByDependency:      make(map[string]int),
+		DependencyProvenanceByDep:     make(map[string]goDependencyProvenance),
 		UndeclaredImportsByDependency: make(map[string]int),
 	}
 }
@@ -304,9 +157,10 @@ func appendScanWarnings(result *scanResult, moduleInfo moduleInfo) {
 	if len(result.Files) == 0 {
 		result.Warnings = append(result.Warnings, "no Go source files found for analysis")
 	}
-	if len(moduleInfo.DeclaredDependencies) == 0 {
+	if len(moduleInfo.DeclaredDependencies) == 0 && len(moduleInfo.VendoredDependencies) == 0 {
 		result.Warnings = append(result.Warnings, "no Go dependencies discovered from go.mod")
 	}
+	result.Warnings = append(result.Warnings, moduleInfo.VendoringWarnings...)
 	appendSkipWarnings(result)
 	appendUndeclaredDependencyWarnings(result)
 }
@@ -376,100 +230,11 @@ func scanGoSourceFile(repoPath, path string, moduleInfo moduleInfo, result *scan
 	return nil
 }
 
-func workspaceRootModuleDirs(repoPath string, moduleInfo moduleInfo) (map[string]struct{}, error) {
-	if moduleInfo.ModulePath != "" {
-		return nil, nil
-	}
-
-	return goWorkModuleDirs(repoPath)
-}
-
-func goWorkModuleDirs(repoPath string) (map[string]struct{}, error) {
-	useEntries, err := readGoWorkUseEntries(repoPath)
-	if err != nil {
-		return nil, err
-	}
-	if len(useEntries) == 0 {
-		return nil, nil
-	}
-
-	workspaceRoots := make(map[string]struct{}, len(useEntries))
-	for _, rel := range useEntries {
-		resolved, ok := resolveRepoBoundedPath(repoPath, rel)
-		if !ok {
-			continue
-		}
-		workspaceRoots[resolved] = struct{}{}
-	}
-	return workspaceRoots, nil
-}
-
-func nestedModuleDirs(repoPath string, workspaceModuleDirs map[string]struct{}) (map[string]struct{}, error) {
-	dirs := make(map[string]struct{})
-	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if !entry.IsDir() {
-			return nil
-		}
-		if shouldSkipDir(entry.Name()) {
-			return filepath.SkipDir
-		}
-		if path == repoPath {
-			return nil
-		}
-		exists, err := manifestPathExists(filepath.Join(path, goModName))
-		if err != nil {
-			return err
-		}
-		if !exists {
-			return nil
-		}
-		if _, ok := workspaceModuleDirs[path]; ok {
-			return nil
-		}
-		dirs[path] = struct{}{}
-		return filepath.SkipDir
-	})
-	if err != nil {
-		return nil, err
-	}
-	return dirs, nil
-}
-
-func discoverNestedModules(repoPath string) ([]string, []string, map[string]string, error) {
-	nestedDirs, err := nestedModuleDirs(repoPath, nil)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	modules := make([]string, 0, len(nestedDirs))
-	dependencies := make([]string, 0)
-	replacements := make(map[string]string)
-	for dir := range nestedDirs {
-		modulePath, deps, moduleReplacements, err := loadGoModFromDir(repoPath, dir)
-		if err != nil {
-			continue
-		}
-		if modulePath != "" {
-			modules = append(modules, modulePath)
-		}
-		dependencies = append(dependencies, deps...)
-		for replacementImport, dependency := range moduleReplacements {
-			if _, ok := replacements[replacementImport]; !ok {
-				replacements[replacementImport] = dependency
-			}
-		}
-	}
-
-	return uniqueStrings(modules), uniqueStrings(dependencies), replacements, nil
-}
-
 type importMetadata struct {
 	Dependency string
 	IsBlank    bool
 	Undeclared bool
+	Provenance goDependencyProvenance
 }
 
 func parseImports(content []byte, relativePath string, moduleInfo moduleInfo) ([]importBinding, []importMetadata) {
@@ -487,15 +252,15 @@ func parseImports(content []byte, relativePath string, moduleInfo moduleInfo) ([
 			continue
 		}
 
-		dependency := dependencyFromImport(importPath, moduleInfo)
-		if dependency == "" {
+		resolved := resolveDependencyFromImport(importPath, moduleInfo)
+		if resolved.Dependency == "" {
 			continue
 		}
 
 		name, local, wildcard := importBindingIdentity(importPath, imported.Name)
 		position := fileSet.Position(imported.Pos())
 		bindings = append(bindings, importBinding{
-			Dependency: dependency,
+			Dependency: resolved.Dependency,
 			Module:     importPath,
 			Name:       name,
 			Local:      local,
@@ -503,9 +268,10 @@ func parseImports(content []byte, relativePath string, moduleInfo moduleInfo) ([
 			Location:   shared.Location(relativePath, position.Line, position.Column),
 		})
 		metadata = append(metadata, importMetadata{
-			Dependency: dependency,
+			Dependency: resolved.Dependency,
 			IsBlank:    imported.Name != nil && imported.Name.Name == "_",
-			Undeclared: !isDeclaredDependency(dependency, moduleInfo.DeclaredDependencies),
+			Undeclared: !isDeclaredDependency(resolved.Dependency, moduleInfo.DeclaredDependencies),
+			Provenance: resolved.Provenance,
 		})
 	}
 
@@ -517,187 +283,6 @@ func trimImportPath(imported *ast.ImportSpec) string {
 		return ""
 	}
 	return strings.Trim(imported.Path.Value, "\"")
-}
-
-func isGeneratedGoFile(content []byte) bool {
-	lines := strings.Split(string(content), "\n")
-	maxLines := minInt(len(lines), 20)
-	for i := 0; i < maxLines; i++ {
-		line := strings.ToLower(strings.TrimSpace(lines[i]))
-		if strings.Contains(line, "code generated") && strings.Contains(line, "do not edit") {
-			return true
-		}
-	}
-	return false
-}
-
-func matchesActiveBuild(content []byte) bool {
-	goBuildExpr, plusBuildExprs := extractBuildConstraintExpressions(content)
-	switch {
-	case goBuildExpr != nil:
-		return goBuildExpr.Eval(isActiveBuildTag)
-	case len(plusBuildExprs) > 0:
-		for _, expr := range plusBuildExprs {
-			if !expr.Eval(isActiveBuildTag) {
-				return false
-			}
-		}
-		return true
-	default:
-		return true
-	}
-}
-
-func extractBuildConstraintExpressions(content []byte) (constraint.Expr, []constraint.Expr) {
-	lines := strings.Split(string(content), "\n")
-	maxLines := minInt(len(lines), maxGoBuildHeaderLine)
-	plusBuildExprs := make([]constraint.Expr, 0)
-	var goBuildExpr constraint.Expr
-
-	for i := 0; i < maxLines; i++ {
-		line := strings.TrimSpace(lines[i])
-		if line == "" {
-			continue
-		}
-		if shouldStopBuildConstraintScan(line) {
-			break
-		}
-		expr, kind := parseBuildConstraintComment(line)
-		switch kind {
-		case "go":
-			if expr != nil {
-				goBuildExpr = expr
-			}
-		case "plus":
-			if expr != nil {
-				plusBuildExprs = append(plusBuildExprs, expr)
-			}
-		}
-	}
-	return goBuildExpr, plusBuildExprs
-}
-
-func shouldStopBuildConstraintScan(line string) bool {
-	if strings.HasPrefix(line, "package ") {
-		return true
-	}
-	return !strings.HasPrefix(line, "//")
-}
-
-func parseBuildConstraintComment(line string) (constraint.Expr, string) {
-	switch {
-	case strings.HasPrefix(line, "//go:build "):
-		expr, err := constraint.Parse(line)
-		if err != nil {
-			return nil, "go"
-		}
-		return expr, "go"
-	case strings.HasPrefix(line, "// +build "):
-		expr, err := constraint.Parse(line)
-		if err != nil {
-			return nil, "plus"
-		}
-		return expr, "plus"
-	default:
-		return nil, ""
-	}
-}
-
-func isActiveBuildTag(tag string) bool {
-	tag = strings.TrimSpace(strings.ToLower(tag))
-	if tag == "" {
-		return false
-	}
-	if tag == runtime.GOOS || tag == runtime.GOARCH {
-		return true
-	}
-	if tag == "unix" {
-		switch runtime.GOOS {
-		case "android", "darwin", "dragonfly", "freebsd", "illumos", "ios", "linux", "netbsd", "openbsd", "solaris":
-			return true
-		}
-	}
-	if tag == "cgo" {
-		return strings.EqualFold(os.Getenv("CGO_ENABLED"), "1")
-	}
-	if strings.HasPrefix(tag, "go1.") {
-		return isSupportedGoReleaseTag(tag)
-	}
-	// Unknown tags are treated as disabled unless set explicitly.
-	return false
-}
-
-func isSupportedGoReleaseTag(tag string) bool {
-	minorCurrent, ok := goVersionMinor(runtime.Version())
-	if !ok {
-		return false
-	}
-	if !strings.HasPrefix(tag, "go1.") {
-		return false
-	}
-	minorTag, ok := leadingInt(strings.TrimPrefix(tag, "go1."))
-	if !ok {
-		return false
-	}
-	return minorTag <= minorCurrent
-}
-
-func goVersionMinor(version string) (int, bool) {
-	normalized := strings.TrimSpace(version)
-	normalized = strings.TrimPrefix(normalized, "devel ")
-	goIndex := strings.Index(normalized, "go")
-	if goIndex < 0 {
-		return 0, false
-	}
-	normalized = strings.TrimPrefix(normalized[goIndex:], "go")
-	normalized = strings.SplitN(normalized, " ", 2)[0]
-	normalized = strings.SplitN(normalized, "-", 2)[0]
-
-	versionParts := strings.Split(normalized, ".")
-	if len(versionParts) < 2 || versionParts[0] != "1" {
-		return 0, false
-	}
-	return leadingInt(versionParts[1])
-}
-
-func leadingInt(value string) (int, bool) {
-	if value == "" {
-		return 0, false
-	}
-	n := 0
-	seen := false
-	for i := 0; i < len(value); i++ {
-		if value[i] < '0' || value[i] > '9' {
-			break
-		}
-		seen = true
-		n = (n * 10) + int(value[i]-'0')
-	}
-	if !seen {
-		return 0, false
-	}
-	return n, true
-}
-
-func parseIntDefault(value string, fallback int) int {
-	if value == "" {
-		return fallback
-	}
-	n := 0
-	for i := 0; i < len(value); i++ {
-		if value[i] < '0' || value[i] > '9' {
-			return fallback
-		}
-		n = (n * 10) + int(value[i]-'0')
-	}
-	return n
-}
-
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 func applyImportMetadata(metadata []importMetadata, result *scanResult) {
@@ -714,27 +299,67 @@ func applyImportMetadata(metadata []importMetadata, result *scanResult) {
 		if item.Undeclared {
 			result.UndeclaredImportsByDependency[item.Dependency]++
 		}
+		current := result.DependencyProvenanceByDep[item.Dependency]
+		current.Declared = current.Declared || item.Provenance.Declared
+		current.Replacement = current.Replacement || item.Provenance.Replacement
+		current.Vendored = current.Vendored || item.Provenance.Vendored
+		result.DependencyProvenanceByDep[item.Dependency] = current
 	}
 }
 
 func dependencyFromImport(importPath string, moduleInfo moduleInfo) string {
+	return resolveDependencyFromImport(importPath, moduleInfo).Dependency
+}
+
+type resolvedGoDependency struct {
+	Dependency string
+	Provenance goDependencyProvenance
+}
+
+func resolveDependencyFromImport(importPath string, moduleInfo moduleInfo) resolvedGoDependency {
 	importPath = strings.TrimSpace(importPath)
 	if importPath == "" || importPath == "C" {
-		return ""
+		return resolvedGoDependency{}
 	}
 	if isLocalModuleImport(importPath, moduleInfo.LocalModulePaths) {
-		return ""
+		return resolvedGoDependency{}
 	}
 	if !looksExternalImport(importPath) {
-		return ""
+		return resolvedGoDependency{}
+	}
+	vendoredDependency := ""
+	if moduleInfo.VendoredProvenanceEnabled {
+		vendoredDependency = normalizeDependencyID(longestVendoredDependency(importPath, moduleInfo.VendoredImportDependencies))
 	}
 	if dependency := longestDeclaredDependency(importPath, moduleInfo.DeclaredDependencies); dependency != "" {
-		return normalizeDependencyID(dependency)
+		dependency = normalizeDependencyID(dependency)
+		return resolvedGoDependency{
+			Dependency: dependency,
+			Provenance: goDependencyProvenance{
+				Declared: true,
+				Vendored: vendoredDependency == dependency,
+			},
+		}
 	}
 	if dependency := longestReplacementDependency(importPath, moduleInfo.ReplacementImports); dependency != "" {
-		return normalizeDependencyID(dependency)
+		dependency = normalizeDependencyID(dependency)
+		return resolvedGoDependency{
+			Dependency: dependency,
+			Provenance: goDependencyProvenance{
+				Replacement: true,
+				Vendored:    vendoredDependency == dependency,
+			},
+		}
 	}
-	return normalizeDependencyID(inferDependency(importPath))
+	if vendoredDependency != "" {
+		return resolvedGoDependency{
+			Dependency: vendoredDependency,
+			Provenance: goDependencyProvenance{Vendored: true},
+		}
+	}
+	return resolvedGoDependency{
+		Dependency: normalizeDependencyID(inferDependency(importPath)),
+	}
 }
 
 func isLocalModuleImport(importPath string, localModules []string) bool {
@@ -750,10 +375,11 @@ func isLocalModuleImport(importPath string, localModules []string) bool {
 }
 
 func looksExternalImport(importPath string) bool {
-	parts := strings.Split(importPath, "/")
-	if len(parts) == 0 {
+	importPath = strings.TrimSpace(importPath)
+	if importPath == "" {
 		return false
 	}
+	parts := strings.Split(importPath, "/")
 	return strings.Contains(parts[0], ".")
 }
 
@@ -794,10 +420,11 @@ func hasImportPathPrefix(importPath, dependency string) bool {
 }
 
 func inferDependency(importPath string) string {
-	parts := strings.Split(importPath, "/")
-	if len(parts) == 0 {
+	importPath = strings.TrimSpace(importPath)
+	if importPath == "" {
 		return ""
 	}
+	parts := strings.Split(importPath, "/")
 	if !strings.Contains(parts[0], ".") {
 		return ""
 	}
@@ -877,6 +504,7 @@ func buildDependencyReport(dependency string, scan scanResult) (report.Dependenc
 	dep.TopUsedSymbols = stats.TopSymbols
 	dep.UsedImports = stats.UsedImports
 	dep.UnusedImports = stats.UnusedImports
+	dep.Provenance = buildGoDependencyProvenance(scan.DependencyProvenanceByDep[dependency])
 
 	warnings := dependencyWarnings(dependency, stats.HasImports)
 	if stats.WildcardImports > 0 {
@@ -902,6 +530,39 @@ func buildDependencyReport(dependency string, scan scanResult) (report.Dependenc
 	}
 	dep.Recommendations = buildRecommendations(dep, scan.UndeclaredImportsByDependency[dependency] > 0)
 	return dep, warnings
+}
+
+func buildGoDependencyProvenance(info goDependencyProvenance) *report.DependencyProvenance {
+	if !info.Declared && !info.Replacement && !info.Vendored {
+		return nil
+	}
+	signals := make([]string, 0, 3)
+	source := "go.mod"
+	confidence := "medium"
+	if info.Declared {
+		signals = append(signals, goModName)
+		confidence = "high"
+	}
+	if info.Replacement {
+		signals = append(signals, "replace")
+		source = "go.mod-replace"
+		confidence = "high"
+	}
+	if info.Vendored {
+		signals = append(signals, vendorModulesTxtName)
+		if info.Declared || info.Replacement {
+			source = "go.mod+vendor"
+			confidence = "high"
+		} else {
+			source = "vendor/modules.txt"
+			confidence = "medium"
+		}
+	}
+	return &report.DependencyProvenance{
+		Source:     source,
+		Confidence: confidence,
+		Signals:    uniqueStrings(signals),
+	}
 }
 
 func buildRecommendations(dep report.DependencyReport, hasUndeclaredImports bool) []report.Recommendation {
@@ -952,296 +613,6 @@ func appendDotImportRecommendation(recs []report.Recommendation, dep report.Depe
 
 func goFileUsages(scan scanResult) []shared.FileUsage {
 	return shared.MapFileUsages(scan.Files, func(file fileScan) []shared.ImportRecord { return file.Imports }, func(file fileScan) map[string]int { return file.Usage })
-}
-
-func parseGoMod(content []byte) (string, []string, map[string]string) {
-	state := goModParseState{
-		depSet:     make(map[string]struct{}),
-		replaceSet: make(map[string]string),
-	}
-	for _, rawLine := range strings.Split(string(content), "\n") {
-		processGoModLine(strings.TrimSpace(stripInlineComment(rawLine)), &state)
-	}
-
-	dependencies := make([]string, 0, len(state.depSet))
-	for dep := range state.depSet {
-		dependencies = append(dependencies, dep)
-	}
-	sort.Strings(dependencies)
-	return state.modulePath, dependencies, state.replaceSet
-}
-
-type goModParseState struct {
-	modulePath     string
-	depSet         map[string]struct{}
-	replaceSet     map[string]string
-	inRequireBlock bool
-	inReplaceBlock bool
-}
-
-func processGoModLine(line string, state *goModParseState) {
-	if line == "" || state == nil {
-		return
-	}
-	if parseGoModModuleLine(line, state) {
-		return
-	}
-	if parseGoModRequireBlockControl(line, state) {
-		return
-	}
-	if parseGoModReplaceBlockControl(line, state) {
-		return
-	}
-	if state.inReplaceBlock {
-		addGoModReplacement(line, state.replaceSet)
-		return
-	}
-	if state.inRequireBlock {
-		addGoModDependency(line, state.depSet)
-		return
-	}
-	parseGoModSingleRequire(line, state.depSet)
-	parseGoModSingleReplace(line, state.replaceSet)
-}
-
-func parseGoModModuleLine(line string, state *goModParseState) bool {
-	if !strings.HasPrefix(line, "module ") {
-		return false
-	}
-	fields := strings.Fields(line)
-	if len(fields) >= 2 {
-		state.modulePath = fields[1]
-	}
-	return true
-}
-
-func parseGoModRequireBlockControl(line string, state *goModParseState) bool {
-	return parseGoModBlockControl(line, "require (", &state.inRequireBlock)
-}
-
-func parseGoModReplaceBlockControl(line string, state *goModParseState) bool {
-	return parseGoModBlockControl(line, "replace (", &state.inReplaceBlock)
-}
-
-func parseGoModBlockControl(line string, startToken string, inBlock *bool) bool {
-	if inBlock == nil {
-		return false
-	}
-	if strings.HasPrefix(line, startToken) {
-		*inBlock = true
-		return true
-	}
-	if *inBlock && line == ")" {
-		*inBlock = false
-		return true
-	}
-	return false
-}
-
-func parseGoModSingleRequire(line string, depSet map[string]struct{}) {
-	parseGoModSingleDirective(line, "require ", func(value string) {
-		addGoModDependency(value, depSet)
-	})
-}
-
-func parseGoModSingleReplace(line string, replaceSet map[string]string) {
-	parseGoModSingleDirective(line, "replace ", func(value string) {
-		addGoModReplacement(value, replaceSet)
-	})
-}
-
-func parseGoModSingleDirective(line, prefix string, handler func(string)) {
-	if handler == nil || !strings.HasPrefix(line, prefix) {
-		return
-	}
-	handler(strings.TrimPrefix(line, prefix))
-}
-
-func addGoModDependency(line string, depSet map[string]struct{}) {
-	if depSet == nil {
-		return
-	}
-	fields := strings.Fields(line)
-	if len(fields) == 0 {
-		return
-	}
-	depSet[fields[0]] = struct{}{}
-}
-
-func addGoModReplacement(line string, replaceSet map[string]string) {
-	if replaceSet == nil {
-		return
-	}
-	parts := strings.SplitN(line, "=>", 2)
-	if len(parts) != 2 {
-		return
-	}
-	oldPath := firstToken(parts[0])
-	newPath := firstToken(parts[1])
-	if oldPath == "" || newPath == "" {
-		return
-	}
-	if isLocalReplaceTarget(newPath) {
-		return
-	}
-	// Track only import-like replacement targets.
-	if !looksExternalImport(newPath) {
-		return
-	}
-	replaceSet[newPath] = oldPath
-}
-
-func isLocalReplaceTarget(pathValue string) bool {
-	pathValue = strings.TrimSpace(pathValue)
-	if pathValue == "" {
-		return false
-	}
-	if strings.HasPrefix(pathValue, "./") || strings.HasPrefix(pathValue, "../") || strings.HasPrefix(pathValue, "/") {
-		return true
-	}
-	if len(pathValue) >= 2 && pathValue[1] == ':' {
-		return true
-	}
-	return false
-}
-
-func firstToken(value string) string {
-	fields := strings.Fields(strings.TrimSpace(value))
-	if len(fields) == 0 {
-		return ""
-	}
-	return fields[0]
-}
-
-func loadGoWorkLocalModules(repoPath string) ([]string, error) {
-	useEntries, err := readGoWorkUseEntries(repoPath)
-	if err != nil {
-		return nil, err
-	}
-	modulePaths := make([]string, 0)
-	for _, rel := range useEntries {
-		resolved, ok := resolveRepoBoundedPath(repoPath, rel)
-		if !ok {
-			continue
-		}
-		modulePath, _, _, err := loadGoModFromDir(repoPath, resolved)
-		if err != nil || modulePath == "" {
-			continue
-		}
-		modulePaths = append(modulePaths, modulePath)
-	}
-	return uniqueStrings(modulePaths), nil
-}
-
-func readGoWorkUseEntries(repoPath string) ([]string, error) {
-	workPath := filepath.Join(repoPath, goWorkName)
-	exists, err := manifestPathExists(workPath)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, nil
-	}
-	content, err := safeio.ReadFileUnder(repoPath, workPath)
-	if err != nil {
-		return nil, err
-	}
-	return parseGoWorkUseEntries(content), nil
-}
-
-func parseGoWorkUseEntries(content []byte) []string {
-	entries := make([]string, 0)
-	inUseBlock := false
-	for _, rawLine := range strings.Split(string(content), "\n") {
-		line := strings.TrimSpace(stripInlineComment(rawLine))
-		if line == "" {
-			continue
-		}
-		switch {
-		case strings.HasPrefix(line, "use ("):
-			inUseBlock = true
-		case inUseBlock && line == ")":
-			inUseBlock = false
-		case inUseBlock:
-			entries = append(entries, normalizeGoWorkPath(line))
-		case strings.HasPrefix(line, "use "):
-			entries = append(entries, normalizeGoWorkPath(strings.TrimPrefix(line, "use ")))
-		}
-	}
-	return uniqueStrings(entries)
-}
-
-func normalizeGoWorkPath(value string) string {
-	value = strings.TrimSpace(value)
-	value = strings.Trim(value, "\"")
-	if value == "" {
-		return ""
-	}
-	return filepath.Clean(value)
-}
-
-func loadGoModFromDir(repoPath, dir string) (string, []string, map[string]string, error) {
-	goModPath := filepath.Join(dir, goModName)
-	content, err := safeio.ReadFileUnder(repoPath, goModPath)
-	if err != nil {
-		return "", nil, nil, err
-	}
-	modulePath, dependencies, replacements := parseGoMod(content)
-	return modulePath, dependencies, replacements, nil
-}
-
-func resolveRepoBoundedPath(repoPath, value string) (string, bool) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "", false
-	}
-
-	resolved := value
-	if !filepath.IsAbs(resolved) {
-		resolved = filepath.Join(repoPath, resolved)
-	}
-	resolved = filepath.Clean(resolved)
-
-	repoAbs, err := filepath.Abs(repoPath)
-	if err != nil {
-		return "", false
-	}
-	resolvedAbs, err := filepath.Abs(resolved)
-	if err != nil {
-		return "", false
-	}
-	relativeToRepo, err := filepath.Rel(repoAbs, resolvedAbs)
-	if err != nil {
-		return "", false
-	}
-	if relativeToRepo == ".." || strings.HasPrefix(relativeToRepo, ".."+string(filepath.Separator)) {
-		return "", false
-	}
-	return resolvedAbs, true
-}
-
-func uniqueStrings(values []string) []string {
-	seen := make(map[string]struct{}, len(values))
-	result := make([]string, 0, len(values))
-	for _, value := range values {
-		normalized := strings.TrimSpace(value)
-		if normalized == "" {
-			continue
-		}
-		if _, ok := seen[normalized]; ok {
-			continue
-		}
-		seen[normalized] = struct{}{}
-		result = append(result, normalized)
-	}
-	return result
-}
-
-func stripInlineComment(line string) string {
-	if index := strings.Index(line, "//"); index >= 0 {
-		return line[:index]
-	}
-	return line
 }
 
 func normalizeDependencyID(value string) string {

--- a/internal/lang/golang/build_tags.go
+++ b/internal/lang/golang/build_tags.go
@@ -1,0 +1,189 @@
+package golang
+
+import (
+	"go/build/constraint"
+	"os"
+	"runtime"
+	"strings"
+)
+
+func isGeneratedGoFile(content []byte) bool {
+	lines := strings.Split(string(content), "\n")
+	maxLines := minInt(len(lines), 20)
+	for i := 0; i < maxLines; i++ {
+		line := strings.ToLower(strings.TrimSpace(lines[i]))
+		if strings.Contains(line, "code generated") && strings.Contains(line, "do not edit") {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesActiveBuild(content []byte) bool {
+	goBuildExpr, plusBuildExprs := extractBuildConstraintExpressions(content)
+	switch {
+	case goBuildExpr != nil:
+		return goBuildExpr.Eval(isActiveBuildTag)
+	case len(plusBuildExprs) > 0:
+		for _, expr := range plusBuildExprs {
+			if !expr.Eval(isActiveBuildTag) {
+				return false
+			}
+		}
+		return true
+	default:
+		return true
+	}
+}
+
+func extractBuildConstraintExpressions(content []byte) (constraint.Expr, []constraint.Expr) {
+	lines := strings.Split(string(content), "\n")
+	maxLines := minInt(len(lines), maxGoBuildHeaderLine)
+	plusBuildExprs := make([]constraint.Expr, 0)
+	var goBuildExpr constraint.Expr
+
+	for i := 0; i < maxLines; i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if shouldStopBuildConstraintScan(line) {
+			break
+		}
+		expr, kind := parseBuildConstraintComment(line)
+		switch kind {
+		case "go":
+			if expr != nil {
+				goBuildExpr = expr
+			}
+		case "plus":
+			if expr != nil {
+				plusBuildExprs = append(plusBuildExprs, expr)
+			}
+		}
+	}
+	return goBuildExpr, plusBuildExprs
+}
+
+func shouldStopBuildConstraintScan(line string) bool {
+	if strings.HasPrefix(line, "package ") {
+		return true
+	}
+	return !strings.HasPrefix(line, "//")
+}
+
+func parseBuildConstraintComment(line string) (constraint.Expr, string) {
+	switch {
+	case strings.HasPrefix(line, "//go:build "):
+		expr, err := constraint.Parse(line)
+		if err != nil {
+			return nil, "go"
+		}
+		return expr, "go"
+	case strings.HasPrefix(line, "// +build "):
+		expr, err := constraint.Parse(line)
+		if err != nil {
+			return nil, "plus"
+		}
+		return expr, "plus"
+	default:
+		return nil, ""
+	}
+}
+
+func isActiveBuildTag(tag string) bool {
+	tag = strings.TrimSpace(strings.ToLower(tag))
+	if tag == "" {
+		return false
+	}
+	if tag == runtime.GOOS || tag == runtime.GOARCH {
+		return true
+	}
+	if tag == "unix" {
+		switch runtime.GOOS {
+		case "android", "darwin", "dragonfly", "freebsd", "illumos", "ios", "linux", "netbsd", "openbsd", "solaris":
+			return true
+		}
+	}
+	if tag == "cgo" {
+		return strings.EqualFold(os.Getenv("CGO_ENABLED"), "1")
+	}
+	if strings.HasPrefix(tag, "go1.") {
+		return isSupportedGoReleaseTag(tag)
+	}
+	// Unknown tags are treated as disabled unless set explicitly.
+	return false
+}
+
+func isSupportedGoReleaseTag(tag string) bool {
+	minorCurrent, ok := goVersionMinor(runtime.Version())
+	if !ok {
+		return false
+	}
+	if !strings.HasPrefix(tag, "go1.") {
+		return false
+	}
+	minorTag, ok := leadingInt(strings.TrimPrefix(tag, "go1."))
+	if !ok {
+		return false
+	}
+	return minorTag <= minorCurrent
+}
+
+func goVersionMinor(version string) (int, bool) {
+	normalized := strings.TrimSpace(version)
+	normalized = strings.TrimPrefix(normalized, "devel ")
+	goIndex := strings.Index(normalized, "go")
+	if goIndex < 0 {
+		return 0, false
+	}
+	normalized = strings.TrimPrefix(normalized[goIndex:], "go")
+	normalized = strings.SplitN(normalized, " ", 2)[0]
+	normalized = strings.SplitN(normalized, "-", 2)[0]
+
+	versionParts := strings.Split(normalized, ".")
+	if len(versionParts) < 2 || versionParts[0] != "1" {
+		return 0, false
+	}
+	return leadingInt(versionParts[1])
+}
+
+func leadingInt(value string) (int, bool) {
+	if value == "" {
+		return 0, false
+	}
+	n := 0
+	seen := false
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			break
+		}
+		seen = true
+		n = (n * 10) + int(value[i]-'0')
+	}
+	if !seen {
+		return 0, false
+	}
+	return n, true
+}
+
+func parseIntDefault(value string, fallback int) int {
+	if value == "" {
+		return fallback
+	}
+	n := 0
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return fallback
+		}
+		n = (n * 10) + int(value[i]-'0')
+	}
+	return n
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/lang/golang/constants.go
+++ b/internal/lang/golang/constants.go
@@ -1,0 +1,15 @@
+package golang
+
+const (
+	goModName                          = "go.mod"
+	goWorkName                         = "go.work"
+	goVendoredProvenancePreviewFeature = "go-vendored-provenance-preview"
+	vendorModulesTxtName               = "vendor/modules.txt"
+	maxScannableGoFile                 = 2 * 1024 * 1024
+	maxGoBuildHeaderLine               = 64
+)
+
+var goSkippedDirs = map[string]bool{
+	"bin":        true,
+	".artifacts": true,
+}

--- a/internal/lang/golang/coverage_helper_test.go
+++ b/internal/lang/golang/coverage_helper_test.go
@@ -1,0 +1,114 @@
+package golang
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestCoverageHelperBranches(t *testing.T) {
+	if looksExternalImport("") {
+		t.Fatalf("expected empty import path to be non-external")
+	}
+	if looksExternalImport("stdlib") {
+		t.Fatalf("expected stdlib import path to be non-external")
+	}
+
+	if got := inferDependency(""); got != "" {
+		t.Fatalf("expected empty import to infer empty dependency, got %q", got)
+	}
+	if got := inferDependency("single"); got != "" {
+		t.Fatalf("expected non-domain import to infer empty dependency, got %q", got)
+	}
+
+	if expr, kind := parseBuildConstraintComment("not a constraint comment"); expr != nil || kind != "" {
+		t.Fatalf("expected non-constraint comment parse to return nil/empty, got expr=%v kind=%q", expr, kind)
+	}
+	if isSupportedGoReleaseTag("invalid") {
+		t.Fatalf("expected invalid release tag to be unsupported")
+	}
+
+	if _, err := readGoWorkUseEntries("\x00"); err == nil {
+		t.Fatalf("expected invalid repo path to fail go.work read")
+	}
+
+	applyVendoredMetadataDirective("## ", &vendoredDependencyMetadata{})
+	appendVendoredMetadataWarnings(nil, vendoredParseState{})
+
+	if _, err := loadGoModuleInfoWithOptions("\x00", moduleLoadOptions{}); err == nil {
+		t.Fatalf("expected invalid repo path to fail module loading")
+	}
+}
+
+func TestLoadGoModuleInfoWithOptionsErrorBranches(t *testing.T) {
+	t.Run("workspace read failure", func(t *testing.T) {
+		repo := t.TempDir()
+		goWorkPath := filepath.Join(repo, goWorkName)
+		testutil.MustWriteFile(t, goWorkPath, "use ./module\n")
+		if err := os.Chmod(goWorkPath, 0); err != nil {
+			t.Skipf("chmod go.work unreadable: %v", err)
+		}
+		defer func() {
+			if chmodErr := os.Chmod(goWorkPath, 0o644); chmodErr != nil {
+				t.Errorf("restore go.work permissions: %v", chmodErr)
+			}
+		}()
+
+		if _, err := loadGoModuleInfoWithOptions(repo, moduleLoadOptions{}); err == nil {
+			t.Fatalf("expected unreadable go.work to fail module loading")
+		}
+	})
+
+	t.Run("nested walk failure", func(t *testing.T) {
+		repo := t.TempDir()
+		locked := filepath.Join(repo, "locked")
+		if err := os.MkdirAll(locked, 0o755); err != nil {
+			t.Fatalf("mkdir locked: %v", err)
+		}
+		if err := os.Chmod(locked, 0); err != nil {
+			t.Skipf("chmod locked dir unreadable: %v", err)
+		}
+		defer func() {
+			if chmodErr := os.Chmod(locked, 0o755); chmodErr != nil {
+				t.Errorf("restore locked dir permissions: %v", chmodErr)
+			}
+		}()
+
+		if _, err := loadGoModuleInfoWithOptions(repo, moduleLoadOptions{}); err == nil {
+			t.Fatalf("expected unreadable nested directory to fail module loading")
+		}
+	})
+
+	t.Run("vendored read failure", func(t *testing.T) {
+		repo := t.TempDir()
+		vendorModules := filepath.Join(repo, vendorModulesTxtName)
+		testutil.MustWriteFile(t, vendorModules, "# github.com/acme/dep v1.0.0\n")
+		if err := os.Chmod(vendorModules, 0); err != nil {
+			t.Skipf("chmod vendor/modules.txt unreadable: %v", err)
+		}
+		defer func() {
+			if chmodErr := os.Chmod(vendorModules, 0o644); chmodErr != nil {
+				t.Errorf("restore vendor/modules.txt permissions: %v", chmodErr)
+			}
+		}()
+
+		if _, err := loadGoModuleInfoWithOptions(repo, moduleLoadOptions{EnableVendoredProvenance: true}); err == nil {
+			t.Fatalf("expected unreadable vendor/modules.txt to fail module loading")
+		}
+	})
+}
+
+func TestResolveRepoBoundedPathAbsoluteOutside(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+
+	if resolved, ok := resolveRepoBoundedPath(repo, filepath.Join(repo, "inside")); !ok || !strings.HasPrefix(resolved, repo) {
+		t.Fatalf("expected absolute in-repo path to resolve, got resolved=%q ok=%v", resolved, ok)
+	}
+	if _, ok := resolveRepoBoundedPath(repo, filepath.Join(outside, "x")); ok {
+		t.Fatalf("expected absolute path outside repo to be rejected")
+	}
+}

--- a/internal/lang/golang/coverage_helper_test.go
+++ b/internal/lang/golang/coverage_helper_test.go
@@ -44,59 +44,54 @@ func TestCoverageHelperBranches(t *testing.T) {
 }
 
 func TestLoadGoModuleInfoWithOptionsErrorBranches(t *testing.T) {
-	t.Run("workspace read failure", func(t *testing.T) {
-		repo := t.TempDir()
-		goWorkPath := filepath.Join(repo, goWorkName)
-		testutil.MustWriteFile(t, goWorkPath, "use ./module\n")
-		if err := os.Chmod(goWorkPath, 0); err != nil {
-			t.Skipf("chmod go.work unreadable: %v", err)
-		}
-		defer func() {
-			if chmodErr := os.Chmod(goWorkPath, 0o644); chmodErr != nil {
-				t.Errorf("restore go.work permissions: %v", chmodErr)
-			}
-		}()
+	t.Run("workspace read failure", testWorkspaceReadFailure)
+	t.Run("nested walk failure", testNestedWalkFailure)
+	t.Run("vendored read failure", testVendoredReadFailure)
+}
 
-		if _, err := loadGoModuleInfoWithOptions(repo, moduleLoadOptions{}); err == nil {
-			t.Fatalf("expected unreadable go.work to fail module loading")
-		}
-	})
+func testWorkspaceReadFailure(t *testing.T) {
+	repo := t.TempDir()
+	goWorkPath := filepath.Join(repo, goWorkName)
+	testutil.MustWriteFile(t, goWorkPath, "use ./module\n")
+	setUnreadableForTest(t, goWorkPath, 0o644, "go.work")
 
-	t.Run("nested walk failure", func(t *testing.T) {
-		repo := t.TempDir()
-		locked := filepath.Join(repo, "locked")
-		if err := os.MkdirAll(locked, 0o755); err != nil {
-			t.Fatalf("mkdir locked: %v", err)
-		}
-		if err := os.Chmod(locked, 0); err != nil {
-			t.Skipf("chmod locked dir unreadable: %v", err)
-		}
-		defer func() {
-			if chmodErr := os.Chmod(locked, 0o755); chmodErr != nil {
-				t.Errorf("restore locked dir permissions: %v", chmodErr)
-			}
-		}()
+	if _, err := loadGoModuleInfoWithOptions(repo, moduleLoadOptions{}); err == nil {
+		t.Fatalf("expected unreadable go.work to fail module loading")
+	}
+}
 
-		if _, err := loadGoModuleInfoWithOptions(repo, moduleLoadOptions{}); err == nil {
-			t.Fatalf("expected unreadable nested directory to fail module loading")
-		}
-	})
+func testNestedWalkFailure(t *testing.T) {
+	repo := t.TempDir()
+	locked := filepath.Join(repo, "locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatalf("mkdir locked: %v", err)
+	}
+	setUnreadableForTest(t, locked, 0o755, "locked dir")
 
-	t.Run("vendored read failure", func(t *testing.T) {
-		repo := t.TempDir()
-		vendorModules := filepath.Join(repo, vendorModulesTxtName)
-		testutil.MustWriteFile(t, vendorModules, "# github.com/acme/dep v1.0.0\n")
-		if err := os.Chmod(vendorModules, 0); err != nil {
-			t.Skipf("chmod vendor/modules.txt unreadable: %v", err)
-		}
-		defer func() {
-			if chmodErr := os.Chmod(vendorModules, 0o644); chmodErr != nil {
-				t.Errorf("restore vendor/modules.txt permissions: %v", chmodErr)
-			}
-		}()
+	if _, err := loadGoModuleInfoWithOptions(repo, moduleLoadOptions{}); err == nil {
+		t.Fatalf("expected unreadable nested directory to fail module loading")
+	}
+}
 
-		if _, err := loadGoModuleInfoWithOptions(repo, moduleLoadOptions{EnableVendoredProvenance: true}); err == nil {
-			t.Fatalf("expected unreadable vendor/modules.txt to fail module loading")
+func testVendoredReadFailure(t *testing.T) {
+	repo := t.TempDir()
+	vendorModules := filepath.Join(repo, vendorModulesTxtName)
+	testutil.MustWriteFile(t, vendorModules, "# github.com/acme/dep v1.0.0\n")
+	setUnreadableForTest(t, vendorModules, 0o644, "vendor/modules.txt")
+
+	if _, err := loadGoModuleInfoWithOptions(repo, moduleLoadOptions{EnableVendoredProvenance: true}); err == nil {
+		t.Fatalf("expected unreadable vendor/modules.txt to fail module loading")
+	}
+}
+
+func setUnreadableForTest(t *testing.T, path string, restoreMode os.FileMode, label string) {
+	t.Helper()
+	if err := os.Chmod(path, 0); err != nil {
+		t.Skipf("chmod %s unreadable: %v", label, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(path, restoreMode); err != nil {
+			t.Errorf("restore %s permissions: %v", label, err)
 		}
 	})
 }

--- a/internal/lang/golang/detection.go
+++ b/internal/lang/golang/detection.go
@@ -1,0 +1,121 @@
+package golang
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
+	"github.com/ben-ranford/lopper/internal/language"
+)
+
+func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (language.Detection, error) {
+	repoPath = shared.DefaultRepoPath(repoPath)
+
+	detection := language.Detection{}
+	roots := make(map[string]struct{})
+	if err := applyGoRootSignals(repoPath, &detection, roots); err != nil {
+		return language.Detection{}, err
+	}
+
+	const maxFiles = 1024
+	visited := 0
+	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if ctx != nil && ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return walkGoDetectionEntry(path, entry, roots, &detection, &visited, maxFiles)
+	})
+	if err != nil && !errors.Is(err, fs.SkipAll) {
+		return language.Detection{}, err
+	}
+
+	return shared.FinalizeDetection(repoPath, detection, roots), nil
+}
+
+func walkGoDetectionEntry(path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection, visited *int, maxFiles int) error {
+	if entry.IsDir() {
+		if shouldSkipDir(entry.Name()) {
+			return filepath.SkipDir
+		}
+		return nil
+	}
+	(*visited)++
+	if *visited > maxFiles {
+		return fs.SkipAll
+	}
+	updateGoDetection(path, entry, roots, detection)
+	return nil
+}
+
+func manifestPathExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if info.IsDir() {
+		return false, nil
+	}
+	return true, nil
+}
+
+func applyGoRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
+	rootSignals := []struct {
+		name       string
+		confidence int
+	}{
+		{name: goModName, confidence: 55},
+		{name: goWorkName, confidence: 45},
+	}
+	for _, signal := range rootSignals {
+		candidate := filepath.Join(repoPath, signal.name)
+		exists, err := manifestPathExists(candidate)
+		if err != nil {
+			return err
+		}
+		if exists {
+			detection.Matched = true
+			detection.Confidence += signal.confidence
+			roots[repoPath] = struct{}{}
+			if signal.name == goWorkName {
+				if err := addGoWorkRoots(repoPath, roots); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func addGoWorkRoots(repoPath string, roots map[string]struct{}) error {
+	moduleDirs, err := goWorkModuleDirs(repoPath)
+	if err != nil {
+		return err
+	}
+	for dir := range moduleDirs {
+		roots[dir] = struct{}{}
+	}
+	return nil
+}
+
+func updateGoDetection(path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection) {
+	switch strings.ToLower(entry.Name()) {
+	case goModName, goWorkName:
+		detection.Matched = true
+		detection.Confidence += 12
+		roots[filepath.Dir(path)] = struct{}{}
+	}
+	if strings.EqualFold(filepath.Ext(path), ".go") {
+		detection.Matched = true
+		detection.Confidence += 2
+	}
+}

--- a/internal/lang/golang/module_loading.go
+++ b/internal/lang/golang/module_loading.go
@@ -10,9 +10,11 @@ import (
 
 var errNilModuleInfo = errors.New("module info is nil")
 
-func loadGoModuleInfo(repoPath string) (moduleInfo, error) {
+func loadGoModuleInfoWithOptions(repoPath string, options moduleLoadOptions) (moduleInfo, error) {
 	info := moduleInfo{
-		ReplacementImports: make(map[string]string),
+		ReplacementImports:         make(map[string]string),
+		VendoredImportDependencies: make(map[string]string),
+		VendoredDependencies:       make(map[string]vendoredDependencyMetadata),
 	}
 
 	if err := loadRootModuleInfo(repoPath, &info); err != nil {
@@ -24,11 +26,22 @@ func loadGoModuleInfo(repoPath string) (moduleInfo, error) {
 	if err := loadNestedModules(repoPath, &info); err != nil {
 		return moduleInfo{}, err
 	}
+	if err := loadVendoredMetadata(repoPath, options, &info); err != nil {
+		return moduleInfo{}, err
+	}
 
 	if err := finalizeGoModuleInfo(&info); err != nil {
 		return moduleInfo{}, err
 	}
 	return info, nil
+}
+
+func loadGoModuleInfo(repoPath string, opts ...moduleLoadOptions) (moduleInfo, error) {
+	options := moduleLoadOptions{}
+	if len(opts) > 0 {
+		options = opts[0]
+	}
+	return loadGoModuleInfoWithOptions(repoPath, options)
 }
 
 func loadRootModuleInfo(repoPath string, info *moduleInfo) error {
@@ -89,6 +102,30 @@ func loadNestedModules(repoPath string, info *moduleInfo) error {
 	return nil
 }
 
+func loadVendoredMetadata(repoPath string, options moduleLoadOptions, info *moduleInfo) error {
+	if info == nil || !options.EnableVendoredProvenance {
+		return nil
+	}
+	metadata, err := loadVendoredModuleMetadata(repoPath)
+	if err != nil {
+		return err
+	}
+	info.VendoredProvenanceEnabled = metadata.ManifestFound
+	info.VendoringWarnings = append(info.VendoringWarnings, metadata.Warnings...)
+	if !metadata.ManifestFound {
+		return nil
+	}
+	for importPrefix, dependency := range metadata.ImportToDependency {
+		if _, ok := info.VendoredImportDependencies[importPrefix]; !ok {
+			info.VendoredImportDependencies[importPrefix] = normalizeDependencyID(dependency)
+		}
+	}
+	for dependency, item := range metadata.Dependencies {
+		info.VendoredDependencies[dependency] = item
+	}
+	return nil
+}
+
 func finalizeGoModuleInfo(info *moduleInfo) error {
 	if info == nil {
 		return errNilModuleInfo
@@ -98,5 +135,6 @@ func finalizeGoModuleInfo(info *moduleInfo) error {
 	info.DeclaredDependencies = uniqueStrings(info.DeclaredDependencies)
 	sort.Strings(info.LocalModulePaths)
 	sort.Strings(info.DeclaredDependencies)
+	sort.Strings(info.VendoringWarnings)
 	return nil
 }

--- a/internal/lang/golang/module_metadata.go
+++ b/internal/lang/golang/module_metadata.go
@@ -359,69 +359,89 @@ func loadVendoredModuleMetadata(repoPath string) (vendoredModuleMetadata, error)
 }
 
 func parseVendoredModuleMetadata(content []byte) vendoredModuleMetadata {
-	metadata := vendoredModuleMetadata{
-		ImportToDependency: make(map[string]string),
-		Dependencies:       make(map[string]vendoredDependencyMetadata),
-	}
-
-	state := vendoredParseState{currentDependency: ""}
+	metadata := newVendoredModuleMetadata()
+	state := vendoredParseState{}
 	for _, rawLine := range strings.Split(string(content), "\n") {
-		line := strings.TrimSpace(rawLine)
-		if line == "" {
-			continue
-		}
-		switch {
-		case strings.HasPrefix(line, "# "):
-			dependency, replacement, ok := parseVendoredModuleHeader(line)
-			if !ok {
-				state.malformedModuleHeaders++
-				state.currentDependency = ""
-				continue
-			}
-			normalizedDependency := normalizeDependencyID(dependency)
-			current := metadata.Dependencies[normalizedDependency]
-			current.ModulePath = dependency
-			if replacement != "" {
-				current.Replacement = true
-				current.ReplacementTarget = replacement
-			}
-			metadata.Dependencies[normalizedDependency] = current
-			if _, ok := metadata.ImportToDependency[dependency]; !ok {
-				metadata.ImportToDependency[dependency] = normalizedDependency
-			}
-			state.currentDependency = normalizedDependency
-		case strings.HasPrefix(line, "## "):
-			if state.currentDependency == "" {
-				continue
-			}
-			current := metadata.Dependencies[state.currentDependency]
-			applyVendoredMetadataDirective(line, &current)
-			metadata.Dependencies[state.currentDependency] = current
-		case strings.HasPrefix(line, "#"):
-			continue
-		default:
-			pkg := firstToken(line)
-			if pkg == "" {
-				continue
-			}
-			if state.currentDependency == "" {
-				state.orphanPackageLines++
-				continue
-			}
-			current := metadata.Dependencies[state.currentDependency]
-			if current.ModulePath != "" && !hasImportPathPrefix(pkg, current.ModulePath) {
-				state.packagePrefixMismatches++
-			}
-			current.PackageCount++
-			metadata.Dependencies[state.currentDependency] = current
-			if _, ok := metadata.ImportToDependency[pkg]; !ok {
-				metadata.ImportToDependency[pkg] = state.currentDependency
-			}
-		}
+		parseVendoredModuleMetadataLine(strings.TrimSpace(rawLine), &metadata, &state)
 	}
 
 	appendVendoredMetadataWarnings(&metadata, state)
 	return metadata
+}
+
+func newVendoredModuleMetadata() vendoredModuleMetadata {
+	return vendoredModuleMetadata{
+		ImportToDependency: make(map[string]string),
+		Dependencies:       make(map[string]vendoredDependencyMetadata),
+	}
+}
+
+func parseVendoredModuleMetadataLine(line string, metadata *vendoredModuleMetadata, state *vendoredParseState) {
+	if line == "" || metadata == nil || state == nil {
+		return
+	}
+	if strings.HasPrefix(line, "# ") {
+		parseVendoredModuleHeaderLine(line, metadata, state)
+		return
+	}
+	if strings.HasPrefix(line, "## ") {
+		parseVendoredMetadataDirectiveLine(line, metadata, state)
+		return
+	}
+	if strings.HasPrefix(line, "#") {
+		return
+	}
+	parseVendoredPackageLine(line, metadata, state)
+}
+
+func parseVendoredModuleHeaderLine(line string, metadata *vendoredModuleMetadata, state *vendoredParseState) {
+	dependency, replacement, ok := parseVendoredModuleHeader(line)
+	if !ok {
+		state.malformedModuleHeaders++
+		state.currentDependency = ""
+		return
+	}
+	normalizedDependency := normalizeDependencyID(dependency)
+	current := metadata.Dependencies[normalizedDependency]
+	current.ModulePath = dependency
+	if replacement != "" {
+		current.Replacement = true
+		current.ReplacementTarget = replacement
+	}
+	metadata.Dependencies[normalizedDependency] = current
+	if _, exists := metadata.ImportToDependency[dependency]; !exists {
+		metadata.ImportToDependency[dependency] = normalizedDependency
+	}
+	state.currentDependency = normalizedDependency
+}
+
+func parseVendoredMetadataDirectiveLine(line string, metadata *vendoredModuleMetadata, state *vendoredParseState) {
+	if state.currentDependency == "" {
+		return
+	}
+	current := metadata.Dependencies[state.currentDependency]
+	applyVendoredMetadataDirective(line, &current)
+	metadata.Dependencies[state.currentDependency] = current
+}
+
+func parseVendoredPackageLine(line string, metadata *vendoredModuleMetadata, state *vendoredParseState) {
+	pkg := firstToken(line)
+	if pkg == "" {
+		return
+	}
+	if state.currentDependency == "" {
+		state.orphanPackageLines++
+		return
+	}
+	current := metadata.Dependencies[state.currentDependency]
+	if current.ModulePath != "" && !hasImportPathPrefix(pkg, current.ModulePath) {
+		state.packagePrefixMismatches++
+	}
+	current.PackageCount++
+	metadata.Dependencies[state.currentDependency] = current
+	if _, exists := metadata.ImportToDependency[pkg]; !exists {
+		metadata.ImportToDependency[pkg] = state.currentDependency
+	}
 }
 
 type vendoredParseState struct {

--- a/internal/lang/golang/module_metadata.go
+++ b/internal/lang/golang/module_metadata.go
@@ -1,0 +1,574 @@
+package golang
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+func workspaceRootModuleDirs(repoPath string, moduleInfo moduleInfo) (map[string]struct{}, error) {
+	if moduleInfo.ModulePath != "" {
+		return nil, nil
+	}
+
+	return goWorkModuleDirs(repoPath)
+}
+
+func goWorkModuleDirs(repoPath string) (map[string]struct{}, error) {
+	useEntries, err := readGoWorkUseEntries(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(useEntries) == 0 {
+		return nil, nil
+	}
+
+	workspaceRoots := make(map[string]struct{}, len(useEntries))
+	for _, rel := range useEntries {
+		resolved, ok := resolveRepoBoundedPath(repoPath, rel)
+		if !ok {
+			continue
+		}
+		workspaceRoots[resolved] = struct{}{}
+	}
+	return workspaceRoots, nil
+}
+
+func nestedModuleDirs(repoPath string, workspaceModuleDirs map[string]struct{}) (map[string]struct{}, error) {
+	dirs := make(map[string]struct{})
+	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		if shouldSkipDir(entry.Name()) {
+			return filepath.SkipDir
+		}
+		if path == repoPath {
+			return nil
+		}
+		exists, err := manifestPathExists(filepath.Join(path, goModName))
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return nil
+		}
+		if _, ok := workspaceModuleDirs[path]; ok {
+			return nil
+		}
+		dirs[path] = struct{}{}
+		return filepath.SkipDir
+	})
+	if err != nil {
+		return nil, err
+	}
+	return dirs, nil
+}
+
+func discoverNestedModules(repoPath string) ([]string, []string, map[string]string, error) {
+	nestedDirs, err := nestedModuleDirs(repoPath, nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	modules := make([]string, 0, len(nestedDirs))
+	dependencies := make([]string, 0)
+	replacements := make(map[string]string)
+	for dir := range nestedDirs {
+		modulePath, deps, moduleReplacements, err := loadGoModFromDir(repoPath, dir)
+		if err != nil {
+			continue
+		}
+		if modulePath != "" {
+			modules = append(modules, modulePath)
+		}
+		dependencies = append(dependencies, deps...)
+		for replacementImport, dependency := range moduleReplacements {
+			if _, ok := replacements[replacementImport]; !ok {
+				replacements[replacementImport] = dependency
+			}
+		}
+	}
+
+	return uniqueStrings(modules), uniqueStrings(dependencies), replacements, nil
+}
+
+func parseGoMod(content []byte) (string, []string, map[string]string) {
+	state := goModParseState{
+		depSet:     make(map[string]struct{}),
+		replaceSet: make(map[string]string),
+	}
+	for _, rawLine := range strings.Split(string(content), "\n") {
+		processGoModLine(strings.TrimSpace(stripInlineComment(rawLine)), &state)
+	}
+
+	dependencies := make([]string, 0, len(state.depSet))
+	for dep := range state.depSet {
+		dependencies = append(dependencies, dep)
+	}
+	sort.Strings(dependencies)
+	return state.modulePath, dependencies, state.replaceSet
+}
+
+type goModParseState struct {
+	modulePath     string
+	depSet         map[string]struct{}
+	replaceSet     map[string]string
+	inRequireBlock bool
+	inReplaceBlock bool
+}
+
+func processGoModLine(line string, state *goModParseState) {
+	if line == "" || state == nil {
+		return
+	}
+	if parseGoModModuleLine(line, state) {
+		return
+	}
+	if parseGoModRequireBlockControl(line, state) {
+		return
+	}
+	if parseGoModReplaceBlockControl(line, state) {
+		return
+	}
+	if state.inReplaceBlock {
+		addGoModReplacement(line, state.replaceSet)
+		return
+	}
+	if state.inRequireBlock {
+		addGoModDependency(line, state.depSet)
+		return
+	}
+	parseGoModSingleRequire(line, state.depSet)
+	parseGoModSingleReplace(line, state.replaceSet)
+}
+
+func parseGoModModuleLine(line string, state *goModParseState) bool {
+	if !strings.HasPrefix(line, "module ") {
+		return false
+	}
+	fields := strings.Fields(line)
+	if len(fields) >= 2 {
+		state.modulePath = fields[1]
+	}
+	return true
+}
+
+func parseGoModRequireBlockControl(line string, state *goModParseState) bool {
+	return parseGoModBlockControl(line, "require (", &state.inRequireBlock)
+}
+
+func parseGoModReplaceBlockControl(line string, state *goModParseState) bool {
+	return parseGoModBlockControl(line, "replace (", &state.inReplaceBlock)
+}
+
+func parseGoModBlockControl(line string, startToken string, inBlock *bool) bool {
+	if inBlock == nil {
+		return false
+	}
+	if strings.HasPrefix(line, startToken) {
+		*inBlock = true
+		return true
+	}
+	if *inBlock && line == ")" {
+		*inBlock = false
+		return true
+	}
+	return false
+}
+
+func parseGoModSingleRequire(line string, depSet map[string]struct{}) {
+	parseGoModSingleDirective(line, "require ", func(value string) {
+		addGoModDependency(value, depSet)
+	})
+}
+
+func parseGoModSingleReplace(line string, replaceSet map[string]string) {
+	parseGoModSingleDirective(line, "replace ", func(value string) {
+		addGoModReplacement(value, replaceSet)
+	})
+}
+
+func parseGoModSingleDirective(line, prefix string, handler func(string)) {
+	if handler == nil || !strings.HasPrefix(line, prefix) {
+		return
+	}
+	handler(strings.TrimPrefix(line, prefix))
+}
+
+func addGoModDependency(line string, depSet map[string]struct{}) {
+	if depSet == nil {
+		return
+	}
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return
+	}
+	depSet[fields[0]] = struct{}{}
+}
+
+func addGoModReplacement(line string, replaceSet map[string]string) {
+	if replaceSet == nil {
+		return
+	}
+	parts := strings.SplitN(line, "=>", 2)
+	if len(parts) != 2 {
+		return
+	}
+	oldPath := firstToken(parts[0])
+	newPath := firstToken(parts[1])
+	if oldPath == "" || newPath == "" {
+		return
+	}
+	if isLocalReplaceTarget(newPath) {
+		return
+	}
+	// Track only import-like replacement targets.
+	if !looksExternalImport(newPath) {
+		return
+	}
+	replaceSet[newPath] = oldPath
+}
+
+func isLocalReplaceTarget(pathValue string) bool {
+	pathValue = strings.TrimSpace(pathValue)
+	if pathValue == "" {
+		return false
+	}
+	if strings.HasPrefix(pathValue, "./") || strings.HasPrefix(pathValue, "../") || strings.HasPrefix(pathValue, "/") {
+		return true
+	}
+	if len(pathValue) >= 2 && pathValue[1] == ':' {
+		return true
+	}
+	return false
+}
+
+func firstToken(value string) string {
+	fields := strings.Fields(strings.TrimSpace(value))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+func loadGoWorkLocalModules(repoPath string) ([]string, error) {
+	useEntries, err := readGoWorkUseEntries(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	modulePaths := make([]string, 0)
+	for _, rel := range useEntries {
+		resolved, ok := resolveRepoBoundedPath(repoPath, rel)
+		if !ok {
+			continue
+		}
+		modulePath, _, _, err := loadGoModFromDir(repoPath, resolved)
+		if err != nil || modulePath == "" {
+			continue
+		}
+		modulePaths = append(modulePaths, modulePath)
+	}
+	return uniqueStrings(modulePaths), nil
+}
+
+func readGoWorkUseEntries(repoPath string) ([]string, error) {
+	workPath := filepath.Join(repoPath, goWorkName)
+	exists, err := manifestPathExists(workPath)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+	content, err := safeio.ReadFileUnder(repoPath, workPath)
+	if err != nil {
+		return nil, err
+	}
+	return parseGoWorkUseEntries(content), nil
+}
+
+func parseGoWorkUseEntries(content []byte) []string {
+	entries := make([]string, 0)
+	inUseBlock := false
+	for _, rawLine := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripInlineComment(rawLine))
+		if line == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "use ("):
+			inUseBlock = true
+		case inUseBlock && line == ")":
+			inUseBlock = false
+		case inUseBlock:
+			entries = append(entries, normalizeGoWorkPath(line))
+		case strings.HasPrefix(line, "use "):
+			entries = append(entries, normalizeGoWorkPath(strings.TrimPrefix(line, "use ")))
+		}
+	}
+	return uniqueStrings(entries)
+}
+
+func normalizeGoWorkPath(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.Trim(value, "\"")
+	if value == "" {
+		return ""
+	}
+	return filepath.Clean(value)
+}
+
+func loadGoModFromDir(repoPath, dir string) (string, []string, map[string]string, error) {
+	goModPath := filepath.Join(dir, goModName)
+	content, err := safeio.ReadFileUnder(repoPath, goModPath)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	modulePath, dependencies, replacements := parseGoMod(content)
+	return modulePath, dependencies, replacements, nil
+}
+
+func loadVendoredModuleMetadata(repoPath string) (vendoredModuleMetadata, error) {
+	metadata := vendoredModuleMetadata{
+		ImportToDependency: make(map[string]string),
+		Dependencies:       make(map[string]vendoredDependencyMetadata),
+	}
+	vendorModulesPath := filepath.Join(repoPath, vendorModulesTxtName)
+	exists, err := manifestPathExists(vendorModulesPath)
+	if err != nil {
+		return metadata, err
+	}
+	if !exists {
+		return metadata, nil
+	}
+	content, err := safeio.ReadFileUnder(repoPath, vendorModulesPath)
+	if err != nil {
+		return metadata, err
+	}
+	metadata = parseVendoredModuleMetadata(content)
+	metadata.ManifestFound = true
+	return metadata, nil
+}
+
+func parseVendoredModuleMetadata(content []byte) vendoredModuleMetadata {
+	metadata := vendoredModuleMetadata{
+		ImportToDependency: make(map[string]string),
+		Dependencies:       make(map[string]vendoredDependencyMetadata),
+	}
+
+	state := vendoredParseState{currentDependency: ""}
+	for _, rawLine := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "# "):
+			dependency, replacement, ok := parseVendoredModuleHeader(line)
+			if !ok {
+				state.malformedModuleHeaders++
+				state.currentDependency = ""
+				continue
+			}
+			normalizedDependency := normalizeDependencyID(dependency)
+			current := metadata.Dependencies[normalizedDependency]
+			current.ModulePath = dependency
+			if replacement != "" {
+				current.Replacement = true
+				current.ReplacementTarget = replacement
+			}
+			metadata.Dependencies[normalizedDependency] = current
+			if _, ok := metadata.ImportToDependency[dependency]; !ok {
+				metadata.ImportToDependency[dependency] = normalizedDependency
+			}
+			state.currentDependency = normalizedDependency
+		case strings.HasPrefix(line, "## "):
+			if state.currentDependency == "" {
+				continue
+			}
+			current := metadata.Dependencies[state.currentDependency]
+			applyVendoredMetadataDirective(line, &current)
+			metadata.Dependencies[state.currentDependency] = current
+		case strings.HasPrefix(line, "#"):
+			continue
+		default:
+			pkg := firstToken(line)
+			if pkg == "" {
+				continue
+			}
+			if state.currentDependency == "" {
+				state.orphanPackageLines++
+				continue
+			}
+			current := metadata.Dependencies[state.currentDependency]
+			if current.ModulePath != "" && !hasImportPathPrefix(pkg, current.ModulePath) {
+				state.packagePrefixMismatches++
+			}
+			current.PackageCount++
+			metadata.Dependencies[state.currentDependency] = current
+			if _, ok := metadata.ImportToDependency[pkg]; !ok {
+				metadata.ImportToDependency[pkg] = state.currentDependency
+			}
+		}
+	}
+
+	appendVendoredMetadataWarnings(&metadata, state)
+	return metadata
+}
+
+type vendoredParseState struct {
+	currentDependency       string
+	malformedModuleHeaders  int
+	orphanPackageLines      int
+	packagePrefixMismatches int
+}
+
+func parseVendoredModuleHeader(line string) (string, string, bool) {
+	line = strings.TrimSpace(strings.TrimPrefix(line, "#"))
+	if line == "" {
+		return "", "", false
+	}
+	parts := strings.SplitN(line, "=>", 2)
+	left := strings.TrimSpace(parts[0])
+	fields := strings.Fields(left)
+	if len(fields) == 0 {
+		return "", "", false
+	}
+	modulePath := fields[0]
+	if !looksExternalImport(modulePath) {
+		return "", "", false
+	}
+	replacement := ""
+	if len(parts) == 2 {
+		replacement = firstToken(parts[1])
+	}
+	return modulePath, replacement, true
+}
+
+func applyVendoredMetadataDirective(line string, metadata *vendoredDependencyMetadata) {
+	if metadata == nil {
+		return
+	}
+	payload := strings.TrimSpace(strings.TrimPrefix(line, "##"))
+	if payload == "" {
+		return
+	}
+	for _, item := range strings.Split(payload, ";") {
+		trimmed := strings.TrimSpace(item)
+		switch {
+		case trimmed == "explicit":
+			metadata.Explicit = true
+		case strings.HasPrefix(trimmed, "go "):
+			metadata.GoVersionDirective = strings.TrimSpace(strings.TrimPrefix(trimmed, "go "))
+		}
+	}
+}
+
+func appendVendoredMetadataWarnings(metadata *vendoredModuleMetadata, state vendoredParseState) {
+	if metadata == nil {
+		return
+	}
+	if len(metadata.Dependencies) == 0 {
+		metadata.Warnings = append(metadata.Warnings, "vendor/modules.txt was found but no module entries were parsed; vendored provenance may be stale")
+		return
+	}
+	if state.malformedModuleHeaders > 0 {
+		metadata.Warnings = append(metadata.Warnings, fmt.Sprintf("vendor/modules.txt contained %d malformed module header line(s)", state.malformedModuleHeaders))
+	}
+	if state.orphanPackageLines > 0 {
+		metadata.Warnings = append(metadata.Warnings, fmt.Sprintf("vendor/modules.txt contained %d package line(s) without a preceding module header", state.orphanPackageLines))
+	}
+	if state.packagePrefixMismatches > 0 {
+		metadata.Warnings = append(metadata.Warnings, fmt.Sprintf("vendor/modules.txt contained %d package path(s) that do not match their module header; vendored metadata may be stale", state.packagePrefixMismatches))
+	}
+
+	modulesWithoutPackages := 0
+	for _, dependency := range metadata.Dependencies {
+		if dependency.PackageCount == 0 {
+			modulesWithoutPackages++
+		}
+	}
+	if modulesWithoutPackages > 0 {
+		metadata.Warnings = append(metadata.Warnings, fmt.Sprintf("vendor/modules.txt listed %d module(s) without package entries", modulesWithoutPackages))
+	}
+}
+
+func longestVendoredDependency(importPath string, vendoredImportDependencies map[string]string) string {
+	if len(vendoredImportDependencies) == 0 {
+		return ""
+	}
+	match := ""
+	dependency := ""
+	for importPrefix, dep := range vendoredImportDependencies {
+		if !hasImportPathPrefix(importPath, importPrefix) {
+			continue
+		}
+		if len(importPrefix) > len(match) {
+			match = importPrefix
+			dependency = dep
+		}
+	}
+	return dependency
+}
+
+func resolveRepoBoundedPath(repoPath, value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", false
+	}
+
+	resolved := value
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(repoPath, resolved)
+	}
+	resolved = filepath.Clean(resolved)
+
+	repoAbs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return "", false
+	}
+	resolvedAbs, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", false
+	}
+	relativeToRepo, err := filepath.Rel(repoAbs, resolvedAbs)
+	if err != nil {
+		return "", false
+	}
+	if relativeToRepo == ".." || strings.HasPrefix(relativeToRepo, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return resolvedAbs, true
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized := strings.TrimSpace(value)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, normalized)
+	}
+	return result
+}
+
+func stripInlineComment(line string) string {
+	if index := strings.Index(line, "//"); index >= 0 {
+		return line[:index]
+	}
+	return line
+}

--- a/internal/lang/golang/types.go
+++ b/internal/lang/golang/types.go
@@ -1,0 +1,60 @@
+package golang
+
+import "github.com/ben-ranford/lopper/internal/lang/shared"
+
+type importBinding = shared.ImportRecord
+
+type fileScan struct {
+	Path    string
+	Imports []importBinding
+	Usage   map[string]int
+}
+
+type scanResult struct {
+	Files                         []fileScan
+	Warnings                      []string
+	BlankImportsByDependency      map[string]int
+	UndeclaredImportsByDependency map[string]int
+	DependencyProvenanceByDep     map[string]goDependencyProvenance
+	SkippedGeneratedFiles         int
+	SkippedBuildTaggedFiles       int
+	SkippedLargeFiles             int
+	SkippedNestedModuleDirs       int
+}
+
+type moduleInfo struct {
+	ModulePath                 string
+	LocalModulePaths           []string
+	DeclaredDependencies       []string
+	ReplacementImports         map[string]string
+	VendoredImportDependencies map[string]string
+	VendoredDependencies       map[string]vendoredDependencyMetadata
+	VendoringWarnings          []string
+	VendoredProvenanceEnabled  bool
+}
+
+type goDependencyProvenance struct {
+	Declared    bool
+	Replacement bool
+	Vendored    bool
+}
+
+type moduleLoadOptions struct {
+	EnableVendoredProvenance bool
+}
+
+type vendoredDependencyMetadata struct {
+	ModulePath         string
+	Explicit           bool
+	Replacement        bool
+	ReplacementTarget  string
+	PackageCount       int
+	GoVersionDirective string
+}
+
+type vendoredModuleMetadata struct {
+	ManifestFound      bool
+	ImportToDependency map[string]string
+	Dependencies       map[string]vendoredDependencyMetadata
+	Warnings           []string
+}

--- a/internal/lang/golang/vendored_test.go
+++ b/internal/lang/golang/vendored_test.go
@@ -189,10 +189,11 @@ func TestVendoredOnlyImportRemainsUndeclared(t *testing.T) {
 		VendoredProvenanceEnabled:  true,
 		VendoredImportDependencies: map[string]string{"github.com/vendor/dep/pkg": "github.com/vendor/dep"},
 	}
-	_, metadata := parseImports([]byte(`package main
+	content := []byte(`package main
 
 import "github.com/vendor/dep/pkg"
-`), "main.go", info)
+`)
+	_, metadata := parseImports(content, "main.go", info)
 	if len(metadata) != 1 {
 		t.Fatalf("expected one import metadata entry, got %#v", metadata)
 	}

--- a/internal/lang/golang/vendored_test.go
+++ b/internal/lang/golang/vendored_test.go
@@ -1,0 +1,293 @@
+package golang
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestParseVendoredModuleMetadata(t *testing.T) {
+	lines := []string{
+		"# github.com/acme/one v1.2.3",
+		"## explicit; go 1.22",
+		"github.com/acme/one/pkg",
+		"github.com/acme/one/sub",
+		"# badheader",
+		"orphan/pkg",
+		"# github.com/acme/two v0.4.0 => github.com/acme/two-fork v0.4.1",
+		"## go 1.21",
+		"github.com/acme/mismatch/pkg",
+		"# github.com/acme/empty v1.0.0",
+	}
+	content := []byte(strings.Join(lines, "\n"))
+
+	metadata := parseVendoredModuleMetadata(content)
+	if len(metadata.Dependencies) != 3 {
+		t.Fatalf("expected three parsed vendored dependencies, got %#v", metadata.Dependencies)
+	}
+
+	one := metadata.Dependencies["github.com/acme/one"]
+	if one.ModulePath != "github.com/acme/one" || !one.Explicit || one.GoVersionDirective != "1.22" || one.PackageCount != 2 {
+		t.Fatalf("unexpected metadata for github.com/acme/one: %#v", one)
+	}
+
+	two := metadata.Dependencies["github.com/acme/two"]
+	if !two.Replacement || two.ReplacementTarget != "github.com/acme/two-fork" || two.GoVersionDirective != "1.21" {
+		t.Fatalf("unexpected replacement metadata for github.com/acme/two: %#v", two)
+	}
+
+	if got := metadata.ImportToDependency["github.com/acme/one/pkg"]; got != "github.com/acme/one" {
+		t.Fatalf("expected package mapping for acme one, got %q", got)
+	}
+
+	assertWarningContains(t, metadata.Warnings, "malformed module header")
+	assertWarningContains(t, metadata.Warnings, "without a preceding module header")
+	assertWarningContains(t, metadata.Warnings, "do not match their module header")
+	assertWarningContains(t, metadata.Warnings, "without package entries")
+}
+
+func TestLoadVendoredModuleMetadata(t *testing.T) {
+	repo := t.TempDir()
+	metadata, err := loadVendoredModuleMetadata(repo)
+	if err != nil {
+		t.Fatalf("load vendored metadata missing file: %v", err)
+	}
+	if metadata.ManifestFound {
+		t.Fatalf("expected missing vendor/modules.txt to report ManifestFound=false")
+	}
+
+	vendorLines := []string{
+		"# github.com/acme/dep v1.0.0",
+		"github.com/acme/dep/pkg",
+	}
+	testutil.MustWriteFile(t, filepath.Join(repo, vendorModulesTxtName), strings.Join(vendorLines, "\n"))
+
+	metadata, err = loadVendoredModuleMetadata(repo)
+	if err != nil {
+		t.Fatalf("load vendored metadata: %v", err)
+	}
+	if !metadata.ManifestFound {
+		t.Fatalf("expected vendored metadata to report manifest found")
+	}
+	if got := metadata.ImportToDependency["github.com/acme/dep/pkg"]; got != "github.com/acme/dep" {
+		t.Fatalf("expected package mapping for vendored dep, got %q", got)
+	}
+}
+
+func TestLoadGoModuleInfoVendoredOption(t *testing.T) {
+	repo := t.TempDir()
+	goModLines := []string{
+		"module example.com/root",
+		"",
+		"require github.com/declared/dep v1.2.3",
+	}
+	testutil.MustWriteFile(t, filepath.Join(repo, goModName), strings.Join(goModLines, "\n"))
+	vendorLines := []string{
+		"# github.com/vendor/dep v1.0.0",
+		"## explicit",
+		"github.com/vendor/dep/pkg",
+	}
+	testutil.MustWriteFile(t, filepath.Join(repo, vendorModulesTxtName), strings.Join(vendorLines, "\n"))
+
+	withoutVendored, err := loadGoModuleInfo(repo)
+	if err != nil {
+		t.Fatalf("load module info without vendored preview: %v", err)
+	}
+	if withoutVendored.VendoredProvenanceEnabled || len(withoutVendored.VendoredDependencies) != 0 {
+		t.Fatalf("expected vendored metadata to stay disabled by default, got %#v", withoutVendored)
+	}
+
+	withVendored, err := loadGoModuleInfo(repo, moduleLoadOptions{EnableVendoredProvenance: true})
+	if err != nil {
+		t.Fatalf("load module info with vendored preview: %v", err)
+	}
+	if !withVendored.VendoredProvenanceEnabled {
+		t.Fatalf("expected vendored provenance enabled when preview option is on")
+	}
+	if len(withVendored.VendoredDependencies) == 0 {
+		t.Fatalf("expected vendored dependencies to be populated")
+	}
+	if isDeclaredDependency("github.com/vendor/dep", withVendored.DeclaredDependencies) {
+		t.Fatalf("expected vendored-only dependency to stay separate from go.mod declarations")
+	}
+}
+
+func TestResolveDependencyFromImportVendoredProvenance(t *testing.T) {
+	info := moduleInfo{
+		LocalModulePaths: []string{"example.com/root"},
+		DeclaredDependencies: []string{
+			"github.com/declared/dep",
+		},
+		ReplacementImports: map[string]string{
+			"github.com/replaced/dep": "github.com/original/dep",
+		},
+		VendoredProvenanceEnabled: true,
+		VendoredImportDependencies: map[string]string{
+			"github.com/declared/dep": "github.com/declared/dep",
+			"github.com/vendor/dep":   "github.com/vendor/dep",
+		},
+	}
+
+	declared := resolveDependencyFromImport("github.com/declared/dep/pkg", info)
+	if declared.Dependency != "github.com/declared/dep" || !declared.Provenance.Declared || !declared.Provenance.Vendored {
+		t.Fatalf("expected combined declared and vendored dependency provenance, got %#v", declared)
+	}
+
+	replaced := resolveDependencyFromImport("github.com/replaced/dep/pkg", info)
+	if replaced.Dependency != "github.com/original/dep" || !replaced.Provenance.Replacement {
+		t.Fatalf("expected replacement dependency provenance, got %#v", replaced)
+	}
+
+	vendored := resolveDependencyFromImport("github.com/vendor/dep/pkg/sub", info)
+	if vendored.Dependency != "github.com/vendor/dep" || !vendored.Provenance.Vendored {
+		t.Fatalf("expected vendored dependency provenance, got %#v", vendored)
+	}
+
+	inferred := resolveDependencyFromImport("github.com/inferred/dep/pkg", info)
+	if inferred.Dependency != "github.com/inferred/dep" {
+		t.Fatalf("expected inferred dependency, got %#v", inferred)
+	}
+
+	local := resolveDependencyFromImport("example.com/root/internal/pkg", info)
+	if local.Dependency != "" {
+		t.Fatalf("expected local module imports to be ignored, got %#v", local)
+	}
+}
+
+func TestBuildGoDependencyProvenance(t *testing.T) {
+	if got := buildGoDependencyProvenance(goDependencyProvenance{}); got != nil {
+		t.Fatalf("expected nil provenance for empty provenance flags, got %#v", got)
+	}
+
+	declared := buildGoDependencyProvenance(goDependencyProvenance{Declared: true})
+	if declared == nil || declared.Source != "go.mod" || declared.Confidence != "high" {
+		t.Fatalf("expected go.mod provenance, got %#v", declared)
+	}
+
+	vendored := buildGoDependencyProvenance(goDependencyProvenance{Vendored: true})
+	if vendored == nil || vendored.Source != "vendor/modules.txt" || vendored.Confidence != "medium" {
+		t.Fatalf("expected vendor provenance, got %#v", vendored)
+	}
+
+	combined := buildGoDependencyProvenance(goDependencyProvenance{Declared: true, Vendored: true})
+	if combined == nil || combined.Source != "go.mod+vendor" || combined.Confidence != "high" {
+		t.Fatalf("expected combined provenance, got %#v", combined)
+	}
+
+	replaced := buildGoDependencyProvenance(goDependencyProvenance{Replacement: true})
+	if replaced == nil || replaced.Source != "go.mod-replace" || replaced.Confidence != "high" {
+		t.Fatalf("expected replacement provenance, got %#v", replaced)
+	}
+}
+
+func TestVendoredOnlyImportRemainsUndeclared(t *testing.T) {
+	info := moduleInfo{
+		ModulePath:                 "example.com/root",
+		LocalModulePaths:           []string{"example.com/root"},
+		VendoredProvenanceEnabled:  true,
+		VendoredImportDependencies: map[string]string{"github.com/vendor/dep/pkg": "github.com/vendor/dep"},
+	}
+	_, metadata := parseImports([]byte(`package main
+
+import "github.com/vendor/dep/pkg"
+`), "main.go", info)
+	if len(metadata) != 1 {
+		t.Fatalf("expected one import metadata entry, got %#v", metadata)
+	}
+	if metadata[0].Dependency != "github.com/vendor/dep" || !metadata[0].Undeclared || !metadata[0].Provenance.Vendored {
+		t.Fatalf("expected vendored-only import to keep undeclared provenance, got %#v", metadata[0])
+	}
+}
+
+func TestLongestVendoredDependencyAndLoadVendoredMetadataNoop(t *testing.T) {
+	if got := longestVendoredDependency("github.com/acme/dep/pkg/sub", map[string]string{
+		"github.com/acme":         "github.com/acme",
+		"github.com/acme/dep/pkg": "github.com/acme/dep",
+	}); got != "github.com/acme/dep" {
+		t.Fatalf("expected longest vendored dependency match, got %q", got)
+	}
+	if got := longestVendoredDependency("github.com/acme/dep/pkg/sub", nil); got != "" {
+		t.Fatalf("expected empty vendored match for nil mappings, got %q", got)
+	}
+
+	repo := t.TempDir()
+	if err := loadVendoredMetadata(repo, moduleLoadOptions{}, &moduleInfo{}); err != nil {
+		t.Fatalf("expected disabled vendored metadata load to no-op, got %v", err)
+	}
+	if err := loadVendoredMetadata(repo, moduleLoadOptions{EnableVendoredProvenance: true}, nil); err != nil {
+		t.Fatalf("expected nil module info vendored load to no-op, got %v", err)
+	}
+}
+
+func TestVendoredHelperBranches(t *testing.T) {
+	if looksExternalImport("fmt") {
+		t.Fatalf("expected stdlib import path to be treated as non-external")
+	}
+	if !looksExternalImport("github.com/acme/dep/pkg") {
+		t.Fatalf("expected fully qualified module path to be treated as external")
+	}
+
+	if _, _, ok := parseVendoredModuleHeader("#"); ok {
+		t.Fatalf("expected empty vendored module header to fail")
+	}
+	if _, _, ok := parseVendoredModuleHeader("# local/module v1.0.0"); ok {
+		t.Fatalf("expected non-external vendored module header to fail")
+	}
+	modulePath, replacement, ok := parseVendoredModuleHeader("# github.com/acme/dep v1.0.0 => github.com/acme/fork v1.1.0")
+	if !ok || modulePath != "github.com/acme/dep" || replacement != "github.com/acme/fork" {
+		t.Fatalf("unexpected vendored module header parse result: module=%q replacement=%q ok=%v", modulePath, replacement, ok)
+	}
+
+	directive := vendoredDependencyMetadata{}
+	applyVendoredMetadataDirective("## explicit; go 1.23; unsupported", &directive)
+	if !directive.Explicit || directive.GoVersionDirective != "1.23" {
+		t.Fatalf("unexpected parsed vendored metadata directive: %#v", directive)
+	}
+	applyVendoredMetadataDirective("##", nil)
+
+	empty := &vendoredModuleMetadata{}
+	appendVendoredMetadataWarnings(empty, vendoredParseState{})
+	assertWarningContains(t, empty.Warnings, "no module entries were parsed")
+
+	repo := t.TempDir()
+	if _, ok := resolveRepoBoundedPath(repo, ""); ok {
+		t.Fatalf("expected empty path to be rejected")
+	}
+	if resolved, ok := resolveRepoBoundedPath(repo, "./module"); !ok || !strings.HasPrefix(resolved, repo) {
+		t.Fatalf("expected in-repo path to resolve, got resolved=%q ok=%v", resolved, ok)
+	}
+	if _, ok := resolveRepoBoundedPath(repo, "../outside"); ok {
+		t.Fatalf("expected path escape outside repo to be rejected")
+	}
+}
+
+func TestLoadGoModuleInfoWithOptionsErrorAndInferDependencyBranches(t *testing.T) {
+	if _, err := loadGoModuleInfoWithOptions(filepath.Join(t.TempDir(), "missing"), moduleLoadOptions{}); err == nil {
+		t.Fatalf("expected missing repo path to fail module info load")
+	}
+	if err := loadVendoredMetadata("\x00", moduleLoadOptions{EnableVendoredProvenance: true}, &moduleInfo{}); err == nil {
+		t.Fatalf("expected invalid repo path to fail vendored metadata load")
+	}
+
+	if got := inferDependency("github.com/acme/dep/pkg"); got != "github.com/acme/dep" {
+		t.Fatalf("expected inferred dependency root, got %q", got)
+	}
+	if got := inferDependency("gopkg.in/yaml.v3"); got != "gopkg.in/yaml.v3" {
+		t.Fatalf("expected inferred two-part dependency, got %q", got)
+	}
+	if got := inferDependency("stdlib/path"); got != "" {
+		t.Fatalf("expected stdlib-like dependency to be ignored, got %q", got)
+	}
+}
+
+func assertWarningContains(t *testing.T, warnings []string, want string) {
+	t.Helper()
+	for _, warning := range warnings {
+		if strings.Contains(warning, want) {
+			return
+		}
+	}
+	t.Fatalf("expected warning containing %q, got %#v", want, warnings)
+}

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -339,6 +339,7 @@ func TestManifestEntries(t *testing.T) {
 	assertManifestEntryDefault(t, manifest, "lockfile-drift-ecosystem-expansion-preview", false)
 	assertManifestEntryDefault(t, manifest, "swift-carthage-preview", false)
 	assertManifestEntryDefault(t, manifest, "powershell-adapter-preview", false)
+	assertManifestEntryDefault(t, manifest, "go-vendored-provenance-preview", false)
 }
 
 func TestRunManifestAndReportUseChannels(t *testing.T) {


### PR DESCRIPTION
## Summary
- split the Go adapter into focused seams (constants, types, detection, build_tags, and module_metadata)
- add vendored dependency provenance parsing from vendor/modules.txt
- gate vendored provenance behavior behind the preview feature flag go-vendored-provenance-preview
- propagate resolved feature sets through analysis request/language adapter boundaries and cache keys
- add targeted tests for vendored metadata parsing, provenance shaping, and featureflags coverage stability

## Validation
- go test ./...
- go test ./internal/lang/golang -coverprofile=/tmp/golang.cover
- go tool cover -func=/tmp/golang.cover | tail -n 1

Closes #452
Closes #627