### PR TITLE
fix: restore darwin/amd64 artifacts in release and rolling workflows

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -82,7 +82,7 @@ jobs:
             dist/*.zip
 
   build-darwin:
-    runs-on: macos-latest
+    runs-on: macos-14
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,11 +111,64 @@ jobs:
           name: release-vscode-extension
           path: dist/*.vsix
 
+  build-darwin-amd64:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}
+    runs-on: macos-15-intel
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag }}
+
+      - name: Compute build metadata
+        id: build_meta
+        run: |
+          echo "commit=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install shellcheck
+        run: brew install shellcheck
+
+      - name: Install Go tooling
+        run: |
+          make tools-install
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Build Darwin amd64 release artifact
+        env:
+          TAG: ${{ needs.release-please.outputs.tag || inputs.tag }}
+          COMMIT_SHA: ${{ steps.build_meta.outputs.commit }}
+          BUILD_DATE: ${{ steps.build_meta.outputs.build_date }}
+        run: |
+          make release \
+            VERSION="$TAG" \
+            GIT_COMMIT="$COMMIT_SHA" \
+            BUILD_DATE="$BUILD_DATE" \
+            RELEASE_BUILD_CHANNEL=release \
+            PLATFORMS="darwin/amd64"
+
+      - name: Upload Darwin amd64 artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-darwin-amd64
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+
   publish:
     needs:
       - release-please
       - orchestrate-release
       - build-vscode-extension
+      - build-darwin-amd64
     if: ${{ needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}
     runs-on: ubuntu-latest
     permissions:
@@ -141,6 +194,18 @@ jobs:
           pattern: release-*
           merge-multiple: true
           path: dist
+
+      - name: Verify Darwin artifacts are present
+        run: |
+          set -euo pipefail
+          if ! find dist -maxdepth 1 -type f -name '*_darwin_amd64.tar.gz' | grep -q .; then
+            echo "Expected darwin/amd64 artifact is missing from dist/" >&2
+            exit 1
+          fi
+          if ! find dist -maxdepth 1 -type f -name '*_darwin_arm64.tar.gz' | grep -q .; then
+            echo "Expected darwin/arm64 artifact is missing from dist/" >&2
+            exit 1
+          fi
 
       - name: Generate feature flag release report
         env:

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -49,10 +49,65 @@ jobs:
         ${{ needs.prepare-rolling.outputs.tag }}
         rolling
 
+  build-darwin-amd64-rolling:
+    needs:
+      - prepare-rolling
+    runs-on: macos-15-intel
+    permissions:
+      contents: read
+    env:
+      ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
+      SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
+    steps:
+      - name: Checkout rolling source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+
+      - name: Compute build metadata
+        id: build_meta
+        run: |
+          echo "commit=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install shellcheck
+        run: brew install shellcheck
+
+      - name: Install Go tooling
+        run: |
+          make tools-install
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Build Darwin amd64 rolling artifact
+        env:
+          COMMIT_SHA: ${{ steps.build_meta.outputs.commit }}
+          BUILD_DATE: ${{ steps.build_meta.outputs.build_date }}
+        run: |
+          make release \
+            VERSION="$ROLLING_TAG" \
+            GIT_COMMIT="$COMMIT_SHA" \
+            BUILD_DATE="$BUILD_DATE" \
+            RELEASE_BUILD_CHANNEL=rolling \
+            PLATFORMS="darwin/amd64"
+
+      - name: Upload Darwin amd64 rolling artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: rolling-darwin-amd64
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+
   publish-rolling:
     needs:
       - prepare-rolling
       - orchestrate-rolling
+      - build-darwin-amd64-rolling
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -80,6 +135,18 @@ jobs:
           pattern: rolling-*
           merge-multiple: true
           path: dist
+
+      - name: Verify Darwin artifacts are present
+        run: |
+          set -euo pipefail
+          if ! find dist -maxdepth 1 -type f -name '*_darwin_amd64.tar.gz' | grep -q .; then
+            echo "Expected darwin/amd64 artifact is missing from dist/" >&2
+            exit 1
+          fi
+          if ! find dist -maxdepth 1 -type f -name '*_darwin_arm64.tar.gz' | grep -q .; then
+            echo "Expected darwin/arm64 artifact is missing from dist/" >&2
+            exit 1
+          fi
 
       - name: Build rolling source bundle
         run: |


### PR DESCRIPTION
## Summary
- add dedicated Intel macOS build jobs for release and rolling workflows to produce `darwin/amd64` binaries
- require publish jobs to wait for those Intel artifact jobs
- add publish-time validation that both `darwin/amd64` and `darwin/arm64` artifacts exist in `dist/`

Fixes #705.
