### PR TITLE
fix(report): recompute waste when used percent is non-positive

### DIFF
--- a/internal/report/baseline_diff.go
+++ b/internal/report/baseline_diff.go
@@ -217,7 +217,7 @@ func wasteFromDependency(dep DependencyReport) float64 {
 		return 0
 	}
 	usedPercent := dep.UsedPercent
-	if usedPercent == 0 && dep.UsedExportsCount > 0 {
+	if usedPercent <= 0 {
 		usedPercent = (float64(dep.UsedExportsCount) / float64(dep.TotalExportsCount)) * 100
 	}
 	return 100 - usedPercent

--- a/internal/report/baseline_diff_test.go
+++ b/internal/report/baseline_diff_test.go
@@ -88,6 +88,23 @@ func TestSummaryHelpersHandleNilInputs(t *testing.T) {
 	}
 }
 
+func TestWasteFromDependencyRecomputesNonPositiveUsedPercent(t *testing.T) {
+	dependency := DependencyReport{
+		UsedExportsCount:  1,
+		TotalExportsCount: 4,
+		UsedPercent:       -1,
+	}
+
+	if got := wasteFromDependency(dependency); got != 75 {
+		t.Fatalf("expected waste to be recomputed from used/total counts, got %f", got)
+	}
+
+	dependency.UsedPercent = 0
+	if got := wasteFromDependency(dependency); got != 75 {
+		t.Fatalf("expected zero used percent to be recomputed from used/total counts, got %f", got)
+	}
+}
+
 func TestComputeBaselineComparisonDeterministic(t *testing.T) {
 	current := Report{
 		Dependencies: []DependencyReport{


### PR DESCRIPTION
## Summary
Fix `internal/report/baseline_diff.go` so baseline waste calculations recompute from counts when `UsedPercent` is zero or a negative sentinel value, preventing impossible waste percentages above 100.

## Changes
- Changed `wasteFromDependency` to recompute usage when `UsedPercent <= 0` instead of only when it equals zero.
- Added regression coverage for both negative and zero `UsedPercent` inputs.
- Kept the existing baseline comparison logic unchanged outside the non-positive fallback.
- Closes #696.

## Validation
Commands and checks run:

```bash
go test ./internal/report
make fmt
make ci
```

Additional manual validation:
- Reviewed the baseline delta path to confirm the new condition matches the existing `dependencyUsageSignal` non-positive handling.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected; this is a constant-time conditional change.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
