### PR TITLE
feat(runtime): add Python runtime trace annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,9 @@ lopper tui \
   --baseline-key commit:abc123
 ```
 
-## Runtime trace annotations (JS/TS)
+## Runtime trace annotations
+
+### JS/TS
 
 Capture a runtime trace:
 
@@ -255,13 +257,43 @@ lopper analyse --top 20 --repo . --language js-ts --runtime-trace .artifacts/lop
 
 With runtime traces enabled:
 
-- `runtimeUsage.correlation` marks each JS/TS dependency as `static-only`, `runtime-only`, or `overlap`.
+- `runtimeUsage.correlation` marks each supported dependency as `static-only`, `runtime-only`, or `overlap`.
 - `runtimeUsage.modules` includes runtime-loaded module paths.
 - `runtimeUsage.parentModules` includes parent module paths that triggered the load.
 - `runtimeUsage.entrypoints` includes entrypoint modules seen in the runtime trace.
 - `runtimeUsage.topSymbols` includes best-effort runtime symbol hits.
 
 If `--runtime-trace` points to a missing file, analysis continues with static results and adds a warning.
+
+### Python preview
+
+Python runtime trace consumption is available behind the `python-runtime-trace-preview` feature flag. Lopper consumes an existing NDJSON trace file; it does not run Python tests or install a Python import hook for you.
+
+Each trace line should identify the Python adapter and the imported module:
+
+```json
+{"language":"python","module":"requests.sessions","parent":"/repo/main.py","entrypoint":"/repo/main.py"}
+```
+
+When the import root differs from the package name, include `dependency`:
+
+```json
+{"language":"python","dependency":"beautifulsoup4","module":"bs4"}
+```
+
+Use the trace in analysis:
+
+```bash
+lopper analyse --top 20 --repo . --language python \
+  --runtime-trace .artifacts/python-runtime.ndjson \
+  --enable-feature python-runtime-trace-preview
+```
+
+Python caveats:
+
+- Runtime module names map to the top-level import package, with common aliases such as `bs4` -> `beautifulsoup4`.
+- Trace producers should emit third-party imports only. Lopper cannot reliably distinguish local modules or every stdlib import from an adapter-neutral trace line.
+- Automatic `--runtime-test-command` capture remains JS/TS-oriented.
 
 ## Development
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -85,4 +85,6 @@ Merged output deduplicates by `(language, dependency)` and computes:
 ## Runtime tracing integration
 
 If your adapter can consume runtime traces, extend `internal/runtime` and
-its annotation logic. The current implementation annotates JS/TS dependencies.
+its annotation logic. The implementation keeps runtime annotations in the shared
+`runtimeUsage` report fields; JS/TS traces are supported by default, and Python
+trace consumption is available behind `python-runtime-trace-preview`.

--- a/docs/report-schema.md
+++ b/docs/report-schema.md
@@ -69,10 +69,11 @@ CSV columns:
 - Signal weights are fixed in v2: runtime correlation `0.20`, export inventory `0.30`, import precision `0.20`, repo usage uncertainty `0.15`, dependency dynamic-loader signal `0.10`, and risk severity `0.05`.
 - `dependencies[].removalCandidate.confidence` remains as a compatibility alias for `dependencies[].reachabilityConfidence.score`.
 - Finding-level `confidenceScore` and `confidenceReasonCodes` fields mirror `dependencies[].reachabilityConfidence.score` and `dependencies[].reachabilityConfidence.rationaleCodes`.
-- `runtimeUsage` currently annotates JS/TS dependencies.
+- `runtimeUsage` annotates JS/TS dependencies and, when `python-runtime-trace-preview` is enabled, Python dependencies from `{"language":"python",...}` trace events.
 - `runtimeUsage.correlation` distinguishes `static-only`, `runtime-only`, and `overlap` evidence categories.
 - `runtimeUsage.modules` lists runtime-loaded module paths seen for a dependency.
 - `runtimeUsage.topSymbols` lists best-effort runtime symbol hits derived from module subpaths.
+- Runtime annotations use the same report fields across supported languages; adapter differences are confined to trace-to-dependency mapping.
 - `cache.invalidations` entries identify deterministic invalidation reasons (for example `input-changed`).
 - `usedPercent` values are adapter best-effort based on static analysis signals.
 - `summary.knownLicenseCount`, `summary.unknownLicenseCount`, and `summary.deniedLicenseCount` are mutually exclusive license buckets across dependency rows. Denied dependencies count only as denied, even when they also have an SPDX value or unknown license metadata.

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ben-ranford/lopper/internal/workspace"
 )
 
+const pythonRuntimeTracePreviewFeature = "python-runtime-trace-preview"
+
 type analysisPipeline struct {
 	service          *Service
 	request          Request
@@ -117,7 +119,7 @@ func (p *analysisPipeline) remappedAnalyzedRoots() []string {
 
 func finalizeReport(req Request, repoPath string, analyzedRoots []string, reportData report.Report) (report.Report, error) {
 	var err error
-	reportData, err = annotateRuntimeTraceIfPresent(req.RuntimeTracePath, req.Language, reportData)
+	reportData, err = annotateRuntimeTraceIfPresent(req.RuntimeTracePath, req.Language, reportData, req.Features.Enabled(pythonRuntimeTracePreviewFeature))
 	if err != nil {
 		return report.Report{}, err
 	}
@@ -310,8 +312,12 @@ func remapAnalyzedRoots(roots []string, fromRepoPath, toRepoPath string) []strin
 	return uniqueSorted(remapped)
 }
 
-func annotateRuntimeTraceIfPresent(runtimeTracePath string, languageID string, reportData report.Report) (report.Report, error) {
+func annotateRuntimeTraceIfPresent(runtimeTracePath string, languageID string, reportData report.Report, pythonRuntimeTraceEnabled bool) (report.Report, error) {
 	if runtimeTracePath == "" {
+		return reportData, nil
+	}
+	supportedLanguages := supportedRuntimeTraceLanguages(languageID, pythonRuntimeTraceEnabled)
+	if len(supportedLanguages) == 0 {
 		return reportData, nil
 	}
 	traceData, err := runtime.Load(runtimeTracePath)
@@ -323,7 +329,8 @@ func annotateRuntimeTraceIfPresent(runtimeTracePath string, languageID string, r
 		return report.Report{}, err
 	}
 	return runtime.Annotate(reportData, traceData, runtime.AnnotateOptions{
-		IncludeRuntimeOnlyRows: supportsJSTraceLanguage(languageID),
+		IncludeRuntimeOnlyRows: true,
+		SupportedLanguages:     supportedLanguages,
 	}), nil
 }
 
@@ -335,6 +342,26 @@ func isMultiLanguage(languageID string) bool {
 func supportsJSTraceLanguage(languageID string) bool {
 	switch strings.TrimSpace(strings.ToLower(languageID)) {
 	case "", "auto", language.All, "js-ts":
+		return true
+	default:
+		return false
+	}
+}
+
+func supportedRuntimeTraceLanguages(languageID string, pythonRuntimeTraceEnabled bool) []string {
+	supported := make([]string, 0, 2)
+	if supportsJSTraceLanguage(languageID) {
+		supported = append(supported, "js-ts")
+	}
+	if pythonRuntimeTraceEnabled && supportsPythonTraceLanguage(languageID) {
+		supported = append(supported, "python")
+	}
+	return supported
+}
+
+func supportsPythonTraceLanguage(languageID string) bool {
+	switch strings.TrimSpace(strings.ToLower(languageID)) {
+	case "", "auto", language.All, "python", "py":
 		return true
 	default:
 		return false

--- a/internal/analysis/pipeline_test.go
+++ b/internal/analysis/pipeline_test.go
@@ -195,7 +195,22 @@ func TestAnnotateRuntimeTraceInvalidFileFails(t *testing.T) {
 		t.Fatalf("write invalid trace: %v", err)
 	}
 
-	if _, err := annotateRuntimeTraceIfPresent(tracePath, "js-ts", report.Report{}); err == nil {
+	if _, err := annotateRuntimeTraceIfPresent(tracePath, "js-ts", report.Report{}, false); err == nil {
 		t.Fatalf("expected invalid runtime trace to fail")
+	}
+}
+
+func TestAnnotateRuntimeTraceSkipsUnsupportedLanguageBeforeReadingTrace(t *testing.T) {
+	tracePath := filepath.Join(t.TempDir(), "trace.ndjson")
+	if err := os.WriteFile(tracePath, []byte("{not-json}\n"), 0o600); err != nil {
+		t.Fatalf("write invalid trace: %v", err)
+	}
+
+	annotated, err := annotateRuntimeTraceIfPresent(tracePath, "python", report.Report{}, false)
+	if err != nil {
+		t.Fatalf("expected disabled Python runtime trace to skip invalid file, got %v", err)
+	}
+	if len(annotated.Warnings) != 0 {
+		t.Fatalf("expected no warnings when unsupported trace is skipped, got %#v", annotated.Warnings)
 	}
 }

--- a/internal/analysis/service_analysis_error_paths_test.go
+++ b/internal/analysis/service_analysis_error_paths_test.go
@@ -20,7 +20,7 @@ func TestServiceAdditionalHelperBranches(t *testing.T) {
 		t.Fatalf("expected scope metadata to keep repo root and skip invalid roots, got %#v", metadata)
 	}
 
-	if _, err := annotateRuntimeTraceIfPresent(t.TempDir(), "js-ts", report.Report{}); err == nil {
+	if _, err := annotateRuntimeTraceIfPresent(t.TempDir(), "js-ts", report.Report{}, false); err == nil {
 		t.Fatalf("expected directory runtime trace path to return error")
 	}
 

--- a/internal/analysis/service_errors_test.go
+++ b/internal/analysis/service_errors_test.go
@@ -192,7 +192,7 @@ func TestMergeReportsAndTopSymbolsBranches(t *testing.T) {
 }
 
 func TestAnnotateRuntimeTraceHelperMissingFileFallback(t *testing.T) {
-	annotated, err := annotateRuntimeTraceIfPresent(filepath.Join(t.TempDir(), "missing.ndjson"), "js-ts", report.Report{})
+	annotated, err := annotateRuntimeTraceIfPresent(filepath.Join(t.TempDir(), "missing.ndjson"), "js-ts", report.Report{}, false)
 	if err != nil {
 		t.Fatalf("expected missing runtime trace fallback, got %v", err)
 	}

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -334,7 +334,7 @@ func TestAnnotateRuntimeTrace(t *testing.T) {
 	rep := report.Report{
 		Dependencies: []report.DependencyReport{{Name: "lodash", UsedImports: []report.ImportUse{{Name: "map", Module: "lodash"}}}},
 	}
-	annotated, err := annotateRuntimeTraceIfPresent("", "js-ts", rep)
+	annotated, err := annotateRuntimeTraceIfPresent("", "js-ts", rep, false)
 	if err != nil {
 		t.Fatalf("annotate without trace: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestAnnotateRuntimeTrace(t *testing.T) {
 	if err := os.WriteFile(path, trace, 0o600); err != nil {
 		t.Fatalf("write runtime trace: %v", err)
 	}
-	annotated, err = annotateRuntimeTraceIfPresent(path, "js-ts", rep)
+	annotated, err = annotateRuntimeTraceIfPresent(path, "js-ts", rep, false)
 	if err != nil {
 		t.Fatalf("annotate with trace: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestAnnotateRuntimeTraceMissingFileFallsBackWithWarning(t *testing.T) {
 	rep := report.Report{
 		Dependencies: []report.DependencyReport{{Name: "lodash", Language: "js-ts"}},
 	}
-	annotated, err := annotateRuntimeTraceIfPresent(filepath.Join(t.TempDir(), "missing.ndjson"), "js-ts", rep)
+	annotated, err := annotateRuntimeTraceIfPresent(filepath.Join(t.TempDir(), "missing.ndjson"), "js-ts", rep, false)
 	if err != nil {
 		t.Fatalf("expected missing runtime trace to be non-fatal: %v", err)
 	}

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -399,6 +399,18 @@ func mustResolveStableDefaultsFeatureSet(t *testing.T) featureflags.Set {
 	return resolved
 }
 
+func mustResolvePythonRuntimeTracePreviewSet(t *testing.T) featureflags.Set {
+	t.Helper()
+	resolved, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  []string{pythonRuntimeTracePreviewFeature},
+	})
+	if err != nil {
+		t.Fatalf("resolve Python runtime trace preview feature set: %v", err)
+	}
+	return resolved
+}
+
 func TestServiceAnalyseRuntimeCorrelationIntegration(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
@@ -443,6 +455,91 @@ func TestServiceAnalyseRuntimeCorrelationIntegration(t *testing.T) {
 	}
 }
 
+func TestServiceAnalysePythonRuntimeTracePreviewIntegration(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "requirements.txt"), "requests==2.32.0\n")
+	writeFile(t, filepath.Join(repo, "main.py"), "import requests\nrequests.get('https://example.test')\n")
+	tracePath := filepath.Join(repo, ".artifacts", "python-runtime.ndjson")
+	writeFile(t, tracePath, "{\"language\":\"python\",\"module\":\"requests.sessions\",\"parent\":\"/repo/main.py\",\"entrypoint\":\"/repo/main.py\"}\n{\"language\":\"python\",\"module\":\"httpx._client\",\"parent\":\"/repo/main.py\",\"entrypoint\":\"/repo/main.py\"}\n")
+
+	service := NewService()
+	withoutFlag, err := service.Analyse(context.Background(), Request{
+		RepoPath:         repo,
+		TopN:             10,
+		Language:         "python",
+		RuntimeTracePath: tracePath,
+		Features:         mustResolveStableDefaultsFeatureSet(t),
+	})
+	if err != nil {
+		t.Fatalf("analyse python runtime without flag: %v", err)
+	}
+	if dep := dependencyByLanguageName(t, withoutFlag.Dependencies, "python", "requests"); dep.RuntimeUsage != nil {
+		t.Fatalf("did not expect Python runtime usage without preview flag, got %#v", dep.RuntimeUsage)
+	}
+
+	withFlag, err := service.Analyse(context.Background(), Request{
+		RepoPath:         repo,
+		TopN:             10,
+		Language:         "python",
+		RuntimeTracePath: tracePath,
+		Features:         mustResolvePythonRuntimeTracePreviewSet(t),
+	})
+	if err != nil {
+		t.Fatalf("analyse python runtime with flag: %v", err)
+	}
+
+	requests := dependencyByLanguageName(t, withFlag.Dependencies, "python", "requests")
+	if requests.RuntimeUsage == nil || requests.RuntimeUsage.Correlation != report.RuntimeCorrelationOverlap {
+		t.Fatalf("expected Python requests overlap correlation, got %#v", requests.RuntimeUsage)
+	}
+	if requests.RuntimeUsage.LoadCount != 1 {
+		t.Fatalf("expected one Python requests runtime load, got %#v", requests.RuntimeUsage)
+	}
+	if len(requests.RuntimeUsage.Modules) != 1 || requests.RuntimeUsage.Modules[0].Module != "requests.sessions" {
+		t.Fatalf("expected Python runtime module detail, got %#v", requests.RuntimeUsage.Modules)
+	}
+	if len(requests.RuntimeUsage.ParentModules) != 1 || requests.RuntimeUsage.ParentModules[0].Module != "/repo/main.py" {
+		t.Fatalf("expected Python runtime parent detail, got %#v", requests.RuntimeUsage.ParentModules)
+	}
+
+	httpx := dependencyByLanguageName(t, withFlag.Dependencies, "python", "httpx")
+	if httpx.RuntimeUsage == nil || httpx.RuntimeUsage.Correlation != report.RuntimeCorrelationRuntimeOnly || !httpx.RuntimeUsage.RuntimeOnly {
+		t.Fatalf("expected Python httpx runtime-only row, got %#v", httpx.RuntimeUsage)
+	}
+}
+
+func TestServiceAnalyseJSTraceIgnoresPythonLanguageEvents(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
+	writeFile(t, filepath.Join(repo, indexJSFileName), "import { map } from \"lodash\"\nimport request from \"requests\"\nmap([1], (x) => x)\nrequest('https://example.test')\n")
+	writeFile(t, filepath.Join(repo, "node_modules", "lodash", packageJSONFileName), nodeMainPackageJSON)
+	writeFile(t, filepath.Join(repo, "node_modules", "lodash", indexJSFileName), mapExportJSContent)
+	writeFile(t, filepath.Join(repo, "node_modules", "requests", packageJSONFileName), nodeMainPackageJSON)
+	writeFile(t, filepath.Join(repo, "node_modules", "requests", indexJSFileName), "export default function request() {}\n")
+	tracePath := filepath.Join(repo, ".artifacts", "runtime.ndjson")
+	writeFile(t, tracePath, "{\"module\":\"lodash/map\"}\n{\"language\":\"python\",\"module\":\"requests.sessions\"}\n")
+
+	reportData, err := NewService().Analyse(context.Background(), Request{
+		RepoPath:         repo,
+		TopN:             10,
+		Language:         "js-ts",
+		RuntimeTracePath: tracePath,
+		Features:         mustResolvePythonRuntimeTracePreviewSet(t),
+	})
+	if err != nil {
+		t.Fatalf("analyse js runtime with python event: %v", err)
+	}
+
+	lodash := dependencyByLanguageName(t, reportData.Dependencies, "js-ts", "lodash")
+	if lodash.RuntimeUsage == nil || lodash.RuntimeUsage.Correlation != report.RuntimeCorrelationOverlap {
+		t.Fatalf("expected lodash JS overlap correlation, got %#v", lodash.RuntimeUsage)
+	}
+	requests := dependencyByLanguageName(t, reportData.Dependencies, "js-ts", "requests")
+	if requests.RuntimeUsage == nil || requests.RuntimeUsage.Correlation != report.RuntimeCorrelationStaticOnly || requests.RuntimeUsage.LoadCount != 0 {
+		t.Fatalf("expected JS requests to ignore Python runtime event, got %#v", requests.RuntimeUsage)
+	}
+}
+
 func TestServiceAnalyseMissingRuntimeTraceFallsBack(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
@@ -463,6 +560,17 @@ func TestServiceAnalyseMissingRuntimeTraceFallsBack(t *testing.T) {
 	if len(reportData.Warnings) == 0 {
 		t.Fatalf("expected warning for missing runtime trace")
 	}
+}
+
+func dependencyByLanguageName(t *testing.T, dependencies []report.DependencyReport, languageID, name string) report.DependencyReport {
+	t.Helper()
+	for _, dependency := range dependencies {
+		if dependency.Language == languageID && dependency.Name == name {
+			return dependency
+		}
+	}
+	t.Fatalf("dependency %s/%s not found in %#v", languageID, name, dependencies)
+	return report.DependencyReport{}
 }
 
 func TestMergeRecommendationsPriorityOrder(t *testing.T) {

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -66,5 +66,11 @@
     "name": "dashboard-remote-repos-preview",
     "description": "Enable dashboard repoUrl entries by materializing remote Git repositories into a deterministic local checkout cache.",
     "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0011",
+    "name": "python-runtime-trace-preview",
+    "description": "Enable preview runtime trace annotations for Python dependencies using shared runtimeUsage report fields.",
+    "lifecycle": "preview"
   }
 ]

--- a/internal/runtime/capture_command_test.go
+++ b/internal/runtime/capture_command_test.go
@@ -229,7 +229,7 @@ func TestWindowsExecutableExtensions(t *testing.T) {
 func TestRuntimeExecutableCandidatesWindowsIncludesPathextEntries(t *testing.T) {
 	setRuntimeOSTest(t, "windows")
 
-	t.Setenv("PATHEXT", ".CMD;.EXE")
+	t.Setenv("PATHEXT", ".CMD;.EXE;.EXE")
 	dir := t.TempDir()
 	got := runtimeExecutableCandidates("npm", dir)
 	want := []string{
@@ -239,6 +239,17 @@ func TestRuntimeExecutableCandidatesWindowsIncludesPathextEntries(t *testing.T) 
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("expected candidates %v, got %v", want, got)
+	}
+}
+
+func TestRuntimeExecutableCandidatesWindowsKeepsExplicitExtension(t *testing.T) {
+	setRuntimeOSTest(t, "windows")
+
+	dir := t.TempDir()
+	got := runtimeExecutableCandidates("npm.cmd", dir)
+	want := []string{filepath.Join(dir, "npm.cmd")}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected explicit-extension candidates %v, got %v", want, got)
 	}
 }
 

--- a/internal/runtime/trace_annotate.go
+++ b/internal/runtime/trace_annotate.go
@@ -8,29 +8,32 @@ import (
 )
 
 func Annotate(rep report.Report, trace Trace, opts AnnotateOptions) report.Report {
-	seen := annotateExistingDependencies(&rep, trace)
+	supported := supportedRuntimeLanguages(opts.SupportedLanguages)
+	seen := annotateExistingDependencies(&rep, trace, supported)
 	if opts.IncludeRuntimeOnlyRows {
-		appendRuntimeOnlyDependencies(&rep, trace, seen)
+		appendRuntimeOnlyDependencies(&rep, trace, seen, supported)
 		sortDependencies(rep.Dependencies)
 	}
 	return rep
 }
 
-func annotateExistingDependencies(rep *report.Report, trace Trace) map[string]struct{} {
-	seen := make(map[string]struct{}, len(rep.Dependencies))
+func annotateExistingDependencies(rep *report.Report, trace Trace, supported map[string]struct{}) map[DependencyKey]struct{} {
+	seen := make(map[DependencyKey]struct{}, len(rep.Dependencies))
 	for i := range rep.Dependencies {
 		dep := &rep.Dependencies[i]
-		if dep.Language != "" && dep.Language != "js-ts" {
+		language := dependencyRuntimeLanguage(*dep)
+		if _, ok := supported[language]; !ok {
 			continue
 		}
-		seen[dep.Name] = struct{}{}
-		annotateDependency(dep, trace)
+		key := DependencyKey{Language: language, Name: dep.Name}
+		seen[key] = struct{}{}
+		annotateDependency(dep, trace, key)
 	}
 	return seen
 }
 
-func annotateDependency(dep *report.DependencyReport, trace Trace) {
-	loads := trace.DependencyLoads[dep.Name]
+func annotateDependency(dep *report.DependencyReport, trace Trace, key DependencyKey) {
+	loads := runtimeLoadCount(trace, key)
 	hasStatic := hasStaticEvidence(*dep)
 	if loads == 0 && !hasStatic && dep.RuntimeUsage == nil {
 		return
@@ -40,35 +43,127 @@ func annotateDependency(dep *report.DependencyReport, trace Trace) {
 		LoadCount:     loads,
 		Correlation:   correlation,
 		RuntimeOnly:   correlation == report.RuntimeCorrelationRuntimeOnly,
-		Modules:       runtimeModules(trace.DependencyModules[dep.Name]),
-		ParentModules: runtimeModules(trace.DependencyParents[dep.Name]),
-		Entrypoints:   runtimeModules(trace.DependencyEntrypoints[dep.Name]),
-		TopSymbols:    runtimeSymbols(trace.DependencySymbols[dep.Name]),
+		Modules:       runtimeModules(runtimeModuleCounts(trace, key)),
+		ParentModules: runtimeModules(runtimeParentCounts(trace, key)),
+		Entrypoints:   runtimeModules(runtimeEntrypointCounts(trace, key)),
+		TopSymbols:    runtimeSymbols(runtimeSymbolCounts(trace, key)),
 	}
 }
 
-func appendRuntimeOnlyDependencies(rep *report.Report, trace Trace, seen map[string]struct{}) {
-	for dependency, loads := range trace.DependencyLoads {
+func appendRuntimeOnlyDependencies(rep *report.Report, trace Trace, seen map[DependencyKey]struct{}, supported map[string]struct{}) {
+	for _, key := range runtimeDependencyKeys(trace, supported) {
+		loads := runtimeLoadCount(trace, key)
 		if loads == 0 {
 			continue
 		}
-		if _, ok := seen[dependency]; ok {
+		if _, ok := seen[key]; ok {
 			continue
 		}
 		rep.Dependencies = append(rep.Dependencies, report.DependencyReport{
-			Language: "js-ts",
-			Name:     dependency,
+			Language: key.Language,
+			Name:     key.Name,
 			RuntimeUsage: &report.RuntimeUsage{
 				LoadCount:     loads,
 				Correlation:   report.RuntimeCorrelationRuntimeOnly,
 				RuntimeOnly:   true,
-				Modules:       runtimeModules(trace.DependencyModules[dependency]),
-				ParentModules: runtimeModules(trace.DependencyParents[dependency]),
-				Entrypoints:   runtimeModules(trace.DependencyEntrypoints[dependency]),
-				TopSymbols:    runtimeSymbols(trace.DependencySymbols[dependency]),
+				Modules:       runtimeModules(runtimeModuleCounts(trace, key)),
+				ParentModules: runtimeModules(runtimeParentCounts(trace, key)),
+				Entrypoints:   runtimeModules(runtimeEntrypointCounts(trace, key)),
+				TopSymbols:    runtimeSymbols(runtimeSymbolCounts(trace, key)),
 			},
 		})
 	}
+}
+
+func supportedRuntimeLanguages(languages []string) map[string]struct{} {
+	supported := make(map[string]struct{}, len(languages)+1)
+	if len(languages) == 0 {
+		supported[runtimeLanguageJSTS] = struct{}{}
+		return supported
+	}
+	for _, language := range languages {
+		normalized := normalizeRuntimeLanguage(language)
+		if normalized == "" {
+			continue
+		}
+		supported[normalized] = struct{}{}
+	}
+	return supported
+}
+
+func dependencyRuntimeLanguage(dep report.DependencyReport) string {
+	return normalizeRuntimeLanguage(dep.Language)
+}
+
+func runtimeDependencyKeys(trace Trace, supported map[string]struct{}) []DependencyKey {
+	seen := make(map[DependencyKey]struct{})
+	for key, loads := range trace.DependencyLoadsByLanguage {
+		if loads == 0 {
+			continue
+		}
+		if _, ok := supported[key.Language]; ok {
+			seen[key] = struct{}{}
+		}
+	}
+	if _, ok := supported[runtimeLanguageJSTS]; ok {
+		for dependency, loads := range trace.DependencyLoads {
+			if loads > 0 {
+				seen[DependencyKey{Language: runtimeLanguageJSTS, Name: dependency}] = struct{}{}
+			}
+		}
+	}
+
+	keys := make([]DependencyKey, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Language == keys[j].Language {
+			return keys[i].Name < keys[j].Name
+		}
+		return keys[i].Language < keys[j].Language
+	})
+	return keys
+}
+
+func runtimeLoadCount(trace Trace, key DependencyKey) int {
+	if trace.DependencyLoadsByLanguage != nil {
+		if loads, ok := trace.DependencyLoadsByLanguage[key]; ok {
+			return loads
+		}
+	}
+	if key.Language == runtimeLanguageJSTS {
+		return trace.DependencyLoads[key.Name]
+	}
+	return 0
+}
+
+func runtimeModuleCounts(trace Trace, key DependencyKey) map[string]int {
+	return runtimeCountsForKey(trace.DependencyModulesByLanguage, trace.DependencyModules, key)
+}
+
+func runtimeParentCounts(trace Trace, key DependencyKey) map[string]int {
+	return runtimeCountsForKey(trace.DependencyParentsByLanguage, trace.DependencyParents, key)
+}
+
+func runtimeEntrypointCounts(trace Trace, key DependencyKey) map[string]int {
+	return runtimeCountsForKey(trace.DependencyEntrypointsByLanguage, trace.DependencyEntrypoints, key)
+}
+
+func runtimeSymbolCounts(trace Trace, key DependencyKey) map[string]int {
+	return runtimeCountsForKey(trace.DependencySymbolsByLanguage, trace.DependencySymbols, key)
+}
+
+func runtimeCountsForKey(scoped map[DependencyKey]map[string]int, legacy map[string]map[string]int, key DependencyKey) map[string]int {
+	if scoped != nil {
+		if values, ok := scoped[key]; ok {
+			return values
+		}
+	}
+	if key.Language == runtimeLanguageJSTS {
+		return legacy[key.Name]
+	}
+	return nil
 }
 
 func sortDependencies(dependencies []report.DependencyReport) {

--- a/internal/runtime/trace_annotate_test.go
+++ b/internal/runtime/trace_annotate_test.go
@@ -94,6 +94,91 @@ func TestAnnotateSkipsUnsupportedLanguageAndZeroLoads(t *testing.T) {
 	t.Fatalf("did not expect runtime usage when js dependency has no static imports and no runtime loads")
 }
 
+func TestAnnotatePythonRuntimeUsageWhenSupported(t *testing.T) {
+	rep := report.Report{
+		Dependencies: []report.DependencyReport{
+			{
+				Name:     "requests",
+				Language: runtimeLanguagePython,
+				UsedImports: []report.ImportUse{
+					{Name: "get", Module: "requests"},
+				},
+			},
+			{
+				Name:     "requests",
+				Language: runtimeLanguageJSTS,
+				UsedImports: []report.ImportUse{
+					{Name: "request", Module: "requests"},
+				},
+			},
+		},
+	}
+	requestsKey := DependencyKey{Language: runtimeLanguagePython, Name: "requests"}
+	httpxKey := DependencyKey{Language: runtimeLanguagePython, Name: "httpx"}
+	trace := Trace{
+		DependencyLoadsByLanguage: map[DependencyKey]int{
+			requestsKey: 2,
+			httpxKey:    1,
+		},
+		DependencyModulesByLanguage: map[DependencyKey]map[string]int{
+			requestsKey: {"requests.sessions": 2},
+			httpxKey:    {"httpx._client": 1},
+		},
+		DependencyParentsByLanguage: map[DependencyKey]map[string]int{
+			requestsKey: {"app.py": 2},
+		},
+		DependencyEntrypointsByLanguage: map[DependencyKey]map[string]int{
+			requestsKey: {"app.py": 2},
+		},
+		DependencySymbolsByLanguage: map[DependencyKey]map[string]int{
+			requestsKey: {"requests.sessions\x00sessions": 2},
+			httpxKey:    {"httpx._client\x00_client": 1},
+		},
+	}
+
+	annotated := Annotate(rep, trace, AnnotateOptions{
+		IncludeRuntimeOnlyRows: true,
+		SupportedLanguages:     []string{runtimeLanguagePython},
+	})
+
+	if len(annotated.Dependencies) != 3 {
+		t.Fatalf("expected python runtime-only row to be added, got %d dependencies", len(annotated.Dependencies))
+	}
+	dependencies := make(map[DependencyKey]report.DependencyReport, len(annotated.Dependencies))
+	for _, dependency := range annotated.Dependencies {
+		dependencies[DependencyKey{Language: dependency.Language, Name: dependency.Name}] = dependency
+	}
+
+	pythonRequests, ok := dependencies[requestsKey]
+	if !ok {
+		t.Fatalf("python requests dependency not found in %#v", annotated.Dependencies)
+	}
+	if pythonRequests.RuntimeUsage == nil {
+		t.Fatalf("expected python requests runtime usage, got %#v", pythonRequests)
+	}
+	if pythonRequests.RuntimeUsage.Correlation != report.RuntimeCorrelationOverlap || pythonRequests.RuntimeUsage.LoadCount != 2 {
+		t.Fatalf("expected python requests overlap with two loads, got %#v", pythonRequests.RuntimeUsage)
+	}
+	if len(pythonRequests.RuntimeUsage.Modules) != 1 || pythonRequests.RuntimeUsage.Modules[0].Module != "requests.sessions" {
+		t.Fatalf("expected python runtime module context, got %#v", pythonRequests.RuntimeUsage.Modules)
+	}
+
+	jsRequests, ok := dependencies[DependencyKey{Language: runtimeLanguageJSTS, Name: "requests"}]
+	if !ok {
+		t.Fatalf("JS requests dependency not found in %#v", annotated.Dependencies)
+	}
+	if jsRequests.RuntimeUsage != nil {
+		t.Fatalf("did not expect python runtime trace to annotate JS dependency, got %#v", jsRequests.RuntimeUsage)
+	}
+	httpx, ok := dependencies[httpxKey]
+	if !ok {
+		t.Fatalf("python httpx dependency not found in %#v", annotated.Dependencies)
+	}
+	if httpx.RuntimeUsage == nil || !httpx.RuntimeUsage.RuntimeOnly {
+		t.Fatalf("expected python runtime-only httpx row, got %#v", httpx)
+	}
+}
+
 func TestAnnotateAddsRuntimeOnlyDependencyRows(t *testing.T) {
 	rep := report.Report{
 		Dependencies: []report.DependencyReport{
@@ -170,8 +255,32 @@ func TestAppendRuntimeOnlyDependenciesSkipsSeenAndZeroLoads(t *testing.T) {
 		},
 	}
 
-	appendRuntimeOnlyDependencies(&rep, trace, map[string]struct{}{"seen": {}})
+	seen := map[DependencyKey]struct{}{{Language: runtimeLanguageJSTS, Name: "seen"}: {}}
+	supported := map[string]struct{}{runtimeLanguageJSTS: {}}
+	appendRuntimeOnlyDependencies(&rep, trace, seen, supported)
 	if len(rep.Dependencies) != 1 || rep.Dependencies[0].Name != "new" {
 		t.Fatalf("expected only unseen runtime dependency to be appended, got %#v", rep.Dependencies)
+	}
+}
+
+func TestRuntimeDependencyKeysSkipsZeroAndUnsupportedLanguages(t *testing.T) {
+	trace := Trace{
+		DependencyLoads: map[string]int{
+			"lodash": 1,
+			"zero":   0,
+		},
+		DependencyLoadsByLanguage: map[DependencyKey]int{
+			{Language: runtimeLanguagePython, Name: "zero"}: 0,
+			{Language: "ruby", Name: "rake"}:                1,
+		},
+	}
+	supported := map[string]struct{}{runtimeLanguageJSTS: {}, runtimeLanguagePython: {}}
+
+	keys := runtimeDependencyKeys(trace, supported)
+	if len(keys) != 1 || keys[0].Language != runtimeLanguageJSTS || keys[0].Name != "lodash" {
+		t.Fatalf("expected only supported nonzero JS key, got %#v", keys)
+	}
+	if got := runtimeLoadCount(Trace{}, DependencyKey{Language: runtimeLanguagePython, Name: "missing"}); got != 0 {
+		t.Fatalf("expected missing non-JS runtime load count 0, got %d", got)
 	}
 }

--- a/internal/runtime/trace_load.go
+++ b/internal/runtime/trace_load.go
@@ -131,6 +131,6 @@ func runtimeContextValue(value string) string {
 	if value == "" {
 		return ""
 	}
-	value = strings.TrimPrefix(value, "file://")
+	value = strings.TrimPrefix(value, fileURLPrefix)
 	return filepath.ToSlash(value)
 }

--- a/internal/runtime/trace_load.go
+++ b/internal/runtime/trace_load.go
@@ -17,13 +17,7 @@ func Load(path string) (Trace, error) {
 		return Trace{}, err
 	}
 
-	trace := Trace{
-		DependencyLoads:       make(map[string]int),
-		DependencyModules:     make(map[string]map[string]int),
-		DependencyParents:     make(map[string]map[string]int),
-		DependencyEntrypoints: make(map[string]map[string]int),
-		DependencySymbols:     make(map[string]map[string]int),
-	}
+	trace := newTrace()
 	scanner := bufio.NewScanner(bytes.NewReader(content))
 	line := 0
 	for scanner.Scan() {
@@ -36,23 +30,52 @@ func Load(path string) (Trace, error) {
 		if err := json.Unmarshal([]byte(text), &event); err != nil {
 			return Trace{}, fmt.Errorf("parse runtime trace line %d: %w", line, err)
 		}
-		dep := dependencyFromEvent(event)
+		language := normalizeRuntimeLanguage(event.Language)
+		dep := dependencyFromEventForLanguage(event, language)
 		if dep == "" {
 			continue
 		}
-		trace.DependencyLoads[dep]++
-		module := runtimeModuleFromEvent(event, dep)
-		addCount(trace.DependencyModules, dep, module)
-		addCount(trace.DependencyParents, dep, runtimeContextValue(event.Parent))
-		addCount(trace.DependencyEntrypoints, dep, runtimeContextValue(event.Entrypoint))
-		symbol := runtimeSymbolFromModule(module, dep)
-		addSymbolCount(trace.DependencySymbols, dep, module, symbol)
+		module := runtimeModuleFromEventForLanguage(event, language, dep)
+		symbol := runtimeSymbolFromModuleForLanguage(module, language, dep)
+		addRuntimeEvent(&trace, language, dep, module, runtimeContextValue(event.Parent), runtimeContextValue(event.Entrypoint), symbol)
 	}
 	if err := scanner.Err(); err != nil {
 		return Trace{}, err
 	}
 
 	return trace, nil
+}
+
+func newTrace() Trace {
+	return Trace{
+		DependencyLoads:                 make(map[string]int),
+		DependencyModules:               make(map[string]map[string]int),
+		DependencyParents:               make(map[string]map[string]int),
+		DependencyEntrypoints:           make(map[string]map[string]int),
+		DependencySymbols:               make(map[string]map[string]int),
+		DependencyLoadsByLanguage:       make(map[DependencyKey]int),
+		DependencyModulesByLanguage:     make(map[DependencyKey]map[string]int),
+		DependencyParentsByLanguage:     make(map[DependencyKey]map[string]int),
+		DependencyEntrypointsByLanguage: make(map[DependencyKey]map[string]int),
+		DependencySymbolsByLanguage:     make(map[DependencyKey]map[string]int),
+	}
+}
+
+func addRuntimeEvent(trace *Trace, language, dependency, module, parent, entrypoint, symbol string) {
+	key := DependencyKey{Language: normalizeRuntimeLanguage(language), Name: dependency}
+	trace.DependencyLoadsByLanguage[key]++
+	addCountByKey(trace.DependencyModulesByLanguage, key, module)
+	addCountByKey(trace.DependencyParentsByLanguage, key, parent)
+	addCountByKey(trace.DependencyEntrypointsByLanguage, key, entrypoint)
+	addSymbolCountByKey(trace.DependencySymbolsByLanguage, key, module, symbol)
+	if key.Language != runtimeLanguageJSTS {
+		return
+	}
+	trace.DependencyLoads[dependency]++
+	addCount(trace.DependencyModules, dependency, module)
+	addCount(trace.DependencyParents, dependency, parent)
+	addCount(trace.DependencyEntrypoints, dependency, entrypoint)
+	addSymbolCount(trace.DependencySymbols, dependency, module, symbol)
 }
 
 func addCount(target map[string]map[string]int, dependency string, value string) {
@@ -75,6 +98,30 @@ func addSymbolCount(target map[string]map[string]int, dependency string, module 
 	if !ok {
 		items = make(map[string]int)
 		target[dependency] = items
+	}
+	items[module+"\x00"+symbol]++
+}
+
+func addCountByKey(target map[DependencyKey]map[string]int, key DependencyKey, value string) {
+	if key.Name == "" || value == "" {
+		return
+	}
+	items, ok := target[key]
+	if !ok {
+		items = make(map[string]int)
+		target[key] = items
+	}
+	items[value]++
+}
+
+func addSymbolCountByKey(target map[DependencyKey]map[string]int, key DependencyKey, module string, symbol string) {
+	if key.Name == "" || symbol == "" {
+		return
+	}
+	items, ok := target[key]
+	if !ok {
+		items = make(map[string]int)
+		target[key] = items
 	}
 	items[module+"\x00"+symbol]++
 }

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -34,6 +34,35 @@ func TestLoadTrace(t *testing.T) {
 	}
 }
 
+func TestLoadTracePythonLanguageEvents(t *testing.T) {
+	trace, err := loadTraceFromContent(t, `{"language":"python","module":"requests.sessions","parent":"/repo/app.py","entrypoint":"/repo/app.py"}`+"\n"+`{"language":"python","dependency":"python-dateutil","module":"dateutil.parser","resolved":"/repo/.venv/lib/python3.12/site-packages/dateutil/parser.py"}`+"\n")
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+
+	requestsKey := DependencyKey{Language: runtimeLanguagePython, Name: "requests"}
+	if got := trace.DependencyLoadsByLanguage[requestsKey]; got != 1 {
+		t.Fatalf("expected python requests load count=1, got %d", got)
+	}
+	if got := trace.DependencyLoads["requests"]; got != 0 {
+		t.Fatalf("did not expect python loads in legacy JS counters, got %d", got)
+	}
+	if got := trace.DependencyModulesByLanguage[requestsKey]["requests.sessions"]; got != 1 {
+		t.Fatalf("expected python module count 1, got %d", got)
+	}
+	if got := trace.DependencyParentsByLanguage[requestsKey]["/repo/app.py"]; got != 1 {
+		t.Fatalf("expected python parent count 1, got %d", got)
+	}
+	if got := trace.DependencySymbolsByLanguage[requestsKey]["requests.sessions\x00sessions"]; got != 1 {
+		t.Fatalf("expected python symbol count 1, got %d", got)
+	}
+
+	dateutilKey := DependencyKey{Language: runtimeLanguagePython, Name: "python-dateutil"}
+	if got := trace.DependencyLoadsByLanguage[dateutilKey]; got != 1 {
+		t.Fatalf("expected python-dateutil load count=1, got %d", got)
+	}
+}
+
 func TestLoadTraceInvalidLine(t *testing.T) {
 	if _, err := loadTraceFromContent(t, "{not-json}\n"); err == nil {
 		t.Fatalf("expected parse error for invalid NDJSON")

--- a/internal/runtime/trace_resolution.go
+++ b/internal/runtime/trace_resolution.go
@@ -6,7 +6,25 @@ import (
 	"strings"
 )
 
+const (
+	runtimeLanguageJSTS   = "js-ts"
+	runtimeLanguagePython = "python"
+)
+
 func runtimeModuleFromEvent(event Event, dependency string) string {
+	return runtimeModuleFromEventForLanguage(event, runtimeLanguageJSTS, dependency)
+}
+
+func runtimeModuleFromEventForLanguage(event Event, language string, dependency string) string {
+	switch normalizeRuntimeLanguage(language) {
+	case runtimeLanguagePython:
+		return pythonRuntimeModuleFromEvent(event, dependency)
+	default:
+		return jsRuntimeModuleFromEvent(event, dependency)
+	}
+}
+
+func jsRuntimeModuleFromEvent(event Event, dependency string) string {
 	if module := runtimeModuleFromSpecifier(event.Module, dependency); module != "" {
 		return module
 	}
@@ -67,6 +85,17 @@ func runtimeModuleFromResolvedPath(value, dependency string) string {
 }
 
 func runtimeSymbolFromModule(module, dependency string) string {
+	return runtimeSymbolFromModuleForLanguage(module, runtimeLanguageJSTS, dependency)
+}
+
+func runtimeSymbolFromModuleForLanguage(module, language, dependency string) string {
+	if normalizeRuntimeLanguage(language) == runtimeLanguagePython {
+		return pythonRuntimeSymbolFromModule(module)
+	}
+	return jsRuntimeSymbolFromModule(module, dependency)
+}
+
+func jsRuntimeSymbolFromModule(module, dependency string) string {
 	if module == "" || dependency == "" {
 		return ""
 	}
@@ -91,6 +120,22 @@ func runtimeSymbolFromModule(module, dependency string) string {
 }
 
 func dependencyFromEvent(event Event) string {
+	return dependencyFromEventForLanguage(event, runtimeLanguageJSTS)
+}
+
+func dependencyFromEventForLanguage(event Event, language string) string {
+	if dependency := normalizeRuntimeDependency(event.Dependency, language); dependency != "" {
+		return dependency
+	}
+	switch normalizeRuntimeLanguage(language) {
+	case runtimeLanguagePython:
+		return pythonDependencyFromEvent(event)
+	default:
+		return jsDependencyFromEvent(event)
+	}
+}
+
+func jsDependencyFromEvent(event Event) string {
 	if dep := dependencyFromSpecifier(event.Module); dep != "" {
 		return dep
 	}
@@ -141,4 +186,144 @@ func dependencyFromResolvedPath(value string) string {
 		return parts[0] + "/" + parts[1]
 	}
 	return parts[0]
+}
+
+func normalizeRuntimeLanguage(language string) string {
+	switch strings.ToLower(strings.TrimSpace(language)) {
+	case "", "js", "ts", "javascript", "typescript", runtimeLanguageJSTS:
+		return runtimeLanguageJSTS
+	case "py", runtimeLanguagePython:
+		return runtimeLanguagePython
+	default:
+		return strings.ToLower(strings.TrimSpace(language))
+	}
+}
+
+func normalizeRuntimeDependency(dependency, language string) string {
+	dependency = strings.TrimSpace(dependency)
+	if dependency == "" {
+		return ""
+	}
+	if normalizeRuntimeLanguage(language) == runtimeLanguagePython {
+		return normalizePythonRuntimeDependency(dependency)
+	}
+	return dependency
+}
+
+func pythonDependencyFromEvent(event Event) string {
+	if dependency := dependencyFromPythonModule(event.Module); dependency != "" {
+		return dependency
+	}
+	return dependencyFromPythonResolvedPath(event.Resolved)
+}
+
+func pythonRuntimeModuleFromEvent(event Event, dependency string) string {
+	module := strings.TrimSpace(event.Module)
+	if module != "" {
+		if dependencyFromPythonModule(module) == dependency || normalizeRuntimeDependency(event.Dependency, runtimeLanguagePython) == dependency {
+			return module
+		}
+	}
+	if module := pythonModuleFromResolvedPath(event.Resolved, dependency); module != "" {
+		return module
+	}
+	return dependency
+}
+
+func pythonRuntimeSymbolFromModule(module string) string {
+	module = trimPythonRuntimeModuleSuffix(module)
+	parts := pythonModuleParts(module)
+	if len(parts) < 2 {
+		return ""
+	}
+	symbol := parts[len(parts)-1]
+	symbol = strings.TrimSuffix(symbol, path.Ext(symbol))
+	if symbol == "" || symbol == "__init__" {
+		return ""
+	}
+	return symbol
+}
+
+func trimPythonRuntimeModuleSuffix(module string) string {
+	module = strings.TrimSpace(module)
+	for _, suffix := range []string{".pyc", ".pyo", ".py"} {
+		if strings.HasSuffix(module, suffix) {
+			return strings.TrimSuffix(module, suffix)
+		}
+	}
+	return module
+}
+
+func dependencyFromPythonModule(module string) string {
+	parts := pythonModuleParts(module)
+	if len(parts) == 0 {
+		return ""
+	}
+	return normalizePythonRuntimeDependency(parts[0])
+}
+
+func pythonModuleParts(module string) []string {
+	module = strings.TrimSpace(module)
+	if module == "" || strings.HasPrefix(module, ".") || strings.HasPrefix(module, "/") || strings.Contains(module, ":") {
+		return nil
+	}
+	return strings.FieldsFunc(module, func(r rune) bool {
+		return r == '.' || r == '/' || r == '\\'
+	})
+}
+
+func dependencyFromPythonResolvedPath(value string) string {
+	module := pythonModuleFromResolvedPath(value, "")
+	if module == "" {
+		return ""
+	}
+	return dependencyFromPythonModule(module)
+}
+
+func pythonModuleFromResolvedPath(value, dependency string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.TrimPrefix(value, "file://")
+	value = filepath.ToSlash(value)
+	for _, marker := range []string{"/site-packages/", "/dist-packages/"} {
+		pos := strings.LastIndex(value, marker)
+		if pos < 0 {
+			continue
+		}
+		rest := strings.TrimPrefix(value[pos+len(marker):], "/")
+		if rest == "" {
+			return ""
+		}
+		module := strings.TrimSuffix(strings.Split(rest, "/")[0], ".py")
+		module = strings.TrimSuffix(module, ".pyc")
+		module = strings.TrimSuffix(module, ".pyo")
+		if module == "__pycache__" || strings.HasSuffix(module, ".dist-info") || strings.HasSuffix(module, ".egg-info") {
+			return ""
+		}
+		if dependency != "" && dependencyFromPythonModule(module) != dependency {
+			return ""
+		}
+		return module
+	}
+	return ""
+}
+
+func normalizePythonRuntimeDependency(dependency string) string {
+	replacer := strings.NewReplacer("_", "-", ".", "-")
+	normalized := replacer.Replace(strings.ToLower(strings.TrimSpace(dependency)))
+	if canonical, ok := pythonRuntimeImportAliases[normalized]; ok {
+		return canonical
+	}
+	return normalized
+}
+
+var pythonRuntimeImportAliases = map[string]string{
+	"bs4":      "beautifulsoup4",
+	"cv2":      "opencv-python",
+	"dateutil": "python-dateutil",
+	"dotenv":   "python-dotenv",
+	"pil":      "pillow",
+	"sklearn":  "scikit-learn",
 }

--- a/internal/runtime/trace_resolution.go
+++ b/internal/runtime/trace_resolution.go
@@ -9,6 +9,7 @@ import (
 const (
 	runtimeLanguageJSTS   = "js-ts"
 	runtimeLanguagePython = "python"
+	fileURLPrefix         = "file://"
 )
 
 func runtimeModuleFromEvent(event Event, dependency string) string {
@@ -50,7 +51,7 @@ func runtimeModuleFromResolvedPath(value, dependency string) string {
 	if value == "" {
 		return ""
 	}
-	value = strings.TrimPrefix(value, "file://")
+	value = strings.TrimPrefix(value, fileURLPrefix)
 	value = filepath.ToSlash(value)
 
 	marker := "/node_modules/"
@@ -166,7 +167,7 @@ func dependencyFromResolvedPath(value string) string {
 	if value == "" {
 		return ""
 	}
-	value = strings.TrimPrefix(value, "file://")
+	value = strings.TrimPrefix(value, fileURLPrefix)
 	value = filepath.ToSlash(value)
 
 	marker := "/node_modules/"
@@ -285,7 +286,7 @@ func pythonModuleFromResolvedPath(value, dependency string) string {
 	if value == "" {
 		return ""
 	}
-	value = strings.TrimPrefix(value, "file://")
+	value = strings.TrimPrefix(value, fileURLPrefix)
 	value = filepath.ToSlash(value)
 	for _, marker := range []string{"/site-packages/", "/dist-packages/"} {
 		pos := strings.LastIndex(value, marker)

--- a/internal/runtime/trace_resolution_test.go
+++ b/internal/runtime/trace_resolution_test.go
@@ -53,6 +53,87 @@ func TestDependencyFromEventPrefersModule(t *testing.T) {
 	}
 }
 
+func TestPythonRuntimeSymbolStripsFileSuffixes(t *testing.T) {
+	cases := []struct {
+		module string
+		want   string
+	}{
+		{module: "requests/sessions.py", want: "sessions"},
+		{module: "requests/sessions.pyc", want: "sessions"},
+		{module: "requests/sessions.pyo", want: "sessions"},
+		{module: "requests.sessions", want: "sessions"},
+	}
+	for _, tc := range cases {
+		if got := runtimeSymbolFromModuleForLanguage(tc.module, runtimeLanguagePython, "requests"); got != tc.want {
+			t.Fatalf("expected Python symbol %q for %q, got %q", tc.want, tc.module, got)
+		}
+	}
+}
+
+func TestPythonRuntimeResolutionBranches(t *testing.T) {
+	if got := normalizeRuntimeDependency("  custom_pkg  ", runtimeLanguageJSTS); got != "custom_pkg" {
+		t.Fatalf("expected non-Python dependency to preserve trimmed value, got %q", got)
+	}
+	if got := normalizeRuntimeDependency("  ", runtimeLanguagePython); got != "" {
+		t.Fatalf("expected blank dependency to stay blank, got %q", got)
+	}
+	if got := dependencyFromEventForLanguage(Event{Dependency: "PIL"}, runtimeLanguagePython); got != "pillow" {
+		t.Fatalf("expected direct Python dependency alias to normalize, got %q", got)
+	}
+	if got := dependencyFromEventForLanguage(Event{Resolved: "file:///repo/.venv/lib/python3.12/site-packages/httpx/_client.py"}, runtimeLanguagePython); got != "httpx" {
+		t.Fatalf("expected Python dependency from resolved path, got %q", got)
+	}
+	if got := dependencyFromPythonResolvedPath("/repo/app.py"); got != "" {
+		t.Fatalf("expected non-site-packages path to be ignored, got %q", got)
+	}
+
+	resolvedRequests := "file:///repo/.venv/lib/python3.12/site-packages/requests/sessions.py"
+	if got := pythonRuntimeModuleFromEvent(Event{Module: "other.module", Resolved: resolvedRequests}, "requests"); got != "requests" {
+		t.Fatalf("expected resolved Python module fallback, got %q", got)
+	}
+	if got := pythonRuntimeModuleFromEvent(Event{Module: "bs4", Dependency: "beautifulsoup4"}, "beautifulsoup4"); got != "bs4" {
+		t.Fatalf("expected direct dependency override to keep Python module, got %q", got)
+	}
+	if got := pythonRuntimeModuleFromEvent(Event{Module: "other.module"}, "requests"); got != "requests" {
+		t.Fatalf("expected Python module fallback to dependency, got %q", got)
+	}
+}
+
+func TestPythonRuntimeResolvedPathBranches(t *testing.T) {
+	cases := []struct {
+		name       string
+		resolved   string
+		dependency string
+		want       string
+	}{
+		{name: "blank", resolved: "", want: ""},
+		{name: "empty site-packages suffix", resolved: "file:///repo/.venv/lib/python3.12/site-packages/", want: ""},
+		{name: "dist info", resolved: "file:///repo/.venv/lib/python3.12/site-packages/requests-2.32.0.dist-info/METADATA", want: ""},
+		{name: "egg info", resolved: "file:///repo/.venv/lib/python3.12/site-packages/demo.egg-info/PKG-INFO", want: ""},
+		{name: "dependency mismatch", resolved: "file:///repo/.venv/lib/python3.12/site-packages/requests/sessions.py", dependency: "httpx", want: ""},
+		{name: "dependency match", resolved: "file:///repo/.venv/lib/python3.12/site-packages/requests/sessions.py", dependency: "requests", want: "requests"},
+		{name: "dist packages", resolved: "/usr/lib/python3/dist-packages/httpx/_client.py", dependency: "httpx", want: "httpx"},
+	}
+	for _, tc := range cases {
+		if got := pythonModuleFromResolvedPath(tc.resolved, tc.dependency); got != tc.want {
+			t.Fatalf("%s: expected resolved module %q, got %q", tc.name, tc.want, got)
+		}
+	}
+}
+
+func TestPythonRuntimeModulePartGuards(t *testing.T) {
+	for _, module := range []string{"", ".", "/abs/module.py", "node:fs"} {
+		if got := dependencyFromPythonModule(module); got != "" {
+			t.Fatalf("expected invalid Python module %q to be ignored, got %q", module, got)
+		}
+	}
+	for _, module := range []string{"", "requests", "requests.__init__"} {
+		if got := pythonRuntimeSymbolFromModule(module); got != "" {
+			t.Fatalf("expected no Python runtime symbol for %q, got %q", module, got)
+		}
+	}
+}
+
 func TestDependencyFromResolvedPathBlankValue(t *testing.T) {
 	if got := dependencyFromResolvedPath("   "); got != "" {
 		t.Fatalf("expected blank resolved path to produce no dependency, got %q", got)

--- a/internal/runtime/trace_types.go
+++ b/internal/runtime/trace_types.go
@@ -1,11 +1,18 @@
 package runtime
 
 type Event struct {
+	Language   string `json:"language,omitempty"`
+	Dependency string `json:"dependency,omitempty"`
 	Module     string `json:"module"`
 	Resolved   string `json:"resolved,omitempty"`
 	Kind       string `json:"kind,omitempty"`
 	Parent     string `json:"parent,omitempty"`
 	Entrypoint string `json:"entrypoint,omitempty"`
+}
+
+type DependencyKey struct {
+	Language string
+	Name     string
 }
 
 type Trace struct {
@@ -14,8 +21,15 @@ type Trace struct {
 	DependencyParents     map[string]map[string]int
 	DependencyEntrypoints map[string]map[string]int
 	DependencySymbols     map[string]map[string]int
+
+	DependencyLoadsByLanguage       map[DependencyKey]int
+	DependencyModulesByLanguage     map[DependencyKey]map[string]int
+	DependencyParentsByLanguage     map[DependencyKey]map[string]int
+	DependencyEntrypointsByLanguage map[DependencyKey]map[string]int
+	DependencySymbolsByLanguage     map[DependencyKey]map[string]int
 }
 
 type AnnotateOptions struct {
 	IncludeRuntimeOnlyRows bool
+	SupportedLanguages     []string
 }


### PR DESCRIPTION
Closes #1043.

## Summary

Extend runtime trace annotations beyond JS/TS by adding preview Python trace consumption while keeping the existing `runtimeUsage` report model and JS/TS behavior intact.

## Changes

- Added language-scoped runtime trace ingestion so `{"language":"python",...}` events map to Python dependency rows without colliding with JS/TS dependencies of the same name.
- Added Python module/dependency normalization, including direct `dependency` overrides for import-root/package-name mismatches such as `bs4` -> `beautifulsoup4`.
- Registered `python-runtime-trace-preview` (`LOP-FEAT-0010`) and gated Python runtime annotation behind it.
- Added runtime/service tests for Python annotation, Python runtime-only rows, JS/TS regression coverage, language isolation, and Copilot-reviewed edge cases.
- Documented the Python NDJSON workflow, shared report fields, and adapter caveats.

## Validation

Commands and checks run:

```bash
go test ./internal/runtime ./internal/analysis
go test ./internal/lang/python ./internal/lang/js
go run ./tools/featureflag validate
make dup-check
make lint
make test
make cov
git diff --check
```

Additional manual validation:

- Verified PR metadata locally after opening: milestone `v1.7.0`, labels `enhancement` and `target-series:1.7.x`, and assignee `ben-ranford`.
- Requested GitHub Copilot review with `gh pr edit 1077 --add-reviewer @copilot`; addressed the two Copilot comments in the current head.

## Risk and compatibility

- Breaking changes: None. Existing JS/TS trace events and report fields are preserved.
- Migration required: None. Python runtime trace consumption is opt-in via `--enable-feature python-runtime-trace-preview` in dev/release builds.
- Performance impact: Trace annotation remains bounded to parsed trace counters and dependency rows; no runtime capture behavior changes for JS/TS.
- Memory benchmark impact: None expected; no memory-sensitive runtime path was added beyond small trace maps.

## Acceptance checklist

- [x] At least one non-JS/TS adapter can consume runtime trace input and surface runtime correlation in reports.
- [x] Existing JS/TS runtime trace workflows continue unchanged.
- [x] Runtime/report model remains coherent rather than splitting into incompatible per-language output shapes.
- [x] Docs explain the supported non-JS/TS runtime workflow and adapter-specific caveats.
- [x] Tests cover the new adapter integration and JS/TS regression protection.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review