### PR TITLE
fix: group cpp include resolution params

### DIFF
--- a/internal/lang/cpp/adapter_helpers_test.go
+++ b/internal/lang/cpp/adapter_helpers_test.go
@@ -183,6 +183,19 @@ func TestMapIncludeToDependencyBranches(t *testing.T) {
 	}
 }
 
+func TestMapIncludeToDependencyIgnoresRepoHeaderFromIncludeDir(t *testing.T) {
+	repo := t.TempDir()
+	source := filepath.Join(repo, "src", testMainCPPFileName)
+	includeDir := filepath.Join(repo, "include")
+	testutil.MustWriteFile(t, source, "#include <project/header.hpp>\n")
+	testutil.MustWriteFile(t, filepath.Join(includeDir, "project", "header.hpp"), "// local")
+
+	dep, unresolved := mapIncludeToDependency(repo, source, parsedInclude{Path: "project/header.hpp", Delimiter: '<'}, []string{includeDir}, newDependencyCatalog())
+	if dep != "" || unresolved {
+		t.Fatalf("expected repo include-dir header to be ignored, got dep=%q unresolved=%v", dep, unresolved)
+	}
+}
+
 func TestDependencyFromIncludePathAndStdHeader(t *testing.T) {
 	if got := dependencyFromIncludePath("openssl/ssl.h"); got != "openssl" {
 		t.Fatalf("expected openssl, got %q", got)

--- a/internal/lang/cpp/include_resolution.go
+++ b/internal/lang/cpp/include_resolution.go
@@ -51,6 +51,11 @@ type includeResolver struct {
 	catalog     dependencyCatalog
 }
 
+type includeLookup struct {
+	sourcePath string
+	header     string
+}
+
 type scanStage struct {
 	scanner includeResolver
 	result  scanResult
@@ -330,7 +335,10 @@ func (r *includeResolver) mapIncludeToDependency(sourcePath string, include pars
 	if isLikelyStdHeader(header) {
 		return "", false
 	}
-	if r.includeResolvesWithinRepo(sourcePath, header) {
+	if r.includeResolvesWithinRepo(includeLookup{
+		sourcePath: sourcePath,
+		header:     header,
+	}) {
 		return "", false
 	}
 	if include.Delimiter == '"' {
@@ -344,11 +352,11 @@ func (r *includeResolver) mapIncludeToDependency(sourcePath string, include pars
 	return correlateDeclaredDependency(dependency, r.catalog), false
 }
 
-func (r *includeResolver) includeResolvesWithinRepo(sourcePath string, header string) bool {
-	sourceDir := filepath.Dir(sourcePath)
-	candidates := []string{filepath.Join(sourceDir, filepath.FromSlash(header))}
+func (r *includeResolver) includeResolvesWithinRepo(include includeLookup) bool {
+	sourceDir := filepath.Dir(include.sourcePath)
+	candidates := []string{filepath.Join(sourceDir, filepath.FromSlash(include.header))}
 	for _, includeDir := range r.includeDirs {
-		candidates = append(candidates, filepath.Join(includeDir, filepath.FromSlash(header)))
+		candidates = append(candidates, filepath.Join(includeDir, filepath.FromSlash(include.header)))
 	}
 	for _, candidate := range candidates {
 		candidate = filepath.Clean(candidate)


### PR DESCRIPTION
## Summary
- replace the consecutive string parameters around includeResolvesWithinRepo with a small typed lookup value
- preserve C/C++ include attribution behavior by keeping the same candidate resolution flow
- add focused coverage for repo-local angle includes resolved through compile include dirs

Closes #763