### PR TITLE
fix(gitexec): strip loader injection env vars

### DIFF
--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -89,6 +89,9 @@ func shouldStripGitEnvKey(key string) bool {
 	if strings.HasPrefix(key, "GIT_") {
 		return true
 	}
+	if strings.HasPrefix(key, "LD_") || strings.HasPrefix(key, "DYLD_") {
+		return true
+	}
 	switch key {
 	case "PATH", "HOME", "XDG_CONFIG_HOME", "XDG_CONFIG_DIRS", "PAGER", "EDITOR", "VISUAL":
 		return true

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -60,6 +60,9 @@ func TestSanitizedEnv(t *testing.T) {
 	t.Setenv("GIT_DIR", "/tmp/fake-git-dir")
 	t.Setenv("GIT_WORK_TREE", "/tmp/fake-worktree")
 	t.Setenv("GIT_INDEX_FILE", "/tmp/fake-index")
+	t.Setenv("LD_PRELOAD", "/tmp/malicious.so")
+	t.Setenv("LD_LIBRARY_PATH", "/tmp/malicious-lib")
+	t.Setenv("DYLD_FOO", "/tmp/malicious-dyld")
 	t.Setenv("GIT_CONFIG_GLOBAL", "/tmp/attacker-global")
 	t.Setenv("GIT_CONFIG_COUNT", "1")
 	t.Setenv("GIT_CONFIG_KEY_0", "core.fsmonitor")
@@ -75,6 +78,9 @@ func TestSanitizedEnv(t *testing.T) {
 	}
 	if containsEnvPrefix(env, "GIT_DIR=") || containsEnvPrefix(env, "GIT_WORK_TREE=") || containsEnvPrefix(env, "GIT_INDEX_FILE=") {
 		t.Fatalf("expected git override vars to be stripped, got %#v", env)
+	}
+	if containsEnvPrefix(env, "LD_") || containsEnvPrefix(env, "DYLD_") {
+		t.Fatalf("expected dynamic loader vars to be stripped, got %#v", env)
 	}
 	if containsEnv(env, attackerGlobalConfigEnvEntry) ||
 		containsEnv(env, "GIT_CONFIG_COUNT=1") ||


### PR DESCRIPTION
## Summary
Harden git subprocess environment sanitization so dynamic-loader injection variables cannot influence git commands used for changed-file and ref-resolution logic.

## Changes
- Strip `LD_*` and `DYLD_*` loader injection variables in `internal/gitexec.SanitizedEnv` alongside the existing Git-specific filtering.
- Extend `internal/gitexec` regression coverage for loader-variable stripping.

## Validation
Commands and checks run:

```bash
go test ./internal/gitexec
```

Additional manual validation:

- Existing CI and Sonar checks for this PR passed locally before metadata-only reruns.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #845