### PR TITLE
fix: drive powershell preview gating from registry

### DIFF
--- a/internal/analysis/feature_gates.go
+++ b/internal/analysis/feature_gates.go
@@ -8,20 +8,54 @@ import (
 )
 
 const (
-	powerShellAdapterID             = "powershell"
-	powerShellAdapterPreviewFeature = "powershell-adapter-preview"
+	adapterPreviewFeatureSuffix = "-adapter-preview"
 )
 
 func adapterFeatureFilter(features featureflags.Set) language.AdapterFilter {
+	previewFeatures := previewAdapterFeatures(featureflags.DefaultRegistry())
 	return func(adapter language.Adapter) bool {
 		if adapter == nil {
 			return false
 		}
-		switch strings.ToLower(strings.TrimSpace(adapter.ID())) {
-		case powerShellAdapterID:
-			return features.Enabled(powerShellAdapterPreviewFeature)
-		default:
+		featureName, ok := previewFeatures[normalizeAdapterID(adapter.ID())]
+		if !ok {
 			return true
 		}
+		return features.Enabled(featureName)
 	}
+}
+
+func previewAdapterFeatures(registry *featureflags.Registry) map[string]string {
+	if registry == nil {
+		registry = featureflags.DefaultRegistry()
+	}
+	flags := registry.Flags()
+	features := make(map[string]string, len(flags))
+	for _, flag := range flags {
+		if flag.Lifecycle != featureflags.LifecyclePreview {
+			continue
+		}
+		adapterID, ok := previewAdapterID(flag.Name)
+		if !ok {
+			continue
+		}
+		features[adapterID] = flag.Name
+	}
+	return features
+}
+
+func previewAdapterID(featureName string) (string, bool) {
+	normalized := normalizeAdapterID(featureName)
+	if !strings.HasSuffix(normalized, adapterPreviewFeatureSuffix) {
+		return "", false
+	}
+	adapterID := strings.TrimSuffix(normalized, adapterPreviewFeatureSuffix)
+	if adapterID == "" {
+		return "", false
+	}
+	return adapterID, true
+}
+
+func normalizeAdapterID(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
 }

--- a/internal/analysis/feature_gates_test.go
+++ b/internal/analysis/feature_gates_test.go
@@ -1,0 +1,89 @@
+package analysis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestPowerShellPreviewFeatureUsesShippedCode(t *testing.T) {
+	flag := mustLookupPowerShellPreviewFlag(t)
+	if flag.Code != "LOP-FEAT-0004" {
+		t.Fatalf("expected powershell preview feature code LOP-FEAT-0004, got %s", flag.Code)
+	}
+}
+
+func TestPreviewAdapterFeaturesUsesRegistryPattern(t *testing.T) {
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{
+		{Code: "LOP-FEAT-0001", Name: "powershell-adapter-preview", Lifecycle: featureflags.LifecyclePreview},
+		{Code: "LOP-FEAT-0002", Name: "swift-carthage-preview", Lifecycle: featureflags.LifecyclePreview},
+		{Code: "LOP-FEAT-0003", Name: "ruby-adapter-preview", Lifecycle: featureflags.LifecycleStable},
+	})
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+
+	got := previewAdapterFeatures(registry)
+	if len(got) != 1 {
+		t.Fatalf("expected only preview adapter features, got %#v", got)
+	}
+	if got["powershell"] != "powershell-adapter-preview" {
+		t.Fatalf("expected powershell preview gate mapping, got %#v", got)
+	}
+	if _, ok := got["swift-carthage"]; ok {
+		t.Fatalf("did not expect non-adapter preview feature in mapping, got %#v", got)
+	}
+	if _, ok := got["ruby"]; ok {
+		t.Fatalf("did not expect stable adapter feature in mapping, got %#v", got)
+	}
+}
+
+func TestAdapterFeatureFilterKeepsUnknownAdaptersEnabled(t *testing.T) {
+	filter := adapterFeatureFilter(featureflags.Set{})
+	if !filter(&gatedAdapterStub{id: "custom-adapter"}) {
+		t.Fatalf("expected unknown adapter to stay enabled by default")
+	}
+}
+
+func TestAdapterFeatureFilterUsesShippedPowerShellPreviewGate(t *testing.T) {
+	flag := mustLookupPowerShellPreviewFlag(t)
+	filter := adapterFeatureFilter(featureflags.Set{})
+	if filter(&gatedAdapterStub{id: "powershell"}) {
+		t.Fatalf("expected powershell adapter to stay gated until %s is enabled", flag.Name)
+	}
+
+	features, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  []string{flag.Code},
+	})
+	if err != nil {
+		t.Fatalf("resolve powershell preview feature: %v", err)
+	}
+	filter = adapterFeatureFilter(features)
+	if !filter(&gatedAdapterStub{id: "powershell"}) {
+		t.Fatalf("expected powershell adapter to be enabled when %s is enabled", flag.Code)
+	}
+}
+
+type gatedAdapterStub struct {
+	id string
+}
+
+func (a *gatedAdapterStub) ID() string {
+	return a.id
+}
+
+func (a *gatedAdapterStub) Aliases() []string {
+	return nil
+}
+
+func (a *gatedAdapterStub) Detect(context.Context, string) (bool, error) {
+	return true, nil
+}
+
+func (a *gatedAdapterStub) Analyse(context.Context, language.Request) (report.Report, error) {
+	return report.Report{}, nil
+}

--- a/internal/analysis/powershell_feature_gate_test.go
+++ b/internal/analysis/powershell_feature_gate_test.go
@@ -11,10 +11,7 @@ import (
 	"github.com/ben-ranford/lopper/internal/language"
 )
 
-const (
-	powerShellFeatureCode = "LOP-FEAT-0001"
-	powerShellFeatureName = "powershell-adapter-preview"
-)
+const powerShellFeatureName = "powershell-adapter-preview"
 
 func TestServicePowerShellPreviewGateDefaultsOff(t *testing.T) {
 	repo := t.TempDir()
@@ -101,21 +98,29 @@ func writePowerShellFixtureRepo(t *testing.T, repo string) {
 
 func mustResolvePowerShellFeatureSet(t *testing.T, enabled bool) featureflags.Set {
 	t.Helper()
-	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
-		Code:      powerShellFeatureCode,
-		Name:      powerShellFeatureName,
-		Lifecycle: featureflags.LifecyclePreview,
-	}})
-	if err != nil {
-		t.Fatalf("new feature registry: %v", err)
-	}
+	flag := mustLookupPowerShellPreviewFlag(t)
 	enable := []string(nil)
 	if enabled {
-		enable = []string{powerShellFeatureName}
+		enable = []string{flag.Code}
 	}
-	set, err := registry.Resolve(featureflags.ResolveOptions{Channel: featureflags.ChannelDev, Enable: enable})
+	set, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  enable,
+	})
 	if err != nil {
 		t.Fatalf("resolve feature set: %v", err)
 	}
 	return set
+}
+
+func mustLookupPowerShellPreviewFlag(t *testing.T) featureflags.Flag {
+	t.Helper()
+	if err := featureflags.ValidateDefaultRegistry(); err != nil {
+		t.Fatalf("validate default registry: %v", err)
+	}
+	flag, ok := featureflags.DefaultRegistry().Lookup(powerShellFeatureName)
+	if !ok {
+		t.Fatalf("expected shipped feature registry to include %q", powerShellFeatureName)
+	}
+	return flag
 }


### PR DESCRIPTION
## Summary
- replace the hard-coded PowerShell adapter gate with preview-adapter gating derived from the shipped feature registry
- bind PowerShell preview tests to the shipped feature flag entry and assert the released code mapping
- add focused gate tests for registry-driven adapter gating and unknown-adapter pass-through

## Testing
- go test ./internal/analysis ./internal/app ./internal/cli ./internal/featureflags
- go test ./...

Closes #774
Closes #775