### PR TITLE
refactor(scoring): consolidate removal weight validation

### DIFF
--- a/internal/app/analyse_prepare.go
+++ b/internal/app/analyse_prepare.go
@@ -28,11 +28,7 @@ func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseE
 
 	lowConfidence := req.Analyse.Thresholds.LowConfidenceWarningPercent
 	minUsage := req.Analyse.Thresholds.MinUsagePercentForRecommendations
-	weights := report.RemovalCandidateWeights{
-		Usage:      req.Analyse.Thresholds.RemovalCandidateWeightUsage,
-		Impact:     req.Analyse.Thresholds.RemovalCandidateWeightImpact,
-		Confidence: req.Analyse.Thresholds.RemovalCandidateWeightConfidence,
-	}
+	weights := req.Analyse.Thresholds.RemovalCandidateWeights()
 	runtimeTracePath, runtimeTracePathExplicit := prepareRuntimeTracePlan(req)
 	effectiveThresholds := report.EffectiveThresholds{
 		FailOnIncreasePercent:             req.Analyse.Thresholds.FailOnIncreasePercent,

--- a/internal/app/analyse_prepare.go
+++ b/internal/app/analyse_prepare.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/thresholds"
 )
 
 type preparedAnalyseExecution struct {
@@ -28,7 +29,7 @@ func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseE
 
 	lowConfidence := req.Analyse.Thresholds.LowConfidenceWarningPercent
 	minUsage := req.Analyse.Thresholds.MinUsagePercentForRecommendations
-	weights := req.Analyse.Thresholds.RemovalCandidateWeights()
+	weights := thresholds.RemovalCandidateWeights(req.Analyse.Thresholds)
 	runtimeTracePath, runtimeTracePathExplicit := prepareRuntimeTracePlan(req)
 	effectiveThresholds := report.EffectiveThresholds{
 		FailOnIncreasePercent:             req.Analyse.Thresholds.FailOnIncreasePercent,

--- a/internal/lang/shared/report_scaffold_test.go
+++ b/internal/lang/shared/report_scaffold_test.go
@@ -72,6 +72,11 @@ func TestResolveSharedReportHelpers(t *testing.T) {
 	if got := ResolveRemovalCandidateWeights(&customWeights); got != wantWeights {
 		t.Fatalf("resolved removal candidate weights = %#v, want %#v", got, wantWeights)
 	}
+
+	invalidWeights := report.RemovalCandidateWeights{}
+	if got := ResolveRemovalCandidateWeights(&invalidWeights); got != defaultWeights {
+		t.Fatalf("invalid removal candidate weights should fall back to defaults = %#v, want %#v", got, defaultWeights)
+	}
 }
 
 func TestRecommendationPriorityRank(t *testing.T) {

--- a/internal/report/scoring.go
+++ b/internal/report/scoring.go
@@ -13,9 +13,9 @@ var defaultRemovalCandidateWeights = RemovalCandidateWeights{
 }
 
 const (
-	RemovalCandidateWeightUsageField      = "removal_candidate_weight_usage"
-	RemovalCandidateWeightImpactField     = "removal_candidate_weight_impact"
-	RemovalCandidateWeightConfidenceField = "removal_candidate_weight_confidence"
+	removalCandidateWeightUsageField      = "removal_candidate_weight_usage"
+	removalCandidateWeightImpactField     = "removal_candidate_weight_impact"
+	removalCandidateWeightConfidenceField = "removal_candidate_weight_confidence"
 )
 
 func AnnotateRemovalCandidateScores(dependencies []DependencyReport) {
@@ -62,7 +62,7 @@ func NormalizeRemovalCandidateWeights(weights RemovalCandidateWeights) RemovalCa
 	}
 }
 
-func ValidateRemovalCandidateWeight(name string, value float64) error {
+func validateRemovalCandidateWeight(name string, value float64) error {
 	if !isFiniteWeight(value) {
 		return fmt.Errorf("invalid threshold %s: %v (must be finite)", name, value)
 	}
@@ -73,13 +73,13 @@ func ValidateRemovalCandidateWeight(name string, value float64) error {
 }
 
 func ValidateRemovalCandidateWeightSet(weights RemovalCandidateWeights) error {
-	if err := ValidateRemovalCandidateWeight(RemovalCandidateWeightUsageField, weights.Usage); err != nil {
+	if err := validateRemovalCandidateWeight(removalCandidateWeightUsageField, weights.Usage); err != nil {
 		return err
 	}
-	if err := ValidateRemovalCandidateWeight(RemovalCandidateWeightImpactField, weights.Impact); err != nil {
+	if err := validateRemovalCandidateWeight(removalCandidateWeightImpactField, weights.Impact); err != nil {
 		return err
 	}
-	if err := ValidateRemovalCandidateWeight(RemovalCandidateWeightConfidenceField, weights.Confidence); err != nil {
+	if err := validateRemovalCandidateWeight(removalCandidateWeightConfidenceField, weights.Confidence); err != nil {
 		return err
 	}
 	if weights.Usage <= 0 && weights.Impact <= 0 && weights.Confidence <= 0 {

--- a/internal/report/scoring.go
+++ b/internal/report/scoring.go
@@ -73,20 +73,16 @@ func ValidateRemovalCandidateWeight(name string, value float64) error {
 }
 
 func ValidateRemovalCandidateWeightSet(weights RemovalCandidateWeights) error {
-	checks := []struct {
-		name  string
-		value float64
-	}{
-		{name: RemovalCandidateWeightUsageField, value: weights.Usage},
-		{name: RemovalCandidateWeightImpactField, value: weights.Impact},
-		{name: RemovalCandidateWeightConfidenceField, value: weights.Confidence},
+	if err := ValidateRemovalCandidateWeight(RemovalCandidateWeightUsageField, weights.Usage); err != nil {
+		return err
 	}
-	for _, check := range checks {
-		if err := ValidateRemovalCandidateWeight(check.name, check.value); err != nil {
-			return err
-		}
+	if err := ValidateRemovalCandidateWeight(RemovalCandidateWeightImpactField, weights.Impact); err != nil {
+		return err
 	}
-	if !hasPositiveWeight(weights.Usage, weights.Impact, weights.Confidence) {
+	if err := ValidateRemovalCandidateWeight(RemovalCandidateWeightConfidenceField, weights.Confidence); err != nil {
+		return err
+	}
+	if weights.Usage <= 0 && weights.Impact <= 0 && weights.Confidence <= 0 {
 		return fmt.Errorf("invalid removal candidate weights: at least one weight must be greater than 0")
 	}
 	return nil
@@ -94,15 +90,6 @@ func ValidateRemovalCandidateWeightSet(weights RemovalCandidateWeights) error {
 
 func isFiniteWeight(value float64) bool {
 	return !math.IsNaN(value) && !math.IsInf(value, 0)
-}
-
-func hasPositiveWeight(values ...float64) bool {
-	for _, value := range values {
-		if value > 0 {
-			return true
-		}
-	}
-	return false
 }
 
 func RemovalCandidateScore(dep DependencyReport) (float64, bool) {

--- a/internal/report/scoring.go
+++ b/internal/report/scoring.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"fmt"
 	"math"
 	"slices"
 )
@@ -10,6 +11,12 @@ var defaultRemovalCandidateWeights = RemovalCandidateWeights{
 	Impact:     0.30,
 	Confidence: 0.20,
 }
+
+const (
+	RemovalCandidateWeightUsageField      = "removal_candidate_weight_usage"
+	RemovalCandidateWeightImpactField     = "removal_candidate_weight_impact"
+	RemovalCandidateWeightConfidenceField = "removal_candidate_weight_confidence"
+)
 
 func AnnotateRemovalCandidateScores(dependencies []DependencyReport) {
 	AnnotateRemovalCandidateScoresWithWeights(dependencies, DefaultRemovalCandidateWeights())
@@ -38,10 +45,7 @@ func DefaultRemovalCandidateWeights() RemovalCandidateWeights {
 }
 
 func NormalizeRemovalCandidateWeights(weights RemovalCandidateWeights) RemovalCandidateWeights {
-	if !isFiniteWeight(weights.Usage) || !isFiniteWeight(weights.Impact) || !isFiniteWeight(weights.Confidence) {
-		return defaultRemovalCandidateWeights
-	}
-	if weights.Usage < 0 || weights.Impact < 0 || weights.Confidence < 0 {
+	if err := ValidateRemovalCandidateWeightSet(weights); err != nil {
 		return defaultRemovalCandidateWeights
 	}
 	total := weights.Usage + weights.Impact + weights.Confidence
@@ -58,8 +62,47 @@ func NormalizeRemovalCandidateWeights(weights RemovalCandidateWeights) RemovalCa
 	}
 }
 
+func ValidateRemovalCandidateWeight(name string, value float64) error {
+	if !isFiniteWeight(value) {
+		return fmt.Errorf("invalid threshold %s: %v (must be finite)", name, value)
+	}
+	if value < 0 {
+		return fmt.Errorf("invalid threshold %s: %v (must be >= 0)", name, value)
+	}
+	return nil
+}
+
+func ValidateRemovalCandidateWeightSet(weights RemovalCandidateWeights) error {
+	checks := []struct {
+		name  string
+		value float64
+	}{
+		{name: RemovalCandidateWeightUsageField, value: weights.Usage},
+		{name: RemovalCandidateWeightImpactField, value: weights.Impact},
+		{name: RemovalCandidateWeightConfidenceField, value: weights.Confidence},
+	}
+	for _, check := range checks {
+		if err := ValidateRemovalCandidateWeight(check.name, check.value); err != nil {
+			return err
+		}
+	}
+	if !hasPositiveWeight(weights.Usage, weights.Impact, weights.Confidence) {
+		return fmt.Errorf("invalid removal candidate weights: at least one weight must be greater than 0")
+	}
+	return nil
+}
+
 func isFiniteWeight(value float64) bool {
 	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}
+
+func hasPositiveWeight(values ...float64) bool {
+	for _, value := range values {
+		if value > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func RemovalCandidateScore(dep DependencyReport) (float64, bool) {

--- a/internal/thresholds/thresholds.go
+++ b/internal/thresholds/thresholds.go
@@ -216,8 +216,17 @@ func validateOptionalWeights(overrides *Overrides) error {
 		overrides.RemovalCandidateWeightConfidence == nil {
 		return nil
 	}
-	values := overrides.Apply(Defaults())
-	return report.ValidateRemovalCandidateWeightSet(RemovalCandidateWeights(values))
+	weights := report.DefaultRemovalCandidateWeights()
+	if overrides.RemovalCandidateWeightUsage != nil {
+		weights.Usage = *overrides.RemovalCandidateWeightUsage
+	}
+	if overrides.RemovalCandidateWeightImpact != nil {
+		weights.Impact = *overrides.RemovalCandidateWeightImpact
+	}
+	if overrides.RemovalCandidateWeightConfidence != nil {
+		weights.Confidence = *overrides.RemovalCandidateWeightConfidence
+	}
+	return report.ValidateRemovalCandidateWeightSet(weights)
 }
 
 func normalizeDenyList(values []string) []string {

--- a/internal/thresholds/thresholds.go
+++ b/internal/thresholds/thresholds.go
@@ -56,7 +56,7 @@ type Overrides struct {
 	LicenseIncludeRegistryProvenance  *bool
 }
 
-func (v Values) RemovalCandidateWeights() report.RemovalCandidateWeights {
+func (v *Values) RemovalCandidateWeights() report.RemovalCandidateWeights {
 	return report.RemovalCandidateWeights{
 		Usage:      v.RemovalCandidateWeightUsage,
 		Impact:     v.RemovalCandidateWeightImpact,

--- a/internal/thresholds/thresholds.go
+++ b/internal/thresholds/thresholds.go
@@ -56,7 +56,7 @@ type Overrides struct {
 	LicenseIncludeRegistryProvenance  *bool
 }
 
-func (v *Values) RemovalCandidateWeights() report.RemovalCandidateWeights {
+func RemovalCandidateWeights(v Values) report.RemovalCandidateWeights {
 	return report.RemovalCandidateWeights{
 		Usage:      v.RemovalCandidateWeightUsage,
 		Impact:     v.RemovalCandidateWeightImpact,
@@ -93,7 +93,7 @@ func (v *Values) Validate() error {
 	if err := validateThresholdWithDisableSentinel("max_uncertain_import_count", v.MaxUncertainImportCount); err != nil {
 		return err
 	}
-	if err := report.ValidateRemovalCandidateWeightSet(v.RemovalCandidateWeights()); err != nil {
+	if err := report.ValidateRemovalCandidateWeightSet(RemovalCandidateWeights(*v)); err != nil {
 		return err
 	}
 	if err := validateLockfileDriftPolicy(v.LockfileDriftPolicy); err != nil {
@@ -217,7 +217,7 @@ func validateOptionalWeights(overrides *Overrides) error {
 		return nil
 	}
 	values := overrides.Apply(Defaults())
-	return report.ValidateRemovalCandidateWeightSet(values.RemovalCandidateWeights())
+	return report.ValidateRemovalCandidateWeightSet(RemovalCandidateWeights(values))
 }
 
 func normalizeDenyList(values []string) []string {

--- a/internal/thresholds/thresholds.go
+++ b/internal/thresholds/thresholds.go
@@ -2,9 +2,10 @@ package thresholds
 
 import (
 	"fmt"
-	"math"
 	"sort"
 	"strings"
+
+	"github.com/ben-ranford/lopper/internal/report"
 )
 
 const (
@@ -14,9 +15,6 @@ const (
 	DefaultMinUsagePercentForRecommendations = 40
 	// -1 disables threshold enforcement; 0 is strict zero-tolerance.
 	DefaultMaxUncertainImportCount          = -1
-	DefaultRemovalCandidateWeightUsage      = 0.50
-	DefaultRemovalCandidateWeightImpact     = 0.30
-	DefaultRemovalCandidateWeightConfidence = 0.20
 	DefaultLockfileDriftPolicy              = "warn"
 	DefaultLicenseFailOnDeny                = false
 	DefaultLicenseIncludeRegistryProvenance = false
@@ -58,15 +56,24 @@ type Overrides struct {
 	LicenseIncludeRegistryProvenance  *bool
 }
 
+func (v Values) RemovalCandidateWeights() report.RemovalCandidateWeights {
+	return report.RemovalCandidateWeights{
+		Usage:      v.RemovalCandidateWeightUsage,
+		Impact:     v.RemovalCandidateWeightImpact,
+		Confidence: v.RemovalCandidateWeightConfidence,
+	}
+}
+
 func Defaults() Values {
+	defaultWeights := report.DefaultRemovalCandidateWeights()
 	return Values{
 		FailOnIncreasePercent:             DefaultFailOnIncreasePercent,
 		LowConfidenceWarningPercent:       DefaultLowConfidenceWarningPercent,
 		MinUsagePercentForRecommendations: DefaultMinUsagePercentForRecommendations,
 		MaxUncertainImportCount:           DefaultMaxUncertainImportCount,
-		RemovalCandidateWeightUsage:       DefaultRemovalCandidateWeightUsage,
-		RemovalCandidateWeightImpact:      DefaultRemovalCandidateWeightImpact,
-		RemovalCandidateWeightConfidence:  DefaultRemovalCandidateWeightConfidence,
+		RemovalCandidateWeightUsage:       defaultWeights.Usage,
+		RemovalCandidateWeightImpact:      defaultWeights.Impact,
+		RemovalCandidateWeightConfidence:  defaultWeights.Confidence,
 		LockfileDriftPolicy:               DefaultLockfileDriftPolicy,
 		LicenseFailOnDeny:                 DefaultLicenseFailOnDeny,
 		LicenseIncludeRegistryProvenance:  DefaultLicenseIncludeRegistryProvenance,
@@ -86,17 +93,8 @@ func (v *Values) Validate() error {
 	if err := validateThresholdWithDisableSentinel("max_uncertain_import_count", v.MaxUncertainImportCount); err != nil {
 		return err
 	}
-	if err := validateWeight("removal_candidate_weight_usage", v.RemovalCandidateWeightUsage); err != nil {
+	if err := report.ValidateRemovalCandidateWeightSet(v.RemovalCandidateWeights()); err != nil {
 		return err
-	}
-	if err := validateWeight("removal_candidate_weight_impact", v.RemovalCandidateWeightImpact); err != nil {
-		return err
-	}
-	if err := validateWeight("removal_candidate_weight_confidence", v.RemovalCandidateWeightConfidence); err != nil {
-		return err
-	}
-	if !hasPositiveWeight(v.RemovalCandidateWeightUsage, v.RemovalCandidateWeightImpact, v.RemovalCandidateWeightConfidence) {
-		return fmt.Errorf("invalid removal candidate weights: at least one weight must be greater than 0")
 	}
 	if err := validateLockfileDriftPolicy(v.LockfileDriftPolicy); err != nil {
 		return err
@@ -198,37 +196,11 @@ func validatePercentageRange(name string, value int) error {
 	return nil
 }
 
-func validateWeight(name string, value float64) error {
-	if math.IsNaN(value) || math.IsInf(value, 0) {
-		return fmt.Errorf("invalid threshold %s: %v (must be finite)", name, value)
-	}
-	if value < 0 {
-		return fmt.Errorf("invalid threshold %s: %v (must be >= 0)", name, value)
-	}
-	return nil
-}
-
-func hasPositiveWeight(values ...float64) bool {
-	for _, value := range values {
-		if value > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 func validateOptionalInt(value *int, validate func(int) error) error {
 	if value == nil {
 		return nil
 	}
 	return validate(*value)
-}
-
-func validateOptionalWeight(name string, value *float64) error {
-	if value == nil {
-		return nil
-	}
-	return validateWeight(name, *value)
 }
 
 func validateOptionalString(value *string, validate func(string) error) error {
@@ -239,31 +211,13 @@ func validateOptionalString(value *string, validate func(string) error) error {
 }
 
 func validateOptionalWeights(overrides *Overrides) error {
-	weightChecks := []struct {
-		name  string
-		value *float64
-	}{
-		{name: "removal_candidate_weight_usage", value: overrides.RemovalCandidateWeightUsage},
-		{name: "removal_candidate_weight_impact", value: overrides.RemovalCandidateWeightImpact},
-		{name: "removal_candidate_weight_confidence", value: overrides.RemovalCandidateWeightConfidence},
-	}
-	anySet := false
-	for _, check := range weightChecks {
-		if check.value != nil {
-			anySet = true
-		}
-		if err := validateOptionalWeight(check.name, check.value); err != nil {
-			return err
-		}
-	}
-	if !anySet {
+	if overrides.RemovalCandidateWeightUsage == nil &&
+		overrides.RemovalCandidateWeightImpact == nil &&
+		overrides.RemovalCandidateWeightConfidence == nil {
 		return nil
 	}
 	values := overrides.Apply(Defaults())
-	if !hasPositiveWeight(values.RemovalCandidateWeightUsage, values.RemovalCandidateWeightImpact, values.RemovalCandidateWeightConfidence) {
-		return fmt.Errorf("invalid removal candidate weights: at least one weight must be greater than 0")
-	}
-	return nil
+	return report.ValidateRemovalCandidateWeightSet(values.RemovalCandidateWeights())
 }
 
 func normalizeDenyList(values []string) []string {

--- a/internal/thresholds/thresholds_test.go
+++ b/internal/thresholds/thresholds_test.go
@@ -4,12 +4,70 @@ import (
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
 )
 
 func TestDefaultsValidate(t *testing.T) {
 	values := Defaults()
 	if err := values.Validate(); err != nil {
 		t.Fatalf("validate defaults: %v", err)
+	}
+}
+
+func TestDefaultsRemovalCandidateWeightsMatchReportDefaults(t *testing.T) {
+	defaults := Defaults()
+	if got, want := defaults.RemovalCandidateWeights(), report.DefaultRemovalCandidateWeights(); got != want {
+		t.Fatalf("default removal candidate weights = %#v, want %#v", got, want)
+	}
+}
+
+func TestValuesRemovalCandidateWeightsNormalizeConsistentlyWithReport(t *testing.T) {
+	values := Defaults()
+	values.RemovalCandidateWeightUsage = 2
+	values.RemovalCandidateWeightImpact = 1
+	values.RemovalCandidateWeightConfidence = 1
+
+	if err := values.Validate(); err != nil {
+		t.Fatalf("validate values: %v", err)
+	}
+
+	want := report.RemovalCandidateWeights{Usage: 0.5, Impact: 0.25, Confidence: 0.25}
+	if got := report.NormalizeRemovalCandidateWeights(values.RemovalCandidateWeights()); got != want {
+		t.Fatalf("normalized removal candidate weights = %#v, want %#v", got, want)
+	}
+}
+
+func TestThresholdWeightsRemainConsistentWithReportScoring(t *testing.T) {
+	values := Defaults()
+	values.RemovalCandidateWeightUsage = 2
+	values.RemovalCandidateWeightImpact = 1
+	values.RemovalCandidateWeightConfidence = 1
+
+	if err := values.Validate(); err != nil {
+		t.Fatalf("validate values: %v", err)
+	}
+
+	baseDeps := []report.DependencyReport{
+		{Name: "alpha", UsedExportsCount: 1, TotalExportsCount: 10, UsedPercent: 10},
+		{Name: "beta", UsedExportsCount: 8, TotalExportsCount: 10, UsedPercent: 80},
+	}
+	depsFromThresholdWeights := append([]report.DependencyReport(nil), baseDeps...)
+	depsFromNormalizedWeights := append([]report.DependencyReport(nil), baseDeps...)
+
+	report.AnnotateRemovalCandidateScoresWithWeights(depsFromThresholdWeights, values.RemovalCandidateWeights())
+	normalizedWeights := report.NormalizeRemovalCandidateWeights(values.RemovalCandidateWeights())
+	report.AnnotateRemovalCandidateScoresWithWeights(depsFromNormalizedWeights, normalizedWeights)
+
+	for i := range depsFromThresholdWeights {
+		got := depsFromThresholdWeights[i].RemovalCandidate
+		want := depsFromNormalizedWeights[i].RemovalCandidate
+		if got == nil || want == nil {
+			t.Fatalf("expected removal candidate scores for dependency index %d", i)
+		}
+		if got.Score != want.Score || got.Usage != want.Usage || got.Impact != want.Impact || got.Confidence != want.Confidence || got.Weights != want.Weights {
+			t.Fatalf("inconsistent scoring at dependency index %d: from thresholds=%#v normalized=%#v", i, got, want)
+		}
 	}
 }
 

--- a/internal/thresholds/thresholds_test.go
+++ b/internal/thresholds/thresholds_test.go
@@ -17,7 +17,7 @@ func TestDefaultsValidate(t *testing.T) {
 
 func TestDefaultsRemovalCandidateWeightsMatchReportDefaults(t *testing.T) {
 	defaults := Defaults()
-	if got, want := defaults.RemovalCandidateWeights(), report.DefaultRemovalCandidateWeights(); got != want {
+	if got, want := RemovalCandidateWeights(defaults), report.DefaultRemovalCandidateWeights(); got != want {
 		t.Fatalf("default removal candidate weights = %#v, want %#v", got, want)
 	}
 }
@@ -33,7 +33,7 @@ func TestValuesRemovalCandidateWeightsNormalizeConsistentlyWithReport(t *testing
 	}
 
 	want := report.RemovalCandidateWeights{Usage: 0.5, Impact: 0.25, Confidence: 0.25}
-	if got := report.NormalizeRemovalCandidateWeights(values.RemovalCandidateWeights()); got != want {
+	if got := report.NormalizeRemovalCandidateWeights(RemovalCandidateWeights(values)); got != want {
 		t.Fatalf("normalized removal candidate weights = %#v, want %#v", got, want)
 	}
 }
@@ -55,8 +55,8 @@ func TestThresholdWeightsRemainConsistentWithReportScoring(t *testing.T) {
 	depsFromThresholdWeights := append([]report.DependencyReport(nil), baseDeps...)
 	depsFromNormalizedWeights := append([]report.DependencyReport(nil), baseDeps...)
 
-	report.AnnotateRemovalCandidateScoresWithWeights(depsFromThresholdWeights, values.RemovalCandidateWeights())
-	normalizedWeights := report.NormalizeRemovalCandidateWeights(values.RemovalCandidateWeights())
+	report.AnnotateRemovalCandidateScoresWithWeights(depsFromThresholdWeights, RemovalCandidateWeights(values))
+	normalizedWeights := report.NormalizeRemovalCandidateWeights(RemovalCandidateWeights(values))
 	report.AnnotateRemovalCandidateScoresWithWeights(depsFromNormalizedWeights, normalizedWeights)
 
 	for i := range depsFromThresholdWeights {


### PR DESCRIPTION
## Summary

Consolidates duplicated removal-candidate weight defaults/validation between `internal/thresholds` and `internal/report` so both modules use the same behavior while preserving existing CLI/config/report defaults and scoring output.

Closes #896.

## Changes

- Added shared removal-candidate weight validation helpers in `internal/report/scoring.go` and reused them in normalization logic.
- Updated `internal/thresholds/thresholds.go` to:
  - derive default removal-candidate weights from `report.DefaultRemovalCandidateWeights()`.
  - validate configured/override weights via `report.ValidateRemovalCandidateWeightSet(...)`.
  - expose `thresholds.RemovalCandidateWeights(values)` as the conversion seam to `report.RemovalCandidateWeights`.
- Updated `internal/app/analyse_prepare.go` to use the package-level conversion seam.
- Added/updated tests for:
  - default weight parity between thresholds and report.
  - normalized custom weights.
  - invalid zero-weight fallback path in shared resolver.
  - scoring consistency when weights originate from thresholds callers.

## Validation

Commands and checks run:

```bash
go test ./internal/report ./internal/thresholds ./internal/app
make ci
```

Additional manual validation:

- Verified diff scope is limited to requested removal-candidate weight seam/validation paths.
- Verified no new suppression markers were introduced.

## Risk and compatibility

- Breaking changes: None expected.
- Migration required: None.
- Performance impact: Avoids allocating a temporary validation slice.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review