### PR TITLE
fix(powershell): tighten requires directive matching

### DIFF
--- a/internal/lang/powershell/parser_test.go
+++ b/internal/lang/powershell/parser_test.go
@@ -133,6 +133,42 @@ func TestParsePowerShellLineHandlesInlineCommentsAndMissingRequiresModules(t *te
 	}
 }
 
+func TestParsePowerShellLineRequiresDirectiveSpacing(t *testing.T) {
+	declared := map[string]struct{}{"pester": {}}
+	validDirectives := []string{
+		"#Requires -Modules Pester",
+		"#Requires\t-Modules Pester",
+		"  #requires -Modules:Pester # trailing comment",
+	}
+	for _, line := range validDirectives {
+		t.Run("valid "+line, func(t *testing.T) {
+			imports, warnings := parsePowerShellLine(line, "run.ps1", 10, declared)
+			if len(warnings) != 0 {
+				t.Fatalf("expected valid #Requires directive to avoid warnings, got %#v", warnings)
+			}
+			if len(imports) != 1 || imports[0].Record.Dependency != "pester" || imports[0].Source != usageSourceRequiresModule {
+				t.Fatalf("expected valid #Requires directive to import pester, got %#v", imports)
+			}
+		})
+	}
+
+	commentLines := []string{
+		"# Requires -Modules Pester",
+		"#\tRequires -Modules Pester",
+		"  # requires -Modules Pester",
+		"# Requires -Modules",
+		"#Requires-Modules Pester",
+	}
+	for _, line := range commentLines {
+		t.Run("comment "+line, func(t *testing.T) {
+			imports, warnings := parsePowerShellLine(line, "run.ps1", 20, declared)
+			if len(imports) != 0 || len(warnings) != 0 {
+				t.Fatalf("expected ordinary comment to be ignored, imports=%#v warnings=%#v", imports, warnings)
+			}
+		})
+	}
+}
+
 func TestParseImportModuleDependencySupportsFlagAndPositionalForms(t *testing.T) {
 	declared := map[string]struct{}{"pester": {}, "az.accounts": {}}
 	cases := []struct {

--- a/internal/lang/powershell/types.go
+++ b/internal/lang/powershell/types.go
@@ -28,7 +28,7 @@ var (
 	requiredModulesAssignmentPattern = regexp.MustCompile(`(?i)\brequiredmodules\b\s*=`)
 	importModulePattern              = regexp.MustCompile(`(?i)^\s*import-module\b(.*)$`)
 	usingModulePattern               = regexp.MustCompile(`(?i)^\s*using\s+module\s+(.+)$`)
-	requiresDirectivePattern         = regexp.MustCompile(`(?i)^\s*#requires\b(.*)$`)
+	requiresDirectivePattern         = regexp.MustCompile(`(?i)^\s*#requires(?:[ \t]+(.*)|)$`)
 	moduleNamePattern                = regexp.MustCompile(`(?is)\bmodulename\b\s*=\s*([^;\r\n}]+)`)
 	powerShellSkippedDirs            = map[string]bool{}
 )


### PR DESCRIPTION
## Summary

Tightens PowerShell `#Requires` directive detection so ordinary comments like `# Requires -Modules Pester` are ignored while valid `#Requires -Modules ...` directives still parse.

Closes #853.

## Changes

- Requires PowerShell directives to use the exact `#Requires` marker followed by whitespace or end-of-line.
- Adds focused parser coverage for spaced-hash comments, tab-spaced comments, `#Requires-Modules` comment text, and valid `#Requires -Modules` forms.

## Validation

Commands and checks run:

```bash
go test -count=1 ./internal/lang/powershell
go test -count=1 ./internal/lang/...
make ci
```

Additional manual validation:

- Inspected the prior closed `bug/issues-832-853-powershell-requires-parser` PR branch before starting this issue-specific branch.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None
- Memory benchmark impact: None

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
