### PR TITLE
bug: avoid .NET central package lockfile false positives

### DIFF
--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -22,8 +22,8 @@ const (
 	lockfileDriftWarningPrefix                     = "lockfile drift detected: "
 	pyprojectManifestName                          = "pyproject.toml"
 	lockfileDriftEcosystemExpansionPreviewFlagName = "lockfile-drift-ecosystem-expansion-preview"
-	dotnetCSharpProjectManifestExt                = ".csproj"
-	dotnetFSharpProjectManifestExt                = ".fsproj"
+	dotnetCSharpProjectManifestExt                 = ".csproj"
+	dotnetFSharpProjectManifestExt                 = ".fsproj"
 )
 
 var resolveGitBinaryPathFn = gitexec.ResolveBinaryPath

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -25,6 +25,8 @@ const (
 )
 
 var resolveGitBinaryPathFn = gitexec.ResolveBinaryPath
+var normalizeRepoPathFn = workspace.NormalizeRepoPath
+var collectLockfileGitContextFn = collectLockfileGitContext
 var execGitCommandContextFn = gitexec.CommandContext
 
 type lockfileRule struct {
@@ -134,11 +136,11 @@ func detectLockfileDrift(ctx context.Context, repoPath string, stopOnFirst bool)
 }
 
 func detectLockfileDriftWithFeatures(ctx context.Context, repoPath string, stopOnFirst bool, features featureflags.Set) ([]string, error) {
-	normalizedPath, err := workspace.NormalizeRepoPath(repoPath)
+	normalizedPath, err := normalizeRepoPathFn(repoPath)
 	if err != nil {
 		return nil, err
 	}
-	gitContext, err := collectLockfileGitContext(ctx, normalizedPath)
+	gitContext, err := collectLockfileGitContextFn(ctx, normalizedPath)
 	if err != nil {
 		return nil, err
 	}
@@ -334,6 +336,10 @@ func evaluateLockfileRule(snapshot lockfileDirSnapshot, rule lockfileRule, gitCo
 		manifestName = manifests[0]
 	}
 	lockfiles := findRuleLockfiles(snapshot.files, rule.lockfiles)
+	lockfiles, err := findDistributedRuleLockfiles(snapshot, rule, manifests, lockfiles)
+	if err != nil {
+		return lockfileDriftFinding{}, false, err
+	}
 
 	finding, handled, err := evaluateMissingOrStaleLockfileWithManifest(snapshot, rule, hasManifest, manifestName, lockfiles)
 	if handled || err != nil {
@@ -432,6 +438,93 @@ func evaluateManifestChangeFinding(snapshot lockfileDirSnapshot, rule lockfileRu
 		manifest: changedManifest,
 		relDir:   snapshot.relDir,
 	}, true, nil
+}
+
+func findDistributedRuleLockfiles(snapshot lockfileDirSnapshot, rule lockfileRule, manifests []string, lockfiles []presentLockfile) ([]presentLockfile, error) {
+	if len(lockfiles) > 0 || !isDotnetCentralOnlyRuleManifest(rule, manifests) {
+		return lockfiles, nil
+	}
+	projectLockfiles, err := findDotnetProjectLockfiles(snapshot.path)
+	if err != nil {
+		return nil, err
+	}
+	if len(projectLockfiles) == 0 {
+		return lockfiles, nil
+	}
+	return projectLockfiles, nil
+}
+
+func isDotnetCentralOnlyRuleManifest(rule lockfileRule, manifests []string) bool {
+	if rule.manager != ".NET" {
+		return false
+	}
+	hasCentralManifest := false
+	for _, manifest := range manifests {
+		lowerName := strings.ToLower(strings.TrimSpace(manifest))
+		switch {
+		case strings.EqualFold(lowerName, rule.manifest):
+			hasCentralManifest = true
+		case strings.HasSuffix(lowerName, ".csproj"), strings.HasSuffix(lowerName, ".fsproj"):
+			return false
+		}
+	}
+	return hasCentralManifest
+}
+
+func findDotnetProjectLockfiles(rootDir string) ([]presentLockfile, error) {
+	rootDir = filepath.Clean(rootDir)
+	lockfiles := make([]presentLockfile, 0)
+	err := filepath.WalkDir(rootDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if path != rootDir && shouldSkipLockfileDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Name() != "packages.lock.json" {
+			return nil
+		}
+
+		lockDir := filepath.Dir(path)
+		hasProjectManifest, err := dirContainsDotnetProjectManifest(lockDir)
+		if err != nil {
+			return err
+		}
+		if !hasProjectManifest {
+			return nil
+		}
+
+		relPath := filepath.ToSlash(strings.TrimPrefix(path, rootDir+string(filepath.Separator)))
+		lockfiles = append(lockfiles, presentLockfile{name: relPath})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(lockfiles, func(i, j int) bool {
+		return lockfiles[i].name < lockfiles[j].name
+	})
+	return lockfiles, nil
+}
+
+func dirContainsDotnetProjectManifest(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		lowerName := strings.ToLower(entry.Name())
+		if strings.HasSuffix(lowerName, ".csproj") || strings.HasSuffix(lowerName, ".fsproj") {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func buildLockfileDriftWarnings(findings []lockfileDriftFinding) []string {

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -22,6 +22,8 @@ const (
 	lockfileDriftWarningPrefix                     = "lockfile drift detected: "
 	pyprojectManifestName                          = "pyproject.toml"
 	lockfileDriftEcosystemExpansionPreviewFlagName = "lockfile-drift-ecosystem-expansion-preview"
+	dotnetCSharpProjectManifestExt                = ".csproj"
+	dotnetFSharpProjectManifestExt                = ".fsproj"
 )
 
 var resolveGitBinaryPathFn = gitexec.ResolveBinaryPath
@@ -81,7 +83,7 @@ var lockfileRules = []lockfileRule{
 	{
 		manager:            ".NET",
 		manifest:           "Directory.Packages.props",
-		manifestExts:       []string{".csproj", ".fsproj"},
+		manifestExts:       []string{dotnetCSharpProjectManifestExt, dotnetFSharpProjectManifestExt},
 		manifestLabel:      ".NET project manifest (*.csproj, *.fsproj) or Directory.Packages.props",
 		lockfiles:          []string{"packages.lock.json"},
 		remedy:             "run dotnet restore --use-lock-file (or dotnet restore for existing lock mode) and commit the updated files",
@@ -464,7 +466,7 @@ func isDotnetCentralOnlyRuleManifest(rule lockfileRule, manifests []string) bool
 		switch {
 		case strings.EqualFold(lowerName, rule.manifest):
 			hasCentralManifest = true
-		case strings.HasSuffix(lowerName, ".csproj"), strings.HasSuffix(lowerName, ".fsproj"):
+		case strings.HasSuffix(lowerName, dotnetCSharpProjectManifestExt), strings.HasSuffix(lowerName, dotnetFSharpProjectManifestExt):
 			return false
 		}
 	}
@@ -520,7 +522,7 @@ func dirContainsDotnetProjectManifest(dir string) (bool, error) {
 			continue
 		}
 		lowerName := strings.ToLower(entry.Name())
-		if strings.HasSuffix(lowerName, ".csproj") || strings.HasSuffix(lowerName, ".fsproj") {
+		if strings.HasSuffix(lowerName, dotnetCSharpProjectManifestExt) || strings.HasSuffix(lowerName, dotnetFSharpProjectManifestExt) {
 			return true, nil
 		}
 	}

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -904,16 +904,38 @@ func TestFindDistributedRuleLockfiles(t *testing.T) {
 		}
 	})
 
-	t.Run("ignores non-dotnet central rules", func(t *testing.T) {
-		repo := t.TempDir()
-		snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
-
-		lockfiles, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: "npm", manifest: manifestFileName}, []string{manifestFileName}, nil)
-		if err != nil {
-			t.Fatalf("findDistributedRuleLockfiles: %v", err)
+	t.Run("returns no lockfiles for non-distributed scenarios", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			rule      lockfileRule
+			manifests []string
+		}{
+			{
+				name:      "non-dotnet rule",
+				rule:      lockfileRule{manager: "npm", manifest: manifestFileName},
+				manifests: []string{manifestFileName},
+			},
+			{
+				name:      "dotnet central without project lockfiles",
+				rule:      lockfileRule{manager: ".NET", manifest: dotnetCentralManifest},
+				manifests: []string{dotnetCentralManifest},
+			},
 		}
-		if len(lockfiles) != 0 {
-			t.Fatalf("expected no distributed lockfiles for non-dotnet rules, got %#v", lockfiles)
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				repo := t.TempDir()
+				snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
+
+				lockfiles, err := findDistributedRuleLockfiles(snapshot, tc.rule, tc.manifests, nil)
+				if err != nil {
+					t.Fatalf("findDistributedRuleLockfiles: %v", err)
+				}
+				if len(lockfiles) != 0 {
+					t.Fatalf("expected no distributed lockfiles, got %#v", lockfiles)
+				}
+			})
 		}
 	})
 
@@ -930,19 +952,6 @@ func TestFindDistributedRuleLockfiles(t *testing.T) {
 		}
 		if len(lockfiles) != 1 || lockfiles[0].name != "src/App/packages.lock.json" {
 			t.Fatalf("unexpected distributed lockfiles: %#v", lockfiles)
-		}
-	})
-
-	t.Run("returns no lockfiles when no project lockfiles exist", func(t *testing.T) {
-		repo := t.TempDir()
-		snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
-
-		lockfiles, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, nil)
-		if err != nil {
-			t.Fatalf("findDistributedRuleLockfiles: %v", err)
-		}
-		if len(lockfiles) != 0 {
-			t.Fatalf("expected no distributed lockfiles, got %#v", lockfiles)
 		}
 	})
 

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -889,81 +889,67 @@ func TestFindDotnetProjectLockfiles(t *testing.T) {
 	})
 }
 
-func TestFindDistributedRuleLockfiles(t *testing.T) {
-	t.Run("returns existing lockfiles when already present", func(t *testing.T) {
-		repo := t.TempDir()
-		snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
-		existing := []presentLockfile{{name: dotnetLockfileName}}
+func TestFindDistributedRuleLockfilesReturnsExisting(t *testing.T) {
+	repo := t.TempDir()
+	snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
+	existing := []presentLockfile{{name: dotnetLockfileName}}
 
-		lockfiles, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, existing)
-		if err != nil {
-			t.Fatalf("findDistributedRuleLockfiles: %v", err)
-		}
-		if len(lockfiles) != 1 || lockfiles[0].name != dotnetLockfileName {
-			t.Fatalf("expected existing lockfile to be preserved, got %#v", lockfiles)
-		}
-	})
+	lockfiles, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, existing)
+	if err != nil {
+		t.Fatalf("findDistributedRuleLockfiles: %v", err)
+	}
+	if len(lockfiles) != 1 || lockfiles[0].name != dotnetLockfileName {
+		t.Fatalf("expected existing lockfile to be preserved, got %#v", lockfiles)
+	}
+}
 
-	t.Run("returns no lockfiles for non-distributed scenarios", func(t *testing.T) {
-		cases := []struct {
-			name      string
-			rule      lockfileRule
-			manifests []string
-		}{
-			{
-				name:      "non-dotnet rule",
-				rule:      lockfileRule{manager: "npm", manifest: manifestFileName},
-				manifests: []string{manifestFileName},
-			},
-			{
-				name:      "dotnet central without project lockfiles",
-				rule:      lockfileRule{manager: ".NET", manifest: dotnetCentralManifest},
-				manifests: []string{dotnetCentralManifest},
-			},
-		}
+func TestFindDistributedRuleLockfilesIgnoresNonDotnetRule(t *testing.T) {
+	repo := t.TempDir()
+	snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
+	assertNoDistributedLockfiles(t, snapshot, lockfileRule{manager: "npm", manifest: manifestFileName}, []string{manifestFileName})
+}
 
-		for _, tc := range cases {
-			tc := tc
-			t.Run(tc.name, func(t *testing.T) {
-				repo := t.TempDir()
-				snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
+func TestFindDistributedRuleLockfilesReturnsNoLockfilesWithoutProjects(t *testing.T) {
+	repo := t.TempDir()
+	snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
+	assertNoDistributedLockfiles(t, snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest})
+}
 
-				lockfiles, err := findDistributedRuleLockfiles(snapshot, tc.rule, tc.manifests, nil)
-				if err != nil {
-					t.Fatalf("findDistributedRuleLockfiles: %v", err)
-				}
-				if len(lockfiles) != 0 {
-					t.Fatalf("expected no distributed lockfiles, got %#v", lockfiles)
-				}
-			})
-		}
-	})
+func TestFindDistributedRuleLockfilesDiscoversProjectLockfiles(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project></Project>\n")
+	writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project></Project>\n")
+	writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{}\n")
+	snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
 
-	t.Run("discovers project lockfiles for central package manifest", func(t *testing.T) {
-		repo := t.TempDir()
-		writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project></Project>\n")
-		writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project></Project>\n")
-		writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{}\n")
-		snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
+	lockfiles, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, nil)
+	if err != nil {
+		t.Fatalf("findDistributedRuleLockfiles: %v", err)
+	}
+	if len(lockfiles) != 1 || lockfiles[0].name != "src/App/packages.lock.json" {
+		t.Fatalf("unexpected distributed lockfiles: %#v", lockfiles)
+	}
+}
 
-		lockfiles, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, nil)
-		if err != nil {
-			t.Fatalf("findDistributedRuleLockfiles: %v", err)
-		}
-		if len(lockfiles) != 1 || lockfiles[0].name != "src/App/packages.lock.json" {
-			t.Fatalf("unexpected distributed lockfiles: %#v", lockfiles)
-		}
-	})
+func TestFindDistributedRuleLockfilesReturnsErrorWhenSnapshotPathMissing(t *testing.T) {
+	root := t.TempDir()
+	snapshot := lockfileDirSnapshot{repoPath: root, path: filepath.Join(root, "missing")}
 
-	t.Run("returns discovery error when snapshot path is missing", func(t *testing.T) {
-		root := t.TempDir()
-		snapshot := lockfileDirSnapshot{repoPath: root, path: filepath.Join(root, "missing")}
+	_, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, nil)
+	if err == nil {
+		t.Fatalf("expected distributed lockfile discovery error")
+	}
+}
 
-		_, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, nil)
-		if err == nil {
-			t.Fatalf("expected distributed lockfile discovery error")
-		}
-	})
+func assertNoDistributedLockfiles(t *testing.T, snapshot lockfileDirSnapshot, rule lockfileRule, manifests []string) {
+	t.Helper()
+	lockfiles, err := findDistributedRuleLockfiles(snapshot, rule, manifests, nil)
+	if err != nil {
+		t.Fatalf("findDistributedRuleLockfiles: %v", err)
+	}
+	if len(lockfiles) != 0 {
+		t.Fatalf("expected no distributed lockfiles, got %#v", lockfiles)
+	}
 }
 
 func TestGitExecutableAvailable(t *testing.T) {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -214,6 +214,55 @@ func TestDetectLockfileDriftPreviewEcosystemsMissingLockfile(t *testing.T) {
 	}
 }
 
+func TestDetectLockfileDriftDotnetCentralProjectLockfilesAvoidRootMissingWarning(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n")
+	writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>\n")
+	writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{\"version\":1,\"dependencies\":{}}\n")
+
+	warnings, err := detectLockfileDriftWithFeatures(context.Background(), repo, false, lockfileDriftFeatureSet(t, true))
+	if err != nil {
+		t.Fatalf(detectLockfileDriftFmt, err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings when only project-level .NET lockfiles are present, got %#v", warnings)
+	}
+}
+
+func TestDetectLockfileDriftDotnetCentralProjectLockfileManifestChange(t *testing.T) {
+	t.Run("warns when central manifest changes without project lockfile changes", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{\"version\":1,\"dependencies\":{}}\n")
+		initGitRepo(t, repo)
+
+		writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /><PackageVersion Include=\"Serilog\" Version=\"3.1.0\" /></ItemGroup></Project>\n")
+
+		warnings, err := detectLockfileDriftWithFeatures(context.Background(), repo, false, lockfileDriftFeatureSet(t, true))
+		assertSingleLockfileDriftWarning(t, warnings, err, ".NET in .: Directory.Packages.props changed while no matching lockfile changed", "dotnet restore --use-lock-file")
+	})
+
+	t.Run("does not warn when central manifest and project lockfile both change", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{\"version\":1,\"dependencies\":{}}\n")
+		initGitRepo(t, repo)
+
+		writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /><PackageVersion Include=\"Serilog\" Version=\"3.1.0\" /></ItemGroup></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{\"version\":1,\"dependencies\":{\"Serilog\":\"3.1.0\"}}\n")
+
+		warnings, err := detectLockfileDriftWithFeatures(context.Background(), repo, false, lockfileDriftFeatureSet(t, true))
+		if err != nil {
+			t.Fatalf(detectLockfileDriftFmt, err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings when project lockfiles changed with Directory.Packages.props, got %#v", warnings)
+		}
+	})
+}
+
 func TestDetectLockfileDriftEcosystemExpansionPreviewDisabledPreservesCurrentBehavior(t *testing.T) {
 	t.Run("preview ecosystems stay disabled", func(t *testing.T) {
 		repo := t.TempDir()
@@ -371,10 +420,42 @@ func TestDetectLockfileDriftInvalidRepoPath(t *testing.T) {
 	}
 }
 
+func TestDetectLockfileDriftWithFeaturesPropagatesGitContextError(t *testing.T) {
+	repo := t.TempDir()
+	original := collectLockfileGitContextFn
+	collectLockfileGitContextFn = func(context.Context, string) (lockfileGitContext, error) {
+		return lockfileGitContext{}, errors.New("forced git context failure")
+	}
+	defer func() { collectLockfileGitContextFn = original }()
+
+	_, err := detectLockfileDriftWithFeatures(context.Background(), repo, false, featureflags.Set{})
+	if err == nil || !strings.Contains(err.Error(), "forced git context failure") {
+		t.Fatalf("expected git context failure, got %v", err)
+	}
+}
+
+func TestDetectLockfileDriftWithFeaturesNormalizePathError(t *testing.T) {
+	original := normalizeRepoPathFn
+	normalizeRepoPathFn = func(string) (string, error) { return "", errors.New("forced normalize error") }
+	defer func() { normalizeRepoPathFn = original }()
+
+	_, err := detectLockfileDriftWithFeatures(context.Background(), t.TempDir(), false, featureflags.Set{})
+	if err == nil || !strings.Contains(err.Error(), "forced normalize error") {
+		t.Fatalf("expected normalize path error, got %v", err)
+	}
+}
+
 func TestReadDirectoryFilesMissingPath(t *testing.T) {
 	_, err := readDirectoryFiles(filepath.Join(t.TempDir(), "missing"))
 	if err == nil {
 		t.Fatalf("expected readDirectoryFiles to fail for missing path")
+	}
+}
+
+func TestScanLockfileDriftMissingRepoPath(t *testing.T) {
+	_, err := scanLockfileDrift(context.Background(), filepath.Join(t.TempDir(), "missing"), lockfileGitContext{}, false, lockfileRules)
+	if err == nil {
+		t.Fatalf("expected scanLockfileDrift to fail for missing repo path")
 	}
 }
 
@@ -679,6 +760,201 @@ func TestFindRuleLockfiles(t *testing.T) {
 	if len(found) != 1 || found[0].name != lockfileName {
 		t.Fatalf("unexpected lockfiles found: %#v", found)
 	}
+}
+
+func TestIsDotnetCentralOnlyRuleManifest(t *testing.T) {
+	cases := []struct {
+		name      string
+		rule      lockfileRule
+		manifests []string
+		want      bool
+	}{
+		{
+			name:      "central manifest only",
+			rule:      lockfileRule{manager: ".NET", manifest: dotnetCentralManifest},
+			manifests: []string{dotnetCentralManifest},
+			want:      true,
+		},
+		{
+			name:      "central manifest with project manifest",
+			rule:      lockfileRule{manager: ".NET", manifest: dotnetCentralManifest},
+			manifests: []string{dotnetCentralManifest, dotnetProjectManifest},
+			want:      false,
+		},
+		{
+			name:      "project manifest only",
+			rule:      lockfileRule{manager: ".NET", manifest: dotnetCentralManifest},
+			manifests: []string{dotnetProjectManifest},
+			want:      false,
+		},
+		{
+			name:      "different manager",
+			rule:      lockfileRule{manager: "npm", manifest: dotnetCentralManifest},
+			manifests: []string{dotnetCentralManifest},
+			want:      false,
+		},
+		{
+			name:      "case-insensitive central manifest",
+			rule:      lockfileRule{manager: ".NET", manifest: dotnetCentralManifest},
+			manifests: []string{"directory.packages.props"},
+			want:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := isDotnetCentralOnlyRuleManifest(tc.rule, tc.manifests)
+			if got != tc.want {
+				t.Fatalf("isDotnetCentralOnlyRuleManifest() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDirContainsDotnetProjectManifest(t *testing.T) {
+	t.Run("finds project manifest", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, dotnetProjectManifest), "<Project></Project>\n")
+
+		hasManifest, err := dirContainsDotnetProjectManifest(dir)
+		if err != nil {
+			t.Fatalf("dirContainsDotnetProjectManifest: %v", err)
+		}
+		if !hasManifest {
+			t.Fatalf("expected %s to be detected", dotnetProjectManifest)
+		}
+	})
+
+	t.Run("returns false when no project manifest exists", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "packages.lock.json"), "{}\n")
+
+		hasManifest, err := dirContainsDotnetProjectManifest(dir)
+		if err != nil {
+			t.Fatalf("dirContainsDotnetProjectManifest: %v", err)
+		}
+		if hasManifest {
+			t.Fatalf("expected false when no project manifest exists")
+		}
+	})
+
+	t.Run("detects fsharp project manifest", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "App.fsproj"), "<Project></Project>\n")
+
+		hasManifest, err := dirContainsDotnetProjectManifest(dir)
+		if err != nil {
+			t.Fatalf("dirContainsDotnetProjectManifest: %v", err)
+		}
+		if !hasManifest {
+			t.Fatalf("expected App.fsproj to be detected")
+		}
+	})
+
+	t.Run("returns error for missing directory", func(t *testing.T) {
+		_, err := dirContainsDotnetProjectManifest(filepath.Join(t.TempDir(), "missing"))
+		if err == nil {
+			t.Fatalf("expected missing directory error")
+		}
+	})
+}
+
+func TestFindDotnetProjectLockfiles(t *testing.T) {
+	t.Run("finds lockfiles next to project manifests and skips irrelevant directories", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{}\n")
+		writeFile(t, filepath.Join(repo, "src", "NoProject", dotnetLockfileName), "{}\n")
+		writeFile(t, filepath.Join(repo, "node_modules", "Ignored", dotnetProjectManifest), "<Project></Project>\n")
+		writeFile(t, filepath.Join(repo, "node_modules", "Ignored", dotnetLockfileName), "{}\n")
+
+		lockfiles, err := findDotnetProjectLockfiles(repo)
+		if err != nil {
+			t.Fatalf("findDotnetProjectLockfiles: %v", err)
+		}
+		if len(lockfiles) != 1 {
+			t.Fatalf("expected one project lockfile, got %#v", lockfiles)
+		}
+		if lockfiles[0].name != "src/App/packages.lock.json" {
+			t.Fatalf("unexpected lockfile path %q", lockfiles[0].name)
+		}
+	})
+
+	t.Run("returns error for missing root directory", func(t *testing.T) {
+		_, err := findDotnetProjectLockfiles(filepath.Join(t.TempDir(), "missing"))
+		if err == nil {
+			t.Fatalf("expected missing directory error")
+		}
+	})
+}
+
+func TestFindDistributedRuleLockfiles(t *testing.T) {
+	t.Run("returns existing lockfiles when already present", func(t *testing.T) {
+		repo := t.TempDir()
+		snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
+		existing := []presentLockfile{{name: dotnetLockfileName}}
+
+		lockfiles, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, existing)
+		if err != nil {
+			t.Fatalf("findDistributedRuleLockfiles: %v", err)
+		}
+		if len(lockfiles) != 1 || lockfiles[0].name != dotnetLockfileName {
+			t.Fatalf("expected existing lockfile to be preserved, got %#v", lockfiles)
+		}
+	})
+
+	t.Run("ignores non-dotnet central rules", func(t *testing.T) {
+		repo := t.TempDir()
+		snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
+
+		lockfiles, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: "npm", manifest: manifestFileName}, []string{manifestFileName}, nil)
+		if err != nil {
+			t.Fatalf("findDistributedRuleLockfiles: %v", err)
+		}
+		if len(lockfiles) != 0 {
+			t.Fatalf("expected no distributed lockfiles for non-dotnet rules, got %#v", lockfiles)
+		}
+	})
+
+	t.Run("discovers project lockfiles for central package manifest", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{}\n")
+		snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
+
+		lockfiles, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, nil)
+		if err != nil {
+			t.Fatalf("findDistributedRuleLockfiles: %v", err)
+		}
+		if len(lockfiles) != 1 || lockfiles[0].name != "src/App/packages.lock.json" {
+			t.Fatalf("unexpected distributed lockfiles: %#v", lockfiles)
+		}
+	})
+
+	t.Run("returns no lockfiles when no project lockfiles exist", func(t *testing.T) {
+		repo := t.TempDir()
+		snapshot := lockfileDirSnapshot{repoPath: repo, path: repo}
+
+		lockfiles, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, nil)
+		if err != nil {
+			t.Fatalf("findDistributedRuleLockfiles: %v", err)
+		}
+		if len(lockfiles) != 0 {
+			t.Fatalf("expected no distributed lockfiles, got %#v", lockfiles)
+		}
+	})
+
+	t.Run("returns discovery error when snapshot path is missing", func(t *testing.T) {
+		root := t.TempDir()
+		snapshot := lockfileDirSnapshot{repoPath: root, path: filepath.Join(root, "missing")}
+
+		_, err := findDistributedRuleLockfiles(snapshot, lockfileRule{manager: ".NET", manifest: dotnetCentralManifest}, []string{dotnetCentralManifest}, nil)
+		if err == nil {
+			t.Fatalf("expected distributed lockfile discovery error")
+		}
+	})
 }
 
 func TestGitExecutableAvailable(t *testing.T) {


### PR DESCRIPTION
## Summary
- avoid false-positive .NET lockfile drift warnings when `Directory.Packages.props` is present at repo root but lockfiles are generated per project
- treat descendant `packages.lock.json` files next to `*.csproj`/`*.fsproj` as valid lockfiles for central package management checks
- add focused regression coverage for central package manifest + project lockfile behavior and helper paths used by lockfile drift evaluation

Closes #786.

## Tests run
- `GOTOOLCHAIN=go1.26.2 go test ./internal/app`
- `make feature-flag-check`
