### PR TITLE
fix(release): sanitize GHCR image tags

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -183,13 +183,11 @@ jobs:
         shell: bash
         env:
           IMAGE_TAGS: ${{ inputs.image_tags }}
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+          IMAGE_ARCH_SUFFIX: -amd64
         run: |
           set -euo pipefail
-          while IFS= read -r tag; do
-            if [ -n "$tag" ]; then
-              echo "${{ steps.image.outputs.name }}:${tag}-amd64"
-            fi
-          done <<< "$IMAGE_TAGS" > image-tags.txt
+          bash scripts/release-image-tags.sh > image-tags.txt
           {
             echo 'tags<<EOF'
             cat image-tags.txt
@@ -254,13 +252,11 @@ jobs:
         shell: bash
         env:
           IMAGE_TAGS: ${{ inputs.image_tags }}
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+          IMAGE_ARCH_SUFFIX: -arm64
         run: |
           set -euo pipefail
-          while IFS= read -r tag; do
-            if [ -n "$tag" ]; then
-              echo "${{ steps.image.outputs.name }}:${tag}-arm64"
-            fi
-          done <<< "$IMAGE_TAGS" > image-tags.txt
+          bash scripts/release-image-tags.sh > image-tags.txt
           {
             echo 'tags<<EOF'
             cat image-tags.txt
@@ -306,6 +302,11 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
+
       - name: Compute image name
         id: image
         run: |
@@ -329,12 +330,11 @@ jobs:
           IMAGE_NAME: ${{ steps.image.outputs.name }}
         run: |
           set -euo pipefail
-          while IFS= read -r tag; do
-            if [ -n "$tag" ]; then
-              docker buildx imagetools create \
-                -t "${IMAGE_NAME}:${tag}" \
-                "${IMAGE_NAME}:${tag}-amd64" \
-                "${IMAGE_NAME}:${tag}-arm64"
-              docker buildx imagetools inspect "${IMAGE_NAME}:${tag}"
-            fi
-          done <<< "$IMAGE_TAGS"
+          bash scripts/release-image-tags.sh > image-tags.txt
+          while IFS= read -r image_ref; do
+            docker buildx imagetools create \
+              -t "${image_ref}" \
+              "${image_ref}-amd64" \
+              "${image_ref}-arm64"
+            docker buildx imagetools inspect "${image_ref}"
+          done < image-tags.txt

--- a/scripts/release-image-tags.sh
+++ b/scripts/release-image-tags.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image_name="${IMAGE_NAME:-}"
+image_tags="${IMAGE_TAGS:-}"
+image_arch_suffix="${IMAGE_ARCH_SUFFIX:-}"
+valid_image_tag_pattern='^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'
+
+fail() {
+  printf '::error::%s\n' "$1" >&2
+  exit 1
+}
+
+trim_tag() {
+  local tag="$1"
+  tag="${tag%$'\r'}"
+  tag="${tag#"${tag%%[![:space:]]*}"}"
+  tag="${tag%"${tag##*[![:space:]]}"}"
+  printf '%s' "$tag"
+}
+
+reject_malformed_tag() {
+  local tag="$1"
+  printf '::error::Malformed image tag rejected. Tags must match %s.\n' "$valid_image_tag_pattern" >&2
+  printf 'Rejected image tag: %q\n' "$tag" >&2
+  exit 1
+}
+
+if [ -z "$image_name" ]; then
+  fail "IMAGE_NAME is required."
+fi
+
+declare -a sanitized_tags=()
+while IFS= read -r raw_tag || [ -n "$raw_tag" ]; do
+  tag="$(trim_tag "$raw_tag")"
+  if [ -z "$tag" ]; then
+    continue
+  fi
+  if [[ ! "$tag" =~ $valid_image_tag_pattern ]]; then
+    reject_malformed_tag "$tag"
+  fi
+  sanitized_tags+=("$tag")
+done <<< "$image_tags"
+
+if [ "${#sanitized_tags[@]}" -eq 0 ]; then
+  fail "No valid image tags were provided."
+fi
+
+for tag in "${sanitized_tags[@]}"; do
+  printf '%s:%s%s\n' "$image_name" "$tag" "$image_arch_suffix"
+done

--- a/scripts/release-image-tags.sh
+++ b/scripts/release-image-tags.sh
@@ -7,7 +7,8 @@ image_arch_suffix="${IMAGE_ARCH_SUFFIX:-}"
 valid_image_tag_pattern='^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'
 
 fail() {
-  printf '::error::%s\n' "$1" >&2
+  local message="$1"
+  printf '::error::%s\n' "$message" >&2
   exit 1
 }
 
@@ -26,14 +27,14 @@ reject_malformed_tag() {
   exit 1
 }
 
-if [ -z "$image_name" ]; then
+if [[ -z "$image_name" ]]; then
   fail "IMAGE_NAME is required."
 fi
 
 declare -a sanitized_tags=()
-while IFS= read -r raw_tag || [ -n "$raw_tag" ]; do
+while IFS= read -r raw_tag || [[ -n "$raw_tag" ]]; do
   tag="$(trim_tag "$raw_tag")"
-  if [ -z "$tag" ]; then
+  if [[ -z "$tag" ]]; then
     continue
   fi
   if [[ ! "$tag" =~ $valid_image_tag_pattern ]]; then
@@ -42,7 +43,7 @@ while IFS= read -r raw_tag || [ -n "$raw_tag" ]; do
   sanitized_tags+=("$tag")
 done <<< "$image_tags"
 
-if [ "${#sanitized_tags[@]}" -eq 0 ]; then
+if [[ "${#sanitized_tags[@]}" -eq 0 ]]; then
   fail "No valid image tags were provided."
 fi
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -245,31 +245,22 @@ func TestReleaseImageTagScriptSanitizesAndValidatesTags(t *testing.T) {
 		{
 			name:   "amd64",
 			suffix: "-amd64",
-			want: strings.Join([]string{
-				"ghcr.io/example/lopper:v1.2.3-amd64",
-				"ghcr.io/example/lopper:latest-amd64",
-				"ghcr.io/example/lopper:v1.2.3-rc.1-amd64",
-				"",
-			}, "\n"),
+			want: "ghcr.io/example/lopper:v1.2.3-amd64\n" +
+				"ghcr.io/example/lopper:latest-amd64\n" +
+				"ghcr.io/example/lopper:v1.2.3-rc.1-amd64\n",
 		},
 		{
 			name:   "arm64",
 			suffix: "-arm64",
-			want: strings.Join([]string{
-				"ghcr.io/example/lopper:v1.2.3-arm64",
-				"ghcr.io/example/lopper:latest-arm64",
-				"ghcr.io/example/lopper:v1.2.3-rc.1-arm64",
-				"",
-			}, "\n"),
+			want: "ghcr.io/example/lopper:v1.2.3-arm64\n" +
+				"ghcr.io/example/lopper:latest-arm64\n" +
+				"ghcr.io/example/lopper:v1.2.3-rc.1-arm64\n",
 		},
 		{
 			name: "manifest",
-			want: strings.Join([]string{
-				"ghcr.io/example/lopper:v1.2.3",
-				"ghcr.io/example/lopper:latest",
-				"ghcr.io/example/lopper:v1.2.3-rc.1",
-				"",
-			}, "\n"),
+			want: "ghcr.io/example/lopper:v1.2.3\n" +
+				"ghcr.io/example/lopper:latest\n" +
+				"ghcr.io/example/lopper:v1.2.3-rc.1\n",
 		},
 	}
 
@@ -362,25 +353,37 @@ func TestReleaseOrchestrationImageTagStepsUseSanitizer(t *testing.T) {
 			t.Parallel()
 
 			step := workflowStepByName(t, workflow.Jobs, tc.jobName, tc.stepName)
-			if step.Shell != "bash" {
-				t.Fatalf("%s shell = %q, want bash", tc.stepName, step.Shell)
-			}
-			if step.Env["IMAGE_NAME"] != "${{ steps.image.outputs.name }}" {
-				t.Fatalf("%s IMAGE_NAME env = %q, want image output", tc.stepName, step.Env["IMAGE_NAME"])
-			}
-			if step.Env["IMAGE_ARCH_SUFFIX"] != tc.suffix {
-				t.Fatalf("%s IMAGE_ARCH_SUFFIX env = %q, want %q", tc.stepName, step.Env["IMAGE_ARCH_SUFFIX"], tc.suffix)
-			}
-			if !strings.Contains(step.Run, "bash scripts/release-image-tags.sh > image-tags.txt") {
-				t.Fatalf("%s must generate tags through scripts/release-image-tags.sh", tc.stepName)
-			}
-			if strings.Contains(step.Run, "while IFS= read -r tag") {
-				t.Fatalf("%s must not use the stale unsanitized tag loop", tc.stepName)
-			}
+			assertArchImageTagStep(t, step, tc.stepName, tc.suffix)
 		})
 	}
 
 	manifestStep := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Publish multi-arch manifests")
+	assertManifestImageTagStep(t, manifestStep)
+}
+
+func assertArchImageTagStep(t *testing.T, step workflowStepConfig, stepName string, suffix string) {
+	t.Helper()
+
+	if step.Shell != "bash" {
+		t.Fatalf("%s shell = %q, want bash", stepName, step.Shell)
+	}
+	if step.Env["IMAGE_NAME"] != "${{ steps.image.outputs.name }}" {
+		t.Fatalf("%s IMAGE_NAME env = %q, want image output", stepName, step.Env["IMAGE_NAME"])
+	}
+	if step.Env["IMAGE_ARCH_SUFFIX"] != suffix {
+		t.Fatalf("%s IMAGE_ARCH_SUFFIX env = %q, want %q", stepName, step.Env["IMAGE_ARCH_SUFFIX"], suffix)
+	}
+	if !strings.Contains(step.Run, "bash scripts/release-image-tags.sh > image-tags.txt") {
+		t.Fatalf("%s must generate tags through scripts/release-image-tags.sh", stepName)
+	}
+	if strings.Contains(step.Run, "while IFS= read -r tag") {
+		t.Fatalf("%s must not use the stale unsanitized tag loop", stepName)
+	}
+}
+
+func assertManifestImageTagStep(t *testing.T, manifestStep workflowStepConfig) {
+	t.Helper()
+
 	sanitizerIndex := strings.Index(manifestStep.Run, "bash scripts/release-image-tags.sh > image-tags.txt")
 	dockerIndex := strings.Index(manifestStep.Run, "docker buildx imagetools create")
 	if sanitizerIndex < 0 {
@@ -468,11 +471,7 @@ func releaseImageTagScriptCommand(t *testing.T, imageTags string, suffix string)
 	t.Helper()
 
 	cmd := exec.Command("bash", repoPath(t, "scripts/release-image-tags.sh"))
-	cmd.Env = append(os.Environ(),
-		"IMAGE_NAME=ghcr.io/example/lopper",
-		"IMAGE_TAGS="+imageTags,
-		"IMAGE_ARCH_SUFFIX="+suffix,
-	)
+	cmd.Env = append(os.Environ(), "IMAGE_NAME=ghcr.io/example/lopper", "IMAGE_TAGS="+imageTags, "IMAGE_ARCH_SUFFIX="+suffix)
 	return cmd
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3,6 +3,7 @@ package scripts
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -27,6 +28,18 @@ type workflowOnConfig struct {
 
 type workflowConfig struct {
 	On workflowOnConfig `yaml:"on"`
+}
+
+type workflowJobConfig struct {
+	Steps []workflowStepConfig `yaml:"steps"`
+}
+
+type workflowStepConfig struct {
+	Name  string            `yaml:"name"`
+	ID    string            `yaml:"id"`
+	Run   string            `yaml:"run"`
+	Shell string            `yaml:"shell"`
+	Env   map[string]string `yaml:"env"`
 }
 
 func TestReleasePleaseWritesRootChangelog(t *testing.T) {
@@ -220,6 +233,173 @@ func TestDarwinReleaseJobsAssertHostArchitecture(t *testing.T) {
 	}
 }
 
+func TestReleaseImageTagScriptSanitizesAndValidatesTags(t *testing.T) {
+	t.Parallel()
+
+	imageTags := "  v1.2.3 \r\n\tlatest\t\n\n \r\n v1.2.3-rc.1 \n"
+	testCases := []struct {
+		name   string
+		suffix string
+		want   string
+	}{
+		{
+			name:   "amd64",
+			suffix: "-amd64",
+			want: strings.Join([]string{
+				"ghcr.io/example/lopper:v1.2.3-amd64",
+				"ghcr.io/example/lopper:latest-amd64",
+				"ghcr.io/example/lopper:v1.2.3-rc.1-amd64",
+				"",
+			}, "\n"),
+		},
+		{
+			name:   "arm64",
+			suffix: "-arm64",
+			want: strings.Join([]string{
+				"ghcr.io/example/lopper:v1.2.3-arm64",
+				"ghcr.io/example/lopper:latest-arm64",
+				"ghcr.io/example/lopper:v1.2.3-rc.1-arm64",
+				"",
+			}, "\n"),
+		},
+		{
+			name: "manifest",
+			want: strings.Join([]string{
+				"ghcr.io/example/lopper:v1.2.3",
+				"ghcr.io/example/lopper:latest",
+				"ghcr.io/example/lopper:v1.2.3-rc.1",
+				"",
+			}, "\n"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			output := runReleaseImageTagScript(t, imageTags, tc.suffix)
+			if output != tc.want {
+				t.Fatalf("script output = %q, want %q", output, tc.want)
+			}
+		})
+	}
+}
+
+func TestReleaseImageTagScriptRejectsMalformedTagsBeforeOutput(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		imageTags string
+	}{
+		{
+			name:      "internal whitespace",
+			imageTags: "v1.2.3\nbad tag\nlatest",
+		},
+		{
+			name:      "slash",
+			imageTags: "release/candidate",
+		},
+		{
+			name:      "leading dash",
+			imageTags: "-latest",
+		},
+		{
+			name:      "too long",
+			imageTags: strings.Repeat("a", 129),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := releaseImageTagScriptCommand(t, tc.imageTags, "-amd64")
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("script succeeded with malformed tag; output: %s", output)
+			}
+			if !strings.Contains(string(output), "::error::Malformed image tag rejected.") {
+				t.Fatalf("script error = %q, want malformed tag error", output)
+			}
+			if strings.Contains(string(output), "ghcr.io/example/lopper:") {
+				t.Fatalf("script emitted image refs before rejecting malformed input: %s", output)
+			}
+		})
+	}
+}
+
+func TestReleaseOrchestrationImageTagStepsUseSanitizer(t *testing.T) {
+	t.Parallel()
+
+	var workflow struct {
+		Jobs map[string]workflowJobConfig `yaml:"jobs"`
+	}
+	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
+
+	testCases := []struct {
+		jobName  string
+		stepName string
+		suffix   string
+	}{
+		{
+			jobName:  "publish-ghcr-amd64",
+			stepName: "Compute amd64 image tags",
+			suffix:   "-amd64",
+		},
+		{
+			jobName:  "publish-ghcr-arm64",
+			stepName: "Compute arm64 image tags",
+			suffix:   "-arm64",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.jobName, func(t *testing.T) {
+			t.Parallel()
+
+			step := workflowStepByName(t, workflow.Jobs, tc.jobName, tc.stepName)
+			if step.Shell != "bash" {
+				t.Fatalf("%s shell = %q, want bash", tc.stepName, step.Shell)
+			}
+			if step.Env["IMAGE_NAME"] != "${{ steps.image.outputs.name }}" {
+				t.Fatalf("%s IMAGE_NAME env = %q, want image output", tc.stepName, step.Env["IMAGE_NAME"])
+			}
+			if step.Env["IMAGE_ARCH_SUFFIX"] != tc.suffix {
+				t.Fatalf("%s IMAGE_ARCH_SUFFIX env = %q, want %q", tc.stepName, step.Env["IMAGE_ARCH_SUFFIX"], tc.suffix)
+			}
+			if !strings.Contains(step.Run, "bash scripts/release-image-tags.sh > image-tags.txt") {
+				t.Fatalf("%s must generate tags through scripts/release-image-tags.sh", tc.stepName)
+			}
+			if strings.Contains(step.Run, "while IFS= read -r tag") {
+				t.Fatalf("%s must not use the stale unsanitized tag loop", tc.stepName)
+			}
+		})
+	}
+
+	manifestStep := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Publish multi-arch manifests")
+	sanitizerIndex := strings.Index(manifestStep.Run, "bash scripts/release-image-tags.sh > image-tags.txt")
+	dockerIndex := strings.Index(manifestStep.Run, "docker buildx imagetools create")
+	if sanitizerIndex < 0 {
+		t.Fatal("manifest publish step must sanitize image tags before use")
+	}
+	if dockerIndex < 0 {
+		t.Fatal("manifest publish step must create Docker manifests")
+	}
+	if sanitizerIndex > dockerIndex {
+		t.Fatal("manifest publish step must validate tags before Docker manifest operations")
+	}
+	if !strings.Contains(manifestStep.Run, "done < image-tags.txt") {
+		t.Fatal("manifest publish step must consume sanitized image tags")
+	}
+	if strings.Contains(manifestStep.Run, "done <<< \"$IMAGE_TAGS\"") {
+		t.Fatal("manifest publish step must not use the stale unsanitized image tag input loop")
+	}
+}
+
 func TestHomebrewTapWorkflowsContainRequiredFormulaValidationCommands(t *testing.T) {
 	t.Parallel()
 
@@ -271,6 +451,45 @@ func hasAutomerge(values []bool, want bool) bool {
 		}
 	}
 	return false
+}
+
+func runReleaseImageTagScript(t *testing.T, imageTags string, suffix string) string {
+	t.Helper()
+
+	cmd := releaseImageTagScriptCommand(t, imageTags, suffix)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run release image tag script: %v\n%s", err, output)
+	}
+	return string(output)
+}
+
+func releaseImageTagScriptCommand(t *testing.T, imageTags string, suffix string) *exec.Cmd {
+	t.Helper()
+
+	cmd := exec.Command("bash", repoPath(t, "scripts/release-image-tags.sh"))
+	cmd.Env = append(os.Environ(),
+		"IMAGE_NAME=ghcr.io/example/lopper",
+		"IMAGE_TAGS="+imageTags,
+		"IMAGE_ARCH_SUFFIX="+suffix,
+	)
+	return cmd
+}
+
+func workflowStepByName(t *testing.T, jobs map[string]workflowJobConfig, jobName string, stepName string) workflowStepConfig {
+	t.Helper()
+
+	job, ok := jobs[jobName]
+	if !ok {
+		t.Fatalf("workflow must define job %s", jobName)
+	}
+	for _, step := range job.Steps {
+		if step.Name == stepName {
+			return step
+		}
+	}
+	t.Fatalf("%s must define step %q", jobName, stepName)
+	return workflowStepConfig{}
 }
 
 func readJSONConfig(t *testing.T, path string, target any) {


### PR DESCRIPTION
<!-- PR title must use Conventional Commits, for example `fix(scope): concise summary`. Squash merges publish that title to `main`, so do not rewrite it into a non-conventional subject. -->

## Summary

Closes #888.

Sanitize GHCR release image tags before Docker push or manifest publication so CRLF input, surrounding whitespace, and blank lines are handled deterministically while malformed tags fail loudly.

## Changes

- Added `scripts/release-image-tags.sh` to trim CR/surrounding whitespace, ignore empty lines, validate Docker tag syntax, and emit refs only after all input validates.
- Updated the amd64, arm64, and manifest GHCR release steps to use the shared sanitizer; manifest publication validates tags before any `docker buildx imagetools` call.
- Added deterministic Go coverage for CR, surrounding whitespace, empty lines, invalid tags, and workflow ordering.

## Validation

Commands and checks run:

```bash
go test ./scripts -run 'TestRelease(ImageTag|Orchestration)' -count=1
go test ./scripts -run Release -count=1
make actionlint
make shellcheck
make test
```

Additional manual validation:

Bugfinder regression pass for valid semver/latest refs with CR and surrounding whitespace:

```bash
IMAGE_NAME=ghcr.io/ben-ranford/lopper IMAGE_TAGS=$'  v1.7.0\r\n latest \n\n\t v1.7.0-rc.1 \r\n' IMAGE_ARCH_SUFFIX=-amd64 bash scripts/release-image-tags.sh
IMAGE_NAME=ghcr.io/ben-ranford/lopper IMAGE_TAGS=$'  v1.7.0\r\n latest \n\n\t v1.7.0-rc.1 \r\n' IMAGE_ARCH_SUFFIX=-arm64 bash scripts/release-image-tags.sh
IMAGE_NAME=ghcr.io/ben-ranford/lopper IMAGE_TAGS=$'  v1.7.0\r\n latest \n\n\t v1.7.0-rc.1 \r\n' bash scripts/release-image-tags.sh
```

Result: valid tags produced `ghcr.io/ben-ranford/lopper:v1.7.0-amd64`, `:latest-amd64`, `:v1.7.0-rc.1-amd64`, matching arm64 refs, and manifest refs without architecture suffixes.

Invalid-tag regression pass:

```bash
IMAGE_NAME=ghcr.io/ben-ranford/lopper IMAGE_TAGS=$'v1.7.0\nbad tag\nlatest' IMAGE_ARCH_SUFFIX=-amd64 bash scripts/release-image-tags.sh
```

Result: exited with status 1, printed `::error::Malformed image tag rejected.`, and emitted no `ghcr.io/ben-ranford/lopper:` image refs before failing.

Sonar and Copilot are pending until CI/review runs.

## Risk and compatibility

- Breaking changes: malformed release image tags now fail before GHCR push/manifest operations.
- Migration required: N/A
- Performance impact: Negligible; release tag lists are small.
- Memory benchmark impact: N/A

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

