### PR TITLE
perf(rust): collapse overlapping scan roots

### DIFF
--- a/internal/lang/rust/adapter_helpers_test.go
+++ b/internal/lang/rust/adapter_helpers_test.go
@@ -160,6 +160,10 @@ func TestManifestDiscoveryAndWorkspaceResolution(t *testing.T) {
 	if len(warnings) == 0 {
 		t.Fatalf("expected warning for unresolved workspace member pattern")
 	}
+	roots := scanRoots(paths, repo)
+	if len(roots) != 1 || !strings.HasSuffix(roots[0], filepath.Join("crates", "a")) {
+		t.Fatalf("expected member-only workspace roots to remain unchanged, got %#v", roots)
+	}
 
 	members := resolveWorkspaceMembers(repo, "crates/*")
 	if len(members) != 1 || !strings.HasSuffix(members[0], filepath.Join("crates", "a")) {
@@ -981,6 +985,9 @@ func TestRootSignalsAndManifestDiscoveryVariants(t *testing.T) {
 	}
 	if len(warnings) != 0 {
 		t.Fatalf("expected no warnings for resolvable workspace members, got %#v", warnings)
+	}
+	if roots := scanRoots(paths, repo); len(roots) != 1 || !samePath(roots[0], repo) {
+		t.Fatalf("expected overlapping workspace roots to collapse to repo root, got %#v", roots)
 	}
 }
 

--- a/internal/lang/rust/scan_traversal.go
+++ b/internal/lang/rust/scan_traversal.go
@@ -18,7 +18,39 @@ func scanRoots(manifestPaths []string, repoPath string) []string {
 	if len(roots) == 0 {
 		return []string{repoPath}
 	}
-	return roots
+	return collapseScanRoots(roots)
+}
+
+func collapseScanRoots(roots []string) []string {
+	collapsed := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if hasScanRootParent(collapsed, root) {
+			continue
+		}
+		collapsed = dropNestedScanRoots(collapsed, root)
+		collapsed = append(collapsed, root)
+	}
+	return collapsed
+}
+
+func hasScanRootParent(roots []string, candidate string) bool {
+	for _, root := range roots {
+		if isSubPath(root, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func dropNestedScanRoots(roots []string, candidate string) []string {
+	filtered := roots[:0]
+	for _, root := range roots {
+		if isSubPath(candidate, root) {
+			continue
+		}
+		filtered = append(filtered, root)
+	}
+	return filtered
 }
 
 func scanRepoRoot(ctx context.Context, repoPath, root string, depLookup map[string]dependencyInfo, scannedFiles map[string]struct{}, fileCount *int, result *scanResult) error {

--- a/internal/lang/rust/scan_traversal_test.go
+++ b/internal/lang/rust/scan_traversal_test.go
@@ -1,0 +1,38 @@
+package rust
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestScanRootsCollapsesOverlappingWorkspaceRoots(t *testing.T) {
+	repo := t.TempDir()
+	manifestPaths := []string{
+		filepath.Join(repo, "crates", "alpha", cargoTomlName),
+		filepath.Join(repo, cargoTomlName),
+		filepath.Join(repo, "crates", "beta", cargoTomlName),
+	}
+
+	roots := scanRoots(manifestPaths, repo)
+	if len(roots) != 1 || !samePath(roots[0], repo) {
+		t.Fatalf("expected overlapping scan roots to collapse to repo root, got %#v", roots)
+	}
+}
+
+func TestScanRootsRetainsMemberRootsWithoutParentManifest(t *testing.T) {
+	repo := t.TempDir()
+	manifestPaths := []string{
+		filepath.Join(repo, "crates", "alpha", cargoTomlName),
+		filepath.Join(repo, "crates", "beta", cargoTomlName),
+	}
+
+	roots := scanRoots(manifestPaths, repo)
+	want := []string{
+		filepath.Join(repo, "crates", "alpha"),
+		filepath.Join(repo, "crates", "beta"),
+	}
+	if !slices.Equal(roots, want) {
+		t.Fatalf("expected workspace member roots without parent to be preserved, got %#v", roots)
+	}
+}


### PR DESCRIPTION
## Summary

Rust workspace scanning could re-traverse member trees when manifest discovery returned overlapping roots (repo root plus workspace member roots). This change preserves manifest discovery output and report semantics while collapsing overlapping traversal roots before scanning.

Closes #821.

## Changes

- collapsed scan scheduling roots in `scanRoots` so child roots are dropped when a parent root is already scheduled
- added traversal helper tests to assert overlap collapse and member-only workspace root preservation
- extended manifest discovery tests to assert discovered manifest paths are unchanged while traversal roots are optimized

## Validation

Commands and checks run:

```bash
go test ./internal/lang/rust
go test ./...
```

Additional manual validation:

- Reviewed git diff to confirm only Rust scan/manifest helper files and related tests were changed.
- Checked changed hunks for suppression markers (`nosec`/`nolint`) and found none.

## Risk and compatibility

- Breaking changes: none
- Migration required: none
- Performance impact: reduces redundant directory traversal for package+workspace Rust repositories with overlapping roots
- Memory benchmark impact: none expected

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
