### PR TITLE
ci(release): require PR metadata validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Summary
 
-Describe the problem and the intent of this change.
+Describe the problem and the intent of this change. Use `N/A` only when the section truly does not apply.
 
 ## Changes
 

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,42 @@
+name: pr metadata
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  validate:
+    name: pr-metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Write PR body
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const bodyPath = path.join(process.env.RUNNER_TEMP, 'pr-body.md');
+            fs.writeFileSync(bodyPath, context.payload.pull_request?.body || '', 'utf8');
+            core.exportVariable('PR_BODY_FILE', bodyPath);
+
+      - name: Validate PR title and template
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: go run ./tools/prcheck --title "$PR_TITLE" --head-ref "$PR_HEAD_REF" --body-file "$PR_BODY_FILE"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,9 @@ Reviewers should ask for a release lock instead of graduation when a release sho
 ## Commit style and releases
 
 Stable releases are prepared by release-please from Conventional Commits merged to `main`.
+Pull request titles are validated in CI and become the default squash commit title, so the PR title must use the same Conventional Commit format.
+Use `fix(scope): summary` for bug fixes; do not use `bug:` because release-please does not treat it as a release note type.
+
 Use these commit types for changes that should appear in release notes:
 
 - `fix(scope): summary` for patch releases.
@@ -104,6 +107,10 @@ Use these commit types for changes that should appear in release notes:
 
 Use non-release types such as `test`, `ci`, `build`, or `chore` when the change should not by itself create a release PR.
 Good scopes include `release`, `ci`, `vscode`, `js`, `jvm`, `go`, `report`, `ui`, `runtime`, and `homebrew`.
+
+PR descriptions are also validated before merge.
+Keep every heading from `.github/PULL_REQUEST_TEMPLATE.md`, fill every risk field with a concrete value such as `None` or `N/A`, and check every checklist item once it has been considered.
+Generated release-please PRs keep their release-generated changelog body, but their title still has to use `chore(main): release x.y.z`.
 
 ## Adapter docs checklist
 

--- a/tools/prcheck/main.go
+++ b/tools/prcheck/main.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var titlePattern = regexp.MustCompile(`^(feat|fix|perf|docs|refactor|revert|test|ci|build|chore)(\([a-z0-9][a-z0-9._/-]*\))?!?: [^\s].+$`)
+
+var placeholderTexts = []string{
+	"Describe the problem and the intent of this change. Use `N/A` only when the section truly does not apply.",
+	"Describe the problem and the intent of this change.",
+	"Commands and checks run:",
+	"Additional manual validation:",
+}
+
+var requiredHeadings = []string{
+	"Summary",
+	"Changes",
+	"Validation",
+	"Risk and compatibility",
+	"Checklist",
+}
+
+var requiredRiskFields = []string{
+	"Breaking changes",
+	"Migration required",
+	"Performance impact",
+	"Memory benchmark impact",
+}
+
+var requiredChecklistItems = []string{
+	"Tests added/updated for behavior changes",
+	"Docs updated (README/docs/schema) if needed",
+	"`memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds",
+	"No unrelated changes included",
+	"Ready for review",
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Getenv, os.Stderr))
+}
+
+func run(args []string, getenv func(string) string, stderr io.Writer) int {
+	fs := flag.NewFlagSet("prcheck", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	title := fs.String("title", strings.TrimSpace(getenv("PR_TITLE")), "pull request title")
+	headRef := fs.String("head-ref", strings.TrimSpace(getenv("PR_HEAD_REF")), "pull request head ref")
+	bodyFile := fs.String("body-file", "", "path to a file containing the pull request body")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	body := strings.TrimSpace(getenv("PR_BODY"))
+	if *bodyFile != "" {
+		data, err := os.ReadFile(*bodyFile)
+		if err != nil {
+			if _, writeErr := fmt.Fprintf(stderr, "read PR body: %v\n", err); writeErr != nil {
+				return 1
+			}
+			return 1
+		}
+		body = string(data)
+	}
+
+	if err := validate(*title, *headRef, body); err != nil {
+		if _, writeErr := fmt.Fprintf(stderr, "%v\n", err); writeErr != nil {
+			return 1
+		}
+		return 1
+	}
+	return 0
+}
+
+func validate(title, headRef, body string) error {
+	var failures []string
+	title = strings.TrimSpace(title)
+	if !titlePattern.MatchString(title) {
+		failures = append(failures, "PR title must be a Conventional Commit title using one of feat, fix, perf, docs, refactor, revert, test, ci, build, or chore; use fix(scope): ... for bug fixes instead of bug: ...")
+	}
+
+	if isReleasePleasePR(headRef, title) {
+		if len(failures) > 0 {
+			return errors.New(strings.Join(failures, "\n"))
+		}
+		return nil
+	}
+
+	sections := parseSections(body)
+	for _, heading := range requiredHeadings {
+		if _, ok := sections[heading]; !ok {
+			failures = append(failures, fmt.Sprintf("PR body is missing required template section %q", heading))
+		}
+	}
+
+	for _, heading := range []string{"Summary", "Changes", "Validation"} {
+		content, ok := sections[heading]
+		if !ok {
+			continue
+		}
+		if !hasMeaningfulContent(content) {
+			failures = append(failures, fmt.Sprintf("PR section %q must be completed; keep the heading and replace placeholder text with real content or N/A", heading))
+		}
+	}
+
+	if content, ok := sections["Risk and compatibility"]; ok {
+		for _, field := range requiredRiskFields {
+			if !fieldHasValue(content, field) {
+				failures = append(failures, fmt.Sprintf("Risk and compatibility field %q must be present and filled, using N/A or None when there is no impact", field))
+			}
+		}
+	}
+
+	if content, ok := sections["Checklist"]; ok {
+		for _, item := range requiredChecklistItems {
+			if !checkedChecklistItem(content, item) {
+				failures = append(failures, fmt.Sprintf("Checklist item %q must be present and checked", item))
+			}
+		}
+	}
+
+	if len(failures) > 0 {
+		return errors.New(strings.Join(failures, "\n"))
+	}
+	return nil
+}
+
+func isReleasePleasePR(headRef, title string) bool {
+	return strings.HasPrefix(strings.TrimSpace(headRef), "release-please--branches--") &&
+		regexp.MustCompile(`^chore\(main\): release [0-9]+\.[0-9]+\.[0-9]+$`).MatchString(strings.TrimSpace(title))
+}
+
+func parseSections(body string) map[string]string {
+	sections := make(map[string]string)
+	var current string
+	var b strings.Builder
+
+	flush := func() {
+		if current == "" {
+			return
+		}
+		sections[current] = strings.TrimSpace(b.String())
+		b.Reset()
+	}
+
+	for _, line := range strings.Split(body, "\n") {
+		if heading, ok := parseH2(line); ok {
+			flush()
+			current = heading
+			continue
+		}
+		if current != "" {
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	flush()
+
+	return sections
+}
+
+func parseH2(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "## ") || strings.HasPrefix(line, "### ") {
+		return "", false
+	}
+	return strings.TrimSpace(strings.TrimPrefix(line, "## ")), true
+}
+
+func hasMeaningfulContent(content string) bool {
+	content = stripCodeFences(content)
+	for _, placeholder := range placeholderTexts {
+		content = strings.ReplaceAll(content, placeholder, "")
+	}
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || trimmed == "-" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "<!--") && strings.HasSuffix(trimmed, "-->") {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func stripCodeFences(content string) string {
+	var kept []string
+	inFence := false
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inFence = !inFence
+			continue
+		}
+		if !inFence {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+func fieldHasValue(content, field string) bool {
+	pattern := regexp.MustCompile(`(?m)^-\s*` + regexp.QuoteMeta(field) + `:\s*(.+)$`)
+	match := pattern.FindStringSubmatch(content)
+	if len(match) != 2 {
+		return false
+	}
+	value := strings.TrimSpace(match[1])
+	return value != ""
+}
+
+func checkedChecklistItem(content, item string) bool {
+	pattern := regexp.MustCompile(`(?mi)^-\s*\[[x]\]\s*` + regexp.QuoteMeta(item) + `\s*$`)
+	return pattern.MatchString(content)
+}

--- a/tools/prcheck/main.go
+++ b/tools/prcheck/main.go
@@ -92,12 +92,29 @@ func validate(title, headRef, body string) error {
 	}
 
 	sections := parseSections(body)
+	failures = append(failures, missingHeadingFailures(sections)...)
+	failures = append(failures, incompleteSectionFailures(sections)...)
+	failures = append(failures, riskFieldFailures(sections)...)
+	failures = append(failures, checklistFailures(sections)...)
+
+	if len(failures) > 0 {
+		return errors.New(strings.Join(failures, "\n"))
+	}
+	return nil
+}
+
+func missingHeadingFailures(sections map[string]string) []string {
+	var failures []string
 	for _, heading := range requiredHeadings {
 		if _, ok := sections[heading]; !ok {
 			failures = append(failures, fmt.Sprintf("PR body is missing required template section %q", heading))
 		}
 	}
+	return failures
+}
 
+func incompleteSectionFailures(sections map[string]string) []string {
+	var failures []string
 	for _, heading := range []string{"Summary", "Changes", "Validation"} {
 		content, ok := sections[heading]
 		if !ok {
@@ -107,27 +124,34 @@ func validate(title, headRef, body string) error {
 			failures = append(failures, fmt.Sprintf("PR section %q must be completed; keep the heading and replace placeholder text with real content or N/A", heading))
 		}
 	}
+	return failures
+}
 
-	if content, ok := sections["Risk and compatibility"]; ok {
-		for _, field := range requiredRiskFields {
-			if !fieldHasValue(content, field) {
-				failures = append(failures, fmt.Sprintf("Risk and compatibility field %q must be present and filled, using N/A or None when there is no impact", field))
-			}
+func riskFieldFailures(sections map[string]string) []string {
+	content, ok := sections["Risk and compatibility"]
+	if !ok {
+		return nil
+	}
+	message := `Risk and compatibility field %q must be present and filled, using N/A or None when there is no impact`
+	return requiredItemFailures(content, requiredRiskFields, fieldHasValue, message)
+}
+
+func checklistFailures(sections map[string]string) []string {
+	content, ok := sections["Checklist"]
+	if !ok {
+		return nil
+	}
+	return requiredItemFailures(content, requiredChecklistItems, checkedChecklistItem, `Checklist item %q must be present and checked`)
+}
+
+func requiredItemFailures(content string, items []string, valid func(string, string) bool, message string) []string {
+	var failures []string
+	for _, item := range items {
+		if !valid(content, item) {
+			failures = append(failures, fmt.Sprintf(message, item))
 		}
 	}
-
-	if content, ok := sections["Checklist"]; ok {
-		for _, item := range requiredChecklistItems {
-			if !checkedChecklistItem(content, item) {
-				failures = append(failures, fmt.Sprintf("Checklist item %q must be present and checked", item))
-			}
-		}
-	}
-
-	if len(failures) > 0 {
-		return errors.New(strings.Join(failures, "\n"))
-	}
-	return nil
+	return failures
 }
 
 func isReleasePleasePR(headRef, title string) bool {

--- a/tools/prcheck/main_test.go
+++ b/tools/prcheck/main_test.go
@@ -105,45 +105,25 @@ func TestValidateRejectsNonConventionalTitle(t *testing.T) {
 
 func TestValidateRequiresTemplateSections(t *testing.T) {
 	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", strings.Replace(validBody(), "## Validation", "## Verification", 1))
-	if err == nil {
-		t.Fatal("validate succeeded with missing Validation section")
-	}
-	if !strings.Contains(err.Error(), `missing required template section "Validation"`) {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	expectValidationError(t, err, `missing required template section "Validation"`)
 }
 
 func TestValidateRejectsPlaceholderOnlySection(t *testing.T) {
 	body := strings.Replace(validBody(), "Stops release-please from missing patch fixes.", "Describe the problem and the intent of this change.", 1)
 	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
-	if err == nil {
-		t.Fatal("validate succeeded with placeholder-only Summary")
-	}
-	if !strings.Contains(err.Error(), `section "Summary" must be completed`) {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	expectValidationError(t, err, `section "Summary" must be completed`)
 }
 
 func TestValidateRequiresRiskFields(t *testing.T) {
 	body := strings.Replace(validBody(), "- Performance impact: None\n", "", 1)
 	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
-	if err == nil {
-		t.Fatal("validate succeeded with missing risk field")
-	}
-	if !strings.Contains(err.Error(), `field "Performance impact"`) {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	expectValidationError(t, err, `field "Performance impact"`)
 }
 
 func TestValidateRequiresCheckedChecklist(t *testing.T) {
 	body := strings.Replace(validBody(), "- [x] Ready for review", "- [ ] Ready for review", 1)
 	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
-	if err == nil {
-		t.Fatal("validate succeeded with unchecked checklist item")
-	}
-	if !strings.Contains(err.Error(), `Checklist item "Ready for review"`) {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	expectValidationError(t, err, `Checklist item "Ready for review"`)
 }
 
 func TestValidateRejectsBlankSectionWithCommentOnly(t *testing.T) {
@@ -209,6 +189,16 @@ Additional manual validation:
 func mapEnv(values map[string]string) func(string) string {
 	return func(key string) string {
 		return values[key]
+	}
+}
+
+func expectValidationError(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("validate succeeded, want error containing %q", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/tools/prcheck/main_test.go
+++ b/tools/prcheck/main_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunAcceptsEnvBody(t *testing.T) {
+	var stderr bytes.Buffer
+	env := mapEnv(map[string]string{
+		"PR_TITLE":    "fix(release): validate PR metadata",
+		"PR_HEAD_REF": "bug/issue-000-pr-title-template-gate",
+		"PR_BODY":     validBody(),
+	})
+	code := run(nil, env, &stderr)
+	if code != 0 {
+		t.Fatalf("run exited with %d, stderr: %s", code, stderr.String())
+	}
+}
+
+func TestRunAcceptsBodyFile(t *testing.T) {
+	bodyFile := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(bodyFile, []byte(validBody()), 0o600); err != nil {
+		t.Fatalf("write body file: %v", err)
+	}
+	var stderr bytes.Buffer
+	args := []string{"--title", "fix(release): validate PR metadata", "--head-ref", "bug/issue-000-pr-title-template-gate", "--body-file", bodyFile}
+	code := run(args, mapEnv(nil), &stderr)
+	if code != 0 {
+		t.Fatalf("run exited with %d, stderr: %s", code, stderr.String())
+	}
+}
+
+func TestRunRejectsMissingBodyFile(t *testing.T) {
+	var stderr bytes.Buffer
+	args := []string{"--title", "fix(release): validate PR metadata", "--body-file", filepath.Join(t.TempDir(), "missing.md")}
+	code := run(args, mapEnv(nil), &stderr)
+	if code != 1 {
+		t.Fatalf("run exited with %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "read PR body") {
+		t.Fatalf("stderr did not explain body read failure: %s", stderr.String())
+	}
+}
+
+func TestRunHandlesBodyReadErrorWriteFailure(t *testing.T) {
+	code := run([]string{"--body-file", filepath.Join(t.TempDir(), "missing.md")}, mapEnv(nil), &errWriter{})
+	if code != 1 {
+		t.Fatalf("run exited with %d", code)
+	}
+}
+
+func TestRunRejectsInvalidFlags(t *testing.T) {
+	var stderr bytes.Buffer
+	code := run([]string{"--unknown"}, mapEnv(nil), &stderr)
+	if code != 2 {
+		t.Fatalf("run exited with %d, stderr: %s", code, stderr.String())
+	}
+}
+
+func TestRunReportsValidationFailures(t *testing.T) {
+	var stderr bytes.Buffer
+	code := run([]string{"--title", "bug: invalid"}, mapEnv(map[string]string{"PR_BODY": validBody()}), &stderr)
+	if code != 1 {
+		t.Fatalf("run exited with %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "PR title must be") {
+		t.Fatalf("stderr did not explain validation failure: %s", stderr.String())
+	}
+}
+
+func TestRunHandlesValidationErrorWriteFailure(t *testing.T) {
+	code := run([]string{"--title", "bug: invalid"}, mapEnv(map[string]string{"PR_BODY": validBody()}), &errWriter{})
+	if code != 1 {
+		t.Fatalf("run exited with %d", code)
+	}
+}
+
+func TestValidateAcceptsCompletedTemplate(t *testing.T) {
+	body := validBody()
+	if err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body); err != nil {
+		t.Fatalf("validate returned error: %v", err)
+	}
+}
+
+func TestValidateRejectsBugTitle(t *testing.T) {
+	err := validate("bug: patch adapter parser", "bug/issue-123-parser", validBody())
+	if err == nil {
+		t.Fatal("validate succeeded for unsupported bug title")
+	}
+	if !strings.Contains(err.Error(), "use fix(scope)") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsNonConventionalTitle(t *testing.T) {
+	err := validate("patch adapter parser", "bug/issue-123-parser", validBody())
+	if err == nil {
+		t.Fatal("validate succeeded for non-conventional title")
+	}
+}
+
+func TestValidateRequiresTemplateSections(t *testing.T) {
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", strings.Replace(validBody(), "## Validation", "## Verification", 1))
+	if err == nil {
+		t.Fatal("validate succeeded with missing Validation section")
+	}
+	if !strings.Contains(err.Error(), `missing required template section "Validation"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsPlaceholderOnlySection(t *testing.T) {
+	body := strings.Replace(validBody(), "Stops release-please from missing patch fixes.", "Describe the problem and the intent of this change.", 1)
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
+	if err == nil {
+		t.Fatal("validate succeeded with placeholder-only Summary")
+	}
+	if !strings.Contains(err.Error(), `section "Summary" must be completed`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRequiresRiskFields(t *testing.T) {
+	body := strings.Replace(validBody(), "- Performance impact: None\n", "", 1)
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
+	if err == nil {
+		t.Fatal("validate succeeded with missing risk field")
+	}
+	if !strings.Contains(err.Error(), `field "Performance impact"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRequiresCheckedChecklist(t *testing.T) {
+	body := strings.Replace(validBody(), "- [x] Ready for review", "- [ ] Ready for review", 1)
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
+	if err == nil {
+		t.Fatal("validate succeeded with unchecked checklist item")
+	}
+	if !strings.Contains(err.Error(), `Checklist item "Ready for review"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsBlankSectionWithCommentOnly(t *testing.T) {
+	body := strings.Replace(validBody(), "Stops release-please from missing patch fixes.", "<!-- TODO -->", 1)
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
+	if err == nil {
+		t.Fatal("validate succeeded with comment-only Summary")
+	}
+}
+
+func TestValidateExemptsGeneratedReleasePleaseBody(t *testing.T) {
+	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser")
+	if err != nil {
+		t.Fatalf("validate returned error: %v", err)
+	}
+}
+
+func TestValidateReleasePleaseExemptionStillRequiresReleaseTitle(t *testing.T) {
+	err := validate("release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser")
+	if err == nil {
+		t.Fatal("validate succeeded for generated release PR with non-conventional title")
+	}
+}
+
+func validBody() string {
+	return `## Summary
+
+Stops release-please from missing patch fixes.
+
+## Changes
+
+- Adds a PR metadata validator.
+
+## Validation
+
+Commands and checks run:
+
+` + "```bash" + `
+go test ./tools/prcheck
+` + "```" + `
+
+Additional manual validation:
+
+- Reviewed release-please title requirements.
+
+## Risk and compatibility
+
+- Breaking changes: None
+- Migration required: None
+- Performance impact: None
+- Memory benchmark impact: None
+
+## Checklist
+
+- [x] Tests added/updated for behavior changes
+- [x] Docs updated (README/docs/schema) if needed
+- [x] ` + "`memory-approved`" + ` requested/applied if intentional memory benchmark regressions exceed CI thresholds
+- [x] No unrelated changes included
+- [x] Ready for review
+`
+}
+
+func mapEnv(values map[string]string) func(string) string {
+	return func(key string) string {
+		return values[key]
+	}
+}
+
+type errWriter struct{}
+
+func (*errWriter) Write([]byte) (int, error) {
+	return 0, os.ErrClosed
+}


### PR DESCRIPTION
## Summary

Adds a required PR metadata gate so squash titles stay compatible with release-please and human-authored PRs cannot merge with incomplete template fields.

## Changes

- Adds a `pr-metadata` GitHub Actions workflow that validates PR titles and template completion.
- Adds a tested `tools/prcheck` validator for Conventional Commit titles, required template sections, risk fields, and checked checklist items.
- Documents that bug fixes must use `fix(scope): ...`, not `bug: ...`, and notes the release-please generated PR body exception.

## Validation

Commands and checks run:

```bash
go test ./tools/prcheck
make actionlint
go test ./...
make ci
```

Additional manual validation:

- Confirmed the existing main ruleset required status check contexts before adding the new `pr-metadata` context.
- Validated this PR body with `go run ./tools/prcheck` before opening the PR.

## Risk and compatibility

- Breaking changes: None
- Migration required: Existing open human-authored PRs may need title/body cleanup before merge once the check is required.
- Performance impact: None
- Memory benchmark impact: None; the memory benchmark gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
