### PR TITLE
fix(shared): ignore manifest-named directories in root signals

### DIFF
--- a/internal/lang/shared/adapter_scaffold.go
+++ b/internal/lang/shared/adapter_scaffold.go
@@ -22,7 +22,11 @@ type RootSignal struct {
 func ApplyRootSignals(repoPath string, signals []RootSignal, detection *language.Detection, roots map[string]struct{}) error {
 	for _, signal := range signals {
 		path := filepath.Join(repoPath, signal.Name)
-		if _, err := os.Stat(path); err == nil {
+		info, err := os.Stat(path)
+		if err == nil {
+			if info.IsDir() {
+				continue
+			}
 			if detection != nil {
 				detection.Matched = true
 				detection.Confidence += signal.Confidence

--- a/internal/lang/shared/dependency_usage_test.go
+++ b/internal/lang/shared/dependency_usage_test.go
@@ -670,6 +670,26 @@ func TestApplyRootSignals(t *testing.T) {
 	}
 }
 
+func TestApplyRootSignalsIgnoresManifestNamedDirectories(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, "CMakeLists.txt"), 0o755); err != nil {
+		t.Fatalf("mkdir manifest-named directory: %v", err)
+	}
+
+	detection := language.Detection{}
+	roots := map[string]struct{}{}
+	err := ApplyRootSignals(repo, []RootSignal{{Name: "CMakeLists.txt", Confidence: 40}}, &detection, roots)
+	if err != nil {
+		t.Fatalf("apply root signals: %v", err)
+	}
+	if detection.Matched || detection.Confidence != 0 {
+		t.Fatalf("expected directory signal to be ignored, got detection=%#v", detection)
+	}
+	if len(roots) != 0 {
+		t.Fatalf("expected no roots from directory signal, got %#v", roots)
+	}
+}
+
 func TestWalkRepoFiles(t *testing.T) {
 	repo := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {


### PR DESCRIPTION
## Summary

`shared.ApplyRootSignals` treated any successful `os.Stat` as a match, including directories named like manifests. This change ignores directory matches so only real files can trigger root signals and detection confidence.

Closes #842.

## Changes

- Updated `internal/lang/shared.ApplyRootSignals` to skip `os.Stat` matches where `FileInfo.IsDir()` is true.
- Added regression test coverage in `internal/lang/shared/dependency_usage_test.go` proving manifest-named directories do not set `Matched`, confidence, or roots.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/shared ./internal/lang/ruby ./internal/lang/swift ./internal/lang/dart ./internal/lang/cpp ./internal/lang/kotlinandroid
go test ./...
```

Additional manual validation:

- Verified only intended shared files changed in this branch.

## Risk and compatibility

- Breaking changes: None expected.
- Migration required: None.
- Performance impact: Negligible; one `IsDir()` check per root signal hit.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

