### PR TITLE
fix(cli): normalize flag parsing and version handling

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -32,13 +32,6 @@ func New(executor Executor, out io.Writer, errOut io.Writer) *CommandLine {
 }
 
 func (c *CommandLine) Run(ctx context.Context, args []string) int {
-	if isVersionArg(args) {
-		if c.writeOutln(c.VersionOutput) != nil {
-			return 1
-		}
-		return 0
-	}
-
 	req, err := ParseArgs(args)
 	if err != nil {
 		return c.handleParseError(err)
@@ -65,6 +58,12 @@ func (c *CommandLine) Run(ctx context.Context, args []string) int {
 }
 
 func (c *CommandLine) handleParseError(parseErr error) int {
+	if errors.Is(parseErr, ErrVersionRequested) {
+		if c.writeOutln(c.VersionOutput) != nil {
+			return 1
+		}
+		return 0
+	}
 	if errors.Is(parseErr, ErrHelpRequested) {
 		if c.writeOut(Usage()) != nil {
 			return 1

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -82,6 +82,27 @@ func TestRunVersion(t *testing.T) {
 	}
 }
 
+func TestRunVersionAliasAndExtraArgs(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	c := New(&fakeRunner{}, &out, &errOut)
+	c.VersionOutput = "lopper 1.2.1"
+
+	if code := c.Run(context.Background(), []string{"version"}); code != 0 {
+		t.Fatalf("expected version alias code 0, got %d", code)
+	}
+	if code := c.Run(context.Background(), []string{"--version", "--help"}); code != 0 {
+		t.Fatalf("expected --version with extra args code 0, got %d", code)
+	}
+
+	if out.String() != "lopper 1.2.1\nlopper 1.2.1\n" {
+		t.Fatalf("expected version output for alias and extra args, got %q", out.String())
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("expected no stderr output for version requests, got %q", errOut.String())
+	}
+}
+
 func TestRunVersionWriterFailure(t *testing.T) {
 	c := New(&fakeRunner{}, &failWriter{}, &bytes.Buffer{})
 	if code := c.Run(context.Background(), []string{"--version"}); code != 1 {

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	ErrHelpRequested      = errors.New("help requested")
+	ErrVersionRequested   = errors.New("version requested")
 	ErrConflictingTargets = errors.New("cannot use both dependency and --top")
 )
 
@@ -20,6 +21,9 @@ func ParseArgs(args []string) (app.Request, error) {
 
 	if isHelpArg(args[0]) {
 		return req, ErrHelpRequested
+	}
+	if isVersionArg(args) {
+		return req, ErrVersionRequested
 	}
 
 	switch args[0] {

--- a/internal/cli/parse_analyse_overrides.go
+++ b/internal/cli/parse_analyse_overrides.go
@@ -172,7 +172,7 @@ func cliThresholdOverrides(visited map[string]bool, values analyseFlagValues) (t
 		overrides.RemovalCandidateWeightConfidence = values.scoreWeightConfidence
 	}
 	if visited["license-deny"] {
-		overrides.LicenseDenyList = splitPatternList(*values.licenseDeny)
+		overrides.SetLicenseDenyList(splitPatternList(*values.licenseDeny))
 	}
 	if visited["license-fail-on-deny"] {
 		overrides.LicenseFailOnDeny = values.licenseFailOnDeny
@@ -224,7 +224,7 @@ func hasThresholdOverrides(overrides thresholds.Overrides) bool {
 		overrides.RemovalCandidateWeightUsage != nil ||
 		overrides.RemovalCandidateWeightImpact != nil ||
 		overrides.RemovalCandidateWeightConfidence != nil ||
-		len(overrides.LicenseDenyList) > 0 ||
+		overrides.HasLicenseDenyListOverride() ||
 		overrides.LicenseFailOnDeny != nil ||
 		overrides.LicenseIncludeRegistryProvenance != nil ||
 		overrides.LockfileDriftPolicy != nil
@@ -256,7 +256,7 @@ func cliPolicyTrace(overrides thresholds.Overrides) []report.PolicyMergeTrace {
 	if overrides.RemovalCandidateWeightConfidence != nil {
 		trace = append(trace, report.PolicyMergeTrace{Field: "removal_candidate_weights.confidence", Source: "cli"})
 	}
-	if len(overrides.LicenseDenyList) > 0 {
+	if overrides.HasLicenseDenyListOverride() {
 		trace = append(trace, report.PolicyMergeTrace{Field: "license.deny", Source: "cli"})
 	}
 	if overrides.LicenseFailOnDeny != nil {

--- a/internal/cli/parse_analyse_test.go
+++ b/internal/cli/parse_analyse_test.go
@@ -549,6 +549,30 @@ func TestParseArgsAnalysePolicySourcesIncludeCLI(t *testing.T) {
 	}
 }
 
+func TestParseArgsAnalyseLicenseDenyCanClearConfigAndPreserveCLITrace(t *testing.T) {
+	repo := t.TempDir()
+	config := "thresholds:\n  license_deny:\n    - GPL-3.0-only\n"
+	testutil.MustWriteFile(t, filepath.Join(repo, parseConfigFileName), config)
+
+	req := mustParseArgs(t, []string{"analyse", "--top", "1", repoFlagName, repo, "--license-deny", ""})
+	if len(req.Analyse.Thresholds.LicenseDenyList) != 0 {
+		t.Fatalf("expected CLI empty deny list to clear config deny list, got %#v", req.Analyse.Thresholds.LicenseDenyList)
+	}
+	if len(req.Analyse.PolicySources) == 0 || req.Analyse.PolicySources[0] != "cli" {
+		t.Fatalf("expected CLI source precedence when clearing deny list, got %#v", req.Analyse.PolicySources)
+	}
+	var traceSource string
+	for _, item := range req.Analyse.PolicyTrace {
+		if item.Field == "license.deny" {
+			traceSource = item.Source
+			break
+		}
+	}
+	if traceSource != "cli" {
+		t.Fatalf("expected CLI policy trace to win for license deny clear, got %q", traceSource)
+	}
+}
+
 func TestParseArgsAnalyseNotificationPrecedence(t *testing.T) {
 	repo := t.TempDir()
 	config := `notifications:

--- a/internal/cli/parse_features.go
+++ b/internal/cli/parse_features.go
@@ -10,6 +10,12 @@ import (
 )
 
 func parseFeatures(args []string, req app.Request) (app.Request, error) {
+	normalizedArgs, err := normalizeArgs(args)
+	if err != nil {
+		return req, err
+	}
+	args = normalizedArgs
+
 	fs := flag.NewFlagSet("features", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	format := fs.String("format", req.Features.Format, "output format")
@@ -20,12 +26,12 @@ func parseFeatures(args []string, req app.Request) (app.Request, error) {
 	if err := parseFlagSet(fs, args); err != nil {
 		return req, err
 	}
-	if len(fs.Args()) > 0 {
-		return req, fmt.Errorf("too many arguments for features")
-	}
 	outputPath, err := resolveOutputPath(*outputFlag, *outputShortFlag)
 	if err != nil {
 		return req, err
+	}
+	if len(fs.Args()) > 0 {
+		return req, fmt.Errorf("too many arguments for features")
 	}
 
 	req.Mode = app.ModeFeatures

--- a/internal/cli/parse_features_test.go
+++ b/internal/cli/parse_features_test.go
@@ -33,6 +33,17 @@ func TestParseArgsFeaturesRejectsPositionals(t *testing.T) {
 	}
 }
 
+func TestParseArgsFeaturesHelpAndMissingValue(t *testing.T) {
+	if _, err := ParseArgs([]string{"features", "--help"}); err != ErrHelpRequested {
+		t.Fatalf("expected features help to request help, got %v", err)
+	}
+
+	err := expectParseArgsError(t, []string{"features", "--output"}, "expected features missing output value")
+	if !strings.Contains(err.Error(), "flag needs an argument") {
+		t.Fatalf("expected missing flag value error, got %v", err)
+	}
+}
+
 func TestParseArgsFeaturesOutputConflict(t *testing.T) {
 	err := expectParseArgsError(t, []string{"features", "--output", "one.json", "-o", "two.json"}, "expected features output conflict")
 	if !strings.Contains(err.Error(), "--output and -o must match") {

--- a/internal/cli/parse_features_test.go
+++ b/internal/cli/parse_features_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestParseArgsFeaturesRejectsPositionals(t *testing.T) {
 }
 
 func TestParseArgsFeaturesHelpAndMissingValue(t *testing.T) {
-	if _, err := ParseArgs([]string{"features", "--help"}); err != ErrHelpRequested {
+	if _, err := ParseArgs([]string{"features", "--help"}); !errors.Is(err, ErrHelpRequested) {
 		t.Fatalf("expected features help to request help, got %v", err)
 	}
 

--- a/internal/cli/parse_features_test.go
+++ b/internal/cli/parse_features_test.go
@@ -39,3 +39,10 @@ func TestParseArgsFeaturesOutputConflict(t *testing.T) {
 		t.Fatalf("expected output conflict, got %v", err)
 	}
 }
+
+func TestParseArgsFeaturesNormalizesFlagsAfterUnexpectedPositional(t *testing.T) {
+	err := expectParseArgsError(t, []string{"features", "extra", "--output", "one.json", "-o", "two.json"}, "expected normalized features flag parsing")
+	if !strings.Contains(err.Error(), "--output and -o must match") {
+		t.Fatalf("expected output conflict after normalization, got %v", err)
+	}
+}

--- a/internal/cli/parse_mcp.go
+++ b/internal/cli/parse_mcp.go
@@ -9,6 +9,12 @@ import (
 )
 
 func parseMCP(args []string, req app.Request) (app.Request, error) {
+	normalizedArgs, err := normalizeArgs(args)
+	if err != nil {
+		return req, err
+	}
+	args = normalizedArgs
+
 	fs := flag.NewFlagSet("mcp", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	enableFeatures := newPatternListFlag(nil)
@@ -18,12 +24,12 @@ func parseMCP(args []string, req app.Request) (app.Request, error) {
 	if err := parseFlagSet(fs, args); err != nil {
 		return req, err
 	}
-	if len(fs.Args()) > 0 {
-		return req, fmt.Errorf("too many arguments for mcp")
-	}
 	features, err := resolveFeatureRefs(enableFeatures.Values(), disableFeatures.Values())
 	if err != nil {
 		return req, err
+	}
+	if len(fs.Args()) > 0 {
+		return req, fmt.Errorf("too many arguments for mcp")
 	}
 	req.Mode = app.ModeMCP
 	req.MCP.Features = features

--- a/internal/cli/parse_mcp_test.go
+++ b/internal/cli/parse_mcp_test.go
@@ -52,3 +52,10 @@ func TestParseArgsMCPNormalizesFlagsAfterUnexpectedPositional(t *testing.T) {
 		t.Fatalf("expected unknown feature error after normalization, got %v", err)
 	}
 }
+
+func TestParseArgsMCPMissingFeatureValue(t *testing.T) {
+	err := expectParseArgsError(t, []string{"mcp", "--enable-feature"}, "expected missing mcp feature value")
+	if !strings.Contains(err.Error(), "flag needs an argument") {
+		t.Fatalf("expected missing flag value error, got %v", err)
+	}
+}

--- a/internal/cli/parse_mcp_test.go
+++ b/internal/cli/parse_mcp_test.go
@@ -43,3 +43,12 @@ func TestParseArgsMCPRejectsPositionals(t *testing.T) {
 		t.Fatalf("expected too many arguments error, got %v", err)
 	}
 }
+
+func TestParseArgsMCPNormalizesFlagsAfterUnexpectedPositional(t *testing.T) {
+	withFeatureRegistry(t, featureflags.ChannelRelease, nil)
+
+	err := expectParseArgsError(t, []string{"mcp", "extra", "--enable-feature", "missing"}, "expected normalized mcp flag parsing")
+	if !strings.Contains(err.Error(), "unknown feature") {
+		t.Fatalf("expected unknown feature error after normalization, got %v", err)
+	}
+}

--- a/internal/cli/parse_shared.go
+++ b/internal/cli/parse_shared.go
@@ -138,7 +138,15 @@ func isHelpArg(arg string) bool {
 }
 
 func isVersionArg(args []string) bool {
-	return len(args) == 1 && strings.TrimSpace(args[0]) == "--version"
+	if len(args) == 0 {
+		return false
+	}
+	switch strings.TrimSpace(args[0]) {
+	case "--version", "version":
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizeArgs(args []string) ([]string, error) {

--- a/internal/cli/parse_shared_test.go
+++ b/internal/cli/parse_shared_test.go
@@ -113,6 +113,12 @@ func TestParseArgsErrorsAndHelp(t *testing.T) {
 	if _, err := ParseArgs([]string{"help"}); !errors.Is(err, ErrHelpRequested) {
 		t.Fatalf("expected top-level help request error, got %v", err)
 	}
+	if _, err := ParseArgs([]string{"version"}); !errors.Is(err, ErrVersionRequested) {
+		t.Fatalf("expected top-level version request error, got %v", err)
+	}
+	if _, err := ParseArgs([]string{"--version", helpFlag}); !errors.Is(err, ErrVersionRequested) {
+		t.Fatalf("expected --version with extra args to remain a version request, got %v", err)
+	}
 	if _, err := ParseArgs([]string{"analyse", helpFlag}); !errors.Is(err, ErrHelpRequested) {
 		t.Fatalf("expected analyse help request error, got %v", err)
 	}
@@ -131,11 +137,11 @@ func TestIsVersionArg(t *testing.T) {
 	if !isVersionArg([]string{"--version"}) {
 		t.Fatalf("expected --version to be recognized")
 	}
-	if isVersionArg([]string{"version"}) {
-		t.Fatalf("did not expect bare version token to be recognized")
+	if !isVersionArg([]string{"version"}) {
+		t.Fatalf("expected bare version token to be recognized")
 	}
-	if isVersionArg([]string{"--version", "--help"}) {
-		t.Fatalf("did not expect mixed args to be recognized as a version request")
+	if !isVersionArg([]string{"--version", "--help"}) {
+		t.Fatalf("expected --version with extra args to be recognized")
 	}
 }
 

--- a/internal/cli/parse_shared_test.go
+++ b/internal/cli/parse_shared_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"flag"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -107,6 +108,15 @@ func TestParseFlagSetHelpAndBlankMissingValueError(t *testing.T) {
 	}
 }
 
+func TestParseFlagSetReturnsNonHelpErrors(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Int("top", 0, "top count")
+	if err := parseFlagSet(fs, []string{"--top", "nope"}); err == nil || errors.Is(err, ErrHelpRequested) {
+		t.Fatalf("expected parseFlagSet to return non-help parse error, got %v", err)
+	}
+}
+
 func TestParseArgsErrorsAndHelp(t *testing.T) {
 	const helpFlag = "--help"
 
@@ -142,6 +152,15 @@ func TestIsVersionArg(t *testing.T) {
 	}
 	if !isVersionArg([]string{"--version", "--help"}) {
 		t.Fatalf("expected --version with extra args to be recognized")
+	}
+	if !isVersionArg([]string{" version "}) {
+		t.Fatalf("expected whitespace-trimmed version token to be recognized")
+	}
+	if isVersionArg(nil) {
+		t.Fatalf("expected nil args not to be recognized as version")
+	}
+	if isVersionArg([]string{"analyse"}) {
+		t.Fatalf("expected non-version args not to be recognized as version")
 	}
 }
 

--- a/internal/thresholds/thresholds.go
+++ b/internal/thresholds/thresholds.go
@@ -62,7 +62,7 @@ func (o *Overrides) SetLicenseDenyList(values []string) {
 	o.licenseDenyListSet = true
 }
 
-func (o Overrides) HasLicenseDenyListOverride() bool {
+func (o *Overrides) HasLicenseDenyListOverride() bool {
 	return o.licenseDenyListSet
 }
 

--- a/internal/thresholds/thresholds.go
+++ b/internal/thresholds/thresholds.go
@@ -57,6 +57,15 @@ type Overrides struct {
 	LicenseIncludeRegistryProvenance  *bool
 }
 
+func (o *Overrides) SetLicenseDenyList(values []string) {
+	o.LicenseDenyList = append(make([]string, 0, len(values)), values...)
+	o.licenseDenyListSet = true
+}
+
+func (o Overrides) HasLicenseDenyListOverride() bool {
+	return o.licenseDenyListSet
+}
+
 func RemovalCandidateWeights(v Values) report.RemovalCandidateWeights {
 	return report.RemovalCandidateWeights{
 		Usage:      v.RemovalCandidateWeightUsage,

--- a/internal/thresholds/thresholds_test.go
+++ b/internal/thresholds/thresholds_test.go
@@ -263,3 +263,19 @@ func TestNormalizeDenyListEmptyAndInvalid(t *testing.T) {
 		t.Fatalf("expected explicit deny list to survive normalization even when entries drop away, got %#v", gotInvalid.LicenseDenyList)
 	}
 }
+
+func TestOverridesSetLicenseDenyListMarksExplicitOverride(t *testing.T) {
+	base := Defaults()
+	base.LicenseDenyList = []string{"GPL-3.0-ONLY"}
+
+	var overrides Overrides
+	overrides.SetLicenseDenyList(nil)
+	if !overrides.HasLicenseDenyListOverride() {
+		t.Fatalf("expected explicit license deny override marker to be set")
+	}
+
+	got := overrides.Apply(base)
+	if len(got.LicenseDenyList) != 0 {
+		t.Fatalf("expected explicit empty license deny override to clear base values, got %#v", got.LicenseDenyList)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #884, #885, #886, and #1024. The CLI mishandled top-level version requests, dropped flags after unexpected positionals on the `features` and `mcp` surfaces, and could not clear inherited `--license-deny` values from the command line.

## Changes
- Routed top-level `version` and `--version` requests through a dedicated parse signal so they return version output instead of falling through to `unknown command`.
- Normalized `features` and `mcp` arguments before flag parsing so post-positional flags still surface the correct validation errors.
- Added explicit empty-list override semantics for `license-deny` so `--license-deny ""` clears inherited config and still records CLI provenance.
- Added regression coverage across the affected CLI and thresholds tests.

## Validation
Commands and checks run:

```bash
go test ./internal/cli ./internal/thresholds -count=1
```

Additional manual validation:
- Confirmed the new version handling, parser normalization, and empty deny-list behavior through the added regression coverage.

## Risk and compatibility
- Breaking changes: None intended.
- Migration required: None.
- Performance impact: Negligible.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
