### PR TITLE
refactor(language): use analysis options for adapters

### DIFF
--- a/internal/analysis/execution.go
+++ b/internal/analysis/execution.go
@@ -60,7 +60,7 @@ func (s *Service) runCandidateOnRoots(ctx context.Context, req Request, repoPath
 			continue
 		}
 
-		current, err := candidate.Adapter.Analyse(ctx, language.Request{
+		current, err := candidate.Adapter.Analyse(ctx, language.AnalysisOptions{
 			RepoPath:                          normalizedRoot,
 			Dependency:                        req.Dependency,
 			TopN:                              req.TopN,

--- a/internal/language/adapter.go
+++ b/internal/language/adapter.go
@@ -12,7 +12,7 @@ import (
 const Auto = "auto"
 const All = "all"
 
-type Request struct {
+type AnalysisOptions struct {
 	RepoPath                          string
 	Dependency                        string
 	TopN                              int
@@ -23,6 +23,9 @@ type Request struct {
 	RemovalCandidateWeights           *report.RemovalCandidateWeights
 	IncludeRegistryProvenance         bool
 }
+
+// Request is kept as a compatibility alias for older adapter tests and callers.
+type Request = AnalysisOptions
 
 type Detection struct {
 	Matched    bool
@@ -102,7 +105,7 @@ type ConfidenceProvider interface {
 }
 
 type Analyser interface {
-	Analyse(ctx context.Context, req Request) (report.Result, error)
+	Analyse(ctx context.Context, opts AnalysisOptions) (report.Result, error)
 }
 
 type Adapter interface {

--- a/internal/language/adapter_test.go
+++ b/internal/language/adapter_test.go
@@ -33,6 +33,17 @@ func TestAdapterContractIDAndNilAliases(t *testing.T) {
 	}
 }
 
+func TestRequestAliasMatchesAnalysisOptions(t *testing.T) {
+	opts := requireAnalysisOptions(Request{RepoPath: "/repo", Dependency: "dep", TopN: 3})
+	if opts.RepoPath != "/repo" || opts.Dependency != "dep" || opts.TopN != 3 {
+		t.Fatalf("unexpected analysis options alias value: %#v", opts)
+	}
+}
+
+func requireAnalysisOptions(opts AnalysisOptions) AnalysisOptions {
+	return opts
+}
+
 func TestAdapterLifecycleDetectUsesSharedConfidenceHandler(t *testing.T) {
 	lifecycle := NewAdapterLifecycle("go", []string{"golang"}, func(ctx context.Context, repoPath string) (Detection, error) {
 		if repoPath != "/repo" {


### PR DESCRIPTION
## Summary

Closes #903.

This introduces `language.AnalysisOptions` as the canonical adapter analysis input while keeping `language.Request` as a compatibility alias. The analysis service now constructs the adapter-facing options type at the core-to-language boundary.

## Changes

- Add `language.AnalysisOptions` for adapter analysis inputs.
- Switch the `language.Analyser` interface to accept `AnalysisOptions`.
- Use `AnalysisOptions` when the analysis service invokes candidate adapters.
- Keep `language.Request` as a compatibility alias so existing adapter implementations and callers continue to compile.

## Validation

Commands and checks run:

```bash
make ci
go test ./...
make lint
go test -count=1 ./internal/language ./internal/analysis ./internal/lang/shared ./internal/lang/js
make dup-check
```

Additional manual validation:

- Confirmed concrete adapters satisfy the new `Analyser` interface through the compatibility alias.

## Risk and compatibility

- Breaking changes: None; `language.Request` remains a type alias and CLI/report schemas are unchanged.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: No regression; memory benchmark gate passed during `make ci`.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
