### PR TITLE
fix(dashboard): preserve repo identity for duplicates

### DIFF
--- a/internal/app/dashboard_rendering_test.go
+++ b/internal/app/dashboard_rendering_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -89,6 +90,54 @@ func TestExecuteDashboardJSON(t *testing.T) {
 	}
 	if len(reportData.CrossRepoDeps) != 1 || reportData.CrossRepoDeps[0].Name != sharedDependencyName {
 		t.Fatalf("unexpected cross-repo duplicate payload: %#v", reportData.CrossRepoDeps)
+	}
+}
+
+func TestExecuteDashboardJSONDistinguishesSameBasenameRepos(t *testing.T) {
+	const (
+		platformAPI = "./platform/api"
+		servicesAPI = "./services/api"
+		worker      = "./worker"
+	)
+	analyzer := &mapAnalyzer{
+		reports: map[string]report.Report{
+			platformAPI: {Dependencies: []report.DependencyReport{{Name: sharedDependencyName}}},
+			servicesAPI: {Dependencies: []report.DependencyReport{{Name: sharedDependencyName}}},
+			worker:      {Dependencies: []report.DependencyReport{{Name: sharedDependencyName}}},
+		},
+		errs: map[string]error{},
+	}
+
+	application := &App{Analyzer: analyzer}
+
+	req := DefaultRequest()
+	req.Mode = ModeDashboard
+	req.Dashboard.Repos = []DashboardRepo{
+		{Path: platformAPI},
+		{Path: servicesAPI},
+		{Path: worker},
+	}
+	req.Dashboard.Format = "json"
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute dashboard: %v", err)
+	}
+
+	reportData := dashboard.Report{}
+	if err := json.Unmarshal([]byte(output), &reportData); err != nil {
+		t.Fatalf("unmarshal dashboard output: %v", err)
+	}
+
+	if reportData.Summary.CrossRepoDuplicates != 1 {
+		t.Fatalf("expected same-basename repos to count as distinct duplicate participants, got %+v", reportData.Summary)
+	}
+	if len(reportData.CrossRepoDeps) != 1 {
+		t.Fatalf("expected one cross-repo dependency, got %#v", reportData.CrossRepoDeps)
+	}
+	wantRepos := []string{"api (./platform/api)", "api (./services/api)", "worker"}
+	if reportData.CrossRepoDeps[0].Count != 3 || !reflect.DeepEqual(reportData.CrossRepoDeps[0].Repositories, wantRepos) {
+		t.Fatalf("unexpected cross-repo duplicate payload: %#v", reportData.CrossRepoDeps[0])
 	}
 }
 

--- a/internal/dashboard/aggregate.go
+++ b/internal/dashboard/aggregate.go
@@ -14,9 +14,14 @@ type RepoAnalysis struct {
 	Err    error
 }
 
+type crossRepoRepository struct {
+	Label string
+}
+
 func Aggregate(generatedAt time.Time, analyses []RepoAnalysis) Report {
 	results := make([]RepoResult, 0, len(analyses))
-	crossRepoIndex := make(map[string]map[string]struct{})
+	crossRepoIndex := make(map[string]map[string]crossRepoRepository)
+	repoNameCounts := countRepoNames(analyses)
 	sourceWarnings := make([]string, 0)
 	summary := Summary{
 		TotalRepos: len(analyses),
@@ -54,16 +59,17 @@ func Aggregate(generatedAt time.Time, analyses []RepoAnalysis) Report {
 		summary.TotalWasteCandidates += wasteCandidateCount
 		summary.CriticalCVEs += criticalCVEs
 
-		repoName := repoResult.Name
+		repoID := repoIdentity(analysis.Input)
+		repoLabel := crossRepoRepositoryLabel(analysis.Input, repoNameCounts)
 		for _, dependency := range analysis.Report.Dependencies {
 			name := strings.TrimSpace(dependency.Name)
 			if name == "" {
 				continue
 			}
 			if _, ok := crossRepoIndex[name]; !ok {
-				crossRepoIndex[name] = make(map[string]struct{})
+				crossRepoIndex[name] = make(map[string]crossRepoRepository)
 			}
-			crossRepoIndex[name][repoName] = struct{}{}
+			crossRepoIndex[name][repoID] = crossRepoRepository{Label: repoLabel}
 		}
 
 		results = append(results, repoResult)
@@ -160,15 +166,47 @@ func countDeniedLicenses(reportData report.Report) int {
 	return count
 }
 
-func buildCrossRepoDependencies(index map[string]map[string]struct{}) []CrossRepoDependency {
+func countRepoNames(analyses []RepoAnalysis) map[string]int {
+	counts := make(map[string]int, len(analyses))
+	for _, analysis := range analyses {
+		name := strings.TrimSpace(analysis.Input.Name)
+		if name == "" {
+			name = strings.TrimSpace(analysis.Input.Path)
+		}
+		counts[name]++
+	}
+	return counts
+}
+
+func repoIdentity(input RepoInput) string {
+	path := strings.TrimSpace(input.Path)
+	if path != "" {
+		return path
+	}
+	return strings.TrimSpace(input.Name)
+}
+
+func crossRepoRepositoryLabel(input RepoInput, repoNameCounts map[string]int) string {
+	name := strings.TrimSpace(input.Name)
+	path := strings.TrimSpace(input.Path)
+	if name == "" {
+		return path
+	}
+	if repoNameCounts[name] > 1 && path != "" {
+		return name + " (" + path + ")"
+	}
+	return name
+}
+
+func buildCrossRepoDependencies(index map[string]map[string]crossRepoRepository) []CrossRepoDependency {
 	items := make([]CrossRepoDependency, 0)
 	for dependencyName, repoSet := range index {
 		if len(repoSet) < 3 {
 			continue
 		}
 		repositories := make([]string, 0, len(repoSet))
-		for repoName := range repoSet {
-			repositories = append(repositories, repoName)
+		for _, repo := range repoSet {
+			repositories = append(repositories, repo.Label)
 		}
 		sort.Strings(repositories)
 		items = append(items, CrossRepoDependency{

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -139,6 +140,42 @@ func TestAggregate(t *testing.T) {
 	}
 	if len(data.SourceWarnings) != 1 || !strings.Contains(data.SourceWarnings[0], "failed") {
 		t.Fatalf("expected source warning from failed repo analysis, got %#v", data.SourceWarnings)
+	}
+}
+
+func TestAggregateCrossRepoDuplicatesDistinguishesSameInferredRepoNames(t *testing.T) {
+	reportData := Aggregate(time.Date(2026, time.March, 10, 1, 2, 3, 0, time.UTC), []RepoAnalysis{
+		{
+			Input: RepoInput{Name: "api", Path: "./platform/api"},
+			Report: report.Report{
+				Dependencies: []report.DependencyReport{{Name: "shared"}},
+			},
+		},
+		{
+			Input: RepoInput{Name: "api", Path: "./services/api"},
+			Report: report.Report{
+				Dependencies: []report.DependencyReport{{Name: "shared"}},
+			},
+		},
+		{
+			Input: RepoInput{Name: "worker", Path: "./worker"},
+			Report: report.Report{
+				Dependencies: []report.DependencyReport{{Name: "shared"}},
+			},
+		},
+	})
+
+	if reportData.Summary.CrossRepoDuplicates != 1 {
+		t.Fatalf("expected same-name repos to count as distinct duplicate participants, got %+v", reportData.Summary)
+	}
+	if len(reportData.CrossRepoDeps) != 1 {
+		t.Fatalf("expected one cross-repo dependency, got %#v", reportData.CrossRepoDeps)
+	}
+
+	dependency := reportData.CrossRepoDeps[0]
+	wantRepos := []string{"api (./platform/api)", "api (./services/api)", "worker"}
+	if dependency.Name != "shared" || dependency.Count != 3 || !reflect.DeepEqual(dependency.Repositories, wantRepos) {
+		t.Fatalf("unexpected cross-repo dependency payload: %#v", dependency)
 	}
 }
 
@@ -307,11 +344,11 @@ func TestCountDeniedLicensesFallbackFromDependencies(t *testing.T) {
 }
 
 func TestBuildCrossRepoDependenciesSortOrder(t *testing.T) {
-	dependencies := buildCrossRepoDependencies(map[string]map[string]struct{}{
-		"zeta":  {testRepoA: {}, testRepoB: {}, testRepoC: {}},
-		"alpha": {testRepoD: {}, "repo-e": {}, "repo-f": {}},
-		"omega": {testRepoA: {}, testRepoB: {}, testRepoC: {}, testRepoD: {}},
-		"skip":  {testRepoA: {}, testRepoB: {}},
+	dependencies := buildCrossRepoDependencies(map[string]map[string]crossRepoRepository{
+		"zeta":  crossRepoTestRepos(testRepoA, testRepoB, testRepoC),
+		"alpha": crossRepoTestRepos(testRepoD, "repo-e", "repo-f"),
+		"omega": crossRepoTestRepos(testRepoA, testRepoB, testRepoC, testRepoD),
+		"skip":  crossRepoTestRepos(testRepoA, testRepoB),
 	})
 	if len(dependencies) != 3 {
 		t.Fatalf("expected three cross-repo dependencies, got %#v", dependencies)
@@ -322,6 +359,14 @@ func TestBuildCrossRepoDependenciesSortOrder(t *testing.T) {
 	if dependencies[1].Name != "alpha" || dependencies[2].Name != "zeta" {
 		t.Fatalf("expected alphabetical order for equal counts, got %#v", dependencies)
 	}
+}
+
+func crossRepoTestRepos(labels ...string) map[string]crossRepoRepository {
+	repos := make(map[string]crossRepoRepository, len(labels))
+	for _, label := range labels {
+		repos[label] = crossRepoRepository{Label: label}
+	}
+	return repos
 }
 
 func TestFormatHTMLIncludesCrossRepoSectionAndEscapes(t *testing.T) {

--- a/internal/dashboard/format_cov_more_test.go
+++ b/internal/dashboard/format_cov_more_test.go
@@ -58,3 +58,24 @@ func TestDashboardAggregateSkipsBlankDependencyNames(t *testing.T) {
 		t.Fatalf("expected blank dependency names to be excluded from cross-repo index, got %#v", reportData.CrossRepoDeps)
 	}
 }
+
+func TestCrossRepoRepositoryIdentityAndLabelFallbacks(t *testing.T) {
+	counts := countRepoNames([]RepoAnalysis{
+		{Input: RepoInput{Path: "./nameless"}},
+		{Input: RepoInput{Name: "api", Path: "./platform/api"}},
+		{Input: RepoInput{Name: "api", Path: "./services/api"}},
+	})
+
+	if counts["./nameless"] != 1 || counts["api"] != 2 {
+		t.Fatalf("unexpected repo name counts: %#v", counts)
+	}
+	if got := repoIdentity(RepoInput{Name: "api"}); got != "api" {
+		t.Fatalf("expected name fallback identity, got %q", got)
+	}
+	if got := crossRepoRepositoryLabel(RepoInput{Path: "./nameless"}, counts); got != "./nameless" {
+		t.Fatalf("expected path fallback label, got %q", got)
+	}
+	if got := crossRepoRepositoryLabel(RepoInput{Name: "api", Path: "./platform/api"}, counts); got != "api (./platform/api)" {
+		t.Fatalf("expected duplicate repo name label to include path, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Dashboard cross-repo duplicate aggregation keyed repository participants by display name, so repos inferred with the same basename from different parents collapsed before the 3-repo duplicate threshold. This keeps readable names while distinguishing repo identities by path.

Closes #830.

## Changes

- Track cross-repo dependency participants by repo path identity instead of display name.
- Render colliding display names as `name (path)` in cross-repo duplicate lists while leaving unique names readable.
- Add dashboard aggregation and app JSON rendering tests for two `api` repos from different parents sharing a dependency with a third repo.

## Validation

Commands and checks run:

```bash
go test ./internal/dashboard
go test ./internal/dashboard -cover
go test ./internal/dashboard ./internal/app
go test ./...
make ci
go run ./tools/prcheck --title "fix(dashboard): preserve repo identity for duplicates" --head-ref bug/issue-830-dashboard-repo-identity --body-file "$body_file"
```

Additional manual validation:

- Confirmed `internal/dashboard` coverage is 98.3% and same-basename repo outputs include disambiguating paths only for colliding names.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Negligible; aggregation adds a small per-run repo name count map.
- Memory benchmark impact: None; `make ci` memory benchmark gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
