### PR TITLE
fix(codemod): preserve mixed newlines when applying suggestions

### DIFF
--- a/internal/app/codemod_apply.go
+++ b/internal/app/codemod_apply.go
@@ -58,6 +58,11 @@ type codemodApplyMutation struct {
 	failedResults  []report.CodemodApplyResult
 }
 
+type codemodContentLine struct {
+	text      string
+	separator string
+}
+
 func applyCodemodIfNeeded(ctx context.Context, reportData report.Report, repoPath string, req AnalyseRequest, now time.Time) (report.Report, error) {
 	if !req.ApplyCodemod {
 		return reportData, nil
@@ -275,21 +280,50 @@ func prepareCodemodFiles(repoPath string, suggestions []report.CodemodSuggestion
 }
 
 func applySuggestionsToContent(content string, suggestions []report.CodemodSuggestion) (string, error) {
-	lineSeparator := "\n"
-	if strings.Contains(content, "\r\n") {
-		lineSeparator = "\r\n"
-	}
-	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	lines := splitCodemodContentLines(content)
 	for _, suggestion := range suggestions {
 		if suggestion.Line <= 0 || suggestion.Line > len(lines) {
 			return "", fmt.Errorf("line %d is out of range for %s", suggestion.Line, suggestion.File)
 		}
-		if lines[suggestion.Line-1] != suggestion.Original {
+		if lines[suggestion.Line-1].text != suggestion.Original {
 			return "", fmt.Errorf("source line mismatch at %s:%d", suggestion.File, suggestion.Line)
 		}
-		lines[suggestion.Line-1] = suggestion.Replacement
+		lines[suggestion.Line-1].text = suggestion.Replacement
 	}
-	return strings.Join(lines, lineSeparator), nil
+	return joinCodemodContentLines(lines), nil
+}
+
+func splitCodemodContentLines(content string) []codemodContentLine {
+	lines := make([]codemodContentLine, 0, strings.Count(content, "\n")+1)
+	start := 0
+	for i := 0; i < len(content); i++ {
+		if content[i] != '\n' {
+			continue
+		}
+
+		textEnd := i
+		separator := "\n"
+		if i > start && content[i-1] == '\r' {
+			textEnd = i - 1
+			separator = "\r\n"
+		}
+		lines = append(lines, codemodContentLine{
+			text:      content[start:textEnd],
+			separator: separator,
+		})
+		start = i + 1
+	}
+	lines = append(lines, codemodContentLine{text: content[start:]})
+	return lines
+}
+
+func joinCodemodContentLines(lines []codemodContentLine) string {
+	var builder strings.Builder
+	for _, line := range lines {
+		builder.WriteString(line.text)
+		builder.WriteString(line.separator)
+	}
+	return builder.String()
 }
 
 func applyPreparedCodemodFiles(repoPath string, prepared []preparedCodemodFile, failures []report.CodemodApplyResult) ([]report.CodemodApplyResult, []report.CodemodApplyResult) {

--- a/internal/app/codemod_apply_helpers_test.go
+++ b/internal/app/codemod_apply_helpers_test.go
@@ -71,8 +71,28 @@ func TestApplySuggestionsToContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply suggestions with CRLF: %v", err)
 	}
-	if !strings.Contains(updated, "\r\n") || !strings.Contains(updated, importLodashMapLine) {
-		t.Fatalf("expected CRLF-preserving updated content, got %q", updated)
+	if want := importLodashMapLine + "\r\nmap()\r\n"; updated != want {
+		t.Fatalf("expected CRLF-preserving updated content %q, got %q", want, updated)
+	}
+
+	mixedLFLine := importLodashLine + "\nconst untouchedCRLF = true;\r\nconst untouchedLF = true;\n"
+	updated, err = applySuggestionsToContent(mixedLFLine, suggestions)
+	if err != nil {
+		t.Fatalf("apply suggestions to LF line in mixed-newline content: %v", err)
+	}
+	if want := importLodashMapLine + "\nconst untouchedCRLF = true;\r\nconst untouchedLF = true;\n"; updated != want {
+		t.Fatalf("expected mixed newline content to preserve surrounding separators %q, got %q", want, updated)
+	}
+
+	mixedCRLFLine := "const untouchedLF = true;\n" + importLodashLine + "\r\nconst stillLF = true;\n"
+	updated, err = applySuggestionsToContent(mixedCRLFLine, []report.CodemodSuggestion{
+		{File: indexJSFile, Line: 2, Original: importLodashLine, Replacement: importLodashMapLine},
+	})
+	if err != nil {
+		t.Fatalf("apply suggestions to CRLF line in mixed-newline content: %v", err)
+	}
+	if want := "const untouchedLF = true;\n" + importLodashMapLine + "\r\nconst stillLF = true;\n"; updated != want {
+		t.Fatalf("expected changed line to keep its separator without rewriting LF neighbors %q, got %q", want, updated)
 	}
 
 	_, err = applySuggestionsToContent(importLodashLineWithLF, []report.CodemodSuggestion{{File: indexJSFile, Line: 3, Original: "x", Replacement: "y"}})


### PR DESCRIPTION
## Summary

Fixes #864.

`applySuggestionsToContent` previously normalized CRLF to LF, then rewrote the whole file using CRLF whenever any CRLF appeared in the input. Mixed-newline files could therefore get unrelated LF lines rewritten while applying a single codemod suggestion.

## Changes

- Preserve each original line separator while applying codemod replacements.
- Add exact-byte tests for CRLF-only and mixed LF/CRLF codemod apply inputs.

## Validation

Commands and checks run:

```bash
go test ./internal/app -run TestApplySuggestionsToContent
go test ./internal/app
```

Additional manual validation:

- Reviewed the scoped diff to confirm only codemod apply implementation and tests changed.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None
- Memory benchmark impact: None

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review