### PR TITLE
refactor(lang): route root signals through shared helper

### DIFF
--- a/internal/lang/dotnet/detection.go
+++ b/internal/lang/dotnet/detection.go
@@ -71,6 +71,8 @@ func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (la
 }
 
 func applyRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
+	// .NET root detection is extension/pattern based and solution files can add
+	// extra roots, so it cannot be represented as exact shared.RootSignal names.
 	entries, err := os.ReadDir(repoPath)
 	if err != nil {
 		return err

--- a/internal/lang/golang/detection.go
+++ b/internal/lang/golang/detection.go
@@ -69,31 +69,22 @@ func manifestPathExists(path string) (bool, error) {
 }
 
 func applyGoRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
-	rootSignals := []struct {
-		name       string
-		confidence int
-	}{
-		{name: goModName, confidence: 55},
-		{name: goWorkName, confidence: 45},
+	if err := shared.ApplyRootSignals(repoPath, goRootSignals, detection, roots); err != nil {
+		return err
 	}
-	for _, signal := range rootSignals {
-		candidate := filepath.Join(repoPath, signal.name)
-		exists, err := manifestPathExists(candidate)
-		if err != nil {
-			return err
-		}
-		if exists {
-			detection.Matched = true
-			detection.Confidence += signal.confidence
-			roots[repoPath] = struct{}{}
-			if signal.name == goWorkName {
-				if err := addGoWorkRoots(repoPath, roots); err != nil {
-					return err
-				}
-			}
-		}
+	goWorkExists, err := manifestPathExists(filepath.Join(repoPath, goWorkName))
+	if err != nil {
+		return err
+	}
+	if goWorkExists {
+		return addGoWorkRoots(repoPath, roots)
 	}
 	return nil
+}
+
+var goRootSignals = []shared.RootSignal{
+	{Name: goModName, Confidence: 55},
+	{Name: goWorkName, Confidence: 45},
 }
 
 func addGoWorkRoots(repoPath string, roots map[string]struct{}) error {

--- a/internal/lang/js/adapter.go
+++ b/internal/lang/js/adapter.go
@@ -59,22 +59,19 @@ func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (la
 }
 
 func addRootSignalDetection(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
-	candidates := []string{jsPackageFile, "tsconfig.json", "jsconfig.json"}
-	for _, name := range candidates {
-		path := filepath.Join(repoPath, name)
-		if _, err := os.Stat(path); err == nil {
-			detection.Matched = true
-			if name == jsPackageFile {
-				detection.Confidence += 45
-				roots[repoPath] = struct{}{}
-				continue
-			}
-			detection.Confidence += 20
-		} else if !os.IsNotExist(err) {
-			return err
-		}
+	if err := shared.ApplyRootSignals(repoPath, jsPackageRootSignals, detection, roots); err != nil {
+		return err
 	}
-	return nil
+	return shared.ApplyRootSignals(repoPath, jsConfigRootSignals, detection, nil)
+}
+
+var jsPackageRootSignals = []shared.RootSignal{
+	{Name: jsPackageFile, Confidence: 45},
+}
+
+var jsConfigRootSignals = []shared.RootSignal{
+	{Name: "tsconfig.json", Confidence: 20},
+	{Name: "jsconfig.json", Confidence: 20},
 }
 
 func scanFilesForJSDetection(repoPath string, detection *language.Detection, roots map[string]struct{}) error {

--- a/internal/lang/js/adapter_cov_more_branches_test.go
+++ b/internal/lang/js/adapter_cov_more_branches_test.go
@@ -35,6 +35,21 @@ func testJSDetectHelpersReturnRealErrors(t *testing.T) {
 	if addRootSignalDetection(repoFile, &detection, roots) == nil {
 		t.Fatalf("expected non-directory repo path to fail root signal detection")
 	}
+
+	rootSignalDirRepo := t.TempDir()
+	for _, name := range []string{jsPackageFile, "tsconfig.json"} {
+		if err := os.Mkdir(filepath.Join(rootSignalDirRepo, name), 0o755); err != nil {
+			t.Fatalf("mkdir root signal dir %s: %v", name, err)
+		}
+	}
+	detection = language.Detection{}
+	roots = map[string]struct{}{}
+	if err := addRootSignalDetection(rootSignalDirRepo, &detection, roots); err != nil {
+		t.Fatalf("add root signal detection for directories: %v", err)
+	}
+	if detection.Matched || detection.Confidence != 0 || len(roots) != 0 {
+		t.Fatalf("expected directory-shaped root signals to be ignored, detection=%#v roots=%#v", detection, roots)
+	}
 }
 
 func testJSDetectHandlesEOFCapAndSkippedDirs(t *testing.T) {

--- a/internal/lang/jvm/detection.go
+++ b/internal/lang/jvm/detection.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -53,29 +52,13 @@ func walkJVMDetectionEntry(path string, entry fs.DirEntry, roots map[string]stru
 }
 
 func applyJVMRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
-	rootSignals := []struct {
-		name       string
-		confidence int
-	}{
-		{name: pomXMLName, confidence: 55},
-		{name: buildGradleName, confidence: 45},
-		{name: buildGradleKTSName, confidence: 45},
-	}
-	for _, signal := range rootSignals {
-		path := filepath.Join(repoPath, signal.name)
-		info, err := os.Stat(path)
-		if err == nil {
-			if info.IsDir() {
-				continue
-			}
-			detection.Matched = true
-			detection.Confidence += signal.confidence
-			roots[repoPath] = struct{}{}
-		} else if !os.IsNotExist(err) {
-			return err
-		}
-	}
-	return nil
+	return shared.ApplyRootSignals(repoPath, jvmRootSignals, detection, roots)
+}
+
+var jvmRootSignals = []shared.RootSignal{
+	{Name: pomXMLName, Confidence: 55},
+	{Name: buildGradleName, Confidence: 45},
+	{Name: buildGradleKTSName, Confidence: 45},
 }
 
 func updateJVMDetection(path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection) {

--- a/internal/lang/php/adapter.go
+++ b/internal/lang/php/adapter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -57,24 +56,12 @@ func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (la
 }
 
 func applyPHPRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
-	signals := []struct {
-		name       string
-		confidence int
-	}{
-		{name: composerJSONName, confidence: 60},
-		{name: composerLockName, confidence: 30},
-	}
-	for _, signal := range signals {
-		candidate := filepath.Join(repoPath, signal.name)
-		if _, err := os.Stat(candidate); err == nil {
-			detection.Matched = true
-			detection.Confidence += signal.confidence
-			roots[repoPath] = struct{}{}
-		} else if !os.IsNotExist(err) {
-			return err
-		}
-	}
-	return nil
+	return shared.ApplyRootSignals(repoPath, phpRootSignals, detection, roots)
+}
+
+var phpRootSignals = []shared.RootSignal{
+	{Name: composerJSONName, Confidence: 60},
+	{Name: composerLockName, Confidence: 30},
 }
 
 func walkPHPDetectionEntry(path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection, visited *int, maxFiles int) error {

--- a/internal/lang/php/adapter_cov_more_branches_test.go
+++ b/internal/lang/php/adapter_cov_more_branches_test.go
@@ -30,6 +30,20 @@ func testPHPRootSignalsAndHelperBranches(t *testing.T) {
 	if _, err := NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
 		t.Fatalf("expected missing repo to fail detection")
 	}
+	rootSignalDirRepo := t.TempDir()
+	for _, name := range []string{composerJSONName, composerLockName} {
+		if err := os.Mkdir(filepath.Join(rootSignalDirRepo, name), 0o755); err != nil {
+			t.Fatalf("mkdir root signal dir %s: %v", name, err)
+		}
+	}
+	detection := language.Detection{}
+	roots := map[string]struct{}{}
+	if err := applyPHPRootSignals(rootSignalDirRepo, &detection, roots); err != nil {
+		t.Fatalf("apply root signals for directories: %v", err)
+	}
+	if detection.Matched || detection.Confidence != 0 || len(roots) != 0 {
+		t.Fatalf("expected directory-shaped root signals to be ignored, detection=%#v roots=%#v", detection, roots)
+	}
 	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
 		t.Fatalf("expected analyse to fail on invalid repo path")
 	}

--- a/internal/lang/powershell/detection.go
+++ b/internal/lang/powershell/detection.go
@@ -44,6 +44,8 @@ func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (la
 }
 
 func applyRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
+	// PowerShell root detection is extension based, not exact manifest-name
+	// based, so shared.RootSignal would not preserve the existing behavior.
 	entries, err := os.ReadDir(repoPath)
 	if err != nil {
 		return err

--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -70,29 +70,17 @@ func walkPythonDetectionEntry(path string, entry fs.DirEntry, roots map[string]s
 }
 
 func applyPythonRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
-	rootSignals := []struct {
-		name       string
-		confidence int
-	}{
-		{name: "pyproject.toml", confidence: 50},
-		{name: "Pipfile", confidence: 45},
-		{name: "Pipfile.lock", confidence: 25},
-		{name: "poetry.lock", confidence: 25},
-		{name: "uv.lock", confidence: 25},
-		{name: "requirements.txt", confidence: 35},
-		{name: "setup.py", confidence: 35},
-	}
-	for _, signal := range rootSignals {
-		path := filepath.Join(repoPath, signal.name)
-		if _, err := os.Stat(path); err == nil {
-			detection.Matched = true
-			detection.Confidence += signal.confidence
-			roots[repoPath] = struct{}{}
-		} else if !os.IsNotExist(err) {
-			return err
-		}
-	}
-	return nil
+	return shared.ApplyRootSignals(repoPath, pythonRootSignals, detection, roots)
+}
+
+var pythonRootSignals = []shared.RootSignal{
+	{Name: "pyproject.toml", Confidence: 50},
+	{Name: "Pipfile", Confidence: 45},
+	{Name: "Pipfile.lock", Confidence: 25},
+	{Name: "poetry.lock", Confidence: 25},
+	{Name: "uv.lock", Confidence: 25},
+	{Name: "requirements.txt", Confidence: 35},
+	{Name: "setup.py", Confidence: 35},
 }
 
 func updateDetectionFromPythonFile(path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection) {

--- a/internal/lang/python/adapter_cov_more_branches_test.go
+++ b/internal/lang/python/adapter_cov_more_branches_test.go
@@ -20,6 +20,20 @@ func TestPythonAdditionalHelperBranches(t *testing.T) {
 	if applyPythonRootSignals(repoFile, &language.Detection{}, map[string]struct{}{}) == nil {
 		t.Fatalf("expected root signal stat error for non-directory repo path")
 	}
+	rootSignalDirRepo := t.TempDir()
+	for _, name := range []string{"pyproject.toml", "requirements.txt"} {
+		if err := os.Mkdir(filepath.Join(rootSignalDirRepo, name), 0o755); err != nil {
+			t.Fatalf("mkdir root signal dir %s: %v", name, err)
+		}
+	}
+	detection := language.Detection{}
+	roots := map[string]struct{}{}
+	if err := applyPythonRootSignals(rootSignalDirRepo, &detection, roots); err != nil {
+		t.Fatalf("apply root signals for directories: %v", err)
+	}
+	if detection.Matched || detection.Confidence != 0 || len(roots) != 0 {
+		t.Fatalf("expected directory-shaped root signals to be ignored, detection=%#v roots=%#v", detection, roots)
+	}
 	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
 		t.Fatalf("expected analyse to fail on invalid repo path")
 	}

--- a/internal/lang/python/adapter_cov_more_branches_test.go
+++ b/internal/lang/python/adapter_cov_more_branches_test.go
@@ -13,6 +13,12 @@ import (
 )
 
 func TestPythonAdditionalHelperBranches(t *testing.T) {
+	t.Run("root signals", testPythonRootSignalHelperBranches)
+	t.Run("invalid analysis paths", testPythonInvalidAnalysisPathBranches)
+	t.Run("import and dependency helpers", testPythonImportAndDependencyHelperBranches)
+}
+
+func testPythonRootSignalHelperBranches(t *testing.T) {
 	repoFile := filepath.Join(t.TempDir(), "repo-file")
 	if err := os.WriteFile(repoFile, []byte("x"), 0o600); err != nil {
 		t.Fatalf("write repo file: %v", err)
@@ -34,13 +40,18 @@ func TestPythonAdditionalHelperBranches(t *testing.T) {
 	if detection.Matched || detection.Confidence != 0 || len(roots) != 0 {
 		t.Fatalf("expected directory-shaped root signals to be ignored, detection=%#v roots=%#v", detection, roots)
 	}
+}
+
+func testPythonInvalidAnalysisPathBranches(t *testing.T) {
 	if _, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: "\x00"}); err == nil {
 		t.Fatalf("expected analyse to fail on invalid repo path")
 	}
 	if _, err := scanRepo(context.Background(), ""); err == nil {
 		t.Fatalf("expected scanRepo to reject empty repo path")
 	}
+}
 
+func testPythonImportAndDependencyHelperBranches(t *testing.T) {
 	if module, local := parseImportPart("   "); module != "" || local != "" {
 		t.Fatalf("expected blank import part to stay empty, got module=%q local=%q", module, local)
 	}


### PR DESCRIPTION
## Summary

Routes repeated language root-signal detection paths through the shared root-signal helper while preserving language-specific behavior such as Go workspace roots and JavaScript config-only detection. Fixes #985.

## Changes

- Replaces duplicated manifest/root-signal loops in Go, JVM, Python, PHP, and JavaScript with `shared.ApplyRootSignals`.
- Keeps .NET and PowerShell on explicit detection paths with comments because their root signals are pattern/extension based.
- Adds branch coverage for directory-shaped manifest/config names so shared helper adoption does not count directories as root-signal files.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/golang ./internal/lang/jvm ./internal/lang/python ./internal/lang/php ./internal/lang/js ./internal/lang/dotnet ./internal/lang/powershell
make lint
make dup-check && git diff --check
make ci
```

Additional manual validation:

- `make ci` completed through the pre-commit hook before publishing the branch, including full tests, goleak, race tests, gosec, govulncheck, memory benchmarks, build, and coverage gate.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None expected; helper reuse preserves the same filesystem checks and detection confidences.
- Memory benchmark impact: None; memory benchmark gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review