### PR TITLE
perf(dotnet): combine scan input discovery

### DIFF
--- a/internal/lang/dotnet/adapter_cov_more_test.go
+++ b/internal/lang/dotnet/adapter_cov_more_test.go
@@ -3,6 +3,7 @@ package dotnet
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -57,6 +58,22 @@ func TestDotNetDetectWithConfidenceGuardBranches(t *testing.T) {
 	detection, err = NewAdapter().DetectWithConfidence(context.Background(), repo)
 	if err != nil || !detection.Matched {
 		t.Fatalf("expected detection success with skipped obj dir, detection=%#v err=%v", detection, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := NewAdapter().DetectWithConfidence(ctx, repo); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled detection, got %v", err)
+	}
+}
+
+func TestDotNetAnalyseEmptyRepoWarnsNoDependencies(t *testing.T) {
+	result, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: t.TempDir(), TopN: 1})
+	if err != nil {
+		t.Fatalf("analyse empty repo: %v", err)
+	}
+	if !slices.Contains(result.Warnings, "no .NET package dependencies discovered from project manifests") {
+		t.Fatalf("expected no dependencies warning, got %#v", result.Warnings)
 	}
 }
 
@@ -131,6 +148,79 @@ func TestDotNetScannerSkipsObjDirAndMissingSource(t *testing.T) {
 	}
 	if discoverer.discoverFile(filePath) == nil {
 		t.Fatalf("expected removed source file to fail discovery")
+	}
+}
+
+func TestDotNetSourceDiscovererWalkCoversDirectoryAndFile(t *testing.T) {
+	repo := t.TempDir()
+	srcDir := filepath.Join(repo, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir src dir: %v", err)
+	}
+	dirEntry := mustReadDirEntry(t, repo, "src")
+
+	discovery := sourceDiscovery{}
+	discoverer := newSourceDiscoverer(repo, &discovery)
+	if err := discoverer.walk(srcDir, dirEntry, nil); err != nil {
+		t.Fatalf("walk src dir: %v", err)
+	}
+
+	sourcePath := filepath.Join(srcDir, dotNetProgramSource)
+	if err := os.WriteFile(sourcePath, []byte("using Vendor.Pkg;\n"), 0o644); err != nil {
+		t.Fatalf(dotNetWriteProgramFileErrFmt, err)
+	}
+	sourceEntry := mustReadDirEntry(t, srcDir, dotNetProgramSource)
+	if err := discoverer.walk(sourcePath, sourceEntry, nil); err != nil {
+		t.Fatalf("walk source file: %v", err)
+	}
+	if len(discovery.Files) != 1 || discovery.Files[0].RelativePath != filepath.Join("src", dotNetProgramSource) {
+		t.Fatalf("unexpected source discovery: %#v", discovery.Files)
+	}
+}
+
+func TestDotNetScanInputDiscovererBranches(t *testing.T) {
+	repo := t.TempDir()
+	objDir := filepath.Join(repo, "obj")
+	if err := os.Mkdir(objDir, 0o755); err != nil {
+		t.Fatalf(dotNetMkdirObjDirErrFmt, err)
+	}
+	objEntry := mustReadDirEntry(t, repo, "obj")
+
+	discovery := sourceDiscovery{}
+	discoverer := newScanInputDiscoverer(repo, &discovery)
+	if err := discoverer.walk(objDir, objEntry, nil); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("expected scan input discoverer to skip obj dir, got %v", err)
+	}
+
+	manifestPath := filepath.Join(repo, "App.csproj")
+	testutil.MustWriteFile(t, manifestPath, `<Project><ItemGroup><PackageReference Include="Vendor.Pkg" /></ItemGroup></Project>`)
+	manifestEntry := mustReadDirEntry(t, repo, "App.csproj")
+	if err := discoverer.walk(manifestPath, manifestEntry, nil); err != nil {
+		t.Fatalf("walk manifest: %v", err)
+	}
+	if _, ok := discoverer.dependencySet["vendor.pkg"]; !ok {
+		t.Fatalf("expected manifest dependency, got %#v", discoverer.dependencySet)
+	}
+
+	badManifestPath := filepath.Join(repo, "Bad.csproj")
+	testutil.MustWriteFile(t, badManifestPath, `<Project />`)
+	badManifestEntry := mustReadDirEntry(t, repo, "Bad.csproj")
+	if err := os.Remove(badManifestPath); err != nil {
+		t.Fatalf("remove bad manifest: %v", err)
+	}
+	if err := discoverer.walk(badManifestPath, badManifestEntry, nil); err == nil {
+		t.Fatalf("expected removed manifest to fail scan input discovery")
+	}
+
+	discoverer.sourceScanLimited = true
+	sourcePath := filepath.Join(repo, dotNetProgramSource)
+	testutil.MustWriteFile(t, sourcePath, "using Vendor.Pkg;\n")
+	sourceEntry := mustReadDirEntry(t, repo, dotNetProgramSource)
+	if err := discoverer.walk(sourcePath, sourceEntry, nil); err != nil {
+		t.Fatalf("walk source while limited: %v", err)
+	}
+	if len(discovery.Files) != 0 {
+		t.Fatalf("expected limited source scan to skip new source files, got %#v", discovery.Files)
 	}
 }
 
@@ -376,7 +466,7 @@ func TestDotNetDiscoverScanInputsPreservesMixedRepoOutputs(t *testing.T) {
 
 func TestDotNetDiscoverScanInputsKeepsManifestDiscoveryAfterSourceCap(t *testing.T) {
 	repo := t.TempDir()
-	for i := 0; i < maxScanFiles+10; i++ {
+	for i := 0; i < maxScanFiles+1; i++ {
 		testutil.MustWriteFile(t, filepath.Join(repo, "a-src", "f"+strconv.Itoa(i)+".cs"), "using Acme.Foo;\n")
 	}
 	testutil.MustWriteFile(t, filepath.Join(repo, "z-manifests", "Late.csproj"), `
@@ -400,8 +490,45 @@ func TestDotNetDiscoverScanInputsKeepsManifestDiscoveryAfterSourceCap(t *testing
 	if !slices.Contains(inputs.DeclaredDependencies, "late.manifest") {
 		t.Fatalf("expected dependencies discovered after source cap, got %#v", inputs.DeclaredDependencies)
 	}
-	if !slices.Contains(inputs.Warnings, "source scan capped at 4096 files") {
+	expectedWarning := fmt.Sprintf("source scan capped at %d files", maxScanFiles)
+	if !slices.Contains(inputs.Warnings, expectedWarning) {
 		t.Fatalf("expected source cap warning, got %#v", inputs.Warnings)
+	}
+}
+
+func TestDotNetSolutionRootsRemainRepoBounded(t *testing.T) {
+	repo := t.TempDir()
+	projectPath := filepath.Join(repo, "src", "App", "App.csproj")
+	testutil.MustWriteFile(t, projectPath, `<Project />`)
+	solutionPath := filepath.Join(repo, "App.sln")
+	testutil.MustWriteFile(t, solutionPath, `
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "src/App/App.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Outside", "../outside/Outside.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+`)
+
+	roots := map[string]struct{}{}
+	if err := addSolutionRoots(repo, solutionPath, roots); err != nil {
+		t.Fatalf("add solution roots: %v", err)
+	}
+	if _, ok := roots[filepath.Dir(projectPath)]; !ok {
+		t.Fatalf("expected in-repo project root, got %#v", roots)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("expected only in-repo project root, got %#v", roots)
+	}
+	if !isRepoBoundedPath(repo, filepath.Join(repo, "src")) {
+		t.Fatalf("expected src to be repo-bounded")
+	}
+	if isRepoBoundedPath(repo, filepath.Dir(repo)) {
+		t.Fatalf("did not expect parent dir to be repo-bounded")
+	}
+	if isRepoBoundedPath(repo, "\x00") {
+		t.Fatalf("expected invalid candidate path to be rejected")
+	}
+	if err := addSolutionRoots(repo, filepath.Join(repo, "missing.sln"), map[string]struct{}{}); err == nil {
+		t.Fatalf("expected missing solution to fail")
 	}
 }
 

--- a/internal/lang/dotnet/adapter_cov_more_test.go
+++ b/internal/lang/dotnet/adapter_cov_more_test.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 const dotNetProgramSource = "Program.cs"
@@ -314,6 +316,92 @@ func TestDotNetDiscoveryAndParsingStagesCompose(t *testing.T) {
 	}
 	if parsed.File.Path != dotNetProgramSource {
 		t.Fatalf("unexpected parsed file path: %#v", parsed.File)
+	}
+}
+
+func TestDotNetDiscoverScanInputsPreservesMixedRepoOutputs(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, centralPackagesFile), `
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="Acme.Logging" Version="1.2.3" />
+  </ItemGroup>
+</Project>`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "App", "App.csproj"), `
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "Lib", "Lib.fsproj"), `
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="8.0.0" />
+  </ItemGroup>
+</Project>`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "App", "packages.lock.json"), `{"version":1}`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "App", "Program.cs"), "using Newtonsoft.Json;\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "Lib", "Module.fs"), "open Acme.Logging\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "App", "Generated.g.cs"), "using Generated;\n")
+
+	inputs, err := discoverScanInputs(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("discover scan inputs: %v", err)
+	}
+
+	if !slices.Equal(inputs.DeclaredDependencies, []string{"acme.logging", "fsharp.core", "newtonsoft.json"}) {
+		t.Fatalf("unexpected declared dependencies: %#v", inputs.DeclaredDependencies)
+	}
+	if inputs.SkippedGenerated != 1 {
+		t.Fatalf("expected one generated source file skip, got %d", inputs.SkippedGenerated)
+	}
+	if !slices.Contains(inputs.Warnings, "skipped 1 generated source file(s)") {
+		t.Fatalf("expected generated source warning, got %#v", inputs.Warnings)
+	}
+	if len(inputs.SourceFiles) != 2 {
+		t.Fatalf("expected two source files, got %#v", inputs.SourceFiles)
+	}
+
+	paths := make([]string, 0, len(inputs.SourceFiles))
+	for _, file := range inputs.SourceFiles {
+		paths = append(paths, file.RelativePath)
+	}
+	if !slices.Contains(paths, filepath.Join("src", "App", "Program.cs")) {
+		t.Fatalf("expected Program.cs source document, got %#v", paths)
+	}
+	if !slices.Contains(paths, filepath.Join("src", "Lib", "Module.fs")) {
+		t.Fatalf("expected Module.fs source document, got %#v", paths)
+	}
+}
+
+func TestDotNetDiscoverScanInputsKeepsManifestDiscoveryAfterSourceCap(t *testing.T) {
+	repo := t.TempDir()
+	for i := 0; i < maxScanFiles+10; i++ {
+		testutil.MustWriteFile(t, filepath.Join(repo, "a-src", "f"+strconv.Itoa(i)+".cs"), "using Acme.Foo;\n")
+	}
+	testutil.MustWriteFile(t, filepath.Join(repo, "z-manifests", "Late.csproj"), `
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Late.Manifest" Version="1.0.0" />
+  </ItemGroup>
+</Project>`)
+
+	inputs, err := discoverScanInputs(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("discover scan inputs with cap: %v", err)
+	}
+
+	if !inputs.SkippedFileLimit {
+		t.Fatalf("expected source scan cap to be triggered")
+	}
+	if len(inputs.SourceFiles) != maxScanFiles {
+		t.Fatalf("expected capped source file count %d, got %d", maxScanFiles, len(inputs.SourceFiles))
+	}
+	if !slices.Contains(inputs.DeclaredDependencies, "late.manifest") {
+		t.Fatalf("expected dependencies discovered after source cap, got %#v", inputs.DeclaredDependencies)
+	}
+	if !slices.Contains(inputs.Warnings, "source scan capped at 4096 files") {
+		t.Fatalf("expected source cap warning, got %#v", inputs.Warnings)
 	}
 }
 

--- a/internal/lang/dotnet/discovery.go
+++ b/internal/lang/dotnet/discovery.go
@@ -56,9 +56,14 @@ func discoverScanInputs(ctx context.Context, repoPath string) (scanInputs, error
 	}
 
 	sourceScan := sourceDiscovery{}
-	scanner := newScanInputDiscoverer(ctx, repoPath, &sourceScan)
+	scanner := newScanInputDiscoverer(repoPath, &sourceScan)
 
-	err := filepath.WalkDir(repoPath, scanner.walk)
+	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, walkErr error) error {
+		if ctx != nil && ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return scanner.walk(path, entry, walkErr)
+	})
 	if err != nil {
 		return inputs, err
 	}
@@ -103,7 +108,6 @@ type sourceDiscoverer struct {
 }
 
 type scanInputDiscoverer struct {
-	ctx               context.Context
 	dependencySet     map[string]struct{}
 	sourceDiscoverer  sourceDiscoverer
 	sourceScanLimited bool
@@ -134,9 +138,8 @@ func newSourceDiscoverer(repoPath string, discovery *sourceDiscovery) sourceDisc
 	}
 }
 
-func newScanInputDiscoverer(ctx context.Context, repoPath string, source *sourceDiscovery) scanInputDiscoverer {
+func newScanInputDiscoverer(repoPath string, source *sourceDiscovery) scanInputDiscoverer {
 	return scanInputDiscoverer{
-		ctx:              ctx,
 		dependencySet:    make(map[string]struct{}),
 		sourceDiscoverer: newSourceDiscoverer(repoPath, source),
 	}
@@ -145,9 +148,6 @@ func newScanInputDiscoverer(ctx context.Context, repoPath string, source *source
 func (d *scanInputDiscoverer) walk(path string, entry fs.DirEntry, walkErr error) error {
 	if walkErr != nil {
 		return walkErr
-	}
-	if d.ctx != nil && d.ctx.Err() != nil {
-		return d.ctx.Err()
 	}
 	if entry.IsDir() {
 		if shouldSkipDir(entry.Name()) {

--- a/internal/lang/dotnet/discovery.go
+++ b/internal/lang/dotnet/discovery.go
@@ -55,20 +55,21 @@ func discoverScanInputs(ctx context.Context, repoPath string) (scanInputs, error
 		return inputs, fs.ErrInvalid
 	}
 
-	declared, err := collectDeclaredDependencies(repoPath)
-	if err != nil {
-		return inputs, err
-	}
-	inputs.DeclaredDependencies = declared
+	sourceScan := sourceDiscovery{}
+	scanner := newScanInputDiscoverer(ctx, repoPath, &sourceScan)
 
-	sources, err := discoverSourceFiles(ctx, repoPath)
+	err := filepath.WalkDir(repoPath, scanner.walk)
 	if err != nil {
 		return inputs, err
 	}
-	inputs.SourceFiles = sources.Files
-	inputs.SkippedGenerated = sources.SkippedGeneratedFiles
-	inputs.SkippedFileLimit = sources.SkippedFileLimit
-	inputs.Warnings = append(inputs.Warnings, sources.Warnings...)
+
+	appendSourceDiscoveryWarnings(&sourceScan)
+
+	inputs.DeclaredDependencies = sortedDependencies(scanner.dependencySet)
+	inputs.SourceFiles = sourceScan.Files
+	inputs.SkippedGenerated = sourceScan.SkippedGeneratedFiles
+	inputs.SkippedFileLimit = sourceScan.SkippedFileLimit
+	inputs.Warnings = append(inputs.Warnings, sourceScan.Warnings...)
 	return inputs, nil
 }
 
@@ -101,6 +102,13 @@ type sourceDiscoverer struct {
 	visitedSourceFiles int
 }
 
+type scanInputDiscoverer struct {
+	ctx               context.Context
+	dependencySet     map[string]struct{}
+	sourceDiscoverer  sourceDiscoverer
+	sourceScanLimited bool
+}
+
 func discoverSourceFiles(ctx context.Context, repoPath string) (sourceDiscovery, error) {
 	discovery := sourceDiscovery{}
 	discoverer := newSourceDiscoverer(repoPath, &discovery)
@@ -124,6 +132,45 @@ func newSourceDiscoverer(repoPath string, discovery *sourceDiscovery) sourceDisc
 		repoPath:  repoPath,
 		discovery: discovery,
 	}
+}
+
+func newScanInputDiscoverer(ctx context.Context, repoPath string, source *sourceDiscovery) scanInputDiscoverer {
+	return scanInputDiscoverer{
+		ctx:              ctx,
+		dependencySet:    make(map[string]struct{}),
+		sourceDiscoverer: newSourceDiscoverer(repoPath, source),
+	}
+}
+
+func (d *scanInputDiscoverer) walk(path string, entry fs.DirEntry, walkErr error) error {
+	if walkErr != nil {
+		return walkErr
+	}
+	if d.ctx != nil && d.ctx.Err() != nil {
+		return d.ctx.Err()
+	}
+	if entry.IsDir() {
+		if shouldSkipDir(entry.Name()) {
+			return filepath.SkipDir
+		}
+		return nil
+	}
+
+	dependencies, err := parseManifestDependenciesForEntry(d.sourceDiscoverer.repoPath, path, entry.Name())
+	if err != nil {
+		return err
+	}
+	addDependencies(d.dependencySet, dependencies)
+
+	if d.sourceScanLimited {
+		return nil
+	}
+	err = d.sourceDiscoverer.discoverFile(path)
+	if errors.Is(err, fs.SkipAll) {
+		d.sourceScanLimited = true
+		return nil
+	}
+	return err
 }
 
 func (d *sourceDiscoverer) walk(path string, entry fs.DirEntry, walkErr error) error {

--- a/internal/lang/dotnet/discovery.go
+++ b/internal/lang/dotnet/discovery.go
@@ -113,24 +113,6 @@ type scanInputDiscoverer struct {
 	sourceScanLimited bool
 }
 
-func discoverSourceFiles(ctx context.Context, repoPath string) (sourceDiscovery, error) {
-	discovery := sourceDiscovery{}
-	discoverer := newSourceDiscoverer(repoPath, &discovery)
-
-	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, walkErr error) error {
-		if ctx != nil && ctx.Err() != nil {
-			return ctx.Err()
-		}
-		return discoverer.walk(path, entry, walkErr)
-	})
-	if err != nil && !errors.Is(err, fs.SkipAll) {
-		return discovery, err
-	}
-
-	appendSourceDiscoveryWarnings(&discovery)
-	return discovery, nil
-}
-
 func newSourceDiscoverer(repoPath string, discovery *sourceDiscovery) sourceDiscoverer {
 	return sourceDiscoverer{
 		repoPath:  repoPath,


### PR DESCRIPTION
## Summary

Dotnet scan input discovery was traversing repositories twice before parse by calling `collectDeclaredDependencies` and `discoverSourceFiles` sequentially. This change merges manifest and source discovery into a single `WalkDir` pass while preserving existing skip, cap, and warning behavior.

Closes #818.

## Changes

- Refactored `discoverScanInputs` to use a single walker (`scanInputDiscoverer`) that collects both manifest dependencies and source documents.
- Preserved existing directory skip rules, generated-source skip counting, source file cap warning behavior, and source parsing inputs.
- Added tests that validate discovery outputs for mixed repos (manifests + lockfile + source files) and that dependency discovery still succeeds when the source file cap is hit.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/dotnet
go test ./...
```

Additional manual validation:

- Verified diff scope is limited to dotnet discovery and related dotnet tests.
- Verified no suppression markers were introduced.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Positive (scan input discovery now uses one tree walk instead of two before parse).
- Memory benchmark impact: No intentional memory-impacting changes.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review