### PR TITLE
fix(vscode): group codemod fetch parameters

### DIFF
--- a/extensions/vscode-lopper/src/lopperRunner.ts
+++ b/extensions/vscode-lopper/src/lopperRunner.ts
@@ -57,6 +57,13 @@ export interface WorkspaceAnalysisRequest {
   saveBaseline?: boolean;
 }
 
+interface CodemodFetchContext {
+  binarySignature: string;
+  requestedLanguage: LopperLanguage;
+  scopeMode: LopperScopeMode;
+  timeoutMs: number | undefined;
+}
+
 export interface WorkspaceExportRequest {
   document?: vscode.TextDocument;
   scopeMode?: LopperScopeMode;
@@ -262,16 +269,12 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       saveBaseline: options.saveBaseline,
     });
 
-    const codemodsByDependency = await this.fetchCodemods(
-      binaryPath,
+    const codemodsByDependency = await this.fetchCodemods(binaryPath, folder, report.dependencies, options, {
       binarySignature,
-      folder,
-      report.dependencies,
       requestedLanguage,
       scopeMode,
-      options,
       timeoutMs,
-    );
+    });
 
     return { folder, binaryPath, binarySignature, requestedLanguage, scopeMode, report, codemodsByDependency };
   }
@@ -544,14 +547,12 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
 
   private async fetchCodemods(
     binaryPath: string,
-    binarySignature: string,
     folder: vscode.WorkspaceFolder,
     dependencies: LopperDependencyReport[],
-    requestedLanguage: LopperLanguage,
-    scopeMode: LopperScopeMode,
     options: WorkspaceAnalysisRequest,
-    timeoutMs: number | undefined,
+    context: CodemodFetchContext,
   ): Promise<Map<string, LopperCodemodReport>> {
+    const { binarySignature, requestedLanguage, scopeMode, timeoutMs } = context;
     const dependencyByCacheKey = new Map<string, LopperDependencyReport>();
     const cacheKeys: string[] = [];
     for (const dependency of dependencies) {


### PR DESCRIPTION
## Summary

fix(vscode): group codemod fetch parameters. This PR addresses a focused SonarCloud finding from `main` on branch `bug/sonar-vscode-fetch-codemods-params`.

## Changes

- Apply the focused Sonar cleanup for this branch.
- Keep the change scoped to the affected file or direct call site required by the refactor.

## Validation

Commands and checks run:

```bash
Targeted worker validation for this branch completed before PR creation.
GitHub PR checks are running for the published branch.
```

Additional manual validation:

- SonarCloud PR analysis has been checked or is queued as part of the required PR checks.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None
- Memory benchmark impact: None expected; CI memory benchmark gate will verify.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
