### PR TITLE
bug: slash-normalize adjusted import locations

### DIFF
--- a/internal/analysis/execution.go
+++ b/internal/analysis/execution.go
@@ -2,7 +2,9 @@ package analysis
 
 import (
 	"context"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
@@ -138,13 +140,34 @@ func adjustRelativeLocations(repoPath string, analyzedRoot string, dependencies 
 }
 
 func adjustImportLocations(prefix string, imports []report.ImportUse) {
+	normalizedPrefix := normalizeLocationPath(prefix)
 	for j := range imports {
 		for k := range imports[j].Locations {
 			location := &imports[j].Locations[k]
-			if filepath.IsAbs(location.File) {
+			normalizedFile := normalizeLocationPath(location.File)
+			if isAbsoluteLocationPath(location.File) {
+				location.File = normalizedFile
 				continue
 			}
-			location.File = filepath.Clean(filepath.Join(prefix, location.File))
+			location.File = path.Clean(path.Join(normalizedPrefix, normalizedFile))
 		}
 	}
+}
+
+func normalizeLocationPath(value string) string {
+	return path.Clean(strings.ReplaceAll(value, "\\", "/"))
+}
+
+func isAbsoluteLocationPath(value string) bool {
+	if value == "" {
+		return false
+	}
+	if filepath.IsAbs(value) || strings.HasPrefix(value, "/") || strings.HasPrefix(value, "\\") {
+		return true
+	}
+	if len(value) >= 3 && value[1] == ':' && (value[2] == '\\' || value[2] == '/') {
+		drive := value[0]
+		return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
+	}
+	return false
 }

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -126,11 +126,33 @@ func TestAdjustRelativeLocationsAndLanguage(t *testing.T) {
 		t.Fatalf("expected language to be applied")
 	}
 	adjustRelativeLocations("/repo", repoPackageARoot, deps)
-	if deps[0].UsedImports[0].Locations[0].File != filepath.Clean("packages/a/src/main.js") {
+	if deps[0].UsedImports[0].Locations[0].File != "packages/a/src/main.js" {
 		t.Fatalf("expected relative file adjustment, got %q", deps[0].UsedImports[0].Locations[0].File)
 	}
 	if deps[0].UnusedImports[0].Locations[0].File != "/abs/file.js" {
 		t.Fatalf("expected absolute file path unchanged")
+	}
+}
+
+func TestAdjustImportLocationsSlashNormalizesWindowsPaths(t *testing.T) {
+	imports := []report.ImportUse{{
+		Locations: []report.Location{
+			{File: `src\main.js`, Line: 1},
+			{File: `src\..\feature\entry.js`, Line: 2},
+			{File: `C:\repo\pkg\abs.js`, Line: 3},
+		},
+	}}
+
+	adjustImportLocations(`packages\a`, imports)
+
+	if got := imports[0].Locations[0].File; got != "packages/a/src/main.js" {
+		t.Fatalf("expected slash-normalized relative import location, got %q", got)
+	}
+	if got := imports[0].Locations[1].File; got != "packages/a/feature/entry.js" {
+		t.Fatalf("expected cleaned slash-normalized relative import location, got %q", got)
+	}
+	if got := imports[0].Locations[2].File; got != "C:/repo/pkg/abs.js" {
+		t.Fatalf("expected absolute windows import location to remain absolute and slash-normalized, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
`adjustImportLocations` now emits slash-normalized import location paths consistently, including when prefix and file inputs use Windows separators.

## Issue
Import location paths in JSON output could preserve `\\` separators or mixed separators depending on platform/input shape.

## Root cause
`adjustImportLocations` used `filepath.Join/Clean` directly, which is host-OS dependent and does not normalize Windows-style separators when running on non-Windows hosts.

## Fix
- Normalize both path prefix and import location file paths to `/` separators before joining.
- Detect absolute paths in a host-agnostic way (POSIX absolute, Windows drive absolute, and rooted paths) so absolute paths are not incorrectly prefixed.
- Keep absolute paths absolute while still slash-normalizing them for consistent JSON output.
- Add targeted regression tests with hardcoded Windows-style separators and explicit `/` expectations.

## Validation
- `GOTOOLCHAIN=go1.26.2 go test ./internal/analysis`
- `make feature-flag-check`
- Pre-commit gates (`make fmt`, `make ci`) passed during commit

Closes #683
