### PR TITLE
refactor(lang): centralize dependency report weights

### DIFF
--- a/internal/lang/cpp/compile_context_analysis_test.go
+++ b/internal/lang/cpp/compile_context_analysis_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -199,7 +200,7 @@ func testCPPIncludeMappingFallbackBranches(t *testing.T) {
 	}
 
 	custom := &report.RemovalCandidateWeights{Usage: 1, Impact: 2, Confidence: 3}
-	got := resolveRemovalCandidateWeights(custom)
+	got := shared.ResolveRemovalCandidateWeights(custom)
 	if got == report.DefaultRemovalCandidateWeights() {
 		t.Fatalf("expected non-nil weights to normalize instead of using defaults")
 	}

--- a/internal/lang/cpp/reporting.go
+++ b/internal/lang/cpp/reporting.go
@@ -11,7 +11,7 @@ import (
 )
 
 func buildRequestedCPPDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
-	weights := resolveRemovalCandidateWeights(req.RemovalCandidateWeights)
+	weights := shared.ResolveRemovalCandidateWeights(req.RemovalCandidateWeights)
 	switch {
 	case req.Dependency != "":
 		dependency := shared.NormalizeDependencyID(req.Dependency)
@@ -45,10 +45,6 @@ func buildTopCPPDependencies(topN int, scan scanResult, weights report.RemovalCa
 		return buildDependencyReport(dependency, scan, false)
 	}
 	return shared.BuildTopReports(topN, dependencies, reportBuilder, weights)
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func buildDependencyReport(dependency string, scan scanResult, warnOnNoUsage bool) (report.DependencyReport, []string) {

--- a/internal/lang/dotnet/adapter_detection_discovery_paths_test.go
+++ b/internal/lang/dotnet/adapter_detection_discovery_paths_test.go
@@ -86,13 +86,6 @@ func TestDotNetMarkDetectionZeroConfidence(t *testing.T) {
 	}
 }
 
-func TestDotNetResolveRemovalCandidateWeightsNormalizes(t *testing.T) {
-	normalized := resolveRemovalCandidateWeights(&report.RemovalCandidateWeights{Usage: 2, Impact: 1, Confidence: 1})
-	if normalized.Usage <= 0 || normalized.Impact <= 0 || normalized.Confidence <= 0 {
-		t.Fatalf("expected normalized weights, got %#v", normalized)
-	}
-}
-
 func TestDotNetAddAncestorCentralPackagesParseError(t *testing.T) {
 	parent := t.TempDir()
 	repo := filepath.Join(parent, "src", "service")

--- a/internal/lang/dotnet/reporting.go
+++ b/internal/lang/dotnet/reporting.go
@@ -11,7 +11,7 @@ import (
 
 func buildRequestedDotNetDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
 	minUsagePercentForRecommendations := resolveMinUsageRecommendationThreshold(req.MinUsagePercentForRecommendations)
-	weights := resolveRemovalCandidateWeights(req.RemovalCandidateWeights)
+	weights := shared.ResolveRemovalCandidateWeights(req.RemovalCandidateWeights)
 	switch {
 	case req.Dependency != "":
 		dependency := normalizeDependencyID(req.Dependency)
@@ -131,8 +131,4 @@ func buildRecommendations(dep report.DependencyReport, ambiguousCount int, undec
 
 func resolveMinUsageRecommendationThreshold(threshold *int) int {
 	return shared.ResolveMinUsageRecommendationThreshold(threshold)
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }

--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -270,12 +271,12 @@ func TestParseImportsIgnoresAliasLikeTextInMultilineStrings(t *testing.T) {
 }
 
 func TestResolveWeights(t *testing.T) {
-	defaults := resolveWeights(nil)
+	defaults := shared.ResolveRemovalCandidateWeights(nil)
 	if defaults != report.DefaultRemovalCandidateWeights() {
 		t.Fatalf("expected default weights, got %#v", defaults)
 	}
 	custom := report.RemovalCandidateWeights{Usage: 0.6, Impact: 0.2, Confidence: 0.2}
-	got := resolveWeights(&custom)
+	got := shared.ResolveRemovalCandidateWeights(&custom)
 	if got != report.NormalizeRemovalCandidateWeights(custom) {
 		t.Fatalf("expected normalized custom weights, got %#v", got)
 	}

--- a/internal/lang/elixir/reporting.go
+++ b/internal/lang/elixir/reporting.go
@@ -40,9 +40,5 @@ func buildRequestedDependencies(req language.Request, scan scanResult) ([]report
 	buildDependency := func(dep string, _ scanResult) (report.DependencyReport, []string) {
 		return buildReport(dep)
 	}
-	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependency, resolveWeights, topBuilder)
-}
-
-func resolveWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
+	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependency, topBuilder)
 }

--- a/internal/lang/golang/adapter_detection_reporting_paths_test.go
+++ b/internal/lang/golang/adapter_detection_reporting_paths_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 )
@@ -22,7 +23,7 @@ func TestGoAdditionalBranchCoverage(t *testing.T) {
 func testGoHelperGuardBranches(t *testing.T) {
 	t.Helper()
 
-	weights := resolveRemovalCandidateWeights(&report.RemovalCandidateWeights{
+	weights := shared.ResolveRemovalCandidateWeights(&report.RemovalCandidateWeights{
 		Usage:      -1,
 		Impact:     2,
 		Confidence: 3,

--- a/internal/lang/golang/reporting.go
+++ b/internal/lang/golang/reporting.go
@@ -9,7 +9,7 @@ import (
 )
 
 func buildRequestedGoDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
-	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, resolveRemovalCandidateWeights, buildTopGoDependencies)
+	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, buildTopGoDependencies)
 }
 
 func buildTopGoDependencies(topN int, scan scanResult, weights report.RemovalCandidateWeights) ([]report.DependencyReport, []string) {
@@ -25,10 +25,6 @@ func buildTopGoReports(topN int, dependencies []string, scan scanResult, weights
 		return buildDependencyReport(dependency, scan)
 	}
 	return shared.BuildTopReports(topN, dependencies, builder, weights)
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func buildDependencyReport(dependency string, scan scanResult) (report.DependencyReport, []string) {

--- a/internal/lang/js/adapter.go
+++ b/internal/lang/js/adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/workspace"
@@ -58,7 +59,7 @@ func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Res
 		}
 		result.Summary = report.ComputeSummary(result.Dependencies)
 	case req.TopN > 0:
-		deps, warnings := buildTopDependencies(repoPath, scanResult, req.TopN, req.RuntimeProfile, resolveMinUsageRecommendationThreshold(req.MinUsagePercentForRecommendations), resolveRemovalCandidateWeights(req.RemovalCandidateWeights), req.IncludeRegistryProvenance)
+		deps, warnings := buildTopDependencies(repoPath, scanResult, req.TopN, req.RuntimeProfile, resolveMinUsageRecommendationThreshold(req.MinUsagePercentForRecommendations), shared.ResolveRemovalCandidateWeights(req.RemovalCandidateWeights), req.IncludeRegistryProvenance)
 		result.Dependencies = deps
 		result.Warnings = append(result.Warnings, warnings...)
 		if len(deps) == 0 {

--- a/internal/lang/js/adapter_dependency_report_paths_test.go
+++ b/internal/lang/js/adapter_dependency_report_paths_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -215,7 +216,7 @@ func testJSResolveRemovalCandidateWeights(t *testing.T) {
 	t.Helper()
 
 	custom := &report.RemovalCandidateWeights{Usage: 1, Impact: 2, Confidence: 3}
-	got := resolveRemovalCandidateWeights(custom)
+	got := shared.ResolveRemovalCandidateWeights(custom)
 	if got == report.DefaultRemovalCandidateWeights() {
 		t.Fatalf("expected non-nil weights to normalize instead of using defaults")
 	}

--- a/internal/lang/js/reporting.go
+++ b/internal/lang/js/reporting.go
@@ -466,7 +466,3 @@ func buildTopDependencies(repoPath string, scanResult ScanResult, topN int, runt
 func resolveMinUsageRecommendationThreshold(value *int) int {
 	return shared.ResolveMinUsageRecommendationThreshold(value)
 }
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
-}

--- a/internal/lang/jvm/adapter_reachability_paths_test.go
+++ b/internal/lang/jvm/adapter_reachability_paths_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 )
@@ -74,7 +75,7 @@ func testJVMRootlessSourceLayoutAndCustomWeights(t *testing.T) {
 		t.Fatalf("expected absolute rootless source layout to stay empty, got %q", got)
 	}
 	custom := &report.RemovalCandidateWeights{Usage: 1, Impact: 2, Confidence: 3}
-	got := resolveRemovalCandidateWeights(custom)
+	got := shared.ResolveRemovalCandidateWeights(custom)
 	if got == report.DefaultRemovalCandidateWeights() {
 		t.Fatalf("expected non-nil removal weights to normalize instead of using defaults")
 	}

--- a/internal/lang/jvm/reporting.go
+++ b/internal/lang/jvm/reporting.go
@@ -7,7 +7,7 @@ import (
 )
 
 func buildRequestedJVMDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
-	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, resolveRemovalCandidateWeights, buildTopJVMDependencies)
+	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, buildTopJVMDependencies)
 }
 
 func buildTopJVMDependencies(topN int, scan scanResult, weights report.RemovalCandidateWeights) ([]report.DependencyReport, []string) {
@@ -17,10 +17,6 @@ func buildTopJVMDependencies(topN int, scan scanResult, weights report.RemovalCa
 		return buildDependencyReport(dependency, scan)
 	}
 	return shared.BuildTopReports(topN, dependencies, reportBuilder, weights)
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func buildDependencyReport(dependency string, scan scanResult) (report.DependencyReport, []string) {

--- a/internal/lang/kotlinandroid/gradle_scan_parsing_paths_test.go
+++ b/internal/lang/kotlinandroid/gradle_scan_parsing_paths_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -347,7 +348,7 @@ func TestLookupBuilderBranches(t *testing.T) {
 	}
 
 	weights := report.RemovalCandidateWeights{Usage: 2, Impact: 3, Confidence: 5}
-	normalized := resolveRemovalCandidateWeights(&weights)
+	normalized := shared.ResolveRemovalCandidateWeights(&weights)
 	if normalized.Usage <= 0 || normalized.Impact <= 0 || normalized.Confidence <= 0 {
 		t.Fatalf("expected normalized positive weights, got %#v", normalized)
 	}

--- a/internal/lang/kotlinandroid/reporting.go
+++ b/internal/lang/kotlinandroid/reporting.go
@@ -7,7 +7,7 @@ import (
 )
 
 func buildRequestedKotlinAndroidDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
-	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, resolveRemovalCandidateWeights, buildTopKotlinAndroidDependencies)
+	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, buildTopKotlinAndroidDependencies)
 }
 
 func buildTopKotlinAndroidDependencies(topN int, scan scanResult, weights report.RemovalCandidateWeights) ([]report.DependencyReport, []string) {
@@ -22,10 +22,6 @@ func kotlinAndroidFileUsages(scan scanResult) []shared.FileUsage {
 	importsOf := func(file fileScan) []shared.ImportRecord { return file.Imports }
 	usageOf := func(file fileScan) map[string]int { return file.Usage }
 	return shared.MapFileUsages(scan.Files, importsOf, usageOf)
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func buildDependencyReport(dependency string, scan scanResult) (report.DependencyReport, []string) {

--- a/internal/lang/php/adapter_scan_error_paths_test.go
+++ b/internal/lang/php/adapter_scan_error_paths_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 )
@@ -58,7 +59,7 @@ func testPHPRootSignalsAndHelperBranches(t *testing.T) {
 	if err := contextErr(context.TODO()); err != nil {
 		t.Fatalf("expected nil context error, got %v", err)
 	}
-	weights := resolveRemovalCandidateWeights(&report.RemovalCandidateWeights{Usage: -1, Impact: 2, Confidence: 3})
+	weights := shared.ResolveRemovalCandidateWeights(&report.RemovalCandidateWeights{Usage: -1, Impact: 2, Confidence: 3})
 	if weights.Usage < 0 || weights.Impact > 1 || weights.Confidence > 1 {
 		t.Fatalf("expected removal candidate weights to normalize, got %#v", weights)
 	}

--- a/internal/lang/php/reporting.go
+++ b/internal/lang/php/reporting.go
@@ -15,7 +15,7 @@ func buildRequestedPHPDependencies(req language.Request, scan scanResult) ([]rep
 		depReport, warnings := buildDependencyReport(dependency, scan, resolveMinUsageRecommendationThreshold(req.MinUsagePercentForRecommendations))
 		return []report.DependencyReport{depReport}, warnings
 	case req.TopN > 0:
-		return buildTopPHPDependencies(req.TopN, scan, resolveMinUsageRecommendationThreshold(req.MinUsagePercentForRecommendations), resolveRemovalCandidateWeights(req.RemovalCandidateWeights))
+		return buildTopPHPDependencies(req.TopN, scan, resolveMinUsageRecommendationThreshold(req.MinUsagePercentForRecommendations), shared.ResolveRemovalCandidateWeights(req.RemovalCandidateWeights))
 	default:
 		return nil, []string{"no dependency or top-N target provided"}
 	}
@@ -127,10 +127,6 @@ func buildRecommendations(dep report.DependencyReport, minUsagePercent int) []re
 		})
 	}
 	return recs
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func hasRiskCue(cues []report.RiskCue, code string) bool {

--- a/internal/lang/powershell/adapter_test.go
+++ b/internal/lang/powershell/adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 )
@@ -109,7 +110,7 @@ func TestPowerShellReportHelpersCoverNilAndEmptyBranches(t *testing.T) {
 		t.Fatalf("expected remove-unused-module recommendation, got %#v", dep.Recommendations)
 	}
 
-	if weights := resolveRemovalCandidateWeights(nil); weights != report.DefaultRemovalCandidateWeights() {
+	if weights := shared.ResolveRemovalCandidateWeights(nil); weights != report.DefaultRemovalCandidateWeights() {
 		t.Fatalf("expected default removal-candidate weights, got %#v", weights)
 	}
 }

--- a/internal/lang/powershell/parser_expression_paths_test.go
+++ b/internal/lang/powershell/parser_expression_paths_test.go
@@ -173,13 +173,6 @@ func TestApplyImportSourceAttributionNilAndMissingSourceBranches(t *testing.T) {
 	}
 }
 
-func TestResolveRemovalCandidateWeightsCustomBranch(t *testing.T) {
-	weights := resolveRemovalCandidateWeights(&report.RemovalCandidateWeights{Usage: 2, Impact: 3, Confidence: 5})
-	if weights.Usage != 0.2 || weights.Impact != 0.3 || weights.Confidence != 0.5 {
-		t.Fatalf("expected normalized custom weights, got %#v", weights)
-	}
-}
-
 func TestAdapterAnalyseAndScanRepoErrorBranches(t *testing.T) {
 	adapter := NewAdapter()
 	if _, err := adapter.Analyse(context.Background(), language.Request{RepoPath: string([]byte{'b', 'a', 'd', 0x00}), TopN: 1}); err == nil {

--- a/internal/lang/powershell/reporting.go
+++ b/internal/lang/powershell/reporting.go
@@ -10,7 +10,7 @@ import (
 )
 
 func buildRequestedPowerShellDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
-	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, resolveRemovalCandidateWeights, buildTopPowerShellDependencies)
+	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, buildTopPowerShellDependencies)
 }
 
 func buildTopPowerShellDependencies(topN int, scan scanResult, weights report.RemovalCandidateWeights) ([]report.DependencyReport, []string) {
@@ -93,10 +93,6 @@ func buildRecommendations(dep report.DependencyReport) []report.Recommendation {
 		})
 	}
 	return recs
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func sortedDependencyUnion(values ...map[string]struct{}) []string {

--- a/internal/lang/python/adapter_detection_reporting_paths_test.go
+++ b/internal/lang/python/adapter_detection_reporting_paths_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -143,11 +144,11 @@ func testPythonSkipDirHelpersAndDefaultWeights(t *testing.T) {
 	if err := scanPythonRepoEntry(repo, skipDir, dirEntry, &scanResult{}); !errors.Is(err, filepath.SkipDir) {
 		t.Fatalf("expected python scanner to skip .venv, got %v", err)
 	}
-	if got := resolveRemovalCandidateWeights(nil); got != report.DefaultRemovalCandidateWeights() {
+	if got := shared.ResolveRemovalCandidateWeights(nil); got != report.DefaultRemovalCandidateWeights() {
 		t.Fatalf("expected default weights, got %#v", got)
 	}
 	customWeights := &report.RemovalCandidateWeights{Usage: 4, Impact: 2, Confidence: 2}
-	if got := resolveRemovalCandidateWeights(customWeights); got != report.NormalizeRemovalCandidateWeights(*customWeights) {
+	if got := shared.ResolveRemovalCandidateWeights(customWeights); got != report.NormalizeRemovalCandidateWeights(*customWeights) {
 		t.Fatalf("expected custom weights to be normalized, got %#v", got)
 	}
 }

--- a/internal/lang/python/reporting.go
+++ b/internal/lang/python/reporting.go
@@ -9,7 +9,7 @@ import (
 )
 
 func buildRequestedPythonDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
-	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, resolveRemovalCandidateWeights, buildTopPythonDependencies)
+	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, buildTopPythonDependencies)
 }
 
 func buildTopPythonDependencies(topN int, scan scanResult, weights report.RemovalCandidateWeights) ([]report.DependencyReport, []string) {
@@ -18,10 +18,6 @@ func buildTopPythonDependencies(topN int, scan scanResult, weights report.Remova
 		return buildDependencyReport(dependency, scan)
 	}
 	return shared.BuildTopReports(topN, dependencies, reportBuilder, weights)
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func buildDependencyReport(dependency string, scan scanResult) (report.DependencyReport, []string) {

--- a/internal/lang/ruby/adapter_detection_analysis_paths_test.go
+++ b/internal/lang/ruby/adapter_detection_analysis_paths_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -57,13 +58,13 @@ func TestRubyAdapterHelperBranches(t *testing.T) {
 		t.Fatalf("did not expect src to be skipped")
 	}
 
-	weights := resolveRemovalCandidateWeights(nil)
+	weights := shared.ResolveRemovalCandidateWeights(nil)
 	if weights != report.DefaultRemovalCandidateWeights() {
 		t.Fatalf("expected default weights")
 	}
 
 	custom := report.RemovalCandidateWeights{Usage: 0.1, Impact: 0.2, Confidence: 0.7}
-	normalized := resolveRemovalCandidateWeights(&custom)
+	normalized := shared.ResolveRemovalCandidateWeights(&custom)
 	if normalized.Confidence == 0 {
 		t.Fatalf("expected non-zero normalized confidence weight")
 	}

--- a/internal/lang/ruby/adapter_test.go
+++ b/internal/lang/ruby/adapter_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -430,7 +431,7 @@ func testRubyRequireParsingAndRiskRecommendations(t *testing.T) {
 	if len(warnings) != 0 || len(dep.RiskCues) == 0 || len(dep.Recommendations) == 0 {
 		t.Fatalf("expected runtime-require risk cues and recommendations, got dep=%#v warnings=%#v", dep, warnings)
 	}
-	if got := resolveRemovalCandidateWeights(nil); got != report.DefaultRemovalCandidateWeights() {
+	if got := shared.ResolveRemovalCandidateWeights(nil); got != report.DefaultRemovalCandidateWeights() {
 		t.Fatalf("expected default removal weights, got %#v", got)
 	}
 }

--- a/internal/lang/ruby/reporting.go
+++ b/internal/lang/ruby/reporting.go
@@ -7,7 +7,7 @@ import (
 )
 
 func buildRequestedRubyDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
-	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, resolveRemovalCandidateWeights, buildTopRubyDependencies)
+	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependencyReport, buildTopRubyDependencies)
 }
 
 func buildTopRubyDependencies(topN int, scan scanResult, weights report.RemovalCandidateWeights) ([]report.DependencyReport, []string) {
@@ -32,10 +32,6 @@ func collectRubyDependencyStats(dependency string, files []fileScan) shared.Depe
 	}
 	fileUsages := shared.MapFileUsages(files, importsOf, usageOf)
 	return shared.BuildDependencyStats(dependency, fileUsages, normalizeDependencyID)
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func sortedDependencyUnion(values ...map[string]struct{}) []string {

--- a/internal/lang/rust/adapter_helper_paths_test.go
+++ b/internal/lang/rust/adapter_helper_paths_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 )
@@ -132,7 +133,7 @@ func assertRustPathAndWeightsHelpers(t *testing.T) {
 	if isLocalRustModuleWithCache(nil, repo, "missing_mod") {
 		t.Fatalf("expected missing local module to be false")
 	}
-	if resolveRemovalCandidateWeights(nil) != report.DefaultRemovalCandidateWeights() {
+	if shared.ResolveRemovalCandidateWeights(nil) != report.DefaultRemovalCandidateWeights() {
 		t.Fatalf("expected default removal weights when nil")
 	}
 	if !isSubPath(repo, repo) {
@@ -141,7 +142,7 @@ func assertRustPathAndWeightsHelpers(t *testing.T) {
 	if samePath(filepath.Join(repo, "a"), filepath.Join(repo, "b")) {
 		t.Fatalf("expected different paths not to be same")
 	}
-	if got := resolveRemovalCandidateWeights(&report.RemovalCandidateWeights{Usage: 2, Impact: 1, Confidence: 1}); got.Usage <= 0 {
+	if got := shared.ResolveRemovalCandidateWeights(&report.RemovalCandidateWeights{Usage: 2, Impact: 1, Confidence: 1}); got.Usage <= 0 {
 		t.Fatalf("expected normalized non-nil removal weights")
 	}
 }

--- a/internal/lang/rust/reporting.go
+++ b/internal/lang/rust/reporting.go
@@ -11,7 +11,7 @@ import (
 
 func buildRequestedRustDependencies(req language.Request, scan scanResult) ([]report.DependencyReport, []string) {
 	minUsageThreshold := resolveMinUsageRecommendationThreshold(req.MinUsagePercentForRecommendations)
-	weights := resolveRemovalCandidateWeights(req.RemovalCandidateWeights)
+	weights := shared.ResolveRemovalCandidateWeights(req.RemovalCandidateWeights)
 	switch {
 	case req.Dependency != "":
 		dependency := normalizeDependencyID(req.Dependency)
@@ -31,10 +31,6 @@ func buildTopRustDependencies(topN int, scan scanResult, minUsageThreshold int, 
 		return buildDependencyReport(dependency, scan, minUsageThreshold), nil
 	}
 	return shared.BuildTopReports(topN, dependencies, reportBuilder, weights)
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }
 
 func buildDependencyReport(dependency string, scan scanResult, minUsageThreshold int) report.DependencyReport {

--- a/internal/lang/shared/dependency_usage_request.go
+++ b/internal/lang/shared/dependency_usage_request.go
@@ -19,9 +19,9 @@ func BuildRequestedDependencies[S any](req language.Request, scan S, normalizeDe
 	return []report.DependencyReport{depReport}, warnings
 }
 
-func BuildRequestedDependenciesWithWeights[S any](req language.Request, scan S, normalizeDependencyID func(string) string, buildDependency func(string, S) (report.DependencyReport, []string), resolveWeights func(*report.RemovalCandidateWeights) report.RemovalCandidateWeights, buildTop func(int, S, report.RemovalCandidateWeights) ([]report.DependencyReport, []string)) ([]report.DependencyReport, []string) {
+func BuildRequestedDependenciesWithWeights[S any](req language.Request, scan S, normalizeDependencyID func(string) string, buildDependency func(string, S) (report.DependencyReport, []string), buildTop func(int, S, report.RemovalCandidateWeights) ([]report.DependencyReport, []string)) ([]report.DependencyReport, []string) {
 	buildTopWithWeights := func(topN int, current S) ([]report.DependencyReport, []string) {
-		return buildTop(topN, current, resolveWeights(req.RemovalCandidateWeights))
+		return buildTop(topN, current, ResolveRemovalCandidateWeights(req.RemovalCandidateWeights))
 	}
 	return BuildRequestedDependencies(req, scan, normalizeDependencyID, buildDependency, buildTopWithWeights)
 }

--- a/internal/lang/shared/dependency_usage_test.go
+++ b/internal/lang/shared/dependency_usage_test.go
@@ -462,7 +462,6 @@ func TestBuildRequestedDependenciesWithWeights(t *testing.T) {
 	dependencyCalled := false
 	topCalled := false
 
-	resolvedWeights := report.RemovalCandidateWeights{Usage: 0.7, Impact: 0.2, Confidence: 0.1}
 	req := language.Request{
 		TopN:                    3,
 		RemovalCandidateWeights: &report.RemovalCandidateWeights{Usage: 0.1, Impact: 0.8, Confidence: 0.1},
@@ -475,23 +474,17 @@ func TestBuildRequestedDependenciesWithWeights(t *testing.T) {
 		dependencyCalled = true
 		return report.DependencyReport{Name: dependency}, []string{fmt.Sprintf("dep-%d", scan)}
 	}
-	resolveWeightsFn := func(input *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-		if input == nil || input.Usage != 0.1 || input.Impact != 0.8 {
-			t.Fatalf("unexpected input weights: %#v", input)
-		}
-		return resolvedWeights
-	}
 	topFn := func(topN int, scan int, weights report.RemovalCandidateWeights) ([]report.DependencyReport, []string) {
 		topCalled = true
 		if topN != 3 || scan != 5 {
 			t.Fatalf("unexpected top arguments: topN=%d scan=%d", topN, scan)
 		}
-		if weights != resolvedWeights {
-			t.Fatalf("unexpected resolved weights: %#v", weights)
+		if weights != report.NormalizeRemovalCandidateWeights(*req.RemovalCandidateWeights) {
+			t.Fatalf("unexpected normalized weights: %#v", weights)
 		}
 		return []report.DependencyReport{{Name: "top"}}, []string{topWarning}
 	}
-	reports, warnings := BuildRequestedDependenciesWithWeights(req, 5, normalizeFn, dependencyFn, resolveWeightsFn, topFn)
+	reports, warnings := BuildRequestedDependenciesWithWeights(req, 5, normalizeFn, dependencyFn, topFn)
 
 	if !topCalled || dependencyCalled || normalizeCalled {
 		t.Fatalf("expected top path only (top=%v dependency=%v normalize=%v)", topCalled, dependencyCalled, normalizeCalled)

--- a/internal/lang/swift/adapter_detection_manifest_paths_test.go
+++ b/internal/lang/swift/adapter_detection_manifest_paths_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -159,11 +160,11 @@ func TestSwiftThresholdAndNormalizationHelpers(t *testing.T) {
 	}
 
 	defaultWeights := report.DefaultRemovalCandidateWeights()
-	if got := resolveRemovalCandidateWeights(nil); got != defaultWeights {
+	if got := shared.ResolveRemovalCandidateWeights(nil); got != defaultWeights {
 		t.Fatalf("expected default weights, got %#v", got)
 	}
 	customWeights := report.RemovalCandidateWeights{Usage: 0.2, Impact: 0.3, Confidence: 0.5}
-	if got := resolveRemovalCandidateWeights(&customWeights); got != customWeights {
+	if got := shared.ResolveRemovalCandidateWeights(&customWeights); got != customWeights {
 		t.Fatalf("expected provided weights to remain unchanged, got %#v", got)
 	}
 

--- a/internal/lang/swift/reporting.go
+++ b/internal/lang/swift/reporting.go
@@ -18,7 +18,7 @@ func buildRequestedSwiftDependencies(req language.Request, scan scanResult, cata
 		}
 		return buildDependencyReport(dependency, scan, catalog, minUsagePercent)
 	}
-	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependency, resolveRemovalCandidateWeights, buildTopSwiftDependencies(scan, catalog, minUsagePercent))
+	return shared.BuildRequestedDependenciesWithWeights(req, scan, normalizeDependencyID, buildDependency, buildTopSwiftDependencies(scan, catalog, minUsagePercent))
 }
 
 func buildTopSwiftDependencies(scan scanResult, catalog dependencyCatalog, minUsagePercent int) func(int, scanResult, report.RemovalCandidateWeights) ([]report.DependencyReport, []string) {
@@ -181,8 +181,4 @@ func usesManagerSpecificMetadata(meta dependencyMeta) bool {
 
 func resolveMinUsageRecommendationThreshold(value *int) int {
 	return shared.ResolveMinUsageRecommendationThreshold(value)
-}
-
-func resolveRemovalCandidateWeights(value *report.RemovalCandidateWeights) report.RemovalCandidateWeights {
-	return shared.ResolveRemovalCandidateWeights(value)
 }


### PR DESCRIPTION
## Summary
Closes #838.

Centralizes dependency-report removal-weight normalization in `internal/lang/shared` so language adapters no longer carry duplicate resolver plumbing.

## Changes
- Moved `BuildRequestedDependenciesWithWeights` to resolve removal candidate weights internally from the request.
- Removed one-line adapter resolver wrappers and updated custom top-N paths to call the shared resolver directly.
- Updated adapter tests to reference the shared resolver where they still cover weight normalization branches.

## Validation
- `go test -count=1 ./internal/lang/shared ./internal/lang/ruby ./internal/lang/kotlinandroid ./internal/lang/powershell ./internal/lang/jvm ./internal/lang/golang ./internal/lang/python ./internal/lang/elixir ./internal/lang/swift ./internal/lang/cpp ./internal/lang/rust ./internal/lang/dotnet ./internal/lang/php ./internal/lang/js`
- `make lint`
- `make dup-check`
- `go test ./...`
- pre-commit `make ci`

## Risk and compatibility
- Breaking changes: None
- Migration required: None
- Performance impact: None expected; behavior and ranking inputs are unchanged.
- Memory benchmark impact: None; pre-commit memory benchmark gate passed with no meaningful delta.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review