### PR TITLE
fix(notify): handle backticks in Slack repository and trigger text

### DIFF
--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -95,8 +95,8 @@ func buildSlackPayload(delivery Delivery) ([]byte, error) {
 			{
 				Type: "section",
 				Text: &slackText{
-					Type: "mrkdwn",
-					Text: fmt.Sprintf("*Repository:* `%s`\n*Trigger:* `%s`", repoPath, delivery.Trigger),
+					Type: "plain_text",
+					Text: fmt.Sprintf("Repository: %s\nTrigger: %s", repoPath, delivery.Trigger),
 				},
 			},
 			{

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -112,6 +112,51 @@ func TestBuildSlackPayloadIncludesThresholdStatus(t *testing.T) {
 	}
 }
 
+func TestBuildSlackPayloadBackticksInRepoPathAndTrigger(t *testing.T) {
+	repoPath := "repo/`service`"
+	trigger := Trigger("bre`ach")
+
+	data, err := buildSlackPayload(Delivery{
+		Channel: ChannelSlack,
+		Trigger: trigger,
+		Report: report.Report{
+			RepoPath: repoPath,
+			Summary:  &report.Summary{DependencyCount: 3, UsedPercent: 45.5},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build payload with backticks: %v", err)
+	}
+
+	type text struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	type block struct {
+		Text *text `json:"text"`
+	}
+	type payload struct {
+		Blocks []block `json:"blocks"`
+	}
+
+	var decoded payload
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if len(decoded.Blocks) < 2 || decoded.Blocks[1].Text == nil {
+		t.Fatalf("expected repository/trigger section in payload, got %#v", decoded)
+	}
+
+	if decoded.Blocks[1].Text.Type != "plain_text" {
+		t.Fatalf("expected repository/trigger section as plain_text, got %q", decoded.Blocks[1].Text.Type)
+	}
+
+	expected := "Repository: " + repoPath + "\nTrigger: " + string(trigger)
+	if decoded.Blocks[1].Text.Text != expected {
+		t.Fatalf("expected repository/trigger text %q, got %q", expected, decoded.Blocks[1].Text.Text)
+	}
+}
+
 func TestSlackNotifierNotifyBuildPayloadError(t *testing.T) {
 	err := NewSlackNotifier(nil).Notify(context.Background(), Delivery{
 		Channel:    ChannelSlack,


### PR DESCRIPTION
## Summary
Fix Slack notification rendering when the repository path or trigger text contains backticks by avoiding mrkdwn inline-code formatting for that block.

## Changes
- Changed the Slack repository/trigger section from `mrkdwn` inline-code text to `plain_text`, so embedded backticks render literally instead of terminating formatting early.
- Added regression coverage for backticks in both `RepoPath` and `Trigger` values.
- Kept the rest of the Slack payload structure unchanged.
- Closes #699.

## Validation
Commands and checks run:

```bash
go test ./internal/notify
make fmt
make ci
```

Additional manual validation:
- Reviewed the payload block structure in `internal/notify/slack.go` to confirm the repository/trigger section now serializes as plain text with literal backticks.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
