### PR TITLE
fix(jvm): ignore manifest-named directories during detection

### DIFF
--- a/internal/lang/jvm/adapter_branches_extra_test.go
+++ b/internal/lang/jvm/adapter_branches_extra_test.go
@@ -57,6 +57,22 @@ func TestJVMRootSignalAndScanErrorBranches(t *testing.T) {
 	if applyJVMRootSignals(repoFile, detection, roots) == nil {
 		t.Fatalf("expected root signal stat error for non-directory repo path")
 	}
+
+	repo := t.TempDir()
+	for _, dirName := range []string{pomXMLName, buildGradleName, buildGradleKTSName} {
+		if err := os.Mkdir(filepath.Join(repo, dirName), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dirName, err)
+		}
+	}
+
+	detection = &language.Detection{}
+	roots = map[string]struct{}{}
+	if err := applyJVMRootSignals(repo, detection, roots); err != nil {
+		t.Fatalf("apply root signals with manifest-named directories: %v", err)
+	}
+	if detection.Matched || detection.Confidence != 0 || len(roots) != 0 {
+		t.Fatalf("expected no root signals from manifest-named directories, got detection=%#v roots=%#v", detection, roots)
+	}
 }
 
 func TestJVMSourceAndBuildFileBranches(t *testing.T) {

--- a/internal/lang/jvm/detection.go
+++ b/internal/lang/jvm/detection.go
@@ -63,7 +63,11 @@ func applyJVMRootSignals(repoPath string, detection *language.Detection, roots m
 	}
 	for _, signal := range rootSignals {
 		path := filepath.Join(repoPath, signal.name)
-		if _, err := os.Stat(path); err == nil {
+		info, err := os.Stat(path)
+		if err == nil {
+			if info.IsDir() {
+				continue
+			}
 			detection.Matched = true
 			detection.Confidence += signal.confidence
 			roots[repoPath] = struct{}{}


### PR DESCRIPTION
## Summary

Fixes JVM root-signal detection so directories named `pom.xml`, `build.gradle`, or `build.gradle.kts` at repo root do not count as JVM manifest signals.

Closes #843.

## Changes

- Updated `applyJVMRootSignals` to require that each root signal is a non-directory file before adding detection confidence/root match.
- Added regression coverage in `TestJVMRootSignalAndScanErrorBranches` for manifest-named directories at repository root.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/jvm
go test ./...
```

Additional manual validation:

- Verified the new regression assertion keeps `Matched=false`, `Confidence=0`, and no roots when only manifest-named directories exist.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: Negligible (single `IsDir` check per root signal)
- Memory benchmark impact: None expected

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
