### PR TITLE
bug: attribute Dart local path dependency imports

### DIFF
--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -298,6 +298,47 @@ func TestServiceAnalyseSwiftCarthageAllModeBehindPreviewFlag(t *testing.T) {
 	assertReportLanguages(t, reportData.Dependencies, "swift", "js-ts")
 }
 
+func TestServiceAnalyseDartStableDefaultsKeepLocalPathImportUsage(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "pubspec.yaml"), `name: demo
+dependencies:
+  local_pkg:
+    path: ../local_pkg
+`)
+	writeFile(t, filepath.Join(repo, "pubspec.lock"), `packages:
+  local_pkg:
+    dependency: "direct main"
+    description: {path: ../local_pkg}
+    source: path
+    version: "0.0.1"
+`)
+	writeFile(t, filepath.Join(repo, "lib", "main.dart"), `import 'package:local_pkg/local_pkg.dart' as local;
+void main() { local.run(); }
+`)
+
+	reportData, err := NewService().Analyse(context.Background(), Request{
+		RepoPath:   repo,
+		Dependency: "local_pkg",
+		Language:   "dart",
+		Features:   mustResolveStableDefaultsFeatureSet(t),
+	})
+	if err != nil {
+		t.Fatalf("analyse dart with stable defaults: %v", err)
+	}
+	dep := singleDependencyReport(t, reportData)
+	if dep.Language != "dart" {
+		t.Fatalf("expected dart language, got %#v", dep)
+	}
+	if dep.TotalExportsCount == 0 || dep.UsedExportsCount == 0 {
+		t.Fatalf("expected local path import usage under stable defaults, got %#v", dep)
+	}
+	for _, warning := range reportData.Warnings {
+		if strings.Contains(strings.ToLower(warning), `no imports found for dependency "local_pkg"`) {
+			t.Fatalf("expected local path import attribution under stable defaults, got warnings %#v", reportData.Warnings)
+		}
+	}
+}
+
 func writeSwiftCarthageAnalysisFixture(t *testing.T, repo string) {
 	t.Helper()
 	writeFile(t, filepath.Join(repo, "Cartfile"), "github \"ReactiveX/RxSwift\" ~> 6.0\n")
@@ -343,6 +384,17 @@ func mustResolveSwiftCarthagePreviewSet(t *testing.T, enabled bool) featureflags
 	resolved, err := featureflags.DefaultRegistry().Resolve(options)
 	if err != nil {
 		t.Fatalf("resolve swift Carthage preview feature set: %v", err)
+	}
+	return resolved
+}
+
+func mustResolveStableDefaultsFeatureSet(t *testing.T) featureflags.Set {
+	t.Helper()
+	resolved, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+	})
+	if err != nil {
+		t.Fatalf("resolve stable defaults feature set: %v", err)
 	}
 	return resolved
 }

--- a/internal/lang/dart/adapter.go
+++ b/internal/lang/dart/adapter.go
@@ -22,7 +22,8 @@ func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Rep
 		return report.Report{}, err
 	}
 
-	scan, err := a.scanRepo(ctx, repoPath, &result)
+	previewEnabled := req.Features.Enabled(dartSourceAttributionPreviewFeature)
+	scan, err := a.scanRepoWithOptions(ctx, repoPath, &result, previewEnabled)
 	if err != nil {
 		return report.Report{}, err
 	}
@@ -39,13 +40,17 @@ func (a *Adapter) newReport(rawRepoPath string) (string, report.Report, error) {
 }
 
 func (a *Adapter) scanRepo(ctx context.Context, repoPath string, result *report.Report) (scanResult, error) {
+	return a.scanRepoWithOptions(ctx, repoPath, result, false)
+}
+
+func (a *Adapter) scanRepoWithOptions(ctx context.Context, repoPath string, result *report.Report, includeLocalPathImports bool) (scanResult, error) {
 	manifests, warnings, err := collectManifestData(repoPath)
 	if err != nil {
 		return scanResult{}, err
 	}
 	result.Warnings = append(result.Warnings, warnings...)
 
-	scan, err := scanRepo(ctx, repoPath, manifests)
+	scan, err := scanRepoWithOptions(ctx, repoPath, manifests, includeLocalPathImports)
 	if err != nil {
 		return scanResult{}, err
 	}

--- a/internal/lang/dart/adapter_test.go
+++ b/internal/lang/dart/adapter_test.go
@@ -505,6 +505,53 @@ void main() {
 	}
 }
 
+func TestDartSourceAttributionStableDefaultsKeepLocalPathImportUsage(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, pubspecYAMLName), `name: app
+dependencies:
+  local_pkg:
+    path: ../local_pkg
+`)
+	writeFile(t, filepath.Join(repo, pubspecLockName), `packages:
+  local_pkg:
+    dependency: "direct main"
+    description: {path: ../local_pkg}
+    source: path
+    version: "0.0.1"
+`)
+	writeFile(t, filepath.Join(repo, "lib", mainDartFileName), `import 'package:local_pkg/local_pkg.dart' as local;
+
+void main() {
+  local.run();
+}
+`)
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath:   repo,
+		Dependency: "local_pkg",
+		Features:   mustDartStableDefaultFeatureSet(t),
+	})
+	if err != nil {
+		t.Fatalf(analyseErrorFormat, err)
+	}
+	if len(reportData.Dependencies) != 1 {
+		t.Fatalf(expectedOneDependencyReport, len(reportData.Dependencies))
+	}
+	dep := reportData.Dependencies[0]
+	if dep.Name != "local_pkg" {
+		t.Fatalf("expected local_pkg dependency, got %#v", dep)
+	}
+	if dep.TotalExportsCount == 0 || dep.UsedExportsCount == 0 {
+		t.Fatalf("expected local path import usage under stable defaults, got %#v", dep)
+	}
+	if !hasRiskCueCode(dep, "local-path-dependency") {
+		t.Fatalf("expected local path dependency cue under stable defaults, got %#v", dep.RiskCues)
+	}
+	if containsWarning(reportData.Warnings, `no imports found for dependency "local_pkg"`) {
+		t.Fatalf("expected local path imports to be attributed under stable defaults, got warnings %#v", reportData.Warnings)
+	}
+}
+
 func findDependency(dependencies []report.DependencyReport, name string) (report.DependencyReport, bool) {
 	for _, dependency := range dependencies {
 		if dependency.Name == name {
@@ -572,6 +619,20 @@ func mustDartPreviewFeatureSet(t *testing.T, enabled bool) featureflags.Set {
 	features, err := registry.Resolve(opts)
 	if err != nil {
 		t.Fatalf("resolve feature set: %v", err)
+	}
+	return features
+}
+
+func mustDartStableDefaultFeatureSet(t *testing.T) featureflags.Set {
+	t.Helper()
+	features, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+	})
+	if err != nil {
+		t.Fatalf("resolve stable default feature set: %v", err)
+	}
+	if !features.Enabled(dartSourceAttributionPreviewFeature) {
+		t.Fatalf("expected %q enabled by stable defaults", dartSourceAttributionPreviewFeature)
 	}
 	return features
 }

--- a/internal/lang/dart/scan.go
+++ b/internal/lang/dart/scan.go
@@ -20,8 +20,9 @@ func scanRepo(ctx context.Context, repoPath string, manifests []packageManifest)
 
 func scanRepoWithOptions(ctx context.Context, repoPath string, manifests []packageManifest, includeLocalPathImports bool) (scanResult, error) {
 	result := scanResult{
-		DeclaredDependencies: make(map[string]dependencyInfo),
-		UnresolvedImports:    make(map[string]int),
+		DeclaredDependencies:    make(map[string]dependencyInfo),
+		UnresolvedImports:       make(map[string]int),
+		includeLocalPathImports: includeLocalPathImports,
 	}
 
 	if len(manifests) == 0 {
@@ -42,7 +43,7 @@ func scanRepoWithOptions(ctx context.Context, repoPath string, manifests []packa
 	}
 
 	for _, manifest := range manifests {
-		stop, err := scanManifestRootWithOptions(ctx, repoPath, manifest, allRoots, scannedFiles, &fileCount, &result, includeLocalPathImports)
+		stop, err := scanManifestRoot(ctx, repoPath, manifest, allRoots, scannedFiles, &fileCount, &result)
 		if err != nil {
 			return scanResult{}, err
 		}
@@ -60,14 +61,10 @@ func scanRepoWithOptions(ctx context.Context, repoPath string, manifests []packa
 }
 
 func scanManifestRoot(ctx context.Context, repoPath string, manifest packageManifest, allRoots map[string]struct{}, scannedFiles map[string]struct{}, fileCount *int, result *scanResult) (bool, error) {
-	return scanManifestRootWithOptions(ctx, repoPath, manifest, allRoots, scannedFiles, fileCount, result, false)
-}
-
-func scanManifestRootWithOptions(ctx context.Context, repoPath string, manifest packageManifest, allRoots map[string]struct{}, scannedFiles map[string]struct{}, fileCount *int, result *scanResult, includeLocalPathImports bool) (bool, error) {
 	if result.SkippedFilesByBound {
 		return true, nil
 	}
-	err := scanPackageRootWithOptions(ctx, repoPath, manifest, allRoots, scannedFiles, fileCount, result, includeLocalPathImports)
+	err := scanPackageRoot(ctx, repoPath, manifest, allRoots, scannedFiles, fileCount, result)
 	switch {
 	case result.SkippedFilesByBound, errors.Is(err, fs.SkipAll):
 		return true, nil
@@ -94,10 +91,6 @@ func mergeDeclaredDependencies(dest, incoming map[string]dependencyInfo) {
 }
 
 func scanPackageRoot(ctx context.Context, repoPath string, manifest packageManifest, allRoots map[string]struct{}, scannedFiles map[string]struct{}, fileCount *int, result *scanResult) error {
-	return scanPackageRootWithOptions(ctx, repoPath, manifest, allRoots, scannedFiles, fileCount, result, false)
-}
-
-func scanPackageRootWithOptions(ctx context.Context, repoPath string, manifest packageManifest, allRoots map[string]struct{}, scannedFiles map[string]struct{}, fileCount *int, result *scanResult, includeLocalPathImports bool) error {
 	root := manifest.Root
 	if root == "" {
 		root = repoPath
@@ -111,7 +104,7 @@ func scanPackageRootWithOptions(ctx context.Context, repoPath string, manifest p
 		scannedFiles:            scannedFiles,
 		fileCount:               fileCount,
 		result:                  result,
-		includeLocalPathImports: includeLocalPathImports,
+		includeLocalPathImports: result.includeLocalPathImports,
 	}
 	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		return walkPackageEntry(ctx, scanner, path, entry, walkErr)

--- a/internal/lang/dart/scan.go
+++ b/internal/lang/dart/scan.go
@@ -15,6 +15,10 @@ import (
 )
 
 func scanRepo(ctx context.Context, repoPath string, manifests []packageManifest) (scanResult, error) {
+	return scanRepoWithOptions(ctx, repoPath, manifests, false)
+}
+
+func scanRepoWithOptions(ctx context.Context, repoPath string, manifests []packageManifest, includeLocalPathImports bool) (scanResult, error) {
 	result := scanResult{
 		DeclaredDependencies: make(map[string]dependencyInfo),
 		UnresolvedImports:    make(map[string]int),
@@ -38,7 +42,7 @@ func scanRepo(ctx context.Context, repoPath string, manifests []packageManifest)
 	}
 
 	for _, manifest := range manifests {
-		stop, err := scanManifestRoot(ctx, repoPath, manifest, allRoots, scannedFiles, &fileCount, &result)
+		stop, err := scanManifestRootWithOptions(ctx, repoPath, manifest, allRoots, scannedFiles, &fileCount, &result, includeLocalPathImports)
 		if err != nil {
 			return scanResult{}, err
 		}
@@ -56,10 +60,14 @@ func scanRepo(ctx context.Context, repoPath string, manifests []packageManifest)
 }
 
 func scanManifestRoot(ctx context.Context, repoPath string, manifest packageManifest, allRoots map[string]struct{}, scannedFiles map[string]struct{}, fileCount *int, result *scanResult) (bool, error) {
+	return scanManifestRootWithOptions(ctx, repoPath, manifest, allRoots, scannedFiles, fileCount, result, false)
+}
+
+func scanManifestRootWithOptions(ctx context.Context, repoPath string, manifest packageManifest, allRoots map[string]struct{}, scannedFiles map[string]struct{}, fileCount *int, result *scanResult, includeLocalPathImports bool) (bool, error) {
 	if result.SkippedFilesByBound {
 		return true, nil
 	}
-	err := scanPackageRoot(ctx, repoPath, manifest, allRoots, scannedFiles, fileCount, result)
+	err := scanPackageRootWithOptions(ctx, repoPath, manifest, allRoots, scannedFiles, fileCount, result, includeLocalPathImports)
 	switch {
 	case result.SkippedFilesByBound, errors.Is(err, fs.SkipAll):
 		return true, nil
@@ -86,19 +94,24 @@ func mergeDeclaredDependencies(dest, incoming map[string]dependencyInfo) {
 }
 
 func scanPackageRoot(ctx context.Context, repoPath string, manifest packageManifest, allRoots map[string]struct{}, scannedFiles map[string]struct{}, fileCount *int, result *scanResult) error {
+	return scanPackageRootWithOptions(ctx, repoPath, manifest, allRoots, scannedFiles, fileCount, result, false)
+}
+
+func scanPackageRootWithOptions(ctx context.Context, repoPath string, manifest packageManifest, allRoots map[string]struct{}, scannedFiles map[string]struct{}, fileCount *int, result *scanResult, includeLocalPathImports bool) error {
 	root := manifest.Root
 	if root == "" {
 		root = repoPath
 	}
 
 	scanner := packageRootScanner{
-		repoPath:     repoPath,
-		root:         root,
-		depLookup:    manifest.Dependencies,
-		allRoots:     allRoots,
-		scannedFiles: scannedFiles,
-		fileCount:    fileCount,
-		result:       result,
+		repoPath:                repoPath,
+		root:                    root,
+		depLookup:               manifest.Dependencies,
+		allRoots:                allRoots,
+		scannedFiles:            scannedFiles,
+		fileCount:               fileCount,
+		result:                  result,
+		includeLocalPathImports: includeLocalPathImports,
 	}
 	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		return walkPackageEntry(ctx, scanner, path, entry, walkErr)
@@ -106,13 +119,14 @@ func scanPackageRoot(ctx context.Context, repoPath string, manifest packageManif
 }
 
 type packageRootScanner struct {
-	repoPath     string
-	root         string
-	depLookup    map[string]dependencyInfo
-	allRoots     map[string]struct{}
-	scannedFiles map[string]struct{}
-	fileCount    *int
-	result       *scanResult
+	repoPath                string
+	root                    string
+	depLookup               map[string]dependencyInfo
+	allRoots                map[string]struct{}
+	scannedFiles            map[string]struct{}
+	fileCount               *int
+	result                  *scanResult
+	includeLocalPathImports bool
 }
 
 func walkPackageEntry(ctx context.Context, scanner packageRootScanner, path string, entry fs.DirEntry, walkErr error) error {
@@ -122,7 +136,7 @@ func walkPackageEntry(ctx context.Context, scanner packageRootScanner, path stri
 	if entry.IsDir() {
 		return scanPackageDir(scanner.root, path, entry.Name(), scanner.allRoots)
 	}
-	return scanPackageFileEntry(scanner.repoPath, path, scanner.depLookup, scanner.scannedFiles, scanner.fileCount, scanner.result)
+	return scanPackageFileEntryWithOptions(scanner.repoPath, path, scanner.depLookup, scanner.scannedFiles, scanner.fileCount, scanner.result, scanner.includeLocalPathImports)
 }
 
 func walkContextErr(ctx context.Context, walkErr error) error {
@@ -143,6 +157,10 @@ func scanPackageDir(root, path, name string, allRoots map[string]struct{}) error
 }
 
 func scanPackageFileEntry(repoPath string, path string, depLookup map[string]dependencyInfo, scannedFiles map[string]struct{}, fileCount *int, result *scanResult) error {
+	return scanPackageFileEntryWithOptions(repoPath, path, depLookup, scannedFiles, fileCount, result, false)
+}
+
+func scanPackageFileEntryWithOptions(repoPath string, path string, depLookup map[string]dependencyInfo, scannedFiles map[string]struct{}, fileCount *int, result *scanResult, includeLocalPathImports bool) error {
 	if !strings.EqualFold(filepath.Ext(path), ".dart") {
 		return nil
 	}
@@ -157,10 +175,14 @@ func scanPackageFileEntry(repoPath string, path string, depLookup map[string]dep
 		result.SkippedFilesByBound = true
 		return fs.SkipAll
 	}
-	return scanDartSourceFile(repoPath, cleanPath, depLookup, result)
+	return scanDartSourceFileWithOptions(repoPath, cleanPath, depLookup, result, includeLocalPathImports)
 }
 
 func scanDartSourceFile(repoPath, path string, depLookup map[string]dependencyInfo, result *scanResult) error {
+	return scanDartSourceFileWithOptions(repoPath, path, depLookup, result, false)
+}
+
+func scanDartSourceFileWithOptions(repoPath, path string, depLookup map[string]dependencyInfo, result *scanResult, includeLocalPathImports bool) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -178,7 +200,7 @@ func scanDartSourceFile(repoPath, path string, depLookup map[string]dependencyIn
 	if relative, relErr := filepath.Rel(repoPath, path); relErr == nil && strings.TrimSpace(relative) != "" {
 		relativePath = relative
 	}
-	imports := parseDartImports(content, relativePath, depLookup, result.UnresolvedImports)
+	imports := parseDartImportsWithOptions(content, relativePath, depLookup, result.UnresolvedImports, includeLocalPathImports)
 	result.Files = append(result.Files, fileScan{
 		Path:    relativePath,
 		Imports: imports,
@@ -188,6 +210,10 @@ func scanDartSourceFile(repoPath, path string, depLookup map[string]dependencyIn
 }
 
 func parseDartImports(content []byte, filePath string, depLookup map[string]dependencyInfo, unresolved map[string]int) []importBinding {
+	return parseDartImportsWithOptions(content, filePath, depLookup, unresolved, false)
+}
+
+func parseDartImportsWithOptions(content []byte, filePath string, depLookup map[string]dependencyInfo, unresolved map[string]int, includeLocalPathImports bool) []importBinding {
 	lines := strings.Split(string(content), "\n")
 	imports := make([]importBinding, 0)
 	for i := 0; i < len(lines); i++ {
@@ -202,7 +228,7 @@ func parseDartImports(content []byte, filePath string, depLookup map[string]depe
 			continue
 		}
 
-		dependency := resolveDependencyFromModule(module, depLookup, unresolved)
+		dependency := resolveDependencyFromModuleWithOptions(module, depLookup, unresolved, includeLocalPathImports)
 		if dependency == "" {
 			continue
 		}
@@ -416,6 +442,10 @@ func parseShowSymbols(clause string) []string {
 }
 
 func resolveDependencyFromModule(module string, depLookup map[string]dependencyInfo, unresolved map[string]int) string {
+	return resolveDependencyFromModuleWithOptions(module, depLookup, unresolved, false)
+}
+
+func resolveDependencyFromModuleWithOptions(module string, depLookup map[string]dependencyInfo, unresolved map[string]int, includeLocalPathImports bool) string {
 	module = strings.TrimSpace(module)
 	if !strings.HasPrefix(module, "package:") {
 		return ""
@@ -433,7 +463,7 @@ func resolveDependencyFromModule(module string, depLookup map[string]dependencyI
 		return ""
 	}
 	if info, ok := depLookup[dependency]; ok {
-		if info.LocalPath {
+		if info.LocalPath && !includeLocalPathImports {
 			return ""
 		}
 		return dependency

--- a/internal/lang/dart/types.go
+++ b/internal/lang/dart/types.go
@@ -96,14 +96,15 @@ type fileScan struct {
 }
 
 type scanResult struct {
-	Files                []fileScan
-	Warnings             []string
-	DeclaredDependencies map[string]dependencyInfo
-	UnresolvedImports    map[string]int
-	HasFlutterProject    bool
-	HasPluginMetadata    bool
-	SkippedLargeFiles    int
-	SkippedFilesByBound  bool
+	Files                   []fileScan
+	Warnings                []string
+	DeclaredDependencies    map[string]dependencyInfo
+	UnresolvedImports       map[string]int
+	includeLocalPathImports bool
+	HasFlutterProject       bool
+	HasPluginMetadata       bool
+	SkippedLargeFiles       int
+	SkippedFilesByBound     bool
 }
 
 var (


### PR DESCRIPTION
## Summary
Fix Dart source attribution so local path dependency imports are preserved when stable defaults enable `dart-source-attribution-preview`.

## Problem
Stable defaults enabled Dart source attribution, but local path imports were still dropped during scan resolution. This caused local path dependencies to appear as if they had no import usage.

## Root Cause
`resolveDependencyFromModule` unconditionally filtered declared local path dependencies, and scanning did not receive the feature state.

## Fix
- Thread feature-aware local-path import behavior into the Dart scan pipeline used by `Analyse`.
- Keep backward-compatible wrapper paths for internal helper calls and legacy default behavior.
- Preserve legacy local-path filtering when the feature is disabled.

## Tests
- `GOTOOLCHAIN=go1.26.2 go test ./internal/lang/dart ./internal/analysis`
- `make feature-flag-check`

Additional verification ran during commit hooks:
- `make ci`

Closes #785
