### PR TITLE
refactor(safeio): introduce filesystem interface

### DIFF
--- a/internal/safeio/atomic_write.go
+++ b/internal/safeio/atomic_write.go
@@ -6,13 +6,13 @@ import (
 )
 
 type atomicWriteSession struct {
-	root      *os.Root
+	root      Root
 	targetRel string
 	tempRel   string
-	tempFile  *os.File
+	tempFile  File
 }
 
-func newAtomicWriteSession(root *os.Root, targetRel string, perm os.FileMode) (*atomicWriteSession, error) {
+func newAtomicWriteSession(root Root, targetRel string, perm os.FileMode) (*atomicWriteSession, error) {
 	tempRel, tempFile, err := createAtomicTempFile(root, filepath.Dir(targetRel), perm)
 	if err != nil {
 		return nil, err
@@ -27,16 +27,16 @@ func newAtomicWriteSession(root *os.Root, targetRel string, perm os.FileMode) (*
 }
 
 func (s *atomicWriteSession) writeAndCommit(data []byte, perm os.FileMode) error {
-	if _, err := writeFileFn(s.tempFile, data); err != nil {
+	if _, err := s.tempFile.Write(data); err != nil {
 		return err
 	}
-	if err := chmodFileFn(s.tempFile, perm); err != nil {
+	if err := s.tempFile.Chmod(perm); err != nil {
 		return err
 	}
 	if err := s.closeTempFile(); err != nil {
 		return err
 	}
-	if err := renameFileFn(s.root, s.tempRel, s.targetRel); err != nil {
+	if err := s.root.Rename(s.tempRel, s.targetRel); err != nil {
 		return err
 	}
 	s.tempRel = ""
@@ -47,7 +47,7 @@ func (s *atomicWriteSession) closeTempFile() error {
 	if s.tempFile == nil {
 		return nil
 	}
-	if err := closeFileFn(s.tempFile); err != nil {
+	if err := s.tempFile.Close(); err != nil {
 		return err
 	}
 	s.tempFile = nil
@@ -55,5 +55,5 @@ func (s *atomicWriteSession) closeTempFile() error {
 }
 
 func (s *atomicWriteSession) cleanup() error {
-	return cleanupTempFileFn(s.root, s.tempRel, s.tempFile)
+	return cleanupAtomicTempFile(s.root, s.tempRel, s.tempFile)
 }

--- a/internal/safeio/filesystem.go
+++ b/internal/safeio/filesystem.go
@@ -1,0 +1,77 @@
+package safeio
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// FileSystem captures the filesystem operations safeio needs.
+type FileSystem interface {
+	Abs(path string) (string, error)
+	Rel(basepath, targpath string) (string, error)
+	OpenRoot(name string) (Root, error)
+}
+
+// Root is a filesystem root used for path-confined operations.
+type Root interface {
+	Open(name string) (File, error)
+	OpenFile(name string, flag int, perm os.FileMode) (File, error)
+	Rename(oldName, newName string) error
+	Remove(name string) error
+	Close() error
+}
+
+// File is the file handle behavior safeio needs for reads and atomic writes.
+type File interface {
+	io.Reader
+	io.Writer
+	io.Closer
+	Stat() (fs.FileInfo, error)
+	Chmod(perm os.FileMode) error
+}
+
+var fileSystem FileSystem = &osFileSystem{}
+
+type osFileSystem struct{}
+
+func (*osFileSystem) Abs(path string) (string, error) {
+	return filepath.Abs(path)
+}
+
+func (*osFileSystem) Rel(basepath, targpath string) (string, error) {
+	return filepath.Rel(basepath, targpath)
+}
+
+func (*osFileSystem) OpenRoot(name string) (Root, error) {
+	root, err := os.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	return &osRoot{root: root}, nil
+}
+
+type osRoot struct {
+	root *os.Root
+}
+
+func (r *osRoot) Open(name string) (File, error) {
+	return r.root.Open(name)
+}
+
+func (r *osRoot) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	return r.root.OpenFile(name, flag, perm)
+}
+
+func (r *osRoot) Rename(oldName, newName string) error {
+	return r.root.Rename(oldName, newName)
+}
+
+func (r *osRoot) Remove(name string) error {
+	return r.root.Remove(name)
+}
+
+func (r *osRoot) Close() error {
+	return r.root.Close()
+}

--- a/internal/safeio/path.go
+++ b/internal/safeio/path.go
@@ -36,7 +36,7 @@ func resolveRootedTarget(rootDir, targetPath string, policy rootedTargetPolicy) 
 		return rootedTarget{}, err
 	}
 
-	rel, err := relPathFn(rootAbs, targetAbs)
+	rel, err := fileSystem.Rel(rootAbs, targetAbs)
 	if err != nil {
 		return rootedTarget{}, fmt.Errorf("compute relative path: %w", err)
 	}
@@ -61,7 +61,7 @@ func resolveExactFileTarget(targetPath string) (exactFileTarget, error) {
 }
 
 func resolveAbsolutePath(kind, path string) (string, error) {
-	absPath, err := absPathFn(path)
+	absPath, err := fileSystem.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("resolve %s path: %w", kind, err)
 	}

--- a/internal/safeio/read.go
+++ b/internal/safeio/read.go
@@ -5,33 +5,14 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"os"
 	"path/filepath"
 )
 
 var ErrFileTooLarge = errors.New("file exceeds size limit")
 
-var (
-	absPathFn      = filepath.Abs
-	relPathFn      = filepath.Rel
-	openRootFn     = os.OpenRoot
-	openRootOpenFn = func(root *os.Root, name string) (*os.File, error) {
-		return root.Open(name)
-	}
-	closeFileFn = func(file *os.File) error {
-		return file.Close()
-	}
-	closeRootFn = func(root *os.Root) error {
-		return root.Close()
-	}
-	closeReadCloserFn = func(reader io.ReadCloser) error {
-		return reader.Close()
-	}
-)
-
 type rootedReadCloser struct {
-	file *os.File
-	root *os.Root
+	file File
+	root Root
 }
 
 func (r *rootedReadCloser) Read(p []byte) (int, error) {
@@ -55,22 +36,22 @@ func ReadFileUnderLimit(rootDir, targetPath string, maxBytes int64) (_ []byte, e
 		return nil, err
 	}
 
-	root, err := openRootFn(target.rootAbs)
+	root, err := fileSystem.OpenRoot(target.rootAbs)
 	if err != nil {
 		return nil, fmt.Errorf("open root: %w", err)
 	}
 	defer func() {
-		if closeErr := closeRootFn(root); closeErr != nil {
+		if closeErr := root.Close(); closeErr != nil {
 			err = errors.Join(err, closeErr)
 		}
 	}()
 
-	file, err := openRootOpenFn(root, filepath.Clean(target.rel))
+	file, err := root.Open(filepath.Clean(target.rel))
 	if err != nil {
 		return nil, translateOpenNotExist(err, targetPath)
 	}
 	defer func() {
-		if closeErr := closeFileFn(file); closeErr != nil {
+		if closeErr := file.Close(); closeErr != nil {
 			err = errors.Join(err, closeErr)
 		}
 	}()
@@ -85,22 +66,22 @@ func ReadFileLimit(targetPath string, maxBytes int64) (data []byte, err error) {
 		return nil, err
 	}
 
-	root, err := openRootFn(target.parentDir)
+	root, err := fileSystem.OpenRoot(target.parentDir)
 	if err != nil {
 		return nil, fmt.Errorf("open parent root: %w", err)
 	}
 	defer func() {
-		if closeErr := closeRootFn(root); closeErr != nil {
+		if closeErr := root.Close(); closeErr != nil {
 			err = errors.Join(err, closeErr)
 		}
 	}()
 
-	file, err := openRootOpenFn(root, target.fileName)
+	file, err := root.Open(target.fileName)
 	if err != nil {
 		return nil, translateOpenNotExist(err, targetPath)
 	}
 	defer func() {
-		if closeErr := closeFileFn(file); closeErr != nil {
+		if closeErr := file.Close(); closeErr != nil {
 			err = errors.Join(err, closeErr)
 		}
 	}()
@@ -115,7 +96,7 @@ func ReadFile(targetPath string) (data []byte, err error) {
 		return nil, err
 	}
 	defer func() {
-		if closeErr := closeReadCloserFn(file); closeErr != nil {
+		if closeErr := file.Close(); closeErr != nil {
 			err = errors.Join(err, closeErr)
 		}
 	}()
@@ -130,15 +111,15 @@ func OpenFile(targetPath string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	root, err := openRootFn(target.parentDir)
+	root, err := fileSystem.OpenRoot(target.parentDir)
 	if err != nil {
 		return nil, fmt.Errorf("open parent root: %w", err)
 	}
 
-	file, err := openRootOpenFn(root, target.fileName)
+	file, err := root.Open(target.fileName)
 	if err != nil {
 		err = translateOpenNotExist(err, targetPath)
-		if closeErr := closeRootFn(root); closeErr != nil {
+		if closeErr := root.Close(); closeErr != nil {
 			return nil, errors.Join(err, closeErr)
 		}
 		return nil, err
@@ -146,7 +127,7 @@ func OpenFile(targetPath string) (io.ReadCloser, error) {
 	return &rootedReadCloser{file: file, root: root}, nil
 }
 
-func readOpenedFile(file *os.File, maxBytes int64) ([]byte, error) {
+func readOpenedFile(file File, maxBytes int64) ([]byte, error) {
 	if maxBytes <= 0 {
 		return io.ReadAll(file)
 	}

--- a/internal/safeio/read_test.go
+++ b/internal/safeio/read_test.go
@@ -103,6 +103,24 @@ func TestReadFileLimitRejectsEmptyPath(t *testing.T) {
 	}
 }
 
+func TestReadFileLimitTargetAbsFailureViaFileSystem(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), writeTestFileName)
+	withFileSystem(t, &fakeFileSystem{abs: func(path string) (string, error) {
+		if path == targetPath {
+			return "", errors.New("target abs failure")
+		}
+		return (&osFileSystem{}).Abs(path)
+	}})
+
+	_, err := ReadFileLimit(targetPath, 1)
+	if err == nil {
+		t.Fatal("expected target path absolute resolution error")
+	}
+	if !strings.Contains(err.Error(), resolveTargetPathErr) {
+		t.Fatalf(unexpectedErrFmt, err)
+	}
+}
+
 func TestReadFileLimitRejectsMissingParentDirectory(t *testing.T) {
 	targetPath := filepath.Join(t.TempDir(), "missing", "file.txt")
 
@@ -121,6 +139,44 @@ func TestReadFileLimitRejectsMissingFile(t *testing.T) {
 	_, err := ReadFileLimit(targetPath, 1)
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected missing file error, got %v", err)
+	}
+}
+
+func TestReadFileLimitCloseRootError(t *testing.T) {
+	rootDir := t.TempDir()
+	targetPath := filepath.Join(rootDir, writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("hi"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+
+	expectedErr := errors.New("read limit root close failure")
+	withRootCloseError(t, expectedErr)
+
+	_, err := ReadFileLimit(targetPath, 0)
+	if err == nil {
+		t.Fatal("expected root close error to be returned")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf(rootCloseErrFmt, err)
+	}
+}
+
+func TestReadFileLimitCloseFileError(t *testing.T) {
+	rootDir := t.TempDir()
+	targetPath := filepath.Join(rootDir, writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("hi"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+
+	expectedErr := errors.New("read limit file close failure")
+	withOpenedFileCloseError(t, expectedErr)
+
+	_, err := ReadFileLimit(targetPath, 0)
+	if err == nil {
+		t.Fatal("expected file close error to be returned")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected file close error, got %v", err)
 	}
 }
 
@@ -384,20 +440,16 @@ func TestReadFileTargetAbsFailureWhenCWDRemoved(t *testing.T) {
 	}
 }
 
-func TestReadFileUnderRootAbsFailureViaHook(t *testing.T) {
+func TestReadFileUnderRootAbsFailureViaFileSystem(t *testing.T) {
 	rootDir := t.TempDir()
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 
-	originalAbs := absPathFn
-	absPathFn = func(path string) (string, error) {
+	withFileSystem(t, &fakeFileSystem{abs: func(path string) (string, error) {
 		if path == rootDir {
 			return "", errors.New("root abs failure")
 		}
-		return originalAbs(path)
-	}
-	t.Cleanup(func() {
-		absPathFn = originalAbs
-	})
+		return (&osFileSystem{}).Abs(path)
+	}})
 
 	_, err := ReadFileUnder(rootDir, targetPath)
 	if err == nil {
@@ -408,20 +460,16 @@ func TestReadFileUnderRootAbsFailureViaHook(t *testing.T) {
 	}
 }
 
-func TestReadFileUnderTargetAbsFailureViaHook(t *testing.T) {
+func TestReadFileUnderTargetAbsFailureViaFileSystem(t *testing.T) {
 	rootDir := t.TempDir()
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 
-	originalAbs := absPathFn
-	absPathFn = func(path string) (string, error) {
+	withFileSystem(t, &fakeFileSystem{abs: func(path string) (string, error) {
 		if path == targetPath {
 			return "", errors.New("target abs failure")
 		}
-		return originalAbs(path)
-	}
-	t.Cleanup(func() {
-		absPathFn = originalAbs
-	})
+		return (&osFileSystem{}).Abs(path)
+	}})
 
 	_, err := ReadFileUnder(rootDir, targetPath)
 	if err == nil {
@@ -432,20 +480,16 @@ func TestReadFileUnderTargetAbsFailureViaHook(t *testing.T) {
 	}
 }
 
-func TestReadFileUnderRelFailureViaHook(t *testing.T) {
+func TestReadFileUnderRelFailureViaFileSystem(t *testing.T) {
 	rootDir := t.TempDir()
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 	if err := os.WriteFile(targetPath, []byte("hi"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
 	}
 
-	originalRel := relPathFn
-	relPathFn = func(_, _ string) (string, error) {
+	withFileSystem(t, &fakeFileSystem{rel: func(_, _ string) (string, error) {
 		return "", errors.New("rel failure")
-	}
-	t.Cleanup(func() {
-		relPathFn = originalRel
-	})
+	}})
 
 	_, err := ReadFileUnder(rootDir, targetPath)
 	if err == nil {
@@ -456,6 +500,53 @@ func TestReadFileUnderRelFailureViaHook(t *testing.T) {
 	}
 }
 
+func withRootCloseError(t *testing.T, expectedErr error) {
+	t.Helper()
+	withFileSystem(t, &fakeFileSystem{openRoot: func(name string) (Root, error) {
+		root, err := (&osFileSystem{}).OpenRoot(name)
+		if err != nil {
+			return nil, err
+		}
+		return &fakeRoot{
+			Root: root,
+			close: func() error {
+				if err := root.Close(); err != nil {
+					return err
+				}
+				return expectedErr
+			},
+		}, nil
+	}})
+}
+
+func withOpenedFileCloseError(t *testing.T, expectedErr error) {
+	t.Helper()
+	withFileSystem(t, &fakeFileSystem{openRoot: func(name string) (Root, error) {
+		root, err := (&osFileSystem{}).OpenRoot(name)
+		if err != nil {
+			return nil, err
+		}
+		return &fakeRoot{
+			Root: root,
+			open: func(name string) (File, error) {
+				file, err := root.Open(name)
+				if err != nil {
+					return nil, err
+				}
+				return &fakeFile{
+					File: file,
+					close: func() error {
+						if err := file.Close(); err != nil {
+							return err
+						}
+						return expectedErr
+					},
+				}, nil
+			},
+		}, nil
+	}})
+}
+
 func TestReadFileUnderCloseRootError(t *testing.T) {
 	rootDir := t.TempDir()
 	targetPath := filepath.Join(rootDir, writeTestFileName)
@@ -464,17 +555,7 @@ func TestReadFileUnderCloseRootError(t *testing.T) {
 	}
 
 	expectedErr := errors.New("root close failure")
-	originalCloseRoot := closeRootFn
-	closeRootFn = func(root *os.Root) error {
-		err := originalCloseRoot(root)
-		if err != nil {
-			return err
-		}
-		return expectedErr
-	}
-	t.Cleanup(func() {
-		closeRootFn = originalCloseRoot
-	})
+	withRootCloseError(t, expectedErr)
 
 	_, err := ReadFileUnder(rootDir, targetPath)
 	if err == nil {
@@ -493,17 +574,7 @@ func TestReadFileUnderCloseFileError(t *testing.T) {
 	}
 
 	expectedErr := errors.New("file close failure")
-	originalCloseFile := closeFileFn
-	closeFileFn = func(file *os.File) error {
-		err := originalCloseFile(file)
-		if err != nil {
-			return err
-		}
-		return expectedErr
-	}
-	t.Cleanup(func() {
-		closeFileFn = originalCloseFile
-	})
+	withOpenedFileCloseError(t, expectedErr)
 
 	_, err := ReadFileUnder(rootDir, targetPath)
 	if err == nil {
@@ -522,17 +593,7 @@ func TestReadFileCloseError(t *testing.T) {
 	}
 
 	expectedErr := errors.New("read closer close failure")
-	originalCloseReadCloser := closeReadCloserFn
-	closeReadCloserFn = func(reader io.ReadCloser) error {
-		err := originalCloseReadCloser(reader)
-		if err != nil {
-			return err
-		}
-		return expectedErr
-	}
-	t.Cleanup(func() {
-		closeReadCloserFn = originalCloseReadCloser
-	})
+	withOpenedFileCloseError(t, expectedErr)
 
 	_, err := ReadFile(targetPath)
 	if err == nil {
@@ -543,19 +604,15 @@ func TestReadFileCloseError(t *testing.T) {
 	}
 }
 
-func TestOpenFileTargetAbsFailureViaHook(t *testing.T) {
+func TestOpenFileTargetAbsFailureViaFileSystem(t *testing.T) {
 	targetPath := filepath.Join(t.TempDir(), writeTestFileName)
 
-	originalAbs := absPathFn
-	absPathFn = func(path string) (string, error) {
+	withFileSystem(t, &fakeFileSystem{abs: func(path string) (string, error) {
 		if path == targetPath {
 			return "", errors.New("openfile target abs failure")
 		}
-		return originalAbs(path)
-	}
-	t.Cleanup(func() {
-		absPathFn = originalAbs
-	})
+		return (&osFileSystem{}).Abs(path)
+	}})
 
 	_, err := OpenFile(targetPath)
 	if err == nil {
@@ -569,26 +626,25 @@ func TestOpenFileTargetAbsFailureViaHook(t *testing.T) {
 func TestOpenFileMissingFileCloseRootError(t *testing.T) {
 	targetPath := filepath.Join(t.TempDir(), missingFileName)
 
-	originalRootOpen := openRootOpenFn
-	openRootOpenFn = func(_ *os.Root, _ string) (*os.File, error) {
-		return nil, os.ErrNotExist
-	}
-	t.Cleanup(func() {
-		openRootOpenFn = originalRootOpen
-	})
-
 	expectedErr := errors.New("open parent root close failure")
-	originalCloseRoot := closeRootFn
-	closeRootFn = func(root *os.Root) error {
-		err := originalCloseRoot(root)
+	withFileSystem(t, &fakeFileSystem{openRoot: func(name string) (Root, error) {
+		root, err := (&osFileSystem{}).OpenRoot(name)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return expectedErr
-	}
-	t.Cleanup(func() {
-		closeRootFn = originalCloseRoot
-	})
+		return &fakeRoot{
+			Root: root,
+			open: func(string) (File, error) {
+				return nil, os.ErrNotExist
+			},
+			close: func() error {
+				if err := root.Close(); err != nil {
+					return err
+				}
+				return expectedErr
+			},
+		}, nil
+	}})
 
 	_, err := OpenFile(targetPath)
 	if err == nil {
@@ -609,27 +665,26 @@ func TestOpenFileOpenErrorCloseRootError(t *testing.T) {
 		t.Fatalf(writeFileErrFmt, err)
 	}
 
-	originalRootOpen := openRootOpenFn
 	openErr := errors.New("open child failure")
-	openRootOpenFn = func(_ *os.Root, _ string) (*os.File, error) {
-		return nil, openErr
-	}
-	t.Cleanup(func() {
-		openRootOpenFn = originalRootOpen
-	})
-
 	expectedErr := errors.New("open root close failure")
-	originalCloseRoot := closeRootFn
-	closeRootFn = func(root *os.Root) error {
-		err := originalCloseRoot(root)
+	withFileSystem(t, &fakeFileSystem{openRoot: func(name string) (Root, error) {
+		root, err := (&osFileSystem{}).OpenRoot(name)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return expectedErr
-	}
-	t.Cleanup(func() {
-		closeRootFn = originalCloseRoot
-	})
+		return &fakeRoot{
+			Root: root,
+			open: func(string) (File, error) {
+				return nil, openErr
+			},
+			close: func() error {
+				if err := root.Close(); err != nil {
+					return err
+				}
+				return expectedErr
+			},
+		}, nil
+	}})
 
 	_, err := OpenFile(targetPath)
 	if err == nil {

--- a/internal/safeio/test_helpers_test.go
+++ b/internal/safeio/test_helpers_test.go
@@ -1,6 +1,8 @@
 package safeio
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,4 +55,150 @@ func withRemovedWorkingDir(t *testing.T, deadDirName string) {
 	if err := os.RemoveAll(deadDir); err != nil {
 		t.Fatalf(removeDeadDirFmt, err)
 	}
+}
+
+func withFileSystem(t *testing.T, fsys FileSystem) {
+	t.Helper()
+	originalFileSystem := fileSystem
+	fileSystem = fsys
+	t.Cleanup(func() {
+		fileSystem = originalFileSystem
+	})
+}
+
+func openTestRoot(t *testing.T, rootDir string) Root {
+	t.Helper()
+	root, err := (&osFileSystem{}).OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf(openRootErrFmt, err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Fatalf(closeRootErrFmt, closeErr)
+		}
+	})
+	return root
+}
+
+type fakeFileSystem struct {
+	base     FileSystem
+	abs      func(path string) (string, error)
+	rel      func(basepath, targpath string) (string, error)
+	openRoot func(name string) (Root, error)
+}
+
+func (f *fakeFileSystem) fallback() FileSystem {
+	if f.base != nil {
+		return f.base
+	}
+	return &osFileSystem{}
+}
+
+func (f *fakeFileSystem) Abs(path string) (string, error) {
+	if f.abs != nil {
+		return f.abs(path)
+	}
+	return f.fallback().Abs(path)
+}
+
+func (f *fakeFileSystem) Rel(basepath, targpath string) (string, error) {
+	if f.rel != nil {
+		return f.rel(basepath, targpath)
+	}
+	return f.fallback().Rel(basepath, targpath)
+}
+
+func (f *fakeFileSystem) OpenRoot(name string) (Root, error) {
+	if f.openRoot != nil {
+		return f.openRoot(name)
+	}
+	return f.fallback().OpenRoot(name)
+}
+
+type fakeRoot struct {
+	Root
+	open     func(name string) (File, error)
+	openFile func(name string, flag int, perm os.FileMode) (File, error)
+	rename   func(oldName, newName string) error
+	remove   func(name string) error
+	close    func() error
+}
+
+func (r *fakeRoot) Open(name string) (File, error) {
+	if r.open != nil {
+		return r.open(name)
+	}
+	return r.Root.Open(name)
+}
+
+func (r *fakeRoot) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	if r.openFile != nil {
+		return r.openFile(name, flag, perm)
+	}
+	return r.Root.OpenFile(name, flag, perm)
+}
+
+func (r *fakeRoot) Rename(oldName, newName string) error {
+	if r.rename != nil {
+		return r.rename(oldName, newName)
+	}
+	return r.Root.Rename(oldName, newName)
+}
+
+func (r *fakeRoot) Remove(name string) error {
+	if r.remove != nil {
+		return r.remove(name)
+	}
+	return r.Root.Remove(name)
+}
+
+func (r *fakeRoot) Close() error {
+	if r.close != nil {
+		return r.close()
+	}
+	return r.Root.Close()
+}
+
+type fakeFile struct {
+	File
+	read  func(p []byte) (int, error)
+	write func(p []byte) (int, error)
+	close func() error
+	stat  func() (fs.FileInfo, error)
+	chmod func(perm os.FileMode) error
+}
+
+func (f *fakeFile) Read(p []byte) (int, error) {
+	if f.read != nil {
+		return f.read(p)
+	}
+	return f.File.Read(p)
+}
+
+func (f *fakeFile) Write(p []byte) (int, error) {
+	if f.write != nil {
+		return f.write(p)
+	}
+	return f.File.Write(p)
+}
+
+func (f *fakeFile) Close() error {
+	if f.close != nil {
+		return f.close()
+	}
+	return f.File.Close()
+}
+
+func (f *fakeFile) Stat() (fs.FileInfo, error) {
+	if f.stat != nil {
+		return f.stat()
+	}
+	return f.File.Stat()
+}
+
+func (f *fakeFile) Chmod(perm os.FileMode) error {
+	if f.chmod != nil {
+		return f.chmod(perm)
+	}
+	return f.File.Chmod(perm)
 }

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -11,21 +11,8 @@ import (
 const atomicTempPrefix = ".safeio-atomic-"
 
 var (
-	randomTempNameFn  = randomTempName
-	randReadFn        = rand.Read
-	cleanupTempFileFn = cleanupAtomicTempFile
-	chmodFileFn       = func(file *os.File, perm os.FileMode) error {
-		return file.Chmod(perm)
-	}
-	openFileFn = func(root *os.Root, rel string, perm os.FileMode) (*os.File, error) {
-		return root.OpenFile(rel, os.O_RDWR|os.O_CREATE|os.O_EXCL, perm)
-	}
-	renameFileFn = func(root *os.Root, oldName, newName string) error {
-		return root.Rename(oldName, newName)
-	}
-	writeFileFn = func(file *os.File, data []byte) (int, error) {
-		return file.Write(data)
-	}
+	randomTempNameFn = randomTempName
+	randReadFn       = rand.Read
 )
 
 // WriteFileUnder atomically writes targetPath only if it resolves under rootDir.
@@ -35,12 +22,12 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 		return err
 	}
 
-	root, err := openRootFn(target.rootAbs)
+	root, err := fileSystem.OpenRoot(target.rootAbs)
 	if err != nil {
 		return fmt.Errorf("open root: %w", err)
 	}
 	defer func() {
-		if closeErr := closeRootFn(root); closeErr != nil {
+		if closeErr := root.Close(); closeErr != nil {
 			returnErr = errors.Join(returnErr, closeErr)
 		}
 	}()
@@ -50,7 +37,8 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 		return err
 	}
 	defer func() {
-		if cleanupErr := session.cleanup(); cleanupErr != nil && returnErr == nil {
+		cleanupErr := session.cleanup()
+		if returnErr == nil {
 			returnErr = cleanupErr
 		}
 	}()
@@ -58,7 +46,7 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 	return session.writeAndCommit(data, perm)
 }
 
-func cleanupAtomicTempFile(root *os.Root, tempRel string, tempFile *os.File) error {
+func cleanupAtomicTempFile(root Root, tempRel string, tempFile File) error {
 	var cleanupErr error
 	if tempFile != nil {
 		if err := tempFile.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
@@ -76,7 +64,7 @@ func cleanupAtomicTempFile(root *os.Root, tempRel string, tempFile *os.File) err
 	return cleanupErr
 }
 
-func createAtomicTempFile(root *os.Root, dir string, perm os.FileMode) (string, *os.File, error) {
+func createAtomicTempFile(root Root, dir string, perm os.FileMode) (string, File, error) {
 	tempDir := filepath.Clean(dir)
 	if tempDir == "." {
 		tempDir = ""
@@ -88,7 +76,7 @@ func createAtomicTempFile(root *os.Root, dir string, perm os.FileMode) (string, 
 			return "", nil, err
 		}
 		tempRel := filepath.Join(tempDir, name)
-		file, err := openFileFn(root, tempRel, perm)
+		file, err := root.OpenFile(tempRel, os.O_RDWR|os.O_CREATE|os.O_EXCL, perm)
 		if errors.Is(err, os.ErrExist) {
 			continue
 		}

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -159,15 +159,7 @@ func TestWriteFileUnderRejectsExistingDirectoryTarget(t *testing.T) {
 
 func TestCreateAtomicTempFileInRootDir(t *testing.T) {
 	rootDir := t.TempDir()
-	root, err := os.OpenRoot(rootDir)
-	if err != nil {
-		t.Fatalf(openRootErrFmt, err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil {
-			t.Fatalf(closeRootErrFmt, closeErr)
-		}
-	})
+	root := openTestRoot(t, rootDir)
 
 	tempRel, tempFile, err := createAtomicTempFile(root, ".", 0o600)
 	if err != nil {
@@ -186,15 +178,7 @@ func TestCreateAtomicTempFileInRootDir(t *testing.T) {
 
 func TestCreateAtomicTempFileReturnsErrorForMissingDir(t *testing.T) {
 	rootDir := t.TempDir()
-	root, err := os.OpenRoot(rootDir)
-	if err != nil {
-		t.Fatalf(openRootErrFmt, err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil {
-			t.Fatalf(closeRootErrFmt, closeErr)
-		}
-	})
+	root := openTestRoot(t, rootDir)
 
 	_, tempFile, err := createAtomicTempFile(root, "missing", 0o600)
 	if tempFile != nil {
@@ -209,15 +193,7 @@ func TestCreateAtomicTempFileReturnsErrorForMissingDir(t *testing.T) {
 
 func TestCreateAtomicTempFilePropagatesRandomNameError(t *testing.T) {
 	rootDir := t.TempDir()
-	root, err := os.OpenRoot(rootDir)
-	if err != nil {
-		t.Fatalf(openRootErrFmt, err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil {
-			t.Fatalf(closeRootErrFmt, closeErr)
-		}
-	})
+	root := openTestRoot(t, rootDir)
 
 	originalRandomTempNameFn := randomTempNameFn
 	randomTempNameFn = func() (string, error) { return "", errors.New("boom") }
@@ -225,7 +201,7 @@ func TestCreateAtomicTempFilePropagatesRandomNameError(t *testing.T) {
 		randomTempNameFn = originalRandomTempNameFn
 	}()
 
-	_, _, err = createAtomicTempFile(root, ".", 0o600)
+	_, _, err := createAtomicTempFile(root, ".", 0o600)
 	if err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("expected random temp name error, got %v", err)
 	}
@@ -233,18 +209,19 @@ func TestCreateAtomicTempFilePropagatesRandomNameError(t *testing.T) {
 
 func TestCreateAtomicTempFileFailsAfterRepeatedCollisions(t *testing.T) {
 	rootDir := t.TempDir()
-	root, err := os.OpenRoot(rootDir)
+
+	seedFile, err := os.OpenFile(filepath.Join(rootDir, "fixed"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
-		t.Fatalf(openRootErrFmt, err)
+		t.Fatalf("create colliding temp file: %v", err)
 	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil {
-			t.Fatalf(closeRootErrFmt, closeErr)
-		}
-	})
-	if err := root.WriteFile("fixed", []byte("x"), 0o600); err != nil {
+	if _, err := seedFile.Write([]byte("x")); err != nil {
 		t.Fatalf("seed colliding temp file: %v", err)
 	}
+	if err := seedFile.Close(); err != nil {
+		t.Fatalf("close colliding temp file: %v", err)
+	}
+
+	root := openTestRoot(t, rootDir)
 
 	originalRandomTempNameFn := randomTempNameFn
 	randomTempNameFn = func() (string, error) { return "fixed", nil }
@@ -260,15 +237,7 @@ func TestCreateAtomicTempFileFailsAfterRepeatedCollisions(t *testing.T) {
 
 func TestCleanupAtomicTempFileIgnoresClosedFileAndMissingTempPath(t *testing.T) {
 	rootDir := t.TempDir()
-	root, err := os.OpenRoot(rootDir)
-	if err != nil {
-		t.Fatalf(openRootErrFmt, err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil {
-			t.Fatalf(closeRootErrFmt, closeErr)
-		}
-	})
+	root := openTestRoot(t, rootDir)
 
 	tempFile, err := root.OpenFile("temp", os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
@@ -288,10 +257,7 @@ func TestCleanupAtomicTempFileIgnoresClosedFileAndMissingTempPath(t *testing.T) 
 
 func TestCleanupAtomicTempFileReturnsRootRemoveError(t *testing.T) {
 	rootDir := t.TempDir()
-	root, err := os.OpenRoot(rootDir)
-	if err != nil {
-		t.Fatalf(openRootErrFmt, err)
-	}
+	root := openTestRoot(t, rootDir)
 
 	tempFile, err := root.OpenFile("temp", os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
@@ -309,15 +275,12 @@ func TestCleanupAtomicTempFileReturnsRootRemoveError(t *testing.T) {
 
 func TestCleanupAtomicTempFileJoinsCloseAndRemoveErrors(t *testing.T) {
 	rootDir := t.TempDir()
-	root, err := os.OpenRoot(rootDir)
-	if err != nil {
-		t.Fatalf(openRootErrFmt, err)
-	}
+	root := openTestRoot(t, rootDir)
 	if err := root.Close(); err != nil {
 		t.Fatalf("close root: %v", err)
 	}
 
-	err = cleanupAtomicTempFile(root, "temp", &os.File{})
+	err := cleanupAtomicTempFile(root, "temp", &os.File{})
 	if err == nil {
 		t.Fatal("expected cleanupAtomicTempFile to join close and remove errors")
 	}
@@ -364,22 +327,32 @@ func TestRandomTempNamePropagatesReadError(t *testing.T) {
 	}
 }
 
+func withAtomicWriteFileSystem(t *testing.T, tempFile File, remove func(string) error) {
+	t.Helper()
+	if remove == nil {
+		remove = func(string) error {
+			return nil
+		}
+	}
+	withFileSystem(t, &fakeFileSystem{openRoot: func(string) (Root, error) {
+		return &fakeRoot{
+			openFile: func(string, int, os.FileMode) (File, error) {
+				return tempFile, nil
+			},
+			remove: remove,
+			close: func() error {
+				return nil
+			},
+		}, nil
+	}})
+}
+
 func TestWriteFileUnderCloseRootError(t *testing.T) {
 	rootDir := t.TempDir()
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 
 	expectedErr := errors.New("close root failure")
-	originalCloseRoot := closeRootFn
-	closeRootFn = func(root *os.Root) error {
-		err := originalCloseRoot(root)
-		if err != nil {
-			return err
-		}
-		return expectedErr
-	}
-	t.Cleanup(func() {
-		closeRootFn = originalCloseRoot
-	})
+	withRootCloseError(t, expectedErr)
 
 	err := WriteFileUnder(rootDir, targetPath, []byte("hello"), 0o600)
 	if err == nil {
@@ -390,28 +363,33 @@ func TestWriteFileUnderCloseRootError(t *testing.T) {
 	}
 }
 
-func TestWriteFileUnderCleanupError(t *testing.T) {
+func TestWriteFileUnderKeepsPrimaryErrorWhenCleanupFails(t *testing.T) {
 	rootDir := t.TempDir()
 	targetPath := filepath.Join(rootDir, writeTestFileName)
-	if err := os.MkdirAll(rootDir, 0o755); err != nil {
-		t.Fatalf(openRootErrFmt, err)
-	}
-
+	writeErr := errors.New("write failure")
 	cleanupErr := errors.New("cleanup failure")
-	originalCleanup := cleanupTempFileFn
-	cleanupTempFileFn = func(*os.Root, string, *os.File) error {
+	tempFile := &fakeFile{
+		write: func([]byte) (int, error) {
+			return 0, writeErr
+		},
+		close: func() error {
+			return nil
+		},
+	}
+	remove := func(string) error {
 		return cleanupErr
 	}
-	t.Cleanup(func() {
-		cleanupTempFileFn = originalCleanup
-	})
+	withAtomicWriteFileSystem(t, tempFile, remove)
 
 	err := WriteFileUnder(rootDir, targetPath, []byte("hello"), 0o600)
 	if err == nil {
-		t.Fatal("expected cleanup error")
+		t.Fatal("expected write error")
 	}
-	if !errors.Is(err, cleanupErr) {
-		t.Fatalf("expected cleanup error, got %v", err)
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("expected write error, got %v", err)
+	}
+	if errors.Is(err, cleanupErr) {
+		t.Fatalf("expected cleanup error to stay secondary, got %v", err)
 	}
 }
 
@@ -420,13 +398,15 @@ func TestWriteFileUnderWriteError(t *testing.T) {
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 
 	writeErr := errors.New("write failure")
-	originalWriteFn := writeFileFn
-	writeFileFn = func(*os.File, []byte) (int, error) {
-		return 0, writeErr
+	tempFile := &fakeFile{
+		write: func([]byte) (int, error) {
+			return 0, writeErr
+		},
+		close: func() error {
+			return nil
+		},
 	}
-	t.Cleanup(func() {
-		writeFileFn = originalWriteFn
-	})
+	withAtomicWriteFileSystem(t, tempFile, nil)
 
 	err := WriteFileUnder(rootDir, targetPath, []byte("hello"), 0o600)
 	if err == nil {
@@ -437,51 +417,71 @@ func TestWriteFileUnderWriteError(t *testing.T) {
 	}
 }
 
-func TestWriteFileUnderChmodError(t *testing.T) {
-	rootDir := t.TempDir()
-	targetPath := filepath.Join(rootDir, writeTestFileName)
+func TestWriteFileUnderTempFileOperationErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*fakeFile, error)
+		assertion string
+		expected  error
+	}{
+		{
+			name:      "chmod",
+			assertion: "expected chmod error",
+			expected:  errors.New("chmod failure"),
+			configure: configureTempChmodError,
+		},
+		{
+			name:      "close",
+			assertion: "expected temp close error",
+			expected:  errors.New("temp close failure"),
+			configure: configureTempCloseError,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rootDir := t.TempDir()
+			targetPath := filepath.Join(rootDir, writeTestFileName)
+			tempFile := &fakeFile{
+				write: func(data []byte) (int, error) {
+					return len(data), nil
+				},
+			}
+			tc.configure(tempFile, tc.expected)
+			withAtomicWriteFileSystem(t, tempFile, nil)
 
-	chmodErr := errors.New("chmod failure")
-	originalChmodFn := chmodFileFn
-	chmodFileFn = func(*os.File, os.FileMode) error {
-		return chmodErr
-	}
-	t.Cleanup(func() {
-		chmodFileFn = originalChmodFn
-	})
-
-	err := WriteFileUnder(rootDir, targetPath, []byte("hello"), 0o600)
-	if err == nil {
-		t.Fatal("expected chmod error")
-	}
-	if !errors.Is(err, chmodErr) {
-		t.Fatalf("expected chmod error, got %v", err)
-	}
-}
-
-func TestWriteFileUnderTempCloseError(t *testing.T) {
-	rootDir := t.TempDir()
-	targetPath := filepath.Join(rootDir, writeTestFileName)
-
-	closeErr := errors.New("temp close failure")
-	originalCloseFn := closeFileFn
-	closeFileFn = func(*os.File) error {
-		return closeErr
-	}
-	t.Cleanup(func() {
-		closeFileFn = originalCloseFn
-	})
-
-	err := WriteFileUnder(rootDir, targetPath, []byte("hello"), 0o600)
-	if err == nil {
-		t.Fatal("expected temp close error")
-	}
-	if !errors.Is(err, closeErr) {
-		t.Fatalf("expected temp close error, got %v", err)
+			err := WriteFileUnder(rootDir, targetPath, []byte("hello"), 0o600)
+			if err == nil {
+				t.Fatal(tc.assertion)
+			}
+			if !errors.Is(err, tc.expected) {
+				t.Fatalf("%s, got %v", tc.assertion, err)
+			}
+		})
 	}
 }
 
-func TestResolveWriteTargetAbsFailuresViaHook(t *testing.T) {
+func configureTempChmodError(file *fakeFile, err error) {
+	file.chmod = func(os.FileMode) error {
+		return err
+	}
+	file.close = closeWithoutError
+}
+
+func configureTempCloseError(file *fakeFile, err error) {
+	file.chmod = chmodWithoutError
+	file.close = func() error {
+		return err
+	}
+}
+
+func chmodWithoutError(os.FileMode) error {
+	return nil
+}
+
+func closeWithoutError() error {
+	return nil
+}
+
+func TestResolveWriteTargetAbsFailuresViaFileSystem(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		hookPath func(rootDir, targetPath string) string
@@ -509,16 +509,12 @@ func TestResolveWriteTargetAbsFailuresViaHook(t *testing.T) {
 			rootDir := t.TempDir()
 			targetPath := filepath.Join(rootDir, writeTestFileName)
 
-			originalAbs := absPathFn
-			absPathFn = func(path string) (string, error) {
+			withFileSystem(t, &fakeFileSystem{abs: func(path string) (string, error) {
 				if path == tc.hookPath(rootDir, targetPath) {
 					return "", tc.hookErr
 				}
-				return originalAbs(path)
-			}
-			t.Cleanup(func() {
-				absPathFn = originalAbs
-			})
+				return (&osFileSystem{}).Abs(path)
+			}})
 
 			err := WriteFileUnder(rootDir, targetPath, []byte("hello"), 0o600)
 			if err == nil {
@@ -531,17 +527,13 @@ func TestResolveWriteTargetAbsFailuresViaHook(t *testing.T) {
 	}
 }
 
-func TestResolveWriteTargetRelFailureViaHook(t *testing.T) {
+func TestResolveWriteTargetRelFailureViaFileSystem(t *testing.T) {
 	rootDir := t.TempDir()
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 
-	originalRel := relPathFn
-	relPathFn = func(_, _ string) (string, error) {
+	withFileSystem(t, &fakeFileSystem{rel: func(_, _ string) (string, error) {
 		return "", errors.New("rel failure")
-	}
-	t.Cleanup(func() {
-		relPathFn = originalRel
-	})
+	}})
 
 	err := WriteFileUnder(rootDir, targetPath, []byte("hello"), 0o600)
 	if err == nil {


### PR DESCRIPTION
## Summary

Introduce a safeio `FileSystem` abstraction so read/write operations can be tested with fake roots and files while preserving current path-confinement behavior. Closes #899.

## Changes

- Added `FileSystem`, `Root`, and `File` interfaces with an OS-backed implementation around `filepath` and `os.Root`.
- Routed safeio path resolution, read, open, and atomic write operations through the interface.
- Replaced per-operation test hooks with focused fake filesystem/root/file helpers and added coverage for read-limit close/path error branches.

## Validation

Commands and checks run:

```bash
gofmt -w internal/safeio/filesystem.go internal/safeio/read.go internal/safeio/path.go internal/safeio/write.go internal/safeio/atomic_write.go internal/safeio/test_helpers_test.go internal/safeio/read_test.go internal/safeio/write_test.go
go test ./internal/safeio
go test ./internal/safeio -coverprofile=/tmp/safeio.cover
go test ./...
git diff --check
go test ./tools/prcheck
make lint
make ci
```

Additional manual validation:

- Rebased on current `origin/main` before final validation and commit.
- Pre-commit hook reran `make fmt` and `make ci` successfully.

## Risk and compatibility

- Breaking changes: None; existing safeio helper signatures are unchanged.
- Migration required: None.
- Performance impact: None expected; filesystem calls delegate to the same OS operations.
- Memory benchmark impact: None; memory benchmark gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
