### PR TITLE
feat(mcp): add stdio server tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Launch the interactive TUI:
 lopper tui --repo . --language all
 ```
 
+Run the local MCP server for agent workflows:
+
+```bash
+lopper mcp --enable-feature mcp-server-preview
+```
+
+See [docs/mcp.md](docs/mcp.md) for tool names, input schemas, client configuration, and safety behavior.
+
 Tune thresholds and score weights:
 
 ```bash
@@ -267,6 +275,7 @@ For watched hotspot packages, run `make mem-profiles` to capture alloc-space sum
 - Memory profiling workflow: `docs/memory-profiling.md`
 - SARIF code scanning: `docs/sarif-code-scanning.md`
 - Threshold tuning: `docs/threshold-tuning.md`
+- MCP server integration: `docs/mcp.md`
 - Runtime trace annotations: `scripts/runtime/`
 - Adapter and architecture extensibility: `docs/extensibility.md`
 - CI and release workflow: `docs/ci-usage.md`

--- a/docs/man/lopper.1
+++ b/docs/man/lopper.1
@@ -1,6 +1,20 @@
-package cli
-
-const usage = `Usage:
+.TH LOPPER 1 "2026-06-10" "lopper" "User Commands"
+.SH NAME
+lopper \- local-first CLI/TUI for dependency surface analysis
+.SH SYNOPSIS
+.nf
+lopper [--version] [tui]
+lopper tui [--repo PATH] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart]
+lopper analyse --top N [options]
+lopper analyse <dependency> [options]
+lopper dashboard [--repos PATH1,PATH2 | --config PATH]
+lopper mcp [--enable-feature mcp-server-preview]
+.fi
+.SH DESCRIPTION
+This man page is generated from the built-in command usage output.
+.PP
+Usage and options:
+.nf
   lopper [--version] [tui]
   lopper tui [--repo PATH] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--top N] [--filter TEXT] [--sort name|waste] [--page-size N] [--snapshot PATH] [--baseline PATH] [--baseline-store DIR] [--baseline-key KEY]
   lopper analyse <dependency> [--repo PATH] [--scope-mode repo|package|changed-packages] [--format table|csv|json|sarif|pr-comment] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--cache=true|false] [--cache-path PATH] [--cache-readonly] [--runtime-profile node-import|node-require|browser-import|browser-require] [--baseline PATH] [--baseline-store DIR] [--baseline-key KEY] [--save-baseline] [--baseline-label LABEL] [--runtime-trace PATH] [--runtime-test-command CMD] [--config PATH] [--include GLOBS] [--exclude GLOBS] [--lockfile-drift-policy off|warn|fail] [--license-deny SPDXS] [--license-fail-on-deny] [--license-provenance-registry] [--notify-on always|breach|regression|improvement] [--notify-slack URL] [--notify-teams URL] [--suggest-only | (--apply-codemod --apply-codemod-confirm [--allow-dirty])]
@@ -75,8 +89,10 @@ Options:
   --version                  Show CLI version metadata
   mcp                        Run a local stdio MCP server with read-only dependency analysis tools
   -h, --help                 Show this help text
-`
-
-func Usage() string {
-	return usage
-}
+.fi
+.SH SEE ALSO
+The lopper project homepage and release notes are published at:
+.I https://github.com/ben-ranford/lopper
+.SH BUGS
+Report issues at:
+.I https://github.com/ben-ranford/lopper/issues

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,120 @@
+# MCP Server
+
+`lopper mcp --enable-feature mcp-server-preview` runs a local stdio Model Context Protocol server for agent workflows that need dependency surface analysis without shelling out to parse CLI text.
+
+The server speaks JSON-RPC over stdio using `Content-Length` frames. It writes protocol responses to stdout and does not emit normal CLI output in MCP mode.
+
+## Client Configuration
+
+Example MCP client entry:
+
+```json
+{
+  "mcpServers": {
+    "lopper": {
+      "command": "lopper",
+      "args": ["mcp", "--enable-feature", "mcp-server-preview"]
+    }
+  }
+}
+```
+
+`mcp-server-preview` is a preview feature flag. Rolling builds enable preview flags by default; dev and stable release builds require the explicit `--enable-feature` argument shown above. During `initialize`, the server advertises tool support and returns Lopper version metadata. Use `tools/list` to inspect tool schemas at runtime.
+
+## Tools
+
+### `lopper_analyse_top_dependencies`
+
+Ranks the top dependencies by unused surface area.
+
+Required input:
+
+- `repoPath`: local repository directory.
+
+Common optional inputs:
+
+- `topN`: number of dependencies to rank. Defaults to `20`.
+- `language`: `auto`, `all`, or a supported adapter ID.
+- `scopeMode`: `package`, `repo`, or `changed-packages`.
+- `configPath`: local config file path.
+- `include` / `exclude`: path glob arrays that override config scope.
+- `cacheEnabled`, `cachePath`, `cacheReadOnly`: incremental cache controls.
+- `runtimeProfile`: `node-import`, `node-require`, `browser-import`, or `browser-require`.
+- `runtimeTracePath`: local NDJSON runtime trace path.
+- `enableFeatures` / `disableFeatures`: feature flag names or codes.
+- threshold and policy overrides: `lowConfidenceWarningPercent`, `minUsagePercentForRecommendations`, `maxUncertainImportCount`, `scoreWeightUsage`, `scoreWeightImpact`, `scoreWeightConfidence`, `licenseDeny`, `licenseFailOnDeny`, `licenseProvenanceRegistry`.
+- `timeoutMillis`: per-tool timeout.
+
+### `lopper_analyse_dependency`
+
+Analyzes one dependency and returns the same report shape as JSON analysis.
+
+Required input:
+
+- `repoPath`: local repository directory.
+- `dependency`: dependency name.
+
+It accepts the same common optional inputs as `lopper_analyse_top_dependencies`, except `topN` is ignored.
+
+### `lopper_compare_baseline`
+
+Runs read-only analysis and compares it with an existing baseline report or immutable baseline snapshot.
+
+Required input:
+
+- `repoPath`: local repository directory.
+- Either `baselinePath`, or `baselineStorePath` with `baselineKey`.
+
+Optional input:
+
+- `dependency`: compare a single dependency.
+- `topN`: compare a top dependency run. Defaults to `20` when `dependency` is omitted.
+- The same common optional inputs as `lopper_analyse_top_dependencies`.
+
+The tool does not save baselines. It only loads existing baseline JSON or snapshot files and adds `wasteIncreasePercent` and `baselineComparison` to the returned report.
+
+### `lopper_list_languages`
+
+Lists supported language adapters and config metadata.
+
+Optional input:
+
+- `repoPath`: local repository directory used to resolve `.lopper.yml`, `.lopper.yaml`, or `lopper.json`.
+- `configPath`: local config file path. Requires `repoPath`.
+- `enableFeatures` / `disableFeatures`: feature overrides used for the metadata response.
+- `timeoutMillis`: per-tool timeout.
+
+The response includes canonical language IDs, aliases, supported language modes, runtime profiles, effective threshold defaults or config values, removal candidate weights, license policy, enabled feature codes, and policy source trace when config is loaded.
+
+## Output Shape
+
+Analysis tools return MCP tool content with:
+
+- `content[0].text`: concise human summary.
+- `structuredContent.schemaVersion`: Lopper report schema version.
+- `structuredContent.summary`: same concise summary string.
+- `structuredContent.report`: full report payload aligned with `docs/report-schema.json`.
+
+Tool failures return `isError: true` with a text message and structured error:
+
+```json
+{
+  "error": {
+    "code": "invalid_input",
+    "message": "repoPath is required"
+  }
+}
+```
+
+Error codes include `invalid_input`, `timeout`, `cancelled`, and `tool_failed`.
+
+## Safety Behavior
+
+The MCP server is local-first and read-only:
+
+- `repoPath` must be an explicit local filesystem directory.
+- Unknown tool arguments are rejected, including mutation or command-execution fields such as `applyCodemod`, `saveBaseline`, and `runtimeTestCommand`.
+- Baseline comparison loads existing files only. It does not write snapshots.
+- Config resolution uses the existing local config and policy-pack rules; remote policy packs are disabled before any fetch.
+- Runtime trace support reads a local trace file only. MCP does not run test commands.
+- Analysis observes JSON-RPC request context and optional `timeoutMillis` cancellation.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/mcp"
 	"github.com/ben-ranford/lopper/internal/notify"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/ui"
@@ -21,14 +23,18 @@ var (
 	ErrDeniedLicenses               = errors.New("denied licenses detected")
 	ErrDirtyWorktree                = errors.New("codemod apply requires a clean git worktree")
 	ErrCodemodApplyFailed           = errors.New("codemod apply failed")
+	ErrMCPPreviewDisabled           = errors.New("mcp server preview feature is disabled")
 )
 
 type App struct {
 	Analyzer  analysis.Analyser
+	In        io.Reader
+	Out       io.Writer
 	Formatter *report.Formatter
 	TUI       ui.TUI
 	Notify    *notify.Dispatcher
 	Features  *featureflags.Registry
+	Languages *language.Registry
 }
 
 func New(out io.Writer, in io.Reader) *App {
@@ -37,10 +43,13 @@ func New(out io.Writer, in io.Reader) *App {
 
 	return &App{
 		Analyzer:  analyzer,
+		In:        in,
+		Out:       out,
 		Formatter: formatter,
 		TUI:       ui.NewSummary(out, in, analyzer, formatter),
 		Notify:    notify.NewDefaultDispatcher(),
 		Features:  featureflags.DefaultRegistry(),
+		Languages: analyzer.Registry,
 	}
 }
 
@@ -54,6 +63,15 @@ func (a *App) Execute(ctx context.Context, req Request) (string, error) {
 		return a.executeDashboard(ctx, req)
 	case ModeFeatures:
 		return a.executeFeatures(req)
+	case ModeMCP:
+		if !req.MCP.Features.Enabled(mcp.ServerPreviewFeature) {
+			return "", ErrMCPPreviewDisabled
+		}
+		return "", mcp.Serve(ctx, a.In, a.Out, mcp.Options{
+			Analyzer:         a.Analyzer,
+			LanguageRegistry: a.Languages,
+			FeatureRegistry:  a.Features,
+		})
 	default:
 		return "", ErrUnknownMode
 	}

--- a/internal/app/app_mcp_test.go
+++ b/internal/app/app_mcp_test.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/mcp"
+)
+
+func TestExecuteMCPRequiresPreviewFeature(t *testing.T) {
+	application := &App{In: strings.NewReader(""), Out: io.Discard}
+	req := DefaultRequest()
+	req.Mode = ModeMCP
+
+	_, err := application.Execute(context.Background(), req)
+	if !errors.Is(err, ErrMCPPreviewDisabled) {
+		t.Fatalf("expected ErrMCPPreviewDisabled, got %v", err)
+	}
+}
+
+func TestExecuteMCPStartsWhenPreviewFeatureEnabled(t *testing.T) {
+	application := &App{In: strings.NewReader(""), Out: io.Discard}
+	req := DefaultRequest()
+	req.Mode = ModeMCP
+	req.MCP.Features = mustMCPPreviewFeatureSet(t)
+
+	if _, err := application.Execute(context.Background(), req); err != nil {
+		t.Fatalf("execute mcp: %v", err)
+	}
+}
+
+func mustMCPPreviewFeatureSet(t *testing.T) featureflags.Set {
+	t.Helper()
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
+		Code:      "LOP-FEAT-0001",
+		Name:      mcp.ServerPreviewFeature,
+		Lifecycle: featureflags.LifecyclePreview,
+	}})
+	if err != nil {
+		t.Fatalf("new feature registry: %v", err)
+	}
+	features, err := registry.Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  []string{mcp.ServerPreviewFeature},
+	})
+	if err != nil {
+		t.Fatalf("resolve feature set: %v", err)
+	}
+	return features
+}

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -15,6 +15,7 @@ const (
 	ModeAnalyse   Mode = "analyse"
 	ModeDashboard Mode = "dashboard"
 	ModeFeatures  Mode = "features"
+	ModeMCP       Mode = "mcp"
 
 	ScopeModeRepo            = analysis.ScopeModeRepo
 	ScopeModePackage         = analysis.ScopeModePackage
@@ -28,6 +29,7 @@ type Request struct {
 	TUI       TUIRequest
 	Dashboard DashboardRequest
 	Features  FeaturesRequest
+	MCP       MCPRequest
 }
 
 type AnalyseRequest struct {
@@ -98,6 +100,10 @@ type FeaturesRequest struct {
 	OutputPath string
 	Channel    string
 	Release    string
+}
+
+type MCPRequest struct {
+	Features featureflags.Set
 }
 
 func DefaultRequest() Request {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -188,6 +188,9 @@ func TestUsageReturnsText(t *testing.T) {
 	if !strings.Contains(Usage(), "lopper analyse") {
 		t.Fatalf("expected usage text to include analyse command")
 	}
+	if !strings.Contains(Usage(), "lopper mcp") {
+		t.Fatalf("expected usage text to include mcp command")
+	}
 	if !strings.Contains(Usage(), "--format table|csv|json|sarif|pr-comment") {
 		t.Fatalf("expected usage text to include analyse csv format")
 	}

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -31,6 +31,8 @@ func ParseArgs(args []string) (app.Request, error) {
 		return parseDashboard(args[1:], req)
 	case "features":
 		return parseFeatures(args[1:], req)
+	case "mcp":
+		return parseMCP(args[1:], req)
 	default:
 		return req, fmt.Errorf("unknown command: %s", args[0])
 	}

--- a/internal/cli/parse_analyse_overrides.go
+++ b/internal/cli/parse_analyse_overrides.go
@@ -66,6 +66,10 @@ func resolveAnalyseFeatures(visited map[string]bool, values analyseFlagValues, c
 }
 
 func resolveDefaultFeatureSet() (featureflags.Set, error) {
+	return resolveFeatureRefs(nil, nil)
+}
+
+func resolveFeatureRefs(enable, disable []string) (featureflags.Set, error) {
 	channel, lock, err := resolveFeatureBuildContext()
 	if err != nil {
 		return featureflags.Set{}, err
@@ -73,6 +77,8 @@ func resolveDefaultFeatureSet() (featureflags.Set, error) {
 	return featureRegistryProvider().Resolve(featureflags.ResolveOptions{
 		Channel: channel,
 		Lock:    lock,
+		Enable:  append([]string{}, enable...),
+		Disable: append([]string{}, disable...),
 	})
 }
 

--- a/internal/cli/parse_mcp.go
+++ b/internal/cli/parse_mcp.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/ben-ranford/lopper/internal/app"
+)
+
+func parseMCP(args []string, req app.Request) (app.Request, error) {
+	fs := flag.NewFlagSet("mcp", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	enableFeatures := newPatternListFlag(nil)
+	disableFeatures := newPatternListFlag(nil)
+	fs.Var(enableFeatures, "enable-feature", "comma-separated feature flag names to enable (repeatable)")
+	fs.Var(disableFeatures, "disable-feature", "comma-separated feature flag names to disable (repeatable)")
+	if err := parseFlagSet(fs, args); err != nil {
+		return req, err
+	}
+	if len(fs.Args()) > 0 {
+		return req, fmt.Errorf("too many arguments for mcp")
+	}
+	features, err := resolveFeatureRefs(enableFeatures.Values(), disableFeatures.Values())
+	if err != nil {
+		return req, err
+	}
+	req.Mode = app.ModeMCP
+	req.MCP.Features = features
+	return req, nil
+}

--- a/internal/cli/parse_mcp_test.go
+++ b/internal/cli/parse_mcp_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/app"
+	"github.com/ben-ranford/lopper/internal/featureflags"
+)
+
+func TestParseArgsMCP(t *testing.T) {
+	req := mustParseArgs(t, []string{"mcp"})
+	if req.Mode != app.ModeMCP {
+		t.Fatalf(modeMismatchFmt, app.ModeMCP, req.Mode)
+	}
+}
+
+func TestParseArgsMCPFeatureFlags(t *testing.T) {
+	withFeatureRegistry(t, featureflags.ChannelRelease, nil)
+
+	req := mustParseArgs(t, []string{"mcp", "--enable-feature", "preview-flag", "--disable-feature", "stable-flag"})
+	if !req.MCP.Features.Enabled("preview-flag") {
+		t.Fatalf("expected mcp preview flag to be enabled")
+	}
+	if req.MCP.Features.Enabled("stable-flag") {
+		t.Fatalf("expected mcp stable flag to be disabled")
+	}
+}
+
+func TestParseArgsMCPFeatureFlagsRejectUnknownAndConflict(t *testing.T) {
+	withFeatureRegistry(t, featureflags.ChannelRelease, nil)
+	if err := expectParseArgsError(t, []string{"mcp", "--enable-feature", "missing"}, "expected unknown feature error"); !strings.Contains(err.Error(), "unknown feature") {
+		t.Fatalf("expected unknown feature error, got %v", err)
+	}
+	if err := expectParseArgsError(t, []string{"mcp", "--enable-feature", "preview-flag", "--disable-feature", "preview-flag"}, "expected feature conflict error"); !strings.Contains(err.Error(), "both enabled and disabled") {
+		t.Fatalf("expected conflict error, got %v", err)
+	}
+}
+
+func TestParseArgsMCPRejectsPositionals(t *testing.T) {
+	err := expectParseArgsError(t, []string{"mcp", "extra"}, "expected mcp positional error")
+	if !strings.Contains(err.Error(), "too many arguments") {
+		t.Fatalf("expected too many arguments error, got %v", err)
+	}
+}

--- a/internal/cli/parse_shared_test.go
+++ b/internal/cli/parse_shared_test.go
@@ -119,6 +119,9 @@ func TestParseArgsErrorsAndHelp(t *testing.T) {
 	if _, err := ParseArgs([]string{"tui", helpFlag}); !errors.Is(err, ErrHelpRequested) {
 		t.Fatalf("expected tui help request error, got %v", err)
 	}
+	if _, err := ParseArgs([]string{"mcp", helpFlag}); !errors.Is(err, ErrHelpRequested) {
+		t.Fatalf("expected mcp help request error, got %v", err)
+	}
 	if _, err := ParseArgs([]string{"unknown"}); err == nil {
 		t.Fatalf("expected unknown command error")
 	}

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -45,5 +45,11 @@
     "name": "vscode-multi-root-workflows-preview",
     "description": "Enable multi-root VS Code analysis workflows, dependency explorer detail views, baseline commands, and export commands.",
     "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0008",
+    "name": "mcp-server-preview",
+    "description": "Enable the local stdio MCP server for read-only dependency analysis workflows.",
+    "lifecycle": "preview"
   }
 ]

--- a/internal/language/registry.go
+++ b/internal/language/registry.go
@@ -15,8 +15,15 @@ var (
 	ErrMultipleLanguages = errors.New("multiple language adapters matched")
 )
 
+var absPath = filepath.Abs
+
 type Registry struct {
 	adapters map[string]Adapter
+}
+
+type AdapterMetadata struct {
+	ID      string
+	Aliases []string
 }
 
 type AdapterFilter func(Adapter) bool
@@ -127,6 +134,31 @@ func (r *Registry) IDs() []string {
 	return ids
 }
 
+func (r *Registry) Metadata() []AdapterMetadata {
+	if r == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	items := make([]AdapterMetadata, 0, len(r.adapters))
+	for _, adapter := range r.adapters {
+		adapterID := adapter.ID()
+		if _, ok := seen[adapterID]; ok {
+			continue
+		}
+		seen[adapterID] = struct{}{}
+		items = append(items, AdapterMetadata{
+			ID:      adapterID,
+			Aliases: append([]string{}, adapter.Aliases()...),
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].ID < items[j].ID
+	})
+	return items
+}
+
 func (r *Registry) resolveAuto(ctx context.Context, repoPath string, filter AdapterFilter) ([]Candidate, error) {
 	matches, err := r.detectMatches(ctx, repoPath, filter)
 	if err != nil {
@@ -211,7 +243,7 @@ func normalizeDetection(repoPath string, detection Detection) Detection {
 		detection.Confidence = 1
 	}
 	if len(detection.Roots) == 0 && repoPath != "" {
-		if abs, err := filepath.Abs(repoPath); err == nil {
+		if abs, err := absPath(repoPath); err == nil {
 			detection.Roots = []string{abs}
 		} else {
 			detection.Roots = []string{repoPath}

--- a/internal/language/registry_test.go
+++ b/internal/language/registry_test.go
@@ -138,6 +138,24 @@ func TestRegisterValidationAndIDs(t *testing.T) {
 	if !slices.Equal(ids, []string{"js-ts"}) {
 		t.Fatalf("unexpected registry IDs: %#v", ids)
 	}
+
+	metadata := registry.Metadata()
+	if len(metadata) != 1 {
+		t.Fatalf("expected one metadata entry, got %#v", metadata)
+	}
+	if metadata[0].ID != "js-ts" || !slices.Equal(metadata[0].Aliases, []string{"js"}) {
+		t.Fatalf("unexpected metadata: %#v", metadata)
+	}
+	metadata[0].Aliases[0] = "mutated"
+	if got := registry.Metadata()[0].Aliases; !slices.Equal(got, []string{"js"}) {
+		t.Fatalf("expected metadata aliases to be copied, got %#v", got)
+	}
+
+	noAliasRegistry := registryWithTestAdapters(t, &testAdapter{id: "go", detection: Detection{Matched: true}})
+	noAliasMetadata := noAliasRegistry.Metadata()
+	if len(noAliasMetadata) != 1 || len(noAliasMetadata[0].Aliases) != 0 {
+		t.Fatalf("expected no-alias metadata, got %#v", noAliasMetadata)
+	}
 }
 
 func TestSelectAndResolveErrors(t *testing.T) {
@@ -216,6 +234,12 @@ func TestResolveAllNoMatchAndIDsNilRegistry(t *testing.T) {
 	if ids := (*Registry)(nil).IDs(); len(ids) != 0 {
 		t.Fatalf("expected nil IDs for nil registry, got %#v", ids)
 	}
+	if metadata := (*Registry)(nil).Metadata(); len(metadata) != 0 {
+		t.Fatalf("expected nil metadata for nil registry, got %#v", metadata)
+	}
+	if _, err := (*Registry)(nil).Select(context.Background(), ".", Auto); err == nil {
+		t.Fatalf("expected nil registry select error")
+	}
 }
 
 func TestResolveExplicitUnmatchedDetectionFallsBackToForcedMatch(t *testing.T) {
@@ -242,6 +266,21 @@ func TestResolveExplicitUnmatchedDetectionFallsBackToForcedMatch(t *testing.T) {
 	}
 	if len(candidates[0].Detection.Roots) == 0 {
 		t.Fatalf("expected fallback roots to be populated")
+	}
+}
+
+func TestNormalizeDetectionFallsBackToRawRootWhenAbsFails(t *testing.T) {
+	previous := absPath
+	absPath = func(string) (string, error) {
+		return "", errors.New("abs failed")
+	}
+	t.Cleanup(func() {
+		absPath = previous
+	})
+
+	detection := normalizeDetection("relative-root", Detection{Matched: true})
+	if !slices.Equal(detection.Roots, []string{"relative-root"}) {
+		t.Fatalf("expected raw repo path root, got %#v", detection.Roots)
 	}
 }
 

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -1,0 +1,513 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/analysis"
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/thresholds"
+	"github.com/ben-ranford/lopper/internal/version"
+)
+
+type failWriteCloser struct{}
+
+func (*failWriteCloser) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+type unsupportedResult struct {
+	Bad chan int `json:"bad"`
+}
+
+func TestServeErrorBranches(t *testing.T) {
+	server := NewServer(Options{})
+	if err := Serve(context.Background(), nil, &bytes.Buffer{}, Options{}); err == nil || !strings.Contains(err.Error(), "input") {
+		t.Fatalf("expected nil input error, got %v", err)
+	}
+	if err := server.Serve(context.Background(), strings.NewReader(""), nil); err == nil || !strings.Contains(err.Error(), "output") {
+		t.Fatalf("expected nil output error, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := server.Serve(ctx, strings.NewReader(""), &bytes.Buffer{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled context, got %v", err)
+	}
+
+	var parseOutput bytes.Buffer
+	if err := server.Serve(context.Background(), strings.NewReader("bad header\r\n\r\n{}"), &parseOutput); err != nil {
+		t.Fatalf("serve parse response: %v", err)
+	}
+	parseFrame, err := readFrame(bufio.NewReader(&parseOutput))
+	if err != nil {
+		t.Fatalf("read parse error frame: %v", err)
+	}
+	var parseResponse rpcResponse
+	if err := json.Unmarshal(parseFrame, &parseResponse); err != nil {
+		t.Fatalf("unmarshal parse response: %v", err)
+	}
+	if parseResponse.Error == nil || parseResponse.Error.Code != codeParseError {
+		t.Fatalf("expected parse error response, got %#v", parseResponse)
+	}
+
+	var input bytes.Buffer
+	writeTestFrame(t, &input, mustJSON(t, rpcRequest{JSONRPC: jsonrpcVersion, ID: json.RawMessage(`1`), Method: methodInitialize}))
+	if err := server.Serve(context.Background(), &input, &failWriteCloser{}); err == nil || !strings.Contains(err.Error(), "write failed") {
+		t.Fatalf("expected write failure, got %v", err)
+	}
+
+	var notificationInput bytes.Buffer
+	writeTestFrame(t, &notificationInput, mustJSON(t, rpcRequest{JSONRPC: jsonrpcVersion, Method: methodCancelled}))
+	var notificationOutput bytes.Buffer
+	if err := server.Serve(context.Background(), &notificationInput, &notificationOutput); err != nil {
+		t.Fatalf("serve notification: %v", err)
+	}
+	if notificationOutput.Len() != 0 {
+		t.Fatalf("expected notification to produce no response, got %q", notificationOutput.String())
+	}
+}
+
+func TestFramingErrorBranches(t *testing.T) {
+	if _, err := readFrame(bufio.NewReader(strings.NewReader("Content-Length: 1"))); err == nil {
+		t.Fatalf("expected partial header EOF error")
+	}
+	if _, err := readFrame(bufio.NewReader(strings.NewReader("Content-Length: nope\r\n\r\n"))); err == nil || !strings.Contains(err.Error(), "invalid Content-Length") {
+		t.Fatalf("expected invalid content length, got %v", err)
+	}
+	if _, err := readFrame(bufio.NewReader(strings.NewReader("Other: 1\r\n\r\n"))); err == nil || !strings.Contains(err.Error(), "missing Content-Length") {
+		t.Fatalf("expected missing content length, got %v", err)
+	}
+	tooLarge := "Content-Length: 16777217\r\n\r\n"
+	if _, err := readFrame(bufio.NewReader(strings.NewReader(tooLarge))); err == nil || !strings.Contains(err.Error(), "frame exceeds") {
+		t.Fatalf("expected frame size error, got %v", err)
+	}
+	if _, err := readFrame(bufio.NewReader(strings.NewReader("Content-Length: 5\r\n\r\nabc"))); err == nil {
+		t.Fatalf("expected short body error")
+	}
+	if err := writeFrame(&failWriteCloser{}, []byte("{}")); err == nil {
+		t.Fatalf("expected writeFrame header write error")
+	}
+}
+
+func TestHandlePayloadBranches(t *testing.T) {
+	server := NewServer(Options{Analyzer: &fakeAnalyser{report: sampleReport(t.TempDir())}})
+
+	parse := server.handlePayload(context.Background(), []byte("{"))
+	if parse.Error == nil || parse.Error.Code != codeParseError {
+		t.Fatalf("expected parse error, got %#v", parse)
+	}
+	invalid := server.handlePayload(context.Background(), mustJSON(t, map[string]any{"jsonrpc": jsonrpcVersion}))
+	if invalid.Error == nil || invalid.Error.Code != codeInvalidRequest {
+		t.Fatalf("expected invalid request, got %#v", invalid)
+	}
+	if response := server.handlePayload(context.Background(), mustJSON(t, rpcRequest{JSONRPC: jsonrpcVersion, Method: methodInitialized})); response != nil {
+		t.Fatalf("expected initialized notification to be ignored, got %#v", response)
+	}
+	if response := server.handlePayload(context.Background(), mustJSON(t, rpcRequest{JSONRPC: jsonrpcVersion, Method: "notifications/unknown"})); response != nil {
+		t.Fatalf("expected unknown notification to be ignored, got %#v", response)
+	}
+
+	call := server.handlePayload(context.Background(), mustJSON(t, rpcRequest{
+		JSONRPC: jsonrpcVersion,
+		ID:      json.RawMessage(`2`),
+		Method:  methodToolsCall,
+		Params:  mustJSON(t, toolCallParams{Name: toolListLanguages}),
+	}))
+	if call.Error != nil {
+		t.Fatalf("expected tools/call success, got %#v", call.Error)
+	}
+
+	badCall := server.handlePayload(context.Background(), mustJSON(t, rpcRequest{
+		JSONRPC: jsonrpcVersion,
+		ID:      json.RawMessage(`3`),
+		Method:  methodToolsCall,
+		Params:  json.RawMessage(`{"name":""}`),
+	}))
+	if badCall.Error == nil || badCall.Error.Code != codeInvalidParams {
+		t.Fatalf("expected invalid params error, got %#v", badCall)
+	}
+}
+
+func TestWriteResponseBranches(t *testing.T) {
+	server := NewServer(Options{})
+	if err := server.writeResponse(&bytes.Buffer{}, newResultResponse(nil, unsupportedResult{Bad: make(chan int)})); err != nil {
+		t.Fatalf("expected fallback error response to marshal, got %v", err)
+	}
+	if err := server.writeResponse(&bytes.Buffer{}, &rpcResponse{JSONRPC: jsonrpcVersion, ID: json.RawMessage(`{`), Result: unsupportedResult{Bad: make(chan int)}}); err == nil {
+		t.Fatalf("expected fallback marshal failure")
+	}
+
+	id := responseID(nil)
+	if string(id) != "null" {
+		t.Fatalf("expected null response id, got %s", id)
+	}
+
+	custom := NewServer(Options{ServerName: "custom", ServerVersion: "1.2.3"})
+	if custom.serverName != "custom" || custom.serverVersion != "1.2.3" {
+		t.Fatalf("expected custom server metadata, got %q %q", custom.serverName, custom.serverVersion)
+	}
+
+	withCurrentVersion(t, version.Info{})
+	fallback := NewServer(Options{})
+	if fallback.serverVersion != defaultServerVersion {
+		t.Fatalf("expected fallback version, got %q", fallback.serverVersion)
+	}
+}
+
+func TestCallToolValidationBranches(t *testing.T) {
+	server := NewServer(Options{})
+	if _, rpcErr := server.callTool(context.Background(), json.RawMessage(`{"name":1}`)); rpcErr == nil || rpcErr.Code != codeInvalidParams {
+		t.Fatalf("expected invalid params rpc error, got %#v", rpcErr)
+	}
+	if _, rpcErr := server.callTool(context.Background(), json.RawMessage(`{"name":""}`)); rpcErr == nil || rpcErr.Code != codeInvalidParams {
+		t.Fatalf("expected missing tool name rpc error, got %#v", rpcErr)
+	}
+	if _, rpcErr := server.callTool(context.Background(), json.RawMessage(`{"name":"missing"}`)); rpcErr == nil || rpcErr.Code != codeInvalidParams {
+		t.Fatalf("expected unknown tool rpc error, got %#v", rpcErr)
+	}
+}
+
+func TestRunAnalysisToolErrorBranches(t *testing.T) {
+	repo := t.TempDir()
+	server := NewServer(Options{Analyzer: &fakeAnalyser{report: sampleReport(repo)}})
+	if result := server.runAnalysisTool(context.Background(), json.RawMessage(`{"repoPath":1}`), analysisToolKindTop); !result.IsError {
+		t.Fatalf("expected decode error")
+	}
+	if result := server.runAnalysisTool(context.Background(), mustJSON(t, analysisToolArguments{RepoPath: repo, TimeoutMillis: -1}), analysisToolKindTop); !result.IsError {
+		t.Fatalf("expected timeout validation error")
+	}
+	errServer := NewServer(Options{Analyzer: &fakeAnalyser{err: errors.New("analyse failed")}})
+	if result := errServer.runAnalysisTool(context.Background(), mustJSON(t, analysisToolArguments{RepoPath: repo}), analysisToolKindTop); !result.IsError {
+		t.Fatalf("expected analyser error")
+	}
+
+	badBaseline := server.runAnalysisTool(context.Background(), mustJSON(t, analysisToolArguments{RepoPath: repo, BaselinePath: filepath.Join(repo, "missing.json")}), analysisToolKindCompare)
+	if !badBaseline.IsError {
+		t.Fatalf("expected missing baseline error")
+	}
+
+	nilAnalyzer := NewServer(Options{})
+	if result := nilAnalyzer.runAnalysisTool(context.Background(), mustJSON(t, analysisToolArguments{RepoPath: repo, Language: "unknown"}), analysisToolKindTop); !result.IsError {
+		t.Fatalf("expected default analyser error for unknown language")
+	}
+}
+
+func TestResolveAnalysisRequestValidationBranches(t *testing.T) {
+	repo := t.TempDir()
+	server := NewServer(Options{})
+	cases := []struct {
+		name string
+		args analysisToolArguments
+		kind analysisToolKind
+		want string
+	}{
+		{"missing dependency", analysisToolArguments{RepoPath: repo}, analysisToolKindDependency, "dependency is required"},
+		{"top rejects dependency", analysisToolArguments{RepoPath: repo, Dependency: "dep"}, analysisToolKindTop, "dependency is not supported"},
+		{"compare requires baseline", analysisToolArguments{RepoPath: repo}, analysisToolKindCompare, "baselinePath or baselineStorePath"},
+		{"invalid topN", analysisToolArguments{RepoPath: repo, TopN: intPtr(0)}, analysisToolKindTop, "topN"},
+		{"invalid scope", analysisToolArguments{RepoPath: repo, ScopeMode: "bad"}, analysisToolKindTop, "scopeMode"},
+		{"unknown kind", analysisToolArguments{RepoPath: repo}, analysisToolKind("bad"), "unknown analysis tool kind"},
+		{"baseline conflict", analysisToolArguments{RepoPath: repo, BaselinePath: "a.json", BaselineStorePath: "store", BaselineKey: "key"}, analysisToolKindCompare, "baselinePath and baselineStorePath"},
+		{"store missing key", analysisToolArguments{RepoPath: repo, BaselineStorePath: "store"}, analysisToolKindCompare, "baselineKey"},
+		{"feature error", analysisToolArguments{RepoPath: repo, EnableFeatures: []string{"missing"}}, analysisToolKindTop, "unknown feature"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := server.resolveAnalysisRequest(context.Background(), tc.args, tc.kind)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+
+	configPath := filepath.Join(repo, ".lopper.yml")
+	if err := os.WriteFile(configPath, []byte("thresholds:\n  low_confidence_warning_percent: 101\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo}, analysisToolKindTop); err == nil || !strings.Contains(err.Error(), "low_confidence") {
+		t.Fatalf("expected config validation error, got %v", err)
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	cleanRepo := t.TempDir()
+	_, err := server.resolveAnalysisRequest(cancelled, analysisToolArguments{RepoPath: cleanRepo}, analysisToolKindTop)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+}
+
+func TestListLanguagesBranches(t *testing.T) {
+	repo := t.TempDir()
+	configPath := filepath.Join(repo, "lopper.json")
+	if err := os.WriteFile(configPath, []byte(`{"thresholds":{"low_confidence_warning_percent":35}}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	server := NewServer(Options{})
+	if result := server.runListLanguagesTool(context.Background(), json.RawMessage(`{"repoPath":1}`)); !result.IsError {
+		t.Fatalf("expected decode error")
+	}
+	if result := server.runListLanguagesTool(context.Background(), mustJSON(t, listLanguagesArguments{ConfigPath: configPath})); !result.IsError {
+		t.Fatalf("expected repoPath required with config")
+	}
+	if result := server.runListLanguagesTool(context.Background(), mustJSON(t, listLanguagesArguments{RepoPath: repo, ConfigPath: configPath})); result.IsError {
+		t.Fatalf("expected config metadata success, got %#v", result)
+	}
+	if result := server.runListLanguagesTool(context.Background(), mustJSON(t, listLanguagesArguments{RepoPath: repo, ConfigPath: "missing.yml"})); !result.IsError {
+		t.Fatalf("expected missing config error")
+	}
+	if result := server.runListLanguagesTool(context.Background(), mustJSON(t, listLanguagesArguments{TimeoutMillis: -1})); !result.IsError {
+		t.Fatalf("expected timeout validation error")
+	}
+	if result := server.runListLanguagesTool(context.Background(), mustJSON(t, listLanguagesArguments{EnableFeatures: []string{"missing"}})); !result.IsError {
+		t.Fatalf("expected feature resolution error")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if result := server.runListLanguagesTool(ctx, mustJSON(t, listLanguagesArguments{})); !result.IsError {
+		t.Fatalf("expected context error")
+	}
+}
+
+func TestLanguageMetadataBranches(t *testing.T) {
+	service := analysis.NewService()
+	serviceServer := NewServer(Options{Analyzer: service})
+	if len(serviceServer.languageMetadata()) == 0 {
+		t.Fatalf("expected metadata from analyser service registry")
+	}
+	defaultServer := NewServer(Options{})
+	if len(defaultServer.languageMetadata()) == 0 {
+		t.Fatalf("expected metadata from default registry")
+	}
+}
+
+func TestResolveFeaturesBranches(t *testing.T) {
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
+		Code:      "LOP-FEAT-0001",
+		Name:      "preview-one",
+		Lifecycle: featureflags.LifecyclePreview,
+	}})
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	server := NewServer(Options{FeatureRegistry: registry})
+	if _, err := server.resolveFeatures(emptyFeatureConfig(), []string{"preview-one"}, []string{"preview-one"}); err == nil {
+		t.Fatalf("expected conflicting feature override error")
+	}
+	resolved, err := server.resolveFeatures(emptyFeatureConfig(), []string{"preview-one"}, nil)
+	if err != nil {
+		t.Fatalf("resolve feature: %v", err)
+	}
+	if !resolved.Enabled("preview-one") {
+		t.Fatalf("expected preview feature enabled")
+	}
+
+	withCurrentVersion(t, version.Info{Version: "1.2.3", BuildChannel: "release"})
+	if _, err := server.resolveFeatures(emptyFeatureConfig(), nil, nil); err != nil {
+		t.Fatalf("expected release-channel feature resolution, got %v", err)
+	}
+	withCurrentVersion(t, version.Info{BuildChannel: "bad"})
+	if _, err := server.resolveFeatures(emptyFeatureConfig(), nil, nil); err == nil {
+		t.Fatalf("expected invalid build channel error")
+	}
+}
+
+func TestThresholdAndPolicyHelpers(t *testing.T) {
+	repo := t.TempDir()
+	bad := analysisToolArguments{LowConfidenceWarningPercent: intPtr(101)}
+	if _, _, _, _, err := resolveThresholds(repo, bad); err == nil {
+		t.Fatalf("expected threshold override validation error")
+	}
+	if _, _, _, _, err := resolveThresholds(repo, analysisToolArguments{ConfigPath: "missing.yml"}); err == nil {
+		t.Fatalf("expected missing config error")
+	}
+
+	args := analysisToolArguments{
+		LowConfidenceWarningPercent:       intPtr(35),
+		MinUsagePercentForRecommendations: intPtr(45),
+		MaxUncertainImportCount:           intPtr(3),
+		ScoreWeightUsage:                  floatPtr(0.5),
+		ScoreWeightImpact:                 floatPtr(0.3),
+		ScoreWeightConfidence:             floatPtr(0.2),
+		LicenseDeny:                       []string{"MIT"},
+		LicenseFailOnDeny:                 boolPtr(true),
+		LicenseProvenanceRegistry:         boolPtr(true),
+	}
+	_, values, sources, trace, err := resolveThresholds(repo, args)
+	if err != nil {
+		t.Fatalf("resolve thresholds: %v", err)
+	}
+	if sources[0] != "mcp" || policyTraceSource(trace, "license.fail_on_deny") != "mcp" {
+		t.Fatalf("expected mcp policy metadata, sources=%#v trace=%#v", sources, trace)
+	}
+	if !values.LicenseFailOnDeny || !values.LicenseIncludeRegistryProvenance {
+		t.Fatalf("expected license policy values, got %#v", values)
+	}
+	if got := prependPolicySource("mcp", []string{"mcp", "defaults"}); !slicesEqual(got, []string{"mcp", "defaults"}) {
+		t.Fatalf("unexpected deduped sources: %#v", got)
+	}
+	if got := mergeMCPPolicyTrace([]report.PolicyMergeTrace{{Field: "existing", Source: "defaults"}}, analysisToolArguments{}); len(got) != 1 || got[0].Source != "defaults" {
+		t.Fatalf("unexpected no-op trace merge: %#v", got)
+	}
+	if got := mergeMCPPolicyTrace(nil, analysisToolArguments{LowConfidenceWarningPercent: intPtr(35)}); len(got) != 1 || got[0].Source != "mcp" {
+		t.Fatalf("unexpected appended trace merge: %#v", got)
+	}
+}
+
+func TestBaselineHelpers(t *testing.T) {
+	repo := t.TempDir()
+	if _, _, _, err := resolveBaselineComparison(repo, analysisToolArguments{BaselinePath: "a", BaselineStorePath: "b", BaselineKey: "k"}); err == nil {
+		t.Fatalf("expected baseline conflict")
+	}
+	if _, _, _, err := resolveBaselineComparison(repo, analysisToolArguments{BaselineStorePath: "store"}); err == nil {
+		t.Fatalf("expected missing baseline key")
+	}
+	directPath, directKey, directCurrent, err := resolveBaselineComparison(repo, analysisToolArguments{BaselinePath: "baseline.json", BaselineKey: "ignored"})
+	if err != nil {
+		t.Fatalf("resolve direct baseline: %v", err)
+	}
+	if directPath != "baseline.json" || directKey != "ignored" || directCurrent == "" {
+		t.Fatalf("unexpected direct baseline resolution: path=%q key=%q current=%q", directPath, directKey, directCurrent)
+	}
+	path, key, current, err := resolveBaselineComparison(repo, analysisToolArguments{BaselineStorePath: "store", BaselineKey: "release/1"})
+	if err != nil {
+		t.Fatalf("resolve baseline store: %v", err)
+	}
+	if !strings.Contains(path, "release_1") || key != "release/1" || current == "" {
+		t.Fatalf("unexpected baseline resolution: path=%q key=%q current=%q", path, key, current)
+	}
+
+	baselinePath := filepath.Join(repo, "baseline.json")
+	writeJSONFile(t, baselinePath, report.Report{SchemaVersion: report.SchemaVersion, Dependencies: []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50}}})
+	currentReport := report.Report{Dependencies: []report.DependencyReport{{Name: "dep", UsedExportsCount: 2, TotalExportsCount: 2, UsedPercent: 100}}}
+	updated, err := applyBaseline(currentReport, baselinePath, "", "current")
+	if err != nil {
+		t.Fatalf("apply baseline: %v", err)
+	}
+	if updated.BaselineComparison == nil {
+		t.Fatalf("expected baseline comparison")
+	}
+	if _, err := applyBaseline(currentReport, filepath.Join(repo, "missing.json"), "", "current"); err == nil {
+		t.Fatalf("expected missing baseline error")
+	}
+}
+
+func TestSmallHelperBranches(t *testing.T) {
+	if _, _, err := contextForTimeout(context.Background(), maxTimeoutMillis+1); err == nil {
+		t.Fatalf("expected invalid timeout")
+	}
+	file := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	for _, path := range []string{"", "https://example.com/repo", "\x00", filepath.Join(t.TempDir(), "missing"), file} {
+		if _, err := validateRepoPath(path); err == nil {
+			t.Fatalf("expected validateRepoPath(%q) error", path)
+		}
+	}
+	for _, mode := range []string{"", analysis.ScopeModePackage, analysis.ScopeModeRepo, analysis.ScopeModeChangedPackages} {
+		if _, err := parseScopeMode(mode); err != nil {
+			t.Fatalf("parse scope %q: %v", mode, err)
+		}
+	}
+	if _, err := parseScopeMode("bad"); err == nil {
+		t.Fatalf("expected bad scope error")
+	}
+	if !cacheEnabled(nil) || cacheEnabled(boolPtr(false)) {
+		t.Fatalf("unexpected cache enabled defaults")
+	}
+	if got := mergeStringOptions([]string{"config"}, nil); !slicesEqual(got, []string{"config"}) {
+		t.Fatalf("expected config patterns, got %#v", got)
+	}
+	if got := mergeStringOptions([]string{"config"}, []string{"arg"}); !slicesEqual(got, []string{"arg"}) {
+		t.Fatalf("expected arg patterns, got %#v", got)
+	}
+	if got := mergeStringOptions(nil, nil); len(got) != 0 {
+		t.Fatalf("expected nil patterns, got %#v", got)
+	}
+	decorateReport(nil, defaultThresholdValues(), nil, nil)
+}
+
+func TestDecodeStrictBranches(t *testing.T) {
+	var target analysisToolArguments
+	if err := decodeStrict(nil, &target); err != nil {
+		t.Fatalf("expected empty args decode success, got %v", err)
+	}
+	if err := decodeStrict(json.RawMessage(`{} {}`), &target); err == nil {
+		t.Fatalf("expected trailing JSON error")
+	}
+}
+
+func TestSummarizeReportBranches(t *testing.T) {
+	if got := summarizeReport(analysisToolKindTop, report.Report{}); !strings.Contains(got, "no dependencies") {
+		t.Fatalf("unexpected empty summary: %q", got)
+	}
+	noTotals := report.Report{Summary: &report.Summary{DependencyCount: 2, UsedPercent: 25}}
+	if got := summarizeReport(analysisToolKindTop, noTotals); !strings.Contains(got, "used exports") {
+		t.Fatalf("unexpected no-total summary: %q", got)
+	}
+	withBaseline := sampleReport(".")
+	withBaseline.BaselineComparison = &report.BaselineComparison{SummaryDelta: report.SummaryDelta{WastePercentDelta: 2.5}}
+	if got := summarizeReport(analysisToolKindCompare, withBaseline); !strings.Contains(got, "Waste delta") {
+		t.Fatalf("unexpected baseline summary: %q", got)
+	}
+}
+
+func TestReadFrameEOF(t *testing.T) {
+	if _, err := readFrame(bufio.NewReader(strings.NewReader(""))); !errors.Is(err, io.EOF) {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+func emptyFeatureConfig() thresholds.FeatureConfig {
+	return thresholds.FeatureConfig{}
+}
+
+func defaultThresholdValues() thresholds.Values {
+	return thresholds.Defaults()
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func floatPtr(value float64) *float64 {
+	return &value
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func slicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func withCurrentVersion(t *testing.T, info version.Info) {
+	t.Helper()
+	previous := currentVersion
+	currentVersion = func() version.Info {
+		return info
+	}
+	t.Cleanup(func() {
+		currentVersion = previous
+	})
+}

--- a/internal/mcp/framing.go
+++ b/internal/mcp/framing.go
@@ -1,0 +1,89 @@
+package mcp
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+const maxFrameBytes = 16 * 1024 * 1024
+
+func readFrame(reader *bufio.Reader) ([]byte, error) {
+	contentLength, err := readContentLengthHeader(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(reader, body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func readContentLengthHeader(reader *bufio.Reader) (int, error) {
+	contentLength := -1
+	sawHeader := false
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return 0, frameReadError(err, sawHeader)
+		}
+		sawHeader = true
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+
+		parsed, ok, err := parseContentLengthHeader(line)
+		if err != nil {
+			return 0, err
+		}
+		if ok {
+			contentLength = parsed
+		}
+	}
+
+	return validateContentLength(contentLength)
+}
+
+func frameReadError(err error, sawHeader bool) error {
+	if errors.Is(err, io.EOF) && !sawHeader {
+		return io.EOF
+	}
+	return err
+}
+
+func parseContentLengthHeader(line string) (int, bool, error) {
+	name, value, ok := strings.Cut(line, ":")
+	if !ok || !strings.EqualFold(strings.TrimSpace(name), "Content-Length") {
+		return 0, false, nil
+	}
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid Content-Length: %w", err)
+	}
+	return parsed, true, nil
+}
+
+func validateContentLength(contentLength int) (int, error) {
+	if contentLength < 0 {
+		return 0, fmt.Errorf("missing Content-Length header")
+	}
+	if contentLength > maxFrameBytes {
+		return 0, fmt.Errorf("frame exceeds %d byte limit", maxFrameBytes)
+	}
+	return contentLength, nil
+}
+
+func writeFrame(writer io.Writer, payload []byte) error {
+	if _, err := fmt.Fprintf(writer, "Content-Length: %d\r\n\r\n", len(payload)); err != nil {
+		return err
+	}
+	_, err := writer.Write(payload)
+	return err
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,268 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/ben-ranford/lopper/internal/analysis"
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/version"
+)
+
+const (
+	// ServerPreviewFeature is the feature flag name that enables MCP server startup.
+	ServerPreviewFeature   = "mcp-server-preview"
+	jsonrpcVersion         = "2.0"
+	defaultProtocolVersion = "2024-11-05"
+	methodInitialize       = "initialize"
+	methodToolsList        = "tools/list"
+	methodToolsCall        = "tools/call"
+	methodInitialized      = "notifications/initialized"
+	methodCancelled        = "notifications/cancelled"
+	codeParseError         = -32700
+	codeInvalidRequest     = -32600
+	codeMethodNotFound     = -32601
+	codeInvalidParams      = -32602
+	codeInternalError      = -32603
+	defaultServerName      = "lopper"
+	defaultServerVersion   = "dev"
+	defaultTopN            = 20
+	defaultLanguage        = "auto"
+	defaultScopeMode       = analysis.ScopeModePackage
+	defaultRuntimeProfile  = "node-import"
+	defaultTimeoutMillis   = 0
+	maxTimeoutMillis       = 24 * 60 * 60 * 1000
+	errorCodeToolFailed    = "tool_failed"
+	errorCodeInvalidInput  = "invalid_input"
+	errorCodeTimeout       = "timeout"
+	errorCodeCancelled     = "cancelled"
+)
+
+type Options struct {
+	Analyzer         analysis.Analyser
+	LanguageRegistry *language.Registry
+	FeatureRegistry  *featureflags.Registry
+	ServerName       string
+	ServerVersion    string
+}
+
+type Server struct {
+	analyzer         analysis.Analyser
+	languageRegistry *language.Registry
+	featureRegistry  *featureflags.Registry
+	serverName       string
+	serverVersion    string
+	writeMu          sync.Mutex
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+type initializeParams struct {
+	ProtocolVersion string `json:"protocolVersion"`
+}
+
+type initializeResult struct {
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    serverCapabilities `json:"capabilities"`
+	ServerInfo      serverInfo         `json:"serverInfo"`
+	Instructions    string             `json:"instructions,omitempty"`
+}
+
+type serverCapabilities struct {
+	Tools map[string]any `json:"tools"`
+}
+
+type serverInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+var currentVersion = version.Current
+
+func NewServer(opts Options) *Server {
+	serverVersion := opts.ServerVersion
+	if serverVersion == "" {
+		serverVersion = currentVersion().Version
+	}
+	if serverVersion == "" {
+		serverVersion = defaultServerVersion
+	}
+
+	serverName := opts.ServerName
+	if serverName == "" {
+		serverName = defaultServerName
+	}
+
+	return &Server{
+		analyzer:         opts.Analyzer,
+		languageRegistry: opts.LanguageRegistry,
+		featureRegistry:  opts.FeatureRegistry,
+		serverName:       serverName,
+		serverVersion:    serverVersion,
+	}
+}
+
+func Serve(ctx context.Context, in io.Reader, out io.Writer, opts Options) error {
+	return NewServer(opts).Serve(ctx, in, out)
+}
+
+func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	if in == nil {
+		return errors.New("mcp input is not configured")
+	}
+	if out == nil {
+		return errors.New("mcp output is not configured")
+	}
+
+	reader := bufio.NewReader(in)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		payload, err := readFrame(reader)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			response := newErrorResponse(nil, codeParseError, err.Error(), nil)
+			return s.writeResponse(out, response)
+		}
+
+		response := s.handlePayload(ctx, payload)
+		if response == nil {
+			continue
+		}
+		if err := s.writeResponse(out, response); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *Server) handlePayload(ctx context.Context, payload []byte) *rpcResponse {
+	var req rpcRequest
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		return newErrorResponse(nil, codeParseError, "parse error", err.Error())
+	}
+	if req.JSONRPC != jsonrpcVersion || req.Method == "" {
+		return newErrorResponse(req.ID, codeInvalidRequest, "invalid JSON-RPC request", nil)
+	}
+	if !hasRequestID(req) {
+		return s.handleNotification(req)
+	}
+
+	switch req.Method {
+	case methodInitialize:
+		return newResultResponse(req.ID, s.initialize(req.Params))
+	case methodToolsList:
+		return newResultResponse(req.ID, map[string]any{"tools": s.tools()})
+	case methodToolsCall:
+		result, rpcErr := s.callTool(ctx, req.Params)
+		if rpcErr != nil {
+			return newErrorResponse(req.ID, rpcErr.Code, rpcErr.Message, rpcErr.Data)
+		}
+		return newResultResponse(req.ID, result)
+	default:
+		return newErrorResponse(req.ID, codeMethodNotFound, fmt.Sprintf("method not found: %s", req.Method), nil)
+	}
+}
+
+func (s *Server) handleNotification(_ rpcRequest) *rpcResponse {
+	return nil
+}
+
+func (s *Server) initialize(params json.RawMessage) initializeResult {
+	protocolVersion := defaultProtocolVersion
+	if len(params) > 0 {
+		var parsed initializeParams
+		if err := json.Unmarshal(params, &parsed); err == nil && parsed.ProtocolVersion != "" {
+			protocolVersion = parsed.ProtocolVersion
+		}
+	}
+	return initializeResult{
+		ProtocolVersion: protocolVersion,
+		Capabilities: serverCapabilities{
+			Tools: map[string]any{},
+		},
+		ServerInfo: serverInfo{
+			Name:    s.serverName,
+			Version: s.serverVersion,
+		},
+		Instructions: "Use Lopper MCP tools for local, read-only dependency surface analysis.",
+	}
+}
+
+func (s *Server) writeResponse(out io.Writer, response *rpcResponse) error {
+	payload, err := json.Marshal(response)
+	if err != nil {
+		fallback, fallbackErr := json.Marshal(newErrorResponse(response.ID, codeInternalError, "marshal response failed", err.Error()))
+		if fallbackErr != nil {
+			return errors.Join(err, fallbackErr)
+		}
+		payload = fallback
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return writeFrame(out, payload)
+}
+
+func newResultResponse(id json.RawMessage, result any) *rpcResponse {
+	return &rpcResponse{
+		JSONRPC: jsonrpcVersion,
+		ID:      responseID(id),
+		Result:  result,
+	}
+}
+
+func newErrorResponse(id json.RawMessage, code int, message string, data any) *rpcResponse {
+	return &rpcResponse{
+		JSONRPC: jsonrpcVersion,
+		ID:      responseID(id),
+		Error: &rpcError{
+			Code:    code,
+			Message: message,
+			Data:    data,
+		},
+	}
+}
+
+func responseID(id json.RawMessage) json.RawMessage {
+	if len(id) == 0 {
+		return json.RawMessage("null")
+	}
+	copied := make(json.RawMessage, len(id))
+	copy(copied, id)
+	return copied
+}
+
+func hasRequestID(req rpcRequest) bool {
+	return len(req.ID) > 0
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,455 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/analysis"
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+type fakeAnalyser struct {
+	report  report.Report
+	err     error
+	wait    bool
+	called  bool
+	lastReq analysis.Request
+}
+
+func (f *fakeAnalyser) Analyse(ctx context.Context, req analysis.Request) (report.Report, error) {
+	f.called = true
+	f.lastReq = req
+	if f.wait {
+		<-ctx.Done()
+		return report.Report{}, ctx.Err()
+	}
+	return f.report, f.err
+}
+
+type testAdapter struct {
+	language.AdapterContract
+}
+
+func newTestAdapter(id string, aliases ...string) *testAdapter {
+	return &testAdapter{AdapterContract: language.NewAdapterContract(id, aliases...)}
+}
+
+func (a *testAdapter) Detect(context.Context, string) (bool, error) {
+	return true, nil
+}
+
+func (a *testAdapter) Analyse(context.Context, language.Request) (report.Result, error) {
+	return report.Report{}, nil
+}
+
+func TestHandleToolsListRegistersExpectedTools(t *testing.T) {
+	server := NewServer(Options{})
+	response := server.handlePayload(context.Background(), mustJSON(t, rpcRequest{
+		JSONRPC: jsonrpcVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  methodToolsList,
+	}))
+	if response == nil || response.Error != nil {
+		t.Fatalf("expected tools/list response, got %#v", response)
+	}
+
+	result := response.Result.(map[string]any)
+	tools := result["tools"].([]toolSpec)
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+		if tool.InputSchema["additionalProperties"] != false {
+			t.Fatalf("expected strict input schema for %s", tool.Name)
+		}
+		if tool.Name == toolAnalyseTop {
+			properties := tool.InputSchema["properties"].(map[string]any)
+			if _, ok := properties["dependency"]; ok {
+				t.Fatalf("top dependency schema should not advertise dependency input")
+			}
+		}
+	}
+	want := []string{toolAnalyseTop, toolAnalyseDependency, toolCompareBaseline, toolListLanguages}
+	if !slices.Equal(names, want) {
+		t.Fatalf("unexpected tools: %#v", names)
+	}
+}
+
+func TestCallAnalyseDependencyMapsRequestAndReturnsStructuredReport(t *testing.T) {
+	repo := t.TempDir()
+	cacheEnabled := false
+	topN := 10
+	lowConfidence := 33
+	minUsage := 44
+	weightUsage := 0.6
+	weightImpact := 0.2
+	weightConfidence := 0.2
+	fake := &fakeAnalyser{report: sampleReport(repo)}
+	server := NewServer(Options{Analyzer: fake})
+
+	result, rpcErr := server.callTool(context.Background(), mustJSON(t, toolCallParams{
+		Name: toolAnalyseDependency,
+		Arguments: mustJSON(t, analysisToolArguments{
+			RepoPath:                          repo,
+			Dependency:                        "lodash",
+			TopN:                              &topN,
+			Language:                          "js-ts",
+			ScopeMode:                         analysis.ScopeModeRepo,
+			Include:                           []string{"src/**"},
+			Exclude:                           []string{"vendor/**"},
+			CacheEnabled:                      &cacheEnabled,
+			CachePath:                         ".cache/lopper",
+			CacheReadOnly:                     true,
+			RuntimeProfile:                    "browser-import",
+			RuntimeTracePath:                  "trace.ndjson",
+			LowConfidenceWarningPercent:       &lowConfidence,
+			MinUsagePercentForRecommendations: &minUsage,
+			ScoreWeightUsage:                  &weightUsage,
+			ScoreWeightImpact:                 &weightImpact,
+			ScoreWeightConfidence:             &weightConfidence,
+			LicenseDeny:                       []string{"GPL-3.0-only"},
+		}),
+	}))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %#v", rpcErr)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %#v", result)
+	}
+	if !fake.called {
+		t.Fatalf("expected analyser to be called")
+	}
+	if fake.lastReq.RepoPath != repo {
+		t.Fatalf("expected normalized repo path %q, got %q", repo, fake.lastReq.RepoPath)
+	}
+	assertAnalysisRequest(t, fake.lastReq)
+
+	payload, ok := result.StructuredContent.(analysisPayload)
+	if !ok {
+		t.Fatalf("expected analysis payload, got %#v", result.StructuredContent)
+	}
+	if payload.Report.EffectiveThresholds == nil {
+		t.Fatalf("expected effective thresholds in report")
+	}
+	if payload.Report.EffectivePolicy == nil {
+		t.Fatalf("expected effective policy in report")
+	}
+	if payload.Report.EffectivePolicy.Sources[0] != "mcp" {
+		t.Fatalf("expected mcp policy source, got %#v", payload.Report.EffectivePolicy.Sources)
+	}
+	if source := policyTraceSource(payload.Report.EffectivePolicy.MergeTrace, "thresholds.low_confidence_warning_percent"); source != "mcp" {
+		t.Fatalf("expected mcp policy trace source, got %q", source)
+	}
+	if payload.Report.EffectivePolicy.License.Deny[0] != "GPL-3.0-ONLY" {
+		t.Fatalf("expected license deny list to be preserved, got %#v", payload.Report.EffectivePolicy.License.Deny)
+	}
+	if !strings.Contains(result.Content[0].Text, "Dependency analysis completed") {
+		t.Fatalf("expected concise text summary, got %#v", result.Content)
+	}
+}
+
+func TestCallAnalyseTopValidatesInputs(t *testing.T) {
+	repo := t.TempDir()
+	server := NewServer(Options{Analyzer: &fakeAnalyser{report: sampleReport(repo)}})
+
+	missingRepo := callToolResult(t, server, toolAnalyseTop, map[string]any{"topN": 5})
+	if !missingRepo.IsError || !strings.Contains(missingRepo.Content[0].Text, "repoPath is required") {
+		t.Fatalf("expected missing repoPath validation error, got %#v", missingRepo)
+	}
+
+	mutationArg := callToolResult(t, server, toolAnalyseTop, map[string]any{
+		"repoPath":           repo,
+		"runtimeTestCommand": "npm test",
+	})
+	if !mutationArg.IsError || !strings.Contains(mutationArg.Content[0].Text, "unknown field") {
+		t.Fatalf("expected unsupported argument validation error, got %#v", mutationArg)
+	}
+
+	badTopN := callToolResult(t, server, toolAnalyseTop, map[string]any{
+		"repoPath": repo,
+		"topN":     0,
+	})
+	if !badTopN.IsError || !strings.Contains(badTopN.Content[0].Text, "topN") {
+		t.Fatalf("expected topN validation error, got %#v", badTopN)
+	}
+}
+
+func TestCallCompareBaselineAppliesBaselineDiff(t *testing.T) {
+	repo := t.TempDir()
+	baselinePath := filepath.Join(repo, "baseline.json")
+	baseline := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		RepoPath:      repo,
+		Dependencies: []report.DependencyReport{
+			{Name: "lodash", Language: "js-ts", UsedExportsCount: 8, TotalExportsCount: 10, UsedPercent: 80},
+		},
+	}
+	writeJSONFile(t, baselinePath, baseline)
+
+	fake := &fakeAnalyser{report: sampleReport(repo)}
+	server := NewServer(Options{Analyzer: fake})
+	result := callToolResult(t, server, toolCompareBaseline, map[string]any{
+		"repoPath":      repo,
+		"dependency":    "lodash",
+		"baselinePath":  baselinePath,
+		"cacheEnabled":  false,
+		"timeoutMillis": 1000,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected compare error: %#v", result)
+	}
+
+	payload := result.StructuredContent.(analysisPayload)
+	if payload.Report.BaselineComparison == nil {
+		t.Fatalf("expected baseline comparison in report")
+	}
+	if payload.Report.WasteIncreasePercent == nil {
+		t.Fatalf("expected waste increase percent in report")
+	}
+	if !strings.Contains(payload.Summary, "Waste delta") {
+		t.Fatalf("expected baseline summary with delta, got %q", payload.Summary)
+	}
+}
+
+func TestCallToolTimeoutCancelsAnalysis(t *testing.T) {
+	repo := t.TempDir()
+	fake := &fakeAnalyser{wait: true}
+	server := NewServer(Options{Analyzer: fake})
+
+	result := callToolResult(t, server, toolAnalyseTop, map[string]any{
+		"repoPath":      repo,
+		"topN":          5,
+		"timeoutMillis": 1,
+		"cacheEnabled":  false,
+	})
+	if !fake.called {
+		t.Fatalf("expected analyser to be called")
+	}
+	if !result.IsError {
+		t.Fatalf("expected timeout tool error, got %#v", result)
+	}
+	payload := result.StructuredContent.(map[string]any)
+	errPayload := payload["error"].(map[string]any)
+	if errPayload["code"] != errorCodeTimeout {
+		t.Fatalf("expected timeout code, got %#v", errPayload)
+	}
+}
+
+func TestListLanguagesReturnsAdapterAndConfigMetadata(t *testing.T) {
+	registry := language.NewRegistry()
+	if err := registry.Register(newTestAdapter("js-ts", "javascript", "typescript")); err != nil {
+		t.Fatalf("register adapter: %v", err)
+	}
+	server := NewServer(Options{LanguageRegistry: registry})
+
+	result := callToolResult(t, server, toolListLanguages, map[string]any{})
+	if result.IsError {
+		t.Fatalf("unexpected language metadata error: %#v", result)
+	}
+
+	payload := result.StructuredContent.(languagesPayload)
+	if len(payload.Languages) != 1 {
+		t.Fatalf("expected one language, got %#v", payload.Languages)
+	}
+	if payload.Languages[0].ID != "js-ts" || !slices.Equal(payload.Languages[0].Aliases, []string{"javascript", "typescript"}) {
+		t.Fatalf("unexpected language metadata: %#v", payload.Languages)
+	}
+	if !slices.Contains(payload.LanguageModes, language.Auto) || !slices.Contains(payload.LanguageModes, language.All) {
+		t.Fatalf("expected auto/all language modes, got %#v", payload.LanguageModes)
+	}
+	if payload.EffectiveThresholds.LowConfidenceWarningPercent == 0 {
+		t.Fatalf("expected threshold defaults in metadata")
+	}
+}
+
+func TestServeProcessesFramedInitialize(t *testing.T) {
+	var input bytes.Buffer
+	writeTestFrame(t, &input, mustJSON(t, rpcRequest{
+		JSONRPC: jsonrpcVersion,
+		ID:      json.RawMessage(`"init-1"`),
+		Method:  methodInitialize,
+		Params:  json.RawMessage(`{"protocolVersion":"2025-06-18"}`),
+	}))
+
+	var output bytes.Buffer
+	server := NewServer(Options{ServerVersion: "test"})
+	if err := server.Serve(context.Background(), &input, &output); err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+
+	frame, err := readFrame(bufio.NewReader(&output))
+	if err != nil {
+		t.Fatalf("read output frame: %v", err)
+	}
+	var response rpcResponse
+	if err := json.Unmarshal(frame, &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.Error != nil {
+		t.Fatalf("unexpected initialize error: %#v", response.Error)
+	}
+	data, err := json.Marshal(response.Result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var result initializeResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.ProtocolVersion != "2025-06-18" {
+		t.Fatalf("expected protocol echo, got %q", result.ProtocolVersion)
+	}
+	if result.ServerInfo.Version != "test" {
+		t.Fatalf("expected server version, got %q", result.ServerInfo.Version)
+	}
+}
+
+func TestHandleUnknownMethodReturnsJSONRPCError(t *testing.T) {
+	server := NewServer(Options{})
+	response := server.handlePayload(context.Background(), mustJSON(t, rpcRequest{
+		JSONRPC: jsonrpcVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  "nope",
+	}))
+	if response == nil || response.Error == nil {
+		t.Fatalf("expected json-rpc error, got %#v", response)
+	}
+	if response.Error.Code != codeMethodNotFound {
+		t.Fatalf("expected method-not-found code, got %#v", response.Error)
+	}
+}
+
+func TestAnalysisErrorResultClassifiesCancellation(t *testing.T) {
+	cancelled := analysisErrorResult(context.Canceled)
+	payload := cancelled.StructuredContent.(map[string]any)
+	if payload["error"].(map[string]any)["code"] != errorCodeCancelled {
+		t.Fatalf("expected cancelled code, got %#v", payload)
+	}
+
+	failed := analysisErrorResult(errors.New("boom"))
+	payload = failed.StructuredContent.(map[string]any)
+	if payload["error"].(map[string]any)["code"] != errorCodeToolFailed {
+		t.Fatalf("expected tool failed code, got %#v", payload)
+	}
+}
+
+func assertAnalysisRequest(t *testing.T, req analysis.Request) {
+	t.Helper()
+	assertAnalysisRequestBasics(t, req)
+	assertAnalysisRequestOptions(t, req)
+	assertAnalysisRequestThresholds(t, req)
+}
+
+func assertAnalysisRequestBasics(t *testing.T, req analysis.Request) {
+	t.Helper()
+	if req.Dependency != "lodash" {
+		t.Fatalf("expected dependency lodash, got %q", req.Dependency)
+	}
+	if req.TopN != 0 {
+		t.Fatalf("expected dependency analysis topN 0, got %d", req.TopN)
+	}
+	if req.Language != "js-ts" {
+		t.Fatalf("expected js-ts language, got %q", req.Language)
+	}
+	if req.ScopeMode != analysis.ScopeModeRepo {
+		t.Fatalf("expected repo scope, got %q", req.ScopeMode)
+	}
+	if !slices.Equal(req.IncludePatterns, []string{"src/**"}) || !slices.Equal(req.ExcludePatterns, []string{"vendor/**"}) {
+		t.Fatalf("unexpected scope patterns: include=%#v exclude=%#v", req.IncludePatterns, req.ExcludePatterns)
+	}
+}
+
+func assertAnalysisRequestOptions(t *testing.T, req analysis.Request) {
+	t.Helper()
+	if req.Cache == nil || req.Cache.Enabled || req.Cache.Path != ".cache/lopper" || !req.Cache.ReadOnly {
+		t.Fatalf("unexpected cache options: %#v", req.Cache)
+	}
+	if req.RuntimeProfile != "browser-import" || req.RuntimeTracePath != "trace.ndjson" || !req.RuntimeTracePathExplicit {
+		t.Fatalf("unexpected runtime options: %#v", req)
+	}
+}
+
+func assertAnalysisRequestThresholds(t *testing.T, req analysis.Request) {
+	t.Helper()
+	if req.LowConfidenceWarningPercent == nil || *req.LowConfidenceWarningPercent != 33 {
+		t.Fatalf("unexpected low-confidence threshold: %#v", req.LowConfidenceWarningPercent)
+	}
+	if req.MinUsagePercentForRecommendations == nil || *req.MinUsagePercentForRecommendations != 44 {
+		t.Fatalf("unexpected min usage threshold: %#v", req.MinUsagePercentForRecommendations)
+	}
+	if req.RemovalCandidateWeights == nil || req.RemovalCandidateWeights.Usage != 0.6 {
+		t.Fatalf("unexpected removal weights: %#v", req.RemovalCandidateWeights)
+	}
+}
+
+func callToolResult(t *testing.T, server *Server, name string, args map[string]any) toolCallResult {
+	t.Helper()
+	result, rpcErr := server.callTool(context.Background(), mustJSON(t, map[string]any{
+		"name":      name,
+		"arguments": args,
+	}))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %#v", rpcErr)
+	}
+	return result
+}
+
+func sampleReport(repoPath string) report.Report {
+	return report.Report{
+		SchemaVersion: report.SchemaVersion,
+		RepoPath:      repoPath,
+		Dependencies: []report.DependencyReport{
+			{Name: "lodash", Language: "js-ts", UsedExportsCount: 5, TotalExportsCount: 10, UsedPercent: 50},
+		},
+		Summary: &report.Summary{
+			DependencyCount:   1,
+			UsedExportsCount:  5,
+			TotalExportsCount: 10,
+			UsedPercent:       50,
+		},
+	}
+}
+
+func mustJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return data
+}
+
+func writeJSONFile(t *testing.T, path string, value any) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal file: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func writeTestFrame(t *testing.T, writer *bytes.Buffer, payload []byte) {
+	t.Helper()
+	if err := writeFrame(writer, payload); err != nil {
+		t.Fatalf("write frame: %v", err)
+	}
+}
+
+func policyTraceSource(trace []report.PolicyMergeTrace, field string) string {
+	for _, item := range trace {
+		if item.Field == field {
+			return item.Source
+		}
+	}
+	return ""
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,885 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/analysis"
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/thresholds"
+	"github.com/ben-ranford/lopper/internal/workspace"
+)
+
+const (
+	toolAnalyseTop        = "lopper_analyse_top_dependencies"
+	toolAnalyseDependency = "lopper_analyse_dependency"
+	toolCompareBaseline   = "lopper_compare_baseline"
+	toolListLanguages     = "lopper_list_languages"
+)
+
+type toolSpec struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+type toolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+type toolCallResult struct {
+	Content           []contentItem `json:"content"`
+	StructuredContent any           `json:"structuredContent,omitempty"`
+	IsError           bool          `json:"isError,omitempty"`
+}
+
+type contentItem struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type analysisToolArguments struct {
+	RepoPath                          string   `json:"repoPath"`
+	Dependency                        string   `json:"dependency,omitempty"`
+	TopN                              *int     `json:"topN,omitempty"`
+	Language                          string   `json:"language,omitempty"`
+	ScopeMode                         string   `json:"scopeMode,omitempty"`
+	ConfigPath                        string   `json:"configPath,omitempty"`
+	Include                           []string `json:"include,omitempty"`
+	Exclude                           []string `json:"exclude,omitempty"`
+	EnableFeatures                    []string `json:"enableFeatures,omitempty"`
+	DisableFeatures                   []string `json:"disableFeatures,omitempty"`
+	CacheEnabled                      *bool    `json:"cacheEnabled,omitempty"`
+	CachePath                         string   `json:"cachePath,omitempty"`
+	CacheReadOnly                     bool     `json:"cacheReadOnly,omitempty"`
+	RuntimeProfile                    string   `json:"runtimeProfile,omitempty"`
+	RuntimeTracePath                  string   `json:"runtimeTracePath,omitempty"`
+	LowConfidenceWarningPercent       *int     `json:"lowConfidenceWarningPercent,omitempty"`
+	MinUsagePercentForRecommendations *int     `json:"minUsagePercentForRecommendations,omitempty"`
+	MaxUncertainImportCount           *int     `json:"maxUncertainImportCount,omitempty"`
+	ScoreWeightUsage                  *float64 `json:"scoreWeightUsage,omitempty"`
+	ScoreWeightImpact                 *float64 `json:"scoreWeightImpact,omitempty"`
+	ScoreWeightConfidence             *float64 `json:"scoreWeightConfidence,omitempty"`
+	LicenseDeny                       []string `json:"licenseDeny,omitempty"`
+	LicenseFailOnDeny                 *bool    `json:"licenseFailOnDeny,omitempty"`
+	LicenseProvenanceRegistry         *bool    `json:"licenseProvenanceRegistry,omitempty"`
+	BaselinePath                      string   `json:"baselinePath,omitempty"`
+	BaselineStorePath                 string   `json:"baselineStorePath,omitempty"`
+	BaselineKey                       string   `json:"baselineKey,omitempty"`
+	TimeoutMillis                     int      `json:"timeoutMillis,omitempty"`
+}
+
+type listLanguagesArguments struct {
+	RepoPath        string   `json:"repoPath,omitempty"`
+	ConfigPath      string   `json:"configPath,omitempty"`
+	EnableFeatures  []string `json:"enableFeatures,omitempty"`
+	DisableFeatures []string `json:"disableFeatures,omitempty"`
+	TimeoutMillis   int      `json:"timeoutMillis,omitempty"`
+}
+
+type analysisPayload struct {
+	SchemaVersion string        `json:"schemaVersion"`
+	Summary       string        `json:"summary"`
+	Report        report.Report `json:"report"`
+}
+
+type languageMetadata struct {
+	ID      string   `json:"id"`
+	Aliases []string `json:"aliases,omitempty"`
+}
+
+type languagesPayload struct {
+	Summary             string                         `json:"summary"`
+	Languages           []languageMetadata             `json:"languages"`
+	LanguageModes       []string                       `json:"languageModes"`
+	RuntimeProfiles     []string                       `json:"runtimeProfiles"`
+	DefaultScopeMode    string                         `json:"defaultScopeMode"`
+	DefaultTopN         int                            `json:"defaultTopN"`
+	ConfigPath          string                         `json:"configPath,omitempty"`
+	EffectiveThresholds report.EffectiveThresholds     `json:"effectiveThresholds"`
+	RemovalWeights      report.RemovalCandidateWeights `json:"removalCandidateWeights"`
+	LicensePolicy       report.LicensePolicy           `json:"licensePolicy"`
+	EnabledFeatures     []string                       `json:"enabledFeatures,omitempty"`
+	PolicySources       []string                       `json:"policySources,omitempty"`
+	PolicyTrace         []report.PolicyMergeTrace      `json:"policyTrace,omitempty"`
+}
+
+type resolvedToolRequest struct {
+	analysisRequest analysis.Request
+	repoPath        string
+	thresholds      thresholds.Values
+	policySources   []string
+	policyTrace     []report.PolicyMergeTrace
+	baselinePath    string
+	baselineKey     string
+	currentKey      string
+}
+
+func (s *Server) tools() []toolSpec {
+	return []toolSpec{
+		{
+			Name:        toolAnalyseTop,
+			Description: "Analyse and rank the top dependencies by unused surface area for a local repository.",
+			InputSchema: analysisInputSchema(false, false, true, false),
+		},
+		{
+			Name:        toolAnalyseDependency,
+			Description: "Analyse one dependency in a local repository and return the report schema plus a concise summary.",
+			InputSchema: analysisInputSchema(true, true, false, false),
+		},
+		{
+			Name:        toolCompareBaseline,
+			Description: "Run a read-only analysis and compare it with a baseline report or immutable baseline snapshot.",
+			InputSchema: analysisInputSchema(false, true, true, true),
+		},
+		{
+			Name:        toolListLanguages,
+			Description: "List supported language adapters, modes, runtime profiles, and effective config metadata.",
+			InputSchema: listLanguagesInputSchema(),
+		},
+	}
+}
+
+func (s *Server) callTool(ctx context.Context, params json.RawMessage) (toolCallResult, *rpcError) {
+	var call toolCallParams
+	if err := decodeStrict(params, &call); err != nil {
+		return toolCallResult{}, &rpcError{Code: codeInvalidParams, Message: "invalid tools/call params", Data: err.Error()}
+	}
+	if strings.TrimSpace(call.Name) == "" {
+		return toolCallResult{}, &rpcError{Code: codeInvalidParams, Message: "tool name is required"}
+	}
+	args := call.Arguments
+	if len(args) == 0 {
+		args = []byte("{}")
+	}
+
+	switch call.Name {
+	case toolAnalyseTop:
+		return s.runAnalysisTool(ctx, args, analysisToolKindTop), nil
+	case toolAnalyseDependency:
+		return s.runAnalysisTool(ctx, args, analysisToolKindDependency), nil
+	case toolCompareBaseline:
+		return s.runAnalysisTool(ctx, args, analysisToolKindCompare), nil
+	case toolListLanguages:
+		return s.runListLanguagesTool(ctx, args), nil
+	default:
+		return toolCallResult{}, &rpcError{Code: codeInvalidParams, Message: fmt.Sprintf("unknown tool: %s", call.Name)}
+	}
+}
+
+type analysisToolKind string
+
+const (
+	analysisToolKindTop        analysisToolKind = "top"
+	analysisToolKindDependency analysisToolKind = "dependency"
+	analysisToolKindCompare    analysisToolKind = "compare"
+)
+
+func (s *Server) runAnalysisTool(ctx context.Context, rawArgs json.RawMessage, kind analysisToolKind) toolCallResult {
+	var args analysisToolArguments
+	if err := decodeStrict(rawArgs, &args); err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+
+	reqCtx, cancel, err := contextForTimeout(ctx, args.TimeoutMillis)
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	defer cancel()
+
+	resolved, err := s.resolveAnalysisRequest(reqCtx, args, kind)
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+
+	analyzer := s.analyzer
+	if analyzer == nil {
+		analyzer = analysis.NewService()
+	}
+	reportData, err := analyzer.Analyse(reqCtx, resolved.analysisRequest)
+	if err != nil {
+		return analysisErrorResult(err)
+	}
+	decorateReport(&reportData, resolved.thresholds, resolved.policySources, resolved.policyTrace)
+	if resolved.baselinePath != "" {
+		reportData, err = applyBaseline(reportData, resolved.baselinePath, resolved.baselineKey, resolved.currentKey)
+		if err != nil {
+			return analysisErrorResult(err)
+		}
+	}
+
+	summary := summarizeReport(kind, reportData)
+	payload := analysisPayload{
+		SchemaVersion: report.SchemaVersion,
+		Summary:       summary,
+		Report:        reportData,
+	}
+	return toolSuccess(summary, payload)
+}
+
+func (s *Server) resolveAnalysisRequest(ctx context.Context, args analysisToolArguments, kind analysisToolKind) (resolvedToolRequest, error) {
+	repoPath, err := validateRepoPath(args.RepoPath)
+	if err != nil {
+		return resolvedToolRequest{}, err
+	}
+
+	dependency, topN, err := resolveAnalysisTarget(args, kind)
+	if err != nil {
+		return resolvedToolRequest{}, err
+	}
+
+	scopeMode, err := parseScopeMode(args.ScopeMode)
+	if err != nil {
+		return resolvedToolRequest{}, err
+	}
+	loadResult, thresholdsValue, policySources, policyTrace, err := resolveThresholds(repoPath, args)
+	if err != nil {
+		return resolvedToolRequest{}, err
+	}
+	features, err := s.resolveFeatures(loadResult.Features, args.EnableFeatures, args.DisableFeatures)
+	if err != nil {
+		return resolvedToolRequest{}, err
+	}
+	analysisReq := newAnalysisRequest(args, analysisRequestContext{
+		repoPath:   repoPath,
+		dependency: dependency,
+		topN:       topN,
+		scopeMode:  scopeMode,
+		loadResult: loadResult,
+		thresholds: thresholdsValue,
+		featureSet: features,
+	})
+
+	baselinePath, baselineKey, currentKey, err := resolveBaselineComparison(repoPath, args)
+	if err != nil {
+		return resolvedToolRequest{}, err
+	}
+	return resolvedToolRequest{
+		analysisRequest: analysisReq,
+		repoPath:        repoPath,
+		thresholds:      thresholdsValue,
+		policySources:   policySources,
+		policyTrace:     policyTrace,
+		baselinePath:    baselinePath,
+		baselineKey:     baselineKey,
+		currentKey:      currentKey,
+	}, ctx.Err()
+}
+
+type analysisRequestContext struct {
+	repoPath   string
+	dependency string
+	topN       int
+	scopeMode  string
+	loadResult thresholds.LoadResult
+	thresholds thresholds.Values
+	featureSet featureflags.Set
+}
+
+func resolveAnalysisTarget(args analysisToolArguments, kind analysisToolKind) (string, int, error) {
+	dependency := strings.TrimSpace(args.Dependency)
+	topN := topNOrDefault(args.TopN)
+	switch kind {
+	case analysisToolKindDependency:
+		if dependency == "" {
+			return "", 0, errors.New("dependency is required")
+		}
+		topN = 0
+	case analysisToolKindTop:
+		if dependency != "" {
+			return "", 0, errors.New("dependency is not supported for top dependency analysis")
+		}
+	case analysisToolKindCompare:
+		if !hasBaselineInput(args) {
+			return "", 0, errors.New("baselinePath or baselineStorePath is required")
+		}
+		if dependency != "" {
+			topN = 0
+		}
+	default:
+		return "", 0, errors.New("unknown analysis tool kind")
+	}
+	if topN < 0 {
+		return "", 0, errors.New("topN must be greater than zero")
+	}
+	return dependency, topN, nil
+}
+
+func hasBaselineInput(args analysisToolArguments) bool {
+	return strings.TrimSpace(args.BaselinePath) != "" || strings.TrimSpace(args.BaselineStorePath) != ""
+}
+
+func newAnalysisRequest(args analysisToolArguments, req analysisRequestContext) analysis.Request {
+	runtimeTracePath := strings.TrimSpace(args.RuntimeTracePath)
+	lowConfidence := req.thresholds.LowConfidenceWarningPercent
+	minUsage := req.thresholds.MinUsagePercentForRecommendations
+	weights := thresholds.RemovalCandidateWeights(req.thresholds)
+	return analysis.Request{
+		RepoPath:                          req.repoPath,
+		Dependency:                        req.dependency,
+		TopN:                              req.topN,
+		ScopeMode:                         req.scopeMode,
+		Language:                          languageOrDefault(args.Language),
+		ConfigPath:                        strings.TrimSpace(req.loadResult.ConfigPath),
+		RuntimeProfile:                    runtimeProfileOrDefault(args.RuntimeProfile),
+		RuntimeTracePath:                  runtimeTracePath,
+		RuntimeTracePathExplicit:          runtimeTracePath != "",
+		IncludePatterns:                   mergeStringOptions(req.loadResult.Scope.Include, args.Include),
+		ExcludePatterns:                   mergeStringOptions(req.loadResult.Scope.Exclude, args.Exclude),
+		Features:                          req.featureSet,
+		LowConfidenceWarningPercent:       &lowConfidence,
+		MinUsagePercentForRecommendations: &minUsage,
+		RemovalCandidateWeights:           &weights,
+		LicenseDenyList:                   append([]string{}, req.thresholds.LicenseDenyList...),
+		IncludeRegistryProvenance:         req.thresholds.LicenseIncludeRegistryProvenance,
+		Cache: &analysis.CacheOptions{
+			Enabled:  cacheEnabled(args.CacheEnabled),
+			Path:     strings.TrimSpace(args.CachePath),
+			ReadOnly: args.CacheReadOnly,
+		},
+	}
+}
+
+func (s *Server) runListLanguagesTool(ctx context.Context, rawArgs json.RawMessage) toolCallResult {
+	var args listLanguagesArguments
+	if err := decodeStrict(rawArgs, &args); err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+
+	reqCtx, cancel, err := contextForTimeout(ctx, args.TimeoutMillis)
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	defer cancel()
+
+	var loadResult thresholds.LoadResult
+	thresholdValues := thresholds.Defaults()
+	if strings.TrimSpace(args.RepoPath) != "" || strings.TrimSpace(args.ConfigPath) != "" {
+		repoPath, err := validateRepoPath(args.RepoPath)
+		if err != nil {
+			return toolError(errorCodeInvalidInput, err)
+		}
+		loadResult, err = thresholds.LoadWithPolicy(repoPath, strings.TrimSpace(args.ConfigPath))
+		if err != nil {
+			return toolError(errorCodeInvalidInput, err)
+		}
+		thresholdValues = loadResult.Resolved
+	}
+	features, err := s.resolveFeatures(loadResult.Features, args.EnableFeatures, args.DisableFeatures)
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	if err := reqCtx.Err(); err != nil {
+		return analysisErrorResult(err)
+	}
+
+	languages := s.languageMetadata()
+	summary := fmt.Sprintf("Lopper supports %d language adapters.", len(languages))
+	payload := languagesPayload{
+		Summary:          summary,
+		Languages:        languages,
+		LanguageModes:    []string{language.Auto, language.All},
+		RuntimeProfiles:  []string{"node-import", "node-require", "browser-import", "browser-require"},
+		DefaultScopeMode: defaultScopeMode,
+		DefaultTopN:      defaultTopN,
+		ConfigPath:       strings.TrimSpace(loadResult.ConfigPath),
+		EffectiveThresholds: report.EffectiveThresholds{
+			FailOnIncreasePercent:             thresholdValues.FailOnIncreasePercent,
+			LowConfidenceWarningPercent:       thresholdValues.LowConfidenceWarningPercent,
+			MinUsagePercentForRecommendations: thresholdValues.MinUsagePercentForRecommendations,
+			MaxUncertainImportCount:           thresholdValues.MaxUncertainImportCount,
+		},
+		RemovalWeights:  thresholds.RemovalCandidateWeights(thresholdValues),
+		LicensePolicy:   licensePolicy(thresholdValues),
+		EnabledFeatures: features.EnabledCodes(),
+		PolicySources:   append([]string{}, loadResult.PolicySources...),
+		PolicyTrace:     append([]report.PolicyMergeTrace{}, loadResult.PolicyTrace...),
+	}
+	return toolSuccess(summary, payload)
+}
+
+func (s *Server) languageMetadata() []languageMetadata {
+	registry := s.languageRegistry
+	if registry == nil {
+		if service, ok := s.analyzer.(*analysis.Service); ok {
+			registry = service.Registry
+		}
+	}
+	if registry == nil {
+		registry = analysis.NewService().Registry
+	}
+
+	adapters := registry.Metadata()
+	items := make([]languageMetadata, 0, len(adapters))
+	for _, adapter := range adapters {
+		items = append(items, languageMetadata{
+			ID:      adapter.ID,
+			Aliases: append([]string{}, adapter.Aliases...),
+		})
+	}
+	return items
+}
+
+func (s *Server) resolveFeatures(config thresholds.FeatureConfig, enable []string, disable []string) (featureflags.Set, error) {
+	registry := s.featureRegistry
+	if registry == nil {
+		if err := featureflags.ValidateDefaultRegistry(); err != nil {
+			return featureflags.Set{}, err
+		}
+		registry = featureflags.DefaultRegistry()
+	}
+	info := currentVersion()
+	channel, err := featureflags.NormalizeChannel(info.BuildChannel)
+	if err != nil {
+		return featureflags.Set{}, err
+	}
+	var lock *featureflags.ReleaseLock
+	if channel == featureflags.ChannelRelease {
+		lock, err = featureflags.DefaultReleaseLock(info.Version)
+		if err != nil {
+			return featureflags.Set{}, err
+		}
+	}
+
+	enabled := append([]string{}, config.Enable...)
+	enabled = append(enabled, enable...)
+	disabled := append([]string{}, config.Disable...)
+	disabled = append(disabled, disable...)
+	return registry.Resolve(featureflags.ResolveOptions{
+		Channel: channel,
+		Lock:    lock,
+		Enable:  enabled,
+		Disable: disabled,
+	})
+}
+
+func resolveThresholds(repoPath string, args analysisToolArguments) (thresholds.LoadResult, thresholds.Values, []string, []report.PolicyMergeTrace, error) {
+	loadResult, err := thresholds.LoadWithPolicy(repoPath, strings.TrimSpace(args.ConfigPath))
+	if err != nil {
+		return thresholds.LoadResult{}, thresholds.Values{}, nil, nil, err
+	}
+	overrides := thresholds.Overrides{
+		LowConfidenceWarningPercent:       args.LowConfidenceWarningPercent,
+		MinUsagePercentForRecommendations: args.MinUsagePercentForRecommendations,
+		MaxUncertainImportCount:           args.MaxUncertainImportCount,
+		RemovalCandidateWeightUsage:       args.ScoreWeightUsage,
+		RemovalCandidateWeightImpact:      args.ScoreWeightImpact,
+		RemovalCandidateWeightConfidence:  args.ScoreWeightConfidence,
+		LicenseDenyList:                   append([]string{}, args.LicenseDeny...),
+		LicenseFailOnDeny:                 args.LicenseFailOnDeny,
+		LicenseIncludeRegistryProvenance:  args.LicenseProvenanceRegistry,
+	}
+	if err := overrides.Validate(); err != nil {
+		return thresholds.LoadResult{}, thresholds.Values{}, nil, nil, err
+	}
+	resolved := overrides.Apply(loadResult.Resolved)
+	if err := resolved.Validate(); err != nil {
+		return thresholds.LoadResult{}, thresholds.Values{}, nil, nil, err
+	}
+	policySources := append([]string{}, loadResult.PolicySources...)
+	policyTrace := append([]report.PolicyMergeTrace{}, loadResult.PolicyTrace...)
+	if hasMCPPolicyOverrides(args) {
+		policySources = prependPolicySource("mcp", policySources)
+		policyTrace = mergeMCPPolicyTrace(policyTrace, args)
+	}
+	return loadResult, resolved, policySources, policyTrace, nil
+}
+
+func hasMCPPolicyOverrides(args analysisToolArguments) bool {
+	return args.LowConfidenceWarningPercent != nil ||
+		args.MinUsagePercentForRecommendations != nil ||
+		args.MaxUncertainImportCount != nil ||
+		args.ScoreWeightUsage != nil ||
+		args.ScoreWeightImpact != nil ||
+		args.ScoreWeightConfidence != nil ||
+		len(args.LicenseDeny) > 0 ||
+		args.LicenseFailOnDeny != nil ||
+		args.LicenseProvenanceRegistry != nil
+}
+
+func prependPolicySource(source string, sources []string) []string {
+	out := []string{source}
+	seen := map[string]struct{}{source: {}}
+	for _, item := range sources {
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func mergeMCPPolicyTrace(trace []report.PolicyMergeTrace, args analysisToolArguments) []report.PolicyMergeTrace {
+	updates := mcpPolicyTrace(args)
+	if len(updates) == 0 {
+		return append([]report.PolicyMergeTrace{}, trace...)
+	}
+	out := append([]report.PolicyMergeTrace{}, trace...)
+	index := make(map[string]int, len(out))
+	for i, item := range out {
+		index[item.Field] = i
+	}
+	for _, item := range updates {
+		if existing, ok := index[item.Field]; ok {
+			out[existing].Source = item.Source
+			continue
+		}
+		index[item.Field] = len(out)
+		out = append(out, item)
+	}
+	return out
+}
+
+func mcpPolicyTrace(args analysisToolArguments) []report.PolicyMergeTrace {
+	trace := make([]report.PolicyMergeTrace, 0, 9)
+	if args.LowConfidenceWarningPercent != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "thresholds.low_confidence_warning_percent", Source: "mcp"})
+	}
+	if args.MinUsagePercentForRecommendations != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "thresholds.min_usage_percent_for_recommendations", Source: "mcp"})
+	}
+	if args.MaxUncertainImportCount != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "thresholds.max_uncertain_import_count", Source: "mcp"})
+	}
+	if args.ScoreWeightUsage != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "removal_candidate_weights.usage", Source: "mcp"})
+	}
+	if args.ScoreWeightImpact != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "removal_candidate_weights.impact", Source: "mcp"})
+	}
+	if args.ScoreWeightConfidence != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "removal_candidate_weights.confidence", Source: "mcp"})
+	}
+	if len(args.LicenseDeny) > 0 {
+		trace = append(trace, report.PolicyMergeTrace{Field: "license.deny", Source: "mcp"})
+	}
+	if args.LicenseFailOnDeny != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "license.fail_on_deny", Source: "mcp"})
+	}
+	if args.LicenseProvenanceRegistry != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "license.include_registry_provenance", Source: "mcp"})
+	}
+	return trace
+}
+
+func resolveBaselineComparison(repoPath string, args analysisToolArguments) (string, string, string, error) {
+	baselinePath := strings.TrimSpace(args.BaselinePath)
+	baselineStorePath := strings.TrimSpace(args.BaselineStorePath)
+	baselineKey := strings.TrimSpace(args.BaselineKey)
+	if baselinePath != "" && baselineStorePath != "" {
+		return "", "", "", errors.New("baselinePath and baselineStorePath cannot both be provided")
+	}
+	if baselineStorePath != "" {
+		if baselineKey == "" {
+			return "", "", "", errors.New("baselineKey is required with baselineStorePath")
+		}
+		baselinePath = report.BaselineSnapshotPath(baselineStorePath, baselineKey)
+	}
+	if baselinePath == "" {
+		return "", "", "", nil
+	}
+	currentKey := "current"
+	if sha, err := workspace.CurrentCommitSHA(repoPath); err == nil {
+		currentKey = "commit:" + sha
+	}
+	return baselinePath, baselineKey, currentKey, nil
+}
+
+func applyBaseline(current report.Report, baselinePath, requestedKey, currentKey string) (report.Report, error) {
+	baseline, loadedKey, err := report.LoadWithKey(baselinePath)
+	if err != nil {
+		return current, err
+	}
+	if strings.TrimSpace(requestedKey) == "" {
+		requestedKey = loadedKey
+	}
+	return report.ApplyBaselineWithKeys(current, baseline, requestedKey, currentKey)
+}
+
+func decorateReport(reportData *report.Report, values thresholds.Values, policySources []string, policyTrace []report.PolicyMergeTrace) {
+	if reportData == nil {
+		return
+	}
+	effective := report.EffectiveThresholds{
+		FailOnIncreasePercent:             values.FailOnIncreasePercent,
+		LowConfidenceWarningPercent:       values.LowConfidenceWarningPercent,
+		MinUsagePercentForRecommendations: values.MinUsagePercentForRecommendations,
+		MaxUncertainImportCount:           values.MaxUncertainImportCount,
+	}
+	reportData.EffectiveThresholds = &effective
+	reportData.EffectivePolicy = &report.EffectivePolicy{
+		Sources:                 append([]string{}, policySources...),
+		MergeTrace:              append([]report.PolicyMergeTrace{}, policyTrace...),
+		Thresholds:              effective,
+		RemovalCandidateWeights: thresholds.RemovalCandidateWeights(values),
+		License:                 licensePolicy(values),
+	}
+}
+
+func licensePolicy(values thresholds.Values) report.LicensePolicy {
+	return report.LicensePolicy{
+		Deny:                      report.SortedDenyList(values.LicenseDenyList),
+		FailOnDenied:              values.LicenseFailOnDeny,
+		IncludeRegistryProvenance: values.LicenseIncludeRegistryProvenance,
+	}
+}
+
+func decodeStrict(data json.RawMessage, target any) error {
+	if len(data) == 0 {
+		data = []byte("{}")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return errors.New("unexpected trailing JSON")
+	}
+	return nil
+}
+
+func contextForTimeout(ctx context.Context, timeoutMillis int) (context.Context, context.CancelFunc, error) {
+	if timeoutMillis == defaultTimeoutMillis {
+		return ctx, func() {
+			// No timeout context was created, so cancellation has no work to do.
+		}, nil
+	}
+	if timeoutMillis < 0 || timeoutMillis > maxTimeoutMillis {
+		return nil, nil, fmt.Errorf("timeoutMillis must be between 1 and %d", maxTimeoutMillis)
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutMillis)*time.Millisecond)
+	return timeoutCtx, cancel, nil
+}
+
+func validateRepoPath(raw string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return "", errors.New("repoPath is required")
+	}
+	if strings.Contains(strings.ToLower(strings.TrimSpace(raw)), "://") {
+		return "", errors.New("repoPath must be a local filesystem path")
+	}
+	repoPath, err := workspace.NormalizeRepoPath(strings.TrimSpace(raw))
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(repoPath)
+	if err != nil {
+		return "", fmt.Errorf("stat repoPath: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("repoPath is not a directory: %s", repoPath)
+	}
+	return repoPath, nil
+}
+
+func topNOrDefault(topN *int) int {
+	if topN == nil {
+		return defaultTopN
+	}
+	if *topN <= 0 {
+		return -1
+	}
+	return *topN
+}
+
+func parseScopeMode(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", analysis.ScopeModePackage:
+		return analysis.ScopeModePackage, nil
+	case analysis.ScopeModeRepo:
+		return analysis.ScopeModeRepo, nil
+	case analysis.ScopeModeChangedPackages:
+		return analysis.ScopeModeChangedPackages, nil
+	default:
+		return "", fmt.Errorf("invalid scopeMode: %s", value)
+	}
+}
+
+func languageOrDefault(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return defaultLanguage
+	}
+	return value
+}
+
+func runtimeProfileOrDefault(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return defaultRuntimeProfile
+	}
+	return value
+}
+
+func cacheEnabled(value *bool) bool {
+	if value == nil {
+		return true
+	}
+	return *value
+}
+
+func mergeStringOptions(configValues, argumentValues []string) []string {
+	if len(argumentValues) > 0 {
+		return append([]string{}, argumentValues...)
+	}
+	if len(configValues) > 0 {
+		return append([]string{}, configValues...)
+	}
+	return nil
+}
+
+func toolSuccess(summary string, structured any) toolCallResult {
+	return toolCallResult{
+		Content: []contentItem{{
+			Type: "text",
+			Text: summary,
+		}},
+		StructuredContent: structured,
+	}
+}
+
+func analysisErrorResult(err error) toolCallResult {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return toolError(errorCodeTimeout, err)
+	case errors.Is(err, context.Canceled):
+		return toolError(errorCodeCancelled, err)
+	default:
+		return toolError(errorCodeToolFailed, err)
+	}
+}
+
+func toolError(code string, err error) toolCallResult {
+	message := err.Error()
+	return toolCallResult{
+		Content: []contentItem{{
+			Type: "text",
+			Text: message,
+		}},
+		StructuredContent: map[string]any{
+			"error": map[string]any{
+				"code":    code,
+				"message": message,
+			},
+		},
+		IsError: true,
+	}
+}
+
+func summarizeReport(kind analysisToolKind, reportData report.Report) string {
+	label := "Analysis"
+	switch kind {
+	case analysisToolKindTop:
+		label = "Top dependency analysis"
+	case analysisToolKindDependency:
+		label = "Dependency analysis"
+	case analysisToolKindCompare:
+		label = "Baseline comparison"
+	}
+	if reportData.Summary == nil {
+		return fmt.Sprintf("%s completed with no dependencies.", label)
+	}
+	waste, ok := report.WastePercent(reportData.Summary)
+	if !ok {
+		return fmt.Sprintf("%s completed: %d dependencies, %.1f%% used exports.", label, reportData.Summary.DependencyCount, reportData.Summary.UsedPercent)
+	}
+	summary := fmt.Sprintf("%s completed: %d dependencies, %.1f%% used exports, %.1f%% waste.", label, reportData.Summary.DependencyCount, reportData.Summary.UsedPercent, waste)
+	if reportData.BaselineComparison != nil {
+		summary += fmt.Sprintf(" Waste delta: %.1f%%.", reportData.BaselineComparison.SummaryDelta.WastePercentDelta)
+	}
+	return summary
+}
+
+func analysisInputSchema(requireDependency, allowDependency, allowTopN, requireBaseline bool) map[string]any {
+	properties := commonAnalysisProperties()
+	required := []string{"repoPath"}
+	if allowDependency {
+		properties["dependency"] = map[string]any{"type": "string"}
+	}
+	if requireDependency {
+		required = append(required, "dependency")
+	}
+	if allowTopN {
+		properties["topN"] = map[string]any{"type": "integer", "minimum": 1, "default": defaultTopN}
+	}
+	if requireBaseline {
+		properties["baselinePath"] = map[string]any{"type": "string", "description": "Baseline report JSON path."}
+		properties["baselineStorePath"] = map[string]any{"type": "string", "description": "Immutable baseline snapshot directory."}
+		properties["baselineKey"] = map[string]any{"type": "string", "description": "Snapshot key to load from baselineStorePath."}
+	}
+	return map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
+}
+
+func commonAnalysisProperties() map[string]any {
+	return map[string]any{
+		"repoPath":                          map[string]any{"type": "string", "description": "Local repository path."},
+		"language":                          map[string]any{"type": "string", "default": defaultLanguage},
+		"scopeMode":                         map[string]any{"type": "string", "enum": []string{analysis.ScopeModeRepo, analysis.ScopeModePackage, analysis.ScopeModeChangedPackages}, "default": defaultScopeMode},
+		"configPath":                        map[string]any{"type": "string"},
+		"include":                           stringArraySchema(),
+		"exclude":                           stringArraySchema(),
+		"enableFeatures":                    stringArraySchema(),
+		"disableFeatures":                   stringArraySchema(),
+		"cacheEnabled":                      map[string]any{"type": "boolean", "default": true},
+		"cachePath":                         map[string]any{"type": "string"},
+		"cacheReadOnly":                     map[string]any{"type": "boolean", "default": false},
+		"runtimeProfile":                    map[string]any{"type": "string", "enum": []string{"node-import", "node-require", "browser-import", "browser-require"}, "default": defaultRuntimeProfile},
+		"runtimeTracePath":                  map[string]any{"type": "string"},
+		"lowConfidenceWarningPercent":       percentageSchema(),
+		"minUsagePercentForRecommendations": percentageSchema(),
+		"maxUncertainImportCount":           map[string]any{"type": "integer", "minimum": -1},
+		"scoreWeightUsage":                  map[string]any{"type": "number", "minimum": 0},
+		"scoreWeightImpact":                 map[string]any{"type": "number", "minimum": 0},
+		"scoreWeightConfidence":             map[string]any{"type": "number", "minimum": 0},
+		"licenseDeny":                       stringArraySchema(),
+		"licenseFailOnDeny":                 map[string]any{"type": "boolean"},
+		"licenseProvenanceRegistry":         map[string]any{"type": "boolean"},
+		"timeoutMillis":                     map[string]any{"type": "integer", "minimum": 1, "maximum": maxTimeoutMillis},
+	}
+}
+
+func listLanguagesInputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"repoPath":        map[string]any{"type": "string", "description": "Optional local repository path used to resolve config metadata."},
+			"configPath":      map[string]any{"type": "string"},
+			"enableFeatures":  stringArraySchema(),
+			"disableFeatures": stringArraySchema(),
+			"timeoutMillis":   map[string]any{"type": "integer", "minimum": 1, "maximum": maxTimeoutMillis},
+		},
+		"additionalProperties": false,
+	}
+}
+
+func stringArraySchema() map[string]any {
+	return map[string]any{
+		"type":  "array",
+		"items": map[string]any{"type": "string"},
+	}
+}
+
+func percentageSchema() map[string]any {
+	return map[string]any{
+		"type":    "integer",
+		"minimum": 0,
+		"maximum": 100,
+	}
+}

--- a/scripts/generate-manpage.sh
+++ b/scripts/generate-manpage.sh
@@ -42,6 +42,7 @@ escape_roff() {
 	printf "lopper analyse --top N [options]\n"
 	printf "lopper analyse <dependency> [options]\n"
 	printf "lopper dashboard [--repos PATH1,PATH2 | --config PATH]\n"
+	printf "lopper mcp [--enable-feature mcp-server-preview]\n"
 	printf ".fi\n"
 	printf ".SH DESCRIPTION\n"
 	printf "This man page is generated from the built-in command usage output.\n"


### PR DESCRIPTION
## Summary

Adds a local stdio MCP server so agent workflows can run read-only Lopper dependency analysis through MCP tools instead of parsing CLI output.

## Changes

- Adds `lopper mcp`, gated by the `mcp-server-preview` preview feature flag, with initialize/tools/list/tools/call support.
- Adds read-only MCP tools for top dependencies, single dependency analysis, baseline comparison, and language/config metadata.
- Documents MCP client setup, preview flag activation, tool contracts, output shape, and safety behavior.

## Validation

Commands and checks run:

```bash
go test ./...
go run ./tools/featureflag validate
make lint
pre-commit make ci
make dup-check
```

Additional manual validation:

- Verified `mcp-server-preview` is registered as `LOP-FEAT-0008` and starts as `preview`.
- Verified the pre-commit memory benchmark gate passed with no meaningful delta.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None expected; MCP server only runs when invoked via `lopper mcp --enable-feature mcp-server-preview` or in rolling builds where preview flags are default-on.
- Memory benchmark impact: None; pre-commit memory benchmark gate passed with no meaningful delta.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #732.