### PR TITLE
perf(go): reuse nested module discovery

### DIFF
--- a/internal/lang/golang/adapter.go
+++ b/internal/lang/golang/adapter.go
@@ -92,11 +92,7 @@ func scanRepo(ctx context.Context, repoPath string, moduleInfo moduleInfo) (scan
 	if repoPath == "" {
 		return result, fs.ErrInvalid
 	}
-	workspaceMemberDirs, err := workspaceRootModuleDirs(repoPath, moduleInfo)
-	if err != nil {
-		return result, err
-	}
-	nestedModules, err := nestedModuleDirs(repoPath, workspaceMemberDirs)
+	nestedModules, err := nestedModuleDirsForScan(repoPath, moduleInfo)
 	if err != nil {
 		return result, err
 	}
@@ -107,6 +103,22 @@ func scanRepo(ctx context.Context, repoPath string, moduleInfo moduleInfo) (scan
 	}
 	appendScanWarnings(&result, moduleInfo)
 	return result, nil
+}
+
+func nestedModuleDirsForScan(repoPath string, info moduleInfo) (map[string]struct{}, error) {
+	if info.NestedModuleDirs != nil {
+		return info.NestedModuleDirs, nil
+	}
+
+	workspaceModuleExclusions := info.WorkspaceModuleExclusions
+	if workspaceModuleExclusions == nil {
+		var err error
+		workspaceModuleExclusions, err = workspaceRootModuleDirs(repoPath, info)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nestedModuleDirs(repoPath, workspaceModuleExclusions)
 }
 
 func newScanResult() scanResult {

--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -453,6 +453,7 @@ func TestScanRepoReusesWorkspaceNestedModuleExclusions(t *testing.T) {
 	writeFile(t, filepath.Join(repo, "svc", "a", fileMainGo), mainUUIDNoopProgram)
 
 	excludedNestedDir := writeNestedLoModule(t, repo, "tools", "api")
+	workspaceNestedDir := writeNestedLoModule(t, repo, "svc", "a", "nested", "api")
 
 	info, err := loadGoModuleInfo(repo)
 	if err != nil {
@@ -468,13 +469,16 @@ func TestScanRepoReusesWorkspaceNestedModuleExclusions(t *testing.T) {
 	if _, ok := info.NestedModuleDirs[excludedNestedDir]; !ok {
 		t.Fatalf("expected non-workspace nested module dir %q cached in %#v", excludedNestedDir, info.NestedModuleDirs)
 	}
+	if _, ok := info.NestedModuleDirs[workspaceNestedDir]; !ok {
+		t.Fatalf("expected nested module under workspace dir %q cached in %#v", workspaceNestedDir, info.NestedModuleDirs)
+	}
 
 	scan, err := scanRepo(context.Background(), repo, info)
 	if err != nil {
 		t.Fatalf("scanRepo: %v", err)
 	}
-	if scan.SkippedNestedModuleDirs != 1 {
-		t.Fatalf("expected one nested module skip, got %d", scan.SkippedNestedModuleDirs)
+	if scan.SkippedNestedModuleDirs != 2 {
+		t.Fatalf("expected two nested module skips, got %d", scan.SkippedNestedModuleDirs)
 	}
 
 	requireScannedDependency(t, scan, depUUID)
@@ -1178,25 +1182,15 @@ func writeNestedLoModule(t *testing.T, repo string, path ...string) string {
 	t.Helper()
 	nestedDir := filepath.Join(append([]string{repo}, path...)...)
 	writeRepoModuleFile(t, nestedDir, "module example.com/api", requirePrefix+depLo+" v1.47.0")
-	writeFile(t, filepath.Join(nestedDir, fileMainGo), strings.Join([]string{
-		packageMainLine,
-		"",
-		importLoLine,
-		"",
-		"func main() { _ = lo.Contains([]int{1,2}, 2) }",
-		"",
-	}, "\n"))
+	mainContent := packageMainLine + "\n\n" + importLoLine + "\n\nfunc main() { _ = lo.Contains([]int{1,2}, 2) }\n"
+	writeFile(t, filepath.Join(nestedDir, fileMainGo), mainContent)
 	return nestedDir
 }
 
 func writeRepoModuleFile(t *testing.T, dir, moduleLine, requireLine string) {
 	t.Helper()
-	writeFile(t, filepath.Join(dir, fileGoMod), strings.Join([]string{
-		moduleLine,
-		"",
-		requireLine,
-		"",
-	}, "\n"))
+	modContent := moduleLine + "\n\n" + requireLine + "\n"
+	writeFile(t, filepath.Join(dir, fileGoMod), modContent)
 }
 
 func mkdirGoWorkDir(t *testing.T, repo string) {

--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -375,25 +375,8 @@ func TestAdapterAnalyseSkipsGeneratedAndBuildTaggedFiles(t *testing.T) {
 
 func TestAdapterAnalyseSkipsNestedModulesFromRootScan(t *testing.T) {
 	repo := t.TempDir()
-	writeRepoGoModLines(t, repo, "module example.com/root", "", requirePrefix+depUUID+versionV160, "")
-	writeRepoMainLines(t, repo, packageMainLine, "", "import \""+depUUID+"\"", "", "func main() { _ = uuid.NewString() }", "")
-
-	nestedGoModLines := []string{
-		"module example.com/api",
-		"",
-		requirePrefix + depLo + " v1.47.0",
-		"",
-	}
-	writeFile(t, filepath.Join(repo, "services", "api", fileGoMod), strings.Join(nestedGoModLines, "\n"))
-	nestedMainLines := []string{
-		packageMainLine,
-		"",
-		importLoLine,
-		"",
-		"func main() { _ = lo.Contains([]int{1,2}, 2) }",
-		"",
-	}
-	writeFile(t, filepath.Join(repo, "services", "api", fileMainGo), strings.Join(nestedMainLines, "\n"))
+	writeRootUUIDModule(t, repo)
+	writeNestedLoModule(t, repo, "services", "api")
 
 	reportData := analyseReport(t, language.Request{
 		RepoPath: repo,
@@ -435,26 +418,8 @@ func TestAdapterAnalyseWorkspaceGoWorkScansMembers(t *testing.T) {
 
 func TestScanRepoReusesLoadedNestedModuleDirs(t *testing.T) {
 	repo := t.TempDir()
-	writeRepoGoModLines(t, repo, "module example.com/root", "", requirePrefix+depUUID+versionV160, "")
-	writeRepoMainLines(t, repo, packageMainLine, "", "import \""+depUUID+"\"", "", "func main() { _ = uuid.NewString() }", "")
-
-	nestedGoModLines := []string{
-		"module example.com/api",
-		"",
-		requirePrefix + depLo + " v1.47.0",
-		"",
-	}
-	nestedMainLines := []string{
-		packageMainLine,
-		"",
-		importLoLine,
-		"",
-		"func main() { _ = lo.Contains([]int{1,2}, 2) }",
-		"",
-	}
-	nestedDir := filepath.Join(repo, "services", "api")
-	writeFile(t, filepath.Join(nestedDir, fileGoMod), strings.Join(nestedGoModLines, "\n"))
-	writeFile(t, filepath.Join(nestedDir, fileMainGo), strings.Join(nestedMainLines, "\n"))
+	writeRootUUIDModule(t, repo)
+	nestedDir := writeNestedLoModule(t, repo, "services", "api")
 
 	info, err := loadGoModuleInfo(repo)
 	if err != nil {
@@ -477,13 +442,8 @@ func TestScanRepoReusesLoadedNestedModuleDirs(t *testing.T) {
 		t.Fatalf("expected one cached nested module skip, got %d", scan.SkippedNestedModuleDirs)
 	}
 
-	deps := dependencySetFromScan(scan)
-	if _, ok := deps[depUUID]; !ok {
-		t.Fatalf("expected root dependency %q in %#v", depUUID, deps)
-	}
-	if _, ok := deps[depLo]; ok {
-		t.Fatalf("did not expect nested dependency %q in %#v", depLo, deps)
-	}
+	requireScannedDependency(t, scan, depUUID)
+	requireSkippedDependency(t, scan, depLo)
 }
 
 func TestScanRepoReusesWorkspaceNestedModuleExclusions(t *testing.T) {
@@ -492,9 +452,7 @@ func TestScanRepoReusesWorkspaceNestedModuleExclusions(t *testing.T) {
 	writeFile(t, filepath.Join(repo, "svc", "a", fileGoMod), goModDemoWithUUID)
 	writeFile(t, filepath.Join(repo, "svc", "a", fileMainGo), mainUUIDNoopProgram)
 
-	excludedNestedDir := filepath.Join(repo, "tools", "api")
-	writeFile(t, filepath.Join(excludedNestedDir, fileGoMod), "module example.com/tools/api\n\nrequire "+depLo+" v1.47.0\n")
-	writeFile(t, filepath.Join(excludedNestedDir, fileMainGo), packageMainLine+"\n\n"+importLoLine+"\n\nfunc main() { _ = lo.Contains([]int{1,2}, 2) }\n")
+	excludedNestedDir := writeNestedLoModule(t, repo, "tools", "api")
 
 	info, err := loadGoModuleInfo(repo)
 	if err != nil {
@@ -519,13 +477,8 @@ func TestScanRepoReusesWorkspaceNestedModuleExclusions(t *testing.T) {
 		t.Fatalf("expected one nested module skip, got %d", scan.SkippedNestedModuleDirs)
 	}
 
-	deps := dependencySetFromScan(scan)
-	if _, ok := deps[depUUID]; !ok {
-		t.Fatalf("expected workspace member dependency %q in %#v", depUUID, deps)
-	}
-	if _, ok := deps[depLo]; ok {
-		t.Fatalf("did not expect excluded nested dependency %q in %#v", depLo, deps)
-	}
+	requireScannedDependency(t, scan, depUUID)
+	requireSkippedDependency(t, scan, depLo)
 }
 
 func TestBuildRequestedGoDependenciesNoInputWarning(t *testing.T) {
@@ -1215,6 +1168,37 @@ func writeRepoMainLines(t *testing.T, repo string, lines ...string) {
 	writeRepoMain(t, repo, strings.Join(lines, "\n"))
 }
 
+func writeRootUUIDModule(t *testing.T, repo string) {
+	t.Helper()
+	writeRepoGoModLines(t, repo, "module example.com/root", "", requirePrefix+depUUID+versionV160, "")
+	writeRepoMainLines(t, repo, packageMainLine, "", "import \""+depUUID+"\"", "", "func main() { _ = uuid.NewString() }", "")
+}
+
+func writeNestedLoModule(t *testing.T, repo string, path ...string) string {
+	t.Helper()
+	nestedDir := filepath.Join(append([]string{repo}, path...)...)
+	writeRepoModuleFile(t, nestedDir, "module example.com/api", requirePrefix+depLo+" v1.47.0")
+	writeFile(t, filepath.Join(nestedDir, fileMainGo), strings.Join([]string{
+		packageMainLine,
+		"",
+		importLoLine,
+		"",
+		"func main() { _ = lo.Contains([]int{1,2}, 2) }",
+		"",
+	}, "\n"))
+	return nestedDir
+}
+
+func writeRepoModuleFile(t *testing.T, dir, moduleLine, requireLine string) {
+	t.Helper()
+	writeFile(t, filepath.Join(dir, fileGoMod), strings.Join([]string{
+		moduleLine,
+		"",
+		requireLine,
+		"",
+	}, "\n"))
+}
+
 func mkdirGoWorkDir(t *testing.T, repo string) {
 	t.Helper()
 	if err := os.Mkdir(filepath.Join(repo, fileGoWork), 0o755); err != nil {
@@ -1257,6 +1241,22 @@ func dependencySetFromScan(scan scanResult) map[string]struct{} {
 		}
 	}
 	return deps
+}
+
+func requireScannedDependency(t *testing.T, scan scanResult, dependency string) {
+	t.Helper()
+	deps := dependencySetFromScan(scan)
+	if _, ok := deps[dependency]; !ok {
+		t.Fatalf("expected dependency %q in %#v", dependency, deps)
+	}
+}
+
+func requireSkippedDependency(t *testing.T, scan scanResult, dependency string) {
+	t.Helper()
+	deps := dependencySetFromScan(scan)
+	if _, ok := deps[dependency]; ok {
+		t.Fatalf("did not expect dependency %q in %#v", dependency, deps)
+	}
 }
 
 func TestUtilityCoverageBranches(t *testing.T) {

--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -433,6 +433,101 @@ func TestAdapterAnalyseWorkspaceGoWorkScansMembers(t *testing.T) {
 	}
 }
 
+func TestScanRepoReusesLoadedNestedModuleDirs(t *testing.T) {
+	repo := t.TempDir()
+	writeRepoGoModLines(t, repo, "module example.com/root", "", requirePrefix+depUUID+versionV160, "")
+	writeRepoMainLines(t, repo, packageMainLine, "", "import \""+depUUID+"\"", "", "func main() { _ = uuid.NewString() }", "")
+
+	nestedGoModLines := []string{
+		"module example.com/api",
+		"",
+		requirePrefix + depLo + " v1.47.0",
+		"",
+	}
+	nestedMainLines := []string{
+		packageMainLine,
+		"",
+		importLoLine,
+		"",
+		"func main() { _ = lo.Contains([]int{1,2}, 2) }",
+		"",
+	}
+	nestedDir := filepath.Join(repo, "services", "api")
+	writeFile(t, filepath.Join(nestedDir, fileGoMod), strings.Join(nestedGoModLines, "\n"))
+	writeFile(t, filepath.Join(nestedDir, fileMainGo), strings.Join(nestedMainLines, "\n"))
+
+	info, err := loadGoModuleInfo(repo)
+	if err != nil {
+		t.Fatalf("loadGoModuleInfo: %v", err)
+	}
+	if _, ok := info.NestedModuleDirs[nestedDir]; !ok {
+		t.Fatalf("expected nested module dir %q cached in %#v", nestedDir, info.NestedModuleDirs)
+	}
+
+	// Removing nested go.mod after module loading verifies scanRepo reuses cached dirs.
+	if err := os.Remove(filepath.Join(nestedDir, fileGoMod)); err != nil {
+		t.Fatalf("remove nested go.mod: %v", err)
+	}
+
+	scan, err := scanRepo(context.Background(), repo, info)
+	if err != nil {
+		t.Fatalf("scanRepo: %v", err)
+	}
+	if scan.SkippedNestedModuleDirs != 1 {
+		t.Fatalf("expected one cached nested module skip, got %d", scan.SkippedNestedModuleDirs)
+	}
+
+	deps := dependencySetFromScan(scan)
+	if _, ok := deps[depUUID]; !ok {
+		t.Fatalf("expected root dependency %q in %#v", depUUID, deps)
+	}
+	if _, ok := deps[depLo]; ok {
+		t.Fatalf("did not expect nested dependency %q in %#v", depLo, deps)
+	}
+}
+
+func TestScanRepoReusesWorkspaceNestedModuleExclusions(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, fileGoWork), go125Line+"\n\nuse ./svc/a\n")
+	writeFile(t, filepath.Join(repo, "svc", "a", fileGoMod), goModDemoWithUUID)
+	writeFile(t, filepath.Join(repo, "svc", "a", fileMainGo), mainUUIDNoopProgram)
+
+	excludedNestedDir := filepath.Join(repo, "tools", "api")
+	writeFile(t, filepath.Join(excludedNestedDir, fileGoMod), "module example.com/tools/api\n\nrequire "+depLo+" v1.47.0\n")
+	writeFile(t, filepath.Join(excludedNestedDir, fileMainGo), packageMainLine+"\n\n"+importLoLine+"\n\nfunc main() { _ = lo.Contains([]int{1,2}, 2) }\n")
+
+	info, err := loadGoModuleInfo(repo)
+	if err != nil {
+		t.Fatalf("loadGoModuleInfo: %v", err)
+	}
+	workspaceDir := filepath.Join(repo, "svc", "a")
+	if _, ok := info.WorkspaceModuleExclusions[workspaceDir]; !ok {
+		t.Fatalf("expected workspace exclusion %q in %#v", workspaceDir, info.WorkspaceModuleExclusions)
+	}
+	if _, ok := info.NestedModuleDirs[workspaceDir]; ok {
+		t.Fatalf("did not expect workspace dir %q in nested module skips %#v", workspaceDir, info.NestedModuleDirs)
+	}
+	if _, ok := info.NestedModuleDirs[excludedNestedDir]; !ok {
+		t.Fatalf("expected non-workspace nested module dir %q cached in %#v", excludedNestedDir, info.NestedModuleDirs)
+	}
+
+	scan, err := scanRepo(context.Background(), repo, info)
+	if err != nil {
+		t.Fatalf("scanRepo: %v", err)
+	}
+	if scan.SkippedNestedModuleDirs != 1 {
+		t.Fatalf("expected one nested module skip, got %d", scan.SkippedNestedModuleDirs)
+	}
+
+	deps := dependencySetFromScan(scan)
+	if _, ok := deps[depUUID]; !ok {
+		t.Fatalf("expected workspace member dependency %q in %#v", depUUID, deps)
+	}
+	if _, ok := deps[depLo]; ok {
+		t.Fatalf("did not expect excluded nested dependency %q in %#v", depLo, deps)
+	}
+}
+
 func TestBuildRequestedGoDependenciesNoInputWarning(t *testing.T) {
 	deps, warnings := buildRequestedGoDependencies(language.Request{}, scanResult{})
 	if len(deps) != 0 {
@@ -1149,6 +1244,19 @@ func dependencyNames(dependencies []report.DependencyReport) []string {
 		names = append(names, dep.Name)
 	}
 	return names
+}
+
+func dependencySetFromScan(scan scanResult) map[string]struct{} {
+	deps := make(map[string]struct{})
+	for _, file := range scan.Files {
+		for _, imported := range file.Imports {
+			if imported.Dependency == "" {
+				continue
+			}
+			deps[imported.Dependency] = struct{}{}
+		}
+	}
+	return deps
 }
 
 func TestUtilityCoverageBranches(t *testing.T) {

--- a/internal/lang/golang/module_loading.go
+++ b/internal/lang/golang/module_loading.go
@@ -88,7 +88,20 @@ func loadNestedModules(repoPath string, info *moduleInfo) error {
 		return errNilModuleInfo
 	}
 
-	nestedModules, nestedDeps, nestedReplacements, err := discoverNestedModules(repoPath)
+	workspaceModuleDirs, err := workspaceRootModuleDirs(repoPath, *info)
+	if err != nil {
+		return err
+	}
+	info.WorkspaceModuleExclusions = normalizedDirSet(workspaceModuleDirs)
+
+	allNestedDirs, err := nestedModuleDirs(repoPath, nil)
+	if err != nil {
+		return err
+	}
+	normalizedNestedDirs := normalizedDirSet(allNestedDirs)
+	info.NestedModuleDirs = excludeDirSet(normalizedNestedDirs, info.WorkspaceModuleExclusions)
+
+	nestedModules, nestedDeps, nestedReplacements, err := discoverNestedModulesFromDirs(repoPath, normalizedNestedDirs)
 	if err != nil {
 		return err
 	}

--- a/internal/lang/golang/module_loading.go
+++ b/internal/lang/golang/module_loading.go
@@ -94,14 +94,14 @@ func loadNestedModules(repoPath string, info *moduleInfo) error {
 	}
 	info.WorkspaceModuleExclusions = normalizedDirSet(workspaceModuleDirs)
 
-	allNestedDirs, err := nestedModuleDirs(repoPath, nil)
+	scanNestedDirs, err := nestedModuleDirs(repoPath, workspaceModuleDirs)
 	if err != nil {
 		return err
 	}
-	normalizedNestedDirs := normalizedDirSet(allNestedDirs)
-	info.NestedModuleDirs = excludeDirSet(normalizedNestedDirs, info.WorkspaceModuleExclusions)
+	info.NestedModuleDirs = normalizedDirSet(scanNestedDirs)
 
-	nestedModules, nestedDeps, nestedReplacements, err := discoverNestedModulesFromDirs(repoPath, normalizedNestedDirs)
+	metadataNestedDirs := unionDirSet(info.NestedModuleDirs, info.WorkspaceModuleExclusions)
+	nestedModules, nestedDeps, nestedReplacements, err := discoverNestedModulesFromDirs(repoPath, metadataNestedDirs)
 	if err != nil {
 		return err
 	}

--- a/internal/lang/golang/module_metadata.go
+++ b/internal/lang/golang/module_metadata.go
@@ -78,7 +78,10 @@ func discoverNestedModules(repoPath string) ([]string, []string, map[string]stri
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	return discoverNestedModulesFromDirs(repoPath, nestedDirs)
+}
 
+func discoverNestedModulesFromDirs(repoPath string, nestedDirs map[string]struct{}) ([]string, []string, map[string]string, error) {
 	modules := make([]string, 0, len(nestedDirs))
 	dependencies := make([]string, 0)
 	replacements := make(map[string]string)
@@ -99,6 +102,31 @@ func discoverNestedModules(repoPath string) ([]string, []string, map[string]stri
 	}
 
 	return uniqueStrings(modules), uniqueStrings(dependencies), replacements, nil
+}
+
+func normalizedDirSet(dirs map[string]struct{}) map[string]struct{} {
+	if dirs == nil {
+		return nil
+	}
+	normalized := make(map[string]struct{}, len(dirs))
+	for dir := range dirs {
+		normalized[filepath.Clean(dir)] = struct{}{}
+	}
+	return normalized
+}
+
+func excludeDirSet(dirs map[string]struct{}, exclusions map[string]struct{}) map[string]struct{} {
+	if dirs == nil {
+		return nil
+	}
+	filtered := make(map[string]struct{}, len(dirs))
+	for dir := range dirs {
+		if _, skip := exclusions[dir]; skip {
+			continue
+		}
+		filtered[dir] = struct{}{}
+	}
+	return filtered
 }
 
 func parseGoMod(content []byte) (string, []string, map[string]string) {

--- a/internal/lang/golang/module_metadata.go
+++ b/internal/lang/golang/module_metadata.go
@@ -115,18 +115,18 @@ func normalizedDirSet(dirs map[string]struct{}) map[string]struct{} {
 	return normalized
 }
 
-func excludeDirSet(dirs map[string]struct{}, exclusions map[string]struct{}) map[string]struct{} {
-	if dirs == nil {
+func unionDirSet(primary map[string]struct{}, extra map[string]struct{}) map[string]struct{} {
+	if len(primary) == 0 && len(extra) == 0 {
 		return nil
 	}
-	filtered := make(map[string]struct{}, len(dirs))
-	for dir := range dirs {
-		if _, skip := exclusions[dir]; skip {
-			continue
-		}
-		filtered[dir] = struct{}{}
+	union := make(map[string]struct{}, len(primary)+len(extra))
+	for dir := range primary {
+		union[dir] = struct{}{}
 	}
-	return filtered
+	for dir := range extra {
+		union[dir] = struct{}{}
+	}
+	return union
 }
 
 func parseGoMod(content []byte) (string, []string, map[string]string) {

--- a/internal/lang/golang/types.go
+++ b/internal/lang/golang/types.go
@@ -26,6 +26,8 @@ type moduleInfo struct {
 	ModulePath                 string
 	LocalModulePaths           []string
 	DeclaredDependencies       []string
+	NestedModuleDirs           map[string]struct{}
+	WorkspaceModuleExclusions  map[string]struct{}
 	ReplacementImports         map[string]string
 	VendoredImportDependencies map[string]string
 	VendoredDependencies       map[string]vendoredDependencyMetadata


### PR DESCRIPTION
## Summary

Fixes duplicated nested-module discovery in the Go adapter by caching nested module directories during module loading and reusing that cache in `scanRepo`. This removes a redundant filesystem walk while preserving root-module and workspace scan behavior.

Closes #819.

## Changes

- Added `NestedModuleDirs` and `WorkspaceModuleExclusions` to `moduleInfo`.
- Updated `loadNestedModules` to:
  - compute workspace exclusions once,
  - perform nested directory discovery once,
  - cache normalized nested directories for scan-time exclusion,
  - reuse discovered directories when loading nested module metadata.
- Updated `scanRepo` to use cached nested-module directories via `nestedModuleDirsForScan` with fallback for direct callers.
- Added focused tests for:
  - cached nested-module directory reuse in `scanRepo`,
  - workspace exclusion caching while still scanning workspace member modules.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/golang
go test ./...
```

Additional manual validation:

- Verified diff scope is limited to Go adapter/module-loading files and directly related Go adapter tests.
- Verified no suppression markers were added.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Positive; removes redundant nested-module directory walk in scan path.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review