### PR TITLE
fix(jvm): harden JVM and Kotlin scan paths

### DIFF
--- a/internal/lang/jvm/build_parsing.go
+++ b/internal/lang/jvm/build_parsing.go
@@ -66,19 +66,37 @@ var (
 )
 
 func collectDeclaredDependencies(repoPath string) ([]dependencyDescriptor, map[string]string, map[string]string, []string) {
-	descriptors := make([]dependencyDescriptor, 0)
-	warnings := make([]string, 0)
-
-	pomDescriptors, pomWarnings := parsePomDependenciesWithWarnings(repoPath)
-	gradleDescriptors, gradleWarnings := parseGradleDependenciesWithWarnings(repoPath)
-	descriptors = append(descriptors, pomDescriptors...)
-	descriptors = append(descriptors, gradleDescriptors...)
-	warnings = append(warnings, pomWarnings...)
-	warnings = append(warnings, gradleWarnings...)
-
+	descriptors, warnings := collectBuildDescriptors(repoPath)
 	descriptors = dedupeAndSortDescriptors(descriptors)
 	prefixes, aliases := buildDescriptorLookups(descriptors)
 	return descriptors, prefixes, aliases, warnings
+}
+
+func collectBuildDescriptors(repoPath string) ([]dependencyDescriptor, []string) {
+	catalogResolver, warnings := shared.LoadGradleCatalogResolver(repoPath)
+	buildParser := func(path, content string) ([]dependencyDescriptor, []string) {
+		switch strings.ToLower(filepath.Base(path)) {
+		case pomXMLName:
+			return parsePomDependencyContent(relativeBuildFilePath(repoPath, path), content)
+		case buildGradleName, buildGradleKTSName:
+			descriptors := parseGradleMatches(content, gradleDependencyPattern)
+			catalogDescriptors, catalogWarnings := catalogResolver.ParseDependencyReferences(path, content)
+			for _, descriptor := range catalogDescriptors {
+				descriptors = append(descriptors, dependencyDescriptor{
+					Name:     descriptor.Artifact,
+					Group:    descriptor.Group,
+					Artifact: descriptor.Artifact,
+				})
+			}
+			return dedupeAndSortDescriptors(descriptors), catalogWarnings
+		default:
+			return nil, nil
+		}
+	}
+
+	descriptors, parseWarnings := parseBuildFilesWithWarnings(repoPath, buildParser, pomXMLName, buildGradleName, buildGradleKTSName)
+	warnings = append(warnings, parseWarnings...)
+	return descriptors, shared.DedupeWarnings(warnings)
 }
 
 func dedupeAndSortDescriptors(descriptors []dependencyDescriptor) []dependencyDescriptor {

--- a/internal/lang/jvm/helpers_test.go
+++ b/internal/lang/jvm/helpers_test.go
@@ -82,6 +82,32 @@ func TestJVMParsePackageAndImports(t *testing.T) {
 	}
 }
 
+func TestJVMParseImportsHandlesBlockComments(t *testing.T) {
+	content := []byte(`package com.example.app;
+import java.util.List;
+import org.junit.jupiter.api.Test; /* trailing block comment */
+/*
+import com.acme.lib.Commented;
+*/
+import com.acme.lib.Widget;
+`)
+
+	pkg := parsePackage(content)
+	prefixes := map[string]string{junitJupiterGroup: junitJupiterAPIName}
+	aliases := map[string]string{"com.acme": acmeLibName}
+
+	imports := parseImports(content, "App.java", pkg, prefixes, aliases)
+	if len(imports) != 2 {
+		t.Fatalf("expected two imports outside block comments, got %#v", imports)
+	}
+	if imports[0].Module != "org.junit.jupiter.api.Test" {
+		t.Fatalf("expected trailing block-comment import to parse, got %#v", imports[0])
+	}
+	if imports[1].Module != "com.acme.lib.Widget" {
+		t.Fatalf("expected non-commented import to parse, got %#v", imports[1])
+	}
+}
+
 func TestJVMIgnoreAndResolveDependencyHelpers(t *testing.T) {
 	pkg := "com.example.app"
 	prefixes := map[string]string{junitJupiterGroup: junitJupiterAPIName}

--- a/internal/lang/jvm/source_scan.go
+++ b/internal/lang/jvm/source_scan.go
@@ -113,7 +113,8 @@ func parsePackage(content []byte) string {
 }
 
 func parseImports(content []byte, filePath string, filePackage string, depPrefixes map[string]string, depAliases map[string]string) []importBinding {
-	return shared.ParseImportLines(content, filePath, func(line string, _ int) []shared.ImportRecord {
+	sanitized := stripBlockComments(content)
+	return shared.ParseImportLines(sanitized, filePath, func(line string, _ int) []shared.ImportRecord {
 		line = stripLineComment(line)
 		matches := importPattern.FindStringSubmatch(line)
 		if len(matches) != importPatternMatchGroups {
@@ -167,6 +168,40 @@ func buildImportRecord(matches []string, module string, dependency string) (shar
 
 func stripLineComment(line string) string {
 	return shared.StripLineComment(line, "//")
+}
+
+func stripBlockComments(content []byte) []byte {
+	if len(content) == 0 {
+		return content
+	}
+
+	stripped := make([]byte, len(content))
+	copy(stripped, content)
+
+	inBlockComment := false
+	for i := 0; i < len(stripped); i++ {
+		if inBlockComment {
+			if i+1 < len(stripped) && stripped[i] == '*' && stripped[i+1] == '/' {
+				stripped[i] = ' '
+				stripped[i+1] = ' '
+				inBlockComment = false
+				i++
+				continue
+			}
+			if stripped[i] != '\n' && stripped[i] != '\r' {
+				stripped[i] = ' '
+			}
+			continue
+		}
+		if i+1 < len(stripped) && stripped[i] == '/' && stripped[i+1] == '*' {
+			stripped[i] = ' '
+			stripped[i+1] = ' '
+			inBlockComment = true
+			i++
+		}
+	}
+
+	return stripped
 }
 
 func shouldIgnoreImport(module, filePackage string) bool {

--- a/internal/lang/jvm/source_scan.go
+++ b/internal/lang/jvm/source_scan.go
@@ -113,7 +113,7 @@ func parsePackage(content []byte) string {
 }
 
 func parseImports(content []byte, filePath string, filePackage string, depPrefixes map[string]string, depAliases map[string]string) []importBinding {
-	sanitized := stripBlockComments(content)
+	sanitized := shared.StripBlockComments(content)
 	return shared.ParseImportLines(sanitized, filePath, func(line string, _ int) []shared.ImportRecord {
 		line = stripLineComment(line)
 		matches := importPattern.FindStringSubmatch(line)
@@ -168,40 +168,6 @@ func buildImportRecord(matches []string, module string, dependency string) (shar
 
 func stripLineComment(line string) string {
 	return shared.StripLineComment(line, "//")
-}
-
-func stripBlockComments(content []byte) []byte {
-	if len(content) == 0 {
-		return content
-	}
-
-	stripped := make([]byte, len(content))
-	copy(stripped, content)
-
-	inBlockComment := false
-	for i := 0; i < len(stripped); i++ {
-		if inBlockComment {
-			if i+1 < len(stripped) && stripped[i] == '*' && stripped[i+1] == '/' {
-				stripped[i] = ' '
-				stripped[i+1] = ' '
-				inBlockComment = false
-				i++
-				continue
-			}
-			if stripped[i] != '\n' && stripped[i] != '\r' {
-				stripped[i] = ' '
-			}
-			continue
-		}
-		if i+1 < len(stripped) && stripped[i] == '/' && stripped[i+1] == '*' {
-			stripped[i] = ' '
-			stripped[i+1] = ' '
-			inBlockComment = true
-			i++
-		}
-	}
-
-	return stripped
 }
 
 func shouldIgnoreImport(module, filePackage string) bool {

--- a/internal/lang/kotlinandroid/adapter_branches_extra_test.go
+++ b/internal/lang/kotlinandroid/adapter_branches_extra_test.go
@@ -567,13 +567,14 @@ func TestScanRepoAndImportBranches(t *testing.T) {
 		Prefixes: map[string]string{"androidx.core": "androidx.core-ktx"},
 		Aliases:  map[string]string{"com.acme": "acme-lib"},
 	}
-	blockCommentImports := parseImports([]byte(`package pkg.demo
+	blockCommentContent := []byte(`package pkg.demo
 import androidx.core.widget.TextViewCompat /* trailing block comment */
 /*
 import com.acme.lib.Commented
 */
 import com.acme.lib.Widget
-`), testMainSourceFileName, "pkg.demo", blockCommentLookups, &scanState)
+`)
+	blockCommentImports := parseImports(blockCommentContent, testMainSourceFileName, "pkg.demo", blockCommentLookups, &scanState)
 	if len(blockCommentImports) != 2 {
 		t.Fatalf("expected imports outside block comments, got %#v", blockCommentImports)
 	}

--- a/internal/lang/kotlinandroid/adapter_branches_extra_test.go
+++ b/internal/lang/kotlinandroid/adapter_branches_extra_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -372,6 +373,33 @@ func TestGradleParsingBranches(t *testing.T) {
 	}
 }
 
+func TestGradleDependencyParsingSupportsAdditionalConfigurations(t *testing.T) {
+	content := `
+dependencies {
+  annotationProcessor "org.projectlombok:lombok:1.18.32"
+  debugImplementation("com.android.support:appcompat-v7:28.0.0")
+  releaseImplementation "com.android.support:multidex:1.0.3"
+  kaptTest("com.google.dagger:dagger-compiler:2.52")
+  classpath "com.android.tools.build:gradle:8.7.0"
+}
+`
+
+	descriptors := parseGradleDependencyContent(content)
+	if len(descriptors) != 5 {
+		t.Fatalf("expected five parsed descriptors from extended configurations, got %#v", descriptors)
+	}
+
+	names := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		names = append(names, descriptor.Name)
+	}
+	for _, want := range []string{"lombok", "appcompat-v7", "multidex", "dagger-compiler", "gradle"} {
+		if !slices.Contains(names, want) {
+			t.Fatalf("expected parsed gradle dependency %q in %#v", want, descriptors)
+		}
+	}
+}
+
 func TestGradleLockfileBranches(t *testing.T) {
 	repo := t.TempDir()
 	lockLink := filepath.Join(repo, gradleLockfileName)
@@ -534,6 +562,26 @@ func TestScanRepoAndImportBranches(t *testing.T) {
 
 	if imports := parseImports([]byte("import java.util.List\n"), testMainSourceFileName, "pkg.demo", dependencyLookups{}, &scanState); len(imports) != 0 {
 		t.Fatalf("expected ignored framework imports to be dropped, got %#v", imports)
+	}
+	blockCommentLookups := dependencyLookups{
+		Prefixes: map[string]string{"androidx.core": "androidx.core-ktx"},
+		Aliases:  map[string]string{"com.acme": "acme-lib"},
+	}
+	blockCommentImports := parseImports([]byte(`package pkg.demo
+import androidx.core.widget.TextViewCompat /* trailing block comment */
+/*
+import com.acme.lib.Commented
+*/
+import com.acme.lib.Widget
+`), testMainSourceFileName, "pkg.demo", blockCommentLookups, &scanState)
+	if len(blockCommentImports) != 2 {
+		t.Fatalf("expected imports outside block comments, got %#v", blockCommentImports)
+	}
+	if blockCommentImports[0].Module != "androidx.core.widget.TextViewCompat" {
+		t.Fatalf("expected trailing block-comment import to parse, got %#v", blockCommentImports[0])
+	}
+	if blockCommentImports[1].Module != "com.acme.lib.Widget" {
+		t.Fatalf("expected non-commented import to parse, got %#v", blockCommentImports[1])
 	}
 	if _, ok := buildImportRecord([]string{"import", "a.", "", ""}, "a.", "dep"); ok {
 		t.Fatalf("expected import record build to fail for empty symbol")

--- a/internal/lang/kotlinandroid/gradle_file_discovery.go
+++ b/internal/lang/kotlinandroid/gradle_file_discovery.go
@@ -33,12 +33,7 @@ func discoverGradleLockfiles(repoPath string) (gradleFileDiscoveryResult, error)
 	})
 }
 
-func collectGradleFileDescriptorsWithWarnings(
-	repoPath string,
-	discover func(string) (gradleFileDiscoveryResult, error),
-	parser func([]discoveredGradleFile) ([]dependencyDescriptor, []string),
-	scanTarget string,
-) ([]dependencyDescriptor, bool, []string) {
+func collectGradleFileDescriptorsWithWarnings(repoPath string, discover func(string) (gradleFileDiscoveryResult, error), parser func([]discoveredGradleFile) ([]dependencyDescriptor, []string), scanTarget string) ([]dependencyDescriptor, bool, []string) {
 	discovery, walkErr := discover(repoPath)
 	descriptors, parseWarnings := parser(discovery.Files)
 	warnings := append([]string{}, discovery.Warnings...)

--- a/internal/lang/kotlinandroid/gradle_file_discovery.go
+++ b/internal/lang/kotlinandroid/gradle_file_discovery.go
@@ -1,10 +1,12 @@
 package kotlinandroid
 
 import (
+	"fmt"
 	"io/fs"
 	"path/filepath"
 	"strings"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
@@ -29,6 +31,22 @@ func discoverGradleLockfiles(repoPath string) (gradleFileDiscoveryResult, error)
 	return discoverGradleFiles(repoPath, func(fileName string) bool {
 		return strings.EqualFold(fileName, gradleLockfileName)
 	})
+}
+
+func collectGradleFileDescriptorsWithWarnings(
+	repoPath string,
+	discover func(string) (gradleFileDiscoveryResult, error),
+	parser func([]discoveredGradleFile) ([]dependencyDescriptor, []string),
+	scanTarget string,
+) ([]dependencyDescriptor, bool, []string) {
+	discovery, walkErr := discover(repoPath)
+	descriptors, parseWarnings := parser(discovery.Files)
+	warnings := append([]string{}, discovery.Warnings...)
+	warnings = append(warnings, parseWarnings...)
+	if walkErr != nil {
+		warnings = append(warnings, fmt.Sprintf("unable to scan %s: %v", scanTarget, walkErr))
+	}
+	return descriptors, discovery.Matched, shared.DedupeWarnings(warnings)
 }
 
 func discoverGradleFiles(repoPath string, matches func(fileName string) bool) (gradleFileDiscoveryResult, error) {

--- a/internal/lang/kotlinandroid/gradle_lockfile_parsing.go
+++ b/internal/lang/kotlinandroid/gradle_lockfile_parsing.go
@@ -8,14 +8,10 @@ import (
 var gradleLockCoordinatePattern = regexp.MustCompile(`^\s*([^:#=\s]+):([^:#=\s]+):([^=\s]+)(?:\s*=.*)?$`)
 
 func parseGradleLockfiles(repoPath string) ([]dependencyDescriptor, bool, []string) {
-	return collectGradleFileDescriptorsWithWarnings(
-		repoPath,
-		discoverGradleLockfiles,
-		func(files []discoveredGradleFile) ([]dependencyDescriptor, []string) {
-			return parseGradleLockfileFiles(files), nil
-		},
-		"lockfiles",
-	)
+	parser := func(files []discoveredGradleFile) ([]dependencyDescriptor, []string) {
+		return parseGradleLockfileFiles(files), nil
+	}
+	return collectGradleFileDescriptorsWithWarnings(repoPath, discoverGradleLockfiles, parser, "lockfiles")
 }
 
 func parseGradleLockfileFiles(files []discoveredGradleFile) []dependencyDescriptor {

--- a/internal/lang/kotlinandroid/gradle_lockfile_parsing.go
+++ b/internal/lang/kotlinandroid/gradle_lockfile_parsing.go
@@ -1,25 +1,21 @@
 package kotlinandroid
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 )
 
 var gradleLockCoordinatePattern = regexp.MustCompile(`^\s*([^:#=\s]+):([^:#=\s]+):([^=\s]+)(?:\s*=.*)?$`)
 
-func collectLockfileDependencyDescriptors(repoPath string) ([]dependencyDescriptor, bool, []string) {
-	return parseGradleLockfiles(repoPath)
-}
-
 func parseGradleLockfiles(repoPath string) ([]dependencyDescriptor, bool, []string) {
-	discovery, walkErr := discoverGradleLockfiles(repoPath)
-	descriptors := parseGradleLockfileFiles(discovery.Files)
-	warnings := discovery.Warnings
-	if walkErr != nil {
-		warnings = append(warnings, fmt.Sprintf("unable to scan lockfiles: %v", walkErr))
-	}
-	return descriptors, discovery.Matched, warnings
+	return collectGradleFileDescriptorsWithWarnings(
+		repoPath,
+		discoverGradleLockfiles,
+		func(files []discoveredGradleFile) ([]dependencyDescriptor, []string) {
+			return parseGradleLockfileFiles(files), nil
+		},
+		"lockfiles",
+	)
 }
 
 func parseGradleLockfileFiles(files []discoveredGradleFile) []dependencyDescriptor {

--- a/internal/lang/kotlinandroid/gradle_lookup.go
+++ b/internal/lang/kotlinandroid/gradle_lookup.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 )
 
 const gradleReadWarningFormat = "unable to read %s: %v"
@@ -27,13 +29,45 @@ type dependencyLookups struct {
 }
 
 func collectDeclaredDependencies(repoPath string) ([]dependencyDescriptor, dependencyLookups, []string) {
-	manifestDescriptors, manifestWarnings := collectManifestDependencyDescriptors(repoPath)
-	lockfileDescriptors, hasLockfile, lockWarnings := collectLockfileDependencyDescriptors(repoPath)
-
+	manifestDescriptors, lockfileDescriptors, hasLockfile, warnings := collectGradleDeclaredDependencyDescriptors(repoPath)
 	descriptors := mergeDescriptors(manifestDescriptors, lockfileDescriptors)
 	lookups := buildDependencyLookupIndex(descriptors)
 	lookups.HasLockfile = hasLockfile
-	return descriptors, lookups, append(manifestWarnings, lockWarnings...)
+	return descriptors, lookups, warnings
+}
+
+func collectGradleDeclaredDependencyDescriptors(repoPath string) ([]dependencyDescriptor, []dependencyDescriptor, bool, []string) {
+	lockfileMatched := false
+	discovery, walkErr := discoverGradleFiles(repoPath, func(fileName string) bool {
+		if strings.EqualFold(fileName, gradleLockfileName) {
+			lockfileMatched = true
+		}
+		return matchesBuildFile(fileName, []string{buildGradleName, buildGradleKTSName}) || strings.EqualFold(fileName, gradleLockfileName)
+	})
+
+	catalogResolver, catalogWarnings := shared.LoadGradleCatalogResolver(repoPath)
+	manifestFiles := make([]discoveredGradleFile, 0, len(discovery.Files))
+	lockfileFiles := make([]discoveredGradleFile, 0, len(discovery.Files))
+	for _, file := range discovery.Files {
+		switch {
+		case strings.EqualFold(filepath.Base(file.Path), gradleLockfileName):
+			lockfileFiles = append(lockfileFiles, file)
+		default:
+			manifestFiles = append(manifestFiles, file)
+		}
+	}
+
+	manifestDescriptors, manifestWarnings := parseGradleManifestFiles(manifestFiles, catalogResolver)
+	lockfileDescriptors := parseGradleLockfileFiles(lockfileFiles)
+
+	warnings := append([]string{}, discovery.Warnings...)
+	warnings = append(warnings, catalogWarnings...)
+	warnings = append(warnings, manifestWarnings...)
+	if walkErr != nil {
+		warnings = append(warnings, fmt.Sprintf("unable to scan build files: %v", walkErr))
+	}
+
+	return manifestDescriptors, lockfileDescriptors, lockfileMatched, shared.DedupeWarnings(warnings)
 }
 
 func mergeDescriptors(manifest, lockfile []dependencyDescriptor) []dependencyDescriptor {

--- a/internal/lang/kotlinandroid/gradle_manifest_parsing.go
+++ b/internal/lang/kotlinandroid/gradle_manifest_parsing.go
@@ -16,10 +16,6 @@ var gradleMapInvocationPattern = regexp.MustCompile(`(?ms)\b` + gradleDependency
 
 var gradleNamedArgPattern = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\s*[:=]\s*["']([^"']+)["']`)
 
-func collectManifestDependencyDescriptors(repoPath string) ([]dependencyDescriptor, []string) {
-	return parseGradleDependenciesWithWarnings(repoPath)
-}
-
 func parseGradleDependencies(repoPath string) []dependencyDescriptor {
 	descriptors, _ := parseGradleDependenciesWithWarnings(repoPath)
 	return descriptors
@@ -27,13 +23,17 @@ func parseGradleDependencies(repoPath string) []dependencyDescriptor {
 
 func parseGradleDependenciesWithWarnings(repoPath string) ([]dependencyDescriptor, []string) {
 	catalogResolver, warnings := shared.LoadGradleCatalogResolver(repoPath)
-	discovery, walkErr := discoverBuildFiles(repoPath, buildGradleName, buildGradleKTSName)
-	warnings = append(warnings, discovery.Warnings...)
-	descriptors, parseWarnings := parseGradleManifestFiles(discovery.Files, catalogResolver)
+	descriptors, _, parseWarnings := collectGradleFileDescriptorsWithWarnings(
+		repoPath,
+		func(path string) (gradleFileDiscoveryResult, error) {
+			return discoverBuildFiles(path, buildGradleName, buildGradleKTSName)
+		},
+		func(files []discoveredGradleFile) ([]dependencyDescriptor, []string) {
+			return parseGradleManifestFiles(files, catalogResolver)
+		},
+		"build files",
+	)
 	warnings = append(warnings, parseWarnings...)
-	if walkErr != nil {
-		warnings = append(warnings, fmt.Sprintf("unable to scan build files: %v", walkErr))
-	}
 	return descriptors, shared.DedupeWarnings(warnings)
 }
 

--- a/internal/lang/kotlinandroid/gradle_manifest_parsing.go
+++ b/internal/lang/kotlinandroid/gradle_manifest_parsing.go
@@ -23,16 +23,13 @@ func parseGradleDependencies(repoPath string) []dependencyDescriptor {
 
 func parseGradleDependenciesWithWarnings(repoPath string) ([]dependencyDescriptor, []string) {
 	catalogResolver, warnings := shared.LoadGradleCatalogResolver(repoPath)
-	descriptors, _, parseWarnings := collectGradleFileDescriptorsWithWarnings(
-		repoPath,
-		func(path string) (gradleFileDiscoveryResult, error) {
-			return discoverBuildFiles(path, buildGradleName, buildGradleKTSName)
-		},
-		func(files []discoveredGradleFile) ([]dependencyDescriptor, []string) {
-			return parseGradleManifestFiles(files, catalogResolver)
-		},
-		"build files",
-	)
+	discover := func(path string) (gradleFileDiscoveryResult, error) {
+		return discoverBuildFiles(path, buildGradleName, buildGradleKTSName)
+	}
+	parser := func(files []discoveredGradleFile) ([]dependencyDescriptor, []string) {
+		return parseGradleManifestFiles(files, catalogResolver)
+	}
+	descriptors, _, parseWarnings := collectGradleFileDescriptorsWithWarnings(repoPath, discover, parser, "build files")
 	warnings = append(warnings, parseWarnings...)
 	return descriptors, shared.DedupeWarnings(warnings)
 }

--- a/internal/lang/kotlinandroid/gradle_manifest_parsing.go
+++ b/internal/lang/kotlinandroid/gradle_manifest_parsing.go
@@ -8,9 +8,11 @@ import (
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 )
 
-var gradleCoordinatePattern = regexp.MustCompile(`(?m)\b(?:implementation|api|compileOnly|runtimeOnly|kapt|ksp|testImplementation|androidTestImplementation|testRuntimeOnly)\s*\(?\s*(?:platform\()?["']([^:"'\s]+):([^:"'\s]+)(?::([^"'\s]+))?["']\s*\)?\s*\)?`)
+const gradleDependencyConfigurationPattern = `(?:implementation|api|compileOnly|runtimeOnly|annotationProcessor|kapt|ksp|testImplementation|androidTestImplementation|testRuntimeOnly|testCompileOnly|testAnnotationProcessor|debugImplementation|releaseImplementation|kaptTest|kaptAndroidTest|classpath)`
 
-var gradleMapInvocationPattern = regexp.MustCompile(`(?ms)\b(?:implementation|api|compileOnly|runtimeOnly|kapt|ksp|testImplementation|androidTestImplementation|testRuntimeOnly)\s*\(?\s*((?:[A-Za-z_][A-Za-z0-9_]*\s*[:=]\s*["'][^"'\n]+["']\s*,?\s*)+)`)
+var gradleCoordinatePattern = regexp.MustCompile(`(?m)\b` + gradleDependencyConfigurationPattern + `\s*\(?\s*(?:platform\()?["']([^:"'\s]+):([^:"'\s]+)(?::([^"'\s]+))?["']\s*\)?\s*\)?`)
+
+var gradleMapInvocationPattern = regexp.MustCompile(`(?ms)\b` + gradleDependencyConfigurationPattern + `\s*\(?\s*((?:[A-Za-z_][A-Za-z0-9_]*\s*[:=]\s*["'][^"'\n]+["']\s*,?\s*)+)`)
 
 var gradleNamedArgPattern = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\s*[:=]\s*["']([^"']+)["']`)
 

--- a/internal/lang/kotlinandroid/scan.go
+++ b/internal/lang/kotlinandroid/scan.go
@@ -185,7 +185,8 @@ func parsePackage(content []byte) string {
 }
 
 func parseImports(content []byte, filePath string, filePackage string, lookups dependencyLookups, result *scanResult) []importBinding {
-	return shared.ParseImportLines(content, filePath, func(line string, _ int) []shared.ImportRecord {
+	sanitized := stripBlockComments(content)
+	return shared.ParseImportLines(sanitized, filePath, func(line string, _ int) []shared.ImportRecord {
 		line = stripLineComment(line)
 		matches := importPattern.FindStringSubmatch(line)
 		if len(matches) != importPatternMatchGroups {
@@ -250,6 +251,40 @@ func resolvedImportSymbol(matches []string, module string) (string, bool) {
 
 func stripLineComment(line string) string {
 	return shared.StripLineComment(line, "//")
+}
+
+func stripBlockComments(content []byte) []byte {
+	if len(content) == 0 {
+		return content
+	}
+
+	stripped := make([]byte, len(content))
+	copy(stripped, content)
+
+	inBlockComment := false
+	for i := 0; i < len(stripped); i++ {
+		if inBlockComment {
+			if i+1 < len(stripped) && stripped[i] == '*' && stripped[i+1] == '/' {
+				stripped[i] = ' '
+				stripped[i+1] = ' '
+				inBlockComment = false
+				i++
+				continue
+			}
+			if stripped[i] != '\n' && stripped[i] != '\r' {
+				stripped[i] = ' '
+			}
+			continue
+		}
+		if i+1 < len(stripped) && stripped[i] == '/' && stripped[i+1] == '*' {
+			stripped[i] = ' '
+			stripped[i+1] = ' '
+			inBlockComment = true
+			i++
+		}
+	}
+
+	return stripped
 }
 
 func shouldIgnoreImport(module, filePackage string) bool {

--- a/internal/lang/kotlinandroid/scan.go
+++ b/internal/lang/kotlinandroid/scan.go
@@ -185,7 +185,7 @@ func parsePackage(content []byte) string {
 }
 
 func parseImports(content []byte, filePath string, filePackage string, lookups dependencyLookups, result *scanResult) []importBinding {
-	sanitized := stripBlockComments(content)
+	sanitized := shared.StripBlockComments(content)
 	return shared.ParseImportLines(sanitized, filePath, func(line string, _ int) []shared.ImportRecord {
 		line = stripLineComment(line)
 		matches := importPattern.FindStringSubmatch(line)
@@ -251,40 +251,6 @@ func resolvedImportSymbol(matches []string, module string) (string, bool) {
 
 func stripLineComment(line string) string {
 	return shared.StripLineComment(line, "//")
-}
-
-func stripBlockComments(content []byte) []byte {
-	if len(content) == 0 {
-		return content
-	}
-
-	stripped := make([]byte, len(content))
-	copy(stripped, content)
-
-	inBlockComment := false
-	for i := 0; i < len(stripped); i++ {
-		if inBlockComment {
-			if i+1 < len(stripped) && stripped[i] == '*' && stripped[i+1] == '/' {
-				stripped[i] = ' '
-				stripped[i+1] = ' '
-				inBlockComment = false
-				i++
-				continue
-			}
-			if stripped[i] != '\n' && stripped[i] != '\r' {
-				stripped[i] = ' '
-			}
-			continue
-		}
-		if i+1 < len(stripped) && stripped[i] == '/' && stripped[i+1] == '*' {
-			stripped[i] = ' '
-			stripped[i+1] = ' '
-			inBlockComment = true
-			i++
-		}
-	}
-
-	return stripped
 }
 
 func shouldIgnoreImport(module, filePackage string) bool {

--- a/internal/lang/shared/import_parsing.go
+++ b/internal/lang/shared/import_parsing.go
@@ -28,6 +28,40 @@ func StripLineComment(line, marker string) string {
 	return line
 }
 
+func StripBlockComments(content []byte) []byte {
+	if len(content) == 0 {
+		return content
+	}
+
+	stripped := make([]byte, len(content))
+	copy(stripped, content)
+
+	inBlockComment := false
+	for i := 0; i < len(stripped); i++ {
+		if inBlockComment {
+			if i+1 < len(stripped) && stripped[i] == '*' && stripped[i+1] == '/' {
+				stripped[i] = ' '
+				stripped[i+1] = ' '
+				inBlockComment = false
+				i++
+				continue
+			}
+			if stripped[i] != '\n' && stripped[i] != '\r' {
+				stripped[i] = ' '
+			}
+			continue
+		}
+		if i+1 < len(stripped) && stripped[i] == '/' && stripped[i+1] == '*' {
+			stripped[i] = ' '
+			stripped[i+1] = ' '
+			inBlockComment = true
+			i++
+		}
+	}
+
+	return stripped
+}
+
 func Location(filePath string, line, column int) report.Location {
 	return report.Location{
 		File:   filePath,

--- a/internal/lang/shared/import_parsing_test.go
+++ b/internal/lang/shared/import_parsing_test.go
@@ -1,6 +1,9 @@
 package shared
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseImportLines(t *testing.T) {
 	content := []byte("import a\n  import b // note\n")
@@ -43,5 +46,24 @@ func TestStripLineCommentAndLocationHelpers(t *testing.T) {
 	locationAtLineTwo := LocationFromLine(appFile, 1, "  import b")
 	if locationAtLineTwo.Line != 2 || locationAtLineTwo.Column != 3 {
 		t.Fatalf("unexpected line location: %+v", locationAtLineTwo)
+	}
+}
+
+func TestStripBlockComments(t *testing.T) {
+	content := []byte("import a\n/* comment\nimport b\n*/\nimport c /* tail */\n")
+
+	stripped := StripBlockComments(content)
+	lines := strings.Split(string(stripped), "\n")
+	if len(lines) != 6 {
+		t.Fatalf("expected 6 lines after stripping, got %#v", lines)
+	}
+	if lines[0] != "import a" {
+		t.Fatalf("expected first line to remain unchanged, got %q", lines[0])
+	}
+	if strings.TrimSpace(lines[1]) != "" || strings.TrimSpace(lines[2]) != "" || strings.TrimSpace(lines[3]) != "" {
+		t.Fatalf("expected block-comment lines to be blanked, got %#v", lines[1:4])
+	}
+	if !strings.HasPrefix(lines[4], "import c") {
+		t.Fatalf("expected trailing inline block comment to preserve import line, got %q", lines[4])
 	}
 }


### PR DESCRIPTION
## Summary

Fixes JVM and Kotlin scanning so imports with trailing or enclosed block comments are ignored correctly, repository walks are consolidated before source analysis, and Kotlin Android Gradle dependency parsing recognizes more valid configurations.

Closes #831, #834, #849, #850, and #855.

## Changes

- sanitize JVM and Kotlin import parsing around `/* ... */` block comments so commented imports stay inert while valid imports with trailing block comments still resolve
- consolidate JVM and Kotlin/Android build-file discovery to avoid repeated full-repo walks before source analysis
- expand Kotlin Android Gradle dependency configuration matching to include additional valid forms such as `annotationProcessor`, `debugImplementation`, `releaseImplementation`, `kaptTest`, and `classpath`
- add focused regression coverage for block-comment cases, combined discovery, and the expanded Gradle configurations

## Validation

Commands and checks run:

```bash
go test ./internal/lang/jvm ./internal/lang/kotlinandroid
```

Additional manual validation:

- Reviewed the new discovery and parsing paths to confirm the issue bundle is covered directly by tests.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Positive for large repositories because build-file discovery now does less repeated walking.
- Memory benchmark impact: N/A.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review