### PR TITLE
bug: classify baseline regressions only for changed dependencies

### DIFF
--- a/internal/report/baseline_diff.go
+++ b/internal/report/baseline_diff.go
@@ -120,11 +120,12 @@ func appendDependencyDelta(comparison *BaselineComparison, delta DependencyDelta
 		comparison.Added = append(comparison.Added, delta)
 	case DependencyDeltaRemoved:
 		comparison.Removed = append(comparison.Removed, delta)
-	}
-	if delta.WastePercentDelta > 0 {
-		comparison.Regressions = append(comparison.Regressions, delta)
-	} else if delta.WastePercentDelta < 0 {
-		comparison.Progressions = append(comparison.Progressions, delta)
+	case DependencyDeltaChanged:
+		if delta.WastePercentDelta > 0 {
+			comparison.Regressions = append(comparison.Regressions, delta)
+		} else if delta.WastePercentDelta < 0 {
+			comparison.Progressions = append(comparison.Progressions, delta)
+		}
 	}
 }
 

--- a/internal/report/baseline_diff_test.go
+++ b/internal/report/baseline_diff_test.go
@@ -93,14 +93,12 @@ func TestComputeBaselineComparisonDeterministic(t *testing.T) {
 		Dependencies: []DependencyReport{
 			{Name: "b", Language: "js-ts", UsedExportsCount: 1, TotalExportsCount: 4, UsedPercent: 25, EstimatedUnusedBytes: 100},
 			{Name: "a", Language: "go", UsedExportsCount: 3, TotalExportsCount: 3, UsedPercent: 100, EstimatedUnusedBytes: 0},
-			{Name: "d", Language: "rust", UsedExportsCount: 2, TotalExportsCount: 4, UsedPercent: 50, EstimatedUnusedBytes: 20},
 		},
 	}
 	baseline := Report{
 		Dependencies: []DependencyReport{
 			{Name: "b", Language: "js-ts", UsedExportsCount: 2, TotalExportsCount: 4, UsedPercent: 50, EstimatedUnusedBytes: 50},
 			{Name: "c", Language: "python", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50, EstimatedUnusedBytes: 10},
-			{Name: "d", Language: "rust", UsedExportsCount: 1, TotalExportsCount: 4, UsedPercent: 25, EstimatedUnusedBytes: 30},
 		},
 	}
 
@@ -109,7 +107,7 @@ func TestComputeBaselineComparisonDeterministic(t *testing.T) {
 	for _, dep := range comparison.Dependencies {
 		gotOrder = append(gotOrder, dep.Language+"/"+dep.Name)
 	}
-	wantOrder := []string{"go/a", "js-ts/b", "python/c", "rust/d"}
+	wantOrder := []string{"go/a", "js-ts/b", "python/c"}
 	if !slices.Equal(gotOrder, wantOrder) {
 		t.Fatalf("unexpected deterministic delta ordering: got=%v want=%v", gotOrder, wantOrder)
 	}
@@ -122,38 +120,23 @@ func TestComputeBaselineComparisonDeterministic(t *testing.T) {
 	if len(comparison.Regressions) != 1 || comparison.Regressions[0].Name != "b" {
 		t.Fatalf("expected one regression dependency, got %#v", comparison.Regressions)
 	}
-	if len(comparison.Progressions) != 1 || comparison.Progressions[0].Name != "d" {
-		t.Fatalf("expected one progression dependency, got %#v", comparison.Progressions)
+	if len(comparison.Progressions) != 0 {
+		t.Fatalf("expected no progression dependencies, got %#v", comparison.Progressions)
 	}
 }
 
-func TestComputeBaselineComparisonClassifiesRegressionsOnlyForChangedDependencies(t *testing.T) {
-	current := Report{
-		Dependencies: []DependencyReport{
-			{Name: "added-high", Language: "go", UsedExportsCount: 1, TotalExportsCount: 10, UsedPercent: 10, EstimatedUnusedBytes: 90},
-			{Name: "changed-reg", Language: "js-ts", UsedExportsCount: 1, TotalExportsCount: 10, UsedPercent: 10, EstimatedUnusedBytes: 90},
-			{Name: "changed-prog", Language: "python", UsedExportsCount: 9, TotalExportsCount: 10, UsedPercent: 90, EstimatedUnusedBytes: 10},
-		},
-	}
-	baseline := Report{
-		Dependencies: []DependencyReport{
-			{Name: "removed-high", Language: "ruby", UsedExportsCount: 1, TotalExportsCount: 10, UsedPercent: 10, EstimatedUnusedBytes: 90},
-			{Name: "changed-reg", Language: "js-ts", UsedExportsCount: 9, TotalExportsCount: 10, UsedPercent: 90, EstimatedUnusedBytes: 10},
-			{Name: "changed-prog", Language: "python", UsedExportsCount: 1, TotalExportsCount: 10, UsedPercent: 10, EstimatedUnusedBytes: 90},
-		},
-	}
+func TestAppendDependencyDeltaClassifiesRegressionsOnlyForChangedDependencies(t *testing.T) {
+	comparison := BaselineComparison{}
 
-	comparison := ComputeBaselineComparison(current, baseline)
-	if len(comparison.Added) != 1 || comparison.Added[0].Name != "added-high" {
-		t.Fatalf("expected one added dependency, got %#v", comparison.Added)
-	}
-	if len(comparison.Removed) != 1 || comparison.Removed[0].Name != "removed-high" {
-		t.Fatalf("expected one removed dependency, got %#v", comparison.Removed)
-	}
-	if len(comparison.Regressions) != 1 || comparison.Regressions[0].Name != "changed-reg" || comparison.Regressions[0].Kind != DependencyDeltaChanged {
+	appendDependencyDelta(&comparison, DependencyDelta{Kind: DependencyDeltaAdded, Name: "added", WastePercentDelta: 90})
+	appendDependencyDelta(&comparison, DependencyDelta{Kind: DependencyDeltaRemoved, Name: "removed", WastePercentDelta: -90})
+	appendDependencyDelta(&comparison, DependencyDelta{Kind: DependencyDeltaChanged, Name: "reg", WastePercentDelta: 1})
+	appendDependencyDelta(&comparison, DependencyDelta{Kind: DependencyDeltaChanged, Name: "prog", WastePercentDelta: -1})
+
+	if len(comparison.Regressions) != 1 || comparison.Regressions[0].Name != "reg" {
 		t.Fatalf("expected only changed dependency regressions, got %#v", comparison.Regressions)
 	}
-	if len(comparison.Progressions) != 1 || comparison.Progressions[0].Name != "changed-prog" || comparison.Progressions[0].Kind != DependencyDeltaChanged {
+	if len(comparison.Progressions) != 1 || comparison.Progressions[0].Name != "prog" {
 		t.Fatalf("expected only changed dependency progressions, got %#v", comparison.Progressions)
 	}
 }

--- a/internal/report/baseline_diff_test.go
+++ b/internal/report/baseline_diff_test.go
@@ -93,12 +93,14 @@ func TestComputeBaselineComparisonDeterministic(t *testing.T) {
 		Dependencies: []DependencyReport{
 			{Name: "b", Language: "js-ts", UsedExportsCount: 1, TotalExportsCount: 4, UsedPercent: 25, EstimatedUnusedBytes: 100},
 			{Name: "a", Language: "go", UsedExportsCount: 3, TotalExportsCount: 3, UsedPercent: 100, EstimatedUnusedBytes: 0},
+			{Name: "d", Language: "rust", UsedExportsCount: 2, TotalExportsCount: 4, UsedPercent: 50, EstimatedUnusedBytes: 20},
 		},
 	}
 	baseline := Report{
 		Dependencies: []DependencyReport{
 			{Name: "b", Language: "js-ts", UsedExportsCount: 2, TotalExportsCount: 4, UsedPercent: 50, EstimatedUnusedBytes: 50},
 			{Name: "c", Language: "python", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50, EstimatedUnusedBytes: 10},
+			{Name: "d", Language: "rust", UsedExportsCount: 1, TotalExportsCount: 4, UsedPercent: 25, EstimatedUnusedBytes: 30},
 		},
 	}
 
@@ -107,7 +109,7 @@ func TestComputeBaselineComparisonDeterministic(t *testing.T) {
 	for _, dep := range comparison.Dependencies {
 		gotOrder = append(gotOrder, dep.Language+"/"+dep.Name)
 	}
-	wantOrder := []string{"go/a", "js-ts/b", "python/c"}
+	wantOrder := []string{"go/a", "js-ts/b", "python/c", "rust/d"}
 	if !slices.Equal(gotOrder, wantOrder) {
 		t.Fatalf("unexpected deterministic delta ordering: got=%v want=%v", gotOrder, wantOrder)
 	}
@@ -120,8 +122,39 @@ func TestComputeBaselineComparisonDeterministic(t *testing.T) {
 	if len(comparison.Regressions) != 1 || comparison.Regressions[0].Name != "b" {
 		t.Fatalf("expected one regression dependency, got %#v", comparison.Regressions)
 	}
-	if len(comparison.Progressions) != 1 || comparison.Progressions[0].Name != "c" {
+	if len(comparison.Progressions) != 1 || comparison.Progressions[0].Name != "d" {
 		t.Fatalf("expected one progression dependency, got %#v", comparison.Progressions)
+	}
+}
+
+func TestComputeBaselineComparisonClassifiesRegressionsOnlyForChangedDependencies(t *testing.T) {
+	current := Report{
+		Dependencies: []DependencyReport{
+			{Name: "added-high", Language: "go", UsedExportsCount: 1, TotalExportsCount: 10, UsedPercent: 10, EstimatedUnusedBytes: 90},
+			{Name: "changed-reg", Language: "js-ts", UsedExportsCount: 1, TotalExportsCount: 10, UsedPercent: 10, EstimatedUnusedBytes: 90},
+			{Name: "changed-prog", Language: "python", UsedExportsCount: 9, TotalExportsCount: 10, UsedPercent: 90, EstimatedUnusedBytes: 10},
+		},
+	}
+	baseline := Report{
+		Dependencies: []DependencyReport{
+			{Name: "removed-high", Language: "ruby", UsedExportsCount: 1, TotalExportsCount: 10, UsedPercent: 10, EstimatedUnusedBytes: 90},
+			{Name: "changed-reg", Language: "js-ts", UsedExportsCount: 9, TotalExportsCount: 10, UsedPercent: 90, EstimatedUnusedBytes: 10},
+			{Name: "changed-prog", Language: "python", UsedExportsCount: 1, TotalExportsCount: 10, UsedPercent: 10, EstimatedUnusedBytes: 90},
+		},
+	}
+
+	comparison := ComputeBaselineComparison(current, baseline)
+	if len(comparison.Added) != 1 || comparison.Added[0].Name != "added-high" {
+		t.Fatalf("expected one added dependency, got %#v", comparison.Added)
+	}
+	if len(comparison.Removed) != 1 || comparison.Removed[0].Name != "removed-high" {
+		t.Fatalf("expected one removed dependency, got %#v", comparison.Removed)
+	}
+	if len(comparison.Regressions) != 1 || comparison.Regressions[0].Name != "changed-reg" || comparison.Regressions[0].Kind != DependencyDeltaChanged {
+		t.Fatalf("expected only changed dependency regressions, got %#v", comparison.Regressions)
+	}
+	if len(comparison.Progressions) != 1 || comparison.Progressions[0].Name != "changed-prog" || comparison.Progressions[0].Kind != DependencyDeltaChanged {
+		t.Fatalf("expected only changed dependency progressions, got %#v", comparison.Progressions)
 	}
 }
 


### PR DESCRIPTION
## Summary
This fixes baseline delta classification so only changed dependencies are considered regressions/progressions.

## Issue
Added and removed dependencies were being double-classified in baseline reports:
- added dependencies with positive waste deltas appeared in both `Added` and `Regressions`
- removed dependencies with negative waste deltas appeared in both `Removed` and `Progressions`

## Root Cause
`appendDependencyDelta` appended regressions/progressions solely from `WastePercentDelta` sign, without checking `DependencyDelta.Kind`.

## Fix
- Restrict regression/progression bucketing to `DependencyDeltaChanged` only.
- Keep added/removed classification unchanged.
- Add focused test coverage that ensures:
  - added/removed dependencies are not counted as regressions/progressions
  - changed dependencies still classify into regressions/progressions by waste delta direction
- Update deterministic comparison test expectations to match corrected classification.

## Validation
- `GOTOOLCHAIN=go1.26.2 go test ./internal/report`
- `make feature-flag-check`
- pre-commit suite (`make ci`) on commit

Closes #695
