### PR TITLE
chore(action): automate marketplace release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,6 +339,7 @@ jobs:
             echo "## Release assets"
             echo
             echo "- Tag: \`${tag}\`"
+            echo "- GitHub Action: \`${GITHUB_REPOSITORY}@${tag}\`"
             echo "- Container image: \`${ghcr_ref}\`"
             echo "- GHCR package: [lopper](${ghcr_package_url})"
             echo "- VSIX asset: \`lopper-vscode-${tag#v}.vsix\`"
@@ -417,6 +418,28 @@ jobs:
           gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
             -F draft=false \
             -f make_latest=true >/dev/null
+
+      - name: Update GitHub Action floating tags
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$ ]]; then
+            echo "::notice::Skipping GitHub Action floating tags for non-stable semver release ${RELEASE_TAG}."
+            exit 0
+          fi
+
+          major_tag="v${BASH_REMATCH[1]}"
+          minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag --force "${major_tag}" "${RELEASE_SHA}"
+          git tag --force "${minor_tag}" "${RELEASE_SHA}"
+          git push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"
 
   update-homebrew-tap:
     needs:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ Run without local install:
 docker run --rm ghcr.io/ben-ranford/lopper:latest --help
 ```
 
+## GitHub Action
+
+Use the first-party `Scan with Lopper` action in CI:
+
+```yaml
+- uses: ben-ranford/lopper@v1
+  with:
+    version: action
+    repo: .
+    language: all
+    top: '20'
+```
+
+For reproducible CI, pin both the action ref and `version` to a concrete release such as `v1.7.0`. See [docs/ci-usage.md](docs/ci-usage.md#first-party-github-action) for PR comment and SARIF workflows.
+
 ## Terminal demos
 
 | Demo | What it demonstrates | GIF preview |

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
-name: Lopper
+name: Scan with Lopper
 description: Run Lopper dependency-surface analysis in GitHub Actions.
 author: ben-ranford
 
 inputs:
   version:
-    description: Lopper CLI release to install. Use action to match a concrete action tag when possible, latest for the newest stable release, or a tag such as v1.7.0.
+    description: Lopper CLI release to install. Use action to match an action tag when possible, latest for the newest stable release, a floating tag such as v1 or v1.7, or a concrete tag such as v1.7.0.
     required: false
     default: action
   github-token:

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -1,9 +1,9 @@
 # CI and release workflow
 
-This repository includes six GitHub Actions workflows:
+This repository includes these GitHub Actions workflows:
 
 - `.github/workflows/ci.yml`: runs checks on pull requests
-- `.github/workflows/release.yml`: release-please-backed stable release workflow. On pushes to `main`, it creates or updates a release PR from Conventional Commits; when that release PR is merged, it creates a draft semver GitHub release, publishes assets, publishes images, optionally publishes the VS Code extension, publishes the draft release, and then updates the Homebrew tap with:
+- `.github/workflows/release.yml`: release-please-backed stable release workflow. On pushes to `main`, it creates or updates a release PR from Conventional Commits; when that release PR is merged, it creates a draft semver GitHub release, publishes assets, publishes images, optionally publishes the VS Code extension, publishes the draft release, updates the GitHub Action floating tags, and then updates the Homebrew tap with:
   - Linux/Windows artifacts from Ubuntu (cross-compiled with `zig`)
   - Darwin artifact from macOS (native arch)
   - GHCR multi-arch image (`linux/amd64`, `linux/arm64`) tagged with the release tag and `latest`
@@ -26,6 +26,7 @@ Stable release automation:
 - The current stable version is also synced into `extensions/vscode-lopper/package.json` and `extensions/vscode-lopper/package-lock.json` by the release-please PR.
 - Manual `workflow_dispatch` runs accept a release tag/version plus an optional `source_sha`, resolve the selected source ref, and create or reuse the draft GitHub release when the tag is not already present.
 - Release commits should use Conventional Commit prefixes: `fix:` for patch releases, `feat:` for minor releases, and any type with a breaking-change marker (for example `feat!:` or `fix!:`) or a `BREAKING CHANGE:` footer for major releases.
+- Stable releases also publish the first-party action version refs. The release tag, such as `v1.7.0`, is the exact action ref; the workflow force-updates `v1` and `v1.7` to the same release commit for standard GitHub Actions major/minor pinning.
 - Set repository secret `RELEASE_PLEASE_TOKEN` to a PAT with contents and pull request write access so release-please-created PRs can trigger normal CI. If it is not configured, the workflow falls back to `MAIN_SYNC_PAT` and then `GITHUB_TOKEN`.
 
 ## Example pipeline
@@ -69,9 +70,11 @@ When running locally with `act`, target the Linux-backed jobs explicitly (for ex
 
 ## First-party GitHub Action
 
-Lopper ships a composite GitHub Action at the repository root. The action downloads a pinned Lopper release binary, builds `lopper analyse` arguments from named inputs, and supports the same CI outputs used by the CLI: threshold-gated analysis, JSON baselines, PR-comment markdown, and SARIF.
+Lopper ships the `Scan with Lopper` composite GitHub Action at the repository root. The action downloads a pinned Lopper release binary, builds `lopper analyse` arguments from named inputs, and supports the same CI outputs used by the CLI: threshold-gated analysis, JSON baselines, PR-comment markdown, and SARIF.
 
-Pin both the action ref and the `version` input for reproducible CI. The default `version: action` uses the matching concrete action tag when the workflow references a full release tag such as `v1.7.0`; otherwise it resolves the latest stable release. The action intentionally does not expose a raw `extra-args` passthrough, so shell values are never re-parsed by `eval` or another shell.
+Pin both the action ref and the `version` input for fully reproducible CI. The default `version: action` uses the matching concrete action tag when the workflow references a full release tag such as `v1.7.0`; when the workflow references a floating action tag such as `v1` or `v1.7`, it resolves the newest stable Lopper release in that series; otherwise it resolves the latest stable release. The action intentionally does not expose a raw `extra-args` passthrough, so shell values are never re-parsed by `eval` or another shell.
+
+The standard release workflow publishes the semver action ref and updates the floating action refs with every stable release.
 
 ### Pull request comment workflow
 

--- a/internal/githubaction/action_test.go
+++ b/internal/githubaction/action_test.go
@@ -48,7 +48,7 @@ func TestActionMetadataDefinesCompositeWrapper(t *testing.T) {
 		t.Fatalf("parse action metadata: %v", err)
 	}
 
-	if metadata.Name != "Lopper" {
+	if metadata.Name != "Scan with Lopper" {
 		t.Fatalf("unexpected action name %q", metadata.Name)
 	}
 	if metadata.Runs.Using != "composite" {
@@ -371,6 +371,42 @@ func TestInstallScriptDryRunDefaultsToConcreteActionRef(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "download-url="+wantURL) {
 		t.Fatalf("dry-run stdout missing action ref download URL %q: %s", wantURL, stdout)
+	}
+}
+
+func TestInstallScriptDryRunResolvesFloatingActionRef(t *testing.T) {
+	root := repoRoot(t)
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "curl"), `#!/usr/bin/env bash
+set -euo pipefail
+cat <<'JSON'
+[
+  {"tag_name":"v1.8.0","draft":false,"prerelease":false},
+  {"tag_name":"v1.7.2","draft":false,"prerelease":false},
+  {"tag_name":"v1.7.1","draft":false,"prerelease":true},
+  {"tag_name":"v1.7.0","draft":false,"prerelease":false},
+  {"tag_name":"v1.6.1","draft":false,"prerelease":false}
+]
+JSON
+`)
+
+	cmd := exec.Command("bash", filepath.Join(root, "scripts", "github-action", "install-lopper.sh"))
+	cmd.Env = append(os.Environ(), []string{
+		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"LOPPER_INSTALL_DRY_RUN=1",
+		"LOPPER_VERSION=action",
+		"LOPPER_ACTION_REF=v1.7",
+		"LOPPER_ACTION_OS=linux",
+		"LOPPER_ACTION_ARCH=amd64",
+	}...)
+	stdout := runCommand(t, cmd)
+
+	wantURL := "https://github.com/ben-ranford/lopper/releases/download/v1.7.2/lopper_v1.7.2_linux_amd64.tar.gz"
+	if !strings.Contains(stdout, "resolved-version=v1.7.2") {
+		t.Fatalf("dry-run stdout missing resolved floating ref version: %s", stdout)
+	}
+	if !strings.Contains(stdout, "download-url="+wantURL) {
+		t.Fatalf("dry-run stdout missing floating ref download URL %q: %s", wantURL, stdout)
 	}
 }
 

--- a/scripts/github-action/install-lopper.sh
+++ b/scripts/github-action/install-lopper.sh
@@ -70,9 +70,14 @@ is_concrete_release_ref() {
   [[ "$value" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([.-][A-Za-z0-9._-]+)?$ || "$value" =~ ^rolling-[A-Za-z0-9._-]+$ ]]
 }
 
+is_floating_release_ref() {
+  local value="$1"
+  [[ "$value" =~ ^v[0-9]+([.][0-9]+)?$ ]]
+}
+
 normalize_explicit_version() {
   local value="$1"
-  if [[ "$value" =~ ^[0-9]+[.][0-9]+[.][0-9]+([.-][A-Za-z0-9._-]+)?$ ]]; then
+  if [[ "$value" =~ ^[0-9]+([.][0-9]+)?([.][0-9]+([.-][A-Za-z0-9._-]+)?)?$ ]]; then
     value="v${value}"
   fi
   printf '%s' "$value"
@@ -81,9 +86,70 @@ normalize_explicit_version() {
 validate_tag() {
   local tag="$1"
   if [[ ! "$tag" =~ ^[A-Za-z0-9._-]+$ ]]; then
-    error "Invalid Lopper version '${tag}'. Use latest, action, or a release tag such as v1.7.0."
+    error "Invalid Lopper version '${tag}'. Use latest, action, a floating tag such as v1 or v1.7, or a release tag such as v1.7.0."
     exit 2
   fi
+}
+
+resolve_release_series_tag() {
+  local series="$1"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    error "python3 is required to resolve floating Lopper release ref '${series}'. Use a concrete tag such as v1.7.0 instead."
+    exit 1
+  fi
+
+  local releases_json
+  releases_json="$(curl_with_token -fsSL "https://api.github.com/repos/ben-ranford/lopper/releases?per_page=100")"
+
+  local tag
+  if ! tag="$(
+    SERIES="$series" RELEASES_JSON="$releases_json" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+series = os.environ["SERIES"]
+try:
+    releases = json.loads(os.environ.get("RELEASES_JSON", "[]"))
+except json.JSONDecodeError:
+    sys.exit(2)
+
+if not isinstance(releases, list):
+    sys.exit(2)
+
+if series.count(".") == 0:
+    pattern = re.compile(r"^" + re.escape(series) + r"\.[0-9]+\.[0-9]+$")
+else:
+    pattern = re.compile(r"^" + re.escape(series) + r"\.[0-9]+$")
+
+def version_key(tag):
+    return tuple(int(part) for part in tag[1:].split("."))
+
+candidates = []
+for release in releases:
+    if not isinstance(release, dict):
+        continue
+    if release.get("draft") or release.get("prerelease"):
+        continue
+    tag = release.get("tag_name", "")
+    if pattern.fullmatch(tag):
+        candidates.append(tag)
+
+if candidates:
+    print(max(candidates, key=version_key))
+PY
+  )"; then
+    error "Unable to parse GitHub releases while resolving floating ref '${series}'."
+    exit 1
+  fi
+
+  if [[ -z "$tag" ]]; then
+    error "Unable to resolve a stable Lopper release for floating ref '${series}'."
+    exit 1
+  fi
+  printf '%s' "$tag"
 }
 
 resolve_requested_tag() {
@@ -99,6 +165,10 @@ resolve_requested_tag() {
       printf '%s' "$action_ref"
       return
     fi
+    if [[ -n "$action_ref" ]] && is_floating_release_ref "$action_ref"; then
+      resolve_release_series_tag "$action_ref"
+      return
+    fi
     resolve_latest_tag
     return
   fi
@@ -108,7 +178,12 @@ resolve_requested_tag() {
     return
   fi
 
-  normalize_explicit_version "$requested"
+  requested="$(normalize_explicit_version "$requested")"
+  if is_floating_release_ref "$requested"; then
+    resolve_release_series_tag "$requested"
+    return
+  fi
+  printf '%s' "$requested"
 }
 
 detect_os() {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -195,6 +195,44 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
+	t.Parallel()
+
+	var workflow struct {
+		Jobs map[string]workflowJobConfig `yaml:"jobs"`
+	}
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	step := workflowStepByName(t, workflow.Jobs, "publish", "Update GitHub Action floating tags")
+	if step.Shell != "bash" {
+		t.Fatalf("action floating tag step shell = %q, want bash", step.Shell)
+	}
+	if step.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" {
+		t.Fatalf("action floating tag step RELEASE_TAG env = %q", step.Env["RELEASE_TAG"])
+	}
+	if step.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
+		t.Fatalf("action floating tag step RELEASE_SHA env = %q", step.Env["RELEASE_SHA"])
+	}
+
+	for _, want := range []string{
+		`^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$`,
+		`major_tag="v${BASH_REMATCH[1]}"`,
+		`minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"`,
+		`git tag --force "${major_tag}" "${RELEASE_SHA}"`,
+		`git tag --force "${minor_tag}" "${RELEASE_SHA}"`,
+		`git push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"`,
+	} {
+		if !strings.Contains(step.Run, want) {
+			t.Fatalf("action floating tag step must contain %q", want)
+		}
+	}
+
+	workflowText := readConfig(t, ".github/workflows/release.yml")
+	if !strings.Contains(workflowText, "- GitHub Action: \\`${GITHUB_REPOSITORY}@${tag}\\`") {
+		t.Fatal("release notes must include the concrete GitHub Action ref")
+	}
+}
+
 func TestRenovateDoesNotAutomergeMajorUpdates(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Automate the first-party GitHub Action release refs as part of the standard stable release pipeline.

## Changes

- Rename the Marketplace-facing action metadata to `Scan with Lopper`.
- Add stable release workflow output for the concrete action ref, such as `ben-ranford/lopper@v1.7.0`.
- Update the stable release workflow to move `vMAJOR` and `vMAJOR.MINOR` action refs, such as `v1` and `v1.7`, to the release commit.
- Teach the action installer to resolve floating refs like `@v1` and `@v1.7` to the newest stable release asset in that series when `version: action` is used.
- Add README and CI docs for the first-party action usage path.

## Validation

- `go test ./internal/githubaction ./scripts`
- `bash -n scripts/github-action/install-lopper.sh scripts/github-action/run-lopper.sh`
- `git diff --check`
- `make actionlint`
- `make shellcheck`
- `go test ./...`

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
