### PR TITLE
perf(app): cache lockfile manifest reads

### DIFF
--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -789,14 +789,7 @@ func pyprojectSectionNeedle(section string) string {
 }
 
 func manifestMatcherNeedle(rule lockfileRule) string {
-	if rule.manifestMatcherNeedle != "" {
-		return rule.manifestMatcherNeedle
-	}
-	section := strings.TrimSpace(rule.manifestMatcherLabel)
-	if section == "" {
-		return ""
-	}
-	return pyprojectSectionNeedle(section)
+	return strings.TrimSpace(rule.manifestMatcherNeedle)
 }
 
 func pyprojectSectionNeedleMatchesContent(needle string, content []byte) bool {

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -304,16 +304,16 @@ func newLockfileManifestCache(snapshot lockfileDirSnapshot) *lockfileManifestCac
 	}
 }
 
-func (cache *lockfileManifestCache) readManifest(manifestName string) ([]byte, error) {
-	if cache == nil {
+func (c *lockfileManifestCache) readManifest(manifestName string) ([]byte, error) {
+	if c == nil {
 		return nil, errors.New("nil lockfile manifest cache")
 	}
-	cached, ok := cache.reads[manifestName]
+	cached, ok := c.reads[manifestName]
 	if ok {
 		return cached.content, cached.err
 	}
-	content, err := readFileUnderFn(cache.snapshot.repoPath, filepath.Join(cache.snapshot.path, manifestName))
-	cache.reads[manifestName] = cachedManifestRead{
+	content, err := readFileUnderFn(c.snapshot.repoPath, filepath.Join(c.snapshot.path, manifestName))
+	c.reads[manifestName] = cachedManifestRead{
 		content: content,
 		err:     err,
 	}
@@ -462,10 +462,6 @@ func evaluateMissingOrStaleLockfile(snapshot lockfileDirSnapshot, rule lockfileR
 	return evaluateMissingOrStaleLockfileWithManifestAndCache(snapshot, rule, hasManifest, manifestName, lockfiles, nil)
 }
 
-func evaluateMissingOrStaleLockfileWithManifest(snapshot lockfileDirSnapshot, rule lockfileRule, hasManifest bool, manifestName string, lockfiles []presentLockfile) (lockfileDriftFinding, bool, error) {
-	return evaluateMissingOrStaleLockfileWithManifestAndCache(snapshot, rule, hasManifest, manifestName, lockfiles, nil)
-}
-
 func evaluateMissingOrStaleLockfileWithManifestAndCache(snapshot lockfileDirSnapshot, rule lockfileRule, hasManifest bool, manifestName string, lockfiles []presentLockfile, cache *lockfileManifestCache) (lockfileDriftFinding, bool, error) {
 	switch {
 	case hasManifest && len(lockfiles) == 0:
@@ -487,15 +483,6 @@ func evaluateMissingOrStaleLockfileWithManifestAndCache(snapshot lockfileDirSnap
 	default:
 		return lockfileDriftFinding{}, false, nil
 	}
-}
-
-func manifestMatchesRule(snapshot lockfileDirSnapshot, rule lockfileRule) (bool, error) {
-	manifestName := rule.manifest
-	manifestNames := findRuleManifests(snapshot.files, rule)
-	if len(manifestNames) > 0 {
-		manifestName = manifestNames[0]
-	}
-	return manifestMatchesRuleWithCache(snapshot, rule, manifestName, nil)
 }
 
 func manifestMatchesRuleWithCache(snapshot lockfileDirSnapshot, rule lockfileRule, manifestName string, cache *lockfileManifestCache) (bool, error) {

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -30,17 +30,19 @@ var resolveGitBinaryPathFn = gitexec.ResolveBinaryPath
 var normalizeRepoPathFn = workspace.NormalizeRepoPath
 var collectLockfileGitContextFn = collectLockfileGitContext
 var execGitCommandContextFn = gitexec.CommandContext
+var readFileUnderFn = safeio.ReadFileUnder
 
 type lockfileRule struct {
-	manager            string
-	manifest           string
-	manifestNames      []string
-	manifestExts       []string
-	manifestLabel      string
-	lockfiles          []string
-	remedy             string
-	previewFeatureFlag string
-	manifestMatcher    func(repoPath, dir string) (bool, error)
+	manager              string
+	manifest             string
+	manifestNames        []string
+	manifestExts         []string
+	manifestLabel        string
+	lockfiles            []string
+	remedy               string
+	previewFeatureFlag   string
+	manifestMatcherLabel string
+	manifestMatcher      func(repoPath, dir string) (bool, error)
 }
 
 type lockfileGitContext struct {
@@ -53,6 +55,16 @@ type lockfileDirSnapshot struct {
 	path     string
 	relDir   string
 	files    map[string]fs.FileInfo
+}
+
+type cachedManifestRead struct {
+	content []byte
+	err     error
+}
+
+type lockfileManifestCache struct {
+	snapshot lockfileDirSnapshot
+	reads    map[string]cachedManifestRead
 }
 
 type lockfileDriftKind uint8
@@ -78,8 +90,24 @@ var lockfileRules = []lockfileRule{
 	{manager: "Cargo", manifest: "Cargo.toml", lockfiles: []string{"Cargo.lock"}, remedy: "run cargo generate-lockfile (or cargo build) and commit the updated files"},
 	{manager: "Go modules", manifest: "go.mod", lockfiles: []string{"go.sum"}, remedy: "run go mod tidy and commit the updated files"},
 	{manager: "Pipenv", manifest: "Pipfile", lockfiles: []string{"Pipfile.lock"}, remedy: "run pipenv lock and commit the updated files"},
-	{manager: "Poetry", manifest: pyprojectManifestName, manifestLabel: "Poetry configuration in pyproject.toml", lockfiles: []string{"poetry.lock"}, remedy: "run poetry lock and commit the updated files", manifestMatcher: pyprojectSectionMatcher("tool.poetry")},
-	{manager: "uv", manifest: pyprojectManifestName, manifestLabel: "uv configuration in pyproject.toml", lockfiles: []string{"uv.lock"}, remedy: "run uv lock and commit the updated files", manifestMatcher: pyprojectSectionMatcher("tool.uv")},
+	{
+		manager:              "Poetry",
+		manifest:             pyprojectManifestName,
+		manifestLabel:        "Poetry configuration in pyproject.toml",
+		lockfiles:            []string{"poetry.lock"},
+		remedy:               "run poetry lock and commit the updated files",
+		manifestMatcherLabel: "tool.poetry",
+		manifestMatcher:      pyprojectSectionMatcher("tool.poetry"),
+	},
+	{
+		manager:              "uv",
+		manifest:             pyprojectManifestName,
+		manifestLabel:        "uv configuration in pyproject.toml",
+		lockfiles:            []string{"uv.lock"},
+		remedy:               "run uv lock and commit the updated files",
+		manifestMatcherLabel: "tool.uv",
+		manifestMatcher:      pyprojectSectionMatcher("tool.uv"),
+	},
 	{
 		manager:            ".NET",
 		manifest:           "Directory.Packages.props",
@@ -269,6 +297,48 @@ func readLockfileDirSnapshot(repoPath, dir string) (lockfileDirSnapshot, error) 
 	}, nil
 }
 
+func newLockfileManifestCache(snapshot lockfileDirSnapshot) *lockfileManifestCache {
+	return &lockfileManifestCache{
+		snapshot: snapshot,
+		reads:    make(map[string]cachedManifestRead),
+	}
+}
+
+func (cache *lockfileManifestCache) readManifest(manifestName string) ([]byte, error) {
+	if cache == nil {
+		return nil, errors.New("nil lockfile manifest cache")
+	}
+	cached, ok := cache.reads[manifestName]
+	if ok {
+		return cached.content, cached.err
+	}
+	content, err := readFileUnderFn(cache.snapshot.repoPath, filepath.Join(cache.snapshot.path, manifestName))
+	cache.reads[manifestName] = cachedManifestRead{
+		content: content,
+		err:     err,
+	}
+	return content, err
+}
+
+func readManifestForLockfileDrift(snapshot lockfileDirSnapshot, manifestName, matcherLabel string, cache *lockfileManifestCache) ([]byte, error) {
+	var (
+		content []byte
+		err     error
+	)
+	if cache != nil {
+		content, err = cache.readManifest(manifestName)
+	} else {
+		content, err = readFileUnderFn(snapshot.repoPath, filepath.Join(snapshot.path, manifestName))
+	}
+	if err != nil {
+		if strings.TrimSpace(matcherLabel) != "" {
+			return nil, fmt.Errorf("read %s for %s lockfile drift detection: %w", manifestName, matcherLabel, err)
+		}
+		return nil, fmt.Errorf("read %s for lockfile drift detection: %w", manifestName, err)
+	}
+	return content, nil
+}
+
 func shouldSkipMissingLockfile(snapshot lockfileDirSnapshot, rule lockfileRule) (bool, error) {
 	manifestNames := findRuleManifests(snapshot.files, rule)
 	manifestName := rule.manifest
@@ -279,11 +349,21 @@ func shouldSkipMissingLockfile(snapshot lockfileDirSnapshot, rule lockfileRule) 
 }
 
 func shouldSkipMissingLockfileForManifest(snapshot lockfileDirSnapshot, rule lockfileRule, manifestName string) (bool, error) {
-	content, err := safeio.ReadFileUnder(snapshot.repoPath, filepath.Join(snapshot.path, manifestName))
+	return shouldSkipMissingLockfileForManifestWithCache(snapshot, rule, manifestName, nil)
+}
+
+func shouldSkipMissingLockfileForManifestWithCache(snapshot lockfileDirSnapshot, rule lockfileRule, manifestName string, cache *lockfileManifestCache) (bool, error) {
+	content, err := readManifestForLockfileDrift(snapshot, manifestName, "", cache)
 	if err != nil {
-		return false, fmt.Errorf("read %s for lockfile drift detection: %w", manifestName, err)
+		return false, err
 	}
-	if rule.manifestMatcher != nil {
+	section := strings.TrimSpace(rule.manifestMatcherLabel)
+	switch {
+	case section != "":
+		if !pyprojectSectionMatchesContent(section, content) {
+			return true, nil
+		}
+	case rule.manifestMatcher != nil:
 		matched, matchErr := rule.manifestMatcher(snapshot.repoPath, snapshot.path)
 		if matchErr != nil {
 			return false, matchErr
@@ -317,8 +397,9 @@ func evaluateLockfileDir(snapshot lockfileDirSnapshot, gitContext lockfileGitCon
 
 func evaluateLockfileDirWithRules(snapshot lockfileDirSnapshot, gitContext lockfileGitContext, rules []lockfileRule) ([]lockfileDriftFinding, error) {
 	findings := make([]lockfileDriftFinding, 0, len(rules))
+	manifestCache := newLockfileManifestCache(snapshot)
 	for _, rule := range rules {
-		finding, ok, err := evaluateLockfileRule(snapshot, rule, gitContext)
+		finding, ok, err := evaluateLockfileRuleWithCache(snapshot, rule, gitContext, manifestCache)
 		if err != nil {
 			return nil, err
 		}
@@ -331,6 +412,10 @@ func evaluateLockfileDirWithRules(snapshot lockfileDirSnapshot, gitContext lockf
 }
 
 func evaluateLockfileRule(snapshot lockfileDirSnapshot, rule lockfileRule, gitContext lockfileGitContext) (lockfileDriftFinding, bool, error) {
+	return evaluateLockfileRuleWithCache(snapshot, rule, gitContext, nil)
+}
+
+func evaluateLockfileRuleWithCache(snapshot lockfileDirSnapshot, rule lockfileRule, gitContext lockfileGitContext, cache *lockfileManifestCache) (lockfileDriftFinding, bool, error) {
 	manifests := findRuleManifests(snapshot.files, rule)
 	hasManifest := len(manifests) > 0
 	manifestName := rule.manifest
@@ -343,7 +428,7 @@ func evaluateLockfileRule(snapshot lockfileDirSnapshot, rule lockfileRule, gitCo
 		return lockfileDriftFinding{}, false, err
 	}
 
-	finding, handled, err := evaluateMissingOrStaleLockfileWithManifest(snapshot, rule, hasManifest, manifestName, lockfiles)
+	finding, handled, err := evaluateMissingOrStaleLockfileWithManifestAndCache(snapshot, rule, hasManifest, manifestName, lockfiles, cache)
 	if handled || err != nil {
 		return finding, handled, err
 	}
@@ -351,7 +436,7 @@ func evaluateLockfileRule(snapshot lockfileDirSnapshot, rule lockfileRule, gitCo
 		return lockfileDriftFinding{}, false, nil
 	}
 
-	matchesManifest, err := manifestMatchesRule(snapshot, rule)
+	matchesManifest, err := manifestMatchesRuleWithCache(snapshot, rule, manifestName, cache)
 	if err != nil {
 		return lockfileDriftFinding{}, false, err
 	}
@@ -374,13 +459,17 @@ func evaluateMissingOrStaleLockfile(snapshot lockfileDirSnapshot, rule lockfileR
 	if hasManifest && len(manifestNames) > 0 {
 		manifestName = manifestNames[0]
 	}
-	return evaluateMissingOrStaleLockfileWithManifest(snapshot, rule, hasManifest, manifestName, lockfiles)
+	return evaluateMissingOrStaleLockfileWithManifestAndCache(snapshot, rule, hasManifest, manifestName, lockfiles, nil)
 }
 
 func evaluateMissingOrStaleLockfileWithManifest(snapshot lockfileDirSnapshot, rule lockfileRule, hasManifest bool, manifestName string, lockfiles []presentLockfile) (lockfileDriftFinding, bool, error) {
+	return evaluateMissingOrStaleLockfileWithManifestAndCache(snapshot, rule, hasManifest, manifestName, lockfiles, nil)
+}
+
+func evaluateMissingOrStaleLockfileWithManifestAndCache(snapshot lockfileDirSnapshot, rule lockfileRule, hasManifest bool, manifestName string, lockfiles []presentLockfile, cache *lockfileManifestCache) (lockfileDriftFinding, bool, error) {
 	switch {
 	case hasManifest && len(lockfiles) == 0:
-		skip, err := shouldSkipMissingLockfileForManifest(snapshot, rule, manifestName)
+		skip, err := shouldSkipMissingLockfileForManifestWithCache(snapshot, rule, manifestName, cache)
 		if err != nil {
 			return lockfileDriftFinding{}, false, err
 		}
@@ -401,6 +490,23 @@ func evaluateMissingOrStaleLockfileWithManifest(snapshot lockfileDirSnapshot, ru
 }
 
 func manifestMatchesRule(snapshot lockfileDirSnapshot, rule lockfileRule) (bool, error) {
+	manifestName := rule.manifest
+	manifestNames := findRuleManifests(snapshot.files, rule)
+	if len(manifestNames) > 0 {
+		manifestName = manifestNames[0]
+	}
+	return manifestMatchesRuleWithCache(snapshot, rule, manifestName, nil)
+}
+
+func manifestMatchesRuleWithCache(snapshot lockfileDirSnapshot, rule lockfileRule, manifestName string, cache *lockfileManifestCache) (bool, error) {
+	section := strings.TrimSpace(rule.manifestMatcherLabel)
+	if section != "" {
+		content, err := readManifestForLockfileDrift(snapshot, manifestName, section, cache)
+		if err != nil {
+			return false, err
+		}
+		return pyprojectSectionMatchesContent(section, content), nil
+	}
 	if rule.manifestMatcher == nil {
 		return true, nil
 	}
@@ -671,14 +777,18 @@ func manifestDescription(rule lockfileRule) string {
 }
 
 func pyprojectSectionMatcher(section string) func(repoPath, dir string) (bool, error) {
-	needle := "[" + strings.ToLower(strings.TrimSpace(section)) + "]"
 	return func(repoPath, dir string) (bool, error) {
-		content, err := safeio.ReadFileUnder(repoPath, filepath.Join(dir, pyprojectManifestName))
+		content, err := readFileUnderFn(repoPath, filepath.Join(dir, pyprojectManifestName))
 		if err != nil {
 			return false, fmt.Errorf("read %s for %s lockfile drift detection: %w", pyprojectManifestName, section, err)
 		}
-		return strings.Contains(strings.ToLower(string(content)), needle), nil
+		return pyprojectSectionMatchesContent(section, content), nil
 	}
+}
+
+func pyprojectSectionMatchesContent(section string, content []byte) bool {
+	needle := "[" + strings.ToLower(strings.TrimSpace(section)) + "]"
+	return strings.Contains(strings.ToLower(string(content)), needle)
 }
 
 func relativeDir(repoPath, dir string) string {

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -24,6 +24,8 @@ const (
 	lockfileDriftEcosystemExpansionPreviewFlagName = "lockfile-drift-ecosystem-expansion-preview"
 	dotnetCSharpProjectManifestExt                 = ".csproj"
 	dotnetFSharpProjectManifestExt                 = ".fsproj"
+	pyprojectPoetrySection                         = "tool.poetry"
+	pyprojectUVSection                             = "tool.uv"
 )
 
 var resolveGitBinaryPathFn = gitexec.ResolveBinaryPath
@@ -97,9 +99,9 @@ var lockfileRules = []lockfileRule{
 		manifestLabel:         "Poetry configuration in pyproject.toml",
 		lockfiles:             []string{"poetry.lock"},
 		remedy:                "run poetry lock and commit the updated files",
-		manifestMatcherLabel:  "tool.poetry",
-		manifestMatcherNeedle: pyprojectSectionNeedle("tool.poetry"),
-		manifestMatcher:       pyprojectSectionMatcher("tool.poetry"),
+		manifestMatcherLabel:  pyprojectPoetrySection,
+		manifestMatcherNeedle: pyprojectSectionNeedle(pyprojectPoetrySection),
+		manifestMatcher:       pyprojectSectionMatcher(pyprojectPoetrySection),
 	},
 	{
 		manager:               "uv",
@@ -107,9 +109,9 @@ var lockfileRules = []lockfileRule{
 		manifestLabel:         "uv configuration in pyproject.toml",
 		lockfiles:             []string{"uv.lock"},
 		remedy:                "run uv lock and commit the updated files",
-		manifestMatcherLabel:  "tool.uv",
-		manifestMatcherNeedle: pyprojectSectionNeedle("tool.uv"),
-		manifestMatcher:       pyprojectSectionMatcher("tool.uv"),
+		manifestMatcherLabel:  pyprojectUVSection,
+		manifestMatcherNeedle: pyprojectSectionNeedle(pyprojectUVSection),
+		manifestMatcher:       pyprojectSectionMatcher(pyprojectUVSection),
 	},
 	{
 		manager:            ".NET",

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -33,16 +33,17 @@ var execGitCommandContextFn = gitexec.CommandContext
 var readFileUnderFn = safeio.ReadFileUnder
 
 type lockfileRule struct {
-	manager              string
-	manifest             string
-	manifestNames        []string
-	manifestExts         []string
-	manifestLabel        string
-	lockfiles            []string
-	remedy               string
-	previewFeatureFlag   string
-	manifestMatcherLabel string
-	manifestMatcher      func(repoPath, dir string) (bool, error)
+	manager               string
+	manifest              string
+	manifestNames         []string
+	manifestExts          []string
+	manifestLabel         string
+	lockfiles             []string
+	remedy                string
+	previewFeatureFlag    string
+	manifestMatcherLabel  string
+	manifestMatcherNeedle string
+	manifestMatcher       func(repoPath, dir string) (bool, error)
 }
 
 type lockfileGitContext struct {
@@ -91,22 +92,24 @@ var lockfileRules = []lockfileRule{
 	{manager: "Go modules", manifest: "go.mod", lockfiles: []string{"go.sum"}, remedy: "run go mod tidy and commit the updated files"},
 	{manager: "Pipenv", manifest: "Pipfile", lockfiles: []string{"Pipfile.lock"}, remedy: "run pipenv lock and commit the updated files"},
 	{
-		manager:              "Poetry",
-		manifest:             pyprojectManifestName,
-		manifestLabel:        "Poetry configuration in pyproject.toml",
-		lockfiles:            []string{"poetry.lock"},
-		remedy:               "run poetry lock and commit the updated files",
-		manifestMatcherLabel: "tool.poetry",
-		manifestMatcher:      pyprojectSectionMatcher("tool.poetry"),
+		manager:               "Poetry",
+		manifest:              pyprojectManifestName,
+		manifestLabel:         "Poetry configuration in pyproject.toml",
+		lockfiles:             []string{"poetry.lock"},
+		remedy:                "run poetry lock and commit the updated files",
+		manifestMatcherLabel:  "tool.poetry",
+		manifestMatcherNeedle: pyprojectSectionNeedle("tool.poetry"),
+		manifestMatcher:       pyprojectSectionMatcher("tool.poetry"),
 	},
 	{
-		manager:              "uv",
-		manifest:             pyprojectManifestName,
-		manifestLabel:        "uv configuration in pyproject.toml",
-		lockfiles:            []string{"uv.lock"},
-		remedy:               "run uv lock and commit the updated files",
-		manifestMatcherLabel: "tool.uv",
-		manifestMatcher:      pyprojectSectionMatcher("tool.uv"),
+		manager:               "uv",
+		manifest:              pyprojectManifestName,
+		manifestLabel:         "uv configuration in pyproject.toml",
+		lockfiles:             []string{"uv.lock"},
+		remedy:                "run uv lock and commit the updated files",
+		manifestMatcherLabel:  "tool.uv",
+		manifestMatcherNeedle: pyprojectSectionNeedle("tool.uv"),
+		manifestMatcher:       pyprojectSectionMatcher("tool.uv"),
 	},
 	{
 		manager:            ".NET",
@@ -300,7 +303,6 @@ func readLockfileDirSnapshot(repoPath, dir string) (lockfileDirSnapshot, error) 
 func newLockfileManifestCache(snapshot lockfileDirSnapshot) *lockfileManifestCache {
 	return &lockfileManifestCache{
 		snapshot: snapshot,
-		reads:    make(map[string]cachedManifestRead),
 	}
 }
 
@@ -308,11 +310,16 @@ func (c *lockfileManifestCache) readManifest(manifestName string) ([]byte, error
 	if c == nil {
 		return nil, errors.New("nil lockfile manifest cache")
 	}
-	cached, ok := c.reads[manifestName]
-	if ok {
-		return cached.content, cached.err
+	if c.reads != nil {
+		cached, ok := c.reads[manifestName]
+		if ok {
+			return cached.content, cached.err
+		}
 	}
 	content, err := readFileUnderFn(c.snapshot.repoPath, filepath.Join(c.snapshot.path, manifestName))
+	if c.reads == nil {
+		c.reads = make(map[string]cachedManifestRead)
+	}
 	c.reads[manifestName] = cachedManifestRead{
 		content: content,
 		err:     err,
@@ -357,10 +364,10 @@ func shouldSkipMissingLockfileForManifestWithCache(snapshot lockfileDirSnapshot,
 	if err != nil {
 		return false, err
 	}
-	section := strings.TrimSpace(rule.manifestMatcherLabel)
+	sectionNeedle := manifestMatcherNeedle(rule)
 	switch {
-	case section != "":
-		if !pyprojectSectionMatchesContent(section, content) {
+	case sectionNeedle != "":
+		if !pyprojectSectionNeedleMatchesContent(sectionNeedle, content) {
 			return true, nil
 		}
 	case rule.manifestMatcher != nil:
@@ -487,12 +494,13 @@ func evaluateMissingOrStaleLockfileWithManifestAndCache(snapshot lockfileDirSnap
 
 func manifestMatchesRuleWithCache(snapshot lockfileDirSnapshot, rule lockfileRule, manifestName string, cache *lockfileManifestCache) (bool, error) {
 	section := strings.TrimSpace(rule.manifestMatcherLabel)
-	if section != "" {
+	sectionNeedle := manifestMatcherNeedle(rule)
+	if sectionNeedle != "" {
 		content, err := readManifestForLockfileDrift(snapshot, manifestName, section, cache)
 		if err != nil {
 			return false, err
 		}
-		return pyprojectSectionMatchesContent(section, content), nil
+		return pyprojectSectionNeedleMatchesContent(sectionNeedle, content), nil
 	}
 	if rule.manifestMatcher == nil {
 		return true, nil
@@ -764,17 +772,32 @@ func manifestDescription(rule lockfileRule) string {
 }
 
 func pyprojectSectionMatcher(section string) func(repoPath, dir string) (bool, error) {
+	needle := pyprojectSectionNeedle(section)
 	return func(repoPath, dir string) (bool, error) {
 		content, err := readFileUnderFn(repoPath, filepath.Join(dir, pyprojectManifestName))
 		if err != nil {
 			return false, fmt.Errorf("read %s for %s lockfile drift detection: %w", pyprojectManifestName, section, err)
 		}
-		return pyprojectSectionMatchesContent(section, content), nil
+		return pyprojectSectionNeedleMatchesContent(needle, content), nil
 	}
 }
 
-func pyprojectSectionMatchesContent(section string, content []byte) bool {
-	needle := "[" + strings.ToLower(strings.TrimSpace(section)) + "]"
+func pyprojectSectionNeedle(section string) string {
+	return "[" + strings.ToLower(strings.TrimSpace(section)) + "]"
+}
+
+func manifestMatcherNeedle(rule lockfileRule) string {
+	if rule.manifestMatcherNeedle != "" {
+		return rule.manifestMatcherNeedle
+	}
+	section := strings.TrimSpace(rule.manifestMatcherLabel)
+	if section == "" {
+		return ""
+	}
+	return pyprojectSectionNeedle(section)
+}
+
+func pyprojectSectionNeedleMatchesContent(needle string, content []byte) bool {
 	return strings.Contains(strings.ToLower(string(content)), needle)
 }
 

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/gitexec"
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 const (
@@ -703,6 +704,61 @@ func TestDetectLockfileDriftPythonManagerSignals(t *testing.T) {
 			t.Fatalf("expected uv warning for changed pyproject.toml without uv.lock update, got %#v", warnings)
 		}
 	})
+}
+
+func TestDetectLockfileDriftCachesPyprojectReadsAcrossPythonRules(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[tool.uv]\n")
+
+	originalReadFileUnder := readFileUnderFn
+	t.Cleanup(func() {
+		readFileUnderFn = originalReadFileUnder
+	})
+
+	pyprojectReads := 0
+	readFileUnderFn = func(rootDir, targetPath string) ([]byte, error) {
+		if filepath.Base(targetPath) == pyprojectManifestName {
+			pyprojectReads++
+		}
+		return safeio.ReadFileUnder(rootDir, targetPath)
+	}
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	if err != nil {
+		t.Fatalf(detectLockfileDriftFmt, err)
+	}
+	if len(warnings) != 2 {
+		t.Fatalf("expected one warning each for Poetry and uv, got %#v", warnings)
+	}
+	if pyprojectReads != 1 {
+		t.Fatalf("expected %s to be read once per directory pass, got %d reads", pyprojectManifestName, pyprojectReads)
+	}
+}
+
+func TestDetectLockfileDriftPythonMatcherReadError(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\nversion = \"0.1.0\"\n")
+	writeFile(t, filepath.Join(repo, poetryLockName), "metadata = {}\n")
+
+	originalReadFileUnder := readFileUnderFn
+	t.Cleanup(func() {
+		readFileUnderFn = originalReadFileUnder
+	})
+
+	readFileUnderFn = func(rootDir, targetPath string) ([]byte, error) {
+		if filepath.Base(targetPath) == pyprojectManifestName {
+			return nil, errors.New("forced read error")
+		}
+		return safeio.ReadFileUnder(rootDir, targetPath)
+	}
+
+	_, err := detectLockfileDrift(context.Background(), repo, false)
+	if err == nil {
+		t.Fatalf("expected read error")
+	}
+	if !strings.Contains(err.Error(), "read pyproject.toml for tool.poetry lockfile drift detection") {
+		t.Fatalf("expected matcher read error context, got %v", err)
+	}
 }
 
 func TestLockfileDriftHelpers(t *testing.T) {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -787,6 +787,9 @@ func TestLockfileManifestCacheDirectBranches(t *testing.T) {
 	}
 
 	cache := newLockfileManifestCache(snapshot)
+	if cache.reads != nil {
+		t.Fatalf("expected manifest reads map to be allocated lazily")
+	}
 	if _, err := cache.readManifest(pyprojectManifestName); err != nil {
 		t.Fatalf("read manifest: %v", err)
 	}

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -761,6 +761,87 @@ func TestDetectLockfileDriftPythonMatcherReadError(t *testing.T) {
 	}
 }
 
+func TestLockfileManifestCacheDirectBranches(t *testing.T) {
+	if _, err := (*lockfileManifestCache)(nil).readManifest(pyprojectManifestName); err == nil {
+		t.Fatalf("expected nil cache read to fail")
+	}
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\n")
+	snapshot, err := readLockfileDirSnapshot(repo, repo)
+	if err != nil {
+		t.Fatalf("read lockfile snapshot: %v", err)
+	}
+
+	originalReadFileUnder := readFileUnderFn
+	t.Cleanup(func() {
+		readFileUnderFn = originalReadFileUnder
+	})
+
+	reads := 0
+	readFileUnderFn = func(rootDir, targetPath string) ([]byte, error) {
+		if filepath.Base(targetPath) == pyprojectManifestName {
+			reads++
+		}
+		return safeio.ReadFileUnder(rootDir, targetPath)
+	}
+
+	cache := newLockfileManifestCache(snapshot)
+	if _, err := cache.readManifest(pyprojectManifestName); err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if _, err := cache.readManifest(pyprojectManifestName); err != nil {
+		t.Fatalf("read cached manifest: %v", err)
+	}
+	if reads != 1 {
+		t.Fatalf("expected cached manifest read once, got %d", reads)
+	}
+}
+
+func TestShouldSkipMissingLockfileManifestMatcherBranches(t *testing.T) {
+	repo := t.TempDir()
+	manifestName := "custom.toml"
+	writeFile(t, filepath.Join(repo, manifestName), "name = \"demo\"\n")
+	snapshot, err := readLockfileDirSnapshot(repo, repo)
+	if err != nil {
+		t.Fatalf("read lockfile snapshot: %v", err)
+	}
+
+	matcherErr := errors.New("forced matcher error")
+	rule := lockfileRule{
+		manifest: manifestName,
+		manifestMatcher: func(string, string) (bool, error) {
+			return false, matcherErr
+		},
+	}
+	if _, err := shouldSkipMissingLockfileForManifestWithCache(snapshot, rule, manifestName, newLockfileManifestCache(snapshot)); !errors.Is(err, matcherErr) {
+		t.Fatalf("expected matcher error, got %v", err)
+	}
+
+	rule.manifestMatcher = func(string, string) (bool, error) {
+		return false, nil
+	}
+	skip, err := shouldSkipMissingLockfileForManifestWithCache(snapshot, rule, manifestName, newLockfileManifestCache(snapshot))
+	if err != nil || !skip {
+		t.Fatalf("expected non-matching manifest to skip, skip=%v err=%v", skip, err)
+	}
+
+	rule.manifestMatcher = func(string, string) (bool, error) {
+		return true, nil
+	}
+	skip, err = shouldSkipMissingLockfileForManifestWithCache(snapshot, rule, manifestName, newLockfileManifestCache(snapshot))
+	if err != nil || skip {
+		t.Fatalf("expected matching generic manifest to warn, skip=%v err=%v", skip, err)
+	}
+}
+
+func TestPyprojectSectionMatcherReadError(t *testing.T) {
+	matched, err := pyprojectSectionMatcher("tool.poetry")(t.TempDir(), t.TempDir())
+	if err == nil || matched {
+		t.Fatalf("expected pyproject section matcher read error, matched=%v err=%v", matched, err)
+	}
+}
+
 func TestLockfileDriftHelpers(t *testing.T) {
 	repo := t.TempDir()
 	nestedDir := filepath.Join(repo, "nested")

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -845,6 +845,18 @@ func TestPyprojectSectionMatcherReadError(t *testing.T) {
 	}
 }
 
+func TestManifestMatcherNeedleDoesNotDeriveFromLabel(t *testing.T) {
+	rule := lockfileRule{manifestMatcherLabel: pyprojectPoetrySection}
+	if got := manifestMatcherNeedle(rule); got != "" {
+		t.Fatalf("expected label-only rule to have no matcher needle, got %q", got)
+	}
+
+	rule.manifestMatcherNeedle = pyprojectSectionNeedle(pyprojectPoetrySection)
+	if got, want := manifestMatcherNeedle(rule), pyprojectSectionNeedle(pyprojectPoetrySection); got != want {
+		t.Fatalf("manifestMatcherNeedle() = %q, want %q", got, want)
+	}
+}
+
 func TestLockfileDriftHelpers(t *testing.T) {
 	repo := t.TempDir()
 	nestedDir := filepath.Join(repo, "nested")


### PR DESCRIPTION
## Summary

Lockfile drift rule evaluation was reading `pyproject.toml` multiple times in the same directory pass when Poetry and uv checks both executed. This change adds a per-directory manifest-read cache and routes matcher checks through cached manifest content so each manifest is read at most once per directory snapshot while preserving existing policy behavior and warning wording.

Closes #820.

## Changes

- Added a per-directory `lockfileManifestCache` to lockfile drift evaluation.
- Updated rule evaluation flow to reuse cached manifest reads across rules in `evaluateLockfileDirWithRules`.
- Added section-aware matcher handling for Poetry/uv using cached manifest bytes.
- Kept existing repo-bounded read behavior and read-error propagation.
- Added lockfile drift tests covering single-read behavior for Poetry+uv and matcher read-error propagation.

## Validation

Commands and checks run:

```bash
go test ./internal/app
go test ./...
```

Additional manual validation:

- N/A

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Positive for lockfile drift scans in directories with shared manifests.
- Memory benchmark impact: Negligible; cache is per-directory snapshot and short-lived.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review