### PR TITLE
fix(app): bootstrap first run baseline store on save-baseline

### DIFF
--- a/internal/app/analyse_postprocess.go
+++ b/internal/app/analyse_postprocess.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -19,6 +21,9 @@ func (a *App) applyBaselineIfNeeded(reportData report.Report, repoPath string, r
 	}
 
 	baseline, loadedKey, err := report.LoadWithKey(baselinePath)
+	if err != nil && isBootstrapableMissingBaseline(req, err) {
+		return reportData, nil
+	}
 	if err != nil {
 		return reportData, err
 	}
@@ -31,6 +36,22 @@ func (a *App) applyBaselineIfNeeded(reportData report.Report, repoPath string, r
 	}
 
 	return reportData, nil
+}
+
+func isBootstrapableMissingBaseline(req AnalyseRequest, err error) bool {
+	if !req.SaveBaseline {
+		return false
+	}
+	if strings.TrimSpace(req.BaselinePath) != "" {
+		return false
+	}
+	if strings.TrimSpace(req.BaselineStorePath) == "" {
+		return false
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	return true
 }
 
 func resolveBaselineComparisonPaths(repoPath string, req AnalyseRequest) (string, string, string, bool, error) {

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -338,3 +338,34 @@ func TestExecuteAnalyseSaveBaselineErrorPreservesOriginalWhenFormatFails(t *test
 		t.Fatalf("expected save-baseline store error, got %v", err)
 	}
 }
+
+func TestExecuteAnalyseBootstrapBaselineStoreOnFirstSave(t *testing.T) {
+	analyzer := &fakeAnalyzer{
+		report: report.Report{
+			RepoPath:      ".",
+			Dependencies:   []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50}},
+			SchemaVersion: "0.1.0",
+		},
+	}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+	baselineStore := t.TempDir()
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = "."
+	req.Analyse.TopN = 1
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.SaveBaseline = true
+	req.Analyse.BaselineStorePath = baselineStore
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected bootstrap execute to succeed, got %v", err)
+	}
+	if !strings.Contains(output, "saved immutable baseline snapshot:") {
+		t.Fatalf("expected baseline save warning in output, got %q", output)
+	}
+	if _, err := os.Stat(report.BaselineSnapshotPath(baselineStore, resolveCurrentBaselineKey("."))); err != nil {
+		t.Fatalf("expected initial baseline snapshot to be written: %v", err)
+	}
+}

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -343,7 +343,7 @@ func TestExecuteAnalyseBootstrapBaselineStoreOnFirstSave(t *testing.T) {
 	analyzer := &fakeAnalyzer{
 		report: report.Report{
 			RepoPath:      ".",
-			Dependencies:   []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50}},
+			Dependencies:  []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50}},
 			SchemaVersion: "0.1.0",
 		},
 	}

--- a/internal/app/app_save_baseline_test.go
+++ b/internal/app/app_save_baseline_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -139,5 +141,67 @@ func TestSaveBaselineIfNeededDisabledNoop(t *testing.T) {
 	}
 	if len(updated.Warnings) != 1 || updated.Warnings[0] != "keep" {
 		t.Fatalf("expected unchanged report on noop save baseline, got %#v", updated)
+	}
+}
+
+func TestIsBootstrapableMissingBaseline(t *testing.T) {
+	testCases := []struct {
+		name string
+		req  AnalyseRequest
+		err  error
+		want bool
+	}{
+		{
+			name: "save baseline store missing baseline",
+			req: AnalyseRequest{
+				SaveBaseline:      true,
+				BaselineStorePath: t.TempDir(),
+			},
+			err:  os.ErrNotExist,
+			want: true,
+		},
+		{
+			name: "save baseline disabled",
+			req: AnalyseRequest{
+				BaselineStorePath: t.TempDir(),
+			},
+			err:  os.ErrNotExist,
+			want: false,
+		},
+		{
+			name: "explicit baseline path bypasses bootstrap",
+			req: AnalyseRequest{
+				SaveBaseline:      true,
+				BaselinePath:      testBaselinePath,
+				BaselineStorePath: t.TempDir(),
+			},
+			err:  os.ErrNotExist,
+			want: false,
+		},
+		{
+			name: "missing baseline store path",
+			req: AnalyseRequest{
+				SaveBaseline: true,
+			},
+			err:  os.ErrNotExist,
+			want: false,
+		},
+		{
+			name: "different error kind",
+			req: AnalyseRequest{
+				SaveBaseline:      true,
+				BaselineStorePath: t.TempDir(),
+			},
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isBootstrapableMissingBaseline(tc.req, tc.err); got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Allow `--save-baseline` to bootstrap the first immutable baseline snapshot when the configured baseline store is empty.

## Changes
- Skip missing baseline-store comparison failures when `--save-baseline` is creating the initial snapshot.
- Add a regression test covering first-run baseline store bootstrap.
- Format the updated regression test file so CI format checks pass.

## Validation
Commands and checks run:

```bash
go test ./internal/app ./internal/report ./cmd/lopper
```

Additional manual validation:

- Confirmed the updated test file is `gofmt`-formatted after the worker commit.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #815