### PR TITLE
fix(tui): reuse loaded summary for detail open

### DIFF
--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -87,7 +87,7 @@ func parseDependencyLanguage(defaultLanguage, dependency string) (string, string
 	return defaultLanguage, dependency
 }
 
-func findSummaryDependencyDetail(dependencies []summaryDependencyView, languageID string, dependency string) (detailDependencyView, bool) {
+func findSummaryDependencyDetail(dependencies []summaryDependencyView, languageID, dependency string) (detailDependencyView, bool) {
 	for _, dep := range dependencies {
 		if dep.Name != dependency {
 			continue

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -47,17 +47,37 @@ func (d *Detail) Show(ctx context.Context, dependency string) error {
 		return err
 	}
 	if len(reportData.Dependencies) == 0 {
-		return writef(d.Out, "No data for dependency %q\n", dependency)
+		return d.printNoData(dependency)
 	}
 
-	dep := mapDetailDependencyView(reportData.Dependencies[0])
+	return d.printDependency(mapDetailDependencyView(reportData.Dependencies[0]), reportData.Warnings)
+}
+
+func (d *Detail) showLoadedSummary(dependency string, reportView summaryReportView) error {
+	if dependency == "" {
+		return fmt.Errorf("dependency name is required")
+	}
+
+	languageID, dependency := parseDependencyLanguage(d.Language, dependency)
+	dep, ok := findSummaryDependencyDetail(reportView.Dependencies, languageID, dependency)
+	if !ok {
+		return d.printNoData(dependency)
+	}
+	return d.printDependency(dep, reportView.Warnings)
+}
+
+func (d *Detail) printNoData(dependency string) error {
+	return writef(d.Out, "No data for dependency %q\n", dependency)
+}
+
+func (d *Detail) printDependency(dep detailDependencyView, warnings []string) error {
 	if err := printDependencyHeader(d.Out, dep); err != nil {
 		return err
 	}
 	if err := printDependencySections(d.Out, dep); err != nil {
 		return err
 	}
-	return printWarnings(d.Out, reportData.Warnings)
+	return printWarnings(d.Out, warnings)
 }
 
 func parseDependencyLanguage(defaultLanguage, dependency string) (string, string) {
@@ -65,6 +85,28 @@ func parseDependencyLanguage(defaultLanguage, dependency string) (string, string
 		return parts[0], parts[1]
 	}
 	return defaultLanguage, dependency
+}
+
+func findSummaryDependencyDetail(dependencies []summaryDependencyView, languageID string, dependency string) (detailDependencyView, bool) {
+	for _, dep := range dependencies {
+		if dep.Name != dependency {
+			continue
+		}
+		if !summaryDependencyLanguageMatches(languageID, dep.Language) {
+			continue
+		}
+		return summaryDependencyDetailView(dep), true
+	}
+	return detailDependencyView{}, false
+}
+
+func summaryDependencyLanguageMatches(languageID string, dependencyLanguage string) bool {
+	switch strings.TrimSpace(languageID) {
+	case "", "auto", "all":
+		return true
+	default:
+		return dependencyLanguage == "" || dependencyLanguage == languageID
+	}
 }
 
 func printDependencyHeader(out io.Writer, dep detailDependencyView) error {

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -130,6 +130,51 @@ func TestDetailParsesLanguagePrefix(t *testing.T) {
 	}
 }
 
+func TestDetailShowLoadedSummaryBranches(t *testing.T) {
+	reportView := mapSummaryReportView(report.Report{
+		Dependencies: []report.DependencyReport{
+			{Name: "other", Language: "python", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100},
+			{Name: "dep", Language: "js-ts", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50},
+		},
+	})
+
+	var out bytes.Buffer
+	detail := NewDetail(&out, nil, ".", "auto")
+	if err := detail.showLoadedSummary("js-ts:dep", reportView); err != nil {
+		t.Fatalf("show loaded detail: %v", err)
+	}
+	if !strings.Contains(out.String(), "Language: js-ts") {
+		t.Fatalf("expected loaded detail language output, got %q", out.String())
+	}
+
+	out.Reset()
+	if err := detail.showLoadedSummary("python:dep", reportView); err != nil {
+		t.Fatalf("show missing language detail: %v", err)
+	}
+	if !strings.Contains(out.String(), `No data for dependency "dep"`) {
+		t.Fatalf("expected no-data output for language mismatch, got %q", out.String())
+	}
+
+	if err := detail.showLoadedSummary("", reportView); err == nil {
+		t.Fatalf("expected empty dependency to fail")
+	}
+}
+
+func TestSummaryDependencyDetailViewFallback(t *testing.T) {
+	dep := summaryDependencyView{
+		Name:              "fallback",
+		Language:          "js-ts",
+		UsedExportsCount:  1,
+		TotalExportsCount: 2,
+		UsedPercent:       50,
+	}
+
+	detail := summaryDependencyDetailView(dep)
+	if detail.Name != "fallback" || detail.Language != "js-ts" || detail.UsedPercent != 50 {
+		t.Fatalf("expected fallback detail to be mapped from summary fields, got %#v", detail)
+	}
+}
+
 func TestDetailRejectsEmptyDependency(t *testing.T) {
 	var out bytes.Buffer
 	detail := NewDetail(&out, &stubAnalyzer{report: report.Report{}}, ".", "")
@@ -254,6 +299,12 @@ func TestDetailRationaleAndRuntimeOnlyOutput(t *testing.T) {
 		Modules: []detailRuntimeModuleView{
 			{Module: "pkg/index", Count: 2},
 		},
+		ParentModules: []detailRuntimeModuleView{
+			{Module: "pkg/parent", Count: 1},
+		},
+		Entrypoints: []detailRuntimeModuleView{
+			{Module: "pkg/main", Count: 1},
+		},
 		TopSymbols: []detailRuntimeSymbolView{
 			{Symbol: "index", Count: 2},
 		},
@@ -269,6 +320,9 @@ func TestDetailRationaleAndRuntimeOnlyOutput(t *testing.T) {
 	}
 	if !strings.Contains(text, "modules: pkg/index (2)") || !strings.Contains(text, "top symbols: index (2)") {
 		t.Fatalf("expected runtime evidence output, got %q", text)
+	}
+	if !strings.Contains(text, "parent modules: pkg/parent (1)") || !strings.Contains(text, "entrypoints: pkg/main (1)") {
+		t.Fatalf("expected runtime parent and entrypoint output, got %q", text)
 	}
 }
 

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -94,6 +94,7 @@ func readSummaryInput(reader *bufio.Reader) (string, error) {
 }
 
 func (s *Summary) handleSummaryInput(ctx context.Context, opts Options, reportView summaryReportView, state *summaryState, input string) (bool, error) {
+	_ = ctx
 	if input == "" || input == "refresh" {
 		return false, nil
 	}
@@ -102,7 +103,7 @@ func (s *Summary) handleSummaryInput(ctx context.Context, opts Options, reportVi
 	}
 	if dependency, ok := isDetailCommand(input); ok {
 		detail := NewDetail(s.Out, s.Analyzer, opts.RepoPath, opts.Language)
-		if err := detail.Show(ctx, dependency); err != nil {
+		if err := detail.showLoadedSummary(dependency, reportView); err != nil {
 			return false, err
 		}
 		return false, nil

--- a/internal/ui/summary_commands_test.go
+++ b/internal/ui/summary_commands_test.go
@@ -326,6 +326,65 @@ func TestSummaryStartAndSnapshotBranches(t *testing.T) {
 	}
 }
 
+type countingAnalyzer struct {
+	report        report.Report
+	calls         int
+	errAfterFirst error
+}
+
+func (a *countingAnalyzer) Analyse(context.Context, analysis.Request) (report.Report, error) {
+	a.calls++
+	if a.calls > 1 && a.errAfterFirst != nil {
+		return report.Report{}, a.errAfterFirst
+	}
+	return a.report, nil
+}
+
+func TestSummaryOpenDetailReusesLoadedSummaryReport(t *testing.T) {
+	unexpectedAnalysis := errors.New("unexpected detail analysis")
+	analyzer := &countingAnalyzer{
+		errAfterFirst: unexpectedAnalysis,
+		report: report.Report{
+			Warnings: []string{"summary warning"},
+			Dependencies: []report.DependencyReport{
+				{
+					Name:              "dep",
+					Language:          "js-ts",
+					UsedExportsCount:  1,
+					TotalExportsCount: 2,
+					UsedPercent:       50,
+					UsedImports: []report.ImportUse{
+						{Name: "map", Module: "dep", Locations: []report.Location{{File: indexJSFile, Line: 1}}},
+					},
+					Recommendations: []report.Recommendation{
+						{Code: "prefer-subpath-imports", Priority: "medium", Message: "Prefer subpath imports."},
+					},
+				},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(openDepCommand+"\nq\n"), analyzer, report.NewFormatter())
+	if err := summary.Start(context.Background(), Options{RepoPath: ".", TopN: 1, PageSize: 1, Language: "auto"}); err != nil {
+		t.Fatalf("summary start: %v", err)
+	}
+	if analyzer.calls != 1 {
+		t.Fatalf("expected summary open to reuse loaded report without re-analysis, got %d analyzer calls", analyzer.calls)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Dependency detail: dep") {
+		t.Fatalf("expected detail view output, got %q", output)
+	}
+	if !strings.Contains(output, "Used imports (1)") || !strings.Contains(output, "map from dep") {
+		t.Fatalf("expected detail-only import data from loaded report, got %q", output)
+	}
+	if !strings.Contains(output, "Warnings:") || !strings.Contains(output, "summary warning") {
+		t.Fatalf("expected loaded report warnings in detail output, got %q", output)
+	}
+}
+
 func TestReadSummaryInputError(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(""))
 	if _, err := readSummaryInput(reader); err == nil {
@@ -541,11 +600,15 @@ func TestClampSummaryPageHandlesNilAndLowerBound(t *testing.T) {
 }
 
 func TestSummaryHandleDetailErrorBranch(t *testing.T) {
-	summary := NewSummary(io.Discard, strings.NewReader(""), &errorAnalyzer{err: errors.New("detail failed")}, report.NewFormatter())
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &errorAnalyzer{err: errors.New("detail failed")}, report.NewFormatter())
 	state := summaryState{}
-	_, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: ".", Language: "auto"}, summaryReportView{}, &state, openDepCommand)
-	if err == nil {
-		t.Fatalf("expected detail error to propagate")
+	quit, err := summary.handleSummaryInput(context.Background(), Options{RepoPath: ".", Language: "auto"}, summaryReportView{}, &state, openDepCommand)
+	if err != nil || quit {
+		t.Fatalf("expected missing loaded detail to continue without analyzer error, quit=%v err=%v", quit, err)
+	}
+	if !strings.Contains(out.String(), `No data for dependency "dep"`) {
+		t.Fatalf("expected no-data detail message, got %q", out.String())
 	}
 }
 
@@ -582,11 +645,14 @@ func TestSummaryStartErrorBranches(t *testing.T) {
 		t.Fatalf("expected EOF from input reader, got %v", err)
 	}
 
-	// handleSummaryInput failure path via open detail command.
+	// Open detail uses the already-loaded summary report instead of calling the analyzer again.
 	seqAnalyzer := &sequenceErrorAnalyzer{}
-	summary = NewSummary(io.Discard, strings.NewReader(openDepCommand+"\n"), seqAnalyzer, report.NewFormatter())
-	if summary.Start(context.Background(), Options{RepoPath: ".", TopN: 1, PageSize: 1, Language: "auto"}) == nil {
-		t.Fatalf("expected detail-open error from handleSummaryInput")
+	summary = NewSummary(io.Discard, strings.NewReader(openDepCommand+"\nq\n"), seqAnalyzer, report.NewFormatter())
+	if err := summary.Start(context.Background(), Options{RepoPath: ".", TopN: 1, PageSize: 1, Language: "auto"}); err != nil {
+		t.Fatalf("expected detail-open to reuse loaded report, got %v", err)
+	}
+	if seqAnalyzer.calls != 1 {
+		t.Fatalf("expected one analyzer call for summary load only, got %d", seqAnalyzer.calls)
 	}
 }
 

--- a/internal/ui/view_model.go
+++ b/internal/ui/view_model.go
@@ -16,6 +16,7 @@ type summaryDependencyView struct {
 	License                *report.DependencyLicense
 	Provenance             *report.DependencyProvenance
 	CodemodApply           *report.CodemodApplyReport
+	detail                 detailDependencyView
 }
 
 type summaryReportView struct {
@@ -83,9 +84,17 @@ func mapSummaryDependencies(dependencies []report.DependencyReport) []summaryDep
 			License:                dep.License,
 			Provenance:             dep.Provenance,
 			CodemodApply:           summaryCodemodApplyView(dep.Codemod),
+			detail:                 mapDetailDependencyView(dep),
 		})
 	}
 	return views
+}
+
+func summaryDependencyDetailView(dep summaryDependencyView) detailDependencyView {
+	if dep.detail.Name != "" || dep.detail.Language != "" {
+		return dep.detail
+	}
+	return mapDetailDependencyView(summaryDependencyToReport(dep))
 }
 
 func buildSummaryDisplayView(base summaryReportView, sorted []summaryDependencyView, paged []summaryDependencyView) summaryDisplayView {


### PR DESCRIPTION
## Summary

Fixes #828.

The TUI summary view already has the dependency report data needed to render detail output, but `open`/`detail` commands were constructing a fresh detail view that invoked analysis again. This change keeps the loaded dependency detail data in the summary view model and renders detail output directly from it.

## Changes

- Preserve each loaded dependency's detail view while mapping the summary report.
- Route summary `open` and `detail` commands through the loaded summary/report data instead of calling the analyzer again.
- Keep standalone detail rendering behavior intact for direct detail usage.
- Add regression tests that fail if opening a detail from summary invokes analysis a second time.

## Validation

Commands and checks run successfully:

- `go test ./internal/ui`
- `go test ./internal/app`
- Pre-commit `make ci` hook, including lint, full tests, goleak, race tests, memory benchmark gate, build, and coverage gate.

Additional manual validation:

- `go run ./tools/prcheck -title "fix(tui): reuse loaded summary for detail open" -head-ref bug/issue-828-tui-detail-reuse-summary -body-file <body-file>`

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Improves TUI detail navigation by avoiding duplicate full analysis when data is already loaded.
- Memory benchmark impact: None; pre-commit memory benchmark gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
