### PR TITLE
refactor(analysis): split final report merge by report family

### DIFF
--- a/internal/analysis/merge.go
+++ b/internal/analysis/merge.go
@@ -62,6 +62,7 @@ var dependencyFamilyMergeOrder = []dependencyFamilyMergeFn{
 	mergeDependencyRiskFamily,
 	mergeDependencyCodemodFamily,
 	mergeDependencyRuntimeFamily,
+	mergeDependencyMetadataFamily,
 }
 
 func mergeDependencyExportFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
@@ -95,6 +96,21 @@ func mergeDependencyCodemodFamily(merged *report.DependencyReport, left, right r
 
 func mergeDependencyRuntimeFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
 	merged.RuntimeUsage = mergeRuntimeUsage(left.RuntimeUsage, right.RuntimeUsage)
+}
+
+func mergeDependencyMetadataFamily(merged *report.DependencyReport, _ report.DependencyReport, right report.DependencyReport) {
+	if merged.ReachabilityConfidence == nil {
+		merged.ReachabilityConfidence = right.ReachabilityConfidence
+	}
+	if merged.RemovalCandidate == nil {
+		merged.RemovalCandidate = right.RemovalCandidate
+	}
+	if merged.License == nil {
+		merged.License = right.License
+	}
+	if merged.Provenance == nil {
+		merged.Provenance = right.Provenance
+	}
 }
 
 func filterUsedOverlaps(unused, used []report.ImportUse) []report.ImportUse {

--- a/internal/analysis/merge.go
+++ b/internal/analysis/merge.go
@@ -8,38 +8,6 @@ import (
 	"github.com/ben-ranford/lopper/internal/report"
 )
 
-func mergeReports(repoPath string, reports []report.Report) report.Report {
-	result := report.Report{
-		RepoPath: repoPath,
-	}
-	mergedByKey := make(map[string]report.DependencyReport)
-	orderedKeys := make([]string, 0)
-
-	for _, current := range reports {
-		result.Warnings = append(result.Warnings, current.Warnings...)
-		result.UsageUncertainty = mergeUsageUncertainty(result.UsageUncertainty, current.UsageUncertainty)
-		if current.GeneratedAt.After(result.GeneratedAt) {
-			result.GeneratedAt = current.GeneratedAt
-		}
-		for _, dep := range current.Dependencies {
-			key := dep.Language + "\x00" + dep.Name
-			if existing, ok := mergedByKey[key]; ok {
-				mergedByKey[key] = mergeDependency(existing, dep)
-				continue
-			}
-			mergedByKey[key] = dep
-			orderedKeys = append(orderedKeys, key)
-		}
-	}
-
-	sort.Strings(orderedKeys)
-	result.Dependencies = make([]report.DependencyReport, 0, len(orderedKeys))
-	for _, key := range orderedKeys {
-		result.Dependencies = append(result.Dependencies, mergedByKey[key])
-	}
-	return result
-}
-
 func mergeUsageUncertainty(left, right *report.UsageUncertainty) *report.UsageUncertainty {
 	if left == nil {
 		if right == nil {
@@ -79,24 +47,56 @@ func cappedSampleCopy(samples []report.Location) []report.Location {
 
 func mergeDependency(left, right report.DependencyReport) report.DependencyReport {
 	merged := left
-	merged.UsedExportsCount += right.UsedExportsCount
-	merged.TotalExportsCount += right.TotalExportsCount
+	for _, mergeFamily := range dependencyFamilyMergeOrder() {
+		mergeFamily(&merged, left, right)
+	}
+	return merged
+}
+
+type dependencyFamilyMergeFn func(merged *report.DependencyReport, left, right report.DependencyReport)
+
+func dependencyFamilyMergeOrder() []dependencyFamilyMergeFn {
+	return []dependencyFamilyMergeFn{
+		mergeDependencyExportFamily,
+		mergeDependencyImportFamily,
+		mergeDependencySymbolFamily,
+		mergeDependencyRiskFamily,
+		mergeDependencyCodemodFamily,
+		mergeDependencyRuntimeFamily,
+	}
+}
+
+func mergeDependencyExportFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
+	merged.UsedExportsCount = left.UsedExportsCount + right.UsedExportsCount
+	merged.TotalExportsCount = left.TotalExportsCount + right.TotalExportsCount
 	if merged.TotalExportsCount > 0 {
 		merged.UsedPercent = (float64(merged.UsedExportsCount) / float64(merged.TotalExportsCount)) * 100
 	}
-	merged.EstimatedUnusedBytes += right.EstimatedUnusedBytes
+	merged.EstimatedUnusedBytes = left.EstimatedUnusedBytes + right.EstimatedUnusedBytes
+}
 
+func mergeDependencyImportFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
 	merged.UsedImports = mergeImportUses(left.UsedImports, right.UsedImports)
 	merged.UnusedImports = mergeImportUses(left.UnusedImports, right.UnusedImports)
 	merged.UnusedImports = filterUsedOverlaps(merged.UnusedImports, merged.UsedImports)
+}
+
+func mergeDependencySymbolFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
 	merged.UnusedExports = mergeSymbolRefs(left.UnusedExports, right.UnusedExports)
+	merged.TopUsedSymbols = mergeTopSymbols(left.TopUsedSymbols, right.TopUsedSymbols)
+}
+
+func mergeDependencyRiskFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
 	merged.RiskCues = mergeRiskCues(left.RiskCues, right.RiskCues)
 	merged.Recommendations = mergeRecommendations(left.Recommendations, right.Recommendations)
-	merged.Codemod = mergeCodemodReport(left.Codemod, right.Codemod)
-	merged.TopUsedSymbols = mergeTopSymbols(left.TopUsedSymbols, right.TopUsedSymbols)
-	merged.RuntimeUsage = mergeRuntimeUsage(left.RuntimeUsage, right.RuntimeUsage)
+}
 
-	return merged
+func mergeDependencyCodemodFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
+	merged.Codemod = mergeCodemodReport(left.Codemod, right.Codemod)
+}
+
+func mergeDependencyRuntimeFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
+	merged.RuntimeUsage = mergeRuntimeUsage(left.RuntimeUsage, right.RuntimeUsage)
 }
 
 func filterUsedOverlaps(unused, used []report.ImportUse) []report.ImportUse {

--- a/internal/analysis/merge.go
+++ b/internal/analysis/merge.go
@@ -47,7 +47,7 @@ func cappedSampleCopy(samples []report.Location) []report.Location {
 
 func mergeDependency(left, right report.DependencyReport) report.DependencyReport {
 	merged := left
-	for _, mergeFamily := range dependencyFamilyMergeOrder() {
+	for _, mergeFamily := range dependencyFamilyMergeOrder {
 		mergeFamily(&merged, left, right)
 	}
 	return merged
@@ -55,15 +55,13 @@ func mergeDependency(left, right report.DependencyReport) report.DependencyRepor
 
 type dependencyFamilyMergeFn func(merged *report.DependencyReport, left, right report.DependencyReport)
 
-func dependencyFamilyMergeOrder() []dependencyFamilyMergeFn {
-	return []dependencyFamilyMergeFn{
-		mergeDependencyExportFamily,
-		mergeDependencyImportFamily,
-		mergeDependencySymbolFamily,
-		mergeDependencyRiskFamily,
-		mergeDependencyCodemodFamily,
-		mergeDependencyRuntimeFamily,
-	}
+var dependencyFamilyMergeOrder = []dependencyFamilyMergeFn{
+	mergeDependencyExportFamily,
+	mergeDependencyImportFamily,
+	mergeDependencySymbolFamily,
+	mergeDependencyRiskFamily,
+	mergeDependencyCodemodFamily,
+	mergeDependencyRuntimeFamily,
 }
 
 func mergeDependencyExportFamily(merged *report.DependencyReport, left, right report.DependencyReport) {

--- a/internal/analysis/merge_report_families.go
+++ b/internal/analysis/merge_report_families.go
@@ -100,7 +100,7 @@ func (m *dependencyReportFamilyMerger) finalize(result *report.Report) {
 	for key := range m.mergedByKey {
 		orderedKeys = append(orderedKeys, key)
 	}
-	// Keep mergeReports deterministic for direct callers; finalReport may apply presentation ordering later.
+	// Preserve deterministic order in the merged report itself.
 	sort.Strings(orderedKeys)
 	result.Dependencies = make([]report.DependencyReport, 0, len(orderedKeys))
 	for _, key := range orderedKeys {

--- a/internal/analysis/merge_report_families.go
+++ b/internal/analysis/merge_report_families.go
@@ -45,7 +45,7 @@ func (m *warningsReportFamilyMerger) merge(current report.Report) {
 }
 
 func (m *warningsReportFamilyMerger) finalize(result *report.Report) {
-	result.Warnings = append(result.Warnings, m.warnings...)
+	result.Warnings = append([]string(nil), m.warnings...)
 }
 
 type usageUncertaintyReportFamilyMerger struct {
@@ -100,6 +100,7 @@ func (m *dependencyReportFamilyMerger) finalize(result *report.Report) {
 	for key := range m.mergedByKey {
 		orderedKeys = append(orderedKeys, key)
 	}
+	// Keep mergeReports deterministic for direct callers; finalReport may apply presentation ordering later.
 	sort.Strings(orderedKeys)
 	result.Dependencies = make([]report.DependencyReport, 0, len(orderedKeys))
 	for _, key := range orderedKeys {

--- a/internal/analysis/merge_report_families.go
+++ b/internal/analysis/merge_report_families.go
@@ -1,0 +1,112 @@
+package analysis
+
+import (
+	"sort"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+type reportFamilyMerger interface {
+	merge(current report.Report)
+	finalize(result *report.Report)
+}
+
+func mergeReports(repoPath string, reports []report.Report) report.Report {
+	result := report.Report{
+		RepoPath: repoPath,
+	}
+
+	families := []reportFamilyMerger{
+		&warningsReportFamilyMerger{},
+		&usageUncertaintyReportFamilyMerger{},
+		&generatedAtReportFamilyMerger{},
+		newDependencyReportFamilyMerger(),
+	}
+
+	for _, current := range reports {
+		for _, family := range families {
+			family.merge(current)
+		}
+	}
+
+	for _, family := range families {
+		family.finalize(&result)
+	}
+	return result
+}
+
+type warningsReportFamilyMerger struct {
+	warnings []string
+}
+
+func (m *warningsReportFamilyMerger) merge(current report.Report) {
+	m.warnings = append(m.warnings, current.Warnings...)
+}
+
+func (m *warningsReportFamilyMerger) finalize(result *report.Report) {
+	result.Warnings = append(result.Warnings, m.warnings...)
+}
+
+type usageUncertaintyReportFamilyMerger struct {
+	usageUncertainty *report.UsageUncertainty
+}
+
+func (m *usageUncertaintyReportFamilyMerger) merge(current report.Report) {
+	m.usageUncertainty = mergeUsageUncertainty(m.usageUncertainty, current.UsageUncertainty)
+}
+
+func (m *usageUncertaintyReportFamilyMerger) finalize(result *report.Report) {
+	result.UsageUncertainty = m.usageUncertainty
+}
+
+type generatedAtReportFamilyMerger struct {
+	generatedAt time.Time
+}
+
+func (m *generatedAtReportFamilyMerger) merge(current report.Report) {
+	if current.GeneratedAt.After(m.generatedAt) {
+		m.generatedAt = current.GeneratedAt
+	}
+}
+
+func (m *generatedAtReportFamilyMerger) finalize(result *report.Report) {
+	result.GeneratedAt = m.generatedAt
+}
+
+type dependencyReportFamilyMerger struct {
+	mergedByKey map[string]report.DependencyReport
+}
+
+func newDependencyReportFamilyMerger() *dependencyReportFamilyMerger {
+	return &dependencyReportFamilyMerger{
+		mergedByKey: make(map[string]report.DependencyReport),
+	}
+}
+
+func (m *dependencyReportFamilyMerger) merge(current report.Report) {
+	for _, dep := range current.Dependencies {
+		key := dependencyMergeKey(dep)
+		if existing, ok := m.mergedByKey[key]; ok {
+			m.mergedByKey[key] = mergeDependency(existing, dep)
+			continue
+		}
+		m.mergedByKey[key] = dep
+	}
+}
+
+func (m *dependencyReportFamilyMerger) finalize(result *report.Report) {
+	orderedKeys := make([]string, 0, len(m.mergedByKey))
+	for key := range m.mergedByKey {
+		orderedKeys = append(orderedKeys, key)
+	}
+	sort.Strings(orderedKeys)
+	result.Dependencies = make([]report.DependencyReport, 0, len(orderedKeys))
+	for _, key := range orderedKeys {
+		result.Dependencies = append(result.Dependencies, m.mergedByKey[key])
+	}
+}
+
+func dependencyMergeKey(dep report.DependencyReport) string {
+	return dep.Language + "\x00" + dep.Name
+}

--- a/internal/analysis/merge_report_families_test.go
+++ b/internal/analysis/merge_report_families_test.go
@@ -11,15 +11,27 @@ func TestMergeReportsCoordinatesFamiliesInStableOrder(t *testing.T) {
 	firstGeneratedAt := time.Date(2026, time.January, 10, 10, 0, 0, 0, time.UTC)
 	secondGeneratedAt := firstGeneratedAt.Add(2 * time.Hour)
 
+	firstSamples := []string{"a.js", "b.js", "c.js"}
+	secondSamples := []string{"d.js", "e.js", "f.js"}
+	firstDependencies := []report.DependencyReport{
+		dependencyReport("js-ts", "lodash", 1, 2, "map"),
+		dependencyReport("go", "cobra", 1, 1, ""),
+	}
+	secondDependencies := []report.DependencyReport{
+		dependencyReport("js-ts", "lodash", 2, 3, "filter"),
+		dependencyReport("python", "requests", 1, 2, ""),
+	}
+	secondDependencies[0].ReachabilityConfidence = &report.ReachabilityConfidence{
+		Model: "static",
+		Score: 0.7,
+	}
+	secondDependencies[0].RemovalCandidate = &report.RemovalCandidate{Score: 42}
+	secondDependencies[0].License = &report.DependencyLicense{SPDX: "MIT"}
+	secondDependencies[0].Provenance = &report.DependencyProvenance{Source: "registry"}
+
 	reports := []report.Report{
-		mergeFamilyReport(firstGeneratedAt, "w-first", 1, 2, []string{"a.js", "b.js", "c.js"},
-			dependencyReport("js-ts", "lodash", 1, 2, "map"),
-			dependencyReport("go", "cobra", 1, 1, ""),
-		),
-		mergeFamilyReport(secondGeneratedAt, "w-second", 3, 4, []string{"d.js", "e.js", "f.js"},
-			dependencyReport("js-ts", "lodash", 2, 3, "filter"),
-			dependencyReport("python", "requests", 1, 2, ""),
-		),
+		mergeFamilyReport(firstGeneratedAt, "w-first", 1, 2, firstSamples, firstDependencies...),
+		mergeFamilyReport(secondGeneratedAt, "w-second", 3, 4, secondSamples, secondDependencies...),
 	}
 
 	merged := mergeReports("/repo", reports)
@@ -117,5 +129,23 @@ func assertMergedDependencies(t *testing.T, merged report.Report) {
 	}
 	if len(merged.Dependencies[1].UsedImports) != 2 {
 		t.Fatalf("expected duplicate dependency used imports to merge, got %#v", merged.Dependencies[1].UsedImports)
+	}
+	assertMergedDependencyMetadata(t, merged.Dependencies[1])
+}
+
+func assertMergedDependencyMetadata(t *testing.T, dependency report.DependencyReport) {
+	t.Helper()
+
+	if dependency.ReachabilityConfidence == nil || dependency.ReachabilityConfidence.Model != "static" {
+		t.Fatalf("expected merged reachability confidence, got %#v", dependency.ReachabilityConfidence)
+	}
+	if dependency.RemovalCandidate == nil || dependency.RemovalCandidate.Score != 42 {
+		t.Fatalf("expected merged removal candidate, got %#v", dependency.RemovalCandidate)
+	}
+	if dependency.License == nil || dependency.License.SPDX != "MIT" {
+		t.Fatalf("expected merged dependency license, got %#v", dependency.License)
+	}
+	if dependency.Provenance == nil || dependency.Provenance.Source != "registry" {
+		t.Fatalf("expected merged dependency provenance, got %#v", dependency.Provenance)
 	}
 }

--- a/internal/analysis/merge_report_families_test.go
+++ b/internal/analysis/merge_report_families_test.go
@@ -1,0 +1,96 @@
+package analysis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestMergeReportsCoordinatesFamiliesInStableOrder(t *testing.T) {
+	firstGeneratedAt := time.Date(2026, time.January, 10, 10, 0, 0, 0, time.UTC)
+	secondGeneratedAt := firstGeneratedAt.Add(2 * time.Hour)
+
+	reports := []report.Report{
+		{
+			GeneratedAt: firstGeneratedAt,
+			Warnings:    []string{"w-first"},
+			UsageUncertainty: &report.UsageUncertainty{
+				ConfirmedImportUses: 1,
+				UncertainImportUses: 2,
+				Samples: []report.Location{
+					{File: "a.js"},
+					{File: "b.js"},
+					{File: "c.js"},
+				},
+			},
+			Dependencies: []report.DependencyReport{
+				{Language: "js-ts", Name: "lodash", UsedExportsCount: 1, TotalExportsCount: 2, UsedImports: []report.ImportUse{{Module: "lodash", Name: "map"}}},
+				{Language: "go", Name: "cobra", UsedExportsCount: 1, TotalExportsCount: 1},
+			},
+		},
+		{
+			GeneratedAt: secondGeneratedAt,
+			Warnings:    []string{"w-second"},
+			UsageUncertainty: &report.UsageUncertainty{
+				ConfirmedImportUses: 3,
+				UncertainImportUses: 4,
+				Samples: []report.Location{
+					{File: "d.js"},
+					{File: "e.js"},
+					{File: "f.js"},
+				},
+			},
+			Dependencies: []report.DependencyReport{
+				{Language: "js-ts", Name: "lodash", UsedExportsCount: 2, TotalExportsCount: 3, UsedImports: []report.ImportUse{{Module: "lodash", Name: "filter"}}},
+				{Language: "python", Name: "requests", UsedExportsCount: 1, TotalExportsCount: 2},
+			},
+		},
+	}
+
+	merged := mergeReports("/repo", reports)
+
+	if merged.RepoPath != "/repo" {
+		t.Fatalf("expected repo path to be preserved, got %q", merged.RepoPath)
+	}
+	if merged.GeneratedAt != secondGeneratedAt {
+		t.Fatalf("expected latest generatedAt timestamp, got %v want %v", merged.GeneratedAt, secondGeneratedAt)
+	}
+	if len(merged.Warnings) != 2 || merged.Warnings[0] != "w-first" || merged.Warnings[1] != "w-second" {
+		t.Fatalf("expected warning merge order to follow report order, got %#v", merged.Warnings)
+	}
+	if merged.UsageUncertainty == nil {
+		t.Fatal("expected merged usage uncertainty")
+	}
+	if merged.UsageUncertainty.ConfirmedImportUses != 4 || merged.UsageUncertainty.UncertainImportUses != 6 {
+		t.Fatalf("unexpected merged usage uncertainty counts: %#v", merged.UsageUncertainty)
+	}
+	if len(merged.UsageUncertainty.Samples) != 5 {
+		t.Fatalf("expected capped sample list of five, got %#v", merged.UsageUncertainty.Samples)
+	}
+	if got := merged.UsageUncertainty.Samples[0].File; got != "a.js" {
+		t.Fatalf("expected first sample to come from first report, got %q", got)
+	}
+	if got := merged.UsageUncertainty.Samples[4].File; got != "e.js" {
+		t.Fatalf("expected last kept sample to come from second report, got %q", got)
+	}
+
+	if len(merged.Dependencies) != 3 {
+		t.Fatalf("expected three merged dependencies, got %#v", merged.Dependencies)
+	}
+	if merged.Dependencies[0].Language != "go" || merged.Dependencies[0].Name != "cobra" {
+		t.Fatalf("expected deterministic dependency sort order, got first row %#v", merged.Dependencies[0])
+	}
+	if merged.Dependencies[1].Language != "js-ts" || merged.Dependencies[1].Name != "lodash" {
+		t.Fatalf("expected lodash row to be second, got %#v", merged.Dependencies[1])
+	}
+	if merged.Dependencies[2].Language != "python" || merged.Dependencies[2].Name != "requests" {
+		t.Fatalf("expected requests row to be third, got %#v", merged.Dependencies[2])
+	}
+	if merged.Dependencies[1].UsedExportsCount != 3 || merged.Dependencies[1].TotalExportsCount != 5 {
+		t.Fatalf("expected duplicate dependency rows to merge export counts, got %#v", merged.Dependencies[1])
+	}
+	if len(merged.Dependencies[1].UsedImports) != 2 {
+		t.Fatalf("expected duplicate dependency used imports to merge, got %#v", merged.Dependencies[1].UsedImports)
+	}
+}

--- a/internal/analysis/merge_report_families_test.go
+++ b/internal/analysis/merge_report_families_test.go
@@ -50,15 +50,28 @@ func TestMergeReportsCoordinatesFamiliesInStableOrder(t *testing.T) {
 
 	merged := mergeReports("/repo", reports)
 
+	assertMergedReportMetadata(t, merged, secondGeneratedAt)
+	assertMergedUsageUncertainty(t, merged)
+	assertMergedDependencies(t, merged)
+}
+
+func assertMergedReportMetadata(t *testing.T, merged report.Report, wantGeneratedAt time.Time) {
+	t.Helper()
+
 	if merged.RepoPath != "/repo" {
 		t.Fatalf("expected repo path to be preserved, got %q", merged.RepoPath)
 	}
-	if merged.GeneratedAt != secondGeneratedAt {
-		t.Fatalf("expected latest generatedAt timestamp, got %v want %v", merged.GeneratedAt, secondGeneratedAt)
+	if merged.GeneratedAt != wantGeneratedAt {
+		t.Fatalf("expected latest generatedAt timestamp, got %v want %v", merged.GeneratedAt, wantGeneratedAt)
 	}
 	if len(merged.Warnings) != 2 || merged.Warnings[0] != "w-first" || merged.Warnings[1] != "w-second" {
 		t.Fatalf("expected warning merge order to follow report order, got %#v", merged.Warnings)
 	}
+}
+
+func assertMergedUsageUncertainty(t *testing.T, merged report.Report) {
+	t.Helper()
+
 	if merged.UsageUncertainty == nil {
 		t.Fatal("expected merged usage uncertainty")
 	}
@@ -74,6 +87,10 @@ func TestMergeReportsCoordinatesFamiliesInStableOrder(t *testing.T) {
 	if got := merged.UsageUncertainty.Samples[4].File; got != "e.js" {
 		t.Fatalf("expected last kept sample to come from second report, got %q", got)
 	}
+}
+
+func assertMergedDependencies(t *testing.T, merged report.Report) {
+	t.Helper()
 
 	if len(merged.Dependencies) != 3 {
 		t.Fatalf("expected three merged dependencies, got %#v", merged.Dependencies)

--- a/internal/analysis/merge_report_families_test.go
+++ b/internal/analysis/merge_report_families_test.go
@@ -12,40 +12,14 @@ func TestMergeReportsCoordinatesFamiliesInStableOrder(t *testing.T) {
 	secondGeneratedAt := firstGeneratedAt.Add(2 * time.Hour)
 
 	reports := []report.Report{
-		{
-			GeneratedAt: firstGeneratedAt,
-			Warnings:    []string{"w-first"},
-			UsageUncertainty: &report.UsageUncertainty{
-				ConfirmedImportUses: 1,
-				UncertainImportUses: 2,
-				Samples: []report.Location{
-					{File: "a.js"},
-					{File: "b.js"},
-					{File: "c.js"},
-				},
-			},
-			Dependencies: []report.DependencyReport{
-				{Language: "js-ts", Name: "lodash", UsedExportsCount: 1, TotalExportsCount: 2, UsedImports: []report.ImportUse{{Module: "lodash", Name: "map"}}},
-				{Language: "go", Name: "cobra", UsedExportsCount: 1, TotalExportsCount: 1},
-			},
-		},
-		{
-			GeneratedAt: secondGeneratedAt,
-			Warnings:    []string{"w-second"},
-			UsageUncertainty: &report.UsageUncertainty{
-				ConfirmedImportUses: 3,
-				UncertainImportUses: 4,
-				Samples: []report.Location{
-					{File: "d.js"},
-					{File: "e.js"},
-					{File: "f.js"},
-				},
-			},
-			Dependencies: []report.DependencyReport{
-				{Language: "js-ts", Name: "lodash", UsedExportsCount: 2, TotalExportsCount: 3, UsedImports: []report.ImportUse{{Module: "lodash", Name: "filter"}}},
-				{Language: "python", Name: "requests", UsedExportsCount: 1, TotalExportsCount: 2},
-			},
-		},
+		mergeFamilyReport(firstGeneratedAt, "w-first", 1, 2, []string{"a.js", "b.js", "c.js"},
+			dependencyReport("js-ts", "lodash", 1, 2, "map"),
+			dependencyReport("go", "cobra", 1, 1, ""),
+		),
+		mergeFamilyReport(secondGeneratedAt, "w-second", 3, 4, []string{"d.js", "e.js", "f.js"},
+			dependencyReport("js-ts", "lodash", 2, 3, "filter"),
+			dependencyReport("python", "requests", 1, 2, ""),
+		),
 	}
 
 	merged := mergeReports("/repo", reports)
@@ -53,6 +27,40 @@ func TestMergeReportsCoordinatesFamiliesInStableOrder(t *testing.T) {
 	assertMergedReportMetadata(t, merged, secondGeneratedAt)
 	assertMergedUsageUncertainty(t, merged)
 	assertMergedDependencies(t, merged)
+}
+
+func mergeFamilyReport(generatedAt time.Time, warning string, confirmed, uncertain int, samples []string, dependencies ...report.DependencyReport) report.Report {
+	return report.Report{
+		GeneratedAt:      generatedAt,
+		Warnings:         []string{warning},
+		UsageUncertainty: usageUncertainty(confirmed, uncertain, samples),
+		Dependencies:     dependencies,
+	}
+}
+
+func usageUncertainty(confirmed, uncertain int, sampleFiles []string) *report.UsageUncertainty {
+	samples := make([]report.Location, 0, len(sampleFiles))
+	for _, file := range sampleFiles {
+		samples = append(samples, report.Location{File: file})
+	}
+	return &report.UsageUncertainty{
+		ConfirmedImportUses: confirmed,
+		UncertainImportUses: uncertain,
+		Samples:             samples,
+	}
+}
+
+func dependencyReport(language, name string, usedExports, totalExports int, usedImport string) report.DependencyReport {
+	dependency := report.DependencyReport{
+		Language:          language,
+		Name:              name,
+		UsedExportsCount:  usedExports,
+		TotalExportsCount: totalExports,
+	}
+	if usedImport != "" {
+		dependency.UsedImports = []report.ImportUse{{Module: name, Name: usedImport}}
+	}
+	return dependency
 }
 
 func assertMergedReportMetadata(t *testing.T, merged report.Report, wantGeneratedAt time.Time) {


### PR DESCRIPTION
## Summary
Split final report synthesis into explicit report-family mergers with deterministic execution order while preserving the existing mergeReports entry point and finalReport behavior.

## Changes
- Added report-family merger adapters for warnings, usage uncertainty, generated timestamps, and dependencies.
- Refactored dependency row synthesis through explicit dependency family merge functions.
- Added focused coverage for report-family coordination and deterministic dependency aggregation.

## Validation
Commands and checks run:

```bash
go test ./internal/analysis ./internal/report
```

Additional manual validation:

- N/A

## Risk and compatibility

- Breaking changes: N/A
- Migration required: N/A
- Performance impact: N/A
- Memory benchmark impact: N/A

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #530
