### PR TITLE
bug: fix python parenthesized from-import symbol parsing

### DIFF
--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -154,6 +154,12 @@ func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) repor
 
 type importBinding = shared.ImportRecord
 
+type fromImportSymbolLine struct {
+	symbols string
+	line    string
+	index   int
+}
+
 type fileScan struct {
 	Path    string
 	Imports []importBinding
@@ -264,9 +270,36 @@ var (
 )
 
 func parseImports(content []byte, filePath string, repoPath string) []importBinding {
+	type pendingFromImport struct {
+		module      string
+		symbolLines []fromImportSymbolLine
+		parenDepth  int
+	}
+
+	var pending *pendingFromImport
+
 	return shared.ParseImportLines(content, filePath, func(line string, index int) []shared.ImportRecord {
 		lineNoComment := stripComment(line)
-		if strings.TrimSpace(lineNoComment) == "" {
+		trimmed := strings.TrimSpace(lineNoComment)
+
+		if pending != nil {
+			if trimmed != "" {
+				pending.symbolLines = append(pending.symbolLines, fromImportSymbolLine{
+					symbols: trimmed,
+					line:    lineNoComment,
+					index:   index,
+				})
+				pending.parenDepth += fromImportParenthesisDelta(trimmed)
+			}
+			if pending.parenDepth <= 0 {
+				records := parseFromImportLines(pending.module, pending.symbolLines, filePath, repoPath)
+				pending = nil
+				return records
+			}
+			return nil
+		}
+
+		if trimmed == "" {
 			return nil
 		}
 
@@ -275,7 +308,21 @@ func parseImports(content []byte, filePath string, repoPath string) []importBind
 		}
 
 		if matches := fromLinePattern.FindStringSubmatch(lineNoComment); len(matches) == 3 {
-			return parseFromImportLine(matches[1], matches[2], filePath, repoPath, index, lineNoComment)
+			symbols := strings.TrimSpace(matches[2])
+			parenDepth := fromImportParenthesisDelta(symbols)
+			if parenDepth > 0 {
+				pending = &pendingFromImport{
+					module: matches[1],
+					symbolLines: []fromImportSymbolLine{{
+						symbols: symbols,
+						line:    lineNoComment,
+						index:   index,
+					}},
+					parenDepth: parenDepth,
+				}
+				return nil
+			}
+			return parseFromImportLine(matches[1], symbols, filePath, repoPath, index, lineNoComment)
 		}
 		return nil
 	})
@@ -307,17 +354,45 @@ func parseImportLine(partsText string, filePath string, repoPath string, index i
 }
 
 func parseFromImportLine(moduleValue string, symbolsValue string, filePath string, repoPath string, index int, line string) []importBinding {
-	moduleName := strings.TrimSpace(moduleValue)
-	if strings.HasPrefix(moduleName, ".") {
+	moduleName, dependency, ok := resolveFromImportDependency(moduleValue, repoPath)
+	if !ok {
 		return nil
 	}
-	dependency := dependencyFromModule(repoPath, moduleName)
-	if dependency == "" {
+
+	return parseFromImportSymbols(moduleName, dependency, symbolsValue, filePath, index, line)
+}
+
+func parseFromImportLines(moduleValue string, symbolLines []fromImportSymbolLine, filePath string, repoPath string) []importBinding {
+	moduleName, dependency, ok := resolveFromImportDependency(moduleValue, repoPath)
+	if !ok {
 		return nil
 	}
 
 	bindings := make([]importBinding, 0)
+	for _, symbolLine := range symbolLines {
+		bindings = append(bindings, parseFromImportSymbols(moduleName, dependency, symbolLine.symbols, filePath, symbolLine.index, symbolLine.line)...)
+	}
+	return bindings
+}
+
+func resolveFromImportDependency(moduleValue string, repoPath string) (string, string, bool) {
+	moduleName := strings.TrimSpace(moduleValue)
+	if strings.HasPrefix(moduleName, ".") {
+		return "", "", false
+	}
+	dependency := dependencyFromModule(repoPath, moduleName)
+	if dependency == "" {
+		return "", "", false
+	}
+	return moduleName, dependency, true
+}
+
+func parseFromImportSymbols(moduleName string, dependency string, symbolsValue string, filePath string, index int, line string) []importBinding {
+	symbolsValue = normalizeFromImportSymbols(symbolsValue)
+
+	bindings := make([]importBinding, 0)
 	for _, part := range splitCSV(symbolsValue) {
+		part = strings.Trim(strings.TrimSpace(part), "()")
 		symbol, local := parseImportPart(part)
 		if symbol == "" {
 			continue
@@ -335,6 +410,18 @@ func parseFromImportLine(moduleValue string, symbolsValue string, filePath strin
 		})
 	}
 	return bindings
+}
+
+func fromImportParenthesisDelta(value string) int {
+	return strings.Count(value, "(") - strings.Count(value, ")")
+}
+
+func normalizeFromImportSymbols(value string) string {
+	value = strings.TrimSpace(value)
+	for len(value) >= 2 && strings.HasPrefix(value, "(") && strings.HasSuffix(value, ")") {
+		value = strings.TrimSpace(value[1 : len(value)-1])
+	}
+	return value
 }
 
 func importLocation(filePath string, index int, line string) report.Location {

--- a/internal/lang/python/adapter_test.go
+++ b/internal/lang/python/adapter_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
@@ -36,13 +37,78 @@ func TestAdapterDetectWithPythonSource(t *testing.T) {
 }
 
 func TestAdapterAnalyseDependency(t *testing.T) {
-	repo := t.TempDir()
 	source := "import requests\nfrom numpy import array, mean\narray([1])\nrequests.get('x')\n"
+	dep := analysePythonDependency(t, source, "numpy")
+	assertDependencyReport(t, dep, dependencyReportExpectation{language: "python", used: 1, total: 2})
+}
+
+func TestParseImportsHandlesParenthesizedFromImports(t *testing.T) {
+	repo := t.TempDir()
+	source := "from django.db import (models, migrations)\nfrom requests import (\n    Session,\n    Response as Resp,\n)\n"
+
+	imports := parseImports([]byte(source), testMainPy, repo)
+	if len(imports) != 4 {
+		t.Fatalf("expected four parsed from-import bindings, got %#v", imports)
+	}
+
+	expected := []importBinding{
+		{Dependency: "django", Module: "django.db", Name: "models", Local: "models"},
+		{Dependency: "django", Module: "django.db", Name: "migrations", Local: "migrations"},
+		{Dependency: "requests", Module: "requests", Name: "Session", Local: "Session"},
+		{Dependency: "requests", Module: "requests", Name: "Response", Local: "Resp"},
+	}
+	for index, want := range expected {
+		assertImportBinding(t, imports[index], want)
+	}
+
+	for _, imported := range imports {
+		if strings.ContainsAny(imported.Name, "()") || strings.ContainsAny(imported.Local, "()") {
+			t.Fatalf("expected sanitized symbol names without parentheses, got %#v", imported)
+		}
+	}
+}
+
+func assertImportBinding(t *testing.T, got importBinding, want importBinding) {
+	t.Helper()
+	if got.Dependency != want.Dependency || got.Module != want.Module || got.Name != want.Name || got.Local != want.Local {
+		t.Fatalf("unexpected import binding: got %#v, want dependency=%q module=%q name=%q local=%q", got, want.Dependency, want.Module, want.Name, want.Local)
+	}
+}
+
+func TestAdapterAnalyseDependencyWithParenthesizedFromImports(t *testing.T) {
+	source := "from requests import (\n    Session,\n    Response,\n)\nSession()\n"
+	dep := analysePythonDependency(t, source, "requests")
+	assertDependencyReport(t, dep, dependencyReportExpectation{name: "requests", used: 1, total: 2})
+}
+
+type dependencyReportExpectation struct {
+	name     string
+	language string
+	used     int
+	total    int
+}
+
+func assertDependencyReport(t *testing.T, got report.DependencyReport, want dependencyReportExpectation) {
+	t.Helper()
+	if want.name != "" && got.Name != want.name {
+		t.Fatalf("expected dependency report for %q, got %q", want.name, got.Name)
+	}
+	if want.language != "" && got.Language != want.language {
+		t.Fatalf("expected language %q, got %q", want.language, got.Language)
+	}
+	if got.UsedExportsCount != want.used || got.TotalExportsCount != want.total {
+		t.Fatalf("expected used/total %d/%d, got %d/%d", want.used, want.total, got.UsedExportsCount, got.TotalExportsCount)
+	}
+}
+
+func analysePythonDependency(t *testing.T, source string, dependency string) report.DependencyReport {
+	t.Helper()
+	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, testMainPy), source)
 
 	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
 		RepoPath:   repo,
-		Dependency: "numpy",
+		Dependency: dependency,
 	})
 	if err != nil {
 		t.Fatalf("analyse: %v", err)
@@ -50,14 +116,7 @@ func TestAdapterAnalyseDependency(t *testing.T) {
 	if len(reportData.Dependencies) != 1 {
 		t.Fatalf("expected one dependency report, got %d", len(reportData.Dependencies))
 	}
-
-	dep := reportData.Dependencies[0]
-	if dep.Language != "python" {
-		t.Fatalf("expected language python, got %q", dep.Language)
-	}
-	if dep.UsedExportsCount != 1 || dep.TotalExportsCount != 2 {
-		t.Fatalf("expected numpy used/total 1/2, got %d/%d", dep.UsedExportsCount, dep.TotalExportsCount)
-	}
+	return reportData.Dependencies[0]
 }
 
 func TestAdapterAnalyseTopNRequiresRequirementsDependencies(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix Python adapter parsing for parenthesized `from ... import (...)` syntax
- preserve clean symbol names without leading/trailing parentheses
- collect multiline parenthesized `from` imports and assign declaration line locations correctly so usage accounting is accurate
- add regression tests for one-line and multiline parenthesized from-imports, plus end-to-end analysis coverage

Closes #684
