### PR TITLE
fix(dart): simplify import scanning

### DIFF
--- a/internal/lang/dart/scan.go
+++ b/internal/lang/dart/scan.go
@@ -258,41 +258,47 @@ func stripBlockCommentLine(line string, commentDepth int) (string, int) {
 	builder.Grow(len(line))
 
 	for i := 0; i < len(line); i++ {
-		if commentDepth == 0 && i+1 < len(line) && line[i] == '/' && line[i+1] == '/' {
+		if commentDepth == 0 && hasCommentMarker(line, i, '/') {
 			builder.WriteString(line[i:])
 			break
 		}
 
-		if commentDepth == 0 {
-			if i+1 < len(line) && line[i] == '/' && line[i+1] == '*' {
-				commentDepth++
-				builder.WriteByte(' ')
-				builder.WriteByte(' ')
-				i++
-				continue
-			}
-			builder.WriteByte(line[i])
+		if hasCommentMarker(line, i, '*') {
+			commentDepth++
+			writeMaskedCommentMarker(&builder)
+			i++
 			continue
 		}
 
-		if i+1 < len(line) && line[i] == '/' && line[i+1] == '*' {
-			commentDepth++
-			builder.WriteByte(' ')
-			builder.WriteByte(' ')
-			i++
-			continue
-		}
-		if i+1 < len(line) && line[i] == '*' && line[i+1] == '/' {
+		if commentDepth > 0 && hasCommentEnd(line, i) {
 			commentDepth--
-			builder.WriteByte(' ')
-			builder.WriteByte(' ')
+			writeMaskedCommentMarker(&builder)
 			i++
 			continue
 		}
-		builder.WriteByte(' ')
+
+		if commentDepth > 0 {
+			builder.WriteByte(' ')
+			continue
+		}
+
+		builder.WriteByte(line[i])
 	}
 
 	return builder.String(), commentDepth
+}
+
+func hasCommentMarker(line string, index int, second byte) bool {
+	return index+1 < len(line) && line[index] == '/' && line[index+1] == second
+}
+
+func hasCommentEnd(line string, index int) bool {
+	return index+1 < len(line) && line[index] == '*' && line[index+1] == '/'
+}
+
+func writeMaskedCommentMarker(builder *strings.Builder) {
+	builder.WriteByte(' ')
+	builder.WriteByte(' ')
 }
 
 func collectDirective(lines []string) (string, int, bool) {


### PR DESCRIPTION
## Summary

fix(dart): simplify import scanning. This PR addresses a focused SonarCloud finding from `main` on branch `bug/sonar-dart-scan-complexity`.

## Changes

- Apply the focused Sonar cleanup for this branch.
- Keep the change scoped to the affected file or direct call site required by the refactor.

## Validation

Commands and checks run:

```bash
Targeted worker validation for this branch completed before PR creation.
GitHub PR checks are running for the published branch.
```

Additional manual validation:

- SonarCloud PR analysis has been checked or is queued as part of the required PR checks.

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None
- Memory benchmark impact: None expected; CI memory benchmark gate will verify.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
