### PR TITLE
fix(powershell): reduce Sonar issues in parser and tests

### DIFF
--- a/internal/cli/powershell_metadata_test.go
+++ b/internal/cli/powershell_metadata_test.go
@@ -15,12 +15,16 @@ type extensionLanguageProperty struct {
 	EnumDescriptions []string `json:"enumDescriptions"`
 }
 
+type extensionConfiguration struct {
+	Properties map[string]extensionLanguageProperty `json:"properties"`
+}
+
+type extensionContributes struct {
+	Configuration extensionConfiguration `json:"configuration"`
+}
+
 type extensionPackageManifest struct {
-	Contributes struct {
-		Configuration struct {
-			Properties map[string]extensionLanguageProperty `json:"properties"`
-		} `json:"configuration"`
-	} `json:"contributes"`
+	Contributes extensionContributes `json:"contributes"`
 }
 
 func TestPowerShellAdapterUserFacingListsIncludePowerShell(t *testing.T) {

--- a/internal/lang/powershell/adapter_test.go
+++ b/internal/lang/powershell/adapter_test.go
@@ -56,34 +56,7 @@ Import-Module $dynamic
 	if err != nil {
 		t.Fatalf("analyse dependency: %v", err)
 	}
-	if len(depReport.Dependencies) != 1 {
-		t.Fatalf("expected one dependency report, got %d", len(depReport.Dependencies))
-	}
-	dependency := depReport.Dependencies[0]
-	if dependency.Language != adapterID {
-		t.Fatalf("expected dependency language %q, got %#v", adapterID, dependency)
-	}
-	if dependency.Name != "pester" {
-		t.Fatalf("expected dependency name pester, got %#v", dependency)
-	}
-	if dependency.UsedExportsCount == 0 {
-		t.Fatalf("expected static usage attribution from Import-Module and #Requires, got %#v", dependency)
-	}
-	if dependency.Provenance == nil || dependency.Provenance.Source != dependencySourceManifest {
-		t.Fatalf("expected manifest provenance on dependency, got %#v", dependency.Provenance)
-	}
-	if len(dependency.Provenance.Signals) == 0 || dependency.Provenance.Signals[0] != "Demo.psd1" {
-		t.Fatalf("expected manifest signal in provenance, got %#v", dependency.Provenance)
-	}
-	if len(dependency.UsedImports) == 0 {
-		t.Fatalf("expected used imports for pester, got %#v", dependency)
-	}
-	importProvenance := strings.Join(dependency.UsedImports[0].Provenance, ",")
-	for _, expected := range []string{usageSourceImportModule, usageSourceRequiresModule} {
-		if !strings.Contains(importProvenance, expected) {
-			t.Fatalf("expected import provenance to include %q, got %#v", expected, dependency.UsedImports)
-		}
-	}
+	assertPowerShellDependencyAnalysis(t, depReport)
 	if !containsPowerShellWarning(depReport.Warnings, "dynamic import-module expression") {
 		t.Fatalf("expected dynamic import warning, got %#v", depReport.Warnings)
 	}
@@ -92,15 +65,7 @@ Import-Module $dynamic
 	if err != nil {
 		t.Fatalf("analyse topN: %v", err)
 	}
-	names := make([]string, 0, len(topReport.Dependencies))
-	for _, dep := range topReport.Dependencies {
-		names = append(names, dep.Name)
-	}
-	for _, expected := range []string{"pester", "az.accounts"} {
-		if !slices.Contains(names, expected) {
-			t.Fatalf("expected %q in top report dependencies, got %#v", expected, names)
-		}
-	}
+	assertPowerShellTopDependencyNames(t, topReport.Dependencies, "pester", "az.accounts")
 }
 
 func TestPowerShellAdapterAnalyseNoFilesAndNoDeclarationsWarnings(t *testing.T) {
@@ -194,6 +159,70 @@ func assertPowerShellDetectWrapper(t *testing.T, matched bool, err error) {
 	if !matched {
 		t.Fatalf("PowerShell Detect returned false")
 	}
+}
+
+func assertPowerShellDependencyAnalysis(t *testing.T, depReport report.Report) {
+	t.Helper()
+	if len(depReport.Dependencies) != 1 {
+		t.Fatalf("expected one dependency report, got %d", len(depReport.Dependencies))
+	}
+
+	dependency := depReport.Dependencies[0]
+	if dependency.Language != adapterID {
+		t.Fatalf("expected dependency language %q, got %#v", adapterID, dependency)
+	}
+	if dependency.Name != "pester" {
+		t.Fatalf("expected dependency name pester, got %#v", dependency)
+	}
+	if dependency.UsedExportsCount == 0 {
+		t.Fatalf("expected static usage attribution from Import-Module and #Requires, got %#v", dependency)
+	}
+	assertPowerShellManifestProvenance(t, dependency)
+	assertPowerShellImportProvenance(t, dependency)
+}
+
+func assertPowerShellManifestProvenance(t *testing.T, dependency report.DependencyReport) {
+	t.Helper()
+	if dependency.Provenance == nil || dependency.Provenance.Source != dependencySourceManifest {
+		t.Fatalf("expected manifest provenance on dependency, got %#v", dependency.Provenance)
+	}
+	if len(dependency.Provenance.Signals) == 0 || dependency.Provenance.Signals[0] != "Demo.psd1" {
+		t.Fatalf("expected manifest signal in provenance, got %#v", dependency.Provenance)
+	}
+}
+
+func assertPowerShellImportProvenance(t *testing.T, dependency report.DependencyReport) {
+	t.Helper()
+	if len(dependency.UsedImports) == 0 {
+		t.Fatalf("expected used imports for pester, got %#v", dependency)
+	}
+
+	importProvenance := strings.Join(dependency.UsedImports[0].Provenance, ",")
+	for _, expected := range []string{usageSourceImportModule, usageSourceRequiresModule} {
+		if !strings.Contains(importProvenance, expected) {
+			t.Fatalf("expected import provenance to include %q, got %#v", expected, dependency.UsedImports)
+		}
+	}
+}
+
+func assertPowerShellTopDependencyNames(t *testing.T, dependencies []report.DependencyReport, expectedNames ...string) {
+	t.Helper()
+	for _, expected := range expectedNames {
+		if slices.ContainsFunc(dependencies, func(dep report.DependencyReport) bool {
+			return dep.Name == expected
+		}) {
+			continue
+		}
+		t.Fatalf("expected %q in top report dependencies, got %#v", expected, powerShellDependencyNames(dependencies))
+	}
+}
+
+func powerShellDependencyNames(dependencies []report.DependencyReport) []string {
+	names := make([]string, 0, len(dependencies))
+	for _, dep := range dependencies {
+		names = append(names, dep.Name)
+	}
+	return names
 }
 
 func containsPowerShellWarning(warnings []string, fragment string) bool {

--- a/internal/lang/powershell/coverage_gap_test.go
+++ b/internal/lang/powershell/coverage_gap_test.go
@@ -13,56 +13,10 @@ import (
 )
 
 func TestCoverageGapParserBranches(t *testing.T) {
-	if expressionComplete("") {
-		t.Fatalf("expected empty expression to be incomplete")
-	}
-	if !expressionComplete("[string]") {
-		t.Fatalf("expected balanced square expression to be complete")
-	}
-
-	modules, warnings := parseModuleExpression("Pester,,Az.Accounts")
-	if !reflect.DeepEqual(modules, []string{"Pester", "Az.Accounts"}) || len(warnings) != 0 {
-		t.Fatalf("unexpected module-expression parse result, modules=%#v warnings=%#v", modules, warnings)
-	}
-
-	module, dynamic, warning := parseModuleExpressionItem("@(@{ Other = 'x' })")
-	if module != "" || dynamic || !strings.Contains(strings.ToLower(warning), "modulename") {
-		t.Fatalf("expected nested warning branch, got module=%q dynamic=%v warning=%q", module, dynamic, warning)
-	}
-
-	imports, lineWarnings := parsePowerShellLine("using module './local.psm1'", "run.ps1", 3, nil)
-	if len(imports) != 0 || len(lineWarnings) != 0 {
-		t.Fatalf("expected local using-module path to be ignored, imports=%#v warnings=%#v", imports, lineWarnings)
-	}
-
-	dependency, parsedModule, dynamic := parseImportModuleDependency("   ", nil)
-	if dependency != "" || parsedModule != "" || dynamic {
-		t.Fatalf("expected blank import-module expression to be ignored, got dep=%q module=%q dynamic=%v", dependency, parsedModule, dynamic)
-	}
-
-	value, tokenDynamic := parseStaticModuleToken(",;")
-	if value != "" || tokenDynamic {
-		t.Fatalf("expected empty static token after trimming separators, got value=%q dynamic=%v", value, tokenDynamic)
-	}
-
-	value, tokenDynamic = parseStaticModuleToken("\"./local.psm1\"")
-	if value != "" || tokenDynamic {
-		t.Fatalf("expected quoted local path to be ignored, got value=%q dynamic=%v", value, tokenDynamic)
-	}
-
-	if !isDynamicToken("prefix$(Resolve-Module)") {
-		t.Fatalf("expected contains-$() branch to classify token as dynamic")
-	}
-	if !isLocalModulePath("module.psm1") {
-		t.Fatalf("expected extension-only module path to be treated as local path")
-	}
-
-	if parts := splitTopLevel("   ", ','); len(parts) != 0 {
-		t.Fatalf("expected empty split for whitespace input, got %#v", parts)
-	}
-	if parts := splitTopLevel("\"a,b\",c", ','); !reflect.DeepEqual(parts, []string{"\"a,b\"", "c"}) {
-		t.Fatalf("unexpected quoted comma split result: %#v", parts)
-	}
+	assertCoverageGapExpressionParsing(t)
+	assertCoverageGapImportParsing(t)
+	assertCoverageGapTokenHelpers(t)
+	assertCoverageGapSplitHelpers(t)
 }
 
 func TestCoverageGapDetectionAndScanBranches(t *testing.T) {
@@ -114,5 +68,68 @@ func TestCoverageGapDetectionAndScanBranches(t *testing.T) {
 
 	if _, err := scanRepo(context.Background(), symlinkRepo); err == nil {
 		t.Fatalf("expected scan to fail when reading symlink outside repo root")
+	}
+}
+
+func assertCoverageGapExpressionParsing(t *testing.T) {
+	t.Helper()
+	if expressionComplete("") {
+		t.Fatalf("expected empty expression to be incomplete")
+	}
+	if !expressionComplete("[string]") {
+		t.Fatalf("expected balanced square expression to be complete")
+	}
+
+	modules, warnings := parseModuleExpression("Pester,,Az.Accounts")
+	if !reflect.DeepEqual(modules, []string{"Pester", "Az.Accounts"}) || len(warnings) != 0 {
+		t.Fatalf("unexpected module-expression parse result, modules=%#v warnings=%#v", modules, warnings)
+	}
+
+	module, dynamic, warning := parseModuleExpressionItem("@(@{ Other = 'x' })")
+	if module != "" || dynamic || !strings.Contains(strings.ToLower(warning), "modulename") {
+		t.Fatalf("expected nested warning branch, got module=%q dynamic=%v warning=%q", module, dynamic, warning)
+	}
+}
+
+func assertCoverageGapImportParsing(t *testing.T) {
+	t.Helper()
+	imports, lineWarnings := parsePowerShellLine("using module './local.psm1'", "run.ps1", 3, nil)
+	if len(imports) != 0 || len(lineWarnings) != 0 {
+		t.Fatalf("expected local using-module path to be ignored, imports=%#v warnings=%#v", imports, lineWarnings)
+	}
+
+	dependency, parsedModule, dynamic := parseImportModuleDependency("   ", nil)
+	if dependency != "" || parsedModule != "" || dynamic {
+		t.Fatalf("expected blank import-module expression to be ignored, got dep=%q module=%q dynamic=%v", dependency, parsedModule, dynamic)
+	}
+}
+
+func assertCoverageGapTokenHelpers(t *testing.T) {
+	t.Helper()
+	value, tokenDynamic := parseStaticModuleToken(",;")
+	if value != "" || tokenDynamic {
+		t.Fatalf("expected empty static token after trimming separators, got value=%q dynamic=%v", value, tokenDynamic)
+	}
+
+	value, tokenDynamic = parseStaticModuleToken("\"./local.psm1\"")
+	if value != "" || tokenDynamic {
+		t.Fatalf("expected quoted local path to be ignored, got value=%q dynamic=%v", value, tokenDynamic)
+	}
+
+	if !isDynamicToken("prefix$(Resolve-Module)") {
+		t.Fatalf("expected contains-$() branch to classify token as dynamic")
+	}
+	if !isLocalModulePath("module.psm1") {
+		t.Fatalf("expected extension-only module path to be treated as local path")
+	}
+}
+
+func assertCoverageGapSplitHelpers(t *testing.T) {
+	t.Helper()
+	if parts := splitTopLevel("   ", ','); len(parts) != 0 {
+		t.Fatalf("expected empty split for whitespace input, got %#v", parts)
+	}
+	if parts := splitTopLevel("\"a,b\",c", ','); !reflect.DeepEqual(parts, []string{"\"a,b\"", "c"}) {
+		t.Fatalf("unexpected quoted comma split result: %#v", parts)
 	}
 }

--- a/internal/lang/powershell/coverage_helper_test.go
+++ b/internal/lang/powershell/coverage_helper_test.go
@@ -43,6 +43,24 @@ func TestCoverageHelperDetectionAndScanBranches(t *testing.T) {
 }
 
 func TestCoverageHelperParserBranches(t *testing.T) {
+	assertCoverageHelperModuleExpressions(t)
+	assertCoverageHelperDependencyParsing(t)
+	assertCoverageHelperTokenClassification(t)
+	assertCoverageHelperSplitTopLevel(t)
+}
+
+func assertContainsWarning(t *testing.T, warnings []string, want string) {
+	t.Helper()
+	for _, warning := range warnings {
+		if strings.Contains(warning, want) {
+			return
+		}
+	}
+	t.Fatalf("expected warning containing %q, got %#v", want, warnings)
+}
+
+func assertCoverageHelperModuleExpressions(t *testing.T) {
+	t.Helper()
 	if module, dynamic, warning := parseModuleExpressionItem(""); module != "" || dynamic || warning != "" {
 		t.Fatalf("expected blank module expression item to be ignored, got module=%q dynamic=%v warning=%q", module, dynamic, warning)
 	}
@@ -52,7 +70,10 @@ func TestCoverageHelperParserBranches(t *testing.T) {
 	if module, dynamic, warning := parseModuleExpressionItem("@{ Something = 'x' }"); module != "" || dynamic || !strings.Contains(warning, "did not include ModuleName") {
 		t.Fatalf("expected missing ModuleName warning, got module=%q dynamic=%v warning=%q", module, dynamic, warning)
 	}
+}
 
+func assertCoverageHelperDependencyParsing(t *testing.T) {
+	t.Helper()
 	if dependency, module, dynamic := parseImportModuleDependency("-Name", nil); dependency != "" || module != "" || !dynamic {
 		t.Fatalf("expected incomplete -Name expression to be dynamic, got dep=%q module=%q dynamic=%v", dependency, module, dynamic)
 	}
@@ -72,7 +93,10 @@ func TestCoverageHelperParserBranches(t *testing.T) {
 	if len(dependencies) != 1 || dependencies[0] != "modulea" || len(warnings) == 0 {
 		t.Fatalf("expected requires modules parsing to keep declared static modules and warn on dynamic values, got deps=%#v warnings=%#v", dependencies, warnings)
 	}
+}
 
+func assertCoverageHelperTokenClassification(t *testing.T) {
+	t.Helper()
 	if value, dynamic := parseStaticModuleToken("\"$moduleName\""); value != "" || !dynamic {
 		t.Fatalf("expected interpolated string token to be dynamic, got value=%q dynamic=%v", value, dynamic)
 	}
@@ -93,19 +117,12 @@ func TestCoverageHelperParserBranches(t *testing.T) {
 	if isLocalModulePath("module.name") {
 		t.Fatalf("expected bare module name to remain non-local")
 	}
+}
 
+func assertCoverageHelperSplitTopLevel(t *testing.T) {
+	t.Helper()
 	segments := splitTopLevel("Name    Value   @(1,2)  @{A=1}", ' ')
 	if len(segments) != 4 {
 		t.Fatalf("expected splitTopLevel to collapse repeated spaces while preserving top-level segments, got %#v", segments)
 	}
-}
-
-func assertContainsWarning(t *testing.T, warnings []string, want string) {
-	t.Helper()
-	for _, warning := range warnings {
-		if strings.Contains(warning, want) {
-			return
-		}
-	}
-	t.Fatalf("expected warning containing %q, got %#v", want, warnings)
 }

--- a/internal/lang/powershell/parser.go
+++ b/internal/lang/powershell/parser.go
@@ -118,7 +118,7 @@ func parseRequiredModules(content []byte, manifestPath string) ([]string, []stri
 	return declared, warnings
 }
 
-func extractRequiredModulesAssignments(content string, manifestPath string) ([]assignmentExpression, []string) {
+func extractRequiredModulesAssignments(content, manifestPath string) ([]assignmentExpression, []string) {
 	lines := strings.Split(content, "\n")
 	assignments := make([]assignmentExpression, 0)
 	warnings := make([]string, 0)
@@ -589,21 +589,32 @@ func splitTopLevel(value string, separator byte) []string {
 		if scanner.advance(ch) {
 			continue
 		}
-		if ch == separator && scanner.complete() {
-			appendSegment(i)
-			if separator == ' ' {
-				for i+1 < len(value) && value[i+1] == ' ' {
-					i++
-				}
-			}
-			start = i + 1
+		nextStart, ok := consumeTopLevelSeparator(value, i, separator, &scanner)
+		if !ok {
+			continue
 		}
+		appendSegment(i)
+		start = nextStart
+		i = nextStart - 1
 	}
 	appendSegment(len(value))
 	return items
 }
 
-func flagValue(value string, flag string) (string, bool) {
+func consumeTopLevelSeparator(value string, index int, separator byte, scanner *powerShellExpressionScanner) (int, bool) {
+	if value[index] != separator || !scanner.complete() {
+		return 0, false
+	}
+	if separator != ' ' {
+		return index + 1, true
+	}
+	for index+1 < len(value) && value[index+1] == ' ' {
+		index++
+	}
+	return index + 1, true
+}
+
+func flagValue(value, flag string) (string, bool) {
 	tokens := splitArguments(value)
 	for i := 0; i < len(tokens); i++ {
 		token := strings.TrimSpace(tokens[i])
@@ -622,37 +633,10 @@ func flagValue(value string, flag string) (string, bool) {
 }
 
 func stripPowerShellInlineComment(line string) string {
-	inSingle := false
-	inDouble := false
-	escaped := false
+	scanner := powerShellExpressionScanner{}
 	for i := 0; i < len(line); i++ {
 		ch := line[i]
-		if escaped {
-			escaped = false
-			continue
-		}
-		if ch == '`' {
-			escaped = true
-			continue
-		}
-		if inSingle {
-			if ch == '\'' {
-				inSingle = false
-			}
-			continue
-		}
-		if inDouble {
-			if ch == '"' {
-				inDouble = false
-			}
-			continue
-		}
-		switch ch {
-		case '\'':
-			inSingle = true
-		case '"':
-			inDouble = true
-		case '#':
+		if !scanner.advance(ch) && ch == '#' {
 			return line[:i]
 		}
 	}

--- a/internal/lang/powershell/parser_test.go
+++ b/internal/lang/powershell/parser_test.go
@@ -240,78 +240,11 @@ func TestParseStaticModuleTokenAndResolveDependencyHelpers(t *testing.T) {
 }
 
 func TestParserPrimitiveHelpers(t *testing.T) {
-	if !expressionComplete("@('Pester')") {
-		t.Fatalf("expected balanced expression to be complete")
-	}
-	if expressionComplete("@('Pester',") {
-		t.Fatalf("expected trailing-comma expression to be incomplete")
-	}
-	if expressionComplete("'unterminated") {
-		t.Fatalf("expected unterminated quote expression to be incomplete")
-	}
-
-	if got, ok := unwrapArrayExpression("@( 'Pester', 'Az.Accounts' )"); !ok || !strings.Contains(got, "Pester") {
-		t.Fatalf("expected wrapped array to unwrap, got value=%q ok=%v", got, ok)
-	}
-	if got, ok := unwrapArrayExpression("'Pester'"); ok || got != "" {
-		t.Fatalf("expected non-array expression to not unwrap, got value=%q ok=%v", got, ok)
-	}
-
-	if got := trimOuterParentheses("(( 'Pester' ))"); got != "'Pester'" {
-		t.Fatalf("unexpected trimmed parenthesized value: %q", got)
-	}
-
-	parts := splitArguments("-Name 'Pester' -ErrorAction Stop")
-	if !reflect.DeepEqual(parts, []string{"-Name", "'Pester'", "-ErrorAction", "Stop"}) {
-		t.Fatalf("unexpected split arguments output: %#v", parts)
-	}
-	parts = splitTopLevel("'a,b',@(1,2),x", ',')
-	if !reflect.DeepEqual(parts, []string{"'a,b'", "@(1,2)", "x"}) {
-		t.Fatalf("unexpected top-level comma split result: %#v", parts)
-	}
-
-	if value, ok := flagValue("-Name:'Pester' -Force", "name"); !ok || value != "'Pester'" {
-		t.Fatalf("expected colon-flag value parse, got value=%q ok=%v", value, ok)
-	}
-	if value, ok := flagValue("-Name 'Pester' -Force", "name"); !ok || value != "'Pester'" {
-		t.Fatalf("expected spaced-flag value parse, got value=%q ok=%v", value, ok)
-	}
-	if value, ok := flagValue("-Force", "name"); ok || value != "" {
-		t.Fatalf("expected missing-flag value to be absent, got value=%q ok=%v", value, ok)
-	}
-
-	if line := stripPowerShellInlineComment("Import-Module 'Pester' # comment"); strings.TrimSpace(line) != "Import-Module 'Pester'" {
-		t.Fatalf("unexpected comment stripping result: %q", line)
-	}
-	if line := stripPowerShellInlineComment("Import-Module 'P#ester'"); !strings.Contains(line, "P#ester") {
-		t.Fatalf("expected quoted hash to be preserved, got %q", line)
-	}
-
-	if !isQuoted("'value'", '\'') || !isQuoted("\"value\"", '"') {
-		t.Fatalf("expected quoted helper checks to pass")
-	}
-	if isQuoted("value", '\'') {
-		t.Fatalf("expected unquoted helper check to fail")
-	}
-	if !isHashtableExpression("@{ ModuleName = 'x' }") {
-		t.Fatalf("expected hashtable expression helper checks to pass")
-	}
-	if isHashtableExpression("x") || isHashtableExpression("{ ModuleName = 'x' }") {
-		t.Fatalf("expected non-hashtable expression helper checks to fail")
-	}
-
-	if !isDynamicToken("$x") || !isDynamicToken("$(Get-Module)") || !isDynamicToken("[string]::Join(',')") || !isDynamicToken("(Get-Module)") {
-		t.Fatalf("expected dynamic token helper checks to pass")
-	}
-	if isDynamicToken("Pester") {
-		t.Fatalf("expected static token to not be treated as dynamic")
-	}
-	if !isLocalModulePath("..\\demo\\module.psd1") || !isLocalModulePath("/modules/demo.psm1") {
-		t.Fatalf("expected local module path helper checks to pass")
-	}
-	if isLocalModulePath("Pester") {
-		t.Fatalf("expected package name to not be treated as local path")
-	}
+	assertParserExpressionPrimitives(t)
+	assertParserSplitHelpers(t)
+	assertParserFlagValueHelpers(t)
+	assertParserCommentHelpers(t)
+	assertParserTokenClassifierHelpers(t)
 }
 
 func TestParseRequiresLineWithoutModulesReturnsNoData(t *testing.T) {
@@ -338,5 +271,93 @@ func TestNewImportBindingNormalizesDependencyAndDefaultsModule(t *testing.T) {
 	}
 	if binding.Source != usageSourceImportModule {
 		t.Fatalf("expected source attribution to be preserved, got %#v", binding)
+	}
+}
+
+func assertParserExpressionPrimitives(t *testing.T) {
+	t.Helper()
+	if !expressionComplete("@('Pester')") {
+		t.Fatalf("expected balanced expression to be complete")
+	}
+	if expressionComplete("@('Pester',") {
+		t.Fatalf("expected trailing-comma expression to be incomplete")
+	}
+	if expressionComplete("'unterminated") {
+		t.Fatalf("expected unterminated quote expression to be incomplete")
+	}
+
+	if got, ok := unwrapArrayExpression("@( 'Pester', 'Az.Accounts' )"); !ok || !strings.Contains(got, "Pester") {
+		t.Fatalf("expected wrapped array to unwrap, got value=%q ok=%v", got, ok)
+	}
+	if got, ok := unwrapArrayExpression("'Pester'"); ok || got != "" {
+		t.Fatalf("expected non-array expression to not unwrap, got value=%q ok=%v", got, ok)
+	}
+
+	if got := trimOuterParentheses("(( 'Pester' ))"); got != "'Pester'" {
+		t.Fatalf("unexpected trimmed parenthesized value: %q", got)
+	}
+}
+
+func assertParserSplitHelpers(t *testing.T) {
+	t.Helper()
+	parts := splitArguments("-Name 'Pester' -ErrorAction Stop")
+	if !reflect.DeepEqual(parts, []string{"-Name", "'Pester'", "-ErrorAction", "Stop"}) {
+		t.Fatalf("unexpected split arguments output: %#v", parts)
+	}
+	parts = splitTopLevel("'a,b',@(1,2),x", ',')
+	if !reflect.DeepEqual(parts, []string{"'a,b'", "@(1,2)", "x"}) {
+		t.Fatalf("unexpected top-level comma split result: %#v", parts)
+	}
+}
+
+func assertParserFlagValueHelpers(t *testing.T) {
+	t.Helper()
+	if value, ok := flagValue("-Name:'Pester' -Force", "name"); !ok || value != "'Pester'" {
+		t.Fatalf("expected colon-flag value parse, got value=%q ok=%v", value, ok)
+	}
+	if value, ok := flagValue("-Name 'Pester' -Force", "name"); !ok || value != "'Pester'" {
+		t.Fatalf("expected spaced-flag value parse, got value=%q ok=%v", value, ok)
+	}
+	if value, ok := flagValue("-Force", "name"); ok || value != "" {
+		t.Fatalf("expected missing-flag value to be absent, got value=%q ok=%v", value, ok)
+	}
+}
+
+func assertParserCommentHelpers(t *testing.T) {
+	t.Helper()
+	if line := stripPowerShellInlineComment("Import-Module 'Pester' # comment"); strings.TrimSpace(line) != "Import-Module 'Pester'" {
+		t.Fatalf("unexpected comment stripping result: %q", line)
+	}
+	if line := stripPowerShellInlineComment("Import-Module 'P#ester'"); !strings.Contains(line, "P#ester") {
+		t.Fatalf("expected quoted hash to be preserved, got %q", line)
+	}
+}
+
+func assertParserTokenClassifierHelpers(t *testing.T) {
+	t.Helper()
+	if !isQuoted("'value'", '\'') || !isQuoted("\"value\"", '"') {
+		t.Fatalf("expected quoted helper checks to pass")
+	}
+	if isQuoted("value", '\'') {
+		t.Fatalf("expected unquoted helper check to fail")
+	}
+	if !isHashtableExpression("@{ ModuleName = 'x' }") {
+		t.Fatalf("expected hashtable expression helper checks to pass")
+	}
+	if isHashtableExpression("x") || isHashtableExpression("{ ModuleName = 'x' }") {
+		t.Fatalf("expected non-hashtable expression helper checks to fail")
+	}
+
+	if !isDynamicToken("$x") || !isDynamicToken("$(Get-Module)") || !isDynamicToken("[string]::Join(',')") || !isDynamicToken("(Get-Module)") {
+		t.Fatalf("expected dynamic token helper checks to pass")
+	}
+	if isDynamicToken("Pester") {
+		t.Fatalf("expected static token to not be treated as dynamic")
+	}
+	if !isLocalModulePath("..\\demo\\module.psd1") || !isLocalModulePath("/modules/demo.psm1") {
+		t.Fatalf("expected local module path helper checks to pass")
+	}
+	if isLocalModulePath("Pester") {
+		t.Fatalf("expected package name to not be treated as local path")
 	}
 }

--- a/internal/lang/powershell/report.go
+++ b/internal/lang/powershell/report.go
@@ -78,7 +78,7 @@ func applyImportSourceAttribution(dependency string, dependencyReport *report.De
 	applyImportProvenance(dependencyReport.UnusedImports)
 }
 
-func importKey(module string, name string) string {
+func importKey(module, name string) string {
 	return normalizeDependencyID(module) + ":" + normalizeDependencyID(name)
 }
 

--- a/internal/lang/powershell/scan.go
+++ b/internal/lang/powershell/scan.go
@@ -12,67 +12,15 @@ import (
 )
 
 func scanRepo(ctx context.Context, repoPath string) (scanResult, error) {
-	scan := scanResult{
-		DeclaredDependencies: make(map[string]struct{}),
-		DeclaredSources:      make(map[string]powerShellDependencySource),
-		ImportedDependencies: make(map[string]struct{}),
-	}
+	scan := newScanResult()
 
 	foundPowerShellFile := false
 	err := shared.WalkRepoFiles(ctx, repoPath, maxScanFiles, shouldSkipPowerShellDir, func(path string, entry fs.DirEntry) error {
-		ext := strings.ToLower(filepath.Ext(entry.Name()))
-		if !isPowerShellSource(ext) {
-			return nil
+		processed, scanErr := scanPowerShellFile(repoPath, path, entry, &scan)
+		if processed {
+			foundPowerShellFile = true
 		}
-		foundPowerShellFile = true
-
-		relPath, relErr := filepath.Rel(repoPath, path)
-		if relErr != nil {
-			relPath = entry.Name()
-		}
-		relPath = filepath.ToSlash(relPath)
-
-		info, err := entry.Info()
-		if err == nil && info.Size() > maxScannablePowerShellBytes {
-			scan.Warnings = append(scan.Warnings, fmt.Sprintf("skipped large PowerShell file %s (%d bytes)", relPath, info.Size()))
-			return nil
-		}
-
-		content, err := safeio.ReadFileUnder(repoPath, path)
-		if err != nil {
-			return err
-		}
-
-		if ext == moduleManifestExt {
-			declared, warnings := parseRequiredModules(content, relPath)
-			scan.Warnings = append(scan.Warnings, warnings...)
-			for _, dependency := range declared {
-				scan.DeclaredDependencies[dependency] = struct{}{}
-				source := scan.DeclaredSources[dependency]
-				source.addManifest(relPath)
-				scan.DeclaredSources[dependency] = source
-			}
-		}
-
-		imports, parseWarnings := parsePowerShellImports(content, relPath, scan.DeclaredDependencies)
-		scan.Warnings = append(scan.Warnings, parseWarnings...)
-		if len(imports) == 0 {
-			return nil
-		}
-
-		records := make([]shared.ImportRecord, 0, len(imports))
-		for _, imported := range imports {
-			dependency := normalizeDependencyID(imported.Record.Dependency)
-			imported.Record.Dependency = dependency
-			scan.ImportedDependencies[dependency] = struct{}{}
-			records = append(records, imported.Record)
-		}
-
-		scan.Files = append(scan.Files, fileScan{
-			Imports: imports,
-			Usage:   shared.CountUsage(content, records),
-		})
-		return nil
+		return scanErr
 	})
 	if err != nil {
 		return scan, err
@@ -85,6 +33,90 @@ func scanRepo(ctx context.Context, repoPath string) (scanResult, error) {
 		scan.Warnings = append(scan.Warnings, "no PowerShell module declarations found in .psd1 RequiredModules")
 	}
 	return scan, nil
+}
+
+func newScanResult() scanResult {
+	return scanResult{
+		DeclaredDependencies: make(map[string]struct{}),
+		DeclaredSources:      make(map[string]powerShellDependencySource),
+		ImportedDependencies: make(map[string]struct{}),
+	}
+}
+
+func scanPowerShellFile(repoPath, path string, entry fs.DirEntry, scan *scanResult) (bool, error) {
+	ext := strings.ToLower(filepath.Ext(entry.Name()))
+	if !isPowerShellSource(ext) {
+		return false, nil
+	}
+
+	relPath := scanRelativePath(repoPath, path, entry)
+	if skip, err := skipLargePowerShellFile(entry, relPath, scan); skip || err != nil {
+		return true, err
+	}
+
+	content, err := safeio.ReadFileUnder(repoPath, path)
+	if err != nil {
+		return true, err
+	}
+
+	if ext == moduleManifestExt {
+		recordDeclaredPowerShellDependencies(scan, relPath, content)
+	}
+	recordImportedPowerShellDependencies(scan, relPath, content)
+	return true, nil
+}
+
+func scanRelativePath(repoPath, path string, entry fs.DirEntry) string {
+	relPath, err := filepath.Rel(repoPath, path)
+	if err != nil {
+		relPath = entry.Name()
+	}
+	return filepath.ToSlash(relPath)
+}
+
+func skipLargePowerShellFile(entry fs.DirEntry, relPath string, scan *scanResult) (bool, error) {
+	info, err := entry.Info()
+	if err != nil {
+		return false, nil
+	}
+	if info.Size() <= maxScannablePowerShellBytes {
+		return false, nil
+	}
+
+	scan.Warnings = append(scan.Warnings, fmt.Sprintf("skipped large PowerShell file %s (%d bytes)", relPath, info.Size()))
+	return true, nil
+}
+
+func recordDeclaredPowerShellDependencies(scan *scanResult, relPath string, content []byte) {
+	declared, warnings := parseRequiredModules(content, relPath)
+	scan.Warnings = append(scan.Warnings, warnings...)
+	for _, dependency := range declared {
+		scan.DeclaredDependencies[dependency] = struct{}{}
+		source := scan.DeclaredSources[dependency]
+		source.addManifest(relPath)
+		scan.DeclaredSources[dependency] = source
+	}
+}
+
+func recordImportedPowerShellDependencies(scan *scanResult, relPath string, content []byte) {
+	imports, warnings := parsePowerShellImports(content, relPath, scan.DeclaredDependencies)
+	scan.Warnings = append(scan.Warnings, warnings...)
+	if len(imports) == 0 {
+		return
+	}
+
+	records := make([]shared.ImportRecord, 0, len(imports))
+	for _, imported := range imports {
+		dependency := normalizeDependencyID(imported.Record.Dependency)
+		imported.Record.Dependency = dependency
+		scan.ImportedDependencies[dependency] = struct{}{}
+		records = append(records, imported.Record)
+	}
+
+	scan.Files = append(scan.Files, fileScan{
+		Imports: imports,
+		Usage:   shared.CountUsage(content, records),
+	})
 }
 
 func isPowerShellSource(ext string) bool {


### PR DESCRIPTION
## Issue
The PowerShell adapter and its test surface still had a batch of open SonarCloud findings on this branch: one nested anonymous test manifest shape, several same-type parameter signatures, and multiple parser/scan/test functions whose branching had grown past the configured cognitive-complexity threshold.

## Cause And User Impact
These findings did not change runtime behavior, but they kept the PowerShell slice noisy in SonarCloud and made the parser/tests harder to review and maintain. Leaving them in place would keep the PR and branch from reaching a clean Sonar state.

## Root Cause
The affected code had accumulated small readability issues over time:
- test-only manifest metadata used a nested anonymous struct shape
- helper signatures repeated adjacent parameter types instead of grouping them idiomatically
- parser, scanner, and coverage-oriented tests concentrated many independent branches and assertions into single functions

## Fix
This change keeps behavior unchanged and removes only the maintainability problems:
- replaced the nested anonymous VS Code manifest test structs with named test-only types
- grouped repeated PowerShell helper parameters to satisfy the Go idiom rule
- extracted small assertion helpers from the flagged PowerShell tests so each test still covers the same branches with lower complexity
- simplified inline comment stripping by reusing the existing PowerShell expression scanner state instead of duplicating quote/escape tracking
- split `scanRepo` into focused helpers for per-file scanning, relative-path shaping, large-file skipping, declared dependency recording, and imported dependency recording
- extracted top-level separator handling from `splitTopLevel` so the parser flow stays flat without changing parsing semantics

## Validation
- `go test ./internal/lang/powershell ./internal/cli`
- `make ci`
