### PR TITLE
fix(lang): harden python and elixir manifest parsing

### DIFF
--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -291,6 +291,9 @@ func TestDetectUmbrellaAppsPathBranches(t *testing.T) {
 	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("def project, do: [apps_path: \"   \"]\n")); !umbrella || appsPath != "apps" {
 		t.Fatalf("expected blank apps_path to fall back to apps, got umbrella=%v appsPath=%q", umbrella, appsPath)
 	}
+	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("def project, do: [apps_path: [\n")); umbrella || appsPath != "" {
+		t.Fatalf("expected malformed apps_path to be ignored, got umbrella=%v appsPath=%q", umbrella, appsPath)
+	}
 }
 
 func TestAddUmbrellaRootsAndDependencyFallbacks(t *testing.T) {

--- a/internal/lang/elixir/detection.go
+++ b/internal/lang/elixir/detection.go
@@ -86,17 +86,15 @@ func detectFromRootFiles(repoPath string, detection *language.Detection, roots m
 
 func detectUmbrellaAppsPath(content []byte) (bool, string) {
 	raw := stripElixirComments(content)
-	if !strings.Contains(raw, "apps_path:") {
-		return false, ""
-	}
 	matches := appsPathRegex.FindStringSubmatch(raw)
 	if len(matches) >= 2 {
 		path := strings.TrimSpace(matches[1])
 		if path != "" {
 			return true, path
 		}
+		return true, "apps"
 	}
-	return true, "apps"
+	return false, ""
 }
 
 func stripElixirComments(content []byte) string {

--- a/internal/lang/python/packaging_manifest_parsers.go
+++ b/internal/lang/python/packaging_manifest_parsers.go
@@ -226,11 +226,34 @@ func addDependencyGroups(dependencies map[string]struct{}, groups map[string]any
 }
 
 func dependencyNameFromRequirement(spec string) string {
+	if isDirectReferenceRequirement(spec) {
+		return ""
+	}
 	matches := pythonRequirementNamePattern.FindStringSubmatch(spec)
 	if len(matches) != 2 {
 		return ""
 	}
 	return normalizeDependencyID(matches[1])
+}
+
+func isDirectReferenceRequirement(spec string) bool {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" {
+		return false
+	}
+	head := trimmed
+	if cut := strings.IndexAny(head, " \t"); cut >= 0 {
+		head = head[:cut]
+	}
+	head = strings.ToLower(head)
+	switch {
+	case strings.Contains(head, "://"):
+		return true
+	case strings.HasPrefix(head, "git+"), strings.HasPrefix(head, "hg+"), strings.HasPrefix(head, "svn+"), strings.HasPrefix(head, "bzr+"):
+		return true
+	default:
+		return false
+	}
 }
 
 func poetryDependencyOptional(value any) bool {

--- a/internal/lang/python/packaging_test.go
+++ b/internal/lang/python/packaging_test.go
@@ -148,6 +148,35 @@ requests==2.32.0
 	}
 }
 
+func TestParseRequirementsDependenciesIgnoresDirectURLAndVCSReferences(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, pythonRequirementsTxt)
+	testutil.MustWriteFile(t, path, `
+git+https://example.test/demo.git#egg=demo
+https://example.test/packages/demo-1.2.3.tar.gz#sha256=abc
+requests==2.32.0
+`)
+
+	dependencies, warnings, err := parseRequirementsDependencies(repo, path)
+	if err != nil {
+		t.Fatalf(parseRequirementsErrFmt, err)
+	}
+	if _, ok := dependencies["requests"]; !ok {
+		t.Fatalf(expectedDependencyInSetFmt, "requests", dependencies)
+	}
+	for _, unexpected := range []string{"git", "https"} {
+		if _, ok := dependencies[unexpected]; ok {
+			t.Fatalf("did not expect phantom dependency %q in %#v", unexpected, dependencies)
+		}
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected one unsupported-format warning, got %#v", warnings)
+	}
+	if !strings.Contains(warnings[0], "skipped 2 requirements entries with unsupported format") {
+		t.Fatalf(expectedWarningFmt, "skipped 2 requirements entries with unsupported format", warnings)
+	}
+}
+
 func TestParseRequirementsDependenciesAcceptsLongLines(t *testing.T) {
 	repo := t.TempDir()
 	path := filepath.Join(repo, pythonRequirementsTxt)


### PR DESCRIPTION
## Summary

Fixes two manifest parsing regressions: Python requirement parsing no longer invents `git` and `https` dependencies from direct URL or VCS specs, and Elixir umbrella detection no longer defaults malformed `apps_path:` lines to `apps`.

Closes #854 and #858.

## Changes

- reject direct URL and VCS requirement lines before extracting Python dependency names
- require a valid `apps_path` pattern match before treating Elixir config as umbrella metadata
- add focused tests for direct-reference requirements and malformed umbrella detection

## Validation

Commands and checks run:

```bash
go test ./internal/lang/python ./internal/lang/elixir
```

Additional manual validation:

- Reviewed the updated parser branches to confirm blank-but-valid Elixir `apps_path` values still fall back to `apps` while malformed lines are ignored.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: N/A.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
