### PR TITLE
fix(featureflags): fail on duplicate feature flags

### DIFF
--- a/tools/featureflag/main.go
+++ b/tools/featureflag/main.go
@@ -223,11 +223,19 @@ func runReport(args []string) error {
 }
 
 func readCatalog(root string) ([]featureflags.Flag, error) {
+	data, err := readCatalogData(root)
+	if err != nil {
+		return nil, err
+	}
+	return featureflags.ParseCatalog(data)
+}
+
+func readCatalogData(root string) ([]byte, error) {
 	data, err := safeio.ReadFileUnder(root, filepath.Join(root, catalogPath))
 	if err != nil {
 		return nil, fmt.Errorf("read feature catalog: %w", err)
 	}
-	return featureflags.ParseCatalog(data)
+	return data, nil
 }
 
 func parseManifestArgs(name string, args []string) (featureflags.Channel, string, string, error) {

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -558,6 +558,153 @@ func TestRunPREnforceRejectsStableAddedFlag(t *testing.T) {
 	}
 }
 
+func TestRunPREnforceRejectsDuplicateFeatureFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		catalog string
+		want    string
+	}{
+		{
+			name: "duplicate code",
+			catalog: `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "existing-flag",
+    "description": "Existing behavior",
+    "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0002",
+    "name": "first-new-flag",
+    "description": "New behavior",
+    "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0002",
+    "name": "second-new-flag",
+    "description": "Other behavior",
+    "lifecycle": "preview"
+  }
+]`,
+			want: "Feature flag ids (`code`) must be unique: `LOP-FEAT-0002`",
+		},
+		{
+			name: "duplicate name",
+			catalog: `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "existing-flag",
+    "description": "Existing behavior",
+    "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0002",
+    "name": "duplicate-new-flag",
+    "description": "New behavior",
+    "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0003",
+    "name": "duplicate-new-flag",
+    "description": "Other behavior",
+    "lifecycle": "preview"
+  }
+]`,
+			want: "Feature flag names must be unique: `duplicate-new-flag`",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFeatureCatalog(t, root, tc.catalog)
+			previousCatalog := "previous-features.json"
+			testutil.MustWriteFile(t, filepath.Join(root, previousCatalog), `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "existing-flag",
+    "description": "Existing behavior",
+    "lifecycle": "preview"
+  }
+]`)
+			t.Chdir(root)
+
+			output, err := captureStdout(t, func() error {
+				return run([]string{"pr-enforce", "--pr-title", "feat(flags): add registry", "--previous-catalog", previousCatalog})
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected duplicate feature flag enforcement error containing %q, got %v", tc.want, err)
+			}
+			if !strings.Contains(output, "Check: failed") || !strings.Contains(output, tc.want) {
+				t.Fatalf("expected duplicate feature flag failure report containing %q, got %s", tc.want, output)
+			}
+		})
+	}
+}
+
+func TestReadCurrentCatalogForPREnforcementFallbacks(t *testing.T) {
+	root := t.TempDir()
+	writeFeatureCatalog(t, root, `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "existing-flag",
+    "description": "Existing behavior",
+    "lifecycle": "preview"
+  }
+]`)
+	flags, violations, err := readCurrentCatalogForPREnforcement(root)
+	if err != nil {
+		t.Fatalf("expected valid catalog to read, got %v", err)
+	}
+	if len(flags) != 1 || flags[0].Code != "LOP-FEAT-0001" || len(violations) != 0 {
+		t.Fatalf("unexpected valid catalog result: flags=%#v violations=%#v", flags, violations)
+	}
+
+	writeFeatureCatalog(t, root, `[
+  {
+    "code": "LOP-FEAT-0002",
+    "name": "",
+    "description": "Missing name",
+    "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0002",
+    "name": "named-flag",
+    "description": "Duplicate code",
+    "lifecycle": "preview"
+  }
+]`)
+	flags, violations, err = readCurrentCatalogForPREnforcement(root)
+	if err != nil {
+		t.Fatalf("expected duplicate catalog to be converted to violations, got %v", err)
+	}
+	if len(flags) != 2 || len(violations) != 1 {
+		t.Fatalf("unexpected duplicate catalog result: flags=%#v violations=%#v", flags, violations)
+	}
+	if !strings.Contains(violations[0], "`<missing>`") || !strings.Contains(violations[0], "`named-flag`") {
+		t.Fatalf("expected duplicate violation to include missing and named refs, got %#v", violations)
+	}
+
+	writeFeatureCatalog(t, root, `[
+  {
+    "code": "bad",
+    "name": "unique-flag",
+    "description": "Invalid but not duplicate",
+    "lifecycle": "preview"
+  }
+]`)
+	if _, _, err := readCurrentCatalogForPREnforcement(root); err == nil || !strings.Contains(err.Error(), "invalid feature code") {
+		t.Fatalf("expected non-duplicate catalog parse error, got %v", err)
+	}
+}
+
+func TestDecodeFeatureCatalogRejectsInvalidInput(t *testing.T) {
+	if _, err := decodeFeatureCatalog([]byte(`not-json`)); err == nil || !strings.Contains(err.Error(), "invalid feature catalog JSON") {
+		t.Fatalf("expected invalid JSON error, got %v", err)
+	}
+	if _, err := decodeFeatureCatalog([]byte(`[] []`)); err == nil || !strings.Contains(err.Error(), "multiple JSON values") {
+		t.Fatalf("expected multiple JSON values error, got %v", err)
+	}
+}
+
 func TestRunPREnforceReportsAddedPreviewFlag(t *testing.T) {
 	root := t.TempDir()
 	writeFeatureCatalog(t, root, `[

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -661,8 +661,8 @@ func TestReadCurrentCatalogForPREnforcementFallbacks(t *testing.T) {
 	writeFeatureCatalog(t, root, `[
   {
     "code": "LOP-FEAT-0002",
-    "name": "",
-    "description": "Missing name",
+    "name": "first-flag",
+    "description": "First flag",
     "lifecycle": "preview"
   },
   {
@@ -676,11 +676,11 @@ func TestReadCurrentCatalogForPREnforcementFallbacks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected duplicate catalog to be converted to violations, got %v", err)
 	}
-	if len(flags) != 2 || len(violations) != 1 {
+	if len(flags) != 0 || len(violations) != 1 {
 		t.Fatalf("unexpected duplicate catalog result: flags=%#v violations=%#v", flags, violations)
 	}
-	if !strings.Contains(violations[0], "`<missing>`") || !strings.Contains(violations[0], "`named-flag`") {
-		t.Fatalf("expected duplicate violation to include missing and named refs, got %#v", violations)
+	if !strings.Contains(violations[0], "`first-flag`") || !strings.Contains(violations[0], "`named-flag`") {
+		t.Fatalf("expected duplicate violation to include colliding refs, got %#v", violations)
 	}
 
 	writeFeatureCatalog(t, root, `[
@@ -693,6 +693,62 @@ func TestReadCurrentCatalogForPREnforcementFallbacks(t *testing.T) {
 ]`)
 	if _, _, err := readCurrentCatalogForPREnforcement(root); err == nil || !strings.Contains(err.Error(), "invalid feature code") {
 		t.Fatalf("expected non-duplicate catalog parse error, got %v", err)
+	}
+
+	writeFeatureCatalog(t, root, `[
+  {
+    "code": "LOP-FEAT-0004",
+    "name": "bad-lifecycle",
+    "description": "Invalid lifecycle",
+    "lifecycle": "not-a-lifecycle"
+  },
+  {
+    "code": "LOP-FEAT-0004",
+    "name": "duplicate-code",
+    "description": "Duplicate code",
+    "lifecycle": "preview"
+  }
+]`)
+	if _, _, err := readCurrentCatalogForPREnforcement(root); err == nil || !strings.Contains(err.Error(), "invalid feature lifecycle") {
+		t.Fatalf("expected invalid lifecycle to take precedence over duplicate fallback, got %v", err)
+	}
+}
+
+func TestEvaluatePREnforcementSkipsAddedFlagChecksForCatalogViolations(t *testing.T) {
+	current := []featureflags.Flag{{Code: "LOP-FEAT-0002", Name: "new-stable", Lifecycle: featureflags.LifecycleStable}}
+	catalogViolations := []string{"Feature flag ids (`code`) must be unique: `LOP-FEAT-0002`."}
+	result := evaluatePREnforcement("feat(flags): add registry", current, nil, catalogViolations)
+	if len(result.AddedFlags) != 0 || len(result.InvalidAddedFlags) != 0 {
+		t.Fatalf("expected catalog violations to short-circuit added flag checks, got %#v", result)
+	}
+	if violations := result.violations(); len(violations) != 1 || !strings.Contains(violations[0], "must be unique") {
+		t.Fatalf("expected only catalog violation, got %#v", violations)
+	}
+}
+
+func TestDuplicateFeatureFlagViolationsFormatsMissingRefs(t *testing.T) {
+	violations := duplicateFeatureFlagViolations([]featureflags.Flag{
+		{Code: "LOP-FEAT-0001"},
+		{Code: "LOP-FEAT-0001", Name: "named-flag"},
+	})
+	if len(violations) != 1 || !strings.Contains(violations[0], "`<missing>`") || !strings.Contains(violations[0], "`named-flag`") {
+		t.Fatalf("expected missing and named refs in duplicate violation, got %#v", violations)
+	}
+}
+
+func TestIsDuplicateFeatureCatalogError(t *testing.T) {
+	for _, tc := range []struct {
+		err  error
+		want bool
+	}{
+		{err: nil, want: false},
+		{err: errors.New("duplicate feature code: LOP-FEAT-0001"), want: true},
+		{err: errors.New("duplicate feature name: preview-flag"), want: true},
+		{err: errors.New("invalid feature lifecycle: bad"), want: false},
+	} {
+		if got := isDuplicateFeatureCatalogError(tc.err); got != tc.want {
+			t.Fatalf("isDuplicateFeatureCatalogError(%v) = %v, want %v", tc.err, got, tc.want)
+		}
 	}
 }
 
@@ -844,6 +900,48 @@ func TestRunReleasePRCommentRejectsCatalogErrors(t *testing.T) {
 	testutil.MustWriteFile(t, filepath.Join(root, badCatalog), `not-json`)
 	if err := run([]string{"release-pr-comment", "--release", "v1.5.0", "--previous-catalog", badCatalog}); err == nil || !strings.Contains(err.Error(), "parse previous feature catalog") {
 		t.Fatalf("expected bad previous catalog error, got %v", err)
+	}
+}
+
+func TestRunReleasePRCommentRejectsInjectedErrors(t *testing.T) {
+	oldValidate := validateDefaultRegistryFn
+	oldValidateLocks := validateDefaultReleaseLocksFn
+	oldDefaultRegistry := defaultRegistryFn
+	oldManifestEntries := manifestEntriesFn
+	t.Cleanup(func() {
+		validateDefaultRegistryFn = oldValidate
+		validateDefaultReleaseLocksFn = oldValidateLocks
+		defaultRegistryFn = oldDefaultRegistry
+		manifestEntriesFn = oldManifestEntries
+	})
+
+	root := t.TempDir()
+	t.Chdir(root)
+	previousCatalog := "previous-features.json"
+	testutil.MustWriteFile(t, filepath.Join(root, previousCatalog), `[]`)
+
+	validateDefaultRegistryFn = func() error { return errors.New("registry failed") }
+	if err := run([]string{"release-pr-comment", "--release", "v1.5.0", "--previous-catalog", previousCatalog}); err == nil || !strings.Contains(err.Error(), "registry failed") {
+		t.Fatalf("expected registry validation error, got %v", err)
+	}
+
+	validateDefaultRegistryFn = func() error { return nil }
+	validateDefaultReleaseLocksFn = func() error { return errors.New("locks failed") }
+	if err := run([]string{"release-pr-comment", "--release", "v1.5.0", "--previous-catalog", previousCatalog}); err == nil || !strings.Contains(err.Error(), "locks failed") {
+		t.Fatalf("expected release lock validation error, got %v", err)
+	}
+
+	validateDefaultReleaseLocksFn = func() error { return nil }
+	defaultRegistryFn = func() *featureflags.Registry { return testRegistry(t) }
+	manifestEntriesFn = func(*featureflags.Registry, featureflags.Channel, string) ([]featureflags.ManifestEntry, error) {
+		return nil, errors.New("manifest failed")
+	}
+	if err := run([]string{"release-pr-comment", "--release", "v1.5.0", "--previous-catalog", previousCatalog}); err == nil || !strings.Contains(err.Error(), "manifest failed") {
+		t.Fatalf("expected manifest error, got %v", err)
+	}
+
+	if got := newlyAddedPreviewFlags(testRegistry(t).Flags(), nil, false); len(got) != 0 {
+		t.Fatalf("expected no preview flags when not compared, got %#v", got)
 	}
 }
 

--- a/tools/featureflag/pr_enforce.go
+++ b/tools/featureflag/pr_enforce.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/featureflags"
@@ -17,6 +21,7 @@ type prEnforcementResult struct {
 	RequireFlag       bool
 	AddedFlags        []featureflags.Flag
 	InvalidAddedFlags []featureflags.Flag
+	CatalogViolations []string
 }
 
 func runPREnforce(args []string) error {
@@ -38,7 +43,7 @@ func runPREnforce(args []string) error {
 	if err != nil {
 		return fmt.Errorf(resolveWorkingDirectoryError, err)
 	}
-	current, err := readCatalog(root)
+	current, catalogViolations, err := readCurrentCatalogForPREnforcement(root)
 	if err != nil {
 		return err
 	}
@@ -50,18 +55,19 @@ func runPREnforce(args []string) error {
 		return fmt.Errorf("previous feature catalog is required")
 	}
 
-	result := evaluatePREnforcement(strings.TrimSpace(*prTitle), current, previous)
+	result := evaluatePREnforcement(strings.TrimSpace(*prTitle), current, previous, catalogViolations)
 	if _, err := fmt.Print(formatPREnforcementReport(result)); err != nil {
 		return err
 	}
 	return result.err()
 }
 
-func evaluatePREnforcement(prTitle string, current, previous []featureflags.Flag) prEnforcementResult {
+func evaluatePREnforcement(prTitle string, current, previous []featureflags.Flag, catalogViolations []string) prEnforcementResult {
 	addedFlags := newlyAddedFlags(current, previous)
 	result := prEnforcementResult{
-		RequireFlag: isFeaturePRTitle(prTitle),
-		AddedFlags:  addedFlags,
+		RequireFlag:       isFeaturePRTitle(prTitle),
+		AddedFlags:        addedFlags,
+		CatalogViolations: catalogViolations,
 	}
 	for _, flag := range addedFlags {
 		if flag.Lifecycle != featureflags.LifecyclePreview {
@@ -69,6 +75,88 @@ func evaluatePREnforcement(prTitle string, current, previous []featureflags.Flag
 		}
 	}
 	return result
+}
+
+func readCurrentCatalogForPREnforcement(root string) ([]featureflags.Flag, []string, error) {
+	data, err := readCatalogData(root)
+	if err != nil {
+		return nil, nil, err
+	}
+	flags, err := featureflags.ParseCatalog(data)
+	if err == nil {
+		return flags, nil, nil
+	}
+
+	decodedFlags, decodeErr := decodeFeatureCatalog(data)
+	if decodeErr != nil {
+		return nil, nil, err
+	}
+	violations := duplicateFeatureFlagViolations(decodedFlags)
+	if len(violations) == 0 {
+		return nil, nil, err
+	}
+	return decodedFlags, violations, nil
+}
+
+func decodeFeatureCatalog(data []byte) ([]featureflags.Flag, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var flags []featureflags.Flag
+	if err := decoder.Decode(&flags); err != nil {
+		return nil, fmt.Errorf("invalid feature catalog JSON: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return nil, fmt.Errorf("invalid feature catalog JSON: multiple JSON values")
+	}
+	return flags, nil
+}
+
+func duplicateFeatureFlagViolations(flags []featureflags.Flag) []string {
+	codes := make(map[string][]string, len(flags))
+	names := make(map[string][]string, len(flags))
+	for _, flag := range flags {
+		code := strings.TrimSpace(flag.Code)
+		name := strings.TrimSpace(flag.Name)
+		if code != "" {
+			codes[code] = append(codes[code], name)
+		}
+		if name != "" {
+			names[name] = append(names[name], code)
+		}
+	}
+
+	violations := make([]string, 0, 2)
+	for _, code := range sortedDuplicateKeys(codes) {
+		violations = append(violations, fmt.Sprintf("Feature flag ids (`code`) must be unique: `%s` is used by %s.", code, formatDuplicateRefs(codes[code])))
+	}
+	for _, name := range sortedDuplicateKeys(names) {
+		violations = append(violations, fmt.Sprintf("Feature flag names must be unique: `%s` is used by %s.", name, formatDuplicateRefs(names[name])))
+	}
+	return violations
+}
+
+func sortedDuplicateKeys(groups map[string][]string) []string {
+	keys := make([]string, 0, len(groups))
+	for key, refs := range groups {
+		if len(refs) > 1 {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func formatDuplicateRefs(refs []string) string {
+	parts := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			ref = "<missing>"
+		}
+		parts = append(parts, fmt.Sprintf("`%s`", ref))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
 }
 
 func isFeaturePRTitle(title string) bool {
@@ -107,7 +195,7 @@ func formatPREnforcementReport(result prEnforcementResult) string {
 		b.WriteString("- Feature PR: no\n")
 	}
 	fmt.Fprintf(&b, "- Check: %s\n", status)
-	b.WriteString("- Rule: feature PRs must add a feature flag, and new flags must start as `preview`.\n\n")
+	b.WriteString("- Rule: feature PRs must add a feature flag, new flags must start as `preview`, and feature flag ids and names must be unique.\n\n")
 
 	b.WriteString("### New feature flags in this PR\n\n")
 	if len(result.AddedFlags) == 0 {
@@ -145,7 +233,8 @@ func formatPREnforcementReport(result prEnforcementResult) string {
 }
 
 func (r *prEnforcementResult) violations() []string {
-	violations := make([]string, 0, 2)
+	violations := make([]string, 0, 2+len(r.CatalogViolations))
+	violations = append(violations, r.CatalogViolations...)
 	if r.RequireFlag && len(r.AddedFlags) == 0 {
 		violations = append(violations, "Feature PRs must add at least one new feature flag in `internal/featureflags/features.json`.")
 	}

--- a/tools/featureflag/pr_enforce.go
+++ b/tools/featureflag/pr_enforce.go
@@ -63,12 +63,16 @@ func runPREnforce(args []string) error {
 }
 
 func evaluatePREnforcement(prTitle string, current, previous []featureflags.Flag, catalogViolations []string) prEnforcementResult {
-	addedFlags := newlyAddedFlags(current, previous)
 	result := prEnforcementResult{
 		RequireFlag:       isFeaturePRTitle(prTitle),
-		AddedFlags:        addedFlags,
 		CatalogViolations: catalogViolations,
 	}
+	if len(catalogViolations) > 0 {
+		return result
+	}
+
+	addedFlags := newlyAddedFlags(current, previous)
+	result.AddedFlags = addedFlags
 	for _, flag := range addedFlags {
 		if flag.Lifecycle != featureflags.LifecyclePreview {
 			result.InvalidAddedFlags = append(result.InvalidAddedFlags, flag)
@@ -86,6 +90,9 @@ func readCurrentCatalogForPREnforcement(root string) ([]featureflags.Flag, []str
 	if err == nil {
 		return flags, nil, nil
 	}
+	if !isDuplicateFeatureCatalogError(err) {
+		return nil, nil, err
+	}
 
 	decodedFlags, decodeErr := decodeFeatureCatalog(data)
 	if decodeErr != nil {
@@ -95,7 +102,16 @@ func readCurrentCatalogForPREnforcement(root string) ([]featureflags.Flag, []str
 	if len(violations) == 0 {
 		return nil, nil, err
 	}
-	return decodedFlags, violations, nil
+	return nil, violations, nil
+}
+
+func isDuplicateFeatureCatalogError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return strings.HasPrefix(message, "duplicate feature code:") ||
+		strings.HasPrefix(message, "duplicate feature name:")
 }
 
 func decodeFeatureCatalog(data []byte) ([]featureflags.Flag, error) {
@@ -235,6 +251,9 @@ func formatPREnforcementReport(result prEnforcementResult) string {
 func (r *prEnforcementResult) violations() []string {
 	violations := make([]string, 0, 2+len(r.CatalogViolations))
 	violations = append(violations, r.CatalogViolations...)
+	if len(violations) > 0 {
+		return violations
+	}
 	if r.RequireFlag && len(r.AddedFlags) == 0 {
 		violations = append(violations, "Feature PRs must add at least one new feature flag in `internal/featureflags/features.json`.")
 	}


### PR DESCRIPTION
## Issue

The feature flag enforcement PR check could reject duplicate feature flag codes or names only as a low-level catalog parse error. That made the check fail, but it did not produce the normal sticky enforcement report explaining which duplicate id or name caused the failure.

## Cause and impact

`pr-enforce` read the current catalog through `featureflags.ParseCatalog`, which normalizes the catalog by constructing a registry. The registry already rejects duplicate feature flag codes and names, but that error happened before the enforcement result was formatted. In CI, authors could get a failed check without the actionable "Check: failed" report body.

## Root cause

The PR enforcement command did not have a duplicate-aware fallback path for catalogs that are structurally valid JSON but invalid only because feature flag ids or names collide.

## Fix

- Split raw catalog reading from catalog parsing so `pr-enforce` can inspect the JSON when registry validation fails.
- Added duplicate detection for feature flag `code` values and `name` values.
- Plumbed duplicate catalog violations into the existing PR enforcement result and report formatter.
- Updated the rule text so the report states ids and names must be unique.
- Added command-level tests for duplicate code and duplicate name failures, plus focused fallback/parser coverage to keep the coverage gate passing.

## Validation

- `GOTOOLCHAIN=go1.26.2 go test ./tools/featureflag -coverprofile .artifacts/featureflag.cover.out` passes with `tools/featureflag` at 98.1% coverage.
- Pre-commit `make ci` passed, including format, module checks, lint, actionlint, suppression check, gosec, govulncheck, normal tests, goleak tests, race tests, memory benchmark gate, build, and coverage gate.
