### PR TITLE
fix(lang): handle inline go.mod require blocks

### DIFF
--- a/internal/lang/golang/adapter_helper_paths_test.go
+++ b/internal/lang/golang/adapter_helper_paths_test.go
@@ -5,6 +5,8 @@ import (
 	"go/ast"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
@@ -147,6 +149,23 @@ func assertGoModHelpers(t *testing.T) {
 	}
 	if len(replacements) != 0 {
 		t.Fatalf("expected local replacement target to be ignored, got %#v", replacements)
+	}
+
+	inlineBlockModulePath, inlineBlockDependencies, inlineBlockReplacements := parseGoMod([]byte(strings.Join([]string{
+		"module example.com/root",
+		"require ( github.com/acme/dep v1.2.3 )",
+		"require github.com/acme/other v1.4.0",
+		"replace example.com/old => github.com/fork/old v1.2.4",
+		"",
+	}, "\n")))
+	if inlineBlockModulePath != "example.com/root" {
+		t.Fatalf("expected inline require block module path, got %q", inlineBlockModulePath)
+	}
+	if !slices.Equal(inlineBlockDependencies, []string{"github.com/acme/dep", "github.com/acme/other"}) {
+		t.Fatalf("expected inline require block dependencies to survive, got %#v", inlineBlockDependencies)
+	}
+	if len(inlineBlockReplacements) != 1 || inlineBlockReplacements["github.com/fork/old"] != "example.com/old" {
+		t.Fatalf("expected inline require block to preserve later replace directives, got %#v", inlineBlockReplacements)
 	}
 
 	malformedModulePath, malformedDependencies, malformedReplacements := parseGoMod([]byte("module example.com/root\nrequire (\n"))

--- a/internal/lang/golang/adapter_helper_paths_test.go
+++ b/internal/lang/golang/adapter_helper_paths_test.go
@@ -151,13 +151,15 @@ func assertGoModHelpers(t *testing.T) {
 		t.Fatalf("expected local replacement target to be ignored, got %#v", replacements)
 	}
 
-	inlineBlockModulePath, inlineBlockDependencies, inlineBlockReplacements := parseGoMod([]byte(strings.Join([]string{
+	inlineBlockGoModLines := []string{
 		"module example.com/root",
 		"require ( github.com/acme/dep v1.2.3 )",
 		"require github.com/acme/other v1.4.0",
 		"replace example.com/old => github.com/fork/old v1.2.4",
 		"",
-	}, "\n")))
+	}
+	inlineBlockGoMod := strings.Join(inlineBlockGoModLines, "\n")
+	inlineBlockModulePath, inlineBlockDependencies, inlineBlockReplacements := parseGoMod([]byte(inlineBlockGoMod))
 	if inlineBlockModulePath != "example.com/root" {
 		t.Fatalf("expected inline require block module path, got %q", inlineBlockModulePath)
 	}

--- a/internal/lang/golang/adapter_helper_paths_test.go
+++ b/internal/lang/golang/adapter_helper_paths_test.go
@@ -170,6 +170,33 @@ func assertGoModHelpers(t *testing.T) {
 		t.Fatalf("expected inline require block to preserve later replace directives, got %#v", inlineBlockReplacements)
 	}
 
+	commentedInlineBlockGoModLines := []string{
+		"module example.com/root",
+		"require ( github.com/acme/dep v1.2.3 ) // keep comment",
+		"",
+	}
+	commentedInlineBlockGoMod := strings.Join(commentedInlineBlockGoModLines, "\n")
+	commentedModulePath, commentedDependencies, commentedReplacements := parseGoMod([]byte(commentedInlineBlockGoMod))
+	if commentedModulePath != "example.com/root" {
+		t.Fatalf("expected commented inline require block module path, got %q", commentedModulePath)
+	}
+	if !slices.Equal(commentedDependencies, []string{"github.com/acme/dep"}) {
+		t.Fatalf("expected commented inline require block dependency, got %#v", commentedDependencies)
+	}
+	if len(commentedReplacements) != 0 {
+		t.Fatalf("expected no replacements from commented inline require block, got %#v", commentedReplacements)
+	}
+
+	normalizedLine, ok := normalizeInlineGoModRequireLine("require ( github.com/acme/dep v1.2.3 ) // keep comment")
+	if !ok || normalizedLine != "require github.com/acme/dep v1.2.3 // keep comment" {
+		t.Fatalf("expected inline require line normalization with comment, got line=%q ok=%v", normalizedLine, ok)
+	}
+
+	emptyLine, emptyOK := normalizeInlineGoModRequireLine("require ( )")
+	if emptyOK || emptyLine != "require ( )" {
+		t.Fatalf("expected empty inline require line to stay unchanged, got line=%q ok=%v", emptyLine, emptyOK)
+	}
+
 	malformedModulePath, malformedDependencies, malformedReplacements := parseGoMod([]byte("module example.com/root\nrequire (\n"))
 	if malformedModulePath != "" {
 		t.Fatalf("expected malformed go.mod parse to return empty module path, got %q", malformedModulePath)
@@ -199,6 +226,10 @@ func assertGoWorkAndPathHelpers(t *testing.T) {
 
 	if _, ok := resolveRepoBoundedPath(repo, ""); ok {
 		t.Fatalf("expected empty resolveRepoBoundedPath input to fail")
+	}
+	resolvedRepoPath, ok := resolveRepoBoundedPath(repo, "./svc")
+	if !ok || resolvedRepoPath != filepath.Join(repo, "svc") {
+		t.Fatalf("expected in-repo relative path to resolve, got path=%q ok=%v", resolvedRepoPath, ok)
 	}
 	if _, ok := resolveRepoBoundedPath(repo, "../outside"); ok {
 		t.Fatalf("expected resolveRepoBoundedPath to reject escaping path")

--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -448,7 +448,7 @@ func TestScanRepoScansLoadedNestedModuleDirs(t *testing.T) {
 
 func TestLoadGoModuleInfoInlineRequireBlock(t *testing.T) {
 	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, fileGoMod), strings.Join([]string{
+	goModContentLines := []string{
 		moduleDemoLine,
 		go125Line,
 		"",
@@ -456,7 +456,9 @@ func TestLoadGoModuleInfoInlineRequireBlock(t *testing.T) {
 		requirePrefix + depLo + " v1.47.0",
 		replacePrefix + moduleOriginal + " => " + sharedForkImport + " v1.0.0",
 		"",
-	}, "\n"))
+	}
+	goModContent := strings.Join(goModContentLines, "\n")
+	writeFile(t, filepath.Join(repo, fileGoMod), goModContent)
 
 	info, err := loadGoModuleInfo(repo)
 	if err != nil {

--- a/internal/lang/golang/adapter_test.go
+++ b/internal/lang/golang/adapter_test.go
@@ -446,6 +446,33 @@ func TestScanRepoScansLoadedNestedModuleDirs(t *testing.T) {
 	requireScannedDependency(t, scan, depLo)
 }
 
+func TestLoadGoModuleInfoInlineRequireBlock(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, fileGoMod), strings.Join([]string{
+		moduleDemoLine,
+		go125Line,
+		"",
+		"require ( " + depUUID + versionV160 + " )",
+		requirePrefix + depLo + " v1.47.0",
+		replacePrefix + moduleOriginal + " => " + sharedForkImport + " v1.0.0",
+		"",
+	}, "\n"))
+
+	info, err := loadGoModuleInfo(repo)
+	if err != nil {
+		t.Fatalf("loadGoModuleInfo: %v", err)
+	}
+	if info.ModulePath != moduleDemo {
+		t.Fatalf("expected module path %q, got %q", moduleDemo, info.ModulePath)
+	}
+	if !slices.Equal(info.DeclaredDependencies, []string{depUUID, depLo}) {
+		t.Fatalf("expected inline require block dependencies, got %#v", info.DeclaredDependencies)
+	}
+	if got := info.ReplacementImports[sharedForkImport]; got != moduleOriginal {
+		t.Fatalf("expected replacement mapping to survive inline require block, got %#v", info.ReplacementImports)
+	}
+}
+
 func TestScanRepoScansWorkspaceAndNestedModules(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, fileGoWork), go125Line+"\n\nuse ./svc/a\n")

--- a/internal/lang/golang/module_metadata.go
+++ b/internal/lang/golang/module_metadata.go
@@ -132,6 +132,12 @@ func unionDirSet(primary map[string]struct{}, extra map[string]struct{}) map[str
 func parseGoMod(content []byte) (string, []string, map[string]string) {
 	file, err := modfile.Parse(goModName, content, nil)
 	if err != nil && file == nil {
+		normalized := normalizeInlineGoModRequireBlocks(content)
+		if string(normalized) != string(content) {
+			file, err = modfile.Parse(goModName, normalized, nil)
+		}
+	}
+	if err != nil && file == nil {
 		return "", []string{}, map[string]string{}
 	}
 	if file == nil {
@@ -139,6 +145,48 @@ func parseGoMod(content []byte) (string, []string, map[string]string) {
 	}
 
 	return goModModulePath(file), goModDependencies(file.Require), goModReplacements(file.Replace)
+}
+
+func normalizeInlineGoModRequireBlocks(content []byte) []byte {
+	lines := strings.Split(string(content), "\n")
+	changed := false
+	for i, rawLine := range lines {
+		normalizedLine, ok := normalizeInlineGoModRequireLine(rawLine)
+		if !ok {
+			continue
+		}
+		lines[i] = normalizedLine
+		changed = true
+	}
+	if !changed {
+		return content
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+func normalizeInlineGoModRequireLine(rawLine string) (string, bool) {
+	commentSuffix := ""
+	lineWithoutComment := rawLine
+	if index := strings.Index(rawLine, "//"); index >= 0 {
+		lineWithoutComment = rawLine[:index]
+		commentSuffix = rawLine[index:]
+	}
+
+	trimmed := strings.TrimSpace(lineWithoutComment)
+	if !strings.HasPrefix(trimmed, "require (") || !strings.HasSuffix(trimmed, ")") {
+		return rawLine, false
+	}
+
+	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "require ("), ")"))
+	if body == "" {
+		return rawLine, false
+	}
+
+	normalized := "require " + body
+	if commentSuffix != "" {
+		normalized += " " + commentSuffix
+	}
+	return normalized, true
 }
 
 func goModModulePath(file *modfile.File) string {


### PR DESCRIPTION
## Summary
Fixes #880. Single-line `require ( module v1.0.0 )` entries in `go.mod` were dropped and could cause later directives to be ignored during Go dependency discovery.

## Changes
- Retried `modfile.Parse` after normalizing same-line `require ( ... )` directives into standard `require ...` lines when the initial parse fails.
- Preserved later directives after the normalized retry path instead of returning an empty parse result.
- Added helper-level and adapter-facing regression coverage for inline require blocks.

## Validation
Commands and checks run:

```bash
go test ./internal/lang/golang -count=1
```

Additional manual validation:
- Verified both the parser helper seam and the adapter-facing load path with explicit inline require regression cases.

## Risk and compatibility
- Breaking changes: None intended.
- Migration required: None.
- Performance impact: Minimal and only on a fallback parse path.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
