### PR TITLE
chore(flags): graduate 1.5.0 preview features to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ lopper dashboard --config lopper-org.yml --format json
 
 ## Languages
 
-- Supported adapters: `js-ts`, `python`, `cpp`, `jvm`, `kotlin-android`, `go`, `php`, `ruby`, `rust`, `dotnet`, `elixir`, `swift`, `dart`, `powershell` (preview-gated by `powershell-adapter-preview`)
+- Supported adapters: `js-ts`, `python`, `cpp`, `jvm`, `kotlin-android`, `go`, `php`, `ruby`, `rust`, `dotnet`, `elixir`, `swift`, `dart`, `powershell`
 - `js-ts` merges workspace-level declarations from `pnpm-workspace.yaml`, `package.json#workspaces`, and Yarn `.yarnrc.yml` catalogs.
 - Source of truth for adapter IDs: `lopper --help`
 - Language modes:

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -18,7 +18,7 @@ The core contracts are in `internal/language`.
 - `elixir` (Elixir/Mix)
 - `swift` (Swift)
 - `dart` (Dart/Flutter)
-- `powershell` (PowerShell, preview-gated)
+- `powershell` (PowerShell)
 
 ## Adapter contract
 

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -276,8 +276,8 @@ func TestAnalysisCachePrepareEntryIncludesFeatureFlags(t *testing.T) {
 func mustResolveFeatureSet(t *testing.T, enabled bool) featureflags.Set {
 	t.Helper()
 	options := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
-	if enabled {
-		options.Enable = []string{"swift-carthage-preview"}
+	if !enabled {
+		options.Disable = []string{"swift-carthage-preview"}
 	}
 	resolved, err := featureflags.DefaultRegistry().Resolve(options)
 	if err != nil {

--- a/internal/analysis/feature_gates.go
+++ b/internal/analysis/feature_gates.go
@@ -12,12 +12,12 @@ const (
 )
 
 func adapterFeatureFilter(features featureflags.Set) language.AdapterFilter {
-	previewFeatures := previewAdapterFeatures(featureflags.DefaultRegistry())
+	adapterFeatures := adapterFeatureFlags(featureflags.DefaultRegistry())
 	return func(adapter language.Adapter) bool {
 		if adapter == nil {
 			return false
 		}
-		featureName, ok := previewFeatures[normalizeAdapterID(adapter.ID())]
+		featureName, ok := adapterFeatures[normalizeAdapterID(adapter.ID())]
 		if !ok {
 			return true
 		}
@@ -25,16 +25,13 @@ func adapterFeatureFilter(features featureflags.Set) language.AdapterFilter {
 	}
 }
 
-func previewAdapterFeatures(registry *featureflags.Registry) map[string]string {
+func adapterFeatureFlags(registry *featureflags.Registry) map[string]string {
 	if registry == nil {
 		registry = featureflags.DefaultRegistry()
 	}
 	flags := registry.Flags()
 	features := make(map[string]string, len(flags))
 	for _, flag := range flags {
-		if flag.Lifecycle != featureflags.LifecyclePreview {
-			continue
-		}
 		adapterID, ok := previewAdapterID(flag.Name)
 		if !ok {
 			continue

--- a/internal/analysis/feature_gates_test.go
+++ b/internal/analysis/feature_gates_test.go
@@ -16,7 +16,7 @@ func TestPowerShellPreviewFeatureUsesShippedCode(t *testing.T) {
 	}
 }
 
-func TestPreviewAdapterFeaturesUsesRegistryPattern(t *testing.T) {
+func TestAdapterFeatureFlagsUsesRegistryPattern(t *testing.T) {
 	registry, err := featureflags.NewRegistry([]featureflags.Flag{
 		{Code: "LOP-FEAT-0001", Name: "powershell-adapter-preview", Lifecycle: featureflags.LifecyclePreview},
 		{Code: "LOP-FEAT-0002", Name: "swift-carthage-preview", Lifecycle: featureflags.LifecyclePreview},
@@ -26,18 +26,18 @@ func TestPreviewAdapterFeaturesUsesRegistryPattern(t *testing.T) {
 		t.Fatalf("new registry: %v", err)
 	}
 
-	got := previewAdapterFeatures(registry)
-	if len(got) != 1 {
-		t.Fatalf("expected only preview adapter features, got %#v", got)
+	got := adapterFeatureFlags(registry)
+	if len(got) != 2 {
+		t.Fatalf("expected adapter feature flags, got %#v", got)
 	}
 	if got["powershell"] != "powershell-adapter-preview" {
-		t.Fatalf("expected powershell preview gate mapping, got %#v", got)
+		t.Fatalf("expected powershell adapter feature mapping, got %#v", got)
 	}
 	if _, ok := got["swift-carthage"]; ok {
-		t.Fatalf("did not expect non-adapter preview feature in mapping, got %#v", got)
+		t.Fatalf("did not expect non-adapter feature in mapping, got %#v", got)
 	}
-	if _, ok := got["ruby"]; ok {
-		t.Fatalf("did not expect stable adapter feature in mapping, got %#v", got)
+	if got["ruby"] != "ruby-adapter-preview" {
+		t.Fatalf("expected stable adapter feature in mapping, got %#v", got)
 	}
 }
 
@@ -48,23 +48,29 @@ func TestAdapterFeatureFilterKeepsUnknownAdaptersEnabled(t *testing.T) {
 	}
 }
 
-func TestAdapterFeatureFilterUsesShippedPowerShellPreviewGate(t *testing.T) {
+func TestAdapterFeatureFilterUsesShippedPowerShellFeatureGate(t *testing.T) {
 	flag := mustLookupPowerShellPreviewFlag(t)
-	filter := adapterFeatureFilter(featureflags.Set{})
-	if filter(&gatedAdapterStub{id: "powershell"}) {
-		t.Fatalf("expected powershell adapter to stay gated until %s is enabled", flag.Name)
-	}
-
 	features, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
 		Channel: featureflags.ChannelDev,
-		Enable:  []string{flag.Code},
 	})
 	if err != nil {
-		t.Fatalf("resolve powershell preview feature: %v", err)
+		t.Fatalf("resolve powershell feature defaults: %v", err)
 	}
-	filter = adapterFeatureFilter(features)
+	filter := adapterFeatureFilter(features)
 	if !filter(&gatedAdapterStub{id: "powershell"}) {
-		t.Fatalf("expected powershell adapter to be enabled when %s is enabled", flag.Code)
+		t.Fatalf("expected powershell adapter to be enabled by stable %s default", flag.Code)
+	}
+
+	disabled, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Disable: []string{flag.Code},
+	})
+	if err != nil {
+		t.Fatalf("resolve powershell feature disabled: %v", err)
+	}
+	filter = adapterFeatureFilter(disabled)
+	if filter(&gatedAdapterStub{id: "powershell"}) {
+		t.Fatalf("expected powershell adapter to be disabled when %s is disabled", flag.Name)
 	}
 }
 

--- a/internal/analysis/powershell_feature_gate_test.go
+++ b/internal/analysis/powershell_feature_gate_test.go
@@ -13,7 +13,7 @@ import (
 
 const powerShellFeatureName = "powershell-adapter-preview"
 
-func TestServicePowerShellPreviewGateDefaultsOff(t *testing.T) {
+func TestServicePowerShellFeatureGateCanBeDisabled(t *testing.T) {
 	repo := t.TempDir()
 	writePowerShellFixtureRepo(t, repo)
 
@@ -22,13 +22,14 @@ func TestServicePowerShellPreviewGateDefaultsOff(t *testing.T) {
 		RepoPath: repo,
 		Language: "powershell",
 		TopN:     1,
+		Features: mustResolvePowerShellFeatureSet(t, false),
 	})
 	if !errors.Is(err, language.ErrNoMatch) {
-		t.Fatalf("expected ErrNoMatch when powershell preview flag is disabled, got %v", err)
+		t.Fatalf("expected ErrNoMatch when powershell feature flag is disabled, got %v", err)
 	}
 }
 
-func TestServicePowerShellPreviewGateEnabled(t *testing.T) {
+func TestServicePowerShellFeatureGateEnabled(t *testing.T) {
 	repo := t.TempDir()
 	writePowerShellFixtureRepo(t, repo)
 
@@ -41,17 +42,17 @@ func TestServicePowerShellPreviewGateEnabled(t *testing.T) {
 		ScopeMode: ScopeModePackage,
 	})
 	if err != nil {
-		t.Fatalf("analyse powershell with preview enabled: %v", err)
+		t.Fatalf("analyse powershell with feature enabled: %v", err)
 	}
 	if len(reportData.Dependencies) == 0 {
-		t.Fatalf("expected powershell dependencies when preview flag is enabled")
+		t.Fatalf("expected powershell dependencies when feature flag is enabled")
 	}
 	if reportData.Dependencies[0].Language != "powershell" {
 		t.Fatalf("expected powershell dependency language, got %#v", reportData.Dependencies)
 	}
 }
 
-func TestServiceAutoSkipsGatedPowerShellAndFallsBack(t *testing.T) {
+func TestServiceAutoSkipsDisabledPowerShellAndFallsBack(t *testing.T) {
 	repo := t.TempDir()
 	writePowerShellFixtureRepo(t, repo)
 	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
@@ -64,9 +65,10 @@ func TestServiceAutoSkipsGatedPowerShellAndFallsBack(t *testing.T) {
 		RepoPath: repo,
 		Language: "auto",
 		TopN:     5,
+		Features: mustResolvePowerShellFeatureSet(t, false),
 	})
 	if err != nil {
-		t.Fatalf("analyse auto with gated powershell: %v", err)
+		t.Fatalf("analyse auto with disabled powershell: %v", err)
 	}
 	if len(reportData.Dependencies) == 0 {
 		t.Fatalf("expected dependencies from fallback adapter")
@@ -79,7 +81,7 @@ func TestServiceAutoSkipsGatedPowerShellAndFallsBack(t *testing.T) {
 		t.Fatalf("expected js-ts dependency rows, got %#v", reportData.Dependencies)
 	}
 	if slices.Contains(languages, "powershell") {
-		t.Fatalf("did not expect powershell rows with preview disabled, got %#v", reportData.Dependencies)
+		t.Fatalf("did not expect powershell rows with feature disabled, got %#v", reportData.Dependencies)
 	}
 }
 
@@ -99,14 +101,13 @@ func writePowerShellFixtureRepo(t *testing.T, repo string) {
 func mustResolvePowerShellFeatureSet(t *testing.T, enabled bool) featureflags.Set {
 	t.Helper()
 	flag := mustLookupPowerShellPreviewFlag(t)
-	enable := []string(nil)
-	if enabled {
-		enable = []string{flag.Code}
-	}
-	set, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
+	options := featureflags.ResolveOptions{
 		Channel: featureflags.ChannelDev,
-		Enable:  enable,
-	})
+	}
+	if !enabled {
+		options.Disable = []string{flag.Code}
+	}
+	set, err := featureflags.DefaultRegistry().Resolve(options)
 	if err != nil {
 		t.Fatalf("resolve feature set: %v", err)
 	}

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -20,7 +20,7 @@ func TestExecuteFeaturesJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute features: %v", err)
 	}
-	if !strings.Contains(output, `"code": "LOP-FEAT-0001"`) || !strings.Contains(output, `"enabledByDefault": false`) {
+	if !strings.Contains(output, `"code": "LOP-FEAT-0001"`) || !strings.Contains(output, `"enabledByDefault": true`) {
 		t.Fatalf("unexpected feature manifest output: %s", output)
 	}
 }
@@ -70,8 +70,8 @@ func TestExecuteFeaturesReleaseChannelAndEmptyRegistry(t *testing.T) {
 		!strings.Contains(emptyOutput, "swift-carthage-preview") ||
 		!strings.Contains(emptyOutput, "powershell-adapter-preview") ||
 		!strings.Contains(emptyOutput, "go-vendored-provenance-preview") ||
-		!strings.Contains(emptyOutput, "false") {
-		t.Fatalf("expected default feature table to include embedded preview flags disabled by default, got %q", emptyOutput)
+		!strings.Contains(emptyOutput, "true") {
+		t.Fatalf("expected default feature table to include embedded graduated flags enabled by default, got %q", emptyOutput)
 	}
 }
 

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -503,11 +503,11 @@ func TestManifestReportsDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil registry manifest to defer to defaults, manifest=%#v err=%v", manifest, err)
 	}
-	assertManifestFlag(t, manifest, "dart-source-attribution-preview", false)
-	assertManifestFlag(t, manifest, "lockfile-drift-ecosystem-expansion-preview", false)
-	assertManifestFlag(t, manifest, "swift-carthage-preview", false)
-	assertManifestFlag(t, manifest, "powershell-adapter-preview", false)
-	assertManifestFlag(t, manifest, "go-vendored-provenance-preview", false)
+	assertManifestFlag(t, manifest, "dart-source-attribution-preview", true)
+	assertManifestFlag(t, manifest, "lockfile-drift-ecosystem-expansion-preview", true)
+	assertManifestFlag(t, manifest, "swift-carthage-preview", true)
+	assertManifestFlag(t, manifest, "powershell-adapter-preview", true)
+	assertManifestFlag(t, manifest, "go-vendored-provenance-preview", true)
 }
 
 func TestFormatManifest(t *testing.T) {
@@ -551,7 +551,7 @@ func TestEnabledFlag(t *testing.T) {
 	}
 }
 
-func TestDefaultRegistryPreviewDefaultsAndOptIn(t *testing.T) {
+func TestDefaultRegistryGraduatedDefaultsAndDisable(t *testing.T) {
 	registry := DefaultRegistry()
 	dev, err := registry.Resolve(ResolveOptions{Channel: ChannelDev})
 	if err != nil {
@@ -564,8 +564,8 @@ func TestDefaultRegistryPreviewDefaultsAndOptIn(t *testing.T) {
 		"powershell-adapter-preview",
 		"go-vendored-provenance-preview",
 	} {
-		if dev.Enabled(name) {
-			t.Fatalf("expected %s default-off in dev channel", name)
+		if !dev.Enabled(name) {
+			t.Fatalf("expected %s default-on in dev channel", name)
 		}
 	}
 
@@ -580,20 +580,20 @@ func TestDefaultRegistryPreviewDefaultsAndOptIn(t *testing.T) {
 		"powershell-adapter-preview",
 		"go-vendored-provenance-preview",
 	} {
-		if release.Enabled(name) {
-			t.Fatalf("expected %s default-off in release channel", name)
+		if !release.Enabled(name) {
+			t.Fatalf("expected %s default-on in release channel", name)
 		}
 	}
 
-	optIn, err := registry.Resolve(ResolveOptions{
-		Channel: ChannelDev,
-		Enable:  []string{"swift-carthage-preview"},
+	disabled, err := registry.Resolve(ResolveOptions{
+		Channel: ChannelRelease,
+		Disable: []string{"swift-carthage-preview"},
 	})
 	if err != nil {
-		t.Fatalf("resolve explicit opt-in: %v", err)
+		t.Fatalf("resolve explicit disable: %v", err)
 	}
-	if !optIn.Enabled("swift-carthage-preview") {
-		t.Fatalf("expected explicit opt-in to enable swift-carthage-preview")
+	if disabled.Enabled("swift-carthage-preview") {
+		t.Fatalf("expected explicit disable to turn off swift-carthage-preview")
 	}
 }
 

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -3,7 +3,7 @@
     "code": "LOP-FEAT-0001",
     "name": "dart-source-attribution-preview",
     "description": "Enable richer Dart and Flutter dependency source attribution and federated plugin relationship reporting.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   },
   {
     "code": "LOP-FEAT-0002",

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -9,24 +9,24 @@
     "code": "LOP-FEAT-0002",
     "name": "lockfile-drift-ecosystem-expansion-preview",
     "description": "Preview expansion of shared lockfile drift checks for .NET, Dart, Elixir, and SwiftPM ecosystems.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   },
   {
     "code": "LOP-FEAT-0003",
     "name": "swift-carthage-preview",
     "description": "Enable Carthage dependency parsing for the Swift adapter.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   },
   {
     "code": "LOP-FEAT-0004",
     "name": "powershell-adapter-preview",
     "description": "Enable preview support for the PowerShell language adapter.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   },
   {
     "code": "LOP-FEAT-0005",
     "name": "go-vendored-provenance-preview",
     "description": "Enable vendored dependency provenance for Go using vendor/modules.txt metadata.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   }
 ]

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -335,11 +335,11 @@ func TestManifestEntries(t *testing.T) {
 	if len(manifest) < 4 {
 		t.Fatalf("expected embedded manifest entries, got %#v", manifest)
 	}
-	assertManifestEntryDefault(t, manifest, "dart-source-attribution-preview", false)
-	assertManifestEntryDefault(t, manifest, "lockfile-drift-ecosystem-expansion-preview", false)
-	assertManifestEntryDefault(t, manifest, "swift-carthage-preview", false)
-	assertManifestEntryDefault(t, manifest, "powershell-adapter-preview", false)
-	assertManifestEntryDefault(t, manifest, "go-vendored-provenance-preview", false)
+	assertManifestEntryDefault(t, manifest, "dart-source-attribution-preview", true)
+	assertManifestEntryDefault(t, manifest, "lockfile-drift-ecosystem-expansion-preview", true)
+	assertManifestEntryDefault(t, manifest, "swift-carthage-preview", true)
+	assertManifestEntryDefault(t, manifest, "powershell-adapter-preview", true)
+	assertManifestEntryDefault(t, manifest, "go-vendored-provenance-preview", true)
 }
 
 func TestRunManifestAndReportUseChannels(t *testing.T) {


### PR DESCRIPTION
## Graduation evidence

- 1.5.0 preview validation covered rolling defaults, focused preview behavior, and full CI on fix PRs #776 and #777.
- Fix PRs #776 and #777 are merged; SonarQube and Copilot reported no outstanding issues or comments.
- Local validation on the consolidated branch passed: go test ./..., make feature-flag-check, and the pre-commit make ci gate.

## Compatibility and rollback

- All five 1.5.0 preview flags now resolve as stable and are enabled by default for dev and release channels.
- Users can roll back individual behavior with --disable-feature <flag> or config features.disable.
- PowerShell adapter gating remains data-driven so explicit disable still gates the adapter after graduation.

## Release lock notes

- internal/featureflags/release_locks.json is empty; no release locks need removal or preservation for v1.5.0.

## Validation

- graduate-feature.yml dispatched for LOP-FEAT-0001 through LOP-FEAT-0005 with milestone v1.5.0.
- go run ./tools/featureflag validate
- go test ./...
- pre-commit make ci