### PR TITLE
refactor(report): use non-relative impact signal

### DIFF
--- a/internal/report/scoring.go
+++ b/internal/report/scoring.go
@@ -16,6 +16,7 @@ const (
 	removalCandidateWeightUsageField      = "removal_candidate_weight_usage"
 	removalCandidateWeightImpactField     = "removal_candidate_weight_impact"
 	removalCandidateWeightConfidenceField = "removal_candidate_weight_confidence"
+	removalCandidateImpactSaturation      = 100.0
 )
 
 func AnnotateRemovalCandidateScores(dependencies []DependencyReport) {
@@ -27,16 +28,9 @@ func AnnotateRemovalCandidateScoresWithWeights(dependencies []DependencyReport, 
 		return
 	}
 	weights = NormalizeRemovalCandidateWeights(weights)
-	maxImpactRaw := 0.0
-	for _, dep := range dependencies {
-		impactRaw := rawImpact(dep)
-		if impactRaw > maxImpactRaw {
-			maxImpactRaw = impactRaw
-		}
-	}
 
 	for i := range dependencies {
-		dependencies[i].RemovalCandidate = buildRemovalCandidate(dependencies[i], maxImpactRaw, weights)
+		dependencies[i].RemovalCandidate = buildRemovalCandidate(dependencies[i], weights)
 	}
 }
 
@@ -99,9 +93,9 @@ func RemovalCandidateScore(dep DependencyReport) (float64, bool) {
 	return dep.RemovalCandidate.Score, true
 }
 
-func buildRemovalCandidate(dep DependencyReport, maxImpactRaw float64, weights RemovalCandidateWeights) *RemovalCandidate {
+func buildRemovalCandidate(dep DependencyReport, weights RemovalCandidateWeights) *RemovalCandidate {
 	usage, usageKnown := dependencyUsageSignal(dep)
-	impact := dependencyImpactSignal(dep, maxImpactRaw)
+	impact := dependencyImpactSignal(dep)
 	confidence, rationale := dependencyConfidenceSignal(dep)
 
 	if !usageKnown {
@@ -143,11 +137,12 @@ func rawImpact(dep DependencyReport) float64 {
 	return float64(unused)
 }
 
-func dependencyImpactSignal(dep DependencyReport, maxImpactRaw float64) float64 {
-	if maxImpactRaw <= 0 {
+func dependencyImpactSignal(dep DependencyReport) float64 {
+	impact := rawImpact(dep)
+	if impact <= 0 {
 		return 0
 	}
-	return clamp((rawImpact(dep)/maxImpactRaw)*100, 0, 100)
+	return clamp((math.Log1p(impact)/math.Log1p(removalCandidateImpactSaturation))*100, 0, 100)
 }
 
 func clamp(value, minValue, maxValue float64) float64 {

--- a/internal/report/scoring_test.go
+++ b/internal/report/scoring_test.go
@@ -144,6 +144,35 @@ func TestDependencyUsageSignalAndRawImpactBranches(t *testing.T) {
 	}
 }
 
+func TestDependencyImpactSignalIsNonRelative(t *testing.T) {
+	target := DependencyReport{Name: "target", UsedExportsCount: 0, TotalExportsCount: 10}
+	alone := []DependencyReport{target}
+	withLargePeer := []DependencyReport{
+		target,
+		{Name: "large", UsedExportsCount: 0, TotalExportsCount: 1000},
+	}
+
+	AnnotateRemovalCandidateScores(alone)
+	AnnotateRemovalCandidateScores(withLargePeer)
+
+	if alone[0].RemovalCandidate.Impact != withLargePeer[0].RemovalCandidate.Impact {
+		t.Fatalf("expected target impact to be independent of peer dependencies, alone=%f withPeer=%f", alone[0].RemovalCandidate.Impact, withLargePeer[0].RemovalCandidate.Impact)
+	}
+}
+
+func TestDependencyImpactSignalUsesFixedLogScale(t *testing.T) {
+	small := dependencyImpactSignal(DependencyReport{UsedExportsCount: 0, TotalExportsCount: 1})
+	large := dependencyImpactSignal(DependencyReport{UsedExportsCount: 0, TotalExportsCount: 100})
+	huge := dependencyImpactSignal(DependencyReport{UsedExportsCount: 0, TotalExportsCount: 10000})
+
+	if small <= 0 || small >= large {
+		t.Fatalf("expected positive impact to grow with unused exports, small=%f large=%f", small, large)
+	}
+	if large != 100 || huge != 100 {
+		t.Fatalf("expected impact to saturate at 100, large=%f huge=%f", large, huge)
+	}
+}
+
 func TestNormalizeRemovalCandidateWeightsFallback(t *testing.T) {
 	defaults := DefaultRemovalCandidateWeights()
 	got := NormalizeRemovalCandidateWeights(RemovalCandidateWeights{Usage: -1, Impact: 0.5, Confidence: 0.5})


### PR DESCRIPTION
## Summary

Closes #904.

## Changes

- Replace repo-relative removal-candidate impact normalization with a fixed logarithmic impact signal.
- Remove the max-impact pass from removal-candidate annotation so each dependency's impact is independent of other dependencies in the same report.
- Add regression coverage proving a dependency's impact score remains stable when a much larger dependency is present.

## Validation

- `make ci` via pre-commit
- `go test ./...`
- `make lint`
- `go test -count=1 ./internal/report -coverprofile=/tmp/report.cover` -> report coverage 98.2%
- `make dup-check` -> 0.00% new-code duplication

## Risk and compatibility

- Breaking changes: No schema or CLI changes; candidate impact values may change because scoring is intentionally no longer repo-relative.
- Migration required: None.
- Performance impact: Negligible; removes one scan over dependencies and uses a constant-time logarithmic calculation per dependency.
- Memory benchmark impact: `make ci` memory benchmark gate passed within thresholds.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review