### PR TITLE
fix(cli): prevent positional capture and preserve mapped run exit codes

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -47,6 +47,9 @@ func (c *CommandLine) Run(ctx context.Context, args []string) int {
 	output, runErr := c.Executor.Execute(ctx, req)
 	writeErr := c.writeOutput(output)
 	if writeErr != nil {
+		if runErr != nil {
+			return exitCodeForRunError(runErr)
+		}
 		return 1
 	}
 

--- a/internal/cli/cli_cov_more_test.go
+++ b/internal/cli/cli_cov_more_test.go
@@ -41,3 +41,23 @@ func TestRunRunnerErrorWriteFailure(t *testing.T) {
 		t.Fatalf("expected err writer failure to return exit code 1, got %d", code)
 	}
 }
+
+func TestRunPreservesRunErrorExitCodeOnOutputWriteFailure(t *testing.T) {
+	cases := []struct {
+		name     string
+		runErr   error
+		wantCode int
+	}{
+		{name: "threshold_breach", runErr: app.ErrFailOnIncrease, wantCode: 3},
+		{name: "lockfile_drift", runErr: app.ErrLockfileDrift, wantCode: 4},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New(&fakeRunner{output: "partial report", err: tc.runErr}, &failWriter{}, &bytes.Buffer{})
+			if code := c.Run(context.Background(), []string{"analyse", "lodash"}); code != tc.wantCode {
+				t.Fatalf("expected mapped run error exit code %d, got %d", tc.wantCode, code)
+			}
+		})
+	}
+}

--- a/internal/cli/parse_analyse.go
+++ b/internal/cli/parse_analyse.go
@@ -26,7 +26,11 @@ type analyseParseState struct {
 }
 
 func parseAnalyse(args []string, req app.Request) (app.Request, error) {
-	args = normalizeArgs(args)
+	normalizedArgs, err := normalizeArgs(args)
+	if err != nil {
+		return req, err
+	}
+	args = normalizedArgs
 
 	fs, flags := newAnalyseFlagSet(req)
 	if err := parseFlagSet(fs, args); err != nil {

--- a/internal/cli/parse_analyse_test.go
+++ b/internal/cli/parse_analyse_test.go
@@ -705,6 +705,16 @@ func TestParseArgsAnalyseInvalidCombinations(t *testing.T) {
 	}
 }
 
+func TestParseArgsAnalyseTrailingFlagDoesNotConsumeDependency(t *testing.T) {
+	_, err := ParseArgs([]string{"analyse", "lodash", "--config"})
+	if err == nil {
+		t.Fatalf("expected missing flag value error")
+	}
+	if !strings.Contains(err.Error(), "flag needs an argument: -config") {
+		t.Fatalf(unexpectedValidationErrFmt, err)
+	}
+}
+
 func TestParseArgsVisitedFlagThresholdAliasMatch(t *testing.T) {
 	req := mustParseArgs(t, []string{
 		"analyse", "--top", "2",

--- a/internal/cli/parse_dashboard.go
+++ b/internal/cli/parse_dashboard.go
@@ -10,7 +10,11 @@ import (
 )
 
 func parseDashboard(args []string, req app.Request) (app.Request, error) {
-	args = normalizeArgs(args)
+	normalizedArgs, err := normalizeArgs(args)
+	if err != nil {
+		return req, err
+	}
+	args = normalizedArgs
 
 	fs := flag.NewFlagSet("dashboard", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)

--- a/internal/cli/parse_shared.go
+++ b/internal/cli/parse_shared.go
@@ -141,9 +141,9 @@ func isVersionArg(args []string) bool {
 	return len(args) == 1 && strings.TrimSpace(args[0]) == "--version"
 }
 
-func normalizeArgs(args []string) []string {
+func normalizeArgs(args []string) ([]string, error) {
 	if len(args) == 0 {
-		return args
+		return args, nil
 	}
 
 	flags := make([]string, 0, len(args))
@@ -157,7 +157,10 @@ func normalizeArgs(args []string) []string {
 		}
 		if strings.HasPrefix(arg, "-") {
 			flags = append(flags, arg)
-			if flagNeedsValue(arg) && i+1 < len(args) {
+			if flagNeedsValue(arg) {
+				if i+1 >= len(args) || args[i+1] == "--" {
+					return nil, missingFlagValueError(arg)
+				}
 				flags = append(flags, args[i+1])
 				i++
 			}
@@ -166,7 +169,15 @@ func normalizeArgs(args []string) []string {
 		positionals = append(positionals, arg)
 	}
 
-	return append(flags, positionals...)
+	return append(flags, positionals...), nil
+}
+
+func missingFlagValueError(arg string) error {
+	name := strings.TrimLeft(arg, "-")
+	if name == "" {
+		name = arg
+	}
+	return fmt.Errorf("flag needs an argument: -%s", name)
 }
 
 func flagNeedsValue(arg string) bool {

--- a/internal/cli/parse_shared_test.go
+++ b/internal/cli/parse_shared_test.go
@@ -63,7 +63,10 @@ func TestSplitPatternListSkipsEmptyAndDuplicateEntries(t *testing.T) {
 }
 
 func TestNormalizeArgsAndFlagNeedsValue(t *testing.T) {
-	args := normalizeArgs([]string{"lodash", "--top", "5", "--format=json", "--", "--literal"})
+	args, err := normalizeArgs([]string{"lodash", "--top", "5", "--format=json", "--", "--literal"})
+	if err != nil {
+		t.Fatalf(unexpectedErrFmt, err)
+	}
 	if len(args) == 0 {
 		t.Fatalf("expected normalized args")
 	}
@@ -78,6 +81,16 @@ func TestNormalizeArgsAndFlagNeedsValue(t *testing.T) {
 	}
 	if flagNeedsValue("--unknown-flag") {
 		t.Fatalf("did not expect unknown flag to be treated as requiring value")
+	}
+}
+
+func TestNormalizeArgsMissingFlagValueReturnsError(t *testing.T) {
+	_, err := normalizeArgs([]string{"lodash", "--config"})
+	if err == nil {
+		t.Fatalf("expected missing flag value error")
+	}
+	if !strings.Contains(err.Error(), "flag needs an argument: -config") {
+		t.Fatalf(unexpectedValidationErrFmt, err)
 	}
 }
 

--- a/internal/cli/parse_tui.go
+++ b/internal/cli/parse_tui.go
@@ -10,7 +10,11 @@ import (
 )
 
 func parseTUI(args []string, req app.Request) (app.Request, error) {
-	args = normalizeArgs(args)
+	normalizedArgs, err := normalizeArgs(args)
+	if err != nil {
+		return req, err
+	}
+	args = normalizedArgs
 
 	fs := flag.NewFlagSet("tui", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)


### PR DESCRIPTION
## Summary
Fix two `internal/cli` error-handling bugs so missing flag values no longer consume the dependency positional and mapped run exit codes survive stdout write failures.

## Changes
- Changed argument normalization to return an error when a value-taking flag is missing its value instead of consuming the dependency positional.
- Updated CLI parsing call sites to handle normalization errors explicitly.
- Preserved mapped run-error exit codes even when stdout writing fails after a threshold or lockfile error is already known.
- Added regression coverage for both the missing-value and exit-code preservation paths.
- Closes #679 and #680.

## Validation
Commands and checks run:

```bash
go test ./internal/cli
make fmt
make ci
```

Additional manual validation:
- Reviewed the `normalizeArgs` flow and `CommandLine.Run` exit handling to confirm the user-facing error and exit-code semantics now match the issue repros.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
