### PR TITLE
bug: align Go build tag handling with go list

### DIFF
--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -373,6 +373,42 @@ func TestAdapterAnalyseSkipsGeneratedAndBuildTaggedFiles(t *testing.T) {
 	}
 }
 
+func TestAdapterAnalyseSkipsBuildTaggedFileBeyondLegacyHeaderLimit(t *testing.T) {
+	repo := t.TempDir()
+	writeRepoGoModLines(t, repo, moduleDemoLine, "", requirePrefix+"(", "\t"+depUUID+versionV160, "\t"+depLo+" v1.47.0", ")", "")
+	writeRepoMainLines(t, repo, packageMainLine, "", "import \""+depUUID+"\"", "", "func main() { _ = uuid.NewString() }", "")
+
+	taggedLines := make([]string, 0, 80)
+	for i := 0; i < 64; i++ {
+		taggedLines = append(taggedLines, "// filler header comment")
+	}
+	taggedLines = append(taggedLines, "//go:build never")
+	taggedLines = append(taggedLines, packageMainLine)
+	taggedLines = append(taggedLines, "")
+	taggedLines = append(taggedLines, importLoLine)
+	taggedLines = append(taggedLines, "")
+	taggedLines = append(taggedLines, "var _ = lo.Contains([]int{1,2}, 2)")
+	taggedLines = append(taggedLines, "")
+	writeFile(t, filepath.Join(repo, "inactive_long_header.go"), strings.Join(taggedLines, "\n"))
+
+	reportData := analyseReport(t, language.Request{
+		RepoPath: repo,
+		TopN:     5,
+	})
+	names := dependencyNames(reportData.Dependencies)
+	if !slices.Contains(names, depUUID) {
+		t.Fatalf("expected uuid dependency in %#v", names)
+	}
+	if slices.Contains(names, depLo) {
+		t.Fatalf("did not expect lo dependency from long-header build-tagged file in %#v", names)
+	}
+
+	warningsText := strings.ToLower(strings.Join(reportData.Warnings, "\n"))
+	if !strings.Contains(warningsText, "build constraints") {
+		t.Fatalf("expected build-constraint warning, got %#v", reportData.Warnings)
+	}
+}
+
 func TestAdapterAnalyseSkipsNestedModulesFromRootScan(t *testing.T) {
 	repo := t.TempDir()
 	writeRepoGoModLines(t, repo, "module example.com/root", "", requirePrefix+depUUID+versionV160, "")
@@ -766,8 +802,10 @@ func TestTrimModuleVersionSuffix(t *testing.T) {
 
 func TestBuildConstraintHelpers(t *testing.T) {
 	t.Run("matching_and_extraction", testBuildConstraintMatchingAndExtraction)
+	t.Run("scan_beyond_legacy_header_limit", testBuildConstraintScanBeyondLegacyHeaderLimit)
 	t.Run("comment_parsing_and_scan_stop", testBuildConstraintCommentAndScanStop)
 	t.Run("tag_helpers", testBuildConstraintTagHelpers)
+	t.Run("unix_os_set", testBuildConstraintUnixOSSet)
 }
 
 func testBuildConstraintMatchingAndExtraction(t *testing.T) {
@@ -812,6 +850,26 @@ func testBuildConstraintCommentAndScanStop(t *testing.T) {
 	}
 }
 
+func testBuildConstraintScanBeyondLegacyHeaderLimit(t *testing.T) {
+	lines := make([]string, 0, 70)
+	for i := 0; i < 64; i++ {
+		lines = append(lines, "// filler header comment")
+	}
+	lines = append(lines, "//go:build never", packageMainLine, "")
+	content := []byte(strings.Join(lines, "\n"))
+
+	goBuildExpr, plusBuildExprs := extractBuildConstraintExpressions(content)
+	if goBuildExpr == nil {
+		t.Fatalf("expected go:build expression beyond line 64 to be parsed")
+	}
+	if len(plusBuildExprs) != 0 {
+		t.Fatalf("expected no +build expressions, got %#v", plusBuildExprs)
+	}
+	if matchesActiveBuild(content) {
+		t.Fatalf("expected //go:build never beyond line 64 to be inactive")
+	}
+}
+
 func testBuildConstraintTagHelpers(t *testing.T) {
 	if isActiveBuildTag("definitely-not-a-real-tag") {
 		t.Fatalf("expected unknown tag to be inactive")
@@ -840,6 +898,23 @@ func testBuildConstraintTagHelpers(t *testing.T) {
 	}
 	if !isActiveBuildTag("go1.1") {
 		t.Fatalf("expected go1.1 tag active")
+	}
+}
+
+func testBuildConstraintUnixOSSet(t *testing.T) {
+	t.Helper()
+	unixGoos := []string{"aix", "android", "darwin", "dragonfly", "freebsd", "hurd", "illumos", "ios", "linux", "netbsd", "openbsd", "solaris"}
+	nonUnixGoos := []string{"js", "plan9", "wasip1", "windows", "zos"}
+
+	for _, goos := range unixGoos {
+		if !isUnixGOOS(goos) {
+			t.Fatalf("expected %q to match unix build tag", goos)
+		}
+	}
+	for _, goos := range nonUnixGoos {
+		if isUnixGOOS(goos) {
+			t.Fatalf("expected %q not to match unix build tag", goos)
+		}
 	}
 }
 

--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -373,42 +373,6 @@ func TestAdapterAnalyseSkipsGeneratedAndBuildTaggedFiles(t *testing.T) {
 	}
 }
 
-func TestAdapterAnalyseSkipsBuildTaggedFileBeyondLegacyHeaderLimit(t *testing.T) {
-	repo := t.TempDir()
-	writeRepoGoModLines(t, repo, moduleDemoLine, "", requirePrefix+"(", "\t"+depUUID+versionV160, "\t"+depLo+" v1.47.0", ")", "")
-	writeRepoMainLines(t, repo, packageMainLine, "", "import \""+depUUID+"\"", "", "func main() { _ = uuid.NewString() }", "")
-
-	taggedLines := make([]string, 0, 80)
-	for i := 0; i < 64; i++ {
-		taggedLines = append(taggedLines, "// filler header comment")
-	}
-	taggedLines = append(taggedLines, "//go:build never")
-	taggedLines = append(taggedLines, packageMainLine)
-	taggedLines = append(taggedLines, "")
-	taggedLines = append(taggedLines, importLoLine)
-	taggedLines = append(taggedLines, "")
-	taggedLines = append(taggedLines, "var _ = lo.Contains([]int{1,2}, 2)")
-	taggedLines = append(taggedLines, "")
-	writeFile(t, filepath.Join(repo, "inactive_long_header.go"), strings.Join(taggedLines, "\n"))
-
-	reportData := analyseReport(t, language.Request{
-		RepoPath: repo,
-		TopN:     5,
-	})
-	names := dependencyNames(reportData.Dependencies)
-	if !slices.Contains(names, depUUID) {
-		t.Fatalf("expected uuid dependency in %#v", names)
-	}
-	if slices.Contains(names, depLo) {
-		t.Fatalf("did not expect lo dependency from long-header build-tagged file in %#v", names)
-	}
-
-	warningsText := strings.ToLower(strings.Join(reportData.Warnings, "\n"))
-	if !strings.Contains(warningsText, "build constraints") {
-		t.Fatalf("expected build-constraint warning, got %#v", reportData.Warnings)
-	}
-}
-
 func TestAdapterAnalyseSkipsNestedModulesFromRootScan(t *testing.T) {
 	repo := t.TempDir()
 	writeRepoGoModLines(t, repo, "module example.com/root", "", requirePrefix+depUUID+versionV160, "")

--- a/internal/lang/golang/build_tags.go
+++ b/internal/lang/golang/build_tags.go
@@ -38,11 +38,10 @@ func matchesActiveBuild(content []byte) bool {
 
 func extractBuildConstraintExpressions(content []byte) (constraint.Expr, []constraint.Expr) {
 	lines := strings.Split(string(content), "\n")
-	maxLines := minInt(len(lines), maxGoBuildHeaderLine)
 	plusBuildExprs := make([]constraint.Expr, 0)
 	var goBuildExpr constraint.Expr
 
-	for i := 0; i < maxLines; i++ {
+	for i := 0; i < len(lines); i++ {
 		line := strings.TrimSpace(lines[i])
 		if line == "" {
 			continue
@@ -100,10 +99,7 @@ func isActiveBuildTag(tag string) bool {
 		return true
 	}
 	if tag == "unix" {
-		switch runtime.GOOS {
-		case "android", "darwin", "dragonfly", "freebsd", "illumos", "ios", "linux", "netbsd", "openbsd", "solaris":
-			return true
-		}
+		return isUnixGOOS(runtime.GOOS)
 	}
 	if tag == "cgo" {
 		return strings.EqualFold(os.Getenv("CGO_ENABLED"), "1")
@@ -113,6 +109,15 @@ func isActiveBuildTag(tag string) bool {
 	}
 	// Unknown tags are treated as disabled unless set explicitly.
 	return false
+}
+
+func isUnixGOOS(goos string) bool {
+	switch strings.TrimSpace(strings.ToLower(goos)) {
+	case "aix", "android", "darwin", "dragonfly", "freebsd", "hurd", "illumos", "ios", "linux", "netbsd", "openbsd", "solaris":
+		return true
+	default:
+		return false
+	}
 }
 
 func isSupportedGoReleaseTag(tag string) bool {

--- a/internal/lang/golang/constants.go
+++ b/internal/lang/golang/constants.go
@@ -6,7 +6,6 @@ const (
 	goVendoredProvenancePreviewFeature = "go-vendored-provenance-preview"
 	vendorModulesTxtName               = "vendor/modules.txt"
 	maxScannableGoFile                 = 2 * 1024 * 1024
-	maxGoBuildHeaderLine               = 64
 )
 
 var goSkippedDirs = map[string]bool{


### PR DESCRIPTION
## Summary
Align Go build-tag handling with `go list` by fixing two gaps:
- `unix` tag evaluation now covers the complete active Unix GOOS set used by Go (`aix` and `hurd` were missing).
- `//go:build` and `// +build` scanning no longer stops at an artificial 64-line header limit.

Closes #689
Closes #787

## Issue
Go files that should be excluded by build constraints could be treated as active, and on certain Unix targets (`aix`, `hurd`) files gated by `//go:build unix` could be incorrectly excluded.

## Cause And User Impact
- Build constraint extraction only scanned the first 64 header lines, so valid constraints after line 64 were ignored.
- Unix tag matching used a hardcoded GOOS set missing valid Unix entries.

This could surface false dependency usage from files Go would ignore, or miss dependencies from files Go would include.

## Root Cause
- `extractBuildConstraintExpressions` used `maxGoBuildHeaderLine = 64`.
- `isActiveBuildTag("unix")` had an incomplete switch list.

## Fix
- Removed the 64-line header cap; scanning now continues through the header until the package clause or first non-comment line.
- Added `isUnixGOOS` and routed unix tag evaluation through it, with the Go-aligned Unix GOOS set.
- Added focused regressions:
  - Parser-level regression for a valid `//go:build never` after 64 header comment lines.
  - Unix GOOS table regression for accepted and rejected values.

## Tests Run
- `GOTOOLCHAIN=go1.26.2 go test ./internal/lang/golang ./internal/analysis`
- `make feature-flag-check`
- Repository pre-commit CI suite (triggered by commit hook): fmt, lint, security, vuln, unit, goleak, race, memory benchmark delta, build, coverage gates.
