### PR TITLE
fix(release): promote v1.6.0 flags and decouple manual publish from tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,6 +687,7 @@ jobs:
           set -euo pipefail
           brew untap ben-ranford/tap >/dev/null 2>&1 || true
           brew tap --custom-remote ben-ranford/tap "file://${PWD}/homebrew-tap"
+          brew trust ben-ranford/tap
           brew audit --strict --online ben-ranford/tap/lopper
           brew install --build-from-source ben-ranford/tap/lopper
           brew test ben-ranford/tap/lopper

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,6 +689,7 @@ jobs:
           brew tap --custom-remote ben-ranford/tap "file://${PWD}/homebrew-tap"
           brew trust ben-ranford/tap
           brew audit --strict --online ben-ranford/tap/lopper
+          export HOMEBREW_NO_SANDBOX_LINUX=1
           brew install --build-from-source ben-ranford/tap/lopper
           brew test ben-ranford/tap/lopper
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -487,6 +487,7 @@ jobs:
           set -euo pipefail
           brew untap ben-ranford/tap >/dev/null 2>&1 || true
           brew tap --custom-remote ben-ranford/tap "file://${PWD}"
+          brew trust ben-ranford/tap
           brew audit --strict --online ben-ranford/tap/lopper
           brew install --build-from-source ben-ranford/tap/lopper
           brew test ben-ranford/tap/lopper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,27 @@ jobs:
           fi
 
           resolved_sha="$(git rev-parse HEAD)"
-          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          encoded_tag="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$tag")"
+          release_json="$(mktemp)"
+          if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" >"${release_json}" 2>/dev/null; then
             echo "Reusing existing GitHub release ${tag}."
+            git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}" >/dev/null 2>&1 || true
+
+            existing_commit=""
+            if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+              existing_commit="$(git rev-list -n 1 "${tag}")"
+            else
+              existing_target="$(jq -r '.target_commitish // empty' "${release_json}")"
+              if [ -n "${existing_target}" ] && git rev-parse -q --verify "${existing_target}^{commit}" >/dev/null 2>&1; then
+                existing_commit="$(git rev-parse "${existing_target}^{commit}")"
+              fi
+            fi
+
+            if [ -n "${existing_commit}" ] && [ "${existing_commit}" != "${resolved_sha}" ]; then
+              echo "::error::Existing release ${tag} points to ${existing_commit}, but this run resolved ${resolved_sha}." >&2
+              rm -f "${release_json}"
+              exit 1
+            fi
           else
             gh release create "${tag}" \
               --repo "${GITHUB_REPOSITORY}" \
@@ -80,6 +99,7 @@ jobs:
               --title "Release ${tag}" \
               --notes ""
           fi
+          rm -f "${release_json}"
 
           {
             echo "release_created=true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing release tag to publish, such as v1.4.1
-        required: false
+        description: Release tag or version to publish, such as v1.6.0 or 1.6.0
+        required: true
         type: string
       source_sha:
-        description: Release source ref or SHA; defaults to tag when omitted
+        description: Release source ref or SHA; defaults to the selected workflow ref when omitted
         required: false
         type: string
 
@@ -21,19 +21,20 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release-please:
+  prepare-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write
       pull-requests: write
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
-      sha: ${{ steps.release.outputs.sha }}
+      release_created: ${{ steps.release.outputs.release_created || steps.manual.outputs.release_created }}
+      tag: ${{ steps.release.outputs.tag_name || steps.manual.outputs.tag }}
+      version: ${{ steps.release.outputs.version || steps.manual.outputs.version }}
+      sha: ${{ steps.release.outputs.sha || steps.manual.outputs.sha }}
     steps:
       - name: Run release-please
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: release
         uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062
         with:
@@ -41,25 +42,71 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Checkout manual release source
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.source_sha || github.sha }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Prepare manual release
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: manual
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="$(printf '%s' "${INPUT_TAG}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+          if [ -z "${tag}" ]; then
+            echo "::error::tag input is required for manual release promotion."
+            exit 1
+          fi
+          if [[ "${tag}" != v* ]]; then
+            tag="v${tag}"
+          fi
+
+          resolved_sha="$(git rev-parse HEAD)"
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Reusing existing GitHub release ${tag}."
+          else
+            gh release create "${tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --target "${resolved_sha}" \
+              --draft \
+              --title "Release ${tag}" \
+              --notes ""
+          fi
+
+          {
+            echo "release_created=true"
+            echo "tag=${tag}"
+            echo "version=${tag#v}"
+            echo "sha=${resolved_sha}"
+          } >> "$GITHUB_OUTPUT"
+
   orchestrate-release:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}
+    needs: prepare-release
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     permissions:
       contents: read
       packages: write
     uses: ./.github/workflows/release-orchestration.yml
     with:
-      tag: ${{ needs.release-please.outputs.tag || inputs.tag }}
-      source_sha: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag }}
+      tag: ${{ needs.prepare-release.outputs.tag }}
+      source_sha: ${{ needs.prepare-release.outputs.sha }}
       artifact_prefix: release
       build_channel: release
       image_tags: |
-        ${{ needs.release-please.outputs.tag || inputs.tag }}
+        ${{ needs.prepare-release.outputs.tag }}
         latest
 
   build-vscode-extension:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}
+    needs: prepare-release
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -67,7 +114,7 @@ jobs:
       - name: Checkout release source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.sha }}
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -83,7 +130,7 @@ jobs:
 
       - name: Build local lopper binary
         env:
-          RELEASE_TAG: ${{ needs.release-please.outputs.tag || inputs.tag }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           version="${RELEASE_TAG#v}"
           make build VERSION="$version" BUILD_CHANNEL=release
@@ -96,7 +143,7 @@ jobs:
 
       - name: Package VS Code extension
         env:
-          RELEASE_TAG: ${{ needs.release-please.outputs.tag || inputs.tag }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
           mkdir -p dist
@@ -112,8 +159,8 @@ jobs:
           path: dist/*.vsix
 
   build-darwin-amd64:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}
+    needs: prepare-release
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: macos-15-intel
     permissions:
       contents: read
@@ -121,7 +168,7 @@ jobs:
       - name: Checkout release source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.sha }}
 
       - name: Compute build metadata
         id: build_meta
@@ -154,7 +201,7 @@ jobs:
 
       - name: Build Darwin amd64 release artifact
         env:
-          TAG: ${{ needs.release-please.outputs.tag || inputs.tag }}
+          TAG: ${{ needs.prepare-release.outputs.tag }}
           COMMIT_SHA: ${{ steps.build_meta.outputs.commit }}
           BUILD_DATE: ${{ steps.build_meta.outputs.build_date }}
         run: |
@@ -175,11 +222,11 @@ jobs:
 
   publish:
     needs:
-      - release-please
+      - prepare-release
       - orchestrate-release
       - build-vscode-extension
       - build-darwin-amd64
-    if: ${{ needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -190,7 +237,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-          ref: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.sha }}
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -218,7 +265,7 @@ jobs:
 
       - name: Generate feature flag release report
         env:
-          RELEASE_TAG: ${{ needs.release-please.outputs.tag || inputs.tag }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
           mkdir -p .artifacts
@@ -246,7 +293,7 @@ jobs:
       - name: Update GitHub Release notes
         run: |
           set -euo pipefail
-          tag="${{ needs.release-please.outputs.tag || inputs.tag }}"
+          tag="${{ needs.prepare-release.outputs.tag }}"
           existing_body="$(mktemp)"
           release_notes="$(mktemp)"
 
@@ -285,7 +332,7 @@ jobs:
       - name: Upload GitHub Release assets
         run: |
           set -euo pipefail
-          tag="${{ needs.release-please.outputs.tag || inputs.tag }}"
+          tag="${{ needs.prepare-release.outputs.tag }}"
           mapfile -t assets < <(find dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.vsix' \) | sort)
           if [ "${#assets[@]}" -eq 0 ]; then
             echo "No release assets found in dist" >&2
@@ -317,7 +364,7 @@ jobs:
       - name: Publish GitHub Release
         run: |
           set -euo pipefail
-          tag="${{ needs.release-please.outputs.tag || inputs.tag }}"
+          tag="${{ needs.prepare-release.outputs.tag }}"
           encoded_tag="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$tag")"
           gh_err_file="$(mktemp)"
           set +e
@@ -353,9 +400,9 @@ jobs:
 
   update-homebrew-tap:
     needs:
-      - release-please
+      - prepare-release
       - publish
-    if: ${{ needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     concurrency:
       group: homebrew-tap-main
@@ -391,7 +438,7 @@ jobs:
         if: ${{ steps.tap_token.outputs.available == 'true' }}
         working-directory: homebrew-tap
         env:
-          RELEASE_TAG: ${{ needs.release-please.outputs.tag || inputs.tag }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
           SOURCE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -458,7 +505,7 @@ jobs:
             exit 0
           fi
 
-          git commit -m "lopper ${{ needs.release-please.outputs.tag || inputs.tag }}"
+          git commit -m "lopper ${{ needs.prepare-release.outputs.tag }}"
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} for Homebrew formula"
             if ! git fetch origin main:refs/remotes/origin/main; then
@@ -487,9 +534,9 @@ jobs:
 
   stamp-feature-release-history:
     needs:
-      - release-please
+      - prepare-release
       - publish
-    if: ${{ needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     concurrency:
       group: feature-release-history-main
@@ -501,7 +548,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-          ref: ${{ needs.release-please.outputs.sha || inputs.source_sha || inputs.tag || github.sha }}
+          ref: ${{ needs.prepare-release.outputs.sha }}
           token: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup Go
@@ -511,7 +558,7 @@ jobs:
 
       - name: Stamp first stable release history
         env:
-          RELEASE_TAG: ${{ needs.release-please.outputs.tag || inputs.tag }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -550,8 +597,8 @@ jobs:
           exit 1
 
   skip-release:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created != 'true' }}
+    needs: prepare-release
+    if: ${{ needs.prepare-release.outputs.release_created != 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -509,6 +509,7 @@ jobs:
           brew tap --custom-remote ben-ranford/tap "file://${PWD}"
           brew trust ben-ranford/tap
           brew audit --strict --online ben-ranford/tap/lopper
+          export HOMEBREW_NO_SANDBOX_LINUX=1
           brew install --build-from-source ben-ranford/tap/lopper
           brew test ben-ranford/tap/lopper
 

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -320,6 +320,7 @@ jobs:
           brew tap --custom-remote ben-ranford/tap "file://${PWD}"
           brew trust ben-ranford/tap
           brew audit --strict --online ben-ranford/tap/lopper-rolling
+          export HOMEBREW_NO_SANDBOX_LINUX=1
           brew install --build-from-source ben-ranford/tap/lopper-rolling
           brew test ben-ranford/tap/lopper-rolling
 

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -318,6 +318,7 @@ jobs:
           set -euo pipefail
           brew untap ben-ranford/tap >/dev/null 2>&1 || true
           brew tap --custom-remote ben-ranford/tap "file://${PWD}"
+          brew trust ben-ranford/tap
           brew audit --strict --online ben-ranford/tap/lopper-rolling
           brew install --build-from-source ben-ranford/tap/lopper-rolling
           brew test ben-ranford/tap/lopper-rolling

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ lopper tui --repo . --language all
 Run the local MCP server for agent workflows:
 
 ```bash
-lopper mcp --enable-feature mcp-server-preview
+lopper mcp
 ```
 
 See [docs/mcp.md](docs/mcp.md) for tool names, input schemas, client configuration, and safety behavior.

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -24,6 +24,7 @@ Stable release automation:
 - Release versioning and changelog generation are configured in `release-please-config.json` and tracked in `.release-please-manifest.json`.
 - The Go project release notes are generated into the root `CHANGELOG.md`; the VS Code extension keeps its own `extensions/vscode-lopper/CHANGELOG.md`.
 - The current stable version is also synced into `extensions/vscode-lopper/package.json` and `extensions/vscode-lopper/package-lock.json` by the release-please PR.
+- Manual `workflow_dispatch` runs accept a release tag/version plus an optional `source_sha`, resolve the selected source ref, and create or reuse the draft GitHub release when the tag is not already present.
 - Release commits should use Conventional Commit prefixes: `fix:` for patch releases, `feat:` for minor releases, and any type with a breaking-change marker (for example `feat!:` or `fix!:`) or a `BREAKING CHANGE:` footer for major releases.
 - Set repository secret `RELEASE_PLEASE_TOKEN` to a PAT with contents and pull request write access so release-please-created PRs can trigger normal CI. If it is not configured, the workflow falls back to `MAIN_SYNC_PAT` and then `GITHUB_TOKEN`.
 

--- a/docs/man/lopper.1
+++ b/docs/man/lopper.1
@@ -1,4 +1,4 @@
-.TH LOPPER 1 "2026-06-10" "lopper" "User Commands"
+.TH LOPPER 1 "2026-06-12" "lopper" "User Commands"
 .SH NAME
 lopper \- local-first CLI/TUI for dependency surface analysis
 .SH SYNOPSIS
@@ -8,7 +8,7 @@ lopper tui [--repo PATH] [--language auto|all|js-ts|python|cpp|jvm|kotlin-androi
 lopper analyse --top N [options]
 lopper analyse <dependency> [options]
 lopper dashboard [--repos PATH1,PATH2 | --config PATH]
-lopper mcp [--enable-feature mcp-server-preview]
+lopper mcp
 .fi
 .SH DESCRIPTION
 This man page is generated from the built-in command usage output.
@@ -22,7 +22,7 @@ Usage and options:
   lopper dashboard --repos PATH1,PATH2 [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline]
   lopper dashboard --config lopper-org.yml [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline]
   lopper features [--format table|json] [--channel dev|rolling|release] [--release VERSION]
-  lopper mcp [--enable-feature mcp-server-preview]
+  lopper mcp
 
 Options:
   --repo PATH                Repository path (default: .)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,6 @@
 # MCP Server
 
-`lopper mcp --enable-feature mcp-server-preview` runs a local stdio Model Context Protocol server for agent workflows that need dependency surface analysis without shelling out to parse CLI text.
+`lopper mcp` runs a local stdio Model Context Protocol server for agent workflows that need dependency surface analysis without shelling out to parse CLI text.
 
 The server speaks JSON-RPC over stdio using `Content-Length` frames. It writes protocol responses to stdout and does not emit normal CLI output in MCP mode.
 
@@ -13,13 +13,13 @@ Example MCP client entry:
   "mcpServers": {
     "lopper": {
       "command": "lopper",
-      "args": ["mcp", "--enable-feature", "mcp-server-preview"]
+      "args": ["mcp"]
     }
   }
 }
 ```
 
-`mcp-server-preview` is a preview feature flag. Rolling builds enable preview flags by default; dev and stable release builds require the explicit `--enable-feature` argument shown above. During `initialize`, the server advertises tool support and returns Lopper version metadata. Use `tools/list` to inspect tool schemas at runtime.
+`mcp-server-preview` is now a stable feature flag and is enabled by default in every build channel. The original flag name remains available for compatibility and explicit rollback testing via `--disable-feature mcp-server-preview`. During `initialize`, the server advertises tool support and returns Lopper version metadata. Use `tools/list` to inspect tool schemas at runtime.
 
 ## Tools
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,7 +23,7 @@ var (
 	ErrDeniedLicenses               = errors.New("denied licenses detected")
 	ErrDirtyWorktree                = errors.New("codemod apply requires a clean git worktree")
 	ErrCodemodApplyFailed           = errors.New("codemod apply failed")
-	ErrMCPPreviewDisabled           = errors.New("mcp server preview feature is disabled")
+	ErrMCPFeatureDisabled           = errors.New("mcp server feature is disabled")
 )
 
 type App struct {
@@ -65,7 +65,7 @@ func (a *App) Execute(ctx context.Context, req Request) (string, error) {
 		return a.executeFeatures(req)
 	case ModeMCP:
 		if !req.MCP.Features.Enabled(mcp.ServerPreviewFeature) {
-			return "", ErrMCPPreviewDisabled
+			return "", ErrMCPFeatureDisabled
 		}
 		return "", mcp.Serve(ctx, a.In, a.Out, mcp.Options{
 			Analyzer:         a.Analyzer,

--- a/internal/app/app_mcp_test.go
+++ b/internal/app/app_mcp_test.go
@@ -11,42 +11,55 @@ import (
 	"github.com/ben-ranford/lopper/internal/mcp"
 )
 
-func TestExecuteMCPRequiresPreviewFeature(t *testing.T) {
+func TestExecuteMCPRequiresFeature(t *testing.T) {
 	application := &App{In: strings.NewReader(""), Out: io.Discard}
 	req := DefaultRequest()
 	req.Mode = ModeMCP
 
 	_, err := application.Execute(context.Background(), req)
-	if !errors.Is(err, ErrMCPPreviewDisabled) {
-		t.Fatalf("expected ErrMCPPreviewDisabled, got %v", err)
+	if !errors.Is(err, ErrMCPFeatureDisabled) {
+		t.Fatalf("expected ErrMCPFeatureDisabled, got %v", err)
 	}
 }
 
-func TestExecuteMCPStartsWhenPreviewFeatureEnabled(t *testing.T) {
+func TestExecuteMCPStartsWhenFeatureEnabled(t *testing.T) {
 	application := &App{In: strings.NewReader(""), Out: io.Discard}
 	req := DefaultRequest()
 	req.Mode = ModeMCP
-	req.MCP.Features = mustMCPPreviewFeatureSet(t)
+	req.MCP.Features = mustMCPFeatureSet(t, false)
 
 	if _, err := application.Execute(context.Background(), req); err != nil {
 		t.Fatalf("execute mcp: %v", err)
 	}
 }
 
-func mustMCPPreviewFeatureSet(t *testing.T) featureflags.Set {
+func TestExecuteMCPRejectsExplicitlyDisabledFeature(t *testing.T) {
+	application := &App{In: strings.NewReader(""), Out: io.Discard}
+	req := DefaultRequest()
+	req.Mode = ModeMCP
+	req.MCP.Features = mustMCPFeatureSet(t, true)
+
+	_, err := application.Execute(context.Background(), req)
+	if !errors.Is(err, ErrMCPFeatureDisabled) {
+		t.Fatalf("expected ErrMCPFeatureDisabled, got %v", err)
+	}
+}
+
+func mustMCPFeatureSet(t *testing.T, disable bool) featureflags.Set {
 	t.Helper()
 	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
 		Code:      "LOP-FEAT-0001",
 		Name:      mcp.ServerPreviewFeature,
-		Lifecycle: featureflags.LifecyclePreview,
+		Lifecycle: featureflags.LifecycleStable,
 	}})
 	if err != nil {
 		t.Fatalf("new feature registry: %v", err)
 	}
-	features, err := registry.Resolve(featureflags.ResolveOptions{
-		Channel: featureflags.ChannelDev,
-		Enable:  []string{mcp.ServerPreviewFeature},
-	})
+	opts := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
+	if disable {
+		opts.Disable = []string{mcp.ServerPreviewFeature}
+	}
+	features, err := registry.Resolve(opts)
 	if err != nil {
 		t.Fatalf("resolve feature set: %v", err)
 	}

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -98,6 +98,9 @@ func TestExecuteFeaturesReleaseChannelAndEmptyRegistry(t *testing.T) {
 		!strings.Contains(emptyOutput, "swift-carthage-preview") ||
 		!strings.Contains(emptyOutput, "powershell-adapter-preview") ||
 		!strings.Contains(emptyOutput, "go-vendored-provenance-preview") ||
+		!strings.Contains(emptyOutput, "baseline-provenance-runtime-context-preview") ||
+		!strings.Contains(emptyOutput, "vscode-multi-root-workflows-preview") ||
+		!strings.Contains(emptyOutput, "mcp-server-preview") ||
 		!strings.Contains(emptyOutput, "true") {
 		t.Fatalf("expected default feature table to include embedded graduated flags enabled by default, got %q", emptyOutput)
 	}

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -8,7 +8,7 @@ const usage = `Usage:
   lopper dashboard --repos PATH1,PATH2 [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline]
   lopper dashboard --config lopper-org.yml [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline]
   lopper features [--format table|json] [--channel dev|rolling|release] [--release VERSION]
-  lopper mcp [--enable-feature mcp-server-preview]
+  lopper mcp
 
 Options:
   --repo PATH                Repository path (default: .)

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -29,6 +29,9 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 	assertDefaultFlag(t, defaultFlags, "swift-carthage-preview", "LOP-FEAT-0003")
 	assertDefaultFlag(t, defaultFlags, "powershell-adapter-preview", "LOP-FEAT-0004")
 	assertDefaultFlag(t, defaultFlags, "go-vendored-provenance-preview", "LOP-FEAT-0005")
+	assertDefaultFlag(t, defaultFlags, "baseline-provenance-runtime-context-preview", "LOP-FEAT-0006")
+	assertDefaultFlag(t, defaultFlags, "vscode-multi-root-workflows-preview", "LOP-FEAT-0007")
+	assertDefaultFlag(t, defaultFlags, "mcp-server-preview", "LOP-FEAT-0008")
 	if defaultFlags[0].FirstStableRelease != "v1.5.0" {
 		t.Fatalf("expected default flags to retain first stable release history, got %#v", defaultFlags[0])
 	}
@@ -502,6 +505,9 @@ func TestManifestReportsDefaults(t *testing.T) {
 	assertManifestFlag(t, manifest, "swift-carthage-preview", true)
 	assertManifestFlag(t, manifest, "powershell-adapter-preview", true)
 	assertManifestFlag(t, manifest, "go-vendored-provenance-preview", true)
+	assertManifestFlag(t, manifest, "baseline-provenance-runtime-context-preview", true)
+	assertManifestFlag(t, manifest, "vscode-multi-root-workflows-preview", true)
+	assertManifestFlag(t, manifest, "mcp-server-preview", true)
 }
 
 func TestFormatManifest(t *testing.T) {
@@ -557,6 +563,9 @@ func TestDefaultRegistryGraduatedDefaultsAndDisable(t *testing.T) {
 		"swift-carthage-preview",
 		"powershell-adapter-preview",
 		"go-vendored-provenance-preview",
+		"baseline-provenance-runtime-context-preview",
+		"vscode-multi-root-workflows-preview",
+		"mcp-server-preview",
 	} {
 		if !dev.Enabled(name) {
 			t.Fatalf("expected %s default-on in dev channel", name)
@@ -573,6 +582,9 @@ func TestDefaultRegistryGraduatedDefaultsAndDisable(t *testing.T) {
 		"swift-carthage-preview",
 		"powershell-adapter-preview",
 		"go-vendored-provenance-preview",
+		"baseline-provenance-runtime-context-preview",
+		"vscode-multi-root-workflows-preview",
+		"mcp-server-preview",
 	} {
 		if !release.Enabled(name) {
 			t.Fatalf("expected %s default-on in release channel", name)

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -29,9 +29,9 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 	assertDefaultFlag(t, defaultFlags, "swift-carthage-preview", "LOP-FEAT-0003")
 	assertDefaultFlag(t, defaultFlags, "powershell-adapter-preview", "LOP-FEAT-0004")
 	assertDefaultFlag(t, defaultFlags, "go-vendored-provenance-preview", "LOP-FEAT-0005")
-	assertDefaultFlag(t, defaultFlags, "baseline-provenance-runtime-context-preview", "LOP-FEAT-0006")
-	assertDefaultFlag(t, defaultFlags, "vscode-multi-root-workflows-preview", "LOP-FEAT-0007")
-	assertDefaultFlag(t, defaultFlags, "mcp-server-preview", "LOP-FEAT-0008")
+	assertDefaultFlagRelease(t, defaultFlags, "baseline-provenance-runtime-context-preview", "LOP-FEAT-0006", "v1.6.0")
+	assertDefaultFlagRelease(t, defaultFlags, "vscode-multi-root-workflows-preview", "LOP-FEAT-0007", "v1.6.0")
+	assertDefaultFlagRelease(t, defaultFlags, "mcp-server-preview", "LOP-FEAT-0008", "v1.6.0")
 	if defaultFlags[0].FirstStableRelease != "v1.5.0" {
 		t.Fatalf("expected default flags to retain first stable release history, got %#v", defaultFlags[0])
 	}
@@ -662,6 +662,22 @@ func assertDefaultFlag(t *testing.T, flags []Flag, name, code string) {
 		if flag.Name == name {
 			if flag.Code != code {
 				t.Fatalf("expected default flag %s to use code %s, got %#v", name, code, flag)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected default registry to include %s, got %#v", name, flags)
+}
+
+func assertDefaultFlagRelease(t *testing.T, flags []Flag, name, code, release string) {
+	t.Helper()
+	for _, flag := range flags {
+		if flag.Name == name {
+			if flag.Code != code {
+				t.Fatalf("expected default flag %s to use code %s, got %#v", name, code, flag)
+			}
+			if flag.FirstStableRelease != release {
+				t.Fatalf("expected default flag %s to record first stable release %s, got %#v", name, release, flag)
 			}
 			return
 		}

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -38,18 +38,21 @@
     "code": "LOP-FEAT-0006",
     "name": "baseline-provenance-runtime-context-preview",
     "description": "Enable baseline comparison, policy provenance, and runtime parent/entrypoint context in reports and dashboard views.",
-    "lifecycle": "stable"
+    "lifecycle": "stable",
+    "firstStableRelease": "v1.6.0"
   },
   {
     "code": "LOP-FEAT-0007",
     "name": "vscode-multi-root-workflows-preview",
     "description": "Enable multi-root VS Code analysis workflows, dependency explorer detail views, baseline commands, and export commands.",
-    "lifecycle": "stable"
+    "lifecycle": "stable",
+    "firstStableRelease": "v1.6.0"
   },
   {
     "code": "LOP-FEAT-0008",
     "name": "mcp-server-preview",
     "description": "Enable the local stdio MCP server for read-only dependency analysis workflows.",
-    "lifecycle": "stable"
+    "lifecycle": "stable",
+    "firstStableRelease": "v1.6.0"
   }
 ]

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -38,18 +38,18 @@
     "code": "LOP-FEAT-0006",
     "name": "baseline-provenance-runtime-context-preview",
     "description": "Enable baseline comparison, policy provenance, and runtime parent/entrypoint context in reports and dashboard views.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   },
   {
     "code": "LOP-FEAT-0007",
     "name": "vscode-multi-root-workflows-preview",
     "description": "Enable multi-root VS Code analysis workflows, dependency explorer detail views, baseline commands, and export commands.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   },
   {
     "code": "LOP-FEAT-0008",
     "name": "mcp-server-preview",
     "description": "Enable the local stdio MCP server for read-only dependency analysis workflows.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   }
 ]

--- a/scripts/generate-manpage.sh
+++ b/scripts/generate-manpage.sh
@@ -42,7 +42,7 @@ escape_roff() {
 	printf "lopper analyse --top N [options]\n"
 	printf "lopper analyse <dependency> [options]\n"
 	printf "lopper dashboard [--repos PATH1,PATH2 | --config PATH]\n"
-	printf "lopper mcp [--enable-feature mcp-server-preview]\n"
+	printf "lopper mcp\n"
 	printf ".fi\n"
 	printf ".SH DESCRIPTION\n"
 	printf "This man page is generated from the built-in command usage output.\n"

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -125,6 +125,9 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	if !strings.Contains(workflowText, "--target \"${resolved_sha}\"") {
 		t.Fatal("manual release flow must target the resolved source SHA")
 	}
+	if !strings.Contains(workflowText, "Existing release ${tag} points to ${existing_commit}, but this run resolved ${resolved_sha}.") {
+		t.Fatal("manual release flow must fail when an existing release tag points to a different commit")
+	}
 	if !strings.Contains(workflowText, "needs.prepare-release.outputs.sha") {
 		t.Fatal("downstream release jobs must use the resolved prepare-release SHA")
 	}

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -80,6 +80,55 @@ func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
+	t.Parallel()
+
+	var workflow struct {
+		On struct {
+			WorkflowDispatch struct {
+				Inputs map[string]struct {
+					Description string `yaml:"description"`
+					Required    bool   `yaml:"required"`
+				} `yaml:"inputs"`
+			} `yaml:"workflow_dispatch"`
+		} `yaml:"on"`
+	}
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	tag, ok := workflow.On.WorkflowDispatch.Inputs["tag"]
+	if !ok {
+		t.Fatal("release workflow must define the tag input")
+	}
+	if !tag.Required {
+		t.Fatal("manual release dispatch must require a release tag or version")
+	}
+	if strings.Contains(strings.ToLower(tag.Description), "existing release tag") {
+		t.Fatal("manual release dispatch should not require a pre-existing release tag")
+	}
+
+	sourceSHA, ok := workflow.On.WorkflowDispatch.Inputs["source_sha"]
+	if !ok {
+		t.Fatal("release workflow must define the source_sha input")
+	}
+	if strings.Contains(strings.ToLower(sourceSHA.Description), "defaults to tag") {
+		t.Fatal("manual release source should not fall back to the tag name")
+	}
+
+	workflowText := readConfig(t, ".github/workflows/release.yml")
+	if strings.Contains(workflowText, "inputs.source_sha || inputs.tag") {
+		t.Fatal("manual release jobs must not fall back to tag names for source checkout")
+	}
+	if !strings.Contains(workflowText, "gh release create \"${tag}\"") {
+		t.Fatal("manual release flow must create a draft GitHub release when one is missing")
+	}
+	if !strings.Contains(workflowText, "--target \"${resolved_sha}\"") {
+		t.Fatal("manual release flow must target the resolved source SHA")
+	}
+	if !strings.Contains(workflowText, "needs.prepare-release.outputs.sha") {
+		t.Fatal("downstream release jobs must use the resolved prepare-release SHA")
+	}
+}
+
 func TestRenovateDoesNotAutomergeMajorUpdates(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -211,41 +211,45 @@ func TestDarwinReleaseJobsAssertHostArchitecture(t *testing.T) {
 	}
 }
 
-func TestHomebrewTapWorkflowsTrustLocalTap(t *testing.T) {
+func TestHomebrewTapWorkflowsContainRequiredFormulaValidationCommands(t *testing.T) {
 	t.Parallel()
 
-	for _, path := range []string{
-		".github/workflows/ci.yml",
-		".github/workflows/release.yml",
-		".github/workflows/rolling.yml",
-	} {
-		path := path
-		t.Run(path, func(t *testing.T) {
-			t.Parallel()
-
-			workflowText := readConfig(t, path)
-			if !strings.Contains(workflowText, "brew trust ben-ranford/tap") {
-				t.Fatalf("%s must trust the local Homebrew tap before auditing formulae", path)
-			}
-		})
+	testCases := []struct {
+		name    string
+		command string
+		message string
+	}{
+		{
+			name:    "trust local tap",
+			command: "brew trust ben-ranford/tap",
+			message: "must trust the local Homebrew tap before auditing formulae",
+		},
+		{
+			name:    "disable linux sandbox",
+			command: "export HOMEBREW_NO_SANDBOX_LINUX=1",
+			message: "must disable the Linux Homebrew sandbox before build-from-source formula validation",
+		},
 	}
-}
 
-func TestHomebrewTapWorkflowsDisableLinuxSandboxForFormulaValidation(t *testing.T) {
-	t.Parallel()
-
-	for _, path := range []string{
-		".github/workflows/ci.yml",
-		".github/workflows/release.yml",
-		".github/workflows/rolling.yml",
-	} {
-		path := path
-		t.Run(path, func(t *testing.T) {
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			workflowText := readConfig(t, path)
-			if !strings.Contains(workflowText, "export HOMEBREW_NO_SANDBOX_LINUX=1") {
-				t.Fatalf("%s must disable the Linux Homebrew sandbox before build-from-source formula validation", path)
+			for _, path := range []string{
+				".github/workflows/ci.yml",
+				".github/workflows/release.yml",
+				".github/workflows/rolling.yml",
+			} {
+				path := path
+				t.Run(path, func(t *testing.T) {
+					t.Parallel()
+
+					workflowText := readConfig(t, path)
+					if !strings.Contains(workflowText, tc.command) {
+						t.Fatalf("%s %s", path, tc.message)
+					}
+				})
 			}
 		})
 	}

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -231,6 +231,26 @@ func TestHomebrewTapWorkflowsTrustLocalTap(t *testing.T) {
 	}
 }
 
+func TestHomebrewTapWorkflowsDisableLinuxSandboxForFormulaValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		".github/workflows/ci.yml",
+		".github/workflows/release.yml",
+		".github/workflows/rolling.yml",
+	} {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			workflowText := readConfig(t, path)
+			if !strings.Contains(workflowText, "export HOMEBREW_NO_SANDBOX_LINUX=1") {
+				t.Fatalf("%s must disable the Linux Homebrew sandbox before build-from-source formula validation", path)
+			}
+		})
+	}
+}
+
 func hasAutomerge(values []bool, want bool) bool {
 	for _, value := range values {
 		if value == want {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -11,6 +11,24 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type workflowInput struct {
+	Default     string `yaml:"default"`
+	Description string `yaml:"description"`
+	Required    bool   `yaml:"required"`
+}
+
+type workflowDispatchConfig struct {
+	Inputs map[string]workflowInput `yaml:"inputs"`
+}
+
+type workflowOnConfig struct {
+	WorkflowDispatch workflowDispatchConfig `yaml:"workflow_dispatch"`
+}
+
+type workflowConfig struct {
+	On workflowOnConfig `yaml:"on"`
+}
+
 func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	t.Parallel()
 
@@ -52,15 +70,7 @@ func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	t.Parallel()
 
-	var workflow struct {
-		On struct {
-			WorkflowDispatch struct {
-				Inputs map[string]struct {
-					Default string `yaml:"default"`
-				} `yaml:"inputs"`
-			} `yaml:"workflow_dispatch"`
-		} `yaml:"on"`
-	}
+	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/graduate-feature.yml", &workflow)
 
 	milestone, ok := workflow.On.WorkflowDispatch.Inputs["milestone"]
@@ -83,16 +93,7 @@ func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	t.Parallel()
 
-	var workflow struct {
-		On struct {
-			WorkflowDispatch struct {
-				Inputs map[string]struct {
-					Description string `yaml:"description"`
-					Required    bool   `yaml:"required"`
-				} `yaml:"inputs"`
-			} `yaml:"workflow_dispatch"`
-		} `yaml:"on"`
-	}
+	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
 	tag, ok := workflow.On.WorkflowDispatch.Inputs["tag"]
@@ -202,6 +203,26 @@ func TestDarwinReleaseJobsAssertHostArchitecture(t *testing.T) {
 			wantCheck := `host_goarch}" != "` + tc.expectedArch + `"`
 			if !strings.Contains(workflowText, wantCheck) {
 				t.Fatalf("%s must fail early unless GOARCH is %s", tc.path, tc.expectedArch)
+			}
+		})
+	}
+}
+
+func TestHomebrewTapWorkflowsTrustLocalTap(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		".github/workflows/ci.yml",
+		".github/workflows/release.yml",
+		".github/workflows/rolling.yml",
+	} {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			workflowText := readConfig(t, path)
+			if !strings.Contains(workflowText, "brew trust ben-ranford/tap") {
+				t.Fatalf("%s must trust the local Homebrew tap before auditing formulae", path)
 			}
 		})
 	}

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -418,6 +418,9 @@ func TestManifestEntries(t *testing.T) {
 	assertManifestEntryDefault(t, manifest, "swift-carthage-preview", true)
 	assertManifestEntryDefault(t, manifest, "powershell-adapter-preview", true)
 	assertManifestEntryDefault(t, manifest, "go-vendored-provenance-preview", true)
+	assertManifestEntryDefault(t, manifest, "baseline-provenance-runtime-context-preview", true)
+	assertManifestEntryDefault(t, manifest, "vscode-multi-root-workflows-preview", true)
+	assertManifestEntryDefault(t, manifest, "mcp-server-preview", true)
 }
 
 func TestRunManifestAndReportUseChannels(t *testing.T) {


### PR DESCRIPTION
## Summary

Promote the three `v1.6.0` release feature flags to stable defaults, fix the manual release promotion flow so it resolves a real source SHA instead of depending on tag state, and clear the follow-up PR blockers found by CI/Sonar.

## Changes

- graduate `LOP-FEAT-0006`, `LOP-FEAT-0007`, and `LOP-FEAT-0008` to `stable`
- update MCP docs/help/manpage examples to `lopper mcp` now that the MCP server feature is stable by default
- refactor the manual release workflow to prepare a resolved release source ref and create/reuse the draft release explicitly
- trust the local Homebrew tap before `brew audit` / install / test in CI, stable release, and rolling release workflows
- replace the nested anonymous YAML workflow config struct with named types and add regression coverage for the Homebrew tap trust requirement

## Validation

Commands and checks run:

```bash
go test ./...
make actionlint
go run ./tools/prcheck \
  --check-repo-policy \
  --title "fix(release): promote v1.6.0 flags and decouple manual publish from tags" \
  --head-ref "bug/issue-000-v1-6-0-feature-flag-promotion" \
  --body-file .artifacts/pr-1023-body.md \
  --allow-merge-commit false \
  --allow-rebase-merge false \
  --allow-squash-merge true \
  --squash-merge-commit-title PR_TITLE
```

Additional manual validation:

- inspected the failing `pr-metadata` and `homebrew-tap-verify` GitHub Actions logs for `#1023`
- confirmed SonarCloud is passing and only reported one actionable issue on this PR
- confirmed there are currently no open Copilot review threads on this PR

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
