### PR TITLE
perf(analysis): memoize cache input digests

### DIFF
--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -30,10 +30,9 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 		ReadOnly: options.ReadOnly,
 	}
 	cache := &analysisCache{
-		options:         options,
-		metadata:        metadata,
-		warnings:        make([]string, 0),
-		inputDigestMemo: make(map[cacheInputDigestMemoKey]string),
+		options:  options,
+		metadata: metadata,
+		warnings: make([]string, 0),
 	}
 	if !options.Enabled {
 		cache.cacheable = false

--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -15,10 +15,11 @@ type resolvedCacheOptions struct {
 }
 
 type analysisCache struct {
-	options   resolvedCacheOptions
-	metadata  report.CacheMetadata
-	warnings  []string
-	cacheable bool
+	options         resolvedCacheOptions
+	metadata        report.CacheMetadata
+	warnings        []string
+	cacheable       bool
+	inputDigestMemo map[cacheInputDigestMemoKey]string
 }
 
 func newAnalysisCache(req Request, repoPath string) *analysisCache {
@@ -29,9 +30,10 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 		ReadOnly: options.ReadOnly,
 	}
 	cache := &analysisCache{
-		options:  options,
-		metadata: metadata,
-		warnings: make([]string, 0),
+		options:         options,
+		metadata:        metadata,
+		warnings:        make([]string, 0),
+		inputDigestMemo: make(map[cacheInputDigestMemoKey]string),
 	}
 	if !options.Enabled {
 		cache.cacheable = false

--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -23,6 +23,11 @@ type cacheDigestInput struct {
 	allowMissing bool
 }
 
+type cacheInputDigestMemoKey struct {
+	normalizedRoot  string
+	cleanConfigPath string
+}
+
 func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot string) (cacheEntryDescriptor, error) {
 	if c == nil || !c.options.Enabled || !c.cacheable {
 		return cacheEntryDescriptor{}, nil
@@ -59,7 +64,7 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 	if err != nil {
 		return cacheEntryDescriptor{}, err
 	}
-	inputDigest, err := c.computeInputDigest(normalizedRoot, req.ConfigPath)
+	inputDigest, err := c.memoizedInputDigest(normalizedRoot, req.ConfigPath)
 	if err != nil {
 		return cacheEntryDescriptor{}, err
 	}
@@ -68,6 +73,25 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 		KeyDigest:   baseDigest,
 		InputDigest: inputDigest,
 	}, nil
+}
+
+func (c *analysisCache) memoizedInputDigest(rootPath, configPath string) (string, error) {
+	if c.inputDigestMemo == nil {
+		c.inputDigestMemo = make(map[cacheInputDigestMemoKey]string)
+	}
+	memoKey := cacheInputDigestMemoKey{
+		normalizedRoot:  filepath.Clean(rootPath),
+		cleanConfigPath: cleanConfigPath(configPath),
+	}
+	if digest, ok := c.inputDigestMemo[memoKey]; ok {
+		return digest, nil
+	}
+	digest, err := c.computeInputDigest(memoKey.normalizedRoot, memoKey.cleanConfigPath)
+	if err != nil {
+		return "", err
+	}
+	c.inputDigestMemo[memoKey] = digest
+	return digest, nil
 }
 
 func (c *analysisCache) computeInputDigest(rootPath, configPath string) (string, error) {
@@ -85,11 +109,11 @@ func (c *analysisCache) computeInputDigest(rootPath, configPath string) (string,
 		})
 	}
 
-	if strings.TrimSpace(configPath) != "" {
-		cleanConfigPath := filepath.Clean(strings.TrimSpace(configPath))
+	cleanedConfigPath := cleanConfigPath(configPath)
+	if cleanedConfigPath != "" {
 		inputs = append(inputs, cacheDigestInput{
-			sortKey:      "config\x00" + cleanConfigPath,
-			path:         cleanConfigPath,
+			sortKey:      "config\x00" + cleanedConfigPath,
+			path:         cleanedConfigPath,
 			allowMissing: true,
 		})
 	}
@@ -104,6 +128,13 @@ func (c *analysisCache) computeInputDigest(rootPath, configPath string) (string,
 		}
 	}
 	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func cleanConfigPath(configPath string) string {
+	if strings.TrimSpace(configPath) == "" {
+		return ""
+	}
+	return filepath.Clean(strings.TrimSpace(configPath))
 }
 
 func writeInputDigestRecord(w io.Writer, input cacheDigestInput) error {

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -273,6 +273,100 @@ func TestAnalysisCachePrepareEntryIncludesFeatureFlags(t *testing.T) {
 	}
 }
 
+func TestAnalysisCachePrepareEntryMemoizesInputDigestForSameRootAndConfig(t *testing.T) {
+	repo := t.TempDir()
+	root := filepath.Join(repo, "root")
+	testutil.MustWriteFile(t, filepath.Join(root, cacheTestJSIndexFileName), "console.log('hello')\n")
+	configPath := filepath.Join(repo, ".lopper.yml")
+	testutil.MustWriteFile(t, configPath, "threshold: 1\n")
+
+	req := Request{
+		RepoPath:   repo,
+		ConfigPath: configPath,
+		TopN:       1,
+		Cache:      &CacheOptions{Enabled: true, Path: filepath.Join(repo, cacheTestDirectoryName)},
+	}
+	cache := newAnalysisCache(req, repo)
+
+	firstEntry, err := cache.prepareEntry(req, "adapter-a", root)
+	if err != nil {
+		t.Fatalf("prepare first entry: %v", err)
+	}
+	if firstEntry.InputDigest == "" {
+		t.Fatalf("expected first entry to include input digest")
+	}
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatalf("remove root: %v", err)
+	}
+
+	secondEntry, err := cache.prepareEntry(req, "adapter-b", root)
+	if err != nil {
+		t.Fatalf("expected memoized digest reuse for same root+config, got error: %v", err)
+	}
+	if firstEntry.InputDigest != secondEntry.InputDigest {
+		t.Fatalf("expected reused input digest for same root+config, first=%q second=%q", firstEntry.InputDigest, secondEntry.InputDigest)
+	}
+	if firstEntry.KeyDigest == secondEntry.KeyDigest {
+		t.Fatalf("expected adapter-specific cache keys to remain distinct")
+	}
+}
+
+func TestAnalysisCachePrepareEntryDoesNotReuseInputDigestForDifferentConfigPath(t *testing.T) {
+	repo := t.TempDir()
+	root := filepath.Join(repo, "root")
+	testutil.MustWriteFile(t, filepath.Join(root, cacheTestJSIndexFileName), "console.log('hello')\n")
+	configPathA := filepath.Join(repo, ".lopper-a.yml")
+	configPathB := filepath.Join(repo, ".lopper-b.yml")
+	testutil.MustWriteFile(t, configPathA, "threshold: 1\n")
+	testutil.MustWriteFile(t, configPathB, "threshold: 2\n")
+
+	baseReq := Request{
+		RepoPath: repo,
+		TopN:     1,
+		Cache:    &CacheOptions{Enabled: true, Path: filepath.Join(repo, cacheTestDirectoryName)},
+	}
+	cache := newAnalysisCache(baseReq, repo)
+
+	reqA := baseReq
+	reqA.ConfigPath = configPathA
+	if _, err := cache.prepareEntry(reqA, "adapter-a", root); err != nil {
+		t.Fatalf("prepare first entry: %v", err)
+	}
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatalf("remove root: %v", err)
+	}
+
+	reqB := baseReq
+	reqB.ConfigPath = configPathB
+	if _, err := cache.prepareEntry(reqB, "adapter-b", root); err == nil {
+		t.Fatalf("expected digest recomputation for different config path to fail after root removal")
+	}
+}
+
+func TestAnalysisCachePrepareEntryDoesNotReuseInputDigestForDifferentRoot(t *testing.T) {
+	repo := t.TempDir()
+	rootA := filepath.Join(repo, "root-a")
+	rootB := filepath.Join(repo, "root-b")
+	testutil.MustWriteFile(t, filepath.Join(rootA, cacheTestJSIndexFileName), "console.log('hello')\n")
+	configPath := filepath.Join(repo, ".lopper.yml")
+	testutil.MustWriteFile(t, configPath, "threshold: 1\n")
+
+	req := Request{
+		RepoPath:   repo,
+		ConfigPath: configPath,
+		TopN:       1,
+		Cache:      &CacheOptions{Enabled: true, Path: filepath.Join(repo, cacheTestDirectoryName)},
+	}
+	cache := newAnalysisCache(req, repo)
+
+	if _, err := cache.prepareEntry(req, "adapter-a", rootA); err != nil {
+		t.Fatalf("prepare first entry: %v", err)
+	}
+	if _, err := cache.prepareEntry(req, "adapter-b", rootB); err == nil {
+		t.Fatalf("expected digest recomputation for different root to fail when root is missing")
+	}
+}
+
 func mustResolveFeatureSet(t *testing.T, enabled bool) featureflags.Set {
 	t.Helper()
 	options := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}


### PR DESCRIPTION
## Summary

`runCandidateOnRoots` prepares cache entries inside the adapter/root loop, and `prepareEntry` recomputed `computeInputDigest` for every adapter even when root and config path were identical. This repeated full-tree hashing work within a single analysis pipeline.

This change memoizes input digests for the lifetime of `analysisCache` using `(normalizedRoot, cleanedConfigPath)` and reuses them across adapters while preserving existing cache key semantics.

Closes #817.

## Changes

- Added per-`analysisCache` in-memory memoization storage for input digests.
- Updated cache entry preparation to resolve input digests through memoization before falling back to full digest computation.
- Kept cache key generation unchanged (adapter/root/request inputs still drive key digest semantics).
- Added focused tests to prove:
- digest reuse for repeated same root+config preparation across adapters,
- no reuse when config path differs,
- no reuse when root differs.

## Validation

Commands and checks run:

```bash
go test ./internal/analysis
go test ./...
```

Additional manual validation:

- Reviewed `git diff` to confirm changes are scoped to `internal/analysis` cache code/tests.
- Verified no suppression comments were introduced.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Positive; avoids redundant input digest recomputation across adapters for the same root/config during one analysis run.
- Memory benchmark impact: Small bounded in-memory map growth per analysis run keyed by unique `(root, config)` pairs.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
