### PR TITLE
fix(mcp): make timeout cancellation test deterministic

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -381,7 +381,7 @@ func TestCallToolTimeoutCancelsAnalysis(t *testing.T) {
 	result := callToolResult(t, server, toolAnalyseTop, map[string]any{
 		"repoPath":      repo,
 		"topN":          5,
-		"timeoutMillis": 1,
+		"timeoutMillis": 250,
 		"cacheEnabled":  false,
 	})
 	if !fake.called {


### PR DESCRIPTION
## Summary

Fixes a flaky MCP timeout cancellation test that failed the `verify (rolling)` job on the Release Please 1.7.0 PR.

## Changes

- Increase `TestCallToolTimeoutCancelsAnalysis` timeout from 1 ms to 250 ms.
- Keep the fake analyser blocked on the request context so the test still verifies timeout propagation after analysis starts.

## Risk and compatibility

- Breaking changes: N/A, test-only change.
- Migration required: N/A.
- Performance impact: N/A, no production code changed.
- Memory benchmark impact: N/A, rolling `make cov` passed and no benchmarked code changed.

## Validation

- `BUILD_CHANNEL=rolling GOFLAGS=-buildvcs=false go test ./internal/mcp -run TestCallToolTimeoutCancelsAnalysis -count=20`
- `BUILD_CHANNEL=rolling make cov`

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
