### PR TITLE
fix(vscode): harden workspace path and tar extraction

### DIFF
--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -1783,10 +1783,24 @@ function isSameWorkspacePath(leftPath: string, rightPath: string): boolean {
 }
 
 function canonicalizeExistingPath(targetPath: string): string | undefined {
-  try {
-    return realpathSync.native(targetPath);
-  } catch {
-    return undefined;
+  const pendingSegments: string[] = [];
+  let currentPath = path.resolve(targetPath);
+
+  while (true) {
+    try {
+      const canonicalBasePath = realpathSync.native(currentPath);
+      if (pendingSegments.length === 0) {
+        return canonicalBasePath;
+      }
+      return path.join(canonicalBasePath, ...pendingSegments.reverse());
+    } catch {
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        return undefined;
+      }
+      pendingSegments.push(path.basename(currentPath));
+      currentPath = parentPath;
+    }
   }
 }
 

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { mkdir, realpath, stat, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import * as vscode from "vscode";
@@ -935,8 +936,8 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
 
   private async openLocation(filePath: string, line = 1, column = 1): Promise<void> {
     const uri = vscode.Uri.file(filePath);
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
-    if (!workspaceFolder || !isPathInsideWorkspace(uri.fsPath, workspaceFolder.uri.fsPath)) {
+    const workspaceFolder = findContainingWorkspaceFolder(uri.fsPath);
+    if (!workspaceFolder) {
       this.output.appendLine(`[open-location:skipped] refusing to open outside workspace: ${filePath}`);
       return;
     }
@@ -1012,10 +1013,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
 
   private async resolveDependencyWorkspaceFolder(folderPath?: string): Promise<vscode.WorkspaceFolder | undefined> {
     if (folderPath) {
-      const resolved = path.resolve(folderPath);
-      const folder = (vscode.workspace.workspaceFolders ?? []).find(
-        (candidate) => path.resolve(candidate.uri.fsPath) === resolved,
-      );
+      const folder = findWorkspaceFolder(folderPath);
       if (folder) {
         return folder;
       }
@@ -1199,8 +1197,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   }
 
   private findWorkspaceFolder(folderPath: string): vscode.WorkspaceFolder | undefined {
-    const resolved = path.resolve(folderPath);
-    return (vscode.workspace.workspaceFolders ?? []).find((folder) => path.resolve(folder.uri.fsPath) === resolved);
+    return findWorkspaceFolder(folderPath);
   }
 
   private pushDiagnostic(
@@ -1402,6 +1399,8 @@ class LopperExtensionBootstrap implements vscode.Disposable {
 export const __testing = {
   createController: (runner: WorkspaceAnalysisRunner): LopperControllerContract =>
     new LopperController({} as vscode.ExtensionContext, runner, { registerWithVSCode: false }),
+  isPathInsideWorkspace,
+  resolveWorkspaceFilePath,
 };
 
 const bootstrap = new LopperExtensionBootstrap();
@@ -1753,7 +1752,12 @@ function resolveWorkspaceFilePath(workspaceRoot: string, relativePath: string): 
 }
 
 function isPathInsideWorkspace(candidatePath: string, workspaceRoot: string): boolean {
-  const relativePath = path.relative(path.resolve(workspaceRoot), path.resolve(candidatePath));
+  const resolvedWorkspaceRoot = canonicalizeExistingPath(workspaceRoot);
+  const resolvedCandidatePath = canonicalizeExistingPath(candidatePath);
+  if (!resolvedWorkspaceRoot || !resolvedCandidatePath) {
+    return false;
+  }
+  const relativePath = path.relative(resolvedWorkspaceRoot, resolvedCandidatePath);
   return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }
 
@@ -1762,8 +1766,28 @@ function formatLocationSummary(location: LopperLocation): string {
 }
 
 function findWorkspaceFolder(folderPath: string): vscode.WorkspaceFolder | undefined {
-  const resolved = path.resolve(folderPath);
-  return (vscode.workspace.workspaceFolders ?? []).find((folder) => path.resolve(folder.uri.fsPath) === resolved);
+  return (vscode.workspace.workspaceFolders ?? []).find((folder) => isSameWorkspacePath(folder.uri.fsPath, folderPath));
+}
+
+function findContainingWorkspaceFolder(candidatePath: string): vscode.WorkspaceFolder | undefined {
+  return (vscode.workspace.workspaceFolders ?? []).find((folder) => isPathInsideWorkspace(candidatePath, folder.uri.fsPath));
+}
+
+function isSameWorkspacePath(leftPath: string, rightPath: string): boolean {
+  const canonicalLeftPath = canonicalizeExistingPath(leftPath);
+  const canonicalRightPath = canonicalizeExistingPath(rightPath);
+  if (canonicalLeftPath && canonicalRightPath) {
+    return canonicalLeftPath === canonicalRightPath;
+  }
+  return path.resolve(leftPath) === path.resolve(rightPath);
+}
+
+function canonicalizeExistingPath(targetPath: string): string | undefined {
+  try {
+    return realpathSync.native(targetPath);
+  } catch {
+    return undefined;
+  }
 }
 
 function dependencySummaryText(dependency: LopperDependencyReport, analysis: WorkspaceAnalysis): string {

--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -679,23 +679,26 @@ async function extractZipArchive(archivePath: string, extractDir: string): Promi
 }
 
 async function extractTarArchive(archivePath: string, extractDir: string): Promise<void> {
-  await tar.t({
-    file: archivePath,
-    gzip: true,
-    onentry: (entry) => {
-      archiveDestinationPath(extractDir, entry.path);
-    },
-  });
-
+  let rejectedEntryMessage: string | undefined;
   await tar.x({
     file: archivePath,
     cwd: extractDir,
     gzip: true,
+    preservePaths: false,
+    strict: true,
     filter: (entryPath) => {
-      archiveDestinationPath(extractDir, entryPath);
-      return true;
+      try {
+        archiveDestinationPath(extractDir, entryPath);
+        return true;
+      } catch (error) {
+        rejectedEntryMessage = error instanceof Error ? error.message : String(error);
+        return false;
+      }
     },
   });
+  if (rejectedEntryMessage) {
+    throw new Error(rejectedEntryMessage);
+  }
 }
 
 export function archiveDestinationPath(rootDir: string, entryName: string): string {

--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -679,7 +679,7 @@ async function extractZipArchive(archivePath: string, extractDir: string): Promi
 }
 
 async function extractTarArchive(archivePath: string, extractDir: string): Promise<void> {
-  let rejectedEntryMessage: string | undefined;
+  let rejectedEntryError: Error | undefined;
   await tar.x({
     file: archivePath,
     cwd: extractDir,
@@ -691,13 +691,15 @@ async function extractTarArchive(archivePath: string, extractDir: string): Promi
         archiveDestinationPath(extractDir, entryPath);
         return true;
       } catch (error) {
-        rejectedEntryMessage = error instanceof Error ? error.message : String(error);
+        if (!rejectedEntryError) {
+          rejectedEntryError = error instanceof Error ? error : new Error(String(error));
+        }
         return false;
       }
     },
   });
-  if (rejectedEntryMessage) {
-    throw new Error(rejectedEntryMessage);
+  if (rejectedEntryError) {
+    throw rejectedEntryError;
   }
 }
 

--- a/extensions/vscode-lopper/src/test/runTest.mjs
+++ b/extensions/vscode-lopper/src/test/runTest.mjs
@@ -1,4 +1,4 @@
-import { chmod, cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,6 +15,7 @@ async function main() {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-vscode-smoke-"));
   const workspacePath = path.join(tempRoot, "workspace");
   const workspacePathTwo = path.join(tempRoot, "workspace-two");
+  const outsideLocationPath = path.join(tempRoot, "outside-location");
   const fixtureBinaryCopyPath = path.join(tempRoot, "lopper-smoke-binary.mjs");
   const userDataDir = path.join(tempRoot, "userdata");
   const extensionsDir = path.join(tempRoot, "extensions");
@@ -28,6 +29,7 @@ async function main() {
     await rm(path.join(workspacePathTwo, ".lopper-cache"), { recursive: true, force: true });
     await mkdir(path.join(workspacePath, "src"), { recursive: true });
     await mkdir(path.join(workspacePathTwo, "src"), { recursive: true });
+    await mkdir(outsideLocationPath, { recursive: true });
     await writeFile(
       path.join(workspacePath, "src", "index.ts"),
       [
@@ -50,6 +52,8 @@ async function main() {
       ].join("\n"),
       "utf8",
     );
+    await writeFile(path.join(outsideLocationPath, "escape.ts"), 'export const escaped = "outside";\n', "utf8");
+    await symlink(outsideLocationPath, path.join(workspacePath, "linked-outside"));
 
     await runTests({
       version: vscodeVersion,

--- a/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
@@ -171,6 +171,25 @@ suite("managed binary installer", () => {
     );
   });
 
+  test("rejects tar.gz managed binaries with escaping archive entries", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-binary-test-"));
+    try {
+      const releaseTag = "v9.8.7";
+      const host = { platform: "linux" as const, arch: "x64" };
+      const archivePath = await createEscapingTarballFixture(tempRoot, releaseTag, host);
+      const installer = await createInstaller(tempRoot, releaseTag, host, archivePath);
+
+      await assert.rejects(
+        installer.ensureInstalled(),
+        (error: unknown) =>
+          error instanceof Error &&
+          error.message.includes("escapes the extraction directory"),
+      );
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test("falls back to managed install when configured/local binaries are unavailable", async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-lifecycle-test-"));
     const previousPath = process.env.PATH;
@@ -620,6 +639,30 @@ async function createTarballFixture(
 
   const archivePath = path.join(tempRoot, assetNameForRelease(releaseTag, host));
   await tar.create({ gzip: true, file: archivePath, cwd: archiveDir }, [path.basename(rootDir)]);
+  return archivePath;
+}
+
+async function createEscapingTarballFixture(
+  tempRoot: string,
+  releaseTag: string,
+  host: { platform: "linux" | "darwin"; arch: string },
+): Promise<string> {
+  const archiveDir = path.join(tempRoot, "tar-escape-source");
+  const outsideDir = path.join(tempRoot, "tar-escape-outside");
+  await mkdir(archiveDir, { recursive: true });
+  await mkdir(outsideDir, { recursive: true });
+  await writeFile(path.join(outsideDir, "escape.txt"), "escape");
+
+  const archivePath = path.join(tempRoot, assetNameForRelease(releaseTag, host));
+  await tar.create(
+    {
+      gzip: true,
+      file: archivePath,
+      cwd: archiveDir,
+      preservePaths: true,
+    },
+    ["../tar-escape-outside/escape.txt"],
+  );
   return archivePath;
 }
 

--- a/extensions/vscode-lopper/src/test/suite/smoke.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/smoke.test.ts
@@ -30,6 +30,17 @@ suite("vscode-lopper smoke", () => {
     const document = await vscode.workspace.openTextDocument(primaryFixtureUri);
     await vscode.window.showTextDocument(document);
 
+    const blockedUri = vscode.Uri.file(path.join(primaryFolder.uri.fsPath, "linked-outside", "escape.ts"));
+    const activeBeforeBlockedOpen = vscode.window.activeTextEditor?.document.uri.toString();
+    await vscode.commands.executeCommand("lopper.openLocation", blockedUri.fsPath, 1, 1);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    assert.equal(vscode.window.activeTextEditor?.document.uri.toString(), activeBeforeBlockedOpen);
+    assert.equal(
+      vscode.workspace.textDocuments.some((item) => item.uri.toString() === blockedUri.toString()),
+      false,
+      "expected symlink-escaped location to remain unopened",
+    );
+
     await vscode.commands.executeCommand("lopper.refreshWorkspace");
     assert.match(api.getLatestSummary(), /package/);
     const commands = await vscode.commands.getCommands(true);

--- a/extensions/vscode-lopper/src/test/suite/smoke.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/smoke.test.ts
@@ -33,7 +33,6 @@ suite("vscode-lopper smoke", () => {
     const blockedUri = vscode.Uri.file(path.join(primaryFolder.uri.fsPath, "linked-outside", "escape.ts"));
     const activeBeforeBlockedOpen = vscode.window.activeTextEditor?.document.uri.toString();
     await vscode.commands.executeCommand("lopper.openLocation", blockedUri.fsPath, 1, 1);
-    await new Promise((resolve) => setTimeout(resolve, 250));
     assert.equal(vscode.window.activeTextEditor?.document.uri.toString(), activeBeforeBlockedOpen);
     assert.equal(
       vscode.workspace.textDocuments.some((item) => item.uri.toString() === blockedUri.toString()),

--- a/extensions/vscode-lopper/src/test/suite/workspacePathResolution.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/workspacePathResolution.test.ts
@@ -1,0 +1,46 @@
+import * as assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { suite, test } from "mocha";
+
+import { __testing } from "../../extension";
+
+suite("workspace path resolution", () => {
+  test("rejects symlinked files that resolve outside the workspace root", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-workspace-paths-"));
+    const workspaceRoot = path.join(tempRoot, "workspace");
+    const outsideRoot = path.join(tempRoot, "outside");
+    const escapedFilePath = path.join(workspaceRoot, "linked-outside", "escape.ts");
+
+    try {
+      await mkdir(workspaceRoot, { recursive: true });
+      await mkdir(outsideRoot, { recursive: true });
+      await writeFile(path.join(outsideRoot, "escape.ts"), "export const escaped = true;\n", "utf8");
+      await symlink(outsideRoot, path.join(workspaceRoot, "linked-outside"));
+
+      assert.equal(__testing.isPathInsideWorkspace(escapedFilePath, workspaceRoot), false);
+      assert.equal(__testing.resolveWorkspaceFilePath(workspaceRoot, "linked-outside/escape.ts"), undefined);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("allows symlinked workspace roots when resolved files stay inside the workspace", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-workspace-paths-"));
+    const realWorkspaceRoot = path.join(tempRoot, "real-workspace");
+    const workspaceRoot = path.join(tempRoot, "workspace-link");
+    const lexicalFilePath = path.join(workspaceRoot, "src", "index.ts");
+
+    try {
+      await mkdir(path.join(realWorkspaceRoot, "src"), { recursive: true });
+      await writeFile(path.join(realWorkspaceRoot, "src", "index.ts"), "export const inside = true;\n", "utf8");
+      await symlink(realWorkspaceRoot, workspaceRoot);
+
+      assert.equal(__testing.isPathInsideWorkspace(lexicalFilePath, workspaceRoot), true);
+      assert.equal(__testing.resolveWorkspaceFilePath(workspaceRoot, "src/index.ts"), lexicalFilePath);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/vscode-lopper/src/test/suite/workspacePathResolution.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/workspacePathResolution.test.ts
@@ -43,4 +43,21 @@ suite("workspace path resolution", () => {
       await rm(tempRoot, { recursive: true, force: true });
     }
   });
+
+  test("allows non-existent leaf paths when their canonical parent stays inside the workspace", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-workspace-paths-"));
+    const realWorkspaceRoot = path.join(tempRoot, "real-workspace");
+    const workspaceRoot = path.join(tempRoot, "workspace-link");
+    const missingLeafPath = path.join(workspaceRoot, "src", "missing.ts");
+
+    try {
+      await mkdir(path.join(realWorkspaceRoot, "src"), { recursive: true });
+      await symlink(realWorkspaceRoot, workspaceRoot);
+
+      assert.equal(__testing.isPathInsideWorkspace(missingLeafPath, workspaceRoot), true);
+      assert.equal(__testing.resolveWorkspaceFilePath(workspaceRoot, "src/missing.ts"), missingLeafPath);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #889 and #1026. The VS Code extension relied on a double-read tar extraction flow for managed binaries and used lexical-only workspace path checks that could follow symlinks outside the workspace.

## Changes
- Collapsed managed tar extraction to a single strict `tar.x` pass that records and rejects escaping entries instead of validating in a separate `tar.t` pre-pass.
- Hardened workspace folder and file location checks around canonical realpaths so symlink escapes are rejected while symlinked workspace roots still work.
- Added regression coverage in managed binary tests, smoke/e2e coverage for blocked symlink opens, and a focused workspace path resolution test.

## Validation
Commands and checks run:

```bash
npm --prefix extensions/vscode-lopper ci
npm --prefix extensions/vscode-lopper run test:e2e
```

Additional manual validation:
- Verified the new workspace path resolution test covers both blocked escapes and allowed symlinked workspace roots.

## Risk and compatibility
- Breaking changes: None intended.
- Migration required: None.
- Performance impact: Minor synchronous realpath checks on workspace path validation.
- Memory benchmark impact: None expected.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
