### PR TITLE
refactor(vscode): clear managed binary sonar findings

### DIFF
--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -500,7 +500,7 @@ function isAssetLike(asset: unknown): asset is GitHubReleaseAsset {
 
 function parseAssetDigest(asset: GitHubReleaseAsset): string {
   if (typeof asset.digest !== "string") {
-    throw new TypeError(`managed release asset ${asset.name} is missing a sha256 digest`);
+    throw new TypeError(`managed release asset ${asset.name} is missing a string sha256 digest`);
   }
 
   const match = /^sha256:([a-fA-F0-9]{64})$/.exec(asset.digest.trim());

--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -121,10 +121,9 @@ export class ManagedBinaryInstaller {
     }
 
     if (
-      !metadata ||
-      metadata.binaryPath !== binaryPath ||
-      metadata.tag !== (explicitTag ?? metadata.tag) ||
-      typeof metadata.binaryDigest !== "string"
+      metadata?.binaryPath !== binaryPath ||
+      metadata?.tag !== (explicitTag ?? metadata?.tag) ||
+      typeof metadata?.binaryDigest !== "string"
     ) {
       this.output.appendLine(`managed binary cache integrity metadata missing; re-downloading ${binaryPath}`);
       return undefined;
@@ -501,10 +500,10 @@ function isAssetLike(asset: unknown): asset is GitHubReleaseAsset {
 
 function parseAssetDigest(asset: GitHubReleaseAsset): string {
   if (typeof asset.digest !== "string") {
-    throw new Error(`managed release asset ${asset.name} is missing a sha256 digest`);
+    throw new TypeError(`managed release asset ${asset.name} is missing a sha256 digest`);
   }
 
-  const match = asset.digest.trim().match(/^sha256:([a-fA-F0-9]{64})$/);
+  const match = /^sha256:([a-fA-F0-9]{64})$/.exec(asset.digest.trim());
   if (!match) {
     throw new Error(`managed release asset ${asset.name} has invalid sha256 digest`);
   }

--- a/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
@@ -190,7 +190,7 @@ suite("refresh lifecycle", () => {
             });
             analysis.codemodsByDependency = new Map([
               [
-                analysis.report.dependencies[0]!.name,
+                analysis.report.dependencies[0].name,
                 {
                   mode: "replace",
                   suggestions: [


### PR DESCRIPTION
## Summary

Address Sonar findings in the VS Code managed-binary path and refresh lifecycle tests with minimal behavior-preserving refactors.

Closes #918
Closes #919
Closes #920
Closes #921

## Changes

- Prefer optional chaining in managed binary cache metadata validation.
- Use `TypeError` for missing/non-string managed asset digest type failures.
- Replace `String.match()` with `RegExp.exec()` for sha256 digest parsing.
- Remove an unnecessary non-null assertion in `refreshLifecycle.test.ts`.

## Validation

Commands and checks run:

```bash
npm --prefix extensions/vscode-lopper ci
npm --prefix extensions/vscode-lopper run compile
npm --prefix extensions/vscode-lopper run test:e2e
# Result: fails consistently on existing smoke timeout in smoke.test.ts
# "refreshes diagnostics, hover details, and quick fixes" (60s timeout)

# Focused headless extension suites for changed areas:
node --input-type=module ... # custom @vscode/test-electron runner for
                             # out/test/suite/managedBinary.test.js and
                             # out/test/suite/refreshLifecycle.test.js
# Result: PASS (22 passing)
```

Additional manual validation:

- Reviewed `git diff` for scoped files only and confirmed no inline suppression comments were introduced.

## Risk and compatibility

- Breaking changes: None expected.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
