### PR TITLE
bug: apply stable feature defaults in dashboard analysis

### DIFF
--- a/internal/app/dashboard.go
+++ b/internal/app/dashboard.go
@@ -205,6 +205,7 @@ func (a *App) runDashboardAnalyses(ctx context.Context, request DashboardRequest
 					TopN:           topN,
 					ScopeMode:      analysis.ScopeModeRepo,
 					Language:       repoInput.Language,
+					Features:       request.Features,
 					RuntimeProfile: "node-import",
 				})
 

--- a/internal/app/dashboard_test.go
+++ b/internal/app/dashboard_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/dashboard"
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/report"
 )
 
@@ -404,6 +405,43 @@ func TestRunDashboardAnalysesDefaultsTopNAndScope(t *testing.T) {
 	}
 	if results[0].Input.Path != "./api" {
 		t.Fatalf("unexpected result ordering: %#v", results)
+	}
+}
+
+func TestRunDashboardAnalysesForwardsFeatures(t *testing.T) {
+	analyzer := &mapAnalyzer{
+		reports: map[string]report.Report{
+			"./scripts": {Dependencies: []report.DependencyReport{{Name: "pester"}}},
+		},
+		errs: map[string]error{},
+	}
+	application := &App{Analyzer: analyzer}
+
+	features, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelRelease,
+	})
+	if err != nil {
+		t.Fatalf("resolve release features: %v", err)
+	}
+	if !features.Enabled("powershell-adapter-preview") {
+		t.Fatalf("expected release default features to include powershell adapter")
+	}
+
+	repos := []dashboard.RepoInput{
+		{Name: "scripts", Path: "./scripts", Language: "powershell"},
+	}
+	dashboardReq := DashboardRequest{
+		Features: features,
+	}
+	results := application.runDashboardAnalyses(context.Background(), dashboardReq, repos)
+	if len(results) != 1 {
+		t.Fatalf("expected one analysis result, got %#v", results)
+	}
+	if len(analyzer.calls) != 1 {
+		t.Fatalf("expected one analyzer call, got %#v", analyzer.calls)
+	}
+	if !analyzer.calls[0].Features.Enabled("powershell-adapter-preview") {
+		t.Fatalf("expected dashboard analysis request to forward powershell feature flag")
 	}
 }
 

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -81,6 +81,7 @@ type DashboardRequest struct {
 	OutputPath      string
 	TopN            int
 	DefaultLanguage string
+	Features        featureflags.Set
 }
 
 type FeaturesRequest struct {

--- a/internal/cli/parse_analyse_overrides.go
+++ b/internal/cli/parse_analyse_overrides.go
@@ -44,21 +44,40 @@ func resolveAnalyseThresholds(values analyseFlagValues, visited map[string]bool)
 }
 
 func resolveAnalyseFeatures(visited map[string]bool, values analyseFlagValues, configFeatures thresholds.FeatureConfig) (featureflags.Set, error) {
-	if err := validateFeatureRegistry(); err != nil {
+	channel, lock, err := resolveFeatureBuildContext()
+	if err != nil {
 		return featureflags.Set{}, err
+	}
+	return resolveFeatureSet(featureRegistryProvider(), channel, lock, visited, values, configFeatures)
+}
+
+func resolveDefaultFeatureSet() (featureflags.Set, error) {
+	channel, lock, err := resolveFeatureBuildContext()
+	if err != nil {
+		return featureflags.Set{}, err
+	}
+	return featureRegistryProvider().Resolve(featureflags.ResolveOptions{
+		Channel: channel,
+		Lock:    lock,
+	})
+}
+
+func resolveFeatureBuildContext() (featureflags.Channel, *featureflags.ReleaseLock, error) {
+	if err := validateFeatureRegistry(); err != nil {
+		return "", nil, err
 	}
 	channel, err := featureflags.NormalizeChannel(featureBuildChannel())
 	if err != nil {
-		return featureflags.Set{}, err
+		return "", nil, err
 	}
 	var lock *featureflags.ReleaseLock
 	if channel == featureflags.ChannelRelease {
 		lock, err = featureReleaseLockProvider(featureReleaseVersion())
 		if err != nil {
-			return featureflags.Set{}, err
+			return "", nil, err
 		}
 	}
-	return resolveFeatureSet(featureRegistryProvider(), channel, lock, visited, values, configFeatures)
+	return channel, lock, nil
 }
 
 func resolveFeatureSet(registry *featureflags.Registry, channel featureflags.Channel, lock *featureflags.ReleaseLock, visited map[string]bool, values analyseFlagValues, configFeatures thresholds.FeatureConfig) (featureflags.Set, error) {

--- a/internal/cli/parse_dashboard.go
+++ b/internal/cli/parse_dashboard.go
@@ -46,6 +46,10 @@ func parseDashboard(args []string, req app.Request) (app.Request, error) {
 	if len(repos) == 0 && strings.TrimSpace(*configFlag) == "" {
 		return req, fmt.Errorf("dashboard requires --repos or --config")
 	}
+	resolvedFeatures, err := resolveDefaultFeatureSet()
+	if err != nil {
+		return req, err
+	}
 
 	dashboardRepos := make([]app.DashboardRepo, 0, len(repos))
 	for _, repoPath := range repos {
@@ -60,6 +64,7 @@ func parseDashboard(args []string, req app.Request) (app.Request, error) {
 		OutputPath:      outputPath,
 		TopN:            *topFlag,
 		DefaultLanguage: strings.TrimSpace(*languageFlag),
+		Features:        resolvedFeatures,
 	}
 
 	return req, nil

--- a/internal/cli/parse_dashboard_test.go
+++ b/internal/cli/parse_dashboard_test.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/app"
+	"github.com/ben-ranford/lopper/internal/featureflags"
 )
 
 func TestParseArgsDashboardRepos(t *testing.T) {
@@ -82,6 +84,39 @@ func TestParseArgsDashboardValidation(t *testing.T) {
 	err = expectParseArgsError(t, []string{"dashboard", dashboardConfigFlagName, dashboardConfigFileName, "--top", "0"}, "expected dashboard top validation error")
 	if !strings.Contains(err.Error(), "--top must be > 0") {
 		t.Fatalf("unexpected dashboard top validation error: %v", err)
+	}
+}
+
+func TestParseArgsDashboardResolvesDefaultFeatureFlags(t *testing.T) {
+	t.Run("release defaults include stable flags", func(t *testing.T) {
+		withFeatureRegistry(t, featureflags.ChannelRelease, nil)
+		req := mustParseArgs(t, []string{"dashboard", dashboardReposFlagName, "./api"})
+		if !req.Dashboard.Features.Enabled("stable-flag") {
+			t.Fatalf("expected stable feature enabled from release defaults")
+		}
+		if req.Dashboard.Features.Enabled("preview-flag") {
+			t.Fatalf("expected preview feature disabled without release lock override")
+		}
+	})
+
+	t.Run("release lock enables preview flags", func(t *testing.T) {
+		lock := &featureflags.ReleaseLock{Release: "v1.4.2", DefaultOn: []string{"preview-flag"}}
+		withFeatureRegistry(t, featureflags.ChannelRelease, lock)
+		req := mustParseArgs(t, []string{"dashboard", dashboardReposFlagName, "./api"})
+		if !req.Dashboard.Features.Enabled("stable-flag") || !req.Dashboard.Features.Enabled("preview-flag") {
+			t.Fatalf("expected release-lock defaults to include stable and preview flags")
+		}
+	})
+}
+
+func TestParseArgsDashboardReturnsFeatureResolutionError(t *testing.T) {
+	oldValidate := validateFeatureRegistry
+	validateFeatureRegistry = func() error { return errors.New("registry invalid") }
+	t.Cleanup(func() { validateFeatureRegistry = oldValidate })
+
+	_, err := ParseArgs([]string{"dashboard", dashboardReposFlagName, "./api"})
+	if err == nil || !strings.Contains(err.Error(), "registry invalid") {
+		t.Fatalf("expected dashboard feature-resolution error, got %v", err)
 	}
 }
 

--- a/internal/cli/parse_feature_defaults_test.go
+++ b/internal/cli/parse_feature_defaults_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/thresholds"
+)
+
+func TestResolveDefaultFeatureSetUsesBuildContext(t *testing.T) {
+	t.Run("rolling build enables preview and stable defaults", func(t *testing.T) {
+		withFeatureRegistry(t, featureflags.ChannelRolling, nil)
+		features, err := resolveDefaultFeatureSet()
+		if err != nil {
+			t.Fatalf("resolve rolling default feature set: %v", err)
+		}
+		if !features.Enabled("preview-flag") || !features.Enabled("stable-flag") {
+			t.Fatalf("expected rolling defaults to enable preview and stable flags")
+		}
+	})
+
+	t.Run("release lock default-on includes preview", func(t *testing.T) {
+		lock := &featureflags.ReleaseLock{Release: "v1.4.2", DefaultOn: []string{"preview-flag"}}
+		withFeatureRegistry(t, featureflags.ChannelRelease, lock)
+		features, err := resolveDefaultFeatureSet()
+		if err != nil {
+			t.Fatalf("resolve release default feature set: %v", err)
+		}
+		if !features.Enabled("preview-flag") || !features.Enabled("stable-flag") {
+			t.Fatalf("expected release lock defaults to include preview and stable flags")
+		}
+	})
+}
+
+func TestResolveFeatureBuildContextErrors(t *testing.T) {
+	t.Run("registry validation failure", func(t *testing.T) {
+		oldValidate := validateFeatureRegistry
+		validateFeatureRegistry = func() error { return errors.New("registry invalid") }
+		t.Cleanup(func() { validateFeatureRegistry = oldValidate })
+
+		if _, err := resolveDefaultFeatureSet(); err == nil || !strings.Contains(err.Error(), "registry invalid") {
+			t.Fatalf("expected registry validation error, got %v", err)
+		}
+	})
+
+	t.Run("invalid build channel", func(t *testing.T) {
+		oldValidate := validateFeatureRegistry
+		oldBuildChannel := featureBuildChannel
+		validateFeatureRegistry = func() error { return nil }
+		featureBuildChannel = func() string { return "not-a-channel" }
+		t.Cleanup(func() {
+			validateFeatureRegistry = oldValidate
+			featureBuildChannel = oldBuildChannel
+		})
+
+		if _, _, err := resolveFeatureBuildContext(); err == nil {
+			t.Fatalf("expected invalid build channel error")
+		}
+	})
+
+	t.Run("release lock resolution failure", func(t *testing.T) {
+		oldValidate := validateFeatureRegistry
+		oldBuildChannel := featureBuildChannel
+		oldReleaseVersion := featureReleaseVersion
+		oldReleaseLockProvider := featureReleaseLockProvider
+		validateFeatureRegistry = func() error { return nil }
+		featureBuildChannel = func() string { return string(featureflags.ChannelRelease) }
+		featureReleaseVersion = func() string { return "v1.4.2" }
+		featureReleaseLockProvider = func(string) (*featureflags.ReleaseLock, error) { return nil, errors.New("lock failure") }
+		t.Cleanup(func() {
+			validateFeatureRegistry = oldValidate
+			featureBuildChannel = oldBuildChannel
+			featureReleaseVersion = oldReleaseVersion
+			featureReleaseLockProvider = oldReleaseLockProvider
+		})
+
+		if _, err := resolveDefaultFeatureSet(); err == nil || !strings.Contains(err.Error(), "lock failure") {
+			t.Fatalf("expected release lock failure error, got %v", err)
+		}
+	})
+}
+
+func TestResolveAnalyseFeaturesPropagatesBuildContextErrors(t *testing.T) {
+	oldValidate := validateFeatureRegistry
+	validateFeatureRegistry = func() error { return errors.New("registry invalid") }
+	t.Cleanup(func() { validateFeatureRegistry = oldValidate })
+
+	_, err := resolveAnalyseFeatures(map[string]bool{}, analyseFlagValues{}, thresholds.FeatureConfig{})
+	if err == nil || !strings.Contains(err.Error(), "registry invalid") {
+		t.Fatalf("expected resolveAnalyseFeatures to propagate build-context error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Issue
Dashboard analyses did not receive resolved feature defaults, so adapter feature gates were evaluated against an empty feature set.

## Cause and user impact
`analyse` resolves feature defaults from build-channel + release-lock context and forwards them into `analysis.Request.Features`, but `dashboard` did not. As a result, stable-gated adapters (notably `powershell-adapter-preview`) could be skipped during dashboard runs even though they are stable defaults.

## Root cause
- `parseDashboard` built `DashboardRequest` without resolving feature defaults.
- `runDashboardAnalyses` built `analysis.Request` without a `Features` payload.

## Fix
- Added shared CLI feature build-context helpers used by both analyse and dashboard parsing.
- Resolved default feature set in dashboard parsing and stored it on `DashboardRequest.Features`.
- Threaded `DashboardRequest.Features` through dashboard analyzer calls.
- Added regression coverage for:
  - dashboard parse default feature resolution (release defaults + release lock behavior)
  - dashboard parse feature-resolution error path
  - feature build-context helper success/error branches
  - dashboard request forwarding of release defaults to analysis requests, including `powershell-adapter-preview`

Closes #789.

## Tests run
- `GOTOOLCHAIN=go1.26.2 go test ./internal/app ./internal/analysis`
- `make feature-flag-check`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli`
- Pre-commit CI suite (fmt, lint, gosec, govulncheck, test, goleak, race, memory delta, build, coverage)
