### PR TITLE
fix(report): skip SARIF increase warnings for reductions

### DIFF
--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -137,6 +137,9 @@ func appendWasteIncreaseResult(results *[]sarifResult, rules *sarifRuleBuilder, 
 	if wasteIncreasePercent == nil {
 		return
 	}
+	if *wasteIncreasePercent <= 0 {
+		return
+	}
 	ruleID := "lopper/waste/increase"
 	rules.add(sarifRule{
 		ID:               ruleID,

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -92,6 +92,39 @@ func TestFormatSARIFWasteOnlyReport(t *testing.T) {
 	}
 }
 
+func TestFormatSARIFWasteOnlyReportNonPositiveDelta(t *testing.T) {
+	testCases := []struct {
+		name         string
+		wasteIncrease float64
+	}{
+		{name: "zero", wasteIncrease: 0},
+		{name: "negative", wasteIncrease: -3.5},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := NewFormatter().Format(Report{WasteIncreasePercent: &tc.wasteIncrease}, FormatSARIF)
+			if err != nil {
+				t.Fatalf("format waste-only sarif report: %v", err)
+			}
+
+			var payload sarifLog
+			if err := json.Unmarshal([]byte(output), &payload); err != nil {
+				t.Fatalf(errParseSARIFOutput, err)
+			}
+			if len(payload.Runs) != 1 {
+				t.Fatalf(errExpectedOneRun, len(payload.Runs))
+			}
+			if len(payload.Runs[0].Results) != 0 {
+				t.Fatalf("expected no results for non-positive waste delta, got %d", len(payload.Runs[0].Results))
+			}
+			if len(payload.Runs[0].Tool.Driver.Rules) != 0 {
+				t.Fatalf("expected no rules for non-positive waste delta, got %d", len(payload.Runs[0].Tool.Driver.Rules))
+			}
+		})
+	}
+}
+
 func TestNormalizeRuleToken(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -117,7 +117,7 @@ func assertWasteOnlySARIFWithoutResult(t *testing.T, wasteIncrease float64) {
 
 func TestFormatSARIFWasteOnlyReportNonPositiveDelta(t *testing.T) {
 	testCases := []struct {
-		name         string
+		name          string
 		wasteIncrease float64
 	}{
 		{name: "zero", wasteIncrease: 0},

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -92,6 +92,29 @@ func TestFormatSARIFWasteOnlyReport(t *testing.T) {
 	}
 }
 
+func assertWasteOnlySARIFWithoutResult(t *testing.T, wasteIncrease float64) {
+	t.Helper()
+
+	output, err := NewFormatter().Format(Report{WasteIncreasePercent: &wasteIncrease}, FormatSARIF)
+	if err != nil {
+		t.Fatalf("format waste-only sarif report: %v", err)
+	}
+
+	var payload sarifLog
+	if err := json.Unmarshal([]byte(output), &payload); err != nil {
+		t.Fatalf(errParseSARIFOutput, err)
+	}
+	if len(payload.Runs) != 1 {
+		t.Fatalf(errExpectedOneRun, len(payload.Runs))
+	}
+	if len(payload.Runs[0].Results) != 0 {
+		t.Fatalf("expected no results for non-positive waste delta, got %d", len(payload.Runs[0].Results))
+	}
+	if len(payload.Runs[0].Tool.Driver.Rules) != 0 {
+		t.Fatalf("expected no rules for non-positive waste delta, got %d", len(payload.Runs[0].Tool.Driver.Rules))
+	}
+}
+
 func TestFormatSARIFWasteOnlyReportNonPositiveDelta(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -103,24 +126,7 @@ func TestFormatSARIFWasteOnlyReportNonPositiveDelta(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := NewFormatter().Format(Report{WasteIncreasePercent: &tc.wasteIncrease}, FormatSARIF)
-			if err != nil {
-				t.Fatalf("format waste-only sarif report: %v", err)
-			}
-
-			var payload sarifLog
-			if err := json.Unmarshal([]byte(output), &payload); err != nil {
-				t.Fatalf(errParseSARIFOutput, err)
-			}
-			if len(payload.Runs) != 1 {
-				t.Fatalf(errExpectedOneRun, len(payload.Runs))
-			}
-			if len(payload.Runs[0].Results) != 0 {
-				t.Fatalf("expected no results for non-positive waste delta, got %d", len(payload.Runs[0].Results))
-			}
-			if len(payload.Runs[0].Tool.Driver.Rules) != 0 {
-				t.Fatalf("expected no rules for non-positive waste delta, got %d", len(payload.Runs[0].Tool.Driver.Rules))
-			}
+			assertWasteOnlySARIFWithoutResult(t, tc.wasteIncrease)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fix SARIF waste increase reporting so warnings are emitted only when waste actually increases compared with baseline.

Closes #846.

## Changes

- Return early in `appendWasteIncreaseResult` when `WasteIncreasePercent` is `nil`, zero, or negative.
- Add SARIF regression coverage to assert non-positive waste deltas emit no `lopper/waste/increase` result or rule metadata.

## Validation

Commands and checks run:

```bash
go test ./internal/report
go test ./...
```

Additional manual validation:

- Verified diff scope is limited to `internal/report/sarif.go` and `internal/report/sarif_test.go`.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Negligible; adds a constant-time guard before SARIF result emission.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

