### PR TITLE
fix(release): enforce conventional squash merge policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- PR title must use Conventional Commits, for example `fix(scope): concise summary`. Squash merges publish that title to `main`, so do not rewrite it into a non-conventional subject. -->
+
 ## Summary
 
 Describe the problem and the intent of this change. Use `N/A` only when the section truly does not apply.

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -39,14 +39,25 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const repo = context.payload.repository || {};
-            const squashTitle = repo.squash_merge_commit_title ??
-              (repo.use_squash_pr_title_as_default === true ? 'PR_TITLE' :
-                repo.use_squash_pr_title_as_default === false ? 'COMMIT_OR_PR_TITLE' : '');
-            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(repo.allow_merge_commit ?? ''));
-            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(repo.allow_rebase_merge ?? ''));
-            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(repo.allow_squash_merge ?? ''));
-            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(squashTitle));
+            const data = await github.graphql(
+              `query($owner: String!, $repo: String!) {
+                repository(owner: $owner, name: $repo) {
+                  mergeCommitAllowed
+                  rebaseMergeAllowed
+                  squashMergeAllowed
+                  squashMergeCommitTitle
+                }
+              }`,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              },
+            );
+            const repo = data.repository;
+            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(repo.mergeCommitAllowed));
+            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(repo.rebaseMergeAllowed));
+            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(repo.squashMergeAllowed));
+            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(repo.squashMergeCommitTitle || ''));
 
       - name: Validate PR title and template
         env:

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -39,11 +39,14 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const { data: repo } = await github.rest.repos.get(context.repo);
-            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(repo.allow_merge_commit));
-            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(repo.allow_rebase_merge));
-            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(repo.allow_squash_merge));
-            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(repo.squash_merge_commit_title || ''));
+            const repo = context.payload.repository || {};
+            const squashTitle = repo.squash_merge_commit_title ??
+              (repo.use_squash_pr_title_as_default === true ? 'PR_TITLE' :
+                repo.use_squash_pr_title_as_default === false ? 'COMMIT_OR_PR_TITLE' : '');
+            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(repo.allow_merge_commit ?? ''));
+            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(repo.allow_rebase_merge ?? ''));
+            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(repo.allow_squash_merge ?? ''));
+            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(squashTitle));
 
       - name: Validate PR title and template
         env:

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -35,8 +35,18 @@ jobs:
             fs.writeFileSync(bodyPath, context.payload.pull_request?.body || '', 'utf8');
             core.exportVariable('PR_BODY_FILE', bodyPath);
 
+      - name: Read repository merge policy
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: repo } = await github.rest.repos.get(context.repo);
+            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(repo.allow_merge_commit));
+            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(repo.allow_rebase_merge));
+            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(repo.allow_squash_merge));
+            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(repo.squash_merge_commit_title || ''));
+
       - name: Validate PR title and template
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: go run ./tools/prcheck --title "$PR_TITLE" --head-ref "$PR_HEAD_REF" --body-file "$PR_BODY_FILE"
+        run: go run ./tools/prcheck --check-repo-policy --title "$PR_TITLE" --head-ref "$PR_HEAD_REF" --body-file "$PR_BODY_FILE"

--- a/tools/prcheck/main.go
+++ b/tools/prcheck/main.go
@@ -42,6 +42,13 @@ var requiredChecklistItems = []string{
 	"Ready for review",
 }
 
+type repoMergePolicy struct {
+	allowMergeCommit       string
+	allowRebaseMerge       string
+	allowSquashMerge       string
+	squashMergeCommitTitle string
+}
+
 func main() {
 	os.Exit(run(os.Args[1:], os.Getenv, os.Stderr))
 }
@@ -52,6 +59,11 @@ func run(args []string, getenv func(string) string, stderr io.Writer) int {
 	title := fs.String("title", strings.TrimSpace(getenv("PR_TITLE")), "pull request title")
 	headRef := fs.String("head-ref", strings.TrimSpace(getenv("PR_HEAD_REF")), "pull request head ref")
 	bodyFile := fs.String("body-file", "", "path to a file containing the pull request body")
+	checkRepoPolicy := fs.Bool("check-repo-policy", false, "validate repository merge policy")
+	allowMergeCommit := fs.String("allow-merge-commit", strings.TrimSpace(getenv("REPO_ALLOW_MERGE_COMMIT")), "whether the repository allows merge commits")
+	allowRebaseMerge := fs.String("allow-rebase-merge", strings.TrimSpace(getenv("REPO_ALLOW_REBASE_MERGE")), "whether the repository allows rebase merges")
+	allowSquashMerge := fs.String("allow-squash-merge", strings.TrimSpace(getenv("REPO_ALLOW_SQUASH_MERGE")), "whether the repository allows squash merges")
+	squashMergeCommitTitle := fs.String("squash-merge-commit-title", strings.TrimSpace(getenv("REPO_SQUASH_MERGE_COMMIT_TITLE")), "repository default squash merge title mode")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -73,6 +85,20 @@ func run(args []string, getenv func(string) string, stderr io.Writer) int {
 			return 1
 		}
 		return 1
+	}
+	if *checkRepoPolicy {
+		policy := repoMergePolicy{
+			allowMergeCommit:       *allowMergeCommit,
+			allowRebaseMerge:       *allowRebaseMerge,
+			allowSquashMerge:       *allowSquashMerge,
+			squashMergeCommitTitle: *squashMergeCommitTitle,
+		}
+		if err := validateRepoMergePolicy(policy); err != nil {
+			if _, writeErr := fmt.Fprintf(stderr, "%v\n", err); writeErr != nil {
+				return 1
+			}
+			return 1
+		}
 	}
 	return 0
 }
@@ -242,4 +268,27 @@ func fieldHasValue(content, field string) bool {
 func checkedChecklistItem(content, item string) bool {
 	pattern := regexp.MustCompile(`(?mi)^-\s*\[[x]\]\s*` + regexp.QuoteMeta(item) + `\s*$`)
 	return pattern.MatchString(content)
+}
+
+func validateRepoMergePolicy(policy repoMergePolicy) error {
+	var failures []string
+	failures = append(failures, repoPolicyExpectationFailure(policy.allowSquashMerge, "true", "Repository must allow squash merges so release-please sees a single PR title-derived commit on main")...)
+	failures = append(failures, repoPolicyExpectationFailure(policy.allowMergeCommit, "false", "Repository must disable merge commits so merged PRs cannot bypass the squash-title release policy")...)
+	failures = append(failures, repoPolicyExpectationFailure(policy.allowRebaseMerge, "false", "Repository must disable rebase merges so merged PRs cannot bypass the squash-title release policy")...)
+	failures = append(failures, repoPolicyExpectationFailure(policy.squashMergeCommitTitle, "PR_TITLE", "Repository squash merge titles must default to the PR title so release-please sees the validated Conventional Commit title")...)
+	if len(failures) > 0 {
+		return errors.New(strings.Join(failures, "\n"))
+	}
+	return nil
+}
+
+func repoPolicyExpectationFailure(actual, expected, message string) []string {
+	actual = strings.TrimSpace(actual)
+	if actual == expected {
+		return nil
+	}
+	if actual == "" {
+		return []string{fmt.Sprintf("%s (expected %q, got empty value)", message, expected)}
+	}
+	return []string{fmt.Sprintf("%s (expected %q, got %q)", message, expected, actual)}
 }

--- a/tools/prcheck/main_test.go
+++ b/tools/prcheck/main_test.go
@@ -34,6 +34,86 @@ func TestRunAcceptsBodyFile(t *testing.T) {
 	}
 }
 
+func TestRunAcceptsValidRepoPolicy(t *testing.T) {
+	var stderr bytes.Buffer
+	base := map[string]string{
+		"PR_TITLE":    "fix(release): validate PR metadata",
+		"PR_HEAD_REF": "bug/issue-000-pr-title-template-gate",
+		"PR_BODY":     validBody(),
+	}
+	values := mergeMaps(base, validRepoPolicyEnv())
+	env := mapEnv(values)
+	code := run([]string{"--check-repo-policy"}, env, &stderr)
+	if code != 0 {
+		t.Fatalf("run exited with %d, stderr: %s", code, stderr.String())
+	}
+}
+
+func TestRunRejectsInvalidRepoPolicy(t *testing.T) {
+	var stderr bytes.Buffer
+	base := map[string]string{
+		"PR_TITLE":    "fix(release): validate PR metadata",
+		"PR_HEAD_REF": "bug/issue-000-pr-title-template-gate",
+		"PR_BODY":     validBody(),
+	}
+	policy := map[string]string{
+		"REPO_ALLOW_MERGE_COMMIT":        "true",
+		"REPO_ALLOW_REBASE_MERGE":        "false",
+		"REPO_ALLOW_SQUASH_MERGE":        "true",
+		"REPO_SQUASH_MERGE_COMMIT_TITLE": "COMMIT_OR_PR_TITLE",
+	}
+	values := mergeMaps(base, policy)
+	env := mapEnv(values)
+	code := run([]string{"--check-repo-policy"}, env, &stderr)
+	if code != 1 {
+		t.Fatalf("run exited with %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Repository must disable merge commits") {
+		t.Fatalf("stderr did not explain repo policy failure: %s", stderr.String())
+	}
+}
+
+func TestRunRejectsMissingRepoPolicyValue(t *testing.T) {
+	var stderr bytes.Buffer
+	base := map[string]string{
+		"PR_TITLE":    "fix(release): validate PR metadata",
+		"PR_HEAD_REF": "bug/issue-000-pr-title-template-gate",
+		"PR_BODY":     validBody(),
+	}
+	policy := map[string]string{
+		"REPO_ALLOW_MERGE_COMMIT": "false",
+		"REPO_ALLOW_REBASE_MERGE": "false",
+		"REPO_ALLOW_SQUASH_MERGE": "true",
+	}
+	values := mergeMaps(base, policy)
+	code := run([]string{"--check-repo-policy"}, mapEnv(values), &stderr)
+	if code != 1 {
+		t.Fatalf("run exited with %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `expected "PR_TITLE", got empty value`) {
+		t.Fatalf("stderr did not explain missing repo policy value: %s", stderr.String())
+	}
+}
+
+func TestRunHandlesRepoPolicyValidationErrorWriteFailure(t *testing.T) {
+	base := map[string]string{
+		"PR_TITLE":    "fix(release): validate PR metadata",
+		"PR_HEAD_REF": "bug/issue-000-pr-title-template-gate",
+		"PR_BODY":     validBody(),
+	}
+	policy := map[string]string{
+		"REPO_ALLOW_MERGE_COMMIT":        "false",
+		"REPO_ALLOW_REBASE_MERGE":        "false",
+		"REPO_ALLOW_SQUASH_MERGE":        "true",
+		"REPO_SQUASH_MERGE_COMMIT_TITLE": "COMMIT_OR_PR_TITLE",
+	}
+	values := mergeMaps(base, policy)
+	code := run([]string{"--check-repo-policy"}, mapEnv(values), &errWriter{})
+	if code != 1 {
+		t.Fatalf("run exited with %d", code)
+	}
+}
+
 func TestRunRejectsMissingBodyFile(t *testing.T) {
 	var stderr bytes.Buffer
 	args := []string{"--title", "fix(release): validate PR metadata", "--body-file", filepath.Join(t.TempDir(), "missing.md")}
@@ -189,6 +269,25 @@ Additional manual validation:
 func mapEnv(values map[string]string) func(string) string {
 	return func(key string) string {
 		return values[key]
+	}
+}
+
+func mergeMaps(parts ...map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for _, part := range parts {
+		for key, value := range part {
+			merged[key] = value
+		}
+	}
+	return merged
+}
+
+func validRepoPolicyEnv() map[string]string {
+	return map[string]string{
+		"REPO_ALLOW_MERGE_COMMIT":        "false",
+		"REPO_ALLOW_REBASE_MERGE":        "false",
+		"REPO_ALLOW_SQUASH_MERGE":        "true",
+		"REPO_SQUASH_MERGE_COMMIT_TITLE": "PR_TITLE",
 	}
 }
 


### PR DESCRIPTION
## Summary

Stop release-please from skipping merged fixes when a single-commit PR is squash-merged with a non-conventional commit subject.

## Changes

- Extended `tools/prcheck` so the required `pr-metadata` check also validates the repository merge policy.
- Updated `pr-metadata` to read the live repo settings and fail if merge commits or rebase merges are enabled, or if squash titles do not default to the PR title.
- Added regression coverage for valid, drifted, missing, and write-failure repo policy paths.
- Added a short PR template note so authors keep the PR title conventional.
- Applied the companion GitHub repo setting change: `allow_merge_commit=false`, `allow_rebase_merge=false`, `allow_squash_merge=true`, `squash_merge_commit_title=PR_TITLE`.

## Validation

Commands and checks run:

```bash
go test ./tools/prcheck
make ci
```

Additional manual validation:

- Verified the live repository settings with `gh api repos/ben-ranford/lopper` after patching them.
- Confirmed the package coverage for `tools/prcheck` returned to `98.6%`, above the repo's `98%` per-package floor.

## Risk and compatibility

- Breaking changes: Merge commits and rebase merges are no longer available for this repository.
- Migration required: Maintainers must merge PRs with squash and keep the PR title conventional.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
