### PR TITLE
fix(ui): preserve detail dependency names and clamp prev pagination

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -439,12 +439,16 @@ func isDetailCommand(input string) (string, bool) {
 	if input == "" {
 		return "", false
 	}
-	fields := strings.Fields(input)
-	if len(fields) < 2 {
+	command, args, ok := strings.Cut(input, " ")
+	if !ok {
 		return "", false
 	}
-	if fields[0] != "open" && fields[0] != "detail" {
+	if command != "open" && command != "detail" {
 		return "", false
 	}
-	return fields[1], true
+	dependency := strings.TrimSpace(args)
+	if dependency == "" {
+		return "", false
+	}
+	return dependency, true
 }

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -188,6 +188,9 @@ func TestIsDetailCommand(t *testing.T) {
 	if dep, ok := isDetailCommand("detail js-ts:lodash"); !ok || dep != "js-ts:lodash" {
 		t.Fatalf("expected detail command parse")
 	}
+	if dep, ok := isDetailCommand("open aws sdk v3"); !ok || dep != "aws sdk v3" {
+		t.Fatalf("expected multi-word dependency to parse without truncation")
+	}
 	if _, ok := isDetailCommand("open"); ok {
 		t.Fatalf("expected invalid detail command to fail")
 	}

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -164,7 +164,9 @@ func applySummaryCommand(state *summaryState, input string, out io.Writer) bool 
 		state.page++
 		return true
 	case "prev", "p":
-		state.page--
+		if state.page > 1 {
+			state.page--
+		}
 		return true
 	case "size":
 		return handleSizeCommand(state, fields)

--- a/internal/ui/summary_commands_test.go
+++ b/internal/ui/summary_commands_test.go
@@ -68,6 +68,14 @@ func TestSummaryCommandHandlersPagingAndShortcuts(t *testing.T) {
 			},
 		},
 		{
+			name: "prev command clamps at first page",
+			expectations: []summaryCommandExpectation{
+				newSummaryCommandExpectation("page 1", true, 1, 10, sortByWaste),
+				newSummaryCommandExpectation("prev", true, 1, 10, sortByWaste),
+				newSummaryCommandExpectation("p", true, 1, 10, sortByWaste),
+			},
+		},
+		{
 			name: "size command resets page",
 			expectations: []summaryCommandExpectation{
 				newSummaryCommandExpectation("size 7", true, 1, 7, sortByWaste),


### PR DESCRIPTION
## Summary
Fix two `internal/ui` regressions in command handling so detail views preserve full dependency names and summary pagination never goes below page 1.

## Changes
- Updated `isDetailCommand` to return the full dependency argument tail instead of truncating after the second whitespace token.
- Updated summary `prev`/`p` handling to clamp at page 1.
- Added regression coverage for multi-word detail commands and first-page pagination clamping.
- Closes #697 and #698.

## Validation
Commands and checks run:

```bash
go test ./internal/ui
make fmt
make ci
```

Additional manual validation:
- Reviewed the command paths in `internal/ui/detail.go` and `internal/ui/summary.go` to confirm the fixes match the reported repros.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected; command parsing and page clamping are constant-time changes.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
