### PR TITLE
fix(python): canonicalize known import aliases

### DIFF
--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -570,7 +570,11 @@ func localModuleSearchRoots(repoPath string) []string {
 
 func normalizeDependencyID(value string) string {
 	replacer := strings.NewReplacer("_", "-", ".", "-")
-	return replacer.Replace(shared.NormalizeDependencyID(value))
+	normalized := replacer.Replace(shared.NormalizeDependencyID(value))
+	if canonical, ok := pythonKnownImportAliases[normalized]; ok {
+		return canonical
+	}
+	return normalized
 }
 
 func shouldSkipDir(name string) bool {
@@ -592,4 +596,13 @@ var pythonStdlib = map[string]bool{
 	"ssl": true, "statistics": true, "string": true, "struct": true, "subprocess": true, "sys": true,
 	"tempfile": true, "textwrap": true, "threading": true, "time": true, "traceback": true, "typing": true,
 	"unittest": true, "urllib": true, "uuid": true, "warnings": true, "weakref": true, "xml": true, "zipfile": true,
+}
+
+var pythonKnownImportAliases = map[string]string{
+	"bs4":      "beautifulsoup4",
+	"cv2":      "opencv-python",
+	"dateutil": "python-dateutil",
+	"dotenv":   "python-dotenv",
+	"pil":      "pillow",
+	"sklearn":  "scikit-learn",
 }

--- a/internal/lang/python/adapter_test.go
+++ b/internal/lang/python/adapter_test.go
@@ -18,6 +18,10 @@ const (
 	testMainPy           = "main.py"
 	testDirOwnerOnlyMode = 0o700
 	testDirBlockedMode   = 0o000
+	testAliasImportsPy   = "from bs4 import BeautifulSoup\n" +
+		"from dateutil import parser\n" +
+		"BeautifulSoup('<p>hi</p>', 'html.parser')\n" +
+		"parser.parse('2026-05-18')\n"
 )
 
 func TestAdapterDetectWithPythonSource(t *testing.T) {
@@ -43,15 +47,10 @@ func TestAdapterAnalyseDependency(t *testing.T) {
 }
 
 func TestAdapterAnalyseDependencyUsesKnownImportAliases(t *testing.T) {
-	source := "from bs4 import BeautifulSoup\n" +
-		"from dateutil import parser\n" +
-		"BeautifulSoup('<p>hi</p>', 'html.parser')\n" +
-		"parser.parse('2026-05-18')\n"
-
-	bs4Dependency := analysePythonDependency(t, source, "beautifulsoup4")
+	bs4Dependency := analysePythonDependency(t, testAliasImportsPy, "beautifulsoup4")
 	assertDependencyReport(t, bs4Dependency, dependencyReportExpectation{name: "beautifulsoup4", language: "python", used: 1, total: 1})
 
-	dateutilDependency := analysePythonDependency(t, source, "python-dateutil")
+	dateutilDependency := analysePythonDependency(t, testAliasImportsPy, "python-dateutil")
 	assertDependencyReport(t, dateutilDependency, dependencyReportExpectation{name: "python-dateutil", language: "python", used: 1, total: 1})
 }
 
@@ -111,6 +110,15 @@ func assertDependencyReport(t *testing.T, got report.DependencyReport, want depe
 	}
 	if got.UsedExportsCount != want.used || got.TotalExportsCount != want.total {
 		t.Fatalf("expected used/total %d/%d, got %d/%d", want.used, want.total, got.UsedExportsCount, got.TotalExportsCount)
+	}
+}
+
+func assertDependencyNamesInclude(t *testing.T, names []string, dependencies ...string) {
+	t.Helper()
+	for _, dependency := range dependencies {
+		if !slices.Contains(names, dependency) {
+			t.Fatalf("expected dependency %q in %#v", dependency, names)
+		}
 	}
 }
 
@@ -177,20 +185,12 @@ func TestAdapterAnalyseTopN(t *testing.T) {
 		t.Fatalf("expected two dependencies, got %d", len(reportData.Dependencies))
 	}
 	names := []string{reportData.Dependencies[0].Name, reportData.Dependencies[1].Name}
-	for _, dependency := range []string{"numpy", "requests"} {
-		if !slices.Contains(names, dependency) {
-			t.Fatalf("expected dependency %q in %#v", dependency, names)
-		}
-	}
+	assertDependencyNamesInclude(t, names, "numpy", "requests")
 }
 
 func TestAdapterAnalyseTopNUsesCanonicalPackageNamesForKnownImportAliases(t *testing.T) {
 	repo := t.TempDir()
-	source := "from bs4 import BeautifulSoup\n" +
-		"from dateutil import parser\n" +
-		"BeautifulSoup('<p>hi</p>', 'html.parser')\n" +
-		"parser.parse('2026-05-18')\n"
-	testutil.MustWriteFile(t, filepath.Join(repo, testMainPy), source)
+	testutil.MustWriteFile(t, filepath.Join(repo, testMainPy), testAliasImportsPy)
 
 	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
 		RepoPath: repo,
@@ -201,11 +201,7 @@ func TestAdapterAnalyseTopNUsesCanonicalPackageNamesForKnownImportAliases(t *tes
 	}
 
 	names := dependencyNames(reportData)
-	for _, dependency := range []string{"beautifulsoup4", "python-dateutil"} {
-		if !slices.Contains(names, dependency) {
-			t.Fatalf("expected dependency %q in %#v", dependency, names)
-		}
-	}
+	assertDependencyNamesInclude(t, names, "beautifulsoup4", "python-dateutil")
 	for _, alias := range []string{"bs4", "dateutil"} {
 		if slices.Contains(names, alias) {
 			t.Fatalf("did not expect import alias %q in %#v", alias, names)
@@ -267,14 +263,18 @@ func TestAdapterMetadataAndDetect(t *testing.T) {
 }
 
 func TestNormalizeDependencyID(t *testing.T) {
-	if got := normalizeDependencyID(" My_Package.Name "); got != "my-package-name" {
-		t.Fatalf("unexpected normalized dependency ID: %q", got)
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: " My_Package.Name ", want: "my-package-name"},
+		{input: "bs4", want: "beautifulsoup4"},
+		{input: "dateutil", want: "python-dateutil"},
 	}
-	if got := normalizeDependencyID("bs4"); got != "beautifulsoup4" {
-		t.Fatalf("expected bs4 alias to canonicalize, got %q", got)
-	}
-	if got := normalizeDependencyID("dateutil"); got != "python-dateutil" {
-		t.Fatalf("expected dateutil alias to canonicalize, got %q", got)
+	for _, tc := range cases {
+		if got := normalizeDependencyID(tc.input); got != tc.want {
+			t.Fatalf("normalizeDependencyID(%q): expected %q, got %q", tc.input, tc.want, got)
+		}
 	}
 }
 

--- a/internal/lang/python/adapter_test.go
+++ b/internal/lang/python/adapter_test.go
@@ -42,6 +42,19 @@ func TestAdapterAnalyseDependency(t *testing.T) {
 	assertDependencyReport(t, dep, dependencyReportExpectation{language: "python", used: 1, total: 2})
 }
 
+func TestAdapterAnalyseDependencyUsesKnownImportAliases(t *testing.T) {
+	source := "from bs4 import BeautifulSoup\n" +
+		"from dateutil import parser\n" +
+		"BeautifulSoup('<p>hi</p>', 'html.parser')\n" +
+		"parser.parse('2026-05-18')\n"
+
+	bs4Dependency := analysePythonDependency(t, source, "beautifulsoup4")
+	assertDependencyReport(t, bs4Dependency, dependencyReportExpectation{name: "beautifulsoup4", language: "python", used: 1, total: 1})
+
+	dateutilDependency := analysePythonDependency(t, source, "python-dateutil")
+	assertDependencyReport(t, dateutilDependency, dependencyReportExpectation{name: "python-dateutil", language: "python", used: 1, total: 1})
+}
+
 func TestParseImportsHandlesParenthesizedFromImports(t *testing.T) {
 	repo := t.TempDir()
 	source := "from django.db import (models, migrations)\nfrom requests import (\n    Session,\n    Response as Resp,\n)\n"
@@ -171,6 +184,35 @@ func TestAdapterAnalyseTopN(t *testing.T) {
 	}
 }
 
+func TestAdapterAnalyseTopNUsesCanonicalPackageNamesForKnownImportAliases(t *testing.T) {
+	repo := t.TempDir()
+	source := "from bs4 import BeautifulSoup\n" +
+		"from dateutil import parser\n" +
+		"BeautifulSoup('<p>hi</p>', 'html.parser')\n" +
+		"parser.parse('2026-05-18')\n"
+	testutil.MustWriteFile(t, filepath.Join(repo, testMainPy), source)
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath: repo,
+		TopN:     2,
+	})
+	if err != nil {
+		t.Fatalf("analyse alias imports: %v", err)
+	}
+
+	names := dependencyNames(reportData)
+	for _, dependency := range []string{"beautifulsoup4", "python-dateutil"} {
+		if !slices.Contains(names, dependency) {
+			t.Fatalf("expected dependency %q in %#v", dependency, names)
+		}
+	}
+	for _, alias := range []string{"bs4", "dateutil"} {
+		if slices.Contains(names, alias) {
+			t.Fatalf("did not expect import alias %q in %#v", alias, names)
+		}
+	}
+}
+
 func TestAdapterAnalyseTopNIgnoresSrcLayoutLocalPackages(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, "pyproject.toml"), "[project]\nname='demo'\nversion='0.1.0'\ndependencies=['requests>=2.0']\n")
@@ -227,6 +269,12 @@ func TestAdapterMetadataAndDetect(t *testing.T) {
 func TestNormalizeDependencyID(t *testing.T) {
 	if got := normalizeDependencyID(" My_Package.Name "); got != "my-package-name" {
 		t.Fatalf("unexpected normalized dependency ID: %q", got)
+	}
+	if got := normalizeDependencyID("bs4"); got != "beautifulsoup4" {
+		t.Fatalf("expected bs4 alias to canonicalize, got %q", got)
+	}
+	if got := normalizeDependencyID("dateutil"); got != "python-dateutil" {
+		t.Fatalf("expected dateutil alias to canonicalize, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes #894 by canonicalizing a small set of high-confidence Python distribution/import mismatches so imports like `bs4` and `dateutil` resolve to their PyPI package names in reports.

## Changes
- canonicalize known Python import aliases during dependency normalization
- apply the canonical names consistently across direct dependency queries and top-N reporting
- add regression coverage for alias-backed dependency analysis and canonical top-N output

## Validation
Commands and checks run:

```bash
go test ./internal/lang/python
go test ./...
make lint
```

Additional manual validation:
- Verified that `from bs4 import BeautifulSoup` reports under `beautifulsoup4` and `from dateutil import parser` reports under `python-dateutil`.

## Risk and compatibility
- Breaking changes: None
- Migration required: None
- Performance impact: negligible map lookup during Python dependency normalization
- Memory benchmark impact: None

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Fixes #894