### PR TITLE
refactor(app): reduce lockfile drift manifest complexity

### DIFF
--- a/internal/app/coverage_thresholds_test.go
+++ b/internal/app/coverage_thresholds_test.go
@@ -229,6 +229,45 @@ func TestWarningHelpersCoverEmptyAndDefaultPaths(t *testing.T) {
 	}
 }
 
+func TestAppendManifestIfPresentGuardsDuplicatesAndMissingFiles(t *testing.T) {
+	repo := t.TempDir()
+	manifestPath := filepath.Join(repo, goModManifestName)
+	writeTextFile(t, manifestPath, "module example.com/test\n", 0o644)
+
+	files := map[string]fs.FileInfo{
+		goModManifestName: mustStatFile(t, manifestPath),
+	}
+	seen := make(map[string]struct{})
+
+	manifests := appendManifestIfPresent(nil, seen, files, goModManifestName)
+	if len(manifests) != 1 || manifests[0] != goModManifestName {
+		t.Fatalf("expected manifest to be appended once, got %#v", manifests)
+	}
+
+	manifests = appendManifestIfPresent(manifests, seen, files, goModManifestName)
+	if len(manifests) != 1 {
+		t.Fatalf("expected duplicate manifest to be ignored, got %#v", manifests)
+	}
+
+	manifests = appendManifestIfPresent(manifests, seen, files, "missing.toml")
+	if len(manifests) != 1 {
+		t.Fatalf("expected missing manifest to be ignored, got %#v", manifests)
+	}
+}
+
+func TestNormalizedManifestExtsDropsBlankEntries(t *testing.T) {
+	got := normalizedManifestExts([]string{" .csproj ", "", "  ", ".FSPROJ"})
+	want := []string{".csproj", ".fsproj"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d extensions, got %#v", len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected normalized extensions %#v, got %#v", want, got)
+		}
+	}
+}
+
 func TestPyprojectMatcherReadErrorsAreWrapped(t *testing.T) {
 	matcher := pyprojectSectionMatcher("tool.poetry")
 	_, err := matcher(t.TempDir(), t.TempDir())

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -509,40 +509,64 @@ func findRuleLockfiles(files map[string]fs.FileInfo, names []string) []presentLo
 func findRuleManifests(files map[string]fs.FileInfo, rule lockfileRule) []string {
 	manifests := make([]string, 0, 1+len(rule.manifestNames))
 	seen := make(map[string]struct{})
-	appendManifest := func(name string) {
-		if _, exists := seen[name]; exists {
-			return
-		}
-		if _, exists := files[name]; !exists {
-			return
-		}
-		seen[name] = struct{}{}
-		manifests = append(manifests, name)
-	}
-
-	appendManifest(rule.manifest)
+	manifests = appendManifestIfPresent(manifests, seen, files, rule.manifest)
 	for _, name := range rule.manifestNames {
-		appendManifest(name)
+		manifests = appendManifestIfPresent(manifests, seen, files, name)
 	}
-
-	if len(rule.manifestExts) > 0 {
-		lowerExts := make([]string, 0, len(rule.manifestExts))
-		for _, ext := range rule.manifestExts {
-			lowerExts = append(lowerExts, strings.ToLower(strings.TrimSpace(ext)))
-		}
-		for name := range files {
-			lowerName := strings.ToLower(name)
-			for _, ext := range lowerExts {
-				if ext != "" && strings.HasSuffix(lowerName, ext) {
-					appendManifest(name)
-					break
-				}
-			}
-		}
+	for _, name := range findManifestExtMatches(files, rule.manifestExts) {
+		manifests = appendManifestIfPresent(manifests, seen, files, name)
 	}
 
 	sort.Strings(manifests)
 	return manifests
+}
+
+func appendManifestIfPresent(manifests []string, seen map[string]struct{}, files map[string]fs.FileInfo, name string) []string {
+	if _, exists := seen[name]; exists {
+		return manifests
+	}
+	if _, exists := files[name]; !exists {
+		return manifests
+	}
+	seen[name] = struct{}{}
+	return append(manifests, name)
+}
+
+func findManifestExtMatches(files map[string]fs.FileInfo, manifestExts []string) []string {
+	lowerExts := normalizedManifestExts(manifestExts)
+	if len(lowerExts) == 0 {
+		return nil
+	}
+
+	matches := make([]string, 0, len(files))
+	for name := range files {
+		if manifestMatchesAnyExt(name, lowerExts) {
+			matches = append(matches, name)
+		}
+	}
+	return matches
+}
+
+func normalizedManifestExts(manifestExts []string) []string {
+	lowerExts := make([]string, 0, len(manifestExts))
+	for _, ext := range manifestExts {
+		normalizedExt := strings.ToLower(strings.TrimSpace(ext))
+		if normalizedExt == "" {
+			continue
+		}
+		lowerExts = append(lowerExts, normalizedExt)
+	}
+	return lowerExts
+}
+
+func manifestMatchesAnyExt(name string, manifestExts []string) bool {
+	lowerName := strings.ToLower(name)
+	for _, ext := range manifestExts {
+		if strings.HasSuffix(lowerName, ext) {
+			return true
+		}
+	}
+	return false
 }
 
 func manifestNameForFinding(finding lockfileDriftFinding) string {


### PR DESCRIPTION
## Issue
SonarCloud reported issue `AZ2--7-7uMdUgzJGHyem` (`go:S3776`) on `internal/app/lockfile_drift.go:509`, flagging `findRuleManifests` for cognitive complexity 18 over the allowed 15.

## Cause And User Impact
`findRuleManifests` was doing three jobs inline: appending explicitly named manifests, normalizing extension-based manifest patterns, and scanning directory files for extension matches. That branching structure pushed the method over Sonar's maintainability threshold even though the behavior itself was correct.

## Root Cause
The manifest collection logic had grown incrementally inside one function instead of extracting the repeatable steps for deduped appends and extension matching into small helpers.

## Fix
This PR keeps the manifest-selection behavior unchanged while splitting the implementation into focused helpers:

- `appendManifestIfPresent` handles deduped appends for present files.
- `findManifestExtMatches` isolates the extension-driven scan.
- `normalizedManifestExts` and `manifestMatchesAnyExt` keep normalization and suffix matching separate from the main control flow.
- `findRuleManifests` now orchestrates the same steps with lower cognitive complexity.

To preserve the package coverage gate after the helper extraction, the PR also adds focused tests covering duplicate suppression, missing-manifest handling, and extension normalization.

## Validation
- `go test ./internal/app -run 'AppendManifestIfPresent|NormalizedManifestExts|LockfileDrift|EvaluateLockfileDrift|FormatLockfileDriftError|WarningHelpers'`
- `make ci`
