### PR TITLE
fix(ui): make summary help rendering one-shot

### DIFF
--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -55,7 +55,7 @@ func (s *Summary) Start(ctx context.Context, opts Options) error {
 				return err
 			}
 		}
-		if err := s.renderSummaryOutput(reportView, state); err != nil {
+		if err := s.renderSummaryOutput(reportView, &state); err != nil {
 			return err
 		}
 
@@ -73,10 +73,17 @@ func (s *Summary) Start(ctx context.Context, opts Options) error {
 	}
 }
 
-func (s *Summary) renderSummaryOutput(reportView summaryReportView, state summaryState) error {
-	output, err := s.renderSummary(reportView, state)
+func (s *Summary) renderSummaryOutput(reportView summaryReportView, state *summaryState) error {
+	currentState := summaryState{}
+	if state != nil {
+		currentState = *state
+	}
+	output, err := s.renderSummary(reportView, currentState)
 	if err != nil {
 		return err
+	}
+	if state != nil {
+		state.showHelp = false
 	}
 	_, err = fmt.Fprint(s.Out, output)
 	return err

--- a/internal/ui/summary_detail_rendering_test.go
+++ b/internal/ui/summary_detail_rendering_test.go
@@ -44,11 +44,46 @@ func TestRenderSummaryOutputSuccess(t *testing.T) {
 
 	var out bytes.Buffer
 	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{report: rep}, report.NewFormatter())
-	if err := summary.renderSummaryOutput(mapSummaryReportView(rep), summaryState{sortMode: sortByWaste, page: 1, pageSize: 10}); err != nil {
+	state := summaryState{sortMode: sortByWaste, page: 1, pageSize: 10}
+	if err := summary.renderSummaryOutput(mapSummaryReportView(rep), &state); err != nil {
 		t.Fatalf("render summary output: %v", err)
 	}
 	if !strings.Contains(out.String(), "Lopper TUI (summary)") {
 		t.Fatalf("expected rendered summary frame, got %q", out.String())
+	}
+}
+
+func TestRenderSummaryOutputHelpIsOneShot(t *testing.T) {
+	rep := report.Report{
+		Dependencies: []report.DependencyReport{
+			{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100},
+		},
+	}
+
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{report: rep}, report.NewFormatter())
+	state := summaryState{sortMode: sortByWaste, page: 1, pageSize: 10, showHelp: true}
+	reportView := mapSummaryReportView(rep)
+
+	if err := summary.renderSummaryOutput(reportView, &state); err != nil {
+		t.Fatalf("render summary output with help: %v", err)
+	}
+	if !strings.Contains(out.String(), "Commands:\n  filter <text>") {
+		t.Fatalf("expected first render to include expanded help, got %q", out.String())
+	}
+	if state.showHelp {
+		t.Fatalf("expected help flag to clear after rendering")
+	}
+
+	out.Reset()
+	if err := summary.renderSummaryOutput(reportView, &state); err != nil {
+		t.Fatalf("render summary output without help: %v", err)
+	}
+	if strings.Contains(out.String(), "Commands:\n  filter <text>") {
+		t.Fatalf("expected second render to omit expanded help, got %q", out.String())
+	}
+	if !strings.Contains(out.String(), "Commands: help | open <dependency> | q") {
+		t.Fatalf("expected second render to include compact command hint, got %q", out.String())
 	}
 }
 
@@ -279,7 +314,7 @@ func testUISummaryFormatterErrorsPropagate(t *testing.T) {
 	if _, err := summary.renderSummary(reportView, state); !errors.Is(err, formatErr) {
 		t.Fatalf("expected renderSummary to return formatter error, got %v", err)
 	}
-	if err := summary.renderSummaryOutput(reportView, state); !errors.Is(err, formatErr) {
+	if err := summary.renderSummaryOutput(reportView, &state); !errors.Is(err, formatErr) {
 		t.Fatalf("expected renderSummaryOutput to return formatter error, got %v", err)
 	}
 	if err := summary.Snapshot(context.Background(), Options{RepoPath: ".", Sort: "name", PageSize: 10}, filepath.Join(t.TempDir(), "summary.txt")); !errors.Is(err, formatErr) {


### PR DESCRIPTION
## Summary
Fixes #883. The summary TUI help panel latched permanently after the first `help` command and kept crowding every later frame.

## Changes
- Passed the interactive `summaryState` by pointer into the render output path.
- Cleared `showHelp` immediately after a frame render so the expanded help panel is one-shot.
- Added a regression that renders twice from the same state and asserts the first frame shows expanded help while the second falls back to the compact hint.

## Validation
Commands and checks run:

```bash
go test ./internal/ui -count=1
```

Additional manual validation:
- Confirmed the one-shot behavior entirely through the new regression coverage around repeated renders.

## Risk and compatibility
- Breaking changes: None intended.
- Migration required: None.
- Performance impact: Negligible.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
