### PR TITLE
fix(lockfile-drift): report missing lockfiles for preview ecosystems

### DIFF
--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -28,16 +28,15 @@ var resolveGitBinaryPathFn = gitexec.ResolveBinaryPath
 var execGitCommandContextFn = gitexec.CommandContext
 
 type lockfileRule struct {
-	manager             string
-	manifest            string
-	manifestNames       []string
-	manifestExts        []string
-	manifestLabel       string
-	lockfiles           []string
-	remedy              string
-	skipMissingLockfile bool
-	previewFeatureFlag  string
-	manifestMatcher     func(repoPath, dir string) (bool, error)
+	manager            string
+	manifest           string
+	manifestNames      []string
+	manifestExts       []string
+	manifestLabel      string
+	lockfiles          []string
+	remedy             string
+	previewFeatureFlag string
+	manifestMatcher    func(repoPath, dir string) (bool, error)
 }
 
 type lockfileGitContext struct {
@@ -78,39 +77,35 @@ var lockfileRules = []lockfileRule{
 	{manager: "Poetry", manifest: pyprojectManifestName, manifestLabel: "Poetry configuration in pyproject.toml", lockfiles: []string{"poetry.lock"}, remedy: "run poetry lock and commit the updated files", manifestMatcher: pyprojectSectionMatcher("tool.poetry")},
 	{manager: "uv", manifest: pyprojectManifestName, manifestLabel: "uv configuration in pyproject.toml", lockfiles: []string{"uv.lock"}, remedy: "run uv lock and commit the updated files", manifestMatcher: pyprojectSectionMatcher("tool.uv")},
 	{
-		manager:             ".NET",
-		manifest:            "Directory.Packages.props",
-		manifestExts:        []string{".csproj", ".fsproj"},
-		manifestLabel:       ".NET project manifest (*.csproj, *.fsproj) or Directory.Packages.props",
-		lockfiles:           []string{"packages.lock.json"},
-		remedy:              "run dotnet restore --use-lock-file (or dotnet restore for existing lock mode) and commit the updated files",
-		skipMissingLockfile: true,
-		previewFeatureFlag:  lockfileDriftEcosystemExpansionPreviewFlagName,
+		manager:            ".NET",
+		manifest:           "Directory.Packages.props",
+		manifestExts:       []string{".csproj", ".fsproj"},
+		manifestLabel:      ".NET project manifest (*.csproj, *.fsproj) or Directory.Packages.props",
+		lockfiles:          []string{"packages.lock.json"},
+		remedy:             "run dotnet restore --use-lock-file (or dotnet restore for existing lock mode) and commit the updated files",
+		previewFeatureFlag: lockfileDriftEcosystemExpansionPreviewFlagName,
 	},
 	{
-		manager:             "Dart",
-		manifest:            "pubspec.yaml",
-		manifestNames:       []string{"pubspec.yml"},
-		lockfiles:           []string{"pubspec.lock"},
-		remedy:              "run dart pub get (or flutter pub get) and commit the updated files",
-		skipMissingLockfile: true,
-		previewFeatureFlag:  lockfileDriftEcosystemExpansionPreviewFlagName,
+		manager:            "Dart",
+		manifest:           "pubspec.yaml",
+		manifestNames:      []string{"pubspec.yml"},
+		lockfiles:          []string{"pubspec.lock"},
+		remedy:             "run dart pub get (or flutter pub get) and commit the updated files",
+		previewFeatureFlag: lockfileDriftEcosystemExpansionPreviewFlagName,
 	},
 	{
-		manager:             "Elixir",
-		manifest:            "mix.exs",
-		lockfiles:           []string{"mix.lock"},
-		remedy:              "run mix deps.get and commit the updated files",
-		skipMissingLockfile: true,
-		previewFeatureFlag:  lockfileDriftEcosystemExpansionPreviewFlagName,
+		manager:            "Elixir",
+		manifest:           "mix.exs",
+		lockfiles:          []string{"mix.lock"},
+		remedy:             "run mix deps.get and commit the updated files",
+		previewFeatureFlag: lockfileDriftEcosystemExpansionPreviewFlagName,
 	},
 	{
-		manager:             "SwiftPM",
-		manifest:            "Package.swift",
-		lockfiles:           []string{"Package.resolved"},
-		remedy:              "run swift package resolve and commit the updated files",
-		skipMissingLockfile: true,
-		previewFeatureFlag:  lockfileDriftEcosystemExpansionPreviewFlagName,
+		manager:            "SwiftPM",
+		manifest:           "Package.swift",
+		lockfiles:          []string{"Package.resolved"},
+		remedy:             "run swift package resolve and commit the updated files",
+		previewFeatureFlag: lockfileDriftEcosystemExpansionPreviewFlagName,
 	},
 }
 
@@ -292,9 +287,6 @@ func shouldSkipMissingLockfileForManifest(snapshot lockfileDirSnapshot, rule loc
 		if !matched {
 			return true, nil
 		}
-	}
-	if rule.skipMissingLockfile {
-		return true, nil
 	}
 	text := string(content)
 	switch manifestName {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -158,6 +158,62 @@ func TestDetectLockfileDriftPreviewEcosystemsManifestChangeWithoutLockfileChange
 	}
 }
 
+func TestDetectLockfileDriftPreviewEcosystemsMissingLockfile(t *testing.T) {
+	cases := []struct {
+		name         string
+		manifest     string
+		manifestBody string
+		wantWarning  string
+		wantRemedy   string
+	}{
+		{
+			name:         "dotnet project",
+			manifest:     dotnetProjectManifest,
+			manifestBody: "<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup><PackageReference Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n",
+			wantWarning:  ".NET in .: App.csproj exists but no matching lockfile (packages.lock.json) was found",
+			wantRemedy:   "dotnet restore --use-lock-file",
+		},
+		{
+			name:         "dotnet central package management",
+			manifest:     dotnetCentralManifest,
+			manifestBody: "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n",
+			wantWarning:  ".NET in .: Directory.Packages.props exists but no matching lockfile (packages.lock.json) was found",
+			wantRemedy:   "dotnet restore --use-lock-file",
+		},
+		{
+			name:         "dart",
+			manifest:     dartManifestName,
+			manifestBody: "name: demo\ndependencies:\n  http: ^1.2.0\n",
+			wantWarning:  "Dart in .: pubspec.yaml exists but no matching lockfile (pubspec.lock) was found",
+			wantRemedy:   "dart pub get",
+		},
+		{
+			name:         "elixir",
+			manifest:     elixirManifestName,
+			manifestBody: "defmodule Demo.MixProject do\n  use Mix.Project\n  def project, do: [app: :demo, version: \"0.1.0\", deps: deps()]\n  defp deps, do: [{:jason, \"~> 1.4\"}]\nend\n",
+			wantWarning:  "Elixir in .: mix.exs exists but no matching lockfile (mix.lock) was found",
+			wantRemedy:   "mix deps.get",
+		},
+		{
+			name:         "swift package manager",
+			manifest:     swiftManifestName,
+			manifestBody: "// swift-tools-version: 5.9\nimport PackageDescription\nlet package = Package(name: \"Demo\", dependencies: [.package(url: \"https://github.com/apple/swift-argument-parser\", from: \"1.3.0\")], targets: [.target(name: \"Demo\")])\n",
+			wantWarning:  "SwiftPM in .: Package.swift exists but no matching lockfile (Package.resolved) was found",
+			wantRemedy:   "swift package resolve",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, tc.manifest), tc.manifestBody)
+
+			warnings, err := detectLockfileDriftWithFeatures(context.Background(), repo, false, lockfileDriftFeatureSet(t, true))
+			assertSingleLockfileDriftWarning(t, warnings, err, tc.wantWarning, tc.wantRemedy)
+		})
+	}
+}
+
 func TestDetectLockfileDriftEcosystemExpansionPreviewDisabledPreservesCurrentBehavior(t *testing.T) {
 	t.Run("preview ecosystems stay disabled", func(t *testing.T) {
 		repo := t.TempDir()
@@ -173,6 +229,19 @@ func TestDetectLockfileDriftEcosystemExpansionPreviewDisabledPreservesCurrentBeh
 		}
 		if len(warnings) != 0 {
 			t.Fatalf("expected no preview warning when feature is disabled, got %#v", warnings)
+		}
+	})
+
+	t.Run("preview missing lockfiles stay disabled", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, dartManifestName), "name: demo\ndependencies:\n  http: ^1.2.0\n")
+
+		warnings, err := detectLockfileDriftWithFeatures(context.Background(), repo, false, lockfileDriftFeatureSet(t, false))
+		if err != nil {
+			t.Fatalf(detectLockfileDriftFmt, err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no preview missing-lockfile warning when feature is disabled, got %#v", warnings)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- remove the blanket missing-lockfile suppression from the preview ecosystem lockfile-drift rules
- add regression coverage for enabled preview missing-lockfile warnings across .NET, Dart, Elixir, and SwiftPM
- preserve disabled-preview behavior for those missing-lockfile cases

Closes #773
