### PR TITLE
fix(powershell): tighten requires parsing

### DIFF
--- a/internal/lang/powershell/parser.go
+++ b/internal/lang/powershell/parser.go
@@ -601,16 +601,26 @@ func splitTopLevel(value string, separator byte) []string {
 }
 
 func consumeTopLevelSeparator(value string, index int, separator byte, scanner *powerShellExpressionScanner) (int, bool) {
-	if value[index] != separator || !scanner.complete() {
+	if !scanner.complete() {
 		return 0, false
 	}
-	if separator != ' ' {
+	if separator == ' ' {
+		if !isArgumentWhitespace(value[index]) {
+			return 0, false
+		}
+		for index+1 < len(value) && isArgumentWhitespace(value[index+1]) {
+			index++
+		}
 		return index + 1, true
 	}
-	for index+1 < len(value) && value[index+1] == ' ' {
-		index++
+	if value[index] != separator {
+		return 0, false
 	}
 	return index + 1, true
+}
+
+func isArgumentWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t'
 }
 
 func flagValue(value, flag string) (string, bool) {

--- a/internal/lang/powershell/parser_test.go
+++ b/internal/lang/powershell/parser_test.go
@@ -119,6 +119,11 @@ func TestParsePowerShellLineHandlesInlineCommentsAndMissingRequiresModules(t *te
 		t.Fatalf("expected static import with comment to parse, imports=%#v warnings=%#v", imports, warnings)
 	}
 
+	imports, warnings = parsePowerShellLine("# Requires -Modules Pester", "run.ps1", 6, declared)
+	if len(imports) != 0 || len(warnings) != 0 {
+		t.Fatalf("expected human comment with spaced hash to be ignored, imports=%#v warnings=%#v", imports, warnings)
+	}
+
 	imports, warnings = parsePowerShellLine("#Requires -Modules", "run.ps1", 8, declared)
 	if len(imports) != 0 || len(warnings) != 1 {
 		t.Fatalf("expected #Requires warning for missing modules, imports=%#v warnings=%#v", imports, warnings)
@@ -279,6 +284,12 @@ func TestParseRequiresLineModuleListParsing(t *testing.T) {
 			line:         "#Requires -Modules Pester, Az.Accounts -RunAsAdministrator",
 			wantDeps:     []string{"az.accounts", "pester"},
 		},
+		{
+			name:         "supports tab-delimited options",
+			requiresBody: " -Modules\tPester\t-Version\t7.0",
+			line:         "#Requires -Modules\tPester\t-Version\t7.0",
+			wantDeps:     []string{"pester"},
+		},
 	}
 
 	for _, tc := range cases {
@@ -339,6 +350,10 @@ func assertParserSplitHelpers(t *testing.T) {
 	parts := splitArguments("-Name 'Pester' -ErrorAction Stop")
 	if !reflect.DeepEqual(parts, []string{"-Name", "'Pester'", "-ErrorAction", "Stop"}) {
 		t.Fatalf("unexpected split arguments output: %#v", parts)
+	}
+	parts = splitArguments("-Name\t'Pester'\t-ErrorAction\tStop")
+	if !reflect.DeepEqual(parts, []string{"-Name", "'Pester'", "-ErrorAction", "Stop"}) {
+		t.Fatalf("unexpected tab-delimited split arguments output: %#v", parts)
 	}
 	parts = splitTopLevel("'a,b',@(1,2),x", ',')
 	if !reflect.DeepEqual(parts, []string{"'a,b'", "@(1,2)", "x"}) {

--- a/internal/lang/powershell/types.go
+++ b/internal/lang/powershell/types.go
@@ -28,7 +28,7 @@ var (
 	requiredModulesAssignmentPattern = regexp.MustCompile(`(?i)\brequiredmodules\b\s*=`)
 	importModulePattern              = regexp.MustCompile(`(?i)^\s*import-module\b(.*)$`)
 	usingModulePattern               = regexp.MustCompile(`(?i)^\s*using\s+module\s+(.+)$`)
-	requiresDirectivePattern         = regexp.MustCompile(`(?i)^\s*#\s*requires\b(.*)$`)
+	requiresDirectivePattern         = regexp.MustCompile(`(?i)^\s*#requires\b(.*)$`)
 	moduleNamePattern                = regexp.MustCompile(`(?is)\bmodulename\b\s*=\s*([^;\r\n}]+)`)
 	powerShellSkippedDirs            = map[string]bool{}
 )


### PR DESCRIPTION
## Summary

Fixes the PowerShell parser so real `#Requires` directives still parse when options are tab-delimited, while ordinary comments beginning with `# Requires` no longer become directives.

Closes #832 and #853.

## Changes

- require exact `#Requires` directive syntax instead of accepting `# Requires`
- treat tabs as top-level whitespace in the PowerShell argument splitter used by `#Requires -Modules`
- add parser coverage for tab-delimited options and comment-looking text that should stay inert

## Validation

Commands and checks run:

```bash
go test ./internal/lang/powershell
```

Additional manual validation:

- Verified the new parser behavior against the targeted `#Requires` cases covered by the updated tests.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected; parsing remains linear over the same inputs.
- Memory benchmark impact: N/A.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
