### PR TITLE
bug(dart): fix multiline import directive parsing

### DIFF
--- a/internal/lang/dart/adapter_branches_extra_test.go
+++ b/internal/lang/dart/adapter_branches_extra_test.go
@@ -42,6 +42,100 @@ func TestParseImportDirectiveAndShowSymbols(t *testing.T) {
 	}
 }
 
+func TestParseDartImportsHandlesMultilineDirective(t *testing.T) {
+	content := []byte(`import 'package:http/http.dart'
+    as http;
+
+void main() {
+  http.Client();
+}
+`)
+	imports := parseDartImports(content, "lib/main.dart", map[string]dependencyInfo{"http": {}}, map[string]int{})
+
+	if len(imports) != 1 {
+		t.Fatalf("expected exactly one import binding, got %#v", imports)
+	}
+	if imports[0].Dependency != "http" || imports[0].Local != "http" {
+		t.Fatalf("expected http alias binding, got %#v", imports[0])
+	}
+	if imports[0].Location.Line != 1 || imports[0].Location.Column != 1 {
+		t.Fatalf("expected multiline directive location at line 1 column 1, got %#v", imports[0].Location)
+	}
+}
+
+func TestParseDartImportsSkipsUnterminatedDirective(t *testing.T) {
+	content := []byte(`import 'package:http/http.dart'
+void main() {
+  print('missing semicolon');
+}
+`)
+	imports := parseDartImports(content, "lib/main.dart", map[string]dependencyInfo{"http": {}}, map[string]int{})
+	if len(imports) != 0 {
+		t.Fatalf("expected unterminated directive to be ignored, got %#v", imports)
+	}
+}
+
+func TestParseDartImportsSkipsUnterminatedDirectiveBeforeIndentedStatement(t *testing.T) {
+	content := []byte(`import 'package:http/http.dart'
+  final value = 'not a directive terminator';
+void main() {}
+`)
+	imports := parseDartImports(content, "lib/main.dart", map[string]dependencyInfo{"http": {}}, map[string]int{})
+	if len(imports) != 0 {
+		t.Fatalf("expected unterminated directive before indented statement to be ignored, got %#v", imports)
+	}
+}
+
+func TestParseDartImportsSkipsMalformedAndNonPackageDirectives(t *testing.T) {
+	content := []byte(`import foo;
+import 'dart:core';
+`)
+	imports := parseDartImports(content, "lib/main.dart", map[string]dependencyInfo{"http": {}}, map[string]int{})
+	if len(imports) != 0 {
+		t.Fatalf("expected malformed and non-package directives to be ignored, got %#v", imports)
+	}
+}
+
+func TestCollectDirectiveBranches(t *testing.T) {
+	if directive, consumed, ok := collectDirective(nil); ok || directive != "" || consumed != 1 {
+		t.Fatalf("expected empty input to fail collect, got directive=%q consumed=%d ok=%v", directive, consumed, ok)
+	}
+
+	if directive, consumed, ok := collectDirective([]string{"part 'x.dart';"}); ok || directive != "" || consumed != 1 {
+		t.Fatalf("expected non-import line to fail collect, got directive=%q consumed=%d ok=%v", directive, consumed, ok)
+	}
+
+	directive, consumed, ok := collectDirective([]string{
+		"import 'package:http/http.dart'",
+		"",
+		"\tas http;",
+	})
+	if !ok || consumed != 3 || !strings.Contains(directive, "as http;") {
+		t.Fatalf("expected blank and tab-indented continuation to parse, got directive=%q consumed=%d ok=%v", directive, consumed, ok)
+	}
+
+	if directive, consumed, ok := collectDirective([]string{
+		"import 'package:http/http.dart'",
+		"    as http",
+	}); ok || directive != "" || consumed != 1 {
+		t.Fatalf("expected unterminated multiline collect to fail, got directive=%q consumed=%d ok=%v", directive, consumed, ok)
+	}
+
+	if directive, consumed, ok := collectDirective([]string{
+		"import 'package:http/http.dart'",
+		"    // semicolon in comment ;",
+	}); ok || directive != "" || consumed != 1 {
+		t.Fatalf("expected comment semicolon to be ignored, got directive=%q consumed=%d ok=%v", directive, consumed, ok)
+	}
+
+	if directive, consumed, ok := collectDirective([]string{
+		"import 'package:http/http.dart'",
+		"    show Foo; // trailing comment",
+	}); !ok || consumed != 2 || !strings.Contains(directive, "show Foo;") {
+		t.Fatalf("expected directive terminator before trailing comment, got directive=%q consumed=%d ok=%v", directive, consumed, ok)
+	}
+}
+
 func TestBuildDirectiveBindingsBranches(t *testing.T) {
 	location := report.Location{File: "lib/main.dart", Line: 1, Column: 1}
 	exportBindings := buildDirectiveBindings("export", fooPackageModule, "", "foo", location)

--- a/internal/lang/dart/adapter_test.go
+++ b/internal/lang/dart/adapter_test.go
@@ -153,6 +153,33 @@ void main() {
 	}
 }
 
+func TestDartAdapterAnalyseMultilineImportDirective(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, pubspecYAMLName), appHTTPManifest)
+	writeFile(t, filepath.Join(repo, "lib", mainDartFileName), `import 'package:http/http.dart'
+    as http;
+
+void main() {
+  final client = http.Client();
+  client.close();
+}
+`)
+
+	depReport, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath:   repo,
+		Dependency: "http",
+	})
+	if err != nil {
+		t.Fatalf("analyse multiline import dependency: %v", err)
+	}
+	if len(depReport.Dependencies) != 1 {
+		t.Fatalf(expectedOneDependencyReport, len(depReport.Dependencies))
+	}
+	if depReport.Dependencies[0].UsedExportsCount == 0 {
+		t.Fatalf("expected multiline import alias usage to be detected")
+	}
+}
+
 func TestDartAdapterUndeclaredImportRisk(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, pubspecYAMLName), appHTTPManifest)

--- a/internal/lang/dart/scan.go
+++ b/internal/lang/dart/scan.go
@@ -190,23 +190,97 @@ func scanDartSourceFile(repoPath, path string, depLookup map[string]dependencyIn
 func parseDartImports(content []byte, filePath string, depLookup map[string]dependencyInfo, unresolved map[string]int) []importBinding {
 	lines := strings.Split(string(content), "\n")
 	imports := make([]importBinding, 0)
-	for i, line := range lines {
-		kind, module, clause, ok := parseImportDirective(line)
+	for i := 0; i < len(lines); i++ {
+		directive, consumed, ok := collectDirective(lines[i:])
 		if !ok {
 			continue
 		}
+		lineIndex := i
+		i += consumed - 1
+		kind, module, clause, ok := parseImportDirective(directive)
+		if !ok {
+			continue
+		}
+
 		dependency := resolveDependencyFromModule(module, depLookup, unresolved)
 		if dependency == "" {
 			continue
 		}
 		location := report.Location{
 			File:   filePath,
-			Line:   i + 1,
-			Column: shared.FirstContentColumn(line),
+			Line:   lineIndex + 1,
+			Column: shared.FirstContentColumn(lines[lineIndex]),
 		}
 		imports = append(imports, buildDirectiveBindings(kind, module, clause, dependency, location)...)
 	}
 	return imports
+}
+
+func collectDirective(lines []string) (string, int, bool) {
+	if len(lines) == 0 || !directiveStartPattern.MatchString(lines[0]) {
+		return "", 1, false
+	}
+	if hasDirectiveTerminator(lines[0]) {
+		return lines[0], 1, true
+	}
+
+	directive := lines[0]
+	for i := 1; i < len(lines); i++ {
+		if !isDirectiveContinuationLine(lines[i]) {
+			return "", 1, false
+		}
+		directive += "\n" + lines[i]
+		if hasDirectiveTerminator(lines[i]) {
+			return directive, i + 1, true
+		}
+	}
+	return "", 1, false
+}
+
+func hasDirectiveTerminator(line string) bool {
+	var quote byte
+	escaped := false
+	for i := 0; i < len(line); i++ {
+		character := line[i]
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if character == '\\' {
+				escaped = true
+				continue
+			}
+			if character == quote {
+				quote = 0
+			}
+			continue
+		}
+
+		switch character {
+		case '\'', '"':
+			quote = character
+		case '/':
+			if i+1 < len(line) && line[i+1] == '/' {
+				return false
+			}
+		case ';':
+			return hasOnlyDirectiveTrailingContent(line[i+1:])
+		}
+	}
+	return false
+}
+
+func hasOnlyDirectiveTrailingContent(suffix string) bool {
+	trimmed := strings.TrimSpace(suffix)
+	return trimmed == "" || strings.HasPrefix(trimmed, "//")
+}
+
+func isDirectiveContinuationLine(line string) bool {
+	if line == "" {
+		return true
+	}
+	return line[0] == ' ' || line[0] == '\t'
 }
 
 func parseImportDirective(line string) (string, string, string, bool) {
@@ -217,7 +291,25 @@ func parseImportDirective(line string) (string, string, string, bool) {
 	kind := strings.TrimSpace(strings.ToLower(match[1]))
 	module := strings.TrimSpace(match[2])
 	clause := strings.TrimSpace(match[3])
+	if !isValidDirectiveClause(clause) {
+		return "", "", "", false
+	}
 	return kind, module, clause, true
+}
+
+func isValidDirectiveClause(clause string) bool {
+	remaining := strings.TrimSpace(clause)
+	for remaining != "" {
+		switch {
+		case directiveAliasClausePattern.MatchString(remaining):
+			remaining = strings.TrimSpace(directiveAliasClausePattern.ReplaceAllString(remaining, ""))
+		case directiveCombinatorClausePattern.MatchString(remaining):
+			remaining = strings.TrimSpace(directiveCombinatorClausePattern.ReplaceAllString(remaining, ""))
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func buildDirectiveBindings(kind, module, clause, dependency string, location report.Location) []importBinding {

--- a/internal/lang/dart/types.go
+++ b/internal/lang/dart/types.go
@@ -107,7 +107,10 @@ type scanResult struct {
 }
 
 var (
-	directivePattern = regexp.MustCompile(`^\s*(import|export)\s+['"]([^'"]+)['"]([^;]*);`)
-	aliasPattern     = regexp.MustCompile(`\bas\s+([A-Za-z_][A-Za-z0-9_]*)`)
-	identPattern     = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	directivePattern                 = regexp.MustCompile(`(?s)^\s*(import|export)\s+['"]([^'"]+)['"]([^;]*);\s*(?://.*)?$`)
+	directiveStartPattern            = regexp.MustCompile(`^\s*(import|export)\b`)
+	directiveAliasClausePattern      = regexp.MustCompile(`^(?:deferred\s+as|as)\s+[A-Za-z_][A-Za-z0-9_]*\b`)
+	directiveCombinatorClausePattern = regexp.MustCompile(`^(?:show|hide)\s+[A-Za-z_][A-Za-z0-9_]*(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*`)
+	aliasPattern                     = regexp.MustCompile(`\bas\s+([A-Za-z_][A-Za-z0-9_]*)`)
+	identPattern                     = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 )


### PR DESCRIPTION
## Summary
- parse Dart import/export directives across indented continuation lines
- keep directive location pinned to the start of the directive line
- add regression tests for multiline directives and malformed/unterminated directives

Closes #691