### PR TITLE
fix(release): harden managed-binary integrity and pin release workflow actions

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.source_sha || github.sha }}
 
@@ -40,7 +40,7 @@ jobs:
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 
@@ -80,7 +80,7 @@ jobs:
             PLATFORMS="linux/amd64 linux/arm64 windows/amd64 windows/arm64"
 
       - name: Upload Linux/Windows artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ inputs.artifact_prefix }}-linux-windows
           path: |
@@ -93,7 +93,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.source_sha || github.sha }}
 
@@ -104,7 +104,7 @@ jobs:
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 
@@ -138,7 +138,7 @@ jobs:
             PLATFORMS="darwin/${host_goarch}"
 
       - name: Upload Darwin artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ inputs.artifact_prefix }}-darwin
           path: |
@@ -152,7 +152,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.source_sha || github.sha }}
 
@@ -223,7 +223,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.source_sha || github.sha }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
@@ -65,17 +65,17 @@ jobs:
       contents: read
     steps:
       - name: Checkout release source
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: npm
@@ -106,7 +106,7 @@ jobs:
           npx @vscode/vsce package --out "../../dist/lopper-vscode-${version}.vsix"
 
       - name: Upload VS Code extension artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-vscode-extension
           path: dist/*.vsix
@@ -119,7 +119,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout release source
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag }}
 
@@ -130,7 +130,7 @@ jobs:
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 
@@ -156,7 +156,7 @@ jobs:
             PLATFORMS="darwin/amd64"
 
       - name: Upload Darwin amd64 artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-darwin-amd64
           path: |
@@ -175,21 +175,20 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      VSCE_PUBLISH: ${{ secrets.VSCE_PUBLISH }}
     steps:
       - name: Checkout release source
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           ref: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: release-*
           merge-multiple: true
@@ -284,21 +283,26 @@ jobs:
           fi
           gh release upload "$tag" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
 
-      - name: Setup Node
-        if: ${{ env.VSCE_PUBLISH != '' }}
-        uses: actions/setup-node@v6
+      - name: Setup Node for VSIX publish
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
 
       - name: Publish VS Code extension to Marketplace
-        if: ${{ env.VSCE_PUBLISH != '' }}
         env:
-          VSCE_PAT: ${{ env.VSCE_PUBLISH }}
+          VSCE_PAT: ${{ secrets.VSCE_PUBLISH }}
         run: |
           set -euo pipefail
+          if [ -z "${VSCE_PAT:-}" ]; then
+            echo "VSCE publish token not configured; skipping marketplace publish."
+            exit 0
+          fi
+
+          make vscode-extension-install
+
           vsix_path="$(find dist -maxdepth 1 -name 'lopper-vscode-*.vsix' | head -n1)"
           test -n "$vsix_path"
-          npx --yes @vscode/vsce publish --packagePath "$vsix_path"
+          ./extensions/vscode-lopper/node_modules/.bin/vsce publish --packagePath "$vsix_path"
 
       - name: Publish GitHub Release
         run: |
@@ -366,7 +370,7 @@ jobs:
 
       - name: Checkout tap repository
         if: ${{ steps.tap_token.outputs.available == 'true' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: ben-ranford/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -484,14 +488,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout release source
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           ref: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag || github.sha }}
           token: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 

--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -1,4 +1,5 @@
 import AdmZip from "adm-zip";
+import { createHash } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import {
   access,
@@ -20,6 +21,7 @@ import * as tar from "tar";
 export interface GitHubReleaseAsset {
   name: string;
   browser_download_url: string;
+  digest?: string;
 }
 
 export interface GitHubRelease {
@@ -77,6 +79,7 @@ export interface ManagedBinaryInstallProgress {
 interface ManagedBinaryMetadata {
   binaryPath: string;
   tag: string;
+  binaryDigest?: string;
 }
 
 interface ManagedBinaryDeps {
@@ -110,16 +113,28 @@ export class ManagedBinaryInstaller {
 
   async findInstalledBinary(releaseTag?: string): Promise<string | undefined> {
     const explicitTag = normalizeReleaseTag(releaseTag);
-    if (explicitTag) {
-      const binaryPath = this.binaryPathFor(explicitTag);
-      return (await fileExists(binaryPath)) ? binaryPath : undefined;
-    }
-
     const metadata = await this.readMetadata();
-    if (!metadata) {
+    const binaryPath = explicitTag ? this.binaryPathFor(explicitTag) : metadata?.binaryPath;
+
+    if (!binaryPath || !(await fileExists(binaryPath))) {
       return undefined;
     }
-    return (await fileExists(metadata.binaryPath)) ? metadata.binaryPath : undefined;
+
+    if (
+      !metadata ||
+      metadata.binaryPath !== binaryPath ||
+      metadata.tag !== (explicitTag ?? metadata.tag) ||
+      typeof metadata.binaryDigest !== "string"
+    ) {
+      this.output.appendLine(`managed binary cache integrity metadata missing; re-downloading ${binaryPath}`);
+      return undefined;
+    }
+
+    if (!(await verifyBinaryDigest(binaryPath, metadata.binaryDigest))) {
+      this.output.appendLine(`managed binary integrity check failed; re-downloading ${binaryPath}`);
+      return undefined;
+    }
+    return binaryPath;
   }
 
   async ensureInstalled(releaseTag?: string): Promise<ManagedBinaryInstallResult> {
@@ -140,8 +155,10 @@ export class ManagedBinaryInstaller {
     this.output.appendLine(`downloading managed lopper binary: ${asset.name}`);
 
     try {
+      const expectedArchiveDigest = parseAssetDigest(asset);
       await mkdir(extractDir, { recursive: true });
       await this.deps.downloadAsset(asset, archivePath);
+      await verifyBinaryArchive(archivePath, expectedArchiveDigest, asset.name);
       await extractArchive(archivePath, extractDir);
 
       const extractedBinary = await findBinaryInDirectory(extractDir, binaryFileName(this.deps.host.platform));
@@ -154,7 +171,8 @@ export class ManagedBinaryInstaller {
       if (this.deps.host.platform !== "win32") {
         await chmod(binaryPath, 0o755);
       }
-      await this.writeMetadata({ binaryPath, tag: release.tag_name });
+      const binaryDigest = await sha256File(binaryPath);
+      await this.writeMetadata({ binaryPath, tag: release.tag_name, binaryDigest });
 
       return { binaryPath, tag: release.tag_name, downloaded: true };
     } finally {
@@ -183,7 +201,11 @@ export class ManagedBinaryInstaller {
       if (typeof parsed.binaryPath !== "string" || typeof parsed.tag !== "string") {
         return undefined;
       }
-      return { binaryPath: parsed.binaryPath, tag: parsed.tag };
+      return {
+        binaryPath: parsed.binaryPath,
+        tag: parsed.tag,
+        binaryDigest: typeof parsed.binaryDigest === "string" ? parsed.binaryDigest : undefined,
+      };
     } catch {
       return undefined;
     }
@@ -475,6 +497,35 @@ function isAssetLike(asset: unknown): asset is GitHubReleaseAsset {
     asset !== null &&
     typeof (asset as Partial<GitHubReleaseAsset>).name === "string" &&
     typeof (asset as Partial<GitHubReleaseAsset>).browser_download_url === "string";
+}
+
+function parseAssetDigest(asset: GitHubReleaseAsset): string {
+  if (typeof asset.digest !== "string") {
+    throw new Error(`managed release asset ${asset.name} is missing a sha256 digest`);
+  }
+
+  const match = asset.digest.trim().match(/^sha256:([a-fA-F0-9]{64})$/);
+  if (!match) {
+    throw new Error(`managed release asset ${asset.name} has invalid sha256 digest`);
+  }
+
+  return match[1].toLowerCase();
+}
+
+async function verifyBinaryArchive(archivePath: string, expectedDigest: string, assetName: string): Promise<void> {
+  const observedDigest = await sha256File(archivePath);
+  if (observedDigest !== expectedDigest) {
+    throw new Error(`managed release archive integrity check failed for ${assetName}`);
+  }
+}
+
+async function verifyBinaryDigest(filePath: string, expectedDigest: string): Promise<boolean> {
+  return (await sha256File(filePath)) === expectedDigest;
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const buffer = await readFile(filePath);
+  return createHash("sha256").update(buffer).digest("hex");
 }
 
 async function downloadAsset(asset: GitHubReleaseAsset, destinationPath: string): Promise<void> {

--- a/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
@@ -1,5 +1,6 @@
 import AdmZip from "adm-zip";
 import * as assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -106,7 +107,7 @@ suite("managed binary installer", () => {
       const releaseTag = "v9.8.7";
       const host = { platform: "linux" as const, arch: "x64" };
       const archivePath = await createTarballFixture(tempRoot, releaseTag, host, "linux binary");
-      const installer = createInstaller(tempRoot, releaseTag, host, archivePath);
+      const installer = await createInstaller(tempRoot, releaseTag, host, archivePath);
 
       const cachedBefore = await installer.findInstalledBinary();
       assert.equal(cachedBefore, undefined);
@@ -129,12 +130,32 @@ suite("managed binary installer", () => {
       const releaseTag = "v1.0.0";
       const host = { platform: "win32" as const, arch: "x64" };
       const archivePath = await createZipFixture(tempRoot, releaseTag, host, "windows binary");
-      const installer = createInstaller(tempRoot, releaseTag, host, archivePath);
+      const installer = await createInstaller(tempRoot, releaseTag, host, archivePath);
 
       const result = await installer.ensureInstalled();
       assert.equal(result.downloaded, true);
       assert.match(result.binaryPath, /lopper\.exe$/);
       assert.equal(await readFile(result.binaryPath, "utf8"), "windows binary");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects managed binary archive downloads with checksum mismatch", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-binary-test-"));
+    try {
+      const releaseTag = "v9.8.7";
+      const host = { platform: "linux" as const, arch: "x64" };
+      const archivePath = await createTarballFixture(tempRoot, releaseTag, host, "linux binary");
+      const badDigest = "0".repeat(64);
+      const installer = await createInstaller(tempRoot, releaseTag, host, archivePath, badDigest);
+
+      await assert.rejects(
+        installer.ensureInstalled(),
+        (error: unknown) =>
+          error instanceof Error &&
+          error.message.includes("integrity check failed"),
+      );
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }
@@ -392,17 +413,21 @@ suite("managed binary installer", () => {
   });
 });
 
-function createInstaller(
+async function createInstaller(
   tempRoot: string,
   releaseTag: string,
   host: { platform: NodeJS.Platform; arch: string },
   archivePath: string,
-): ManagedBinaryInstaller {
+  archiveDigest?: string,
+): Promise<ManagedBinaryInstaller> {
+  const binaryDigest = archiveDigest ?? (await sha256File(archivePath));
+
   const release: GitHubRelease = {
     tag_name: releaseTag,
     assets: [
       {
         name: assetNameForRelease(releaseTag, host),
+        digest: `sha256:${binaryDigest}`,
         browser_download_url: `file://${archivePath}`,
       },
     ],
@@ -419,6 +444,11 @@ function createInstaller(
       },
     },
   );
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const buffer = await readFile(filePath);
+  return createHash("sha256").update(buffer).digest("hex");
 }
 
 async function createTarballFixture(


### PR DESCRIPTION
## Summary
Harden release and VS Code managed-binary supply-chain handling by pinning privileged workflow actions and enforcing archive integrity for managed downloads.

## Changes
- Verify managed binary archive checksums before extraction and re-validate cached binary hashes before use.
- Persist binary digest metadata and invalidate mismatched cached installs.
- Pin mutable action refs in privileged release workflows.
- Use the repository-installed `vsce` binary and scope the publish token to the publish step.

## Validation
Commands and checks run:

```bash
make actionlint
make vscode-extension-install
cd extensions/vscode-lopper && npm run compile
cd extensions/vscode-lopper && npm run test:e2e
make build
```

Additional manual validation:

- Verified PR CI and Sonar are green; only metadata rerun was pending before this body update.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: Negligible checksum and hash work during install/cache validation only.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #823
Closes #824
Closes #825