### PR TITLE
fix(lang): scan hoisted js and go monorepo sources

### DIFF
--- a/internal/lang/golang/adapter.go
+++ b/internal/lang/golang/adapter.go
@@ -66,33 +66,11 @@ func scanRepo(ctx context.Context, repoPath string, moduleInfo moduleInfo) (scan
 	if repoPath == "" {
 		return result, fs.ErrInvalid
 	}
-	nestedModules, err := nestedModuleDirsForScan(repoPath, moduleInfo)
-	if err != nil {
-		return result, err
-	}
-
-	err = walkGoFiles(ctx, repoPath, nestedModules, moduleInfo, &result)
-	if err != nil {
+	if err := walkGoFiles(ctx, repoPath, moduleInfo, &result); err != nil {
 		return result, err
 	}
 	appendScanWarnings(&result, moduleInfo)
 	return result, nil
-}
-
-func nestedModuleDirsForScan(repoPath string, info moduleInfo) (map[string]struct{}, error) {
-	if info.NestedModuleDirs != nil {
-		return info.NestedModuleDirs, nil
-	}
-
-	workspaceModuleExclusions := info.WorkspaceModuleExclusions
-	if workspaceModuleExclusions == nil {
-		var err error
-		workspaceModuleExclusions, err = workspaceRootModuleDirs(repoPath, info)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return nestedModuleDirs(repoPath, workspaceModuleExclusions)
 }
 
 func newScanResult() scanResult {
@@ -103,7 +81,7 @@ func newScanResult() scanResult {
 	}
 }
 
-func walkGoFiles(ctx context.Context, repoPath string, nestedModules map[string]struct{}, moduleInfo moduleInfo, result *scanResult) error {
+func walkGoFiles(ctx context.Context, repoPath string, moduleInfo moduleInfo, result *scanResult) error {
 	return filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -112,7 +90,7 @@ func walkGoFiles(ctx context.Context, repoPath string, nestedModules map[string]
 			return ctx.Err()
 		}
 		if entry.IsDir() {
-			return handleScanDirEntry(path, repoPath, entry, nestedModules, result)
+			return handleScanDirEntry(entry)
 		}
 		if !strings.EqualFold(filepath.Ext(path), ".go") {
 			return nil
@@ -121,17 +99,9 @@ func walkGoFiles(ctx context.Context, repoPath string, nestedModules map[string]
 	})
 }
 
-func handleScanDirEntry(path, repoPath string, entry fs.DirEntry, nestedModules map[string]struct{}, result *scanResult) error {
+func handleScanDirEntry(entry fs.DirEntry) error {
 	if shouldSkipDir(entry.Name()) {
 		return filepath.SkipDir
-	}
-	if path != repoPath {
-		if _, ok := nestedModules[path]; ok {
-			if result != nil {
-				result.SkippedNestedModuleDirs++
-			}
-			return filepath.SkipDir
-		}
 	}
 	return nil
 }

--- a/internal/lang/golang/adapter_detection_reporting_paths_test.go
+++ b/internal/lang/golang/adapter_detection_reporting_paths_test.go
@@ -31,7 +31,7 @@ func testGoHelperGuardBranches(t *testing.T) {
 		t.Fatalf("expected removal weights to be normalized, got %#v", weights)
 	}
 
-	if walkGoFiles(context.Background(), filepath.Join(t.TempDir(), "missing"), nil, moduleInfo{}, &scanResult{}) == nil {
+	if walkGoFiles(context.Background(), filepath.Join(t.TempDir(), "missing"), moduleInfo{}, &scanResult{}) == nil {
 		t.Fatalf("expected walkGoFiles to fail for missing repo")
 	}
 

--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -373,7 +373,7 @@ func TestAdapterAnalyseSkipsGeneratedAndBuildTaggedFiles(t *testing.T) {
 	}
 }
 
-func TestAdapterAnalyseSkipsNestedModulesFromRootScan(t *testing.T) {
+func TestAdapterAnalyseScansNestedModulesFromRootScan(t *testing.T) {
 	repo := t.TempDir()
 	writeRootUUIDModule(t, repo)
 	writeNestedLoModule(t, repo, "services", "api")
@@ -386,13 +386,13 @@ func TestAdapterAnalyseSkipsNestedModulesFromRootScan(t *testing.T) {
 	if !slices.Contains(names, depUUID) {
 		t.Fatalf("expected root dependency uuid in %#v", names)
 	}
-	if slices.Contains(names, depLo) {
-		t.Fatalf("did not expect nested module dependency lo in root scan %#v", names)
+	if !slices.Contains(names, depLo) {
+		t.Fatalf("expected nested module dependency lo in root scan %#v", names)
 	}
 
 	warningsText := strings.ToLower(strings.Join(reportData.Warnings, "\n"))
-	if !strings.Contains(warningsText, "nested module directories") {
-		t.Fatalf("expected nested-module warning, got %#v", reportData.Warnings)
+	if strings.Contains(warningsText, "nested module directories") {
+		t.Fatalf("did not expect nested-module skip warning, got %#v", reportData.Warnings)
 	}
 }
 
@@ -416,7 +416,7 @@ func TestAdapterAnalyseWorkspaceGoWorkScansMembers(t *testing.T) {
 	}
 }
 
-func TestScanRepoReusesLoadedNestedModuleDirs(t *testing.T) {
+func TestScanRepoScansLoadedNestedModuleDirs(t *testing.T) {
 	repo := t.TempDir()
 	writeRootUUIDModule(t, repo)
 	nestedDir := writeNestedLoModule(t, repo, "services", "api")
@@ -438,15 +438,15 @@ func TestScanRepoReusesLoadedNestedModuleDirs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scanRepo: %v", err)
 	}
-	if scan.SkippedNestedModuleDirs != 1 {
-		t.Fatalf("expected one cached nested module skip, got %d", scan.SkippedNestedModuleDirs)
+	if scan.SkippedNestedModuleDirs != 0 {
+		t.Fatalf("expected no nested module skips, got %d", scan.SkippedNestedModuleDirs)
 	}
 
 	requireScannedDependency(t, scan, depUUID)
-	requireSkippedDependency(t, scan, depLo)
+	requireScannedDependency(t, scan, depLo)
 }
 
-func TestScanRepoReusesWorkspaceNestedModuleExclusions(t *testing.T) {
+func TestScanRepoScansWorkspaceAndNestedModules(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, fileGoWork), go125Line+"\n\nuse ./svc/a\n")
 	writeFile(t, filepath.Join(repo, "svc", "a", fileGoMod), goModDemoWithUUID)
@@ -477,12 +477,12 @@ func TestScanRepoReusesWorkspaceNestedModuleExclusions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scanRepo: %v", err)
 	}
-	if scan.SkippedNestedModuleDirs != 2 {
-		t.Fatalf("expected two nested module skips, got %d", scan.SkippedNestedModuleDirs)
+	if scan.SkippedNestedModuleDirs != 0 {
+		t.Fatalf("expected no nested module skips, got %d", scan.SkippedNestedModuleDirs)
 	}
 
 	requireScannedDependency(t, scan, depUUID)
-	requireSkippedDependency(t, scan, depLo)
+	requireScannedDependency(t, scan, depLo)
 }
 
 func TestBuildRequestedGoDependenciesNoInputWarning(t *testing.T) {
@@ -1245,14 +1245,6 @@ func requireScannedDependency(t *testing.T, scan scanResult, dependency string) 
 	}
 }
 
-func requireSkippedDependency(t *testing.T, scan scanResult, dependency string) {
-	t.Helper()
-	deps := dependencySetFromScan(scan)
-	if _, ok := deps[dependency]; ok {
-		t.Fatalf("did not expect dependency %q in %#v", dependency, deps)
-	}
-}
-
 func TestUtilityCoverageBranches(t *testing.T) {
 	if stripInlineComment("value // comment") != "value " {
 		t.Fatalf("expected inline comment to be stripped")
@@ -1309,7 +1301,7 @@ func TestHandleScanDirAndWarningHelpers(t *testing.T) {
 	}
 	entry := fs.FileInfoToDirEntry(info)
 
-	if err := handleScanDirEntry(repo, repo, entry, nil, nil); err != nil {
+	if err := handleScanDirEntry(entry); err != nil {
 		t.Fatalf("expected nil scan dir err for repo root, got %v", err)
 	}
 	vendorInfo, err := os.Stat(vendor)
@@ -1317,22 +1309,18 @@ func TestHandleScanDirAndWarningHelpers(t *testing.T) {
 		t.Fatalf("stat vendor: %v", err)
 	}
 	vendorEntry := fs.FileInfoToDirEntry(vendorInfo)
-	if err := handleScanDirEntry(vendor, repo, vendorEntry, nil, nil); !errors.Is(err, filepath.SkipDir) {
+	if err := handleScanDirEntry(vendorEntry); !errors.Is(err, filepath.SkipDir) {
 		t.Fatalf("expected vendor skip dir, got %v", err)
 	}
-	nested := map[string]struct{}{child: {}}
-	result := newScanResult()
-	if err := handleScanDirEntry(child, repo, entry, nested, &result); !errors.Is(err, filepath.SkipDir) {
-		t.Fatalf("expected nested module skip, got %v", err)
-	}
-	if err := handleScanDirEntry(child, repo, entry, nested, nil); !errors.Is(err, filepath.SkipDir) {
-		t.Fatalf("expected nested module skip with nil result, got %v", err)
+	if err := handleScanDirEntry(entry); err != nil {
+		t.Fatalf("expected nested module dir to be scanned, got %v", err)
 	}
 
 	appendScanWarnings(nil, moduleInfo{})
 	appendSkipWarnings(nil)
 	appendUndeclaredDependencyWarnings(nil)
 
+	result := newScanResult()
 	result.UndeclaredImportsByDependency[exampleModuleX] = 2
 	appendUndeclaredDependencyWarnings(&result)
 	if len(result.Warnings) == 0 {

--- a/internal/lang/js/adapter_test.go
+++ b/internal/lang/js/adapter_test.go
@@ -440,6 +440,17 @@ func TestListDependenciesMissingAndBuiltinFiltering(t *testing.T) {
 func TestListDependenciesNestedWorkspaceNodeModules(t *testing.T) {
 	repo := t.TempDir()
 	appDir := filepath.Join(repo, "apps", "api")
+	assertWorkspaceExpressRoot(t, repo, appDir, appDir)
+}
+
+func TestListDependenciesHoistedNodeModulesFromWorkspace(t *testing.T) {
+	repo := t.TempDir()
+	appDir := filepath.Join(repo, "apps", "api")
+	assertWorkspaceExpressRoot(t, repo, appDir, repo)
+}
+
+func assertWorkspaceExpressRoot(t *testing.T, repo, appDir, installRoot string) {
+	t.Helper()
 	srcFile := filepath.Join(appDir, "src", testIndexJS)
 	if err := os.MkdirAll(filepath.Dir(srcFile), 0o755); err != nil {
 		t.Fatalf("mkdir src: %v", err)
@@ -447,8 +458,7 @@ func TestListDependenciesNestedWorkspaceNodeModules(t *testing.T) {
 	if err := os.WriteFile(srcFile, []byte(""), 0o600); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-
-	if err := writeDependency(appDir, "express", testModuleExportsStub); err != nil {
+	if err := writeDependency(installRoot, "express", testModuleExportsStub); err != nil {
 		t.Fatalf("write express dependency: %v", err)
 	}
 
@@ -462,6 +472,7 @@ func TestListDependenciesNestedWorkspaceNodeModules(t *testing.T) {
 			},
 		},
 	}
+
 	deps, roots, warnings := listDependencies(repo, scan)
 	if len(warnings) != 0 {
 		t.Fatalf("expected no missing dependency warning, got %#v", warnings)
@@ -469,7 +480,7 @@ func TestListDependenciesNestedWorkspaceNodeModules(t *testing.T) {
 	if len(deps) != 1 || deps[0] != "express" {
 		t.Fatalf("expected express dependency, got %#v", deps)
 	}
-	if got := roots["express"]; got != filepath.Join(appDir, "node_modules", "express") {
+	if got := roots["express"]; got != filepath.Join(installRoot, "node_modules", "express") {
 		t.Fatalf("unexpected resolved dependency root: %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
Closes #897.

Fixes dependency discovery for JavaScript workspaces that hoist `node_modules` to the repository root and Go repositories that contain nested modules under a root scan.

## Changes
- Scan loaded nested Go module directories during root analysis instead of skipping them as nested module paths.
- Simplify the Go scan directory filter so only standard ignored directories are skipped.
- Add JavaScript coverage for dependencies resolved through a workspace-level hoisted `node_modules` tree.
- Update Go tests to assert nested module source files are included in dependency analysis.

## Validation
- [x] `go test ./internal/lang/golang ./internal/lang/js`
- [x] `make lint`
- [x] `make dup-check`
- [x] `git diff --check`
- [x] full pre-commit suite via `git commit` hook, including tests, gosec, govulncheck, race tests, memory benchmark gate, build, and coverage

## Risk and compatibility
- Breaking changes: None expected.
- Migration required: No.
- Performance impact: Low; Go scans now include nested loaded modules that were previously skipped incorrectly.
- Memory benchmark impact: No benchmark regression observed in the pre-commit memory gate.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review