### PR TITLE
feat(flags): graduate LOP-FEAT-0003 to stable

### DIFF
--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -15,7 +15,7 @@
     "code": "LOP-FEAT-0003",
     "name": "swift-carthage-preview",
     "description": "Enable Carthage dependency parsing for the Swift adapter.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   },
   {
     "code": "LOP-FEAT-0004",


### PR DESCRIPTION
Closes #721.

## Graduation evidence

1.5.0 preview validation covered rolling defaults, focused preview behavior, and full CI on the fix PRs. The validation fixes are merged in #776 and #777, and SonarQube/Copilot reported no outstanding issues or comments.

## Compatibility and rollback

Graduation makes swift-carthage-preview a release default. Roll back with --disable-feature swift-carthage-preview or config features.disable; no breaking CLI/config change is expected.

## Release lock notes

internal/featureflags/release_locks.json is empty; no release locks need removal or preservation for v1.5.0.

## Validation

- `go run ./tools/featureflag graduate --feature LOP-FEAT-0003`
- `go run ./tools/featureflag validate`
