### PR TITLE
chore(ci): enforce feature flag policy in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,6 +510,74 @@ jobs:
           test -f bin/lopper
           ls -lh bin/lopper
 
+  verify-rolling:
+    name: verify (rolling)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        if: ${{ !env.ACT }}
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Go (act)
+        if: ${{ env.ACT }}
+        run: |
+          if ! command -v go >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y golang-go
+          fi
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y shellcheck
+          fi
+          go version
+
+      - name: Install shellcheck
+        if: ${{ !env.ACT }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Install Go tooling
+        run: |
+          make tools-install
+          if [ -z "${ACT:-}" ]; then
+            echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Fetch PR base
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          base_ref="${PR_BASE_REF:-main}"
+          git fetch --no-tags --depth=1 origin "${base_ref}"
+
+      - name: Run CI target with rolling defaults
+        env:
+          BUILD_CHANNEL: rolling
+          GH_EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [ "${GH_EVENT_NAME}" = "pull_request" ]; then
+            base_ref="${PR_BASE_REF:-main}"
+            export MEMORY_BENCH_BASE="origin/${base_ref}"
+            export MEMORY_BENCH_ENFORCE=0
+          fi
+          if [ -n "${ACT:-}" ]; then
+            PATH="$(go env GOPATH)/bin:$PATH" make ci BUILD_CHANNEL="${BUILD_CHANNEL}"
+          else
+            make ci BUILD_CHANNEL="${BUILD_CHANNEL}"
+          fi
+
   os-smoke:
     name: os-smoke (${{ matrix.os }})
     strategy:

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -86,9 +86,11 @@ jobs:
               'See the workflow logs for the failure details.',
             ].join('\n');
 
-            const body = fs.existsSync(summaryPath)
-              ? fs.readFileSync(summaryPath, 'utf8').trim()
-              : fallbackBody;
+            let summary = '';
+            if (fs.existsSync(summaryPath)) {
+              summary = fs.readFileSync(summaryPath, 'utf8').trim();
+            }
+            const body = summary || fallbackBody;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -1,0 +1,134 @@
+name: feature flag enforcement
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - ready_for_review
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Fetch PR base
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          base_ref="${PR_BASE_REF:-main}"
+          git fetch --no-tags --depth=1 origin "${base_ref}"
+
+      - name: Capture base feature catalog
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          base_ref="${PR_BASE_REF:-main}"
+          mkdir -p .artifacts
+          if git cat-file -e "origin/${base_ref}:internal/featureflags/features.json"; then
+            git show "origin/${base_ref}:internal/featureflags/features.json" > .artifacts/previous-features.json
+          else
+            printf '[]\n' > .artifacts/previous-features.json
+          fi
+
+      - name: Enforce feature flags on PRs
+        id: enforce_flags
+        continue-on-error: true
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          go run ./tools/featureflag pr-enforce \
+            --pr-title "${PR_TITLE}" \
+            --previous-catalog .artifacts/previous-features.json \
+            > .artifacts/feature-flag-enforcement.md
+
+      - name: Write feature flag summary
+        if: ${{ always() }}
+        run: |
+          if [ -s .artifacts/feature-flag-enforcement.md ]; then
+            cat .artifacts/feature-flag-enforcement.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf '%s\n\n%s\n' \
+              '## Feature flag enforcement' \
+              '❌ Feature flag enforcement summary was not produced. Check the workflow logs.' \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Comment feature flag report on PR
+        if: ${{ always() && !env.ACT }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('node:fs');
+
+            const marker = '<!-- lopper-feature-flag-enforcement -->';
+            const summaryPath = '.artifacts/feature-flag-enforcement.md';
+            const fallbackBody = [
+              marker,
+              '## Feature flag enforcement',
+              '',
+              '❌ Feature flag enforcement summary was not produced.',
+              '',
+              'See the workflow logs for the failure details.',
+            ].join('\n');
+
+            const body = fs.existsSync(summaryPath)
+              ? fs.readFileSync(summaryPath, 'utf8').trim()
+              : fallbackBody;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.filter(
+              (comment) =>
+                comment.user?.type === 'Bot' &&
+                typeof comment.body === 'string' &&
+                comment.body.includes(marker),
+            );
+
+            if (existing.length > 0) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing[0].id,
+                body,
+              });
+              for (const duplicate of existing.slice(1)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: duplicate.id,
+                });
+              }
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail on feature flag enforcement errors
+        if: ${{ steps.enforce_flags.outcome == 'failure' }}
+        run: |
+          echo "Feature flag enforcement failed. See the summary above for the added flags and any violations."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ Contributor rules:
 - Release locks are release-specific default-on decisions; they do not change the lifecycle to `stable`.
 - Graduation requires a separate PR that changes the registry lifecycle to `stable` and states the rollout evidence.
 - Use `make feature-flag-graduate FEATURE=...` locally, or run `graduate-feature.yml`, to prepare a graduation PR.
+- PRs that use the `feat` Conventional Commit type must add at least one new feature flag entry, and new entries must stay `preview`.
 - PRs that add, lock, or graduate a feature flag must run `go run ./tools/featureflag validate`.
 
 Reviewers should ask for a flag when the change changes default user behavior but lacks enough evidence for immediate stable rollout.

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ GO_VERSION_LDFLAGS = -X $(VERSION_PKG).version=$(VERSION) -X $(VERSION_PKG).comm
 RELEASE_VERSION_LDFLAGS = -X $(VERSION_PKG).version=$(VERSION) -X $(VERSION_PKG).commit=$(GIT_COMMIT) -X $(VERSION_PKG).buildDate=$(BUILD_DATE) -X $(VERSION_PKG).buildChannel=$(RELEASE_BUILD_CHANNEL)
 BUILD_GO_LDFLAGS ?= $(GO_VERSION_LDFLAGS)
 RELEASE_GO_LDFLAGS ?= -s -w $(RELEASE_VERSION_LDFLAGS)
+TEST_VERSION_LDFLAGS = -X $(VERSION_PKG).buildChannel=$(BUILD_CHANNEL)
+GO_TEST_LDFLAGS ?= $(TEST_VERSION_LDFLAGS)
+GO_TEST_LDFLAGS_ARGS = $(if $(strip $(GO_TEST_LDFLAGS)),-ldflags "$(GO_TEST_LDFLAGS)")
 
 format:
 	gofmt -w .
@@ -151,19 +154,19 @@ vuln-check:
 	$(GO_CMD) run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
 test:
-	$(GO_CMD) test ./...
+	$(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) ./...
 
 test-leaks:
-	GOLEAK=1 $(GO_CMD) test ./...
+	GOLEAK=1 $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) ./...
 
 test-race:
-	$(GO_CMD) test -race ./...
+	$(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -race ./...
 
 bench-mem:
 	@mkdir -p $$(dirname "$(BENCH_OUTPUT)"); \
 	bench_output_tmp=$$(mktemp); \
 	trap 'rm -f "$$bench_output_tmp"' EXIT INT TERM; \
-	if ! GOFLAGS=-buildvcs=false $(GO_CMD) test -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES) > "$$bench_output_tmp" 2>&1; then \
+	if ! GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES) > "$$bench_output_tmp" 2>&1; then \
 		cat "$$bench_output_tmp"; \
 		exit 1; \
 	fi; \
@@ -208,13 +211,13 @@ bench-gate:
 		echo "Running memory benchmark delta against $$base_ref."; \
 	fi; \
 	(unset GIT_INDEX_FILE; git worktree add --detach "$$base_tree" "$$base_commit" >/dev/null); \
-	if ! (cd "$$base_tree" && GOFLAGS=-buildvcs=false $(GO_CMD) test -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES)) > "$$base_output_tmp" 2>&1; then \
+	if ! (cd "$$base_tree" && GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES)) > "$$base_output_tmp" 2>&1; then \
 		cat "$$base_output_tmp"; \
 		exit 1; \
 	fi; \
 	cat "$$base_output_tmp"; \
 	cp "$$base_output_tmp" "$(BENCH_BASE_OUTPUT)"; \
-	if ! GOFLAGS=-buildvcs=false $(GO_CMD) test -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES) > "$$head_output_tmp" 2>&1; then \
+	if ! GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES) > "$$head_output_tmp" 2>&1; then \
 		cat "$$head_output_tmp"; \
 		exit 1; \
 	fi; \
@@ -235,7 +238,7 @@ bench-gate:
 cov:
 	@mkdir -p $$(dirname "$(COVERAGE_FILE)")
 	@pkgs=$$(GOFLAGS=-buildvcs=false $(GO_CMD) list ./... | grep -Ev '/internal/testutil$$|/internal/testsupport$$|/tools/benchdelta$$'); \
-		GOFLAGS=-buildvcs=false $(GO_CMD) test $$pkgs -covermode=atomic -coverprofile="$(COVERAGE_FILE)"
+		GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) $$pkgs -covermode=atomic -coverprofile="$(COVERAGE_FILE)"
 	@GOFLAGS=-buildvcs=false $(GO_CMD) run ./tools/coveragegate \
 		-coverprofile="$(COVERAGE_FILE)" \
 		-min="$(COVERAGE_MIN)" \

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -56,6 +56,9 @@ Validate the registry and release locks before opening a PR:
 go run ./tools/featureflag validate
 ```
 
+PRs titled with the `feat` Conventional Commit type must add at least one new feature flag entry, and CI rejects any newly added flag whose lifecycle is not `preview`.
+The PR enforcement workflow also comments with the list of new feature flags introduced by the change.
+
 ## User Activation
 
 Preview flags can be enabled or disabled by code or name.

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -14,6 +14,7 @@ func TestExecuteFeaturesJSON(t *testing.T) {
 	req := DefaultRequest()
 	req.Mode = ModeFeatures
 	req.Features.Format = "json"
+	req.Features.Channel = "dev"
 
 	output, err := application.Execute(context.Background(), req)
 	if err != nil {
@@ -71,6 +72,7 @@ func TestExecuteFeaturesTableAndInvalidFormat(t *testing.T) {
 	application := &App{Features: mustFeatureRegistry(t)}
 	req := DefaultRequest()
 	req.Mode = ModeFeatures
+	req.Features.Channel = "dev"
 
 	output, err := application.Execute(context.Background(), req)
 	if err != nil {

--- a/tools/featureflag/main.go
+++ b/tools/featureflag/main.go
@@ -38,7 +38,7 @@ func main() {
 
 func run(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: featureflag add|graduate|validate|manifest|report")
+		return fmt.Errorf("usage: featureflag add|graduate|validate|manifest|report|pr-enforce")
 	}
 	switch args[0] {
 	case "add":
@@ -51,6 +51,8 @@ func run(args []string) error {
 		return runManifest(args[1:])
 	case "report":
 		return runReport(args[1:])
+	case "pr-enforce":
+		return runPREnforce(args[1:])
 	default:
 		return fmt.Errorf("unknown featureflag command: %s", args[0])
 	}

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -77,6 +77,8 @@ func TestRunFeatureFlagErrors(t *testing.T) {
 		{name: "extra add argument", args: []string{"add", "--name", "new-flag", "extra"}, want: "too many arguments"},
 		{name: "missing graduate feature", args: []string{"graduate"}, want: "feature code or name is required"},
 		{name: "extra graduate argument", args: []string{"graduate", "--feature", "preview-flag", "extra"}, want: "too many arguments"},
+		{name: "missing previous catalog", args: []string{"pr-enforce", "--pr-title", "feat(flags): add registry"}, want: "previous feature catalog is required"},
+		{name: "extra pr-enforce argument", args: []string{"pr-enforce", "--previous-catalog", "previous.json", "extra"}, want: "too many arguments"},
 	} {
 		assertRunErrorContains(t, tc.name, tc.args, tc.want)
 	}
@@ -86,6 +88,7 @@ func TestRunFeatureFlagErrors(t *testing.T) {
 	}{
 		{name: "bad add flag", args: []string{"add", "--definitely-not-a-flag"}},
 		{name: "bad graduate flag", args: []string{"graduate", "--definitely-not-a-flag"}},
+		{name: "bad pr-enforce flag", args: []string{"pr-enforce", "--definitely-not-a-flag"}},
 	} {
 		assertRunError(t, tc.name, tc.args)
 	}
@@ -473,6 +476,177 @@ func TestFormatReportReleaseLockSection(t *testing.T) {
 	}
 	if !strings.Contains(output, "None.") {
 		t.Fatalf("expected no newly added preview flags, got %s", output)
+	}
+}
+
+func TestRunPREnforceFeaturePRRequiresNewFlag(t *testing.T) {
+	root := t.TempDir()
+	writeFeatureCatalog(t, root, `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "existing-flag",
+    "description": "Existing behavior",
+    "lifecycle": "preview"
+  }
+]`)
+	previousCatalog := "previous-features.json"
+	testutil.MustWriteFile(t, filepath.Join(root, previousCatalog), `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "existing-flag",
+    "description": "Existing behavior",
+    "lifecycle": "preview"
+  }
+]`)
+	t.Chdir(root)
+
+	output, err := captureStdout(t, func() error {
+		return run([]string{"pr-enforce", "--pr-title", "feat(runtime): add new feature", "--previous-catalog", previousCatalog})
+	})
+	if err == nil || !strings.Contains(err.Error(), "must add at least one new feature flag") {
+		t.Fatalf("expected missing feature flag enforcement error, got %v", err)
+	}
+	if !strings.Contains(output, "Check: failed") || !strings.Contains(output, "New feature flags in this PR") {
+		t.Fatalf("expected failure report, got %s", output)
+	}
+}
+
+func TestRunPREnforceRejectsStableAddedFlag(t *testing.T) {
+	root := t.TempDir()
+	writeFeatureCatalog(t, root, `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "existing-flag",
+    "description": "Existing behavior",
+    "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0002",
+    "name": "new-flag",
+    "description": "New behavior",
+    "lifecycle": "stable"
+  }
+]`)
+	previousCatalog := "previous-features.json"
+	testutil.MustWriteFile(t, filepath.Join(root, previousCatalog), `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "existing-flag",
+    "description": "Existing behavior",
+    "lifecycle": "preview"
+  }
+]`)
+	t.Chdir(root)
+
+	output, err := captureStdout(t, func() error {
+		return run([]string{"pr-enforce", "--pr-title", "chore(ci): add workflow", "--previous-catalog", previousCatalog})
+	})
+	if err == nil || !strings.Contains(err.Error(), "must start as `preview`") {
+		t.Fatalf("expected preview lifecycle enforcement error, got %v", err)
+	}
+	if !strings.Contains(output, "`LOP-FEAT-0002` `new-flag` (`stable`)") {
+		t.Fatalf("expected stable flag to be listed in report, got %s", output)
+	}
+}
+
+func TestRunPREnforceReportsAddedPreviewFlag(t *testing.T) {
+	root := t.TempDir()
+	writeFeatureCatalog(t, root, `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "existing-flag",
+    "description": "Existing behavior",
+    "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0002",
+    "name": "new-flag",
+    "description": "New behavior",
+    "lifecycle": "preview"
+  }
+]`)
+	previousCatalog := "previous-features.json"
+	testutil.MustWriteFile(t, filepath.Join(root, previousCatalog), `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "existing-flag",
+    "description": "Existing behavior",
+    "lifecycle": "preview"
+  }
+]`)
+	t.Chdir(root)
+
+	output, err := captureStdout(t, func() error {
+		return run([]string{"pr-enforce", "--pr-title", "feat(vscode): add preview workflow", "--previous-catalog", previousCatalog})
+	})
+	if err != nil {
+		t.Fatalf("expected preview feature flag enforcement success, got %v", err)
+	}
+	for _, want := range []string{"Check: passed", "`LOP-FEAT-0002` `new-flag` (`preview`)", "Passed. This feature PR adds at least one new preview feature flag."} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected report to contain %q, got %s", want, output)
+		}
+	}
+}
+
+func TestRunPREnforceGetwdAndCatalogErrors(t *testing.T) {
+	oldGetwd := getwdFn
+	getwdFn = func() (string, error) { return "", errors.New("cwd failed") }
+	if err := run([]string{"pr-enforce", "--pr-title", "feat(ci): add gate", "--previous-catalog", "previous.json"}); err == nil || !strings.Contains(err.Error(), "resolve working directory") {
+		t.Fatalf("expected getwd error, got %v", err)
+	}
+	getwdFn = oldGetwd
+
+	root := t.TempDir()
+	t.Chdir(root)
+	testutil.MustWriteFile(t, filepath.Join(root, "previous-features.json"), `[]`)
+	if err := run([]string{"pr-enforce", "--pr-title", "feat(ci): add gate", "--previous-catalog", "previous-features.json"}); err == nil || !strings.Contains(err.Error(), "read feature catalog") {
+		t.Fatalf("expected current catalog read error, got %v", err)
+	}
+
+	writeFeatureCatalog(t, root, `[]`)
+	testutil.MustWriteFile(t, filepath.Join(root, "bad-previous.json"), `not-json`)
+	if err := run([]string{"pr-enforce", "--pr-title", "feat(ci): add gate", "--previous-catalog", "bad-previous.json"}); err == nil || !strings.Contains(err.Error(), "parse previous feature catalog") {
+		t.Fatalf("expected previous catalog parse error, got %v", err)
+	}
+}
+
+func TestFormatPREnforcementReportNonFeatureBranches(t *testing.T) {
+	previewFlag := featureflags.Flag{
+		Code:        "LOP-FEAT-0002",
+		Name:        "new-flag",
+		Description: "New behavior",
+		Lifecycle:   featureflags.LifecyclePreview,
+	}
+	addedPreview := formatPREnforcementReport(prEnforcementResult{
+		RequireFlag: false,
+		AddedFlags:  []featureflags.Flag{previewFlag},
+	})
+	if !strings.Contains(addedPreview, "Passed. Added feature flags all start as `preview`.") {
+		t.Fatalf("expected non-feature added preview success message, got %s", addedPreview)
+	}
+
+	noRequirement := formatPREnforcementReport(prEnforcementResult{})
+	if !strings.Contains(noRequirement, "Passed. No new feature flag was required for this PR.") {
+		t.Fatalf("expected no-requirement success message, got %s", noRequirement)
+	}
+}
+
+func TestIsFeaturePRTitle(t *testing.T) {
+	for _, tc := range []struct {
+		title string
+		want  bool
+	}{
+		{title: "feat: add preview workflow", want: true},
+		{title: "feat(ci): add preview workflow", want: true},
+		{title: "feat(ci)!: add preview workflow", want: true},
+		{title: "fix(ci): repair workflow", want: false},
+		{title: "refactor(ci): split workflow", want: false},
+		{title: "", want: false},
+	} {
+		if got := isFeaturePRTitle(tc.title); got != tc.want {
+			t.Fatalf("isFeaturePRTitle(%q) = %v, want %v", tc.title, got, tc.want)
+		}
 	}
 }
 

--- a/tools/featureflag/pr_enforce.go
+++ b/tools/featureflag/pr_enforce.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/featureflags"
+)
+
+var featurePRTitlePattern = regexp.MustCompile(`(?i)^feat(?:\([^)]*\))?(?:!)?:\s+\S`)
+
+type prEnforcementResult struct {
+	RequireFlag       bool
+	AddedFlags        []featureflags.Flag
+	InvalidAddedFlags []featureflags.Flag
+}
+
+func runPREnforce(args []string) error {
+	fs := flag.NewFlagSet("pr-enforce", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	prTitle := fs.String("pr-title", strings.TrimSpace(os.Getenv("PR_TITLE")), "pull request title")
+	previousCatalog := fs.String("previous-catalog", strings.TrimSpace(os.Getenv("PREVIOUS_CATALOG")), "previous feature catalog path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if len(fs.Args()) > 0 {
+		return fmt.Errorf("too many arguments for featureflag pr-enforce")
+	}
+	if strings.TrimSpace(*previousCatalog) == "" {
+		return fmt.Errorf("previous feature catalog is required")
+	}
+
+	root, err := getwdFn()
+	if err != nil {
+		return fmt.Errorf(resolveWorkingDirectoryError, err)
+	}
+	current, err := readCatalog(root)
+	if err != nil {
+		return err
+	}
+	previous, compared, err := readPreviousCatalog(*previousCatalog)
+	if err != nil {
+		return err
+	}
+	if !compared {
+		return fmt.Errorf("previous feature catalog is required")
+	}
+
+	result := evaluatePREnforcement(strings.TrimSpace(*prTitle), current, previous)
+	if _, err := fmt.Print(formatPREnforcementReport(result)); err != nil {
+		return err
+	}
+	return result.err()
+}
+
+func evaluatePREnforcement(prTitle string, current, previous []featureflags.Flag) prEnforcementResult {
+	addedFlags := newlyAddedFlags(current, previous)
+	result := prEnforcementResult{
+		RequireFlag: isFeaturePRTitle(prTitle),
+		AddedFlags:  addedFlags,
+	}
+	for _, flag := range addedFlags {
+		if flag.Lifecycle != featureflags.LifecyclePreview {
+			result.InvalidAddedFlags = append(result.InvalidAddedFlags, flag)
+		}
+	}
+	return result
+}
+
+func isFeaturePRTitle(title string) bool {
+	return featurePRTitlePattern.MatchString(strings.TrimSpace(title))
+}
+
+func newlyAddedFlags(current, previous []featureflags.Flag) []featureflags.Flag {
+	previousByCode := make(map[string]struct{}, len(previous))
+	previousByName := make(map[string]struct{}, len(previous))
+	for _, flag := range previous {
+		previousByCode[flag.Code] = struct{}{}
+		previousByName[flag.Name] = struct{}{}
+	}
+
+	added := make([]featureflags.Flag, 0)
+	for _, flag := range current {
+		_, seenCode := previousByCode[flag.Code]
+		_, seenName := previousByName[flag.Name]
+		if !seenCode && !seenName {
+			added = append(added, flag)
+		}
+	}
+	return added
+}
+
+func formatPREnforcementReport(result prEnforcementResult) string {
+	violations := result.violations()
+	status := "passed"
+	if len(violations) > 0 {
+		status = "failed"
+	}
+
+	var b strings.Builder
+	b.WriteString("<!-- lopper-feature-flag-enforcement -->\n")
+	b.WriteString("## Feature flag enforcement\n\n")
+	if result.RequireFlag {
+		b.WriteString("- Feature PR: yes (`feat` PR title)\n")
+	} else {
+		b.WriteString("- Feature PR: no\n")
+	}
+	fmt.Fprintf(&b, "- Check: %s\n", status)
+	b.WriteString("- Rule: feature PRs must add a feature flag, and new flags must start as `preview`.\n\n")
+
+	b.WriteString("### New feature flags in this PR\n\n")
+	if len(result.AddedFlags) == 0 {
+		b.WriteString("None.\n\n")
+	} else {
+		for _, flag := range result.AddedFlags {
+			fmt.Fprintf(&b, "- `%s` `%s` (`%s`)", flag.Code, flag.Name, flag.Lifecycle)
+			if flag.Description != "" {
+				fmt.Fprintf(&b, " - %s", flag.Description)
+			}
+			b.WriteByte('\n')
+		}
+		b.WriteByte('\n')
+	}
+
+	if len(violations) == 0 {
+		b.WriteString("### Result\n\n")
+		switch {
+		case result.RequireFlag:
+			b.WriteString("Passed. This feature PR adds at least one new preview feature flag.\n")
+		case len(result.AddedFlags) > 0:
+			b.WriteString("Passed. Added feature flags all start as `preview`.\n")
+		default:
+			b.WriteString("Passed. No new feature flag was required for this PR.\n")
+		}
+		return b.String()
+	}
+
+	b.WriteString("### Violations\n\n")
+	for _, violation := range violations {
+		fmt.Fprintf(&b, "- %s\n", violation)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func (r *prEnforcementResult) violations() []string {
+	violations := make([]string, 0, 2)
+	if r.RequireFlag && len(r.AddedFlags) == 0 {
+		violations = append(violations, "Feature PRs must add at least one new feature flag in `internal/featureflags/features.json`.")
+	}
+	if len(r.InvalidAddedFlags) > 0 {
+		parts := make([]string, 0, len(r.InvalidAddedFlags))
+		for _, flag := range r.InvalidAddedFlags {
+			parts = append(parts, fmt.Sprintf("`%s` `%s` is `%s`", flag.Code, flag.Name, flag.Lifecycle))
+		}
+		violations = append(violations, "New feature flags must start as `preview`: "+strings.Join(parts, ", ")+".")
+	}
+	return violations
+}
+
+func (r *prEnforcementResult) err() error {
+	violations := r.violations()
+	if len(violations) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(violations, " "))
+}

--- a/tools/featureflag/pr_enforce.go
+++ b/tools/featureflag/pr_enforce.go
@@ -77,17 +77,14 @@ func isFeaturePRTitle(title string) bool {
 
 func newlyAddedFlags(current, previous []featureflags.Flag) []featureflags.Flag {
 	previousByCode := make(map[string]struct{}, len(previous))
-	previousByName := make(map[string]struct{}, len(previous))
 	for _, flag := range previous {
 		previousByCode[flag.Code] = struct{}{}
-		previousByName[flag.Name] = struct{}{}
 	}
 
 	added := make([]featureflags.Flag, 0)
 	for _, flag := range current {
 		_, seenCode := previousByCode[flag.Code]
-		_, seenName := previousByName[flag.Name]
-		if !seenCode && !seenName {
+		if !seenCode {
 			added = append(added, flag)
 		}
 	}


### PR DESCRIPTION
Related: #721

## Issue
Feature flagging guidance existed in docs and the helper validated registry shape, but there was no pull-request enforcement that feature work actually introduced a flag or that new flags stayed in preview.

## Cause and user impact
That gap allowed feature PRs to merge without a registered flag and allowed newly added entries to skip straight to `stable`, which weakens the rollout model and makes release-channel behavior easier to drift from source control.

## Root cause
The repository had the registry, reporting, and validation pieces, but it did not have a workflow that compared the PR catalog to the base branch catalog or a command that turned that diff into a policy result reviewers could see in the PR.

## Fix
- add a dedicated pull-request workflow that enforces the feature-flag policy
- add `go run ./tools/featureflag pr-enforce` to compare the current catalog with the base branch catalog
- fail `feat(...)` PRs that do not add at least one new feature flag entry
- fail PRs that add new feature flags with a lifecycle other than `preview`
- publish a sticky PR comment and job summary listing new feature flags added in the PR and any violations
- extend `tools/featureflag` tests to cover the new enforcement and report branches
- document the enforced `feat` PR policy in contributor and feature-flag docs

## Validation
- pre-commit pipeline (`make ci`, `go test`, `go test -race`, memory delta, coverage gate)
- `go test ./tools/featureflag`
- `make actionlint`
