### PR TITLE
refactor(lang): delegate resolver defaults and enable dupl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
 
       - name: Comment lopper report on PR
         if: ${{ github.event_name == 'pull_request' && !env.ACT }}
+        continue-on-error: true
         uses: actions/github-script@v9
         env:
           LOPPER_BASE_OUTCOME: ${{ steps.lopper_base.outcome }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   enable:
     - errcheck
     - errorlint
+    - dupl
     - gocritic
     - govet
     - unused

--- a/internal/lang/cpp/reporting.go
+++ b/internal/lang/cpp/reporting.go
@@ -48,10 +48,7 @@ func buildTopCPPDependencies(topN int, scan scanResult, weights report.RemovalCa
 }
 
 func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	if value == nil {
-		return report.DefaultRemovalCandidateWeights()
-	}
-	return report.NormalizeRemovalCandidateWeights(*value)
+	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func buildDependencyReport(dependency string, scan scanResult, warnOnNoUsage bool) (report.DependencyReport, []string) {

--- a/internal/lang/dotnet/adapter.go
+++ b/internal/lang/dotnet/adapter.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
-	"github.com/ben-ranford/lopper/internal/thresholds"
 	"github.com/ben-ranford/lopper/internal/workspace"
 )
 
@@ -200,15 +199,9 @@ func buildRecommendations(dep report.DependencyReport, ambiguousCount int, undec
 }
 
 func resolveMinUsageRecommendationThreshold(threshold *int) int {
-	if threshold != nil {
-		return *threshold
-	}
-	return thresholds.Defaults().MinUsagePercentForRecommendations
+	return shared.ResolveMinUsageRecommendationThreshold(threshold)
 }
 
 func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	if value == nil {
-		return report.DefaultRemovalCandidateWeights()
-	}
-	return report.NormalizeRemovalCandidateWeights(*value)
+	return shared.ResolveRemovalCandidateWeights(value)
 }

--- a/internal/lang/elixir/report.go
+++ b/internal/lang/elixir/report.go
@@ -44,8 +44,5 @@ func buildRequestedDependencies(req language.Request, scan scanResult) ([]report
 }
 
 func resolveWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	if value == nil {
-		return report.DefaultRemovalCandidateWeights()
-	}
-	return report.NormalizeRemovalCandidateWeights(*value)
+	return shared.ResolveRemovalCandidateWeights(value)
 }

--- a/internal/lang/golang/adapter.go
+++ b/internal/lang/golang/adapter.go
@@ -81,10 +81,7 @@ func buildTopGoReports(topN int, dependencies []string, scan scanResult, weights
 }
 
 func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	if value == nil {
-		return report.DefaultRemovalCandidateWeights()
-	}
-	return report.NormalizeRemovalCandidateWeights(*value)
+	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func scanRepo(ctx context.Context, repoPath string, moduleInfo moduleInfo) (scanResult, error) {

--- a/internal/lang/js/adapter.go
+++ b/internal/lang/js/adapter.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
-	"github.com/ben-ranford/lopper/internal/thresholds"
 	"github.com/ben-ranford/lopper/internal/workspace"
 )
 
@@ -781,17 +780,11 @@ func dependencyFromModule(module string) string {
 }
 
 func resolveMinUsageRecommendationThreshold(value *int) int {
-	if value != nil {
-		return *value
-	}
-	return thresholds.Defaults().MinUsagePercentForRecommendations
+	return shared.ResolveMinUsageRecommendationThreshold(value)
 }
 
 func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	if value == nil {
-		return report.DefaultRemovalCandidateWeights()
-	}
-	return report.NormalizeRemovalCandidateWeights(*value)
+	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 type dependencyResolutionRequest struct {

--- a/internal/lang/jvm/adapter.go
+++ b/internal/lang/jvm/adapter.go
@@ -79,10 +79,7 @@ func buildTopJVMDependencies(topN int, scan scanResult, weights report.RemovalCa
 }
 
 func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	if value == nil {
-		return report.DefaultRemovalCandidateWeights()
-	}
-	return report.NormalizeRemovalCandidateWeights(*value)
+	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func buildDependencyReport(dependency string, scan scanResult) (report.DependencyReport, []string) {

--- a/internal/lang/php/reporting.go
+++ b/internal/lang/php/reporting.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
-	"github.com/ben-ranford/lopper/internal/thresholds"
 )
 
 func buildRequestedPHPDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
@@ -23,10 +22,7 @@ func buildRequestedPHPDependencies(req language.Request, scan scanResult) ([]rep
 }
 
 func resolveMinUsageRecommendationThreshold(threshold *int) int {
-	if threshold != nil {
-		return *threshold
-	}
-	return thresholds.Defaults().MinUsagePercentForRecommendations
+	return shared.ResolveMinUsageRecommendationThreshold(threshold)
 }
 
 func buildTopPHPDependencies(topN int, scan scanResult, minUsagePercent int, weights report.RemovalCandidateWeights) ([]report.DependencyReport, []string) {
@@ -134,10 +130,7 @@ func buildRecommendations(dep report.DependencyReport, minUsagePercent int) []re
 }
 
 func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	if value == nil {
-		return report.DefaultRemovalCandidateWeights()
-	}
-	return report.NormalizeRemovalCandidateWeights(*value)
+	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func hasRiskCue(cues []report.RiskCue, code string) bool {

--- a/internal/lang/powershell/report.go
+++ b/internal/lang/powershell/report.go
@@ -96,10 +96,7 @@ func buildRecommendations(dep report.DependencyReport) []report.Recommendation {
 }
 
 func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	if value == nil {
-		return report.DefaultRemovalCandidateWeights()
-	}
-	return report.NormalizeRemovalCandidateWeights(*value)
+	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func sortedDependencyUnion(values ...map[string]struct{}) []string {

--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -146,10 +146,7 @@ func buildTopPythonDependencies(topN int, scan scanResult, weights report.Remova
 }
 
 func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	if value == nil {
-		return report.DefaultRemovalCandidateWeights()
-	}
-	return report.NormalizeRemovalCandidateWeights(*value)
+	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 type importBinding = shared.ImportRecord

--- a/internal/lang/ruby/report.go
+++ b/internal/lang/ruby/report.go
@@ -35,10 +35,7 @@ func collectRubyDependencyStats(dependency string, files []fileScan) shared.Depe
 }
 
 func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	if value == nil {
-		return report.DefaultRemovalCandidateWeights()
-	}
-	return report.NormalizeRemovalCandidateWeights(*value)
+	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func sortedDependencyUnion(values ...map[string]struct{}) []string {

--- a/internal/language/registry_test.go
+++ b/internal/language/registry_test.go
@@ -58,14 +58,24 @@ func (a *testAdapter) Analyse(ctx context.Context, req Request) (report.Report, 
 	return report.Report{}, nil
 }
 
-func TestResolveAutoSelectsHighestConfidence(t *testing.T) {
+func registryWithTestAdapters(t *testing.T, adapters ...*testAdapter) *Registry {
+	t.Helper()
 	registry := NewRegistry()
-	if err := registry.Register(&testAdapter{id: "js-ts", detection: Detection{Matched: true, Confidence: 70}}); err != nil {
-		t.Fatalf(registerJSErrFmt, err)
+	for _, adapter := range adapters {
+		if err := registry.Register(adapter); err != nil {
+			t.Fatalf("register %s: %v", adapter.id, err)
+		}
 	}
-	if err := registry.Register(&testAdapter{id: "python", detection: Detection{Matched: true, Confidence: 85}}); err != nil {
-		t.Fatalf(registerPythonErrFmt, err)
-	}
+	return registry
+}
+
+func registryForResolve(t *testing.T, js Detection, python Detection) *Registry {
+	t.Helper()
+	return registryWithTestAdapters(t, &testAdapter{id: "js-ts", detection: js}, &testAdapter{id: "python", detection: python})
+}
+
+func TestResolveAutoSelectsHighestConfidence(t *testing.T) {
+	registry := registryForResolve(t, Detection{Matched: true, Confidence: 70}, Detection{Matched: true, Confidence: 85})
 
 	candidates, err := registry.Resolve(context.Background(), ".", Auto)
 	if err != nil {
@@ -80,13 +90,7 @@ func TestResolveAutoSelectsHighestConfidence(t *testing.T) {
 }
 
 func TestResolveAllReturnsMatches(t *testing.T) {
-	registry := NewRegistry()
-	if err := registry.Register(&testAdapter{id: "js-ts", detection: Detection{Matched: true, Confidence: 70}}); err != nil {
-		t.Fatalf(registerJSErrFmt, err)
-	}
-	if err := registry.Register(&testAdapter{id: "python", detection: Detection{Matched: false, Confidence: 0}}); err != nil {
-		t.Fatalf(registerPythonErrFmt, err)
-	}
+	registry := registryForResolve(t, Detection{Matched: true, Confidence: 70}, Detection{Matched: false, Confidence: 0})
 
 	candidates, err := registry.Resolve(context.Background(), ".", All)
 	if err != nil {

--- a/internal/language/registry_test.go
+++ b/internal/language/registry_test.go
@@ -74,34 +74,28 @@ func registryForResolve(t *testing.T, js Detection, python Detection) *Registry 
 	return registryWithTestAdapters(t, &testAdapter{id: "js-ts", detection: js}, &testAdapter{id: "python", detection: python})
 }
 
-func TestResolveAutoSelectsHighestConfidence(t *testing.T) {
-	registry := registryForResolve(t, Detection{Matched: true, Confidence: 70}, Detection{Matched: true, Confidence: 85})
-
-	candidates, err := registry.Resolve(context.Background(), ".", Auto)
+func requireResolvedAdapterID(t *testing.T, registry *Registry, mode string, want string) {
+	t.Helper()
+	candidates, err := registry.Resolve(context.Background(), ".", mode)
 	if err != nil {
-		t.Fatalf("resolve auto: %v", err)
+		t.Fatalf("resolve %v: %v", mode, err)
 	}
 	if len(candidates) != 1 {
 		t.Fatalf("expected one candidate, got %d", len(candidates))
 	}
-	if candidates[0].Adapter.ID() != "python" {
-		t.Fatalf("expected python adapter, got %q", candidates[0].Adapter.ID())
+	if candidates[0].Adapter.ID() != want {
+		t.Fatalf("expected %s adapter, got %q", want, candidates[0].Adapter.ID())
 	}
+}
+
+func TestResolveAutoSelectsHighestConfidence(t *testing.T) {
+	registry := registryForResolve(t, Detection{Matched: true, Confidence: 70}, Detection{Matched: true, Confidence: 85})
+	requireResolvedAdapterID(t, registry, Auto, "python")
 }
 
 func TestResolveAllReturnsMatches(t *testing.T) {
 	registry := registryForResolve(t, Detection{Matched: true, Confidence: 70}, Detection{Matched: false, Confidence: 0})
-
-	candidates, err := registry.Resolve(context.Background(), ".", All)
-	if err != nil {
-		t.Fatalf("resolve all: %v", err)
-	}
-	if len(candidates) != 1 {
-		t.Fatalf("expected one matched candidate, got %d", len(candidates))
-	}
-	if candidates[0].Adapter.ID() != "js-ts" {
-		t.Fatalf("expected js-ts adapter, got %q", candidates[0].Adapter.ID())
-	}
+	requireResolvedAdapterID(t, registry, All, "js-ts")
 }
 
 func TestResolveAutoTieReturnsError(t *testing.T) {


### PR DESCRIPTION
## Summary

Delegate duplicated language-adapter resolver defaults to shared helpers, enable the `dupl` linter so future verbatim duplication is caught in CI, and make the lopper PR report comment non-gating when GitHub comment auth is unavailable.

Closes #984
Closes #986
Closes #989

## Changes

- Replaced local removal-candidate weight fallback bodies with `shared.ResolveRemovalCandidateWeights` across C++, .NET, Elixir, Go, JS, JVM, PHP, PowerShell, Python, and Ruby adapters.
- Replaced .NET, JS, and PHP min-usage recommendation threshold fallback bodies with `shared.ResolveMinUsageRecommendationThreshold`.
- Enabled `dupl` in `.golangci.yml` and factored duplicated registry test setup/assertions that the new duplication gates reported.
- Marked the lopper PR report comment step as non-gating so CI verifies analysis results without failing solely on GitHub comment 401s.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/cpp ./internal/lang/dotnet ./internal/lang/golang ./internal/lang/js ./internal/lang/jvm ./internal/lang/php ./internal/lang/powershell ./internal/lang/python ./internal/lang/ruby ./internal/lang/elixir
make lint
go test ./internal/lang/cpp ./internal/lang/dotnet ./internal/lang/golang ./internal/lang/js ./internal/lang/jvm ./internal/lang/php ./internal/lang/powershell ./internal/lang/python ./internal/lang/ruby ./internal/lang/elixir ./internal/language && make dup-check
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
go test ./internal/language && make dup-check
make ci
```

Additional manual validation:

- Verified the PR diff against `origin/main` includes shared resolver delegation, `dupl` lint enablement, the registry test helper needed by duplication gates, and the non-gating lopper report comment workflow flag.

## Risk and compatibility

- Breaking changes: none
- Migration required: none
- Performance impact: none expected
- Memory benchmark impact: `make ci` memory benchmark gate passed with no regression

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review