### PR TITLE
fix(php): parse inline use statements after open tag

### DIFF
--- a/internal/lang/php/adapter_test.go
+++ b/internal/lang/php/adapter_test.go
@@ -234,6 +234,45 @@ $logger = new \Monolog\Logger("app");
 	}
 }
 
+func TestPHPAdapterParsesUseStatementsInlineWithPHPOpenTag(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, testComposerJSON), fmt.Sprintf(`{"require":{%q:"^3.0"}}`, testMonologDependency))
+	lockTemplate := `{
+  "packages": [
+    {
+      "name": %q,
+      "autoload": {"psr-4": {"Monolog\\": "src/Monolog"}}
+    }
+  ]
+}
+`
+	lockContent := fmt.Sprintf(lockTemplate, testMonologDependency)
+	writeFile(t, filepath.Join(repo, testComposerLock), lockContent)
+	writeFile(t, filepath.Join(repo, "src", testIndexPHP), `<?php use Monolog\Logger; $logger = new Logger("app");
+`)
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath:   repo,
+		Dependency: testMonologDependency,
+	})
+	if err != nil {
+		t.Fatalf(testAnalyseErrFmt, err)
+	}
+	if len(reportData.Dependencies) != 1 {
+		t.Fatalf(testExpectedOneDependencyReportFmt, len(reportData.Dependencies))
+	}
+	dep := reportData.Dependencies[0]
+	if dep.TotalExportsCount == 0 {
+		t.Fatalf("expected inline open-tag use import to be counted")
+	}
+	if dep.UsedExportsCount == 0 {
+		t.Fatalf("expected inline open-tag use import usage to be counted")
+	}
+	if containsWarning(reportData.Warnings, "no imports found") {
+		t.Fatalf("did not expect no-import warning for inline open-tag use import: %#v", reportData.Warnings)
+	}
+}
+
 func TestPHPAdapterIgnoresNamespaceMentionsInCommentsAndStrings(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, testComposerJSON), fmt.Sprintf(`{"require":{%q:"^3.0"}}`, testMonologDependency))

--- a/internal/lang/php/import_parser.go
+++ b/internal/lang/php/import_parser.go
@@ -15,7 +15,7 @@ type importParseResult struct {
 	unresolvedCount int
 }
 
-var useStmtPattern = regexp.MustCompile(`(?ms)^\s*use\s+([^;]+);`)
+var useStmtPattern = regexp.MustCompile(`(?ms)(?:^\s*|<\?php\s+)use\s+([^;]+);`)
 var namespaceRefPattern = regexp.MustCompile(`\\?[A-Za-z_][A-Za-z0-9_]*(?:\\[A-Za-z_][A-Za-z0-9_]*)+`)
 var dynamicPattern = regexp.MustCompile(`(?m)(new\s+\$[A-Za-z_]|\$[A-Za-z_][A-Za-z0-9_]*\s*::|\b(class_exists|interface_exists|trait_exists|method_exists)\s*\()`) //nolint:lll
 


### PR DESCRIPTION
## Summary
Fix PHP import parsing so `use` statements written on the same line as the `<?php` open tag are still recognized and attributed correctly.

## Changes
- Expanded the PHP `use` regex to match `use` immediately after `<?php` on the same line.
- Added a regression test that exercises inline-open-tag imports and verifies the dependency is counted through normal adapter analysis.
- Left the broader namespace reference and dynamic-use heuristics unchanged.
- Closes #686.

## Validation
Commands and checks run:

```bash
go test ./internal/lang/php
make fmt
make ci
```

Additional manual validation:
- Reviewed the updated import parser to confirm the new pattern only broadens the open-tag prefix case without changing standard line-start parsing.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected; the regex change is narrow and only affects import extraction.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
