### PR TITLE
fix(analysis): avoid counting symlink includes as matches

### DIFF
--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -126,9 +126,6 @@ func (w *scopeWalker) walk(currentPath string, entry fs.DirEntry, walkErr error)
 		return nil
 	}
 	if entry.Type()&fs.ModeSymlink != 0 {
-		if includeMatched {
-			w.stats.includeMatches[includePattern]++
-		}
 		recordScopeSkipReason(w.stats, slashed, "is symlink (not copied)")
 		return nil
 	}

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -120,6 +120,9 @@ func TestApplyPathScopeSkipsSymlinkedFiles(t *testing.T) {
 	if _, err := os.Lstat(filepath.Join(scopedPath, "src", "linked.js")); !os.IsNotExist(err) {
 		t.Fatalf("expected symlinked file to be skipped, got err=%v", err)
 	}
+	if !containsWarning(warnings, "analysis scope include matches: src/**/*.js=1") {
+		t.Fatalf("expected include summary to count only copied files, got %#v", warnings)
+	}
 	if !containsWarning(warnings, "analysis scope skipped file: src/linked.js (is symlink (not copied))") {
 		t.Fatalf("expected symlink skip diagnostic, got %#v", warnings)
 	}


### PR DESCRIPTION
## Summary
Fix `internal/analysis/scope.go` so include-match diagnostics count only files that are actually copied into the scoped workspace, excluding skipped symlinks.

## Changes
- Removed the symlink-branch include-match increment in `scopeWalker.walk`.
- Added a regression assertion in `TestApplyPathScopeSkipsSymlinkedFiles` to require `analysis scope include matches: src/**/*.js=1`.
- Kept the existing symlink-skip warning behavior intact.
- Closes #682.

## Validation
Commands and checks run:

```bash
go test ./internal/analysis
make fmt
make ci
```

Additional manual validation:
- Reviewed the symlink skip path in `internal/analysis/scope.go` to confirm the counter now advances only after a file survives the symlink guard.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected; this removes one counter increment from a skipped-file branch.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
