### PR TITLE
fix: gate unsafe runtime test command shapes

### DIFF
--- a/internal/cli/parse_analyse.go
+++ b/internal/cli/parse_analyse.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/notify"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/runtime"
 	"github.com/ben-ranford/lopper/internal/thresholds"
 )
 
@@ -54,6 +55,9 @@ func parseAnalyseState(fs *flag.FlagSet, flags analyseFlagValues) (analyseParseS
 		return analyseParseState{}, err
 	}
 	if err := validateCodemodApplyFlags(*flags.suggestOnly, *flags.applyCodemod, *flags.applyCodemodConfirm, *flags.allowDirty, dependency, *flags.top); err != nil {
+		return analyseParseState{}, err
+	}
+	if err := runtime.ValidateRuntimeCommand(*flags.runtimeTestCommand); err != nil {
 		return analyseParseState{}, err
 	}
 

--- a/internal/cli/parse_analyse.go
+++ b/internal/cli/parse_analyse.go
@@ -57,7 +57,7 @@ func parseAnalyseState(fs *flag.FlagSet, flags analyseFlagValues) (analyseParseS
 	if err := validateCodemodApplyFlags(*flags.suggestOnly, *flags.applyCodemod, *flags.applyCodemodConfirm, *flags.allowDirty, dependency, *flags.top); err != nil {
 		return analyseParseState{}, err
 	}
-	if err := runtime.ValidateRuntimeCommand(*flags.runtimeTestCommand); err != nil {
+	if err := runtime.ValidateCommand(*flags.runtimeTestCommand); err != nil {
 		return analyseParseState{}, err
 	}
 

--- a/internal/cli/parse_analyse_test.go
+++ b/internal/cli/parse_analyse_test.go
@@ -282,6 +282,18 @@ func TestParseArgsAnalyseRuntimeTestCommand(t *testing.T) {
 	}
 }
 
+func TestParseArgsAnalyseRuntimeTestCommandRejectsUnsafeShape(t *testing.T) {
+	err := expectParseArgsError(t, []string{"analyse", "--top", "5", "--runtime-test-command", "npm test && echo bad"}, "expected unsafe runtime command rejection")
+	if !strings.Contains(err.Error(), "indirect command execution") {
+		t.Fatalf("expected indirect command execution rejection, got %v", err)
+	}
+
+	err = expectParseArgsError(t, []string{"analyse", "--top", "5", "--runtime-test-command", "node -e 'console.log(\"hi\")'"}, "expected unsafe runtime flag rejection")
+	if !strings.Contains(err.Error(), "unsafe executable flag") {
+		t.Fatalf("expected unsafe executable flag rejection, got %v", err)
+	}
+}
+
 func TestParseArgsAnalyseSuggestOnly(t *testing.T) {
 	req := mustParseArgs(t, []string{"analyse", "lodash", suggestOnlyFlag})
 	if !req.Analyse.SuggestOnly {

--- a/internal/runtime/capture_command.go
+++ b/internal/runtime/capture_command.go
@@ -105,10 +105,7 @@ func validateRuntimeCommand(command string, fields []string) error {
 		return fmt.Errorf("runtime test command is required")
 	}
 
-	if err := rejectRuntimeCommandUnsafeFlags(fields[0], fields[1:]); err != nil {
-		return err
-	}
-	return nil
+	return rejectRuntimeCommandUnsafeFlags(fields[0], fields[1:])
 }
 
 func containsUnsafeRuntimeCommandSyntax(command string) bool {

--- a/internal/runtime/capture_command.go
+++ b/internal/runtime/capture_command.go
@@ -36,6 +36,9 @@ func buildRuntimeCommand(ctx context.Context, command string) (*exec.Cmd, error)
 	if err != nil {
 		return nil, err
 	}
+	if err := validateRuntimeCommand(command, fields); err != nil {
+		return nil, err
+	}
 	if len(fields) == 0 {
 		return nil, fmt.Errorf("runtime test command is required")
 	}
@@ -54,6 +57,17 @@ func buildRuntimeCommand(ctx context.Context, command string) (*exec.Cmd, error)
 	cmd.Path = executablePath
 	cmd.Args = append([]string{executablePath}, args...)
 	return cmd, nil
+}
+
+func ValidateRuntimeCommand(command string) error {
+	if strings.TrimSpace(command) == "" {
+		return nil
+	}
+	fields, err := parseRuntimeCommand(command)
+	if err != nil {
+		return err
+	}
+	return validateRuntimeCommand(command, fields)
 }
 
 type runtimeCommandParser struct {
@@ -80,6 +94,92 @@ func parseRuntimeCommand(command string) ([]string, error) {
 	parser.flush()
 
 	return parser.fields, nil
+}
+
+func validateRuntimeCommand(command string, fields []string) error {
+	if containsUnsafeRuntimeCommandSyntax(command) {
+		return fmt.Errorf("runtime test command uses indirect command execution operators; pass a direct executable and arguments instead")
+	}
+
+	if len(fields) == 0 {
+		return fmt.Errorf("runtime test command is required")
+	}
+
+	if err := rejectRuntimeCommandUnsafeFlags(fields[0], fields[1:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func containsUnsafeRuntimeCommandSyntax(command string) bool {
+	inSingleQuote := false
+	inDoubleQuote := false
+	escaped := false
+	runes := []rune(command)
+
+	for i, ch := range runes {
+		if escaped {
+			escaped = false
+			continue
+		}
+
+		switch ch {
+		case '\\':
+			if inSingleQuote {
+				continue
+			}
+			escaped = true
+		case '\'':
+			if inDoubleQuote {
+				continue
+			}
+			inSingleQuote = !inSingleQuote
+		case '"':
+			if inSingleQuote {
+				continue
+			}
+			inDoubleQuote = !inDoubleQuote
+		case '|', '&', ';', '>', '<', '`', '\n', '\r':
+			if inSingleQuote {
+				continue
+			}
+			return true
+		case '$':
+			if inSingleQuote {
+				continue
+			}
+			if i+1 < len(runes) && runes[i+1] == '(' {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func rejectRuntimeCommandUnsafeFlags(executable string, args []string) error {
+	flags, ok := runtimeCommandUnsafeFlags[executable]
+	if !ok {
+		return nil
+	}
+
+	for _, arg := range args {
+		for _, flag := range flags {
+			if arg == flag || strings.HasPrefix(arg, flag+"=") {
+				return fmt.Errorf("runtime test command uses unsafe executable flag %q for %q", arg, executable)
+			}
+		}
+	}
+	return nil
+}
+
+var runtimeCommandUnsafeFlags = map[string][]string{
+	"node": {"-e", "--eval", "-p", "--print"},
+	"bun":  {"-e", "--eval", "-p", "--print"},
+	"deno": {"eval"},
+	"npm":  {"exec"},
+	"pnpm": {"exec"},
+	"yarn": {"dlx"},
 }
 
 func (p *runtimeCommandParser) consume(ch rune) {

--- a/internal/runtime/capture_command.go
+++ b/internal/runtime/capture_command.go
@@ -32,11 +32,8 @@ var runtimeExecutableAllowlist = map[string]struct{}{
 }
 
 func buildRuntimeCommand(ctx context.Context, command string) (*exec.Cmd, error) {
-	fields, err := parseRuntimeCommand(command)
+	fields, err := parseValidatedCommand(command)
 	if err != nil {
-		return nil, err
-	}
-	if err := validateRuntimeCommand(command, fields); err != nil {
 		return nil, err
 	}
 	if len(fields) == 0 {
@@ -63,11 +60,8 @@ func ValidateCommand(command string) error {
 	if strings.TrimSpace(command) == "" {
 		return nil
 	}
-	fields, err := parseRuntimeCommand(command)
-	if err != nil {
-		return err
-	}
-	return validateRuntimeCommand(command, fields)
+	_, err := parseValidatedCommand(command)
+	return err
 }
 
 type runtimeCommandParser struct {
@@ -94,6 +88,17 @@ func parseRuntimeCommand(command string) ([]string, error) {
 	parser.flush()
 
 	return parser.fields, nil
+}
+
+func parseValidatedCommand(command string) ([]string, error) {
+	fields, err := parseRuntimeCommand(command)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateRuntimeCommand(command, fields); err != nil {
+		return nil, err
+	}
+	return fields, nil
 }
 
 func validateRuntimeCommand(command string, fields []string) error {

--- a/internal/runtime/capture_command.go
+++ b/internal/runtime/capture_command.go
@@ -59,7 +59,7 @@ func buildRuntimeCommand(ctx context.Context, command string) (*exec.Cmd, error)
 	return cmd, nil
 }
 
-func ValidateRuntimeCommand(command string) error {
+func ValidateCommand(command string) error {
 	if strings.TrimSpace(command) == "" {
 		return nil
 	}

--- a/internal/runtime/capture_command_test.go
+++ b/internal/runtime/capture_command_test.go
@@ -101,16 +101,6 @@ func TestBuildRuntimeCommandRejectsInvalidInput(t *testing.T) {
 			command: `node -e "console.log('hello world')`,
 			wantErr: "unterminated quote",
 		},
-		{
-			name:    "shell operator",
-			command: `npm test && echo bad`,
-			wantErr: "indirect command execution operators",
-		},
-		{
-			name:    "eval flag",
-			command: `node -e 'console.log("hi")'`,
-			wantErr: "unsafe executable flag",
-		},
 	}
 
 	for _, tc := range testCases {
@@ -124,6 +114,23 @@ func TestBuildRuntimeCommandRejectsInvalidInput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildRuntimeCommandRejectsUnsafeSyntaxAndFlags(t *testing.T) {
+	checkRejects := func(command, wantErr string) {
+		t.Helper()
+
+		_, err := buildRuntimeCommand(context.Background(), command)
+		if err == nil {
+			t.Fatalf("expected error containing %q", wantErr)
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Fatalf("expected error containing %q, got %v", wantErr, err)
+		}
+	}
+
+	checkRejects(`npm test && echo bad`, "indirect command execution operators")
+	checkRejects(`node -e 'console.log("hi")'`, "unsafe executable flag")
 }
 
 func TestResolveRuntimeExecutablePathSkipsNonExecutableCandidate(t *testing.T) {

--- a/internal/runtime/capture_command_test.go
+++ b/internal/runtime/capture_command_test.go
@@ -85,7 +85,7 @@ func TestBuildRuntimeCommandRequiresInput(t *testing.T) {
 	}
 }
 
-func TestBuildRuntimeCommandRejectsMalformedInput(t *testing.T) {
+func TestBuildRuntimeCommandRejectsInvalidInput(t *testing.T) {
 	testCases := []struct {
 		name    string
 		command string
@@ -101,27 +101,6 @@ func TestBuildRuntimeCommandRejectsMalformedInput(t *testing.T) {
 			command: `node -e "console.log('hello world')`,
 			wantErr: "unterminated quote",
 		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := buildRuntimeCommand(context.Background(), tc.command)
-			if err == nil {
-				t.Fatalf("expected error containing %q", tc.wantErr)
-			}
-			if !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
-			}
-		})
-	}
-}
-
-func TestBuildRuntimeCommandRejectsUnsafeCommands(t *testing.T) {
-	testCases := []struct {
-		name    string
-		command string
-		wantErr string
-	}{
 		{
 			name:    "shell operator",
 			command: `npm test && echo bad`,

--- a/internal/runtime/capture_command_test.go
+++ b/internal/runtime/capture_command_test.go
@@ -133,6 +133,35 @@ func TestBuildRuntimeCommandRejectsUnsafeSyntaxAndFlags(t *testing.T) {
 	checkRejects(`node -e 'console.log("hi")'`, "unsafe executable flag")
 }
 
+func TestValidateCommand(t *testing.T) {
+	if err := ValidateCommand(" "); err != nil {
+		t.Fatalf("expected blank command to be ignored, got %v", err)
+	}
+	if err := ValidateCommand("npm test"); err != nil {
+		t.Fatalf("expected safe command to validate, got %v", err)
+	}
+
+	err := ValidateCommand(`node -e 'console.log("hi")'`)
+	if err == nil || !strings.Contains(err.Error(), "unsafe executable flag") {
+		t.Fatalf("expected unsafe executable flag rejection, got %v", err)
+	}
+}
+
+func TestContainsUnsafeRuntimeCommandSyntax(t *testing.T) {
+	if containsUnsafeRuntimeCommandSyntax(`node -r 'const value = "a\\b"'`) {
+		t.Fatalf("expected backslashes in single quotes to stay safe")
+	}
+	if containsUnsafeRuntimeCommandSyntax(`node -r 'console.log("a && b")'`) {
+		t.Fatalf("expected shell operators in single quotes to stay safe")
+	}
+	if containsUnsafeRuntimeCommandSyntax(`node -r '$(pwd)'`) {
+		t.Fatalf("expected subshell syntax in single quotes to stay safe")
+	}
+	if !containsUnsafeRuntimeCommandSyntax(`node -r $(pwd)`) {
+		t.Fatalf("expected subshell syntax outside quotes to be rejected")
+	}
+}
+
 func TestResolveRuntimeExecutablePathSkipsNonExecutableCandidate(t *testing.T) {
 	if isWindowsRuntime() {
 		t.Skip("non-executable mode bit checks are Unix-specific")

--- a/internal/runtime/capture_command_test.go
+++ b/internal/runtime/capture_command_test.go
@@ -48,13 +48,13 @@ func TestBuildRuntimeCommandPreservesParsedArgs(t *testing.T) {
 	}{
 		{
 			name:    "quoted args",
-			command: `node -e "console.log('hello world')"`,
-			want:    []string{"node", "-e", "console.log('hello world')"},
+			command: `node -r "console.log('hello world')"`,
+			want:    []string{"node", "-r", "console.log('hello world')"},
 		},
 		{
 			name:    "single quoted args",
-			command: `node -e 'console.log("hello")'`,
-			want:    []string{"node", "-e", `console.log("hello")`},
+			command: `node -r 'console.log("hello")'`,
+			want:    []string{"node", "-r", `console.log("hello")`},
 		},
 		{
 			name:    "escaped whitespace",
@@ -100,6 +100,37 @@ func TestBuildRuntimeCommandRejectsMalformedInput(t *testing.T) {
 			name:    "unterminated quote",
 			command: `node -e "console.log('hello world')`,
 			wantErr: "unterminated quote",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildRuntimeCommand(context.Background(), tc.command)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestBuildRuntimeCommandRejectsUnsafeCommands(t *testing.T) {
+	testCases := []struct {
+		name    string
+		command string
+		wantErr string
+	}{
+		{
+			name:    "shell operator",
+			command: `npm test && echo bad`,
+			wantErr: "indirect command execution operators",
+		},
+		{
+			name:    "eval flag",
+			command: `node -e 'console.log("hi")'`,
+			wantErr: "unsafe executable flag",
 		},
 	}
 


### PR DESCRIPTION
## Summary
Reject unsafe `--runtime-test-command` shapes before execution so shell-style operator chains and eval flags cannot slip through runtime command parsing.

## Changes
- Add runtime command validation to reject shell operators and unsafe interpreter/eval flags.
- Wire the validation into CLI parsing so invalid command shapes fail fast.
- Add regression coverage in `internal/cli` and `internal/runtime`.
- Simplify the validation return path so revive passes cleanly.

## Validation
Commands and checks run:

```bash
go test ./internal/cli ./internal/runtime ./internal/app
```

Additional manual validation:

- Confirmed the revive lint finding is resolved by the follow-up simplification commit.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #895