### PR TITLE
bug: parse PowerShell Requires module options correctly

### DIFF
--- a/internal/lang/powershell/parser.go
+++ b/internal/lang/powershell/parser.go
@@ -328,11 +328,10 @@ func parsePowerShellLine(line string, filePath string, lineNo int, declared map[
 
 func parseRequiresLine(requiresBody string, line string, filePath string, lineNo int, declared map[string]struct{}) ([]importBinding, []string) {
 	requiresBody = stripPowerShellInlineComment(requiresBody)
-	match := requiresModulesOptionPattern.FindStringSubmatch(requiresBody)
-	if len(match) != 2 {
+	expr, hasModulesOption := extractRequiresModulesExpression(requiresBody)
+	if !hasModulesOption {
 		return nil, nil
 	}
-	expr := strings.TrimSpace(match[1])
 	if expr == "" {
 		warning := fmt.Sprintf("#Requires -Modules in %s:%d had no module list", filePath, lineNo)
 		return nil, []string{warning}
@@ -630,6 +629,42 @@ func flagValue(value, flag string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func extractRequiresModulesExpression(requiresBody string) (string, bool) {
+	tokens := splitArguments(requiresBody)
+	for i := 0; i < len(tokens); i++ {
+		token := strings.TrimSpace(tokens[i])
+		if token == "" {
+			continue
+		}
+		if strings.EqualFold(token, "-modules") {
+			return collectRequiresModulesExpression(tokens, i+1), true
+		}
+		if strings.HasPrefix(strings.ToLower(token), "-modules:") {
+			inline := strings.TrimSpace(token[len("-modules:"):])
+			if inline != "" {
+				return inline, true
+			}
+			return collectRequiresModulesExpression(tokens, i+1), true
+		}
+	}
+	return "", false
+}
+
+func collectRequiresModulesExpression(tokens []string, start int) string {
+	moduleTokens := make([]string, 0, len(tokens)-start)
+	for i := start; i < len(tokens); i++ {
+		token := strings.TrimSpace(tokens[i])
+		if token == "" {
+			continue
+		}
+		if strings.HasPrefix(token, "-") {
+			break
+		}
+		moduleTokens = append(moduleTokens, token)
+	}
+	return strings.TrimSpace(strings.Join(moduleTokens, " "))
 }
 
 func stripPowerShellInlineComment(line string) string {

--- a/internal/lang/powershell/parser_test.go
+++ b/internal/lang/powershell/parser_test.go
@@ -264,6 +264,32 @@ func TestParseRequiresLineStripsTrailingComment(t *testing.T) {
 	}
 }
 
+func TestParseRequiresLineIgnoresTrailingRequiresOptions(t *testing.T) {
+	imports, warnings := parseRequiresLine(" -Modules Pester -Version 7.0", "#Requires -Modules Pester -Version 7.0", "script.ps1", 5, nil)
+	if len(warnings) != 0 || len(imports) != 1 {
+		t.Fatalf("expected one #Requires import and no warnings, imports=%#v warnings=%#v", imports, warnings)
+	}
+	if imports[0].Record.Dependency != "pester" {
+		t.Fatalf("expected trailing #Requires options to be excluded from dependency, got %#v", imports[0])
+	}
+}
+
+func TestParseRequiresLineParsesAllModulesBeforeTrailingOption(t *testing.T) {
+	imports, warnings := parseRequiresLine(" -Modules Pester, Az.Accounts -RunAsAdministrator", "#Requires -Modules Pester, Az.Accounts -RunAsAdministrator", "script.ps1", 5, nil)
+	if len(warnings) != 0 || len(imports) != 2 {
+		t.Fatalf("expected two #Requires imports and no warnings, imports=%#v warnings=%#v", imports, warnings)
+	}
+
+	dependencies := make([]string, 0, len(imports))
+	for _, imp := range imports {
+		dependencies = append(dependencies, imp.Record.Dependency)
+	}
+	slices.Sort(dependencies)
+	if !reflect.DeepEqual(dependencies, []string{"az.accounts", "pester"}) {
+		t.Fatalf("unexpected #Requires dependencies from module list, got %#v", dependencies)
+	}
+}
+
 func TestNewImportBindingNormalizesDependencyAndDefaultsModule(t *testing.T) {
 	binding := newImportBinding(" Pester ", "", "script.ps1", 3, "Import-Module Pester", usageSourceImportModule)
 	if binding.Record.Dependency != "pester" || binding.Record.Module != "pester" {

--- a/internal/lang/powershell/parser_test.go
+++ b/internal/lang/powershell/parser_test.go
@@ -254,39 +254,49 @@ func TestParseRequiresLineWithoutModulesReturnsNoData(t *testing.T) {
 	}
 }
 
-func TestParseRequiresLineStripsTrailingComment(t *testing.T) {
-	imports, warnings := parseRequiresLine(" -Modules Pester # comment", "#Requires -Modules Pester # comment", "script.ps1", 5, nil)
-	if len(warnings) != 0 || len(imports) != 1 {
-		t.Fatalf("expected one #Requires import and no warnings, imports=%#v warnings=%#v", imports, warnings)
+func TestParseRequiresLineModuleListParsing(t *testing.T) {
+	cases := []struct {
+		name         string
+		requiresBody string
+		line         string
+		wantDeps     []string
+	}{
+		{
+			name:         "strips trailing comment",
+			requiresBody: " -Modules Pester # comment",
+			line:         "#Requires -Modules Pester # comment",
+			wantDeps:     []string{"pester"},
+		},
+		{
+			name:         "ignores trailing requires options",
+			requiresBody: " -Modules Pester -Version 7.0",
+			line:         "#Requires -Modules Pester -Version 7.0",
+			wantDeps:     []string{"pester"},
+		},
+		{
+			name:         "parses all modules before trailing option",
+			requiresBody: " -Modules Pester, Az.Accounts -RunAsAdministrator",
+			line:         "#Requires -Modules Pester, Az.Accounts -RunAsAdministrator",
+			wantDeps:     []string{"az.accounts", "pester"},
+		},
 	}
-	if imports[0].Record.Dependency != "pester" {
-		t.Fatalf("expected trailing comment to be excluded from dependency, got %#v", imports[0])
-	}
-}
 
-func TestParseRequiresLineIgnoresTrailingRequiresOptions(t *testing.T) {
-	imports, warnings := parseRequiresLine(" -Modules Pester -Version 7.0", "#Requires -Modules Pester -Version 7.0", "script.ps1", 5, nil)
-	if len(warnings) != 0 || len(imports) != 1 {
-		t.Fatalf("expected one #Requires import and no warnings, imports=%#v warnings=%#v", imports, warnings)
-	}
-	if imports[0].Record.Dependency != "pester" {
-		t.Fatalf("expected trailing #Requires options to be excluded from dependency, got %#v", imports[0])
-	}
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			imports, warnings := parseRequiresLine(tc.requiresBody, tc.line, "script.ps1", 5, nil)
+			if len(warnings) != 0 {
+				t.Fatalf("expected no #Requires warnings, got %#v", warnings)
+			}
 
-func TestParseRequiresLineParsesAllModulesBeforeTrailingOption(t *testing.T) {
-	imports, warnings := parseRequiresLine(" -Modules Pester, Az.Accounts -RunAsAdministrator", "#Requires -Modules Pester, Az.Accounts -RunAsAdministrator", "script.ps1", 5, nil)
-	if len(warnings) != 0 || len(imports) != 2 {
-		t.Fatalf("expected two #Requires imports and no warnings, imports=%#v warnings=%#v", imports, warnings)
-	}
-
-	dependencies := make([]string, 0, len(imports))
-	for _, imp := range imports {
-		dependencies = append(dependencies, imp.Record.Dependency)
-	}
-	slices.Sort(dependencies)
-	if !reflect.DeepEqual(dependencies, []string{"az.accounts", "pester"}) {
-		t.Fatalf("unexpected #Requires dependencies from module list, got %#v", dependencies)
+			dependencies := make([]string, 0, len(imports))
+			for _, imp := range imports {
+				dependencies = append(dependencies, imp.Record.Dependency)
+			}
+			slices.Sort(dependencies)
+			if !reflect.DeepEqual(dependencies, tc.wantDeps) {
+				t.Fatalf("unexpected #Requires dependencies: got=%#v want=%#v", dependencies, tc.wantDeps)
+			}
+		})
 	}
 }
 

--- a/internal/lang/powershell/types.go
+++ b/internal/lang/powershell/types.go
@@ -29,7 +29,6 @@ var (
 	importModulePattern              = regexp.MustCompile(`(?i)^\s*import-module\b(.*)$`)
 	usingModulePattern               = regexp.MustCompile(`(?i)^\s*using\s+module\s+(.+)$`)
 	requiresDirectivePattern         = regexp.MustCompile(`(?i)^\s*#\s*requires\b(.*)$`)
-	requiresModulesOptionPattern     = regexp.MustCompile(`(?i)-modules\b(.*)$`)
 	moduleNamePattern                = regexp.MustCompile(`(?is)\bmodulename\b\s*=\s*([^;\r\n}]+)`)
 	powerShellSkippedDirs            = map[string]bool{}
 )


### PR DESCRIPTION
## Summary
Fixes PowerShell `#Requires -Modules` parsing so trailing `#Requires` options (for example `-Version`) are not included in module dependency names.

Closes #790.

## Issue
`#Requires -Modules Pester -Version 7.0` was being attributed as dependency `pester -version 7.0`.

## Cause and Impact
The parser captured everything after `-Modules`, so trailing directive options were treated as part of the module expression. This produced false dependency keys and incorrect analysis attribution.

## Root Cause
`parseRequiresLine` used a greedy regex capture for `-Modules` and consumed the rest of the directive body as module text.

## Fix
- Replaced greedy `-Modules` capture with token-aware extraction that isolates only the `-Modules` argument segment.
- Stop module expression collection at the next top-level option token (for example `-Version`, `-RunAsAdministrator`).
- Keep support for both `-Modules <expr>` and `-Modules:<expr>` forms.
- Added focused regression tests for trailing option handling.

## Tests Run
- `GOTOOLCHAIN=go1.26.2 go test ./internal/lang/powershell ./internal/analysis`
- `make feature-flag-check`
- Pre-commit hook suite (`make fmt` + `make ci`) during commit
