### PR TITLE
fix(flags): suppress repeated release PR graduation candidates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -471,6 +471,70 @@ jobs:
         if: ${{ steps.tap_token.outputs.available != 'true' }}
         run: echo "HOMEBREW_TAP_TOKEN not configured; skipping tap update."
 
+  stamp-feature-release-history:
+    needs:
+      - release-please
+      - publish
+    if: ${{ needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: feature-release-history-main
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag || github.sha }}
+          token: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Stamp first stable release history
+        env:
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag || inputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          go run ./tools/featureflag stamp-release --release "${RELEASE_TAG}"
+          go run ./tools/featureflag validate
+
+          git add internal/featureflags/features.json
+          if git diff --cached --quiet; then
+            echo "No feature release history changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore(flags): stamp ${RELEASE_TAG} feature release history"
+          for attempt in 1 2 3; do
+            echo "Push attempt ${attempt} for feature release history"
+            if ! git fetch origin main:refs/remotes/origin/main; then
+              echo "git fetch failed on attempt ${attempt}" >&2
+              sleep 2
+              continue
+            fi
+            if ! git rebase origin/main; then
+              echo "git rebase failed on attempt ${attempt}; aborting rebase and retrying" >&2
+              git rebase --abort || true
+              sleep 2
+              continue
+            fi
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Failed to push feature release history after retries" >&2
+          exit 1
+
   skip-release:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created != 'true' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ Contributor rules:
 - Rolling builds enable every registered flag by default.
 - Stable release builds enable `stable` flags by default and may enable specific `preview` flags through `internal/featureflags/release_locks.json`.
 - Release locks are release-specific default-on decisions; they do not change the lifecycle to `stable`.
+- The stable release workflow stamps `firstStableRelease` after a flag ships in a semver release so later release PRs only surface first-release preview flags.
 - Graduation requires a separate PR that changes the registry lifecycle to `stable` and states the rollout evidence.
 - Use `make feature-flag-graduate FEATURE=...` locally, or run `graduate-feature.yml`, to prepare a graduation PR.
 - PRs that use the `feat` Conventional Commit type must add at least one new feature flag entry, and new entries must stay `preview`.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -176,6 +176,9 @@ Release-please PRs also receive an automated sticky comment with the same releas
 - edit `internal/featureflags/release_locks.json` to ship a preview flag default-on for that release only
 - run `graduate-feature.yml` to open a dedicated PR that changes a flag from `preview` to `stable`
 
+After a stable release publishes, the release workflow stamps `firstStableRelease` on any flags that shipped in that release for the first time.
+Subsequent release PR comments treat only unstamped preview flags as first-release graduation candidates.
+
 ## Graduation
 
 Graduation is a deliberate registry update from `preview` to `stable`.

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -37,6 +37,10 @@ func TestNewRegistryValidatesEntries(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "invalid feature lifecycle") {
 		t.Fatalf("expected invalid lifecycle error, got %v", err)
 	}
+	_, err = NewRegistry([]Flag{{Code: "LOP-FEAT-0001", Name: "alpha", Lifecycle: LifecyclePreview, FirstStableRelease: "nope"}})
+	if err == nil || !strings.Contains(err.Error(), "invalid first stable release") {
+		t.Fatalf("expected invalid first stable release error, got %v", err)
+	}
 }
 
 func TestDefaultRegistryAndLookup(t *testing.T) {
@@ -49,6 +53,9 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 	assertDefaultFlag(t, defaultFlags, "swift-carthage-preview", "LOP-FEAT-0003")
 	assertDefaultFlag(t, defaultFlags, "powershell-adapter-preview", "LOP-FEAT-0004")
 	assertDefaultFlag(t, defaultFlags, "go-vendored-provenance-preview", "LOP-FEAT-0005")
+	if defaultFlags[0].FirstStableRelease != "v1.5.0" {
+		t.Fatalf("expected default flags to retain first stable release history, got %#v", defaultFlags[0])
+	}
 	if flags := (*Registry)(nil).Flags(); len(flags) != 0 {
 		t.Fatalf("expected nil registry flags to be empty, got %#v", flags)
 	}
@@ -72,7 +79,7 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 
 func TestCatalogParseAndFormat(t *testing.T) {
 	flags, err := ParseCatalog([]byte(`[
-		{"code":"LOP-FEAT-0002","name":"stable-flag","description":"Stable behavior","lifecycle":"stable"},
+		{"code":"LOP-FEAT-0002","name":"stable-flag","description":"Stable behavior","lifecycle":"stable","firstStableRelease":"1.5.0"},
 		{"code":"LOP-FEAT-0001","name":"preview-flag","description":"Preview behavior","lifecycle":"preview"}
 	]`))
 	if err != nil {
@@ -81,12 +88,15 @@ func TestCatalogParseAndFormat(t *testing.T) {
 	if len(flags) != 2 || flags[0].Code != "LOP-FEAT-0001" || flags[1].Code != "LOP-FEAT-0002" {
 		t.Fatalf("expected catalog flags sorted by code, got %#v", flags)
 	}
+	if flags[1].FirstStableRelease != "v1.5.0" {
+		t.Fatalf("expected first stable release to normalize, got %#v", flags[1])
+	}
 	data, err := FormatCatalog(flags)
 	if err != nil {
 		t.Fatalf("format catalog: %v", err)
 	}
 	formatted := string(data)
-	if !strings.Contains(formatted, `"code": "LOP-FEAT-0001"`) || !strings.HasSuffix(formatted, "\n") {
+	if !strings.Contains(formatted, `"code": "LOP-FEAT-0001"`) || !strings.Contains(formatted, `"firstStableRelease": "v1.5.0"`) || !strings.HasSuffix(formatted, "\n") {
 		t.Fatalf("expected formatted JSON catalog with newline, got %q", formatted)
 	}
 
@@ -637,10 +647,11 @@ func testRegistry(t *testing.T) *Registry {
 			Lifecycle:   LifecyclePreview,
 		},
 		{
-			Code:        "LOP-FEAT-0002",
-			Name:        "stable-flag",
-			Description: "Stable behavior",
-			Lifecycle:   LifecycleStable,
+			Code:               "LOP-FEAT-0002",
+			Name:               "stable-flag",
+			Description:        "Stable behavior",
+			Lifecycle:          LifecycleStable,
+			FirstStableRelease: "v1.5.0",
 		},
 	})
 	if err != nil {

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -3,30 +3,35 @@
     "code": "LOP-FEAT-0001",
     "name": "dart-source-attribution-preview",
     "description": "Enable richer Dart and Flutter dependency source attribution and federated plugin relationship reporting.",
-    "lifecycle": "stable"
+    "lifecycle": "stable",
+    "firstStableRelease": "v1.5.0"
   },
   {
     "code": "LOP-FEAT-0002",
     "name": "lockfile-drift-ecosystem-expansion-preview",
     "description": "Preview expansion of shared lockfile drift checks for .NET, Dart, Elixir, and SwiftPM ecosystems.",
-    "lifecycle": "stable"
+    "lifecycle": "stable",
+    "firstStableRelease": "v1.5.0"
   },
   {
     "code": "LOP-FEAT-0003",
     "name": "swift-carthage-preview",
     "description": "Enable Carthage dependency parsing for the Swift adapter.",
-    "lifecycle": "stable"
+    "lifecycle": "stable",
+    "firstStableRelease": "v1.5.0"
   },
   {
     "code": "LOP-FEAT-0004",
     "name": "powershell-adapter-preview",
     "description": "Enable preview support for the PowerShell language adapter.",
-    "lifecycle": "stable"
+    "lifecycle": "stable",
+    "firstStableRelease": "v1.5.0"
   },
   {
     "code": "LOP-FEAT-0005",
     "name": "go-vendored-provenance-preview",
     "description": "Enable vendored dependency provenance for Go using vendor/modules.txt metadata.",
-    "lifecycle": "stable"
+    "lifecycle": "stable",
+    "firstStableRelease": "v1.5.0"
   }
 ]

--- a/internal/featureflags/registry.go
+++ b/internal/featureflags/registry.go
@@ -2,12 +2,15 @@ package featureflags
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
 
 const featureCodePrefix = "LOP-FEAT-"
 const maxFeatureCode = 9999
+
+var stableReleaseVersionPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$`)
 
 type Lifecycle string
 
@@ -25,10 +28,11 @@ const (
 )
 
 type Flag struct {
-	Code        string    `json:"code" yaml:"code"`
-	Name        string    `json:"name" yaml:"name"`
-	Description string    `json:"description" yaml:"description"`
-	Lifecycle   Lifecycle `json:"lifecycle" yaml:"lifecycle"`
+	Code               string    `json:"code" yaml:"code"`
+	Name               string    `json:"name" yaml:"name"`
+	Description        string    `json:"description" yaml:"description"`
+	Lifecycle          Lifecycle `json:"lifecycle" yaml:"lifecycle"`
+	FirstStableRelease string    `json:"firstStableRelease,omitempty" yaml:"firstStableRelease,omitempty"`
 }
 
 type Registry struct {
@@ -166,7 +170,28 @@ func normalizeFlag(flag Flag) (Flag, error) {
 		return Flag{}, fmt.Errorf("feature %s: %w", flag.Code, err)
 	}
 	flag.Lifecycle = lifecycle
+	firstStableRelease, err := normalizeStableReleaseVersion(flag.FirstStableRelease)
+	if err != nil {
+		return Flag{}, fmt.Errorf("feature %s: %w", flag.Code, err)
+	}
+	flag.FirstStableRelease = firstStableRelease
 	return flag, nil
+}
+
+func normalizeStableReleaseVersion(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	if strings.HasPrefix(strings.ToLower(value), "v") {
+		value = "v" + strings.TrimSpace(value[1:])
+	} else {
+		value = "v" + value
+	}
+	if !stableReleaseVersionPattern.MatchString(value) {
+		return "", fmt.Errorf("invalid first stable release %q: must use vMAJOR.MINOR.PATCH", value)
+	}
+	return value, nil
 }
 
 func validateFeatureCode(code string) error {

--- a/tools/featureflag/main.go
+++ b/tools/featureflag/main.go
@@ -38,13 +38,15 @@ func main() {
 
 func run(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: featureflag add|graduate|validate|manifest|report|pr-enforce|release-pr-comment")
+		return fmt.Errorf("usage: featureflag add|graduate|stamp-release|validate|manifest|report|pr-enforce|release-pr-comment")
 	}
 	switch args[0] {
 	case "add":
 		return runAdd(args[1:])
 	case "graduate":
 		return runGraduate(args[1:])
+	case "stamp-release":
+		return runStampRelease(args[1:])
 	case "validate":
 		return runValidate()
 	case "manifest":

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -77,6 +77,8 @@ func TestRunFeatureFlagErrors(t *testing.T) {
 		{name: "extra add argument", args: []string{"add", "--name", "new-flag", "extra"}, want: "too many arguments"},
 		{name: "missing graduate feature", args: []string{"graduate"}, want: "feature code or name is required"},
 		{name: "extra graduate argument", args: []string{"graduate", "--feature", "preview-flag", "extra"}, want: "too many arguments"},
+		{name: "missing stamp release version", args: []string{"stamp-release"}, want: "release version is required"},
+		{name: "extra stamp-release argument", args: []string{"stamp-release", "--release", "v1.5.0", "extra"}, want: "too many arguments"},
 		{name: "missing previous catalog", args: []string{"pr-enforce", "--pr-title", "feat(flags): add registry"}, want: "previous feature catalog is required"},
 		{name: "extra pr-enforce argument", args: []string{"pr-enforce", "--previous-catalog", "previous.json", "extra"}, want: "too many arguments"},
 		{name: "missing release version", args: []string{"release-pr-comment"}, want: "release version is required"},
@@ -90,6 +92,7 @@ func TestRunFeatureFlagErrors(t *testing.T) {
 	}{
 		{name: "bad add flag", args: []string{"add", "--definitely-not-a-flag"}},
 		{name: "bad graduate flag", args: []string{"graduate", "--definitely-not-a-flag"}},
+		{name: "bad stamp-release flag", args: []string{"stamp-release", "--definitely-not-a-flag"}},
 		{name: "bad pr-enforce flag", args: []string{"pr-enforce", "--definitely-not-a-flag"}},
 		{name: "bad release-pr-comment flag", args: []string{"release-pr-comment", "--definitely-not-a-flag"}},
 	} {
@@ -104,6 +107,56 @@ func TestRunFeatureFlagErrors(t *testing.T) {
 		{name: "report", args: []string{"report"}},
 	} {
 		assertRunOK(t, tc.name, tc.args)
+	}
+}
+
+func TestRunStampRelease(t *testing.T) {
+	root := t.TempDir()
+	writeFeatureCatalog(t, root, graduateFeatureCatalog)
+	t.Chdir(root)
+
+	output, err := captureStdout(t, func() error {
+		return run([]string{"stamp-release", "--release", "1.5.0"})
+	})
+	if err != nil {
+		t.Fatalf("run stamp-release: %v", err)
+	}
+	flags := readFeatureCatalog(t, filepath.Join(root, "internal", "featureflags"))
+	for _, flag := range flags {
+		if flag.FirstStableRelease != "v1.5.0" {
+			t.Fatalf("expected stamped release for %s, got %#v", flag.Code, flag)
+		}
+	}
+	if !strings.Contains(output, "stamped 2 feature(s) with first stable release v1.5.0") {
+		t.Fatalf("expected stamp output, got %q", output)
+	}
+}
+
+func TestRunStampReleaseNoopWhenAlreadyStamped(t *testing.T) {
+	root := t.TempDir()
+	writeFeatureCatalog(t, root, `[
+  {
+    "code": "LOP-FEAT-0001",
+    "name": "preview-flag",
+    "description": "Preview behavior",
+    "lifecycle": "preview",
+    "firstStableRelease": "v1.5.0"
+  }
+]`)
+	t.Chdir(root)
+
+	output, err := captureStdout(t, func() error {
+		return run([]string{"stamp-release", "--release", "v1.5.1"})
+	})
+	if err != nil {
+		t.Fatalf("run stamp-release noop: %v", err)
+	}
+	flags := readFeatureCatalog(t, filepath.Join(root, "internal", "featureflags"))
+	if flags[0].FirstStableRelease != "v1.5.0" {
+		t.Fatalf("expected existing stamp to remain unchanged, got %#v", flags[0])
+	}
+	if !strings.Contains(output, "no feature release stamps to update for v1.5.1") {
+		t.Fatalf("expected noop output, got %q", output)
 	}
 }
 
@@ -252,6 +305,31 @@ func TestRunGraduateFeatureFlagGetwdAndWriteErrors(t *testing.T) {
 		writeFileUnderFn = oldWrite
 	})
 	if err := run([]string{"graduate", "--feature", "preview-flag"}); err == nil || !strings.Contains(err.Error(), "write feature catalog") {
+		t.Fatalf("expected write error, got %v", err)
+	}
+}
+
+func TestRunStampReleaseGetwdAndWriteErrors(t *testing.T) {
+	oldGetwd := getwdFn
+	getwdFn = func() (string, error) { return "", errors.New("cwd failed") }
+	if err := run([]string{"stamp-release", "--release", "v1.5.0"}); err == nil || !strings.Contains(err.Error(), "resolve working directory") {
+		t.Fatalf("expected getwd error, got %v", err)
+	}
+	getwdFn = oldGetwd
+
+	root := t.TempDir()
+	writeFeatureCatalog(t, root, graduateFeatureCatalog)
+	t.Chdir(root)
+
+	oldWrite := writeFileUnderFn
+	writeFileUnderFn = func(string, string, []byte, os.FileMode) error {
+		return errors.New("write failed")
+	}
+	t.Cleanup(func() {
+		getwdFn = oldGetwd
+		writeFileUnderFn = oldWrite
+	})
+	if err := run([]string{"stamp-release", "--release", "v1.5.0"}); err == nil || !strings.Contains(err.Error(), "write feature catalog") {
 		t.Fatalf("expected write error, got %v", err)
 	}
 }
@@ -826,17 +904,14 @@ func TestRunReleasePRComment(t *testing.T) {
 	oldValidate := validateDefaultRegistryFn
 	oldValidateLocks := validateDefaultReleaseLocksFn
 	oldDefaultRegistry := defaultRegistryFn
-	oldReleaseLockProvider := releaseLockProviderFn
 	t.Cleanup(func() {
 		validateDefaultRegistryFn = oldValidate
 		validateDefaultReleaseLocksFn = oldValidateLocks
 		defaultRegistryFn = oldDefaultRegistry
-		releaseLockProviderFn = oldReleaseLockProvider
 	})
 	validateDefaultRegistryFn = func() error { return nil }
 	validateDefaultReleaseLocksFn = func() error { return nil }
 	defaultRegistryFn = func() *featureflags.Registry { return testRegistry(t) }
-	releaseLockProviderFn = func(string) (*featureflags.ReleaseLock, error) { return nil, nil }
 
 	root := t.TempDir()
 	t.Chdir(root)
@@ -939,8 +1014,8 @@ func TestRunReleasePRCommentRejectsInjectedErrors(t *testing.T) {
 		t.Fatalf("expected manifest error, got %v", err)
 	}
 
-	if got := newlyAddedPreviewFlags(testRegistry(t).Flags(), nil, false); len(got) != 0 {
-		t.Fatalf("expected no preview flags when not compared, got %#v", got)
+	if got := graduationCandidatePreviewFlags(testRegistry(t).Flags()); len(got) != 1 || got[0].Code != "LOP-FEAT-0001" {
+		t.Fatalf("expected only unstamped preview flags as candidates, got %#v", got)
 	}
 }
 
@@ -999,13 +1074,31 @@ func TestReleasePleaseVersionFromTitle(t *testing.T) {
 }
 
 func TestFormatReleasePRCommentWithoutCandidates(t *testing.T) {
-	registry := testRegistry(t)
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{
+		{
+			Code:               "LOP-FEAT-0001",
+			Name:               "preview-flag",
+			Description:        "Preview behavior",
+			Lifecycle:          featureflags.LifecyclePreview,
+			FirstStableRelease: "v1.5.0",
+		},
+		{
+			Code:               "LOP-FEAT-0002",
+			Name:               "stable-flag",
+			Description:        "Stable behavior",
+			Lifecycle:          featureflags.LifecycleStable,
+			FirstStableRelease: "v1.5.0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
 	manifest, err := registry.Manifest(featureflags.ResolveOptions{Channel: featureflags.ChannelRelease})
 	if err != nil {
 		t.Fatalf("manifest: %v", err)
 	}
 	output := formatReleasePRComment("v1.5.0", registry.Flags(), manifest, registry.Flags(), true, "")
-	if !strings.Contains(output, "No newly added preview flags were detected for this release candidate.") {
+	if !strings.Contains(output, "No preview flags are shipping in their first stable release candidate.") {
 		t.Fatalf("expected no-candidate note, got %s", output)
 	}
 	if strings.Contains(output, "### Graduation candidates") {

--- a/tools/featureflag/release_pr_comment.go
+++ b/tools/featureflag/release_pr_comment.go
@@ -11,6 +11,7 @@ import (
 )
 
 var releasePleasePRTitlePattern = regexp.MustCompile(`(?i)\brelease\s+v?([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)\b`)
+var releaseVersionPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$`)
 
 func runReleasePRComment(args []string) error {
 	fs := flag.NewFlagSet("release-pr-comment", flag.ContinueOnError)
@@ -60,9 +61,14 @@ func normalizeReleaseVersion(value string) string {
 		return ""
 	}
 	if strings.HasPrefix(strings.ToLower(value), "v") {
-		return "v" + strings.TrimSpace(value[1:])
+		value = "v" + strings.TrimSpace(value[1:])
+	} else {
+		value = "v" + value
 	}
-	return "v" + value
+	if !releaseVersionPattern.MatchString(value) {
+		return ""
+	}
+	return value
 }
 
 func releasePleaseVersionFromTitle(title string) string {
@@ -97,6 +103,19 @@ func newlyAddedPreviewFlags(current, previous []featureflags.Flag, compared bool
 	return added
 }
 
+func graduationCandidatePreviewFlags(current []featureflags.Flag) []featureflags.Flag {
+	candidates := make([]featureflags.Flag, 0)
+	for _, flag := range current {
+		if flag.Lifecycle != featureflags.LifecyclePreview {
+			continue
+		}
+		if flag.FirstStableRelease == "" {
+			candidates = append(candidates, flag)
+		}
+	}
+	return candidates
+}
+
 func formatReleasePRComment(release string, current []featureflags.Flag, manifest []featureflags.ManifestEntry, previous []featureflags.Flag, compared bool, workflowURL string) string {
 	var b strings.Builder
 	b.WriteString("<!-- lopper-feature-flag-release-pr -->\n")
@@ -112,9 +131,9 @@ func formatReleasePRComment(release string, current []featureflags.Flag, manifes
 		fmt.Fprintf(&b, "- Graduate a preview flag for future releases with `graduate-feature.yml` using the feature code or name, then merge that PR before publishing `%s`.\n", release)
 	}
 
-	candidates := newlyAddedPreviewFlags(current, previous, compared)
+	candidates := graduationCandidatePreviewFlags(current)
 	if len(candidates) == 0 {
-		b.WriteString("- No newly added preview flags were detected for this release candidate.\n")
+		b.WriteString("- No preview flags are shipping in their first stable release candidate.\n")
 		return b.String()
 	}
 

--- a/tools/featureflag/stamp_release.go
+++ b/tools/featureflag/stamp_release.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/featureflags"
+)
+
+func runStampRelease(args []string) error {
+	fs := flag.NewFlagSet("stamp-release", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	release := fs.String("release", strings.TrimSpace(os.Getenv("RELEASE")), "stable release version to stamp")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if len(fs.Args()) > 0 {
+		return fmt.Errorf("too many arguments for featureflag stamp-release")
+	}
+
+	resolvedRelease := normalizeReleaseVersion(*release)
+	if resolvedRelease == "" {
+		return fmt.Errorf("release version is required")
+	}
+
+	root, err := getwdFn()
+	if err != nil {
+		return fmt.Errorf(resolveWorkingDirectoryError, err)
+	}
+	flags, err := readCatalog(root)
+	if err != nil {
+		return err
+	}
+
+	stamped := 0
+	for i := range flags {
+		if flags[i].FirstStableRelease != "" {
+			continue
+		}
+		flags[i].FirstStableRelease = resolvedRelease
+		stamped++
+	}
+
+	if stamped == 0 {
+		_, err = fmt.Fprintf(os.Stdout, "no feature release stamps to update for %s\n", resolvedRelease)
+		return err
+	}
+
+	data, err := featureflags.FormatCatalog(flags)
+	if err != nil {
+		return err
+	}
+	if err := writeFileUnderFn(root, filepath.Join(root, catalogPath), data, 0o644); err != nil {
+		return fmt.Errorf("write feature catalog: %w", err)
+	}
+
+	_, err = fmt.Fprintf(os.Stdout, "stamped %d feature(s) with first stable release %s\n", stamped, resolvedRelease)
+	return err
+}


### PR DESCRIPTION
## Summary

Related: #721

Release feature flag PRs needed a durable source of truth for whether a preview flag had already shipped in a stable release. Without that, release guidance could keep calling out the same preview flag as a graduation candidate instead of limiting the list to first-release preview flags.

## Changes

- add `firstStableRelease` to feature flag catalog entries and validate/normalize it in the registry
- add `go run ./tools/featureflag stamp-release --release <tag>` so workflows stamp release history through tested code instead of shell-only JSON edits
- switch release PR graduation-candidate selection to unstamped preview flags while keeping the previous-release diff report intact
- stamp `internal/featureflags/features.json` from `release.yml` after publish and replay that commit onto `main`
- backfill existing feature flags with `v1.5.0` and document the new release-history behavior

## Validation

Commands and checks run:

- pre-commit `make ci` hook on commit (fmt, lint, actionlint, duplication, suppressions, gosec, govulncheck, go test, goleak, race, memory delta, build, coverage)
- `go test ./internal/featureflags ./tools/featureflag`
- `go test ./...`
- `make actionlint`
- `go run ./tools/featureflag validate`

Additional manual validation:

- N/A

## Risk and compatibility

- Breaking changes: None.
- Migration required: No; existing flags are backfilled in the catalog.
- Performance impact: None expected.
- Memory benchmark impact: None; the pre-commit memory delta gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
