### PR TITLE
feat(flags): graduate LOP-FEAT-0005 to stable

### DIFF
--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -27,6 +27,6 @@
     "code": "LOP-FEAT-0005",
     "name": "go-vendored-provenance-preview",
     "description": "Enable vendored dependency provenance for Go using vendor/modules.txt metadata.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   }
 ]


### PR DESCRIPTION
Closes #721.

## Graduation evidence

1.5.0 preview validation covered rolling defaults, focused preview behavior, and full CI on the fix PRs. The validation fixes are merged in #776 and #777, and SonarQube/Copilot reported no outstanding issues or comments.

## Compatibility and rollback

Graduation makes go-vendored-provenance-preview a release default. Roll back with --disable-feature go-vendored-provenance-preview or config features.disable; no breaking CLI/config change is expected.

## Release lock notes

internal/featureflags/release_locks.json is empty; no release locks need removal or preservation for v1.5.0.

## Validation

- `go run ./tools/featureflag graduate --feature LOP-FEAT-0005`
- `go run ./tools/featureflag validate`
