### PR TITLE
fix(lang): parse manifests with structured parsers

### DIFF
--- a/internal/lang/dotnet/adapter_detection_discovery_paths_test.go
+++ b/internal/lang/dotnet/adapter_detection_discovery_paths_test.go
@@ -107,12 +107,6 @@ func TestDotNetAddAncestorCentralPackagesParseError(t *testing.T) {
 	}
 }
 
-func TestDotNetCaptureMatchesIgnoresMalformedInput(t *testing.T) {
-	if !slices.Equal(captureMatches([][][]byte{{[]byte("skip")}, {[]byte(" "), []byte(" ")}}), []string{}) {
-		t.Fatalf("expected malformed/blank captureMatches input to be ignored")
-	}
-}
-
 func TestDotNetCollectorAndScannerReturnWalkErrors(t *testing.T) {
 	repo := t.TempDir()
 	collector := newDependencyCollector(repo, map[string]struct{}{})

--- a/internal/lang/dotnet/discovery.go
+++ b/internal/lang/dotnet/discovery.go
@@ -3,8 +3,10 @@ package dotnet
 import (
 	"bytes"
 	"context"
+	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -257,43 +259,48 @@ func parseManifestDependenciesForEntry(repoPath, path, name string) ([]string, e
 }
 
 func parsePackageReferences(repoPath, manifestPath string) ([]string, error) {
-	return parseManifestDependencies(repoPath, manifestPath, packageReferencePattern)
+	return parseManifestDependencies(repoPath, manifestPath, "PackageReference")
 }
 
 func parsePackageVersions(repoPath, manifestPath string) ([]string, error) {
-	return parseManifestDependencies(repoPath, manifestPath, packageVersionPattern)
+	return parseManifestDependencies(repoPath, manifestPath, "PackageVersion")
 }
 
-func parseManifestDependencies(repoPath, manifestPath string, pattern *regexp.Regexp) ([]string, error) {
+func parseManifestDependencies(repoPath, manifestPath string, elementName string) ([]string, error) {
 	content, err := safeio.ReadFileUnder(repoPath, manifestPath)
 	if err != nil {
 		return nil, err
 	}
-	matches := pattern.FindAllSubmatch(stripXMLCommentsBytes(content), -1)
-	return captureMatches(matches), nil
+	return parseXMLManifestIncludes(content, elementName)
 }
 
-func captureMatches(matches [][][]byte) []string {
-	if len(matches) == 0 {
-		return nil
-	}
+func parseXMLManifestIncludes(content []byte, elementName string) ([]string, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(content))
 	set := make(map[string]struct{})
-	for _, match := range matches {
-		if len(match) < 2 {
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok || !strings.EqualFold(start.Name.Local, elementName) {
 			continue
 		}
-		value := normalizeDependencyID(string(match[1]))
-		if value == "" {
-			continue
+		for _, attr := range start.Attr {
+			if !strings.EqualFold(attr.Name.Local, "Include") {
+				continue
+			}
+			value := normalizeDependencyID(attr.Value)
+			if value != "" {
+				set[value] = struct{}{}
+			}
+			break
 		}
-		set[value] = struct{}{}
 	}
-	items := make([]string, 0, len(set))
-	for value := range set {
-		items = append(items, value)
-	}
-	sort.Strings(items)
-	return items
+	return sortedDependencies(set), nil
 }
 
 func readSourceFile(repoPath, sourcePath string) ([]byte, string, error) {
@@ -426,46 +433,6 @@ func isRepoBoundedPath(repoPath, candidatePath string) bool {
 	return relativeToRepo != ".." && !strings.HasPrefix(relativeToRepo, ".."+string(filepath.Separator))
 }
 
-func stripXMLCommentsBytes(content []byte) []byte {
-	if len(content) == 0 {
-		return content
-	}
-	if !bytes.Contains(content, []byte("<!--")) {
-		return bytes.TrimSpace(content)
-	}
-
-	out := make([]byte, 0, len(content))
-	inComment := false
-
-	for i := 0; i < len(content); {
-		if inComment {
-			if i+2 < len(content) && content[i] == '-' && content[i+1] == '-' && content[i+2] == '>' {
-				inComment = false
-				i += 3
-				continue
-			}
-			i++
-			continue
-		}
-
-		if i+3 < len(content) && content[i] == '<' && content[i+1] == '!' && content[i+2] == '-' && content[i+3] == '-' {
-			if len(out) > 0 && !isSpaceByte(out[len(out)-1]) {
-				out = append(out, ' ')
-			}
-			inComment = true
-			i += 4
-			continue
-		}
-
-		out = append(out, content[i])
-		i++
-	}
-
-	return bytes.TrimSpace(out)
-}
-
 var (
-	packageReferencePattern = regexp.MustCompile(`(?is)<PackageReference\b[^>]*\bInclude\s*=\s*["']([^"']+)["']`)
-	packageVersionPattern   = regexp.MustCompile(`(?is)<PackageVersion\b[^>]*\bInclude\s*=\s*["']([^"']+)["']`)
-	solutionProjectPattern  = regexp.MustCompile(`Project\([^\)]*\)\s*=\s*"[^"]+"\s*,\s*"([^"]+\.(?:csproj|fsproj))"`)
+	solutionProjectPattern = regexp.MustCompile(`Project\([^\)]*\)\s*=\s*"[^"]+"\s*,\s*"([^"]+\.(?:csproj|fsproj))"`)
 )

--- a/internal/lang/dotnet/manifest_xml_test.go
+++ b/internal/lang/dotnet/manifest_xml_test.go
@@ -1,0 +1,76 @@
+package dotnet
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestParseXMLManifestIncludesStructuredBranches(t *testing.T) {
+	content := []byte(`
+	<Project xmlns:msb="urn:test">
+	  <ItemGroup>
+	    <msb:PackageReference Include="Namespace.Package" />
+    <PackageReference Include=" " />
+    <PackageReference />
+    <PackageVersion Include="Central.Package" />
+	  </ItemGroup>
+	</Project>
+	`)
+	deps, err := parseXMLManifestIncludes(content, "PackageReference")
+	if err != nil {
+		t.Fatalf("parse package references: %v", err)
+	}
+	if len(deps) != 1 || deps[0] != "namespace.package" {
+		t.Fatalf("expected only namespaced package reference include, got %#v", deps)
+	}
+
+	deps, err = parseXMLManifestIncludes([]byte(`<Project><PackageVersion Include="Central.Package" /></Project>`), "PackageVersion")
+	if err != nil {
+		t.Fatalf("parse package versions: %v", err)
+	}
+	if len(deps) != 1 || deps[0] != "central.package" {
+		t.Fatalf("expected package version include, got %#v", deps)
+	}
+
+	if _, err := parseXMLManifestIncludes([]byte(`<Project><PackageReference Include="broken"`), "PackageReference"); err == nil {
+		t.Fatalf("expected malformed XML to return an error")
+	}
+}
+
+func TestDotNetDiscoveryPathBoundaryBranches(t *testing.T) {
+	repo := t.TempDir()
+	if !isRepoBoundedPath(repo, filepath.Join(repo, "src", "App.csproj")) {
+		t.Fatalf("expected in-repo candidate path to be accepted")
+	}
+	if isRepoBoundedPath(repo, filepath.Join(filepath.Dir(repo), "outside.csproj")) {
+		t.Fatalf("expected outside candidate path to be rejected")
+	}
+	if isRepoBoundedPath("\x00", repo) {
+		t.Fatalf("expected invalid repo path to be rejected")
+	}
+	if isRepoBoundedPath(repo, "\x00") {
+		t.Fatalf("expected invalid candidate path to be rejected")
+	}
+
+	roots := map[string]struct{}{}
+	testutil.MustWriteFile(t, filepath.Join(repo, "App.sln"), `Project("{FAKE}") = "Outside", "../outside/Outside.csproj", "{ONE}"`)
+	if err := addSolutionRoots(repo, filepath.Join(repo, "App.sln"), roots); err != nil {
+		t.Fatalf("add solution roots: %v", err)
+	}
+	if len(roots) != 0 {
+		t.Fatalf("expected out-of-repo solution project to be ignored, got %#v", roots)
+	}
+
+	if _, _, err := readSourceFile(repo, filepath.Join(repo, "missing.cs")); err == nil {
+		t.Fatalf("expected missing source file to return an error")
+	}
+	deps := map[string]struct{}{}
+	if err := addAncestorCentralPackages(filepath.Join(repo, "nested"), deps); err != nil {
+		t.Fatalf("add ancestor central packages without ancestor file: %v", err)
+	}
+	if len(deps) != 0 {
+		t.Fatalf("expected no ancestor central package deps, got %#v", deps)
+	}
+}

--- a/internal/lang/dotnet/parsing_detection_error_paths_test.go
+++ b/internal/lang/dotnet/parsing_detection_error_paths_test.go
@@ -272,18 +272,6 @@ func TestIsRepoBoundedPathAdditionalBranches(t *testing.T) {
 	}
 }
 
-func TestStripXMLCommentsBytesAdditionalBranches(t *testing.T) {
-	got := stripXMLCommentsBytes([]byte("<Project><!-- comment --><ItemGroup /></Project>"))
-	if !bytes.Equal(got, []byte("<Project> <ItemGroup /></Project>")) {
-		t.Fatalf("expected inline XML comment to be stripped with spacing preserved, got %q", got)
-	}
-
-	got = stripXMLCommentsBytes([]byte("<Project><ItemGroup /></Project><!-- trailing"))
-	if !bytes.Equal(got, []byte("<Project><ItemGroup /></Project>")) {
-		t.Fatalf("expected unterminated trailing XML comment to be stripped, got %q", got)
-	}
-}
-
 func TestAnalyseDeclaredDependenciesWithoutTarget(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, appProjectName), `<Project><ItemGroup><PackageReference Include="Newtonsoft.Json" Version="13.0.3" /></ItemGroup></Project>`)
@@ -331,18 +319,6 @@ func TestParseImportsIgnoreBlockComments(t *testing.T) {
 	}
 	if imports[0].Location.Line != 4 {
 		t.Fatalf("expected import line 4 after skipping block comment, got %#v", imports[0].Location)
-	}
-}
-
-func TestStripXMLCommentsBytesFastPathAllocations(t *testing.T) {
-	content := []byte("\n  <Project><ItemGroup><PackageReference Include=\"Dapper\" /></ItemGroup></Project>  \n")
-	if allocs := testing.AllocsPerRun(1000, func() {
-		got := stripXMLCommentsBytes(content)
-		if !bytes.Equal(got, []byte("<Project><ItemGroup><PackageReference Include=\"Dapper\" /></ItemGroup></Project>")) {
-			t.Fatalf("unexpected stripped xml: %q", got)
-		}
-	}); allocs != 0 {
-		t.Fatalf("expected zero allocations on no-comment fast path, got %f", allocs)
 	}
 }
 
@@ -441,13 +417,6 @@ func assertRiskyDependencyReport(t *testing.T) {
 }
 
 func TestCaptureMatchesAndSolutionRootsBranches(t *testing.T) {
-	if len(captureMatches(nil)) != 0 {
-		t.Fatalf("expected nil matches result")
-	}
-	if got := captureMatches([][][]byte{{[]byte("only-one-element")}}); len(got) != 0 {
-		t.Fatalf("expected empty result for malformed match set, got %#v", got)
-	}
-
 	repo := t.TempDir()
 	sln := filepath.Join(repo, "App.sln")
 	testutil.MustWriteFile(t, sln, `

--- a/internal/lang/jvm/build_parsing.go
+++ b/internal/lang/jvm/build_parsing.go
@@ -62,7 +62,6 @@ const (
 
 var (
 	pomPropertyTokenPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
-	gradleDependencyPattern = regexp.MustCompile(`(?m)(?:implementation|api|compileOnly|runtimeOnly|testImplementation|testRuntimeOnly|kapt|annotationProcessor|testAnnotationProcessor|testCompileOnly|debugImplementation|releaseImplementation|kaptTest|kaptAndroidTest|classpath)\s*\(?\s*["']([^:"'\s]+):([^:"'\s]+):[^"'\s]+["']\s*\)?`)
 )
 
 func collectDeclaredDependencies(repoPath string) ([]dependencyDescriptor, map[string]string, map[string]string, []string) {
@@ -79,7 +78,7 @@ func collectBuildDescriptors(repoPath string) ([]dependencyDescriptor, []string)
 		case pomXMLName:
 			return parsePomDependencyContent(relativeBuildFilePath(repoPath, path), content)
 		case buildGradleName, buildGradleKTSName:
-			descriptors := parseGradleMatches(content, gradleDependencyPattern)
+			descriptors := parseGradleDependencyContent(path, content)
 			catalogDescriptors, catalogWarnings := catalogResolver.ParseDependencyReferences(path, content)
 			for _, descriptor := range catalogDescriptors {
 				descriptors = append(descriptors, dependencyDescriptor{
@@ -379,7 +378,7 @@ func parseGradleDependencies(repoPath string) []dependencyDescriptor {
 func parseGradleDependenciesWithWarnings(repoPath string) ([]dependencyDescriptor, []string) {
 	catalogResolver, warnings := shared.LoadGradleCatalogResolver(repoPath)
 	gradleParser := func(path, content string) ([]dependencyDescriptor, []string) {
-		descriptors := parseGradleMatches(content, gradleDependencyPattern)
+		descriptors := parseGradleDependencyContent(path, content)
 		catalogDescriptors, catalogWarnings := catalogResolver.ParseDependencyReferences(path, content)
 		for _, descriptor := range catalogDescriptors {
 			descriptors = append(descriptors, dependencyDescriptor{
@@ -395,8 +394,17 @@ func parseGradleDependenciesWithWarnings(repoPath string) ([]dependencyDescripto
 	return descriptors, shared.DedupeWarnings(warnings)
 }
 
-func parseGradleMatches(content string, pattern *regexp.Regexp) []dependencyDescriptor {
-	return parseDependencyDescriptorsFromMatches(pattern.FindAllStringSubmatch(content, -1))
+func parseGradleDependencyContent(path, content string) []dependencyDescriptor {
+	coordinates := shared.ParseGradleDependencyCoordinatesForFile(path, content)
+	descriptors := make([]dependencyDescriptor, 0, len(coordinates))
+	for _, coordinate := range coordinates {
+		descriptors = append(descriptors, dependencyDescriptor{
+			Name:     coordinate.Artifact,
+			Group:    coordinate.Group,
+			Artifact: coordinate.Artifact,
+		})
+	}
+	return descriptors
 }
 
 func parseDependencyDescriptorsFromMatches(matches [][]string) []dependencyDescriptor {

--- a/internal/lang/jvm/helpers_test.go
+++ b/internal/lang/jvm/helpers_test.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -525,11 +524,6 @@ func TestJVMParseHelpersEdgeBranches(t *testing.T) {
 	descriptors := parseDependencyDescriptorsFromMatches(matches)
 	if len(descriptors) != 1 || descriptors[0].Name != "lib" {
 		t.Fatalf("unexpected descriptor parse result: %#v", descriptors)
-	}
-
-	pattern := regexp.MustCompile(`does-not-match`)
-	if got := parseGradleMatches("", pattern); len(got) != 0 {
-		t.Fatalf("expected no gradle matches for nil pattern, got %#v", got)
 	}
 
 	if got := fallbackDependency(""); got != "" {

--- a/internal/lang/kotlinandroid/adapter_detection_lookup_paths_test.go
+++ b/internal/lang/kotlinandroid/adapter_detection_lookup_paths_test.go
@@ -84,7 +84,7 @@ func TestKotlinAndroidLookupAndGradleMoreBranches(t *testing.T) {
 		t.Fatalf("unexpected artifact lookup strategy result: prefixes=%#v aliases=%#v", prefixes, aliases)
 	}
 
-	if descriptors := parseGradleMapDependencies(`implementation(group: "com.example")`); len(descriptors) != 0 {
+	if descriptors := parseGradleDependencyContent(`implementation(group = "com.example")`); len(descriptors) != 0 {
 		t.Fatalf("expected incomplete map-style gradle dependency to be ignored, got %#v", descriptors)
 	}
 

--- a/internal/lang/kotlinandroid/gradle_manifest_parsing.go
+++ b/internal/lang/kotlinandroid/gradle_manifest_parsing.go
@@ -2,19 +2,9 @@ package kotlinandroid
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 )
-
-const gradleDependencyConfigurationPattern = `(?:implementation|api|compileOnly|runtimeOnly|annotationProcessor|kapt|ksp|testImplementation|androidTestImplementation|testRuntimeOnly|testCompileOnly|testAnnotationProcessor|debugImplementation|releaseImplementation|kaptTest|kaptAndroidTest|classpath)`
-
-var gradleCoordinatePattern = regexp.MustCompile(`(?m)\b` + gradleDependencyConfigurationPattern + `\s*\(?\s*(?:platform\()?["']([^:"'\s]+):([^:"'\s]+)(?::([^"'\s]+))?["']\s*\)?\s*\)?`)
-
-var gradleMapInvocationPattern = regexp.MustCompile(`(?ms)\b` + gradleDependencyConfigurationPattern + `\s*\(?\s*((?:[A-Za-z_][A-Za-z0-9_]*\s*[:=]\s*["'][^"'\n]+["']\s*,?\s*)+)`)
-
-var gradleNamedArgPattern = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\s*[:=]\s*["']([^"']+)["']`)
 
 func parseGradleDependencies(repoPath string) []dependencyDescriptor {
 	descriptors, _ := parseGradleDependenciesWithWarnings(repoPath)
@@ -41,14 +31,27 @@ func parseGradleManifestFiles(files []discoveredGradleFile, catalogResolver shar
 }
 
 func parseGradleDependencyContent(content string) []dependencyDescriptor {
+	descriptors := parseGradleDependencyContentForPath(buildGradleName, content)
+	descriptors = append(descriptors, parseGradleDependencyContentForPath(buildGradleKTSName, content)...)
+	return dedupeDescriptors(descriptors)
+}
+
+func parseGradleDependencyContentForPath(path, content string) []dependencyDescriptor {
+	coordinates := shared.ParseGradleDependencyCoordinatesForFile(path, content)
 	descriptors := make([]dependencyDescriptor, 0)
-	descriptors = append(descriptors, parseGradleDependencyMatches(content, gradleCoordinatePattern)...)
-	descriptors = append(descriptors, parseGradleMapDependencies(content)...)
+	for _, coordinate := range coordinates {
+		descriptors = append(descriptors, dependencyDescriptor{
+			Name:     coordinate.Artifact,
+			Group:    coordinate.Group,
+			Artifact: coordinate.Artifact,
+			Version:  coordinate.Version,
+		})
+	}
 	return dedupeDescriptors(descriptors)
 }
 
 func parseGradleDependencyContentWithCatalog(path string, content string, catalogResolver shared.GradleCatalogResolver) ([]dependencyDescriptor, []string) {
-	descriptors := parseGradleDependencyContent(content)
+	descriptors := parseGradleDependencyContentForPath(path, content)
 	catalogDescriptors, warnings := catalogResolver.ParseDependencyReferences(path, content)
 	for _, descriptor := range catalogDescriptors {
 		descriptors = append(descriptors, dependencyDescriptor{
@@ -59,71 +62,6 @@ func parseGradleDependencyContentWithCatalog(path string, content string, catalo
 		})
 	}
 	return dedupeDescriptors(descriptors), warnings
-}
-
-func parseGradleMapDependencies(content string) []dependencyDescriptor {
-	matches := gradleMapInvocationPattern.FindAllStringSubmatch(content, -1)
-	descriptors := make([]dependencyDescriptor, 0, len(matches))
-	for _, match := range matches {
-		if len(match) < 2 {
-			continue
-		}
-		args := match[1]
-		group := ""
-		artifact := ""
-		version := ""
-		for _, pair := range gradleNamedArgPattern.FindAllStringSubmatch(args, -1) {
-			if len(pair) != 3 {
-				continue
-			}
-			key := strings.ToLower(strings.TrimSpace(pair[1]))
-			value := strings.TrimSpace(pair[2])
-			switch key {
-			case "group":
-				group = value
-			case "name":
-				artifact = value
-			case "version":
-				version = value
-			}
-		}
-		if group == "" || artifact == "" {
-			continue
-		}
-		descriptors = append(descriptors, dependencyDescriptor{
-			Name:     artifact,
-			Group:    group,
-			Artifact: artifact,
-			Version:  version,
-		})
-	}
-	return descriptors
-}
-
-func parseGradleDependencyMatches(content string, pattern *regexp.Regexp) []dependencyDescriptor {
-	matches := pattern.FindAllStringSubmatch(content, -1)
-	descriptors := make([]dependencyDescriptor, 0, len(matches))
-	for _, match := range matches {
-		if len(match) < 3 {
-			continue
-		}
-		group := strings.TrimSpace(match[1])
-		artifact := strings.TrimSpace(match[2])
-		version := ""
-		if len(match) > 3 {
-			version = strings.TrimSpace(match[3])
-		}
-		if group == "" || artifact == "" {
-			continue
-		}
-		descriptors = append(descriptors, dependencyDescriptor{
-			Name:     artifact,
-			Group:    group,
-			Artifact: artifact,
-			Version:  version,
-		})
-	}
-	return descriptors
 }
 
 func parseBuildFiles(repoPath string, parser func(content string) []dependencyDescriptor, names ...string) []dependencyDescriptor {

--- a/internal/lang/kotlinandroid/gradle_scan_parsing_paths_test.go
+++ b/internal/lang/kotlinandroid/gradle_scan_parsing_paths_test.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -358,11 +357,7 @@ func TestLookupBuilderBranches(t *testing.T) {
 }
 
 func TestGradleParsingBranches(t *testing.T) {
-	if descriptors := parseGradleDependencyMatches("anything", regexp.MustCompile(`anything`)); len(descriptors) != 0 {
-		t.Fatalf("expected no descriptors for regex with insufficient capture groups, got %#v", descriptors)
-	}
-	pattern := regexp.MustCompile(`(?m)^\s*([^:]*):([^:\n]*)`)
-	if descriptors := parseGradleDependencyMatches(" :artifact\n", pattern); len(descriptors) != 0 {
+	if descriptors := parseGradleDependencyContent(`implementation(":artifact")`); len(descriptors) != 0 {
 		t.Fatalf("expected no descriptors when group/artifact values are empty, got %#v", descriptors)
 	}
 	if descriptors := parseGradleLockfileContent("# comment\nbad-line\n:artifact:1.0.0\n"); len(descriptors) != 0 {

--- a/internal/lang/rust/manifest.go
+++ b/internal/lang/rust/manifest.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/safeio"
+	toml "github.com/pelletier/go-toml/v2"
 )
 
 type manifestDiscoveryResult struct {
@@ -299,36 +300,19 @@ func parseCargoManifest(manifestPath, repoPath string) (manifestMeta, map[string
 	if err != nil {
 		return manifestMeta{}, nil, err
 	}
-	return parseCargoManifestContent(string(content)), parseCargoDependencies(string(content)), nil
+	document, err := parseCargoManifestDocument(content)
+	if err != nil {
+		return manifestMeta{}, nil, fmt.Errorf("parse Cargo manifest %s: %w", relativeManifestPath(repoPath, manifestPath), err)
+	}
+	return cargoManifestMeta(document), cargoManifestDependencies(document), nil
 }
 
 func parseCargoManifestContent(content string) manifestMeta {
-	meta := manifestMeta{}
-	inWorkspaceMembers := false
-	onSection := func(section string) {
-		inWorkspaceMembers = false
-		markManifestPackageSection(section, &meta)
+	document, err := parseCargoManifestDocument([]byte(content))
+	if err != nil {
+		return manifestMeta{}
 	}
-	onLine := func(section, clean string) {
-		inWorkspaceMembers = parseWorkspaceMembersLine(clean, section, inWorkspaceMembers, &meta)
-	}
-	consumeTomlContent(content, onSection, onLine)
-	meta.WorkspaceMembers = dedupeStrings(meta.WorkspaceMembers)
-	return meta
-}
-
-func parseTomlSectionName(clean string) (string, bool) {
-	match := tablePattern.FindStringSubmatch(clean)
-	if len(match) != 2 {
-		return "", false
-	}
-	return strings.ToLower(strings.TrimSpace(match[1])), true
-}
-
-func markManifestPackageSection(section string, meta *manifestMeta) {
-	if section == "package" {
-		meta.HasPackage = true
-	}
+	return cargoManifestMeta(document)
 }
 
 func parseWorkspaceMembersLine(clean, section string, inWorkspaceMembers bool, meta *manifestMeta) bool {
@@ -360,29 +344,11 @@ func workspaceMembersAssignmentValue(clean string) (string, bool) {
 }
 
 func parseCargoDependencies(content string) map[string]dependencyInfo {
-	deps := make(map[string]dependencyInfo)
-	consumeTomlContent(content, nil, func(section, clean string) {
-		addDependencyFromLine(deps, section, clean)
-	})
-	return deps
-}
-
-func consumeTomlContent(content string, onSection func(string), onLine func(section, clean string)) {
-	section := ""
-	for _, line := range strings.Split(content, "\n") {
-		clean := strings.TrimSpace(stripTomlComment(line))
-		if clean == "" {
-			continue
-		}
-		if nextSection, isSection := parseTomlSectionName(clean); isSection {
-			section = nextSection
-			if onSection != nil {
-				onSection(section)
-			}
-			continue
-		}
-		onLine(section, clean)
+	document, err := parseCargoManifestDocument([]byte(content))
+	if err != nil {
+		return map[string]dependencyInfo{}
 	}
+	return cargoManifestDependencies(document)
 }
 
 func addDependencyFromLine(deps map[string]dependencyInfo, section, clean string) {
@@ -460,15 +426,176 @@ func parseTomlAssignment(line string) (string, string, bool) {
 }
 
 func parseInlineFields(value string) map[string]string {
+	document, err := parseInlineTomlFields(value)
+	if err == nil {
+		return flattenTomlStringFields(document)
+	}
+
 	fields := make(map[string]string)
-	for _, match := range stringFieldPattern.FindAllStringSubmatch(value, -1) {
-		if len(match) != 3 {
+	for _, item := range strings.Split(strings.Trim(value, "{}"), ",") {
+		key, raw, ok := parseTomlAssignment(item)
+		if !ok {
 			continue
 		}
-		key := strings.ToLower(strings.TrimSpace(match[1]))
-		fields[key] = strings.Trim(strings.TrimSpace(match[2]), `"'`)
+		unquoted, ok := parseTomlStringLiteral(raw)
+		if !ok {
+			continue
+		}
+		fields[strings.ToLower(key)] = unquoted
 	}
 	return fields
+}
+
+func parseCargoManifestDocument(content []byte) (map[string]any, error) {
+	document := make(map[string]any)
+	if err := toml.Unmarshal(content, &document); err != nil {
+		return nil, err
+	}
+	return document, nil
+}
+
+func cargoManifestMeta(document map[string]any) manifestMeta {
+	meta := manifestMeta{}
+	if _, ok := document["package"].(map[string]any); ok {
+		meta.HasPackage = true
+	}
+	workspace, _ := document["workspace"].(map[string]any)
+	meta.WorkspaceMembers = dedupeStrings(tomlStringSlice(workspace["members"]))
+	return meta
+}
+
+func cargoManifestDependencies(document map[string]any) map[string]dependencyInfo {
+	deps := make(map[string]dependencyInfo)
+	addTomlDependencyTable(deps, document["dependencies"])
+	addTomlDependencyTable(deps, document["dev-dependencies"])
+	addTomlDependencyTable(deps, document["build-dependencies"])
+	if workspace, ok := document["workspace"].(map[string]any); ok {
+		addTomlDependencyTable(deps, workspace["dependencies"])
+	}
+	if target, ok := document["target"].(map[string]any); ok {
+		addTargetTomlDependencyTables(deps, target)
+	}
+	return deps
+}
+
+func addTargetTomlDependencyTables(deps map[string]dependencyInfo, target map[string]any) {
+	for _, value := range target {
+		targetTable, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		addTomlDependencyTable(deps, targetTable["dependencies"])
+		addTomlDependencyTable(deps, targetTable["dev-dependencies"])
+		addTomlDependencyTable(deps, targetTable["build-dependencies"])
+	}
+}
+
+func addTomlDependencyTable(deps map[string]dependencyInfo, value any) {
+	table, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	for alias, raw := range table {
+		addTomlDependency(deps, alias, raw)
+	}
+}
+
+func addTomlDependency(deps map[string]dependencyInfo, alias string, raw any) {
+	alias = normalizeDependencyID(alias)
+	if alias == "" {
+		return
+	}
+	info := dependencyInfo{Canonical: alias}
+	if fields, ok := raw.(map[string]any); ok {
+		if pkg := tomlString(fields["package"]); pkg != "" {
+			info.Canonical = normalizeDependencyID(pkg)
+			info.Renamed = info.Canonical != alias
+		}
+		if tomlString(fields["path"]) != "" {
+			info.LocalPath = true
+		}
+	}
+	deps[alias] = info
+	ensureCanonicalDependencyAlias(deps, info)
+}
+
+func tomlString(value any) string {
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
+}
+
+func tomlStringSlice(value any) []string {
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	values := make([]string, 0, len(items))
+	for _, item := range items {
+		text := tomlString(item)
+		if text != "" {
+			values = append(values, text)
+		}
+	}
+	return values
+}
+
+func parseInlineTomlFields(value string) (map[string]any, error) {
+	document := make(map[string]any)
+	content := []byte("value = " + strings.TrimSpace(value))
+	if err := toml.Unmarshal(content, &document); err != nil {
+		return nil, err
+	}
+	fields, ok := document["value"].(map[string]any)
+	if !ok {
+		return map[string]any{}, nil
+	}
+	return fields, nil
+}
+
+func flattenTomlStringFields(document map[string]any) map[string]string {
+	fields := make(map[string]string)
+	flattenTomlStringFieldsInto(fields, "", document)
+	return fields
+}
+
+func flattenTomlStringFieldsInto(fields map[string]string, prefix string, document map[string]any) {
+	for key, value := range document {
+		key = strings.ToLower(strings.TrimSpace(key))
+		if key == "" {
+			continue
+		}
+		if prefix != "" {
+			key = prefix + "." + key
+		}
+		switch typed := value.(type) {
+		case string:
+			fields[key] = strings.TrimSpace(typed)
+		case map[string]any:
+			flattenTomlStringFieldsInto(fields, key, typed)
+		}
+	}
+}
+
+func parseTomlStringLiteral(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 {
+		return "", false
+	}
+	if (value[0] != '"' || value[len(value)-1] != '"') && (value[0] != '\'' || value[len(value)-1] != '\'') {
+		return "", false
+	}
+	return strings.Trim(value, `"'`), true
+}
+
+func relativeManifestPath(repoPath, manifestPath string) string {
+	relative, err := filepath.Rel(repoPath, manifestPath)
+	if err != nil {
+		return manifestPath
+	}
+	return relative
 }
 
 func stripTomlComment(line string) string {

--- a/internal/lang/rust/manifest_structured_test.go
+++ b/internal/lang/rust/manifest_structured_test.go
@@ -1,0 +1,152 @@
+package rust
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStructuredCargoManifestParserBranches(t *testing.T) {
+	content := []byte(`
+[package]
+name = "demo"
+
+[workspace]
+members = ["crates/a", "crates/b"]
+
+[dependencies]
+serde = "1"
+serde_json_alias = { package = "serde_json", path = "./vendor/serde_json" }
+
+[workspace.dependencies]
+workspace_dep = "1"
+
+[target.'cfg(unix)'.dev-dependencies]
+clap_alias = { package = "clap", version = "4" }
+`)
+	document, err := parseCargoManifestDocument(content)
+	if err != nil {
+		t.Fatalf("parse manifest document: %v", err)
+	}
+	meta := cargoManifestMeta(document)
+	if !meta.HasPackage || strings.Join(meta.WorkspaceMembers, ",") != "crates/a,crates/b" {
+		t.Fatalf("unexpected manifest meta: %#v", meta)
+	}
+	deps := cargoManifestDependencies(document)
+	if deps["serde"].Canonical != "serde" {
+		t.Fatalf("expected string dependency to map canonically, got %#v", deps["serde"])
+	}
+	if deps["serde-json-alias"].Canonical != "serde-json" || !deps["serde-json-alias"].LocalPath || !deps["serde-json-alias"].Renamed {
+		t.Fatalf("expected renamed local dependency from inline table, got %#v", deps["serde-json-alias"])
+	}
+	if deps["workspace-dep"].Canonical != "workspace-dep" {
+		t.Fatalf("expected workspace dependency table to parse, got %#v", deps["workspace-dep"])
+	}
+	if deps["clap-alias"].Canonical != "clap" || !deps["clap-alias"].Renamed {
+		t.Fatalf("expected target dependency table to parse, got %#v", deps["clap-alias"])
+	}
+	direct := map[string]dependencyInfo{}
+	addTargetTomlDependencyTables(direct, map[string]any{
+		"cfg(windows)": "ignored",
+		"cfg(test)": map[string]any{
+			"build-dependencies": map[string]any{"build_dep": "1"},
+		},
+	})
+	addTomlDependencyTable(direct, "ignored")
+	addTomlDependency(direct, "", "ignored")
+	addTomlDependency(direct, "plain_dep", "1")
+	addTomlDependency(direct, "weird_dep", map[string]any{"package": 12, "path": 13})
+	if direct["build-dep"].Canonical != "build-dep" || direct["plain-dep"].Canonical != "plain-dep" {
+		t.Fatalf("expected direct TOML dependency helpers to keep canonical aliases, got %#v", direct)
+	}
+	if direct["weird-dep"].Renamed || direct["weird-dep"].LocalPath {
+		t.Fatalf("expected non-string inline fields to be ignored, got %#v", direct["weird-dep"])
+	}
+	fields := flattenTomlStringFields(map[string]any{
+		" version ": map[string]any{" ref ": "shared"},
+		"ignored":   12,
+		" ":         "skip",
+	})
+	if fields["version.ref"] != "shared" || len(fields) != 1 {
+		t.Fatalf("expected nested TOML string fields only, got %#v", fields)
+	}
+
+	if meta := parseCargoManifestContent("not valid = "); meta.HasPackage || len(meta.WorkspaceMembers) != 0 {
+		t.Fatalf("expected invalid content helper to return zero meta, got %#v", meta)
+	}
+	if deps := parseCargoDependencies("not valid = "); len(deps) != 0 {
+		t.Fatalf("expected invalid dependency content to return no deps, got %#v", deps)
+	}
+}
+
+func TestParseCargoManifestReportsRelativeTOMLError(t *testing.T) {
+	repo := t.TempDir()
+	manifestPath := filepath.Join(repo, cargoTomlName)
+	writeFile(t, manifestPath, "not valid = ")
+	if _, _, err := parseCargoManifest(manifestPath, repo); err == nil || !strings.Contains(err.Error(), cargoTomlName) {
+		t.Fatalf("expected relative Cargo.toml parse error, got %v", err)
+	}
+}
+
+func TestInlineTomlFieldFallbackBranches(t *testing.T) {
+	fields := parseInlineFields(`{ package = "serde_json", bad = provider("x"), path = "./vendor" }`)
+	if fields["package"] != "serde_json" || fields["path"] != "./vendor" {
+		t.Fatalf("expected fallback inline field parser to keep string fields, got %#v", fields)
+	}
+	if got, ok := parseTomlStringLiteral(`"serde_json"`); !ok || got != "serde_json" {
+		t.Fatalf("expected quoted TOML literal to parse, got %q %t", got, ok)
+	}
+	if got, ok := parseTomlStringLiteral(`serde_json`); ok || got != "" {
+		t.Fatalf("expected unquoted TOML literal to be rejected, got %q %t", got, ok)
+	}
+	if fields, err := parseInlineTomlFields("1"); err != nil || len(fields) != 0 {
+		t.Fatalf("expected non-table inline TOML value to parse as empty fields, got %#v %v", fields, err)
+	}
+	if got := tomlStringSlice([]any{" a ", 12, ""}); strings.Join(got, ",") != "a" {
+		t.Fatalf("expected TOML string slice helper to keep only non-empty strings, got %#v", got)
+	}
+}
+
+func TestRustManifestHelperCoverageBranches(t *testing.T) {
+	repo := t.TempDir()
+	inside := filepath.Join(repo, "src", "lib.rs")
+	outside := filepath.Join(filepath.Dir(repo), "outside.rs")
+	if !isSubPath(repo, repo) || !isSubPath(repo, inside) {
+		t.Fatalf("expected repo and child paths to be within root")
+	}
+	if isSubPath(repo, outside) || isSubPath("\x00", inside) || isSubPath(repo, "\x00") {
+		t.Fatalf("expected outside or invalid paths to be rejected")
+	}
+	if !samePath("\x00", "\x00") || samePath("\x00", "\x00-other") {
+		t.Fatalf("expected samePath fallback to compare cleaned invalid paths")
+	}
+	if got := uniquePaths([]string{" b ", "a", "", "b", "a"}); strings.Join(got, ",") != ".,a,b" {
+		t.Fatalf("expected unique paths to trim, sort, and dedupe, got %#v", got)
+	}
+
+	if matched, err := workspaceMemberPatternMatches("", "crate"); err != nil || matched {
+		t.Fatalf("expected empty workspace member pattern to miss, got %t %v", matched, err)
+	}
+	if _, err := workspaceMemberPatternMatches("[", "crate"); err == nil {
+		t.Fatalf("expected invalid workspace member glob to return an error")
+	}
+	meta := manifestMeta{}
+	if parseWorkspaceMembersLine(`"crates/a"]`, "workspace", true, &meta) {
+		t.Fatalf("expected closing workspace members continuation to report completion")
+	}
+	if len(meta.WorkspaceMembers) != 1 || meta.WorkspaceMembers[0] != "crates/a" {
+		t.Fatalf("expected continuation workspace member to parse, got %#v", meta.WorkspaceMembers)
+	}
+
+	for _, section := range []string{"target.cfg.dependencies", "target.cfg.dev-dependencies", "target.cfg.build-dependencies"} {
+		if !isDependencySection(section) {
+			t.Fatalf("expected %s to be a dependency section", section)
+		}
+	}
+	if isDependencySection("target.cfg.profile") {
+		t.Fatalf("expected non-dependency target section to be ignored")
+	}
+	if got := stripTomlComment(`name = 'x#y' # comment`); strings.TrimSpace(got) != `name = 'x#y'` {
+		t.Fatalf("expected single-quoted hash to be preserved while stripping comment, got %q", got)
+	}
+}

--- a/internal/lang/rust/types.go
+++ b/internal/lang/rust/types.go
@@ -66,8 +66,6 @@ type usePathEntry struct {
 }
 
 var (
-	tablePattern       = regexp.MustCompile(`^\s*\[([^\]]+)\]\s*$`)
-	stringFieldPattern = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*("(?:[^"]*)"|'(?:[^']*)')`)
 	macroInvokePattern = regexp.MustCompile(`(?m)\b[A-Za-z_][A-Za-z0-9_]*!\s*(?:\(|\{|\[)`)
 )
 

--- a/internal/lang/shared/adapter_scaffold_walk_context_test.go
+++ b/internal/lang/shared/adapter_scaffold_walk_context_test.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -31,5 +32,23 @@ func TestResolvePathWithMissingLeaf(t *testing.T) {
 	want := filepath.Join(wantPrefix, "missing", "leaf.txt")
 	if resolved != want {
 		t.Fatalf("resolved path = %q, want %q", resolved, want)
+	}
+	if resolved, err := resolvePathWithMissingLeaf("/"); err != nil || resolved != "/" {
+		t.Fatalf("expected root path to resolve to itself, got %q %v", resolved, err)
+	}
+	if _, err := resolvePathWithMissingLeaf("\x00"); err == nil {
+		t.Fatalf("expected invalid path to fail resolution")
+	}
+	brokenSymlink := filepath.Join(repo, "broken")
+	if err := os.Symlink(filepath.Join(repo, "missing-target"), brokenSymlink); err == nil {
+		if _, err := resolvePathWithMissingLeaf(brokenSymlink); err == nil {
+			t.Fatalf("expected broken symlink resolution to fail")
+		}
+	}
+	if !pathWithin(repo, repo) {
+		t.Fatalf("expected pathWithin to accept the root itself")
+	}
+	if pathWithin(repo, repo+"-sibling") {
+		t.Fatalf("expected pathWithin to reject sibling paths with matching prefixes")
 	}
 }

--- a/internal/lang/shared/dependency_usage_test.go
+++ b/internal/lang/shared/dependency_usage_test.go
@@ -215,6 +215,9 @@ func TestDeclarationAndMaskingHelpers(t *testing.T) {
 	if declarationLineContainsToken(content, lineStarts, 1, "bar") {
 		t.Fatalf("expected missing token to return false")
 	}
+	if declarationLineContainsToken([]byte("x"), []int{1, 1}, 1, "x") {
+		t.Fatalf("expected malformed line offsets to be rejected")
+	}
 
 	escaped := []byte("\\\"")
 	next, state := scanQuoted(escaped, 0, '"', scannerStateDoubleQuote)
@@ -533,6 +536,14 @@ func TestSortReportsByWasteAndHelpers(t *testing.T) {
 	SortReportsByWaste(reports)
 	if reports[0].Name != "a" {
 		t.Fatalf("expected alpha tie-break on name, got %q", reports[0].Name)
+	}
+	scoreOrdered := []report.DependencyReport{
+		{Name: "low-waste", UsedPercent: 90, TotalExportsCount: 10},
+		{Name: "high-waste", UsedPercent: 10, TotalExportsCount: 10},
+	}
+	SortReportsByWaste(scoreOrdered)
+	if scoreOrdered[0].Name != "high-waste" {
+		t.Fatalf("expected higher waste score to sort first, got %#v", scoreOrdered)
 	}
 
 	if score, ok := WasteScore(report.DependencyReport{TotalExportsCount: 0}); ok || score != -1 {

--- a/internal/lang/shared/gradle_build.go
+++ b/internal/lang/shared/gradle_build.go
@@ -1,0 +1,449 @@
+package shared
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/groovy"
+	"github.com/smacker/go-tree-sitter/kotlin"
+)
+
+type GradleDependencyCoordinate struct {
+	Group    string
+	Artifact string
+	Version  string
+}
+
+type gradleCatalogReference struct {
+	catalogName           string
+	alias                 string
+	bundle                bool
+	unsupportedExpression string
+}
+
+var gradleDependencyConfigurations = map[string]struct{}{
+	"androidTestImplementation": {},
+	"annotationProcessor":       {},
+	"api":                       {},
+	"classpath":                 {},
+	"compileOnly":               {},
+	"debugImplementation":       {},
+	"implementation":            {},
+	"kapt":                      {},
+	"kaptAndroidTest":           {},
+	"kaptTest":                  {},
+	"ksp":                       {},
+	"releaseImplementation":     {},
+	"runtimeOnly":               {},
+	"testAnnotationProcessor":   {},
+	"testCompileOnly":           {},
+	"testImplementation":        {},
+	"testRuntimeOnly":           {},
+}
+
+func ParseGradleDependencyCoordinatesForFile(path, content string) []GradleDependencyCoordinate {
+	return ParseGradleDependencyCoordinates(content, gradleLanguageForPath(path))
+}
+
+func ParseGradleDependencyCoordinates(content string, language *sitter.Language) []GradleDependencyCoordinate {
+	if language == nil || strings.TrimSpace(content) == "" {
+		return nil
+	}
+	parser := sitter.NewParser()
+	parser.SetLanguage(language)
+	tree, err := parser.ParseCtx(context.Background(), nil, []byte(content))
+	if err != nil || tree == nil {
+		return nil
+	}
+	source := []byte(content)
+	coordinates := make([]GradleDependencyCoordinate, 0)
+	walkGradleNode(tree.RootNode(), func(node *sitter.Node) {
+		if !isGradleDependencyCall(node, source) {
+			return
+		}
+		if coordinate, ok := gradleCoordinateFromCall(node, source); ok {
+			coordinates = append(coordinates, coordinate)
+		}
+	})
+	return coordinates
+}
+
+func parseGradleCatalogReferencesForFile(path, content string) []gradleCatalogReference {
+	language := gradleLanguageForPath(path)
+	if language == nil || strings.TrimSpace(content) == "" {
+		return nil
+	}
+	parser := sitter.NewParser()
+	parser.SetLanguage(language)
+	tree, err := parser.ParseCtx(context.Background(), nil, []byte(content))
+	if err != nil || tree == nil {
+		return nil
+	}
+	source := []byte(content)
+	references := make([]gradleCatalogReference, 0)
+	walkGradleNode(tree.RootNode(), func(node *sitter.Node) {
+		if !isGradleDependencyCall(node, source) {
+			return
+		}
+		for _, arg := range gradleCallArguments(node) {
+			for _, expression := range gradleDependencyArgumentExpressions(arg, source) {
+				reference, ok := parseGradleCatalogReferenceExpression(expression)
+				if ok {
+					references = append(references, reference)
+				}
+			}
+		}
+	})
+	return references
+}
+
+func gradleLanguageForPath(path string) *sitter.Language {
+	if strings.EqualFold(filepath.Ext(path), ".kts") {
+		return kotlin.GetLanguage()
+	}
+	return groovy.GetLanguage()
+}
+
+func walkGradleNode(node *sitter.Node, visit func(*sitter.Node)) {
+	if node == nil {
+		return
+	}
+	visit(node)
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		walkGradleNode(node.NamedChild(i), visit)
+	}
+}
+
+func isGradleDependencyCall(node *sitter.Node, source []byte) bool {
+	name, ok := gradleCallName(node, source)
+	if !ok {
+		return false
+	}
+	_, ok = gradleDependencyConfigurations[name]
+	return ok
+}
+
+func gradleCallName(node *sitter.Node, source []byte) (string, bool) {
+	switch node.Type() {
+	case "call_expression":
+		first := node.NamedChild(0)
+		if first == nil || first.Type() != "simple_identifier" {
+			return "", false
+		}
+		return gradleNodeText(first, source), true
+	case "function_call", "juxt_function_call":
+		first := node.NamedChild(0)
+		if first == nil || first.Type() != "identifier" {
+			return "", false
+		}
+		return gradleNodeText(first, source), true
+	default:
+		return "", false
+	}
+}
+
+func gradleCoordinateFromCall(node *sitter.Node, source []byte) (GradleDependencyCoordinate, bool) {
+	args := gradleCallArguments(node)
+	fields := make(map[string]string)
+	for _, arg := range args {
+		if coordinate, ok := gradleCoordinateFromArgument(arg, source); ok {
+			return coordinate, true
+		}
+		collectGradleNamedArgument(fields, arg, source)
+	}
+	return gradleCoordinateFromFields(fields)
+}
+
+func gradleCallArguments(node *sitter.Node) []*sitter.Node {
+	if node == nil || node.NamedChildCount() < 2 {
+		return nil
+	}
+	container := node.NamedChild(1)
+	if container == nil {
+		return nil
+	}
+	switch container.Type() {
+	case "call_suffix":
+		return gradleCallSuffixArguments(container)
+	case "argument_list":
+		return gradleNamedChildren(container)
+	default:
+		return gradleNamedChildren(container)
+	}
+}
+
+func gradleCallSuffixArguments(node *sitter.Node) []*sitter.Node {
+	args := make([]*sitter.Node, 0)
+	for _, child := range gradleNamedChildren(node) {
+		if child.Type() == "value_arguments" {
+			args = append(args, gradleNamedChildren(child)...)
+			continue
+		}
+		args = append(args, child)
+	}
+	return args
+}
+
+func gradleNamedChildren(node *sitter.Node) []*sitter.Node {
+	if node == nil {
+		return nil
+	}
+	children := make([]*sitter.Node, 0, int(node.NamedChildCount()))
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(i)
+		if child != nil {
+			children = append(children, child)
+		}
+	}
+	return children
+}
+
+func gradleCoordinateFromArgument(node *sitter.Node, source []byte) (GradleDependencyCoordinate, bool) {
+	if node == nil {
+		return GradleDependencyCoordinate{}, false
+	}
+	if text, ok := gradleStringValue(node, source); ok {
+		return parseGradleCoordinate(text)
+	}
+	if isGradlePlatformCall(node, source) {
+		for _, arg := range gradleCallArguments(node) {
+			if text, ok := gradleStringValue(arg, source); ok {
+				return parseGradleCoordinate(text)
+			}
+		}
+	}
+	if node.Type() == "value_argument" && node.NamedChildCount() == 1 {
+		return gradleCoordinateFromArgument(node.NamedChild(0), source)
+	}
+	return GradleDependencyCoordinate{}, false
+}
+
+func gradleDependencyArgumentExpressions(node *sitter.Node, source []byte) []string {
+	if node == nil {
+		return nil
+	}
+	if node.Type() == "value_argument" && node.NamedChildCount() == 1 {
+		return gradleDependencyArgumentExpressions(node.NamedChild(0), source)
+	}
+	if isGradlePlatformCall(node, source) {
+		expressions := make([]string, 0)
+		for _, arg := range gradleCallArguments(node) {
+			expressions = append(expressions, gradleDependencyArgumentExpressions(arg, source)...)
+		}
+		return expressions
+	}
+	if _, ok := gradleStringValue(node, source); ok {
+		return nil
+	}
+	return []string{gradleNodeText(node, source)}
+}
+
+func isGradlePlatformCall(node *sitter.Node, source []byte) bool {
+	name, ok := gradleCallName(node, source)
+	if !ok {
+		return false
+	}
+	return name == "platform" || name == "enforcedPlatform"
+}
+
+func gradleStringValue(node *sitter.Node, source []byte) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	switch node.Type() {
+	case "string", "string_literal":
+		return gradleStringLiteralText(node, source)
+	case "value_argument":
+		if node.NamedChildCount() == 1 {
+			return gradleStringValue(node.NamedChild(0), source)
+		}
+	}
+	return "", false
+}
+
+func gradleStringLiteralText(node *sitter.Node, source []byte) (string, bool) {
+	parts := make([]string, 0)
+	walkGradleNode(node, func(child *sitter.Node) {
+		if child.Type() == "string_content" {
+			parts = append(parts, gradleNodeText(child, source))
+		}
+	})
+	if len(parts) == 0 {
+		return "", false
+	}
+	return strings.Join(parts, ""), true
+}
+
+func collectGradleNamedArgument(fields map[string]string, node *sitter.Node, source []byte) {
+	if node == nil {
+		return
+	}
+	switch node.Type() {
+	case "map_item":
+		if node.NamedChildCount() < 2 {
+			return
+		}
+		key := gradleNodeText(node.NamedChild(0), source)
+		value, ok := gradleStringValue(node.NamedChild(1), source)
+		if ok {
+			fields[strings.ToLower(strings.TrimSpace(key))] = value
+		}
+	case "value_argument":
+		if node.NamedChildCount() < 2 {
+			return
+		}
+		keyNode := node.NamedChild(0)
+		if keyNode == nil || keyNode.Type() != "simple_identifier" {
+			return
+		}
+		value, ok := gradleStringValue(node.NamedChild(1), source)
+		if ok {
+			fields[strings.ToLower(strings.TrimSpace(gradleNodeText(keyNode, source)))] = value
+		}
+	}
+}
+
+func gradleCoordinateFromFields(fields map[string]string) (GradleDependencyCoordinate, bool) {
+	group := strings.TrimSpace(fields["group"])
+	artifact := strings.TrimSpace(fields["name"])
+	if group == "" || artifact == "" {
+		return GradleDependencyCoordinate{}, false
+	}
+	return GradleDependencyCoordinate{
+		Group:    group,
+		Artifact: artifact,
+		Version:  strings.TrimSpace(fields["version"]),
+	}, true
+}
+
+func parseGradleCoordinate(value string) (GradleDependencyCoordinate, bool) {
+	parts := strings.Split(strings.TrimSpace(value), ":")
+	if len(parts) != 2 && len(parts) != 3 {
+		return GradleDependencyCoordinate{}, false
+	}
+	group := strings.TrimSpace(parts[0])
+	artifact := strings.TrimSpace(parts[1])
+	if group == "" || artifact == "" {
+		return GradleDependencyCoordinate{}, false
+	}
+	coordinate := GradleDependencyCoordinate{
+		Group:    group,
+		Artifact: artifact,
+	}
+	if len(parts) == 3 {
+		coordinate.Version = strings.TrimSpace(parts[2])
+	}
+	return coordinate, true
+}
+
+func parseGradleCatalogReferenceExpression(expression string) (gradleCatalogReference, bool) {
+	expression = strings.TrimSpace(expression)
+	if expression == "" {
+		return gradleCatalogReference{}, false
+	}
+	if reference, ok := parseGradleCatalogFinderExpression(expression); ok {
+		return reference, true
+	}
+	if reference, ok := parseGradleCatalogBracketExpression(expression); ok {
+		return reference, true
+	}
+	return parseGradleCatalogPropertyExpression(expression)
+}
+
+func parseGradleCatalogFinderExpression(expression string) (gradleCatalogReference, bool) {
+	clean := stripGradleExpressionSpaces(expression)
+	for _, method := range []string{".findLibrary(", ".findBundle("} {
+		index := strings.Index(clean, method)
+		if index < 1 {
+			continue
+		}
+		catalogName := clean[:index]
+		alias, ok := firstGradleQuotedValue(clean[index+len(method):])
+		if !ok {
+			return gradleCatalogReference{}, false
+		}
+		return gradleCatalogReference{
+			catalogName: normalizeGradleCatalogName(catalogName),
+			alias:       normalizeGradleCatalogAccessor(alias),
+			bundle:      method == ".findBundle(",
+		}, true
+	}
+	return gradleCatalogReference{}, false
+}
+
+func parseGradleCatalogBracketExpression(expression string) (gradleCatalogReference, bool) {
+	clean := stripGradleExpressionSpaces(expression)
+	index := strings.Index(clean, "[")
+	if index < 1 {
+		return gradleCatalogReference{}, false
+	}
+	alias, ok := firstGradleQuotedValue(clean[index+1:])
+	if !ok {
+		return gradleCatalogReference{}, false
+	}
+	return gradleCatalogReference{
+		catalogName: normalizeGradleCatalogName(clean[:index]),
+		alias:       normalizeGradleCatalogAccessor(alias),
+	}, true
+}
+
+func parseGradleCatalogPropertyExpression(expression string) (gradleCatalogReference, bool) {
+	clean := normalizeGradleCatalogExpression(expression)
+	if clean == "" || strings.Contains(clean, ".findlibrary") || strings.Contains(clean, ".findbundle") {
+		return gradleCatalogReference{}, false
+	}
+	segments := strings.Split(clean, ".")
+	if len(segments) < 2 {
+		return gradleCatalogReference{}, false
+	}
+	reference := gradleCatalogReference{catalogName: normalizeGradleCatalogName(segments[0])}
+	switch {
+	case len(segments) >= 3 && segments[1] == "bundles":
+		reference.alias = normalizeGradleCatalogAccessor(strings.Join(segments[2:], "."))
+		reference.bundle = true
+	case len(segments) >= 3 && (segments[1] == "versions" || segments[1] == "plugins"):
+		reference.unsupportedExpression = clean
+	default:
+		reference.alias = normalizeGradleCatalogAccessor(strings.Join(segments[1:], "."))
+	}
+	return reference, true
+}
+
+func stripGradleExpressionSpaces(value string) string {
+	var builder strings.Builder
+	builder.Grow(len(value))
+	for _, r := range value {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			continue
+		}
+		builder.WriteRune(r)
+	}
+	return builder.String()
+}
+
+func firstGradleQuotedValue(value string) (string, bool) {
+	quote := rune(0)
+	var builder strings.Builder
+	for _, r := range value {
+		if quote == 0 {
+			if r == '\'' || r == '"' {
+				quote = r
+			}
+			continue
+		}
+		if r == quote {
+			return builder.String(), true
+		}
+		builder.WriteRune(r)
+	}
+	return "", false
+}
+
+func gradleNodeText(node *sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	return string(source[node.StartByte():node.EndByte()])
+}

--- a/internal/lang/shared/gradle_build_test.go
+++ b/internal/lang/shared/gradle_build_test.go
@@ -1,0 +1,158 @@
+package shared
+
+import (
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+func TestParseGradleDependencyCoordinatesForGroovyAndKotlin(t *testing.T) {
+	groovyDeps := ParseGradleDependencyCoordinatesForFile("build.gradle", `
+dependencies {
+  implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+  implementation group: 'com.google.guava', name: 'guava', version: '33.2.0-jre'
+  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.0"))
+}
+`)
+	assertGradleCoordinate(t, groovyDeps, "com.squareup.okhttp3", "okhttp", "4.12.0")
+	assertGradleCoordinate(t, groovyDeps, "com.google.guava", "guava", "33.2.0-jre")
+	assertGradleCoordinate(t, groovyDeps, "org.springframework.boot", "spring-boot-dependencies", "3.3.0")
+
+	kotlinDeps := ParseGradleDependencyCoordinatesForFile("build.gradle.kts", `
+dependencies {
+  implementation("androidx.core:core-ktx:1.13.1")
+  implementation(group = "com.squareup.okhttp3", name = "okhttp", version = "4.12.0")
+  implementation(enforcedPlatform("org.springframework.boot:spring-boot-dependencies:3.3.0"))
+}
+`)
+	assertGradleCoordinate(t, kotlinDeps, "androidx.core", "core-ktx", "1.13.1")
+	assertGradleCoordinate(t, kotlinDeps, "com.squareup.okhttp3", "okhttp", "4.12.0")
+	assertGradleCoordinate(t, kotlinDeps, "org.springframework.boot", "spring-boot-dependencies", "3.3.0")
+
+	if got := ParseGradleDependencyCoordinates("", nil); len(got) != 0 {
+		t.Fatalf("expected nil parser inputs to produce no coordinates, got %#v", got)
+	}
+}
+
+func TestParseGradleCatalogReferencesFromDependencyCalls(t *testing.T) {
+	references := parseGradleCatalogReferencesForFile("build.gradle.kts", `
+dependencies {
+  implementation(libs.okhttp)
+  implementation(libs.bundles.networking)
+  implementation(testLibs.findBundle("qa").get())
+  implementation(testLibs.findLibrary("junit").get())
+  implementation(libs["retrofit"])
+  implementation(libs.plugins.android)
+  implementation(libs.versions.kotlin)
+  implementation(platform(libs.spring.boot))
+}
+`)
+	assertGradleCatalogReference(t, references, "libs", "okhttp", false, "")
+	assertGradleCatalogReference(t, references, "libs", "networking", true, "")
+	assertGradleCatalogReference(t, references, "testlibs", "qa", true, "")
+	assertGradleCatalogReference(t, references, "testlibs", "junit", false, "")
+	assertGradleCatalogReference(t, references, "libs", "retrofit", false, "")
+	assertGradleCatalogReference(t, references, "libs", "", false, "libs.plugins.android")
+	assertGradleCatalogReference(t, references, "libs", "", false, "libs.versions.kotlin")
+	assertGradleCatalogReference(t, references, "libs", "spring.boot", false, "")
+
+	if _, ok := parseGradleCatalogFinderExpression(`libs.findLibrary(foo).get()`); ok {
+		t.Fatalf("expected finder expression without quoted alias to be rejected")
+	}
+	if _, ok := parseGradleCatalogBracketExpression(`libs[foo]`); ok {
+		t.Fatalf("expected bracket expression without quoted alias to be rejected")
+	}
+	if _, ok := parseGradleCatalogPropertyExpression("libs"); ok {
+		t.Fatalf("expected single-segment catalog expression to be rejected")
+	}
+	if got := parseGradleCatalogReferencesForFile("build.gradle", ""); len(got) != 0 {
+		t.Fatalf("expected empty Gradle content to produce no catalog references, got %#v", got)
+	}
+	if _, ok := parseGradleCatalogReferenceExpression(""); ok {
+		t.Fatalf("expected empty catalog reference expression to be rejected")
+	}
+	if _, ok := parseGradleCatalogFinderExpression("libs.findLibrary()"); ok {
+		t.Fatalf("expected finder expression without quoted value to be rejected")
+	}
+	if got := stripGradleExpressionSpaces(" libs . foo \n"); got != "libs.foo" {
+		t.Fatalf("unexpected Gradle expression whitespace stripping: %q", got)
+	}
+	if got, ok := firstGradleQuotedValue("no quote"); ok || got != "" {
+		t.Fatalf("expected missing quoted value to be rejected, got %q %t", got, ok)
+	}
+}
+
+func TestGradleBuildParserDefensiveHelpers(t *testing.T) {
+	if args := gradleCallArguments(nil); len(args) != 0 {
+		t.Fatalf("expected nil call arguments to return none, got %#v", args)
+	}
+	if children := gradleNamedChildren(nil); len(children) != 0 {
+		t.Fatalf("expected nil named children to return none, got %#v", children)
+	}
+	if text := gradleNodeText(nil, nil); text != "" {
+		t.Fatalf("expected nil node text to be empty, got %q", text)
+	}
+	if _, ok := gradleCoordinateFromArgument(nil, nil); ok {
+		t.Fatalf("expected nil coordinate argument to be rejected")
+	}
+	if _, ok := parseGradleCoordinate("missing-version-parts"); ok {
+		t.Fatalf("expected malformed Gradle coordinate to be rejected")
+	}
+	if _, ok := parseGradleCoordinate(":artifact:1.0.0"); ok {
+		t.Fatalf("expected Gradle coordinate without group to be rejected")
+	}
+	if coordinate, ok := parseGradleCoordinate("com.example:demo"); !ok || coordinate.Group != "com.example" || coordinate.Artifact != "demo" || coordinate.Version != "" {
+		t.Fatalf("expected two-part Gradle coordinate to parse without version, got %#v %t", coordinate, ok)
+	}
+	visited := false
+	walkGradleNode(nil, func(*sitter.Node) { visited = true })
+	if visited {
+		t.Fatalf("expected nil Gradle node walk to skip visitor")
+	}
+	if _, ok := gradleStringValue(nil, nil); ok {
+		t.Fatalf("expected nil Gradle string value to be rejected")
+	}
+	if expressions := gradleDependencyArgumentExpressions(nil, nil); len(expressions) != 0 {
+		t.Fatalf("expected nil Gradle dependency argument to return no expressions, got %#v", expressions)
+	}
+	if text, ok := gradleStringLiteralText(nil, nil); ok || text != "" {
+		t.Fatalf("expected nil Gradle string literal to be rejected, got %q %t", text, ok)
+	}
+	fields := map[string]string{}
+	collectGradleNamedArgument(fields, nil, nil)
+	if len(fields) != 0 {
+		t.Fatalf("expected nil named Gradle argument to leave fields empty, got %#v", fields)
+	}
+	if _, ok := gradleCoordinateFromFields(map[string]string{"group": "com.example"}); ok {
+		t.Fatalf("expected incomplete Gradle coordinate fields to be rejected")
+	}
+	if _, ok := parseGradleCatalogBracketExpression(`["okhttp"]`); ok {
+		t.Fatalf("expected bracket catalog expression without catalog name to be rejected")
+	}
+	if _, ok := parseGradleCatalogPropertyExpression("libs.findLibrary.foo"); ok {
+		t.Fatalf("expected malformed finder property expression to be rejected")
+	}
+	if _, ok := firstGradleQuotedValue(`"unterminated`); ok {
+		t.Fatalf("expected unterminated quoted value to be rejected")
+	}
+}
+
+func assertGradleCoordinate(t *testing.T, coordinates []GradleDependencyCoordinate, group, artifact, version string) {
+	t.Helper()
+	for _, coordinate := range coordinates {
+		if coordinate.Group == group && coordinate.Artifact == artifact && coordinate.Version == version {
+			return
+		}
+	}
+	t.Fatalf("expected Gradle coordinate %s:%s:%s in %#v", group, artifact, version, coordinates)
+}
+
+func assertGradleCatalogReference(t *testing.T, references []gradleCatalogReference, catalogName, alias string, bundle bool, unsupported string) {
+	t.Helper()
+	for _, reference := range references {
+		if reference.catalogName == catalogName && reference.alias == alias && reference.bundle == bundle && reference.unsupportedExpression == unsupported {
+			return
+		}
+	}
+	t.Fatalf("expected Gradle catalog reference catalog=%q alias=%q bundle=%t unsupported=%q in %#v", catalogName, alias, bundle, unsupported, references)
+}

--- a/internal/lang/shared/gradle_catalog.go
+++ b/internal/lang/shared/gradle_catalog.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/safeio"
+	toml "github.com/pelletier/go-toml/v2"
 )
 
 const gradleCatalogScopeKeySeparator = "\x00"
@@ -84,34 +85,17 @@ type gradleCatalogReferenceCollector struct {
 }
 
 type gradleCatalogFileParser struct {
-	catalogName    string
-	relativePath   string
-	versions       map[string]string
-	libraries      map[string]GradleCatalogLibrary
-	bundleSpecs    map[string][]string
-	warnings       []string
-	section        string
-	pendingSection string
-	pendingKey     string
-	pendingValue   strings.Builder
-}
-
-type gradleCatalogDelimiterState struct {
-	braceDepth   int
-	bracketDepth int
-	inDouble     bool
-	inSingle     bool
+	catalogName  string
+	relativePath string
+	versions     map[string]string
+	libraries    map[string]GradleCatalogLibrary
+	bundleSpecs  map[string][]string
+	warnings     []string
 }
 
 var (
 	gradleCatalogCreateBlockPattern    = regexp.MustCompile(`(?ms)\bcreate\s*\(\s*["']([^"']+)["']\s*\)\s*\{(.*?)\}`)
 	gradleCatalogQuotedFilePathPattern = regexp.MustCompile(`["']([^"']+\.toml)["']`)
-	gradleCatalogSectionPattern        = regexp.MustCompile(`^\s*\[([^\]]+)\]\s*$`)
-	gradleCatalogInlineFieldPattern    = regexp.MustCompile(`\b([A-Za-z0-9_.-]+)\s*=\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')`)
-	gradleCatalogNestedVersionRefRegex = regexp.MustCompile(`\bversion\s*=\s*\{\s*ref\s*=\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')`)
-	gradleCatalogPropertyPattern       = regexp.MustCompile(`(?ms)\b(?:implementation|api|compileOnly|runtimeOnly|kapt|ksp|testImplementation|androidTestImplementation|testRuntimeOnly)\s*\(?\s*(?:platform\s*\(\s*)?([A-Za-z_][A-Za-z0-9_]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)+)`)
-	gradleCatalogBracketPattern        = regexp.MustCompile(`(?ms)\b(?:implementation|api|compileOnly|runtimeOnly|kapt|ksp|testImplementation|androidTestImplementation|testRuntimeOnly)\s*\(?\s*(?:platform\s*\(\s*)?([A-Za-z_][A-Za-z0-9_]*)\s*\[\s*["']([^"']+)["']\s*\]`)
-	gradleCatalogFinderPattern         = regexp.MustCompile(`(?ms)\b(?:implementation|api|compileOnly|runtimeOnly|kapt|ksp|testImplementation|androidTestImplementation|testRuntimeOnly)\s*\(?\s*(?:platform\s*\(\s*)?([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*(findLibrary|findBundle)\s*\(\s*["']([^"']+)["']\s*\)\s*\.get\s*\(\s*\)`)
 	gradleCatalogAliasSeparatorPattern = regexp.MustCompile(`[-_.]+`)
 	gradleCatalogCollapsedSpacePattern = regexp.MustCompile(`\s+`)
 )
@@ -321,9 +305,7 @@ func (r *GradleCatalogResolver) ParseDependencyReferences(buildFilePath, content
 		return nil, nil
 	}
 	collector := newGradleCatalogReferenceCollector(r, buildFilePath)
-	collector.collectFinderMatches(content)
-	collector.collectBracketMatches(content)
-	collector.collectPropertyMatches(content)
+	collector.collectReferences(content)
 	return collector.dependencies, dedupeGradleCatalogWarnings(collector.warnings)
 }
 
@@ -335,67 +317,21 @@ func newGradleCatalogReferenceCollector(resolver *GradleCatalogResolver, buildFi
 	}
 }
 
-func (c *gradleCatalogReferenceCollector) collectFinderMatches(content string) {
-	for _, match := range gradleCatalogFinderPattern.FindAllStringSubmatch(content, -1) {
-		if len(match) != 4 {
+func (c *gradleCatalogReferenceCollector) collectReferences(content string) {
+	for _, reference := range parseGradleCatalogReferencesForFile(c.buildFilePath, content) {
+		if !c.resolver.shouldProcessCatalogReference(reference.catalogName) {
 			continue
 		}
-		catalogName := normalizeGradleCatalogName(match[1])
-		if !c.resolver.shouldProcessCatalogReference(catalogName) {
+		if reference.unsupportedExpression != "" {
+			c.warnings = append(c.warnings, fmt.Sprintf(unsupportedGradleCatalogReferenceFormat, reference.unsupportedExpression, relativeGradleCatalogPathFromFile(c.buildFilePath)))
 			continue
 		}
-		alias := normalizeGradleCatalogAccessor(match[3])
-		if strings.EqualFold(strings.TrimSpace(match[2]), "findBundle") {
-			c.addBundleReference(catalogName, alias)
+		if reference.bundle {
+			c.addBundleReference(reference.catalogName, reference.alias)
 			continue
 		}
-		c.addLibraryReference(catalogName, alias)
+		c.addLibraryReference(reference.catalogName, reference.alias)
 	}
-}
-
-func (c *gradleCatalogReferenceCollector) collectBracketMatches(content string) {
-	for _, match := range gradleCatalogBracketPattern.FindAllStringSubmatch(content, -1) {
-		if len(match) != 3 {
-			continue
-		}
-		catalogName := normalizeGradleCatalogName(match[1])
-		if !c.resolver.shouldProcessCatalogReference(catalogName) {
-			continue
-		}
-		c.addLibraryReference(catalogName, normalizeGradleCatalogAccessor(match[2]))
-	}
-}
-
-func (c *gradleCatalogReferenceCollector) collectPropertyMatches(content string) {
-	for _, match := range gradleCatalogPropertyPattern.FindAllStringSubmatch(content, -1) {
-		if len(match) != 2 {
-			continue
-		}
-		c.handlePropertyExpression(normalizeGradleCatalogExpression(match[1]))
-	}
-}
-
-func (c *gradleCatalogReferenceCollector) handlePropertyExpression(expression string) {
-	if expression == "" || strings.Contains(expression, ".findlibrary") || strings.Contains(expression, ".findbundle") {
-		return
-	}
-	segments := strings.Split(expression, ".")
-	if len(segments) < 2 {
-		return
-	}
-	catalogName := normalizeGradleCatalogName(segments[0])
-	if !c.resolver.shouldProcessCatalogReference(catalogName) {
-		return
-	}
-	if len(segments) >= 3 && segments[1] == "bundles" {
-		c.addBundleReference(catalogName, normalizeGradleCatalogAccessor(strings.Join(segments[2:], ".")))
-		return
-	}
-	if len(segments) >= 3 && (segments[1] == "versions" || segments[1] == "plugins") {
-		c.warnings = append(c.warnings, fmt.Sprintf(unsupportedGradleCatalogReferenceFormat, expression, relativeGradleCatalogPathFromFile(c.buildFilePath)))
-		return
-	}
-	c.addLibraryReference(catalogName, normalizeGradleCatalogAccessor(strings.Join(segments[1:], ".")))
 }
 
 func (c *gradleCatalogReferenceCollector) addLibraryReference(catalogName, alias string) {
@@ -557,7 +493,12 @@ func parseGradleSettingsCatalogRefs(content, relativePath string) ([]gradleCatal
 
 func parseGradleCatalogFile(content, catalogName, relativePath string) (gradleCatalogFile, []string) {
 	parser := newGradleCatalogFileParser(catalogName, relativePath)
-	parser.parse(content)
+	document := make(map[string]any)
+	if err := toml.Unmarshal([]byte(content), &document); err != nil {
+		parser.warnings = append(parser.warnings, fmt.Sprintf("unable to parse Gradle version catalog %s: %v", relativePath, err))
+		return parser.finalize()
+	}
+	parser.consumeDocument(document)
 	return parser.finalize()
 }
 
@@ -571,106 +512,60 @@ func newGradleCatalogFileParser(catalogName, relativePath string) *gradleCatalog
 	}
 }
 
-func (p *gradleCatalogFileParser) parse(content string) {
-	for _, line := range strings.Split(content, "\n") {
-		p.consumeLine(line)
-	}
-	if p.pendingKey != "" {
-		p.warnings = append(p.warnings, fmt.Sprintf("unterminated Gradle version catalog entry %q in %s", p.pendingKey, p.relativePath))
-	}
+func (p *gradleCatalogFileParser) consumeDocument(document map[string]any) {
+	p.consumeVersionTable(document["versions"])
+	p.consumeLibraryTable(document["libraries"])
+	p.consumeBundleTable(document["bundles"])
 }
 
-func (p *gradleCatalogFileParser) consumeLine(line string) {
-	clean := strings.TrimSpace(stripGradleCatalogComment(line))
-	if clean == "" {
-		return
-	}
-	if p.appendPending(clean) {
-		return
-	}
-	if nextSection, ok := parseGradleCatalogSection(clean); ok {
-		p.section = nextSection
-		return
-	}
-	key, value, ok := parseGradleCatalogAssignment(clean)
+func (p *gradleCatalogFileParser) consumeVersionTable(value any) {
+	table, ok := value.(map[string]any)
 	if !ok {
 		return
 	}
-	if gradleCatalogValueBalanced(value) {
-		p.consumeAssignment(p.section, key, value)
+	for key, raw := range table {
+		version, ok := raw.(string)
+		if !ok || strings.TrimSpace(version) == "" {
+			continue
+		}
+		trimmedKey := strings.TrimSpace(key)
+		p.versions[trimmedKey] = version
+		p.versions[strings.ToLower(trimmedKey)] = version
+	}
+}
+
+func (p *gradleCatalogFileParser) consumeLibraryTable(value any) {
+	table, ok := value.(map[string]any)
+	if !ok {
 		return
 	}
-	p.startPendingAssignment(key, value)
-}
-
-func (p *gradleCatalogFileParser) appendPending(clean string) bool {
-	if p.pendingKey == "" {
-		return false
-	}
-	p.pendingValue.WriteByte('\n')
-	p.pendingValue.WriteString(clean)
-	if !gradleCatalogValueBalanced(p.pendingValue.String()) {
-		return true
-	}
-	p.consumeAssignment(p.pendingSection, p.pendingKey, p.pendingValue.String())
-	p.clearPendingAssignment()
-	return true
-}
-
-func (p *gradleCatalogFileParser) startPendingAssignment(key, value string) {
-	p.pendingKey = key
-	p.pendingSection = p.section
-	p.pendingValue.Reset()
-	p.pendingValue.WriteString(value)
-}
-
-func (p *gradleCatalogFileParser) clearPendingAssignment() {
-	p.pendingKey = ""
-	p.pendingSection = ""
-	p.pendingValue.Reset()
-}
-
-func (p *gradleCatalogFileParser) consumeAssignment(section, key, value string) {
-	switch section {
-	case "versions":
-		p.consumeVersionEntry(key, value)
-	case "libraries":
-		p.consumeLibraryEntry(key, value)
-	case "bundles":
-		p.consumeBundleEntry(key, value)
+	for alias, raw := range table {
+		library, warnings := parseGradleCatalogLibraryValue(p.catalogName, alias, raw, p.versions, p.relativePath)
+		p.warnings = append(p.warnings, warnings...)
+		if library.Group == "" || library.Artifact == "" {
+			continue
+		}
+		p.libraries[normalizeGradleCatalogAccessor(alias)] = library
 	}
 }
 
-func (p *gradleCatalogFileParser) consumeVersionEntry(key, value string) {
-	version, ok := parseGradleCatalogStringValue(value)
-	if !ok || version == "" {
+func (p *gradleCatalogFileParser) consumeBundleTable(value any) {
+	table, ok := value.(map[string]any)
+	if !ok {
 		return
 	}
-	trimmedKey := strings.TrimSpace(key)
-	p.versions[trimmedKey] = version
-	p.versions[strings.ToLower(trimmedKey)] = version
-}
-
-func (p *gradleCatalogFileParser) consumeLibraryEntry(key, value string) {
-	library, libraryWarnings := parseGradleCatalogLibraryEntry(p.catalogName, key, value, p.versions, p.relativePath)
-	p.warnings = append(p.warnings, libraryWarnings...)
-	if library.Group == "" || library.Artifact == "" {
-		return
+	for alias, raw := range table {
+		members := parseGradleCatalogBundleValue(raw)
+		if len(members) == 0 {
+			p.warnings = append(p.warnings, fmt.Sprintf(unsupportedGradleCatalogBundleFormat, alias, p.relativePath))
+			continue
+		}
+		normalizedMembers := make([]string, 0, len(members))
+		for _, member := range members {
+			normalizedMembers = append(normalizedMembers, normalizeGradleCatalogAccessor(member))
+		}
+		p.bundleSpecs[normalizeGradleCatalogAccessor(alias)] = normalizedMembers
 	}
-	p.libraries[normalizeGradleCatalogAccessor(key)] = library
-}
-
-func (p *gradleCatalogFileParser) consumeBundleEntry(key, value string) {
-	members := parseGradleCatalogBundleMembers(value)
-	if len(members) == 0 {
-		p.warnings = append(p.warnings, fmt.Sprintf(unsupportedGradleCatalogBundleFormat, key, p.relativePath))
-		return
-	}
-	normalizedMembers := make([]string, 0, len(members))
-	for _, member := range members {
-		normalizedMembers = append(normalizedMembers, normalizeGradleCatalogAccessor(member))
-	}
-	p.bundleSpecs[normalizeGradleCatalogAccessor(key)] = normalizedMembers
 }
 
 func (p *gradleCatalogFileParser) finalize() (gradleCatalogFile, []string) {
@@ -705,25 +600,19 @@ func (p *gradleCatalogFileParser) resolveBundles() map[string][]GradleCatalogLib
 	return bundles
 }
 
-func parseGradleCatalogLibraryEntry(catalogName, alias, value string, versions map[string]string, relativePath string) (GradleCatalogLibrary, []string) {
+func parseGradleCatalogLibraryValue(catalogName, alias string, value any, versions map[string]string, relativePath string) (GradleCatalogLibrary, []string) {
 	library := GradleCatalogLibrary{
 		Alias:   normalizeGradleCatalogAccessor(alias),
 		Catalog: normalizeGradleCatalogName(catalogName),
 	}
-
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return library, nil
-	}
-
-	if coords, ok := parseGradleCatalogStringValue(trimmed); ok {
-		return parseGradleCatalogStringLibrary(library, alias, coords, relativePath)
-	}
-
-	if !strings.HasPrefix(trimmed, "{") {
+	switch typed := value.(type) {
+	case string:
+		return parseGradleCatalogStringLibrary(library, alias, typed, relativePath)
+	case map[string]any:
+		return parseGradleCatalogInlineLibraryFields(library, alias, typed, versions, relativePath)
+	default:
 		return GradleCatalogLibrary{}, unsupportedGradleCatalogLibraryWarning(alias, relativePath)
 	}
-	return parseGradleCatalogInlineLibrary(library, alias, trimmed, versions, relativePath)
 }
 
 func parseGradleCatalogStringLibrary(library GradleCatalogLibrary, alias, coords, relativePath string) (GradleCatalogLibrary, []string) {
@@ -737,9 +626,8 @@ func parseGradleCatalogStringLibrary(library GradleCatalogLibrary, alias, coords
 	return library, nil
 }
 
-func parseGradleCatalogInlineLibrary(library GradleCatalogLibrary, alias, value string, versions map[string]string, relativePath string) (GradleCatalogLibrary, []string) {
-	fields := parseGradleCatalogInlineFields(value)
-	if module := fields["module"]; module != "" {
+func parseGradleCatalogInlineLibraryFields(library GradleCatalogLibrary, alias string, fields map[string]any, versions map[string]string, relativePath string) (GradleCatalogLibrary, []string) {
+	if module := gradleCatalogStringField(fields, "module"); module != "" {
 		group, artifact, _, ok := parseGradleCatalogCoordinates(module)
 		if !ok {
 			return GradleCatalogLibrary{}, unsupportedGradleCatalogModuleWarning(alias, relativePath)
@@ -747,32 +635,61 @@ func parseGradleCatalogInlineLibrary(library GradleCatalogLibrary, alias, value 
 		library.Group = group
 		library.Artifact = artifact
 	} else {
-		library.Group = fields["group"]
-		library.Artifact = fields["name"]
+		library.Group = gradleCatalogStringField(fields, "group")
+		library.Artifact = gradleCatalogStringField(fields, "name")
 	}
-	library.Version = resolveGradleCatalogVersion(fields, value, versions)
+	library.Version = resolveGradleCatalogVersionFields(fields, versions)
 	if library.Group == "" || library.Artifact == "" {
 		return GradleCatalogLibrary{}, unsupportedGradleCatalogLibraryWarning(alias, relativePath)
 	}
 	return library, nil
 }
 
-func resolveGradleCatalogVersion(fields map[string]string, value string, versions map[string]string) string {
-	version := fields["version"]
-	if version != "" {
+func resolveGradleCatalogVersionFields(fields map[string]any, versions map[string]string) string {
+	if version := gradleCatalogStringField(fields, "version"); version != "" {
 		return version
 	}
-	versionRef := fields["version.ref"]
+	versionRef := gradleCatalogStringField(fields, "version.ref")
 	if versionRef == "" {
-		versionRef = parseGradleCatalogNestedVersionRef(value)
+		if versionTable, ok := fields["version"].(map[string]any); ok {
+			versionRef = gradleCatalogStringField(versionTable, "ref")
+		}
 	}
 	if versionRef == "" {
 		return ""
 	}
-	if version = versions[versionRef]; version != "" {
+	if version := versions[versionRef]; version != "" {
 		return version
 	}
 	return versions[strings.ToLower(versionRef)]
+}
+
+func gradleCatalogStringField(fields map[string]any, key string) string {
+	value, ok := fields[key]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
+}
+
+func parseGradleCatalogBundleValue(value any) []string {
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	members := make([]string, 0, len(items))
+	for _, item := range items {
+		text, ok := item.(string)
+		if !ok || strings.TrimSpace(text) == "" {
+			continue
+		}
+		members = append(members, strings.TrimSpace(text))
+	}
+	return members
 }
 
 func unsupportedGradleCatalogLibraryWarning(alias, relativePath string) []string {
@@ -798,178 +715,6 @@ func parseGradleCatalogCoordinates(value string) (string, string, string, bool) 
 		return "", "", "", false
 	}
 	return group, artifact, version, true
-}
-
-func parseGradleCatalogInlineFields(value string) map[string]string {
-	fields := make(map[string]string)
-	for _, match := range gradleCatalogInlineFieldPattern.FindAllStringSubmatch(value, -1) {
-		if len(match) != 3 {
-			continue
-		}
-		key := strings.ToLower(strings.TrimSpace(match[1]))
-		fields[key] = trimGradleCatalogQuotes(strings.TrimSpace(match[2]))
-	}
-	return fields
-}
-
-func parseGradleCatalogNestedVersionRef(value string) string {
-	match := gradleCatalogNestedVersionRefRegex.FindStringSubmatch(value)
-	if len(match) != 2 {
-		return ""
-	}
-	return trimGradleCatalogQuotes(strings.TrimSpace(match[1]))
-}
-
-func parseGradleCatalogBundleMembers(value string) []string {
-	return extractGradleCatalogQuotedStrings(value)
-}
-
-func parseGradleCatalogStringValue(value string) (string, bool) {
-	value = strings.TrimSpace(value)
-	if len(value) < 2 {
-		return "", false
-	}
-	if (value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'') {
-		return trimGradleCatalogQuotes(value), true
-	}
-	return "", false
-}
-
-func parseGradleCatalogSection(line string) (string, bool) {
-	match := gradleCatalogSectionPattern.FindStringSubmatch(line)
-	if len(match) != 2 {
-		return "", false
-	}
-	return strings.ToLower(strings.TrimSpace(match[1])), true
-}
-
-func parseGradleCatalogAssignment(line string) (string, string, bool) {
-	parts := strings.SplitN(line, "=", 2)
-	if len(parts) != 2 {
-		return "", "", false
-	}
-	key := strings.Trim(strings.TrimSpace(parts[0]), `"'`)
-	value := strings.TrimSpace(parts[1])
-	if key == "" || value == "" {
-		return "", "", false
-	}
-	return key, value, true
-}
-
-func stripGradleCatalogComment(line string) string {
-	inDouble := false
-	inSingle := false
-	for index, r := range line {
-		switch r {
-		case '"':
-			if !inSingle {
-				inDouble = !inDouble
-			}
-		case '\'':
-			if !inDouble {
-				inSingle = !inSingle
-			}
-		case '#':
-			if !inDouble && !inSingle {
-				return line[:index]
-			}
-		}
-	}
-	return line
-}
-
-func extractGradleCatalogQuotedStrings(value string) []string {
-	values := make([]string, 0)
-	current := strings.Builder{}
-	inString := false
-	quote := byte(0)
-	for index := 0; index < len(value); index++ {
-		ch := value[index]
-		if !inString {
-			if ch == '"' || ch == '\'' {
-				inString = true
-				quote = ch
-				current.Reset()
-			}
-			continue
-		}
-		if ch == quote {
-			inString = false
-			values = append(values, current.String())
-			continue
-		}
-		current.WriteByte(ch)
-	}
-	return values
-}
-
-func gradleCatalogValueBalanced(value string) bool {
-	state := gradleCatalogDelimiterState{}
-	for _, r := range value {
-		state.consume(r)
-	}
-	return state.balanced()
-}
-
-func (s *gradleCatalogDelimiterState) consume(r rune) {
-	if s.toggleQuote(r) || s.inQuoted() {
-		return
-	}
-	if delta, ok := gradleCatalogBraceDelta(r); ok {
-		s.braceDepth += delta
-	}
-	if delta, ok := gradleCatalogBracketDelta(r); ok {
-		s.bracketDepth += delta
-	}
-}
-
-func (s *gradleCatalogDelimiterState) toggleQuote(r rune) bool {
-	switch r {
-	case '"':
-		if s.inSingle {
-			return false
-		}
-		s.inDouble = !s.inDouble
-		return true
-	case '\'':
-		if s.inDouble {
-			return false
-		}
-		s.inSingle = !s.inSingle
-		return true
-	default:
-		return false
-	}
-}
-
-func (s *gradleCatalogDelimiterState) inQuoted() bool {
-	return s.inDouble || s.inSingle
-}
-
-func (s *gradleCatalogDelimiterState) balanced() bool {
-	return s.braceDepth <= 0 && s.bracketDepth <= 0
-}
-
-func gradleCatalogBraceDelta(r rune) (int, bool) {
-	switch r {
-	case '{':
-		return 1, true
-	case '}':
-		return -1, true
-	default:
-		return 0, false
-	}
-}
-
-func gradleCatalogBracketDelta(r rune) (int, bool) {
-	switch r {
-	case '[':
-		return 1, true
-	case ']':
-		return -1, true
-	default:
-		return 0, false
-	}
 }
 
 func normalizeGradleCatalogName(value string) string {
@@ -1020,10 +765,6 @@ func relativeGradleCatalogPathFromFile(path string) string {
 
 func formatGradleCatalogReadWarning(repoPath, path string, err error) string {
 	return fmt.Sprintf(gradleCatalogReadWarningFormat, relativeGradleCatalogPath(repoPath, path), err)
-}
-
-func trimGradleCatalogQuotes(value string) string {
-	return strings.Trim(strings.TrimSpace(value), `"'`)
 }
 
 func DedupeWarnings(warnings []string) []string {

--- a/internal/lang/shared/gradle_catalog_internal_test.go
+++ b/internal/lang/shared/gradle_catalog_internal_test.go
@@ -44,23 +44,28 @@ shared = "1.2.3"
 
 [libraries]
 compose-bom = "androidx.compose:compose-bom:2024.05.00"
-retrofit = { module = "com.squareup.retrofit2:retrofit",
-  version = "2.11.0" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "shared" }
-multiline = { group = "org.sample",
-  name = "artifact",
-  version = { ref = "AGP" } }
-pending-lib = { group = "org.pending",
-  name = "pending-lib",
-  version = "1.0.0" }
 broken = "not-a-coordinate"
 bad-module = { module = "missing-artifact", version = "1.0.0" }
 missing-fields = { version = "1.0.0" }
 
+[libraries.retrofit]
+module = "com.squareup.retrofit2:retrofit"
+version = "2.11.0"
+
+[libraries.multiline]
+group = "org.sample"
+name = "artifact"
+version = { ref = "AGP" }
+
+[libraries.pending-lib]
+group = "org.pending"
+name = "pending-lib"
+version = "1.0.0"
+
 [bundles]
 networking = ["retrofit", "okhttp", "retrofit", "missing"]
 unsupported = []
-broken-tail = { group = "org.tail"
 `
 	parsed, warnings := parseGradleCatalogFile(content, gradleCatalogName, gradleDefaultCatalogPath)
 
@@ -84,9 +89,16 @@ broken-tail = { group = "org.tail"
 		`unsupported Gradle version catalog library "missing-fields" in ` + gradleDefaultCatalogPath,
 		`unsupported Gradle version catalog bundle "unsupported" in ` + gradleDefaultCatalogPath,
 		`unable to resolve Gradle version catalog bundle member "missing" in ` + gradleDefaultCatalogPath,
-		`unterminated Gradle version catalog entry "broken-tail" in ` + gradleDefaultCatalogPath,
 	}
 	assertGradleCatalogWarningsContain(t, warnings, expectedWarnings...)
+}
+
+func TestGradleCatalogParserReportsInvalidTOML(t *testing.T) {
+	parsed, warnings := parseGradleCatalogFile("[libraries]\nbroken = { group = \"org.tail\"\n", gradleCatalogName, gradleDefaultCatalogPath)
+	if len(parsed.libraries) != 0 || len(parsed.bundles) != 0 {
+		t.Fatalf("expected invalid TOML to leave catalog empty, got %#v", parsed)
+	}
+	assertGradleCatalogWarningsContain(t, warnings, "unable to parse Gradle version catalog "+gradleDefaultCatalogPath)
 }
 
 func TestGradleCatalogResolverCollectsAllReferenceForms(t *testing.T) {
@@ -303,116 +315,76 @@ dependencyResolutionManagement {
 	if resolver.scopes[0].root != filepath.Join(repo, "module", "nested") || resolver.scopes[1].root != filepath.Join(repo, "aa") || resolver.scopes[2].root != filepath.Join(repo, "zz") {
 		t.Fatalf("expected resolver scopes sorted by depth then lexical order, got %#v", resolver.scopes)
 	}
-}
 
-func TestGradleCatalogStringAndAssignmentHelpers(t *testing.T) {
-	if got, ok := parseGradleCatalogStringValue(`'1.2.3'`); !ok || got != "1.2.3" {
-		t.Fatalf("expected single-quoted value to parse, got %q %t", got, ok)
+	var nilIndex *gradleCatalogLookupIndex
+	if nilIndex.resolve(testBuildFile) != nil {
+		t.Fatalf("expected nil catalog lookup index to miss")
 	}
-	if got, ok := parseGradleCatalogStringValue("oops"); ok || got != "" {
-		t.Fatalf("expected unquoted value to be rejected, got %q %t", got, ok)
+	emptyIndex := gradleCatalogLookupIndex{}
+	if emptyIndex.resolve(testBuildFile) != nil {
+		t.Fatalf("expected empty catalog lookup index to miss")
 	}
-	if got, ok := parseGradleCatalogSection("[Libraries]"); !ok || got != "libraries" {
-		t.Fatalf("expected section header to normalize, got %q %t", got, ok)
+	index := newGradleCatalogLookupIndex([]gradleCatalogScope{{root: testAppRoot}})
+	firstMatch := index.resolve(testBuildFile)
+	secondMatch := index.resolve(testBuildFile)
+	if firstMatch == nil || secondMatch == nil {
+		t.Fatalf("expected catalog lookup index to cache matched scopes")
 	}
-	if _, ok := parseGradleCatalogSection("libraries"); ok {
-		t.Fatalf("expected invalid section to be rejected")
-	}
-	if key, value, ok := parseGradleCatalogAssignment(` "demo-lib" = "org.example:demo:1.0.0" `); !ok || key != "demo-lib" || value != `"org.example:demo:1.0.0"` {
-		t.Fatalf("expected assignment to parse, got %q %q %t", key, value, ok)
-	}
-	if _, _, ok := parseGradleCatalogAssignment("missing-equals"); ok {
-		t.Fatalf("expected malformed assignment to be rejected")
-	}
-	if _, _, ok := parseGradleCatalogAssignment("name = "); ok {
-		t.Fatalf("expected assignment missing a value to be rejected")
-	}
-}
-
-func TestGradleCatalogCommentAndDelimiterHelpers(t *testing.T) {
-	if got := stripGradleCatalogComment(`group = "org.example#demo" # comment`); got != `group = "org.example#demo" ` {
-		t.Fatalf("expected inline comment to be stripped without touching quoted hash, got %q", got)
-	}
-	if got := stripGradleCatalogComment(`group = 'org.example#demo' # comment`); got != `group = 'org.example#demo' ` {
-		t.Fatalf("expected single-quoted hash to be preserved, got %q", got)
-	}
-	if got := extractGradleCatalogQuotedStrings(`["one", 'two', "three"]`); strings.Join(got, ",") != "one,two,three" {
-		t.Fatalf("expected quoted members to be extracted, got %#v", got)
-	}
-
-	if !gradleCatalogValueBalanced(`{ module = "org.example:demo", version = { ref = "v" } }`) {
-		t.Fatalf("expected balanced inline table to be treated as complete")
-	}
-	if gradleCatalogValueBalanced(`{ module = "org.example:demo"`) {
-		t.Fatalf("expected unbalanced inline table to be treated as incomplete")
-	}
-	state := gradleCatalogDelimiterState{}
-	state.consume('"')
-	state.consume('{')
-	state.consume('"')
-	state.consume('{')
-	state.consume('}')
-	if !state.balanced() {
-		t.Fatalf("expected delimiter state to ignore braces inside quotes and balance real braces")
-	}
-	if delta, ok := gradleCatalogBraceDelta('{'); !ok || delta != 1 {
-		t.Fatalf("expected opening brace to increment depth, got %d %t", delta, ok)
-	}
-	if delta, ok := gradleCatalogBracketDelta(']'); !ok || delta != -1 {
-		t.Fatalf("expected closing bracket to decrement depth, got %d %t", delta, ok)
-	}
-	quoteState := gradleCatalogDelimiterState{inSingle: true}
-	if quoteState.toggleQuote('"') {
-		t.Fatalf("expected double quote inside single-quoted string to be ignored")
-	}
-	if !quoteState.toggleQuote('\'') || quoteState.inQuoted() {
-		t.Fatalf("expected matching single quote to toggle single-quoted state off")
-	}
-	quoteState = gradleCatalogDelimiterState{inDouble: true}
-	if quoteState.toggleQuote('\'') {
-		t.Fatalf("expected single quote inside double-quoted string to be ignored")
+	firstMiss := index.resolve(testOtherBuildFile)
+	secondMiss := index.resolve(testOtherBuildFile)
+	if firstMiss != nil || secondMiss != nil {
+		t.Fatalf("expected catalog lookup index to cache unmatched scopes")
 	}
 }
 
 func TestGradleCatalogLibraryEntryHelpers(t *testing.T) {
-	library, warnings := parseGradleCatalogLibraryEntry(gradleToolsCatalogName, "cli", `"dev.example:cli:1.0.0"`, nil, gradleToolsCatalogPath)
+	library, warnings := parseGradleCatalogLibraryValue(gradleToolsCatalogName, "cli", "dev.example:cli:1.0.0", nil, gradleToolsCatalogPath)
 	if len(warnings) != 0 || library.Group != "dev.example" || library.Artifact != "cli" || library.Version != "1.0.0" {
 		t.Fatalf("expected string catalog dependency to parse, got %#v %#v", library, warnings)
 	}
 	pluginVersions := map[string]string{"plugin": "2.0.0"}
-	library, warnings = parseGradleCatalogLibraryEntry(gradleToolsCatalogName, "plugin", `{ module = "dev.example:plugin", version = { ref = "PLUGIN" } }`, pluginVersions, gradleToolsCatalogPath)
+	pluginValue := map[string]any{
+		"module":  "dev.example:plugin",
+		"version": map[string]any{"ref": "PLUGIN"},
+	}
+	library, warnings = parseGradleCatalogLibraryValue(gradleToolsCatalogName, "plugin", pluginValue, pluginVersions, gradleToolsCatalogPath)
 	if len(warnings) != 0 || library.Version != "2.0.0" {
 		t.Fatalf("expected nested version ref to resolve case-insensitively, got %#v %#v", library, warnings)
 	}
-	if _, warnings = parseGradleCatalogLibraryEntry(gradleToolsCatalogName, "broken", `"not-a-coordinate"`, nil, gradleToolsCatalogPath); len(warnings) == 0 {
+	namedValue := map[string]any{
+		"group":   "dev.example",
+		"name":    "named",
+		"version": "1.2.3",
+	}
+	library, warnings = parseGradleCatalogLibraryValue(gradleToolsCatalogName, "named", namedValue, nil, gradleToolsCatalogPath)
+	if len(warnings) != 0 || library.Group != "dev.example" || library.Artifact != "named" || library.Version != "1.2.3" {
+		t.Fatalf("expected group/name catalog dependency to parse, got %#v %#v", library, warnings)
+	}
+	if _, warnings = parseGradleCatalogLibraryValue(gradleToolsCatalogName, "broken", "not-a-coordinate", nil, gradleToolsCatalogPath); len(warnings) == 0 {
 		t.Fatalf("expected invalid string library to emit a warning")
 	}
-	if _, warnings = parseGradleCatalogLibraryEntry(gradleToolsCatalogName, "bad-module", `{ module = "bad-module", version = "1.0.0" }`, nil, gradleToolsCatalogPath); len(warnings) == 0 {
+	if _, warnings = parseGradleCatalogLibraryValue(gradleToolsCatalogName, "bad-module", map[string]any{"module": "bad-module"}, nil, gradleToolsCatalogPath); len(warnings) == 0 {
 		t.Fatalf("expected invalid module field to emit a warning")
 	}
-	if _, warnings = parseGradleCatalogLibraryEntry(gradleToolsCatalogName, "missing-fields", `{ version = "1.0.0" }`, nil, gradleToolsCatalogPath); len(warnings) == 0 {
+	if _, warnings = parseGradleCatalogLibraryValue(gradleToolsCatalogName, "missing-fields", map[string]any{"version": "1.0.0"}, nil, gradleToolsCatalogPath); len(warnings) == 0 {
 		t.Fatalf("expected missing coordinates to emit a warning")
 	}
-	if _, warnings = parseGradleCatalogLibraryEntry(gradleToolsCatalogName, "invalid", "provider(\"coords\")", nil, gradleToolsCatalogPath); len(warnings) == 0 {
+	if _, warnings = parseGradleCatalogLibraryValue(gradleToolsCatalogName, "invalid", 42, nil, gradleToolsCatalogPath); len(warnings) == 0 {
 		t.Fatalf("expected unsupported library format to emit a warning")
-	}
-	emptyLibrary, warnings := parseGradleCatalogLibraryEntry(gradleToolsCatalogName, "empty", "   ", nil, gradleToolsCatalogPath)
-	if len(warnings) != 0 || emptyLibrary.Group != "" || emptyLibrary.Artifact != "" || emptyLibrary.Alias != "empty" {
-		t.Fatalf("expected blank library value to be ignored, got %#v %#v", emptyLibrary, warnings)
 	}
 }
 
 func TestGradleCatalogVersionAndCoordinateHelpers(t *testing.T) {
-	if version := resolveGradleCatalogVersion(map[string]string{"version": "1.0.0"}, "", nil); version != "1.0.0" {
+	if version := resolveGradleCatalogVersionFields(map[string]any{"version": "1.0.0"}, nil); version != "1.0.0" {
 		t.Fatalf("expected explicit version field to win, got %q", version)
 	}
-	if version := resolveGradleCatalogVersion(map[string]string{"version.ref": "shared"}, "", map[string]string{"shared": "2.0.0"}); version != "2.0.0" {
+	if version := resolveGradleCatalogVersionFields(map[string]any{"version.ref": "shared"}, map[string]string{"shared": "2.0.0"}); version != "2.0.0" {
 		t.Fatalf("expected version ref lookup to resolve, got %q", version)
 	}
-	if version := resolveGradleCatalogVersion(nil, `{ version = { ref = "SHARED" } }`, map[string]string{"shared": "3.0.0"}); version != "3.0.0" {
+	if version := resolveGradleCatalogVersionFields(map[string]any{"version": map[string]any{"ref": "SHARED"}}, map[string]string{"shared": "3.0.0"}); version != "3.0.0" {
 		t.Fatalf("expected nested version ref to resolve, got %q", version)
 	}
-	if version := resolveGradleCatalogVersion(nil, "", nil); version != "" {
+	if version := resolveGradleCatalogVersionFields(nil, nil); version != "" {
 		t.Fatalf("expected missing version to stay empty, got %q", version)
 	}
 
@@ -428,23 +400,32 @@ func TestGradleCatalogVersionAndCoordinateHelpers(t *testing.T) {
 	if _, _, _, ok := parseGradleCatalogCoordinates(":artifact:1.0.0"); ok {
 		t.Fatalf("expected coordinates missing a group to be rejected")
 	}
-	if got := parseGradleCatalogNestedVersionRef(`{ version = { ref = "shared" } }`); got != "shared" {
-		t.Fatalf("expected nested version ref to parse, got %q", got)
-	}
-	if got := parseGradleCatalogNestedVersionRef(`{ version = "1.0.0" }`); got != "" {
-		t.Fatalf("expected missing nested version ref to return empty, got %q", got)
-	}
 }
 
-func TestGradleCatalogParserInputHelpers(t *testing.T) {
+func TestGradleCatalogDecodedParserDefensiveBranches(t *testing.T) {
 	parser := newGradleCatalogFileParser(gradleCatalogName, gradleDefaultCatalogPath)
-	parser.consumeLine("not an assignment")
-	parser.consumeVersionEntry("bad", "nope")
-	if len(parser.versions) != 0 {
-		t.Fatalf("expected invalid parser inputs to leave version table empty, got %#v", parser.versions)
+	parser.consumeDocument(map[string]any{
+		"versions":  "not-a-table",
+		"libraries": "not-a-table",
+		"bundles":   "not-a-table",
+	})
+	parsed, warnings := parser.finalize()
+	if len(parsed.libraries) != 0 || len(parsed.bundles) != 0 || len(warnings) != 0 {
+		t.Fatalf("expected non-table decoded sections to be ignored, got %#v %#v", parsed, warnings)
 	}
-	if got, ok := parseGradleCatalogStringValue(`"`); ok || got != "" {
-		t.Fatalf("expected short quoted value to be rejected, got %q %t", got, ok)
+
+	parser.consumeVersionTable(map[string]any{"empty": "", "bad": 12})
+	if len(parser.versions) != 0 {
+		t.Fatalf("expected invalid decoded versions to be ignored, got %#v", parser.versions)
+	}
+	if got := parseGradleCatalogBundleValue([]any{"okhttp", "", 12}); len(got) != 1 || got[0] != "okhttp" {
+		t.Fatalf("expected decoded bundle values to keep only strings, got %#v", got)
+	}
+	if got := parseGradleCatalogBundleValue("bad"); len(got) != 0 {
+		t.Fatalf("expected non-array bundle value to be ignored, got %#v", got)
+	}
+	if version := resolveGradleCatalogVersionFields(map[string]any{"version": 12, "version.ref": 13}, nil); version != "" {
+		t.Fatalf("expected non-string version fields to be ignored, got %q", version)
 	}
 }
 
@@ -514,9 +495,13 @@ func TestGradleCatalogLookupIndexCachesScopeMatches(t *testing.T) {
 func TestGradleCatalogReferenceCollectorIgnoresUnknownInputs(t *testing.T) {
 	resolver := GradleCatalogResolver{knownCatalogs: map[string]struct{}{gradleCatalogName: {}}}
 	collector := newGradleCatalogReferenceCollector(&resolver, testBuildFile)
-	collector.collectFinderMatches(`implementation(unknownCatalog.findLibrary("missing").get())`)
-	collector.collectBracketMatches(`implementation(unknownCatalog["missing"])`)
-	collector.handlePropertyExpression(gradleCatalogName)
+	collector.collectReferences(`
+dependencies {
+  implementation(unknownCatalog.findLibrary("missing").get())
+  implementation(unknownCatalog["missing"])
+  implementation(libs)
+}
+`)
 	if len(collector.dependencies) != 0 || len(collector.warnings) != 0 {
 		t.Fatalf("expected unmatched collector inputs to be ignored, got %#v %#v", collector.dependencies, collector.warnings)
 	}

--- a/internal/lang/shared/import_parsing_test.go
+++ b/internal/lang/shared/import_parsing_test.go
@@ -50,6 +50,10 @@ func TestStripLineCommentAndLocationHelpers(t *testing.T) {
 }
 
 func TestStripBlockComments(t *testing.T) {
+	if stripped := StripBlockComments(nil); len(stripped) != 0 {
+		t.Fatalf("expected nil block-comment input to stay nil, got %#v", stripped)
+	}
+
 	content := []byte("import a\n/* comment\nimport b\n*/\nimport c /* tail */\n")
 
 	stripped := StripBlockComments(content)


### PR DESCRIPTION
## Summary

Closes #898.

## Changes

- Replace regex-based .NET XML PackageReference/PackageVersion extraction with `encoding/xml` decoding.
- Replace Cargo.toml dependency parsing helpers with structured TOML decoding.
- Replace direct Gradle dependency and version-catalog parsing paths with tree-sitter Gradle build parsing plus TOML catalog decoding.
- Update JVM and Kotlin Android Gradle dependency discovery to use the shared structured Gradle parser.
- Add parser branch coverage for XML, TOML, Gradle dependency calls, and Gradle version catalogs.

## Validation

- `make ci` via pre-commit
- `make dup-check` -> 0.00% new-code duplication
- `go test ./...`
- `make lint`
- Focused coverage: dotnet 98.0%, rust 98.4%, shared 98.0%

## Risk and compatibility

- Breaking changes: No intended CLI or report schema changes.
- Migration required: None.
- Performance impact: Low; Gradle parsing now uses tree-sitter for build files and TOML/XML structured parsers for manifests.
- Memory benchmark impact: `make ci` memory benchmark gate passed with +0.0% deltas.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review