### PR TITLE
fix(policy): preserve explicit clears and upstream deny state

### DIFF
--- a/internal/report/format_pr_comment.go
+++ b/internal/report/format_pr_comment.go
@@ -65,7 +65,7 @@ func formatPRComment(report Report) string {
 
 func topDependencyDeltas(deltas []DependencyDelta, limit int) []DependencyDelta {
 	if len(deltas) == 0 || limit <= 0 {
-		return nil
+		return make([]DependencyDelta, 0)
 	}
 	copied := append([]DependencyDelta(nil), deltas...)
 	sort.Slice(copied, func(i, j int) bool {

--- a/internal/report/format_table_sections.go
+++ b/internal/report/format_table_sections.go
@@ -211,7 +211,7 @@ func escapeTableWarning(warning string) string {
 
 func topWasteDeltas(deltas []DependencyDelta, limit int) []DependencyDelta {
 	if len(deltas) == 0 || limit <= 0 {
-		return nil
+		return make([]DependencyDelta, 0)
 	}
 	copied := append([]DependencyDelta(nil), deltas...)
 	sort.Slice(copied, func(i, j int) bool {

--- a/internal/report/license.go
+++ b/internal/report/license.go
@@ -45,9 +45,6 @@ func CountDeniedLicenses(dependencies []DependencyReport) int {
 }
 
 func normalizeDenyList(values []string) map[string]struct{} {
-	if len(values) == 0 {
-		return nil
-	}
 	normalized := make(map[string]struct{}, len(values))
 	for _, value := range values {
 		id := normalizeSPDXID(value)
@@ -55,9 +52,6 @@ func normalizeDenyList(values []string) map[string]struct{} {
 			continue
 		}
 		normalized[id] = struct{}{}
-	}
-	if len(normalized) == 0 {
-		return nil
 	}
 	return normalized
 }
@@ -119,9 +113,6 @@ func spdxExpressionContainsDenied(expression string, deny map[string]struct{}) b
 
 func SortedDenyList(values []string) []string {
 	seen := normalizeDenyList(values)
-	if len(seen) == 0 {
-		return nil
-	}
 	items := make([]string, 0, len(seen))
 	for value := range seen {
 		items = append(items, value)

--- a/internal/report/license.go
+++ b/internal/report/license.go
@@ -22,12 +22,6 @@ func NormalizeDependencyLicenses(dependencies []DependencyReport) {
 func ApplyLicensePolicy(dependencies []DependencyReport, denyList []string) {
 	normalizedDeny := normalizeDenyList(denyList)
 	if len(normalizedDeny) == 0 {
-		for i := range dependencies {
-			if dependencies[i].License == nil {
-				continue
-			}
-			dependencies[i].License.Denied = false
-		}
 		return
 	}
 

--- a/internal/report/license_test.go
+++ b/internal/report/license_test.go
@@ -40,14 +40,21 @@ func TestApplyLicensePolicyAndCountDenied(t *testing.T) {
 	}
 }
 
-func TestApplyLicensePolicyClearsDeniedWhenNoDenyList(t *testing.T) {
+func TestApplyLicensePolicyPreservesDeniedWhenNoDenyList(t *testing.T) {
 	deps := []DependencyReport{
 		{Name: "x", License: &DependencyLicense{SPDX: reportTestGPL30OnlyLower, Denied: true}},
-		{Name: "y", License: nil},
+		{Name: "y", License: &DependencyLicense{SPDX: "MIT", Denied: false}},
+		{Name: "z", License: nil},
 	}
 	ApplyLicensePolicy(deps, nil)
-	if deps[0].License.Denied {
-		t.Fatalf("expected denied flag to clear when denylist is empty")
+	if !deps[0].License.Denied {
+		t.Fatalf("expected upstream denied flag to remain set when denylist is empty")
+	}
+	if deps[1].License.Denied {
+		t.Fatalf("expected non-denied licenses to remain unchanged")
+	}
+	if deps[2].License != nil {
+		t.Fatalf("expected nil license to remain untouched")
 	}
 }
 
@@ -79,8 +86,8 @@ func TestLicenseAdditionalBranches(t *testing.T) {
 		{Name: "set", License: &DependencyLicense{Denied: true}},
 	}
 	ApplyLicensePolicy(deps, nil)
-	if deps[1].License.Denied {
-		t.Fatalf("expected deny flag to clear when deny list is empty")
+	if !deps[1].License.Denied {
+		t.Fatalf("expected deny flag to remain set when deny list is empty")
 	}
 
 	if got := SortedDenyList([]string{"###"}); len(got) != 0 {

--- a/internal/thresholds/config.go
+++ b/internal/thresholds/config.go
@@ -22,13 +22,17 @@ type LoadResult struct {
 }
 
 type PathScope struct {
-	Include []string
-	Exclude []string
+	Include    []string
+	Exclude    []string
+	includeSet bool
+	excludeSet bool
 }
 
 type FeatureConfig struct {
-	Enable  []string
-	Disable []string
+	Enable     []string
+	Disable    []string
+	enableSet  bool
+	disableSet bool
 }
 
 func Load(repoPath, explicitPath string) (Overrides, string, error) {
@@ -53,7 +57,8 @@ func LoadWithPolicy(repoPath, explicitPath string) (LoadResult, error) {
 	if !found {
 		return LoadResult{
 			Resolved:      Defaults(),
-			Scope:         PathScope{},
+			Scope:         normalizePathScope(PathScope{}),
+			Features:      normalizeFeatureConfig(FeatureConfig{}),
 			PolicySources: []string{defaultPolicySource},
 		}, nil
 	}
@@ -73,10 +78,10 @@ func LoadWithPolicy(repoPath, explicitPath string) (LoadResult, error) {
 	}
 
 	return LoadResult{
-		Overrides:     mergeResult.overrides,
+		Overrides:     normalizeOverrides(mergeResult.overrides),
 		Resolved:      resolved,
-		Scope:         mergeResult.scope,
-		Features:      mergeResult.features,
+		Scope:         normalizePathScope(mergeResult.scope),
+		Features:      normalizeFeatureConfig(mergeResult.features),
 		ConfigPath:    configPath,
 		PolicySources: mergeResult.policySourcesHighToLow(),
 	}, nil
@@ -93,17 +98,17 @@ type rawConfig struct {
 
 	Thresholds rawThresholds `yaml:"thresholds" json:"thresholds"`
 
-	FailOnIncreasePercent             *int     `yaml:"fail_on_increase_percent" json:"fail_on_increase_percent"`
-	LowConfidenceWarningPercent       *int     `yaml:"low_confidence_warning_percent" json:"low_confidence_warning_percent"`
-	MinUsagePercentForRecommendations *int     `yaml:"min_usage_percent_for_recommendations" json:"min_usage_percent_for_recommendations"`
-	MaxUncertainImportCount           *int     `yaml:"max_uncertain_import_count" json:"max_uncertain_import_count"`
-	RemovalCandidateWeightUsage       *float64 `yaml:"removal_candidate_weight_usage" json:"removal_candidate_weight_usage"`
-	RemovalCandidateWeightImpact      *float64 `yaml:"removal_candidate_weight_impact" json:"removal_candidate_weight_impact"`
-	RemovalCandidateWeightConfidence  *float64 `yaml:"removal_candidate_weight_confidence" json:"removal_candidate_weight_confidence"`
-	LockfileDriftPolicy               *string  `yaml:"lockfile_drift_policy" json:"lockfile_drift_policy"`
-	LicenseDeny                       []string `yaml:"license_deny" json:"license_deny"`
-	LicenseFailOnDeny                 *bool    `yaml:"license_fail_on_deny" json:"license_fail_on_deny"`
-	LicenseIncludeRegistryProvenance  *bool    `yaml:"license_include_registry_provenance" json:"license_include_registry_provenance"`
+	FailOnIncreasePercent             *int      `yaml:"fail_on_increase_percent" json:"fail_on_increase_percent"`
+	LowConfidenceWarningPercent       *int      `yaml:"low_confidence_warning_percent" json:"low_confidence_warning_percent"`
+	MinUsagePercentForRecommendations *int      `yaml:"min_usage_percent_for_recommendations" json:"min_usage_percent_for_recommendations"`
+	MaxUncertainImportCount           *int      `yaml:"max_uncertain_import_count" json:"max_uncertain_import_count"`
+	RemovalCandidateWeightUsage       *float64  `yaml:"removal_candidate_weight_usage" json:"removal_candidate_weight_usage"`
+	RemovalCandidateWeightImpact      *float64  `yaml:"removal_candidate_weight_impact" json:"removal_candidate_weight_impact"`
+	RemovalCandidateWeightConfidence  *float64  `yaml:"removal_candidate_weight_confidence" json:"removal_candidate_weight_confidence"`
+	LockfileDriftPolicy               *string   `yaml:"lockfile_drift_policy" json:"lockfile_drift_policy"`
+	LicenseDeny                       *[]string `yaml:"license_deny" json:"license_deny"`
+	LicenseFailOnDeny                 *bool     `yaml:"license_fail_on_deny" json:"license_fail_on_deny"`
+	LicenseIncludeRegistryProvenance  *bool     `yaml:"license_include_registry_provenance" json:"license_include_registry_provenance"`
 }
 
 type rawPolicy struct {
@@ -111,25 +116,25 @@ type rawPolicy struct {
 }
 
 type rawScope struct {
-	Include []string `yaml:"include" json:"include"`
-	Exclude []string `yaml:"exclude" json:"exclude"`
+	Include *[]string `yaml:"include" json:"include"`
+	Exclude *[]string `yaml:"exclude" json:"exclude"`
 }
 
 type rawFeatures struct {
-	Enable  []string `yaml:"enable" json:"enable"`
-	Disable []string `yaml:"disable" json:"disable"`
+	Enable  *[]string `yaml:"enable" json:"enable"`
+	Disable *[]string `yaml:"disable" json:"disable"`
 }
 
 type rawThresholds struct {
-	FailOnIncreasePercent             *int     `yaml:"fail_on_increase_percent" json:"fail_on_increase_percent"`
-	LowConfidenceWarningPercent       *int     `yaml:"low_confidence_warning_percent" json:"low_confidence_warning_percent"`
-	MinUsagePercentForRecommendations *int     `yaml:"min_usage_percent_for_recommendations" json:"min_usage_percent_for_recommendations"`
-	MaxUncertainImportCount           *int     `yaml:"max_uncertain_import_count" json:"max_uncertain_import_count"`
-	RemovalCandidateWeightUsage       *float64 `yaml:"removal_candidate_weight_usage" json:"removal_candidate_weight_usage"`
-	RemovalCandidateWeightImpact      *float64 `yaml:"removal_candidate_weight_impact" json:"removal_candidate_weight_impact"`
-	RemovalCandidateWeightConfidence  *float64 `yaml:"removal_candidate_weight_confidence" json:"removal_candidate_weight_confidence"`
-	LockfileDriftPolicy               *string  `yaml:"lockfile_drift_policy" json:"lockfile_drift_policy"`
-	LicenseDeny                       []string `yaml:"license_deny" json:"license_deny"`
-	LicenseFailOnDeny                 *bool    `yaml:"license_fail_on_deny" json:"license_fail_on_deny"`
-	LicenseIncludeRegistryProvenance  *bool    `yaml:"license_include_registry_provenance" json:"license_include_registry_provenance"`
+	FailOnIncreasePercent             *int      `yaml:"fail_on_increase_percent" json:"fail_on_increase_percent"`
+	LowConfidenceWarningPercent       *int      `yaml:"low_confidence_warning_percent" json:"low_confidence_warning_percent"`
+	MinUsagePercentForRecommendations *int      `yaml:"min_usage_percent_for_recommendations" json:"min_usage_percent_for_recommendations"`
+	MaxUncertainImportCount           *int      `yaml:"max_uncertain_import_count" json:"max_uncertain_import_count"`
+	RemovalCandidateWeightUsage       *float64  `yaml:"removal_candidate_weight_usage" json:"removal_candidate_weight_usage"`
+	RemovalCandidateWeightImpact      *float64  `yaml:"removal_candidate_weight_impact" json:"removal_candidate_weight_impact"`
+	RemovalCandidateWeightConfidence  *float64  `yaml:"removal_candidate_weight_confidence" json:"removal_candidate_weight_confidence"`
+	LockfileDriftPolicy               *string   `yaml:"lockfile_drift_policy" json:"lockfile_drift_policy"`
+	LicenseDeny                       *[]string `yaml:"license_deny" json:"license_deny"`
+	LicenseFailOnDeny                 *bool     `yaml:"license_fail_on_deny" json:"license_fail_on_deny"`
+	LicenseIncludeRegistryProvenance  *bool     `yaml:"license_include_registry_provenance" json:"license_include_registry_provenance"`
 }

--- a/internal/thresholds/config_cov_more_branches_test.go
+++ b/internal/thresholds/config_cov_more_branches_test.go
@@ -17,13 +17,36 @@ func TestThresholdConfigAdditionalBranches(t *testing.T) {
 	}
 
 	if got := normalizePathPatterns([]string{" ", "\t"}); len(got) != 0 {
-		t.Fatalf("expected blank path patterns to normalize to nil, got %#v", got)
+		t.Fatalf("expected blank path patterns to normalize to empty, got %#v", got)
+	}
+	if got := normalizePathPatterns([]string{}); got == nil || len(got) != 0 {
+		t.Fatalf("expected explicit empty path patterns to remain allocated, got %#v", got)
 	}
 
 	maxUncertain := 2
 	merged := mergeOverrides(Overrides{}, Overrides{MaxUncertainImportCount: &maxUncertain})
 	if merged.MaxUncertainImportCount == nil || *merged.MaxUncertainImportCount != 2 {
 		t.Fatalf("expected max_uncertain_import_count override to merge, got %#v", merged)
+	}
+	merged = mergeOverrides(Overrides{LicenseDenyList: []string{"GPL-3.0-ONLY"}}, Overrides{LicenseDenyList: []string{}})
+	if merged.LicenseDenyList == nil || len(merged.LicenseDenyList) != 0 {
+		t.Fatalf("expected explicit empty deny list to clear inherited deny list, got %#v", merged.LicenseDenyList)
+	}
+
+	scope := mergeScope(
+		PathScope{Include: []string{"src/**"}, Exclude: []string{"vendor/**"}},
+		PathScope{Include: []string{}, Exclude: []string{}},
+	)
+	if scope.Include == nil || len(scope.Include) != 0 || scope.Exclude == nil || len(scope.Exclude) != 0 {
+		t.Fatalf("expected explicit empty scope lists to clear inherited scope, got %#v", scope)
+	}
+
+	features := mergeFeatures(
+		FeatureConfig{Enable: []string{"alpha"}, Disable: []string{"beta"}},
+		FeatureConfig{Enable: []string{}, Disable: []string{}},
+	)
+	if features.Enable == nil || len(features.Enable) != 0 || features.Disable == nil || len(features.Disable) != 0 {
+		t.Fatalf("expected explicit empty feature lists to clear inherited features, got %#v", features)
 	}
 
 	sources := (&resolveMergeResult{appliedSourcesLow: []string{packAPolicySource, defaultPolicySource, packAPolicySource}}).policySourcesHighToLow()

--- a/internal/thresholds/config_cov_more_branches_test.go
+++ b/internal/thresholds/config_cov_more_branches_test.go
@@ -11,44 +11,54 @@ import (
 
 const packAPolicySource = "pack-a"
 
-func TestThresholdConfigAdditionalBranches(t *testing.T) {
+func TestThresholdConfigRejectsInvalidRepoPath(t *testing.T) {
 	if _, err := LoadWithPolicy("\x00", ""); err == nil {
 		t.Fatalf("expected LoadWithPolicy to reject invalid repo path")
 	}
+}
 
+func TestThresholdConfigNormalizeBranches(t *testing.T) {
 	if got := normalizePathPatterns([]string{" ", "\t"}); len(got) != 0 {
 		t.Fatalf("expected blank path patterns to normalize to empty, got %#v", got)
 	}
-	if got := normalizePathPatterns([]string{}); got == nil || len(got) != 0 {
-		t.Fatalf("expected explicit empty path patterns to remain allocated, got %#v", got)
+	if got := normalizePathPatterns(make([]string, 0)); len(got) != 0 {
+		t.Fatalf("expected explicit empty path patterns to remain empty, got %#v", got)
 	}
+}
 
+func TestThresholdConfigMergeBranches(t *testing.T) {
 	maxUncertain := 2
 	merged := mergeOverrides(Overrides{}, Overrides{MaxUncertainImportCount: &maxUncertain})
 	if merged.MaxUncertainImportCount == nil || *merged.MaxUncertainImportCount != 2 {
 		t.Fatalf("expected max_uncertain_import_count override to merge, got %#v", merged)
 	}
-	merged = mergeOverrides(Overrides{LicenseDenyList: []string{"GPL-3.0-ONLY"}}, Overrides{LicenseDenyList: []string{}})
-	if merged.LicenseDenyList == nil || len(merged.LicenseDenyList) != 0 {
+
+	merged = mergeOverrides(
+		Overrides{LicenseDenyList: []string{"GPL-3.0-ONLY"}, licenseDenyListSet: true},
+		Overrides{LicenseDenyList: make([]string, 0), licenseDenyListSet: true},
+	)
+	if len(merged.LicenseDenyList) != 0 {
 		t.Fatalf("expected explicit empty deny list to clear inherited deny list, got %#v", merged.LicenseDenyList)
 	}
 
 	scope := mergeScope(
-		PathScope{Include: []string{"src/**"}, Exclude: []string{"vendor/**"}},
-		PathScope{Include: []string{}, Exclude: []string{}},
+		PathScope{Include: []string{"src/**"}, Exclude: []string{"vendor/**"}, includeSet: true, excludeSet: true},
+		PathScope{Include: make([]string, 0), Exclude: make([]string, 0), includeSet: true, excludeSet: true},
 	)
-	if scope.Include == nil || len(scope.Include) != 0 || scope.Exclude == nil || len(scope.Exclude) != 0 {
+	if len(scope.Include) != 0 || len(scope.Exclude) != 0 {
 		t.Fatalf("expected explicit empty scope lists to clear inherited scope, got %#v", scope)
 	}
 
 	features := mergeFeatures(
-		FeatureConfig{Enable: []string{"alpha"}, Disable: []string{"beta"}},
-		FeatureConfig{Enable: []string{}, Disable: []string{}},
+		FeatureConfig{Enable: []string{"alpha"}, Disable: []string{"beta"}, enableSet: true, disableSet: true},
+		FeatureConfig{Enable: make([]string, 0), Disable: make([]string, 0), enableSet: true, disableSet: true},
 	)
-	if features.Enable == nil || len(features.Enable) != 0 || features.Disable == nil || len(features.Disable) != 0 {
+	if len(features.Enable) != 0 || len(features.Disable) != 0 {
 		t.Fatalf("expected explicit empty feature lists to clear inherited features, got %#v", features)
 	}
+}
 
+func TestThresholdConfigPolicySourcesAndRemoteValidation(t *testing.T) {
 	sources := (&resolveMergeResult{appliedSourcesLow: []string{packAPolicySource, defaultPolicySource, packAPolicySource}}).policySourcesHighToLow()
 	if !reflect.DeepEqual(sources, []string{packAPolicySource, defaultPolicySource}) {
 		t.Fatalf("unexpected policy source ordering: %#v", sources)
@@ -67,7 +77,9 @@ func TestThresholdConfigAdditionalBranches(t *testing.T) {
 	if _, err := readRemotePolicyFile(location); err == nil || !strings.Contains(err.Error(), "unexpected status") {
 		t.Fatalf("expected remote status error, got %v", err)
 	}
+}
 
+func TestThresholdConfigRootContainment(t *testing.T) {
 	if isPathUnderRoot("\x00", filepath.Join(t.TempDir(), "policy.yml")) {
 		t.Fatalf("expected invalid root path to fail root containment check")
 	}

--- a/internal/thresholds/config_cov_more_branches_test.go
+++ b/internal/thresholds/config_cov_more_branches_test.go
@@ -33,26 +33,17 @@ func TestThresholdConfigMergeBranches(t *testing.T) {
 		t.Fatalf("expected max_uncertain_import_count override to merge, got %#v", merged)
 	}
 
-	merged = mergeOverrides(
-		Overrides{LicenseDenyList: []string{"GPL-3.0-ONLY"}, licenseDenyListSet: true},
-		Overrides{LicenseDenyList: make([]string, 0), licenseDenyListSet: true},
-	)
+	merged = mergeOverrides(Overrides{LicenseDenyList: []string{"GPL-3.0-ONLY"}, licenseDenyListSet: true}, Overrides{LicenseDenyList: make([]string, 0), licenseDenyListSet: true})
 	if len(merged.LicenseDenyList) != 0 {
 		t.Fatalf("expected explicit empty deny list to clear inherited deny list, got %#v", merged.LicenseDenyList)
 	}
 
-	scope := mergeScope(
-		PathScope{Include: []string{"src/**"}, Exclude: []string{"vendor/**"}, includeSet: true, excludeSet: true},
-		PathScope{Include: make([]string, 0), Exclude: make([]string, 0), includeSet: true, excludeSet: true},
-	)
+	scope := mergeScope(PathScope{Include: []string{"src/**"}, Exclude: []string{"vendor/**"}, includeSet: true, excludeSet: true}, PathScope{Include: make([]string, 0), Exclude: make([]string, 0), includeSet: true, excludeSet: true})
 	if len(scope.Include) != 0 || len(scope.Exclude) != 0 {
 		t.Fatalf("expected explicit empty scope lists to clear inherited scope, got %#v", scope)
 	}
 
-	features := mergeFeatures(
-		FeatureConfig{Enable: []string{"alpha"}, Disable: []string{"beta"}, enableSet: true, disableSet: true},
-		FeatureConfig{Enable: make([]string, 0), Disable: make([]string, 0), enableSet: true, disableSet: true},
-	)
+	features := mergeFeatures(FeatureConfig{Enable: []string{"alpha"}, Disable: []string{"beta"}, enableSet: true, disableSet: true}, FeatureConfig{Enable: make([]string, 0), Disable: make([]string, 0), enableSet: true, disableSet: true})
 	if len(features.Enable) != 0 || len(features.Disable) != 0 {
 		t.Fatalf("expected explicit empty feature lists to clear inherited features, got %#v", features)
 	}

--- a/internal/thresholds/config_cov_more_http_test.go
+++ b/internal/thresholds/config_cov_more_http_test.go
@@ -70,12 +70,12 @@ func TestThresholdConfigAdditionalRemotePolicyBranches(t *testing.T) {
 		t.Cleanup(func() {
 			remotePolicyHTTPClient = originalClient
 		})
-		remotePolicyHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		remotePolicyHTTPClient = &http.Client{Transport: &roundTripFunc{fn: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       &staticReadCloser{data: body, closeErr: closeErr},
 			}, nil
-		})}
+		}}}
 
 		location := "https://example.com/policy.yml#sha256=" + hex.EncodeToString(sum[:])
 		if _, err := readRemotePolicyFile(location); err == nil || !strings.Contains(err.Error(), closeErr.Error()) {
@@ -90,12 +90,12 @@ func TestThresholdConfigAdditionalRemotePolicyBranches(t *testing.T) {
 		t.Cleanup(func() {
 			remotePolicyHTTPClient = originalClient
 		})
-		remotePolicyHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		remotePolicyHTTPClient = &http.Client{Transport: &roundTripFunc{fn: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       &errReadCloser{readErr: readErr},
 			}, nil
-		})}
+		}}}
 
 		location := "https://example.com/policy.yml#sha256=" + strings.Repeat("a", 64)
 		if _, err := readRemotePolicyFile(location); err == nil || !strings.Contains(err.Error(), "read remote policy response") {

--- a/internal/thresholds/config_overrides.go
+++ b/internal/thresholds/config_overrides.go
@@ -18,9 +18,11 @@ func (c *rawConfig) toOverrides() (Overrides, error) {
 		RemovalCandidateWeightImpact:      c.RemovalCandidateWeightImpact,
 		RemovalCandidateWeightConfidence:  c.RemovalCandidateWeightConfidence,
 		LockfileDriftPolicy:               c.LockfileDriftPolicy,
-		LicenseDenyList:                   append([]string{}, c.LicenseDeny...),
 		LicenseFailOnDeny:                 c.LicenseFailOnDeny,
 		LicenseIncludeRegistryProvenance:  c.LicenseIncludeRegistryProvenance,
+	}
+	if c.LicenseDeny != nil {
+		overrides.LicenseDenyList = append([]string{}, c.LicenseDeny...)
 	}
 	if err := applyNestedOverride("fail_on_increase_percent", &overrides.FailOnIncreasePercent, c.Thresholds.FailOnIncreasePercent); err != nil {
 		return Overrides{}, err
@@ -92,10 +94,10 @@ func applyNestedStringOverride(name string, target **string, nested *string) err
 }
 
 func applyNestedListOverride(name string, target *[]string, nested []string) error {
-	if len(nested) == 0 {
+	if nested == nil {
 		return nil
 	}
-	if len(*target) > 0 {
+	if *target != nil {
 		return fmt.Errorf(duplicateThresholdErrFmt, name)
 	}
 	*target = append([]string{}, nested...)
@@ -139,7 +141,7 @@ func mergeOverrides(base, higher Overrides) Overrides {
 	if higher.LockfileDriftPolicy != nil {
 		merged.LockfileDriftPolicy = higher.LockfileDriftPolicy
 	}
-	if len(higher.LicenseDenyList) > 0 {
+	if higher.LicenseDenyList != nil {
 		merged.LicenseDenyList = append([]string{}, higher.LicenseDenyList...)
 	}
 	if higher.LicenseFailOnDeny != nil {
@@ -162,8 +164,11 @@ func (s *rawScope) toPathScope() PathScope {
 }
 
 func normalizePathPatterns(patterns []string) []string {
-	if len(patterns) == 0 {
+	if patterns == nil {
 		return nil
+	}
+	if len(patterns) == 0 {
+		return []string{}
 	}
 	seen := make(map[string]struct{}, len(patterns))
 	normalized := make([]string, 0, len(patterns))
@@ -179,17 +184,17 @@ func normalizePathPatterns(patterns []string) []string {
 		normalized = append(normalized, normalizedPattern)
 	}
 	if len(normalized) == 0 {
-		return nil
+		return []string{}
 	}
 	return normalized
 }
 
 func mergeScope(base, higher PathScope) PathScope {
 	merged := base
-	if len(higher.Include) > 0 {
+	if higher.Include != nil {
 		merged.Include = append([]string{}, higher.Include...)
 	}
-	if len(higher.Exclude) > 0 {
+	if higher.Exclude != nil {
 		merged.Exclude = append([]string{}, higher.Exclude...)
 	}
 	return merged
@@ -206,8 +211,11 @@ func (f *rawFeatures) toFeatureConfig() FeatureConfig {
 }
 
 func normalizeFeatureRefs(refs []string) []string {
-	if len(refs) == 0 {
+	if refs == nil {
 		return nil
+	}
+	if len(refs) == 0 {
+		return []string{}
 	}
 	seen := make(map[string]struct{}, len(refs))
 	normalized := make([]string, 0, len(refs))
@@ -223,17 +231,17 @@ func normalizeFeatureRefs(refs []string) []string {
 		normalized = append(normalized, trimmed)
 	}
 	if len(normalized) == 0 {
-		return nil
+		return []string{}
 	}
 	return normalized
 }
 
 func mergeFeatures(base, higher FeatureConfig) FeatureConfig {
 	merged := base
-	if len(higher.Enable) > 0 {
+	if higher.Enable != nil {
 		merged.Enable = append([]string{}, higher.Enable...)
 	}
-	if len(higher.Disable) > 0 {
+	if higher.Disable != nil {
 		merged.Disable = append([]string{}, higher.Disable...)
 	}
 	return merged

--- a/internal/thresholds/config_overrides.go
+++ b/internal/thresholds/config_overrides.go
@@ -8,6 +8,13 @@ import (
 
 const duplicateThresholdErrFmt = "threshold %s is defined more than once"
 
+type optionalStringPair struct {
+	first     []string
+	second    []string
+	firstSet  bool
+	secondSet bool
+}
+
 func (c *rawConfig) toOverrides() (Overrides, error) {
 	overrides := Overrides{
 		FailOnIncreasePercent:             c.FailOnIncreasePercent,
@@ -157,107 +164,35 @@ func mergeOverrides(base, higher Overrides) Overrides {
 }
 
 func (s *rawScope) toPathScope() PathScope {
-	scope := PathScope{
-		Include: make([]string, 0),
-		Exclude: make([]string, 0),
-	}
 	if s == nil {
-		return scope
+		return scopeFromOptionalStringPair(emptyOptionalStringPair())
 	}
-	if s.Include != nil {
-		scope.Include = normalizePathPatterns(*s.Include)
-		scope.includeSet = true
-	}
-	if s.Exclude != nil {
-		scope.Exclude = normalizePathPatterns(*s.Exclude)
-		scope.excludeSet = true
-	}
-	return scope
+	return scopeFromOptionalStringPair(rawOptionalStringPair(s.Include, normalizePathPatterns, s.Exclude, normalizePathPatterns))
 }
 
 func normalizePathPatterns(patterns []string) []string {
-	seen := make(map[string]struct{}, len(patterns))
-	normalized := make([]string, 0, len(patterns))
-	for _, pattern := range patterns {
-		normalizedPattern := filepath.ToSlash(strings.ReplaceAll(strings.TrimSpace(pattern), "\\", "/"))
-		if normalizedPattern == "" {
-			continue
-		}
-		if _, exists := seen[normalizedPattern]; exists {
-			continue
-		}
-		seen[normalizedPattern] = struct{}{}
-		normalized = append(normalized, normalizedPattern)
-	}
-	if len(normalized) == 0 {
-		return normalized
-	}
-	return normalized
+	return normalizeUniqueStrings(patterns, func(pattern string) string {
+		return filepath.ToSlash(strings.ReplaceAll(strings.TrimSpace(pattern), "\\", "/"))
+	})
 }
 
 func mergeScope(base, higher PathScope) PathScope {
-	merged := base
-	if higher.includeSet || len(higher.Include) > 0 {
-		merged.Include = cloneStrings(higher.Include)
-		merged.includeSet = true
-	}
-	if higher.excludeSet || len(higher.Exclude) > 0 {
-		merged.Exclude = cloneStrings(higher.Exclude)
-		merged.excludeSet = true
-	}
-	return merged
+	return scopeFromOptionalStringPair(mergedOptionalStringPair(base.Include, base.includeSet, higher.Include, higher.includeSet, base.Exclude, base.excludeSet, higher.Exclude, higher.excludeSet))
 }
 
 func (f *rawFeatures) toFeatureConfig() FeatureConfig {
-	features := FeatureConfig{
-		Enable:  make([]string, 0),
-		Disable: make([]string, 0),
-	}
 	if f == nil {
-		return features
+		return featureConfigFromOptionalStringPair(emptyOptionalStringPair())
 	}
-	if f.Enable != nil {
-		features.Enable = normalizeFeatureRefs(*f.Enable)
-		features.enableSet = true
-	}
-	if f.Disable != nil {
-		features.Disable = normalizeFeatureRefs(*f.Disable)
-		features.disableSet = true
-	}
-	return features
+	return featureConfigFromOptionalStringPair(rawOptionalStringPair(f.Enable, normalizeFeatureRefs, f.Disable, normalizeFeatureRefs))
 }
 
 func normalizeFeatureRefs(refs []string) []string {
-	seen := make(map[string]struct{}, len(refs))
-	normalized := make([]string, 0, len(refs))
-	for _, ref := range refs {
-		trimmed := strings.TrimSpace(ref)
-		if trimmed == "" {
-			continue
-		}
-		if _, exists := seen[trimmed]; exists {
-			continue
-		}
-		seen[trimmed] = struct{}{}
-		normalized = append(normalized, trimmed)
-	}
-	if len(normalized) == 0 {
-		return normalized
-	}
-	return normalized
+	return normalizeUniqueStrings(refs, strings.TrimSpace)
 }
 
 func mergeFeatures(base, higher FeatureConfig) FeatureConfig {
-	merged := base
-	if higher.enableSet || len(higher.Enable) > 0 {
-		merged.Enable = cloneStrings(higher.Enable)
-		merged.enableSet = true
-	}
-	if higher.disableSet || len(higher.Disable) > 0 {
-		merged.Disable = cloneStrings(higher.Disable)
-		merged.disableSet = true
-	}
-	return merged
+	return featureConfigFromOptionalStringPair(mergedOptionalStringPair(base.Enable, base.enableSet, higher.Enable, higher.enableSet, base.Disable, base.disableSet, higher.Disable, higher.disableSet))
 }
 
 func normalizePathScope(scope PathScope) PathScope {
@@ -289,6 +224,97 @@ func normalizeOverrides(overrides Overrides) Overrides {
 
 func cloneStrings(values []string) []string {
 	return append(make([]string, 0, len(values)), values...)
+}
+
+func normalizeOptionalStringList(values *[]string, normalize func([]string) []string) ([]string, bool) {
+	if values == nil {
+		return make([]string, 0), false
+	}
+	return normalize(*values), true
+}
+
+func normalizeOptionalStringPair(first *[]string, normalizeFirst func([]string) []string, second *[]string, normalizeSecond func([]string) []string) ([]string, bool, []string, bool) {
+	firstValues, firstSet := normalizeOptionalStringList(first, normalizeFirst)
+	secondValues, secondSet := normalizeOptionalStringList(second, normalizeSecond)
+	return firstValues, firstSet, secondValues, secondSet
+}
+
+func normalizeUniqueStrings(values []string, normalize func(string) string) []string {
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		normalizedValue := normalize(value)
+		if normalizedValue == "" {
+			continue
+		}
+		if _, exists := seen[normalizedValue]; exists {
+			continue
+		}
+		seen[normalizedValue] = struct{}{}
+		normalized = append(normalized, normalizedValue)
+	}
+	if len(normalized) == 0 {
+		return normalized
+	}
+	return normalized
+}
+
+func mergeOptionalStringList(base []string, baseSet bool, higher []string, higherSet bool) ([]string, bool) {
+	if higherSet || len(higher) > 0 {
+		return cloneStrings(higher), true
+	}
+	return base, baseSet
+}
+
+func mergeOptionalStringPair(baseFirst []string, baseFirstSet bool, higherFirst []string, higherFirstSet bool, baseSecond []string, baseSecondSet bool, higherSecond []string, higherSecondSet bool) ([]string, bool, []string, bool) {
+	firstValues, firstSet := mergeOptionalStringList(baseFirst, baseFirstSet, higherFirst, higherFirstSet)
+	secondValues, secondSet := mergeOptionalStringList(baseSecond, baseSecondSet, higherSecond, higherSecondSet)
+	return firstValues, firstSet, secondValues, secondSet
+}
+
+func emptyOptionalStringPair() optionalStringPair {
+	return optionalStringPair{
+		first:  make([]string, 0),
+		second: make([]string, 0),
+	}
+}
+
+func rawOptionalStringPair(first *[]string, normalizeFirst func([]string) []string, second *[]string, normalizeSecond func([]string) []string) optionalStringPair {
+	firstValues, firstSet, secondValues, secondSet := normalizeOptionalStringPair(first, normalizeFirst, second, normalizeSecond)
+	return optionalStringPair{
+		first:     firstValues,
+		second:    secondValues,
+		firstSet:  firstSet,
+		secondSet: secondSet,
+	}
+}
+
+func mergedOptionalStringPair(baseFirst []string, baseFirstSet bool, higherFirst []string, higherFirstSet bool, baseSecond []string, baseSecondSet bool, higherSecond []string, higherSecondSet bool) optionalStringPair {
+	firstValues, firstSet, secondValues, secondSet := mergeOptionalStringPair(baseFirst, baseFirstSet, higherFirst, higherFirstSet, baseSecond, baseSecondSet, higherSecond, higherSecondSet)
+	return optionalStringPair{
+		first:     firstValues,
+		second:    secondValues,
+		firstSet:  firstSet,
+		secondSet: secondSet,
+	}
+}
+
+func scopeFromOptionalStringPair(values optionalStringPair) PathScope {
+	return PathScope{
+		Include:    values.first,
+		Exclude:    values.second,
+		includeSet: values.firstSet,
+		excludeSet: values.secondSet,
+	}
+}
+
+func featureConfigFromOptionalStringPair(values optionalStringPair) FeatureConfig {
+	return FeatureConfig{
+		Enable:     values.first,
+		Disable:    values.second,
+		enableSet:  values.firstSet,
+		disableSet: values.secondSet,
+	}
 }
 
 func dedupeStable(values []string) []string {

--- a/internal/thresholds/config_overrides.go
+++ b/internal/thresholds/config_overrides.go
@@ -22,7 +22,8 @@ func (c *rawConfig) toOverrides() (Overrides, error) {
 		LicenseIncludeRegistryProvenance:  c.LicenseIncludeRegistryProvenance,
 	}
 	if c.LicenseDeny != nil {
-		overrides.LicenseDenyList = append([]string{}, c.LicenseDeny...)
+		overrides.LicenseDenyList = cloneStrings(*c.LicenseDeny)
+		overrides.licenseDenyListSet = true
 	}
 	if err := applyNestedOverride("fail_on_increase_percent", &overrides.FailOnIncreasePercent, c.Thresholds.FailOnIncreasePercent); err != nil {
 		return Overrides{}, err
@@ -48,7 +49,7 @@ func (c *rawConfig) toOverrides() (Overrides, error) {
 	if err := applyNestedStringOverride("lockfile_drift_policy", &overrides.LockfileDriftPolicy, c.Thresholds.LockfileDriftPolicy); err != nil {
 		return Overrides{}, err
 	}
-	if err := applyNestedListOverride("license_deny", &overrides.LicenseDenyList, c.Thresholds.LicenseDeny); err != nil {
+	if err := applyNestedListOverride("license_deny", &overrides.LicenseDenyList, &overrides.licenseDenyListSet, c.Thresholds.LicenseDeny); err != nil {
 		return Overrides{}, err
 	}
 	if err := applyNestedBoolOverride("license_fail_on_deny", &overrides.LicenseFailOnDeny, c.Thresholds.LicenseFailOnDeny); err != nil {
@@ -93,14 +94,15 @@ func applyNestedStringOverride(name string, target **string, nested *string) err
 	return nil
 }
 
-func applyNestedListOverride(name string, target *[]string, nested []string) error {
+func applyNestedListOverride(name string, target *[]string, targetSet *bool, nested *[]string) error {
 	if nested == nil {
 		return nil
 	}
-	if *target != nil {
+	if *targetSet {
 		return fmt.Errorf(duplicateThresholdErrFmt, name)
 	}
-	*target = append([]string{}, nested...)
+	*target = cloneStrings(*nested)
+	*targetSet = true
 	return nil
 }
 
@@ -141,8 +143,9 @@ func mergeOverrides(base, higher Overrides) Overrides {
 	if higher.LockfileDriftPolicy != nil {
 		merged.LockfileDriftPolicy = higher.LockfileDriftPolicy
 	}
-	if higher.LicenseDenyList != nil {
-		merged.LicenseDenyList = append([]string{}, higher.LicenseDenyList...)
+	if higher.licenseDenyListSet || len(higher.LicenseDenyList) > 0 {
+		merged.LicenseDenyList = cloneStrings(higher.LicenseDenyList)
+		merged.licenseDenyListSet = true
 	}
 	if higher.LicenseFailOnDeny != nil {
 		merged.LicenseFailOnDeny = higher.LicenseFailOnDeny
@@ -154,22 +157,25 @@ func mergeOverrides(base, higher Overrides) Overrides {
 }
 
 func (s *rawScope) toPathScope() PathScope {
+	scope := PathScope{
+		Include: make([]string, 0),
+		Exclude: make([]string, 0),
+	}
 	if s == nil {
-		return PathScope{}
+		return scope
 	}
-	return PathScope{
-		Include: normalizePathPatterns(s.Include),
-		Exclude: normalizePathPatterns(s.Exclude),
+	if s.Include != nil {
+		scope.Include = normalizePathPatterns(*s.Include)
+		scope.includeSet = true
 	}
+	if s.Exclude != nil {
+		scope.Exclude = normalizePathPatterns(*s.Exclude)
+		scope.excludeSet = true
+	}
+	return scope
 }
 
 func normalizePathPatterns(patterns []string) []string {
-	if patterns == nil {
-		return nil
-	}
-	if len(patterns) == 0 {
-		return []string{}
-	}
 	seen := make(map[string]struct{}, len(patterns))
 	normalized := make([]string, 0, len(patterns))
 	for _, pattern := range patterns {
@@ -184,39 +190,44 @@ func normalizePathPatterns(patterns []string) []string {
 		normalized = append(normalized, normalizedPattern)
 	}
 	if len(normalized) == 0 {
-		return []string{}
+		return normalized
 	}
 	return normalized
 }
 
 func mergeScope(base, higher PathScope) PathScope {
 	merged := base
-	if higher.Include != nil {
-		merged.Include = append([]string{}, higher.Include...)
+	if higher.includeSet || len(higher.Include) > 0 {
+		merged.Include = cloneStrings(higher.Include)
+		merged.includeSet = true
 	}
-	if higher.Exclude != nil {
-		merged.Exclude = append([]string{}, higher.Exclude...)
+	if higher.excludeSet || len(higher.Exclude) > 0 {
+		merged.Exclude = cloneStrings(higher.Exclude)
+		merged.excludeSet = true
 	}
 	return merged
 }
 
 func (f *rawFeatures) toFeatureConfig() FeatureConfig {
+	features := FeatureConfig{
+		Enable:  make([]string, 0),
+		Disable: make([]string, 0),
+	}
 	if f == nil {
-		return FeatureConfig{}
+		return features
 	}
-	return FeatureConfig{
-		Enable:  normalizeFeatureRefs(f.Enable),
-		Disable: normalizeFeatureRefs(f.Disable),
+	if f.Enable != nil {
+		features.Enable = normalizeFeatureRefs(*f.Enable)
+		features.enableSet = true
 	}
+	if f.Disable != nil {
+		features.Disable = normalizeFeatureRefs(*f.Disable)
+		features.disableSet = true
+	}
+	return features
 }
 
 func normalizeFeatureRefs(refs []string) []string {
-	if refs == nil {
-		return nil
-	}
-	if len(refs) == 0 {
-		return []string{}
-	}
 	seen := make(map[string]struct{}, len(refs))
 	normalized := make([]string, 0, len(refs))
 	for _, ref := range refs {
@@ -231,20 +242,53 @@ func normalizeFeatureRefs(refs []string) []string {
 		normalized = append(normalized, trimmed)
 	}
 	if len(normalized) == 0 {
-		return []string{}
+		return normalized
 	}
 	return normalized
 }
 
 func mergeFeatures(base, higher FeatureConfig) FeatureConfig {
 	merged := base
-	if higher.Enable != nil {
-		merged.Enable = append([]string{}, higher.Enable...)
+	if higher.enableSet || len(higher.Enable) > 0 {
+		merged.Enable = cloneStrings(higher.Enable)
+		merged.enableSet = true
 	}
-	if higher.Disable != nil {
-		merged.Disable = append([]string{}, higher.Disable...)
+	if higher.disableSet || len(higher.Disable) > 0 {
+		merged.Disable = cloneStrings(higher.Disable)
+		merged.disableSet = true
 	}
 	return merged
+}
+
+func normalizePathScope(scope PathScope) PathScope {
+	if len(scope.Include) == 0 {
+		scope.Include = make([]string, 0)
+	}
+	if len(scope.Exclude) == 0 {
+		scope.Exclude = make([]string, 0)
+	}
+	return scope
+}
+
+func normalizeFeatureConfig(features FeatureConfig) FeatureConfig {
+	if len(features.Enable) == 0 {
+		features.Enable = make([]string, 0)
+	}
+	if len(features.Disable) == 0 {
+		features.Disable = make([]string, 0)
+	}
+	return features
+}
+
+func normalizeOverrides(overrides Overrides) Overrides {
+	if len(overrides.LicenseDenyList) == 0 {
+		overrides.LicenseDenyList = make([]string, 0)
+	}
+	return overrides
+}
+
+func cloneStrings(values []string) []string {
+	return append(make([]string, 0, len(values)), values...)
 }
 
 func dedupeStable(values []string) []string {

--- a/internal/thresholds/config_test.go
+++ b/internal/thresholds/config_test.go
@@ -111,8 +111,8 @@ func TestRawScopeToPathScope(t *testing.T) {
 	}
 
 	scope := &rawScope{
-		Include: []string{" src\\**\\*.ts ", "src/**/*.ts"},
-		Exclude: []string{" " + vendorGlob + " ", "vendor\\**"},
+		Include: stringList(" src\\**\\*.ts ", "src/**/*.ts"),
+		Exclude: stringList(" "+vendorGlob+" ", "vendor\\**"),
 	}
 	got := scope.toPathScope()
 	if strings.Join(got.Include, ",") != "src/**/*.ts" {
@@ -125,8 +125,10 @@ func TestRawScopeToPathScope(t *testing.T) {
 
 func TestMergeScope(t *testing.T) {
 	base := PathScope{
-		Include: []string{"src/**"},
-		Exclude: []string{vendorGlob},
+		Include:    []string{"src/**"},
+		Exclude:    []string{vendorGlob},
+		includeSet: true,
+		excludeSet: true,
 	}
 
 	if got := mergeScope(base, PathScope{}); strings.Join(got.Include, ",") != "src/**" || strings.Join(got.Exclude, ",") != vendorGlob {
@@ -134,8 +136,10 @@ func TestMergeScope(t *testing.T) {
 	}
 
 	higher := PathScope{
-		Include: []string{"packages/**"},
-		Exclude: []string{"dist/**"},
+		Include:    []string{"packages/**"},
+		Exclude:    []string{"dist/**"},
+		includeSet: true,
+		excludeSet: true,
 	}
 	got := mergeScope(base, higher)
 	if strings.Join(got.Include, ",") != "packages/**" || strings.Join(got.Exclude, ",") != "dist/**" {
@@ -262,8 +266,8 @@ func TestLoadConfigLicensePolicyFields(t *testing.T) {
 }
 
 func TestRawConfigToOverridesDuplicateNestedLicensePolicyFields(t *testing.T) {
-	rootDeny := []string{"gpl-3.0-only"}
-	nestedDeny := []string{"agpl-3.0-only"}
+	rootDeny := stringList("gpl-3.0-only")
+	nestedDeny := stringList("agpl-3.0-only")
 	cfg := rawConfig{
 		LicenseDeny: rootDeny,
 		Thresholds: rawThresholds{
@@ -643,13 +647,13 @@ features:
 		t.Fatalf("load with policy packs: %v", err)
 	}
 
-	if result.Resolved.LicenseDenyList == nil || len(result.Resolved.LicenseDenyList) != 0 {
+	if len(result.Resolved.LicenseDenyList) != 0 {
 		t.Fatalf("expected explicit empty license deny list to clear inherited pack values, got %#v", result.Resolved.LicenseDenyList)
 	}
-	if result.Scope.Include == nil || len(result.Scope.Include) != 0 {
+	if len(result.Scope.Include) != 0 {
 		t.Fatalf("expected explicit empty scope include list to clear inherited pack values, got %#v", result.Scope.Include)
 	}
-	if result.Features.Enable == nil || len(result.Features.Enable) != 0 {
+	if len(result.Features.Enable) != 0 {
 		t.Fatalf("expected explicit empty feature enable list to clear inherited pack values, got %#v", result.Features.Enable)
 	}
 }
@@ -1103,9 +1107,9 @@ func TestRemotePolicyURLValidationAndFetchErrors(t *testing.T) {
 	t.Cleanup(func() {
 		remotePolicyHTTPClient = originalClient
 	})
-	remotePolicyHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+	remotePolicyHTTPClient = &http.Client{Transport: &roundTripFunc{fn: func(*http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("boom")
-	})}
+	}}}
 	if _, err := readRemotePolicyFile("https://example.com/policy.yml#sha256=" + strings.Repeat("a", 64)); err == nil || !strings.Contains(err.Error(), "fetch remote policy") {
 		t.Fatalf("expected fetch remote policy error, got %v", err)
 	}
@@ -1139,8 +1143,15 @@ func assertLoadConfigErrorContains(t *testing.T, config string, expectedText str
 	}
 }
 
-type roundTripFunc func(*http.Request) (*http.Response, error)
+func stringList(values ...string) *[]string {
+	out := append(make([]string, 0, len(values)), values...)
+	return &out
+}
 
-func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return fn(req)
+type roundTripFunc struct {
+	fn func(*http.Request) (*http.Response, error)
+}
+
+func (rt *roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return rt.fn(req)
 }

--- a/internal/thresholds/config_test.go
+++ b/internal/thresholds/config_test.go
@@ -608,6 +608,52 @@ thresholds:
 	}
 }
 
+func TestLoadWithPolicyExplicitEmptyListsClearInheritedPackValues(t *testing.T) {
+	repo := t.TempDir()
+	basePolicy := `thresholds:
+  license_deny:
+    - gpl-3.0-only
+scope:
+  include:
+    - src/**
+features:
+  enable:
+    - alpha
+`
+	overlayPolicy := `policy:
+  packs:
+    - ` + basePackFileName + `
+thresholds:
+  license_deny: []
+scope:
+  include: []
+features:
+  enable: []
+`
+	rootPolicy := `policy:
+  packs:
+    - packs/overlay.yml
+`
+	testutil.MustWriteFile(t, filepath.Join(repo, "packs", basePackFileName), basePolicy)
+	testutil.MustWriteFile(t, filepath.Join(repo, "packs", overlayPackName), overlayPolicy)
+	testutil.MustWriteFile(t, filepath.Join(repo, lopperYMLName), rootPolicy)
+
+	result, err := LoadWithPolicy(repo, "")
+	if err != nil {
+		t.Fatalf("load with policy packs: %v", err)
+	}
+
+	if result.Resolved.LicenseDenyList == nil || len(result.Resolved.LicenseDenyList) != 0 {
+		t.Fatalf("expected explicit empty license deny list to clear inherited pack values, got %#v", result.Resolved.LicenseDenyList)
+	}
+	if result.Scope.Include == nil || len(result.Scope.Include) != 0 {
+		t.Fatalf("expected explicit empty scope include list to clear inherited pack values, got %#v", result.Scope.Include)
+	}
+	if result.Features.Enable == nil || len(result.Features.Enable) != 0 {
+		t.Fatalf("expected explicit empty feature enable list to clear inherited pack values, got %#v", result.Features.Enable)
+	}
+}
+
 func TestLoadWithPolicyScopePrecedence(t *testing.T) {
 	repo := t.TempDir()
 	basePolicy := `scope:

--- a/internal/thresholds/thresholds.go
+++ b/internal/thresholds/thresholds.go
@@ -52,6 +52,7 @@ type Overrides struct {
 	RemovalCandidateWeightConfidence  *float64
 	LockfileDriftPolicy               *string
 	LicenseDenyList                   []string
+	licenseDenyListSet                bool
 	LicenseFailOnDeny                 *bool
 	LicenseIncludeRegistryProvenance  *bool
 }
@@ -75,6 +76,7 @@ func Defaults() Values {
 		RemovalCandidateWeightImpact:      defaultWeights.Impact,
 		RemovalCandidateWeightConfidence:  defaultWeights.Confidence,
 		LockfileDriftPolicy:               DefaultLockfileDriftPolicy,
+		LicenseDenyList:                   make([]string, 0),
 		LicenseFailOnDeny:                 DefaultLicenseFailOnDeny,
 		LicenseIncludeRegistryProvenance:  DefaultLicenseIncludeRegistryProvenance,
 	}
@@ -129,8 +131,8 @@ func (o *Overrides) Apply(base Values) Values {
 	if o.LockfileDriftPolicy != nil {
 		resolved.LockfileDriftPolicy = *o.LockfileDriftPolicy
 	}
-	if o.LicenseDenyList != nil {
-		resolved.LicenseDenyList = append([]string{}, o.LicenseDenyList...)
+	if o.licenseDenyListSet || len(o.LicenseDenyList) > 0 {
+		resolved.LicenseDenyList = append(make([]string, 0, len(o.LicenseDenyList)), o.LicenseDenyList...)
 	}
 	if o.LicenseFailOnDeny != nil {
 		resolved.LicenseFailOnDeny = *o.LicenseFailOnDeny
@@ -230,12 +232,6 @@ func validateOptionalWeights(overrides *Overrides) error {
 }
 
 func normalizeDenyList(values []string) []string {
-	if values == nil {
-		return nil
-	}
-	if len(values) == 0 {
-		return []string{}
-	}
 	seen := make(map[string]struct{}, len(values))
 	out := make([]string, 0, len(values))
 	for _, value := range values {
@@ -248,9 +244,6 @@ func normalizeDenyList(values []string) []string {
 		}
 		seen[item] = struct{}{}
 		out = append(out, item)
-	}
-	if len(out) == 0 {
-		return []string{}
 	}
 	sort.Strings(out)
 	return out

--- a/internal/thresholds/thresholds.go
+++ b/internal/thresholds/thresholds.go
@@ -129,7 +129,7 @@ func (o *Overrides) Apply(base Values) Values {
 	if o.LockfileDriftPolicy != nil {
 		resolved.LockfileDriftPolicy = *o.LockfileDriftPolicy
 	}
-	if len(o.LicenseDenyList) > 0 {
+	if o.LicenseDenyList != nil {
 		resolved.LicenseDenyList = append([]string{}, o.LicenseDenyList...)
 	}
 	if o.LicenseFailOnDeny != nil {
@@ -230,8 +230,11 @@ func validateOptionalWeights(overrides *Overrides) error {
 }
 
 func normalizeDenyList(values []string) []string {
-	if len(values) == 0 {
+	if values == nil {
 		return nil
+	}
+	if len(values) == 0 {
+		return []string{}
 	}
 	seen := make(map[string]struct{}, len(values))
 	out := make([]string, 0, len(values))
@@ -247,7 +250,7 @@ func normalizeDenyList(values []string) []string {
 		out = append(out, item)
 	}
 	if len(out) == 0 {
-		return nil
+		return []string{}
 	}
 	sort.Strings(out)
 	return out

--- a/internal/thresholds/thresholds_test.go
+++ b/internal/thresholds/thresholds_test.go
@@ -252,9 +252,17 @@ func TestNormalizeDenyListEmptyAndInvalid(t *testing.T) {
 	if len(gotEmpty.LicenseDenyList) != 0 {
 		t.Fatalf("expected empty deny list when unset, got %#v", gotEmpty.LicenseDenyList)
 	}
+	if gotEmpty.LicenseDenyList != nil {
+		t.Fatalf("expected unset deny list to remain nil, got %#v", gotEmpty.LicenseDenyList)
+	}
+
+	gotCleared := (&Overrides{LicenseDenyList: []string{}}).Apply(Defaults())
+	if gotCleared.LicenseDenyList == nil || len(gotCleared.LicenseDenyList) != 0 {
+		t.Fatalf("expected explicit empty deny list to remain allocated, got %#v", gotCleared.LicenseDenyList)
+	}
 
 	gotInvalid := (&Overrides{LicenseDenyList: []string{"", "   ", "!!!", "@@@", "()"}}).Apply(Defaults())
-	if len(gotInvalid.LicenseDenyList) != 0 {
-		t.Fatalf("expected empty deny list when all entries normalize away, got %#v", gotInvalid.LicenseDenyList)
+	if gotInvalid.LicenseDenyList == nil || len(gotInvalid.LicenseDenyList) != 0 {
+		t.Fatalf("expected explicit deny list to survive normalization even when entries drop away, got %#v", gotInvalid.LicenseDenyList)
 	}
 }

--- a/internal/thresholds/thresholds_test.go
+++ b/internal/thresholds/thresholds_test.go
@@ -252,17 +252,14 @@ func TestNormalizeDenyListEmptyAndInvalid(t *testing.T) {
 	if len(gotEmpty.LicenseDenyList) != 0 {
 		t.Fatalf("expected empty deny list when unset, got %#v", gotEmpty.LicenseDenyList)
 	}
-	if gotEmpty.LicenseDenyList != nil {
-		t.Fatalf("expected unset deny list to remain nil, got %#v", gotEmpty.LicenseDenyList)
-	}
 
-	gotCleared := (&Overrides{LicenseDenyList: []string{}}).Apply(Defaults())
-	if gotCleared.LicenseDenyList == nil || len(gotCleared.LicenseDenyList) != 0 {
+	gotCleared := (&Overrides{LicenseDenyList: make([]string, 0), licenseDenyListSet: true}).Apply(Defaults())
+	if len(gotCleared.LicenseDenyList) != 0 {
 		t.Fatalf("expected explicit empty deny list to remain allocated, got %#v", gotCleared.LicenseDenyList)
 	}
 
 	gotInvalid := (&Overrides{LicenseDenyList: []string{"", "   ", "!!!", "@@@", "()"}}).Apply(Defaults())
-	if gotInvalid.LicenseDenyList == nil || len(gotInvalid.LicenseDenyList) != 0 {
+	if len(gotInvalid.LicenseDenyList) != 0 {
 		t.Fatalf("expected explicit deny list to survive normalization even when entries drop away, got %#v", gotInvalid.LicenseDenyList)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes policy-pack list override semantics so explicit empty lists clear inherited values instead of being treated as omitted, and preserves upstream `Denied=true` state when license policy runs with no active deny list.

Closes #859 and #860.

## Changes

- preserve explicit-empty versus omitted list intent through policy normalization and pack merging for deny, scope, and feature lists
- treat explicit empty list overrides as clears during policy resolution
- make `ApplyLicensePolicy` leave existing denied state untouched when no deny list is active

## Validation

Commands and checks run:

```bash
go test ./internal/thresholds ./internal/report ./internal/app
```

Additional manual validation:

- Verified the new tests cover both explicit-clear semantics and preservation of upstream denied state.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: N/A.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review