### PR TITLE
fix(python): ignore src-layout local modules

### DIFF
--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -546,13 +546,26 @@ func dependencyFromModule(repoPath, moduleName string) string {
 }
 
 func isLocalModule(repoPath, root string) bool {
-	if _, err := os.Stat(filepath.Join(repoPath, root+".py")); err == nil {
-		return true
-	}
-	if _, err := os.Stat(filepath.Join(repoPath, root, "__init__.py")); err == nil {
-		return true
+	for _, searchRoot := range localModuleSearchRoots(repoPath) {
+		if _, err := os.Stat(filepath.Join(searchRoot, root+".py")); err == nil {
+			return true
+		}
+		if _, err := os.Stat(filepath.Join(searchRoot, root, "__init__.py")); err == nil {
+			return true
+		}
 	}
 	return false
+}
+
+func localModuleSearchRoots(repoPath string) []string {
+	roots := []string{repoPath}
+
+	srcRoot := filepath.Join(repoPath, "src")
+	if info, err := os.Stat(srcRoot); err == nil && info.IsDir() {
+		roots = append(roots, srcRoot)
+	}
+
+	return roots
 }
 
 func normalizeDependencyID(value string) string {

--- a/internal/lang/python/adapter_test.go
+++ b/internal/lang/python/adapter_test.go
@@ -171,6 +171,29 @@ func TestAdapterAnalyseTopN(t *testing.T) {
 	}
 }
 
+func TestAdapterAnalyseTopNIgnoresSrcLayoutLocalPackages(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "pyproject.toml"), "[project]\nname='demo'\nversion='0.1.0'\ndependencies=['requests>=2.0']\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "app", "__init__.py"), localModuleContent)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", testMainPy), "import app\nimport requests\n")
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath: repo,
+		TopN:     10,
+	})
+	if err != nil {
+		t.Fatalf("analyse src-layout repo: %v", err)
+	}
+
+	names := dependencyNames(reportData)
+	if slices.Contains(names, "app") {
+		t.Fatalf("expected src-layout local package to be excluded, got %#v", names)
+	}
+	if !slices.Contains(names, "requests") {
+		t.Fatalf("expected external dependency to remain present, got %#v", names)
+	}
+}
+
 func TestAdapterMetadataAndDetect(t *testing.T) {
 	adapter := NewAdapter()
 	if adapter.ID() != "python" {

--- a/internal/lang/python/helpers_test.go
+++ b/internal/lang/python/helpers_test.go
@@ -53,12 +53,14 @@ func TestPythonModuleResolutionHelpers(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, "localpkg", "__init__.py"), localModuleContent)
 	testutil.MustWriteFile(t, filepath.Join(repo, "single.py"), localModuleContent)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "app", "__init__.py"), localModuleContent)
 	dependencyCases := []struct {
 		module string
 		want   string
 	}{
 		{module: "os", want: ""},
 		{module: "localpkg.module", want: ""},
+		{module: "app.module", want: ""},
 		{module: "requests.sessions", want: "requests"},
 	}
 	for _, tc := range dependencyCases {
@@ -72,6 +74,7 @@ func TestPythonModuleResolutionHelpers(t *testing.T) {
 	}{
 		{module: "localpkg", want: true},
 		{module: "single", want: true},
+		{module: "app", want: true},
 		{module: "missing", want: false},
 	}
 	for _, tc := range localCases {


### PR DESCRIPTION
## Summary
Fixes #814 by teaching the Python adapter to treat first-party packages under `src/` as local modules rather than external dependencies.

## Changes
- update `isLocalModule` to search both the repo root and `src/` when present
- add a small helper that defines the local module search roots
- add regression coverage for helper resolution and top-N analysis in a src-layout repo

## Validation
Commands and checks run:

```bash
go test ./internal/lang/python
go test ./...
```

Additional manual validation:
- Verified that a repo with `src/app/__init__.py` and `import app` no longer reports `app` as an external dependency.

## Risk and compatibility
- Breaking changes: None
- Migration required: None
- Performance impact: negligible extra `os.Stat` checks when resolving local Python modules
- Memory benchmark impact: None

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review