### PR TITLE
fix(vscode): prefer at in runner tests

### DIFF
--- a/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
@@ -268,7 +268,7 @@ suite("lopper runner", () => {
           runCommand: async () => "",
           runReport: async (_binaryPath, args): Promise<LopperReport> => {
             if (args.includes("--suggest-only")) {
-              const dependencyName = args[args.length - 1];
+              const dependencyName = args.at(-1);
               assert.ok(dependencyName, "expected dependency name in codemod command");
               codemodNames.push(dependencyName);
               activeCodemods += 1;
@@ -352,7 +352,7 @@ suite("lopper runner", () => {
               return {
                 dependencies: [
                   {
-                    name: args[args.length - 1] ?? "unknown",
+                    name: args.at(-1) ?? "unknown",
                     usedExportsCount: 1,
                     totalExportsCount: 2,
                     usedPercent: 50,


### PR DESCRIPTION
## Summary

fix(vscode): prefer at in runner tests. This PR addresses a focused SonarCloud finding from `main` on branch `bug/sonar-vscode-lopperrunner-at`.

## Changes

- Apply the focused Sonar cleanup for this branch.
- Keep the change scoped to the affected file or direct call site required by the refactor.

## Validation

Commands and checks run:

```bash
Targeted worker validation for this branch completed before PR creation.
GitHub PR checks are running for the published branch.
```

Additional manual validation:

- SonarCloud PR analysis has been checked or is queued as part of the required PR checks.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None
- Memory benchmark impact: None expected; CI memory benchmark gate will verify.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
