### PR TITLE
fix(php): handle grouped function and const imports

### DIFF
--- a/internal/lang/php/adapter_helpers_extra_test.go
+++ b/internal/lang/php/adapter_helpers_extra_test.go
@@ -347,6 +347,32 @@ func TestParseUseStatementFunctionAndConstImports(t *testing.T) {
 	}
 }
 
+func assertGroupedUseStatementImports(t *testing.T, resolver composerResolver, statement string, expectedModules []string) {
+	t.Helper()
+
+	imports, groupedDeps, unresolved := parseUseStatement(statement, "x.php", 1, resolver)
+	if unresolved != 0 {
+		t.Fatalf(helpersUnexpectedUnresolvedFmt, unresolved)
+	}
+	if len(groupedDeps) != 1 {
+		t.Fatalf("expected grouped dependency attribution, got %#v", groupedDeps)
+	}
+	if _, ok := groupedDeps[helpersVendorLibDependency]; !ok {
+		t.Fatalf("expected grouped dependency %q, got %#v", helpersVendorLibDependency, groupedDeps)
+	}
+	if len(imports) != len(expectedModules) {
+		t.Fatalf("expected %d imports, got %d", len(expectedModules), len(imports))
+	}
+	for i, imp := range imports {
+		if imp.Dependency != helpersVendorLibDependency {
+			t.Fatalf("expected dependency %q, got %#v", helpersVendorLibDependency, imp)
+		}
+		if imp.Module != expectedModules[i] {
+			t.Fatalf("expected module %q, got %#v", expectedModules[i], imp)
+		}
+	}
+}
+
 func TestParseGroupedUseStatementFunctionAndConstImports(t *testing.T) {
 	resolver := composerResolver{declared: map[string]struct{}{helpersVendorLibDependency: {}}}
 	resolver.namespaceToDep = map[string]string{"Vendor\\Lib": helpersVendorLibDependency}
@@ -367,27 +393,7 @@ func TestParseGroupedUseStatementFunctionAndConstImports(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.statement, func(t *testing.T) {
-			imports, groupedDeps, unresolved := parseUseStatement(tc.statement, "x.php", 1, resolver)
-			if unresolved != 0 {
-				t.Fatalf(helpersUnexpectedUnresolvedFmt, unresolved)
-			}
-			if len(groupedDeps) != 1 {
-				t.Fatalf("expected grouped dependency attribution, got %#v", groupedDeps)
-			}
-			if _, ok := groupedDeps[helpersVendorLibDependency]; !ok {
-				t.Fatalf("expected grouped dependency %q, got %#v", helpersVendorLibDependency, groupedDeps)
-			}
-			if len(imports) != len(tc.expectedModules) {
-				t.Fatalf("expected %d imports, got %d", len(tc.expectedModules), len(imports))
-			}
-			for i, imp := range imports {
-				if imp.Dependency != helpersVendorLibDependency {
-					t.Fatalf("expected dependency %q, got %#v", helpersVendorLibDependency, imp)
-				}
-				if imp.Module != tc.expectedModules[i] {
-					t.Fatalf("expected module %q, got %#v", tc.expectedModules[i], imp)
-				}
-			}
+			assertGroupedUseStatementImports(t, resolver, tc.statement, tc.expectedModules)
 		})
 	}
 }

--- a/internal/lang/php/adapter_helpers_extra_test.go
+++ b/internal/lang/php/adapter_helpers_extra_test.go
@@ -347,6 +347,51 @@ func TestParseUseStatementFunctionAndConstImports(t *testing.T) {
 	}
 }
 
+func TestParseGroupedUseStatementFunctionAndConstImports(t *testing.T) {
+	resolver := composerResolver{declared: map[string]struct{}{helpersVendorLibDependency: {}}}
+	resolver.namespaceToDep = map[string]string{"Vendor\\Lib": helpersVendorLibDependency}
+
+	tests := []struct {
+		statement       string
+		expectedModules []string
+	}{
+		{
+			statement:       "function Vendor\\Lib\\{helper, util as utilAlias}",
+			expectedModules: []string{"Vendor\\Lib\\helper", "Vendor\\Lib\\util"},
+		},
+		{
+			statement:       "const Vendor\\Lib\\{VERSION, BUILD as B}",
+			expectedModules: []string{"Vendor\\Lib\\VERSION", "Vendor\\Lib\\BUILD"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.statement, func(t *testing.T) {
+			imports, groupedDeps, unresolved := parseUseStatement(tc.statement, "x.php", 1, resolver)
+			if unresolved != 0 {
+				t.Fatalf(helpersUnexpectedUnresolvedFmt, unresolved)
+			}
+			if len(groupedDeps) != 1 {
+				t.Fatalf("expected grouped dependency attribution, got %#v", groupedDeps)
+			}
+			if _, ok := groupedDeps[helpersVendorLibDependency]; !ok {
+				t.Fatalf("expected grouped dependency %q, got %#v", helpersVendorLibDependency, groupedDeps)
+			}
+			if len(imports) != len(tc.expectedModules) {
+				t.Fatalf("expected %d imports, got %d", len(tc.expectedModules), len(imports))
+			}
+			for i, imp := range imports {
+				if imp.Dependency != helpersVendorLibDependency {
+					t.Fatalf("expected dependency %q, got %#v", helpersVendorLibDependency, imp)
+				}
+				if imp.Module != tc.expectedModules[i] {
+					t.Fatalf("expected module %q, got %#v", tc.expectedModules[i], imp)
+				}
+			}
+		})
+	}
+}
+
 func TestParseNamespaceReferencesSkipsUseLine(t *testing.T) {
 	resolver := composerResolver{namespaceToDep: map[string]string{"Monolog": helpersMonologDependency}}
 	imports, unresolved := parseNamespaceReferences([]byte(helpersPHPHeader+"use Monolog\\Logger;\n"), "x.php", resolver)

--- a/internal/lang/php/import_parser.go
+++ b/internal/lang/php/import_parser.go
@@ -186,7 +186,7 @@ func parseGroupedUseStatement(statement, filePath string, line int, resolver com
 	if open < 0 || closeBrace <= open {
 		return nil, nil, 0, false
 	}
-	base := normalizeNamespace(statement[:open])
+	base := normalizeNamespace(stripUseImportQualifier(statement[:open]))
 	inside := statement[open+1 : closeBrace]
 	imports, groupedDeps, unresolved := parseUseParts(strings.Split(inside, ","), base, filePath, line, resolver, true)
 	return imports, groupedDeps, unresolved, true


### PR DESCRIPTION
## Summary

Fix grouped PHP `use function` and `use const` parsing so grouped imports are attributed to the correct dependency instead of being dropped.

Closes #813.

## Changes

- Strip `function`/`const` qualifiers from grouped `use` statement bases before namespace normalization.
- Add regression coverage for grouped `use function Vendor\\Lib\\{...}` and grouped `use const Vendor\\Lib\\{...}` statements.
- Assert grouped dependency attribution and resolved modules for both grouped forms.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/php
go test ./internal/lang/php ./internal/analysis ./cmd/lopper
go test ./...
```

Additional manual validation:

- N/A

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
