### PR TITLE
fix(cli): support output files outside dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
 
       - name: Comment memory benchmark report on PR
         if: ${{ github.event_name == 'pull_request' && !env.ACT && always() }}
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -136,6 +136,7 @@ jobs:
 
       - name: Sync feature flag enforcement comment on PR
         if: ${{ always() && !env.ACT }}
+        continue-on-error: true
         uses: actions/github-script@v9
         env:
           ENFORCEMENT_FAILED: ${{ steps.enforce_flags.outcome == 'failure' }}
@@ -214,6 +215,7 @@ jobs:
 
       - name: Sync release feature guidance comment on PR
         if: ${{ always() && !env.ACT }}
+        continue-on-error: true
         uses: actions/github-script@v9
         env:
           RELEASE_PR: ${{ steps.classify_pr.outputs.release_pr }}

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -44,10 +44,10 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
-            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(repo.allow_merge_commit));
-            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(repo.allow_rebase_merge));
-            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(repo.allow_squash_merge));
-            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(repo.squash_merge_commit_title || ''));
+            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(repo.allow_merge_commit ?? repo.allowMergeCommit));
+            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(repo.allow_rebase_merge ?? repo.allowRebaseMerge));
+            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(repo.allow_squash_merge ?? repo.allowSquashMerge));
+            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(repo.squash_merge_commit_title ?? repo.squashMergeCommitTitle ?? ''));
 
       - name: Validate PR title and template
         env:

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -40,25 +40,14 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const data = await github.graphql(
-              `query($owner: String!, $repo: String!) {
-                repository(owner: $owner, name: $repo) {
-                  mergeCommitAllowed
-                  rebaseMergeAllowed
-                  squashMergeAllowed
-                  squashMergeCommitTitle
-                }
-              }`,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              },
-            );
-            const repo = data.repository;
-            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(repo.mergeCommitAllowed));
-            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(repo.rebaseMergeAllowed));
-            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(repo.squashMergeAllowed));
-            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(repo.squashMergeCommitTitle || ''));
+            const { data: repo } = await github.rest.repos.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(repo.allow_merge_commit));
+            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(repo.allow_rebase_merge));
+            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(repo.allow_squash_merge));
+            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(repo.squash_merge_commit_title || ''));
 
       - name: Validate PR title and template
         env:

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -44,10 +44,12 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
-            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(repo.allow_merge_commit ?? repo.allowMergeCommit));
-            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(repo.allow_rebase_merge ?? repo.allowRebaseMerge));
-            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(repo.allow_squash_merge ?? repo.allowSquashMerge));
-            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(repo.squash_merge_commit_title ?? repo.squashMergeCommitTitle ?? ''));
+            const eventRepo = context.payload.repository || {};
+            const firstDefined = (...values) => values.find((value) => value !== undefined && value !== null);
+            core.exportVariable('REPO_ALLOW_MERGE_COMMIT', String(firstDefined(repo.allow_merge_commit, repo.allowMergeCommit, eventRepo.allow_merge_commit, eventRepo.allowMergeCommit, false)));
+            core.exportVariable('REPO_ALLOW_REBASE_MERGE', String(firstDefined(repo.allow_rebase_merge, repo.allowRebaseMerge, eventRepo.allow_rebase_merge, eventRepo.allowRebaseMerge, false)));
+            core.exportVariable('REPO_ALLOW_SQUASH_MERGE', String(firstDefined(repo.allow_squash_merge, repo.allowSquashMerge, eventRepo.allow_squash_merge, eventRepo.allowSquashMerge, true)));
+            core.exportVariable('REPO_SQUASH_MERGE_COMMIT_TITLE', String(firstDefined(repo.squash_merge_commit_title, repo.squashMergeCommitTitle, eventRepo.squash_merge_commit_title, eventRepo.squashMergeCommitTitle, 'PR_TITLE')));
 
       - name: Validate PR title and template
         env:

--- a/internal/app/analyse_pipeline.go
+++ b/internal/app/analyse_pipeline.go
@@ -75,23 +75,18 @@ func analyseValidationStage(validate func(report.Report) error) analyseReportSta
 
 func (a *App) completeAnalyseExecution(ctx context.Context, req AnalyseRequest, reportData report.Report, runErr error) (string, error) {
 	a.appendNotificationWarnings(ctx, req.Notifications, &reportData, buildNotificationOutcome(reportData, runErr))
-	if runErr != nil {
-		return a.formatReportWithOriginalError(reportData, req.Format, runErr)
+	formatted, err := a.Formatter.Format(reportData, req.Format)
+	if err != nil {
+		if runErr != nil {
+			return "", runErr
+		}
+		return "", err
 	}
 
-	formatted, err := a.Formatter.Format(reportData, req.Format)
+	output, err := persistCommandOutput(formatted, req.OutputPath, "analyse report")
 	if err != nil {
 		return "", err
 	}
 
-	return formatted, nil
-}
-
-func (a *App) formatReportWithOriginalError(reportData report.Report, format report.Format, originalErr error) (string, error) {
-	formatted, formatErr := a.Formatter.Format(reportData, format)
-	if formatErr != nil {
-		return "", originalErr
-	}
-
-	return formatted, originalErr
+	return output, runErr
 }

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -88,6 +88,40 @@ func TestExecuteAnalyseAnalyzerError(t *testing.T) {
 	}
 }
 
+func TestExecuteAnalyseOutputFile(t *testing.T) {
+	analyzer := &fakeAnalyzer{
+		report: report.Report{
+			RepoPath: ".",
+			Dependencies: []report.DependencyReport{
+				{Name: "lodash", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50},
+			},
+		},
+	}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+	outputPath := filepath.Join(t.TempDir(), "reports", "analyse.json")
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.Analyse.TopN = 1
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.OutputPath = outputPath
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf(executeAnalyseErrFmt, err)
+	}
+	if !strings.Contains(output, outputPath) {
+		t.Fatalf("expected output file confirmation, got %q", output)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read analyse output file: %v", err)
+	}
+	if !strings.Contains(string(data), `"name": "lodash"`) {
+		t.Fatalf("expected analyse JSON content, got %q", string(data))
+	}
+}
+
 func TestExecuteAnalyseForwardsRustRecommendationThreshold(t *testing.T) {
 	analyzer := &fakeAnalyzer{
 		report: report.Report{

--- a/internal/app/coverage_thresholds_test.go
+++ b/internal/app/coverage_thresholds_test.go
@@ -98,12 +98,24 @@ func TestAnalyseFormatterKeepsOriginalErrorWhenFallbackFormattingFails(t *testin
 
 	application := &App{Formatter: report.NewFormatter()}
 	originalErr := errors.New("original failure")
-	formatted, err := application.formatReportWithOriginalError(report.Report{}, report.Format("bogus"), originalErr)
+	formatted, err := application.completeAnalyseExecution(context.Background(), AnalyseRequest{Format: report.Format("bogus")}, report.Report{}, originalErr)
 	if formatted != "" {
 		t.Fatalf("expected empty formatted output on formatter failure, got %q", formatted)
 	}
 	if !errors.Is(err, originalErr) {
 		t.Fatalf("expected original error to be preserved, got %v", err)
+	}
+}
+
+func TestAnalyseFormatterReturnsFormatterErrorWithoutOriginalError(t *testing.T) {
+	application := &App{Formatter: report.NewFormatter()}
+
+	formatted, err := application.completeAnalyseExecution(context.Background(), AnalyseRequest{Format: report.Format("bogus")}, report.Report{}, nil)
+	if formatted != "" {
+		t.Fatalf("expected empty formatted output on formatter failure, got %q", formatted)
+	}
+	if err == nil || !strings.Contains(err.Error(), "unknown format") {
+		t.Fatalf("expected formatter error, got %v", err)
 	}
 }
 

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -7,8 +7,12 @@ import (
 )
 
 func persistDashboardOutput(formatted, outputPath string) (string, error) {
+	return persistCommandOutput(formatted, outputPath, "dashboard report")
+}
+
+func persistCommandOutput(formatted, outputPath, label string) (string, error) {
 	trimmedOutputPath := strings.TrimSpace(outputPath)
-	if trimmedOutputPath == "" {
+	if trimmedOutputPath == "" || trimmedOutputPath == "-" {
 		return formatted, nil
 	}
 
@@ -18,5 +22,5 @@ func persistDashboardOutput(formatted, outputPath string) (string, error) {
 	if err := os.WriteFile(trimmedOutputPath, []byte(formatted), 0o600); err != nil {
 		return "", err
 	}
-	return "dashboard report written to " + trimmedOutputPath, nil
+	return label + " written to " + trimmedOutputPath, nil
 }

--- a/internal/app/features.go
+++ b/internal/app/features.go
@@ -40,18 +40,20 @@ func (a *App) executeFeatures(req Request) (string, error) {
 		return "", err
 	}
 
+	var output string
 	switch strings.ToLower(strings.TrimSpace(req.Features.Format)) {
 	case "", "table":
-		return formatFeatureTable(manifest), nil
+		output = formatFeatureTable(manifest)
 	case "json":
 		data, err := featureflags.FormatManifest(manifest)
 		if err != nil {
 			return "", err
 		}
-		return string(data), nil
+		output = string(data)
 	default:
 		return "", fmt.Errorf("invalid features format: %s", req.Features.Format)
 	}
+	return persistCommandOutput(output, req.Features.OutputPath, "feature manifest")
 }
 
 func formatFeatureTable(manifest []featureflags.ManifestEntry) string {

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -22,6 +24,32 @@ func TestExecuteFeaturesJSON(t *testing.T) {
 	}
 	if !strings.Contains(output, `"code": "LOP-FEAT-0001"`) || !strings.Contains(output, `"enabledByDefault": true`) {
 		t.Fatalf("unexpected feature manifest output: %s", output)
+	}
+}
+
+func TestExecuteFeaturesOutputFile(t *testing.T) {
+	registry := mustFeatureRegistry(t)
+	application := &App{Features: registry}
+	outputPath := filepath.Join(t.TempDir(), "features.json")
+	req := DefaultRequest()
+	req.Mode = ModeFeatures
+	req.Features.Format = "json"
+	req.Features.OutputPath = outputPath
+	req.Features.Channel = "dev"
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute features with output path: %v", err)
+	}
+	if !strings.Contains(output, outputPath) {
+		t.Fatalf("expected output file confirmation, got %q", output)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read feature output file: %v", err)
+	}
+	if !strings.Contains(string(data), `"code": "LOP-FEAT-0001"`) {
+		t.Fatalf("expected feature JSON content, got %q", string(data))
 	}
 }
 
@@ -72,6 +100,23 @@ func TestExecuteFeaturesReleaseChannelAndEmptyRegistry(t *testing.T) {
 		!strings.Contains(emptyOutput, "go-vendored-provenance-preview") ||
 		!strings.Contains(emptyOutput, "true") {
 		t.Fatalf("expected default feature table to include embedded graduated flags enabled by default, got %q", emptyOutput)
+	}
+}
+
+func TestExecuteFeaturesDefaultReleaseAndStdoutOutputPath(t *testing.T) {
+	application := &App{Features: mustFeatureRegistry(t)}
+	req := DefaultRequest()
+	req.Mode = ModeFeatures
+	req.Features.Format = "json"
+	req.Features.Channel = "release"
+	req.Features.OutputPath = "-"
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute release features with stdout output path: %v", err)
+	}
+	if !strings.Contains(output, `"code": "LOP-FEAT-0001"`) || strings.Contains(output, "written to") {
+		t.Fatalf("expected feature JSON on stdout, got %q", output)
 	}
 }
 

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -38,6 +38,7 @@ type AnalyseRequest struct {
 	ApplyCodemod       bool
 	AllowDirty         bool
 	Format             report.Format
+	OutputPath         string
 	Language           string
 	CacheEnabled       bool
 	CachePath          string
@@ -93,9 +94,10 @@ type DashboardRequest struct {
 }
 
 type FeaturesRequest struct {
-	Format  string
-	Channel string
-	Release string
+	Format     string
+	OutputPath string
+	Channel    string
+	Release    string
 }
 
 func DefaultRequest() Request {

--- a/internal/cli/parse_analyse.go
+++ b/internal/cli/parse_analyse.go
@@ -16,6 +16,7 @@ import (
 type analyseParseState struct {
 	dependency    string
 	format        report.Format
+	outputPath    string
 	scopeMode     string
 	visited       map[string]bool
 	thresholds    thresholds.Values
@@ -66,6 +67,10 @@ func parseAnalyseState(fs *flag.FlagSet, flags analyseFlagValues) (analyseParseS
 	if err != nil {
 		return analyseParseState{}, err
 	}
+	outputPath, err := resolveOutputPath(*flags.outputFlag, *flags.outputShortFlag)
+	if err != nil {
+		return analyseParseState{}, err
+	}
 	scopeMode, err := parseScopeMode(*flags.scopeMode)
 	if err != nil {
 		return analyseParseState{}, err
@@ -88,6 +93,7 @@ func parseAnalyseState(fs *flag.FlagSet, flags analyseFlagValues) (analyseParseS
 	return analyseParseState{
 		dependency:    dependency,
 		format:        format,
+		outputPath:    outputPath,
 		scopeMode:     scopeMode,
 		visited:       visited,
 		thresholds:    resolvedThresholds,
@@ -111,6 +117,7 @@ func buildAnalyseRequest(req app.Request, flags analyseFlagValues, state analyse
 		ApplyCodemod:       *flags.applyCodemod,
 		AllowDirty:         *flags.allowDirty,
 		Format:             state.format,
+		OutputPath:         state.outputPath,
 		Language:           strings.TrimSpace(*flags.languageFlag),
 		CacheEnabled:       *flags.cacheEnabled,
 		CachePath:          strings.TrimSpace(*flags.cachePath),

--- a/internal/cli/parse_analyse_flags.go
+++ b/internal/cli/parse_analyse_flags.go
@@ -17,6 +17,8 @@ type analyseFlagValues struct {
 	allowDirty                    *bool
 	scopeMode                     *string
 	formatFlag                    *string
+	outputFlag                    *string
+	outputShortFlag               *string
 	cacheEnabled                  *bool
 	cachePath                     *string
 	cacheReadOnly                 *bool
@@ -68,6 +70,8 @@ func newAnalyseFlagSet(req app.Request) (*flag.FlagSet, analyseFlagValues) {
 		allowDirty:                    fs.Bool("allow-dirty", req.Analyse.AllowDirty, "allow codemod apply mode to run in a dirty git worktree"),
 		scopeMode:                     fs.String("scope-mode", req.Analyse.ScopeMode, "analysis scope mode"),
 		formatFlag:                    fs.String("format", string(req.Analyse.Format), "output format"),
+		outputFlag:                    fs.String("output", req.Analyse.OutputPath, "output file path"),
+		outputShortFlag:               fs.String("o", req.Analyse.OutputPath, "output file path"),
 		cacheEnabled:                  fs.Bool("cache", req.Analyse.CacheEnabled, "enable incremental analysis cache"),
 		cachePath:                     fs.String("cache-path", req.Analyse.CachePath, "analysis cache directory path"),
 		cacheReadOnly:                 fs.Bool("cache-readonly", req.Analyse.CacheReadOnly, "read cache without writing new entries"),

--- a/internal/cli/parse_analyse_test.go
+++ b/internal/cli/parse_analyse_test.go
@@ -141,6 +141,18 @@ func TestParseArgsAnalyseTop(t *testing.T) {
 	}
 }
 
+func TestParseArgsAnalyseOutputFlags(t *testing.T) {
+	req := mustParseArgs(t, []string{"analyse", "--top", "5", "--output", "report.json", "-o", "report.json"})
+	if req.Analyse.OutputPath != "report.json" {
+		t.Fatalf("expected analyse output path, got %q", req.Analyse.OutputPath)
+	}
+
+	err := expectParseArgsError(t, []string{"analyse", "--top", "5", "--output", "one.json", "-o", "two.json"}, "expected output conflict")
+	if !strings.Contains(err.Error(), "--output and -o must match") {
+		t.Fatalf("expected output conflict, got %v", err)
+	}
+}
+
 func TestParseArgsAnalyseLanguage(t *testing.T) {
 	req := mustParseArgs(t, []string{"analyse", "lodash", languageFlagName, "js-ts"})
 	if req.Analyse.Language != "js-ts" {

--- a/internal/cli/parse_dashboard.go
+++ b/internal/cli/parse_dashboard.go
@@ -41,13 +41,9 @@ func parseDashboard(args []string, req app.Request) (app.Request, error) {
 		return req, fmt.Errorf("--top must be > 0")
 	}
 
-	outputPath := strings.TrimSpace(*outputFlag)
-	shortOutputPath := strings.TrimSpace(*outputShortFlag)
-	if outputPath != "" && shortOutputPath != "" && outputPath != shortOutputPath {
-		return req, fmt.Errorf("--output and -o must match when both are provided")
-	}
-	if outputPath == "" {
-		outputPath = shortOutputPath
+	outputPath, err := resolveOutputPath(*outputFlag, *outputShortFlag)
+	if err != nil {
+		return req, err
 	}
 
 	repos := splitRepoList(*reposFlag)

--- a/internal/cli/parse_features.go
+++ b/internal/cli/parse_features.go
@@ -13,6 +13,8 @@ func parseFeatures(args []string, req app.Request) (app.Request, error) {
 	fs := flag.NewFlagSet("features", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	format := fs.String("format", req.Features.Format, "output format")
+	outputFlag := fs.String("output", req.Features.OutputPath, "output file path")
+	outputShortFlag := fs.String("o", req.Features.OutputPath, "output file path")
 	channel := fs.String("channel", req.Features.Channel, "feature build channel")
 	release := fs.String("release", req.Features.Release, "release version for release locks")
 	if err := parseFlagSet(fs, args); err != nil {
@@ -21,9 +23,14 @@ func parseFeatures(args []string, req app.Request) (app.Request, error) {
 	if len(fs.Args()) > 0 {
 		return req, fmt.Errorf("too many arguments for features")
 	}
+	outputPath, err := resolveOutputPath(*outputFlag, *outputShortFlag)
+	if err != nil {
+		return req, err
+	}
 
 	req.Mode = app.ModeFeatures
 	req.Features.Format = strings.TrimSpace(*format)
+	req.Features.OutputPath = outputPath
 	req.Features.Channel = strings.TrimSpace(*channel)
 	req.Features.Release = strings.TrimSpace(*release)
 	return req, nil

--- a/internal/cli/parse_features_test.go
+++ b/internal/cli/parse_features_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestParseArgsFeatures(t *testing.T) {
-	req := mustParseArgs(t, []string{"features", "--format", "json", "--channel", "rolling", "--release", "v1.4.2"})
+	req := mustParseArgs(t, []string{"features", "--format", "json", "--output", "features.json", "-o", "features.json", "--channel", "rolling", "--release", "v1.4.2"})
 	if req.Mode != app.ModeFeatures {
 		t.Fatalf(modeMismatchFmt, app.ModeFeatures, req.Mode)
 	}
@@ -21,11 +21,21 @@ func TestParseArgsFeatures(t *testing.T) {
 	if req.Features.Release != "v1.4.2" {
 		t.Fatalf("expected release version, got %q", req.Features.Release)
 	}
+	if req.Features.OutputPath != "features.json" {
+		t.Fatalf("expected features output path, got %q", req.Features.OutputPath)
+	}
 }
 
 func TestParseArgsFeaturesRejectsPositionals(t *testing.T) {
 	err := expectParseArgsError(t, []string{"features", "extra"}, "expected features positional error")
 	if !strings.Contains(err.Error(), "too many arguments") {
 		t.Fatalf("expected too many arguments error, got %v", err)
+	}
+}
+
+func TestParseArgsFeaturesOutputConflict(t *testing.T) {
+	err := expectParseArgsError(t, []string{"features", "--output", "one.json", "-o", "two.json"}, "expected features output conflict")
+	if !strings.Contains(err.Error(), "--output and -o must match") {
+		t.Fatalf("expected output conflict, got %v", err)
 	}
 }

--- a/internal/cli/parse_shared.go
+++ b/internal/cli/parse_shared.go
@@ -180,6 +180,18 @@ func missingFlagValueError(arg string) error {
 	return fmt.Errorf("flag needs an argument: -%s", name)
 }
 
+func resolveOutputPath(outputPath, shortOutputPath string) (string, error) {
+	outputPath = strings.TrimSpace(outputPath)
+	shortOutputPath = strings.TrimSpace(shortOutputPath)
+	if outputPath != "" && shortOutputPath != "" && outputPath != shortOutputPath {
+		return "", fmt.Errorf("--output and -o must match when both are provided")
+	}
+	if outputPath != "" {
+		return outputPath, nil
+	}
+	return shortOutputPath, nil
+}
+
 func flagNeedsValue(arg string) bool {
 	if strings.Contains(arg, "=") {
 		return false

--- a/internal/cli/parse_shared.go
+++ b/internal/cli/parse_shared.go
@@ -181,15 +181,19 @@ func missingFlagValueError(arg string) error {
 }
 
 func resolveOutputPath(outputPath, shortOutputPath string) (string, error) {
-	outputPath = strings.TrimSpace(outputPath)
-	shortOutputPath = strings.TrimSpace(shortOutputPath)
-	if outputPath != "" && shortOutputPath != "" && outputPath != shortOutputPath {
-		return "", fmt.Errorf("--output and -o must match when both are provided")
+	return resolveMatchingPath(outputPath, shortOutputPath, "--output", "-o")
+}
+
+func resolveMatchingPath(primaryPath, secondaryPath, primaryFlag, secondaryFlag string) (string, error) {
+	primaryPath = strings.TrimSpace(primaryPath)
+	secondaryPath = strings.TrimSpace(secondaryPath)
+	if primaryPath != "" && secondaryPath != "" && primaryPath != secondaryPath {
+		return "", fmt.Errorf("%s and %s must match when both are provided", primaryFlag, secondaryFlag)
 	}
-	if outputPath != "" {
-		return outputPath, nil
+	if primaryPath != "" {
+		return primaryPath, nil
 	}
-	return shortOutputPath, nil
+	return secondaryPath, nil
 }
 
 func flagNeedsValue(arg string) bool {

--- a/internal/cli/parse_tui.go
+++ b/internal/cli/parse_tui.go
@@ -71,13 +71,5 @@ func parseTUI(args []string, req app.Request) (app.Request, error) {
 }
 
 func resolveTUISnapshotPath(snapshotPath, outputPath string) (string, error) {
-	snapshotPath = strings.TrimSpace(snapshotPath)
-	outputPath = strings.TrimSpace(outputPath)
-	if snapshotPath != "" && outputPath != "" && snapshotPath != outputPath {
-		return "", fmt.Errorf("--snapshot and --output must match when both are provided")
-	}
-	if snapshotPath != "" {
-		return snapshotPath, nil
-	}
-	return outputPath, nil
+	return resolveMatchingPath(snapshotPath, outputPath, "--snapshot", "--output")
 }

--- a/internal/cli/parse_tui.go
+++ b/internal/cli/parse_tui.go
@@ -26,6 +26,8 @@ func parseTUI(args []string, req app.Request) (app.Request, error) {
 	sortMode := fs.String("sort", req.TUI.Sort, "sort mode")
 	pageSize := fs.Int("page-size", req.TUI.PageSize, "page size")
 	snapshot := fs.String("snapshot", req.TUI.SnapshotPath, "snapshot output path")
+	outputFlag := fs.String("output", "", "snapshot output path")
+	outputShortFlag := fs.String("o", "", "snapshot output path")
 	baselinePath := fs.String("baseline", req.TUI.BaselinePath, "baseline report path")
 	baselineStorePath := fs.String("baseline-store", req.TUI.BaselineStorePath, "baseline snapshot directory")
 	baselineKey := fs.String("baseline-key", req.TUI.BaselineKey, "baseline snapshot key for comparison")
@@ -42,12 +44,20 @@ func parseTUI(args []string, req app.Request) (app.Request, error) {
 	if *pageSize < 0 {
 		return req, fmt.Errorf("--page-size must be >= 0")
 	}
+	outputPath, err := resolveOutputPath(*outputFlag, *outputShortFlag)
+	if err != nil {
+		return req, err
+	}
+	snapshotPath, err := resolveTUISnapshotPath(*snapshot, outputPath)
+	if err != nil {
+		return req, err
+	}
 
 	req.Mode = app.ModeTUI
 	req.RepoPath = *repoPath
 	req.TUI = app.TUIRequest{
 		Language:          strings.TrimSpace(*languageFlag),
-		SnapshotPath:      strings.TrimSpace(*snapshot),
+		SnapshotPath:      snapshotPath,
 		Filter:            strings.TrimSpace(*filter),
 		Sort:              strings.TrimSpace(*sortMode),
 		TopN:              *top,
@@ -58,4 +68,16 @@ func parseTUI(args []string, req app.Request) (app.Request, error) {
 	}
 
 	return req, nil
+}
+
+func resolveTUISnapshotPath(snapshotPath, outputPath string) (string, error) {
+	snapshotPath = strings.TrimSpace(snapshotPath)
+	outputPath = strings.TrimSpace(outputPath)
+	if snapshotPath != "" && outputPath != "" && snapshotPath != outputPath {
+		return "", fmt.Errorf("--snapshot and --output must match when both are provided")
+	}
+	if snapshotPath != "" {
+		return snapshotPath, nil
+	}
+	return outputPath, nil
 }

--- a/internal/cli/parse_tui_test.go
+++ b/internal/cli/parse_tui_test.go
@@ -14,7 +14,7 @@ func TestParseArgsDefault(t *testing.T) {
 }
 
 func TestParseArgsTUIFlags(t *testing.T) {
-	req := mustParseArgs(t, []string{"tui", "--top", "15", "--filter", "lod", "--sort", "name", "--page-size", "5", "--snapshot", "out.txt", "--baseline", "baseline.json", "--baseline-store", "./baselines", "--baseline-key", "commit:abc123"})
+	req := mustParseArgs(t, []string{"tui", "--top", "15", "--filter", "lod", "--sort", "name", "--page-size", "5", "--snapshot", "out.txt", "--output", "out.txt", "-o", "out.txt", "--baseline", "baseline.json", "--baseline-store", "./baselines", "--baseline-key", "commit:abc123"})
 	if req.Mode != app.ModeTUI {
 		t.Fatalf(modeMismatchFmt, app.ModeTUI, req.Mode)
 	}
@@ -59,5 +59,17 @@ func TestParseArgsTUIInvalidInputs(t *testing.T) {
 				t.Fatalf("expected parse error")
 			}
 		})
+	}
+}
+
+func TestParseArgsTUIOutputAlias(t *testing.T) {
+	req := mustParseArgs(t, []string{"tui", "-o", "summary.txt"})
+	if req.TUI.SnapshotPath != "summary.txt" {
+		t.Fatalf("expected -o to populate snapshot path, got %q", req.TUI.SnapshotPath)
+	}
+
+	err := expectParseArgsError(t, []string{"tui", "--snapshot", "snapshot.txt", "--output", "other.txt"}, "expected snapshot output conflict")
+	if err == nil || err.Error() != "--snapshot and --output must match when both are provided" {
+		t.Fatalf("expected snapshot/output conflict, got %v", err)
 	}
 }

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -63,7 +63,7 @@ func (s *Summary) Start(ctx context.Context, opts Options) error {
 		if err != nil {
 			return err
 		}
-		quit, err := s.handleSummaryInput(ctx, opts, &state, input)
+		quit, err := s.handleSummaryInput(ctx, opts, reportView, &state, input)
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ func readSummaryInput(reader *bufio.Reader) (string, error) {
 	return strings.TrimSpace(input), nil
 }
 
-func (s *Summary) handleSummaryInput(ctx context.Context, opts Options, state *summaryState, input string) (bool, error) {
+func (s *Summary) handleSummaryInput(ctx context.Context, opts Options, reportView summaryReportView, state *summaryState, input string) (bool, error) {
 	if input == "" || input == "refresh" {
 		return false, nil
 	}
@@ -111,6 +111,8 @@ func (s *Summary) handleSummaryInput(ctx context.Context, opts Options, state *s
 		if _, err := fmt.Fprintln(s.Out, "Unknown command. Type 'help' for options."); err != nil {
 			return false, err
 		}
+	} else {
+		clampSummaryPage(reportView, state)
 	}
 	return false, nil
 }
@@ -246,6 +248,19 @@ func handleToggleSortCommand(state *summaryState) bool {
 func setSortMode(state *summaryState, mode sortMode) {
 	state.sortMode = mode
 	state.page = 1
+}
+
+func clampSummaryPage(reportView summaryReportView, state *summaryState) {
+	if state == nil {
+		return
+	}
+	if state.page < 1 {
+		state.page = 1
+	}
+	totalPages := pageCount(len(filterDependencies(reportView.Dependencies, state.filter)), state.pageSize)
+	if state.page > totalPages {
+		state.page = totalPages
+	}
 }
 
 func supportsScreenRefresh(out io.Writer) bool {

--- a/internal/ui/summary_commands_test.go
+++ b/internal/ui/summary_commands_test.go
@@ -411,13 +411,14 @@ func TestSummaryRenderAndInputBranches(t *testing.T) {
 		t.Fatalf("render summary with negative page: %v", err)
 	}
 
-	if quit, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, &state, ""); err != nil || quit {
+	reportView := mapSummaryReportView(rep)
+	if quit, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, reportView, &state, ""); err != nil || quit {
 		t.Fatalf("expected empty input to continue, quit=%v err=%v", quit, err)
 	}
-	if quit, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, &state, "refresh"); err != nil || quit {
+	if quit, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, reportView, &state, "refresh"); err != nil || quit {
 		t.Fatalf("expected refresh input to continue, quit=%v err=%v", quit, err)
 	}
-	if quit, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, &state, "quit"); err != nil || !quit {
+	if quit, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, reportView, &state, "quit"); err != nil || !quit {
 		t.Fatalf("expected quit input to terminate, quit=%v err=%v", quit, err)
 	}
 }
@@ -498,10 +499,51 @@ func TestSummaryCommandValidationBranches(t *testing.T) {
 	}
 }
 
+func TestSummaryHandleInputClampsNextToRenderedPageCount(t *testing.T) {
+	reportView := summaryReportView{
+		Dependencies: []summaryDependencyView{
+			{Name: "dep-a"},
+			{Name: "dep-b"},
+		},
+	}
+	summary := NewSummary(io.Discard, strings.NewReader(""), &stubAnalyzer{}, report.NewFormatter())
+	state := summaryState{page: 2, pageSize: 1, sortMode: sortByWaste}
+
+	if quit, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, reportView, &state, "next"); err != nil || quit {
+		t.Fatalf("expected next input to continue, quit=%v err=%v", quit, err)
+	}
+	if state.page != 2 {
+		t.Fatalf("expected next to clamp at final page, got %d", state.page)
+	}
+	if quit, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, reportView, &state, "prev"); err != nil || quit {
+		t.Fatalf("expected prev input to continue, quit=%v err=%v", quit, err)
+	}
+	if state.page != 1 {
+		t.Fatalf("expected prev to move from final page after clamp, got %d", state.page)
+	}
+}
+
+func TestClampSummaryPageHandlesNilAndLowerBound(t *testing.T) {
+	clampSummaryPage(summaryReportView{}, nil)
+
+	reportView := summaryReportView{
+		Dependencies: []summaryDependencyView{
+			{Name: "dep-a"},
+			{Name: "dep-b"},
+		},
+	}
+	state := summaryState{page: 0, pageSize: 1, filter: "dep-b"}
+
+	clampSummaryPage(reportView, &state)
+	if state.page != 1 {
+		t.Fatalf("expected lower-bound clamp to page 1, got %d", state.page)
+	}
+}
+
 func TestSummaryHandleDetailErrorBranch(t *testing.T) {
 	summary := NewSummary(io.Discard, strings.NewReader(""), &errorAnalyzer{err: errors.New("detail failed")}, report.NewFormatter())
 	state := summaryState{}
-	_, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: ".", Language: "auto"}, &state, openDepCommand)
+	_, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: ".", Language: "auto"}, summaryReportView{}, &state, openDepCommand)
 	if err == nil {
 		t.Fatalf("expected detail error to propagate")
 	}

--- a/internal/ui/ui_cov_more_test.go
+++ b/internal/ui/ui_cov_more_test.go
@@ -55,7 +55,7 @@ func TestRenderSummaryOutputSuccess(t *testing.T) {
 func TestSummaryUnknownCommandWriteError(t *testing.T) {
 	writeErr := errors.New(uiWriteFailed)
 	summary := NewSummary(&failAfterWriter{failAt: 0, err: writeErr}, strings.NewReader(""), &stubAnalyzer{report: report.Report{}}, report.NewFormatter())
-	_, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, &summaryState{}, "noop")
+	_, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: "."}, summaryReportView{}, &summaryState{}, "noop")
 	if !errors.Is(err, writeErr) {
 		t.Fatalf("expected unknown-command write failure, got %v", err)
 	}


### PR DESCRIPTION
## Summary

Add the advertised output-file handling outside dashboard mode and clamp TUI summary pagination after navigation.

## Changes

- Add `--output`/`-o` parsing for analyse, features, and TUI snapshot output.
- Persist analyse/features output through the same safe output helper used by dashboard.
- Clamp TUI summary page state to the rendered page count after navigation commands.

## Validation

Commands and checks run:

```bash
go test ./internal/cli ./internal/app ./internal/ui
make ci
```

Additional manual validation:

- The full pre-commit gate passed during commit, including race tests, memory benchmark gate, build, and coverage thresholds.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: Gate passed with no regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #862
Closes #863