### PR TITLE
feat(flags): graduate LOP-FEAT-0010 to stable

### DIFF
--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -65,7 +65,7 @@
     "code": "LOP-FEAT-0010",
     "name": "dashboard-remote-repos-preview",
     "description": "Enable dashboard repoUrl entries by materializing remote Git repositories into a deterministic local checkout cache.",
-    "lifecycle": "preview"
+    "lifecycle": "stable"
   },
   {
     "code": "LOP-FEAT-0011",


### PR DESCRIPTION
Closes #1039.

## Summary

Graduates `LOP-FEAT-0010` from preview to stable.

## Changes

- Marks `LOP-FEAT-0010` stable in `internal/featureflags/features.json`.
- Graduation evidence: Delivered in PR #1076 for the v1.7.0 dashboard repoUrl workflow; CI, SonarCloud, and bugfinder review passed before merge.
- Release lock notes: None.

## Validation

Commands and checks run:

```bash
go run ./tools/featureflag graduate --feature LOP-FEAT-0010
go run ./tools/featureflag validate
```

Additional manual validation:

- Reviewed graduation evidence and compatibility notes supplied to the workflow.

## Risk and compatibility

- Breaking changes: None expected; this graduates an existing preview feature flag.
- Migration required: No migration required; this graduates an existing preview flag to stable defaults for dashboard repoUrl entries.
- Performance impact: None expected.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
