### PR TITLE
bug: surface VS Code local binary validation errors

### DIFF
--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -245,26 +245,23 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
 
   private async resolveLocalBinaryPath(request: BinaryResolutionRequest): Promise<string | undefined> {
     const localBinary = path.join(request.workspaceRoot, "bin", binaryFileName(this.platform));
-    try {
-      const fileStat = await stat(localBinary);
-      if (!fileStat.isFile()) {
-        throw new Error("Local lopper binary is not a regular file");
-      }
-      if (this.platform === "win32") {
-        // On Windows, executability is inferred from .exe and file accessibility.
-        await access(localBinary);
-      } else {
-        // On POSIX, require execute permission.
-        await access(localBinary, fsConstants.X_OK);
-      }
-      if (!request.workspaceTrusted) {
-        this.output.appendLine(`skipping workspace-local lopper binary in untrusted workspace: ${localBinary}`);
-        return this.resolvePathBinary(request);
-      }
-      return localBinary;
-    } catch {
+    const localBinaryStats = await this.localBinaryStats(localBinary);
+    if (!localBinaryStats) {
       return this.resolvePathBinary(request);
     }
+
+    if (!localBinaryStats.isFile()) {
+      throw new BinaryResolutionError(`workspace-local lopper binary must point to a file: ${localBinary}`);
+    }
+
+    await this.ensureWorkspaceLocalBinaryExecutable(localBinary);
+
+    if (!request.workspaceTrusted) {
+      this.output.appendLine(`skipping workspace-local lopper binary in untrusted workspace: ${localBinary}`);
+      return this.resolvePathBinary(request);
+    }
+
+    return localBinary;
   }
 
   private async resolvePathBinary(request: BinaryResolutionRequest): Promise<string | undefined> {
@@ -326,6 +323,33 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
       await access(binaryPath, fsConstants.X_OK);
     } catch {
       throw new BinaryResolutionError(`${source} points to a non-executable file: ${binaryPath}`);
+    }
+  }
+
+  private async localBinaryStats(localBinaryPath: string) {
+    try {
+      return await stat(localBinaryPath);
+    } catch (error) {
+      if (isFileMissingError(error)) {
+        return undefined;
+      }
+      throw new BinaryResolutionError(
+        `failed to access workspace-local lopper binary: ${localBinaryPath}${formatErrorDetail(error)}`,
+      );
+    }
+  }
+
+  private async ensureWorkspaceLocalBinaryExecutable(localBinaryPath: string): Promise<void> {
+    try {
+      if (this.platform === "win32") {
+        // On Windows, executability is inferred from .exe and file accessibility.
+        await access(localBinaryPath);
+      } else {
+        // On POSIX, require execute permission.
+        await access(localBinaryPath, fsConstants.X_OK);
+      }
+    } catch {
+      throw new BinaryResolutionError(`workspace-local lopper binary is not executable: ${localBinaryPath}`);
     }
   }
 
@@ -613,4 +637,17 @@ function isPathInsideWorkspace(candidatePath: string, workspaceRoot: string): bo
 
 async function canonicalPath(targetPath: string): Promise<string> {
   return realpath(targetPath);
+}
+
+function isFileMissingError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT",
+  );
+}
+
+function formatErrorDetail(error: unknown): string {
+  return error instanceof Error && error.message ? `: ${error.message}` : "";
 }

--- a/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
@@ -194,27 +194,7 @@ suite("managed binary installer", () => {
   });
 
   test("falls back to PATH when workspace-local bin binary is missing", async () => {
-    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-missing-"));
-    const pathRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-path-"));
-    const fallbackBinary = path.join(pathRoot, platformBinaryName());
-    const previousPath = process.env.PATH;
-
-    try {
-      await writeExecutable(fallbackBinary);
-      process.env.PATH = joinPathEntries([pathRoot, previousPath]);
-
-      const lifecycle = new LopperBinaryLifecycleManager(
-        {
-          findInstalledBinary: async () => undefined,
-          ensureInstalled: async () => {
-            throw new Error("should not install when PATH fallback resolves");
-          },
-        },
-        { appendLine: () => undefined },
-        undefined,
-        process.platform,
-      );
-
+    await withPathFallbackFixture("missing", async ({ workspaceRoot, fallbackBinary, lifecycle }) => {
       const resolvedPath = await lifecycle.resolveBinaryPath({
         workspaceRoot,
         workspaceTrusted: true,
@@ -222,36 +202,12 @@ suite("managed binary installer", () => {
       });
 
       assert.equal(resolvedPath, fallbackBinary);
-    } finally {
-      restoreEnv("PATH", previousPath);
-      await rm(workspaceRoot, { recursive: true, force: true });
-      await rm(pathRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   test("rejects workspace-local bin paths that are directories", async () => {
-    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-dir-"));
-    const pathRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-dir-path-"));
-    const fallbackBinary = path.join(pathRoot, platformBinaryName());
-    const localBinaryPath = path.join(workspaceRoot, "bin", platformBinaryName());
-    const previousPath = process.env.PATH;
-
-    try {
+    await withPathFallbackFixture("directory", async ({ workspaceRoot, localBinaryPath, lifecycle }) => {
       await mkdir(localBinaryPath, { recursive: true });
-      await writeExecutable(fallbackBinary);
-      process.env.PATH = joinPathEntries([pathRoot, previousPath]);
-
-      const lifecycle = new LopperBinaryLifecycleManager(
-        {
-          findInstalledBinary: async () => undefined,
-          ensureInstalled: async () => {
-            throw new Error("should not install when auto-download is disabled");
-          },
-        },
-        { appendLine: () => undefined },
-        undefined,
-        process.platform,
-      );
 
       await assert.rejects(
         lifecycle.resolveBinaryPath({
@@ -264,11 +220,7 @@ suite("managed binary installer", () => {
           error.message.includes("workspace-local lopper binary must point to a file") &&
           error.message.includes(localBinaryPath),
       );
-    } finally {
-      restoreEnv("PATH", previousPath);
-      await rm(workspaceRoot, { recursive: true, force: true });
-      await rm(pathRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   test("rejects non-executable workspace-local bin binaries on unix hosts", async function () {
@@ -276,30 +228,10 @@ suite("managed binary installer", () => {
       this.skip();
     }
 
-    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-nonexec-"));
-    const pathRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-nonexec-path-"));
-    const fallbackBinary = path.join(pathRoot, platformBinaryName());
-    const localBinaryPath = path.join(workspaceRoot, "bin", platformBinaryName());
-    const previousPath = process.env.PATH;
-
-    try {
+    await withPathFallbackFixture("nonexec", async ({ workspaceRoot, localBinaryPath, lifecycle }) => {
       await mkdir(path.dirname(localBinaryPath), { recursive: true });
       await writeFile(localBinaryPath, "#!/bin/sh\nexit 0\n", "utf8");
       await chmod(localBinaryPath, 0o644);
-      await writeExecutable(fallbackBinary);
-      process.env.PATH = joinPathEntries([pathRoot, previousPath]);
-
-      const lifecycle = new LopperBinaryLifecycleManager(
-        {
-          findInstalledBinary: async () => undefined,
-          ensureInstalled: async () => {
-            throw new Error("should not install when auto-download is disabled");
-          },
-        },
-        { appendLine: () => undefined },
-        undefined,
-        process.platform,
-      );
 
       await assert.rejects(
         lifecycle.resolveBinaryPath({
@@ -312,11 +244,7 @@ suite("managed binary installer", () => {
           error.message.includes("workspace-local lopper binary is not executable") &&
           error.message.includes(localBinaryPath),
       );
-    } finally {
-      restoreEnv("PATH", previousPath);
-      await rm(workspaceRoot, { recursive: true, force: true });
-      await rm(pathRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   test("fails when auto-download is disabled and no binaries resolve", async () => {
@@ -526,6 +454,52 @@ async function createZipFixture(
   const archivePath = path.join(tempRoot, assetNameForRelease(releaseTag, host));
   zip.writeZip(archivePath);
   return archivePath;
+}
+
+interface PathFallbackFixture {
+  workspaceRoot: string;
+  fallbackBinary: string;
+  localBinaryPath: string;
+  lifecycle: LopperBinaryLifecycleManager;
+}
+
+async function withPathFallbackFixture(
+  namePrefix: string,
+  run: (fixture: PathFallbackFixture) => Promise<void>,
+): Promise<void> {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), `lopper-managed-local-${namePrefix}-`));
+  const pathRoot = await mkdtemp(path.join(os.tmpdir(), `lopper-managed-local-${namePrefix}-path-`));
+  const fallbackBinary = path.join(pathRoot, platformBinaryName());
+  const previousPath = process.env.PATH;
+
+  try {
+    await writeExecutable(fallbackBinary);
+    process.env.PATH = joinPathEntries([pathRoot, previousPath]);
+    await run({
+      workspaceRoot,
+      fallbackBinary,
+      localBinaryPath: path.join(workspaceRoot, "bin", platformBinaryName()),
+      lifecycle: createPathFallbackLifecycle(),
+    });
+  } finally {
+    restoreEnv("PATH", previousPath);
+    await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(pathRoot, { recursive: true, force: true });
+  }
+}
+
+function createPathFallbackLifecycle(): LopperBinaryLifecycleManager {
+  return new LopperBinaryLifecycleManager(
+    {
+      findInstalledBinary: async () => undefined,
+      ensureInstalled: async () => {
+        throw new Error("should not install when PATH fallback resolves");
+      },
+    },
+    { appendLine: () => undefined },
+    undefined,
+    process.platform,
+  );
 }
 
 function restoreEnv(name: string, value: string | undefined): void {

--- a/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
@@ -193,6 +193,132 @@ suite("managed binary installer", () => {
     }
   });
 
+  test("falls back to PATH when workspace-local bin binary is missing", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-missing-"));
+    const pathRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-path-"));
+    const fallbackBinary = path.join(pathRoot, platformBinaryName());
+    const previousPath = process.env.PATH;
+
+    try {
+      await writeExecutable(fallbackBinary);
+      process.env.PATH = joinPathEntries([pathRoot, previousPath]);
+
+      const lifecycle = new LopperBinaryLifecycleManager(
+        {
+          findInstalledBinary: async () => undefined,
+          ensureInstalled: async () => {
+            throw new Error("should not install when PATH fallback resolves");
+          },
+        },
+        { appendLine: () => undefined },
+        undefined,
+        process.platform,
+      );
+
+      const resolvedPath = await lifecycle.resolveBinaryPath({
+        workspaceRoot,
+        workspaceTrusted: true,
+        autoDownloadBinary: false,
+      });
+
+      assert.equal(resolvedPath, fallbackBinary);
+    } finally {
+      restoreEnv("PATH", previousPath);
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(pathRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects workspace-local bin paths that are directories", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-dir-"));
+    const pathRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-dir-path-"));
+    const fallbackBinary = path.join(pathRoot, platformBinaryName());
+    const localBinaryPath = path.join(workspaceRoot, "bin", platformBinaryName());
+    const previousPath = process.env.PATH;
+
+    try {
+      await mkdir(localBinaryPath, { recursive: true });
+      await writeExecutable(fallbackBinary);
+      process.env.PATH = joinPathEntries([pathRoot, previousPath]);
+
+      const lifecycle = new LopperBinaryLifecycleManager(
+        {
+          findInstalledBinary: async () => undefined,
+          ensureInstalled: async () => {
+            throw new Error("should not install when auto-download is disabled");
+          },
+        },
+        { appendLine: () => undefined },
+        undefined,
+        process.platform,
+      );
+
+      await assert.rejects(
+        lifecycle.resolveBinaryPath({
+          workspaceRoot,
+          workspaceTrusted: true,
+          autoDownloadBinary: false,
+        }),
+        (error: unknown) =>
+          error instanceof BinaryResolutionError &&
+          error.message.includes("workspace-local lopper binary must point to a file") &&
+          error.message.includes(localBinaryPath),
+      );
+    } finally {
+      restoreEnv("PATH", previousPath);
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(pathRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects non-executable workspace-local bin binaries on unix hosts", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-nonexec-"));
+    const pathRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-local-nonexec-path-"));
+    const fallbackBinary = path.join(pathRoot, platformBinaryName());
+    const localBinaryPath = path.join(workspaceRoot, "bin", platformBinaryName());
+    const previousPath = process.env.PATH;
+
+    try {
+      await mkdir(path.dirname(localBinaryPath), { recursive: true });
+      await writeFile(localBinaryPath, "#!/bin/sh\nexit 0\n", "utf8");
+      await chmod(localBinaryPath, 0o644);
+      await writeExecutable(fallbackBinary);
+      process.env.PATH = joinPathEntries([pathRoot, previousPath]);
+
+      const lifecycle = new LopperBinaryLifecycleManager(
+        {
+          findInstalledBinary: async () => undefined,
+          ensureInstalled: async () => {
+            throw new Error("should not install when auto-download is disabled");
+          },
+        },
+        { appendLine: () => undefined },
+        undefined,
+        process.platform,
+      );
+
+      await assert.rejects(
+        lifecycle.resolveBinaryPath({
+          workspaceRoot,
+          workspaceTrusted: true,
+          autoDownloadBinary: false,
+        }),
+        (error: unknown) =>
+          error instanceof BinaryResolutionError &&
+          error.message.includes("workspace-local lopper binary is not executable") &&
+          error.message.includes(localBinaryPath),
+      );
+    } finally {
+      restoreEnv("PATH", previousPath);
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(pathRoot, { recursive: true, force: true });
+    }
+  });
+
   test("fails when auto-download is disabled and no binaries resolve", async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-lifecycle-test-"));
     const previousPath = process.env.PATH;


### PR DESCRIPTION
## Summary
Fixes VS Code local/workspace binary resolution so invalid `bin/lopper` states are surfaced instead of silently falling back to PATH.

## Root cause
`resolveLocalBinaryPath` wrapped local binary validation in a broad `try/catch`, so directory and non-executable validation failures were swallowed and treated like a missing file.

## Changes
- Refactored workspace-local binary resolution to only fall back to PATH when `bin/lopper` is missing (`ENOENT`).
- Added explicit `BinaryResolutionError` paths for:
  - workspace-local binary path is a directory/non-file
  - workspace-local binary is not executable
  - non-ENOENT stat/access failures
- Added focused TypeScript regression tests to lock behavior:
  - missing workspace-local binary falls back to PATH
  - directory path fails with actionable error
  - non-executable file fails with actionable error

Closes #702.

## Tests run
- `cd extensions/vscode-lopper && npm run compile`
- `cd extensions/vscode-lopper && npm run test:e2e`
- `cd extensions/vscode-lopper && npx mocha --ui tdd --timeout 120000 ./out/test/suite/managedBinary.test.js`
- `make feature-flag-check`
