### PR TITLE
fix(mcp): align tool schemas with accepted inputs

### DIFF
--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -443,6 +443,9 @@ func TestDecodeStrictBranches(t *testing.T) {
 	if err := decodeStrict(nil, &target); err != nil {
 		t.Fatalf("expected empty args decode success, got %v", err)
 	}
+	if err := decodeStrict(json.RawMessage(` null `), &target); err != nil {
+		t.Fatalf("expected null args decode success, got %v", err)
+	}
 	if err := decodeStrict(json.RawMessage(`{} {}`), &target); err == nil {
 		t.Fatalf("expected trailing JSON error")
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -64,22 +64,64 @@ func TestHandleToolsListRegistersExpectedTools(t *testing.T) {
 
 	result := response.Result.(map[string]any)
 	tools := result["tools"].([]toolSpec)
+	assertToolOrder(t, tools)
+	assertStrictToolSchemas(t, tools)
+	byName := toolSpecsByName(tools)
+	assertTopDependencySchema(t, byName[toolAnalyseTop])
+	assertDependencySchema(t, byName[toolAnalyseDependency])
+	assertBaselineSchema(t, byName[toolCompareBaseline])
+}
+
+func assertToolOrder(t *testing.T, tools []toolSpec) {
+	t.Helper()
 	names := make([]string, 0, len(tools))
 	for _, tool := range tools {
 		names = append(names, tool.Name)
-		if tool.InputSchema["additionalProperties"] != false {
-			t.Fatalf("expected strict input schema for %s", tool.Name)
-		}
-		if tool.Name == toolAnalyseTop {
-			properties := tool.InputSchema["properties"].(map[string]any)
-			if _, ok := properties["dependency"]; ok {
-				t.Fatalf("top dependency schema should not advertise dependency input")
-			}
-		}
 	}
 	want := []string{toolAnalyseTop, toolAnalyseDependency, toolCompareBaseline, toolListLanguages}
 	if !slices.Equal(names, want) {
 		t.Fatalf("unexpected tools: %#v", names)
+	}
+}
+
+func assertStrictToolSchemas(t *testing.T, tools []toolSpec) {
+	t.Helper()
+	for _, tool := range tools {
+		if tool.InputSchema["additionalProperties"] != false {
+			t.Fatalf("expected strict input schema for %s", tool.Name)
+		}
+	}
+}
+
+func toolSpecsByName(tools []toolSpec) map[string]toolSpec {
+	byName := make(map[string]toolSpec, len(tools))
+	for _, tool := range tools {
+		byName[tool.Name] = tool
+	}
+	return byName
+}
+
+func assertTopDependencySchema(t *testing.T, tool toolSpec) {
+	t.Helper()
+	properties := tool.InputSchema["properties"].(map[string]any)
+	if _, ok := properties["dependency"]; ok {
+		t.Fatalf("top dependency schema should not advertise dependency input")
+	}
+}
+
+func assertDependencySchema(t *testing.T, tool toolSpec) {
+	t.Helper()
+	properties := tool.InputSchema["properties"].(map[string]any)
+	if _, ok := properties["topN"]; !ok {
+		t.Fatalf("dependency schema should advertise topN as accepted input")
+	}
+}
+
+func assertBaselineSchema(t *testing.T, tool toolSpec) {
+	t.Helper()
+	anyOf, ok := tool.InputSchema["anyOf"].([]map[string]any)
+	if !ok || len(anyOf) != 2 {
+		t.Fatalf("baseline schema should describe baselinePath or baselineStorePath alternatives, got %#v", tool.InputSchema["anyOf"])
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -135,7 +135,7 @@ func (s *Server) tools() []toolSpec {
 		{
 			Name:        toolAnalyseDependency,
 			Description: "Analyse one dependency in a local repository and return the report schema plus a concise summary.",
-			InputSchema: analysisInputSchema(true, true, false, false),
+			InputSchema: analysisInputSchema(true, true, true, false),
 		},
 		{
 			Name:        toolCompareBaseline,
@@ -636,7 +636,7 @@ func licensePolicy(values thresholds.Values) report.LicensePolicy {
 }
 
 func decodeStrict(data json.RawMessage, target any) error {
-	if len(data) == 0 {
+	if len(data) == 0 || bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
 		data = []byte("{}")
 	}
 	decoder := json.NewDecoder(bytes.NewReader(data))
@@ -819,12 +819,19 @@ func analysisInputSchema(requireDependency, allowDependency, allowTopN, requireB
 		properties["baselineStorePath"] = map[string]any{"type": "string", "description": "Immutable baseline snapshot directory."}
 		properties["baselineKey"] = map[string]any{"type": "string", "description": "Snapshot key to load from baselineStorePath."}
 	}
-	return map[string]any{
+	schema := map[string]any{
 		"type":                 "object",
 		"properties":           properties,
 		"required":             required,
 		"additionalProperties": false,
 	}
+	if requireBaseline {
+		schema["anyOf"] = []map[string]any{
+			{"required": []string{"baselinePath"}},
+			{"required": []string{"baselineStorePath", "baselineKey"}},
+		}
+	}
+	return schema
 }
 
 func commonAnalysisProperties() map[string]any {


### PR DESCRIPTION
## Summary

Addresses unresolved Copilot review feedback from the merged MCP PR by tightening the advertised MCP tool contracts and no-argument decoding behavior.

## Changes

- Advertises `topN` in the single-dependency MCP tool schema because the argument is accepted and ignored for dependency runs.
- Adds `anyOf` alternatives to the baseline comparison schema for `baselinePath` or `baselineStorePath` plus `baselineKey`.
- Treats JSON `null` params/arguments as empty objects in strict MCP decoding.

## Validation

Commands and checks run:

```bash
go test ./internal/mcp
go test ./...
make lint
pre-commit make ci
```

Additional manual validation:

- Verified this maps directly to the three unresolved Copilot threads on PR #1020.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None expected; schema/decoder-only contract fix.
- Memory benchmark impact: None; pre-commit memory benchmark gate passed with no meaningful delta.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review