### PR TITLE
fix(workspace): return descriptive missing-ref lookup errors

### DIFF
--- a/internal/workspace/git_refs.go
+++ b/internal/workspace/git_refs.go
@@ -1,7 +1,9 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -69,10 +71,10 @@ func findPackedRefSHA(packedRefs, ref string) string {
 }
 
 func resolveRefLookupError(ref string, refErr, packedErr error) error {
-	if refErr != nil {
+	if refErr != nil && !errors.Is(refErr, os.ErrNotExist) {
 		return refErr
 	}
-	if packedErr != nil {
+	if packedErr != nil && !errors.Is(packedErr, os.ErrNotExist) {
 		return packedErr
 	}
 	return fmt.Errorf("ref %s not found", ref)

--- a/internal/workspace/workspace_commit_test.go
+++ b/internal/workspace/workspace_commit_test.go
@@ -144,23 +144,23 @@ func TestResolveRefSHAFallsBackToCommonDir(t *testing.T) {
 }
 
 func TestResolveRefSHAErrorPaths(t *testing.T) {
-	t.Run("returns packed refs read error when loose ref invalid", func(t *testing.T) {
+	t.Run("returns ref not found when loose ref invalid and packed refs are missing", func(t *testing.T) {
 		gitDir := t.TempDir()
 		mustWrite(t, filepath.Join(gitDir, "refs", "heads", "main"), "bad-sha\n")
 
 		_, err := resolveRefSHA(gitDir, mainRefPath)
-		if err == nil || !strings.Contains(err.Error(), packedRefsFile) {
-			t.Fatalf("expected packed-refs error, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "ref "+mainRefPath+" not found") {
+			t.Fatalf("expected ref-not-found error, got %v", err)
 		}
 	})
 
-	t.Run("returns loose ref read error when packed refs do not match", func(t *testing.T) {
+	t.Run("returns ref not found when loose ref is missing and packed refs do not match", func(t *testing.T) {
 		gitDir := t.TempDir()
 		mustWrite(t, filepath.Join(gitDir, packedRefsFile), shaMain+" "+otherMainRef+"\n")
 
 		_, err := resolveRefSHA(gitDir, mainRefPath)
-		if err == nil || !strings.Contains(err.Error(), mainRefPath) {
-			t.Fatalf("expected loose ref error, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "ref "+mainRefPath+" not found") {
+			t.Fatalf("expected ref-not-found error, got %v", err)
 		}
 	})
 
@@ -172,6 +172,28 @@ func TestResolveRefSHAErrorPaths(t *testing.T) {
 		_, err := resolveRefSHA(gitDir, mainRefPath)
 		if err == nil || !strings.Contains(err.Error(), "ref "+mainRefPath+" not found") {
 			t.Fatalf("expected ref-not-found error, got %v", err)
+		}
+	})
+
+	t.Run("returns ref not found when loose and packed refs are missing", func(t *testing.T) {
+		gitDir := t.TempDir()
+
+		_, err := resolveRefSHA(gitDir, mainRefPath)
+		if err == nil || !strings.Contains(err.Error(), "ref "+mainRefPath+" not found") {
+			t.Fatalf("expected ref-not-found error, got %v", err)
+		}
+	})
+
+	t.Run("returns packed refs read error when packed refs path is unreadable", func(t *testing.T) {
+		gitDir := t.TempDir()
+		mustWrite(t, filepath.Join(gitDir, "refs", "heads", "main"), "bad-sha\n")
+		if err := os.MkdirAll(filepath.Join(gitDir, packedRefsFile), 0o755); err != nil {
+			t.Fatalf("mkdir packed-refs dir: %v", err)
+		}
+
+		_, err := resolveRefSHA(gitDir, mainRefPath)
+		if err == nil || !strings.Contains(err.Error(), packedRefsFile) {
+			t.Fatalf("expected packed-refs read error, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
Fix workspace ref lookup errors so missing loose refs no longer surface opaque `os.ErrNotExist` messages when the real outcome should be a descriptive missing-ref error.

## Changes
- Updated `resolveRefLookupError` to ignore `os.ErrNotExist` from loose-ref and packed-ref lookup paths unless the underlying read failed for another reason.
- Added error-path tests covering missing loose refs, missing packed refs, mismatched refs, and unreadable `packed-refs` cases.
- Preserved existing behavior for genuine read failures.
- Closes #694.

## Validation
Commands and checks run:

```bash
go test ./internal/workspace
make fmt
make ci
```

Additional manual validation:
- Reviewed the lookup flow in `internal/workspace/git_refs.go` to confirm only `ErrNotExist` noise is suppressed and non-existence still resolves to `ref <name> not found`.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
