### PR TITLE
refactor(analysis): derive report metrics before formatting

### DIFF
--- a/internal/analysis/derived_metrics.go
+++ b/internal/analysis/derived_metrics.go
@@ -1,0 +1,31 @@
+package analysis
+
+import "github.com/ben-ranford/lopper/internal/report"
+
+func annotateDerivedDependencyMetrics(dependencies []report.DependencyReport) {
+	for index := range dependencies {
+		annotateDependencyUsedPercent(&dependencies[index])
+		annotateRuntimeCorrelation(dependencies[index].RuntimeUsage)
+	}
+}
+
+func annotateDependencyUsedPercent(dep *report.DependencyReport) {
+	if dep == nil || dep.UsedPercent > 0 || dep.TotalExportsCount <= 0 {
+		return
+	}
+	dep.UsedPercent = (float64(dep.UsedExportsCount) / float64(dep.TotalExportsCount)) * 100
+}
+
+func annotateRuntimeCorrelation(usage *report.RuntimeUsage) {
+	if usage == nil || usage.Correlation != "" {
+		return
+	}
+	switch {
+	case usage.RuntimeOnly:
+		usage.Correlation = report.RuntimeCorrelationRuntimeOnly
+	case usage.LoadCount > 0:
+		usage.Correlation = report.RuntimeCorrelationOverlap
+	default:
+		usage.Correlation = report.RuntimeCorrelationStaticOnly
+	}
+}

--- a/internal/analysis/derived_metrics_test.go
+++ b/internal/analysis/derived_metrics_test.go
@@ -1,0 +1,54 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestAnnotateDerivedDependencyMetrics(t *testing.T) {
+	dependencies := []report.DependencyReport{
+		{
+			Name:              "derived-percent-overlap",
+			UsedExportsCount:  1,
+			TotalExportsCount: 4,
+			RuntimeUsage:      &report.RuntimeUsage{LoadCount: 2},
+		},
+		{
+			Name:         "runtime-only",
+			RuntimeUsage: &report.RuntimeUsage{RuntimeOnly: true},
+		},
+		{
+			Name:         "static-only",
+			RuntimeUsage: &report.RuntimeUsage{},
+		},
+		{
+			Name:              "preserve-explicit-values",
+			UsedExportsCount:  1,
+			TotalExportsCount: 4,
+			UsedPercent:       80,
+			RuntimeUsage: &report.RuntimeUsage{
+				LoadCount:   3,
+				Correlation: report.RuntimeCorrelationRuntimeOnly,
+			},
+		},
+	}
+
+	annotateDerivedDependencyMetrics(dependencies)
+
+	if dependencies[0].UsedPercent != 25 {
+		t.Fatalf("expected used percent to be derived from counts, got %.1f", dependencies[0].UsedPercent)
+	}
+	if dependencies[0].RuntimeUsage.Correlation != report.RuntimeCorrelationOverlap {
+		t.Fatalf("expected load count to derive overlap correlation, got %q", dependencies[0].RuntimeUsage.Correlation)
+	}
+	if dependencies[1].RuntimeUsage.Correlation != report.RuntimeCorrelationRuntimeOnly {
+		t.Fatalf("expected runtime-only correlation, got %q", dependencies[1].RuntimeUsage.Correlation)
+	}
+	if dependencies[2].RuntimeUsage.Correlation != report.RuntimeCorrelationStaticOnly {
+		t.Fatalf("expected static-only correlation, got %q", dependencies[2].RuntimeUsage.Correlation)
+	}
+	if dependencies[3].UsedPercent != 80 || dependencies[3].RuntimeUsage.Correlation != report.RuntimeCorrelationRuntimeOnly {
+		t.Fatalf("expected explicit values to be preserved, got %#v", dependencies[3])
+	}
+}

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -123,6 +123,7 @@ func finalizeReport(req Request, repoPath string, analyzedRoots []string, report
 	}
 
 	lowConfidenceThreshold := float64(resolveLowConfidenceWarningThreshold(req.LowConfidenceWarningPercent))
+	annotateDerivedDependencyMetrics(reportData.Dependencies)
 	report.AnnotateReachabilityConfidence(&reportData)
 	report.AnnotateFindingConfidence(reportData.Dependencies)
 	report.FilterFindingsByConfidence(reportData.Dependencies, lowConfidenceThreshold)

--- a/internal/report/format_csv.go
+++ b/internal/report/format_csv.go
@@ -94,10 +94,9 @@ func formatDependencyCSVRow(reportData Report, dep DependencyReport) []string {
 		scopePackages = joinSortedStrings(reportData.Scope.Packages)
 	}
 
-	usedPercent := effectiveUsedPercent(dep)
 	wastePercent := 0.0
 	if dep.TotalExportsCount > 0 {
-		wastePercent = 100 - usedPercent
+		wastePercent = 100 - dep.UsedPercent
 	}
 	license := normalizedDependencyLicenseCSV(dep.License)
 
@@ -111,7 +110,7 @@ func formatDependencyCSVRow(reportData Report, dep DependencyReport) []string {
 		dep.Name,
 		strconv.Itoa(dep.UsedExportsCount),
 		strconv.Itoa(dep.TotalExportsCount),
-		formatCSVFloat(usedPercent),
+		formatCSVFloat(dep.UsedPercent),
 		formatCSVFloat(wastePercent),
 		strconv.FormatInt(dep.EstimatedUnusedBytes, 10),
 		formatCSVTopUsedSymbols(dep.TopUsedSymbols),
@@ -145,13 +144,6 @@ func formatDependencyCSVRow(reportData Report, dep DependencyReport) []string {
 		formatCSVProvenanceConfidence(dep.Provenance),
 		formatCSVProvenanceSignals(dep.Provenance),
 	}
-}
-
-func effectiveUsedPercent(dep DependencyReport) float64 {
-	if dep.UsedPercent > 0 || dep.TotalExportsCount == 0 {
-		return dep.UsedPercent
-	}
-	return (float64(dep.UsedExportsCount) / float64(dep.TotalExportsCount)) * 100
 }
 
 func normalizedDependencyLicenseCSV(license *DependencyLicense) DependencyLicense {
@@ -342,23 +334,6 @@ func formatCSVRecommendations(recommendations []Recommendation) string {
 	return formatCSVCodeValues(recommendations, recommendationCode, recommendationPriority)
 }
 
-func runtimeCorrelationValue(usage *RuntimeUsage) string {
-	if usage == nil {
-		return ""
-	}
-	if usage.Correlation != "" {
-		return string(usage.Correlation)
-	}
-	switch {
-	case usage.RuntimeOnly:
-		return string(RuntimeCorrelationRuntimeOnly)
-	case usage.LoadCount > 0:
-		return string(RuntimeCorrelationOverlap)
-	default:
-		return string(RuntimeCorrelationStaticOnly)
-	}
-}
-
 func formatCSVRuntimeLoadCount(usage *RuntimeUsage) string {
 	if usage == nil {
 		return ""
@@ -367,7 +342,10 @@ func formatCSVRuntimeLoadCount(usage *RuntimeUsage) string {
 }
 
 func formatCSVRuntimeCorrelation(usage *RuntimeUsage) string {
-	return runtimeCorrelationValue(usage)
+	if usage == nil {
+		return ""
+	}
+	return string(usage.Correlation)
 }
 
 func formatCSVRuntimeOnly(usage *RuntimeUsage) string {

--- a/internal/report/format_csv_test.go
+++ b/internal/report/format_csv_test.go
@@ -32,6 +32,7 @@ func TestFormatCSV(t *testing.T) {
 				Name:                 "alpha",
 				UsedExportsCount:     2,
 				TotalExportsCount:    4,
+				UsedPercent:          50,
 				EstimatedUnusedBytes: 2048,
 				TopUsedSymbols: []SymbolUsage{
 					{Name: "Println", Module: "fmt", Count: 2},
@@ -301,12 +302,12 @@ func TestFormatCSVSortingHelpers(t *testing.T) {
 	}
 }
 
-func TestRuntimeCorrelationValue(t *testing.T) {
-	assertRuntimeCorrelationValue(t, nil, "")
-	assertRuntimeCorrelationValue(t, &RuntimeUsage{Correlation: RuntimeCorrelationRuntimeOnly}, string(RuntimeCorrelationRuntimeOnly))
-	assertRuntimeCorrelationValue(t, &RuntimeUsage{RuntimeOnly: true}, string(RuntimeCorrelationRuntimeOnly))
-	assertRuntimeCorrelationValue(t, &RuntimeUsage{LoadCount: 2}, string(RuntimeCorrelationOverlap))
-	assertRuntimeCorrelationValue(t, &RuntimeUsage{}, string(RuntimeCorrelationStaticOnly))
+func TestFormatCSVRuntimeCorrelationUsesModelField(t *testing.T) {
+	assertCSVRuntimeCorrelation(t, nil, "")
+	assertCSVRuntimeCorrelation(t, &RuntimeUsage{Correlation: RuntimeCorrelationRuntimeOnly}, string(RuntimeCorrelationRuntimeOnly))
+	assertCSVRuntimeCorrelation(t, &RuntimeUsage{RuntimeOnly: true}, "")
+	assertCSVRuntimeCorrelation(t, &RuntimeUsage{LoadCount: 2}, "")
+	assertCSVRuntimeCorrelation(t, &RuntimeUsage{}, "")
 }
 
 func TestFormatCSVRemovalCandidateMetric(t *testing.T) {
@@ -351,9 +352,9 @@ func assertCSVRowHasValues(t *testing.T, got map[string]string, expected map[str
 	}
 }
 
-func assertRuntimeCorrelationValue(t *testing.T, usage *RuntimeUsage, want string) {
+func assertCSVRuntimeCorrelation(t *testing.T, usage *RuntimeUsage, want string) {
 	t.Helper()
-	if got := runtimeCorrelationValue(usage); got != want {
-		t.Fatalf("runtimeCorrelationValue(%#v)=%q want %q", usage, got, want)
+	if got := formatCSVRuntimeCorrelation(usage); got != want {
+		t.Fatalf("formatCSVRuntimeCorrelation(%#v)=%q want %q", usage, got, want)
 	}
 }

--- a/internal/report/format_policy_runtime_tables_test.go
+++ b/internal/report/format_policy_runtime_tables_test.go
@@ -47,8 +47,8 @@ func TestAppendEffectivePolicyAndBaselineComparisonMoreBranches(t *testing.T) {
 }
 
 func TestFormatRuntimeUsageAndLicenseMoreBranches(t *testing.T) {
-	if got := formatRuntimeUsage(&RuntimeUsage{LoadCount: 1}); !strings.Contains(got, "overlap (1 loads)") {
-		t.Fatalf("expected overlap fallback correlation, got %q", got)
+	if got := formatRuntimeUsage(&RuntimeUsage{LoadCount: 1, Correlation: RuntimeCorrelationOverlap}); !strings.Contains(got, "overlap (1 loads)") {
+		t.Fatalf("expected overlap correlation, got %q", got)
 	}
 	if got := formatDependencyLicense(&DependencyLicense{Unknown: true}); got != "unknown" {
 		t.Fatalf("expected unknown license fallback, got %q", got)

--- a/internal/report/format_table.go
+++ b/internal/report/format_table.go
@@ -101,16 +101,11 @@ func writeTableHeader(writer *tabwriter.Writer, showLanguage, showRuntime, showR
 }
 
 func formatTableRow(dep DependencyReport, showLanguage, showRuntime, showReachability bool) string {
-	usedPercent := dep.UsedPercent
-	if usedPercent <= 0 && dep.TotalExportsCount > 0 {
-		usedPercent = (float64(dep.UsedExportsCount) / float64(dep.TotalExportsCount)) * 100
-	}
-
 	columns := make([]string, 0, 12)
 	if showLanguage {
 		columns = append(columns, sanitizeTerminalString(dep.Language))
 	}
-	columns = append(columns, sanitizeTerminalString(dep.Name), fmt.Sprintf("%d/%d", dep.UsedExportsCount, dep.TotalExportsCount), fmt.Sprintf("%.1f", usedPercent))
+	columns = append(columns, sanitizeTerminalString(dep.Name), fmt.Sprintf("%d/%d", dep.UsedExportsCount, dep.TotalExportsCount), fmt.Sprintf("%.1f", dep.UsedPercent))
 	if showRuntime {
 		columns = append(columns, formatRuntimeUsage(dep.RuntimeUsage))
 	}

--- a/internal/report/format_table_values.go
+++ b/internal/report/format_table_values.go
@@ -50,15 +50,8 @@ func formatRuntimeUsage(usage *RuntimeUsage) string {
 		return "-"
 	}
 	correlation := string(usage.Correlation)
-	if correlation == "" {
-		switch {
-		case usage.RuntimeOnly:
-			correlation = string(RuntimeCorrelationRuntimeOnly)
-		case usage.LoadCount > 0:
-			correlation = string(RuntimeCorrelationOverlap)
-		default:
-			correlation = string(RuntimeCorrelationStaticOnly)
-		}
+	if strings.TrimSpace(correlation) == "" {
+		correlation = "-"
 	}
 	parts := []string{fmt.Sprintf("%s (%d loads)", correlation, usage.LoadCount)}
 	if len(usage.ParentModules) > 0 {

--- a/internal/report/format_test.go
+++ b/internal/report/format_test.go
@@ -451,11 +451,11 @@ func TestFormattingHelpersProvenanceFields(t *testing.T) {
 }
 
 func TestFormatRuntimeUsageBranches(t *testing.T) {
-	if got := formatRuntimeUsage(&RuntimeUsage{RuntimeOnly: true}); !strings.Contains(got, "runtime-only") {
-		t.Fatalf("expected runtime-only fallback correlation, got %q", got)
+	if got := formatRuntimeUsage(&RuntimeUsage{Correlation: RuntimeCorrelationRuntimeOnly}); !strings.Contains(got, "runtime-only") {
+		t.Fatalf("expected runtime-only correlation, got %q", got)
 	}
-	if got := formatRuntimeUsage(&RuntimeUsage{LoadCount: 0}); !strings.Contains(got, "static-only") {
-		t.Fatalf("expected static-only fallback correlation, got %q", got)
+	if got := formatRuntimeUsage(&RuntimeUsage{}); !strings.Contains(got, "- (0 loads)") {
+		t.Fatalf("expected missing correlation placeholder, got %q", got)
 	}
 }
 
@@ -465,14 +465,14 @@ func TestFormatUnknownFormat(t *testing.T) {
 	}
 }
 
-func TestFormatTableUsedPercentFallbackAndNoLanguageColumn(t *testing.T) {
+func TestFormatTableUsesModelUsedPercentAndNoLanguageColumn(t *testing.T) {
 	reportData := Report{
 		Dependencies: []DependencyReport{
 			{
 				Name:              "dep",
 				UsedExportsCount:  1,
 				TotalExportsCount: 4,
-				UsedPercent:       0,
+				UsedPercent:       25,
 			},
 		},
 	}
@@ -484,7 +484,7 @@ func TestFormatTableUsedPercentFallbackAndNoLanguageColumn(t *testing.T) {
 		t.Fatalf("did not expect language column for single-language anonymous rows")
 	}
 	if !strings.Contains(output, "25.0") {
-		t.Fatalf("expected used-percent fallback calculation in output, got %q", output)
+		t.Fatalf("expected model used percent in output, got %q", output)
 	}
 }
 
@@ -722,11 +722,11 @@ func TestFormatRuntimeUsageFallbacks(t *testing.T) {
 	if got := formatRuntimeUsage(nil); got != "-" {
 		t.Fatalf("expected runtime dash for nil usage, got %q", got)
 	}
-	if got := formatRuntimeUsage(&RuntimeUsage{LoadCount: 1, RuntimeOnly: true}); !strings.Contains(got, "runtime-only") {
-		t.Fatalf("expected runtime-only fallback, got %q", got)
+	if got := formatRuntimeUsage(&RuntimeUsage{LoadCount: 1, Correlation: RuntimeCorrelationOverlap}); !strings.Contains(got, "overlap") {
+		t.Fatalf("expected explicit overlap correlation, got %q", got)
 	}
-	if got := formatRuntimeUsage(&RuntimeUsage{LoadCount: 0}); !strings.Contains(got, "static-only") {
-		t.Fatalf("expected static-only fallback, got %q", got)
+	if got := formatRuntimeUsage(&RuntimeUsage{LoadCount: 0}); !strings.Contains(got, "- (0 loads)") {
+		t.Fatalf("expected missing correlation placeholder, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Move derived report metrics out of formatter fallback code and into analysis finalization before scoring and rendering.

Closes #901

## Changes

- Derive dependency `UsedPercent` from export counts during analysis finalization when adapters leave it unset.
- Derive runtime correlation during analysis finalization before reachability and removal scoring run.
- Simplify table and CSV formatters so they render supplied model values instead of inferring analysis fields.
- Update formatter tests for the new boundary and add analysis coverage for derived metrics.

## Validation

Commands and checks run:

```bash
go test ./internal/analysis ./internal/report
make lint
make dup-check
# full pre-commit make ci via git commit hook
```

Additional manual validation:

- Confirmed post-commit duplication gate reports 0.00% duplicated added lines.
- Confirmed full pre-commit coverage stayed at 98.3% total with per-package minimums satisfied.

## Risk and compatibility

- Breaking changes: none expected; final report output keeps the same values for analysed reports.
- Migration required: none.
- Performance impact: none expected; derivation is linear over dependencies and replaces formatter work.
- Memory benchmark impact: CI/local memory benchmark gate passed with no threshold regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review