### PR TITLE
fix(analysis): fallback changed-packages when HEAD~1 is unavailable

### DIFF
--- a/internal/analysis/pipeline_test.go
+++ b/internal/analysis/pipeline_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 func TestAnalysisPipelineFinalReportMergedPath(t *testing.T) {
@@ -158,6 +159,30 @@ func TestScopedCandidateRootsChangedPackagesFallsBack(t *testing.T) {
 	roots, warnings := scopedCandidateRoots(ScopeModeChangedPackages, []string{root}, repo)
 	if len(roots) != 1 || roots[0] != root {
 		t.Fatalf("expected package roots fallback, got %#v", roots)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "falling back to package scope") {
+		t.Fatalf("expected changed-packages fallback warning, got %#v", warnings)
+	}
+}
+
+func TestScopedCandidateRootsChangedPackagesFallsBackForSingleCommitRepo(t *testing.T) {
+	repo := t.TempDir()
+	root := filepath.Join(repo, "packages", "a")
+	if err := os.MkdirAll(root, 0o750); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("a1\n"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	testutil.RunGit(t, repo, "init")
+	testutil.RunGit(t, repo, "config", "user.email", "analysis-test@example.com")
+	testutil.RunGit(t, repo, "config", "user.name", "Analysis Test")
+	testutil.RunGit(t, repo, "add", ".")
+	testutil.RunGit(t, repo, "commit", "-m", "initial commit")
+
+	roots, warnings := scopedCandidateRoots(ScopeModeChangedPackages, []string{root}, repo)
+	if len(roots) != 1 || roots[0] != root {
+		t.Fatalf("expected package-root fallback, got %#v", roots)
 	}
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "falling back to package scope") {
 		t.Fatalf("expected changed-packages fallback warning, got %#v", warnings)

--- a/internal/workspace/changed_files.go
+++ b/internal/workspace/changed_files.go
@@ -23,7 +23,11 @@ func ChangedFiles(repoPath string) ([]string, error) {
 		return nil, errors.Join(diffErr, statusErr)
 	}
 	if diffErr != nil {
-		return parsePorcelainChangedFiles(statusOutput), nil
+		statusFiles := parsePorcelainChangedFiles(statusOutput)
+		if len(statusFiles) == 0 {
+			return nil, diffErr
+		}
+		return statusFiles, nil
 	}
 	if statusErr != nil {
 		return parseChangedFileLines(diffOutput), nil

--- a/internal/workspace/workspace_changed_files_test.go
+++ b/internal/workspace/workspace_changed_files_test.go
@@ -79,6 +79,24 @@ func TestChangedFilesParsesDiffAndStatusFallback(t *testing.T) {
 	}
 }
 
+func TestChangedFilesReturnsDiffFailureForSingleCommitRepoWhenStatusClean(t *testing.T) {
+	repo := t.TempDir()
+	testutil.RunGit(t, repo, "init")
+	testutil.RunGit(t, repo, "config", "user.name", "Workspace Test")
+	testutil.RunGit(t, repo, "config", "user.email", "workspace-test@example.com")
+	mustWrite(t, filepath.Join(repo, "tracked.txt"), "tracked\n")
+	testutil.RunGit(t, repo, "add", ".")
+	testutil.RunGit(t, repo, "commit", "-m", "initial commit")
+
+	changed, err := ChangedFiles(repo)
+	if err == nil || !strings.Contains(err.Error(), "HEAD~1") {
+		t.Fatalf("expected HEAD~1 diff failure error for single-commit clean repo, got files=%#v err=%v", changed, err)
+	}
+	if len(changed) != 0 {
+		t.Fatalf("expected no changed file names after no-status fallback failure, got %#v", changed)
+	}
+}
+
 func TestChangedFilesReturnsJoinedGitErrors(t *testing.T) {
 	setupFakeGitResolver(t, "#!/bin/sh\nif [ \"$3\" = \"diff\" ]; then\n  echo \"diff failed\" >&2\n  exit 2\nfi\nif [ \"$3\" = \"status\" ]; then\n  echo \"status failed\" >&2\n  exit 3\nfi\nexit 1\n")
 


### PR DESCRIPTION
## Summary
Fall back from `changed-packages` scope to package scope when a single-commit repository does not have `HEAD~1` available.

## Changes
- Treat a failed `HEAD~1..HEAD` diff with no status fallback as a hard error in `workspace.ChangedFiles`.
- Preserve the existing status-based fallback when working-tree changes are present.
- Add regression coverage in `internal/workspace` and `internal/analysis` for clean single-commit repositories.

## Validation
Commands and checks run:

```bash
go test ./internal/workspace/...
go test ./internal/analysis/...
go test ./cmd/...
```

Additional manual validation:

- Existing CI and Sonar checks for this PR passed locally before metadata-only reruns.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #816