### PR TITLE
fix(dotnet): simplify project reference parsing

### DIFF
--- a/internal/lang/dotnet/discovery.go
+++ b/internal/lang/dotnet/discovery.go
@@ -285,22 +285,24 @@ func parseXMLManifestIncludes(content []byte, elementName string) ([]string, err
 		if err != nil {
 			return nil, err
 		}
-		start, ok := token.(xml.StartElement)
-		if !ok || !strings.EqualFold(start.Name.Local, elementName) {
-			continue
-		}
-		for _, attr := range start.Attr {
-			if !strings.EqualFold(attr.Name.Local, "Include") {
-				continue
-			}
-			value := normalizeDependencyID(attr.Value)
-			if value != "" {
-				set[value] = struct{}{}
-			}
-			break
+		if include := parseManifestInclude(token, elementName); include != "" {
+			set[include] = struct{}{}
 		}
 	}
 	return sortedDependencies(set), nil
+}
+
+func parseManifestInclude(token xml.Token, elementName string) string {
+	start, ok := token.(xml.StartElement)
+	if !ok || !strings.EqualFold(start.Name.Local, elementName) {
+		return ""
+	}
+	for _, attr := range start.Attr {
+		if strings.EqualFold(attr.Name.Local, "Include") {
+			return normalizeDependencyID(attr.Value)
+		}
+	}
+	return ""
 }
 
 func readSourceFile(repoPath, sourcePath string) ([]byte, string, error) {


### PR DESCRIPTION
## Summary

fix(dotnet): simplify project reference parsing. This PR addresses a focused SonarCloud finding from `main` on branch `bug/sonar-dotnet-discovery-complexity`.

## Changes

- Apply the focused Sonar cleanup for this branch.
- Keep the change scoped to the affected file or direct call site required by the refactor.

## Validation

Commands and checks run:

```bash
Targeted worker validation for this branch completed before PR creation.
GitHub PR checks are running for the published branch.
```

Additional manual validation:

- SonarCloud PR analysis has been checked or is queued as part of the required PR checks.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None
- Memory benchmark impact: None expected; CI memory benchmark gate will verify.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
