### PR TITLE
fix(release): harden workflow release config

### DIFF
--- a/.github/workflows/graduate-feature.yml
+++ b/.github/workflows/graduate-feature.yml
@@ -28,7 +28,7 @@ on:
       milestone:
         description: Milestone to assign to the graduation PR
         required: false
-        default: "v1.4.2"
+        default: "v1.6.0"
         type: string
 
 permissions:
@@ -119,7 +119,7 @@ jobs:
             --title "feat(flags): graduate ${FEATURE} to stable"
             --body-file .artifacts/graduate-feature-pr.md
             --label enhancement
-            --label target-series:1.4.x
+            --label target-series:1.6.x
           )
           if [ -n "${MILESTONE}" ]; then
             pr_args+=(--milestone "${MILESTONE}")

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -108,6 +108,16 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Assert Darwin arm64 host
+        shell: bash
+        run: |
+          set -euo pipefail
+          host_goarch="$(go env GOARCH)"
+          if [ "${host_goarch}" != "arm64" ]; then
+            echo "::error::Expected darwin/arm64 runner, got darwin/${host_goarch}."
+            exit 1
+          fi
+
       - name: Install shellcheck
         run: brew install shellcheck
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,16 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Assert Darwin amd64 host
+        shell: bash
+        run: |
+          set -euo pipefail
+          host_goarch="$(go env GOARCH)"
+          if [ "${host_goarch}" != "amd64" ]; then
+            echo "::error::Expected darwin/amd64 runner, got darwin/${host_goarch}."
+            exit 1
+          fi
+
       - name: Install shellcheck
         run: brew install shellcheck
 

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -75,6 +75,16 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Assert Darwin amd64 host
+        shell: bash
+        run: |
+          set -euo pipefail
+          host_goarch="$(go env GOARCH)"
+          if [ "${host_goarch}" != "amd64" ]; then
+            echo "::error::Expected darwin/amd64 runner, got darwin/${host_goarch}."
+            exit 1
+          fi
+
       - name: Install shellcheck
         run: brew install shellcheck
 

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -22,6 +22,7 @@ Homebrew tap automation:
 Stable release automation:
 
 - Release versioning and changelog generation are configured in `release-please-config.json` and tracked in `.release-please-manifest.json`.
+- The Go project release notes are generated into the root `CHANGELOG.md`; the VS Code extension keeps its own `extensions/vscode-lopper/CHANGELOG.md`.
 - The current stable version is also synced into `extensions/vscode-lopper/package.json` and `extensions/vscode-lopper/package-lock.json` by the release-please PR.
 - Release commits should use Conventional Commit prefixes: `fix:` for patch releases, `feat:` for minor releases, and any type with a breaking-change marker (for example `feat!:` or `fix!:`) or a `BREAKING CHANGE:` footer for major releases.
 - Set repository secret `RELEASE_PLEASE_TOKEN` to a PAT with contents and pull request write access so release-please-created PRs can trigger normal CI. If it is not configured, the workflow falls back to `MAIN_SYNC_PAT` and then `GITHUB_TOKEN`.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -216,6 +216,7 @@ gh workflow run graduate-feature.yml \
 
 The workflow changes only the registry lifecycle and opens a PR.
 It does not merge the PR, remove release locks automatically, or infer stability from release-please.
+It defaults the graduation PR to the `v1.6.0` milestone and `target-series:1.6.x` label.
 Use the optional `issue` and `milestone` inputs when the graduation belongs somewhere other than the current feature flagging rollout issue.
 
 After graduation, future release builds enable the feature by default through `lifecycle: "stable"`.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
   "packages": {
     ".": {
       "release-type": "go",
-      "changelog-path": "extensions/vscode-lopper/CHANGELOG.md",
+      "changelog-path": "CHANGELOG.md",
       "changelog-sections": [
         {
           "type": "feat",

--- a/renovate.json
+++ b/renovate.json
@@ -10,13 +10,18 @@
   "packageRules": [
     {
       "matchUpdateTypes": [
-        "major",
         "minor",
         "patch",
         "pin",
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
     }
   ]
 }

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -1,0 +1,206 @@
+package scripts
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestReleasePleaseWritesRootChangelog(t *testing.T) {
+	t.Parallel()
+
+	var config struct {
+		Packages map[string]struct {
+			ChangelogPath string `json:"changelog-path"`
+			ExtraFiles    []struct {
+				Path string `json:"path"`
+			} `json:"extra-files"`
+		} `json:"packages"`
+	}
+	readJSONConfig(t, "release-please-config.json", &config)
+
+	rootPackage, ok := config.Packages["."]
+	if !ok {
+		t.Fatal("release-please config must define the root package")
+	}
+	if rootPackage.ChangelogPath != "CHANGELOG.md" {
+		t.Fatalf("root package changelog path = %q, want CHANGELOG.md", rootPackage.ChangelogPath)
+	}
+	if rootPackage.ChangelogPath == "extensions/vscode-lopper/CHANGELOG.md" {
+		t.Fatal("root release notes must not be written to the VS Code extension changelog")
+	}
+
+	extraFiles := map[string]bool{}
+	for _, extraFile := range rootPackage.ExtraFiles {
+		extraFiles[extraFile.Path] = true
+	}
+	for _, path := range []string{
+		"extensions/vscode-lopper/package.json",
+		"extensions/vscode-lopper/package-lock.json",
+	} {
+		if !extraFiles[path] {
+			t.Fatalf("release-please config should keep syncing %s", path)
+		}
+	}
+}
+
+func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
+	t.Parallel()
+
+	var workflow struct {
+		On struct {
+			WorkflowDispatch struct {
+				Inputs map[string]struct {
+					Default string `yaml:"default"`
+				} `yaml:"inputs"`
+			} `yaml:"workflow_dispatch"`
+		} `yaml:"on"`
+	}
+	readYAMLConfig(t, ".github/workflows/graduate-feature.yml", &workflow)
+
+	milestone, ok := workflow.On.WorkflowDispatch.Inputs["milestone"]
+	if !ok {
+		t.Fatal("graduate-feature workflow must define the milestone input")
+	}
+	if milestone.Default != "v1.6.0" {
+		t.Fatalf("graduate-feature milestone default = %q, want v1.6.0", milestone.Default)
+	}
+
+	workflowText := readConfig(t, ".github/workflows/graduate-feature.yml")
+	if !strings.Contains(workflowText, "--label target-series:1.6.x") {
+		t.Fatal("graduate-feature workflow must label PRs with target-series:1.6.x")
+	}
+	if strings.Contains(workflowText, "target-series:1.4.x") {
+		t.Fatal("graduate-feature workflow still references stale target-series:1.4.x")
+	}
+}
+
+func TestRenovateDoesNotAutomergeMajorUpdates(t *testing.T) {
+	t.Parallel()
+
+	var config struct {
+		PackageRules []struct {
+			MatchUpdateTypes []string `json:"matchUpdateTypes"`
+			Automerge        *bool    `json:"automerge"`
+		} `json:"packageRules"`
+	}
+	readJSONConfig(t, "renovate.json", &config)
+
+	automergeByUpdateType := map[string][]bool{}
+	for _, rule := range config.PackageRules {
+		if rule.Automerge == nil {
+			continue
+		}
+		for _, updateType := range rule.MatchUpdateTypes {
+			automergeByUpdateType[updateType] = append(automergeByUpdateType[updateType], *rule.Automerge)
+		}
+	}
+
+	for _, enabled := range automergeByUpdateType["major"] {
+		if enabled {
+			t.Fatal("major updates must not be covered by an automerge=true Renovate rule")
+		}
+	}
+	if !hasAutomerge(automergeByUpdateType["major"], false) {
+		t.Fatal("major updates should have an explicit automerge=false Renovate rule")
+	}
+	for _, updateType := range []string{"minor", "patch"} {
+		if !hasAutomerge(automergeByUpdateType[updateType], true) {
+			t.Fatalf("%s updates should retain Renovate automerge=true", updateType)
+		}
+	}
+}
+
+func TestDarwinReleaseJobsAssertHostArchitecture(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		path         string
+		stepName     string
+		expectedArch string
+	}{
+		{
+			path:         ".github/workflows/release-orchestration.yml",
+			stepName:     "Assert Darwin arm64 host",
+			expectedArch: "arm64",
+		},
+		{
+			path:         ".github/workflows/release.yml",
+			stepName:     "Assert Darwin amd64 host",
+			expectedArch: "amd64",
+		},
+		{
+			path:         ".github/workflows/rolling.yml",
+			stepName:     "Assert Darwin amd64 host",
+			expectedArch: "amd64",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+
+			workflowText := readConfig(t, tc.path)
+			if !strings.Contains(workflowText, tc.stepName) {
+				t.Fatalf("%s must contain step %q", tc.path, tc.stepName)
+			}
+			wantCheck := `host_goarch}" != "` + tc.expectedArch + `"`
+			if !strings.Contains(workflowText, wantCheck) {
+				t.Fatalf("%s must fail early unless GOARCH is %s", tc.path, tc.expectedArch)
+			}
+		})
+	}
+}
+
+func hasAutomerge(values []bool, want bool) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func readJSONConfig(t *testing.T, path string, target any) {
+	t.Helper()
+
+	data := readConfig(t, path)
+	if err := json.Unmarshal([]byte(data), target); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+}
+
+func readYAMLConfig(t *testing.T, path string, target any) {
+	t.Helper()
+
+	data := readConfig(t, path)
+	if err := yaml.Unmarshal([]byte(data), target); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+}
+
+func readConfig(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(repoPath(t, path))
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func repoPath(t *testing.T, path string) string {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test file path")
+	}
+	return filepath.Join(filepath.Dir(filename), "..", path)
+}


### PR DESCRIPTION
## Summary

Harden the release and graduation workflows for v1.6.0 so generated changelogs, runner architecture checks, Renovate automerge policy, and graduate-feature defaults match the current release line.

## Changes

- Scope release-please changelog handling away from the VS Code extension changelog.
- Update graduate-feature defaults for the v1.6.0 milestone and labels.
- Restrict Renovate automerge behavior for risky update types.
- Add early architecture validation for Darwin release builds and related workflow documentation/tests.

## Validation

Commands and checks run:

```bash
go test ./scripts
actionlint
go test ./tools/featureflag ./internal/featureflags
jq . release-please-config.json renovate.json
renovate-config-validator
make ci
```

Additional manual validation:

- CI verify and SonarCloud checks were triggered on the PR branch.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #872
Closes #873
Closes #874
Closes #875