### PR TITLE
fix: make inline suppression awk matching portable

### DIFF
--- a/scripts/check-inline-suppressions.sh
+++ b/scripts/check-inline-suppressions.sh
@@ -67,7 +67,6 @@ trap 'rm -f "$tmp_matches"' EXIT INT TERM
 set +e
 "${diff_args[@]}" | awk -v pattern="$marker_pattern" -v file_pattern="$source_file_pattern" '
 BEGIN {
-	IGNORECASE = 1
 	file = ""
 	line = 0
 	found = 0
@@ -88,7 +87,8 @@ BEGIN {
 }
 /^\+/ && $0 !~ /^\+\+\+/ {
 	content = substr($0, 2)
-	if (check_file && content ~ pattern) {
+	# Use POSIX tolower() instead of gawk IGNORECASE so this works with BSD awk and mawk.
+	if (check_file && tolower(content) ~ pattern) {
 		printf "%s:%d:%s\n", file, line, content
 		found = 1
 	}

--- a/scripts/check_inline_suppressions_test.go
+++ b/scripts/check_inline_suppressions_test.go
@@ -26,6 +26,18 @@ func TestInlineSuppressionCheckRejectsStagedMarkers(t *testing.T) {
 			want:    "//" + "nosec",
 		},
 		{
+			name:    "NOSEC uppercase",
+			path:    mainGoPath,
+			content: mainGoWithComment("NOSEC G404"),
+			want:    "//" + "NOSEC",
+		},
+		{
+			name:    "NOSONAR uppercase block comment",
+			path:    mainGoPath,
+			content: mainGoWithBlockComment("NOSONAR"),
+			want:    "NOSONAR",
+		},
+		{
 			name:    "nolint",
 			path:    mainGoPath,
 			content: mainGoWithComment("nolint:staticcheck"),
@@ -121,6 +133,10 @@ func mainGoWithoutComment() string {
 
 func mainGoWithComment(comment string) string {
 	return "package main\n\nfunc main() {\n\t_ = 1 //" + comment + "\n}\n"
+}
+
+func mainGoWithBlockComment(comment string) string {
+	return "package main\n\nfunc main() {\n\t_ = 1 /* " + comment + " */\n}\n"
 }
 
 func newInlineSuppressionRepo(t *testing.T) string {


### PR DESCRIPTION
## Summary
- replace non-portable awk `IGNORECASE` usage in inline suppression gate with POSIX `tolower(...)` matching
- add regression coverage for uppercase `NOSEC` and uppercase block-comment `NOSONAR` markers

## Validation
- go test ./scripts -run InlineSuppression -count=1
- make suppression-check
- make shellcheck
- make test
- pre-commit hooks (make fmt + make ci)

Closes #703
