### PR TITLE
fix(workspace): preserve arrow substrings in changed files

### DIFF
--- a/internal/workspace/changed_files.go
+++ b/internal/workspace/changed_files.go
@@ -71,14 +71,40 @@ func parsePorcelainChangedFiles(output []byte) []string {
 		if len(line) < 4 {
 			return ""
 		}
+		status := line[:2]
 		// Porcelain format is positional (`XY PATH`); trimming line whitespace corrupts
 		// unstaged entries that start with a leading status-space (`" M path"`).
 		path := line[3:]
-		if idx := strings.LastIndex(path, " -> "); idx >= 0 {
-			path = path[idx+4:]
+		if strings.ContainsAny(status, "RC") {
+			if idx := findPorcelainRenameSeparator(path); idx >= 0 {
+				path = path[idx+4:]
+			}
 		}
 		return decodeGitQuotedPath(path)
 	})
+}
+
+func findPorcelainRenameSeparator(path string) int {
+	inQuotes := false
+	escaped := false
+	for i := 0; i+3 < len(path); i++ {
+		if !inQuotes && strings.HasPrefix(path[i:], " -> ") {
+			return i
+		}
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch path[i] {
+		case '\\':
+			if inQuotes {
+				escaped = true
+			}
+		case '"':
+			inQuotes = !inQuotes
+		}
+	}
+	return -1
 }
 
 func decodeGitQuotedPath(path string) string {

--- a/internal/workspace/workspace_changed_files_test.go
+++ b/internal/workspace/workspace_changed_files_test.go
@@ -206,6 +206,20 @@ func TestParseChangedFileHelpers(t *testing.T) {
 	}
 }
 
+func TestParseChangedFileHelperEdgeCases(t *testing.T) {
+	if idx := findPorcelainRenameSeparator("\"old \\\"->\\\" name.go\" -> \"new.go\""); idx < 0 {
+		t.Fatalf("expected rename separator outside escaped quoted content")
+	}
+
+	if idx := findPorcelainRenameSeparator("\"weird -> name.go\""); idx != -1 {
+		t.Fatalf("expected quoted arrow substring without rename separator, got %d", idx)
+	}
+
+	if decoded := decodeGitQuotedPath("\"\\xG1\""); decoded != "\"\\xG1\"" {
+		t.Fatalf("expected invalid quoted path to remain unchanged, got %q", decoded)
+	}
+}
+
 func TestResolveGitBinaryPathMissing(t *testing.T) {
 	original := resolveGitBinaryPathFn
 	originalExec := execGitCommandFn

--- a/internal/workspace/workspace_changed_files_test.go
+++ b/internal/workspace/workspace_changed_files_test.go
@@ -62,6 +62,11 @@ func TestChangedFilesParsesDiffAndStatusFallback(t *testing.T) {
 			script: "#!/bin/sh\nif [ \"$3\" = \"diff\" ]; then\n  printf '%s\\n' '\"\\303\\261ame.go\"'\n  exit 0\nfi\nif [ \"$3\" = \"status\" ]; then\n  echo 'M  \"\\303\\261ame.go\"'\n  exit 0\nfi\nexit 1\n",
 			want:   []string{"ñame.go"},
 		},
+		{
+			name:   "quoted_modified_path_with_arrow_substring",
+			script: "#!/bin/sh\nif [ \"$3\" = \"diff\" ]; then\n  echo \"diff fail\" >&2\n  exit 2\nfi\nif [ \"$3\" = \"status\" ]; then\n  echo 'M  \"weird -> name.go\"'\n  exit 0\nfi\nexit 1\n",
+			want:   []string{"weird -> name.go"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -178,6 +183,16 @@ func TestParseChangedFileHelpers(t *testing.T) {
 	quotedPorcelain := parsePorcelainChangedFiles([]byte("M  \"\\303\\261ame.go\"\n"))
 	if len(quotedPorcelain) != 1 || quotedPorcelain[0] != "ñame.go" {
 		t.Fatalf("expected quoted porcelain path to decode, got %#v", quotedPorcelain)
+	}
+
+	quotedWithArrow := parsePorcelainChangedFiles([]byte("M  \"weird -> name.go\"\n"))
+	if len(quotedWithArrow) != 1 || quotedWithArrow[0] != "weird -> name.go" {
+		t.Fatalf("expected modified quoted path with arrow substring to stay intact, got %#v", quotedWithArrow)
+	}
+
+	renamedQuotedWithArrow := parsePorcelainChangedFiles([]byte("R  \"old -> name.go\" -> \"new -> name.go\"\n"))
+	if len(renamedQuotedWithArrow) != 1 || renamedQuotedWithArrow[0] != "new -> name.go" {
+		t.Fatalf("expected renamed quoted path with arrow substring to parse destination, got %#v", renamedQuotedWithArrow)
 	}
 
 	unstaged := parsePorcelainChangedFiles([]byte(" M main.go\n"))


### PR DESCRIPTION
## Summary
Fixes #1025. `ChangedFiles` mis-parsed ordinary modified filenames containing the literal substring ` -> `.

## Changes
- Limited rename parsing to porcelain records whose status actually indicates rename or copy.
- Added a quote-aware separator finder so quoted rename paths still resolve to the destination correctly.
- Added regression coverage for both the reported modified-path case and quoted rename cases with ` -> ` inside filenames.

## Validation
Commands and checks run:

```bash
go test ./internal/workspace -count=1
```

Additional manual validation:
- Confirmed both the changed-file fallback path and the lower-level helper path with explicit quoted filename coverage.

## Risk and compatibility
- Breaking changes: None intended.
- Migration required: None.
- Performance impact: Negligible.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
