### PR TITLE
fix: make threshold 0 enforce zero-tolerance

### DIFF
--- a/internal/app/analyse_postprocess.go
+++ b/internal/app/analyse_postprocess.go
@@ -104,7 +104,7 @@ func resolveCurrentBaselineKey(repoPath string) string {
 }
 
 func validateFailOnIncrease(reportData report.Report, threshold int) error {
-	if threshold <= 0 {
+	if threshold < 0 {
 		return nil
 	}
 	if reportData.WasteIncreasePercent == nil {
@@ -118,7 +118,7 @@ func validateFailOnIncrease(reportData report.Report, threshold int) error {
 }
 
 func validateUncertaintyThreshold(reportData report.Report, threshold int) error {
-	if threshold <= 0 {
+	if threshold < 0 {
 		return nil
 	}
 

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -37,7 +37,8 @@ func TestExecuteAnalyseEmitsEffectiveThresholds(t *testing.T) {
 	req.Analyse.Features = mustEnabledPreviewFeatureSet(t)
 	req.Analyse.PolicySources = []string{"cli", "defaults"}
 	req.Analyse.Thresholds = thresholds.Values{
-		FailOnIncreasePercent:             0,
+		FailOnIncreasePercent:             -1,
+		MaxUncertainImportCount:           thresholds.DefaultMaxUncertainImportCount,
 		LowConfidenceWarningPercent:       33,
 		MinUsagePercentForRecommendations: 44,
 		RemovalCandidateWeightUsage:       0.6,
@@ -104,7 +105,8 @@ func TestExecuteAnalyseForwardsRustRecommendationThreshold(t *testing.T) {
 	req.Analyse.Dependency = "serde"
 	req.Analyse.Format = report.FormatJSON
 	req.Analyse.Thresholds = thresholds.Values{
-		FailOnIncreasePercent:             0,
+		FailOnIncreasePercent:             -1,
+		MaxUncertainImportCount:           thresholds.DefaultMaxUncertainImportCount,
 		LowConfidenceWarningPercent:       35,
 		MinUsagePercentForRecommendations: 70,
 	}

--- a/internal/app/app_validation_test.go
+++ b/internal/app/app_validation_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ben-ranford/lopper/internal/thresholds"
 )
 
-func TestExecuteAnalyseFailOnIncreaseThreshold(t *testing.T) {
-	delta := 3.5
+func TestExecuteAnalyseFailOnIncreaseZeroToleranceThreshold(t *testing.T) {
+	delta := 0.1
 	analyzer := &fakeAnalyzer{
 		report: report.Report{
 			RepoPath:             ".",
@@ -27,7 +27,8 @@ func TestExecuteAnalyseFailOnIncreaseThreshold(t *testing.T) {
 	req.Mode = ModeAnalyse
 	req.Analyse.TopN = 1
 	req.Analyse.Thresholds = thresholds.Values{
-		FailOnIncreasePercent:             2,
+		FailOnIncreasePercent:             0,
+		MaxUncertainImportCount:           -1,
 		LowConfidenceWarningPercent:       thresholds.DefaultLowConfidenceWarningPercent,
 		MinUsagePercentForRecommendations: thresholds.DefaultMinUsagePercentForRecommendations,
 	}
@@ -72,8 +73,11 @@ func TestValidateFailOnIncreaseRequiresBaseline(t *testing.T) {
 	if !errors.Is(err, ErrBaselineRequired) {
 		t.Fatalf("expected ErrBaselineRequired, got %v", err)
 	}
-	if err := validateFailOnIncrease(report.Report{}, 0); err != nil {
-		t.Fatalf("expected no error when threshold disabled, got %v", err)
+	if err := validateFailOnIncrease(report.Report{}, 0); !errors.Is(err, ErrBaselineRequired) {
+		t.Fatalf("expected zero-threshold fail-on-increase to require baseline, got %v", err)
+	}
+	if err := validateFailOnIncrease(report.Report{}, -1); err != nil {
+		t.Fatalf("expected no error when threshold disabled via -1 sentinel, got %v", err)
 	}
 }
 
@@ -139,6 +143,12 @@ func TestValidateUncertaintyThreshold(t *testing.T) {
 	if err := validateUncertaintyThreshold(reportData, 1); !errors.Is(err, ErrUncertaintyThresholdExceeded) {
 		t.Fatalf("expected uncertainty threshold error, got %v", err)
 	}
+	if err := validateUncertaintyThreshold(reportData, 0); !errors.Is(err, ErrUncertaintyThresholdExceeded) {
+		t.Fatalf("expected zero-threshold uncertainty validation error, got %v", err)
+	}
+	if err := validateUncertaintyThreshold(reportData, -1); err != nil {
+		t.Fatalf("expected -1 sentinel to disable uncertainty threshold, got %v", err)
+	}
 }
 
 func TestExecuteAnalyseUncertaintyThresholdError(t *testing.T) {
@@ -147,7 +157,7 @@ func TestExecuteAnalyseUncertaintyThresholdError(t *testing.T) {
 			RepoPath:     ".",
 			Dependencies: []report.DependencyReport{{Name: "lodash", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50}},
 			UsageUncertainty: &report.UsageUncertainty{
-				UncertainImportUses: 2,
+				UncertainImportUses: 1,
 			},
 		},
 	}
@@ -157,7 +167,7 @@ func TestExecuteAnalyseUncertaintyThresholdError(t *testing.T) {
 	req.Mode = ModeAnalyse
 	req.Analyse.TopN = 1
 	req.Analyse.Format = report.FormatJSON
-	req.Analyse.Thresholds.MaxUncertainImportCount = 1
+	req.Analyse.Thresholds.MaxUncertainImportCount = 0
 
 	output, err := application.Execute(context.Background(), req)
 	if !errors.Is(err, ErrUncertaintyThresholdExceeded) {

--- a/internal/thresholds/config_test.go
+++ b/internal/thresholds/config_test.go
@@ -73,6 +73,30 @@ func TestLoadYAMLConfig(t *testing.T) {
 	}
 }
 
+func TestLoadYAMLConfigAllowsDisabledSentinelThresholds(t *testing.T) {
+	repo := t.TempDir()
+	cfg := strings.Join([]string{"thresholds:", " fail_on_increase_percent: -1", " max_uncertain_import_count: -1", ""}, "\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, lopperYMLName), cfg)
+
+	overrides, _, err := Load(repo, "")
+	if err != nil {
+		t.Fatalf(loadConfigErrFmt, err)
+	}
+	if overrides.FailOnIncreasePercent == nil || *overrides.FailOnIncreasePercent != -1 {
+		t.Fatalf("expected parsed fail_on_increase_percent override=-1, got %#v", overrides.FailOnIncreasePercent)
+	}
+	if overrides.MaxUncertainImportCount == nil || *overrides.MaxUncertainImportCount != -1 {
+		t.Fatalf("expected parsed max_uncertain_import_count override=-1, got %#v", overrides.MaxUncertainImportCount)
+	}
+	resolved := overrides.Apply(Defaults())
+	if resolved.FailOnIncreasePercent != -1 {
+		t.Fatalf("expected fail_on_increase_percent=-1, got %d", resolved.FailOnIncreasePercent)
+	}
+	if resolved.MaxUncertainImportCount != -1 {
+		t.Fatalf("expected max_uncertain_import_count=-1, got %d", resolved.MaxUncertainImportCount)
+	}
+}
+
 func TestNormalizePathPatternsNormalizesSeparatorsAndDedupes(t *testing.T) {
 	got := normalizePathPatterns([]string{"src\\**\\*.go", " src/**/*.go ", "vendor\\**"})
 	if strings.Join(got, ",") != "src/**/*.go,"+vendorGlob {

--- a/internal/thresholds/thresholds.go
+++ b/internal/thresholds/thresholds.go
@@ -8,16 +8,18 @@ import (
 )
 
 const (
-	DefaultFailOnIncreasePercent             = 0
+	// -1 disables threshold enforcement; 0 is strict zero-tolerance.
+	DefaultFailOnIncreasePercent             = -1
 	DefaultLowConfidenceWarningPercent       = 40
 	DefaultMinUsagePercentForRecommendations = 40
-	DefaultMaxUncertainImportCount           = 0
-	DefaultRemovalCandidateWeightUsage       = 0.50
-	DefaultRemovalCandidateWeightImpact      = 0.30
-	DefaultRemovalCandidateWeightConfidence  = 0.20
-	DefaultLockfileDriftPolicy               = "warn"
-	DefaultLicenseFailOnDeny                 = false
-	DefaultLicenseIncludeRegistryProvenance  = false
+	// -1 disables threshold enforcement; 0 is strict zero-tolerance.
+	DefaultMaxUncertainImportCount          = -1
+	DefaultRemovalCandidateWeightUsage      = 0.50
+	DefaultRemovalCandidateWeightImpact     = 0.30
+	DefaultRemovalCandidateWeightConfidence = 0.20
+	DefaultLockfileDriftPolicy              = "warn"
+	DefaultLicenseFailOnDeny                = false
+	DefaultLicenseIncludeRegistryProvenance = false
 )
 
 var validLockfileDriftPolicies = map[string]struct{}{
@@ -81,7 +83,7 @@ func (v *Values) Validate() error {
 	if err := validatePercentageRange("min_usage_percent_for_recommendations", v.MinUsagePercentForRecommendations); err != nil {
 		return err
 	}
-	if err := validateNonNegative("max_uncertain_import_count", v.MaxUncertainImportCount); err != nil {
+	if err := validateThresholdWithDisableSentinel("max_uncertain_import_count", v.MaxUncertainImportCount); err != nil {
 		return err
 	}
 	if err := validateWeight("removal_candidate_weight_usage", v.RemovalCandidateWeightUsage); err != nil {
@@ -157,7 +159,7 @@ func (o *Overrides) Validate() error {
 		return err
 	}
 	if err := validateOptionalInt(o.MaxUncertainImportCount, func(value int) error {
-		return validateNonNegative("max_uncertain_import_count", value)
+		return validateThresholdWithDisableSentinel("max_uncertain_import_count", value)
 	}); err != nil {
 		return err
 	}
@@ -171,16 +173,13 @@ func (o *Overrides) Validate() error {
 	return nil
 }
 
-func validateNonNegative(name string, value int) error {
-	if value < 0 {
-		return fmt.Errorf("invalid threshold %s: %d (must be >= 0)", name, value)
-	}
-	return nil
+func validateFailOnIncrease(value int) error {
+	return validateThresholdWithDisableSentinel("fail_on_increase_percent", value)
 }
 
-func validateFailOnIncrease(value int) error {
-	if value < 0 {
-		return fmt.Errorf("invalid threshold fail_on_increase_percent: %d (must be >= 0)", value)
+func validateThresholdWithDisableSentinel(name string, value int) error {
+	if value < -1 {
+		return fmt.Errorf("invalid threshold %s: %d (must be -1 (disabled) or >= 0)", name, value)
 	}
 	return nil
 }

--- a/internal/thresholds/thresholds_test.go
+++ b/internal/thresholds/thresholds_test.go
@@ -30,10 +30,10 @@ func TestOverridesApply(t *testing.T) {
 
 func TestValuesValidateErrors(t *testing.T) {
 	tests := []Values{
-		{FailOnIncreasePercent: -1, LowConfidenceWarningPercent: 40, MinUsagePercentForRecommendations: 40, MaxUncertainImportCount: 0, RemovalCandidateWeightUsage: 0.5, RemovalCandidateWeightImpact: 0.3, RemovalCandidateWeightConfidence: 0.2},
+		{FailOnIncreasePercent: -2, LowConfidenceWarningPercent: 40, MinUsagePercentForRecommendations: 40, MaxUncertainImportCount: 0, RemovalCandidateWeightUsage: 0.5, RemovalCandidateWeightImpact: 0.3, RemovalCandidateWeightConfidence: 0.2},
 		{FailOnIncreasePercent: 0, LowConfidenceWarningPercent: 101, MinUsagePercentForRecommendations: 40, MaxUncertainImportCount: 0, RemovalCandidateWeightUsage: 0.5, RemovalCandidateWeightImpact: 0.3, RemovalCandidateWeightConfidence: 0.2},
 		{FailOnIncreasePercent: 0, LowConfidenceWarningPercent: 40, MinUsagePercentForRecommendations: -2, MaxUncertainImportCount: 0, RemovalCandidateWeightUsage: 0.5, RemovalCandidateWeightImpact: 0.3, RemovalCandidateWeightConfidence: 0.2},
-		{FailOnIncreasePercent: 0, LowConfidenceWarningPercent: 40, MinUsagePercentForRecommendations: 40, MaxUncertainImportCount: -1, RemovalCandidateWeightUsage: 0.5, RemovalCandidateWeightImpact: 0.3, RemovalCandidateWeightConfidence: 0.2},
+		{FailOnIncreasePercent: 0, LowConfidenceWarningPercent: 40, MinUsagePercentForRecommendations: 40, MaxUncertainImportCount: -2, RemovalCandidateWeightUsage: 0.5, RemovalCandidateWeightImpact: 0.3, RemovalCandidateWeightConfidence: 0.2},
 		{FailOnIncreasePercent: 0, LowConfidenceWarningPercent: 40, MinUsagePercentForRecommendations: 40, MaxUncertainImportCount: 0, RemovalCandidateWeightUsage: -0.1, RemovalCandidateWeightImpact: 0.3, RemovalCandidateWeightConfidence: 0.2},
 		{FailOnIncreasePercent: 0, LowConfidenceWarningPercent: 40, MinUsagePercentForRecommendations: 40, MaxUncertainImportCount: 0, RemovalCandidateWeightUsage: 0, RemovalCandidateWeightImpact: 0, RemovalCandidateWeightConfidence: 0},
 	}
@@ -45,10 +45,10 @@ func TestValuesValidateErrors(t *testing.T) {
 }
 
 func TestOverridesValidateErrors(t *testing.T) {
-	fail := -1
+	fail := -2
 	low := 200
 	minUsage := -5
-	maxUncertain := -1
+	maxUncertain := -2
 	weight := -1.0
 	nan := math.NaN()
 	inf := math.Inf(1)
@@ -121,6 +121,32 @@ func TestOverridesValidateErrors(t *testing.T) {
 				t.Fatalf("expected error containing %q, got %v", tc.want, err)
 			}
 		})
+	}
+}
+
+func TestThresholdDisableSentinelAccepted(t *testing.T) {
+	values := Values{
+		FailOnIncreasePercent:             -1,
+		LowConfidenceWarningPercent:       40,
+		MinUsagePercentForRecommendations: 40,
+		MaxUncertainImportCount:           -1,
+		RemovalCandidateWeightUsage:       0.5,
+		RemovalCandidateWeightImpact:      0.3,
+		RemovalCandidateWeightConfidence:  0.2,
+		LockfileDriftPolicy:               DefaultLockfileDriftPolicy,
+	}
+	if err := values.Validate(); err != nil {
+		t.Fatalf("expected -1 sentinel values to validate, got %v", err)
+	}
+
+	fail := -1
+	maxUncertain := -1
+	overrides := Overrides{
+		FailOnIncreasePercent:   &fail,
+		MaxUncertainImportCount: &maxUncertain,
+	}
+	if err := overrides.Validate(); err != nil {
+		t.Fatalf("expected -1 sentinel overrides to validate, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- treat `fail_on_increase_percent: 0` and `max_uncertain_import_count: 0` as active zero-tolerance checks
- reserve `-1` as the explicit disabled sentinel for both thresholds
- add regression coverage in threshold config/validation and analyse enforcement tests

Fixes #700.
