### PR TITLE
feat(flags): graduate LOP-FEAT-0004 to stable

### DIFF
--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -21,7 +21,7 @@
     "code": "LOP-FEAT-0004",
     "name": "powershell-adapter-preview",
     "description": "Enable preview support for the PowerShell language adapter.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   },
   {
     "code": "LOP-FEAT-0005",


### PR DESCRIPTION
Closes #721.

## Graduation evidence

1.5.0 preview validation covered rolling defaults, focused preview behavior, and full CI on the fix PRs. The validation fixes are merged in #776 and #777, and SonarQube/Copilot reported no outstanding issues or comments.

## Compatibility and rollback

Graduation makes powershell-adapter-preview a release default. Roll back with --disable-feature powershell-adapter-preview or config features.disable; adapter gating is registry-driven after #777.

## Release lock notes

internal/featureflags/release_locks.json is empty; no release locks need removal or preservation for v1.5.0.

## Validation

- `go run ./tools/featureflag graduate --feature LOP-FEAT-0004`
- `go run ./tools/featureflag validate`
