### PR TITLE
fix(vscode-lopper): reject workspace-escaping CLI diagnostics paths

### DIFF
--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -572,7 +572,14 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   ): void {
     for (const importUse of dependency.unusedImports ?? []) {
       for (const location of importUse.locations ?? []) {
-        const { uri, range } = this.resolveLocation(analysis.folder, location, importUse);
+        const uri = this.resolveWorkspacePath(analysis.folder, location.file);
+        if (!uri) {
+          this.output.appendLine(
+            `[refresh:skipped] ignoring out-of-workspace unused-import location for ${dependency.name}: ${location.file}`,
+          );
+          continue;
+        }
+        const { range } = this.resolveLocation(analysis.folder, location, importUse);
         const key = this.metadataKey(dependency.name, "unused-import", location.file, location.line, importUse.name);
         const diagnostic = new vscode.Diagnostic(
           range,
@@ -599,7 +606,13 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   ): void {
     const codemod = analysis.codemodsByDependency.get(dependency.name);
     for (const suggestion of codemod?.suggestions ?? []) {
-      const uri = vscode.Uri.file(path.join(analysis.folder.uri.fsPath, suggestion.file));
+      const uri = this.resolveWorkspacePath(analysis.folder, suggestion.file);
+      if (!uri) {
+        this.output.appendLine(
+          `[refresh:skipped] ignoring out-of-workspace codemod suggestion for ${dependency.name}: ${suggestion.file}`,
+        );
+        continue;
+      }
       const lineIndex = Math.max(0, suggestion.line - 1);
       const range = new vscode.Range(lineIndex, 0, lineIndex, suggestion.original.length);
       const key = this.metadataKey(dependency.name, "codemod", suggestion.file, suggestion.line, suggestion.importName);
@@ -625,7 +638,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     location: LopperLocation,
     importUse: LopperImportUse,
   ): { uri: vscode.Uri; range: vscode.Range } {
-    const uri = vscode.Uri.file(path.join(folder.uri.fsPath, location.file));
+    const uri = vscode.Uri.file(path.resolve(folder.uri.fsPath, location.file));
     const line = Math.max(0, location.line - 1);
     const startColumn = Math.max(0, location.column - 1);
     const endColumn = startColumn + Math.max(importUse.name.length, 1);
@@ -633,6 +646,17 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       uri,
       range: new vscode.Range(line, startColumn, line, endColumn),
     };
+  }
+
+  private resolveWorkspacePath(folder: vscode.WorkspaceFolder, relativePath: string): vscode.Uri | undefined {
+    const workspaceRoot = path.resolve(folder.uri.fsPath);
+    const candidatePath = path.resolve(workspaceRoot, relativePath);
+    return this.isPathInsideWorkspace(candidatePath, workspaceRoot) ? vscode.Uri.file(candidatePath) : undefined;
+  }
+
+  private isPathInsideWorkspace(candidatePath: string, workspaceRoot: string): boolean {
+    const relativePath = path.relative(path.resolve(workspaceRoot), path.resolve(candidatePath));
+    return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
   }
 
   private pushDiagnostic(

--- a/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
@@ -142,6 +142,90 @@ suite("refresh lifecycle", () => {
       );
     });
   });
+
+  test("skips unused import diagnostics for out-of-workspace file paths", async function () {
+    this.timeout(30_000);
+
+    await withHarness(async (harness) => {
+      const escapedPath = "../outside.ts";
+
+      await withController(
+        {
+          analyseWorkspace: async (): Promise<WorkspaceAnalysis> => {
+            return makeAnalysis(harness, {
+              dependencyCount: 1,
+              usedPercent: 50,
+              unusedImportLocations: [{ file: escapedPath, line: 1, column: 1 }],
+            });
+          },
+        },
+        async (controller) => {
+          await refresh(controller, harness);
+
+          const diagnostics = vscode.languages.getDiagnostics(harness.document.uri).filter((item) => item.source === "lopper");
+          assert.equal(diagnostics.length, 0);
+        },
+      );
+    });
+  });
+
+  test("skips escaped codemod suggestions while keeping in-workspace diagnostics", async function () {
+    this.timeout(30_000);
+
+    await withHarness(async (harness) => {
+      const validSuggestionPath = "src/index.ts";
+      const escapedSuggestionPath = "../outside.ts";
+
+      await withController(
+        {
+          analyseWorkspace: async (): Promise<WorkspaceAnalysis> => {
+            const analysis = makeAnalysis(harness, {
+              dependencyCount: 1,
+              usedPercent: 50,
+              withUnusedImport: true,
+            });
+            analysis.codemodsByDependency = new Map([
+              [
+                analysis.report.dependencies[0]!.name,
+                {
+                  mode: "replace",
+                  suggestions: [
+                    {
+                      file: escapedSuggestionPath,
+                      line: 1,
+                      importName: "scope-lib",
+                      fromModule: "scope-lib",
+                      toModule: "scope-lib",
+                      original: "import scope-lib from \"scope-lib\";",
+                      replacement: "import scope-lib from \"scope-lib\";",
+                    },
+                    {
+                      file: validSuggestionPath,
+                      line: 1,
+                      importName: "chunk",
+                      fromModule: "scope-lib",
+                      toModule: "scope-lib/chunk",
+                      original: "import chunk from \"scope-lib\";",
+                      replacement: "import chunk from \"scope-lib/chunk\";",
+                    },
+                  ],
+                },
+              ],
+            ]);
+            return analysis;
+          },
+        },
+        async (controller) => {
+          await refresh(controller, harness);
+
+          const diagnostics = vscode.languages.getDiagnostics(harness.document.uri).filter((item) => item.source === "lopper");
+          const codemodDiagnostics = diagnostics.filter((item) => item.message.includes("subpath import"));
+          assert.equal(codemodDiagnostics.length, 1);
+          assert.equal(diagnostics.length, 2);
+        },
+      );
+    });
+  });
 });
 
 async function withHarness(run: (harness: LifecycleHarness) => Promise<void>): Promise<void> {
@@ -230,6 +314,7 @@ function makeAnalysis(
     dependencyCount: number;
     usedPercent: number;
     withUnusedImport?: boolean;
+    unusedImportLocations?: Array<{ file: string; line: number; column: number }>;
   },
 ): WorkspaceAnalysis {
   return makeWorkspaceAnalysis({
@@ -247,7 +332,9 @@ function makeWorkspaceAnalysis(options: {
   dependencyCount: number;
   usedPercent: number;
   withUnusedImport?: boolean;
+  unusedImportLocations?: Array<{ file: string; line: number; column: number }>;
 }): WorkspaceAnalysis {
+  const unusedImportLocations = options.unusedImportLocations ?? [{ file: "src/index.ts", line: 1, column: 1 }];
   const dependency = {
     name: "scope-lib",
     usedExportsCount: 1,
@@ -256,12 +343,7 @@ function makeWorkspaceAnalysis(options: {
     unusedImports:
       options.withUnusedImport === false
         ? []
-        : [
-          {
-            name: "chunk",
-            locations: [{ file: "src/index.ts", line: 1, column: 1 }],
-          },
-        ],
+        : [{ name: "chunk", locations: unusedImportLocations }],
   };
 
   return {

--- a/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
@@ -2,10 +2,10 @@ import * as assert from "node:assert/strict";
 import { chmod, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { suite, test } from "mocha";
+import { setup, suite, test } from "mocha";
 import * as vscode from "vscode";
 
-import { __testing } from "../../extension";
+import { __testing, deactivate } from "../../extension";
 import type { RefreshWorkspaceOptions } from "../../extension";
 import type { WorkspaceAnalysis, WorkspaceAnalysisRunner } from "../../lopperRunner";
 
@@ -24,6 +24,10 @@ interface LifecycleHarness {
 type TestController = ReturnType<typeof __testing.createController>;
 
 suite("refresh lifecycle", () => {
+  setup(() => {
+    deactivate();
+  });
+
   test("reuses in-flight refreshes for identical requests", async function () {
     this.timeout(30_000);
 

--- a/extensions/vscode-lopper/src/test/suite/smoke.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/smoke.test.ts
@@ -1,7 +1,9 @@
 import * as assert from "node:assert/strict";
 import * as path from "node:path";
 import * as vscode from "vscode";
-import { suite, test } from "mocha";
+import { suite, teardown, test } from "mocha";
+
+import { deactivate } from "../../extension";
 
 suite("vscode-lopper smoke", () => {
   const fixturePath = path.join(
@@ -10,6 +12,10 @@ suite("vscode-lopper smoke", () => {
     "index.ts",
   );
   const fixtureUri = vscode.Uri.file(fixturePath);
+
+  teardown(() => {
+    deactivate();
+  });
 
   test("refreshes diagnostics, hover details, and quick fixes", async function () {
     this.timeout(60_000);
@@ -53,9 +59,7 @@ suite("vscode-lopper smoke", () => {
     assert.match(normalizedHoverText, /Provenance:/);
     assert.match(normalizedHoverText, /unknown/i);
 
-    const quickFixes = await vscode.commands.executeCommand<
-      (vscode.CodeAction | vscode.Command)[]
-    >("vscode.executeCodeActionProvider", fixtureUri, new vscode.Range(0, 0, 0, 10));
+    const quickFixes = await waitForCodeActions(fixtureUri, new vscode.Range(0, 0, 0, 10));
     assert.ok(quickFixes && quickFixes.length > 0, "expected quick fixes");
     const codeAction = quickFixes.find(
       (item): item is vscode.CodeAction =>
@@ -81,4 +85,39 @@ async function waitForDiagnostics(uri: vscode.Uri, minimumCount: number): Promis
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   return vscode.languages.getDiagnostics(uri);
+}
+
+async function waitForCodeActions(
+  uri: vscode.Uri,
+  range: vscode.Range,
+): Promise<(vscode.CodeAction | vscode.Command)[]> {
+  const timeoutAt = Date.now() + 20_000;
+  let lastError: unknown;
+  while (Date.now() < timeoutAt) {
+    try {
+      const actions = await vscode.commands.executeCommand<(vscode.CodeAction | vscode.Command)[]>(
+        "vscode.executeCodeActionProvider",
+        uri,
+        range,
+      );
+      if ((actions?.length ?? 0) > 0) {
+        return actions;
+      }
+    } catch (error) {
+      lastError = error;
+      if (!isCanceledError(error)) {
+        throw error;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  if (lastError) {
+    throw lastError;
+  }
+  return [];
+}
+
+function isCanceledError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("Canceled");
 }


### PR DESCRIPTION
## Summary
Reject CLI-reported diagnostic and codemod file paths that escape the active VS Code workspace before the extension creates diagnostics or code actions.

## Changes
- Add workspace-boundary validation for diagnostic and codemod file targets before creating URIs.
- Ignore out-of-workspace unused-import locations and codemod suggestions while preserving in-workspace diagnostics.
- Add focused regression coverage for workspace-escaping locations and suggestions.
- Isolate VS Code smoke diagnostics between suites and retry transient code-action cancellation so extension E2E remains stable in CI.

## Validation
Commands and checks run:

```bash
cd extensions/vscode-lopper && npm run compile
cd extensions/vscode-lopper && npm run test:e2e
```

Additional manual validation:

- Full extension E2E suite passes locally after the smoke/test-isolation follow-up.

## Risk and compatibility
- Breaking changes: None.
- Migration required: None.
- Performance impact: Negligible path normalization and relative-path checks during render.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #826