### PR TITLE
test(workspace): reduce commit test complexity

### DIFF
--- a/internal/workspace/workspace_commit_test.go
+++ b/internal/workspace/workspace_commit_test.go
@@ -144,24 +144,20 @@ func TestResolveRefSHAFallsBackToCommonDir(t *testing.T) {
 }
 
 func TestResolveRefSHAErrorPaths(t *testing.T) {
+	wantRefNotFound := "ref " + mainRefPath + " not found"
+
 	t.Run("returns ref not found when loose ref invalid and packed refs are missing", func(t *testing.T) {
 		gitDir := t.TempDir()
 		mustWrite(t, filepath.Join(gitDir, "refs", "heads", "main"), "bad-sha\n")
 
-		_, err := resolveRefSHA(gitDir, mainRefPath)
-		if err == nil || !strings.Contains(err.Error(), "ref "+mainRefPath+" not found") {
-			t.Fatalf("expected ref-not-found error, got %v", err)
-		}
+		assertResolveRefSHAErrorContains(t, gitDir, mainRefPath, wantRefNotFound)
 	})
 
 	t.Run("returns ref not found when loose ref is missing and packed refs do not match", func(t *testing.T) {
 		gitDir := t.TempDir()
 		mustWrite(t, filepath.Join(gitDir, packedRefsFile), shaMain+" "+otherMainRef+"\n")
 
-		_, err := resolveRefSHA(gitDir, mainRefPath)
-		if err == nil || !strings.Contains(err.Error(), "ref "+mainRefPath+" not found") {
-			t.Fatalf("expected ref-not-found error, got %v", err)
-		}
+		assertResolveRefSHAErrorContains(t, gitDir, mainRefPath, wantRefNotFound)
 	})
 
 	t.Run("returns ref not found when loose ref invalid and packed refs do not match", func(t *testing.T) {
@@ -169,19 +165,13 @@ func TestResolveRefSHAErrorPaths(t *testing.T) {
 		mustWrite(t, filepath.Join(gitDir, "refs", "heads", "main"), "also-bad\n")
 		mustWrite(t, filepath.Join(gitDir, packedRefsFile), shaMain+" "+otherMainRef+"\n")
 
-		_, err := resolveRefSHA(gitDir, mainRefPath)
-		if err == nil || !strings.Contains(err.Error(), "ref "+mainRefPath+" not found") {
-			t.Fatalf("expected ref-not-found error, got %v", err)
-		}
+		assertResolveRefSHAErrorContains(t, gitDir, mainRefPath, wantRefNotFound)
 	})
 
 	t.Run("returns ref not found when loose and packed refs are missing", func(t *testing.T) {
 		gitDir := t.TempDir()
 
-		_, err := resolveRefSHA(gitDir, mainRefPath)
-		if err == nil || !strings.Contains(err.Error(), "ref "+mainRefPath+" not found") {
-			t.Fatalf("expected ref-not-found error, got %v", err)
-		}
+		assertResolveRefSHAErrorContains(t, gitDir, mainRefPath, wantRefNotFound)
 	})
 
 	t.Run("returns packed refs read error when packed refs path is unreadable", func(t *testing.T) {
@@ -191,11 +181,17 @@ func TestResolveRefSHAErrorPaths(t *testing.T) {
 			t.Fatalf("mkdir packed-refs dir: %v", err)
 		}
 
-		_, err := resolveRefSHA(gitDir, mainRefPath)
-		if err == nil || !strings.Contains(err.Error(), packedRefsFile) {
-			t.Fatalf("expected packed-refs read error, got %v", err)
-		}
+		assertResolveRefSHAErrorContains(t, gitDir, mainRefPath, packedRefsFile)
 	})
+}
+
+func assertResolveRefSHAErrorContains(t *testing.T, gitDir, ref, wantErrPart string) {
+	t.Helper()
+
+	_, err := resolveRefSHA(gitDir, ref)
+	if err == nil || !strings.Contains(err.Error(), wantErrPart) {
+		t.Fatalf("expected error containing %q, got %v", wantErrPart, err)
+	}
 }
 
 func TestResolveCommonGitDirScenarios(t *testing.T) {


### PR DESCRIPTION
## Summary

Refactors `TestResolveRefSHAErrorPaths` in `internal/workspace/workspace_commit_test.go` to reduce cognitive complexity by extracting repeated error assertion logic into a dedicated test helper while preserving existing scenarios and expectations.

Closes #926.

## Changes

- Introduced `assertResolveRefSHAErrorContains` helper to centralize repeated `resolveRefSHA` error assertions.
- Replaced repeated inline error assertion blocks in `TestResolveRefSHAErrorPaths` with helper calls.
- Kept all existing test cases, setup, and expected error content unchanged.

## Validation

Commands and checks run:

```bash
go test ./internal/workspace
go test ./...
```

Additional manual validation:

- Reviewed `git diff` for test-only scope and assertion parity.
- Verified no inline suppression comments were introduced (`nolint`, `NOSONAR`, `go:S3776`, `sonar-ignore`).

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None (test-only refactor).
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
