### PR TITLE
test(flags): guard graduation PR body template

### DIFF
--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -103,6 +103,46 @@ func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	}
 }
 
+func TestGraduateFeatureWorkflowCreatesTemplateCompatiblePRBody(t *testing.T) {
+	t.Parallel()
+
+	workflowText := readConfig(t, ".github/workflows/graduate-feature.yml")
+	for _, want := range []string{
+		"cat > .artifacts/graduate-feature-pr.md <<PR_BODY",
+		"## Summary",
+		"## Changes",
+		"## Validation",
+		"Commands and checks run:",
+		"Additional manual validation:",
+		"## Risk and compatibility",
+		"- Breaking changes:",
+		"- Migration required:",
+		"- Performance impact:",
+		"- Memory benchmark impact:",
+		"## Checklist",
+		"- [x] Tests added/updated for behavior changes",
+		"- [x] Docs updated (README/docs/schema) if needed",
+		"- [x] \\`memory-approved\\` requested/applied if intentional memory benchmark regressions exceed CI thresholds",
+		"- [x] No unrelated changes included",
+		"- [x] Ready for review",
+		"--body-file .artifacts/graduate-feature-pr.md",
+	} {
+		if !strings.Contains(workflowText, want) {
+			t.Fatalf("graduate-feature workflow must create template-compatible PR body containing %q", want)
+		}
+	}
+
+	for _, staleHeading := range []string{
+		"## Graduation evidence",
+		"## Compatibility and rollback",
+		"## Release lock notes",
+	} {
+		if strings.Contains(workflowText, staleHeading) {
+			t.Fatalf("graduate-feature workflow must not use stale non-template body heading %q", staleHeading)
+		}
+	}
+}
+
 func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds a regression guard that verifies the graduation workflow automatically creates a PR body compatible with the repository PR metadata template.

## Changes

- Asserts `graduate-feature.yml` writes `.artifacts/graduate-feature-pr.md` with the standard required sections.
- Asserts the generated body is passed to `gh pr create` via `--body-file`.
- Rejects the older non-template graduation-only headings.

## Validation

Commands and checks run:

```bash
go test ./scripts -run 'TestGraduateFeatureWorkflow' -count=1
make actionlint
make lint
go test ./scripts -count=1
make dup-check
make suppression-check
git diff --check
make test
```

Additional manual validation:

- Verified current `origin/main` already writes the full standard graduation PR body after #1080.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
