### PR TITLE
feat(mcp): add explicit mutation tools

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -21,6 +21,19 @@ Example MCP client entry:
 
 `mcp-server-preview` is now a stable feature flag and is enabled by default in every build channel. The original flag name remains available for compatibility and explicit rollback testing via `--disable-feature mcp-server-preview`. During `initialize`, the server advertises tool support and returns Lopper version metadata. Use `tools/list` to inspect tool schemas at runtime.
 
+Mutation tools are behind the preview flag `mcp-mutation-tools-preview` and are not advertised unless the MCP server is started with that flag enabled, for example:
+
+```json
+{
+  "mcpServers": {
+    "lopper": {
+      "command": "lopper",
+      "args": ["mcp", "--enable-feature", "mcp-mutation-tools-preview"]
+    }
+  }
+}
+```
+
 ## Tools
 
 ### `lopper_analyse_top_dependencies`
@@ -73,6 +86,66 @@ Optional input:
 
 The tool does not save baselines. It only loads existing baseline JSON or snapshot files and adds `wasteIncreasePercent` and `baselineComparison` to the returned report.
 
+### `lopper_apply_codemod`
+
+Preview mutation tool. Runs dependency analysis in codemod suggestion mode for one dependency, then applies deterministic safe patch previews through the same app workflow used by `lopper analyse --apply-codemod`.
+
+Required input:
+
+- `repoPath`: local repository directory.
+- `dependency`: dependency name. Codemod apply is not available for top-N analysis.
+- `confirmApply`: must be `true`.
+
+Optional input:
+
+- `allowDirty`: allow the mutation to run when git reports uncommitted changes. Defaults to `false`.
+- The same common optional analysis inputs as `lopper_analyse_top_dependencies`, except `topN` and runtime test commands are not supported.
+
+Structured output includes `appliedFiles`, `appliedPatches`, `skippedFiles`, `failedFiles`, `backupPath`, per-file `results`, and the full report containing `dependencies[].codemod.apply`.
+
+### `lopper_save_baseline`
+
+Preview mutation tool. Runs analysis and saves the resulting report as an immutable baseline snapshot through the same app workflow used by `lopper analyse --save-baseline`.
+
+Required input:
+
+- `repoPath`: local repository directory.
+- `baselineStorePath`: local snapshot directory. Relative paths resolve under `repoPath`.
+- `confirmSave`: must be `true`.
+
+Optional input:
+
+- `dependency`: analyse and save a single dependency report.
+- `topN`: number of dependencies to include when `dependency` is omitted. Defaults to `20`.
+- `baselineKey`: explicit snapshot key.
+- `baselineLabel`: label used to save `label:<value>`. Mutually exclusive with `baselineKey`.
+- The same common optional analysis inputs as `lopper_analyse_top_dependencies`, except baseline comparison inputs and runtime test commands are not supported.
+
+When neither `baselineKey` nor `baselineLabel` is provided, the key defaults to the current git commit, `commit:<sha>`. Structured output includes `baselineKey`, `snapshotPath`, `reportSummary`, and the saved report.
+
+### `lopper_save_dashboard_baseline`
+
+Preview mutation tool. Runs dashboard aggregation and saves an immutable dashboard baseline snapshot through the existing dashboard baseline workflow.
+
+Required input:
+
+- `repoPath`: local repository directory used for default commit-key resolution.
+- `baselineStorePath`: local snapshot directory. Relative paths resolve under `repoPath`.
+- `confirmSave`: must be `true`.
+- Either `repos` or `configPath`.
+
+Optional input:
+
+- `repos`: array of `{ "path": "...", "name": "...", "language": "..." }` entries.
+- `configPath`: dashboard config file path.
+- `topN`: number of dependencies per repo. Defaults to `20`.
+- `defaultLanguage`: language applied to repo entries without a language. Defaults to `auto`.
+- `baselineKey` or `baselineLabel`, with the same rules as `lopper_save_baseline`.
+- `enableFeatures` / `disableFeatures`.
+- `timeoutMillis`.
+
+Structured output includes `baselineKey`, `snapshotPath`, `dashboardSummary`, and the saved dashboard report.
+
 ### `lopper_list_languages`
 
 Lists supported language adapters and config metadata.
@@ -88,12 +161,12 @@ The response includes canonical language IDs, aliases, supported language modes,
 
 ## Output Shape
 
-Analysis tools return MCP tool content with:
+Analysis and mutation tools return MCP tool content with:
 
 - `content[0].text`: concise human summary.
 - `structuredContent.schemaVersion`: Lopper report schema version.
 - `structuredContent.summary`: same concise summary string.
-- `structuredContent.report`: full report payload aligned with `docs/report-schema.json`.
+- `structuredContent.report`: full report payload aligned with `docs/report-schema.json` for analysis and analysis-baseline tools, or the dashboard report shape for dashboard baseline saves.
 
 Tool failures return `isError: true` with a text message and structured error:
 
@@ -110,11 +183,21 @@ Error codes include `invalid_input`, `timeout`, `cancelled`, and `tool_failed`.
 
 ## Safety Behavior
 
-The MCP server is local-first and read-only:
+The MCP server is local-first and read-only by default:
 
 - `repoPath` must be an explicit local filesystem directory.
-- Unknown tool arguments are rejected, including mutation or command-execution fields such as `applyCodemod`, `saveBaseline`, and `runtimeTestCommand`.
+- Read-only tools reject unknown tool arguments, including mutation or command-execution fields such as `applyCodemod`, `saveBaseline`, `baselineStorePath` on non-baseline tools, and `runtimeTestCommand`.
 - Baseline comparison loads existing files only. It does not write snapshots.
 - Config resolution uses the existing local config and policy-pack rules; remote policy packs are disabled before any fetch.
 - Runtime trace support reads a local trace file only. MCP does not run test commands.
 - Analysis observes JSON-RPC request context and optional `timeoutMillis` cancellation.
+
+Explicit mutation tools add these guardrails:
+
+- The MCP process must be started with `mcp-mutation-tools-preview` enabled; per-call `enableFeatures` cannot turn on hidden mutation tools after startup.
+- Mutations require a dedicated tool name plus `confirmApply: true` or `confirmSave: true`.
+- Mutation store paths and dashboard repo paths must be local filesystem paths. Relative `baselineStorePath` values resolve under `repoPath`.
+- `baselineKey` and `baselineLabel` are mutually exclusive.
+- Codemod apply requires a specific dependency and refuses dirty git worktrees unless `allowDirty` is true.
+- Codemod apply writes rollback artifacts under `.artifacts/lopper-codemod-backups`.
+- Baseline saves use immutable exclusive-create snapshots and fail if the key already exists.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -74,6 +74,8 @@ func (a *App) Execute(ctx context.Context, req Request) (string, error) {
 			Analyzer:         a.Analyzer,
 			LanguageRegistry: a.Languages,
 			FeatureRegistry:  a.Features,
+			Features:         req.MCP.Features,
+			MutationRunner:   a.mcpMutationRunner(),
 		})
 	default:
 		return "", ErrUnknownMode

--- a/internal/app/app_mcp_mutations_test.go
+++ b/internal/app/app_mcp_mutations_test.go
@@ -1,0 +1,351 @@
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+const (
+	mcpLodashPackageJSON = "{\n  \"main\": \"index.js\",\n  \"exports\": {\n    \".\": \"./index.js\",\n    \"./map\": \"./map.js\"\n  }\n}\n"
+	mcpMapSource         = "import { map } from \"lodash\";\nmap([1], (x) => x)\n"
+)
+
+type mcpTestResponse struct {
+	Result *struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+		StructuredContent json.RawMessage `json:"structuredContent"`
+		IsError           bool            `json:"isError,omitempty"`
+	} `json:"result,omitempty"`
+	Error *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+func TestExecuteMCPApplyCodemodMutation(t *testing.T) {
+	repo, sourcePath := setupMCPGitLodashFixture(t)
+
+	response := executeMCPTool(t, "lopper_apply_codemod", map[string]any{
+		"repoPath":      repo,
+		"dependency":    "lodash",
+		"confirmApply":  true,
+		"cacheEnabled":  false,
+		"timeoutMillis": 10000,
+	})
+	if response.Result == nil || response.Result.IsError {
+		t.Fatalf("expected successful codemod mutation, got %#v", response)
+	}
+
+	var payload struct {
+		AppliedFiles   int                         `json:"appliedFiles"`
+		AppliedPatches int                         `json:"appliedPatches"`
+		BackupPath     string                      `json:"backupPath"`
+		Results        []report.CodemodApplyResult `json:"results"`
+	}
+	decodeMCPStructuredContent(t, response, &payload)
+	if payload.AppliedFiles != 1 || payload.AppliedPatches != 1 || len(payload.Results) == 0 {
+		t.Fatalf("unexpected codemod payload: %#v", payload)
+	}
+	if payload.BackupPath == "" {
+		t.Fatalf("expected rollback artifact path in structured payload")
+	}
+	if _, err := os.Stat(filepath.Join(repo, filepath.FromSlash(payload.BackupPath))); err != nil {
+		t.Fatalf("expected rollback artifact to exist: %v", err)
+	}
+	if got := readTextFile(t, sourcePath); !strings.Contains(got, "import map from \"lodash/map\";") {
+		t.Fatalf("expected source rewrite, got %q", got)
+	}
+}
+
+func TestExecuteMCPSaveBaselineMutation(t *testing.T) {
+	repo, _ := setupMCPGitLodashFixture(t)
+
+	response := executeMCPTool(t, "lopper_save_baseline", map[string]any{
+		"repoPath":          repo,
+		"topN":              1,
+		"baselineStorePath": ".artifacts/lopper-baselines",
+		"baselineLabel":     "nightly",
+		"confirmSave":       true,
+		"cacheEnabled":      false,
+		"timeoutMillis":     10000,
+	})
+	if response.Result == nil || response.Result.IsError {
+		t.Fatalf("expected successful baseline save, got %#v", response)
+	}
+
+	var payload struct {
+		BaselineKey   string          `json:"baselineKey"`
+		SnapshotPath  string          `json:"snapshotPath"`
+		ReportSummary *report.Summary `json:"reportSummary"`
+	}
+	decodeMCPStructuredContent(t, response, &payload)
+	if payload.BaselineKey != "label:nightly" || payload.SnapshotPath == "" {
+		t.Fatalf("unexpected baseline payload: %#v", payload)
+	}
+	if payload.ReportSummary == nil || payload.ReportSummary.DependencyCount == 0 {
+		t.Fatalf("expected report summary in payload, got %#v", payload.ReportSummary)
+	}
+	if _, err := os.Stat(payload.SnapshotPath); err != nil {
+		t.Fatalf("expected baseline snapshot to exist: %v", err)
+	}
+}
+
+func TestExecuteMCPSaveDashboardBaselineMutation(t *testing.T) {
+	repo, _ := setupMCPGitLodashFixture(t)
+
+	response := executeMCPTool(t, "lopper_save_dashboard_baseline", map[string]any{
+		"repoPath":          repo,
+		"repos":             []map[string]any{{"name": "fixture", "path": repo, "language": "js-ts"}},
+		"topN":              1,
+		"baselineStorePath": ".artifacts/lopper-dashboard-baselines",
+		"baselineLabel":     "nightly",
+		"confirmSave":       true,
+		"timeoutMillis":     10000,
+	})
+	if response.Result == nil || response.Result.IsError {
+		t.Fatalf("expected successful dashboard baseline save, got %#v", response)
+	}
+
+	var payload struct {
+		BaselineKey      string `json:"baselineKey"`
+		SnapshotPath     string `json:"snapshotPath"`
+		DashboardSummary struct {
+			TotalRepos int `json:"total_repos"`
+		} `json:"dashboardSummary"`
+	}
+	decodeMCPStructuredContent(t, response, &payload)
+	if payload.BaselineKey != "label:nightly" || payload.SnapshotPath == "" || payload.DashboardSummary.TotalRepos != 1 {
+		t.Fatalf("unexpected dashboard baseline payload: %#v", payload)
+	}
+	if _, err := os.Stat(payload.SnapshotPath); err != nil {
+		t.Fatalf("expected dashboard baseline snapshot to exist: %v", err)
+	}
+}
+
+func TestExecuteMCPBaselineMutationsWithExplicitKeys(t *testing.T) {
+	repo, _ := setupMCPGitLodashFixture(t)
+
+	baselineResponse := executeMCPTool(t, "lopper_save_baseline", map[string]any{
+		"repoPath":          repo,
+		"topN":              1,
+		"baselineStorePath": ".artifacts/explicit-baselines",
+		"baselineKey":       "manual",
+		"confirmSave":       true,
+		"cacheEnabled":      false,
+		"timeoutMillis":     10000,
+	})
+	if baselineResponse.Result == nil || baselineResponse.Result.IsError {
+		t.Fatalf("expected successful explicit-key baseline save, got %#v", baselineResponse)
+	}
+	var baselinePayload struct {
+		BaselineKey  string `json:"baselineKey"`
+		SnapshotPath string `json:"snapshotPath"`
+	}
+	decodeMCPStructuredContent(t, baselineResponse, &baselinePayload)
+	if baselinePayload.BaselineKey != "manual" || baselinePayload.SnapshotPath == "" {
+		t.Fatalf("unexpected explicit-key baseline payload: %#v", baselinePayload)
+	}
+	if _, err := os.Stat(baselinePayload.SnapshotPath); err != nil {
+		t.Fatalf("expected explicit-key baseline snapshot to exist: %v", err)
+	}
+
+	dashboardResponse := executeMCPTool(t, "lopper_save_dashboard_baseline", map[string]any{
+		"repoPath":          repo,
+		"repos":             []map[string]any{{"name": "fixture", "path": repo, "language": "js-ts"}},
+		"topN":              1,
+		"baselineStorePath": ".artifacts/explicit-dashboard-baselines",
+		"baselineKey":       "manual-dashboard",
+		"confirmSave":       true,
+		"timeoutMillis":     10000,
+	})
+	if dashboardResponse.Result == nil || dashboardResponse.Result.IsError {
+		t.Fatalf("expected successful explicit-key dashboard baseline save, got %#v", dashboardResponse)
+	}
+	var dashboardPayload struct {
+		BaselineKey  string `json:"baselineKey"`
+		SnapshotPath string `json:"snapshotPath"`
+	}
+	decodeMCPStructuredContent(t, dashboardResponse, &dashboardPayload)
+	if dashboardPayload.BaselineKey != "manual-dashboard" || dashboardPayload.SnapshotPath == "" {
+		t.Fatalf("unexpected explicit-key dashboard payload: %#v", dashboardPayload)
+	}
+	if _, err := os.Stat(dashboardPayload.SnapshotPath); err != nil {
+		t.Fatalf("expected explicit-key dashboard snapshot to exist: %v", err)
+	}
+}
+
+func TestExecuteMCPMutationRejectsDirtyWorktree(t *testing.T) {
+	repo, sourcePath := setupMCPGitLodashFixture(t)
+	writeTextFile(t, filepath.Join(repo, "README.md"), "dirty\n", 0o644)
+
+	response := executeMCPTool(t, "lopper_apply_codemod", map[string]any{
+		"repoPath":      repo,
+		"dependency":    "lodash",
+		"confirmApply":  true,
+		"cacheEnabled":  false,
+		"timeoutMillis": 10000,
+	})
+	if response.Result == nil || !response.Result.IsError {
+		t.Fatalf("expected dirty worktree rejection, got %#v", response)
+	}
+	if !strings.Contains(response.Result.Content[0].Text, "clean git worktree") {
+		t.Fatalf("expected clean-worktree error, got %#v", response.Result.Content)
+	}
+	if got := readTextFile(t, sourcePath); got != mcpMapSource {
+		t.Fatalf("expected source to remain unchanged, got %q", got)
+	}
+}
+
+func TestExecuteMCPReadOnlyToolRejectsMutationArguments(t *testing.T) {
+	repo, _ := setupMCPGitLodashFixture(t)
+	response := executeMCPTool(t, "lopper_analyse_dependency", map[string]any{
+		"repoPath":          repo,
+		"dependency":        "lodash",
+		"saveBaseline":      true,
+		"baselineStorePath": ".artifacts/should-not-exist",
+		"cacheEnabled":      false,
+	})
+	if response.Result == nil || !response.Result.IsError {
+		t.Fatalf("expected read-only mutation argument rejection, got %#v", response)
+	}
+	if !strings.Contains(response.Result.Content[0].Text, "unknown field") {
+		t.Fatalf("expected unknown field error, got %#v", response.Result.Content)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".artifacts")); !os.IsNotExist(err) {
+		t.Fatalf("expected read-only tool not to create artifacts, stat err=%v", err)
+	}
+}
+
+func TestMCPMutationRunnerHelperBranches(t *testing.T) {
+	var nilApp *App
+	if nilApp.mcpMutationRunner() != nil {
+		t.Fatalf("expected nil app to have no MCP mutation runner")
+	}
+
+	if _, err := decodeMCPCommandReport[report.Report]("{", nil); err == nil {
+		t.Fatalf("expected invalid JSON output to fail when command succeeded")
+	}
+	if got := savedSnapshotPath([]string{"unrelated warning"}, baselineSaveWarningPrefix); got != "" {
+		t.Fatalf("expected no saved snapshot path, got %q", got)
+	}
+}
+
+func executeMCPTool(t *testing.T, toolName string, arguments map[string]any) mcpTestResponse {
+	t.Helper()
+	var input bytes.Buffer
+	writeMCPTestFrame(t, &input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      toolName,
+			"arguments": arguments,
+		},
+	})
+
+	var output bytes.Buffer
+	application := New(&output, &input)
+	req := DefaultRequest()
+	req.Mode = ModeMCP
+	req.MCP.Features = mustMCPMutationFeatureSet(t)
+	if _, err := application.Execute(context.Background(), req); err != nil {
+		t.Fatalf("execute MCP server: %v", err)
+	}
+
+	return readMCPTestResponse(t, output.Bytes())
+}
+
+func writeMCPTestFrame(t *testing.T, writer *bytes.Buffer, value any) {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal MCP request: %v", err)
+	}
+	if _, err := fmt.Fprintf(writer, "Content-Length: %d\r\n\r\n", len(payload)); err != nil {
+		t.Fatalf("write MCP header: %v", err)
+	}
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatalf("write MCP payload: %v", err)
+	}
+}
+
+func readMCPTestResponse(t *testing.T, data []byte) mcpTestResponse {
+	t.Helper()
+	reader := bufio.NewReader(bytes.NewReader(data))
+	contentLength := -1
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read MCP response header: %v", err)
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok || strings.TrimSpace(strings.ToLower(key)) != "content-length" {
+			continue
+		}
+		contentLength, err = strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			t.Fatalf("parse content length: %v", err)
+		}
+	}
+	if contentLength < 0 {
+		t.Fatalf("missing content length in MCP response %q", string(data))
+	}
+	payload := make([]byte, contentLength)
+	if _, err := io.ReadFull(reader, payload); err != nil {
+		t.Fatalf("read MCP response payload: %v", err)
+	}
+	var response mcpTestResponse
+	if err := json.Unmarshal(payload, &response); err != nil {
+		t.Fatalf("decode MCP response: %v\n%s", err, string(payload))
+	}
+	return response
+}
+
+func decodeMCPStructuredContent(t *testing.T, response mcpTestResponse, target any) {
+	t.Helper()
+	if response.Result == nil {
+		t.Fatalf("missing MCP result: %#v", response)
+	}
+	if err := json.Unmarshal(response.Result.StructuredContent, target); err != nil {
+		t.Fatalf("decode structured content: %v\n%s", err, string(response.Result.StructuredContent))
+	}
+}
+
+func setupMCPGitLodashFixture(t *testing.T) (string, string) {
+	t.Helper()
+	repo := t.TempDir()
+	sourcePath := filepath.Join(repo, indexJSFile)
+	writeTextFile(t, sourcePath, mcpMapSource, 0o644)
+
+	dependencyRoot := filepath.Join(repo, "node_modules", "lodash")
+	mustMkdirAll(t, dependencyRoot)
+	writeTextFile(t, filepath.Join(dependencyRoot, "package.json"), mcpLodashPackageJSON, 0o644)
+	writeTextFile(t, filepath.Join(dependencyRoot, "index.js"), "export { map } from './map.js'\n", 0o644)
+	writeTextFile(t, filepath.Join(dependencyRoot, "map.js"), "export default function map() {}\n", 0o644)
+
+	testutil.RunGit(t, repo, "init")
+	testutil.RunGit(t, repo, "config", "user.email", "test@example.com")
+	testutil.RunGit(t, repo, "config", "user.name", "Test User")
+	testutil.RunGit(t, repo, "add", ".")
+	testutil.RunGit(t, repo, "commit", "-m", "fixture")
+
+	return repo, sourcePath
+}

--- a/internal/app/app_mcp_test.go
+++ b/internal/app/app_mcp_test.go
@@ -47,17 +47,37 @@ func TestExecuteMCPRejectsExplicitlyDisabledFeature(t *testing.T) {
 
 func mustMCPFeatureSet(t *testing.T, disable bool) featureflags.Set {
 	t.Helper()
-	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
-		Code:      "LOP-FEAT-0001",
-		Name:      mcp.ServerPreviewFeature,
-		Lifecycle: featureflags.LifecycleStable,
-	}})
+	return mustMCPFeatureSetWithMutations(t, disable, false)
+}
+
+func mustMCPMutationFeatureSet(t *testing.T) featureflags.Set {
+	t.Helper()
+	return mustMCPFeatureSetWithMutations(t, false, true)
+}
+
+func mustMCPFeatureSetWithMutations(t *testing.T, disableServer bool, enableMutations bool) featureflags.Set {
+	t.Helper()
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{
+		{
+			Code:      "LOP-FEAT-0001",
+			Name:      mcp.ServerPreviewFeature,
+			Lifecycle: featureflags.LifecycleStable,
+		},
+		{
+			Code:      "LOP-FEAT-0002",
+			Name:      mcp.MutationToolsFeature,
+			Lifecycle: featureflags.LifecyclePreview,
+		},
+	})
 	if err != nil {
 		t.Fatalf("new feature registry: %v", err)
 	}
 	opts := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
-	if disable {
+	if disableServer {
 		opts.Disable = []string{mcp.ServerPreviewFeature}
+	}
+	if enableMutations {
+		opts.Enable = append(opts.Enable, mcp.MutationToolsFeature)
 	}
 	features, err := registry.Resolve(opts)
 	if err != nil {

--- a/internal/app/mcp_mutations.go
+++ b/internal/app/mcp_mutations.go
@@ -1,0 +1,153 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/analysis"
+	"github.com/ben-ranford/lopper/internal/dashboard"
+	"github.com/ben-ranford/lopper/internal/mcp"
+	"github.com/ben-ranford/lopper/internal/notify"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const (
+	baselineSaveWarningPrefix          = "saved immutable baseline snapshot: "
+	dashboardBaselineSaveWarningPrefix = "saved immutable dashboard baseline snapshot: "
+)
+
+type appMCPMutationRunner struct {
+	app *App
+}
+
+func (a *App) mcpMutationRunner() mcp.MutationRunner {
+	if a == nil {
+		return nil
+	}
+	a.ensureMCPMutationDefaults()
+	return &appMCPMutationRunner{app: a}
+}
+
+func (a *App) ensureMCPMutationDefaults() {
+	if a.Analyzer == nil {
+		service := analysis.NewService()
+		a.Analyzer = service
+		if a.Languages == nil {
+			a.Languages = service.Registry
+		}
+	}
+	if a.Formatter == nil {
+		a.Formatter = report.NewFormatter()
+	}
+	if a.Notify == nil {
+		a.Notify = notify.NewDefaultDispatcher()
+	}
+}
+
+func (r *appMCPMutationRunner) ApplyCodemod(ctx context.Context, req mcp.AnalysisMutationRequest) (report.Report, error) {
+	appReq := newMCPAnalyseRequest(req)
+	appReq.Analyse.ApplyCodemod = true
+	appReq.Analyse.AllowDirty = req.AllowDirty
+	return r.runAnalyseReport(ctx, appReq)
+}
+
+func (r *appMCPMutationRunner) SaveBaseline(ctx context.Context, req mcp.AnalysisMutationRequest) (report.Report, string, error) {
+	appReq := newMCPAnalyseRequest(req)
+	appReq.Analyse.SaveBaseline = true
+	appReq.Analyse.BaselineStorePath = req.BaselineStorePath
+	if strings.TrimSpace(req.BaselineLabel) == "" {
+		appReq.Analyse.BaselineKey = req.BaselineKey
+	}
+	appReq.Analyse.BaselineLabel = req.BaselineLabel
+
+	reportData, err := r.runAnalyseReport(ctx, appReq)
+	return reportData, savedSnapshotPath(reportData.Warnings, baselineSaveWarningPrefix), err
+}
+
+func (r *appMCPMutationRunner) SaveDashboardBaseline(ctx context.Context, req mcp.DashboardMutationRequest) (dashboard.Report, string, error) {
+	appReq := DefaultRequest()
+	appReq.Mode = ModeDashboard
+	appReq.RepoPath = req.RepoPath
+	appReq.Dashboard.Repos = mapMCPDashboardRepos(req.Repos)
+	appReq.Dashboard.ConfigPath = req.ConfigPath
+	appReq.Dashboard.Format = string(dashboard.FormatJSON)
+	appReq.Dashboard.TopN = req.TopN
+	appReq.Dashboard.DefaultLanguage = req.DefaultLanguage
+	appReq.Dashboard.BaselineStorePath = req.BaselineStorePath
+	if strings.TrimSpace(req.BaselineLabel) == "" {
+		appReq.Dashboard.BaselineKey = req.BaselineKey
+	}
+	appReq.Dashboard.BaselineLabel = req.BaselineLabel
+	appReq.Dashboard.SaveBaseline = true
+	appReq.Dashboard.Features = req.Features
+
+	reportData, err := r.runDashboardReport(ctx, appReq)
+	return reportData, savedSnapshotPath(reportData.SourceWarnings, dashboardBaselineSaveWarningPrefix), err
+}
+
+func newMCPAnalyseRequest(req mcp.AnalysisMutationRequest) Request {
+	appReq := DefaultRequest()
+	appReq.Mode = ModeAnalyse
+	appReq.RepoPath = req.RepoPath
+	appReq.Analyse.Dependency = req.Dependency
+	appReq.Analyse.TopN = req.TopN
+	appReq.Analyse.ScopeMode = req.ScopeMode
+	appReq.Analyse.Format = report.FormatJSON
+	appReq.Analyse.Language = req.Language
+	appReq.Analyse.CacheEnabled = req.CacheEnabled
+	appReq.Analyse.CachePath = req.CachePath
+	appReq.Analyse.CacheReadOnly = req.CacheReadOnly
+	appReq.Analyse.RuntimeProfile = req.RuntimeProfile
+	appReq.Analyse.RuntimeTracePath = req.RuntimeTracePath
+	appReq.Analyse.IncludePatterns = append([]string{}, req.IncludePatterns...)
+	appReq.Analyse.ExcludePatterns = append([]string{}, req.ExcludePatterns...)
+	appReq.Analyse.ConfigPath = req.ConfigPath
+	appReq.Analyse.PolicySources = append([]string{}, req.PolicySources...)
+	appReq.Analyse.PolicyTrace = append([]report.PolicyMergeTrace{}, req.PolicyTrace...)
+	appReq.Analyse.Features = req.Features
+	appReq.Analyse.Thresholds = req.Thresholds
+	return appReq
+}
+
+func (r *appMCPMutationRunner) runAnalyseReport(ctx context.Context, req Request) (report.Report, error) {
+	output, err := r.app.executeAnalyse(ctx, req)
+	return decodeMCPCommandReport[report.Report](output, err)
+}
+
+func (r *appMCPMutationRunner) runDashboardReport(ctx context.Context, req Request) (dashboard.Report, error) {
+	output, err := r.app.executeDashboard(ctx, req)
+	return decodeMCPCommandReport[dashboard.Report](output, err)
+}
+
+func decodeMCPCommandReport[T any](output string, runErr error) (T, error) {
+	var v T
+	if output != "" {
+		if decodeErr := json.Unmarshal([]byte(output), &v); decodeErr != nil && runErr == nil {
+			var zero T
+			return zero, decodeErr
+		}
+	}
+	return v, runErr
+}
+
+func mapMCPDashboardRepos(repos []mcp.DashboardRepoInput) []DashboardRepo {
+	mapped := make([]DashboardRepo, 0, len(repos))
+	for _, repo := range repos {
+		mapped = append(mapped, DashboardRepo{
+			Name:     repo.Name,
+			Path:     repo.Path,
+			Language: repo.Language,
+		})
+	}
+	return mapped
+}
+
+func savedSnapshotPath(warnings []string, prefix string) string {
+	for _, warning := range warnings {
+		if path := strings.TrimSpace(strings.TrimPrefix(warning, prefix)); path != warning {
+			return path
+		}
+	}
+	return ""
+}

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -72,5 +72,11 @@
     "name": "python-runtime-trace-preview",
     "description": "Enable preview runtime trace annotations for Python dependencies using shared runtimeUsage report fields.",
     "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0012",
+    "name": "mcp-mutation-tools-preview",
+    "description": "Enable explicit MCP mutation tools for codemod apply and baseline snapshot save workflows.",
+    "lifecycle": "preview"
   }
 ]

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -94,6 +94,9 @@ func TestFramingErrorBranches(t *testing.T) {
 	if _, err := readFrame(bufio.NewReader(strings.NewReader("Content-Length: 5\r\n\r\nabc"))); err == nil {
 		t.Fatalf("expected short body error")
 	}
+	if err := frameReadError(io.ErrUnexpectedEOF, true); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected non-empty partial header error to pass through, got %v", err)
+	}
 	if err := writeFrame(&failWriteCloser{}, []byte("{}")); err == nil {
 		t.Fatalf("expected writeFrame header write error")
 	}
@@ -320,6 +323,36 @@ func TestResolveFeaturesBranches(t *testing.T) {
 	if _, err := server.resolveFeatures(emptyFeatureConfig(), nil, nil); err == nil {
 		t.Fatalf("expected invalid build channel error")
 	}
+}
+
+func TestDefaultServerFeatureBranches(t *testing.T) {
+	t.Run("invalid channel returns empty defaults", func(t *testing.T) {
+		withCurrentVersion(t, version.Info{BuildChannel: "bad"})
+		features := resolveDefaultServerFeatures(featureflags.DefaultRegistry())
+		if features.Snapshot() != nil {
+			t.Fatalf("expected empty feature set for invalid channel, got %#v", features.Snapshot())
+		}
+	})
+
+	t.Run("release channel resolves defaults", func(t *testing.T) {
+		withCurrentVersion(t, version.Info{Version: "v1.6.0", BuildChannel: "release"})
+		features := resolveDefaultServerFeatures(featureflags.DefaultRegistry())
+		if features.Snapshot() == nil {
+			t.Fatalf("expected release feature defaults")
+		}
+	})
+
+	t.Run("nil registry fallback", func(t *testing.T) {
+		withCurrentVersion(t, version.Info{BuildChannel: "dev"})
+		server := &Server{}
+		features, err := server.resolveFeatures(emptyFeatureConfig(), nil, nil)
+		if err != nil {
+			t.Fatalf("resolve fallback features: %v", err)
+		}
+		if features.Snapshot() == nil {
+			t.Fatalf("expected fallback default registry features")
+		}
+	})
 }
 
 func TestThresholdAndPolicyHelpers(t *testing.T) {

--- a/internal/mcp/mutations.go
+++ b/internal/mcp/mutations.go
@@ -1,0 +1,698 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/dashboard"
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/thresholds"
+	"github.com/ben-ranford/lopper/internal/workspace"
+)
+
+// MutationToolsFeature gates explicit MCP mutation tools. Read-only MCP tools
+// stay available under ServerPreviewFeature and do not use this flag.
+const MutationToolsFeature = "mcp-mutation-tools-preview"
+
+type MutationRunner interface {
+	ApplyCodemod(context.Context, AnalysisMutationRequest) (report.Report, error)
+	SaveBaseline(context.Context, AnalysisMutationRequest) (report.Report, string, error)
+	SaveDashboardBaseline(context.Context, DashboardMutationRequest) (dashboard.Report, string, error)
+}
+
+type AnalysisMutationRequest struct {
+	RepoPath          string
+	Dependency        string
+	TopN              int
+	ScopeMode         string
+	Language          string
+	ConfigPath        string
+	IncludePatterns   []string
+	ExcludePatterns   []string
+	CacheEnabled      bool
+	CachePath         string
+	CacheReadOnly     bool
+	RuntimeProfile    string
+	RuntimeTracePath  string
+	Features          featureflags.Set
+	Thresholds        thresholds.Values
+	PolicySources     []string
+	PolicyTrace       []report.PolicyMergeTrace
+	AllowDirty        bool
+	BaselineStorePath string
+	BaselineKey       string
+	BaselineLabel     string
+}
+
+type DashboardMutationRequest struct {
+	RepoPath          string
+	Repos             []DashboardRepoInput
+	ConfigPath        string
+	TopN              int
+	DefaultLanguage   string
+	BaselineStorePath string
+	BaselineKey       string
+	BaselineLabel     string
+	Features          featureflags.Set
+}
+
+type DashboardRepoInput struct {
+	Name     string `json:"name,omitempty"`
+	Path     string `json:"path"`
+	Language string `json:"language,omitempty"`
+}
+
+type mutationAnalysisArguments struct {
+	RepoPath                          string   `json:"repoPath"`
+	Dependency                        string   `json:"dependency,omitempty"`
+	TopN                              *int     `json:"topN,omitempty"`
+	Language                          string   `json:"language,omitempty"`
+	ScopeMode                         string   `json:"scopeMode,omitempty"`
+	ConfigPath                        string   `json:"configPath,omitempty"`
+	Include                           []string `json:"include,omitempty"`
+	Exclude                           []string `json:"exclude,omitempty"`
+	EnableFeatures                    []string `json:"enableFeatures,omitempty"`
+	DisableFeatures                   []string `json:"disableFeatures,omitempty"`
+	CacheEnabled                      *bool    `json:"cacheEnabled,omitempty"`
+	CachePath                         string   `json:"cachePath,omitempty"`
+	CacheReadOnly                     bool     `json:"cacheReadOnly,omitempty"`
+	RuntimeProfile                    string   `json:"runtimeProfile,omitempty"`
+	RuntimeTracePath                  string   `json:"runtimeTracePath,omitempty"`
+	LowConfidenceWarningPercent       *int     `json:"lowConfidenceWarningPercent,omitempty"`
+	MinUsagePercentForRecommendations *int     `json:"minUsagePercentForRecommendations,omitempty"`
+	MaxUncertainImportCount           *int     `json:"maxUncertainImportCount,omitempty"`
+	ScoreWeightUsage                  *float64 `json:"scoreWeightUsage,omitempty"`
+	ScoreWeightImpact                 *float64 `json:"scoreWeightImpact,omitempty"`
+	ScoreWeightConfidence             *float64 `json:"scoreWeightConfidence,omitempty"`
+	LicenseDeny                       []string `json:"licenseDeny,omitempty"`
+	LicenseFailOnDeny                 *bool    `json:"licenseFailOnDeny,omitempty"`
+	LicenseProvenanceRegistry         *bool    `json:"licenseProvenanceRegistry,omitempty"`
+	TimeoutMillis                     int      `json:"timeoutMillis,omitempty"`
+}
+
+type codemodApplyArguments struct {
+	mutationAnalysisArguments
+	ConfirmApply bool `json:"confirmApply"`
+	AllowDirty   bool `json:"allowDirty,omitempty"`
+}
+
+type baselineSaveArguments struct {
+	mutationAnalysisArguments
+	BaselineStorePath string `json:"baselineStorePath"`
+	BaselineKey       string `json:"baselineKey,omitempty"`
+	BaselineLabel     string `json:"baselineLabel,omitempty"`
+	ConfirmSave       bool   `json:"confirmSave"`
+}
+
+type dashboardBaselineSaveArguments struct {
+	RepoPath          string               `json:"repoPath"`
+	Repos             []DashboardRepoInput `json:"repos,omitempty"`
+	ConfigPath        string               `json:"configPath,omitempty"`
+	TopN              *int                 `json:"topN,omitempty"`
+	DefaultLanguage   string               `json:"defaultLanguage,omitempty"`
+	BaselineStorePath string               `json:"baselineStorePath"`
+	BaselineKey       string               `json:"baselineKey,omitempty"`
+	BaselineLabel     string               `json:"baselineLabel,omitempty"`
+	ConfirmSave       bool                 `json:"confirmSave"`
+	EnableFeatures    []string             `json:"enableFeatures,omitempty"`
+	DisableFeatures   []string             `json:"disableFeatures,omitempty"`
+	TimeoutMillis     int                  `json:"timeoutMillis,omitempty"`
+}
+
+type structuredToolError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type codemodApplyPayload struct {
+	SchemaVersion  string                      `json:"schemaVersion"`
+	Summary        string                      `json:"summary"`
+	RepoPath       string                      `json:"repoPath"`
+	Dependency     string                      `json:"dependency"`
+	AppliedFiles   int                         `json:"appliedFiles"`
+	AppliedPatches int                         `json:"appliedPatches"`
+	SkippedFiles   int                         `json:"skippedFiles"`
+	SkippedPatches int                         `json:"skippedPatches"`
+	FailedFiles    int                         `json:"failedFiles"`
+	FailedPatches  int                         `json:"failedPatches"`
+	BackupPath     string                      `json:"backupPath,omitempty"`
+	Results        []report.CodemodApplyResult `json:"results,omitempty"`
+	Report         report.Report               `json:"report"`
+	Error          *structuredToolError        `json:"error,omitempty"`
+}
+
+type baselineSavePayload struct {
+	SchemaVersion     string               `json:"schemaVersion"`
+	Summary           string               `json:"summary"`
+	RepoPath          string               `json:"repoPath"`
+	BaselineStorePath string               `json:"baselineStorePath"`
+	BaselineKey       string               `json:"baselineKey"`
+	SnapshotPath      string               `json:"snapshotPath"`
+	ReportSummary     *report.Summary      `json:"reportSummary,omitempty"`
+	Report            report.Report        `json:"report"`
+	Error             *structuredToolError `json:"error,omitempty"`
+}
+
+type dashboardBaselineSavePayload struct {
+	SchemaVersion     string               `json:"schemaVersion"`
+	Summary           string               `json:"summary"`
+	RepoPath          string               `json:"repoPath"`
+	BaselineStorePath string               `json:"baselineStorePath"`
+	BaselineKey       string               `json:"baselineKey"`
+	SnapshotPath      string               `json:"snapshotPath"`
+	DashboardSummary  dashboard.Summary    `json:"dashboardSummary"`
+	Report            dashboard.Report     `json:"report"`
+	Error             *structuredToolError `json:"error,omitempty"`
+}
+
+func (s *Server) mutationToolsEnabled() bool {
+	return s.features.Enabled(MutationToolsFeature)
+}
+
+func (s *Server) runCodemodApplyTool(ctx context.Context, rawArgs json.RawMessage) toolCallResult {
+	if err := s.validateMutationToolCall(); err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+
+	var args codemodApplyArguments
+	if err := decodeStrict(rawArgs, &args); err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	if !args.ConfirmApply {
+		return toolError(errorCodeInvalidInput, errors.New("confirmApply must be true to apply codemod mutations"))
+	}
+	if strings.TrimSpace(args.Dependency) == "" {
+		return toolError(errorCodeInvalidInput, errors.New("dependency is required for codemod apply"))
+	}
+	if args.TopN != nil {
+		return toolError(errorCodeInvalidInput, errors.New("topN is not supported for codemod apply"))
+	}
+
+	reqCtx, cancel, err := contextForTimeout(ctx, args.TimeoutMillis)
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	defer cancel()
+
+	request, err := s.resolveAnalysisMutationRequest(reqCtx, args.mutationAnalysisArguments, mutationAnalysisKindDependency)
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	request.AllowDirty = args.AllowDirty
+
+	reportData, runErr := s.mutationRunner.ApplyCodemod(reqCtx, request)
+	payload := shapeCodemodApplyPayload(request, reportData, runErr)
+	if runErr != nil {
+		return mutationToolError(runErr, payload)
+	}
+	return toolSuccess(payload.Summary, payload)
+}
+
+func (s *Server) runBaselineSaveTool(ctx context.Context, rawArgs json.RawMessage) toolCallResult {
+	if err := s.validateMutationToolCall(); err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+
+	var args baselineSaveArguments
+	if err := decodeStrict(rawArgs, &args); err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	if !args.ConfirmSave {
+		return toolError(errorCodeInvalidInput, errors.New("confirmSave must be true to save baseline snapshots"))
+	}
+
+	reqCtx, cancel, err := contextForTimeout(ctx, args.TimeoutMillis)
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	defer cancel()
+
+	request, err := s.resolveAnalysisMutationRequest(reqCtx, args.mutationAnalysisArguments, mutationAnalysisKindTopOrDependency)
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	storePath, key, err := resolveBaselineMutationTarget(request.RepoPath, args.BaselineStorePath, args.BaselineKey, args.BaselineLabel, "baseline")
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	request.BaselineStorePath = storePath
+	request.BaselineKey = key
+	request.BaselineLabel = strings.TrimSpace(args.BaselineLabel)
+
+	reportData, savedPath, runErr := s.mutationRunner.SaveBaseline(reqCtx, request)
+	if savedPath == "" {
+		savedPath = report.BaselineSnapshotPath(storePath, key)
+	}
+	payload := shapeBaselineSavePayload(request, reportData, savedPath, runErr)
+	if runErr != nil {
+		return mutationToolError(runErr, payload)
+	}
+	return toolSuccess(payload.Summary, payload)
+}
+
+func (s *Server) runDashboardBaselineSaveTool(ctx context.Context, rawArgs json.RawMessage) toolCallResult {
+	if err := s.validateMutationToolCall(); err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+
+	var args dashboardBaselineSaveArguments
+	if err := decodeStrict(rawArgs, &args); err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	if !args.ConfirmSave {
+		return toolError(errorCodeInvalidInput, errors.New("confirmSave must be true to save dashboard baseline snapshots"))
+	}
+
+	reqCtx, cancel, err := contextForTimeout(ctx, args.TimeoutMillis)
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	defer cancel()
+
+	request, err := s.resolveDashboardMutationRequest(reqCtx, args)
+	if err != nil {
+		return toolError(errorCodeInvalidInput, err)
+	}
+	reportData, savedPath, runErr := s.mutationRunner.SaveDashboardBaseline(reqCtx, request)
+	if savedPath == "" {
+		savedPath = dashboard.BaselineSnapshotPath(request.BaselineStorePath, request.BaselineKey)
+	}
+	payload := shapeDashboardBaselineSavePayload(request, reportData, savedPath, runErr)
+	if runErr != nil {
+		return mutationToolError(runErr, payload)
+	}
+	return toolSuccess(payload.Summary, payload)
+}
+
+func (s *Server) validateMutationToolCall() error {
+	if !s.mutationToolsEnabled() {
+		return fmt.Errorf("%s must be enabled at MCP server startup to use mutation tools", MutationToolsFeature)
+	}
+	if s.mutationRunner == nil {
+		return errors.New("mcp mutation runner is not configured")
+	}
+	return nil
+}
+
+type mutationAnalysisKind string
+
+const (
+	mutationAnalysisKindDependency      mutationAnalysisKind = "dependency"
+	mutationAnalysisKindTopOrDependency mutationAnalysisKind = "top-or-dependency"
+)
+
+func (s *Server) resolveAnalysisMutationRequest(ctx context.Context, args mutationAnalysisArguments, kind mutationAnalysisKind) (AnalysisMutationRequest, error) {
+	repoPath, err := validateRepoPath(args.RepoPath)
+	if err != nil {
+		return AnalysisMutationRequest{}, err
+	}
+	dependency, topN, err := resolveMutationAnalysisTarget(args, kind)
+	if err != nil {
+		return AnalysisMutationRequest{}, err
+	}
+	scopeMode, err := parseScopeMode(args.ScopeMode)
+	if err != nil {
+		return AnalysisMutationRequest{}, err
+	}
+	analysisArgs := analysisArgsFromMutation(args)
+	loadResult, thresholdsValue, policySources, policyTrace, err := resolveThresholds(repoPath, analysisArgs)
+	if err != nil {
+		return AnalysisMutationRequest{}, err
+	}
+	features, err := s.resolveFeatures(loadResult.Features, args.EnableFeatures, args.DisableFeatures)
+	if err != nil {
+		return AnalysisMutationRequest{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return AnalysisMutationRequest{}, err
+	}
+
+	return AnalysisMutationRequest{
+		RepoPath:         repoPath,
+		Dependency:       dependency,
+		TopN:             topN,
+		ScopeMode:        scopeMode,
+		Language:         languageOrDefault(args.Language),
+		ConfigPath:       strings.TrimSpace(loadResult.ConfigPath),
+		IncludePatterns:  mergeStringOptions(loadResult.Scope.Include, args.Include),
+		ExcludePatterns:  mergeStringOptions(loadResult.Scope.Exclude, args.Exclude),
+		CacheEnabled:     cacheEnabled(args.CacheEnabled),
+		CachePath:        strings.TrimSpace(args.CachePath),
+		CacheReadOnly:    args.CacheReadOnly,
+		RuntimeProfile:   runtimeProfileOrDefault(args.RuntimeProfile),
+		RuntimeTracePath: strings.TrimSpace(args.RuntimeTracePath),
+		Features:         features,
+		Thresholds:       thresholdsValue,
+		PolicySources:    policySources,
+		PolicyTrace:      policyTrace,
+	}, nil
+}
+
+func resolveMutationAnalysisTarget(args mutationAnalysisArguments, kind mutationAnalysisKind) (string, int, error) {
+	dependency := strings.TrimSpace(args.Dependency)
+	topN := topNOrDefault(args.TopN)
+	switch kind {
+	case mutationAnalysisKindDependency:
+		if dependency == "" {
+			return "", 0, errors.New("dependency is required")
+		}
+		return dependency, 0, nil
+	case mutationAnalysisKindTopOrDependency:
+		if dependency != "" {
+			if args.TopN != nil {
+				return "", 0, errors.New("topN cannot be combined with dependency")
+			}
+			return dependency, 0, nil
+		}
+		if topN < 0 {
+			return "", 0, errors.New("topN must be greater than zero")
+		}
+		return "", topN, nil
+	default:
+		return "", 0, errors.New("unknown mutation analysis kind")
+	}
+}
+
+func analysisArgsFromMutation(args mutationAnalysisArguments) analysisToolArguments {
+	return analysisToolArguments{
+		RepoPath:                          args.RepoPath,
+		Dependency:                        args.Dependency,
+		TopN:                              args.TopN,
+		Language:                          args.Language,
+		ScopeMode:                         args.ScopeMode,
+		ConfigPath:                        args.ConfigPath,
+		Include:                           append([]string{}, args.Include...),
+		Exclude:                           append([]string{}, args.Exclude...),
+		EnableFeatures:                    append([]string{}, args.EnableFeatures...),
+		DisableFeatures:                   append([]string{}, args.DisableFeatures...),
+		CacheEnabled:                      args.CacheEnabled,
+		CachePath:                         args.CachePath,
+		CacheReadOnly:                     args.CacheReadOnly,
+		RuntimeProfile:                    args.RuntimeProfile,
+		RuntimeTracePath:                  args.RuntimeTracePath,
+		LowConfidenceWarningPercent:       args.LowConfidenceWarningPercent,
+		MinUsagePercentForRecommendations: args.MinUsagePercentForRecommendations,
+		MaxUncertainImportCount:           args.MaxUncertainImportCount,
+		ScoreWeightUsage:                  args.ScoreWeightUsage,
+		ScoreWeightImpact:                 args.ScoreWeightImpact,
+		ScoreWeightConfidence:             args.ScoreWeightConfidence,
+		LicenseDeny:                       append([]string{}, args.LicenseDeny...),
+		LicenseFailOnDeny:                 args.LicenseFailOnDeny,
+		LicenseProvenanceRegistry:         args.LicenseProvenanceRegistry,
+		TimeoutMillis:                     args.TimeoutMillis,
+	}
+}
+
+func (s *Server) resolveDashboardMutationRequest(ctx context.Context, args dashboardBaselineSaveArguments) (DashboardMutationRequest, error) {
+	repoPath, err := validateRepoPath(args.RepoPath)
+	if err != nil {
+		return DashboardMutationRequest{}, err
+	}
+	if len(args.Repos) == 0 && strings.TrimSpace(args.ConfigPath) == "" {
+		return DashboardMutationRequest{}, errors.New("repos or configPath is required for dashboard baseline save")
+	}
+	if err := validateDashboardMutationRepos(args.Repos); err != nil {
+		return DashboardMutationRequest{}, err
+	}
+	topN := topNOrDefault(args.TopN)
+	if topN < 0 {
+		return DashboardMutationRequest{}, errors.New("topN must be greater than zero")
+	}
+	storePath, key, err := resolveBaselineMutationTarget(repoPath, args.BaselineStorePath, args.BaselineKey, args.BaselineLabel, "dashboard baseline")
+	if err != nil {
+		return DashboardMutationRequest{}, err
+	}
+	features, err := s.resolveFeatures(thresholds.FeatureConfig{}, args.EnableFeatures, args.DisableFeatures)
+	if err != nil {
+		return DashboardMutationRequest{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return DashboardMutationRequest{}, err
+	}
+	return DashboardMutationRequest{
+		RepoPath:          repoPath,
+		Repos:             append([]DashboardRepoInput{}, args.Repos...),
+		ConfigPath:        strings.TrimSpace(args.ConfigPath),
+		TopN:              topN,
+		DefaultLanguage:   languageOrDefault(args.DefaultLanguage),
+		BaselineStorePath: storePath,
+		BaselineKey:       key,
+		BaselineLabel:     strings.TrimSpace(args.BaselineLabel),
+		Features:          features,
+	}, nil
+}
+
+func validateDashboardMutationRepos(repos []DashboardRepoInput) error {
+	for _, repo := range repos {
+		path := strings.TrimSpace(repo.Path)
+		if path == "" {
+			return errors.New("dashboard repo path is required")
+		}
+		if strings.Contains(strings.ToLower(path), "://") {
+			return fmt.Errorf("dashboard repo path must be a local filesystem path: %s", path)
+		}
+		if strings.ContainsRune(path, '\x00') {
+			return errors.New("dashboard repo path contains an invalid NUL byte")
+		}
+	}
+	return nil
+}
+
+func resolveBaselineMutationTarget(repoPath, storePath, key, label, keyName string) (string, string, error) {
+	resolvedStorePath, err := resolveLocalMutationPath(repoPath, storePath, "baselineStorePath")
+	if err != nil {
+		return "", "", err
+	}
+	trimmedKey := strings.TrimSpace(key)
+	trimmedLabel := strings.TrimSpace(label)
+	if trimmedKey != "" && trimmedLabel != "" {
+		return "", "", errors.New("baselineKey and baselineLabel cannot both be provided")
+	}
+	switch {
+	case trimmedLabel != "":
+		return resolvedStorePath, "label:" + trimmedLabel, nil
+	case trimmedKey != "":
+		return resolvedStorePath, trimmedKey, nil
+	default:
+		currentKey := resolveMutationCurrentBaselineKey(repoPath)
+		if currentKey == "" {
+			return "", "", fmt.Errorf("unable to resolve git commit for %s key; pass baselineLabel or baselineKey", keyName)
+		}
+		return resolvedStorePath, currentKey, nil
+	}
+}
+
+func resolveLocalMutationPath(repoPath, rawPath, field string) (string, error) {
+	trimmed := strings.TrimSpace(rawPath)
+	if trimmed == "" {
+		return "", fmt.Errorf("%s is required", field)
+	}
+	if strings.Contains(strings.ToLower(trimmed), "://") {
+		return "", fmt.Errorf("%s must be a local filesystem path", field)
+	}
+	if strings.ContainsRune(trimmed, '\x00') {
+		return "", fmt.Errorf("%s contains an invalid NUL byte", field)
+	}
+	if filepath.IsAbs(trimmed) {
+		return filepath.Clean(trimmed), nil
+	}
+	return filepath.Join(repoPath, trimmed), nil
+}
+
+func resolveMutationCurrentBaselineKey(repoPath string) string {
+	sha, err := workspace.CurrentCommitSHA(repoPath)
+	if err != nil || strings.TrimSpace(sha) == "" {
+		return ""
+	}
+	return "commit:" + sha
+}
+
+func shapeCodemodApplyPayload(req AnalysisMutationRequest, reportData report.Report, err error) codemodApplyPayload {
+	apply := findCodemodApplyReport(reportData, req.Dependency)
+	payload := codemodApplyPayload{
+		SchemaVersion: report.SchemaVersion,
+		RepoPath:      req.RepoPath,
+		Dependency:    req.Dependency,
+		Report:        reportData,
+	}
+	if apply != nil {
+		payload.AppliedFiles = apply.AppliedFiles
+		payload.AppliedPatches = apply.AppliedPatches
+		payload.SkippedFiles = apply.SkippedFiles
+		payload.SkippedPatches = apply.SkippedPatches
+		payload.FailedFiles = apply.FailedFiles
+		payload.FailedPatches = apply.FailedPatches
+		payload.BackupPath = apply.BackupPath
+		payload.Results = append([]report.CodemodApplyResult{}, apply.Results...)
+	}
+	payload.Summary = summarizeCodemodApply(req.Dependency, apply, err)
+	if err != nil {
+		payload.Error = &structuredToolError{Code: errorCodeToolFailed, Message: err.Error()}
+	}
+	return payload
+}
+
+func findCodemodApplyReport(reportData report.Report, dependency string) *report.CodemodApplyReport {
+	for _, item := range reportData.Dependencies {
+		if strings.TrimSpace(dependency) != "" && item.Name != dependency {
+			continue
+		}
+		if item.Codemod != nil && item.Codemod.Apply != nil {
+			return item.Codemod.Apply
+		}
+	}
+	return nil
+}
+
+func summarizeCodemodApply(dependency string, apply *report.CodemodApplyReport, err error) string {
+	prefix := fmt.Sprintf("Codemod apply completed for %s", dependency)
+	if err != nil {
+		prefix = fmt.Sprintf("Codemod apply failed for %s", dependency)
+	}
+	if apply == nil {
+		return prefix + ": no codemod changes were produced."
+	}
+	return fmt.Sprintf("%s: %d files changed, %d patches applied, %d files skipped, %d files failed.", prefix, apply.AppliedFiles, apply.AppliedPatches, apply.SkippedFiles, apply.FailedFiles)
+}
+
+func shapeBaselineSavePayload(req AnalysisMutationRequest, reportData report.Report, savedPath string, err error) baselineSavePayload {
+	payload := baselineSavePayload{
+		SchemaVersion:     report.SchemaVersion,
+		Summary:           summarizeSnapshotSave("baseline", req.BaselineKey, savedPath, err),
+		RepoPath:          req.RepoPath,
+		BaselineStorePath: req.BaselineStorePath,
+		BaselineKey:       req.BaselineKey,
+		SnapshotPath:      savedPath,
+		ReportSummary:     reportData.Summary,
+		Report:            reportData,
+	}
+	payload.Error = structuredError(err)
+	return payload
+}
+
+func shapeDashboardBaselineSavePayload(req DashboardMutationRequest, reportData dashboard.Report, savedPath string, err error) dashboardBaselineSavePayload {
+	payload := dashboardBaselineSavePayload{
+		SchemaVersion:     dashboard.BaselineSnapshotSchemaVersion,
+		Summary:           summarizeSnapshotSave("dashboard baseline", req.BaselineKey, savedPath, err),
+		RepoPath:          req.RepoPath,
+		BaselineStorePath: req.BaselineStorePath,
+		BaselineKey:       req.BaselineKey,
+		SnapshotPath:      savedPath,
+		DashboardSummary:  reportData.Summary,
+		Report:            reportData,
+	}
+	payload.Error = structuredError(err)
+	return payload
+}
+
+func summarizeSnapshotSave(kind, key, savedPath string, err error) string {
+	if err != nil {
+		return fmt.Sprintf("%s snapshot save failed for %s.", titleCaseFirst(kind), key)
+	}
+	return fmt.Sprintf("Saved %s snapshot %s to %s.", kind, key, savedPath)
+}
+
+func structuredError(err error) *structuredToolError {
+	if err == nil {
+		return nil
+	}
+	return &structuredToolError{Code: errorCodeToolFailed, Message: err.Error()}
+}
+
+func titleCaseFirst(value string) string {
+	if value == "" {
+		return ""
+	}
+	return strings.ToUpper(value[:1]) + value[1:]
+}
+
+func mutationToolError(err error, structured any) toolCallResult {
+	message := err.Error()
+	return toolCallResult{
+		Content: []contentItem{{
+			Type: "text",
+			Text: message,
+		}},
+		StructuredContent: structured,
+		IsError:           true,
+	}
+}
+
+func codemodApplyInputSchema() map[string]any {
+	properties := mutationAnalysisProperties()
+	properties["dependency"] = map[string]any{"type": "string", "description": "Dependency name to analyse and apply codemods for."}
+	properties["confirmApply"] = map[string]any{"type": "boolean", "description": "Must be true to confirm source-file mutation."}
+	properties["allowDirty"] = map[string]any{"type": "boolean", "default": false, "description": "Allow codemod apply when the git worktree has uncommitted changes."}
+	return mutationObjectSchema(properties, []string{"repoPath", "dependency", "confirmApply"})
+}
+
+func baselineSaveInputSchema() map[string]any {
+	properties := mutationAnalysisProperties()
+	properties["dependency"] = map[string]any{"type": "string", "description": "Optional dependency to analyse before saving."}
+	properties["topN"] = map[string]any{"type": "integer", "minimum": 1, "default": defaultTopN}
+	addBaselineSaveProperties(properties, "save the baseline snapshot")
+	return mutationObjectSchema(properties, []string{"repoPath", "baselineStorePath", "confirmSave"})
+}
+
+func dashboardBaselineSaveInputSchema() map[string]any {
+	properties := map[string]any{
+		"repoPath":        map[string]any{"type": "string", "description": "Local repository path used for default commit-key resolution."},
+		"repos":           dashboardReposSchema(),
+		"configPath":      map[string]any{"type": "string"},
+		"topN":            map[string]any{"type": "integer", "minimum": 1, "default": defaultTopN},
+		"defaultLanguage": map[string]any{"type": "string", "default": defaultLanguage},
+		"enableFeatures":  stringArraySchema(),
+		"disableFeatures": stringArraySchema(),
+		"timeoutMillis":   map[string]any{"type": "integer", "minimum": 1, "maximum": maxTimeoutMillis},
+	}
+	addBaselineSaveProperties(properties, "save the dashboard baseline snapshot")
+	schema := mutationObjectSchema(properties, []string{"repoPath", "baselineStorePath", "confirmSave"})
+	schema["anyOf"] = []map[string]any{
+		{"required": []string{"repos"}},
+		{"required": []string{"configPath"}},
+	}
+	return schema
+}
+
+func mutationAnalysisProperties() map[string]any {
+	properties := commonAnalysisProperties()
+	delete(properties, "runtimeTestCommand")
+	return properties
+}
+
+func addBaselineSaveProperties(properties map[string]any, confirmationDescription string) {
+	properties["baselineStorePath"] = map[string]any{"type": "string", "description": "Local directory where the immutable snapshot will be written. Relative paths resolve under repoPath."}
+	properties["baselineKey"] = map[string]any{"type": "string", "description": "Explicit snapshot key. Mutually exclusive with baselineLabel."}
+	properties["baselineLabel"] = map[string]any{"type": "string", "description": "Label used to create a label:<value> snapshot key. Mutually exclusive with baselineKey."}
+	properties["confirmSave"] = map[string]any{"type": "boolean", "description": "Must be true to " + confirmationDescription + "."}
+}
+
+func mutationObjectSchema(properties map[string]any, required []string) map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
+}
+
+func dashboardReposSchema() map[string]any {
+	return map[string]any{
+		"type": "array",
+		"items": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name":     map[string]any{"type": "string"},
+				"path":     map[string]any{"type": "string"},
+				"language": map[string]any{"type": "string"},
+			},
+			"required":             []string{"path"},
+			"additionalProperties": false,
+		},
+	}
+}

--- a/internal/mcp/mutations_test.go
+++ b/internal/mcp/mutations_test.go
@@ -1,0 +1,501 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/dashboard"
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestRunCodemodApplyToolReturnsStructuredPayload(t *testing.T) {
+	repo := t.TempDir()
+	applyReport := &report.CodemodApplyReport{
+		AppliedFiles:   2,
+		AppliedPatches: 3,
+		SkippedFiles:   1,
+		SkippedPatches: 1,
+		FailedFiles:    0,
+		FailedPatches:  0,
+		BackupPath:     filepath.Join(repo, ".lopper-backups", "codemod"),
+		Results: []report.CodemodApplyResult{{
+			File:       "src/app.ts",
+			Status:     "applied",
+			PatchCount: 3,
+		}},
+	}
+	rep := sampleReport(repo)
+	rep.Dependencies[0].Codemod = &report.CodemodReport{Mode: "apply", Apply: applyReport}
+	runner := &fakeMutationRunner{applyReport: rep}
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
+
+	result := callToolResult(t, server, toolApplyCodemod, map[string]any{
+		"repoPath":     repo,
+		"dependency":   "lodash",
+		"confirmApply": true,
+		"allowDirty":   true,
+		"include":      []string{"src/**"},
+		"cacheEnabled": false,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected codemod apply error: %#v", result)
+	}
+	if !runner.applyCalled {
+		t.Fatalf("expected mutation runner to be called")
+	}
+	if !runner.lastApply.AllowDirty || runner.lastApply.Dependency != "lodash" {
+		t.Fatalf("unexpected mutation request: %#v", runner.lastApply)
+	}
+	if !slicesEqual(runner.lastApply.IncludePatterns, []string{"src/**"}) {
+		t.Fatalf("expected include patterns to be passed through, got %#v", runner.lastApply.IncludePatterns)
+	}
+
+	payload, ok := result.StructuredContent.(codemodApplyPayload)
+	if !ok {
+		t.Fatalf("expected codemod payload, got %#v", result.StructuredContent)
+	}
+	if payload.AppliedFiles != 2 || payload.AppliedPatches != 3 || payload.SkippedFiles != 1 {
+		t.Fatalf("unexpected codemod counts: %#v", payload)
+	}
+	if payload.BackupPath == "" || len(payload.Results) != 1 {
+		t.Fatalf("expected backup and per-file results, got %#v", payload)
+	}
+	if !strings.Contains(payload.Summary, "2 files changed") {
+		t.Fatalf("unexpected codemod summary: %q", payload.Summary)
+	}
+}
+
+func TestRunBaselineSaveToolReturnsStructuredPayload(t *testing.T) {
+	repo := t.TempDir()
+	rep := sampleReport(repo)
+	runner := &fakeMutationRunner{baselineReport: rep}
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
+
+	result := callToolResult(t, server, toolSaveBaseline, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": "baselines",
+		"baselineLabel":     "nightly",
+		"topN":              3,
+		"confirmSave":       true,
+		"cacheEnabled":      false,
+		"disableFeatures":   []string{MutationToolsFeature},
+		"timeoutMillis":     1000,
+		"licenseFailOnDeny": false,
+		"licenseDeny":       []string{"GPL-3.0-only"},
+		"runtimeTracePath":  "trace.ndjson",
+		"runtimeProfile":    "node-import",
+		"cacheReadOnly":     true,
+		"cachePath":         ".cache/lopper",
+		"scopeMode":         "package",
+		"language":          "auto",
+		"exclude":           []string{"vendor/**"},
+		"include":           []string{"src/**"},
+	})
+	if result.IsError {
+		t.Fatalf("unexpected baseline save error: %#v", result)
+	}
+	if !runner.baselineCalled {
+		t.Fatalf("expected baseline runner to be called")
+	}
+	wantStore := filepath.Join(repo, "baselines")
+	wantPath := report.BaselineSnapshotPath(wantStore, "label:nightly")
+	if runner.lastBaseline.TopN != 3 || runner.lastBaseline.BaselineStorePath != wantStore || runner.lastBaseline.BaselineKey != "label:nightly" {
+		t.Fatalf("unexpected baseline request: %#v", runner.lastBaseline)
+	}
+
+	payload, ok := result.StructuredContent.(baselineSavePayload)
+	if !ok {
+		t.Fatalf("expected baseline payload, got %#v", result.StructuredContent)
+	}
+	if payload.SnapshotPath != wantPath || payload.BaselineKey != "label:nightly" {
+		t.Fatalf("unexpected baseline snapshot details: %#v", payload)
+	}
+	if payload.ReportSummary == nil || payload.ReportSummary.DependencyCount != 1 {
+		t.Fatalf("expected report summary in structured content, got %#v", payload.ReportSummary)
+	}
+}
+
+func TestRunDashboardBaselineSaveToolReturnsStructuredPayload(t *testing.T) {
+	repo := t.TempDir()
+	childRepo := t.TempDir()
+	store := filepath.Join(repo, "dashboard-baselines")
+	runner := &fakeMutationRunner{
+		dashboardReport: dashboard.Report{
+			Summary: dashboard.Summary{
+				TotalRepos: 1,
+				TotalDeps:  2,
+			},
+		},
+	}
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
+
+	result := callToolResult(t, server, toolSaveDashboardBaseline, map[string]any{
+		"repoPath":          repo,
+		"repos":             []map[string]any{{"name": "app", "path": childRepo, "language": "js-ts"}},
+		"baselineStorePath": store,
+		"baselineKey":       "release/1",
+		"confirmSave":       true,
+		"topN":              4,
+		"defaultLanguage":   "js-ts",
+	})
+	if result.IsError {
+		t.Fatalf("unexpected dashboard baseline save error: %#v", result)
+	}
+	if !runner.dashboardCalled {
+		t.Fatalf("expected dashboard runner to be called")
+	}
+	if runner.lastDashboard.TopN != 4 || runner.lastDashboard.DefaultLanguage != "js-ts" || len(runner.lastDashboard.Repos) != 1 {
+		t.Fatalf("unexpected dashboard request: %#v", runner.lastDashboard)
+	}
+
+	payload, ok := result.StructuredContent.(dashboardBaselineSavePayload)
+	if !ok {
+		t.Fatalf("expected dashboard baseline payload, got %#v", result.StructuredContent)
+	}
+	if payload.SnapshotPath != dashboard.BaselineSnapshotPath(store, "release/1") || payload.DashboardSummary.TotalRepos != 1 {
+		t.Fatalf("unexpected dashboard payload: %#v", payload)
+	}
+}
+
+func TestMutationToolErrorsReturnStructuredPayloads(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeMutationRunner{
+		applyReport:     sampleReport(repo),
+		applyErr:        errors.New("apply failed"),
+		baselineReport:  sampleReport(repo),
+		baselinePath:    filepath.Join(repo, "saved-baseline.json"),
+		baselineErr:     errors.New("baseline save failed"),
+		dashboardReport: dashboard.Report{Summary: dashboard.Summary{TotalRepos: 1}},
+		dashboardPath:   filepath.Join(repo, "saved-dashboard.json"),
+		dashboardErr:    errors.New("dashboard save failed"),
+	}
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
+
+	applyResult := callToolResult(t, server, toolApplyCodemod, map[string]any{
+		"repoPath":     repo,
+		"dependency":   "lodash",
+		"confirmApply": true,
+		"cacheEnabled": false,
+	})
+	if !applyResult.IsError {
+		t.Fatalf("expected codemod apply error")
+	}
+	applyPayload, ok := applyResult.StructuredContent.(codemodApplyPayload)
+	if !ok {
+		t.Fatalf("expected codemod payload, got %#v", applyResult.StructuredContent)
+	}
+	if applyPayload.Error == nil || applyPayload.Error.Code != errorCodeToolFailed || !strings.Contains(applyPayload.Summary, "failed") {
+		t.Fatalf("expected structured error payload, got %#v", applyPayload)
+	}
+
+	baselineResult := callToolResult(t, server, toolSaveBaseline, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": "baselines",
+		"baselineKey":       "release",
+		"confirmSave":       true,
+		"cacheEnabled":      false,
+	})
+	if !baselineResult.IsError {
+		t.Fatalf("expected baseline save error")
+	}
+	baselinePayload, ok := baselineResult.StructuredContent.(baselineSavePayload)
+	if !ok || baselinePayload.Error == nil || baselinePayload.SnapshotPath != runner.baselinePath {
+		t.Fatalf("expected structured baseline error payload, got %#v", baselineResult.StructuredContent)
+	}
+
+	dashboardResult := callToolResult(t, server, toolSaveDashboardBaseline, map[string]any{
+		"repoPath":          repo,
+		"repos":             []map[string]any{{"path": repo}},
+		"baselineStorePath": "dashboard-baselines",
+		"baselineKey":       "release",
+		"confirmSave":       true,
+	})
+	if !dashboardResult.IsError {
+		t.Fatalf("expected dashboard baseline save error")
+	}
+	dashboardPayload, ok := dashboardResult.StructuredContent.(dashboardBaselineSavePayload)
+	if !ok || dashboardPayload.Error == nil || dashboardPayload.SnapshotPath != runner.dashboardPath {
+		t.Fatalf("expected structured dashboard error payload, got %#v", dashboardResult.StructuredContent)
+	}
+}
+
+func TestMutationValidationBranches(t *testing.T) {
+	repo := t.TempDir()
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: &fakeMutationRunner{}})
+
+	if result := server.runCodemodApplyTool(context.Background(), jsonRaw(`{"repoPath":1}`)); !result.IsError {
+		t.Fatalf("expected codemod decode error")
+	}
+	if result := server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":      repo,
+		"dependency":    "lodash",
+		"confirmApply":  true,
+		"timeoutMillis": -1,
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "timeout") {
+		t.Fatalf("expected codemod timeout rejection, got %#v", result)
+	}
+	if result := server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":     filepath.Join(repo, "missing"),
+		"dependency":   "lodash",
+		"confirmApply": true,
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "stat repoPath") {
+		t.Fatalf("expected codemod request resolution error, got %#v", result)
+	}
+	if result := server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":     repo,
+		"confirmApply": true,
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "dependency") {
+		t.Fatalf("expected missing dependency rejection, got %#v", result)
+	}
+	if result := server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":     repo,
+		"dependency":   "lodash",
+		"topN":         2,
+		"confirmApply": true,
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "topN") {
+		t.Fatalf("expected topN rejection, got %#v", result)
+	}
+	if result := server.runBaselineSaveTool(context.Background(), jsonRaw(`{"repoPath":1}`)); !result.IsError {
+		t.Fatalf("expected baseline decode error")
+	}
+	if result := server.runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": "store",
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "confirmSave") {
+		t.Fatalf("expected missing baseline confirmation, got %#v", result)
+	}
+	if result := server.runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": "store",
+		"baselineKey":       "release",
+		"confirmSave":       true,
+		"timeoutMillis":     -1,
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "timeout") {
+		t.Fatalf("expected baseline timeout rejection, got %#v", result)
+	}
+	if result := server.runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": "store",
+		"baselineKey":       "release",
+		"scopeMode":         "bad",
+		"confirmSave":       true,
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "scopeMode") {
+		t.Fatalf("expected baseline request resolution error, got %#v", result)
+	}
+	if result := server.runDashboardBaselineSaveTool(context.Background(), jsonRaw(`{"repoPath":1}`)); !result.IsError {
+		t.Fatalf("expected dashboard decode error")
+	}
+	if result := server.runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": "store",
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "confirmSave") {
+		t.Fatalf("expected missing dashboard confirmation, got %#v", result)
+	}
+	if result := server.runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":          repo,
+		"repos":             []map[string]any{{"path": repo}},
+		"baselineStorePath": "store",
+		"baselineKey":       "release",
+		"confirmSave":       true,
+		"timeoutMillis":     -1,
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "timeout") {
+		t.Fatalf("expected dashboard timeout rejection, got %#v", result)
+	}
+	if result := NewServer(Options{Features: mustMutationFeatureSet(t, false), MutationRunner: &fakeMutationRunner{}}).runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":          repo,
+		"repos":             []map[string]any{{"path": repo}},
+		"baselineStorePath": "store",
+		"baselineKey":       "release",
+		"confirmSave":       true,
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, MutationToolsFeature) {
+		t.Fatalf("expected dashboard feature rejection, got %#v", result)
+	}
+	if result := server.runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": "store",
+		"baselineKey":       "release",
+		"confirmSave":       true,
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "repos or configPath") {
+		t.Fatalf("expected dashboard source rejection, got %#v", result)
+	}
+	if result := NewServer(Options{Features: mustMutationFeatureSet(t, true)}).runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": "store",
+		"baselineKey":       "release",
+		"confirmSave":       true,
+	})); !result.IsError || !strings.Contains(result.Content[0].Text, "runner") {
+		t.Fatalf("expected missing runner rejection, got %#v", result)
+	}
+
+	cases := []struct {
+		name string
+		args mutationAnalysisArguments
+		kind mutationAnalysisKind
+		want string
+	}{
+		{"missing dependency", mutationAnalysisArguments{RepoPath: repo}, mutationAnalysisKindDependency, "dependency"},
+		{"dependency target success", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep"}, mutationAnalysisKindTopOrDependency, ""},
+		{"top with dependency and topN", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", TopN: intPtr(2)}, mutationAnalysisKindTopOrDependency, "topN"},
+		{"invalid topN", mutationAnalysisArguments{RepoPath: repo, TopN: intPtr(0)}, mutationAnalysisKindTopOrDependency, "topN"},
+		{"unknown kind", mutationAnalysisArguments{RepoPath: repo}, mutationAnalysisKind("bad"), "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dependency, _, err := resolveMutationAnalysisTarget(tc.args, tc.kind)
+			if tc.want == "" {
+				if err != nil || dependency == "" {
+					t.Fatalf("expected dependency target success, dependency=%q err=%v", dependency, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestResolveMutationRequestValidationBranches(t *testing.T) {
+	repo := t.TempDir()
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: &fakeMutationRunner{}})
+
+	analysisCases := []struct {
+		name string
+		args mutationAnalysisArguments
+		want string
+	}{
+		{"bad repo", mutationAnalysisArguments{RepoPath: filepath.Join(repo, "missing"), Dependency: "dep"}, "stat repoPath"},
+		{"missing dependency", mutationAnalysisArguments{RepoPath: repo}, "dependency"},
+		{"bad scope", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", ScopeMode: "bad"}, "scopeMode"},
+		{"bad threshold", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", LowConfidenceWarningPercent: intPtr(101)}, "low_confidence"},
+		{"unknown feature", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", EnableFeatures: []string{"missing"}}, "unknown feature"},
+	}
+	for _, tc := range analysisCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := server.resolveAnalysisMutationRequest(context.Background(), tc.args, mutationAnalysisKindDependency)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := server.resolveAnalysisMutationRequest(cancelled, mutationAnalysisArguments{RepoPath: repo, Dependency: "dep"}, mutationAnalysisKindDependency)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled analysis request, got %v", err)
+	}
+
+	dashboardCases := []struct {
+		name string
+		args dashboardBaselineSaveArguments
+		want string
+	}{
+		{"bad repo", dashboardBaselineSaveArguments{RepoPath: filepath.Join(repo, "missing"), Repos: []DashboardRepoInput{{Path: repo}}, BaselineStorePath: "store", BaselineKey: "key"}, "stat repoPath"},
+		{"bad child repo", dashboardBaselineSaveArguments{RepoPath: repo, Repos: []DashboardRepoInput{{Path: "https://example.com/repo"}}, BaselineStorePath: "store", BaselineKey: "key"}, "local filesystem"},
+		{"bad topN", dashboardBaselineSaveArguments{RepoPath: repo, Repos: []DashboardRepoInput{{Path: repo}}, BaselineStorePath: "store", BaselineKey: "key", TopN: intPtr(0)}, "topN"},
+		{"bad store", dashboardBaselineSaveArguments{RepoPath: repo, Repos: []DashboardRepoInput{{Path: repo}}, BaselineStorePath: "https://example.com/store", BaselineKey: "key"}, "local filesystem"},
+		{"unknown feature", dashboardBaselineSaveArguments{RepoPath: repo, Repos: []DashboardRepoInput{{Path: repo}}, BaselineStorePath: "store", BaselineKey: "key", EnableFeatures: []string{"missing"}}, "unknown feature"},
+	}
+	for _, tc := range dashboardCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := server.resolveDashboardMutationRequest(context.Background(), tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+
+	cancelled, cancel = context.WithCancel(context.Background())
+	cancel()
+	_, err = server.resolveDashboardMutationRequest(cancelled, dashboardBaselineSaveArguments{
+		RepoPath:          repo,
+		Repos:             []DashboardRepoInput{{Path: repo}},
+		BaselineStorePath: "store",
+		BaselineKey:       "key",
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled dashboard request, got %v", err)
+	}
+}
+
+func TestMutationPathAndPayloadHelpers(t *testing.T) {
+	repo := t.TempDir()
+	absStore := filepath.Join(repo, "store")
+	resolved, err := resolveLocalMutationPath(repo, absStore, "baselineStorePath")
+	if err != nil || resolved != absStore {
+		t.Fatalf("resolve absolute path: path=%q err=%v", resolved, err)
+	}
+	for _, rawPath := range []string{"", "https://example.com/store", "bad\x00path"} {
+		if _, err := resolveLocalMutationPath(repo, rawPath, "baselineStorePath"); err == nil {
+			t.Fatalf("expected local path validation error for %q", rawPath)
+		}
+	}
+	if _, _, err := resolveBaselineMutationTarget(repo, "store", "key", "label", "baseline"); err == nil {
+		t.Fatalf("expected key/label conflict")
+	}
+	if store, key, err := resolveBaselineMutationTarget(repo, "store", "explicit", "", "baseline"); err != nil || store != filepath.Join(repo, "store") || key != "explicit" {
+		t.Fatalf("unexpected explicit key resolution: store=%q key=%q err=%v", store, key, err)
+	}
+	if _, _, err := resolveBaselineMutationTarget(repo, "store", "", "", "baseline"); err == nil {
+		t.Fatalf("expected non-git repo key resolution error")
+	}
+	gitRepo := t.TempDir()
+	writeGitFixture(t, gitRepo)
+	store, key, err := resolveBaselineMutationTarget(gitRepo, "store", "", "", "baseline")
+	if err != nil || store != filepath.Join(gitRepo, "store") || !strings.HasPrefix(key, "commit:") {
+		t.Fatalf("unexpected current commit key resolution: store=%q key=%q err=%v", store, key, err)
+	}
+
+	for _, repos := range [][]DashboardRepoInput{
+		{{Path: ""}},
+		{{Path: "https://example.com/repo"}},
+		{{Path: "bad\x00path"}},
+	} {
+		if err := validateDashboardMutationRepos(repos); err == nil {
+			t.Fatalf("expected dashboard repo validation error for %#v", repos)
+		}
+	}
+	if err := validateDashboardMutationRepos([]DashboardRepoInput{{Path: repo}}); err != nil {
+		t.Fatalf("expected local dashboard repo path, got %v", err)
+	}
+
+	if got := summarizeCodemodApply("dep", nil, nil); !strings.Contains(got, "no codemod changes") {
+		t.Fatalf("unexpected empty codemod summary: %q", got)
+	}
+	if got := summarizeSnapshotSave("baseline", "key", "path", errors.New("save failed")); !strings.Contains(got, "failed") {
+		t.Fatalf("unexpected failed snapshot summary: %q", got)
+	}
+	if errPayload := structuredError(errors.New("boom")); errPayload == nil || errPayload.Code != errorCodeToolFailed {
+		t.Fatalf("unexpected structured error: %#v", errPayload)
+	}
+	if titleCaseFirst("") != "" {
+		t.Fatalf("expected empty title-case result")
+	}
+	rep := sampleReport(repo)
+	rep.Dependencies = append([]report.DependencyReport{{Name: "other", Codemod: &report.CodemodReport{Apply: &report.CodemodApplyReport{AppliedFiles: 1}}}}, rep.Dependencies...)
+	if apply := findCodemodApplyReport(rep, "lodash"); apply != nil {
+		t.Fatalf("expected dependency-specific codemod lookup to skip other dependency, got %#v", apply)
+	}
+}
+
+func jsonRaw(value string) []byte {
+	return []byte(value)
+}
+
+func writeGitFixture(t *testing.T, repo string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("fixture\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	testutil.RunGit(t, repo, "init")
+	testutil.RunGit(t, repo, "config", "user.email", "test@example.com")
+	testutil.RunGit(t, repo, "config", "user.name", "Test User")
+	testutil.RunGit(t, repo, "add", ".")
+	testutil.RunGit(t, repo, "commit", "-m", "fixture")
+}

--- a/internal/mcp/mutations_test.go
+++ b/internal/mcp/mutations_test.go
@@ -224,114 +224,185 @@ func TestMutationToolErrorsReturnStructuredPayloads(t *testing.T) {
 	}
 }
 
-func TestMutationValidationBranches(t *testing.T) {
+func TestMutationToolValidationBranches(t *testing.T) {
 	repo := t.TempDir()
 	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: &fakeMutationRunner{}})
 
-	if result := server.runCodemodApplyTool(context.Background(), jsonRaw(`{"repoPath":1}`)); !result.IsError {
-		t.Fatalf("expected codemod decode error")
+	cases := []struct {
+		name string
+		run  func() toolCallResult
+		want string
+	}{
+		{
+			name: "codemod decode error",
+			run: func() toolCallResult {
+				return server.runCodemodApplyTool(context.Background(), jsonRaw(`{"repoPath":1}`))
+			},
+		},
+		{
+			name: "codemod timeout",
+			run: func() toolCallResult {
+				return server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":      repo,
+					"dependency":    "lodash",
+					"confirmApply":  true,
+					"timeoutMillis": -1,
+				}))
+			},
+			want: "timeout",
+		},
+		{
+			name: "codemod missing repo",
+			run: func() toolCallResult {
+				return server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":     filepath.Join(repo, "missing"),
+					"dependency":   "lodash",
+					"confirmApply": true,
+				}))
+			},
+			want: "stat repoPath",
+		},
+		{
+			name: "codemod missing dependency",
+			run: func() toolCallResult {
+				return server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":     repo,
+					"confirmApply": true,
+				}))
+			},
+			want: "dependency",
+		},
+		{
+			name: "codemod topN",
+			run: func() toolCallResult {
+				return server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":     repo,
+					"dependency":   "lodash",
+					"topN":         2,
+					"confirmApply": true,
+				}))
+			},
+			want: "topN",
+		},
+		{
+			name: "baseline decode error",
+			run: func() toolCallResult {
+				return server.runBaselineSaveTool(context.Background(), jsonRaw(`{"repoPath":1}`))
+			},
+		},
+		{
+			name: "baseline missing confirmation",
+			run: func() toolCallResult {
+				return server.runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":          repo,
+					"baselineStorePath": "store",
+				}))
+			},
+			want: "confirmSave",
+		},
+		{
+			name: "baseline timeout",
+			run: func() toolCallResult {
+				return server.runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":          repo,
+					"baselineStorePath": "store",
+					"baselineKey":       "release",
+					"confirmSave":       true,
+					"timeoutMillis":     -1,
+				}))
+			},
+			want: "timeout",
+		},
+		{
+			name: "baseline bad scope",
+			run: func() toolCallResult {
+				return server.runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":          repo,
+					"baselineStorePath": "store",
+					"baselineKey":       "release",
+					"scopeMode":         "bad",
+					"confirmSave":       true,
+				}))
+			},
+			want: "scopeMode",
+		},
+		{
+			name: "dashboard decode error",
+			run: func() toolCallResult {
+				return server.runDashboardBaselineSaveTool(context.Background(), jsonRaw(`{"repoPath":1}`))
+			},
+		},
+		{
+			name: "dashboard missing confirmation",
+			run: func() toolCallResult {
+				return server.runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":          repo,
+					"baselineStorePath": "store",
+				}))
+			},
+			want: "confirmSave",
+		},
+		{
+			name: "dashboard timeout",
+			run: func() toolCallResult {
+				return server.runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":          repo,
+					"repos":             []map[string]any{{"path": repo}},
+					"baselineStorePath": "store",
+					"baselineKey":       "release",
+					"confirmSave":       true,
+					"timeoutMillis":     -1,
+				}))
+			},
+			want: "timeout",
+		},
+		{
+			name: "dashboard feature disabled",
+			run: func() toolCallResult {
+				return NewServer(Options{Features: mustMutationFeatureSet(t, false), MutationRunner: &fakeMutationRunner{}}).runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":          repo,
+					"repos":             []map[string]any{{"path": repo}},
+					"baselineStorePath": "store",
+					"baselineKey":       "release",
+					"confirmSave":       true,
+				}))
+			},
+			want: MutationToolsFeature,
+		},
+		{
+			name: "dashboard missing source",
+			run: func() toolCallResult {
+				return server.runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":          repo,
+					"baselineStorePath": "store",
+					"baselineKey":       "release",
+					"confirmSave":       true,
+				}))
+			},
+			want: "repos or configPath",
+		},
+		{
+			name: "baseline missing runner",
+			run: func() toolCallResult {
+				return NewServer(Options{Features: mustMutationFeatureSet(t, true)}).runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
+					"repoPath":          repo,
+					"baselineStorePath": "store",
+					"baselineKey":       "release",
+					"confirmSave":       true,
+				}))
+			},
+			want: "runner",
+		},
 	}
-	if result := server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":      repo,
-		"dependency":    "lodash",
-		"confirmApply":  true,
-		"timeoutMillis": -1,
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "timeout") {
-		t.Fatalf("expected codemod timeout rejection, got %#v", result)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertMutationToolErrorContains(t, tc.run(), tc.want)
+		})
 	}
-	if result := server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":     filepath.Join(repo, "missing"),
-		"dependency":   "lodash",
-		"confirmApply": true,
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "stat repoPath") {
-		t.Fatalf("expected codemod request resolution error, got %#v", result)
-	}
-	if result := server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":     repo,
-		"confirmApply": true,
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "dependency") {
-		t.Fatalf("expected missing dependency rejection, got %#v", result)
-	}
-	if result := server.runCodemodApplyTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":     repo,
-		"dependency":   "lodash",
-		"topN":         2,
-		"confirmApply": true,
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "topN") {
-		t.Fatalf("expected topN rejection, got %#v", result)
-	}
-	if result := server.runBaselineSaveTool(context.Background(), jsonRaw(`{"repoPath":1}`)); !result.IsError {
-		t.Fatalf("expected baseline decode error")
-	}
-	if result := server.runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":          repo,
-		"baselineStorePath": "store",
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "confirmSave") {
-		t.Fatalf("expected missing baseline confirmation, got %#v", result)
-	}
-	if result := server.runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":          repo,
-		"baselineStorePath": "store",
-		"baselineKey":       "release",
-		"confirmSave":       true,
-		"timeoutMillis":     -1,
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "timeout") {
-		t.Fatalf("expected baseline timeout rejection, got %#v", result)
-	}
-	if result := server.runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":          repo,
-		"baselineStorePath": "store",
-		"baselineKey":       "release",
-		"scopeMode":         "bad",
-		"confirmSave":       true,
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "scopeMode") {
-		t.Fatalf("expected baseline request resolution error, got %#v", result)
-	}
-	if result := server.runDashboardBaselineSaveTool(context.Background(), jsonRaw(`{"repoPath":1}`)); !result.IsError {
-		t.Fatalf("expected dashboard decode error")
-	}
-	if result := server.runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":          repo,
-		"baselineStorePath": "store",
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "confirmSave") {
-		t.Fatalf("expected missing dashboard confirmation, got %#v", result)
-	}
-	if result := server.runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":          repo,
-		"repos":             []map[string]any{{"path": repo}},
-		"baselineStorePath": "store",
-		"baselineKey":       "release",
-		"confirmSave":       true,
-		"timeoutMillis":     -1,
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "timeout") {
-		t.Fatalf("expected dashboard timeout rejection, got %#v", result)
-	}
-	if result := NewServer(Options{Features: mustMutationFeatureSet(t, false), MutationRunner: &fakeMutationRunner{}}).runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":          repo,
-		"repos":             []map[string]any{{"path": repo}},
-		"baselineStorePath": "store",
-		"baselineKey":       "release",
-		"confirmSave":       true,
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, MutationToolsFeature) {
-		t.Fatalf("expected dashboard feature rejection, got %#v", result)
-	}
-	if result := server.runDashboardBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":          repo,
-		"baselineStorePath": "store",
-		"baselineKey":       "release",
-		"confirmSave":       true,
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "repos or configPath") {
-		t.Fatalf("expected dashboard source rejection, got %#v", result)
-	}
-	if result := NewServer(Options{Features: mustMutationFeatureSet(t, true)}).runBaselineSaveTool(context.Background(), mustJSON(t, map[string]any{
-		"repoPath":          repo,
-		"baselineStorePath": "store",
-		"baselineKey":       "release",
-		"confirmSave":       true,
-	})); !result.IsError || !strings.Contains(result.Content[0].Text, "runner") {
-		t.Fatalf("expected missing runner rejection, got %#v", result)
-	}
+}
 
+func TestResolveMutationAnalysisTargetBranches(t *testing.T) {
+	repo := t.TempDir()
 	cases := []struct {
 		name string
 		args mutationAnalysisArguments
@@ -424,7 +495,7 @@ func TestResolveMutationRequestValidationBranches(t *testing.T) {
 	}
 }
 
-func TestMutationPathAndPayloadHelpers(t *testing.T) {
+func TestResolveLocalMutationPath(t *testing.T) {
 	repo := t.TempDir()
 	absStore := filepath.Join(repo, "store")
 	resolved, err := resolveLocalMutationPath(repo, absStore, "baselineStorePath")
@@ -436,6 +507,10 @@ func TestMutationPathAndPayloadHelpers(t *testing.T) {
 			t.Fatalf("expected local path validation error for %q", rawPath)
 		}
 	}
+}
+
+func TestResolveBaselineMutationTarget(t *testing.T) {
+	repo := t.TempDir()
 	if _, _, err := resolveBaselineMutationTarget(repo, "store", "key", "label", "baseline"); err == nil {
 		t.Fatalf("expected key/label conflict")
 	}
@@ -451,7 +526,10 @@ func TestMutationPathAndPayloadHelpers(t *testing.T) {
 	if err != nil || store != filepath.Join(gitRepo, "store") || !strings.HasPrefix(key, "commit:") {
 		t.Fatalf("unexpected current commit key resolution: store=%q key=%q err=%v", store, key, err)
 	}
+}
 
+func TestValidateDashboardMutationRepos(t *testing.T) {
+	repo := t.TempDir()
 	for _, repos := range [][]DashboardRepoInput{
 		{{Path: ""}},
 		{{Path: "https://example.com/repo"}},
@@ -464,7 +542,10 @@ func TestMutationPathAndPayloadHelpers(t *testing.T) {
 	if err := validateDashboardMutationRepos([]DashboardRepoInput{{Path: repo}}); err != nil {
 		t.Fatalf("expected local dashboard repo path, got %v", err)
 	}
+}
 
+func TestMutationPayloadSummaryHelpers(t *testing.T) {
+	repo := t.TempDir()
 	if got := summarizeCodemodApply("dep", nil, nil); !strings.Contains(got, "no codemod changes") {
 		t.Fatalf("unexpected empty codemod summary: %q", got)
 	}
@@ -481,6 +562,19 @@ func TestMutationPathAndPayloadHelpers(t *testing.T) {
 	rep.Dependencies = append([]report.DependencyReport{{Name: "other", Codemod: &report.CodemodReport{Apply: &report.CodemodApplyReport{AppliedFiles: 1}}}}, rep.Dependencies...)
 	if apply := findCodemodApplyReport(rep, "lodash"); apply != nil {
 		t.Fatalf("expected dependency-specific codemod lookup to skip other dependency, got %#v", apply)
+	}
+}
+
+func assertMutationToolErrorContains(t *testing.T, result toolCallResult, want string) {
+	t.Helper()
+	if !result.IsError {
+		t.Fatalf("expected mutation tool error, got %#v", result)
+	}
+	if want == "" {
+		return
+	}
+	if len(result.Content) == 0 || !strings.Contains(result.Content[0].Text, want) {
+		t.Fatalf("expected %q error, got %#v", want, result)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -49,6 +49,8 @@ type Options struct {
 	Analyzer         analysis.Analyser
 	LanguageRegistry *language.Registry
 	FeatureRegistry  *featureflags.Registry
+	Features         featureflags.Set
+	MutationRunner   MutationRunner
 	ServerName       string
 	ServerVersion    string
 }
@@ -57,6 +59,8 @@ type Server struct {
 	analyzer         analysis.Analyser
 	languageRegistry *language.Registry
 	featureRegistry  *featureflags.Registry
+	features         featureflags.Set
+	mutationRunner   MutationRunner
 	serverName       string
 	serverVersion    string
 	writeMu          sync.Mutex
@@ -105,6 +109,15 @@ type serverInfo struct {
 var currentVersion = version.Current
 
 func NewServer(opts Options) *Server {
+	featureRegistry := opts.FeatureRegistry
+	if featureRegistry == nil {
+		featureRegistry = featureflags.DefaultRegistry()
+	}
+	features := opts.Features
+	if features.Snapshot() == nil {
+		features = resolveDefaultServerFeatures(featureRegistry)
+	}
+
 	serverVersion := opts.ServerVersion
 	if serverVersion == "" {
 		serverVersion = currentVersion().Version
@@ -121,10 +134,35 @@ func NewServer(opts Options) *Server {
 	return &Server{
 		analyzer:         opts.Analyzer,
 		languageRegistry: opts.LanguageRegistry,
-		featureRegistry:  opts.FeatureRegistry,
+		featureRegistry:  featureRegistry,
+		features:         features,
+		mutationRunner:   opts.MutationRunner,
 		serverName:       serverName,
 		serverVersion:    serverVersion,
 	}
+}
+
+func resolveDefaultServerFeatures(registry *featureflags.Registry) featureflags.Set {
+	info := currentVersion()
+	channel, err := featureflags.NormalizeChannel(info.BuildChannel)
+	if err != nil {
+		return featureflags.Set{}
+	}
+	var lock *featureflags.ReleaseLock
+	if channel == featureflags.ChannelRelease {
+		lock, err = featureflags.DefaultReleaseLock(info.Version)
+		if err != nil {
+			return featureflags.Set{}
+		}
+	}
+	features, err := registry.Resolve(featureflags.ResolveOptions{
+		Channel: channel,
+		Lock:    lock,
+	})
+	if err != nil {
+		return featureflags.Set{}
+	}
+	return features
 }
 
 func Serve(ctx context.Context, in io.Reader, out io.Writer, opts Options) error {
@@ -215,7 +253,7 @@ func (s *Server) initialize(params json.RawMessage) initializeResult {
 			Name:    s.serverName,
 			Version: s.serverVersion,
 		},
-		Instructions: "Use Lopper MCP tools for local, read-only dependency surface analysis.",
+		Instructions: "Use Lopper MCP tools for local dependency surface analysis. Mutation tools are explicit, feature-gated, and require confirmation.",
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/analysis"
+	"github.com/ben-ranford/lopper/internal/dashboard"
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 )
@@ -39,6 +41,41 @@ type testAdapter struct {
 	language.AdapterContract
 }
 
+type fakeMutationRunner struct {
+	applyReport     report.Report
+	applyErr        error
+	baselineReport  report.Report
+	baselinePath    string
+	baselineErr     error
+	dashboardReport dashboard.Report
+	dashboardPath   string
+	dashboardErr    error
+	applyCalled     bool
+	baselineCalled  bool
+	dashboardCalled bool
+	lastApply       AnalysisMutationRequest
+	lastBaseline    AnalysisMutationRequest
+	lastDashboard   DashboardMutationRequest
+}
+
+func (f *fakeMutationRunner) ApplyCodemod(_ context.Context, req AnalysisMutationRequest) (report.Report, error) {
+	f.applyCalled = true
+	f.lastApply = req
+	return f.applyReport, f.applyErr
+}
+
+func (f *fakeMutationRunner) SaveBaseline(_ context.Context, req AnalysisMutationRequest) (report.Report, string, error) {
+	f.baselineCalled = true
+	f.lastBaseline = req
+	return f.baselineReport, f.baselinePath, f.baselineErr
+}
+
+func (f *fakeMutationRunner) SaveDashboardBaseline(_ context.Context, req DashboardMutationRequest) (dashboard.Report, string, error) {
+	f.dashboardCalled = true
+	f.lastDashboard = req
+	return f.dashboardReport, f.dashboardPath, f.dashboardErr
+}
+
 func newTestAdapter(id string, aliases ...string) *testAdapter {
 	return &testAdapter{AdapterContract: language.NewAdapterContract(id, aliases...)}
 }
@@ -52,7 +89,7 @@ func (a *testAdapter) Analyse(context.Context, language.Request) (report.Result,
 }
 
 func TestHandleToolsListRegistersExpectedTools(t *testing.T) {
-	server := NewServer(Options{})
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, false)})
 	response := server.handlePayload(context.Background(), mustJSON(t, rpcRequest{
 		JSONRPC: jsonrpcVersion,
 		ID:      json.RawMessage(`1`),
@@ -70,6 +107,31 @@ func TestHandleToolsListRegistersExpectedTools(t *testing.T) {
 	assertTopDependencySchema(t, byName[toolAnalyseTop])
 	assertDependencySchema(t, byName[toolAnalyseDependency])
 	assertBaselineSchema(t, byName[toolCompareBaseline])
+}
+
+func TestHandleToolsListRegistersMutationToolsWhenFeatureEnabled(t *testing.T) {
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: &fakeMutationRunner{}})
+	response := server.handlePayload(context.Background(), mustJSON(t, rpcRequest{
+		JSONRPC: jsonrpcVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  methodToolsList,
+	}))
+	if response == nil || response.Error != nil {
+		t.Fatalf("expected tools/list response, got %#v", response)
+	}
+
+	result := response.Result.(map[string]any)
+	tools := result["tools"].([]toolSpec)
+	byName := toolSpecsByName(tools)
+	for _, name := range []string{toolApplyCodemod, toolSaveBaseline, toolSaveDashboardBaseline} {
+		if _, ok := byName[name]; !ok {
+			t.Fatalf("expected mutation tool %s to be registered, got %#v", name, byName)
+		}
+	}
+	assertStrictToolSchemas(t, tools)
+	assertRequiredSchemaFields(t, byName[toolApplyCodemod], "repoPath", "dependency", "confirmApply")
+	assertRequiredSchemaFields(t, byName[toolSaveBaseline], "repoPath", "baselineStorePath", "confirmSave")
+	assertRequiredSchemaFields(t, byName[toolSaveDashboardBaseline], "repoPath", "baselineStorePath", "confirmSave")
 }
 
 func assertToolOrder(t *testing.T, tools []toolSpec) {
@@ -122,6 +184,19 @@ func assertBaselineSchema(t *testing.T, tool toolSpec) {
 	anyOf, ok := tool.InputSchema["anyOf"].([]map[string]any)
 	if !ok || len(anyOf) != 2 {
 		t.Fatalf("baseline schema should describe baselinePath or baselineStorePath alternatives, got %#v", tool.InputSchema["anyOf"])
+	}
+}
+
+func assertRequiredSchemaFields(t *testing.T, tool toolSpec, names ...string) {
+	t.Helper()
+	required, ok := tool.InputSchema["required"].([]string)
+	if !ok {
+		t.Fatalf("expected required string list for %s, got %#v", tool.Name, tool.InputSchema["required"])
+	}
+	for _, name := range names {
+		if !slices.Contains(required, name) {
+			t.Fatalf("expected %s to require %s, got %#v", tool.Name, name, required)
+		}
 	}
 }
 
@@ -208,8 +283,8 @@ func TestCallAnalyseTopValidatesInputs(t *testing.T) {
 	}
 
 	mutationArg := callToolResult(t, server, toolAnalyseTop, map[string]any{
-		"repoPath":           repo,
-		"runtimeTestCommand": "npm test",
+		"repoPath":     repo,
+		"applyCodemod": true,
 	})
 	if !mutationArg.IsError || !strings.Contains(mutationArg.Content[0].Text, "unknown field") {
 		t.Fatalf("expected unsupported argument validation error, got %#v", mutationArg)
@@ -221,6 +296,43 @@ func TestCallAnalyseTopValidatesInputs(t *testing.T) {
 	})
 	if !badTopN.IsError || !strings.Contains(badTopN.Content[0].Text, "topN") {
 		t.Fatalf("expected topN validation error, got %#v", badTopN)
+	}
+}
+
+func TestMutationToolsValidateFeatureAndConfirmation(t *testing.T) {
+	repo := t.TempDir()
+	disabled := NewServer(Options{Features: mustMutationFeatureSet(t, false), MutationRunner: &fakeMutationRunner{}})
+	result := callToolResult(t, disabled, toolApplyCodemod, map[string]any{
+		"repoPath":      repo,
+		"dependency":    "lodash",
+		"confirmApply":  true,
+		"cacheEnabled":  false,
+		"timeoutMillis": 1000,
+	})
+	if !result.IsError || !strings.Contains(result.Content[0].Text, MutationToolsFeature) {
+		t.Fatalf("expected feature flag rejection, got %#v", result)
+	}
+
+	enabled := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: &fakeMutationRunner{}})
+	missingConfirm := callToolResult(t, enabled, toolApplyCodemod, map[string]any{
+		"repoPath":     repo,
+		"dependency":   "lodash",
+		"cacheEnabled": false,
+	})
+	if !missingConfirm.IsError || !strings.Contains(missingConfirm.Content[0].Text, "confirmApply") {
+		t.Fatalf("expected missing confirmation rejection, got %#v", missingConfirm)
+	}
+
+	unsafeStore := callToolResult(t, enabled, toolSaveBaseline, map[string]any{
+		"repoPath":                    repo,
+		"baselineStorePath":           "https://example.com/baselines",
+		"baselineLabel":               "nightly",
+		"confirmSave":                 true,
+		"cacheEnabled":                false,
+		"lowConfidenceWarningPercent": 25,
+	})
+	if !unsafeStore.IsError || !strings.Contains(unsafeStore.Content[0].Text, "local filesystem path") {
+		t.Fatalf("expected unsafe path rejection, got %#v", unsafeStore)
 	}
 }
 
@@ -494,4 +606,26 @@ func policyTraceSource(trace []report.PolicyMergeTrace, field string) string {
 		}
 	}
 	return ""
+}
+
+func mustMutationFeatureSet(t *testing.T, enabled bool) featureflags.Set {
+	t.Helper()
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
+		Code:        "LOP-FEAT-0001",
+		Name:        MutationToolsFeature,
+		Description: "test mutation tools",
+		Lifecycle:   featureflags.LifecyclePreview,
+	}})
+	if err != nil {
+		t.Fatalf("new feature registry: %v", err)
+	}
+	opts := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
+	if enabled {
+		opts.Enable = []string{MutationToolsFeature}
+	}
+	features, err := registry.Resolve(opts)
+	if err != nil {
+		t.Fatalf("resolve mutation feature: %v", err)
+	}
+	return features
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -20,10 +20,13 @@ import (
 )
 
 const (
-	toolAnalyseTop        = "lopper_analyse_top_dependencies"
-	toolAnalyseDependency = "lopper_analyse_dependency"
-	toolCompareBaseline   = "lopper_compare_baseline"
-	toolListLanguages     = "lopper_list_languages"
+	toolAnalyseTop            = "lopper_analyse_top_dependencies"
+	toolAnalyseDependency     = "lopper_analyse_dependency"
+	toolCompareBaseline       = "lopper_compare_baseline"
+	toolListLanguages         = "lopper_list_languages"
+	toolApplyCodemod          = "lopper_apply_codemod"
+	toolSaveBaseline          = "lopper_save_baseline"
+	toolSaveDashboardBaseline = "lopper_save_dashboard_baseline"
 )
 
 type toolSpec struct {
@@ -126,7 +129,7 @@ type resolvedToolRequest struct {
 }
 
 func (s *Server) tools() []toolSpec {
-	return []toolSpec{
+	tools := []toolSpec{
 		{
 			Name:        toolAnalyseTop,
 			Description: "Analyse and rank the top dependencies by unused surface area for a local repository.",
@@ -148,6 +151,27 @@ func (s *Server) tools() []toolSpec {
 			InputSchema: listLanguagesInputSchema(),
 		},
 	}
+	if s.mutationToolsEnabled() {
+		mutationTools := []toolSpec{
+			{
+				Name:        toolApplyCodemod,
+				Description: "Apply deterministic codemod suggestions for one dependency after explicit confirmation.",
+				InputSchema: codemodApplyInputSchema(),
+			},
+			{
+				Name:        toolSaveBaseline,
+				Description: "Run analysis and save the report as an immutable baseline snapshot after explicit confirmation.",
+				InputSchema: baselineSaveInputSchema(),
+			},
+			{
+				Name:        toolSaveDashboardBaseline,
+				Description: "Run dashboard aggregation and save an immutable dashboard baseline snapshot after explicit confirmation.",
+				InputSchema: dashboardBaselineSaveInputSchema(),
+			},
+		}
+		tools = append(tools, mutationTools...)
+	}
+	return tools
 }
 
 func (s *Server) callTool(ctx context.Context, params json.RawMessage) (toolCallResult, *rpcError) {
@@ -172,6 +196,12 @@ func (s *Server) callTool(ctx context.Context, params json.RawMessage) (toolCall
 		return s.runAnalysisTool(ctx, args, analysisToolKindCompare), nil
 	case toolListLanguages:
 		return s.runListLanguagesTool(ctx, args), nil
+	case toolApplyCodemod:
+		return s.runCodemodApplyTool(ctx, args), nil
+	case toolSaveBaseline:
+		return s.runBaselineSaveTool(ctx, args), nil
+	case toolSaveDashboardBaseline:
+		return s.runDashboardBaselineSaveTool(ctx, args), nil
 	default:
 		return toolCallResult{}, &rpcError{Code: codeInvalidParams, Message: fmt.Sprintf("unknown tool: %s", call.Name)}
 	}


### PR DESCRIPTION
## Summary
Closes #1044.

Adds explicit, preview-gated MCP mutation parity for workflows that already existed in the CLI/app layer: codemod apply, analysis baseline save, and dashboard baseline save. Read-only MCP tools remain strict read-only tools and continue to reject hidden mutation fields.

## Changes
- Added preview flag `mcp-mutation-tools-preview`.
- Added `lopper_apply_codemod`, `lopper_save_baseline`, and `lopper_save_dashboard_baseline` as separate MCP tools behind that flag.
- Added an app-backed MCP mutation runner so MCP uses existing analyse/dashboard post-processing, codemod rollback artifacts, dirty-worktree checks, and immutable snapshot saves.
- Added structured mutation outputs for applied files/patches/results and saved baseline keys/paths.
- Added MCP/app tests for tool registration, successful codemod and baseline mutations, dirty worktree rejection, missing confirmation, unsafe path rejection, read-only non-mutation behavior, rolling defaults, and coverage-gated mutation helper branches.
- Updated `docs/mcp.md` with the new tools, schemas, startup feature flag, structured outputs, and safety model.

## Validation
Commands and checks run:

```bash
go run ./tools/featureflag validate
go test ./internal/featureflags ./internal/mcp ./internal/app
BUILD_CHANNEL=rolling go test ./internal/mcp ./internal/app
make lint
make test
make cov
make dup-check DUPLICATION_BASE=origin/main
git diff --check
git diff --cached --check
```

Additional local validation results:

- Coverage gate passed: total coverage 98.3%, package floor 98%; `internal/mcp` 99.0%, `internal/app` 98.2%.
- Duplication gate passed locally at 2.23% duplicated added lines, under the 3% gate, against the latest `origin/main`.
- Confirmed Copilot review was requested with `gh pr edit 1078 --add-reviewer @copilot`; Copilot responded that the requesting user has reached quota.

## Risk and compatibility
- Breaking changes: None. Existing read-only MCP tools and clients remain unchanged.
- Migration required: None. New mutation tools are preview-only and default-off outside rolling builds; enable with `lopper mcp --enable-feature mcp-mutation-tools-preview`.
- Performance impact: None expected. Mutation tools reuse existing analyse/dashboard execution paths.
- Memory benchmark impact: None expected. No intentional memory benchmark regression.

Additional safety notes:
- Mutations require explicit tool names plus `confirmApply: true` or `confirmSave: true`.
- Baseline store paths and dashboard repo paths must be local filesystem paths; relative baseline stores resolve under `repoPath`.
- Codemod apply still refuses dirty worktrees unless `allowDirty` is true and writes rollback artifacts.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
- [x] New MCP tools exist for codemod apply and baseline save workflows that already exist in the CLI/app layer
- [x] Existing read-only tools do not gain hidden mutation behavior
- [x] Mutation tools return structured outputs that summarize what changed or what snapshot was saved
- [x] Unsafe inputs and mutation requests without required guardrails are rejected clearly
- [x] MCP docs are updated with the new tools, schemas, and safety model
