### PR TITLE
fix(ci): add release guidance for release-please PRs

### DIFF
--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -45,6 +45,24 @@ jobs:
             printf '[]\n' > .artifacts/previous-features.json
           fi
 
+      - name: Classify PR
+        id: classify_pr
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          if printf '%s\n' "${PR_TITLE}" | grep -Eq '^feat(\([^)]+\))?(!)?:[[:space:]]+[^[:space:]]'; then
+            echo "feature_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "feature_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ "${PR_HEAD_REF}" == release-please--branches--* ]]; then
+            echo "release_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Enforce feature flags on PRs
         id: enforce_flags
         continue-on-error: true
@@ -56,21 +74,71 @@ jobs:
             --previous-catalog .artifacts/previous-features.json \
             > .artifacts/feature-flag-enforcement.md
 
+      - name: Fetch tags for release PR guidance
+        if: ${{ steps.classify_pr.outputs.release_pr == 'true' }}
+        run: git fetch --tags --force
+
+      - name: Capture previous release feature catalog
+        if: ${{ steps.classify_pr.outputs.release_pr == 'true' }}
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts
+          previous_catalog=".artifacts/previous-release-features.json"
+          previous_tag="$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)"
+          if [ -n "${previous_tag}" ] && git cat-file -e "${previous_tag}:internal/featureflags/features.json" 2>/dev/null; then
+            git show "${previous_tag}:internal/featureflags/features.json" > "${previous_catalog}"
+          else
+            printf '[]\n' > "${previous_catalog}"
+          fi
+
+      - name: Write release feature guidance
+        if: ${{ steps.classify_pr.outputs.release_pr == 'true' }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          RELEASE_WORKFLOW_URL: ${{ format('https://github.com/{0}/actions/workflows/graduate-feature.yml', github.repository) }}
+        run: |
+          set -euo pipefail
+          go run ./tools/featureflag release-pr-comment \
+            --pr-title "${PR_TITLE}" \
+            --previous-catalog .artifacts/previous-release-features.json \
+            --workflow-url "${RELEASE_WORKFLOW_URL}" \
+            > .artifacts/release-feature-flag-comment.md
+
       - name: Write feature flag summary
         if: ${{ always() }}
+        env:
+          ENFORCEMENT_FAILED: ${{ steps.enforce_flags.outcome == 'failure' }}
+          FEATURE_PR: ${{ steps.classify_pr.outputs.feature_pr }}
+          RELEASE_PR: ${{ steps.classify_pr.outputs.release_pr }}
         run: |
-          if [ -s .artifacts/feature-flag-enforcement.md ]; then
+          set -euo pipefail
+          if [ "${RELEASE_PR}" = "true" ] && [ -s .artifacts/release-feature-flag-comment.md ]; then
+            cat .artifacts/release-feature-flag-comment.md >> "$GITHUB_STEP_SUMMARY"
+          elif { [ "${FEATURE_PR}" = "true" ] || [ "${ENFORCEMENT_FAILED}" = "true" ]; } && [ -s .artifacts/feature-flag-enforcement.md ]; then
             cat .artifacts/feature-flag-enforcement.md >> "$GITHUB_STEP_SUMMARY"
-          else
+          elif [ "${RELEASE_PR}" = "true" ]; then
+            printf '%s\n\n%s\n' \
+              '## Release feature flags' \
+              '❌ Release feature flag guidance was not produced. Check the workflow logs.' \
+              >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${FEATURE_PR}" = "true" ] || [ "${ENFORCEMENT_FAILED}" = "true" ]; then
             printf '%s\n\n%s\n' \
               '## Feature flag enforcement' \
               '❌ Feature flag enforcement summary was not produced. Check the workflow logs.' \
               >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf '%s\n\n%s\n' \
+              '## Feature flag enforcement' \
+              'Skipped. This PR is neither a feature PR nor a release-please promotion PR.' \
+              >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Comment feature flag report on PR
+      - name: Sync feature flag enforcement comment on PR
         if: ${{ always() && !env.ACT }}
         uses: actions/github-script@v9
+        env:
+          ENFORCEMENT_FAILED: ${{ steps.enforce_flags.outcome == 'failure' }}
+          FEATURE_PR: ${{ steps.classify_pr.outputs.feature_pr }}
         with:
           script: |
             const fs = require('node:fs');
@@ -90,7 +158,6 @@ jobs:
             if (fs.existsSync(summaryPath)) {
               summary = fs.readFileSync(summaryPath, 'utf8').trim();
             }
-            const body = summary || fallbackBody;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
@@ -105,6 +172,93 @@ jobs:
                 typeof comment.body === 'string' &&
                 comment.body.includes(marker),
             );
+
+            const shouldComment =
+              process.env.FEATURE_PR === 'true' ||
+              process.env.ENFORCEMENT_FAILED === 'true';
+            if (!shouldComment) {
+              for (const duplicate of existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: duplicate.id,
+                });
+              }
+              return;
+            }
+
+            const body = summary || fallbackBody;
+            if (existing.length > 0) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing[0].id,
+                body,
+              });
+              for (const duplicate of existing.slice(1)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: duplicate.id,
+                });
+              }
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Sync release feature guidance comment on PR
+        if: ${{ always() && !env.ACT }}
+        uses: actions/github-script@v9
+        env:
+          RELEASE_PR: ${{ steps.classify_pr.outputs.release_pr }}
+        with:
+          script: |
+            const fs = require('node:fs');
+
+            const marker = '<!-- lopper-feature-flag-release-pr -->';
+            const summaryPath = '.artifacts/release-feature-flag-comment.md';
+            const fallbackBody = [
+              marker,
+              '## Release feature flags',
+              '',
+              '❌ Release feature flag guidance was not produced.',
+              '',
+              'See the workflow logs for the failure details.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.filter(
+              (comment) =>
+                comment.user?.type === 'Bot' &&
+                typeof comment.body === 'string' &&
+                comment.body.includes(marker),
+            );
+
+            if (process.env.RELEASE_PR !== 'true') {
+              for (const duplicate of existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: duplicate.id,
+                });
+              }
+              return;
+            }
+
+            const body = fs.existsSync(summaryPath)
+              ? fs.readFileSync(summaryPath, 'utf8').trim()
+              : fallbackBody;
 
             if (existing.length > 0) {
               await github.rest.issues.updateComment({

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -57,7 +57,7 @@ go run ./tools/featureflag validate
 ```
 
 PRs titled with the `feat` Conventional Commit type must add at least one new feature flag entry, and CI rejects any newly added flag whose lifecycle is not `preview`.
-The PR enforcement workflow also comments with the list of new feature flags introduced by the change.
+The PR enforcement workflow keeps a sticky report on feature PRs and on any PR that violates the preview-lifecycle rule.
 
 ## User Activation
 
@@ -170,6 +170,11 @@ The report groups:
 - preview flags available by opt-in
 - preview flags enabled by rolling or locked default-on for a release
 - newly added preview flags since the previous catalog, when provided
+
+Release-please PRs also receive an automated sticky comment with the same release-channel feature flag report plus promotion guidance:
+
+- edit `internal/featureflags/release_locks.json` to ship a preview flag default-on for that release only
+- run `graduate-feature.yml` to open a dedicated PR that changes a flag from `preview` to `stable`
 
 ## Graduation
 

--- a/tools/featureflag/main.go
+++ b/tools/featureflag/main.go
@@ -38,7 +38,7 @@ func main() {
 
 func run(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: featureflag add|graduate|validate|manifest|report|pr-enforce")
+		return fmt.Errorf("usage: featureflag add|graduate|validate|manifest|report|pr-enforce|release-pr-comment")
 	}
 	switch args[0] {
 	case "add":
@@ -53,6 +53,8 @@ func run(args []string) error {
 		return runReport(args[1:])
 	case "pr-enforce":
 		return runPREnforce(args[1:])
+	case "release-pr-comment":
+		return runReleasePRComment(args[1:])
 	default:
 		return fmt.Errorf("unknown featureflag command: %s", args[0])
 	}
@@ -339,23 +341,7 @@ func writeNewPreviewSection(b *strings.Builder, current []featureflags.Flag, pre
 		b.WriteString("Not compared; no previous feature catalog was provided.\n\n")
 		return
 	}
-	previousByCode := make(map[string]struct{}, len(previous))
-	previousByName := make(map[string]struct{}, len(previous))
-	for _, flag := range previous {
-		previousByCode[flag.Code] = struct{}{}
-		previousByName[flag.Name] = struct{}{}
-	}
-	added := make([]featureflags.Flag, 0)
-	for _, flag := range current {
-		if flag.Lifecycle != featureflags.LifecyclePreview {
-			continue
-		}
-		_, seenCode := previousByCode[flag.Code]
-		_, seenName := previousByName[flag.Name]
-		if !seenCode && !seenName {
-			added = append(added, flag)
-		}
-	}
+	added := newlyAddedPreviewFlags(current, previous, compared)
 	if len(added) == 0 {
 		b.WriteString("None.\n\n")
 		return

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -79,6 +79,8 @@ func TestRunFeatureFlagErrors(t *testing.T) {
 		{name: "extra graduate argument", args: []string{"graduate", "--feature", "preview-flag", "extra"}, want: "too many arguments"},
 		{name: "missing previous catalog", args: []string{"pr-enforce", "--pr-title", "feat(flags): add registry"}, want: "previous feature catalog is required"},
 		{name: "extra pr-enforce argument", args: []string{"pr-enforce", "--previous-catalog", "previous.json", "extra"}, want: "too many arguments"},
+		{name: "missing release version", args: []string{"release-pr-comment"}, want: "release version is required"},
+		{name: "extra release-pr-comment argument", args: []string{"release-pr-comment", "--release", "v1.5.0", "extra"}, want: "too many arguments"},
 	} {
 		assertRunErrorContains(t, tc.name, tc.args, tc.want)
 	}
@@ -89,6 +91,7 @@ func TestRunFeatureFlagErrors(t *testing.T) {
 		{name: "bad add flag", args: []string{"add", "--definitely-not-a-flag"}},
 		{name: "bad graduate flag", args: []string{"graduate", "--definitely-not-a-flag"}},
 		{name: "bad pr-enforce flag", args: []string{"pr-enforce", "--definitely-not-a-flag"}},
+		{name: "bad release-pr-comment flag", args: []string{"release-pr-comment", "--definitely-not-a-flag"}},
 	} {
 		assertRunError(t, tc.name, tc.args)
 	}
@@ -614,6 +617,86 @@ func TestRunPREnforceGetwdAndCatalogErrors(t *testing.T) {
 	}
 }
 
+func TestRunReleasePRComment(t *testing.T) {
+	oldValidate := validateDefaultRegistryFn
+	oldValidateLocks := validateDefaultReleaseLocksFn
+	oldDefaultRegistry := defaultRegistryFn
+	oldReleaseLockProvider := releaseLockProviderFn
+	t.Cleanup(func() {
+		validateDefaultRegistryFn = oldValidate
+		validateDefaultReleaseLocksFn = oldValidateLocks
+		defaultRegistryFn = oldDefaultRegistry
+		releaseLockProviderFn = oldReleaseLockProvider
+	})
+	validateDefaultRegistryFn = func() error { return nil }
+	validateDefaultReleaseLocksFn = func() error { return nil }
+	defaultRegistryFn = func() *featureflags.Registry { return testRegistry(t) }
+	releaseLockProviderFn = func(string) (*featureflags.ReleaseLock, error) { return nil, nil }
+
+	root := t.TempDir()
+	t.Chdir(root)
+	previousCatalog := "previous-features.json"
+	testutil.MustWriteFile(t, filepath.Join(root, previousCatalog), `[
+  {
+    "code": "LOP-FEAT-0002",
+    "name": "stable-flag",
+    "description": "Stable behavior",
+    "lifecycle": "stable"
+  }
+]`)
+
+	output, err := captureStdout(t, func() error {
+		return run([]string{
+			"release-pr-comment",
+			"--pr-title", "chore(main): release 1.5.0",
+			"--previous-catalog", previousCatalog,
+			"--workflow-url", "https://example.com/graduate-feature",
+		})
+	})
+	if err != nil {
+		t.Fatalf("run release-pr-comment: %v", err)
+	}
+	for _, want := range []string{
+		"<!-- lopper-feature-flag-release-pr -->",
+		"This release PR is preparing `v1.5.0`.",
+		"## Feature flags",
+		"### Promotion options",
+		"[`graduate-feature.yml`](https://example.com/graduate-feature)",
+		"### Graduation candidates",
+		"`LOP-FEAT-0001` `preview-flag`",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected release PR comment to contain %q, got %s", want, output)
+		}
+	}
+}
+
+func TestRunReleasePRCommentRejectsCatalogErrors(t *testing.T) {
+	oldValidate := validateDefaultRegistryFn
+	oldValidateLocks := validateDefaultReleaseLocksFn
+	oldDefaultRegistry := defaultRegistryFn
+	t.Cleanup(func() {
+		validateDefaultRegistryFn = oldValidate
+		validateDefaultReleaseLocksFn = oldValidateLocks
+		defaultRegistryFn = oldDefaultRegistry
+	})
+	validateDefaultRegistryFn = func() error { return nil }
+	validateDefaultReleaseLocksFn = func() error { return nil }
+	defaultRegistryFn = func() *featureflags.Registry { return testRegistry(t) }
+
+	root := t.TempDir()
+	t.Chdir(root)
+	if err := run([]string{"release-pr-comment", "--release", "v1.5.0", "--previous-catalog", "missing.json"}); err == nil || !strings.Contains(err.Error(), "read previous feature catalog") {
+		t.Fatalf("expected missing previous catalog error, got %v", err)
+	}
+
+	badCatalog := "bad-features.json"
+	testutil.MustWriteFile(t, filepath.Join(root, badCatalog), `not-json`)
+	if err := run([]string{"release-pr-comment", "--release", "v1.5.0", "--previous-catalog", badCatalog}); err == nil || !strings.Contains(err.Error(), "parse previous feature catalog") {
+		t.Fatalf("expected bad previous catalog error, got %v", err)
+	}
+}
+
 func TestFormatPREnforcementReportNonFeatureBranches(t *testing.T) {
 	previewFlag := featureflags.Flag{
 		Code:        "LOP-FEAT-0002",
@@ -650,6 +733,36 @@ func TestIsFeaturePRTitle(t *testing.T) {
 		if got := isFeaturePRTitle(tc.title); got != tc.want {
 			t.Fatalf("isFeaturePRTitle(%q) = %v, want %v", tc.title, got, tc.want)
 		}
+	}
+}
+
+func TestReleasePleaseVersionFromTitle(t *testing.T) {
+	for _, tc := range []struct {
+		title string
+		want  string
+	}{
+		{title: "chore(main): release 1.5.0", want: "v1.5.0"},
+		{title: "chore(main): release v1.5.1-rc.1", want: "v1.5.1-rc.1"},
+		{title: "feat(ci): add gate", want: ""},
+	} {
+		if got := releasePleaseVersionFromTitle(tc.title); got != tc.want {
+			t.Fatalf("releasePleaseVersionFromTitle(%q) = %q, want %q", tc.title, got, tc.want)
+		}
+	}
+}
+
+func TestFormatReleasePRCommentWithoutCandidates(t *testing.T) {
+	registry := testRegistry(t)
+	manifest, err := registry.Manifest(featureflags.ResolveOptions{Channel: featureflags.ChannelRelease})
+	if err != nil {
+		t.Fatalf("manifest: %v", err)
+	}
+	output := formatReleasePRComment("v1.5.0", registry.Flags(), manifest, registry.Flags(), true, "")
+	if !strings.Contains(output, "No newly added preview flags were detected for this release candidate.") {
+		t.Fatalf("expected no-candidate note, got %s", output)
+	}
+	if strings.Contains(output, "### Graduation candidates") {
+		t.Fatalf("did not expect graduation candidate section, got %s", output)
 	}
 }
 

--- a/tools/featureflag/release_pr_comment.go
+++ b/tools/featureflag/release_pr_comment.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/featureflags"
+)
+
+var releasePleasePRTitlePattern = regexp.MustCompile(`(?i)\brelease\s+v?([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)\b`)
+
+func runReleasePRComment(args []string) error {
+	fs := flag.NewFlagSet("release-pr-comment", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	prTitle := fs.String("pr-title", strings.TrimSpace(os.Getenv("PR_TITLE")), "release-please pull request title")
+	release := fs.String("release", strings.TrimSpace(os.Getenv("RELEASE")), "release version")
+	previousCatalog := fs.String("previous-catalog", strings.TrimSpace(os.Getenv("PREVIOUS_CATALOG")), "previous feature catalog path")
+	workflowURL := fs.String("workflow-url", strings.TrimSpace(os.Getenv("WORKFLOW_URL")), "graduate-feature workflow URL")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if len(fs.Args()) > 0 {
+		return fmt.Errorf("too many arguments for featureflag release-pr-comment")
+	}
+
+	resolvedRelease := normalizeReleaseVersion(*release)
+	if resolvedRelease == "" {
+		resolvedRelease = releasePleaseVersionFromTitle(*prTitle)
+	}
+	if resolvedRelease == "" {
+		return fmt.Errorf("release version is required")
+	}
+
+	if err := validateDefaultRegistryFn(); err != nil {
+		return err
+	}
+	if err := validateDefaultReleaseLocksFn(); err != nil {
+		return err
+	}
+
+	registry := defaultRegistryFn()
+	manifest, err := manifestEntriesFn(registry, featureflags.ChannelRelease, resolvedRelease)
+	if err != nil {
+		return err
+	}
+	previous, compared, err := readPreviousCatalog(*previousCatalog)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Print(formatReleasePRComment(resolvedRelease, registry.Flags(), manifest, previous, compared, strings.TrimSpace(*workflowURL)))
+	return err
+}
+
+func normalizeReleaseVersion(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(value), "v") {
+		return "v" + strings.TrimSpace(value[1:])
+	}
+	return "v" + value
+}
+
+func releasePleaseVersionFromTitle(title string) string {
+	matches := releasePleasePRTitlePattern.FindStringSubmatch(strings.TrimSpace(title))
+	if len(matches) < 2 {
+		return ""
+	}
+	return normalizeReleaseVersion(matches[1])
+}
+
+func newlyAddedPreviewFlags(current, previous []featureflags.Flag, compared bool) []featureflags.Flag {
+	if !compared {
+		return nil
+	}
+	previousByCode := make(map[string]struct{}, len(previous))
+	previousByName := make(map[string]struct{}, len(previous))
+	for _, flag := range previous {
+		previousByCode[flag.Code] = struct{}{}
+		previousByName[flag.Name] = struct{}{}
+	}
+	added := make([]featureflags.Flag, 0)
+	for _, flag := range current {
+		if flag.Lifecycle != featureflags.LifecyclePreview {
+			continue
+		}
+		_, seenCode := previousByCode[flag.Code]
+		_, seenName := previousByName[flag.Name]
+		if !seenCode && !seenName {
+			added = append(added, flag)
+		}
+	}
+	return added
+}
+
+func formatReleasePRComment(release string, current []featureflags.Flag, manifest []featureflags.ManifestEntry, previous []featureflags.Flag, compared bool, workflowURL string) string {
+	var b strings.Builder
+	b.WriteString("<!-- lopper-feature-flag-release-pr -->\n")
+	b.WriteString("## Release feature flags\n\n")
+	fmt.Fprintf(&b, "This release PR is preparing `%s`.\n\n", release)
+	b.WriteString(formatReport(featureflags.ChannelRelease, release, current, manifest, previous, compared))
+	b.WriteString("\n")
+	b.WriteString("### Promotion options\n\n")
+	fmt.Fprintf(&b, "- Ship a preview flag default-on only in `%s` by editing `internal/featureflags/release_locks.json`.\n", release)
+	if workflowURL != "" {
+		fmt.Fprintf(&b, "- Graduate a preview flag for future releases with [`graduate-feature.yml`](%s) using the feature code or name, then merge that PR before publishing `%s`.\n", workflowURL, release)
+	} else {
+		fmt.Fprintf(&b, "- Graduate a preview flag for future releases with `graduate-feature.yml` using the feature code or name, then merge that PR before publishing `%s`.\n", release)
+	}
+
+	candidates := newlyAddedPreviewFlags(current, previous, compared)
+	if len(candidates) == 0 {
+		b.WriteString("- No newly added preview flags were detected for this release candidate.\n")
+		return b.String()
+	}
+
+	b.WriteString("\n### Graduation candidates\n\n")
+	for _, flag := range candidates {
+		fmt.Fprintf(&b, "- `%s` `%s`", flag.Code, flag.Name)
+		if flag.Description != "" {
+			fmt.Fprintf(&b, " - %s", flag.Description)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}


### PR DESCRIPTION
Related: #721

## Issue
Release-please PRs were still getting the generic feature flag enforcement sticky comment even though they are not feature branches, and they did not surface the graduation or release-lock guidance maintainers need while reviewing a release PR like #758.

## Cause and user impact
The feature flag enforcement workflow runs on every pull request. Before this change it always wrote the same enforcement sticky comment, so release-please PRs showed a misleading "Feature PR: no" report and offered no direct path to promote preview flags from the release review flow.

## Root cause
The workflow only understood one reporting mode. It evaluated PR titles for enforcement, but it did not classify PR head branches, suppress the generic sticky comment on non-feature PRs, or generate a release-specific feature flag guidance comment for `release-please--branches--main`.

## Fix
- classify PRs in the workflow so feature PRs, release-please PRs, and everything else are handled differently
- keep the existing enforcement report only for actual feature PRs or true enforcement failures
- add a `featureflag release-pr-comment` command to generate a tested sticky comment for release-please PRs
- post release-channel feature flag reporting plus release-lock and graduation guidance on release PRs
- document the new release-please comment behavior in the feature flag docs

## Validation
- pre-commit pipeline (`make fmt`, full `make ci`, security, race, memory delta, coverage gate)
- `go test ./tools/featureflag`
- `make actionlint`
