### PR TITLE
refactor(language): return report result from adapters

### DIFF
--- a/internal/lang/cpp/adapter.go
+++ b/internal/lang/cpp/adapter.go
@@ -18,7 +18,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, err := workspace.NormalizeRepoPath(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/dart/adapter.go
+++ b/internal/lang/dart/adapter.go
@@ -16,7 +16,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, result, err := a.newReport(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/dotnet/adapter.go
+++ b/internal/lang/dotnet/adapter.go
@@ -30,7 +30,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, err := workspace.NormalizeRepoPath(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/elixir/adapter.go
+++ b/internal/lang/elixir/adapter.go
@@ -17,7 +17,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, err := workspace.NormalizeRepoPath(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/golang/adapter.go
+++ b/internal/lang/golang/adapter.go
@@ -29,7 +29,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, err := workspace.NormalizeRepoPath(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/js/adapter.go
+++ b/internal/lang/js/adapter.go
@@ -23,7 +23,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, err := workspace.NormalizeRepoPath(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/jvm/adapter.go
+++ b/internal/lang/jvm/adapter.go
@@ -34,7 +34,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, err := workspace.NormalizeRepoPath(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/kotlinandroid/adapter.go
+++ b/internal/lang/kotlinandroid/adapter.go
@@ -45,7 +45,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, result, err := shared.NewReport(req.RepoPath, a.Clock)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/php/analysis.go
+++ b/internal/lang/php/analysis.go
@@ -15,7 +15,7 @@ type analysisPipelineState struct {
 	warnings []string
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, err := workspace.NormalizeRepoPath(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/powershell/adapter.go
+++ b/internal/lang/powershell/adapter.go
@@ -18,7 +18,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, result, err := shared.NewReport(req.RepoPath, a.Clock)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -26,7 +26,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, err := workspace.NormalizeRepoPath(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/ruby/adapter.go
+++ b/internal/lang/ruby/adapter.go
@@ -19,7 +19,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, err := workspace.NormalizeRepoPath(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/rust/adapter.go
+++ b/internal/lang/rust/adapter.go
@@ -18,7 +18,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, result, err := shared.NewReport(req.RepoPath, a.Clock)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/lang/swift/adapter.go
+++ b/internal/lang/swift/adapter.go
@@ -18,7 +18,7 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
 	repoPath, result, err := shared.NewReport(req.RepoPath, a.Clock)
 	if err != nil {
 		return report.Report{}, err

--- a/internal/language/adapter.go
+++ b/internal/language/adapter.go
@@ -102,7 +102,7 @@ type ConfidenceProvider interface {
 }
 
 type Analyser interface {
-	Analyse(ctx context.Context, req Request) (report.Report, error)
+	Analyse(ctx context.Context, req Request) (report.Result, error)
 }
 
 type Adapter interface {

--- a/internal/language/registry_test.go
+++ b/internal/language/registry_test.go
@@ -54,7 +54,7 @@ func (a *testAdapter) DetectWithConfidence(ctx context.Context, repoPath string)
 	return a.detection, nil
 }
 
-func (a *testAdapter) Analyse(ctx context.Context, req Request) (report.Report, error) {
+func (a *testAdapter) Analyse(ctx context.Context, req Request) (report.Result, error) {
 	return report.Report{}, nil
 }
 

--- a/internal/report/model_aliases.go
+++ b/internal/report/model_aliases.go
@@ -5,6 +5,7 @@ import "github.com/ben-ranford/lopper/internal/report/model"
 const SchemaVersion = model.SchemaVersion
 
 type Report = model.Report
+type Result = model.Report
 
 type DependencyReport = model.DependencyReport
 type DependencyLicense = model.DependencyLicense

--- a/internal/report/model_aliases_test.go
+++ b/internal/report/model_aliases_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestReportModelAliasesExposeModelTypes(t *testing.T) {
 	assertSameType[Report, model.Report](t)
+	assertSameType[Result, model.Report](t)
 	assertSameType[DependencyReport, model.DependencyReport](t)
 	assertSameType[Summary, model.Summary](t)
 	assertSameType[BaselineComparison, model.BaselineComparison](t)


### PR DESCRIPTION
## Summary

Closes #902.

This moves the language adapter analysis contract onto a report-level result surface so callers depend on `report.Result` rather than the concrete report model package directly.

## Changes

- Add `report.Result` as the analysis result surface exposed by the report package.
- Update the language adapter contract to return `report.Result`.
- Move concrete adapters and registry tests onto the report result return surface.

## Validation

Commands and checks run:

```bash
make ci
go test ./...
make lint
go test -count=1 ./internal/language ./internal/report ./internal/lang/js
go test -count=1 ./internal/language ./internal/report
make dup-check
```

Additional manual validation:

- Confirmed post-rebase duplication remains 0.00% against `origin/main`.

## Risk and compatibility

- Breaking changes: None; CLI and report schema are unchanged.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: No regression; memory benchmark gate passed during `make ci`.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
