### PR TITLE
fix(release): gate skip-release on manual tag dispatches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -620,11 +620,11 @@ jobs:
 
   skip-release:
     needs: prepare-release
-    if: ${{ needs.prepare-release.outputs.release_created != 'true' }}
+    if: ${{ needs.prepare-release.outputs.release_created != 'true' && (github.event_name != 'workflow_dispatch' || inputs.tag == '') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: No release created
+      - name: No release published
         run: |
-          echo "Release Please did not create a release; the release PR was created or updated instead."
+          echo "Release Please did not create a release on this push; the release PR was created or updated instead."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -620,7 +620,7 @@ jobs:
 
   skip-release:
     needs: prepare-release
-    if: ${{ needs.prepare-release.outputs.release_created != 'true' && (github.event_name != 'workflow_dispatch' || inputs.tag == '') }}
+    if: ${{ needs.prepare-release.outputs.release_created != 'true' && (github.event_name != 'workflow_dispatch' || github.event.inputs.tag == '') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -131,8 +131,11 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	if !strings.Contains(workflowText, "needs.prepare-release.outputs.sha") {
 		t.Fatal("downstream release jobs must use the resolved prepare-release SHA")
 	}
-	if !strings.Contains(workflowText, "needs.prepare-release.outputs.release_created != 'true' && (github.event_name != 'workflow_dispatch' || inputs.tag == '')") {
+	if !strings.Contains(workflowText, "needs.prepare-release.outputs.release_created != 'true' && (github.event_name != 'workflow_dispatch' || github.event.inputs.tag == '')") {
 		t.Fatal("skip-release must ignore manual dispatches that publish a requested tag")
+	}
+	if !strings.Contains(workflowText, "Release Please did not create a release on this push; the release PR was created or updated instead.") {
+		t.Fatal("skip-release must log the push-specific message when no release is published")
 	}
 	if strings.Contains(workflowText, "Release Please did not create a release; the release PR was created or updated instead.") {
 		t.Fatal("skip-release log must not use the stale message that also appears during manual tag dispatches")

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -131,6 +131,12 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	if !strings.Contains(workflowText, "needs.prepare-release.outputs.sha") {
 		t.Fatal("downstream release jobs must use the resolved prepare-release SHA")
 	}
+	if !strings.Contains(workflowText, "needs.prepare-release.outputs.release_created != 'true' && (github.event_name != 'workflow_dispatch' || inputs.tag == '')") {
+		t.Fatal("skip-release must ignore manual dispatches that publish a requested tag")
+	}
+	if strings.Contains(workflowText, "Release Please did not create a release; the release PR was created or updated instead.") {
+		t.Fatal("skip-release log must not use the stale message that also appears during manual tag dispatches")
+	}
 }
 
 func TestRenovateDoesNotAutomergeMajorUpdates(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #887. `skip-release` ran alongside the manual publish path on tagged `workflow_dispatch` runs and printed a misleading Release Please message during real publishes.

## Changes
- Gated `skip-release` behind the explicit manual-dispatch exception from the issue so tagged `workflow_dispatch` publishes no longer satisfy the skip path.
- Kept the updated log text focused on push-time Release Please no-op behavior instead of implying that manual publishes were skipped.
- Added workflow config coverage for the updated condition and message.

## Validation
Commands and checks run:

```bash
go test ./scripts -count=1
```

Additional manual validation:
- Verified the final `skip-release` condition matches the issue’s requested `workflow_dispatch` + `inputs.tag` exception.

## Risk and compatibility
- Breaking changes: None intended.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
