### PR TITLE
fix(js): track destructured namespace imports

### DIFF
--- a/internal/lang/js/adapter.go
+++ b/internal/lang/js/adapter.go
@@ -480,7 +480,7 @@ func applyNamespaceOrDefaultImportUsage(imp ImportBinding, file FileScan, usedEx
 			counts[prop] += count
 		}
 	}
-	if count := file.IdentifierUsage[imp.LocalName]; count > 0 {
+	if count := file.IdentifierUsage[imp.LocalName]; count > 0 && hasDirectIdentifierUsage(imp, file) {
 		used = true
 		if imp.Kind == ImportDefault {
 			usedExports["default"] = struct{}{}

--- a/internal/lang/js/helpers_cov_more_extra_test.go
+++ b/internal/lang/js/helpers_cov_more_extra_test.go
@@ -149,6 +149,87 @@ function fn(param, { nested }, ...rest) {
 	}
 }
 
+func TestJSCollectIdentifierUsageSuppressesStaticNamespaceDestructureValues(t *testing.T) {
+	parser := newSourceParser()
+	source := []byte(`
+import * as util from "pkg";
+const { map, "filter": alias } = util;
+let pick;
+({ pick } = (util));
+const { ...rest } = util;
+void rest;
+`)
+
+	tree := mustParseJS(t, parser, source)
+	counts := collectIdentifierUsage(tree, source)
+	if counts["util"] != 1 {
+		t.Fatalf("expected only rest destructure to count namespace identifier usage, got %#v", counts)
+	}
+}
+
+func TestJSStaticObjectDestructureHelpers(t *testing.T) {
+	parser := newSourceParser()
+	source := []byte(`
+const {} = util;
+const { ...rest } = util;
+const { plain, "quoted": alias, value = fallback } = util;
+`)
+
+	tree := mustParseJS(t, parser, source)
+	patterns := make([]*sitter.Node, 0, 3)
+	utilIdentifiers := make([]*sitter.Node, 0, 3)
+	walkNode(tree.RootNode(), func(node *sitter.Node) {
+		switch {
+		case node.Type() == "object_pattern":
+			patterns = append(patterns, node)
+		case node.Type() == "identifier" && nodeText(node, source) == "util":
+			utilIdentifiers = append(utilIdentifiers, node)
+		}
+	})
+
+	if len(patterns) != 3 || len(utilIdentifiers) != 3 {
+		t.Fatalf("expected three object patterns and util identifiers, got patterns=%d identifiers=%d", len(patterns), len(utilIdentifiers))
+	}
+	if isStaticObjectPatternProperty(nil) {
+		t.Fatalf("expected nil node not to count as a static object pattern property")
+	}
+	if isStaticObjectPatternProperty(patterns[1].NamedChild(0)) {
+		t.Fatalf("expected rest pattern not to count as a static object pattern property")
+	}
+	if !isStaticObjectPatternProperty(patterns[2].NamedChild(0)) {
+		t.Fatalf("expected shorthand property to count as a static object pattern property")
+	}
+	if hasOnlyStaticObjectPatternProperties(patterns[0]) {
+		t.Fatalf("expected empty object pattern not to count as static property usage")
+	}
+	if hasOnlyStaticObjectPatternProperties(patterns[1]) {
+		t.Fatalf("expected rest destructure not to count as static property usage")
+	}
+	if !hasOnlyStaticObjectPatternProperties(patterns[2]) {
+		t.Fatalf("expected property-only destructure to count as static property usage")
+	}
+
+	if isStaticObjectDestructureValueUsage(utilIdentifiers[0]) {
+		t.Fatalf("expected empty object pattern value not to be suppressed")
+	}
+	if isStaticObjectDestructureValueUsage(utilIdentifiers[1]) {
+		t.Fatalf("expected rest destructure value not to be suppressed")
+	}
+	if !isStaticObjectDestructureValueUsage(utilIdentifiers[2]) {
+		t.Fatalf("expected property-only destructure value to be suppressed")
+	}
+}
+
+func TestApplySideEffectImportUsagePreservesExplicitExportName(t *testing.T) {
+	usedExports := make(map[string]struct{})
+	if !applySideEffectImportUsage(ImportBinding{ExportName: "side-effect"}, usedExports) {
+		t.Fatalf("expected side-effect import usage to be marked used")
+	}
+	if _, ok := usedExports["side-effect"]; !ok {
+		t.Fatalf("expected explicit side-effect export marker, got %#v", usedExports)
+	}
+}
+
 func TestJSRequireBindingAndDynamicImportBranches(t *testing.T) {
 	parser := newSourceParser()
 	source := []byte(`

--- a/internal/lang/js/scan_usage.go
+++ b/internal/lang/js/scan_usage.go
@@ -40,6 +40,9 @@ func isIdentifierUsage(node *sitter.Node) bool {
 	if parent == nil {
 		return false
 	}
+	if isStaticObjectDestructureValueUsage(node) {
+		return false
+	}
 
 	switch parent.Type() {
 	case "import_specifier", "import_clause", "namespace_import", "named_imports", "import_statement":
@@ -67,4 +70,70 @@ func isIdentifierUsage(node *sitter.Node) bool {
 	default:
 		return true
 	}
+}
+
+func isStaticObjectDestructureValueUsage(node *sitter.Node) bool {
+	expr := node
+	parent := expr.Parent()
+	for parent != nil && parent.Type() == "parenthesized_expression" {
+		expr = parent
+		parent = expr.Parent()
+	}
+	if parent == nil {
+		return false
+	}
+
+	var pattern, value *sitter.Node
+	switch parent.Type() {
+	case "variable_declarator":
+		pattern = parent.ChildByFieldName("name")
+		value = parent.ChildByFieldName("value")
+	case "assignment_expression":
+		pattern = parent.ChildByFieldName("left")
+		value = parent.ChildByFieldName("right")
+	default:
+		return false
+	}
+
+	if value == nil || value.ID() != expr.ID() {
+		return false
+	}
+
+	return hasOnlyStaticObjectPatternProperties(pattern)
+}
+
+func hasOnlyStaticObjectPatternProperties(pattern *sitter.Node) bool {
+	if pattern == nil || pattern.Type() != "object_pattern" || pattern.NamedChildCount() == 0 {
+		return false
+	}
+
+	for i := 0; i < int(pattern.NamedChildCount()); i++ {
+		if !isStaticObjectPatternProperty(pattern.NamedChild(i)) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isStaticObjectPatternProperty(node *sitter.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	switch node.Type() {
+	case "shorthand_property_identifier_pattern", "property_identifier", "object_assignment_pattern":
+		return true
+	case "pair_pattern":
+		key := node.ChildByFieldName("key")
+		if key == nil {
+			return false
+		}
+		switch key.Type() {
+		case "property_identifier", "identifier", "string":
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/lang/js/usage.go
+++ b/internal/lang/js/usage.go
@@ -21,6 +21,10 @@ func collectNamespaceReferences(tree *sitter.Tree, content []byte) []NamespaceRe
 			addMemberReference(node, content, &refs)
 		case "subscript_expression":
 			addSubscriptReference(node, content, &refs)
+		case "variable_declarator":
+			addVariableDestructureReference(node, content, &refs)
+		case "assignment_expression":
+			addAssignmentDestructureReference(node, content, &refs)
 		}
 	})
 
@@ -95,6 +99,76 @@ func addSubscriptReference(node *sitter.Node, content []byte, refs *[]NamespaceR
 		Property: propertyName,
 		Count:    1,
 	})
+}
+
+func addVariableDestructureReference(node *sitter.Node, content []byte, refs *[]NamespaceReference) {
+	pattern := node.ChildByFieldName("name")
+	value := node.ChildByFieldName("value")
+	addObjectPatternDestructureReferences(pattern, value, content, refs)
+}
+
+func addAssignmentDestructureReference(node *sitter.Node, content []byte, refs *[]NamespaceReference) {
+	pattern := node.ChildByFieldName("left")
+	value := node.ChildByFieldName("right")
+	addObjectPatternDestructureReferences(pattern, value, content, refs)
+}
+
+func addObjectPatternDestructureReferences(pattern, value *sitter.Node, content []byte, refs *[]NamespaceReference) {
+	if pattern == nil || pattern.Type() != "object_pattern" {
+		return
+	}
+	local := extractIdentifierExpression(value, content)
+	if local == "" {
+		return
+	}
+
+	for i := 0; i < int(pattern.NamedChildCount()); i++ {
+		property := extractObjectPatternProperty(pattern.NamedChild(i), content)
+		if property == "" {
+			continue
+		}
+		*refs = append(*refs, NamespaceReference{
+			Local:    local,
+			Property: property,
+			Count:    1,
+		})
+	}
+}
+
+func extractIdentifierExpression(node *sitter.Node, content []byte) string {
+	for node != nil && node.Type() == "parenthesized_expression" && node.NamedChildCount() == 1 {
+		node = node.NamedChild(0)
+	}
+	if node == nil || node.Type() != "identifier" {
+		return ""
+	}
+	return nodeText(node, content)
+}
+
+func extractObjectPatternProperty(node *sitter.Node, content []byte) string {
+	if node == nil {
+		return ""
+	}
+
+	switch node.Type() {
+	case "shorthand_property_identifier_pattern", "property_identifier":
+		return nodeText(node, content)
+	case "object_assignment_pattern":
+		return nodeText(node.ChildByFieldName("left"), content)
+	case "pair_pattern":
+		key := node.ChildByFieldName("key")
+		if key == nil {
+			return ""
+		}
+		switch key.Type() {
+		case "property_identifier", "identifier":
+			return nodeText(key, content)
+		case "string":
+			return extractPropertyString(key, content)
+		}
+	}
+
+	return ""
 }
 
 func extractPropertyString(node *sitter.Node, content []byte) string {

--- a/internal/lang/js/usage_test.go
+++ b/internal/lang/js/usage_test.go
@@ -63,6 +63,41 @@ func TestNamespaceUsageMemberExpression(t *testing.T) {
 	}
 }
 
+func TestNamespaceUsageObjectDestructuring(t *testing.T) {
+	repo := t.TempDir()
+	source := `import * as util from "lodash"
+const { map, filter: alias, reduce = fallback } = util
+let pick
+({ pick } = util)
+`
+	path := filepath.Join(repo, indexJSFile)
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	result, err := ScanRepo(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("scan repo: %v", err)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(result.Files))
+	}
+
+	usage := result.Files[0].NamespaceUsage["util"]
+	if usage["map"] == 0 {
+		t.Fatalf("expected destructured shorthand map usage")
+	}
+	if usage["filter"] == 0 {
+		t.Fatalf("expected destructured aliased filter usage")
+	}
+	if usage["reduce"] == 0 {
+		t.Fatalf("expected destructured default reduce usage")
+	}
+	if usage["pick"] == 0 {
+		t.Fatalf("expected assignment destructure pick usage")
+	}
+}
+
 func TestHasDirectIdentifierUsage(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -340,6 +375,28 @@ func TestCollectDependencyImportUsageSideEffectImport(t *testing.T) {
 	}
 	if usage.HasAmbiguousWildcard {
 		t.Fatalf("did not expect side-effect import to mark wildcard ambiguity")
+	}
+}
+
+func TestCollectDependencyImportUsageNamespaceDestructureTracksProperties(t *testing.T) {
+	repo := t.TempDir()
+	source := `import * as util from "lodash"
+const { map } = util
+map([1], (x) => x)
+`
+	path := filepath.Join(repo, indexJSFile)
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	scan, err := ScanRepo(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("scan repo: %v", err)
+	}
+
+	usage := collectDependencyImportUsage(scan, "lodash")
+	if _, ok := usage.UsedExports["map"]; !ok {
+		t.Fatalf("expected map export usage from namespace destructure, got %#v", usage.UsedExports)
 	}
 }
 

--- a/internal/lang/js/usage_test.go
+++ b/internal/lang/js/usage_test.go
@@ -16,6 +16,23 @@ const (
 	indexJSFile = "index.js"
 )
 
+func collectDependencyImportUsageFromSource(t *testing.T, dependency, source string) dependencyImportUsage {
+	t.Helper()
+
+	repo := t.TempDir()
+	path := filepath.Join(repo, indexJSFile)
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	scan, err := ScanRepo(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("scan repo: %v", err)
+	}
+
+	return collectDependencyImportUsage(scan, dependency)
+}
+
 func TestNamespaceUsageComputedProperty(t *testing.T) {
 	repo := t.TempDir()
 	source := "import * as util from \"lodash\"\nutil['map']([1], (x) => x)\n"
@@ -382,22 +399,10 @@ func TestCollectDependencyImportUsageSideEffectImport(t *testing.T) {
 }
 
 func TestCollectDependencyImportUsageNamespaceDestructureTracksProperties(t *testing.T) {
-	repo := t.TempDir()
-	source := `import * as util from "lodash"
+	usage := collectDependencyImportUsageFromSource(t, "lodash", `import * as util from "lodash"
 const { map } = util
 map([1], (x) => x)
-`
-	path := filepath.Join(repo, indexJSFile)
-	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
-		t.Fatalf("write file: %v", err)
-	}
-
-	scan, err := ScanRepo(context.Background(), repo)
-	if err != nil {
-		t.Fatalf("scan repo: %v", err)
-	}
-
-	usage := collectDependencyImportUsage(scan, "lodash")
+`)
 	if _, ok := usage.UsedExports["map"]; !ok {
 		t.Fatalf("expected map export usage from namespace destructure, got %#v", usage.UsedExports)
 	}
@@ -410,23 +415,11 @@ map([1], (x) => x)
 }
 
 func TestCollectDependencyImportUsageNamespaceDestructureRestKeepsWildcard(t *testing.T) {
-	repo := t.TempDir()
-	source := `import * as util from "lodash"
+	usage := collectDependencyImportUsageFromSource(t, "lodash", `import * as util from "lodash"
 const { map, ...rest } = util
 map([1], (x) => x)
 void rest
-`
-	path := filepath.Join(repo, indexJSFile)
-	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
-		t.Fatalf("write file: %v", err)
-	}
-
-	scan, err := ScanRepo(context.Background(), repo)
-	if err != nil {
-		t.Fatalf("scan repo: %v", err)
-	}
-
-	usage := collectDependencyImportUsage(scan, "lodash")
+`)
 	if _, ok := usage.UsedExports["map"]; !ok {
 		t.Fatalf("expected map export usage from namespace destructure, got %#v", usage.UsedExports)
 	}

--- a/internal/lang/js/usage_test.go
+++ b/internal/lang/js/usage_test.go
@@ -66,9 +66,9 @@ func TestNamespaceUsageMemberExpression(t *testing.T) {
 func TestNamespaceUsageObjectDestructuring(t *testing.T) {
 	repo := t.TempDir()
 	source := `import * as util from "lodash"
-const { map, filter: alias, reduce = fallback } = util
+const { map, filter: alias, reduce = fallback, "select": picker } = util
 let pick
-({ pick } = util)
+({ pick } = (util))
 `
 	path := filepath.Join(repo, indexJSFile)
 	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
@@ -92,6 +92,9 @@ let pick
 	}
 	if usage["reduce"] == 0 {
 		t.Fatalf("expected destructured default reduce usage")
+	}
+	if usage["select"] == 0 {
+		t.Fatalf("expected destructured string-key select usage")
 	}
 	if usage["pick"] == 0 {
 		t.Fatalf("expected assignment destructure pick usage")
@@ -398,6 +401,41 @@ map([1], (x) => x)
 	if _, ok := usage.UsedExports["map"]; !ok {
 		t.Fatalf("expected map export usage from namespace destructure, got %#v", usage.UsedExports)
 	}
+	if _, ok := usage.UsedExports["*"]; ok {
+		t.Fatalf("did not expect wildcard usage for static namespace destructure, got %#v", usage.UsedExports)
+	}
+	if usage.HasAmbiguousWildcard {
+		t.Fatalf("did not expect ambiguous wildcard usage for static namespace destructure")
+	}
+}
+
+func TestCollectDependencyImportUsageNamespaceDestructureRestKeepsWildcard(t *testing.T) {
+	repo := t.TempDir()
+	source := `import * as util from "lodash"
+const { map, ...rest } = util
+map([1], (x) => x)
+void rest
+`
+	path := filepath.Join(repo, indexJSFile)
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	scan, err := ScanRepo(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("scan repo: %v", err)
+	}
+
+	usage := collectDependencyImportUsage(scan, "lodash")
+	if _, ok := usage.UsedExports["map"]; !ok {
+		t.Fatalf("expected map export usage from namespace destructure, got %#v", usage.UsedExports)
+	}
+	if _, ok := usage.UsedExports["*"]; !ok {
+		t.Fatalf("expected wildcard usage for rest destructure, got %#v", usage.UsedExports)
+	}
+	if !usage.HasAmbiguousWildcard {
+		t.Fatalf("expected ambiguous wildcard usage for rest destructure")
+	}
 }
 
 func TestNamespaceReferenceExtractionBranches(t *testing.T) {
@@ -444,5 +482,31 @@ func TestExtractPropertyStringBackticksAndRaw(t *testing.T) {
 	})
 	if !slices.Contains(found, "value") || !slices.Contains(found, "quoted") {
 		t.Fatalf("expected string extraction from template and quoted strings, got %#v", found)
+	}
+}
+
+func TestExtractObjectPatternPropertyUnsupportedNodes(t *testing.T) {
+	if got := extractObjectPatternProperty(nil, nil); got != "" {
+		t.Fatalf("expected empty property for nil node, got %q", got)
+	}
+
+	parser := newSourceParser()
+	source := []byte(`const { ...rest } = util`)
+	tree, err := parser.Parse(context.Background(), indexJSFile, source)
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+
+	var restPattern *sitter.Node
+	walkNode(tree.RootNode(), func(node *sitter.Node) {
+		if restPattern == nil && node.Type() == "rest_pattern" {
+			restPattern = node
+		}
+	})
+	if restPattern == nil {
+		t.Fatalf("expected rest pattern node")
+	}
+	if got := extractObjectPatternProperty(restPattern, source); got != "" {
+		t.Fatalf("expected rest pattern to have no static property, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes JS namespace usage tracking for object destructuring so `import * as ns from ...; const { x } = ns` records `x` as an exported symbol use instead of only wildcard/direct identifier usage.

Closes #893.

## Changes

- extend namespace reference collection to include object-pattern destructuring from namespace identifiers in both declarations and assignment expressions
- add object-pattern property extraction for shorthand, aliased, and defaulted destructured properties
- add regression tests for namespace destructuring usage collection and dependency export usage attribution

## Validation

Commands and checks run:

```bash
go test ./internal/lang/js
go test ./...
```

Additional manual validation:

- Verified namespace usage map includes destructured properties (`map`, `filter`, `reduce`, `pick`) from `util`.

## Risk and compatibility

- Breaking changes: none
- Migration required: none
- Performance impact: negligible; adds small extra AST branch handling
- Memory benchmark impact: none expected

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

