### PR TITLE
fix(release): show only new stable defaults in published notes

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -166,7 +166,7 @@ go run ./tools/featureflag report \
 
 The report groups:
 
-- stable flags enabled by default
+- stable flags enabled by default since the previous catalog, when provided
 - preview flags available by opt-in
 - preview flags enabled by rolling or locked default-on for a release
 - newly added preview flags since the previous catalog, when provided

--- a/tools/featureflag/main.go
+++ b/tools/featureflag/main.go
@@ -315,7 +315,7 @@ func formatReport(channel featureflags.Channel, release string, current []featur
 		}
 	}
 	stableDefaultTitle := "Stable by default"
-	if opts.StableDefaultSincePreviousOnly {
+	if opts.StableDefaultSincePreviousOnly && compared {
 		stableDefault = stableByDefaultSincePrevious(stableDefault, previous)
 		stableDefaultTitle = "Stable by default since previous version"
 	}
@@ -340,7 +340,7 @@ func formatReport(channel featureflags.Channel, release string, current []featur
 	return b.String()
 }
 
-func stableByDefaultSincePrevious(current []featureflags.Flag, previous []featureflags.Flag) []featureflags.Flag {
+func stableByDefaultSincePrevious(current, previous []featureflags.Flag) []featureflags.Flag {
 	previousStableByCode := make(map[string]struct{}, len(previous))
 	previousStableByName := make(map[string]struct{}, len(previous))
 	for _, flag := range previous {

--- a/tools/featureflag/main.go
+++ b/tools/featureflag/main.go
@@ -220,7 +220,9 @@ func runReport(args []string) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Print(formatReport(channel, release, registry.Flags(), manifest, previousFlags, compared))
+	_, err = fmt.Print(formatReport(channel, release, registry.Flags(), manifest, previousFlags, compared, formatReportOptions{
+		StableDefaultSincePreviousOnly: compared,
+	}))
 	return err
 }
 
@@ -290,7 +292,11 @@ func readPreviousCatalog(path string) ([]featureflags.Flag, bool, error) {
 	return flags, true, nil
 }
 
-func formatReport(channel featureflags.Channel, release string, current []featureflags.Flag, manifest []featureflags.ManifestEntry, previous []featureflags.Flag, compared bool) string {
+type formatReportOptions struct {
+	StableDefaultSincePreviousOnly bool
+}
+
+func formatReport(channel featureflags.Channel, release string, current []featureflags.Flag, manifest []featureflags.ManifestEntry, previous []featureflags.Flag, compared bool, opts formatReportOptions) string {
 	enabledByCode := make(map[string]bool, len(manifest))
 	for _, entry := range manifest {
 		enabledByCode[entry.Code] = entry.EnabledByDefault
@@ -308,6 +314,11 @@ func formatReport(channel featureflags.Channel, release string, current []featur
 			previewOptIn = append(previewOptIn, flag)
 		}
 	}
+	stableDefaultTitle := "Stable by default"
+	if opts.StableDefaultSincePreviousOnly {
+		stableDefault = stableByDefaultSincePrevious(stableDefault, previous)
+		stableDefaultTitle = "Stable by default since previous version"
+	}
 
 	var b strings.Builder
 	b.WriteString("<!-- lopper-feature-flags:start -->\n")
@@ -317,7 +328,7 @@ func formatReport(channel featureflags.Channel, release string, current []featur
 		fmt.Fprintf(&b, "- Release: `%s`\n", release)
 	}
 	b.WriteString("\n")
-	writeFlagSection(&b, "Stable by default", stableDefault)
+	writeFlagSection(&b, stableDefaultTitle, stableDefault)
 	writeFlagSection(&b, "Preview available by opt-in", previewOptIn)
 	if channel == featureflags.ChannelRolling {
 		writeFlagSection(&b, "Preview enabled by rolling channel", previewDefault)
@@ -327,6 +338,29 @@ func formatReport(channel featureflags.Channel, release string, current []featur
 	writeNewPreviewSection(&b, current, previous, compared)
 	b.WriteString("<!-- lopper-feature-flags:end -->\n")
 	return b.String()
+}
+
+func stableByDefaultSincePrevious(current []featureflags.Flag, previous []featureflags.Flag) []featureflags.Flag {
+	previousStableByCode := make(map[string]struct{}, len(previous))
+	previousStableByName := make(map[string]struct{}, len(previous))
+	for _, flag := range previous {
+		if flag.Lifecycle != featureflags.LifecycleStable {
+			continue
+		}
+		previousStableByCode[flag.Code] = struct{}{}
+		previousStableByName[flag.Name] = struct{}{}
+	}
+
+	filtered := make([]featureflags.Flag, 0, len(current))
+	for _, flag := range current {
+		_, seenCode := previousStableByCode[flag.Code]
+		_, seenName := previousStableByName[flag.Name]
+		if seenCode || seenName {
+			continue
+		}
+		filtered = append(filtered, flag)
+	}
+	return filtered
 }
 
 func writeFlagSection(b *strings.Builder, title string, flags []featureflags.Flag) {

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -459,10 +459,13 @@ func TestRunManifestAndReportUseChannels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run feature report: %v", err)
 	}
-	for _, want := range []string{"Stable by default", "Preview available by opt-in", "Newly added preview flags", "LOP-FEAT-0001"} {
+	for _, want := range []string{"Stable by default since previous version", "Preview available by opt-in", "Newly added preview flags", "LOP-FEAT-0001"} {
 		if !strings.Contains(reportOutput, want) {
 			t.Fatalf("expected report to contain %q, got %s", want, reportOutput)
 		}
+	}
+	if strings.Contains(reportOutput, "`LOP-FEAT-0002` `stable-flag`") {
+		t.Fatalf("expected release report to omit unchanged stable defaults, got %s", reportOutput)
 	}
 
 	rollingReport, err := captureStdout(t, func() error {
@@ -559,12 +562,41 @@ func TestFormatReportReleaseLockSection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("manifest: %v", err)
 	}
-	output := formatReport(featureflags.ChannelRelease, "v1.4.2", registry.Flags(), manifest, registry.Flags(), true)
+	output := formatReport(featureflags.ChannelRelease, "v1.4.2", registry.Flags(), manifest, registry.Flags(), true, formatReportOptions{})
 	if !strings.Contains(output, "Preview locked default-on for this release") || !strings.Contains(output, "Preview behavior") {
 		t.Fatalf("expected release lock report section, got %s", output)
 	}
 	if !strings.Contains(output, "None.") {
 		t.Fatalf("expected no newly added preview flags, got %s", output)
+	}
+}
+
+func TestFormatReportStableDefaultsSincePrevious(t *testing.T) {
+	current := []featureflags.Flag{
+		{Code: "LOP-FEAT-0002", Name: "existing-stable", Description: "Existing stable behavior", Lifecycle: featureflags.LifecycleStable},
+		{Code: "LOP-FEAT-0003", Name: "newly-stable", Description: "New stable behavior", Lifecycle: featureflags.LifecycleStable},
+	}
+	manifest := []featureflags.ManifestEntry{
+		{Code: "LOP-FEAT-0002", Name: "existing-stable", EnabledByDefault: true},
+		{Code: "LOP-FEAT-0003", Name: "newly-stable", EnabledByDefault: true},
+	}
+	previous := []featureflags.Flag{
+		{Code: "LOP-FEAT-0001", Name: "preview-flag", Lifecycle: featureflags.LifecyclePreview},
+		{Code: "LOP-FEAT-0002", Name: "existing-stable", Lifecycle: featureflags.LifecycleStable},
+	}
+
+	output := formatReport(featureflags.ChannelRelease, "v1.6.0", current, manifest, previous, true, formatReportOptions{
+		StableDefaultSincePreviousOnly: true,
+	})
+
+	if !strings.Contains(output, "Stable by default since previous version") {
+		t.Fatalf("expected stable defaults section title to reflect previous comparison, got %s", output)
+	}
+	if strings.Contains(output, "`LOP-FEAT-0002` `existing-stable`") {
+		t.Fatalf("expected existing stable default to be omitted, got %s", output)
+	}
+	if !strings.Contains(output, "`LOP-FEAT-0003` `newly-stable`") {
+		t.Fatalf("expected newly stable default to remain in report, got %s", output)
 	}
 }
 

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -600,6 +600,32 @@ func TestFormatReportStableDefaultsSincePrevious(t *testing.T) {
 	}
 }
 
+func TestFormatReportStableDefaultsRequiresComparison(t *testing.T) {
+	current := []featureflags.Flag{
+		{Code: "LOP-FEAT-0002", Name: "existing-stable", Description: "Existing stable behavior", Lifecycle: featureflags.LifecycleStable},
+	}
+	manifest := []featureflags.ManifestEntry{
+		{Code: "LOP-FEAT-0002", Name: "existing-stable", EnabledByDefault: true},
+	}
+	previous := []featureflags.Flag{
+		{Code: "LOP-FEAT-0002", Name: "existing-stable", Lifecycle: featureflags.LifecycleStable},
+	}
+
+	output := formatReport(featureflags.ChannelRelease, "v1.6.0", current, manifest, previous, false, formatReportOptions{
+		StableDefaultSincePreviousOnly: true,
+	})
+
+	if strings.Contains(output, "Stable by default since previous version") {
+		t.Fatalf("expected stable defaults section title to stay generic without a comparison, got %s", output)
+	}
+	if !strings.Contains(output, "Not compared; no previous feature catalog was provided.") {
+		t.Fatalf("expected report to keep the not-compared preview note, got %s", output)
+	}
+	if !strings.Contains(output, "`LOP-FEAT-0002` `existing-stable`") {
+		t.Fatalf("expected stable defaults to remain unfiltered without comparison, got %s", output)
+	}
+}
+
 func TestRunPREnforceFeaturePRRequiresNewFlag(t *testing.T) {
 	root := t.TempDir()
 	writeFeatureCatalog(t, root, `[

--- a/tools/featureflag/release_pr_comment.go
+++ b/tools/featureflag/release_pr_comment.go
@@ -121,7 +121,7 @@ func formatReleasePRComment(release string, current []featureflags.Flag, manifes
 	b.WriteString("<!-- lopper-feature-flag-release-pr -->\n")
 	b.WriteString("## Release feature flags\n\n")
 	fmt.Fprintf(&b, "This release PR is preparing `%s`.\n\n", release)
-	b.WriteString(formatReport(featureflags.ChannelRelease, release, current, manifest, previous, compared))
+	b.WriteString(formatReport(featureflags.ChannelRelease, release, current, manifest, previous, compared, formatReportOptions{}))
 	b.WriteString("\n")
 	b.WriteString("### Promotion options\n\n")
 	fmt.Fprintf(&b, "- Ship a preview flag default-on only in `%s` by editing `internal/featureflags/release_locks.json`.\n", release)


### PR DESCRIPTION
## Summary

Published GitHub release notes were listing every stable-by-default feature instead of only the stable defaults that became newly relevant since the previous version. This change narrows the published release report to the stable-default delta while keeping the release PR guidance on the full feature view.

## Changes

- filter `featureflag report` stable-by-default output against the previous feature catalog when one is provided
- rename the published release-note section to `Stable by default since previous version`
- keep `release-pr-comment` on the full feature view so promotion guidance still sees all stable and preview flags
- add regression coverage for unchanged stable defaults and update the feature-flag docs

## Validation

Commands and checks run:

```bash
go test ./tools/featureflag
go test ./scripts
```

Additional manual validation:

- rendered `go run ./tools/featureflag report --channel release --release v1.6.0 --previous-catalog .artifacts/previous-features-test.json` and confirmed the stable section only lists `LOP-FEAT-0006`, `LOP-FEAT-0007`, and `LOP-FEAT-0008`

## Risk and compatibility

- Breaking changes: none
- Migration required: none
- Performance impact: none expected
- Memory benchmark impact: none expected

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
