### PR TITLE
fix(flags): derive graduation target series labels

### DIFF
--- a/.github/workflows/graduate-feature.yml
+++ b/.github/workflows/graduate-feature.yml
@@ -28,7 +28,7 @@ on:
       milestone:
         description: Milestone to assign to the graduation PR
         required: false
-        default: "v1.6.0"
+        default: "v1.7.0"
         type: string
 
 permissions:
@@ -90,6 +90,10 @@ jobs:
           if [ -n "${ISSUE_NUMBER}" ]; then
             issue_line="Closes #${ISSUE_NUMBER}."
           fi
+          target_series_label=""
+          if [[ "${MILESTONE}" =~ ^v?([0-9]+)\.([0-9]+)(\.[0-9]+)?([-.].*)?$ ]]; then
+            target_series_label="target-series:${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.x"
+          fi
 
           mkdir -p .artifacts
           cat > .artifacts/graduate-feature-pr.md <<PR_BODY
@@ -140,8 +144,10 @@ jobs:
             --title "feat(flags): graduate ${FEATURE} to stable"
             --body-file .artifacts/graduate-feature-pr.md
             --label enhancement
-            --label target-series:1.6.x
           )
+          if [ -n "${target_series_label}" ]; then
+            pr_args+=(--label "${target_series_label}")
+          fi
           if [ -n "${MILESTONE}" ]; then
             pr_args+=(--milestone "${MILESTONE}")
           fi

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -90,16 +90,16 @@ func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	if !ok {
 		t.Fatal("graduate-feature workflow must define the milestone input")
 	}
-	if milestone.Default != "v1.6.0" {
-		t.Fatalf("graduate-feature milestone default = %q, want v1.6.0", milestone.Default)
+	if milestone.Default != "v1.7.0" {
+		t.Fatalf("graduate-feature milestone default = %q, want v1.7.0", milestone.Default)
 	}
 
 	workflowText := readConfig(t, ".github/workflows/graduate-feature.yml")
-	if !strings.Contains(workflowText, "--label target-series:1.6.x") {
-		t.Fatal("graduate-feature workflow must label PRs with target-series:1.6.x")
+	if !strings.Contains(workflowText, `target_series_label="target-series:${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.x"`) {
+		t.Fatal("graduate-feature workflow must derive target-series labels from the milestone")
 	}
-	if strings.Contains(workflowText, "target-series:1.4.x") {
-		t.Fatal("graduate-feature workflow still references stale target-series:1.4.x")
+	if strings.Contains(workflowText, "--label target-series:") {
+		t.Fatal("graduate-feature workflow must not hardcode a target-series label")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes feature graduation PR generation so target-series labels follow the selected milestone instead of always using `target-series:1.6.x`.

## Changes

- Defaults the graduation workflow milestone input to `v1.7.0`.
- Derives `target-series:<major>.<minor>.x` from `MILESTONE` when creating graduation PRs.
- Updates the workflow config test to reject hardcoded `target-series` labels.

## Validation

Commands and checks run:

```bash
go test ./scripts -run TestGraduateFeatureWorkflowTargetsCurrentSeries -count=1
make actionlint
make lint
go test ./scripts -count=1
make test
make dup-check
make suppression-check
git diff --check
```

Additional manual validation:

- Replayed the shell label derivation for `v1.7.0`, `1.7.3`, `v2.0.0`, `v1.7.0-rc.1`, invalid, and empty milestones.
- Checked PR #1079 live labels; it currently has `target-series:1.7.x`.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
