### PR TITLE
fix(vscode): avoid sync filesystem reads on save

### DIFF
--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -4,6 +4,8 @@ import * as vscode from "vscode";
 
 import {
   configuredLopperLanguage,
+  clearAndroidModuleSignalCache,
+  invalidateAndroidModuleSignalCacheForPath,
   resolveLopperLanguage,
   shouldAutoRefreshForDocument,
   supportedDocumentSelectors,
@@ -201,23 +203,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
         }),
         vscode.window.registerTreeDataProvider("lopperExplorer", this.explorer),
         vscode.workspace.onDidSaveTextDocument((document) => {
-          const folder = vscode.workspace.getWorkspaceFolder(document.uri);
-          if (!folder) {
-            return;
-          }
-          this.invalidateWorkspaceSession(folder, `document saved: ${path.basename(document.fileName)}`);
-          if (!this.shouldAutoRefresh(document)) {
-            return;
-          }
-          const timerKey = folder.uri.toString();
-          this.clearRefreshTimer(timerKey);
-          this.refreshTimers.set(
-            timerKey,
-            setTimeout(() => {
-              this.refreshTimers.delete(timerKey);
-              void this.refreshWorkspace({ folder, revealErrors: false, document, trigger: "auto-save" });
-            }, 400),
-          );
+          void this.handleDidSaveTextDocument(document);
         }),
         vscode.workspace.onDidChangeConfiguration((event) => {
           for (const folder of vscode.workspace.workspaceFolders ?? []) {
@@ -271,6 +257,15 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
           }
         }),
       );
+      for (const watcherPattern of ["**/build.gradle", "**/build.gradle.kts", "**/AndroidManifest.xml"]) {
+        const watcher = vscode.workspace.createFileSystemWatcher(watcherPattern);
+        disposables.push(
+          watcher,
+          watcher.onDidChange((uri) => this.invalidateLanguageInferenceCache(uri)),
+          watcher.onDidCreate((uri) => this.invalidateLanguageInferenceCache(uri)),
+          watcher.onDidDelete((uri) => this.invalidateLanguageInferenceCache(uri)),
+        );
+      }
     }
     this.disposable = vscode.Disposable.from(...disposables);
   }
@@ -315,7 +310,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     }
 
     const scopeMode = this.requestedScopeMode(folder, options.scopeModeOverride);
-    const requestedLanguage = resolveLopperLanguage(configuredLopperLanguage(folder), document, folder.uri.fsPath);
+    const requestedLanguage = await resolveLopperLanguage(configuredLopperLanguage(folder), document, folder.uri.fsPath);
     const workspaceKey = folder.uri.toString();
     const sessionKey = this.sessionKey(workspaceKey, requestedLanguage, scopeMode);
 
@@ -670,6 +665,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   dispose(): void {
     this.cancelActiveRefreshes("extension disposed");
     this.refreshAbortHandles.clear();
+    clearAndroidModuleSignalCache();
     for (const timer of this.refreshTimers.values()) {
       clearTimeout(timer);
     }
@@ -720,7 +716,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     return activeFolder?.uri.toString() === folder.uri.toString() ? document : undefined;
   }
 
-  private shouldAutoRefresh(document: vscode.TextDocument): boolean {
+  private async shouldAutoRefresh(document: vscode.TextDocument): Promise<boolean> {
     if (document.isUntitled) {
       return false;
     }
@@ -734,6 +730,31 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     return shouldAutoRefreshForDocument(configuredLopperLanguage(folder), document, folder.uri.fsPath);
   }
 
+  private async handleDidSaveTextDocument(document: vscode.TextDocument): Promise<void> {
+    const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (!folder) {
+      return;
+    }
+    this.invalidateLanguageInferenceCache(document.uri, folder);
+    this.invalidateWorkspaceSession(folder, `document saved: ${path.basename(document.fileName)}`);
+    if (!await this.shouldAutoRefresh(document)) {
+      return;
+    }
+    const timerKey = folder.uri.toString();
+    this.clearRefreshTimer(timerKey);
+    this.refreshTimers.set(
+      timerKey,
+      setTimeout(() => {
+        this.refreshTimers.delete(timerKey);
+        void this.refreshWorkspace({ folder, revealErrors: false, document, trigger: "auto-save" });
+      }, 400),
+    );
+  }
+
+  private invalidateLanguageInferenceCache(uri: vscode.Uri, folder = vscode.workspace.getWorkspaceFolder(uri)): void {
+    invalidateAndroidModuleSignalCacheForPath(uri.fsPath, folder?.uri.fsPath);
+  }
+
   private async refreshRuntimeWorkspace(folderPath?: string): Promise<void> {
     const folder = await this.resolveDependencyWorkspaceFolder(folderPath);
     if (!folder) {
@@ -741,7 +762,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       return;
     }
 
-    const requestedLanguage = resolveLopperLanguage(
+    const requestedLanguage = await resolveLopperLanguage(
       configuredLopperLanguage(folder),
       this.activeDocumentForFolder(folder),
       folder.uri.fsPath,

--- a/extensions/vscode-lopper/src/languageConfiguration.ts
+++ b/extensions/vscode-lopper/src/languageConfiguration.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs";
+import { access, readFile } from "node:fs/promises";
 import * as path from "node:path";
 import * as vscode from "vscode";
 
@@ -30,9 +30,14 @@ interface DocumentLike {
   languageId: string;
 }
 
+interface AndroidModuleSignalProvider {
+  hasAndroidModuleSignals(fileName: string, workspaceFolderPath?: string): Promise<boolean>;
+}
+
 const knownLanguages = new Set<LopperLanguage>(lopperLanguageValues);
 const jvmLikeLanguageIds = new Set(["java", "kotlin"]);
 const jvmLikeExtensions = new Set([".java", ".kt", ".kts"]);
+const androidManifestRelativePath = path.join("src", "main", "AndroidManifest.xml");
 const androidBuildPluginMarkers = [
   "com.android.application",
   "com.android.dynamic-feature",
@@ -122,17 +127,77 @@ export function configuredLopperLanguage(folder?: vscode.WorkspaceFolder): Loppe
   return normalizeLopperLanguage(configured);
 }
 
-export function inferLopperLanguageForDocument(
+export class AndroidModuleSignalCache implements AndroidModuleSignalProvider {
+  private readonly moduleSignalsByRoot = new Map<string, Promise<boolean>>();
+
+  async hasAndroidModuleSignals(fileName: string, workspaceFolderPath?: string): Promise<boolean> {
+    if (!workspaceFolderPath) {
+      return false;
+    }
+
+    const workspaceRoot = path.resolve(workspaceFolderPath);
+    const resolvedFile = path.resolve(fileName);
+    const relativeFile = path.relative(workspaceRoot, resolvedFile);
+    if (relativeFile.startsWith("..") || path.isAbsolute(relativeFile)) {
+      return false;
+    }
+
+    let currentDir = path.dirname(resolvedFile);
+    while (currentDir.startsWith(workspaceRoot)) {
+      if (await this.moduleSignalsAndroid(currentDir)) {
+        return true;
+      }
+      if (currentDir === workspaceRoot) {
+        break;
+      }
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) {
+        break;
+      }
+      currentDir = parentDir;
+    }
+
+    return false;
+  }
+
+  invalidateForPath(filePath: string, workspaceFolderPath?: string): void {
+    const moduleRoot = androidSignalModuleRoot(filePath, workspaceFolderPath);
+    if (moduleRoot) {
+      this.moduleSignalsByRoot.delete(moduleRoot);
+    }
+  }
+
+  clear(): void {
+    this.moduleSignalsByRoot.clear();
+  }
+
+  private moduleSignalsAndroid(moduleRoot: string): Promise<boolean> {
+    const cacheKey = path.resolve(moduleRoot);
+    const cached = this.moduleSignalsByRoot.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const result = readAndroidModuleSignals(cacheKey);
+    this.moduleSignalsByRoot.set(cacheKey, result);
+    return result;
+  }
+}
+
+const defaultAndroidModuleSignalCache = new AndroidModuleSignalCache();
+
+export async function inferLopperLanguageForDocument(
   document?: DocumentLike,
   workspaceFolderPath?: string,
-): ConcreteLopperLanguage | undefined {
+  androidSignals: AndroidModuleSignalProvider = defaultAndroidModuleSignalCache,
+): Promise<ConcreteLopperLanguage | undefined> {
   if (!document || document.isUntitled) {
     return undefined;
   }
 
   const languageId = document.languageId.trim().toLowerCase();
   if (jvmLikeLanguageIds.has(languageId)) {
-    return inferJvmFamilyAdapter(document.fileName, workspaceFolderPath);
+    return inferJvmFamilyAdapter(document.fileName, workspaceFolderPath, androidSignals);
   }
   if (adapterByLanguageId.has(languageId)) {
     return adapterByLanguageId.get(languageId);
@@ -140,7 +205,7 @@ export function inferLopperLanguageForDocument(
 
   const extension = path.extname(document.fileName).toLowerCase();
   if (jvmLikeExtensions.has(extension)) {
-    return inferJvmFamilyAdapter(document.fileName, workspaceFolderPath);
+    return inferJvmFamilyAdapter(document.fileName, workspaceFolderPath, androidSignals);
   }
   if (adapterByExtension.has(extension)) {
     return adapterByExtension.get(extension);
@@ -149,24 +214,26 @@ export function inferLopperLanguageForDocument(
   return undefined;
 }
 
-export function resolveLopperLanguage(
+export async function resolveLopperLanguage(
   configuredLanguage: LopperLanguage,
   document?: DocumentLike,
   workspaceFolderPath?: string,
-): LopperLanguage {
+  androidSignals: AndroidModuleSignalProvider = defaultAndroidModuleSignalCache,
+): Promise<LopperLanguage> {
   if (configuredLanguage !== "auto") {
     return configuredLanguage;
   }
 
-  return inferLopperLanguageForDocument(document, workspaceFolderPath) ?? "auto";
+  return await inferLopperLanguageForDocument(document, workspaceFolderPath, androidSignals) ?? "auto";
 }
 
-export function shouldAutoRefreshForDocument(
+export async function shouldAutoRefreshForDocument(
   configuredLanguage: LopperLanguage,
   document: DocumentLike,
   workspaceFolderPath?: string,
-): boolean {
-  const inferred = inferLopperLanguageForDocument(document, workspaceFolderPath);
+  androidSignals: AndroidModuleSignalProvider = defaultAndroidModuleSignalCache,
+): Promise<boolean> {
+  const inferred = await inferLopperLanguageForDocument(document, workspaceFolderPath, androidSignals);
   if (!inferred) {
     return false;
   }
@@ -186,59 +253,86 @@ function normalizeLopperLanguage(value: string | undefined): LopperLanguage {
   return normalized;
 }
 
-function inferJvmFamilyAdapter(fileName: string, workspaceFolderPath?: string): ConcreteLopperLanguage {
-  return hasAndroidModuleSignals(fileName, workspaceFolderPath) ? "kotlin-android" : "jvm";
+export function invalidateAndroidModuleSignalCacheForPath(filePath: string, workspaceFolderPath?: string): void {
+  defaultAndroidModuleSignalCache.invalidateForPath(filePath, workspaceFolderPath);
 }
 
-function hasAndroidModuleSignals(fileName: string, workspaceFolderPath?: string): boolean {
-  if (!workspaceFolderPath) {
-    return false;
-  }
-
-  const workspaceRoot = path.resolve(workspaceFolderPath);
-  const resolvedFile = path.resolve(fileName);
-  const relativeFile = path.relative(workspaceRoot, resolvedFile);
-  if (relativeFile.startsWith("..") || path.isAbsolute(relativeFile)) {
-    return false;
-  }
-
-  let currentDir = path.dirname(resolvedFile);
-  while (currentDir.startsWith(workspaceRoot)) {
-    if (moduleSignalsAndroid(currentDir)) {
-      return true;
-    }
-    if (currentDir === workspaceRoot) {
-      break;
-    }
-    const parentDir = path.dirname(currentDir);
-    if (parentDir === currentDir) {
-      break;
-    }
-    currentDir = parentDir;
-  }
-
-  return false;
+export function clearAndroidModuleSignalCache(): void {
+  defaultAndroidModuleSignalCache.clear();
 }
 
-function moduleSignalsAndroid(moduleRoot: string): boolean {
-  if (fs.existsSync(path.join(moduleRoot, "src", "main", "AndroidManifest.xml"))) {
+async function inferJvmFamilyAdapter(
+  fileName: string,
+  workspaceFolderPath: string | undefined,
+  androidSignals: AndroidModuleSignalProvider,
+): Promise<ConcreteLopperLanguage> {
+  return await androidSignals.hasAndroidModuleSignals(fileName, workspaceFolderPath) ? "kotlin-android" : "jvm";
+}
+
+async function readAndroidModuleSignals(moduleRoot: string): Promise<boolean> {
+  if (await pathExists(path.join(moduleRoot, androidManifestRelativePath))) {
     return true;
   }
 
   for (const buildFileName of ["build.gradle", "build.gradle.kts"]) {
     const buildFilePath = path.join(moduleRoot, buildFileName);
-    if (!fs.existsSync(buildFilePath)) {
-      continue;
-    }
-    try {
-      const buildFile = fs.readFileSync(buildFilePath, "utf8").toLowerCase();
-      if (androidBuildPluginMarkers.some((marker) => buildFile.includes(marker))) {
-        return true;
-      }
-    } catch {
-      continue;
+    const buildFile = await readTextFile(buildFilePath);
+    if (buildFile && androidBuildPluginMarkers.some((marker) => buildFile.toLowerCase().includes(marker))) {
+      return true;
     }
   }
 
   return false;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readTextFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function androidSignalModuleRoot(filePath: string, workspaceFolderPath?: string): string | undefined {
+  const resolvedFile = path.resolve(filePath);
+  const baseName = path.basename(resolvedFile);
+  const moduleRoot = moduleRootForAndroidSignal(resolvedFile, baseName);
+  if (!moduleRoot) {
+    return undefined;
+  }
+  if (!workspaceFolderPath) {
+    return moduleRoot;
+  }
+
+  const workspaceRoot = path.resolve(workspaceFolderPath);
+  const relativeModuleRoot = path.relative(workspaceRoot, moduleRoot);
+  if (relativeModuleRoot.startsWith("..") || path.isAbsolute(relativeModuleRoot)) {
+    return undefined;
+  }
+  return moduleRoot;
+}
+
+function moduleRootForAndroidSignal(resolvedFile: string, baseName: string): string | undefined {
+  if (baseName === "build.gradle" || baseName === "build.gradle.kts") {
+    return path.dirname(resolvedFile);
+  }
+
+  if (baseName !== "AndroidManifest.xml") {
+    return undefined;
+  }
+
+  const relativeManifestPath = path.join(path.basename(path.dirname(path.dirname(resolvedFile))), path.basename(path.dirname(resolvedFile)), baseName);
+  if (relativeManifestPath !== androidManifestRelativePath) {
+    return undefined;
+  }
+  return path.dirname(path.dirname(path.dirname(resolvedFile)));
 }

--- a/extensions/vscode-lopper/src/lopperRunner.ts
+++ b/extensions/vscode-lopper/src/lopperRunner.ts
@@ -240,7 +240,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     const { document, scopeMode: scopeModeOption, dependencyName } = options;
     const binaryPath = await this.resolveBinaryPath(folder);
     const binarySignature = await this.binarySignature(binaryPath);
-    const requestedLanguage = resolveLopperLanguage(configuredLopperLanguage(folder), document, folder.uri.fsPath);
+    const requestedLanguage = await resolveLopperLanguage(configuredLopperLanguage(folder), document, folder.uri.fsPath);
     const scopeMode = normalizeScopeMode(scopeModeOption);
     const timeoutMs = this.runTimeoutMs(folder);
     const report = await this.executeReport(binaryPath, folder, {
@@ -282,7 +282,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
   ): Promise<string> {
     const { document, scopeMode: scopeModeOption } = options;
     const binaryPath = await this.resolveBinaryPath(folder);
-    const requestedLanguage = resolveLopperLanguage(configuredLopperLanguage(folder), document, folder.uri.fsPath);
+    const requestedLanguage = await resolveLopperLanguage(configuredLopperLanguage(folder), document, folder.uri.fsPath);
     const scopeMode = normalizeScopeMode(scopeModeOption);
     const timeoutMs = this.runTimeoutMs(folder);
     return this.executeText(binaryPath, folder, {

--- a/extensions/vscode-lopper/src/test/suite/languageConfiguration.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/languageConfiguration.test.ts
@@ -5,36 +5,38 @@ import * as assert from "node:assert/strict";
 import { suite, test } from "mocha";
 
 import {
+  clearAndroidModuleSignalCache,
+  invalidateAndroidModuleSignalCacheForPath,
   inferLopperLanguageForDocument,
   resolveLopperLanguage,
   shouldAutoRefreshForDocument,
 } from "../../languageConfiguration";
 
 suite("language configuration", () => {
-  test("infers adapters from VS Code language ids and file extensions", () => {
-    assert.equal(inferLopperLanguageForDocument({ fileName: "/repo/src/main.go", languageId: "go" }), "go");
+  test("infers adapters from VS Code language ids and file extensions", async () => {
+    assert.equal(await inferLopperLanguageForDocument({ fileName: "/repo/src/main.go", languageId: "go" }), "go");
     assert.equal(
-      inferLopperLanguageForDocument({ fileName: "/repo/src/app.tsx", languageId: "typescriptreact" }),
+      await inferLopperLanguageForDocument({ fileName: "/repo/src/app.tsx", languageId: "typescriptreact" }),
       "js-ts",
     );
     assert.equal(
-      inferLopperLanguageForDocument({ fileName: "/repo/src/program.kt", languageId: "plaintext" }, "/repo"),
+      await inferLopperLanguageForDocument({ fileName: "/repo/src/program.kt", languageId: "plaintext" }, "/repo"),
       "jvm",
     );
     assert.equal(
-      inferLopperLanguageForDocument({ fileName: "/repo/src/service.exs", languageId: "plaintext" }),
+      await inferLopperLanguageForDocument({ fileName: "/repo/src/service.exs", languageId: "plaintext" }),
       "elixir",
     );
     assert.equal(
-      inferLopperLanguageForDocument({ fileName: "/repo/src/lib.cs", languageId: "csharp" }),
+      await inferLopperLanguageForDocument({ fileName: "/repo/src/lib.cs", languageId: "csharp" }),
       "dotnet",
     );
     assert.equal(
-      inferLopperLanguageForDocument({ fileName: "/repo/scripts/bootstrap.ps1", languageId: "powershell" }),
+      await inferLopperLanguageForDocument({ fileName: "/repo/scripts/bootstrap.ps1", languageId: "powershell" }),
       "powershell",
     );
     assert.equal(
-      inferLopperLanguageForDocument({ fileName: "/repo/modules/demo.psd1", languageId: "plaintext" }),
+      await inferLopperLanguageForDocument({ fileName: "/repo/modules/demo.psd1", languageId: "plaintext" }),
       "powershell",
     );
   });
@@ -59,41 +61,76 @@ suite("language configuration", () => {
       await writeFile(javaSource, "class MainActivity {}", "utf8");
 
       assert.equal(
-        inferLopperLanguageForDocument({ fileName: kotlinSource, languageId: "kotlin" }, tempRoot),
+        await inferLopperLanguageForDocument({ fileName: kotlinSource, languageId: "kotlin" }, tempRoot),
         "kotlin-android",
       );
       assert.equal(
-        inferLopperLanguageForDocument({ fileName: javaSource, languageId: "java" }, tempRoot),
+        await inferLopperLanguageForDocument({ fileName: javaSource, languageId: "java" }, tempRoot),
         "kotlin-android",
       );
-      assert.equal(resolveLopperLanguage("auto", { fileName: kotlinSource, languageId: "kotlin" }, tempRoot), "kotlin-android");
-      assert.equal(shouldAutoRefreshForDocument("kotlin-android", { fileName: kotlinSource, languageId: "kotlin" }, tempRoot), true);
+      assert.equal(await resolveLopperLanguage("auto", { fileName: kotlinSource, languageId: "kotlin" }, tempRoot), "kotlin-android");
+      assert.equal(await shouldAutoRefreshForDocument("kotlin-android", { fileName: kotlinSource, languageId: "kotlin" }, tempRoot), true);
     } finally {
+      clearAndroidModuleSignalCache();
       await rm(tempRoot, { recursive: true, force: true });
     }
   });
 
-  test("resolves auto to the current document adapter and preserves explicit modes", () => {
-    const pythonDocument = { fileName: "/repo/app/main.py", languageId: "python" };
+  test("invalidates cached Android module signals for Gradle file changes", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-vscode-language-cache-"));
+    const androidModule = path.join(tempRoot, "app");
+    const kotlinSource = path.join(androidModule, "src", "main", "kotlin", "MainActivity.kt");
+    const buildFile = path.join(androidModule, "build.gradle.kts");
 
-    assert.equal(resolveLopperLanguage("auto", pythonDocument), "python");
-    assert.equal(resolveLopperLanguage("auto", { fileName: "/repo/README.md", languageId: "markdown" }), "auto");
-    assert.equal(resolveLopperLanguage("all", pythonDocument), "all");
-    assert.equal(resolveLopperLanguage("kotlin-android", pythonDocument), "kotlin-android");
-    assert.equal(resolveLopperLanguage("powershell", pythonDocument), "powershell");
-    assert.equal(resolveLopperLanguage("rust", pythonDocument), "rust");
+    try {
+      await mkdir(path.dirname(kotlinSource), { recursive: true });
+      await writeFile(kotlinSource, "class MainActivity", "utf8");
+      await writeFile(buildFile, "plugins { kotlin(\"jvm\") }", "utf8");
+
+      assert.equal(
+        await inferLopperLanguageForDocument({ fileName: kotlinSource, languageId: "kotlin" }, tempRoot),
+        "jvm",
+      );
+
+      await writeFile(buildFile, 'plugins { id("com.android.application") }', "utf8");
+      assert.equal(
+        await inferLopperLanguageForDocument({ fileName: kotlinSource, languageId: "kotlin" }, tempRoot),
+        "jvm",
+        "cached module signal should be reused until a relevant path is invalidated",
+      );
+
+      invalidateAndroidModuleSignalCacheForPath(buildFile, tempRoot);
+      assert.equal(
+        await inferLopperLanguageForDocument({ fileName: kotlinSource, languageId: "kotlin" }, tempRoot),
+        "kotlin-android",
+      );
+    } finally {
+      clearAndroidModuleSignalCache();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 
-  test("auto refresh only reacts to files that match the selected mode", () => {
+  test("resolves auto to the current document adapter and preserves explicit modes", async () => {
+    const pythonDocument = { fileName: "/repo/app/main.py", languageId: "python" };
+
+    assert.equal(await resolveLopperLanguage("auto", pythonDocument), "python");
+    assert.equal(await resolveLopperLanguage("auto", { fileName: "/repo/README.md", languageId: "markdown" }), "auto");
+    assert.equal(await resolveLopperLanguage("all", pythonDocument), "all");
+    assert.equal(await resolveLopperLanguage("kotlin-android", pythonDocument), "kotlin-android");
+    assert.equal(await resolveLopperLanguage("powershell", pythonDocument), "powershell");
+    assert.equal(await resolveLopperLanguage("rust", pythonDocument), "rust");
+  });
+
+  test("auto refresh only reacts to files that match the selected mode", async () => {
     const goDocument = { fileName: "/repo/main.go", languageId: "go" };
     const jsDocument = { fileName: "/repo/src/index.ts", languageId: "typescript" };
     const markdownDocument = { fileName: "/repo/README.md", languageId: "markdown" };
 
-    assert.equal(shouldAutoRefreshForDocument("auto", goDocument), true);
-    assert.equal(shouldAutoRefreshForDocument("all", jsDocument), true);
-    assert.equal(shouldAutoRefreshForDocument("go", goDocument), true);
-    assert.equal(shouldAutoRefreshForDocument("go", jsDocument), false);
-    assert.equal(shouldAutoRefreshForDocument("kotlin-android", jsDocument), false);
-    assert.equal(shouldAutoRefreshForDocument("auto", markdownDocument), false);
+    assert.equal(await shouldAutoRefreshForDocument("auto", goDocument), true);
+    assert.equal(await shouldAutoRefreshForDocument("all", jsDocument), true);
+    assert.equal(await shouldAutoRefreshForDocument("go", goDocument), true);
+    assert.equal(await shouldAutoRefreshForDocument("go", jsDocument), false);
+    assert.equal(await shouldAutoRefreshForDocument("kotlin-android", jsDocument), false);
+    assert.equal(await shouldAutoRefreshForDocument("auto", markdownDocument), false);
   });
 });

--- a/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
@@ -48,7 +48,7 @@ suite("refresh lifecycle", () => {
           const firstRefresh = refresh(controller, harness);
           const secondRefresh = refresh(controller, harness);
 
-          assert.equal(analyseCalls, 1);
+          await waitForAssertion(() => assert.equal(analyseCalls, 1));
 
           pendingAnalysis.resolve(makeAnalysis(harness, { dependencyCount: 1, usedPercent: 50 }));
           await Promise.all([firstRefresh, secondRefresh]);
@@ -101,7 +101,9 @@ suite("refresh lifecycle", () => {
           const firstRefresh = refresh(controller, harness, { forceFresh: true });
           const secondRefresh = refresh(controller, harness, { forceFresh: true });
 
-          assert.equal(deferredAnalyses.length, 2, "expected two independent fresh runs");
+          await waitForAssertion(() => {
+            assert.equal(deferredAnalyses.length, 2, "expected two independent fresh runs");
+          });
 
           deferredAnalyses[1].resolve(
             makeAnalysis(harness, {
@@ -150,7 +152,9 @@ suite("refresh lifecycle", () => {
           const firstRefresh = refresh(controller, harness, { forceFresh: true });
           const secondRefresh = refresh(controller, harness, { forceFresh: true });
 
-          assert.equal(deferredAnalyses.length, 2, "expected two independent fresh runs");
+          await waitForAssertion(() => {
+            assert.equal(deferredAnalyses.length, 2, "expected two independent fresh runs");
+          });
           assert.equal(signals[0].aborted, true, "superseded run should be aborted");
           assert.equal(signals[1].aborted, false, "latest run should remain active");
 
@@ -358,6 +362,24 @@ function deferred<T>(): Deferred<T> {
     reject = rejecter;
   });
   return { promise, resolve, reject };
+}
+
+async function waitForAssertion(assertion: () => void, timeoutMs = 1_000): Promise<void> {
+  const started = Date.now();
+  let lastError: unknown;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  if (lastError) {
+    throw lastError;
+  }
+  assertion();
 }
 
 function makeAnalysis(


### PR DESCRIPTION
## Summary

Avoid blocking the VS Code extension save/refresh path on synchronous filesystem reads during JVM/Kotlin language inference.

Closes #827.

## Changes

- Converted Android module signal detection from sync `fs` calls to async `fs/promises` checks with per-module-root memoization.
- Invalidated cached Android module signals when `build.gradle`, `build.gradle.kts`, or `AndroidManifest.xml` paths change, including saved documents and workspace file watchers.
- Awaited language inference in the save/refresh path and runner, and adjusted refresh lifecycle tests for the new async boundary.

## Validation

Validated dependency install, TypeScript compile, VS Code extension e2e coverage, prcheck tests, diff whitespace, and PR metadata policy.

```bash
npm ci
npm run compile
npm run test:e2e
go test ./tools/prcheck
git diff --check
go run ./tools/prcheck --check-repo-policy --title "fix(vscode): avoid sync filesystem reads on save" --head-ref bug/issue-827-vscode-save-path-async-io --body-file /tmp/lopper-827-pr-body.md --allow-merge-commit false --allow-rebase-merge false --allow-squash-merge true --squash-merge-commit-title PR_TITLE
```

## Risk and compatibility

- Breaking changes: None expected.
- Migration required: None.
- Performance impact: Save-triggered language inference no longer runs blocking filesystem reads; Android module checks are async and cached.
- Memory benchmark impact: None; VS Code extension TypeScript-only change with no Go runtime path changes.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
