### PR TITLE
chore(vscode): add codemod apply actions

### DIFF
--- a/extensions/vscode-lopper/README.md
+++ b/extensions/vscode-lopper/README.md
@@ -10,6 +10,7 @@ Lopper brings dependency-surface analysis into VS Code with inline diagnostics a
 - Surfaces a dependency explorer sidebar with folder summaries, dependency drilldown, and source-navigation links.
 - Supports multi-root workspaces by analyzing each workspace folder independently.
 - Offers deterministic quick fixes for safe `--suggest-only` JS/TS subpath rewrites.
+- Applies available safe JS/TS codemods through the guarded CLI flow and reports rollback artifact paths.
 - Supports `package`, `repo`, and `changed-packages` analysis scope modes directly in VS Code.
 - Keeps a status-bar summary and manual refresh commands, including force-fresh, runtime-aware, baseline, and export workflows.
 
@@ -30,6 +31,7 @@ The extension shells out to `lopper`.
 - If no local binary is available, the extension can download a matching GitHub release into extension-managed storage.
 - You can always override detection with `lopper.binaryPath` or `LOPPER_BINARY_PATH`.
 - Workspace-local binaries, including `bin/lopper` and `lopper.binaryPath` values inside the repo, are blocked until the workspace is trusted.
+- Codemod apply actions are disabled until the workspace is trusted and keep the CLI's clean-worktree protection unless you explicitly retry with the dirty-worktree override.
 
 ## Install
 
@@ -73,6 +75,7 @@ code --install-extension lopper-vscode-<version>.vsix
 - `Lopper: Save Baseline Snapshot`: save the current workspace analysis as a baseline snapshot.
 - `Lopper: Compare Baseline`: compare the current workspace analysis against a saved baseline key or file.
 - `Lopper: Analyse Dependency...`: open a focused dependency analysis and detail view.
+- `Lopper: Apply Codemod`: apply an available safe codemod for a dependency and print applied, skipped, failed, and rollback artifact details.
 - `Lopper: Export Analysis as JSON|CSV|SARIF|PR Comment`: export the current analysis in a machine-readable format.
 
 The extension deduplicates in-flight refreshes per folder/language/scope, prevents stale runs from overwriting newer diagnostics, and logs refresh lifecycle states to the `Lopper` output channel.

--- a/extensions/vscode-lopper/package.json
+++ b/extensions/vscode-lopper/package.json
@@ -51,6 +51,7 @@
     "onCommand:lopper.saveBaseline",
     "onCommand:lopper.compareBaseline",
     "onCommand:lopper.analyseDependency",
+    "onCommand:lopper.applyCodemod",
     "onCommand:lopper.exportAnalysis.json",
     "onCommand:lopper.exportAnalysis.csv",
     "onCommand:lopper.exportAnalysis.sarif",
@@ -102,6 +103,10 @@
         "title": "Lopper: Analyse Dependency..."
       },
       {
+        "command": "lopper.applyCodemod",
+        "title": "Lopper: Apply Codemod"
+      },
+      {
         "command": "lopper.exportAnalysis.json",
         "title": "Lopper: Export Analysis as JSON"
       },
@@ -128,6 +133,15 @@
           "id": "lopperExplorer",
           "name": "Lopper",
           "contextualTitle": "Lopper"
+        }
+      ]
+    },
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "lopper.applyCodemod",
+          "when": "view == lopperExplorer && viewItem == lopperDependency.codemod",
+          "group": "inline"
         }
       ]
     },

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -49,6 +49,10 @@ interface DiagnosticMetadata {
   suggestion?: LopperCodemodSuggestion;
 }
 
+interface CodemodDiagnosticMetadata extends DiagnosticMetadata {
+  suggestion: LopperCodemodSuggestion;
+}
+
 interface ExtensionApi {
   refreshWorkspace(): Promise<void>;
   getLatestSummary(): string;
@@ -641,55 +645,24 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
 
     const actions: vscode.CodeAction[] = [];
     const fullApplyDependencies = new Set<string>();
+    const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+    const workspaceAnalysis = folder ? this.analysisByWorkspace.get(folder.uri.toString()) : undefined;
     for (const diagnostic of context.diagnostics) {
-      const code = typeof diagnostic.code === "string" ? diagnostic.code : undefined;
-      if (!code) {
-        continue;
-      }
-      const metadata = documentMetadata.get(code);
-      const suggestion = metadata?.suggestion;
-      if (metadata?.kind !== "codemod" || !suggestion) {
+      const metadata = codemodMetadataForDiagnostic(documentMetadata, diagnostic);
+      if (!metadata) {
         continue;
       }
 
-      const folder = vscode.workspace.getWorkspaceFolder(document.uri);
-      const workspaceAnalysis = folder ? this.analysisByWorkspace.get(folder.uri.toString()) : undefined;
       const codemodSuggestionCount = workspaceAnalysis?.codemodsByDependency.get(metadata.dependency.name)?.suggestions?.length ?? 0;
       if (!fullApplyDependencies.has(metadata.dependency.name)) {
         fullApplyDependencies.add(metadata.dependency.name);
-        const applyAction = new vscode.CodeAction(
-          `Apply Lopper codemod for ${metadata.dependency.name}`,
-          vscode.CodeActionKind.QuickFix,
-        );
-        applyAction.command = {
-          command: "lopper.applyCodemod",
-          title: `Apply Lopper codemod for ${metadata.dependency.name}`,
-          arguments: [metadata.dependency.name, folder?.uri.fsPath],
-        };
-        applyAction.diagnostics = [diagnostic];
-        applyAction.isPreferred = codemodSuggestionCount > 1;
-        actions.push(applyAction);
+        actions.push(createApplyCodemodCodeAction(metadata, diagnostic, folder, codemodSuggestionCount));
       }
 
-      const lineIndex = suggestion.line - 1;
-      if (lineIndex < 0 || lineIndex >= document.lineCount) {
-        continue;
+      const inlineAction = createInlineCodemodCodeAction(document, diagnostic, metadata.suggestion, codemodSuggestionCount);
+      if (inlineAction) {
+        actions.push(inlineAction);
       }
-      const currentLine = document.lineAt(lineIndex).text;
-      if (currentLine !== suggestion.original) {
-        continue;
-      }
-
-      const action = new vscode.CodeAction(
-        `Use ${suggestion.toModule} subpath import`,
-        vscode.CodeActionKind.QuickFix,
-      );
-      action.isPreferred = codemodSuggestionCount <= 1;
-      action.diagnostics = [diagnostic];
-      const edit = new vscode.WorkspaceEdit();
-      edit.replace(document.uri, document.lineAt(lineIndex).range, suggestion.replacement);
-      action.edit = edit;
-      actions.push(action);
     }
 
     return actions;
@@ -983,39 +956,9 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
 
     try {
       const result = await this.runCodemodApply(folder, targetDependency, scopeMode, options.allowDirty === true);
-      this.renderCodemodApplyResult(result);
-      if (codemodApplyFailed(result.apply)) {
-        await vscode.window.showErrorMessage(formatCodemodApplyNotification(targetDependency, result.apply, "failed"));
-        return;
-      }
-
-      await vscode.window.showInformationMessage(formatCodemodApplyNotification(targetDependency, result.apply, "applied"));
-      if ((result.apply?.appliedFiles ?? 0) > 0) {
-        this.invalidateWorkspaceSession(folder, `codemod applied for ${targetDependency}`);
-        await this.refreshWorkspace({
-          folder,
-          document: this.activeDocumentForFolder(folder),
-          forceFresh: true,
-          revealErrors: false,
-          scopeModeOverride: scopeMode,
-          trigger: "command",
-        });
-      }
+      await this.handleCodemodApplyResult(folder, targetDependency, scopeMode, result);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.output.appendLine(`[codemod-apply:error] ${targetDependency}: ${message}`);
-      if (!options.allowDirty && isDirtyWorktreeApplyError(message)) {
-        const choice = await vscode.window.showWarningMessage(
-          `Lopper refused to apply the codemod because the Git worktree is dirty: ${message}`,
-          { modal: true },
-          "Apply Anyway",
-        );
-        if (choice === "Apply Anyway") {
-          await this.applyCodemod(targetDependency, folder.uri.fsPath, { allowDirty: true });
-        }
-        return;
-      }
-      await vscode.window.showErrorMessage(`Lopper codemod apply failed for ${targetDependency}: ${message}`);
+      await this.handleCodemodApplyError(error, targetDependency, folder, options.allowDirty === true);
     }
   }
 
@@ -1220,11 +1163,67 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       this.output.appendLine(`[codemod-apply:rollback] ${result.apply.backupPath}`);
     }
     for (const item of result.apply?.results ?? []) {
-      this.output.appendLine(
-        `[codemod-apply:file] ${item.status} ${item.file} patches=${item.patchCount}${item.message ? ` message=${item.message}` : ""}`,
-      );
+      const message = item.message ? " message=" + item.message : "";
+      this.output.appendLine(`[codemod-apply:file] ${item.status} ${item.file} patches=${item.patchCount}${message}`);
     }
     this.output.show(true);
+  }
+
+  private async handleCodemodApplyResult(
+    folder: vscode.WorkspaceFolder,
+    targetDependency: string,
+    scopeMode: LopperScopeMode,
+    result: WorkspaceCodemodApplyResult,
+  ): Promise<void> {
+    this.renderCodemodApplyResult(result);
+    if (codemodApplyFailed(result.apply)) {
+      await vscode.window.showErrorMessage(formatCodemodApplyNotification(targetDependency, result.apply, "failed"));
+      return;
+    }
+
+    await vscode.window.showInformationMessage(formatCodemodApplyNotification(targetDependency, result.apply, "applied"));
+    if ((result.apply?.appliedFiles ?? 0) === 0) {
+      return;
+    }
+    this.invalidateWorkspaceSession(folder, `codemod applied for ${targetDependency}`);
+    await this.refreshWorkspace({
+      folder,
+      document: this.activeDocumentForFolder(folder),
+      forceFresh: true,
+      revealErrors: false,
+      scopeModeOverride: scopeMode,
+      trigger: "command",
+    });
+  }
+
+  private async handleCodemodApplyError(
+    error: unknown,
+    targetDependency: string,
+    folder: vscode.WorkspaceFolder,
+    allowDirty: boolean,
+  ): Promise<void> {
+    const message = error instanceof Error ? error.message : String(error);
+    this.output.appendLine(`[codemod-apply:error] ${targetDependency}: ${message}`);
+    if (!allowDirty && isDirtyWorktreeApplyError(message)) {
+      await this.offerDirtyCodemodRetry(targetDependency, folder, message);
+      return;
+    }
+    await vscode.window.showErrorMessage(`Lopper codemod apply failed for ${targetDependency}: ${message}`);
+  }
+
+  private async offerDirtyCodemodRetry(
+    targetDependency: string,
+    folder: vscode.WorkspaceFolder,
+    message: string,
+  ): Promise<void> {
+    const choice = await vscode.window.showWarningMessage(
+      `Lopper refused to apply the codemod because the Git worktree is dirty: ${message}`,
+      { modal: true },
+      "Apply Anyway",
+    );
+    if (choice === "Apply Anyway") {
+      await this.applyCodemod(targetDependency, folder.uri.fsPath, { allowDirty: true });
+    }
   }
 
   private showDependencyDetailPanel(
@@ -2068,6 +2067,69 @@ function dependencySummaryText(dependency: LopperDependencyReport, analysis: Wor
 
 function hasSafeCodemodSuggestions(analysis: WorkspaceAnalysis | undefined, dependencyName: string): boolean {
   return (analysis?.codemodsByDependency.get(dependencyName)?.suggestions?.length ?? 0) > 0;
+}
+
+function codemodMetadataForDiagnostic(
+  documentMetadata: Map<string, DiagnosticMetadata>,
+  diagnostic: vscode.Diagnostic,
+): CodemodDiagnosticMetadata | undefined {
+  const code = typeof diagnostic.code === "string" ? diagnostic.code : undefined;
+  if (!code) {
+    return undefined;
+  }
+  const metadata = documentMetadata.get(code);
+  if (metadata?.kind !== "codemod" || !metadata.suggestion) {
+    return undefined;
+  }
+  return metadata as CodemodDiagnosticMetadata;
+}
+
+function createApplyCodemodCodeAction(
+  metadata: CodemodDiagnosticMetadata,
+  diagnostic: vscode.Diagnostic,
+  folder: vscode.WorkspaceFolder | undefined,
+  codemodSuggestionCount: number,
+): vscode.CodeAction {
+  const dependencyName = metadata.dependency.name;
+  const action = new vscode.CodeAction(
+    `Apply Lopper codemod for ${dependencyName}`,
+    vscode.CodeActionKind.QuickFix,
+  );
+  action.command = {
+    command: "lopper.applyCodemod",
+    title: `Apply Lopper codemod for ${dependencyName}`,
+    arguments: [dependencyName, folder?.uri.fsPath],
+  };
+  action.diagnostics = [diagnostic];
+  action.isPreferred = codemodSuggestionCount > 1;
+  return action;
+}
+
+function createInlineCodemodCodeAction(
+  document: vscode.TextDocument,
+  diagnostic: vscode.Diagnostic,
+  suggestion: LopperCodemodSuggestion,
+  codemodSuggestionCount: number,
+): vscode.CodeAction | undefined {
+  const lineIndex = suggestion.line - 1;
+  if (lineIndex < 0 || lineIndex >= document.lineCount) {
+    return undefined;
+  }
+  const targetLine = document.lineAt(lineIndex);
+  if (targetLine.text !== suggestion.original) {
+    return undefined;
+  }
+
+  const action = new vscode.CodeAction(
+    `Use ${suggestion.toModule} subpath import`,
+    vscode.CodeActionKind.QuickFix,
+  );
+  action.isPreferred = codemodSuggestionCount <= 1;
+  action.diagnostics = [diagnostic];
+  const edit = new vscode.WorkspaceEdit();
+  edit.replace(document.uri, targetLine.range, suggestion.replacement);
+  action.edit = edit;
+  return action;
 }
 
 function codemodApplyFailed(apply: LopperCodemodApplyReport | undefined): boolean {

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -18,11 +18,13 @@ import {
   type WorkspaceAnalysis,
   type WorkspaceAnalysisRequest,
   type WorkspaceAnalysisRunner,
+  type WorkspaceCodemodApplyResult,
 } from "./lopperRunner";
 import { RefreshSessionStore } from "./refreshSession";
 import { lopperScopeModeValues } from "./types";
 import type {
   LopperBaselineComparison,
+  LopperCodemodApplyReport,
   LopperDependencyLicense,
   LopperDependencyDelta,
   LopperEffectivePolicy,
@@ -74,6 +76,7 @@ export interface RefreshWorkspaceOptions {
 interface LopperControllerContract extends vscode.Disposable {
   initialize(): Promise<void>;
   refreshWorkspace(options?: RefreshWorkspaceOptions): Promise<void>;
+  applyCodemod(dependencyName?: string, folderPath?: string, options?: ApplyCodemodCommandOptions): Promise<void>;
   getLatestSummary(): string;
 }
 
@@ -96,6 +99,11 @@ interface RefreshAbortHandle {
   folderName: string;
   runId: number;
   controller: AbortController;
+}
+
+interface ApplyCodemodCommandOptions {
+  allowDirty?: boolean;
+  skipConfirmation?: boolean;
 }
 
 class LopperController implements LopperControllerContract, vscode.HoverProvider, vscode.CodeActionProvider {
@@ -182,6 +190,10 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
         }),
         vscode.commands.registerCommand("lopper.analyseDependency", async (dependencyName?: string, folderPath?: string) => {
           await this.analyseDependency(dependencyName, folderPath);
+        }),
+        vscode.commands.registerCommand("lopper.applyCodemod", async (target?: unknown, folderPath?: string) => {
+          const commandTarget = normalizeApplyCodemodCommandTarget(target, folderPath);
+          await this.applyCodemod(commandTarget.dependencyName, commandTarget.folderPath);
         }),
         vscode.commands.registerCommand("lopper.exportAnalysis.json", async (folderPath?: string) => {
           await this.exportAnalysis("json", folderPath);
@@ -628,6 +640,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     }
 
     const actions: vscode.CodeAction[] = [];
+    const fullApplyDependencies = new Set<string>();
     for (const diagnostic of context.diagnostics) {
       const code = typeof diagnostic.code === "string" ? diagnostic.code : undefined;
       if (!code) {
@@ -637,6 +650,25 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       const suggestion = metadata?.suggestion;
       if (metadata?.kind !== "codemod" || !suggestion) {
         continue;
+      }
+
+      const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+      const workspaceAnalysis = folder ? this.analysisByWorkspace.get(folder.uri.toString()) : undefined;
+      const codemodSuggestionCount = workspaceAnalysis?.codemodsByDependency.get(metadata.dependency.name)?.suggestions?.length ?? 0;
+      if (!fullApplyDependencies.has(metadata.dependency.name)) {
+        fullApplyDependencies.add(metadata.dependency.name);
+        const applyAction = new vscode.CodeAction(
+          `Apply Lopper codemod for ${metadata.dependency.name}`,
+          vscode.CodeActionKind.QuickFix,
+        );
+        applyAction.command = {
+          command: "lopper.applyCodemod",
+          title: `Apply Lopper codemod for ${metadata.dependency.name}`,
+          arguments: [metadata.dependency.name, folder?.uri.fsPath],
+        };
+        applyAction.diagnostics = [diagnostic];
+        applyAction.isPreferred = codemodSuggestionCount > 1;
+        actions.push(applyAction);
       }
 
       const lineIndex = suggestion.line - 1;
@@ -652,7 +684,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
         `Use ${suggestion.toModule} subpath import`,
         vscode.CodeActionKind.QuickFix,
       );
-      action.isPreferred = true;
+      action.isPreferred = codemodSuggestionCount <= 1;
       action.diagnostics = [diagnostic];
       const edit = new vscode.WorkspaceEdit();
       edit.replace(document.uri, document.lineAt(lineIndex).range, suggestion.replacement);
@@ -912,6 +944,81 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     this.showDependencyDetailPanel(folder, focused, focusedDependency, targetDependency);
   }
 
+  async applyCodemod(
+    dependencyName?: string,
+    folderPath?: string,
+    options: ApplyCodemodCommandOptions = {},
+  ): Promise<void> {
+    const folder = await this.resolveDependencyWorkspaceFolder(folderPath);
+    if (!folder) {
+      await vscode.window.showInformationMessage("Open a folder before applying a Lopper codemod.");
+      return;
+    }
+    if (!vscode.workspace.isTrusted) {
+      await vscode.window.showWarningMessage("Trust this workspace before applying Lopper codemods.");
+      return;
+    }
+
+    const targetDependency = await this.resolveDependencyNameForCodemod(folder, dependencyName);
+    if (!targetDependency) {
+      return;
+    }
+
+    const analysis = this.analysisByWorkspace.get(folder.uri.toString());
+    if (!hasSafeCodemodSuggestions(analysis, targetDependency)) {
+      await vscode.window.showInformationMessage(
+        `No safe Lopper codemod suggestions are currently available for ${targetDependency}. Refresh diagnostics and try again.`,
+      );
+      return;
+    }
+
+    if (!options.skipConfirmation && !await this.confirmCodemodApply(targetDependency, folder, options.allowDirty === true)) {
+      return;
+    }
+
+    const scopeMode = analysis?.scopeMode ?? this.requestedScopeMode(folder);
+    this.output.appendLine(
+      `[codemod-apply:running] ${folder.name} dependency=${targetDependency} scope=${scopeMode}${options.allowDirty ? " allow-dirty" : ""}`,
+    );
+
+    try {
+      const result = await this.runCodemodApply(folder, targetDependency, scopeMode, options.allowDirty === true);
+      this.renderCodemodApplyResult(result);
+      if (codemodApplyFailed(result.apply)) {
+        await vscode.window.showErrorMessage(formatCodemodApplyNotification(targetDependency, result.apply, "failed"));
+        return;
+      }
+
+      await vscode.window.showInformationMessage(formatCodemodApplyNotification(targetDependency, result.apply, "applied"));
+      if ((result.apply?.appliedFiles ?? 0) > 0) {
+        this.invalidateWorkspaceSession(folder, `codemod applied for ${targetDependency}`);
+        await this.refreshWorkspace({
+          folder,
+          document: this.activeDocumentForFolder(folder),
+          forceFresh: true,
+          revealErrors: false,
+          scopeModeOverride: scopeMode,
+          trigger: "command",
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.output.appendLine(`[codemod-apply:error] ${targetDependency}: ${message}`);
+      if (!options.allowDirty && isDirtyWorktreeApplyError(message)) {
+        const choice = await vscode.window.showWarningMessage(
+          `Lopper refused to apply the codemod because the Git worktree is dirty: ${message}`,
+          { modal: true },
+          "Apply Anyway",
+        );
+        if (choice === "Apply Anyway") {
+          await this.applyCodemod(targetDependency, folder.uri.fsPath, { allowDirty: true });
+        }
+        return;
+      }
+      await vscode.window.showErrorMessage(`Lopper codemod apply failed for ${targetDependency}: ${message}`);
+    }
+  }
+
   private async exportAnalysis(format: LopperOutputFormat, folderPath?: string): Promise<void> {
     const folder = await this.resolveDependencyWorkspaceFolder(folderPath);
     if (!folder) {
@@ -1032,6 +1139,92 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       placeHolder: "scope-lib",
     });
     return value?.trim().length ? value.trim() : undefined;
+  }
+
+  private async resolveDependencyNameForCodemod(
+    folder: vscode.WorkspaceFolder,
+    dependencyName?: string,
+  ): Promise<string | undefined> {
+    const trimmed = dependencyName?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+
+    const analysis = this.analysisByWorkspace.get(folder.uri.toString());
+    const candidates = (analysis?.report.dependencies ?? [])
+      .map((dependency) => dependency.name)
+      .filter((name) => hasSafeCodemodSuggestions(analysis, name))
+      .sort((left, right) => left.localeCompare(right));
+    if (candidates.length === 0) {
+      return undefined;
+    }
+    return vscode.window.showQuickPick(candidates, {
+      title: "Apply Lopper codemod",
+      placeHolder: "Choose a dependency with a safe codemod suggestion",
+    });
+  }
+
+  private async confirmCodemodApply(
+    dependencyName: string,
+    folder: vscode.WorkspaceFolder,
+    allowDirty: boolean,
+  ): Promise<boolean> {
+    const detail = allowDirty
+      ? "This will mutate source files even though the Git worktree is dirty. Lopper will still write rollback artifacts for changed files."
+      : "This will mutate source files through the guarded Lopper CLI apply workflow and write rollback artifacts for changed files.";
+    const choice = await vscode.window.showWarningMessage(
+      `Apply Lopper codemod for ${dependencyName} in ${folder.name}?`,
+      { modal: true, detail },
+      "Apply Codemod",
+    );
+    return choice === "Apply Codemod";
+  }
+
+  private async runCodemodApply(
+    folder: vscode.WorkspaceFolder,
+    dependencyName: string,
+    scopeMode: LopperScopeMode,
+    allowDirty: boolean,
+  ): Promise<WorkspaceCodemodApplyResult> {
+    return vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `Applying Lopper codemod for ${dependencyName}`,
+        cancellable: true,
+      },
+      async (_progress, token) => {
+        const abortController = new AbortController();
+        const cancellation = token.onCancellationRequested(() => abortController.abort());
+        try {
+          if (token.isCancellationRequested) {
+            abortController.abort();
+          }
+          return await this.runner.applyCodemod(folder, dependencyName, {
+            document: this.activeDocumentForFolder(folder),
+            scopeMode,
+            requestedLanguage: "js-ts",
+            allowDirty,
+            signal: abortController.signal,
+          });
+        } finally {
+          cancellation.dispose();
+        }
+      },
+    );
+  }
+
+  private renderCodemodApplyResult(result: WorkspaceCodemodApplyResult): void {
+    const summary = formatCodemodApplySummary(result.dependencyName, result.apply);
+    this.output.appendLine(`[codemod-apply:result] ${result.folder.name}: ${summary}`);
+    if (result.apply?.backupPath) {
+      this.output.appendLine(`[codemod-apply:rollback] ${result.apply.backupPath}`);
+    }
+    for (const item of result.apply?.results ?? []) {
+      this.output.appendLine(
+        `[codemod-apply:file] ${item.status} ${item.file} patches=${item.patchCount}${item.message ? ` message=${item.message}` : ""}`,
+      );
+    }
+    this.output.show(true);
   }
 
   private showDependencyDetailPanel(
@@ -1399,6 +1592,9 @@ class LopperExtensionBootstrap implements vscode.Disposable {
 export const __testing = {
   createController: (runner: WorkspaceAnalysisRunner): LopperControllerContract =>
     new LopperController({} as vscode.ExtensionContext, runner, { registerWithVSCode: false }),
+  formatCodemodApplySummary,
+  formatCodemodApplyNotification,
+  isDirtyWorktreeApplyError,
   isPathInsideWorkspace,
   resolveWorkspaceFilePath,
 };
@@ -1431,6 +1627,34 @@ interface LopperExplorerNodeData {
   filePath?: string;
   line?: number;
   column?: number;
+}
+
+interface ApplyCodemodCommandTarget {
+  dependencyName?: string;
+  folderPath?: string;
+}
+
+function normalizeApplyCodemodCommandTarget(target: unknown, folderPath?: string): ApplyCodemodCommandTarget {
+  if (typeof target === "string") {
+    return { dependencyName: target, folderPath };
+  }
+  const data = explorerNodeDataFrom(target);
+  if (data) {
+    return { dependencyName: data.dependencyName, folderPath: data.folderPath };
+  }
+  return { folderPath };
+}
+
+function explorerNodeDataFrom(value: unknown): LopperExplorerNodeData | undefined {
+  if (!value || typeof value !== "object" || !("data" in value)) {
+    return undefined;
+  }
+  const candidate = (value as { data?: unknown }).data;
+  if (!candidate || typeof candidate !== "object") {
+    return undefined;
+  }
+  const data = candidate as Partial<LopperExplorerNodeData>;
+  return typeof data.folderPath === "string" ? data as LopperExplorerNodeData : undefined;
 }
 
 class LopperExplorerTreeItem extends vscode.TreeItem {
@@ -1607,6 +1831,9 @@ class LopperExplorerTreeDataProvider implements vscode.TreeDataProvider<LopperEx
     };
     item.description = dependencySummaryText(dependency, analysis);
     item.tooltip = buildDependencyTooltip(folder, analysis, dependency);
+    if (hasSafeCodemodSuggestions(analysis, dependency.name)) {
+      item.contextValue = "lopperDependency.codemod";
+    }
     return item;
   }
 
@@ -1625,6 +1852,9 @@ class LopperExplorerTreeDataProvider implements vscode.TreeDataProvider<LopperEx
     }
 
     const children: LopperExplorerTreeItem[] = [];
+    if (hasSafeCodemodSuggestions(analysis, dependency.name)) {
+      children.push(this.createCodemodApplyItem(folder, dependency.name));
+    }
 
     const runtimeLabel = runtimeUsageSummary(dependency.runtimeUsage);
     if (runtimeLabel) {
@@ -1661,6 +1891,25 @@ class LopperExplorerTreeDataProvider implements vscode.TreeDataProvider<LopperEx
     }
 
     return children;
+  }
+
+  private createCodemodApplyItem(
+    folder: vscode.WorkspaceFolder,
+    dependencyName: string,
+  ): LopperExplorerTreeItem {
+    const item = new LopperExplorerTreeItem(
+      "Apply Lopper codemod",
+      { kind: "metric", folderPath: folder.uri.fsPath, dependencyName },
+      vscode.TreeItemCollapsibleState.None,
+    );
+    item.command = {
+      command: "lopper.applyCodemod",
+      title: "Apply Lopper codemod",
+      arguments: [dependencyName, folder.uri.fsPath],
+    };
+    item.iconPath = new vscode.ThemeIcon("wand");
+    item.tooltip = `Run the guarded Lopper codemod apply workflow for ${dependencyName}.`;
+    return item;
   }
 
   private createMetricItem(
@@ -1817,6 +2066,54 @@ function dependencySummaryText(dependency: LopperDependencyReport, analysis: Wor
   return parts.join(" • ");
 }
 
+function hasSafeCodemodSuggestions(analysis: WorkspaceAnalysis | undefined, dependencyName: string): boolean {
+  return (analysis?.codemodsByDependency.get(dependencyName)?.suggestions?.length ?? 0) > 0;
+}
+
+function codemodApplyFailed(apply: LopperCodemodApplyReport | undefined): boolean {
+  return !apply || (apply.failedFiles ?? 0) > 0;
+}
+
+function formatCodemodApplySummary(
+  dependencyName: string,
+  apply: LopperCodemodApplyReport | undefined,
+): string {
+  if (!apply) {
+    return `No codemod changes were applied for ${dependencyName}. Refresh diagnostics and try again.`;
+  }
+  const counts = [
+    `applied ${formatCodemodApplyCount(apply.appliedFiles, apply.appliedPatches)}`,
+    `skipped ${formatCodemodApplyCount(apply.skippedFiles, apply.skippedPatches)}`,
+    `failed ${formatCodemodApplyCount(apply.failedFiles, apply.failedPatches)}`,
+    `rollback ${apply.backupPath && apply.backupPath.length > 0 ? apply.backupPath : "none"}`,
+  ];
+  return `${dependencyName}: ${counts.join(" | ")}`;
+}
+
+function formatCodemodApplyNotification(
+  dependencyName: string,
+  apply: LopperCodemodApplyReport | undefined,
+  status: "applied" | "failed",
+): string {
+  if (!apply) {
+    return `Lopper found no codemod changes for ${dependencyName}.`;
+  }
+  const prefix = status === "failed" ? "Lopper codemod failed" : "Lopper codemod finished";
+  const rollback = apply.backupPath ? ` Rollback: ${apply.backupPath}` : "";
+  return `${prefix} for ${dependencyName}: ${formatCodemodApplyCount(apply.appliedFiles, apply.appliedPatches)} applied, ${formatCodemodApplyCount(apply.skippedFiles, apply.skippedPatches)} skipped, ${formatCodemodApplyCount(apply.failedFiles, apply.failedPatches)} failed.${rollback}`;
+}
+
+function formatCodemodApplyCount(files: number | undefined, patches: number | undefined): string {
+  return `${files ?? 0} files/${patches ?? 0} patches`;
+}
+
+function isDirtyWorktreeApplyError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return normalized.includes("codemod apply requires a clean git worktree")
+    || (normalized.includes("uncommitted changes") && normalized.includes("--allow-dirty"))
+    || (normalized.includes("dirty") && normalized.includes("--allow-dirty"));
+}
+
 function buildFolderTooltip(folder: vscode.WorkspaceFolder, analysis: WorkspaceAnalysis): string {
   const summary = analysis.report.summary;
   const lines = [
@@ -1942,7 +2239,7 @@ function renderDependencyDetailHtml(
   const baselineDependency = baseline?.dependencies?.find((item) => item.name === dependencyName);
   const sections = [
     renderDependencyOverviewSection(selectedDependency),
-    renderDependencyActionsSection(folder, dependencyName),
+    renderDependencyActionsSection(folder, dependencyName, hasSafeCodemodSuggestions(analysis, dependencyName)),
     renderDependencyContextSection(report, baseline, baselineDependency),
     renderDependencyMetadataSection(selectedDependency),
     selectedDependency.runtimeUsage ? renderHtmlSection("Runtime usage", renderRuntimeUsage(selectedDependency.runtimeUsage)) : "",
@@ -2053,14 +2350,21 @@ function renderDependencyOverviewSection(dependency: LopperDependencyReport): st
   );
 }
 
-function renderDependencyActionsSection(folder: vscode.WorkspaceFolder, dependencyName: string): string {
-  return renderHtmlSection(
-    "Actions",
-    [
-      `<a class="button" href="${commandUri("lopper.refreshWorkspace", [folder.uri.fsPath])}">Refresh folder</a>`,
-      `<a class="button" href="${commandUri("lopper.analyseDependency", [dependencyName, folder.uri.fsPath])}">Re-run detail analysis</a>`,
-    ].join(" "),
-  );
+function renderDependencyActionsSection(
+  folder: vscode.WorkspaceFolder,
+  dependencyName: string,
+  hasCodemodSuggestions: boolean,
+): string {
+  const actions = [
+    `<a class="button" href="${commandUri("lopper.refreshWorkspace", [folder.uri.fsPath])}">Refresh folder</a>`,
+    `<a class="button" href="${commandUri("lopper.analyseDependency", [dependencyName, folder.uri.fsPath])}">Re-run detail analysis</a>`,
+  ];
+  if (hasCodemodSuggestions) {
+    actions.push(
+      `<a class="button" href="${commandUri("lopper.applyCodemod", [dependencyName, folder.uri.fsPath])}">Apply Lopper codemod</a>`,
+    );
+  }
+  return renderHtmlSection("Actions", actions.join(" "));
 }
 
 function renderDependencyContextSection(

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -1176,13 +1176,14 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     result: WorkspaceCodemodApplyResult,
   ): Promise<void> {
     this.renderCodemodApplyResult(result);
-    if (codemodApplyFailed(result.apply)) {
+    const failed = codemodApplyFailed(result.apply);
+    if (failed) {
       await vscode.window.showErrorMessage(formatCodemodApplyNotification(targetDependency, result.apply, "failed"));
-      return;
+    } else {
+      await vscode.window.showInformationMessage(formatCodemodApplyNotification(targetDependency, result.apply, "applied"));
     }
 
-    await vscode.window.showInformationMessage(formatCodemodApplyNotification(targetDependency, result.apply, "applied"));
-    if ((result.apply?.appliedFiles ?? 0) === 0) {
+    if (!codemodApplyMutatedFiles(result.apply)) {
       return;
     }
     this.invalidateWorkspaceSession(folder, `codemod applied for ${targetDependency}`);
@@ -2134,6 +2135,10 @@ function createInlineCodemodCodeAction(
 
 function codemodApplyFailed(apply: LopperCodemodApplyReport | undefined): boolean {
   return !apply || (apply.failedFiles ?? 0) > 0;
+}
+
+function codemodApplyMutatedFiles(apply: LopperCodemodApplyReport | undefined): boolean {
+  return (apply?.appliedFiles ?? 0) > 0;
 }
 
 function formatCodemodApplySummary(

--- a/extensions/vscode-lopper/src/lopperRunner.ts
+++ b/extensions/vscode-lopper/src/lopperRunner.ts
@@ -14,6 +14,7 @@ import {
 export { BinaryResolutionError } from "./managedBinary";
 import {
   lopperScopeModeValues,
+  type LopperCodemodApplyReport,
   type LopperCodemodReport,
   type LopperDependencyReport,
   type LopperReport,
@@ -40,6 +41,11 @@ export interface WorkspaceAnalysis {
 export interface WorkspaceAnalysisRunner {
   analyseWorkspace(folder: vscode.WorkspaceFolder, options?: WorkspaceAnalysisRequest): Promise<WorkspaceAnalysis>;
   exportWorkspace(folder: vscode.WorkspaceFolder, format: LopperOutputFormat, options?: WorkspaceExportRequest): Promise<string>;
+  applyCodemod(
+    folder: vscode.WorkspaceFolder,
+    dependencyName: string,
+    options?: WorkspaceCodemodApplyRequest,
+  ): Promise<WorkspaceCodemodApplyResult>;
 }
 
 export interface WorkspaceAnalysisRequest {
@@ -55,6 +61,31 @@ export interface WorkspaceAnalysisRequest {
   baselineKey?: string;
   baselineLabel?: string;
   saveBaseline?: boolean;
+}
+
+export interface WorkspaceCodemodApplyRequest {
+  document?: vscode.TextDocument;
+  scopeMode?: LopperScopeMode;
+  requestedLanguage?: LopperLanguage;
+  signal?: AbortSignal;
+  allowDirty?: boolean;
+  runtimeTracePath?: string;
+  runtimeTestCommand?: string;
+  baselinePath?: string;
+  baselineStorePath?: string;
+  baselineKey?: string;
+  baselineLabel?: string;
+  saveBaseline?: boolean;
+}
+
+export interface WorkspaceCodemodApplyResult {
+  folder: vscode.WorkspaceFolder;
+  binaryPath: string;
+  requestedLanguage: LopperLanguage;
+  scopeMode: LopperScopeMode;
+  dependencyName: string;
+  report: LopperReport;
+  apply?: LopperCodemodApplyReport;
 }
 
 interface CodemodFetchContext {
@@ -90,6 +121,26 @@ export interface LopperRunnerDeps {
 export interface LopperExecutionOptions {
   signal?: AbortSignal;
   timeoutMs?: number;
+}
+
+interface AnalysisArgsOptions {
+  format: LopperOutputFormat;
+  requestedLanguage: string;
+  scopeMode: LopperScopeMode;
+  document?: vscode.TextDocument;
+  dependencyName?: string;
+  suggestOnly?: boolean;
+  applyCodemod?: boolean;
+  allowDirty?: boolean;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  runtimeTracePath?: string;
+  runtimeTestCommand?: string;
+  baselinePath?: string;
+  baselineStorePath?: string;
+  baselineKey?: string;
+  baselineLabel?: string;
+  saveBaseline?: boolean;
 }
 
 export class LopperCliReportExecutor implements ReportCommandExecutor {
@@ -306,6 +357,51 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     });
   }
 
+  async applyCodemod(
+    folder: vscode.WorkspaceFolder,
+    dependencyName: string,
+    options: WorkspaceCodemodApplyRequest = {},
+  ): Promise<WorkspaceCodemodApplyResult> {
+    const targetDependency = normalizeDependencyArgument(dependencyName);
+    if (!targetDependency) {
+      throw new Error("Choose a dependency before applying a Lopper codemod.");
+    }
+
+    const binaryPath = await this.resolveBinaryPath(folder);
+    const requestedLanguage = options.requestedLanguage
+      ?? await resolveLopperLanguage(configuredLopperLanguage(folder), options.document, folder.uri.fsPath);
+    const scopeMode = normalizeScopeMode(options.scopeMode);
+    const timeoutMs = this.runTimeoutMs(folder);
+    const report = await this.executeReport(binaryPath, folder, {
+      format: "json",
+      requestedLanguage,
+      scopeMode,
+      document: options.document,
+      dependencyName: targetDependency,
+      applyCodemod: true,
+      allowDirty: options.allowDirty,
+      signal: options.signal,
+      timeoutMs,
+      runtimeTracePath: options.runtimeTracePath,
+      runtimeTestCommand: options.runtimeTestCommand,
+      baselinePath: options.baselinePath,
+      baselineStorePath: options.baselineStorePath,
+      baselineKey: options.baselineKey,
+      baselineLabel: options.baselineLabel,
+      saveBaseline: options.saveBaseline,
+    });
+    const dependency = report.dependencies.find((item) => item.name === targetDependency) ?? report.dependencies[0];
+    return {
+      folder,
+      binaryPath,
+      requestedLanguage,
+      scopeMode,
+      dependencyName: targetDependency,
+      report,
+      apply: dependency?.codemod?.apply,
+    };
+  }
+
   async resolveBinaryPath(
     folder: vscode.WorkspaceFolder,
     workspaceTrusted = vscode.workspace.isTrusted,
@@ -342,23 +438,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
   private async executeReport(
     binaryPath: string,
     folder: vscode.WorkspaceFolder,
-    options: {
-      format: LopperOutputFormat;
-      requestedLanguage: string;
-      scopeMode: LopperScopeMode;
-      document?: vscode.TextDocument;
-      dependencyName?: string;
-      suggestOnly?: boolean;
-      signal?: AbortSignal;
-      timeoutMs?: number;
-      runtimeTracePath?: string;
-      runtimeTestCommand?: string;
-      baselinePath?: string;
-      baselineStorePath?: string;
-      baselineKey?: string;
-      baselineLabel?: string;
-      saveBaseline?: boolean;
-    },
+    options: AnalysisArgsOptions,
   ): Promise<LopperReport> {
     const args = this.buildAnalysisArgs(folder, options);
     return this.reportExecutor.runReport(binaryPath, args, folder.uri.fsPath, {
@@ -370,21 +450,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
   private async executeText(
     binaryPath: string,
     folder: vscode.WorkspaceFolder,
-    options: {
-      format: LopperOutputFormat;
-      requestedLanguage: string;
-      scopeMode: LopperScopeMode;
-      document?: vscode.TextDocument;
-      signal?: AbortSignal;
-      timeoutMs?: number;
-      runtimeTracePath?: string;
-      runtimeTestCommand?: string;
-      baselinePath?: string;
-      baselineStorePath?: string;
-      baselineKey?: string;
-      baselineLabel?: string;
-      saveBaseline?: boolean;
-    },
+    options: AnalysisArgsOptions,
   ): Promise<string> {
     const args = this.buildAnalysisArgs(folder, options);
     return this.reportExecutor.runCommand(binaryPath, args, folder.uri.fsPath, {
@@ -395,23 +461,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
 
   private buildAnalysisArgs(
     folder: vscode.WorkspaceFolder,
-    options: {
-      format: LopperOutputFormat;
-      requestedLanguage: string;
-      scopeMode: LopperScopeMode;
-      document?: vscode.TextDocument;
-      dependencyName?: string;
-      suggestOnly?: boolean;
-      signal?: AbortSignal;
-      timeoutMs?: number;
-      runtimeTracePath?: string;
-      runtimeTestCommand?: string;
-      baselinePath?: string;
-      baselineStorePath?: string;
-      baselineKey?: string;
-      baselineLabel?: string;
-      saveBaseline?: boolean;
-    },
+    options: AnalysisArgsOptions,
   ): string[] {
     const args = ["analyse"];
     const dependencyName = normalizeDependencyArgument(options.dependencyName);
@@ -434,6 +484,12 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     this.appendBaselineArgs(args, options.baselinePath, options.baselineStorePath, options.baselineKey, options.baselineLabel, options.saveBaseline);
     if (options.suggestOnly) {
       args.push("--suggest-only");
+    }
+    if (options.applyCodemod) {
+      args.push("--apply-codemod", "--apply-codemod-confirm");
+      if (options.allowDirty) {
+        args.push("--allow-dirty");
+      }
     }
     if (dependencyName) {
       args.push("--", dependencyName);

--- a/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
@@ -250,6 +250,79 @@ suite("lopper runner", () => {
     assert.equal(resolvedRequest?.workspaceRoot, folder.uri.fsPath);
   });
 
+  test("applies codemods with guarded CLI flags and optional dirty override", async () => {
+    const folder = workspaceFolder();
+    const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
+    const calls: string[][] = [];
+
+    const runner = new LopperRunner(
+      { appendLine: () => undefined },
+      context,
+      {
+        binaryLifecycle: {
+          resolveBinaryPath: async () => path.join(folder.uri.fsPath, ".lopper-managed", "lopper"),
+        },
+        reportExecutor: {
+          runCommand: async () => "",
+          runReport: async (_binaryPath, args): Promise<LopperReport> => {
+            calls.push(args);
+            return {
+              dependencies: [
+                {
+                  name: "scope-lib",
+                  language: "js-ts",
+                  usedExportsCount: 1,
+                  totalExportsCount: 2,
+                  usedPercent: 50,
+                  codemod: {
+                    mode: "apply",
+                    apply: {
+                      appliedFiles: 1,
+                      appliedPatches: 2,
+                      skippedFiles: 0,
+                      skippedPatches: 0,
+                      failedFiles: 0,
+                      failedPatches: 0,
+                      backupPath: ".artifacts/lopper-codemod-backups/scope-lib.json",
+                      results: [{ file: "src/index.ts", status: "applied", patchCount: 2 }],
+                    },
+                  },
+                },
+              ],
+            };
+          },
+        },
+      },
+    );
+
+    const result = await runner.applyCodemod(folder, "scope-lib", {
+      scopeMode: "repo",
+      requestedLanguage: "js-ts",
+    });
+    assert.equal(result.apply?.appliedFiles, 1);
+    assert.equal(result.apply?.backupPath, ".artifacts/lopper-codemod-backups/scope-lib.json");
+
+    const applyArgs = calls[0];
+    assert.ok(applyArgs, "expected codemod apply invocation");
+    assert.deepEqual(applyArgs.slice(0, 1), ["analyse"]);
+    assert.ok(applyArgs.includes("--apply-codemod"), "expected guarded apply flag");
+    assert.ok(applyArgs.includes("--apply-codemod-confirm"), "expected apply confirmation flag");
+    assert.ok(!applyArgs.includes("--suggest-only"), "apply command must not combine suggest-only");
+    assert.ok(!applyArgs.includes("--allow-dirty"), "dirty override must be opt-in");
+    assert.equal(applyArgs[applyArgs.indexOf("--format") + 1], "json");
+    assert.equal(applyArgs[applyArgs.indexOf("--language") + 1], "js-ts");
+    assert.equal(applyArgs[applyArgs.indexOf("--scope-mode") + 1], "repo");
+    assert.deepEqual(applyArgs.slice(-2), ["--", "scope-lib"]);
+
+    await runner.applyCodemod(folder, "scope-lib", {
+      scopeMode: "repo",
+      requestedLanguage: "js-ts",
+      allowDirty: true,
+    });
+    const dirtyApplyArgs = calls[1];
+    assert.ok(dirtyApplyArgs?.includes("--allow-dirty"), "expected explicit dirty override flag");
+  });
+
   test("fetches codemods with bounded concurrency and reuses duplicate dependencies", async () => {
     const folder = workspaceFolder();
     const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;

--- a/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
@@ -222,8 +222,8 @@ suite("refresh lifecycle", () => {
     });
   });
 
-  test("skips escaped codemod suggestions while keeping in-workspace diagnostics", async function () {
-    this.timeout(30_000);
+	  test("skips escaped codemod suggestions while keeping in-workspace diagnostics", async function () {
+	    this.timeout(30_000);
 
     await withHarness(async (harness) => {
       const validSuggestionPath = "src/index.ts";
@@ -278,11 +278,76 @@ suite("refresh lifecycle", () => {
           assert.equal(diagnostics.length, 2);
         },
       );
-    });
-  });
+	    });
+	  });
 
-  test("formats codemod apply summaries and dirty-worktree guard errors", () => {
-    const apply = {
+	  test("refreshes diagnostics after mixed codemod apply mutates files", async function () {
+	    this.timeout(30_000);
+
+	    await withHarness(async (harness) => {
+	      let analyseCalls = 0;
+	      let applyCalls = 0;
+	      let firstAnalysis: WorkspaceAnalysis | undefined;
+	      const restoreNotifications = stubCodemodApplyNotifications();
+	      try {
+
+	        await withController(
+	          {
+	            analyseWorkspace: async (): Promise<WorkspaceAnalysis> => {
+	              analyseCalls += 1;
+	              const analysis = makeAnalysis(harness, {
+	                dependencyCount: 1,
+	                usedPercent: analyseCalls === 1 ? 50 : 100,
+	                withUnusedImport: analyseCalls === 1,
+	              });
+	              attachScopeLibCodemod(analysis);
+	              firstAnalysis ??= analysis;
+	              return analysis;
+	            },
+	            applyCodemod: async (folder, dependencyName): Promise<WorkspaceCodemodApplyResult> => {
+	              applyCalls += 1;
+	              assert.equal(folder.uri.fsPath, harness.folder.uri.fsPath);
+	              assert.equal(dependencyName, "scope-lib");
+	              return {
+	                folder,
+	                binaryPath: harness.binaryPath,
+	                requestedLanguage: "js-ts",
+	                scopeMode: "package",
+	                dependencyName,
+	                report: firstAnalysis?.report ?? makeAnalysis(harness, { dependencyCount: 1, usedPercent: 50 }).report,
+	                apply: {
+	                  appliedFiles: 1,
+	                  appliedPatches: 1,
+	                  skippedFiles: 0,
+	                  skippedPatches: 0,
+	                  failedFiles: 1,
+	                  failedPatches: 1,
+	                  backupPath: ".artifacts/lopper-codemod-backups/scope-lib.json",
+	                  results: [
+	                    { file: "src/index.ts", status: "applied", patchCount: 1 },
+	                    { file: "src/readonly.ts", status: "failed", patchCount: 0, message: "permission denied" },
+	                  ],
+	                },
+	              };
+	            },
+	            exportWorkspace: async (): Promise<string> => "",
+	          },
+	          async (controller) => {
+	            await refresh(controller, harness);
+	            await controller.applyCodemod("scope-lib", harness.folder.uri.fsPath, { skipConfirmation: true });
+
+	            assert.equal(applyCalls, 1);
+	            assert.equal(analyseCalls, 2, "mixed apply with file mutations should force a diagnostics refresh");
+	          },
+	        );
+	      } finally {
+	        restoreNotifications();
+	      }
+	    });
+	  });
+
+	  test("formats codemod apply summaries and dirty-worktree guard errors", () => {
+	    const apply = {
       appliedFiles: 1,
       appliedPatches: 2,
       skippedFiles: 3,
@@ -415,6 +480,41 @@ async function waitForAssertion(assertion: () => void, timeoutMs = 1_000): Promi
     throw lastError;
   }
   assertion();
+	}
+
+function attachScopeLibCodemod(analysis: WorkspaceAnalysis): void {
+	analysis.codemodsByDependency = new Map([
+		[
+			"scope-lib",
+			{
+				mode: "replace",
+				suggestions: [
+					{
+						file: "src/index.ts",
+						line: 1,
+						importName: "chunk",
+						fromModule: "scope-lib",
+						toModule: "scope-lib/chunk",
+						original: "import chunk from \"scope-lib\";",
+						replacement: "import chunk from \"scope-lib/chunk\";",
+					},
+				],
+			},
+		],
+	]);
+}
+
+function stubCodemodApplyNotifications(): () => void {
+	const originalShowErrorMessage = vscode.window.showErrorMessage;
+	const originalShowInformationMessage = vscode.window.showInformationMessage;
+	(vscode.window as typeof vscode.window & { showErrorMessage: typeof vscode.window.showErrorMessage }).showErrorMessage =
+		(async () => undefined) as typeof vscode.window.showErrorMessage;
+	(vscode.window as typeof vscode.window & { showInformationMessage: typeof vscode.window.showInformationMessage }).showInformationMessage =
+		(async () => undefined) as typeof vscode.window.showInformationMessage;
+	return () => {
+		(vscode.window as typeof vscode.window & { showErrorMessage: typeof vscode.window.showErrorMessage }).showErrorMessage = originalShowErrorMessage;
+		(vscode.window as typeof vscode.window & { showInformationMessage: typeof vscode.window.showInformationMessage }).showInformationMessage = originalShowInformationMessage;
+	};
 }
 
 function makeAnalysis(

--- a/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 
 import { __testing, deactivate } from "../../extension";
 import type { RefreshWorkspaceOptions } from "../../extension";
-import type { WorkspaceAnalysis, WorkspaceAnalysisRunner } from "../../lopperRunner";
+import type { WorkspaceAnalysis, WorkspaceAnalysisRunner, WorkspaceCodemodApplyResult } from "../../lopperRunner";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -280,6 +280,35 @@ suite("refresh lifecycle", () => {
       );
     });
   });
+
+  test("formats codemod apply summaries and dirty-worktree guard errors", () => {
+    const apply = {
+      appliedFiles: 1,
+      appliedPatches: 2,
+      skippedFiles: 3,
+      skippedPatches: 4,
+      failedFiles: 0,
+      failedPatches: 0,
+      backupPath: ".artifacts/lopper-codemod-backups/scope-lib.json",
+      results: [{ file: "src/index.ts", status: "applied", patchCount: 2 }],
+    };
+
+    const summary = __testing.formatCodemodApplySummary("scope-lib", apply);
+    assert.match(summary, /scope-lib/);
+    assert.match(summary, /applied 1 files\/2 patches/);
+    assert.match(summary, /skipped 3 files\/4 patches/);
+    assert.match(summary, /failed 0 files\/0 patches/);
+    assert.match(summary, /rollback \.artifacts\/lopper-codemod-backups\/scope-lib\.json/);
+
+    const notification = __testing.formatCodemodApplyNotification("scope-lib", apply, "applied");
+    assert.match(notification, /Rollback: \.artifacts\/lopper-codemod-backups\/scope-lib\.json/);
+    assert.equal(
+      __testing.isDirtyWorktreeApplyError(
+        "codemod apply requires a clean git worktree: detected uncommitted changes in README.md; pass --allow-dirty",
+      ),
+      true,
+    );
+  });
 });
 
 async function withHarness(run: (harness: LifecycleHarness) => Promise<void>): Promise<void> {
@@ -294,10 +323,16 @@ async function withHarness(run: (harness: LifecycleHarness) => Promise<void>): P
 }
 
 async function withController(
-  runner: WorkspaceAnalysisRunner,
+  runner: Omit<WorkspaceAnalysisRunner, "applyCodemod"> & Partial<Pick<WorkspaceAnalysisRunner, "applyCodemod">>,
   run: (controller: TestController) => Promise<void>,
 ): Promise<void> {
-  const controller = __testing.createController(runner);
+  const completeRunner: WorkspaceAnalysisRunner = {
+    applyCodemod: async (): Promise<WorkspaceCodemodApplyResult> => {
+      throw new Error("unexpected codemod apply in refresh lifecycle test");
+    },
+    ...runner,
+  };
+  const controller = __testing.createController(completeRunner);
   try {
     await run(controller);
   } finally {

--- a/extensions/vscode-lopper/src/test/suite/smoke.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/smoke.test.ts
@@ -47,6 +47,7 @@ suite("vscode-lopper smoke", () => {
     assert.ok(commands.includes("lopper.saveBaseline"), "expected baseline save command");
     assert.ok(commands.includes("lopper.exportAnalysis.csv"), "expected CSV export command");
     assert.ok(commands.includes("lopper.refreshWorkspace.runtime"), "expected runtime refresh command");
+    assert.ok(commands.includes("lopper.applyCodemod"), "expected codemod apply command");
 
     const primaryDiagnostics = await waitForDiagnostics(primaryFixtureUri, 2);
     const unusedImportDiagnostic = primaryDiagnostics.find((item) => item.message.includes("unused"));

--- a/extensions/vscode-lopper/src/types.ts
+++ b/extensions/vscode-lopper/src/types.ts
@@ -163,6 +163,7 @@ export interface LopperLocation {
 export interface LopperCodemodReport {
   mode: string;
   suggestions?: LopperCodemodSuggestion[];
+  apply?: LopperCodemodApplyReport;
 }
 
 export interface LopperCodemodSuggestion {
@@ -173,6 +174,24 @@ export interface LopperCodemodSuggestion {
   toModule: string;
   original: string;
   replacement: string;
+}
+
+export interface LopperCodemodApplyReport {
+  appliedFiles?: number;
+  appliedPatches?: number;
+  skippedFiles?: number;
+  skippedPatches?: number;
+  failedFiles?: number;
+  failedPatches?: number;
+  backupPath?: string;
+  results?: LopperCodemodApplyResult[];
+}
+
+export interface LopperCodemodApplyResult {
+  file: string;
+  status: "applied" | "skipped" | "failed" | string;
+  patchCount: number;
+  message?: string;
 }
 
 export interface LopperSymbolUsage {

--- a/extensions/vscode-lopper/src/types.ts
+++ b/extensions/vscode-lopper/src/types.ts
@@ -189,7 +189,7 @@ export interface LopperCodemodApplyReport {
 
 export interface LopperCodemodApplyResult {
   file: string;
-  status: "applied" | "skipped" | "failed" | string;
+  status: string;
   patchCount: number;
   message?: string;
 }

--- a/extensions/vscode-lopper/test-fixtures/lopper-smoke-binary.mjs
+++ b/extensions/vscode-lopper/test-fixtures/lopper-smoke-binary.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 const args = process.argv.slice(2);
@@ -20,13 +20,18 @@ if (format !== "json") {
 
 const dependencyName = options._[0] ?? "scope-lib";
 const suggestOnly = options["suggest-only"] !== undefined;
-const report = await buildReport(cwd, dependencyName, suggestOnly);
+const applyCodemod = options["apply-codemod"] !== undefined;
+const report = await buildReport(cwd, dependencyName, suggestOnly, applyCodemod);
 process.stdout.write(JSON.stringify(report, null, 2));
 
 function parseArgs(tokens) {
   const parsed = { _: [] };
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index];
+    if (token === "--") {
+      parsed._.push(...tokens.slice(index + 1));
+      break;
+    }
     if (token.startsWith("--")) {
       const key = token.slice(2);
       const next = tokens[index + 1];
@@ -43,7 +48,7 @@ function parseArgs(tokens) {
   return parsed;
 }
 
-async function buildReport(workspaceRoot, dependencyName, suggestOnly) {
+async function buildReport(workspaceRoot, dependencyName, suggestOnly, applyCodemod) {
   const indexPath = path.join(workspaceRoot, "src", "index.ts");
   const source = await readFile(indexPath, "utf8");
   const lines = source.split(/\r?\n/);
@@ -212,7 +217,23 @@ async function buildReport(workspaceRoot, dependencyName, suggestOnly) {
     wasteIncreasePercent: 0,
   };
 
-  if (suggestOnly) {
+  if (suggestOnly || applyCodemod) {
+    const suggestion = {
+      file: "src/index.ts",
+      line: 1,
+      importName: "chunk",
+      fromModule: "scope-lib",
+      toModule: "scope-lib/chunk",
+      original: 'import { chunk } from "scope-lib";',
+      replacement: 'import chunk from "scope-lib/chunk";',
+    };
+    const codemod = {
+      mode: applyCodemod ? "apply" : "suggest-only",
+      suggestions: [suggestion],
+    };
+    if (applyCodemod) {
+      codemod.apply = await applySmokeCodemod(workspaceRoot, indexPath, source, dependencyName, suggestion);
+    }
     analysis.dependencies = [
       {
         language: "js-ts",
@@ -220,25 +241,49 @@ async function buildReport(workspaceRoot, dependencyName, suggestOnly) {
         usedExportsCount: 1,
         totalExportsCount: 2,
         usedPercent: 50,
-        codemod: {
-          mode: "suggest-only",
-          suggestions: [
-            {
-              file: "src/index.ts",
-              line: 1,
-              importName: "chunk",
-              fromModule: "scope-lib",
-              toModule: "scope-lib/chunk",
-              original: 'import { chunk } from "scope-lib";',
-              replacement: 'import chunk from "scope-lib/chunk";',
-            },
-          ],
-        },
+        codemod,
       },
     ];
   }
 
   return analysis;
+}
+
+async function applySmokeCodemod(workspaceRoot, indexPath, source, dependencyName, suggestion) {
+  if (!source.includes(suggestion.original)) {
+    return {
+      failedFiles: 1,
+      failedPatches: 1,
+      results: [{ file: suggestion.file, status: "failed", patchCount: 1, message: "original line mismatch" }],
+    };
+  }
+
+  const backupPath = ".artifacts/lopper-codemod-backups/scope-lib-smoke.json";
+  await mkdir(path.dirname(path.join(workspaceRoot, backupPath)), { recursive: true });
+  await writeFile(
+    path.join(workspaceRoot, backupPath),
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        dependency: dependencyName,
+        files: [{ file: suggestion.file, mode: 0o644, content: source }],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(indexPath, source.replace(suggestion.original, suggestion.replacement), "utf8");
+  return {
+    appliedFiles: 1,
+    appliedPatches: 1,
+    skippedFiles: 0,
+    skippedPatches: 0,
+    failedFiles: 0,
+    failedPatches: 0,
+    backupPath,
+    results: [{ file: suggestion.file, status: "applied", patchCount: 1 }],
+  };
 }
 
 function renderExport(commandName, parsedOptions, workspaceRoot) {


### PR DESCRIPTION
## Summary

Adds VS Code actions to apply available safe Lopper codemods for a selected dependency through the existing guarded CLI workflow.

Closes #1087

## Changes

- Adds `lopper.applyCodemod` command wiring for dependency explorer rows, dependency detail actions, and diagnostic quick-fix context.
- Extends the VS Code runner to call `lopper analyse --apply-codemod --apply-codemod-confirm --format json`, with `--allow-dirty` only after explicit user retry.
- Adds apply-result TypeScript types, output/notification rendering, diagnostics refresh after successful file mutation, README docs, and extension fixture/test coverage.
- Refactors the new quick-fix/apply helpers to keep the extension controller under Sonar complexity thresholds.

## Validation

Commands and checks run:

```bash
cd extensions/vscode-lopper && npm run compile
make vscode-extension-compile
make vscode-extension-test
GOTOOLCHAIN=go1.26.4 go test ./cmd/lopper -run 'TestRunAnalyseApplyCodemod'
GOTOOLCHAIN=go1.26.4 go test ./internal/app -run 'CodemodApply|ValidateCodemodApplyPreconditions'
make test
git diff --check
```

Additional manual validation:

- Confirmed the command remains extension-only UI over the existing CLI apply contract.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected; actions run only on explicit user command.
- Memory benchmark impact: None expected.
- Dirty worktrees remain blocked by default; the override is only passed after explicit user confirmation.
- Failed or stale applies are surfaced as failures and do not refresh diagnostics as if successful.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
