### PR TITLE
fix(parser): reduce sonar complexity in dart and python parsers

### DIFF
--- a/internal/lang/dart/scan.go
+++ b/internal/lang/dart/scan.go
@@ -238,37 +238,54 @@ func collectDirective(lines []string) (string, int, bool) {
 }
 
 func hasDirectiveTerminator(line string) bool {
-	var quote byte
-	escaped := false
+	state := directiveTerminatorState{}
 	for i := 0; i < len(line); i++ {
 		character := line[i]
-		if quote != 0 {
-			if escaped {
-				escaped = false
-				continue
-			}
-			if character == '\\' {
-				escaped = true
-				continue
-			}
-			if character == quote {
-				quote = 0
-			}
+		if state.consumeQuoted(character) {
 			continue
 		}
 
-		switch character {
-		case '\'', '"':
-			quote = character
-		case '/':
-			if i+1 < len(line) && line[i+1] == '/' {
-				return false
-			}
-		case ';':
+		if directiveCommentStarts(line, i) {
+			return false
+		}
+		if character == ';' {
 			return hasOnlyDirectiveTrailingContent(line[i+1:])
 		}
+		state.openQuote(character)
 	}
 	return false
+}
+
+type directiveTerminatorState struct {
+	quote   byte
+	escaped bool
+}
+
+func (s *directiveTerminatorState) consumeQuoted(character byte) bool {
+	if s.quote == 0 {
+		return false
+	}
+	if s.escaped {
+		s.escaped = false
+		return true
+	}
+	switch character {
+	case '\\':
+		s.escaped = true
+	case s.quote:
+		s.quote = 0
+	}
+	return true
+}
+
+func (s *directiveTerminatorState) openQuote(character byte) {
+	if character == '\'' || character == '"' {
+		s.quote = character
+	}
+}
+
+func directiveCommentStarts(line string, index int) bool {
+	return line[index] == '/' && index+1 < len(line) && line[index+1] == '/'
 }
 
 func hasOnlyDirectiveTrailingContent(suffix string) bool {

--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -160,6 +160,12 @@ type fromImportSymbolLine struct {
 	index   int
 }
 
+type pendingFromImport struct {
+	module      string
+	symbolLines []fromImportSymbolLine
+	parenDepth  int
+}
+
 type fileScan struct {
 	Path    string
 	Imports []importBinding
@@ -270,62 +276,74 @@ var (
 )
 
 func parseImports(content []byte, filePath string, repoPath string) []importBinding {
-	type pendingFromImport struct {
-		module      string
-		symbolLines []fromImportSymbolLine
-		parenDepth  int
-	}
-
 	var pending *pendingFromImport
 
 	return shared.ParseImportLines(content, filePath, func(line string, index int) []shared.ImportRecord {
 		lineNoComment := stripComment(line)
 		trimmed := strings.TrimSpace(lineNoComment)
 
-		if pending != nil {
-			if trimmed != "" {
-				pending.symbolLines = append(pending.symbolLines, fromImportSymbolLine{
-					symbols: trimmed,
-					line:    lineNoComment,
-					index:   index,
-				})
-				pending.parenDepth += fromImportParenthesisDelta(trimmed)
-			}
-			if pending.parenDepth <= 0 {
-				records := parseFromImportLines(pending.module, pending.symbolLines, filePath, repoPath)
-				pending = nil
-				return records
-			}
-			return nil
+		if records, handled := continuePendingFromImport(&pending, trimmed, lineNoComment, filePath, repoPath, index); handled {
+			return records
 		}
 
-		if trimmed == "" {
-			return nil
-		}
+		return parseImportRecord(trimmed, lineNoComment, filePath, repoPath, index, &pending)
+	})
+}
 
-		if matches := importLinePattern.FindStringSubmatch(lineNoComment); len(matches) == 2 {
-			return parseImportLine(matches[1], filePath, repoPath, index, lineNoComment)
-		}
+func continuePendingFromImport(pending **pendingFromImport, trimmed string, lineNoComment string, filePath string, repoPath string, index int) ([]importBinding, bool) {
+	if *pending == nil {
+		return nil, false
+	}
+	if trimmed != "" {
+		appendPendingFromImportLine(*pending, trimmed, lineNoComment, index)
+	}
+	if (*pending).parenDepth > 0 {
+		return nil, true
+	}
+	records := parseFromImportLines((*pending).module, (*pending).symbolLines, filePath, repoPath)
+	*pending = nil
+	return records, true
+}
 
-		if matches := fromLinePattern.FindStringSubmatch(lineNoComment); len(matches) == 3 {
-			symbols := strings.TrimSpace(matches[2])
-			parenDepth := fromImportParenthesisDelta(symbols)
-			if parenDepth > 0 {
-				pending = &pendingFromImport{
-					module: matches[1],
-					symbolLines: []fromImportSymbolLine{{
-						symbols: symbols,
-						line:    lineNoComment,
-						index:   index,
-					}},
-					parenDepth: parenDepth,
-				}
-				return nil
-			}
-			return parseFromImportLine(matches[1], symbols, filePath, repoPath, index, lineNoComment)
+func appendPendingFromImportLine(pending *pendingFromImport, symbols string, line string, index int) {
+	pending.symbolLines = append(pending.symbolLines, fromImportSymbolLine{
+		symbols: symbols,
+		line:    line,
+		index:   index,
+	})
+	pending.parenDepth += fromImportParenthesisDelta(symbols)
+}
+
+func parseImportRecord(trimmed string, lineNoComment string, filePath string, repoPath string, index int, pending **pendingFromImport) []importBinding {
+	if trimmed == "" {
+		return nil
+	}
+	if matches := importLinePattern.FindStringSubmatch(lineNoComment); len(matches) == 2 {
+		return parseImportLine(matches[1], filePath, repoPath, index, lineNoComment)
+	}
+	return parseFromImportRecord(lineNoComment, filePath, repoPath, index, pending)
+}
+
+func parseFromImportRecord(lineNoComment string, filePath string, repoPath string, index int, pending **pendingFromImport) []importBinding {
+	matches := fromLinePattern.FindStringSubmatch(lineNoComment)
+	if len(matches) != 3 {
+		return nil
+	}
+	symbols := strings.TrimSpace(matches[2])
+	parenDepth := fromImportParenthesisDelta(symbols)
+	if parenDepth > 0 {
+		*pending = &pendingFromImport{
+			module: matches[1],
+			symbolLines: []fromImportSymbolLine{{
+				symbols: symbols,
+				line:    lineNoComment,
+				index:   index,
+			}},
+			parenDepth: parenDepth,
 		}
 		return nil
-	})
+	}
+	return parseFromImportLine(matches[1], symbols, filePath, repoPath, index, lineNoComment)
 }
 
 func parseImportLine(partsText string, filePath string, repoPath string, index int, line string) []importBinding {
@@ -375,7 +393,7 @@ func parseFromImportLines(moduleValue string, symbolLines []fromImportSymbolLine
 	return bindings
 }
 
-func resolveFromImportDependency(moduleValue string, repoPath string) (string, string, bool) {
+func resolveFromImportDependency(moduleValue, repoPath string) (string, string, bool) {
 	moduleName := strings.TrimSpace(moduleValue)
 	if strings.HasPrefix(moduleName, ".") {
 		return "", "", false


### PR DESCRIPTION
## Issue
SonarCloud flagged three maintainability issues in the Dart and Python import scanners:

- `AZ2_j6W_jNY6cixFnNZY` in `internal/lang/dart/scan.go` for `go:S3776`
- `AZ2_VAfODYuIHC9AMjyn` in `internal/lang/python/adapter.go` for `go:S3776`
- `AZ2_VAfODYuIHC9AMjyo` in `internal/lang/python/adapter.go` for `godre:S8209`

These findings were blocking the branch with parser logic that had grown past the configured complexity threshold and one helper signature that still used consecutive same-type parameters separately.

## Cause And Impact
The affected helpers had accumulated multiple nested branches while preserving parser edge cases such as quoted delimiters, inline comments, and multi-line `from ... import (...)` statements. That made the code harder to review and triggered SonarCloud's maintainability rules even though behavior remained correct.

## Root Cause
Both parsers embedded state transitions directly inside single functions:

- the Dart directive terminator scan mixed quote tracking, escape handling, comment detection, and semicolon termination in one loop
- the Python import parser mixed pending multi-line state handling, line classification, and from-import initialization in one closure

That concentration of control flow pushed cognitive complexity over the repo threshold.

## Fix
The change keeps behavior unchanged while splitting the control flow into private helpers:

- extracted a small `directiveTerminatorState` helper in the Dart scanner so quoted-state handling and comment detection are isolated from the main terminator loop
- split Python `parseImports` into focused helpers for continuing pending multi-line imports, appending pending symbol lines, and classifying import records
- grouped the `resolveFromImportDependency` string parameters into the standard Go short form to satisfy the parameter-grouping rule

No public or internal API surface changed beyond private helper refactoring.

## Validation
Focused validation:

- `go test ./internal/lang/dart ./internal/lang/python`

Full repository validation:

- `make ci`
- repository pre-commit hook `make fmt` + `make ci` during commit
