### PR TITLE
perf(analysis): index changed package roots

### DIFF
--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -196,23 +196,31 @@ func changedRoots(roots []string, repoPath string, changedFiles []string) []stri
 	changed := make([]string, 0, len(roots))
 	seen := make(map[string]struct{}, len(roots))
 	for _, file := range changedFiles {
-		for current := absoluteChangedPath(repoPath, file); ; current = filepath.Dir(current) {
-			if matchingRoots, ok := rootIndex[current]; ok {
-				for _, root := range matchingRoots {
-					if _, exists := seen[root]; exists {
-						continue
-					}
-					seen[root] = struct{}{}
-					changed = append(changed, root)
-				}
-			}
-			parent := filepath.Dir(current)
-			if parent == current {
-				break
-			}
-		}
+		changed = appendChangedRootAncestors(changed, seen, rootIndex, absoluteChangedPath(repoPath, file))
 	}
 	return uniqueSorted(changed)
+}
+
+func appendChangedRootAncestors(changed []string, seen map[string]struct{}, rootIndex map[string][]string, path string) []string {
+	for current := path; ; {
+		changed = appendChangedRoots(changed, seen, rootIndex[current])
+		parent := filepath.Dir(current)
+		if parent == current {
+			return changed
+		}
+		current = parent
+	}
+}
+
+func appendChangedRoots(changed []string, seen map[string]struct{}, roots []string) []string {
+	for _, root := range roots {
+		if _, exists := seen[root]; exists {
+			continue
+		}
+		seen[root] = struct{}{}
+		changed = append(changed, root)
+	}
+	return changed
 }
 
 func changedRootIndex(roots []string, repoPath string) map[string][]string {

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -185,20 +185,57 @@ func scopedCandidateRoots(scopeMode string, roots []string, repoPath string) ([]
 }
 
 func changedRoots(roots []string, repoPath string, changedFiles []string) []string {
-	absoluteChangedFiles := make([]string, 0, len(changedFiles))
-	for _, file := range changedFiles {
-		absoluteChangedFiles = append(absoluteChangedFiles, filepath.Join(repoPath, file))
+	if len(roots) == 0 || len(changedFiles) == 0 {
+		return nil
 	}
+	rootIndex := changedRootIndex(roots, repoPath)
+	if len(rootIndex) == 0 {
+		return nil
+	}
+
 	changed := make([]string, 0, len(roots))
-	for _, root := range roots {
-		for _, file := range absoluteChangedFiles {
-			if rootContainsFile(root, file) {
-				changed = append(changed, root)
+	seen := make(map[string]struct{}, len(roots))
+	for _, file := range changedFiles {
+		for current := absoluteChangedPath(repoPath, file); ; current = filepath.Dir(current) {
+			if matchingRoots, ok := rootIndex[current]; ok {
+				for _, root := range matchingRoots {
+					if _, exists := seen[root]; exists {
+						continue
+					}
+					seen[root] = struct{}{}
+					changed = append(changed, root)
+				}
+			}
+			parent := filepath.Dir(current)
+			if parent == current {
 				break
 			}
 		}
 	}
 	return uniqueSorted(changed)
+}
+
+func changedRootIndex(roots []string, repoPath string) map[string][]string {
+	index := make(map[string][]string, len(roots))
+	for _, root := range roots {
+		path := absoluteRootPath(repoPath, root)
+		index[path] = append(index[path], root)
+	}
+	return index
+}
+
+func absoluteRootPath(repoPath, root string) string {
+	if filepath.IsAbs(root) {
+		return filepath.Clean(root)
+	}
+	return filepath.Clean(filepath.Join(repoPath, root))
+}
+
+func absoluteChangedPath(repoPath, file string) string {
+	if filepath.IsAbs(file) {
+		return filepath.Clean(file)
+	}
+	return filepath.Clean(filepath.Join(repoPath, file))
 }
 
 func rootContainsFile(root, file string) bool {

--- a/internal/analysis/pipeline_benchmark_test.go
+++ b/internal/analysis/pipeline_benchmark_test.go
@@ -1,0 +1,27 @@
+package analysis
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkChangedRootsIndexedLookup(b *testing.B) {
+	repo := filepath.Join(b.TempDir(), "repo")
+	const count = 4096
+	roots := make([]string, 0, count)
+	changedFiles := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		pkg := fmt.Sprintf("pkg-%04d", i)
+		roots = append(roots, filepath.Join(repo, "packages", pkg))
+		changedFiles = append(changedFiles, filepath.ToSlash(filepath.Join("packages", pkg, "src", "index.ts")))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := changedRoots(roots, repo, changedFiles); len(got) != count {
+			b.Fatalf("expected %d changed roots, got %d", count, len(got))
+		}
+	}
+}

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -58,6 +58,54 @@ func TestChangedRootsAndScopeMetadata(t *testing.T) {
 	}
 }
 
+func TestChangedRootsPreservesNestedRootSemantics(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	appRoot := filepath.Join(repo, "app")
+	webRoot := filepath.Join(appRoot, "web")
+	apiRoot := filepath.Join(appRoot, "api")
+	app2Root := filepath.Join(repo, "app2")
+
+	got := changedRoots(
+		[]string{app2Root, webRoot, appRoot, apiRoot},
+		repo,
+		[]string{"app/web/src/index.ts"},
+	)
+
+	want := []string{appRoot, webRoot}
+	if len(got) != len(want) {
+		t.Fatalf("expected nested changed roots %#v, got %#v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected nested changed roots %#v, got %#v", want, got)
+		}
+	}
+}
+
+func TestChangedRootsRejectsSiblingPrefixMatches(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	appRoot := filepath.Join(repo, "app")
+
+	got := changedRoots([]string{appRoot}, repo, []string{"app2/src/index.ts"})
+	if len(got) != 0 {
+		t.Fatalf("expected sibling-prefix path to be excluded, got %#v", got)
+	}
+}
+
+func TestChangedRootsHandlesRelativeRootsAndNoChangedFiles(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	relativeRoot := filepath.Join("packages", "a")
+
+	got := changedRoots([]string{relativeRoot, filepath.Join("packages", "b")}, repo, []string{"packages/a/src/index.ts"})
+	if len(got) != 1 || got[0] != relativeRoot {
+		t.Fatalf("expected relative changed root selection, got %#v", got)
+	}
+
+	if empty := changedRoots([]string{relativeRoot}, repo, nil); len(empty) != 0 {
+		t.Fatalf("expected no changed files to select no roots, got %#v", empty)
+	}
+}
+
 func TestScopedCandidateRootsNonGitModes(t *testing.T) {
 	repo := t.TempDir()
 	pkg := filepath.Join(repo, "packages", "a")

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -99,8 +99,37 @@ func TestChangedRootsHandlesRelativeRootsAndNoChangedFiles(t *testing.T) {
 		t.Fatalf("expected relative changed root selection, got %#v", got)
 	}
 
+	absoluteFile := filepath.Join(repo, relativeRoot, "src", "absolute.ts")
+	got = changedRoots([]string{relativeRoot}, repo, []string{absoluteFile})
+	if len(got) != 1 || got[0] != relativeRoot {
+		t.Fatalf("expected absolute changed path selection, got %#v", got)
+	}
+
 	if empty := changedRoots([]string{relativeRoot}, repo, nil); len(empty) != 0 {
 		t.Fatalf("expected no changed files to select no roots, got %#v", empty)
+	}
+}
+
+func TestAppendChangedRootAncestorsDeduplicatesIndexedRoots(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	appRoot := filepath.Join(repo, "app")
+	equivalentAppRoot := appRoot + string(filepath.Separator) + "."
+	webRoot := filepath.Join(appRoot, "web")
+	rootIndex := map[string][]string{
+		appRoot: {appRoot, equivalentAppRoot},
+		webRoot: {webRoot},
+	}
+	seen := map[string]struct{}{appRoot: {}}
+
+	got := appendChangedRootAncestors([]string{appRoot}, seen, rootIndex, filepath.Join(webRoot, "src", "index.ts"))
+	want := []string{appRoot, webRoot, equivalentAppRoot}
+	if len(got) != len(want) {
+		t.Fatalf("expected changed roots %#v, got %#v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected changed roots %#v, got %#v", want, got)
+		}
 	}
 }
 

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -65,11 +65,9 @@ func TestChangedRootsPreservesNestedRootSemantics(t *testing.T) {
 	apiRoot := filepath.Join(appRoot, "api")
 	app2Root := filepath.Join(repo, "app2")
 
-	got := changedRoots(
-		[]string{app2Root, webRoot, appRoot, apiRoot},
-		repo,
-		[]string{"app/web/src/index.ts"},
-	)
+	roots := []string{app2Root, webRoot, appRoot, apiRoot}
+	changedFiles := []string{"app/web/src/index.ts"}
+	got := changedRoots(roots, repo, changedFiles)
 
 	want := []string{appRoot, webRoot}
 	if len(got) != len(want) {


### PR DESCRIPTION
<!-- PR title must use Conventional Commits, for example `fix(scope): concise summary`. Squash merges publish that title to `main`, so do not rewrite it into a non-conventional subject. -->

## Summary

Replace changed-packages root selection's repeated root/file containment scan with an indexed ancestor lookup over cleaned absolute paths. This keeps nested package roots and path boundary behavior intact while avoiding O(len(roots) * len(changedFiles)) comparisons for large workspaces.

Closes #1027

## Changes

- Build a cleaned absolute package-root index inside `changedRoots`, preserving the original root values returned to downstream analysis.
- Resolve each changed file by walking its ancestor directories and selecting every indexed matching root, including nested roots.
- Add regression coverage for nested root selection, sibling-prefix false positives, relative roots, and no changed files.
- Add `BenchmarkChangedRootsIndexedLookup` for large root/file sets.

## Validation

Commands and checks run:

```bash
gofmt -w internal/analysis/pipeline.go internal/analysis/service_helpers_test.go internal/analysis/pipeline_benchmark_test.go
go test ./internal/analysis -run 'TestChangedRoots|TestRootContainsFileAndUniqueSortedEdges|TestScopedCandidateRootsChangedPackages' -count=1
go test ./internal/analysis -count=1
go test ./internal/analysis -run '^$' -bench '^BenchmarkChangedRootsIndexedLookup$' -benchmem -count=1
go test ./internal/analysis -run 'TestChangedRootsPreservesNestedRootSemantics|TestChangedRootsRejectsSiblingPrefixMatches|TestChangedRootsHandlesRelativeRootsAndNoChangedFiles' -count=1
make test
```

Additional manual validation:

- Benchmark evidence on darwin/arm64 Apple M1 Pro: `BenchmarkChangedRootsIndexedLookup-10 60 19922671 ns/op 1398460 B/op 8229 allocs/op` with 4096 candidate roots and 4096 changed files.
- Bugfinder regression pass: the explicit changed-roots test command above validates nested root selection, sibling-prefix exclusion (`app` vs `app2`), and no changed files behavior.
- `git diff --check` passed.
- Sonar/Copilot are pending until CI/review runs.

## Risk and compatibility

- Breaking changes: None expected; selected roots are still sorted/deduped and returned using original root strings.
- Migration required: None.
- Performance impact: Improved for large changed-packages scopes; lookup is bounded by root indexing plus changed file ancestor depth instead of root/file Cartesian scans.
- Memory benchmark impact: Adds a transient root index and seen set during changed-packages scope resolution; no intentional memory benchmark regression requiring `memory-approved`.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
