### PR TITLE
refactor(report): use text templates for table sections

### DIFF
--- a/internal/report/format_table.go
+++ b/internal/report/format_table.go
@@ -9,17 +9,23 @@ import (
 
 func formatTable(report Report) (string, error) {
 	if len(report.Dependencies) == 0 {
-		return formatEmpty(report), nil
+		return formatEmpty(report)
 	}
 
 	var buffer bytes.Buffer
-	appendSummary(&buffer, report.Summary)
+	if err := appendSummary(&buffer, report.Summary); err != nil {
+		return "", err
+	}
 	appendUsageUncertainty(&buffer, report.UsageUncertainty)
 	appendScopeMetadata(&buffer, report.Scope)
 	appendCacheMetadata(&buffer, report.Cache)
-	appendEffectiveThresholds(&buffer, report)
+	if err := appendEffectiveThresholds(&buffer, report); err != nil {
+		return "", err
+	}
 	appendEffectivePolicy(&buffer, report)
-	appendLanguageBreakdown(&buffer, report.LanguageBreakdown)
+	if err := appendLanguageBreakdown(&buffer, report.LanguageBreakdown); err != nil {
+		return "", err
+	}
 	appendBaselineComparison(&buffer, report.BaselineComparison)
 	appendCodemodApply(&buffer, report.Dependencies)
 
@@ -62,16 +68,18 @@ func sanitizeOutputArgs(args []any) []any {
 	return sanitizedArgs
 }
 
-func formatEmpty(report Report) string {
+func formatEmpty(report Report) (string, error) {
 	var buffer bytes.Buffer
 	buffer.WriteString("No dependencies to report.\n")
 	appendUsageUncertainty(&buffer, report.UsageUncertainty)
 	appendScopeMetadata(&buffer, report.Scope)
-	appendEffectiveThresholds(&buffer, report)
+	if err := appendEffectiveThresholds(&buffer, report); err != nil {
+		return "", err
+	}
 	appendEffectivePolicy(&buffer, report)
 	appendCodemodApply(&buffer, report.Dependencies)
 	appendWarnings(&buffer, report)
-	return buffer.String()
+	return buffer.String(), nil
 }
 
 func writeTableHeader(writer *tabwriter.Writer, showLanguage, showRuntime, showReachability bool) error {

--- a/internal/report/format_table_sections.go
+++ b/internal/report/format_table_sections.go
@@ -4,19 +4,39 @@ import (
 	"bytes"
 	"sort"
 	"strings"
+	"text/template"
 )
 
 var tableWarningReplacer = strings.NewReplacer("\r\n", "\\n", "\r", "\\n", "\n", "\\n", "\t", "\\t")
 
-func appendSummary(buffer *bytes.Buffer, summary *Summary) {
+var (
+	summarySectionTemplate = template.Must(template.New("summary-section").Parse(`Summary: {{.DependencyCount}} deps, Used/Total: {{.UsedExportsCount}}/{{.TotalExportsCount}} ({{printf "%.1f" .UsedPercent}}%)
+
+Licenses: known={{.KnownLicenseCount}}, unknown={{.UnknownLicenseCount}}, denied={{.DeniedLicenseCount}}
+
+{{if .Reachability}}Reachability confidence: avg={{printf "%.1f" .Reachability.AverageScore}} range={{printf "%.1f" .Reachability.LowestScore}}-{{printf "%.1f" .Reachability.HighestScore}} ({{.Reachability.Model}})
+
+{{end}}`))
+
+	effectiveThresholdsSectionTemplate = template.Must(template.New("effective-thresholds-section").Parse(`Effective thresholds:
+- fail_on_increase_percent: {{.FailOnIncreasePercent}}
+- low_confidence_warning_percent: {{.LowConfidenceWarningPercent}}
+- min_usage_percent_for_recommendations: {{.MinUsagePercentForRecommendations}}
+- max_uncertain_import_count: {{.MaxUncertainImportCount}}
+
+`))
+
+	languageBreakdownSectionTemplate = template.Must(template.New("language-breakdown-section").Parse(`Languages:
+{{range .Items}}- {{.Language}}: {{.DependencyCount}} deps, Used/Total: {{.UsedExportsCount}}/{{.TotalExportsCount}} ({{printf "%.1f" .UsedPercent}}%)
+{{end}}
+`))
+)
+
+func appendSummary(buffer *bytes.Buffer, summary *Summary) error {
 	if summary == nil {
-		return
+		return nil
 	}
-	writef(buffer, "Summary: %d deps, Used/Total: %d/%d (%.1f%%)\n\n", summary.DependencyCount, summary.UsedExportsCount, summary.TotalExportsCount, summary.UsedPercent)
-	writef(buffer, "Licenses: known=%d, unknown=%d, denied=%d\n\n", summary.KnownLicenseCount, summary.UnknownLicenseCount, summary.DeniedLicenseCount)
-	if summary.Reachability != nil {
-		writef(buffer, "Reachability confidence: avg=%.1f range=%.1f-%.1f (%s)\n\n", summary.Reachability.AverageScore, summary.Reachability.LowestScore, summary.Reachability.HighestScore, summary.Reachability.Model)
-	}
+	return executeReportTemplate(buffer, summarySectionTemplate, newSummarySectionData(summary))
 }
 
 func appendUsageUncertainty(buffer *bytes.Buffer, usage *UsageUncertainty) {
@@ -61,16 +81,11 @@ func appendCacheMetadata(buffer *bytes.Buffer, cache *CacheMetadata) {
 	buffer.WriteString("\n")
 }
 
-func appendEffectiveThresholds(buffer *bytes.Buffer, report Report) {
+func appendEffectiveThresholds(buffer *bytes.Buffer, report Report) error {
 	if report.EffectiveThresholds == nil {
-		return
+		return nil
 	}
-	buffer.WriteString("Effective thresholds:\n")
-	writef(buffer, "- fail_on_increase_percent: %d\n", report.EffectiveThresholds.FailOnIncreasePercent)
-	writef(buffer, "- low_confidence_warning_percent: %d\n", report.EffectiveThresholds.LowConfidenceWarningPercent)
-	writef(buffer, "- min_usage_percent_for_recommendations: %d\n", report.EffectiveThresholds.MinUsagePercentForRecommendations)
-	writef(buffer, "- max_uncertain_import_count: %d\n", report.EffectiveThresholds.MaxUncertainImportCount)
-	buffer.WriteString("\n")
+	return executeReportTemplate(buffer, effectiveThresholdsSectionTemplate, report.EffectiveThresholds)
 }
 
 func appendEffectivePolicy(buffer *bytes.Buffer, report Report) {
@@ -106,18 +121,80 @@ func appendEffectivePolicy(buffer *bytes.Buffer, report Report) {
 	buffer.WriteString("\n")
 }
 
-func appendLanguageBreakdown(buffer *bytes.Buffer, breakdown []LanguageSummary) {
+func appendLanguageBreakdown(buffer *bytes.Buffer, breakdown []LanguageSummary) error {
 	if len(breakdown) == 0 {
-		return
+		return nil
 	}
-	buffer.WriteString("Languages:\n")
+	return executeReportTemplate(buffer, languageBreakdownSectionTemplate, newLanguageBreakdownSectionData(breakdown))
+}
+
+type summarySectionData struct {
+	DependencyCount     int
+	UsedExportsCount    int
+	TotalExportsCount   int
+	UsedPercent         float64
+	KnownLicenseCount   int
+	UnknownLicenseCount int
+	DeniedLicenseCount  int
+	Reachability        *reachabilitySectionData
+}
+
+type reachabilitySectionData struct {
+	AverageScore float64
+	LowestScore  float64
+	HighestScore float64
+	Model        string
+}
+
+type languageBreakdownSectionData struct {
+	Items []languageBreakdownSectionItem
+}
+
+type languageBreakdownSectionItem struct {
+	Language          string
+	DependencyCount   int
+	UsedExportsCount  int
+	TotalExportsCount int
+	UsedPercent       float64
+}
+
+func newSummarySectionData(summary *Summary) summarySectionData {
+	data := summarySectionData{
+		DependencyCount:     summary.DependencyCount,
+		UsedExportsCount:    summary.UsedExportsCount,
+		TotalExportsCount:   summary.TotalExportsCount,
+		UsedPercent:         summary.UsedPercent,
+		KnownLicenseCount:   summary.KnownLicenseCount,
+		UnknownLicenseCount: summary.UnknownLicenseCount,
+		DeniedLicenseCount:  summary.DeniedLicenseCount,
+	}
+	if summary.Reachability != nil {
+		data.Reachability = &reachabilitySectionData{
+			AverageScore: summary.Reachability.AverageScore,
+			LowestScore:  summary.Reachability.LowestScore,
+			HighestScore: summary.Reachability.HighestScore,
+			Model:        sanitizeTerminalString(summary.Reachability.Model),
+		}
+	}
+	return data
+}
+
+func newLanguageBreakdownSectionData(breakdown []LanguageSummary) languageBreakdownSectionData {
+	items := make([]languageBreakdownSectionItem, 0, len(breakdown))
 	for _, item := range breakdown {
-		buffer.WriteString("- ")
-		buffer.WriteString(sanitizeTerminalString(item.Language))
-		buffer.WriteString(": ")
-		writef(buffer, "%d deps, Used/Total: %d/%d (%.1f%%)\n", item.DependencyCount, item.UsedExportsCount, item.TotalExportsCount, item.UsedPercent)
+		items = append(items, languageBreakdownSectionItem{
+			Language:          sanitizeTerminalString(item.Language),
+			DependencyCount:   item.DependencyCount,
+			UsedExportsCount:  item.UsedExportsCount,
+			TotalExportsCount: item.TotalExportsCount,
+			UsedPercent:       item.UsedPercent,
+		})
 	}
-	buffer.WriteString("\n")
+	return languageBreakdownSectionData{Items: items}
+}
+
+func executeReportTemplate(buffer *bytes.Buffer, tmpl *template.Template, data any) error {
+	return tmpl.Execute(buffer, data)
 }
 
 func appendBaselineComparison(buffer *bytes.Buffer, comparison *BaselineComparison) {

--- a/internal/report/format_table_sections_test.go
+++ b/internal/report/format_table_sections_test.go
@@ -1,0 +1,150 @@
+package report
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+)
+
+func TestAppendSummaryTemplateOutput(t *testing.T) {
+	var buffer bytes.Buffer
+	if err := appendSummary(&buffer, &Summary{
+		DependencyCount:     2,
+		UsedExportsCount:    3,
+		TotalExportsCount:   4,
+		UsedPercent:         75,
+		KnownLicenseCount:   1,
+		UnknownLicenseCount: 0,
+		DeniedLicenseCount:  1,
+		Reachability: &ReachabilityRollup{
+			AverageScore: 88.25,
+			LowestScore:  77,
+			HighestScore: 99,
+			Model:        "reachability-v2\x1b[31m",
+		},
+	}); err != nil {
+		t.Fatalf("append summary: %v", err)
+	}
+
+	want := "Summary: 2 deps, Used/Total: 3/4 (75.0%)\n\n" +
+		"Licenses: known=1, unknown=0, denied=1\n\n" +
+		"Reachability confidence: avg=88.2 range=77.0-99.0 (reachability-v2\\x1b[31m)\n\n"
+	if got := buffer.String(); got != want {
+		t.Fatalf("unexpected summary output:\ngot  %q\nwant %q", got, want)
+	}
+
+	buffer.Reset()
+	if err := appendSummary(&buffer, &Summary{
+		DependencyCount:     1,
+		UsedExportsCount:    1,
+		TotalExportsCount:   2,
+		UsedPercent:         50,
+		KnownLicenseCount:   1,
+		UnknownLicenseCount: 0,
+		DeniedLicenseCount:  0,
+	}); err != nil {
+		t.Fatalf("append summary without reachability: %v", err)
+	}
+
+	want = "Summary: 1 deps, Used/Total: 1/2 (50.0%)\n\n" +
+		"Licenses: known=1, unknown=0, denied=0\n\n"
+	if got := buffer.String(); got != want {
+		t.Fatalf("unexpected summary output without reachability:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+func TestAppendEffectiveThresholdsTemplateOutput(t *testing.T) {
+	var buffer bytes.Buffer
+	if err := appendEffectiveThresholds(&buffer, Report{
+		EffectiveThresholds: &EffectiveThresholds{
+			FailOnIncreasePercent:             2,
+			LowConfidenceWarningPercent:       35,
+			MinUsagePercentForRecommendations: 45,
+			MaxUncertainImportCount:           1,
+		},
+	}); err != nil {
+		t.Fatalf("append thresholds: %v", err)
+	}
+
+	want := "Effective thresholds:\n" +
+		"- fail_on_increase_percent: 2\n" +
+		"- low_confidence_warning_percent: 35\n" +
+		"- min_usage_percent_for_recommendations: 45\n" +
+		"- max_uncertain_import_count: 1\n\n"
+	if got := buffer.String(); got != want {
+		t.Fatalf("unexpected thresholds output:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+func TestAppendLanguageBreakdownTemplateOutput(t *testing.T) {
+	var buffer bytes.Buffer
+	if err := appendLanguageBreakdown(&buffer, []LanguageSummary{
+		{Language: "go", DependencyCount: 2, UsedExportsCount: 3, TotalExportsCount: 6, UsedPercent: 50},
+		{Language: "js-ts\x1b[31m", DependencyCount: 1, UsedExportsCount: 1, TotalExportsCount: 4, UsedPercent: 25},
+	}); err != nil {
+		t.Fatalf("append language breakdown: %v", err)
+	}
+
+	want := "Languages:\n" +
+		"- go: 2 deps, Used/Total: 3/6 (50.0%)\n" +
+		"- js-ts\\x1b[31m: 1 deps, Used/Total: 1/4 (25.0%)\n\n"
+	if got := buffer.String(); got != want {
+		t.Fatalf("unexpected language breakdown output:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+func TestFormatTableReturnsTemplateErrors(t *testing.T) {
+	brokenTemplate := template.Must(template.New("broken").Parse(`{{.Missing}}`))
+	tests := []struct {
+		name         string
+		templateSlot **template.Template
+		report       Report
+	}{
+		{
+			name:         "summary",
+			templateSlot: &summarySectionTemplate,
+			report: Report{
+				Summary:      &Summary{},
+				Dependencies: []DependencyReport{{Name: "dep"}},
+			},
+		},
+		{
+			name:         "thresholds in populated table",
+			templateSlot: &effectiveThresholdsSectionTemplate,
+			report: Report{
+				EffectiveThresholds: &EffectiveThresholds{},
+				Dependencies:        []DependencyReport{{Name: "dep"}},
+			},
+		},
+		{
+			name:         "thresholds in empty table",
+			templateSlot: &effectiveThresholdsSectionTemplate,
+			report:       Report{EffectiveThresholds: &EffectiveThresholds{}},
+		},
+		{
+			name:         "language breakdown",
+			templateSlot: &languageBreakdownSectionTemplate,
+			report: Report{
+				LanguageBreakdown: []LanguageSummary{{Language: "go"}},
+				Dependencies:      []DependencyReport{{Name: "dep"}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(replaceReportTemplate(tc.templateSlot, brokenTemplate))
+			if _, err := formatTable(tc.report); err == nil {
+				t.Fatal("expected template error")
+			}
+		})
+	}
+}
+
+func replaceReportTemplate(slot **template.Template, replacement *template.Template) func() {
+	original := *slot
+	*slot = replacement
+	return func() {
+		*slot = original
+	}
+}


### PR DESCRIPTION
## Summary

Refactors the table report Summary, Effective thresholds, and Language breakdown sections to render through package-local `text/template` templates while preserving the existing terminal output. Closes #900.

## Changes

- Added local templates and small view structs for the Summary, Thresholds, and Breakdown report sections.
- Propagated template execution errors through table formatting instead of panicking.
- Added exact-output tests for the templated sections and template-error coverage for the new error paths.

## Validation

Commands and checks run:

```bash
gofmt -w internal/report/format_table.go internal/report/format_table_sections.go internal/report/format_table_sections_test.go
go test ./internal/report
go test ./cmd/... ./internal/app ./internal/cli
go test ./tools/prcheck
git diff --check
make dup-check
make ci
```

Additional manual validation:

- Confirmed `origin/main..HEAD` only changes `internal/report` formatter internals and focused report tests.

## Risk and compatibility

- Breaking changes: None; report section output is covered by exact string tests.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: `make ci` memory benchmark gate passed within thresholds.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
