### PR TITLE
fix(release): include historical bug commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,8 @@ Reviewers should ask for a release lock instead of graduation when a release sho
 
 Stable releases are prepared by release-please from Conventional Commits merged to `main`.
 Pull request titles are validated in CI and become the default squash commit title, so the PR title must use the same Conventional Commit format.
-Use `fix(scope): summary` for bug fixes; do not use `bug:` because release-please does not treat it as a release note type.
+Use `fix(scope): summary` for bug fixes; do not use `bug:` for new PRs.
+The release-please config still treats historical `bug:` commits as Bug Fixes so already-merged fixes are not stranded outside the next patch release.
 
 Use these commit types for changes that should appear in release notes:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,10 @@
           "section": "Bug Fixes"
         },
         {
+          "type": "bug",
+          "section": "Bug Fixes"
+        },
+        {
           "type": "perf",
           "section": "Performance Improvements"
         },


### PR DESCRIPTION
## Summary

Manual `release` runs with no explicit tag/source SHA were correctly invoking release-please, but release-please skipped the next patch release because the post-`v1.5.0` fixes used the repo's historical `bug:` commit type. The current config only exposed `fix:` as Bug Fixes, so the 1.5.1 candidate changelog was empty even though `main` had moved through `c9db02c`.

## Changes

- Add `bug` to release-please changelog sections as Bug Fixes so already-merged historical bugfix commits are releaseable.
- Keep the new PR/commit guidance on `fix(scope): ...` for future bug fixes while documenting the compatibility bridge.

## Validation

Commands and checks run:

```bash
jq . release-please-config.json >/dev/null
jq . .release-please-manifest.json >/dev/null
go test ./tools/prcheck ./tools/featureflag
git diff --check
make ci
```

Additional manual validation:

- Ran `release-please@17.6.0 release-pr --dry-run` against an isolated temporary `main` containing this config change and the current post-`v1.5.0` history.
- Confirmed the dry run would open `chore(main): release 1.5.1` with Bug Fixes for PRs #791, #792, #793, #794, #795, #796, and #799, including `c9db02c`.

## Risk and compatibility

- Breaking changes: none.
- Migration required: none.
- Performance impact: none; release metadata only.
- Memory benchmark impact: none; local memory benchmark gate passed in `make ci`.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
