### PR TITLE
fix(ci): align gosec pin with release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y shellcheck
 
+      - name: Resolve gosec version
+        id: gosec_version
+        run: echo "value=$(make --silent print-gosec-version)" >> "$GITHUB_OUTPUT"
+
       - name: Install Go tooling
+        env:
+          GOSEC_VERSION: ${{ steps.gosec_version.outputs.value }}
         run: |
           make tools-install
           if [ -z "${ACT:-}" ]; then

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -54,7 +54,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y shellcheck
 
+      - name: Resolve gosec version
+        id: gosec_version
+        run: echo "value=$(make --silent print-gosec-version)" >> "$GITHUB_OUTPUT"
+
       - name: Install Go tooling
+        env:
+          GOSEC_VERSION: ${{ steps.gosec_version.outputs.value }}
         run: |
           make tools-install
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
@@ -105,7 +111,13 @@ jobs:
       - name: Install shellcheck
         run: brew install shellcheck
 
+      - name: Resolve gosec version
+        id: gosec_version
+        run: echo "value=$(make --silent print-gosec-version)" >> "$GITHUB_OUTPUT"
+
       - name: Install Go tooling
+        env:
+          GOSEC_VERSION: ${{ steps.gosec_version.outputs.value }}
         run: |
           make tools-install
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format fmt format-check gostyle lint actionlint shellcheck mod-check feature-flag feature-flag-graduate feature-flag-check dup-check suppression-check security vuln-check test test-leaks test-race bench-mem bench-delta bench-gate cov build manpage ci smoke demos demos-check mem-profiles release clean toolchain-check toolchain-install toolchain-install-macos toolchain-install-linux tools-install setup hooks-install hooks-uninstall sync-version vscode-extension-install vscode-extension-compile vscode-extension-test vscode-extension-package
+.PHONY: format fmt format-check gostyle lint actionlint shellcheck mod-check feature-flag feature-flag-graduate feature-flag-check dup-check suppression-check security vuln-check test test-leaks test-race bench-mem bench-delta bench-gate cov build manpage ci smoke demos demos-check mem-profiles release clean toolchain-check toolchain-install toolchain-install-macos toolchain-install-linux print-gosec-version tools-install setup hooks-install hooks-uninstall sync-version vscode-extension-install vscode-extension-compile vscode-extension-test vscode-extension-package
 
 BINARY_NAME ?= lopper
 CMD_PATH ?= ./cmd/lopper
@@ -329,6 +329,9 @@ tools-install:
 	$(GO_CMD) install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)
 	$(GO_CMD) install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)
 	$(GO_CMD) install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+
+print-gosec-version:
+	@echo $(GOSEC_VERSION)
 
 sync-version:
 	cd $(VSCODE_EXTENSION_DIR) && npm version "$(VERSION)" --no-git-tag-version --allow-same-version


### PR DESCRIPTION
## Summary
- add a Makefile helper target (`print-gosec-version`) as the single source of truth for the gosec version pin
- resolve that value in CI and release-orchestration workflows before `make tools-install`
- pass `GOSEC_VERSION` explicitly into tooling install steps so CI and release paths consume the same pinned version

Fixes #704.
