### PR TITLE
fix(vscode): avoid mutating reverse in path helper

### DIFF
--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -1792,14 +1792,13 @@ function canonicalizeExistingPath(targetPath: string): string | undefined {
       if (pendingSegments.length === 0) {
         return canonicalBasePath;
       }
-      pendingSegments.reverse();
       return path.join(canonicalBasePath, ...pendingSegments);
     } catch {
       const parentPath = path.dirname(currentPath);
       if (parentPath === currentPath) {
         return undefined;
       }
-      pendingSegments.push(path.basename(currentPath));
+      pendingSegments.unshift(path.basename(currentPath));
       currentPath = parentPath;
     }
   }

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -1792,7 +1792,8 @@ function canonicalizeExistingPath(targetPath: string): string | undefined {
       if (pendingSegments.length === 0) {
         return canonicalBasePath;
       }
-      return path.join(canonicalBasePath, ...pendingSegments.reverse());
+      pendingSegments.reverse();
+      return path.join(canonicalBasePath, ...pendingSegments);
     } catch {
       const parentPath = path.dirname(currentPath);
       if (parentPath === currentPath) {


### PR DESCRIPTION
## Summary

fix(vscode): avoid mutating reverse in path helper. This PR addresses a focused SonarCloud finding from `main` on branch `bug/sonar-extension-reverse`.

## Changes

- Apply the focused Sonar cleanup for this branch.
- Keep the change scoped to the affected file or direct call site required by the refactor.

## Validation

Commands and checks run:

```bash
Targeted worker validation for this branch completed before PR creation.
GitHub PR checks are running for the published branch.
```

Additional manual validation:

- SonarCloud PR analysis has been checked or is queued as part of the required PR checks.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None
- Memory benchmark impact: None expected; CI memory benchmark gate will verify.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
