### PR TITLE
feat(flags): graduate LOP-FEAT-0012 to stable

### DIFF
--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -77,6 +77,6 @@
     "code": "LOP-FEAT-0012",
     "name": "mcp-mutation-tools-preview",
     "description": "Enable explicit MCP mutation tools for codemod apply and baseline snapshot save workflows.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   }
 ]


### PR DESCRIPTION
Closes #1044.

## Summary

Graduates `LOP-FEAT-0012` from preview to stable.

## Changes

- Marks `LOP-FEAT-0012` stable in `internal/featureflags/features.json`.
- Graduation evidence: Delivered in PR #1078 for the v1.7.0 MCP mutation tools workflow; CI, SonarCloud, and bugfinder review passed before merge.
- Release lock notes: None.

## Validation

Commands and checks run:

```bash
go run ./tools/featureflag graduate --feature LOP-FEAT-0012
go run ./tools/featureflag validate
```

Additional manual validation:

- Reviewed graduation evidence and compatibility notes supplied to the workflow.

## Risk and compatibility

- Breaking changes: None expected; this graduates an existing preview feature flag.
- Migration required: No migration required; this graduates an existing preview flag to stable defaults for explicit MCP mutation tools.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
