### PR TITLE
refactor(runtime): reduce capture command complexity

### DIFF
--- a/internal/runtime/capture_command.go
+++ b/internal/runtime/capture_command.go
@@ -114,49 +114,81 @@ func validateRuntimeCommand(command string, fields []string) error {
 }
 
 func containsUnsafeRuntimeCommandSyntax(command string) bool {
-	inSingleQuote := false
-	inDoubleQuote := false
-	escaped := false
+	var parser runtimeCommandUnsafeSyntaxParser
 	runes := []rune(command)
 
 	for i, ch := range runes {
-		if escaped {
-			escaped = false
-			continue
-		}
-
-		switch ch {
-		case '\\':
-			if inSingleQuote {
-				continue
-			}
-			escaped = true
-		case '\'':
-			if inDoubleQuote {
-				continue
-			}
-			inSingleQuote = !inSingleQuote
-		case '"':
-			if inSingleQuote {
-				continue
-			}
-			inDoubleQuote = !inDoubleQuote
-		case '|', '&', ';', '>', '<', '`', '\n', '\r':
-			if inSingleQuote {
-				continue
-			}
+		if parser.consume(ch, nextRuntimeCommandRune(runes, i)) {
 			return true
-		case '$':
-			if inSingleQuote {
-				continue
-			}
-			if i+1 < len(runes) && runes[i+1] == '(' {
-				return true
-			}
 		}
 	}
 
 	return false
+}
+
+type runtimeCommandUnsafeSyntaxParser struct {
+	inSingleQuote bool
+	inDoubleQuote bool
+	escaped       bool
+}
+
+func (p *runtimeCommandUnsafeSyntaxParser) consume(ch, next rune) bool {
+	if p.escaped {
+		p.escaped = false
+		return false
+	}
+
+	switch ch {
+	case '\\':
+		if p.inSingleQuote {
+			return false
+		}
+		p.escaped = true
+		return false
+	case '\'':
+		if p.inDoubleQuote {
+			return false
+		}
+		p.inSingleQuote = !p.inSingleQuote
+		return false
+	case '"':
+		if p.inSingleQuote {
+			return false
+		}
+		p.inDoubleQuote = !p.inDoubleQuote
+		return false
+	case '$':
+		return p.isSubshellStart(next)
+	default:
+		return p.isUnsafeOperator(ch)
+	}
+}
+
+func (p *runtimeCommandUnsafeSyntaxParser) isSubshellStart(next rune) bool {
+	if p.inSingleQuote {
+		return false
+	}
+	return next == '('
+}
+
+func (p *runtimeCommandUnsafeSyntaxParser) isUnsafeOperator(ch rune) bool {
+	if p.inSingleQuote {
+		return false
+	}
+
+	switch ch {
+	case '|', '&', ';', '>', '<', '`', '\n', '\r':
+		return true
+	default:
+		return false
+	}
+}
+
+func nextRuntimeCommandRune(runes []rune, index int) rune {
+	if index+1 >= len(runes) {
+		return 0
+	}
+	return runes[index+1]
 }
 
 func rejectRuntimeCommandUnsafeFlags(executable string, args []string) error {


### PR DESCRIPTION
## Summary

Refactors runtime command unsafe-syntax detection to reduce Sonar cognitive complexity in `internal/runtime/capture_command.go` while preserving existing behavior. This addresses the `go:S3776` finding on the capture command validator path.

Closes #922

## Changes

- Extracted unsafe-syntax state handling into a focused parser helper (`runtimeCommandUnsafeSyntaxParser`).
- Simplified `containsUnsafeRuntimeCommandSyntax` to a linear scan that delegates token handling and lookahead.
- Kept detection semantics unchanged for quotes, escapes, operators, and subshell markers.

## Validation

Commands and checks run:

```bash
go test ./internal/runtime
make format-check
make lint
```

Additional manual validation:

- Reviewed `git diff` to confirm only `internal/runtime/capture_command.go` changed.
- Verified no inline suppression comments were introduced.

## Risk and compatibility

- Breaking changes: None expected.
- Migration required: None.
- Performance impact: Negligible; same linear scan with lightweight helper methods.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
