### PR TITLE
fix(vscode): harden lopper execution and managed installs

### DIFF
--- a/extensions/vscode-lopper/package.json
+++ b/extensions/vscode-lopper/package.json
@@ -47,6 +47,7 @@
     "onCommand:lopper.refreshWorkspace.package",
     "onCommand:lopper.refreshWorkspace.repo",
     "onCommand:lopper.refreshWorkspace.changedPackages",
+    "onCommand:lopper.cancelRefresh",
     "onCommand:lopper.saveBaseline",
     "onCommand:lopper.compareBaseline",
     "onCommand:lopper.analyseDependency",
@@ -83,6 +84,10 @@
       {
         "command": "lopper.refreshWorkspace.changedPackages",
         "title": "Lopper: Refresh Diagnostics (Scope: changed-packages)"
+      },
+      {
+        "command": "lopper.cancelRefresh",
+        "title": "Lopper: Cancel Refresh"
       },
       {
         "command": "lopper.saveBaseline",
@@ -210,6 +215,12 @@
           "type": "string",
           "default": "",
           "description": "Optional lopper release tag to download for managed installs. Leave empty to use the latest GitHub release."
+        },
+        "lopper.runTimeoutMs": {
+          "type": "number",
+          "default": 120000,
+          "minimum": 0,
+          "description": "Maximum time in milliseconds to allow each lopper CLI run before cancelling it. Set to 0 to disable the timeout."
         },
         "lopper.runtimeTracePath": {
           "type": "string",

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -88,6 +88,13 @@ interface LopperControllerOptions {
   registerWithVSCode?: boolean;
 }
 
+interface RefreshAbortHandle {
+  workspaceKey: string;
+  folderName: string;
+  runId: number;
+  controller: AbortController;
+}
+
 class LopperController implements LopperControllerContract, vscode.HoverProvider, vscode.CodeActionProvider {
   private readonly diagnostics = vscode.languages.createDiagnosticCollection("lopper");
   private readonly statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
@@ -97,6 +104,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   private readonly documentUrisByWorkspace = new Map<string, Set<string>>();
   private readonly refreshTimers = new Map<string, NodeJS.Timeout>();
   private readonly refreshSessions = new RefreshSessionStore<WorkspaceAnalysis>();
+  private readonly refreshAbortHandles = new Map<string, RefreshAbortHandle>();
   private readonly analysisByWorkspace = new Map<string, WorkspaceAnalysis>();
   private readonly detailPanels = new Map<string, vscode.WebviewPanel>();
   private readonly explorer: LopperExplorerTreeDataProvider;
@@ -135,6 +143,9 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
             forceFresh: true,
             trigger: "command",
           });
+        }),
+        vscode.commands.registerCommand("lopper.cancelRefresh", () => {
+          this.cancelActiveRefreshes("user requested cancellation");
         }),
         vscode.commands.registerCommand("lopper.refreshWorkspace.runtime", async (folderPath?: string) => {
           await this.refreshRuntimeWorkspace(folderPath);
@@ -322,9 +333,19 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     }
 
     const runId = this.refreshSessions.reserveRun(workspaceKey);
+    this.abortSupersededRefreshes(workspaceKey, runId);
+    const abortController = new AbortController();
+    const abortKey = this.refreshAbortKey(workspaceKey, runId);
+    this.refreshAbortHandles.set(abortKey, {
+      workspaceKey,
+      folderName: folder.name,
+      runId,
+      controller: abortController,
+    });
     this.updateStatus(
       `Lopper: analysing (${scopeMode})`,
       `Running lopper for ${folder.name} (${requestedLanguage}, scope ${scopeMode}).`,
+      "lopper.cancelRefresh",
     );
     this.output.appendLine(
       `[refresh:running] ${folder.name} (${requestedLanguage}, ${scopeMode}) trigger=${trigger}${forceFresh ? " force-fresh" : ""}`,
@@ -346,6 +367,8 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       baselineKey: options.baselineKey,
       baselineLabel: options.baselineLabel,
       saveBaseline: options.saveBaseline,
+      signal: abortController.signal,
+      abortKey,
     });
     this.refreshSessions.setInFlight(workspaceKey, sessionKey, runId, refreshPromise);
     await refreshPromise;
@@ -372,6 +395,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       this.updateStatus(
         `Lopper: analysing (${options.scopeMode})`,
         `Reusing in-flight analysis for ${options.folder.name} (${options.requestedLanguage}, scope ${options.scopeMode}).`,
+        "lopper.cancelRefresh",
       );
       return inFlight.promise.then(() => true);
     }
@@ -381,6 +405,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       return this.canReuseCachedAnalysis(cached.value).then((canReuse) => {
         if (canReuse) {
           const runId = this.refreshSessions.reserveRun(options.workspaceKey);
+          this.abortSupersededRefreshes(options.workspaceKey, runId);
           this.output.appendLine(
             `[refresh:reused-cache] ${options.folder.name} (${options.requestedLanguage}, ${options.scopeMode}) trigger=${options.trigger}`,
           );
@@ -414,6 +439,8 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     baselineKey?: string;
     baselineLabel?: string;
     saveBaseline?: boolean;
+    signal?: AbortSignal;
+    abortKey?: string;
   }): Promise<void> {
     const {
       folder,
@@ -431,6 +458,8 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       baselineKey,
       baselineLabel,
       saveBaseline,
+      signal,
+      abortKey,
     } = options;
     try {
       const request: WorkspaceAnalysisRequest = {
@@ -443,6 +472,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
         baselineKey,
         baselineLabel,
         saveBaseline,
+        signal,
       };
       const analysis = await this.runner.analyseWorkspace(folder, request);
       if (!this.refreshSessions.isLatestRun(workspaceKey, runId)) {
@@ -482,6 +512,9 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       }
     } finally {
       this.refreshSessions.clearInFlight(workspaceKey, sessionKey, runId);
+      if (abortKey) {
+        this.refreshAbortHandles.delete(abortKey);
+      }
     }
   }
 
@@ -635,6 +668,8 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   }
 
   dispose(): void {
+    this.cancelActiveRefreshes("extension disposed");
+    this.refreshAbortHandles.clear();
     for (const timer of this.refreshTimers.values()) {
       clearTimeout(timer);
     }
@@ -1211,10 +1246,42 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     );
   }
 
-  private updateStatus(text: string, tooltip: string): void {
+  private abortSupersededRefreshes(workspaceKey: string, latestRunId: number): void {
+    for (const handle of this.refreshAbortHandles.values()) {
+      if (handle.workspaceKey !== workspaceKey || handle.runId === latestRunId || handle.controller.signal.aborted) {
+        continue;
+      }
+      this.output.appendLine(
+        `[refresh:abort] ${handle.folderName} run=${handle.runId} superseded by run=${latestRunId}`,
+      );
+      handle.controller.abort();
+    }
+  }
+
+  private cancelActiveRefreshes(reason: string): void {
+    let cancelled = 0;
+    for (const handle of this.refreshAbortHandles.values()) {
+      if (handle.controller.signal.aborted) {
+        continue;
+      }
+      cancelled += 1;
+      this.output.appendLine(`[refresh:abort] ${handle.folderName} run=${handle.runId}: ${reason}`);
+      handle.controller.abort();
+    }
+    if (cancelled > 0) {
+      this.updateStatus("Lopper: cancelling", "Cancelling active Lopper analysis.");
+    }
+  }
+
+  private refreshAbortKey(workspaceKey: string, runId: number): string {
+    return `${workspaceKey}|${runId}`;
+  }
+
+  private updateStatus(text: string, tooltip: string, command = "lopper.refreshWorkspace"): void {
     this.latestSummary = text;
     this.statusBar.text = text;
     this.statusBar.tooltip = tooltip;
+    this.statusBar.command = command;
   }
 }
 

--- a/extensions/vscode-lopper/src/lopperRunner.ts
+++ b/extensions/vscode-lopper/src/lopperRunner.ts
@@ -22,6 +22,8 @@ import {
 
 export type LopperOutputFormat = "json" | "csv" | "sarif" | "pr-comment";
 
+export const defaultLopperRunTimeoutMs = 120_000;
+
 const execFileAsync = promisify(execFile);
 
 export interface WorkspaceAnalysis {
@@ -44,6 +46,7 @@ export interface WorkspaceAnalysisRequest {
   scopeMode?: LopperScopeMode;
   dependencyName?: string;
   suggestOnly?: boolean;
+  signal?: AbortSignal;
   runtimeTracePath?: string;
   runtimeTestCommand?: string;
   baselinePath?: string;
@@ -56,6 +59,7 @@ export interface WorkspaceAnalysisRequest {
 export interface WorkspaceExportRequest {
   document?: vscode.TextDocument;
   scopeMode?: LopperScopeMode;
+  signal?: AbortSignal;
   runtimeTracePath?: string;
   runtimeTestCommand?: string;
   baselinePath?: string;
@@ -66,8 +70,8 @@ export interface WorkspaceExportRequest {
 }
 
 export interface ReportCommandExecutor {
-  runCommand(binaryPath: string, args: string[], cwd: string): Promise<string>;
-  runReport(binaryPath: string, args: string[], cwd: string): Promise<LopperReport>;
+  runCommand(binaryPath: string, args: string[], cwd: string, options?: LopperExecutionOptions): Promise<string>;
+  runReport(binaryPath: string, args: string[], cwd: string, options?: LopperExecutionOptions): Promise<LopperReport>;
 }
 
 export interface LopperRunnerDeps {
@@ -75,28 +79,50 @@ export interface LopperRunnerDeps {
   reportExecutor?: ReportCommandExecutor;
 }
 
-class LopperCliReportExecutor implements ReportCommandExecutor {
+export interface LopperExecutionOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+export class LopperCliReportExecutor implements ReportCommandExecutor {
   constructor(private readonly output: Pick<vscode.OutputChannel, "appendLine">) {}
 
-  async runCommand(binaryPath: string, args: string[], cwd: string): Promise<string> {
+  async runCommand(
+    binaryPath: string,
+    args: string[],
+    cwd: string,
+    options: LopperExecutionOptions = {},
+  ): Promise<string> {
     this.output.appendLine(`running: ${binaryPath} ${args.join(" ")}`);
     try {
       const { stdout, stderr } = await execFileAsync(binaryPath, args, {
         cwd,
         env: process.env,
         maxBuffer: 10 * 1024 * 1024,
+        signal: options.signal,
+        timeout: options.timeoutMs,
       });
       if (stderr.trim().length > 0) {
         this.output.appendLine(stderr.trim());
       }
       return stdout;
     } catch (error) {
-      return this.handleRunCommandError(error as NodeJS.ErrnoException & { stdout?: string; stderr?: string }, args, binaryPath);
+      return this.handleRunCommandError(
+        error as NodeJS.ErrnoException & { killed?: boolean; signal?: NodeJS.Signals; stdout?: string; stderr?: string },
+        args,
+        binaryPath,
+        options,
+      );
     }
   }
 
-  async runReport(binaryPath: string, args: string[], cwd: string): Promise<LopperReport> {
-    const stdout = await this.runCommand(binaryPath, args, cwd);
+  async runReport(
+    binaryPath: string,
+    args: string[],
+    cwd: string,
+    options: LopperExecutionOptions = {},
+  ): Promise<LopperReport> {
+    const stdout = await this.runCommand(binaryPath, args, cwd, options);
     return this.parseReport(stdout, binaryPath);
   }
 
@@ -111,14 +137,23 @@ class LopperCliReportExecutor implements ReportCommandExecutor {
   }
 
   private handleRunCommandError(
-    execError: NodeJS.ErrnoException & { stdout?: string; stderr?: string },
+    execError: NodeJS.ErrnoException & { killed?: boolean; signal?: NodeJS.Signals; stdout?: string; stderr?: string },
     args: string[],
     binaryPath: string,
+    options: LopperExecutionOptions,
   ): string {
     if (execError.code === "ENOENT") {
       throw new BinaryResolutionError(
         "Lopper binary not found. Set lopper.binaryPath or LOPPER_BINARY_PATH before running the extension.",
       );
+    }
+
+    if (isAbortError(execError) || options.signal?.aborted) {
+      throw new Error("lopper command was cancelled");
+    }
+
+    if (isExecTimeout(execError, options.timeoutMs)) {
+      throw new Error(`lopper command timed out after ${options.timeoutMs}ms`);
     }
 
     const stdout = execError.stdout ?? "";
@@ -172,14 +207,24 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
             {
               location: vscode.ProgressLocation.Notification,
               title: "Installing lopper CLI",
+              cancellable: true,
             },
-            async (progress) => {
+            async (progress, token) => {
               progress.report({
                 message: releaseTag
                   ? `Downloading ${releaseTag} for ${process.platform}/${process.arch}`
                   : `Downloading latest release for ${process.platform}/${process.arch}`,
               });
-              return install();
+              const abortController = new AbortController();
+              const cancellation = token.onCancellationRequested(() => abortController.abort());
+              try {
+                if (token.isCancellationRequested) {
+                  abortController.abort();
+                }
+                return install(abortController.signal);
+              } finally {
+                cancellation.dispose();
+              }
             },
           );
         },
@@ -197,6 +242,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     const binarySignature = await this.binarySignature(binaryPath);
     const requestedLanguage = resolveLopperLanguage(configuredLopperLanguage(folder), document, folder.uri.fsPath);
     const scopeMode = normalizeScopeMode(scopeModeOption);
+    const timeoutMs = this.runTimeoutMs(folder);
     const report = await this.executeReport(binaryPath, folder, {
       format: "json",
       requestedLanguage,
@@ -204,6 +250,8 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       document,
       dependencyName,
       suggestOnly: options.suggestOnly,
+      signal: options.signal,
+      timeoutMs,
       runtimeTracePath: options.runtimeTracePath,
       runtimeTestCommand: options.runtimeTestCommand,
       baselinePath: options.baselinePath,
@@ -218,7 +266,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       if (!shouldFetchCodemod(dependency, requestedLanguage)) {
         continue;
       }
-      const codemod = await this.fetchCodemod(binaryPath, folder, dependency, scopeMode, options);
+      const codemod = await this.fetchCodemod(binaryPath, folder, dependency, scopeMode, options, timeoutMs);
       if (codemod) {
         codemodsByDependency.set(dependency.name, codemod);
       }
@@ -236,11 +284,14 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     const binaryPath = await this.resolveBinaryPath(folder);
     const requestedLanguage = resolveLopperLanguage(configuredLopperLanguage(folder), document, folder.uri.fsPath);
     const scopeMode = normalizeScopeMode(scopeModeOption);
+    const timeoutMs = this.runTimeoutMs(folder);
     return this.executeText(binaryPath, folder, {
       format,
       requestedLanguage,
       scopeMode,
       document,
+      signal: options.signal,
+      timeoutMs,
       runtimeTracePath: options.runtimeTracePath,
       runtimeTestCommand: options.runtimeTestCommand,
       baselinePath: options.baselinePath,
@@ -272,6 +323,18 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     return Number.isFinite(configured) && configured > 0 ? Math.floor(configured) : 20;
   }
 
+  private runTimeoutMs(folder: vscode.WorkspaceFolder): number | undefined {
+    const configured = vscode.workspace.getConfiguration("lopper", folder.uri).get<number>(
+      "runTimeoutMs",
+      defaultLopperRunTimeoutMs,
+    );
+    if (!Number.isFinite(configured)) {
+      return defaultLopperRunTimeoutMs;
+    }
+    const timeoutMs = Math.floor(configured);
+    return timeoutMs > 0 ? timeoutMs : undefined;
+  }
+
   private async executeReport(
     binaryPath: string,
     folder: vscode.WorkspaceFolder,
@@ -282,6 +345,8 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       document?: vscode.TextDocument;
       dependencyName?: string;
       suggestOnly?: boolean;
+      signal?: AbortSignal;
+      timeoutMs?: number;
       runtimeTracePath?: string;
       runtimeTestCommand?: string;
       baselinePath?: string;
@@ -292,7 +357,10 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     },
   ): Promise<LopperReport> {
     const args = this.buildAnalysisArgs(folder, options);
-    return this.reportExecutor.runReport(binaryPath, args, folder.uri.fsPath);
+    return this.reportExecutor.runReport(binaryPath, args, folder.uri.fsPath, {
+      signal: options.signal,
+      timeoutMs: options.timeoutMs,
+    });
   }
 
   private async executeText(
@@ -303,6 +371,8 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       requestedLanguage: string;
       scopeMode: LopperScopeMode;
       document?: vscode.TextDocument;
+      signal?: AbortSignal;
+      timeoutMs?: number;
       runtimeTracePath?: string;
       runtimeTestCommand?: string;
       baselinePath?: string;
@@ -313,7 +383,10 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     },
   ): Promise<string> {
     const args = this.buildAnalysisArgs(folder, options);
-    return this.reportExecutor.runCommand(binaryPath, args, folder.uri.fsPath);
+    return this.reportExecutor.runCommand(binaryPath, args, folder.uri.fsPath, {
+      signal: options.signal,
+      timeoutMs: options.timeoutMs,
+    });
   }
 
   private buildAnalysisArgs(
@@ -325,6 +398,8 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       document?: vscode.TextDocument;
       dependencyName?: string;
       suggestOnly?: boolean;
+      signal?: AbortSignal;
+      timeoutMs?: number;
       runtimeTracePath?: string;
       runtimeTestCommand?: string;
       baselinePath?: string;
@@ -335,9 +410,8 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     },
   ): string[] {
     const args = ["analyse"];
-    if (options.dependencyName) {
-      args.push(options.dependencyName);
-    } else {
+    const dependencyName = normalizeDependencyArgument(options.dependencyName);
+    if (!dependencyName) {
       args.push("--top", String(this.topN(folder)));
     }
     args.push(
@@ -356,6 +430,9 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     this.appendBaselineArgs(args, options.baselinePath, options.baselineStorePath, options.baselineKey, options.baselineLabel, options.saveBaseline);
     if (options.suggestOnly) {
       args.push("--suggest-only");
+    }
+    if (dependencyName) {
+      args.push("--", dependencyName);
     }
     return args;
   }
@@ -426,6 +503,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     dependency: LopperDependencyReport,
     scopeMode: LopperScopeMode,
     options: WorkspaceAnalysisRequest,
+    timeoutMs: number | undefined,
   ): Promise<LopperCodemodReport | undefined> {
     if (!dependency.name) {
       return undefined;
@@ -438,6 +516,8 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
           requestedLanguage: "js-ts",
           scopeMode,
           dependencyName: dependency.name,
+          signal: options.signal,
+          timeoutMs,
           runtimeTracePath: options.runtimeTracePath,
           runtimeTestCommand: options.runtimeTestCommand,
           baselinePath: options.baselinePath,
@@ -448,6 +528,10 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
           suggestOnly: true,
         }),
         folder.uri.fsPath,
+        {
+          signal: options.signal,
+          timeoutMs,
+        },
       );
       return report.dependencies[0]?.codemod;
     } catch (error) {
@@ -481,4 +565,26 @@ function normalizeScopeMode(scopeMode: LopperScopeMode | undefined): LopperScope
     return scopeMode;
   }
   return "package";
+}
+
+function normalizeDependencyArgument(dependencyName: string | undefined): string | undefined {
+  const normalized = dependencyName?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.startsWith("-")) {
+    throw new Error(`unsafe dependency name rejected before lopper execution: ${normalized}`);
+  }
+  return normalized;
+}
+
+function isAbortError(error: NodeJS.ErrnoException): boolean {
+  return error.name === "AbortError" || error.code === "ABORT_ERR";
+}
+
+function isExecTimeout(
+  error: NodeJS.ErrnoException & { killed?: boolean; signal?: NodeJS.Signals },
+  timeoutMs: number | undefined,
+): boolean {
+  return timeoutMs !== undefined && error.killed === true && error.signal === "SIGTERM";
 }

--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -40,6 +40,8 @@ export interface ManagedBinaryInstallResult {
   downloaded: boolean;
 }
 
+export const defaultManagedBinaryHttpTimeoutMs = 30_000;
+
 export class BinaryResolutionError extends Error {
   constructor(message: string) {
     super(message);
@@ -66,13 +68,13 @@ export interface BinaryLifecycleManager {
 
 export interface ManagedBinaryInstallerClient {
   findInstalledBinary(releaseTag?: string): Promise<string | undefined>;
-  ensureInstalled(releaseTag?: string): Promise<ManagedBinaryInstallResult>;
+  ensureInstalled(releaseTag?: string, signal?: AbortSignal): Promise<ManagedBinaryInstallResult>;
 }
 
 export interface ManagedBinaryInstallProgress {
   install(
     releaseTag: string | undefined,
-    install: () => Promise<ManagedBinaryInstallResult>,
+    install: (signal?: AbortSignal) => Promise<ManagedBinaryInstallResult>,
   ): Promise<ManagedBinaryInstallResult>;
 }
 
@@ -82,9 +84,9 @@ interface ManagedBinaryMetadata {
   binaryDigest?: string;
 }
 
-interface ManagedBinaryDeps {
-  downloadAsset?: (asset: GitHubReleaseAsset, destinationPath: string) => Promise<void>;
-  fetchRelease?: (releaseTag?: string) => Promise<GitHubRelease>;
+export interface ManagedBinaryDeps {
+  downloadAsset?: (asset: GitHubReleaseAsset, destinationPath: string, signal?: AbortSignal) => Promise<void>;
+  fetchRelease?: (releaseTag?: string, signal?: AbortSignal) => Promise<GitHubRelease>;
   host?: HostPlatform;
 }
 
@@ -136,7 +138,8 @@ export class ManagedBinaryInstaller {
     return binaryPath;
   }
 
-  async ensureInstalled(releaseTag?: string): Promise<ManagedBinaryInstallResult> {
+  async ensureInstalled(releaseTag?: string, signal?: AbortSignal): Promise<ManagedBinaryInstallResult> {
+    throwIfAborted(signal);
     const cachedBinary = await this.findInstalledBinary(releaseTag);
     if (cachedBinary) {
       const tag = normalizeReleaseTag(releaseTag) ?? (await this.readMetadata())?.tag ?? "unknown";
@@ -144,7 +147,8 @@ export class ManagedBinaryInstaller {
     }
 
     const requestedTag = normalizeReleaseTag(releaseTag);
-    const release = await this.deps.fetchRelease(requestedTag);
+    const release = await this.deps.fetchRelease(requestedTag, signal);
+    throwIfAborted(signal);
     const asset = selectReleaseAsset(release, this.deps.host);
     const binaryPath = this.binaryPathFor(release.tag_name);
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-binary-"));
@@ -156,9 +160,12 @@ export class ManagedBinaryInstaller {
     try {
       const expectedArchiveDigest = parseAssetDigest(asset);
       await mkdir(extractDir, { recursive: true });
-      await this.deps.downloadAsset(asset, archivePath);
+      await this.deps.downloadAsset(asset, archivePath, signal);
+      throwIfAborted(signal);
       await verifyBinaryArchive(archivePath, expectedArchiveDigest, asset.name);
+      throwIfAborted(signal);
       await extractArchive(archivePath, extractDir);
+      throwIfAborted(signal);
 
       const extractedBinary = await findBinaryInDirectory(extractDir, binaryFileName(this.deps.host.platform));
       if (!extractedBinary) {
@@ -271,16 +278,16 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
       return this.resolvePathBinary(request);
     }
 
+    if (!request.workspaceTrusted) {
+      this.output.appendLine(`skipping workspace-local lopper binary in untrusted workspace: ${localBinary}`);
+      return this.resolvePathBinary(request);
+    }
+
     if (!localBinaryStats.isFile()) {
       throw new BinaryResolutionError(`workspace-local lopper binary must point to a file: ${localBinary}`);
     }
 
     await this.ensureWorkspaceLocalBinaryExecutable(localBinary);
-
-    if (!request.workspaceTrusted) {
-      this.output.appendLine(`skipping workspace-local lopper binary in untrusted workspace: ${localBinary}`);
-      return this.resolvePathBinary(request);
-    }
 
     return localBinary;
   }
@@ -313,7 +320,7 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
       return cachedBinary;
     }
 
-    const installResult = await this.progress.install(releaseTag, async () => this.installer.ensureInstalled(releaseTag));
+    const installResult = await this.progress.install(releaseTag, async (signal) => this.installer.ensureInstalled(releaseTag, signal));
     if (installResult.downloaded) {
       this.output.appendLine(`managed lopper binary installed: ${installResult.binaryPath} (${installResult.tag})`);
     }
@@ -465,30 +472,42 @@ function normalizeReleaseTag(releaseTag?: string): string | undefined {
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
 }
 
-async function fetchRelease(releaseTag?: string): Promise<GitHubRelease> {
+export async function fetchRelease(
+  releaseTag?: string,
+  signal?: AbortSignal,
+  timeoutMs = defaultManagedBinaryHttpTimeoutMs,
+): Promise<GitHubRelease> {
   const normalizedTag = normalizeReleaseTag(releaseTag);
   const endpoint = normalizedTag
     ? `https://api.github.com/repos/${releaseOwner}/${releaseRepo}/releases/tags/${encodeURIComponent(normalizedTag)}`
     : `https://api.github.com/repos/${releaseOwner}/${releaseRepo}/releases/latest`;
 
-  const response = await fetch(endpoint, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      "User-Agent": "lopper-vscode-extension",
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`release lookup failed (${response.status})`);
-  }
+  const abortable = abortSignalWithTimeout(signal, timeoutMs);
+  try {
+    const response = await fetch(endpoint, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "lopper-vscode-extension",
+      },
+      signal: abortable.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`release lookup failed (${response.status})`);
+    }
 
-  const payload = (await response.json()) as Partial<GitHubRelease>;
-  if (typeof payload.tag_name !== "string" || !Array.isArray(payload.assets)) {
-    throw new TypeError("release lookup returned an unexpected payload");
+    const payload = (await response.json()) as Partial<GitHubRelease>;
+    if (typeof payload.tag_name !== "string" || !Array.isArray(payload.assets)) {
+      throw new TypeError("release lookup returned an unexpected payload");
+    }
+    return {
+      tag_name: payload.tag_name,
+      assets: payload.assets.filter(isAssetLike),
+    };
+  } catch (error) {
+    throw managedBinaryHttpError(error, abortable, "release lookup");
+  } finally {
+    abortable.dispose();
   }
-  return {
-    tag_name: payload.tag_name,
-    assets: payload.assets.filter(isAssetLike),
-  };
 }
 
 function isAssetLike(asset: unknown): asset is GitHubReleaseAsset {
@@ -527,18 +546,90 @@ async function sha256File(filePath: string): Promise<string> {
   return createHash("sha256").update(buffer).digest("hex");
 }
 
-async function downloadAsset(asset: GitHubReleaseAsset, destinationPath: string): Promise<void> {
-  const response = await fetch(asset.browser_download_url, {
-    headers: {
-      "User-Agent": "lopper-vscode-extension",
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`asset download failed (${response.status})`);
+export async function downloadAsset(
+  asset: GitHubReleaseAsset,
+  destinationPath: string,
+  signal?: AbortSignal,
+  timeoutMs = defaultManagedBinaryHttpTimeoutMs,
+): Promise<void> {
+  const abortable = abortSignalWithTimeout(signal, timeoutMs);
+  try {
+    const response = await fetch(asset.browser_download_url, {
+      headers: {
+        "User-Agent": "lopper-vscode-extension",
+      },
+      signal: abortable.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`asset download failed (${response.status})`);
+    }
+
+    const archiveBytes = Buffer.from(await response.arrayBuffer());
+    await writeFile(destinationPath, archiveBytes);
+  } catch (error) {
+    throw managedBinaryHttpError(error, abortable, "asset download");
+  } finally {
+    abortable.dispose();
+  }
+}
+
+interface AbortableSignal {
+  readonly signal: AbortSignal;
+  readonly timeoutMs: number | undefined;
+  didTimeout(): boolean;
+  dispose(): void;
+}
+
+function abortSignalWithTimeout(parentSignal: AbortSignal | undefined, timeoutMs: number | undefined): AbortableSignal {
+  const controller = new AbortController();
+  let timedOut = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  const abortFromParent = () => controller.abort();
+  if (parentSignal?.aborted) {
+    abortFromParent();
+  } else {
+    parentSignal?.addEventListener("abort", abortFromParent, { once: true });
   }
 
-  const archiveBytes = Buffer.from(await response.arrayBuffer());
-  await writeFile(destinationPath, archiveBytes);
+  if (timeoutMs !== undefined && timeoutMs > 0) {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
+  }
+
+  return {
+    signal: controller.signal,
+    timeoutMs,
+    didTimeout: () => timedOut,
+    dispose: () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      parentSignal?.removeEventListener("abort", abortFromParent);
+    },
+  };
+}
+
+function managedBinaryHttpError(error: unknown, abortable: AbortableSignal, operation: string): Error {
+  if (abortable.didTimeout()) {
+    return new Error(`${operation} timed out after ${abortable.timeoutMs}ms`);
+  }
+  if (abortable.signal.aborted || isAbortError(error)) {
+    return new Error(`${operation} cancelled`);
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new Error("managed binary install cancelled");
+  }
 }
 
 async function extractArchive(archivePath: string, extractDir: string): Promise<void> {

--- a/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
@@ -6,7 +6,7 @@ import { suite, test } from "mocha";
 import * as vscode from "vscode";
 
 import type { BinaryResolutionRequest } from "../../managedBinary";
-import { BinaryResolutionError, LopperRunner, type ReportCommandExecutor } from "../../lopperRunner";
+import { BinaryResolutionError, LopperCliReportExecutor, LopperRunner, type ReportCommandExecutor } from "../../lopperRunner";
 import type { LopperReport } from "../../types";
 
 suite("lopper runner", () => {
@@ -237,10 +237,54 @@ suite("lopper runner", () => {
     assert.equal(firstCall.args[firstCall.args.indexOf("--scope-mode") + 1], "package");
     assert.ok(secondCall.args.includes("--scope-mode"), "expected scope mode arg in codemod command");
     assert.equal(secondCall.args[secondCall.args.indexOf("--scope-mode") + 1], "package");
-    assert.equal(secondCall.args.at(-1), "--suggest-only");
+    assert.ok(secondCall.args.includes("--suggest-only"), "expected codemod command to request suggest-only mode");
+    assert.deepEqual(secondCall.args.slice(-2), ["--", "scope-lib"]);
     assert.equal(analysis.scopeMode, "package");
     assert.equal(analysis.codemodsByDependency.get("scope-lib")?.suggestions?.[0]?.toModule, "scope-lib/chunk");
     assert.equal(resolvedRequest?.workspaceRoot, folder.uri.fsPath);
+  });
+
+  test("skips codemod analysis for flag-shaped dependency names", async () => {
+    const folder = workspaceFolder();
+    const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
+    const calls: string[][] = [];
+    const outputLines: string[] = [];
+
+    const runner = new LopperRunner(
+      { appendLine: (value) => outputLines.push(value) },
+      context,
+      {
+        binaryLifecycle: {
+          resolveBinaryPath: async () => path.join(folder.uri.fsPath, ".lopper-managed", "lopper"),
+        },
+        reportExecutor: {
+          runCommand: async () => "",
+          runReport: async (_binaryPath, args): Promise<LopperReport> => {
+            calls.push(args);
+            return {
+              dependencies: [
+                {
+                  name: "--cache-path=/tmp/lopper-escape",
+                  language: "js-ts",
+                  usedExportsCount: 1,
+                  totalExportsCount: 2,
+                  usedPercent: 50,
+                },
+              ],
+            };
+          },
+        },
+      },
+    );
+
+    const analysis = await runner.analyseWorkspace(folder);
+
+    assert.equal(calls.length, 1, "flag-shaped dependency must not be forwarded to a child process");
+    assert.equal(analysis.codemodsByDependency.size, 0);
+    assert.ok(
+      outputLines.some((line) => line.includes("unsafe dependency name rejected")),
+      "expected unsafe dependency skip to be logged",
+    );
   });
 
   test("passes explicit scope mode to primary and codemod analysis commands", async () => {
@@ -372,6 +416,54 @@ suite("lopper runner", () => {
     assert.ok(exportArgs.includes("--runtime-trace"));
     assert.ok(exportArgs.includes("--baseline-key"));
   });
+
+  test("times out hung lopper commands", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-runner-timeout-"));
+    const binaryPath = path.join(tempRoot, "lopper");
+
+    try {
+      await writeSleepingExecutable(binaryPath);
+      const executor = new LopperCliReportExecutor({ appendLine: () => undefined });
+
+      await assert.rejects(
+        executor.runCommand(binaryPath, [], tempRoot, { timeoutMs: 50 }),
+        /lopper command timed out after 50ms/,
+      );
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("aborts lopper commands when the caller cancels", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-runner-abort-"));
+    const binaryPath = path.join(tempRoot, "lopper");
+    const controller = new AbortController();
+
+    try {
+      await writeSleepingExecutable(binaryPath);
+      const executor = new LopperCliReportExecutor({ appendLine: () => undefined });
+      const abortTimer = setTimeout(() => controller.abort(), 50);
+
+      try {
+        await assert.rejects(
+          executor.runCommand(binaryPath, [], tempRoot, { signal: controller.signal, timeoutMs: 5_000 }),
+          /lopper command was cancelled/,
+        );
+      } finally {
+        clearTimeout(abortTimer);
+      }
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 function workspaceFolder(): vscode.WorkspaceFolder {
@@ -391,6 +483,12 @@ async function writeExecutable(binaryPath: string): Promise<void> {
   if (process.platform !== "win32") {
     await chmod(binaryPath, 0o755);
   }
+}
+
+async function writeSleepingExecutable(binaryPath: string): Promise<void> {
+  await mkdir(path.dirname(binaryPath), { recursive: true });
+  await writeFile(binaryPath, "#!/bin/sh\nsleep 10\n", "utf8");
+  await chmod(binaryPath, 0o755);
 }
 
 function joinPathEntries(entries: Array<string | undefined>): string {

--- a/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
@@ -11,9 +11,12 @@ import {
   BinaryResolutionError,
   archiveDestinationPath,
   assetNameForRelease,
+  downloadAsset,
+  fetchRelease,
   LopperBinaryLifecycleManager,
   ManagedBinaryInstaller,
   type GitHubRelease,
+  type GitHubReleaseAsset,
   selectReleaseAsset,
 } from "../../managedBinary";
 
@@ -244,6 +247,20 @@ suite("managed binary installer", () => {
     });
   });
 
+  test("skips workspace-local bin directories in untrusted workspaces", async () => {
+    await withPathFallbackFixture("directory-untrusted", async ({ workspaceRoot, localBinaryPath, fallbackBinary, lifecycle }) => {
+      await mkdir(localBinaryPath, { recursive: true });
+
+      const resolvedPath = await lifecycle.resolveBinaryPath({
+        workspaceRoot,
+        workspaceTrusted: false,
+        autoDownloadBinary: false,
+      });
+
+      assert.equal(resolvedPath, fallbackBinary);
+    });
+  });
+
   test("rejects non-executable workspace-local bin binaries on unix hosts", async function () {
     if (process.platform === "win32") {
       this.skip();
@@ -266,6 +283,142 @@ suite("managed binary installer", () => {
           error.message.includes(localBinaryPath),
       );
     });
+  });
+
+  test("skips non-executable workspace-local bin binaries in untrusted workspaces", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    await withPathFallbackFixture("nonexec-untrusted", async ({ workspaceRoot, localBinaryPath, fallbackBinary, lifecycle }) => {
+      await mkdir(path.dirname(localBinaryPath), { recursive: true });
+      await writeFile(localBinaryPath, "#!/bin/sh\nexit 0\n", "utf8");
+      await chmod(localBinaryPath, 0o644);
+
+      const resolvedPath = await lifecycle.resolveBinaryPath({
+        workspaceRoot,
+        workspaceTrusted: false,
+        autoDownloadBinary: false,
+      });
+
+      assert.equal(resolvedPath, fallbackBinary);
+    });
+  });
+
+  test("forwards progress cancellation signals to managed installer", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-lifecycle-signal-"));
+    const controller = new AbortController();
+    const previousPath = process.env.PATH;
+    let observedSignal: AbortSignal | undefined;
+
+    try {
+      process.env.PATH = "";
+      const lifecycle = new LopperBinaryLifecycleManager(
+        {
+          findInstalledBinary: async () => undefined,
+          ensureInstalled: async (_releaseTag, signal) => {
+            observedSignal = signal;
+            return {
+              binaryPath: path.join(tempRoot, "managed", "lopper"),
+              tag: "latest",
+              downloaded: true,
+            };
+          },
+        },
+        { appendLine: () => undefined },
+        {
+          install: async (_releaseTag, install) => install(controller.signal),
+        },
+        "linux",
+      );
+
+      const binaryPath = await lifecycle.resolveBinaryPath({
+        workspaceRoot: tempRoot,
+        workspaceTrusted: true,
+        autoDownloadBinary: true,
+      });
+
+      assert.equal(binaryPath, path.join(tempRoot, "managed", "lopper"));
+      assert.equal(observedSignal, controller.signal);
+    } finally {
+      restoreEnv("PATH", previousPath);
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("forwards abort signals to release lookup and asset download", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-signal-"));
+    const controller = new AbortController();
+    let fetchSignal: AbortSignal | undefined;
+    let downloadSignal: AbortSignal | undefined;
+
+    try {
+      const releaseTag = "v9.8.7";
+      const host = { platform: "linux" as const, arch: "x64" };
+      const archivePath = await createTarballFixture(tempRoot, releaseTag, host, "linux binary");
+      const binaryDigest = await sha256File(archivePath);
+      const release: GitHubRelease = {
+        tag_name: releaseTag,
+        assets: [
+          {
+            name: assetNameForRelease(releaseTag, host),
+            digest: `sha256:${binaryDigest}`,
+            browser_download_url: `file://${archivePath}`,
+          },
+        ],
+      };
+      const installer = new ManagedBinaryInstaller(
+        path.join(tempRoot, "storage"),
+        { appendLine: () => undefined },
+        {
+          host,
+          fetchRelease: async (_releaseTag, signal) => {
+            fetchSignal = signal;
+            return release;
+          },
+          downloadAsset: async (_asset, destinationPath, signal) => {
+            downloadSignal = signal;
+            await copyFile(archivePath, destinationPath);
+          },
+        },
+      );
+
+      await installer.ensureInstalled(undefined, controller.signal);
+
+      assert.equal(fetchSignal, controller.signal);
+      assert.equal(downloadSignal, controller.signal);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("times out release lookup fetches", async () => {
+    await withHangingFetch(async () => {
+      await assert.rejects(
+        fetchRelease(undefined, undefined, 10),
+        /release lookup timed out after 10ms/,
+      );
+    });
+  });
+
+  test("times out managed asset downloads", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-download-timeout-"));
+    const asset: GitHubReleaseAsset = {
+      name: "lopper_v9.8.7_linux_amd64.tar.gz",
+      browser_download_url: "https://example.test/lopper.tar.gz",
+      digest: `sha256:${"0".repeat(64)}`,
+    };
+
+    try {
+      await withHangingFetch(async () => {
+        await assert.rejects(
+          downloadAsset(asset, path.join(tempRoot, asset.name), undefined, 10),
+          /asset download timed out after 10ms/,
+        );
+      });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 
   test("fails when auto-download is disabled and no binaries resolve", async () => {
@@ -516,6 +669,38 @@ async function withPathFallbackFixture(
     await rm(workspaceRoot, { recursive: true, force: true });
     await rm(pathRoot, { recursive: true, force: true });
   }
+}
+
+async function withHangingFetch(run: () => Promise<void>): Promise<void> {
+  const previousFetch = globalThis.fetch;
+  const hangingFetch: typeof fetch = async (_input, init) => {
+    const signal = init?.signal ?? undefined;
+    return new Promise<Response>((_resolve, reject) => {
+      if (!signal) {
+        reject(new Error("expected fetch signal"));
+        return;
+      }
+      const abort = () => reject(abortFetchError());
+      if (signal.aborted) {
+        abort();
+        return;
+      }
+      signal.addEventListener("abort", abort, { once: true });
+    });
+  };
+
+  try {
+    globalThis.fetch = hangingFetch;
+    await run();
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+}
+
+function abortFetchError(): Error {
+  const error = new Error("This operation was aborted");
+  error.name = "AbortError";
+  return error;
 }
 
 function createPathFallbackLifecycle(): LopperBinaryLifecycleManager {

--- a/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
@@ -12,6 +12,7 @@ import type { WorkspaceAnalysis, WorkspaceAnalysisRunner } from "../../lopperRun
 interface Deferred<T> {
   promise: Promise<T>;
   resolve: (value: T) => void;
+  reject: (error: Error) => void;
 }
 
 interface LifecycleHarness {
@@ -121,6 +122,45 @@ suite("refresh lifecycle", () => {
           await firstRefresh;
 
           assert.match(controller.getLatestSummary(), /0 deps/);
+        },
+      );
+    });
+  });
+
+  test("aborts superseded fresh refreshes", async function () {
+    this.timeout(30_000);
+
+    await withHarness(async (harness) => {
+      const deferredAnalyses: Array<Deferred<WorkspaceAnalysis>> = [];
+      const signals: AbortSignal[] = [];
+
+      await withController(
+        {
+          analyseWorkspace: async (_folder, options): Promise<WorkspaceAnalysis> => {
+            const next = deferred<WorkspaceAnalysis>();
+            deferredAnalyses.push(next);
+            assert.ok(options?.signal, "expected refresh signal to be forwarded");
+            signals.push(options.signal);
+            options.signal.addEventListener("abort", () => next.reject(new Error("aborted")), { once: true });
+            return next.promise;
+          },
+          exportWorkspace: async (): Promise<string> => "",
+        },
+        async (controller) => {
+          const firstRefresh = refresh(controller, harness, { forceFresh: true });
+          const secondRefresh = refresh(controller, harness, { forceFresh: true });
+
+          assert.equal(deferredAnalyses.length, 2, "expected two independent fresh runs");
+          assert.equal(signals[0].aborted, true, "superseded run should be aborted");
+          assert.equal(signals[1].aborted, false, "latest run should remain active");
+
+          deferredAnalyses[1].resolve(
+            makeAnalysis(harness, {
+              dependencyCount: 1,
+              usedPercent: 80,
+            }),
+          );
+          await Promise.all([firstRefresh, secondRefresh]);
         },
       );
     });
@@ -312,10 +352,12 @@ async function binarySignature(binaryPath: string): Promise<string> {
 
 function deferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolver) => {
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((resolver, rejecter) => {
     resolve = resolver;
+    reject = rejecter;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function makeAnalysis(


### PR DESCRIPTION
## Summary

Harden the VS Code extension execution and managed-binary paths so repo-controlled inputs and stalled subprocess/network operations cannot wedge the extension or flip CLI behavior.

Closes #871, closes #876, closes #877, closes #878, closes #879.

## Changes

- Build dependency-specific lopper invocations with flags before a `--` separator and reject flag-shaped dependency names before spawning.
- Add `lopper.runTimeoutMs`, abort signal propagation, superseded-refresh cancellation, and a `lopper.cancelRefresh` command.
- Skip invalid workspace-local `bin/lopper` entries before validation when the workspace is untrusted so PATH/managed fallback still works.
- Make managed-binary install progress cancellable and thread abort signals through release lookup/download.
- Add timeout-backed HTTP handling for GitHub release lookup and asset download, including response body reads.
- Extend VS Code extension tests for argument safety, abort/timeout behavior, untrusted local binary fallback, cancellable installs, and HTTP timeouts.

## Validation

Commands and checks run:

```bash
npm ci
npm run compile
npm run test:e2e
make ci
make format-check
go test ./tools/prcheck
git diff --check
go run ./tools/prcheck --title "fix(vscode): harden lopper execution and managed installs" --head-ref bug/issues-871-876-877-878-879-vscode-hardening --body-file /tmp/lopper-vscode-hardening-pr-body.md
```

Additional manual validation:

- Confirmed the branch was rebased onto current `origin/main`.
- Confirmed the diff is limited to `extensions/vscode-lopper/**` and extension tests.

## Risk and compatibility

- Breaking changes: None expected; only flag-shaped dependency names are rejected before extension-spawned child processes.
- Migration required: None.
- Performance impact: Minimal; subprocess and HTTP operations now carry bounded timeout/abort handling.
- Memory benchmark impact: None; extension-only TypeScript change, no Go runtime path changes.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
