### PR TITLE
bug: fix Swift parser comment and Carthage edge cases

### DIFF
--- a/internal/lang/swift/carthage.go
+++ b/internal/lang/swift/carthage.go
@@ -137,33 +137,39 @@ func parseCarthageLine(line string, requireReference bool) (carthageDependency, 
 }
 
 func stripHashCommentOutsideQuotes(line string) string {
-	inString := false
-	escaped := false
+	state := carthageCommentScanState{}
 	for i := 0; i < len(line); i++ {
-		ch := line[i]
-		if inString {
-			if escaped {
-				escaped = false
-				continue
-			}
-			if ch == '\\' {
-				escaped = true
-				continue
-			}
-			if ch == '"' {
-				inString = false
-			}
-			continue
-		}
-		if ch == '"' {
-			inString = true
-			continue
-		}
-		if ch == '#' {
+		if endsCarthageLineAtHash(line[i], &state) {
 			return line[:i]
 		}
 	}
 	return line
+}
+
+type carthageCommentScanState struct {
+	inString bool
+	escaped  bool
+}
+
+func endsCarthageLineAtHash(ch byte, state *carthageCommentScanState) bool {
+	if state.inString {
+		if state.escaped {
+			state.escaped = false
+			return false
+		}
+		switch ch {
+		case '\\':
+			state.escaped = true
+		case '"':
+			state.inString = false
+		}
+		return false
+	}
+	if ch == '"' {
+		state.inString = true
+		return false
+	}
+	return ch == '#'
 }
 
 func splitCarthageLinePrefix(line string) (string, string, bool) {

--- a/internal/lang/swift/carthage.go
+++ b/internal/lang/swift/carthage.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
@@ -105,7 +104,7 @@ func parseCarthageDependencies(content []byte, requireReference bool) []carthage
 }
 
 func parseCarthageLine(line string, requireReference bool) (carthageDependency, bool) {
-	line = strings.TrimSpace(shared.StripLineComment(line, "#"))
+	line = strings.TrimSpace(stripHashCommentOutsideQuotes(line))
 	if line == "" {
 		return carthageDependency{}, false
 	}
@@ -135,6 +134,36 @@ func parseCarthageLine(line string, requireReference bool) (carthageDependency, 
 		Reference:  strings.TrimSpace(reference),
 		Dependency: depID,
 	}, true
+}
+
+func stripHashCommentOutsideQuotes(line string) string {
+	inString := false
+	escaped := false
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+		if ch == '"' {
+			inString = true
+			continue
+		}
+		if ch == '#' {
+			return line[:i]
+		}
+	}
+	return line
 }
 
 func splitCarthageLinePrefix(line string) (string, string, bool) {

--- a/internal/lang/swift/catalog.go
+++ b/internal/lang/swift/catalog.go
@@ -340,24 +340,25 @@ func parseStringFields(expression string) map[string]string {
 }
 
 func extractDotCallArguments(content, callName string, maxItems int) []string {
+	contentNoComments := blankSwiftCommentsPreservingStrings(content)
 	token := "." + callName
 	items := make([]string, 0)
 	searchFrom := 0
-	for searchFrom < len(content) {
-		idx := strings.Index(content[searchFrom:], token)
+	for searchFrom < len(contentNoComments) {
+		idx := strings.Index(contentNoComments[searchFrom:], token)
 		if idx < 0 {
 			break
 		}
 		callStart := searchFrom + idx
 		cursor := callStart + len(token)
-		for cursor < len(content) && unicode.IsSpace(rune(content[cursor])) {
+		for cursor < len(contentNoComments) && unicode.IsSpace(rune(contentNoComments[cursor])) {
 			cursor++
 		}
-		if cursor >= len(content) || content[cursor] != '(' {
+		if cursor >= len(contentNoComments) || contentNoComments[cursor] != '(' {
 			searchFrom = callStart + len(token)
 			continue
 		}
-		arguments, nextPos, ok := captureParenthesized(content, cursor)
+		arguments, nextPos, ok := captureParenthesized(contentNoComments, cursor)
 		if !ok {
 			break
 		}
@@ -396,7 +397,7 @@ func captureParenthesized(content string, openParenIndex int) (string, int, bool
 
 func consumeQuotedByte(ch byte, inString *byte, escaped *bool) bool {
 	if *inString == 0 {
-		if ch == '\'' || ch == '"' {
+		if ch == '"' {
 			*inString = ch
 			return true
 		}

--- a/internal/lang/swift/imports.go
+++ b/internal/lang/swift/imports.go
@@ -7,8 +7,8 @@ import (
 )
 
 func parseSwiftImports(content []byte, filePath string) []importBinding {
-	return shared.ParseImportLines(content, filePath, func(line string, index int) []shared.ImportRecord {
-		line = shared.StripLineComment(line, "//")
+	sanitized := blankSwiftStringsAndComments(content)
+	return shared.ParseImportLines([]byte(sanitized), filePath, func(line string, index int) []shared.ImportRecord {
 		matches := swiftImportPattern.FindStringSubmatch(line)
 		if len(matches) != 2 {
 			return nil

--- a/internal/lang/swift/parser_regression_test.go
+++ b/internal/lang/swift/parser_regression_test.go
@@ -1,0 +1,120 @@
+package swift
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestSwiftManifestParserIgnoresCommentedPackagesAndInlineApostrophes(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, packageManifestName), `import PackageDescription
+let package = Package(
+  name: "Demo",
+  dependencies: [
+    // .package(url: "https://github.com/commented/inline.git", from: "9.9.9"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"), // don't break on apostrophes
+    /*
+     .package(url: "https://github.com/commented/block.git", from: "9.9.9")
+    */
+  ],
+  targets: [
+    .target(name: "Demo")
+  ]
+)`)
+
+	catalog := newTestSwiftCatalog()
+	found, warnings, err := loadManifestData(repo, &catalog)
+	if err != nil || !found {
+		t.Fatalf("expected manifest loader success, found=%v err=%v", found, err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for manifest with active package declarations, got %#v", warnings)
+	}
+	if len(catalog.Dependencies) != 1 {
+		t.Fatalf("expected only active dependency to be discovered, got %#v", catalog.Dependencies)
+	}
+	if _, ok := catalog.Dependencies["swift-nio"]; !ok {
+		t.Fatalf("expected swift-nio to be discovered, got %#v", catalog.Dependencies)
+	}
+	for _, depID := range []string{"inline", "block"} {
+		if _, ok := catalog.Dependencies[depID]; ok {
+			t.Fatalf("expected commented dependency %q to be ignored, got %#v", depID, catalog.Dependencies)
+		}
+	}
+}
+
+func TestSwiftCarthageParserPreservesHashFragmentsInQuotedSource(t *testing.T) {
+	entry, ok := parseCarthageLine(`binary "https://example.com/FancyKit.json#sha256=abc123" "1.2.3" # trailing comment`, true)
+	if !ok {
+		t.Fatalf("expected Carthage line with quoted hash fragment to parse")
+	}
+	if entry.Source != "https://example.com/FancyKit.json#sha256=abc123" {
+		t.Fatalf("expected hash fragment in source to be preserved, got %#v", entry)
+	}
+	if entry.Dependency != "fancykit" {
+		t.Fatalf("expected dependency to derive from binary source path, got %#v", entry)
+	}
+}
+
+func TestSwiftParseImportsIgnoresBlockCommentedImports(t *testing.T) {
+	content := []byte(`/* import HiddenKit */
+/*
+import NestedHidden
+/* import AlsoHidden */
+*/
+import Alamofire
+`)
+	imports := parseSwiftImports(content, swiftMainFileName)
+	modules := make([]string, 0, len(imports))
+	for _, imported := range imports {
+		modules = append(modules, imported.Module)
+	}
+	if !slices.Equal(modules, []string{"Alamofire"}) {
+		t.Fatalf("expected only active imports outside block comments, got %#v", modules)
+	}
+}
+
+func TestStripHashCommentOutsideQuotes(t *testing.T) {
+	cases := []struct {
+		line string
+		want string
+	}{
+		{line: `github "owner/repo" "1.0.0" # trailing`, want: `github "owner/repo" "1.0.0" `},
+		{line: `binary "https://example.com/FancyKit.json#sha=abc" "1.2.3"`, want: `binary "https://example.com/FancyKit.json#sha=abc" "1.2.3"`},
+		{line: `binary "https://example.com/FancyKit.json#sha=abc\"def" "1.2.3" # trailing`, want: `binary "https://example.com/FancyKit.json#sha=abc\"def" "1.2.3" `},
+		{line: `git "https://example.com/kit.git" "main"`, want: `git "https://example.com/kit.git" "main"`},
+	}
+
+	for _, tc := range cases {
+		if got := stripHashCommentOutsideQuotes(tc.line); got != tc.want {
+			t.Fatalf("unexpected hash comment stripping for %q: got %q want %q", tc.line, got, tc.want)
+		}
+	}
+}
+
+func TestSwiftCommentMaskPreservesStringContent(t *testing.T) {
+	masked := blankSwiftCommentsPreservingStrings(`let escaped = "value \"quoted\" # keep"
+let multiline = """
+keep this line
+"""
+// strip this comment
+/* strip this block */
+let done = true
+`)
+	if !strings.Contains(masked, `"value \"quoted\" # keep"`) {
+		t.Fatalf("expected escaped quoted string to be preserved, got %q", masked)
+	}
+	if !strings.Contains(masked, "keep this line") {
+		t.Fatalf("expected multiline string body to be preserved, got %q", masked)
+	}
+	if strings.Contains(masked, "strip this comment") || strings.Contains(masked, "strip this block") {
+		t.Fatalf("expected comments to be stripped while preserving strings, got %q", masked)
+	}
+	if !strings.Contains(masked, "let done = true") {
+		t.Fatalf("expected non-comment code to remain visible, got %q", masked)
+	}
+}

--- a/internal/lang/swift/source_sanitizer.go
+++ b/internal/lang/swift/source_sanitizer.go
@@ -16,7 +16,53 @@ func blankSwiftStringsAndComments(content []byte) string {
 			index = consumeSwiftStringContent(content, index, &builder, &state)
 			continue
 		}
+		if state.blockDepth > 0 {
+			index = consumeSwiftBlockCommentContent(content, index, &builder, &state)
+			continue
+		}
 		index = consumeSwiftCodeContent(content, index, &builder, &state)
+	}
+	return builder.String()
+}
+
+func blankSwiftCommentsPreservingStrings(content string) string {
+	builder := strings.Builder{}
+	builder.Grow(len(content))
+
+	bytes := []byte(content)
+	state := swiftStringScanState{}
+	for index := 0; index < len(bytes); {
+		if state.inString {
+			index = consumeSwiftStringContentPreservingContent(bytes, index, &builder, &state)
+			continue
+		}
+		if state.blockDepth > 0 {
+			index = consumeSwiftBlockCommentContent(bytes, index, &builder, &state)
+			continue
+		}
+		if startsSwiftLineComment(bytes, index) {
+			index = blankSwiftLineComment(bytes, index, &builder)
+			continue
+		}
+		if startsSwiftBlockComment(bytes, index) {
+			state.blockDepth = 1
+			builder.WriteString("  ")
+			index += 2
+			continue
+		}
+		hashCount, nextIndex, isMultiline, ok := detectSwiftStringStart(bytes, index)
+		if ok {
+			builder.WriteString(content[index:nextIndex])
+			state.inString = true
+			state.multiline = isMultiline
+			state.rawHashCount = hashCount
+			state.escaped = false
+			index = nextIndex
+			continue
+		}
+
+		builder.WriteByte(bytes[index])
+		index++
 	}
 	return builder.String()
 }
@@ -50,6 +96,11 @@ func consumeSwiftCodeContent(content []byte, index int, builder *strings.Builder
 	if startsSwiftLineComment(content, index) {
 		return blankSwiftLineComment(content, index, builder)
 	}
+	if startsSwiftBlockComment(content, index) {
+		state.blockDepth = 1
+		builder.WriteString("  ")
+		return index + 2
+	}
 
 	hashCount, nextIndex, isMultiline, ok := detectSwiftStringStart(content, index)
 	if ok {
@@ -70,6 +121,48 @@ func resetSwiftStringScanState(state *swiftStringScanState) {
 	state.multiline = false
 	state.rawHashCount = 0
 	state.escaped = false
+}
+
+func consumeSwiftBlockCommentContent(content []byte, index int, builder *strings.Builder, state *swiftStringScanState) int {
+	if startsSwiftBlockComment(content, index) {
+		state.blockDepth++
+		builder.WriteString("  ")
+		return index + 2
+	}
+	if endsSwiftBlockComment(content, index) {
+		state.blockDepth--
+		builder.WriteString("  ")
+		return index + 2
+	}
+	if content[index] == '\n' {
+		builder.WriteByte('\n')
+		return index + 1
+	}
+	builder.WriteByte(' ')
+	return index + 1
+}
+
+func consumeSwiftStringContentPreservingContent(content []byte, index int, builder *strings.Builder, state *swiftStringScanState) int {
+	if matchesSwiftStringDelimiter(content, index, state.rawHashCount, state.multiline) {
+		delimiterLen := swiftStringDelimiterLength(state.rawHashCount, state.multiline)
+		builder.Write(content[index : index+delimiterLen])
+		resetSwiftStringScanState(state)
+		return index + delimiterLen
+	}
+
+	ch := content[index]
+	builder.WriteByte(ch)
+	if ch == '\n' {
+		state.escaped = false
+		return index + 1
+	}
+	if ch == '\\' && !state.multiline && state.rawHashCount == 0 && !state.escaped {
+		state.escaped = true
+		return index + 1
+	}
+
+	state.escaped = false
+	return index + 1
 }
 
 func detectSwiftStringStart(content []byte, index int) (int, int, bool, bool) {
@@ -119,6 +212,14 @@ func swiftStringDelimiterLength(rawHashCount int, multiline bool) int {
 
 func startsSwiftLineComment(content []byte, index int) bool {
 	return index+1 < len(content) && content[index] == '/' && content[index+1] == '/'
+}
+
+func startsSwiftBlockComment(content []byte, index int) bool {
+	return index+1 < len(content) && content[index] == '/' && content[index+1] == '*'
+}
+
+func endsSwiftBlockComment(content []byte, index int) bool {
+	return index+1 < len(content) && content[index] == '*' && content[index+1] == '/'
 }
 
 func blankSwiftLineComment(content []byte, index int, builder *strings.Builder) int {

--- a/internal/lang/swift/types.go
+++ b/internal/lang/swift/types.go
@@ -78,6 +78,7 @@ type swiftStringScanState struct {
 	multiline    bool
 	rawHashCount int
 	escaped      bool
+	blockDepth   int
 }
 
 type resolvedPin struct {


### PR DESCRIPTION
## Summary
Fixes Swift parser/scanner edge cases across manifest parsing, Carthage parsing, and import scanning in shared Swift parser files.

### What was broken
- `Package.swift` parsing could break when inline comments contained apostrophes.
- Commented-out `.package(...)` declarations were still treated as active.
- Carthage quoted URLs with `#` fragments could be truncated by comment stripping.
- Imports inside Swift block comments could be counted as real imports.

### Root cause
- Dot-call extraction did not strip Swift comments before token/parenthesis scanning.
- Parenthesis scanning treated `'` as a quote delimiter in Swift source contexts.
- Carthage line comment stripping treated every `#` as comment start, including quoted URLs.
- Swift import parsing only stripped `//` comments, not `/* ... */` blocks.

### Fix
- Added comment-aware Swift manifest preprocessing (`//` and nested `/* ... */`) that preserves string content before extracting `.package(...)` and related dot-calls.
- Updated parenthesis quote handling to treat only `"` as string delimiter for Swift call parsing.
- Added quote-aware `#` stripping for Carthage lines so hash fragments in quoted sources are preserved.
- Updated Swift import parsing to run against sanitized content that blanks strings and both line/block comments.
- Added focused regression tests in `internal/lang/swift/parser_regression_test.go` covering all four issue cases and added helper coverage for new parsing branches.

## Issues
Closes #690
Closes #783
Closes #784
Closes #788

## Tests run
- `GOTOOLCHAIN=go1.26.2 go test ./internal/lang/swift`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/lang/swift ./internal/analysis`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/lang/...`
- `make feature-flag-check`
- Pre-commit pipeline (`make fmt` + `make ci`) including lint/security/vuln/test/goleak/race/memory delta/build/coverage gates
