### PR TITLE
bug(js): treat side-effect-only imports as used

### DIFF
--- a/internal/lang/js/adapter.go
+++ b/internal/lang/js/adapter.go
@@ -454,6 +454,8 @@ func applyImportUsage(imp ImportBinding, file FileScan, usedExports map[string]s
 		return applyNamedImportUsage(imp, file, usedExports, counts)
 	case ImportNamespace, ImportDefault:
 		return applyNamespaceOrDefaultImportUsage(imp, file, usedExports, counts)
+	case ImportSideEffect:
+		return applySideEffectImportUsage(imp, usedExports)
 	default:
 		return false
 	}
@@ -489,6 +491,15 @@ func applyNamespaceOrDefaultImportUsage(imp ImportBinding, file FileScan, usedEx
 		}
 	}
 	return used
+}
+
+func applySideEffectImportUsage(imp ImportBinding, usedExports map[string]struct{}) bool {
+	exportName := imp.ExportName
+	if exportName == "" {
+		exportName = sideEffectImportName
+	}
+	usedExports[exportName] = struct{}{}
+	return true
 }
 
 func recordImportUse(binding ImportBinding, provenance string) report.ImportUse {

--- a/internal/lang/js/adapter_test.go
+++ b/internal/lang/js/adapter_test.go
@@ -73,6 +73,57 @@ func TestAdapterAnalyseDependency(t *testing.T) {
 	}
 }
 
+func TestAdapterAnalyseSideEffectImportIsUsed(t *testing.T) {
+	repo := t.TempDir()
+	source := "import \"reflect-metadata\"\n"
+	path := filepath.Join(repo, testIndexJS)
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if err := writeDependency(repo, "reflect-metadata", testModuleExportsStub); err != nil {
+		t.Fatalf("write dependency: %v", err)
+	}
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath:   repo,
+		Dependency: "reflect-metadata",
+	})
+	if err != nil {
+		t.Fatalf(testAnalyseErrFmt, err)
+	}
+	if len(reportData.Dependencies) != 1 {
+		t.Fatalf(testExpectedOneDepFmt, len(reportData.Dependencies))
+	}
+
+	dep := reportData.Dependencies[0]
+	if len(dep.UsedImports) != 1 {
+		t.Fatalf("expected one used import for side-effect dependency, got %#v", dep.UsedImports)
+	}
+	if len(dep.UnusedImports) != 0 {
+		t.Fatalf("expected no unused imports for side-effect dependency, got %#v", dep.UnusedImports)
+	}
+	if dep.UsedImports[0].Name != sideEffectImportName {
+		t.Fatalf("expected side-effect import marker name, got %#v", dep.UsedImports[0])
+	}
+
+	recCodes := make([]string, 0, len(dep.Recommendations))
+	for _, rec := range dep.Recommendations {
+		recCodes = append(recCodes, rec.Code)
+	}
+	if slices.Contains(recCodes, "remove-unused-dependency") {
+		t.Fatalf("did not expect remove-unused-dependency recommendation for side-effect import, got %#v", recCodes)
+	}
+	if slices.Contains(recCodes, "avoid-wildcard-default-imports") {
+		t.Fatalf("did not expect wildcard/default recommendation for side-effect import, got %#v", recCodes)
+	}
+
+	joinedWarnings := strings.Join(reportData.Warnings, "\n")
+	if strings.Contains(joinedWarnings, "no used exports found for dependency") {
+		t.Fatalf("did not expect no-used-exports warning for side-effect import, got %#v", reportData.Warnings)
+	}
+}
+
 func TestAdapterAnalyseTopN(t *testing.T) {
 	repo := t.TempDir()
 	source := "import { used } from \"alpha\"\nimport { unused } from \"beta\"\nused()\n"

--- a/internal/lang/js/codemod.go
+++ b/internal/lang/js/codemod.go
@@ -152,6 +152,8 @@ func codemodSkipOrder(item report.CodemodSkip) string {
 
 func codemodSkipReason(imp ImportBinding, file FileScan) (string, string) {
 	switch imp.Kind {
+	case ImportSideEffect:
+		return codemodReasonSideEffectImport, "side-effect imports are not safe to rewrite automatically"
 	case ImportNamespace:
 		if imp.LocalName == "*" && imp.ExportName == "*" {
 			return codemodReasonSideEffectImport, "side-effect imports are not safe to rewrite automatically"

--- a/internal/lang/js/scan.go
+++ b/internal/lang/js/scan.go
@@ -16,10 +16,13 @@ import (
 type ImportKind string
 
 const (
-	ImportNamed     ImportKind = "named"
-	ImportNamespace ImportKind = "namespace"
-	ImportDefault   ImportKind = "default"
+	ImportNamed      ImportKind = "named"
+	ImportNamespace  ImportKind = "namespace"
+	ImportDefault    ImportKind = "default"
+	ImportSideEffect ImportKind = "side-effect"
 )
+
+const sideEffectImportName = "<side-effect>"
 
 type ImportBinding struct {
 	Module     string

--- a/internal/lang/js/scan_imports.go
+++ b/internal/lang/js/scan_imports.go
@@ -41,12 +41,12 @@ func parseImportStatement(node *sitter.Node, content []byte, relPath string) []I
 		clause = firstNamedChildOfType(node, "import_clause")
 	}
 	if clause == nil {
-		return []ImportBinding{makeImportBinding(module, "*", "*", ImportNamespace, relPath, node)}
+		return []ImportBinding{makeImportBinding(module, sideEffectImportName, "", ImportSideEffect, relPath, node)}
 	}
 
 	bindings := parseImportClause(clause, content, module, relPath)
 	if len(bindings) == 0 {
-		bindings = []ImportBinding{makeImportBinding(module, "*", "*", ImportNamespace, relPath, node)}
+		bindings = []ImportBinding{makeImportBinding(module, sideEffectImportName, "", ImportSideEffect, relPath, node)}
 	}
 
 	return bindings
@@ -128,7 +128,7 @@ func parseRequireCall(node *sitter.Node, content []byte, relPath string) []Impor
 
 	bindings := parseRequireBinding(node, content, module, relPath)
 	if len(bindings) == 0 {
-		return []ImportBinding{makeImportBinding(module, "*", "*", ImportNamespace, relPath, node)}
+		return []ImportBinding{makeImportBinding(module, sideEffectImportName, "", ImportSideEffect, relPath, node)}
 	}
 	return bindings
 }

--- a/internal/lang/js/scan_unit_extra_test.go
+++ b/internal/lang/js/scan_unit_extra_test.go
@@ -61,8 +61,11 @@ foo("x");
 	}
 
 	firstImport := parseImportStatement(importStmts[0], source, unitIndexJS)
-	if len(firstImport) != 1 || firstImport[0].Kind != ImportNamespace {
-		t.Fatalf("expected namespace fallback import for bare import, got %#v", firstImport)
+	if len(firstImport) != 1 || firstImport[0].Kind != ImportSideEffect {
+		t.Fatalf("expected side-effect fallback import for bare import, got %#v", firstImport)
+	}
+	if firstImport[0].ExportName != sideEffectImportName || firstImport[0].LocalName != "" {
+		t.Fatalf("expected side-effect import marker and empty local name, got %#v", firstImport[0])
 	}
 
 	secondImport := parseImportStatement(importStmts[1], source, unitIndexJS)
@@ -71,15 +74,24 @@ foo("x");
 	}
 
 	var sawRequire bool
+	var sawBareRequireSideEffect bool
 	for _, call := range callExprs {
 		bindings := parseRequireCall(call, source, unitIndexJS)
 		if len(bindings) == 0 {
 			continue
 		}
 		sawRequire = true
+		if len(bindings) == 1 && bindings[0].Module == "leftpad" {
+			sawBareRequireSideEffect = bindings[0].Kind == ImportSideEffect &&
+				bindings[0].ExportName == sideEffectImportName &&
+				bindings[0].LocalName == ""
+		}
 	}
 	if !sawRequire {
 		t.Fatalf("expected parsed require bindings")
+	}
+	if !sawBareRequireSideEffect {
+		t.Fatalf("expected bare require to be treated as a side-effect import")
 	}
 }
 

--- a/internal/lang/js/scan_unit_extra_test.go
+++ b/internal/lang/js/scan_unit_extra_test.go
@@ -32,20 +32,7 @@ func parseJSNodeByType(t *testing.T, source []byte, nodeType string) *sitter.Nod
 	return found
 }
 
-func TestScanImportAndRequireHelperBranches(t *testing.T) {
-	source := []byte(`
-import "pkg";
-import { map as m } from "lodash";
-const { map: mm, filter } = require("lodash");
-const ns = require("axios");
-require("leftpad");
-foo("x");
-`)
-	tree, err := newSourceParser().Parse(context.Background(), unitIndexJS, source)
-	if err != nil {
-		t.Fatalf(parseSourceErrFmt, err)
-	}
-
+func collectImportAndCallNodes(tree *sitter.Tree) ([]*sitter.Node, []*sitter.Node) {
 	var importStmts []*sitter.Node
 	var callExprs []*sitter.Node
 	walkNode(tree.RootNode(), func(node *sitter.Node) {
@@ -56,10 +43,11 @@ foo("x");
 			callExprs = append(callExprs, node)
 		}
 	})
-	if len(importStmts) < 2 || len(callExprs) == 0 {
-		t.Fatalf("expected import and call expressions")
-	}
+	return importStmts, callExprs
+}
 
+func assertBareImportSideEffect(t *testing.T, importStmts []*sitter.Node, source []byte) {
+	t.Helper()
 	firstImport := parseImportStatement(importStmts[0], source, unitIndexJS)
 	if len(firstImport) != 1 || firstImport[0].Kind != ImportSideEffect {
 		t.Fatalf("expected side-effect fallback import for bare import, got %#v", firstImport)
@@ -67,12 +55,17 @@ foo("x");
 	if firstImport[0].ExportName != sideEffectImportName || firstImport[0].LocalName != "" {
 		t.Fatalf("expected side-effect import marker and empty local name, got %#v", firstImport[0])
 	}
+}
 
+func assertNamedImportParsing(t *testing.T, importStmts []*sitter.Node, source []byte) {
+	t.Helper()
 	secondImport := parseImportStatement(importStmts[1], source, unitIndexJS)
 	if len(secondImport) == 0 || secondImport[0].Kind != ImportNamed {
 		t.Fatalf("expected named import parsing, got %#v", secondImport)
 	}
+}
 
+func scanRequireBindings(callExprs []*sitter.Node, source []byte) (bool, bool) {
 	var sawRequire bool
 	var sawBareRequireSideEffect bool
 	for _, call := range callExprs {
@@ -87,6 +80,31 @@ foo("x");
 				bindings[0].LocalName == ""
 		}
 	}
+	return sawRequire, sawBareRequireSideEffect
+}
+
+func TestScanImportAndRequireHelperBranches(t *testing.T) {
+	source := []byte(`
+import "pkg";
+import { map as m } from "lodash";
+const { map: mm, filter } = require("lodash");
+const ns = require("axios");
+require("leftpad");
+foo("x");
+`)
+	tree, err := newSourceParser().Parse(context.Background(), unitIndexJS, source)
+	if err != nil {
+		t.Fatalf(parseSourceErrFmt, err)
+	}
+
+	importStmts, callExprs := collectImportAndCallNodes(tree)
+	if len(importStmts) < 2 || len(callExprs) == 0 {
+		t.Fatalf("expected import and call expressions")
+	}
+
+	assertBareImportSideEffect(t, importStmts, source)
+	assertNamedImportParsing(t, importStmts, source)
+	sawRequire, sawBareRequireSideEffect := scanRequireBindings(callExprs, source)
 	if !sawRequire {
 		t.Fatalf("expected parsed require bindings")
 	}

--- a/internal/lang/js/usage_test.go
+++ b/internal/lang/js/usage_test.go
@@ -308,6 +308,41 @@ func TestCollectDependencyImportUsageWildcardWarning(t *testing.T) {
 	}
 }
 
+func TestCollectDependencyImportUsageSideEffectImport(t *testing.T) {
+	scan := ScanResult{
+		Files: []FileScan{
+			{
+				Path: testJsFile,
+				Imports: []ImportBinding{
+					{
+						Module:     "reflect-metadata",
+						ExportName: sideEffectImportName,
+						LocalName:  "",
+						Kind:       ImportSideEffect,
+						Location:   report.Location{File: testJsFile, Line: 1},
+					},
+				},
+				IdentifierUsage: map[string]int{},
+				NamespaceUsage:  map[string]map[string]int{},
+			},
+		},
+	}
+
+	usage := collectDependencyImportUsage(scan, "reflect-metadata")
+	if len(usage.UsedImports) != 1 {
+		t.Fatalf("expected side-effect import to be marked used, got %#v", usage.UsedImports)
+	}
+	if len(usage.UnusedImports) != 0 {
+		t.Fatalf("expected no unused imports for side-effect import, got %#v", usage.UnusedImports)
+	}
+	if _, ok := usage.UsedExports[sideEffectImportName]; !ok {
+		t.Fatalf("expected side-effect usage marker in used exports, got %#v", usage.UsedExports)
+	}
+	if usage.HasAmbiguousWildcard {
+		t.Fatalf("did not expect side-effect import to mark wildcard ambiguity")
+	}
+}
+
 func TestNamespaceReferenceExtractionBranches(t *testing.T) {
 	parser := newSourceParser()
 	source := []byte(`


### PR DESCRIPTION
## Summary
- classify bare JS imports (`import "pkg"`) and bare requires (`require("pkg")`) as explicit side-effect imports
- treat side-effect imports as used during dependency usage attribution so they are not marked unused
- preserve codemod skip behavior for side-effect imports and add regression tests across parser/usage/adapter flows

## Validation
- go test ./internal/lang/js/...
- make test
- make format-check lint

Fixes #685
