### PR TITLE
fix(rust): harden import and workspace parsing

### DIFF
--- a/internal/lang/rust/adapter_cov_more_branches_test.go
+++ b/internal/lang/rust/adapter_cov_more_branches_test.go
@@ -126,3 +126,154 @@ func TestRustWorkspaceMemberOutsideRepoBranch(t *testing.T) {
 		t.Fatalf("expected outside workspace member to be ignored, got %#v", roots)
 	}
 }
+
+func TestRustWorkspaceMemberPatternBranches(t *testing.T) {
+	matched, err := workspaceMemberPatternMatches(filepath.Join("crates", "**", "tool"), filepath.Join("crates", "tool"))
+	if err != nil || !matched {
+		t.Fatalf("expected recursive glob to match zero intermediate segments, matched=%v err=%v", matched, err)
+	}
+
+	matched, err = workspaceMemberPatternMatches(filepath.Join("crates", "**", "tool"), filepath.Join("crates", "nested", "bin", "tool"))
+	if err != nil || !matched {
+		t.Fatalf("expected recursive glob to match nested segments, matched=%v err=%v", matched, err)
+	}
+
+	matched, err = workspaceMemberPatternMatches(filepath.Join("crates", "**", "tool"), filepath.Join("crates", "nested", "bin", "lib"))
+	if err != nil || matched {
+		t.Fatalf("expected non-matching recursive glob to fail, matched=%v err=%v", matched, err)
+	}
+
+	matched, err = matchWorkspaceMemberPatternParts(nil, nil)
+	if err != nil || !matched {
+		t.Fatalf("expected empty pattern parts to match empty candidate, matched=%v err=%v", matched, err)
+	}
+
+	if matched, err = workspaceMemberPatternMatches("[", "crate"); err == nil || matched {
+		t.Fatalf("expected invalid workspace glob to report an error, matched=%v err=%v", matched, err)
+	}
+
+	if matched, err = workspaceMemberPatternMatches("crates/*", ""); err != nil || matched {
+		t.Fatalf("expected empty candidate not to match, matched=%v err=%v", matched, err)
+	}
+}
+
+func TestRustWorkspaceMemberCollectorBranches(t *testing.T) {
+	repo := t.TempDir()
+	collector := workspaceMemberCollector{
+		repoPath: repo,
+		pattern:  filepath.Join("crates", "*"),
+		roots:    map[string]struct{}{},
+	}
+
+	if matched, err := collector.matchDirectory("", nil, context.Canceled); err != context.Canceled || matched {
+		t.Fatalf("expected walk error to short-circuit collector, matched=%v err=%v", matched, err)
+	}
+
+	targetDir := filepath.Join(repo, "target")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	targetEntry := rustDirEntry(t, repo, "target")
+	if matched, err := collector.matchDirectory(targetDir, targetEntry, nil); err != filepath.SkipDir || matched {
+		t.Fatalf("expected target dir to be skipped, matched=%v err=%v", matched, err)
+	}
+
+	filePath := filepath.Join(repo, "crates", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("mkdir crates: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("not a manifest"), 0o644); err != nil {
+		t.Fatalf("write file entry: %v", err)
+	}
+	fileEntry := rustDirEntry(t, filepath.Dir(filePath), filepath.Base(filePath))
+	if matched, err := collector.matchDirectory(filePath, fileEntry, nil); err != nil || matched {
+		t.Fatalf("expected file entry not to match workspace member, matched=%v err=%v", matched, err)
+	}
+
+	noManifestDir := filepath.Join(repo, "crates", "no-manifest")
+	if err := os.MkdirAll(noManifestDir, 0o755); err != nil {
+		t.Fatalf("mkdir no-manifest dir: %v", err)
+	}
+	noManifestEntry := rustDirEntry(t, filepath.Dir(noManifestDir), filepath.Base(noManifestDir))
+	if matched, err := collector.matchDirectory(noManifestDir, noManifestEntry, nil); err != nil || matched {
+		t.Fatalf("expected directory without Cargo.toml not to match, matched=%v err=%v", matched, err)
+	}
+
+	memberDir := filepath.Join(repo, "crates", "member")
+	if err := os.MkdirAll(memberDir, 0o755); err != nil {
+		t.Fatalf("mkdir member dir: %v", err)
+	}
+	writeFile(t, filepath.Join(memberDir, cargoManifestFile), "[package]\nname = \"member\"\nversion = \"0.1.0\"\n")
+	memberEntry := rustDirEntry(t, filepath.Dir(memberDir), filepath.Base(memberDir))
+	if matched, err := collector.matchDirectory(memberDir, memberEntry, nil); err != nil || !matched {
+		t.Fatalf("expected directory with Cargo.toml to match, matched=%v err=%v", matched, err)
+	}
+	if err := collector.walk(memberDir, memberEntry, nil); err != nil {
+		t.Fatalf("collector walk: %v", err)
+	}
+	if _, ok := collector.roots[memberDir]; !ok {
+		t.Fatalf("expected collector walk to record matched root, got %#v", collector.roots)
+	}
+}
+
+func TestRustHelperBranchCoverage(t *testing.T) {
+	repo := t.TempDir()
+	nested := filepath.Join(repo, "nested", "crate")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested crate: %v", err)
+	}
+	other := filepath.Join(repo, "other")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatalf("mkdir other dir: %v", err)
+	}
+
+	if !isSubPath(repo, nested) {
+		t.Fatalf("expected nested path to be a subpath")
+	}
+	if isSubPath(nested, repo) {
+		t.Fatalf("did not expect repo root to be a subpath of nested path")
+	}
+	if !samePath(filepath.Join(repo, ".", "nested"), filepath.Join(repo, "nested")) {
+		t.Fatalf("expected cleaned equivalent paths to compare equal")
+	}
+	if samePath(filepath.Join(repo, "nested"), other) {
+		t.Fatalf("did not expect different directories to compare equal")
+	}
+
+	roots := dropNestedScanRoots([]string{repo, nested, other}, nested)
+	if len(roots) != 2 || roots[0] != repo || roots[1] != other {
+		t.Fatalf("expected only nested candidate root to be dropped, got %#v", roots)
+	}
+
+	if index := findRustUseAliasIndex("serde as de"); index <= 0 {
+		t.Fatalf("expected alias index for valid use alias, got %d", index)
+	}
+	if index := findRustUseAliasIndex("serdeasde"); index != -1 {
+		t.Fatalf("expected invalid alias form to be ignored, got %d", index)
+	}
+
+	base, local := parseUseLocalAlias("serde as de")
+	if base != "serde" || local != "de" {
+		t.Fatalf("expected parseUseLocalAlias to split base/local, got base=%q local=%q", base, local)
+	}
+	base, local = parseUseLocalAlias(" as de")
+	if base != " as de" || local != "" {
+		t.Fatalf("expected malformed alias to round-trip unchanged, got base=%q local=%q", base, local)
+	}
+}
+
+func rustDirEntry(t *testing.T, dir, name string) os.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return entry
+		}
+	}
+	t.Fatalf("expected dir entry %s in %s", name, dir)
+	return nil
+}

--- a/internal/lang/rust/adapter_cov_more_branches_test.go
+++ b/internal/lang/rust/adapter_cov_more_branches_test.go
@@ -174,7 +174,7 @@ func TestRustWorkspaceMemberCollectorBranches(t *testing.T) {
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		t.Fatalf("mkdir target: %v", err)
 	}
-	targetEntry := rustDirEntry(t, repo, "target")
+	targetEntry := mustFindDirEntryByName(t, repo, "target")
 	if matched, err := collector.matchDirectory(targetDir, targetEntry, nil); !errors.Is(err, filepath.SkipDir) || matched {
 		t.Fatalf("expected target dir to be skipped, matched=%v err=%v", matched, err)
 	}
@@ -186,7 +186,7 @@ func TestRustWorkspaceMemberCollectorBranches(t *testing.T) {
 	if err := os.WriteFile(filePath, []byte("not a manifest"), 0o644); err != nil {
 		t.Fatalf("write file entry: %v", err)
 	}
-	fileEntry := rustDirEntry(t, filepath.Dir(filePath), filepath.Base(filePath))
+	fileEntry := mustFindDirEntryByName(t, filepath.Dir(filePath), filepath.Base(filePath))
 	if matched, err := collector.matchDirectory(filePath, fileEntry, nil); err != nil || matched {
 		t.Fatalf("expected file entry not to match workspace member, matched=%v err=%v", matched, err)
 	}
@@ -195,7 +195,7 @@ func TestRustWorkspaceMemberCollectorBranches(t *testing.T) {
 	if err := os.MkdirAll(noManifestDir, 0o755); err != nil {
 		t.Fatalf("mkdir no-manifest dir: %v", err)
 	}
-	noManifestEntry := rustDirEntry(t, filepath.Dir(noManifestDir), filepath.Base(noManifestDir))
+	noManifestEntry := mustFindDirEntryByName(t, filepath.Dir(noManifestDir), filepath.Base(noManifestDir))
 	if matched, err := collector.matchDirectory(noManifestDir, noManifestEntry, nil); err != nil || matched {
 		t.Fatalf("expected directory without Cargo.toml not to match, matched=%v err=%v", matched, err)
 	}
@@ -205,7 +205,7 @@ func TestRustWorkspaceMemberCollectorBranches(t *testing.T) {
 		t.Fatalf("mkdir member dir: %v", err)
 	}
 	writeFile(t, filepath.Join(memberDir, cargoManifestFile), "[package]\nname = \"member\"\nversion = \"0.1.0\"\n")
-	memberEntry := rustDirEntry(t, filepath.Dir(memberDir), filepath.Base(memberDir))
+	memberEntry := mustFindDirEntryByName(t, filepath.Dir(memberDir), filepath.Base(memberDir))
 	if matched, err := collector.matchDirectory(memberDir, memberEntry, nil); err != nil || !matched {
 		t.Fatalf("expected directory with Cargo.toml to match, matched=%v err=%v", matched, err)
 	}
@@ -261,20 +261,4 @@ func TestRustHelperBranchCoverage(t *testing.T) {
 	if base != " as de" || local != "" {
 		t.Fatalf("expected malformed alias to round-trip unchanged, got base=%q local=%q", base, local)
 	}
-}
-
-func rustDirEntry(t *testing.T, dir, name string) os.DirEntry {
-	t.Helper()
-
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read dir %s: %v", dir, err)
-	}
-	for _, entry := range entries {
-		if entry.Name() == name {
-			return entry
-		}
-	}
-	t.Fatalf("expected dir entry %s in %s", name, dir)
-	return nil
 }

--- a/internal/lang/rust/adapter_cov_more_branches_test.go
+++ b/internal/lang/rust/adapter_cov_more_branches_test.go
@@ -2,6 +2,7 @@ package rust
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -165,7 +166,7 @@ func TestRustWorkspaceMemberCollectorBranches(t *testing.T) {
 		roots:    map[string]struct{}{},
 	}
 
-	if matched, err := collector.matchDirectory("", nil, context.Canceled); err != context.Canceled || matched {
+	if matched, err := collector.matchDirectory("", nil, context.Canceled); !errors.Is(err, context.Canceled) || matched {
 		t.Fatalf("expected walk error to short-circuit collector, matched=%v err=%v", matched, err)
 	}
 
@@ -174,7 +175,7 @@ func TestRustWorkspaceMemberCollectorBranches(t *testing.T) {
 		t.Fatalf("mkdir target: %v", err)
 	}
 	targetEntry := rustDirEntry(t, repo, "target")
-	if matched, err := collector.matchDirectory(targetDir, targetEntry, nil); err != filepath.SkipDir || matched {
+	if matched, err := collector.matchDirectory(targetDir, targetEntry, nil); !errors.Is(err, filepath.SkipDir) || matched {
 		t.Fatalf("expected target dir to be skipped, matched=%v err=%v", matched, err)
 	}
 

--- a/internal/lang/rust/adapter_helpers_test.go
+++ b/internal/lang/rust/adapter_helpers_test.go
@@ -75,6 +75,12 @@ func TestParseCargoDependencies(t *testing.T) {
 	if deps[serdeJSONDep].Canonical != serdeJSONDep {
 		t.Fatalf("expected canonical serde-json mapping, got %#v", deps[serdeJSONDep])
 	}
+	if deps["workspace-serde"].Canonical != serdeJSONDep {
+		t.Fatalf("expected workspace dependency parsing, got %#v", deps["workspace-serde"])
+	}
+	if deps[serdeJSONDep].Canonical != serdeJSONDep {
+		t.Fatalf("expected canonical workspace dependency alias, got %#v", deps[serdeJSONDep])
+	}
 	if !deps["local-dep"].LocalPath {
 		t.Fatalf("expected local path dependency handling, got %#v", deps["local-dep"])
 	}
@@ -135,6 +141,9 @@ func manifestParsingHelpersFixture() string {
 		"",
 		"[target.'cfg(unix)'.dependencies]",
 		`clap = "4"`,
+		"",
+		"[workspace.dependencies]",
+		fmt.Sprintf(`workspace_serde = { package = %q, version = "1.0" }`, serdeJSONDep),
 		"",
 	}
 	return strings.Join(lines, "\n")
@@ -221,6 +230,9 @@ func TestUseClauseAndImportHelpers(t *testing.T) {
 	}
 	if lastPathSegment("a::b::c") != "c" {
 		t.Fatalf("unexpected last path segment")
+	}
+	if base, local := parseUseLocalAlias("serde::de::DeserializeOwned\tas\tserde_owned"); base != "serde::de::DeserializeOwned" || local != "serde_owned" {
+		t.Fatalf("expected tab-delimited alias parsing, got base=%q local=%q", base, local)
 	}
 
 	content := "line1\nline2\nline3"
@@ -1046,6 +1058,38 @@ func TestWorkspaceResolutionAndParsingEdgeBranches(t *testing.T) {
 	}
 	if fields := parseInlineFields("{ version = \"1.0\" }"); fields["version"] != "1.0" {
 		t.Fatalf("expected inline field extraction for version, got %#v", fields)
+	}
+}
+
+func TestWorkspaceMemberRecursiveGlobResolution(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, cargoManifestFile), fmt.Sprintf("%s\nmembers = [\"crates/**\"]\n", workspaceSection))
+	writeFile(t, filepath.Join(repo, "crates", "direct", cargoManifestFile), "[package]\nname=\"direct\"\nversion=\"0.1.0\"\n")
+	writeFile(t, filepath.Join(repo, "crates", "nested", "deep", cargoManifestFile), "[package]\nname=\"deep\"\nversion=\"0.1.0\"\n")
+	if err := os.WriteFile(filepath.Join(repo, "crates", "nested", "ignored"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write ignored file: %v", err)
+	}
+
+	roots := resolveWorkspaceMembers(repo, "crates/**")
+	if len(roots) != 2 {
+		t.Fatalf("expected recursive glob to resolve two roots, got %#v", roots)
+	}
+	if !strings.HasSuffix(roots[0], filepath.Join("crates", "direct")) && !strings.HasSuffix(roots[1], filepath.Join("crates", "direct")) {
+		t.Fatalf("expected direct member root in %#v", roots)
+	}
+	if !strings.HasSuffix(roots[0], filepath.Join("crates", "nested", "deep")) && !strings.HasSuffix(roots[1], filepath.Join("crates", "nested", "deep")) {
+		t.Fatalf("expected nested member root in %#v", roots)
+	}
+
+	paths, warnings, err := discoverManifestPaths(repo)
+	if err != nil {
+		t.Fatalf("discover manifests recursive glob: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected recursive glob manifest discovery, got %#v", paths)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for recursive glob members, got %#v", warnings)
 	}
 }
 

--- a/internal/lang/rust/adapter_helpers_test.go
+++ b/internal/lang/rust/adapter_helpers_test.go
@@ -78,8 +78,11 @@ func TestParseCargoDependencies(t *testing.T) {
 	if deps["workspace-serde"].Canonical != serdeJSONDep {
 		t.Fatalf("expected workspace dependency parsing, got %#v", deps["workspace-serde"])
 	}
-	if deps[serdeJSONDep].Canonical != serdeJSONDep {
-		t.Fatalf("expected canonical workspace dependency alias, got %#v", deps[serdeJSONDep])
+	if !deps["workspace-serde"].Renamed {
+		t.Fatalf("expected workspace dependency alias to be marked renamed, got %#v", deps["workspace-serde"])
+	}
+	if deps[serdeJSONDep].Renamed {
+		t.Fatalf("expected canonical workspace dependency entry to remain unrenamed, got %#v", deps[serdeJSONDep])
 	}
 	if !deps["local-dep"].LocalPath {
 		t.Fatalf("expected local path dependency handling, got %#v", deps["local-dep"])

--- a/internal/lang/rust/helpers_cov_more_extra_test.go
+++ b/internal/lang/rust/helpers_cov_more_extra_test.go
@@ -180,3 +180,51 @@ func testRustAdditionalExactBranchCoverageOffsets(t *testing.T) {
 		t.Fatalf("expected offset before base offset to clamp to base position, got %d:%d", line, col)
 	}
 }
+
+func TestRustAdditionalUncoveredCoverageBranches(t *testing.T) {
+	repo := t.TempDir()
+	badManifest := filepath.Join(repo, cargoTomlName)
+	if err := os.MkdirAll(badManifest, 0o755); err != nil {
+		t.Fatalf("mkdir bad manifest dir: %v", err)
+	}
+
+	if _, _, _, err := extractManifestDependencies(repo, manifestDiscoveryResult{
+		ManifestPaths:      []string{badManifest},
+		ParsedDependencies: map[string]map[string]dependencyInfo{},
+	}); err == nil {
+		t.Fatalf("expected manifest extraction to fail for directory manifest path")
+	}
+
+	if roots := resolveWorkspaceMembers(repo, "   "); len(roots) != 0 {
+		t.Fatalf("expected blank workspace pattern to produce no roots, got %#v", roots)
+	}
+
+	if matched, err := workspaceMemberPatternMatches(" ", "crate"); err != nil || matched {
+		t.Fatalf("expected blank workspace pattern match to be false without error, matched=%v err=%v", matched, err)
+	}
+
+	if matched, err := matchWorkspaceMemberPatternParts([]string{"**", "["}, []string{"crate"}); err == nil || matched {
+		t.Fatalf("expected invalid recursive workspace pattern to error, matched=%v err=%v", matched, err)
+	}
+
+	if _, _, ok := parseDependencyInfo(`" " = "1"`); ok {
+		t.Fatalf("expected whitespace-only dependency alias to be rejected")
+	}
+
+	if got := resolveDependency(" ::serde", "", nil, nil); got != "" {
+		t.Fatalf("expected empty normalized dependency root to be ignored, got %q", got)
+	}
+
+	if _, _, ok := parseRustRawStringStart([]byte("abc"), len("abc")); ok {
+		t.Fatalf("expected raw string start parse to fail at end of line")
+	}
+
+	lookup := map[string]dependencyInfo{"serde": {Canonical: "serde"}}
+	if _, ok := parseExternCrateClause([]byte("serde as serde_alias extra"), srcLibRS, "", lookup, nil, 1, 1); ok {
+		t.Fatalf("expected extern crate alias with trailing tokens to fail")
+	}
+
+	if index := findRustUseAliasIndex("serde as"); index != -1 {
+		t.Fatalf("expected incomplete use alias marker to be ignored, got %d", index)
+	}
+}

--- a/internal/lang/rust/manifest.go
+++ b/internal/lang/rust/manifest.go
@@ -195,28 +195,85 @@ func discoverManifestsByWalk(repoPath string) ([]string, []string, error) {
 }
 
 func resolveWorkspaceMembers(repoPath, pattern string) []string {
-	glob := filepath.Join(repoPath, pattern)
-	matches, err := filepath.Glob(glob)
+	roots := make(map[string]struct{})
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return nil
+	}
+	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		if shouldSkipDir(entry.Name()) {
+			return filepath.SkipDir
+		}
+
+		rel, relErr := filepath.Rel(repoPath, path)
+		if relErr != nil {
+			return relErr
+		}
+		matched, matchErr := workspaceMemberPatternMatches(pattern, rel)
+		if matchErr != nil {
+			return matchErr
+		}
+		if !matched {
+			return nil
+		}
+
+		manifest := filepath.Join(path, cargoTomlName)
+		if _, manifestErr := os.Stat(manifest); manifestErr != nil {
+			return nil
+		}
+		roots[path] = struct{}{}
+		return nil
+	})
 	if err != nil {
 		return nil
 	}
-	roots := make(map[string]struct{})
-	for _, match := range matches {
-		match = filepath.Clean(match)
-		info, statErr := os.Stat(match)
-		if statErr != nil || !info.IsDir() {
-			continue
-		}
-		if !isSubPath(repoPath, match) {
-			continue
-		}
-		manifest := filepath.Join(match, cargoTomlName)
-		if _, manifestErr := os.Stat(manifest); manifestErr != nil {
-			continue
-		}
-		roots[match] = struct{}{}
-	}
 	return shared.SortedKeys(roots)
+}
+
+func workspaceMemberPatternMatches(pattern, candidate string) (bool, error) {
+	pattern = filepath.ToSlash(filepath.Clean(strings.TrimSpace(pattern)))
+	candidate = filepath.ToSlash(filepath.Clean(strings.TrimSpace(candidate)))
+	if pattern == "" || candidate == "" {
+		return false, nil
+	}
+	patternParts := strings.Split(pattern, "/")
+	candidateParts := strings.Split(candidate, "/")
+	return matchWorkspaceMemberPatternParts(patternParts, candidateParts)
+}
+
+func matchWorkspaceMemberPatternParts(patternParts, candidateParts []string) (bool, error) {
+	if len(patternParts) == 0 {
+		return len(candidateParts) == 0, nil
+	}
+	if patternParts[0] == "**" {
+		if len(patternParts) == 1 {
+			return true, nil
+		}
+		for index := 0; index <= len(candidateParts); index++ {
+			matched, err := matchWorkspaceMemberPatternParts(patternParts[1:], candidateParts[index:])
+			if err != nil {
+				return false, err
+			}
+			if matched {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	if len(candidateParts) == 0 {
+		return false, nil
+	}
+	matched, err := filepath.Match(patternParts[0], candidateParts[0])
+	if err != nil || !matched {
+		return false, err
+	}
+	return matchWorkspaceMemberPatternParts(patternParts[1:], candidateParts[1:])
 }
 
 func parseCargoManifest(manifestPath, repoPath string) (manifestMeta, map[string]dependencyInfo, error) {
@@ -361,7 +418,7 @@ func ensureCanonicalDependencyAlias(deps map[string]dependencyInfo, info depende
 
 func isDependencySection(section string) bool {
 	section = strings.ToLower(strings.TrimSpace(section))
-	if section == "dependencies" || section == "dev-dependencies" || section == "build-dependencies" {
+	if section == "dependencies" || section == "dev-dependencies" || section == "build-dependencies" || section == "workspace.dependencies" {
 		return true
 	}
 	if strings.HasPrefix(section, "target.") {

--- a/internal/lang/rust/manifest.go
+++ b/internal/lang/rust/manifest.go
@@ -218,7 +218,7 @@ type workspaceMemberCollector struct {
 	roots    map[string]struct{}
 }
 
-func (c workspaceMemberCollector) walk(path string, entry fs.DirEntry, walkErr error) error {
+func (c *workspaceMemberCollector) walk(path string, entry fs.DirEntry, walkErr error) error {
 	matched, err := c.matchDirectory(path, entry, walkErr)
 	if err != nil || !matched {
 		return err
@@ -227,7 +227,7 @@ func (c workspaceMemberCollector) walk(path string, entry fs.DirEntry, walkErr e
 	return nil
 }
 
-func (c workspaceMemberCollector) matchDirectory(path string, entry fs.DirEntry, walkErr error) (bool, error) {
+func (c *workspaceMemberCollector) matchDirectory(path string, entry fs.DirEntry, walkErr error) (bool, error) {
 	if walkErr != nil {
 		return false, walkErr
 	}

--- a/internal/lang/rust/manifest.go
+++ b/internal/lang/rust/manifest.go
@@ -200,40 +200,58 @@ func resolveWorkspaceMembers(repoPath, pattern string) []string {
 	if pattern == "" {
 		return nil
 	}
-	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if !entry.IsDir() {
-			return nil
-		}
-		if shouldSkipDir(entry.Name()) {
-			return filepath.SkipDir
-		}
-
-		rel, relErr := filepath.Rel(repoPath, path)
-		if relErr != nil {
-			return relErr
-		}
-		matched, matchErr := workspaceMemberPatternMatches(pattern, rel)
-		if matchErr != nil {
-			return matchErr
-		}
-		if !matched {
-			return nil
-		}
-
-		manifest := filepath.Join(path, cargoTomlName)
-		if _, manifestErr := os.Stat(manifest); manifestErr != nil {
-			return nil
-		}
-		roots[path] = struct{}{}
-		return nil
-	})
+	collector := workspaceMemberCollector{
+		repoPath: repoPath,
+		pattern:  pattern,
+		roots:    roots,
+	}
+	err := filepath.WalkDir(repoPath, collector.walk)
 	if err != nil {
 		return nil
 	}
 	return shared.SortedKeys(roots)
+}
+
+type workspaceMemberCollector struct {
+	repoPath string
+	pattern  string
+	roots    map[string]struct{}
+}
+
+func (c workspaceMemberCollector) walk(path string, entry fs.DirEntry, walkErr error) error {
+	matched, err := c.matchDirectory(path, entry, walkErr)
+	if err != nil || !matched {
+		return err
+	}
+	c.roots[path] = struct{}{}
+	return nil
+}
+
+func (c workspaceMemberCollector) matchDirectory(path string, entry fs.DirEntry, walkErr error) (bool, error) {
+	if walkErr != nil {
+		return false, walkErr
+	}
+	if !entry.IsDir() {
+		return false, nil
+	}
+	if shouldSkipDir(entry.Name()) {
+		return false, filepath.SkipDir
+	}
+
+	rel, err := filepath.Rel(c.repoPath, path)
+	if err != nil {
+		return false, err
+	}
+	matched, err := workspaceMemberPatternMatches(c.pattern, rel)
+	if err != nil || !matched {
+		return false, err
+	}
+
+	manifest := filepath.Join(path, cargoTomlName)
+	if _, err := os.Stat(manifest); err != nil {
+		return false, nil
+	}
+	return true, nil
 }
 
 func workspaceMemberPatternMatches(pattern, candidate string) (bool, error) {

--- a/internal/lang/rust/scan_imports.go
+++ b/internal/lang/rust/scan_imports.go
@@ -69,7 +69,7 @@ func scanRustImportStatements(content []byte, includeUse bool, visit func(rustIm
 		for lineEnd < len(content) && content[lineEnd] != '\n' {
 			lineEnd++
 		}
-		if !state.insideRawString() {
+		if !state.insideRawString() && state.blockCommentDepth == 0 && !state.inString {
 			if kind, stmt, ok := parseRustImportStatement(content, lineStart, lineEnd, line, includeUse); ok {
 				visit(kind, stmt)
 			}

--- a/internal/lang/rust/scan_imports_lex_test.go
+++ b/internal/lang/rust/scan_imports_lex_test.go
@@ -45,6 +45,20 @@ func TestRustImportLexStateTracksCommentsAndStrings(t *testing.T) {
 	}
 }
 
+func TestParseRustImportsSkipsBlockComments(t *testing.T) {
+	lookup := map[string]dependencyInfo{"serde": {Canonical: "serde"}}
+	scan := &scanResult{UnresolvedImports: map[string]int{}}
+
+	content := "/*\nuse serde::Deserialize;\n*/\nuse serde::Serialize;\n"
+	imports := parseRustImports(content, srcLibRS, "", lookup, scan)
+	if len(imports) != 1 {
+		t.Fatalf("expected only the real import to be parsed, got %#v", imports)
+	}
+	if imports[0].Name != "Serialize" {
+		t.Fatalf("expected trailing import outside block comment, got %#v", imports[0])
+	}
+}
+
 func TestRustRawStringHelpers(t *testing.T) {
 	hashCount, consumed, ok := parseRustRawStringStart([]byte(`br##"`), 0)
 	if !ok || hashCount != 2 || consumed != len(`br##"`) {

--- a/internal/lang/rust/scan_use.go
+++ b/internal/lang/rust/scan_use.go
@@ -127,13 +127,33 @@ func expandUseSegments(inner, prefix string, out *[]usePathEntry) {
 }
 
 func parseUseLocalAlias(part string) (string, string) {
-	idx := strings.LastIndex(part, " as ")
+	idx := findRustUseAliasIndex(part)
 	if idx <= 0 {
 		return part, ""
 	}
-	local := strings.TrimSpace(part[idx+4:])
+	local := strings.TrimSpace(part[idx+2:])
 	base := strings.TrimSpace(part[:idx])
+	if base == "" || local == "" {
+		return part, ""
+	}
 	return base, local
+}
+
+func findRustUseAliasIndex(part string) int {
+	for index := 0; index+1 < len(part); index++ {
+		if part[index] != 'a' || part[index+1] != 's' {
+			continue
+		}
+		if index == 0 || !isRustWhitespace(part[index-1]) {
+			continue
+		}
+		next := index + 2
+		if next >= len(part) || !isRustWhitespace(part[next]) {
+			continue
+		}
+		return index
+	}
+	return -1
 }
 
 func normalizeUseWildcard(part, prefix string) (string, string, bool) {


### PR DESCRIPTION
## Summary

Fixes four Rust adapter regressions: tab-delimited `use ... as ...` aliases now parse correctly, imports inside `/* ... */` blocks are ignored, `**` workspace globs resolve nested members, and `[workspace.dependencies]` entries participate in dependency matching.

Closes #833, #847, #856, and #857.

## Changes

- make Rust import scanning tolerate tab-delimited `as` aliases while preserving block-comment masking
- ignore `use` clauses that only appear inside block comments
- expand workspace member resolution to honor `**` patterns for nested crates
- thread `[workspace.dependencies]` metadata into dependency lookup and add regression coverage for the combined cases

## Validation

Commands and checks run:

```bash
go test ./internal/lang/rust
```

Additional manual validation:

- Reviewed the updated scan and manifest code paths to confirm the workspace-member and workspace-dependency fixes stay aligned with the existing Cargo parsing model.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected beyond the intended nested-workspace glob support.
- Memory benchmark impact: N/A.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
