### PR TITLE
fix(jvm): parse missing common Gradle dependency configurations

### DIFF
--- a/internal/lang/jvm/build_parsing.go
+++ b/internal/lang/jvm/build_parsing.go
@@ -60,7 +60,10 @@ const (
 	pomDependencyManaged
 )
 
-var pomPropertyTokenPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+var (
+	pomPropertyTokenPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+	gradleDependencyPattern = regexp.MustCompile(`(?m)(?:implementation|api|compileOnly|runtimeOnly|testImplementation|testRuntimeOnly|kapt|annotationProcessor|testAnnotationProcessor|testCompileOnly|debugImplementation|releaseImplementation|kaptTest|kaptAndroidTest|classpath)\s*\(?\s*["']([^:"'\s]+):([^:"'\s]+):[^"'\s]+["']\s*\)?`)
+)
 
 func collectDeclaredDependencies(repoPath string) ([]dependencyDescriptor, map[string]string, map[string]string, []string) {
 	descriptors := make([]dependencyDescriptor, 0)
@@ -356,10 +359,9 @@ func parseGradleDependencies(repoPath string) []dependencyDescriptor {
 }
 
 func parseGradleDependenciesWithWarnings(repoPath string) ([]dependencyDescriptor, []string) {
-	pattern := regexp.MustCompile(`(?m)(?:implementation|api|compileOnly|runtimeOnly|testImplementation|testRuntimeOnly|kapt)\s*\(?\s*["']([^:"'\s]+):([^:"'\s]+):[^"'\s]+["']\s*\)?`)
 	catalogResolver, warnings := shared.LoadGradleCatalogResolver(repoPath)
 	gradleParser := func(path, content string) ([]dependencyDescriptor, []string) {
-		descriptors := parseGradleMatches(content, pattern)
+		descriptors := parseGradleMatches(content, gradleDependencyPattern)
 		catalogDescriptors, catalogWarnings := catalogResolver.ParseDependencyReferences(path, content)
 		for _, descriptor := range catalogDescriptors {
 			descriptors = append(descriptors, dependencyDescriptor{

--- a/internal/lang/jvm/helpers_test.go
+++ b/internal/lang/jvm/helpers_test.go
@@ -194,6 +194,52 @@ func TestJVMDescriptorAndBuildFileHelpers(t *testing.T) {
 	}
 }
 
+func TestJVMParseGradleDependenciesSupportsCommonConfigurations(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), `
+dependencies {
+  annotationProcessor "org.projectlombok:lombok:1.18.32"
+  testAnnotationProcessor("org.mapstruct:mapstruct-processor:1.6.0")
+  testCompileOnly "org.jetbrains:annotations:24.1.0"
+  debugImplementation "com.android.support:appcompat-v7:28.0.0"
+  releaseImplementation("com.android.support:multidex:1.0.3")
+  kaptTest "com.google.dagger:dagger-compiler:2.52"
+  kaptAndroidTest("com.google.dagger:dagger-android-processor:2.52")
+  classpath "com.android.tools.build:gradle:8.7.0"
+}
+`)
+
+	descriptors, warnings := parseGradleDependenciesWithWarnings(repo)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no gradle warnings, got %#v", warnings)
+	}
+
+	names := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		names = append(names, descriptor.Name)
+	}
+
+	expected := []string{
+		"lombok",
+		"mapstruct-processor",
+		"annotations",
+		"appcompat-v7",
+		"multidex",
+		"dagger-compiler",
+		"dagger-android-processor",
+		"gradle",
+	}
+	if len(descriptors) != len(expected) {
+		t.Fatalf("expected %d gradle descriptors, got %#v", len(expected), descriptors)
+	}
+
+	for _, name := range expected {
+		if !slices.Contains(names, name) {
+			t.Fatalf("expected gradle dependency %q in %#v", name, descriptors)
+		}
+	}
+}
+
 func TestJVMParsePomDependenciesIncludesManagedAndBOMEntries(t *testing.T) {
 	repo := t.TempDir()
 	properties := `


### PR DESCRIPTION
## Summary
- expand JVM Gradle dependency parsing to include common configurations missing from the matcher
- add regression coverage for annotationProcessor/testAnnotationProcessor/testCompileOnly/debugImplementation/releaseImplementation/kaptTest/kaptAndroidTest/classpath
- keep existing Gradle parsing behavior and sorting/deduping intact

## Testing
- go test ./internal/lang/jvm/...
- make format-check
- make test
- make ci

Closes #688