### PR TITLE
fix(vscode): parallelize codemod refresh analysis

### DIFF
--- a/extensions/vscode-lopper/src/lopperRunner.ts
+++ b/extensions/vscode-lopper/src/lopperRunner.ts
@@ -23,6 +23,7 @@ import {
 export type LopperOutputFormat = "json" | "csv" | "sarif" | "pr-comment";
 
 export const defaultLopperRunTimeoutMs = 120_000;
+export const defaultCodemodAnalysisConcurrency = 4;
 
 const execFileAsync = promisify(execFile);
 
@@ -261,16 +262,16 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       saveBaseline: options.saveBaseline,
     });
 
-    const codemodsByDependency = new Map<string, LopperCodemodReport>();
-    for (const dependency of report.dependencies) {
-      if (!shouldFetchCodemod(dependency, requestedLanguage)) {
-        continue;
-      }
-      const codemod = await this.fetchCodemod(binaryPath, folder, dependency, scopeMode, options, timeoutMs);
-      if (codemod) {
-        codemodsByDependency.set(dependency.name, codemod);
-      }
-    }
+    const codemodsByDependency = await this.fetchCodemods(
+      binaryPath,
+      binarySignature,
+      folder,
+      report.dependencies,
+      requestedLanguage,
+      scopeMode,
+      options,
+      timeoutMs,
+    );
 
     return { folder, binaryPath, binarySignature, requestedLanguage, scopeMode, report, codemodsByDependency };
   }
@@ -541,6 +542,58 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     }
   }
 
+  private async fetchCodemods(
+    binaryPath: string,
+    binarySignature: string,
+    folder: vscode.WorkspaceFolder,
+    dependencies: LopperDependencyReport[],
+    requestedLanguage: LopperLanguage,
+    scopeMode: LopperScopeMode,
+    options: WorkspaceAnalysisRequest,
+    timeoutMs: number | undefined,
+  ): Promise<Map<string, LopperCodemodReport>> {
+    const dependencyByCacheKey = new Map<string, LopperDependencyReport>();
+    const cacheKeys: string[] = [];
+    for (const dependency of dependencies) {
+      if (!shouldFetchCodemod(dependency, requestedLanguage)) {
+        continue;
+      }
+
+      const cacheKey = codemodCacheKey(binarySignature, scopeMode, dependency.name);
+      if (dependencyByCacheKey.has(cacheKey)) {
+        continue;
+      }
+
+      dependencyByCacheKey.set(cacheKey, dependency);
+      cacheKeys.push(cacheKey);
+    }
+
+    const codemodByCacheKey = new Map<string, LopperCodemodReport | undefined>();
+    await runWithConcurrency(cacheKeys, codemodAnalysisConcurrency(options), async (cacheKey) => {
+      const dependency = dependencyByCacheKey.get(cacheKey);
+      if (!dependency) {
+        return;
+      }
+
+      const codemod = await this.fetchCodemod(binaryPath, folder, dependency, scopeMode, options, timeoutMs);
+      codemodByCacheKey.set(cacheKey, codemod);
+    });
+
+    const codemodsByDependency = new Map<string, LopperCodemodReport>();
+    for (const dependency of dependencies) {
+      if (!shouldFetchCodemod(dependency, requestedLanguage)) {
+        continue;
+      }
+
+      const codemod = codemodByCacheKey.get(codemodCacheKey(binarySignature, scopeMode, dependency.name));
+      if (codemod) {
+        codemodsByDependency.set(dependency.name, codemod);
+      }
+    }
+
+    return codemodsByDependency;
+  }
+
   private async binarySignature(binaryPath: string): Promise<string> {
     try {
       const resolvedPath = await realpath(binaryPath);
@@ -550,6 +603,40 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       return `${binaryPath}:unknown`;
     }
   }
+}
+
+function codemodCacheKey(binarySignature: string, scopeMode: LopperScopeMode, dependencyName: string): string {
+  return [binarySignature, scopeMode, dependencyName].join("\0");
+}
+
+function codemodAnalysisConcurrency(options: WorkspaceAnalysisRequest): number {
+  if (hasValue(options.runtimeTestCommand) || options.saveBaseline) {
+    return 1;
+  }
+  return defaultCodemodAnalysisConcurrency;
+}
+
+function hasValue(value: string | undefined): boolean {
+  return value !== undefined && value.trim().length > 0;
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  const workerCount = Math.min(items.length, Math.max(1, Math.floor(concurrency)));
+  let nextIndex = 0;
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const item = items[nextIndex];
+        nextIndex += 1;
+        await worker(item);
+      }
+    }),
+  );
 }
 
 function shouldFetchCodemod(dependency: LopperDependencyReport, requestedLanguage: LopperLanguage): boolean {

--- a/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
@@ -6,7 +6,13 @@ import { suite, test } from "mocha";
 import * as vscode from "vscode";
 
 import type { BinaryResolutionRequest } from "../../managedBinary";
-import { BinaryResolutionError, LopperCliReportExecutor, LopperRunner, type ReportCommandExecutor } from "../../lopperRunner";
+import {
+  BinaryResolutionError,
+  defaultCodemodAnalysisConcurrency,
+  LopperCliReportExecutor,
+  LopperRunner,
+  type ReportCommandExecutor,
+} from "../../lopperRunner";
 import type { LopperReport } from "../../types";
 
 suite("lopper runner", () => {
@@ -242,6 +248,137 @@ suite("lopper runner", () => {
     assert.equal(analysis.scopeMode, "package");
     assert.equal(analysis.codemodsByDependency.get("scope-lib")?.suggestions?.[0]?.toModule, "scope-lib/chunk");
     assert.equal(resolvedRequest?.workspaceRoot, folder.uri.fsPath);
+  });
+
+  test("fetches codemods with bounded concurrency and reuses duplicate dependencies", async () => {
+    const folder = workspaceFolder();
+    const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
+    const codemodNames: string[] = [];
+    let activeCodemods = 0;
+    let maxActiveCodemods = 0;
+
+    const runner = new LopperRunner(
+      { appendLine: () => undefined },
+      context,
+      {
+        binaryLifecycle: {
+          resolveBinaryPath: async () => path.join(folder.uri.fsPath, ".lopper-managed", "lopper"),
+        },
+        reportExecutor: {
+          runCommand: async () => "",
+          runReport: async (_binaryPath, args): Promise<LopperReport> => {
+            if (args.includes("--suggest-only")) {
+              const dependencyName = args[args.length - 1];
+              assert.ok(dependencyName, "expected dependency name in codemod command");
+              codemodNames.push(dependencyName);
+              activeCodemods += 1;
+              maxActiveCodemods = Math.max(maxActiveCodemods, activeCodemods);
+              try {
+                await delay(20);
+              } finally {
+                activeCodemods -= 1;
+              }
+
+              return {
+                dependencies: [
+                  {
+                    name: dependencyName,
+                    usedExportsCount: 1,
+                    totalExportsCount: 2,
+                    usedPercent: 50,
+                    codemod: { mode: "suggest-only", suggestions: [] },
+                  },
+                ],
+              };
+            }
+
+            return {
+              dependencies: ["scope-a", "scope-b", "scope-a", "scope-c", "scope-d", "scope-e"].map((name) => ({
+                name,
+                language: "js-ts",
+                usedExportsCount: 1,
+                totalExportsCount: 2,
+                usedPercent: 50,
+              })),
+            };
+          },
+        },
+      },
+    );
+
+    const analysis = await runner.analyseWorkspace(folder);
+
+    assert.equal(codemodNames.length, 5);
+    assert.equal(codemodNames.filter((name) => name === "scope-a").length, 1);
+    assert.ok(maxActiveCodemods > 1, "expected codemod analyses to run concurrently");
+    assert.ok(
+      maxActiveCodemods <= defaultCodemodAnalysisConcurrency,
+      "codemod concurrency must stay below the default cap",
+    );
+    assert.deepEqual([...analysis.codemodsByDependency.keys()], [
+      "scope-a",
+      "scope-b",
+      "scope-c",
+      "scope-d",
+      "scope-e",
+    ]);
+  });
+
+  test("keeps side-effecting codemod refreshes serial", async () => {
+    const folder = workspaceFolder();
+    const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
+    let activeCodemods = 0;
+    let maxActiveCodemods = 0;
+
+    const runner = new LopperRunner(
+      { appendLine: () => undefined },
+      context,
+      {
+        binaryLifecycle: {
+          resolveBinaryPath: async () => path.join(folder.uri.fsPath, ".lopper-managed", "lopper"),
+        },
+        reportExecutor: {
+          runCommand: async () => "",
+          runReport: async (_binaryPath, args): Promise<LopperReport> => {
+            if (args.includes("--suggest-only")) {
+              activeCodemods += 1;
+              maxActiveCodemods = Math.max(maxActiveCodemods, activeCodemods);
+              try {
+                await delay(20);
+              } finally {
+                activeCodemods -= 1;
+              }
+
+              return {
+                dependencies: [
+                  {
+                    name: args[args.length - 1] ?? "unknown",
+                    usedExportsCount: 1,
+                    totalExportsCount: 2,
+                    usedPercent: 50,
+                    codemod: { mode: "suggest-only", suggestions: [] },
+                  },
+                ],
+              };
+            }
+
+            return {
+              dependencies: ["scope-a", "scope-b", "scope-c"].map((name) => ({
+                name,
+                language: "js-ts",
+                usedExportsCount: 1,
+                totalExportsCount: 2,
+                usedPercent: 50,
+              })),
+            };
+          },
+        },
+      },
+    );
+
+    await runner.analyseWorkspace(folder, { runtimeTestCommand: "npm test" });
+
+    assert.equal(maxActiveCodemods, 1);
   });
 
   test("skips codemod analysis for flag-shaped dependency names", async () => {
@@ -495,6 +632,12 @@ function joinPathEntries(entries: Array<string | undefined>): string {
   return entries
     .filter((entry): entry is string => entry !== undefined && entry.length > 0)
     .join(path.delimiter);
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 function platformBinaryName(): string {


### PR DESCRIPTION
## Summary

Fixes the VS Code refresh path where `analyseWorkspace` performed codemod follow-up subprocesses sequentially for each eligible JS/TS dependency. The runner now deduplicates repeated dependency lookups per refresh and uses bounded concurrency for ordinary codemod suggestions while preserving serial execution for runtime-test or baseline-save flows.

Closes #835

## Changes

- Added bounded codemod analysis fan-out capped at four concurrent subprocesses.
- Added per-refresh codemod result reuse keyed by binary signature, scope mode, and dependency name.
- Preserved serial codemod execution when runtime test commands or baseline saves can have side effects.
- Added VS Code extension runner tests for concurrency, duplicate dependency reuse, and side-effecting serial behavior.

## Validation

Commands and checks run:

```bash
npm ci
npm run compile
npm run test:e2e
git diff --check
go test ./tools/prcheck
PR_BODY=<this PR body> go run ./tools/prcheck --title "fix(vscode): parallelize codemod refresh analysis" --head-ref "bug/issue-835-codemod-refresh-n-plus-one"
```

Additional manual validation:

- Reviewed final diff to confirm only VS Code runner and focused runner tests changed.
- Pre-commit hook ran full `make ci` successfully before commit.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Ordinary JS/TS refreshes can fetch codemod suggestions in parallel with a cap of 4 subprocesses; side-effecting refreshes stay serial.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
