### PR TITLE
fix(dotnet): ignore commented imports and package refs

### DIFF
--- a/internal/lang/dotnet/adapter_branches_extra_test.go
+++ b/internal/lang/dotnet/adapter_branches_extra_test.go
@@ -213,6 +213,17 @@ func TestParseImportsWithCRLFPreservesColumns(t *testing.T) {
 	}
 }
 
+func TestParseImportsIgnoreBlockComments(t *testing.T) {
+	mapper := newDependencyMapper([]string{"foo.bar"})
+	imports, _ := parseImports([]byte("/*\nusing Foo.Bar;\n*/\n"+fooBarImportLine+"\n"), programSourceName, mapper)
+	if len(imports) != 1 {
+		t.Fatalf("expected only one import outside block comments, got %#v", imports)
+	}
+	if imports[0].Location.Line != 4 {
+		t.Fatalf("expected import line 4 after skipping block comment, got %#v", imports[0].Location)
+	}
+}
+
 func TestParseImportsAndBuildFunctionsBranches(t *testing.T) {
 	mapper := newDependencyMapper([]string{acmeBarName, "acme.baz"})
 	content := []byte(`

--- a/internal/lang/dotnet/adapter_branches_extra_test.go
+++ b/internal/lang/dotnet/adapter_branches_extra_test.go
@@ -190,6 +190,24 @@ func TestByteWhitespaceAndCommentHelpers(t *testing.T) {
 	}
 }
 
+func TestStripSourceCommentsBytesFastPathAllocations(t *testing.T) {
+	line := []byte("  using Foo.Bar;  ")
+	if allocs := testing.AllocsPerRun(1000, func() {
+		got, column, inBlock := stripSourceCommentsBytes(line, false)
+		if inBlock {
+			t.Fatalf("expected fast path to keep block comment state false")
+		}
+		if column != 3 {
+			t.Fatalf("expected first non-space column 3, got %d", column)
+		}
+		if !bytes.Equal(got, []byte("using Foo.Bar;")) {
+			t.Fatalf("unexpected stripped line: %q", got)
+		}
+	}); allocs != 0 {
+		t.Fatalf("expected zero allocations on no-comment fast path, got %f", allocs)
+	}
+}
+
 func TestByteDependencyHelperBranches(t *testing.T) {
 	mapper := newDependencyMapper([]string{"Acme.Core", "", "serilog.aspnetcore"})
 	if len(mapper.declared) != 2 || mapper.declared[0].id != "acme.core" {
@@ -221,6 +239,18 @@ func TestParseImportsIgnoreBlockComments(t *testing.T) {
 	}
 	if imports[0].Location.Line != 4 {
 		t.Fatalf("expected import line 4 after skipping block comment, got %#v", imports[0].Location)
+	}
+}
+
+func TestStripXMLCommentsBytesFastPathAllocations(t *testing.T) {
+	content := []byte("\n  <Project><ItemGroup><PackageReference Include=\"Dapper\" /></ItemGroup></Project>  \n")
+	if allocs := testing.AllocsPerRun(1000, func() {
+		got := stripXMLCommentsBytes(content)
+		if !bytes.Equal(got, []byte("<Project><ItemGroup><PackageReference Include=\"Dapper\" /></ItemGroup></Project>")) {
+			t.Fatalf("unexpected stripped xml: %q", got)
+		}
+	}); allocs != 0 {
+		t.Fatalf("expected zero allocations on no-comment fast path, got %f", allocs)
 	}
 }
 

--- a/internal/lang/dotnet/adapter_branches_extra_test.go
+++ b/internal/lang/dotnet/adapter_branches_extra_test.go
@@ -208,6 +208,98 @@ func TestStripSourceCommentsBytesFastPathAllocations(t *testing.T) {
 	}
 }
 
+func TestStripSourceCommentsBytesAdditionalBranches(t *testing.T) {
+	if got, column, inBlock := stripSourceCommentsBytes(nil, false); len(got) != 0 || column != 1 || inBlock {
+		t.Fatalf("expected nil input to remain empty, got %q column=%d inBlock=%v", got, column, inBlock)
+	}
+
+	if got, column, inBlock := stripSourceCommentsBytes([]byte("// comment only"), false); len(got) != 0 || column != 1 || inBlock {
+		t.Fatalf("expected line comment to strip to empty, got %q column=%d inBlock=%v", got, column, inBlock)
+	}
+
+	got, column, inBlock := stripSourceCommentsBytes([]byte("/* comment */ using Foo.Bar;"), false)
+	if !bytes.Equal(got, []byte("using Foo.Bar;")) || column <= 1 || inBlock {
+		t.Fatalf("expected closed block comment prefix to preserve trailing import, got %q column=%d inBlock=%v", got, column, inBlock)
+	}
+
+	got, column, inBlock = stripSourceCommentsBytes([]byte("using /* comment */ Foo.Bar;"), false)
+	if !bytes.Contains(got, []byte("using")) || !bytes.Contains(got, []byte("Foo.Bar;")) || column != 1 || inBlock {
+		t.Fatalf("expected inline block comment to preserve import fragments, got %q column=%d inBlock=%v", got, column, inBlock)
+	}
+
+	if got, column, inBlock := stripSourceCommentsBytes([]byte("/* unterminated"), false); len(got) != 0 || column != 1 || !inBlock {
+		t.Fatalf("expected unterminated block comment to carry state forward, got %q column=%d inBlock=%v", got, column, inBlock)
+	}
+
+	got, column, inBlock = stripSourceCommentsBytes([]byte("still hidden */ using Foo.Bar;"), true)
+	if !bytes.Equal(got, []byte("using Foo.Bar;")) || column <= 1 || inBlock {
+		t.Fatalf("expected closing block comment to resume parsing, got %q column=%d inBlock=%v", got, column, inBlock)
+	}
+}
+
+func TestAdvanceSourceCommentStateBranches(t *testing.T) {
+	if next, column, inBlock, stop, handled := advanceSourceCommentState([]byte("x"), 0, 1, false); next != 0 || column != 1 || inBlock || stop || handled {
+		t.Fatalf("expected single-byte non-comment to be ignored, got next=%d column=%d inBlock=%v stop=%v handled=%v", next, column, inBlock, stop, handled)
+	}
+
+	if next, column, inBlock, stop, handled := advanceSourceCommentState([]byte("// comment"), 0, 1, false); next != 0 || column != 1 || inBlock || !stop || !handled {
+		t.Fatalf("expected line comment to stop parsing, got next=%d column=%d inBlock=%v stop=%v handled=%v", next, column, inBlock, stop, handled)
+	}
+
+	if next, column, inBlock, stop, handled := advanceSourceCommentState([]byte("/* comment"), 0, 1, false); next != 2 || column != 3 || !inBlock || stop || !handled {
+		t.Fatalf("expected block comment opener to advance state, got next=%d column=%d inBlock=%v stop=%v handled=%v", next, column, inBlock, stop, handled)
+	}
+
+	if next, column, inBlock, stop, handled := advanceSourceCommentState([]byte("*/"), 0, 1, true); next != 2 || column != 3 || inBlock || stop || !handled {
+		t.Fatalf("expected block comment closer to clear state, got next=%d column=%d inBlock=%v stop=%v handled=%v", next, column, inBlock, stop, handled)
+	}
+
+	if next, column, inBlock, stop, handled := advanceSourceCommentState([]byte("x"), 0, 1, true); next != 1 || column != 2 || !inBlock || stop || !handled {
+		t.Fatalf("expected in-block content to advance one byte, got next=%d column=%d inBlock=%v stop=%v handled=%v", next, column, inBlock, stop, handled)
+	}
+}
+
+func TestIsRepoBoundedPathAdditionalBranches(t *testing.T) {
+	repo := t.TempDir()
+	if !isRepoBoundedPath(repo, repo) {
+		t.Fatalf("expected repo root itself to be repo-bounded")
+	}
+	if !isRepoBoundedPath(repo, filepath.Join(repo, ".", "src", "..", "src")) {
+		t.Fatalf("expected cleaned in-repo candidate to remain repo-bounded")
+	}
+	if isRepoBoundedPath(repo, filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-sibling")) {
+		t.Fatalf("expected sibling path not to be repo-bounded")
+	}
+}
+
+func TestStripXMLCommentsBytesAdditionalBranches(t *testing.T) {
+	got := stripXMLCommentsBytes([]byte("<Project><!-- comment --><ItemGroup /></Project>"))
+	if !bytes.Equal(got, []byte("<Project> <ItemGroup /></Project>")) {
+		t.Fatalf("expected inline XML comment to be stripped with spacing preserved, got %q", got)
+	}
+
+	got = stripXMLCommentsBytes([]byte("<Project><ItemGroup /></Project><!-- trailing"))
+	if !bytes.Equal(got, []byte("<Project><ItemGroup /></Project>")) {
+		t.Fatalf("expected unterminated trailing XML comment to be stripped, got %q", got)
+	}
+}
+
+func TestAnalyseDeclaredDependenciesWithoutTarget(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, appProjectName), `<Project><ItemGroup><PackageReference Include="Newtonsoft.Json" Version="13.0.3" /></ItemGroup></Project>`)
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo})
+	if err != nil {
+		t.Fatalf("analyse declared dependency without target: %v", err)
+	}
+	if !slices.Contains(reportData.Warnings, "no dependency or top-N target provided") {
+		t.Fatalf("expected missing target warning, got %#v", reportData.Warnings)
+	}
+	if slices.Contains(reportData.Warnings, "no .NET package dependencies discovered from project manifests") {
+		t.Fatalf("did not expect missing manifest warning when dependency is declared, got %#v", reportData.Warnings)
+	}
+}
+
 func TestByteDependencyHelperBranches(t *testing.T) {
 	mapper := newDependencyMapper([]string{"Acme.Core", "", "serilog.aspnetcore"})
 	if len(mapper.declared) != 2 || mapper.declared[0].id != "acme.core" {

--- a/internal/lang/dotnet/adapter_test.go
+++ b/internal/lang/dotnet/adapter_test.go
@@ -215,6 +215,29 @@ func TestParseManifestReferences(t *testing.T) {
 	}
 }
 
+func TestParseManifestReferencesIgnoreXMLComments(t *testing.T) {
+	repo := t.TempDir()
+	projectPath := filepath.Join(repo, appProjectFileName)
+	writeManifestFixture(t, projectPath, `
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <!-- <PackageReference Include="Commented.Package" Version="1.0.0" /> -->
+    <PackageReference Include="Real.Package" Version="1.0.0" />
+  </ItemGroup>
+</Project>`)
+
+	projectDeps, err := parsePackageReferences(repo, projectPath)
+	if err != nil {
+		t.Fatalf("parse project: %v", err)
+	}
+	if slices.Contains(projectDeps, "commented.package") {
+		t.Fatalf("expected XML-commented package reference to be ignored, got %#v", projectDeps)
+	}
+	if !slices.Contains(projectDeps, "real.package") {
+		t.Fatalf("expected real package reference to remain visible, got %#v", projectDeps)
+	}
+}
+
 func TestAdapterRecommendationsHonorMinUsageThreshold(t *testing.T) {
 	repo := t.TempDir()
 	writeManifestFixture(t, filepath.Join(repo, appProjectFileName), newtonsoftProjectManifest)

--- a/internal/lang/dotnet/discovery.go
+++ b/internal/lang/dotnet/discovery.go
@@ -1,6 +1,7 @@
 package dotnet
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -268,7 +269,7 @@ func parseManifestDependencies(repoPath, manifestPath string, pattern *regexp.Re
 	if err != nil {
 		return nil, err
 	}
-	matches := pattern.FindAllSubmatch(content, -1)
+	matches := pattern.FindAllSubmatch(stripXMLCommentsBytes(content), -1)
 	return captureMatches(matches), nil
 }
 
@@ -423,6 +424,41 @@ func isRepoBoundedPath(repoPath, candidatePath string) bool {
 		return false
 	}
 	return relativeToRepo != ".." && !strings.HasPrefix(relativeToRepo, ".."+string(filepath.Separator))
+}
+
+func stripXMLCommentsBytes(content []byte) []byte {
+	if len(content) == 0 {
+		return content
+	}
+
+	out := make([]byte, 0, len(content))
+	inComment := false
+
+	for i := 0; i < len(content); {
+		if inComment {
+			if i+2 < len(content) && content[i] == '-' && content[i+1] == '-' && content[i+2] == '>' {
+				inComment = false
+				i += 3
+				continue
+			}
+			i++
+			continue
+		}
+
+		if i+3 < len(content) && content[i] == '<' && content[i+1] == '!' && content[i+2] == '-' && content[i+3] == '-' {
+			if len(out) > 0 && !isSpaceByte(out[len(out)-1]) {
+				out = append(out, ' ')
+			}
+			inComment = true
+			i += 4
+			continue
+		}
+
+		out = append(out, content[i])
+		i++
+	}
+
+	return bytes.TrimSpace(out)
 }
 
 var (

--- a/internal/lang/dotnet/discovery.go
+++ b/internal/lang/dotnet/discovery.go
@@ -430,7 +430,7 @@ func stripXMLCommentsBytes(content []byte) []byte {
 	if len(content) == 0 {
 		return content
 	}
-	if bytes.Index(content, []byte("<!--")) < 0 {
+	if !bytes.Contains(content, []byte("<!--")) {
 		return bytes.TrimSpace(content)
 	}
 

--- a/internal/lang/dotnet/discovery.go
+++ b/internal/lang/dotnet/discovery.go
@@ -430,6 +430,9 @@ func stripXMLCommentsBytes(content []byte) []byte {
 	if len(content) == 0 {
 		return content
 	}
+	if bytes.Index(content, []byte("<!--")) < 0 {
+		return bytes.TrimSpace(content)
+	}
 
 	out := make([]byte, 0, len(content))
 	inComment := false

--- a/internal/lang/dotnet/parsing.go
+++ b/internal/lang/dotnet/parsing.go
@@ -36,8 +36,11 @@ func parseImports(content []byte, relativePath string, mapper dependencyMapper) 
 		undeclaredByDependency: make(map[string]int),
 	}
 	imports := make([]importBinding, 0)
+	inBlockComment := false
 	forEachSourceLine(content, func(lineNo int, raw, line []byte) {
-		if binding := parseImportLine(line, raw, relativePath, lineNo, mapper, &meta); binding != nil {
+		var column int
+		line, column, inBlockComment = stripSourceCommentsBytes(raw, inBlockComment)
+		if binding := parseImportLine(line, column, relativePath, lineNo, mapper, &meta); binding != nil {
 			imports = append(imports, *binding)
 		}
 	})
@@ -52,7 +55,7 @@ func forEachSourceLine(content []byte, visit func(lineNo int, raw, line []byte))
 			end++
 		}
 		raw := trimTrailingCarriageReturn(content[start:end])
-		visit(lineNo, raw, stripLineCommentBytes(raw))
+		visit(lineNo, raw, raw)
 		if end == len(content) {
 			break
 		}
@@ -60,11 +63,10 @@ func forEachSourceLine(content []byte, visit func(lineNo int, raw, line []byte))
 	}
 }
 
-func parseImportLine(line, raw []byte, relativePath string, lineNo int, mapper dependencyMapper, meta *mappingMetadata) *importBinding {
+func parseImportLine(line []byte, column int, relativePath string, lineNo int, mapper dependencyMapper, meta *mappingMetadata) *importBinding {
 	if len(line) == 0 {
 		return nil
 	}
-	column := firstContentColumnBytes(raw)
 	if binding, handled := parseCSharpImportLine(line, relativePath, lineNo, column, mapper, meta); handled {
 		return binding
 	}
@@ -257,6 +259,51 @@ func stripLineCommentBytes(line []byte) []byte {
 		}
 	}
 	return bytes.TrimSpace(line)
+}
+
+func stripSourceCommentsBytes(line []byte, inBlockComment bool) ([]byte, int, bool) {
+	if len(line) == 0 {
+		return line, 1, inBlockComment
+	}
+
+	out := make([]byte, 0, len(line))
+	firstColumn := 1
+	sawCode := false
+	column := 1
+
+	for i := 0; i < len(line); {
+		if inBlockComment {
+			if i+1 < len(line) && line[i] == '*' && line[i+1] == '/' {
+				inBlockComment = false
+				i += 2
+				column += 2
+				continue
+			}
+			i++
+			column++
+			continue
+		}
+
+		if i+1 < len(line) && line[i] == '/' && line[i+1] == '/' {
+			break
+		}
+		if i+1 < len(line) && line[i] == '/' && line[i+1] == '*' {
+			inBlockComment = true
+			i += 2
+			column += 2
+			continue
+		}
+
+		if !sawCode && !isSpaceByte(line[i]) {
+			firstColumn = column
+			sawCode = true
+		}
+		out = append(out, line[i])
+		i++
+		column++
+	}
+
+	return bytes.TrimSpace(out), firstColumn, inBlockComment
 }
 
 func trimTrailingCarriageReturn(line []byte) []byte {

--- a/internal/lang/dotnet/parsing.go
+++ b/internal/lang/dotnet/parsing.go
@@ -37,9 +37,9 @@ func parseImports(content []byte, relativePath string, mapper dependencyMapper) 
 	}
 	imports := make([]importBinding, 0)
 	inBlockComment := false
-	forEachSourceLine(content, func(lineNo int, raw, line []byte) {
-		var column int
-		line, column, inBlockComment = stripSourceCommentsBytes(raw, inBlockComment)
+	forEachSourceLine(content, func(lineNo int, raw, _ []byte) {
+		line, column, nextBlockComment := stripSourceCommentsBytes(raw, inBlockComment)
+		inBlockComment = nextBlockComment
 		if binding := parseImportLine(line, column, relativePath, lineNo, mapper, &meta); binding != nil {
 			imports = append(imports, *binding)
 		}

--- a/internal/lang/dotnet/parsing.go
+++ b/internal/lang/dotnet/parsing.go
@@ -265,6 +265,9 @@ func stripSourceCommentsBytes(line []byte, inBlockComment bool) ([]byte, int, bo
 	if len(line) == 0 {
 		return line, 1, inBlockComment
 	}
+	if !inBlockComment && bytes.IndexByte(line, '/') < 0 {
+		return bytes.TrimSpace(line), firstContentColumnBytes(line), false
+	}
 
 	out := make([]byte, 0, len(line))
 	firstColumn := 1

--- a/internal/lang/dotnet/parsing.go
+++ b/internal/lang/dotnet/parsing.go
@@ -272,25 +272,14 @@ func stripSourceCommentsBytes(line []byte, inBlockComment bool) ([]byte, int, bo
 	column := 1
 
 	for i := 0; i < len(line); {
-		if inBlockComment {
-			if i+1 < len(line) && line[i] == '*' && line[i+1] == '/' {
-				inBlockComment = false
-				i += 2
-				column += 2
-				continue
-			}
-			i++
-			column++
-			continue
-		}
-
-		if i+1 < len(line) && line[i] == '/' && line[i+1] == '/' {
+		nextIndex, nextColumn, nextBlockComment, stop, handled := advanceSourceCommentState(line, i, column, inBlockComment)
+		if stop {
 			break
 		}
-		if i+1 < len(line) && line[i] == '/' && line[i+1] == '*' {
-			inBlockComment = true
-			i += 2
-			column += 2
+		if handled {
+			i = nextIndex
+			column = nextColumn
+			inBlockComment = nextBlockComment
 			continue
 		}
 
@@ -304,6 +293,25 @@ func stripSourceCommentsBytes(line []byte, inBlockComment bool) ([]byte, int, bo
 	}
 
 	return bytes.TrimSpace(out), firstColumn, inBlockComment
+}
+
+func advanceSourceCommentState(line []byte, index, column int, inBlockComment bool) (int, int, bool, bool, bool) {
+	if inBlockComment {
+		if index+1 < len(line) && line[index] == '*' && line[index+1] == '/' {
+			return index + 2, column + 2, false, false, true
+		}
+		return index + 1, column + 1, true, false, true
+	}
+	if index+1 >= len(line) {
+		return index, column, false, false, false
+	}
+	if line[index] == '/' && line[index+1] == '/' {
+		return index, column, false, true, true
+	}
+	if line[index] == '/' && line[index+1] == '*' {
+		return index + 2, column + 2, true, false, true
+	}
+	return index, column, false, false, false
 }
 
 func trimTrailingCarriageReturn(line []byte) []byte {


### PR DESCRIPTION
## Summary

Fixes the .NET parser so imports inside `/* ... */` block comments are ignored and XML-commented `<PackageReference ...>` entries no longer count as declared dependencies.

Closes #851 and #852.

## Changes

- add block-comment-aware filtering before collecting C# and F# import bindings
- strip XML comments before applying the `PackageReference` regex in manifest parsing
- add focused parser coverage for commented source imports and commented package references

## Validation

Commands and checks run:

```bash
go test ./internal/lang/dotnet
```

Additional manual validation:

- Reviewed the updated parser branches to confirm real imports and real package references still flow through after the new comment filtering.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected; the parser remains text-based with bounded extra filtering.
- Memory benchmark impact: N/A.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
