### PR TITLE
feat(flags): graduate LOP-FEAT-0002 to stable

### DIFF
--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -9,7 +9,7 @@
     "code": "LOP-FEAT-0002",
     "name": "lockfile-drift-ecosystem-expansion-preview",
     "description": "Preview expansion of shared lockfile drift checks for .NET, Dart, Elixir, and SwiftPM ecosystems.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   },
   {
     "code": "LOP-FEAT-0003",


### PR DESCRIPTION
Closes #721.

## Graduation evidence

1.5.0 preview validation covered rolling defaults, focused preview behavior, and full CI on the fix PRs. The validation fixes are merged in #776 and #777, and SonarQube/Copilot reported no outstanding issues or comments.

## Compatibility and rollback

Graduation makes lockfile-drift-ecosystem-expansion-preview a release default. Roll back with --disable-feature lockfile-drift-ecosystem-expansion-preview or config features.disable; missing lockfiles now report as intended.

## Release lock notes

internal/featureflags/release_locks.json is empty; no release locks need removal or preservation for v1.5.0.

## Validation

- `go run ./tools/featureflag graduate --feature LOP-FEAT-0002`
- `go run ./tools/featureflag validate`
