### PR TITLE
fix(golang): use modfile for go.mod parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.uber.org/goleak v1.3.0
+	golang.org/x/mod v0.36.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/lang/golang/adapter_cov_extra_test.go
+++ b/internal/lang/golang/adapter_cov_extra_test.go
@@ -52,13 +52,6 @@ func TestGoAdapterCoverageHelpersMore(t *testing.T) {
 		t.Fatalf("expected wildcard import risk cue")
 	}
 
-	processGoModLine("replace (", &goModParseState{
-		replaceSet: make(map[string]string),
-	})
-	if parseGoModReplaceBlockControl("replace (", &goModParseState{}) != true {
-		t.Fatalf("expected replace block control to start block")
-	}
-
 	if got := inferDependency("example.com/x"); got != "example.com/x" {
 		t.Fatalf("expected short external path inference, got %q", got)
 	}
@@ -139,13 +132,21 @@ func assertGoTagVersionHelpers(t *testing.T) {
 
 func assertGoModHelpers(t *testing.T) {
 	t.Helper()
-	if parseGoModBlockControl("x", "require (", nil) {
-		t.Fatalf("expected nil inBlock pointer to return false")
-	}
 	replaceSet := map[string]string{}
 	addGoModReplacement("example.com/old => local/module", replaceSet)
 	if len(replaceSet) != 0 {
 		t.Fatalf("expected non-external replacement target to be ignored")
+	}
+
+	modulePath, dependencies, replacements := parseGoMod([]byte("module example.com/root\n\nrequire github.com/acme/dep v1.2.3\nreplace example.com/old => ./local/module\n"))
+	if modulePath != "example.com/root" {
+		t.Fatalf("expected module path from modfile parse, got %q", modulePath)
+	}
+	if len(dependencies) != 1 || dependencies[0] != "github.com/acme/dep" {
+		t.Fatalf("expected dependency from modfile parse, got %#v", dependencies)
+	}
+	if len(replacements) != 0 {
+		t.Fatalf("expected local replacement target to be ignored, got %#v", replacements)
 	}
 }
 

--- a/internal/lang/golang/adapter_cov_extra_test.go
+++ b/internal/lang/golang/adapter_cov_extra_test.go
@@ -148,6 +148,17 @@ func assertGoModHelpers(t *testing.T) {
 	if len(replacements) != 0 {
 		t.Fatalf("expected local replacement target to be ignored, got %#v", replacements)
 	}
+
+	malformedModulePath, malformedDependencies, malformedReplacements := parseGoMod([]byte("module example.com/root\nrequire (\n"))
+	if malformedModulePath != "" {
+		t.Fatalf("expected malformed go.mod parse to return empty module path, got %q", malformedModulePath)
+	}
+	if malformedDependencies == nil || len(malformedDependencies) != 0 {
+		t.Fatalf("expected malformed go.mod parse to preserve empty dependency slice, got %#v", malformedDependencies)
+	}
+	if len(malformedReplacements) != 0 {
+		t.Fatalf("expected malformed go.mod parse to preserve empty replacements, got %#v", malformedReplacements)
+	}
 }
 
 func assertGoWorkAndPathHelpers(t *testing.T) {

--- a/internal/lang/golang/adapter_cov_extra_test.go
+++ b/internal/lang/golang/adapter_cov_extra_test.go
@@ -153,7 +153,7 @@ func assertGoModHelpers(t *testing.T) {
 	if malformedModulePath != "" {
 		t.Fatalf("expected malformed go.mod parse to return empty module path, got %q", malformedModulePath)
 	}
-	if malformedDependencies == nil || len(malformedDependencies) != 0 {
+	if len(malformedDependencies) != 0 {
 		t.Fatalf("expected malformed go.mod parse to preserve empty dependency slice, got %#v", malformedDependencies)
 	}
 	if len(malformedReplacements) != 0 {

--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -911,7 +911,6 @@ func TestGoModReplacementAndTokensEdgeCases(t *testing.T) {
 		t.Fatalf("expected local replacement target to be skipped, got %#v", replaceSet)
 	}
 
-	addGoModDependency("", nil)
 	addGoModReplacement("", nil)
 	addGoModReplacement("=> github.com/new/path", replaceSet)
 	addGoModReplacement("example.com/old =>", replaceSet)
@@ -1323,9 +1322,6 @@ func TestDiscoverNestedModulesIgnoresGoModDirectory(t *testing.T) {
 }
 
 func TestMiscCoverageBranches(t *testing.T) {
-	// nil state and empty line branch
-	processGoModLine("", nil)
-
 	if normalizeGoWorkPath("   ") != "" {
 		t.Fatalf("expected empty normalized go.work path")
 	}
@@ -1352,9 +1348,6 @@ func TestMiscCoverageBranches(t *testing.T) {
 		BlankImportsByDependency:      map[string]int{},
 		UndeclaredImportsByDependency: map[string]int{},
 	})
-	addGoModDependency("   ", map[string]struct{}{})
-	processGoModLine(moduleDemoLine, nil)
-	processGoModLine("", &goModParseState{depSet: map[string]struct{}{}, replaceSet: map[string]string{}})
 	if isLocalReplaceTarget("") {
 		t.Fatalf("expected empty path not to be local replacement")
 	}
@@ -1430,34 +1423,33 @@ func TestSafeReadGuardsForGoModuleAndSource(t *testing.T) {
 	}
 }
 
-func TestParseGoModReplaceControlBranches(t *testing.T) {
-	state := &goModParseState{}
-	if parseGoModReplaceBlockControl("replace (", state) != true || !state.inReplaceBlock {
-		t.Fatalf("expected start replace block")
-	}
-	if parseGoModReplaceBlockControl(")", state) != true || state.inReplaceBlock {
-		t.Fatalf("expected close replace block")
-	}
-	if parseGoModReplaceBlockControl("not replace", state) {
-		t.Fatalf("expected no replace block control")
-	}
-}
+func TestParseGoModRequireAndReplaceBlocks(t *testing.T) {
+	content := strings.Join([]string{
+		"module example.com/root",
+		"",
+		"require (",
+		"\t" + depUUID + versionV160,
+		"\t" + depLo + " v1.47.0 // indirect",
+		")",
+		"",
+		"replace (",
+		"\t" + moduleOriginal + " v1.0.0 => github.com/fork/original v1.0.0",
+		"\texample.com/local => ./local",
+		")",
+		"",
+	}, "\n")
 
-func TestProcessGoModLineInBlockBranches(t *testing.T) {
-	state := &goModParseState{
-		depSet:         map[string]struct{}{},
-		replaceSet:     map[string]string{},
-		inRequireBlock: true,
+	modulePath, dependencies, replacements := parseGoMod([]byte(content))
+	if modulePath != "example.com/root" {
+		t.Fatalf("expected module path example.com/root, got %q", modulePath)
 	}
-	processGoModLine(depUUID+" v1.6.0", state)
-	if _, ok := state.depSet[depUUID]; !ok {
-		t.Fatalf("expected dependency from require block")
+	if !slices.Equal(dependencies, []string{depUUID, depLo}) {
+		t.Fatalf("unexpected dependencies: %#v", dependencies)
 	}
-
-	state.inRequireBlock = false
-	state.inReplaceBlock = true
-	processGoModLine(moduleOriginal+" => github.com/fork/original v1.0.0", state)
-	if got := state.replaceSet["github.com/fork/original"]; got != moduleOriginal {
+	if len(replacements) != 1 {
+		t.Fatalf("expected one non-local replacement, got %#v", replacements)
+	}
+	if got := replacements["github.com/fork/original"]; got != moduleOriginal {
 		t.Fatalf("expected replacement mapping from replace block, got %q", got)
 	}
 }

--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -1424,7 +1424,7 @@ func TestSafeReadGuardsForGoModuleAndSource(t *testing.T) {
 }
 
 func TestParseGoModRequireAndReplaceBlocks(t *testing.T) {
-	content := strings.Join([]string{
+	contentLines := []string{
 		"module example.com/root",
 		"",
 		"require (",
@@ -1437,7 +1437,8 @@ func TestParseGoModRequireAndReplaceBlocks(t *testing.T) {
 		"\texample.com/local => ./local",
 		")",
 		"",
-	}, "\n")
+	}
+	content := strings.Join(contentLines, "\n")
 
 	modulePath, dependencies, replacements := parseGoMod([]byte(content))
 	if modulePath != "example.com/root" {

--- a/internal/lang/golang/coverage_helper_test.go
+++ b/internal/lang/golang/coverage_helper_test.go
@@ -1,12 +1,16 @@
 package golang
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/testutil"
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 )
 
 func TestCoverageHelperBranches(t *testing.T) {
@@ -105,5 +109,62 @@ func TestResolveRepoBoundedPathAbsoluteOutside(t *testing.T) {
 	}
 	if _, ok := resolveRepoBoundedPath(repo, filepath.Join(outside, "x")); ok {
 		t.Fatalf("expected absolute path outside repo to be rejected")
+	}
+}
+
+func TestAdditionalGoCoverageBranches(t *testing.T) {
+	if _, err := scanRepo(context.Background(), "\x00", moduleInfo{}); err == nil {
+		t.Fatalf("expected invalid repo path to fail scanRepo")
+	}
+
+	info := &moduleInfo{}
+	if err := loadVendoredMetadata(t.TempDir(), moduleLoadOptions{EnableVendoredProvenance: true}, info); err != nil {
+		t.Fatalf("expected vendored metadata load without manifest to succeed, got %v", err)
+	}
+	if info.VendoredProvenanceEnabled {
+		t.Fatalf("expected vendored provenance flag to remain disabled without manifest")
+	}
+
+	if got := goModModulePath(&modfile.File{}); got != "" {
+		t.Fatalf("expected empty module path for nil modfile module, got %q", got)
+	}
+
+	dependencies := goModDependencies([]*modfile.Require{
+		{Mod: module.Version{Path: ""}},
+		{Mod: module.Version{Path: "github.com/acme/dep"}},
+	})
+	if !slices.Equal(dependencies, []string{"github.com/acme/dep"}) {
+		t.Fatalf("expected blank dependency paths to be ignored, got %#v", dependencies)
+	}
+
+	if shouldTrackGoModReplacement("", "github.com/acme/fork") {
+		t.Fatalf("expected empty old path replacement to be ignored")
+	}
+	if shouldTrackGoModReplacement("example.com/original", "") {
+		t.Fatalf("expected empty new path replacement to be ignored")
+	}
+	if !shouldTrackGoModReplacement("example.com/original", "github.com/acme/fork") {
+		t.Fatalf("expected external replacement target to be tracked")
+	}
+
+	replaceSet := map[string]string{}
+	addGoModReplacement("example.com/original => github.com/acme/fork v1.0.0", replaceSet)
+	if got := replaceSet["github.com/acme/fork"]; got != "example.com/original" {
+		t.Fatalf("expected replacement import mapping, got %q", got)
+	}
+
+	metadata := newVendoredModuleMetadata()
+	state := &vendoredParseState{}
+	parseVendoredModuleMetadataLine("", &metadata, state)
+	parseVendoredModuleMetadataLine("# comment", &metadata, state)
+	parseVendoredMetadataDirectiveLine("## explicit", &metadata, &vendoredParseState{})
+	parseVendoredPackageLine("   ", &metadata, state)
+
+	if _, _, ok := parseVendoredModuleHeader("# => github.com/acme/fork v1.0.0"); ok {
+		t.Fatalf("expected vendored header without module path to be rejected")
+	}
+
+	if expr, kind := parseBuildConstraintComment("// +build !"); expr == nil || kind != "plus" {
+		t.Fatalf("expected +build directive to parse with plus kind, got expr=%v kind=%q", expr, kind)
 	}
 }

--- a/internal/lang/golang/module_metadata.go
+++ b/internal/lang/golang/module_metadata.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/safeio"
+	"golang.org/x/mod/modfile"
 )
 
 func workspaceRootModuleDirs(repoPath string, moduleInfo moduleInfo) (map[string]struct{}, error) {
@@ -101,117 +102,48 @@ func discoverNestedModules(repoPath string) ([]string, []string, map[string]stri
 }
 
 func parseGoMod(content []byte) (string, []string, map[string]string) {
-	state := goModParseState{
-		depSet:     make(map[string]struct{}),
-		replaceSet: make(map[string]string),
-	}
-	for _, rawLine := range strings.Split(string(content), "\n") {
-		processGoModLine(strings.TrimSpace(stripInlineComment(rawLine)), &state)
+	depSet := make(map[string]struct{})
+	replaceSet := make(map[string]string)
+
+	file, _ := modfile.Parse(goModName, content, nil)
+	if file == nil {
+		return "", nil, replaceSet
 	}
 
-	dependencies := make([]string, 0, len(state.depSet))
-	for dep := range state.depSet {
+	modulePath := ""
+	if file.Module != nil {
+		modulePath = strings.TrimSpace(file.Module.Mod.Path)
+	}
+
+	for _, requirement := range file.Require {
+		dependency := strings.TrimSpace(requirement.Mod.Path)
+		if dependency == "" {
+			continue
+		}
+		depSet[dependency] = struct{}{}
+	}
+	for _, replacement := range file.Replace {
+		oldPath := strings.TrimSpace(replacement.Old.Path)
+		newPath := strings.TrimSpace(replacement.New.Path)
+		if oldPath == "" || newPath == "" {
+			continue
+		}
+		if isLocalReplaceTarget(newPath) {
+			continue
+		}
+		// Track only import-like replacement targets.
+		if !looksExternalImport(newPath) {
+			continue
+		}
+		replaceSet[newPath] = oldPath
+	}
+
+	dependencies := make([]string, 0, len(depSet))
+	for dep := range depSet {
 		dependencies = append(dependencies, dep)
 	}
 	sort.Strings(dependencies)
-	return state.modulePath, dependencies, state.replaceSet
-}
-
-type goModParseState struct {
-	modulePath     string
-	depSet         map[string]struct{}
-	replaceSet     map[string]string
-	inRequireBlock bool
-	inReplaceBlock bool
-}
-
-func processGoModLine(line string, state *goModParseState) {
-	if line == "" || state == nil {
-		return
-	}
-	if parseGoModModuleLine(line, state) {
-		return
-	}
-	if parseGoModRequireBlockControl(line, state) {
-		return
-	}
-	if parseGoModReplaceBlockControl(line, state) {
-		return
-	}
-	if state.inReplaceBlock {
-		addGoModReplacement(line, state.replaceSet)
-		return
-	}
-	if state.inRequireBlock {
-		addGoModDependency(line, state.depSet)
-		return
-	}
-	parseGoModSingleRequire(line, state.depSet)
-	parseGoModSingleReplace(line, state.replaceSet)
-}
-
-func parseGoModModuleLine(line string, state *goModParseState) bool {
-	if !strings.HasPrefix(line, "module ") {
-		return false
-	}
-	fields := strings.Fields(line)
-	if len(fields) >= 2 {
-		state.modulePath = fields[1]
-	}
-	return true
-}
-
-func parseGoModRequireBlockControl(line string, state *goModParseState) bool {
-	return parseGoModBlockControl(line, "require (", &state.inRequireBlock)
-}
-
-func parseGoModReplaceBlockControl(line string, state *goModParseState) bool {
-	return parseGoModBlockControl(line, "replace (", &state.inReplaceBlock)
-}
-
-func parseGoModBlockControl(line string, startToken string, inBlock *bool) bool {
-	if inBlock == nil {
-		return false
-	}
-	if strings.HasPrefix(line, startToken) {
-		*inBlock = true
-		return true
-	}
-	if *inBlock && line == ")" {
-		*inBlock = false
-		return true
-	}
-	return false
-}
-
-func parseGoModSingleRequire(line string, depSet map[string]struct{}) {
-	parseGoModSingleDirective(line, "require ", func(value string) {
-		addGoModDependency(value, depSet)
-	})
-}
-
-func parseGoModSingleReplace(line string, replaceSet map[string]string) {
-	parseGoModSingleDirective(line, "replace ", func(value string) {
-		addGoModReplacement(value, replaceSet)
-	})
-}
-
-func parseGoModSingleDirective(line, prefix string, handler func(string)) {
-	if handler == nil || !strings.HasPrefix(line, prefix) {
-		return
-	}
-	handler(strings.TrimPrefix(line, prefix))
-}
-
-func addGoModDependency(line string, depSet map[string]struct{}) {
-	if depSet == nil {
-		return
-	}
-	fields := strings.Fields(line)
-	if len(fields) == 0 {
-		return
-	}
-	depSet[fields[0]] = struct{}{}
+	return modulePath, dependencies, replaceSet
 }
 
 func addGoModReplacement(line string, replaceSet map[string]string) {

--- a/internal/lang/golang/module_metadata.go
+++ b/internal/lang/golang/module_metadata.go
@@ -105,9 +105,12 @@ func parseGoMod(content []byte) (string, []string, map[string]string) {
 	depSet := make(map[string]struct{})
 	replaceSet := make(map[string]string)
 
-	file, _ := modfile.Parse(goModName, content, nil)
+	file, err := modfile.Parse(goModName, content, nil)
+	if err != nil && file == nil {
+		return "", []string{}, replaceSet
+	}
 	if file == nil {
-		return "", nil, replaceSet
+		return "", []string{}, replaceSet
 	}
 
 	modulePath := ""

--- a/internal/lang/golang/module_metadata.go
+++ b/internal/lang/golang/module_metadata.go
@@ -102,43 +102,33 @@ func discoverNestedModules(repoPath string) ([]string, []string, map[string]stri
 }
 
 func parseGoMod(content []byte) (string, []string, map[string]string) {
-	depSet := make(map[string]struct{})
-	replaceSet := make(map[string]string)
-
 	file, err := modfile.Parse(goModName, content, nil)
 	if err != nil && file == nil {
-		return "", []string{}, replaceSet
+		return "", []string{}, map[string]string{}
 	}
 	if file == nil {
-		return "", []string{}, replaceSet
+		return "", []string{}, map[string]string{}
 	}
 
-	modulePath := ""
-	if file.Module != nil {
-		modulePath = strings.TrimSpace(file.Module.Mod.Path)
+	return goModModulePath(file), goModDependencies(file.Require), goModReplacements(file.Replace)
+}
+
+func goModModulePath(file *modfile.File) string {
+	if file == nil || file.Module == nil {
+		return ""
 	}
 
-	for _, requirement := range file.Require {
+	return strings.TrimSpace(file.Module.Mod.Path)
+}
+
+func goModDependencies(requirements []*modfile.Require) []string {
+	depSet := make(map[string]struct{}, len(requirements))
+	for _, requirement := range requirements {
 		dependency := strings.TrimSpace(requirement.Mod.Path)
 		if dependency == "" {
 			continue
 		}
 		depSet[dependency] = struct{}{}
-	}
-	for _, replacement := range file.Replace {
-		oldPath := strings.TrimSpace(replacement.Old.Path)
-		newPath := strings.TrimSpace(replacement.New.Path)
-		if oldPath == "" || newPath == "" {
-			continue
-		}
-		if isLocalReplaceTarget(newPath) {
-			continue
-		}
-		// Track only import-like replacement targets.
-		if !looksExternalImport(newPath) {
-			continue
-		}
-		replaceSet[newPath] = oldPath
 	}
 
 	dependencies := make([]string, 0, len(depSet))
@@ -146,7 +136,33 @@ func parseGoMod(content []byte) (string, []string, map[string]string) {
 		dependencies = append(dependencies, dep)
 	}
 	sort.Strings(dependencies)
-	return modulePath, dependencies, replaceSet
+
+	return dependencies
+}
+
+func goModReplacements(replacements []*modfile.Replace) map[string]string {
+	replaceSet := make(map[string]string)
+	for _, replacement := range replacements {
+		oldPath := strings.TrimSpace(replacement.Old.Path)
+		newPath := strings.TrimSpace(replacement.New.Path)
+		if !shouldTrackGoModReplacement(oldPath, newPath) {
+			continue
+		}
+		replaceSet[newPath] = oldPath
+	}
+
+	return replaceSet
+}
+
+func shouldTrackGoModReplacement(oldPath, newPath string) bool {
+	if oldPath == "" || newPath == "" {
+		return false
+	}
+	if isLocalReplaceTarget(newPath) {
+		return false
+	}
+	// Track only import-like replacement targets.
+	return looksExternalImport(newPath)
 }
 
 func addGoModReplacement(line string, replaceSet map[string]string) {


### PR DESCRIPTION
## Summary

Replace the fragile manual `go.mod` line parser with `golang.org/x/mod/modfile` so module path, `require` dependencies, and `replace` mappings are derived from the official parser.

Closes #890.

## Changes

- switched `internal/lang/golang/parseGoMod` to parse `go.mod` with `modfile.Parse`
- preserved existing output contract:
- module path from `module` directive
- declared dependency list from `require` directives (deduped + sorted)
- replacement mapping as `replacement import path -> original dependency`, while still ignoring local replace targets
- removed now-unused manual `go.mod` line/block parser internals
- updated Go adapter tests to validate require/replace behavior through the new parser path
- added `golang.org/x/mod v0.36.0` dependency

## Validation

Commands and checks run:

```bash
go test ./internal/lang/golang
go test ./...
go mod tidy
go test ./internal/lang/golang && go test ./...
```

Additional manual validation:

- N/A

## Risk and compatibility

- Breaking changes: none intended
- Migration required: none
- Performance impact: negligible; parser is now delegated to `modfile`
- Memory benchmark impact: none observed

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

