### PR TITLE
feat(runtime): capture Python imports during tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,8 @@ release:
 			esac; \
 			CC="$(ZIG) cc -target $$target" CXX="$(ZIG) c++ -target $$target" CGO_ENABLED=1 GOOS=$$GOOS GOARCH=$$GOARCH $(GO_CMD) build -ldflags "$(RELEASE_GO_LDFLAGS)" -o "$$output_dir/$(BINARY_NAME)$$ext" $(CMD_PATH); \
 		fi; \
+		mkdir -p "$$output_dir/share/lopper/scripts"; \
+		cp -R scripts/runtime "$$output_dir/share/lopper/scripts/"; \
 		mkdir -p "$$output_dir/share/man/man1"; \
 		./scripts/generate-manpage.sh "$$output_dir/share/man/man1/$(BINARY_NAME).1"; \
 		if [ "$$GOOS" = "windows" ]; then \

--- a/README.md
+++ b/README.md
@@ -296,7 +296,17 @@ If `--runtime-trace` points to a missing file, analysis continues with static re
 
 ### Python preview
 
-Python runtime trace consumption is available behind the `python-runtime-trace-preview` feature flag. Lopper consumes an existing NDJSON trace file; it does not run Python tests or install a Python import hook for you.
+First-party Python runtime capture is available behind the `python-runtime-capture-preview` feature flag for conservative test commands:
+
+```bash
+lopper analyse --top 20 --repo . --language python \
+  --runtime-test-command "pytest" \
+  --enable-feature python-runtime-capture-preview
+```
+
+`python -m pytest` and `python3 -m pytest` are also supported. Lopper injects its import hook only into the runtime command environment by prepending the shipped `scripts/runtime/sitecustomize.py` directory to `PYTHONPATH`; it does not install project dependencies or run Python outside the user-provided command.
+
+Explicit Python trace consumption remains compatible through `--runtime-trace`.
 
 Each trace line should identify the Python adapter and the imported module:
 
@@ -313,16 +323,15 @@ When the import root differs from the package name, include `dependency`:
 Use the trace in analysis:
 
 ```bash
-lopper analyse --top 20 --repo . --language python \
-  --runtime-trace .artifacts/python-runtime.ndjson \
-  --enable-feature python-runtime-trace-preview
+lopper analyse --top 20 --repo . --language python --runtime-trace .artifacts/python-runtime.ndjson
 ```
 
 Python caveats:
 
 - Runtime module names map to the top-level import package, with common aliases such as `bs4` -> `beautifulsoup4`.
-- Trace producers should emit third-party imports only. Lopper cannot reliably distinguish local modules or every stdlib import from an adapter-neutral trace line.
-- Automatic `--runtime-test-command` capture remains JS/TS-oriented.
+- The first-party hook emits third-party imports resolved from `site-packages` or `dist-packages` and filters local modules and stdlib imports.
+- Subprocesses and pytest workers inherit the trace environment when they inherit the parent process environment; concurrent writers append NDJSON lines to the same trace file.
+- Existing project `sitecustomize.py` behavior can be affected while the runtime command is running because Python imports only one `sitecustomize` module from `PYTHONPATH`.
 
 ## Development
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -86,5 +86,6 @@ Merged output deduplicates by `(language, dependency)` and computes:
 
 If your adapter can consume runtime traces, extend `internal/runtime` and
 its annotation logic. The implementation keeps runtime annotations in the shared
-`runtimeUsage` report fields; JS/TS traces are supported by default, and Python
-trace consumption is available behind `python-runtime-trace-preview`.
+`runtimeUsage` report fields; JS/TS and Python trace consumption are supported
+by default, and first-party Python capture is available behind
+`python-runtime-capture-preview`.

--- a/docs/man/lopper.1
+++ b/docs/man/lopper.1
@@ -45,7 +45,7 @@ Options:
   --save-baseline            Save current run as immutable baseline snapshot
   --baseline-label LABEL     Label key to use when saving baseline snapshots
   --runtime-trace PATH       Runtime import trace (NDJSON) for annotations
-  --runtime-test-command CMD Run command with JS/TS runtime hooks to capture trace before analysis
+  --runtime-test-command CMD Run command with JS/TS or preview Python runtime hooks to capture trace before analysis
   --repos PATH1,PATH2        Comma-separated repo paths for org dashboard input
   --baseline-store DIR       Directory for immutable keyed dashboard baseline snapshots
   --baseline-key KEY         Baseline snapshot key for dashboard comparison

--- a/docs/report-schema.md
+++ b/docs/report-schema.md
@@ -106,7 +106,7 @@ CycloneDX characteristics:
 - Signal weights are fixed in v2: runtime correlation `0.20`, export inventory `0.30`, import precision `0.20`, repo usage uncertainty `0.15`, dependency dynamic-loader signal `0.10`, and risk severity `0.05`.
 - `dependencies[].removalCandidate.confidence` remains as a compatibility alias for `dependencies[].reachabilityConfidence.score`.
 - Finding-level `confidenceScore` and `confidenceReasonCodes` fields mirror `dependencies[].reachabilityConfidence.score` and `dependencies[].reachabilityConfidence.rationaleCodes`.
-- `runtimeUsage` annotates JS/TS dependencies and, when `python-runtime-trace-preview` is enabled, Python dependencies from `{"language":"python",...}` trace events.
+- `runtimeUsage` annotates JS/TS dependencies and Python dependencies from `{"language":"python",...}` trace events; first-party Python capture is gated by `python-runtime-capture-preview`.
 - `runtimeUsage.correlation` distinguishes `static-only`, `runtime-only`, and `overlap` evidence categories.
 - `runtimeUsage.modules` lists runtime-loaded module paths seen for a dependency.
 - `runtimeUsage.topSymbols` lists best-effort runtime symbol hits derived from module subpaths.

--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -39,10 +39,18 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 		"adapter":        adapterID,
 		"root":           normalizedRoot,
 		"dependency":     req.Dependency,
+		"language":       normalizeCacheLanguage(req.Language),
 		"topN":           req.TopN,
 		"suggestOnly":    req.SuggestOnly,
 		"runtimeProfile": req.RuntimeProfile,
 		"configPath":     strings.TrimSpace(req.ConfigPath),
+	}
+	if command := strings.TrimSpace(req.RuntimeTestCommand); command != "" {
+		baseKey["runtimeTestCommand"] = command
+		baseKey["runtimeTracePathExplicit"] = req.RuntimeTracePathExplicit
+		if tracePath := cleanRuntimeTracePath(req.RuntimeTracePath); tracePath != "" {
+			baseKey["runtimeTracePath"] = tracePath
+		}
 	}
 	if req.MinUsagePercentForRecommendations != nil {
 		baseKey["minUsagePercent"] = *req.MinUsagePercentForRecommendations
@@ -135,6 +143,17 @@ func cleanConfigPath(configPath string) string {
 		return ""
 	}
 	return filepath.Clean(strings.TrimSpace(configPath))
+}
+
+func cleanRuntimeTracePath(tracePath string) string {
+	if strings.TrimSpace(tracePath) == "" {
+		return ""
+	}
+	return filepath.Clean(strings.TrimSpace(tracePath))
+}
+
+func normalizeCacheLanguage(languageID string) string {
+	return strings.ToLower(strings.TrimSpace(languageID))
 }
 
 func writeInputDigestRecord(w io.Writer, input cacheDigestInput) error {

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -273,6 +273,60 @@ func TestAnalysisCachePrepareEntryIncludesFeatureFlags(t *testing.T) {
 	}
 }
 
+func TestAnalysisCachePrepareEntryIncludesRuntimeCaptureRequestScope(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "console.log('hello')\n")
+	req := Request{
+		RepoPath: repo,
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    filepath.Join(repo, cacheTestDirectoryName),
+		},
+	}
+	cache := newAnalysisCache(req, repo)
+
+	baseReq := Request{
+		RepoPath:           repo,
+		Language:           "all",
+		RuntimeTestCommand: "make test",
+	}
+	baseEntry, err := cache.prepareEntry(baseReq, "python", repo)
+	if err != nil {
+		t.Fatalf("prepare base entry: %v", err)
+	}
+
+	pythonReq := baseReq
+	pythonReq.Language = "python"
+	pythonEntry, err := cache.prepareEntry(pythonReq, "python", repo)
+	if err != nil {
+		t.Fatalf("prepare python entry: %v", err)
+	}
+	if baseEntry.KeyDigest == pythonEntry.KeyDigest {
+		t.Fatalf("expected different cache keys when requested language changes")
+	}
+
+	commandReq := baseReq
+	commandReq.RuntimeTestCommand = "pytest"
+	commandEntry, err := cache.prepareEntry(commandReq, "python", repo)
+	if err != nil {
+		t.Fatalf("prepare command entry: %v", err)
+	}
+	if baseEntry.KeyDigest == commandEntry.KeyDigest {
+		t.Fatalf("expected different cache keys when runtime test command changes")
+	}
+
+	traceReq := baseReq
+	traceReq.RuntimeTracePath = filepath.Join(repo, ".artifacts", "python.ndjson")
+	traceReq.RuntimeTracePathExplicit = true
+	traceEntry, err := cache.prepareEntry(traceReq, "python", repo)
+	if err != nil {
+		t.Fatalf("prepare trace path entry: %v", err)
+	}
+	if baseEntry.KeyDigest == traceEntry.KeyDigest {
+		t.Fatalf("expected different cache keys when runtime trace path changes")
+	}
+}
+
 func TestAnalysisCachePrepareEntryMemoizesInputDigestForSameRootAndConfig(t *testing.T) {
 	repo := t.TempDir()
 	root := filepath.Join(repo, "root")

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -15,7 +15,10 @@ import (
 	"github.com/ben-ranford/lopper/internal/workspace"
 )
 
-const pythonRuntimeTracePreviewFeature = "python-runtime-trace-preview"
+const (
+	pythonRuntimeTracePreviewFeature   = "python-runtime-trace-preview"
+	pythonRuntimeCapturePreviewFeature = "python-runtime-capture-preview"
+)
 
 type analysisPipeline struct {
 	service          *Service
@@ -71,7 +74,7 @@ func (p *analysisPipeline) execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	runtimeWarnings, runtimeTracePath := captureRuntimeTraceIfNeeded(ctx, p.request, p.repoPath, p.cache)
+	runtimeWarnings, runtimeTracePath := captureRuntimeTraceIfNeeded(ctx, p.request, p.repoPath, p.cache, p.candidates)
 	p.reports = reports
 	warnings = append(warnings, runtimeWarnings...)
 	p.warnings = warnings
@@ -119,7 +122,8 @@ func (p *analysisPipeline) remappedAnalyzedRoots() []string {
 
 func finalizeReport(req Request, repoPath string, analyzedRoots []string, reportData report.Report) (report.Report, error) {
 	var err error
-	reportData, err = annotateRuntimeTraceIfPresent(req.RuntimeTracePath, req.Language, reportData, req.Features.Enabled(pythonRuntimeTracePreviewFeature))
+	pythonRuntimeTraceEnabled := req.Features.Enabled(pythonRuntimeTracePreviewFeature) || req.Features.Enabled(pythonRuntimeCapturePreviewFeature)
+	reportData, err = annotateRuntimeTraceIfPresent(req.RuntimeTracePath, req.Language, reportData, pythonRuntimeTraceEnabled)
 	if err != nil {
 		return report.Report{}, err
 	}

--- a/internal/analysis/runtime_capture.go
+++ b/internal/analysis/runtime_capture.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"strings"
 
+	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/runtime"
 )
 
 const runtimeTraceCommandWarningPrefix = "runtime trace command failed; continuing with static analysis: "
 
-func captureRuntimeTraceIfNeeded(ctx context.Context, req Request, repoPath string, cache *analysisCache) ([]string, string) {
+func captureRuntimeTraceIfNeeded(ctx context.Context, req Request, repoPath string, cache *analysisCache, candidates []language.Candidate) ([]string, string) {
 	tracePath := strings.TrimSpace(req.RuntimeTracePath)
 	command := strings.TrimSpace(req.RuntimeTestCommand)
 	if command == "" {
@@ -23,6 +24,7 @@ func captureRuntimeTraceIfNeeded(ctx context.Context, req Request, repoPath stri
 		RepoPath:         repoPath,
 		TracePath:        tracePath,
 		Command:          command,
+		Provider:         captureProviderForRequest(req, command, candidates),
 		ReuseIfUnchanged: shouldReuseRuntimeTrace(cache),
 	}); err != nil {
 		warning := runtimeTraceCommandWarningPrefix + err.Error()
@@ -32,6 +34,44 @@ func captureRuntimeTraceIfNeeded(ctx context.Context, req Request, repoPath stri
 		return []string{warning}, ""
 	}
 	return nil, tracePath
+}
+
+func captureProviderForRequest(req Request, command string, candidates []language.Candidate) runtime.CaptureProvider {
+	if !req.Features.Enabled(pythonRuntimeCapturePreviewFeature) || !hasPythonRuntimeCandidate(req.Language, candidates) {
+		return runtime.CaptureProviderNode
+	}
+	if isExplicitPythonLanguage(req.Language) || runtime.IsPythonTestCommand(command) || hasOnlyPythonRuntimeCandidate(candidates) {
+		return runtime.CaptureProviderPython
+	}
+	return runtime.CaptureProviderNode
+}
+
+func hasPythonRuntimeCandidate(languageID string, candidates []language.Candidate) bool {
+	if isExplicitPythonLanguage(languageID) {
+		return true
+	}
+	for _, candidate := range candidates {
+		if candidate.Adapter != nil && normalizeAdapterID(candidate.Adapter.ID()) == "python" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasOnlyPythonRuntimeCandidate(candidates []language.Candidate) bool {
+	if len(candidates) != 1 || candidates[0].Adapter == nil {
+		return false
+	}
+	return normalizeAdapterID(candidates[0].Adapter.ID()) == "python"
+}
+
+func isExplicitPythonLanguage(languageID string) bool {
+	switch strings.TrimSpace(strings.ToLower(languageID)) {
+	case "python", "py":
+		return true
+	default:
+		return false
+	}
 }
 
 func shouldReuseRuntimeTrace(cache *analysisCache) bool {

--- a/internal/analysis/runtime_capture_test.go
+++ b/internal/analysis/runtime_capture_test.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/runtime"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
@@ -63,7 +66,7 @@ func TestCaptureRuntimeTraceIfNeededWarningAndReuseBranches(t *testing.T) {
 		RuntimeTracePath:         explicitTrace,
 		RuntimeTracePathExplicit: true,
 	}
-	warnings, tracePath := captureRuntimeTraceIfNeeded(context.Background(), explicitReq, repo, nil)
+	warnings, tracePath := captureRuntimeTraceIfNeeded(context.Background(), explicitReq, repo, nil, nil)
 	if len(warnings) != 1 || !strings.Contains(warnings[0], runtimeTraceCommandWarningPrefix) {
 		t.Fatalf("expected explicit runtime capture warning, got %#v", warnings)
 	}
@@ -72,7 +75,7 @@ func TestCaptureRuntimeTraceIfNeededWarningAndReuseBranches(t *testing.T) {
 	}
 
 	implicitReq := Request{RuntimeTestCommand: "foobar test"}
-	warnings, tracePath = captureRuntimeTraceIfNeeded(context.Background(), implicitReq, repo, nil)
+	warnings, tracePath = captureRuntimeTraceIfNeeded(context.Background(), implicitReq, repo, nil, nil)
 	if len(warnings) != 1 || !strings.Contains(warnings[0], runtimeTraceCommandWarningPrefix) {
 		t.Fatalf("expected implicit runtime capture warning, got %#v", warnings)
 	}
@@ -80,7 +83,7 @@ func TestCaptureRuntimeTraceIfNeededWarningAndReuseBranches(t *testing.T) {
 		t.Fatalf("expected implicit trace path to be cleared after failure, got %q", tracePath)
 	}
 
-	if warnings, tracePath = captureRuntimeTraceIfNeeded(context.Background(), Request{}, repo, nil); len(warnings) != 0 || tracePath != "" {
+	if warnings, tracePath = captureRuntimeTraceIfNeeded(context.Background(), Request{}, repo, nil, nil); len(warnings) != 0 || tracePath != "" {
 		t.Fatalf("expected empty runtime command to skip capture, got warnings=%#v tracePath=%q", warnings, tracePath)
 	}
 
@@ -99,6 +102,76 @@ func TestCaptureRuntimeTraceIfNeededWarningAndReuseBranches(t *testing.T) {
 			t.Fatalf("%s: expected shouldReuseRuntimeTrace=%v, got %v", testCase.name, testCase.want, got)
 		}
 	}
+}
+
+func TestCaptureProviderForPythonRuntimeRequests(t *testing.T) {
+	features := mustResolvePythonRuntimeCaptureFeatureSet(t, true)
+	pythonCandidate := language.Candidate{Adapter: &stubAdapter{id: "python"}}
+	jsCandidate := language.Candidate{Adapter: &stubAdapter{id: "js-ts"}}
+
+	testCases := []struct {
+		name       string
+		req        Request
+		command    string
+		candidates []language.Candidate
+		want       runtime.CaptureProvider
+	}{
+		{
+			name:    "explicit python language",
+			req:     Request{Language: "python", Features: features},
+			command: "make test",
+			want:    runtime.CaptureProviderPython,
+		},
+		{
+			name:       "auto python command with python candidate",
+			req:        Request{Language: "auto", Features: features},
+			command:    "pytest",
+			candidates: []language.Candidate{pythonCandidate},
+			want:       runtime.CaptureProviderPython,
+		},
+		{
+			name:       "python only candidate with make command",
+			req:        Request{Features: features},
+			command:    "make test",
+			candidates: []language.Candidate{pythonCandidate},
+			want:       runtime.CaptureProviderPython,
+		},
+		{
+			name:       "mixed repo keeps js command on node provider",
+			req:        Request{Language: "all", Features: features},
+			command:    "npm test",
+			candidates: []language.Candidate{pythonCandidate, jsCandidate},
+			want:       runtime.CaptureProviderNode,
+		},
+		{
+			name:       "disabled capture flag keeps node provider",
+			req:        Request{Language: "python", Features: mustResolvePythonRuntimeCaptureFeatureSet(t, false)},
+			command:    "pytest",
+			candidates: []language.Candidate{pythonCandidate},
+			want:       runtime.CaptureProviderNode,
+		},
+	}
+
+	for _, tc := range testCases {
+		if got := captureProviderForRequest(tc.req, tc.command, tc.candidates); got != tc.want {
+			t.Fatalf("%s: expected provider %q, got %q", tc.name, tc.want, got)
+		}
+	}
+}
+
+func mustResolvePythonRuntimeCaptureFeatureSet(t *testing.T, enabled bool) featureflags.Set {
+	t.Helper()
+	options := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
+	if enabled {
+		options.Enable = []string{pythonRuntimeCapturePreviewFeature}
+	} else {
+		options.Disable = []string{pythonRuntimeCapturePreviewFeature}
+	}
+	resolved, err := featureflags.DefaultRegistry().Resolve(options)
+	if err != nil {
+		t.Fatalf("resolve Python runtime capture feature set: %v", err)
+	}
+	return resolved
 }
 
 func setupFakeAnalysisRuntimeTool(t *testing.T) string {

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -418,6 +418,19 @@ func mustResolvePythonRuntimeTraceFeatureSet(t *testing.T, enabled bool) feature
 	return resolved
 }
 
+func mustResolvePythonRuntimeCaptureOnlyFeatureSet(t *testing.T) featureflags.Set {
+	t.Helper()
+	resolved, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  []string{pythonRuntimeCapturePreviewFeature},
+		Disable: []string{pythonRuntimeTracePreviewFeature},
+	})
+	if err != nil {
+		t.Fatalf("resolve Python runtime capture-only feature set: %v", err)
+	}
+	return resolved
+}
+
 func TestServiceAnalyseRuntimeCorrelationIntegration(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
@@ -482,6 +495,20 @@ func TestServiceAnalysePythonRuntimeTraceIntegration(t *testing.T) {
 	}
 	if dep := dependencyByLanguageName(t, disabledFeature.Dependencies, "python", "requests"); dep.RuntimeUsage != nil {
 		t.Fatalf("did not expect Python runtime usage with feature disabled, got %#v", dep.RuntimeUsage)
+	}
+
+	captureOnly, err := service.Analyse(context.Background(), Request{
+		RepoPath:         repo,
+		TopN:             10,
+		Language:         "python",
+		RuntimeTracePath: tracePath,
+		Features:         mustResolvePythonRuntimeCaptureOnlyFeatureSet(t),
+	})
+	if err != nil {
+		t.Fatalf("analyse python runtime with capture feature: %v", err)
+	}
+	if requests := dependencyByLanguageName(t, captureOnly.Dependencies, "python", "requests"); requests.RuntimeUsage == nil {
+		t.Fatalf("expected Python runtime usage when capture feature is enabled")
 	}
 
 	stableDefault, err := service.Analyse(context.Background(), Request{

--- a/internal/cli/parse_analyse_flags.go
+++ b/internal/cli/parse_analyse_flags.go
@@ -94,7 +94,7 @@ func newAnalyseFlagSet(req app.Request) (*flag.FlagSet, analyseFlagValues) {
 		baselineLabel:                 fs.String("baseline-label", req.Analyse.BaselineLabel, "label to use when saving a baseline snapshot"),
 		saveBaseline:                  fs.Bool("save-baseline", req.Analyse.SaveBaseline, "save current run as immutable baseline snapshot"),
 		runtimeTracePath:              fs.String("runtime-trace", req.Analyse.RuntimeTracePath, "runtime trace file path"),
-		runtimeTestCommand:            fs.String("runtime-test-command", req.Analyse.RuntimeTestCommand, "optional command to execute tests with runtime tracing"),
+		runtimeTestCommand:            fs.String("runtime-test-command", req.Analyse.RuntimeTestCommand, "optional command to execute tests with JS/TS or preview Python runtime tracing"),
 		configPath:                    fs.String("config", req.Analyse.ConfigPath, "config file path"),
 		enableFeatures:                enableFeatures,
 		disableFeatures:               disableFeatures,

--- a/internal/cli/parse_analyse_test.go
+++ b/internal/cli/parse_analyse_test.go
@@ -294,6 +294,11 @@ func TestParseArgsAnalyseRuntimeTestCommand(t *testing.T) {
 	if req.Analyse.RuntimeTestCommand != "npm test" {
 		t.Fatalf("expected runtime test command, got %q", req.Analyse.RuntimeTestCommand)
 	}
+
+	req = mustParseArgs(t, []string{"analyse", "--top", "5", "--runtime-test-command", "python3 -m pytest tests"})
+	if req.Analyse.RuntimeTestCommand != "python3 -m pytest tests" {
+		t.Fatalf("expected python runtime test command, got %q", req.Analyse.RuntimeTestCommand)
+	}
 }
 
 func TestParseArgsAnalyseRuntimeTestCommandRejectsUnsafeShape(t *testing.T) {
@@ -305,6 +310,11 @@ func TestParseArgsAnalyseRuntimeTestCommandRejectsUnsafeShape(t *testing.T) {
 	err = expectParseArgsError(t, []string{"analyse", "--top", "5", "--runtime-test-command", "node -e 'console.log(\"hi\")'"}, "expected unsafe runtime flag rejection")
 	if !strings.Contains(err.Error(), "unsafe executable flag") {
 		t.Fatalf("expected unsafe executable flag rejection, got %v", err)
+	}
+
+	err = expectParseArgsError(t, []string{"analyse", "--top", "5", "--runtime-test-command", "python -m pip install pytest"}, "expected unsafe python module rejection")
+	if !strings.Contains(err.Error(), "may only run '-m pytest'") {
+		t.Fatalf("expected unsafe python module rejection, got %v", err)
 	}
 }
 

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -30,7 +30,7 @@ Options:
   --save-baseline            Save current run as immutable baseline snapshot
   --baseline-label LABEL     Label key to use when saving baseline snapshots
   --runtime-trace PATH       Runtime import trace (NDJSON) for annotations
-  --runtime-test-command CMD Run command with JS/TS runtime hooks to capture trace before analysis
+  --runtime-test-command CMD Run command with JS/TS or preview Python runtime hooks to capture trace before analysis
   --repos PATH1,PATH2        Comma-separated repo paths for org dashboard input
   --baseline-store DIR       Directory for immutable keyed dashboard baseline snapshots
   --baseline-key KEY         Baseline snapshot key for dashboard comparison

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -88,5 +88,11 @@
     "name": "sbom-attestation-exports-preview",
     "description": "Enable preview CycloneDX SBOM exports with Lopper dependency-surface metadata.",
     "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0014",
+    "name": "python-runtime-capture-preview",
+    "description": "Enable first-party Python runtime import capture for runtime-test-command analysis.",
+    "lifecycle": "preview"
   }
 ]

--- a/internal/runtime/capture.go
+++ b/internal/runtime/capture.go
@@ -43,7 +43,7 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 	}
 
 	if req.ReuseIfUnchanged {
-		reused, err := reuseRuntimeTraceIfPossible(plan.tracePath, plan.command)
+		reused, err := reuseRuntimeTraceIfPossible(plan.tracePath, plan.command, plan.provider)
 		if err == nil && reused {
 			return nil
 		}
@@ -67,7 +67,7 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 	if err != nil {
 		return formatRuntimeCommandError(err, output)
 	}
-	if err := writeRuntimeTraceState(plan.tracePath, plan.command); err != nil {
+	if err := writeRuntimeTraceState(plan.tracePath, plan.command, plan.provider); err != nil {
 		return fmt.Errorf("write runtime trace state: %w", err)
 	}
 

--- a/internal/runtime/capture.go
+++ b/internal/runtime/capture.go
@@ -14,13 +14,22 @@ type CaptureRequest struct {
 	RepoPath         string
 	TracePath        string
 	Command          string
+	Provider         CaptureProvider
 	ReuseIfUnchanged bool
 }
+
+type CaptureProvider string
+
+const (
+	CaptureProviderNode   CaptureProvider = "node"
+	CaptureProviderPython CaptureProvider = "python"
+)
 
 type capturePlan struct {
 	repoPath  string
 	tracePath string
 	command   string
+	provider  CaptureProvider
 }
 
 func DefaultTracePath(repoPath string) string {
@@ -49,7 +58,7 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 		return err
 	}
 	cmd.Dir = plan.repoPath
-	cmd.Env, err = withRuntimeTraceEnv(os.Environ(), plan.tracePath)
+	cmd.Env, err = withRuntimeTraceEnv(os.Environ(), plan.tracePath, plan.provider)
 	if err != nil {
 		return err
 	}
@@ -70,6 +79,7 @@ func resolveCapturePlan(req CaptureRequest) (capturePlan, error) {
 		repoPath:  strings.TrimSpace(req.RepoPath),
 		tracePath: strings.TrimSpace(req.TracePath),
 		command:   strings.TrimSpace(req.Command),
+		provider:  normalizeCaptureProvider(req.Provider),
 	}
 	if plan.repoPath == "" {
 		return capturePlan{}, fmt.Errorf("repo path is required")
@@ -80,7 +90,21 @@ func resolveCapturePlan(req CaptureRequest) (capturePlan, error) {
 	if plan.tracePath == "" {
 		plan.tracePath = DefaultTracePath(plan.repoPath)
 	}
+	if plan.provider == "" {
+		return capturePlan{}, fmt.Errorf("unsupported runtime capture provider %q", req.Provider)
+	}
 	return plan, nil
+}
+
+func normalizeCaptureProvider(provider CaptureProvider) CaptureProvider {
+	switch provider {
+	case "", CaptureProviderNode:
+		return CaptureProviderNode
+	case CaptureProviderPython:
+		return CaptureProviderPython
+	default:
+		return ""
+	}
 }
 
 func prepareTracePath(tracePath string) error {

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -66,6 +67,60 @@ func TestCaptureUsesAbsoluteNodeHookPaths(t *testing.T) {
 	}
 	if !strings.Contains(got, "--loader="+loaderPath) {
 		t.Fatalf("expected absolute loader hook path, got %q", got)
+	}
+}
+
+func TestCapturePythonRuntimeImports(t *testing.T) {
+	pythonPath, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+
+	repo := t.TempDir()
+	tracePath := filepath.Join(repo, ".artifacts", runtimeTraceNDJSON)
+	sitePackages := filepath.Join(t.TempDir(), "lib", "python3.12", "site-packages")
+	if err := os.MkdirAll(filepath.Join(sitePackages, "thirdparty"), 0o750); err != nil {
+		t.Fatalf("mkdir thirdparty package: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sitePackages, "thirdparty", "__init__.py"), []byte("VALUE = 1\n"), 0o600); err != nil {
+		t.Fatalf("write thirdparty package: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "localmod.py"), []byte("VALUE = 1\n"), 0o600); err != nil {
+		t.Fatalf("write local module: %v", err)
+	}
+
+	t.Setenv("LOPPER_TEST_PYTHON", pythonPath)
+	t.Setenv("PYTHONPATH", sitePackages)
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", "#!/bin/sh\nexec \"$LOPPER_TEST_PYTHON\" -c 'import thirdparty; import localmod'\n"))
+
+	err = Capture(context.Background(), CaptureRequest{
+		RepoPath:  repo,
+		TracePath: tracePath,
+		Command:   "pytest",
+		Provider:  CaptureProviderPython,
+	})
+	if err != nil {
+		t.Fatalf("capture python runtime trace: %v", err)
+	}
+
+	content, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read python runtime trace: %v", err)
+	}
+	if !strings.Contains(string(content), `"language":"python"`) || !strings.Contains(string(content), `"module":"thirdparty"`) {
+		t.Fatalf("expected third-party python import event, got %s", content)
+	}
+	if strings.Contains(string(content), "localmod") {
+		t.Fatalf("expected local module import to be filtered, got %s", content)
+	}
+
+	trace, err := Load(tracePath)
+	if err != nil {
+		t.Fatalf("load captured python runtime trace: %v", err)
+	}
+	key := DependencyKey{Language: runtimeLanguagePython, Name: "thirdparty"}
+	if trace.DependencyLoadsByLanguage[key] == 0 {
+		t.Fatalf("expected thirdparty load in parsed trace, got %#v", trace.DependencyLoadsByLanguage)
 	}
 }
 

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -273,18 +273,35 @@ func TestCaptureReuseIfUnchangedSkipsRepeatedCommand(t *testing.T) {
 	}
 
 	third := second
-	third.Command = "npm run test"
+	third.Provider = CaptureProviderPython
 	if err := Capture(context.Background(), third); err != nil {
-		t.Fatalf("capture third run command change: %v", err)
+		t.Fatalf("capture third run provider change: %v", err)
 	}
 	if got := readCaptureCounter(t, counterPath); got != 2 {
+		t.Fatalf("expected changed provider to rerun capture, got %d", got)
+	}
+
+	fourth := third
+	if err := Capture(context.Background(), fourth); err != nil {
+		t.Fatalf("capture fourth run: %v", err)
+	}
+	if got := readCaptureCounter(t, counterPath); got != 2 {
+		t.Fatalf("expected repeated provider-specific capture to reuse trace, got %d", got)
+	}
+
+	fifth := second
+	fifth.Command = "npm run test"
+	if err := Capture(context.Background(), fifth); err != nil {
+		t.Fatalf("capture fifth run command change: %v", err)
+	}
+	if got := readCaptureCounter(t, counterPath); got != 3 {
 		t.Fatalf("expected changed command to rerun capture, got %d", got)
 	}
 }
 
 func TestReuseRuntimeTraceIfPossibleMissingTraceSkipsReuse(t *testing.T) {
 	tracePath := filepath.Join(t.TempDir(), ".artifacts", runtimeTraceNDJSON)
-	assertRuntimeReuseResult(t, tracePath, npmTestCommand, false)
+	assertDefaultRuntimeReuseResult(t, tracePath, npmTestCommand, false)
 }
 
 func TestReuseRuntimeTraceIfPossibleDirectoryTraceSkipsReuse(t *testing.T) {
@@ -292,12 +309,12 @@ func TestReuseRuntimeTraceIfPossibleDirectoryTraceSkipsReuse(t *testing.T) {
 	if err := os.MkdirAll(tracePath, 0o750); err != nil {
 		t.Fatalf("mkdir trace path dir: %v", err)
 	}
-	assertRuntimeReuseResult(t, tracePath, npmTestCommand, false)
+	assertDefaultRuntimeReuseResult(t, tracePath, npmTestCommand, false)
 }
 
 func TestReuseRuntimeTraceIfPossibleMissingStateSkipsReuse(t *testing.T) {
 	tracePath := writeTraceFixture(t)
-	assertRuntimeReuseResult(t, tracePath, npmTestCommand, false)
+	assertDefaultRuntimeReuseResult(t, tracePath, npmTestCommand, false)
 }
 
 func TestReuseRuntimeTraceIfPossibleInvalidStateSkipsReuse(t *testing.T) {
@@ -305,37 +322,41 @@ func TestReuseRuntimeTraceIfPossibleInvalidStateSkipsReuse(t *testing.T) {
 	if err := os.WriteFile(runtimeTraceStatePath(tracePath), []byte("{"), 0o600); err != nil {
 		t.Fatalf("write invalid state file: %v", err)
 	}
-	assertRuntimeReuseResult(t, tracePath, npmTestCommand, false)
+	assertDefaultRuntimeReuseResult(t, tracePath, npmTestCommand, false)
 }
 
 func TestParseRuntimeTraceStateValidation(t *testing.T) {
 	if _, ok := parseRuntimeTraceState([]byte(`{"schema":"wrong","command":"npm test"}`)); ok {
 		t.Fatalf("expected wrong runtime trace schema to be rejected")
 	}
-	if _, ok := parseRuntimeTraceState([]byte(`{"schema":"v1","command":"  "}`)); ok {
+	if _, ok := parseRuntimeTraceState([]byte(`{"schema":"v2","command":"  ","provider":"node"}`)); ok {
 		t.Fatalf("expected blank runtime trace command to be rejected")
+	}
+	if _, ok := parseRuntimeTraceState([]byte(`{"schema":"v2","command":"npm test","provider":"ruby"}`)); ok {
+		t.Fatalf("expected unsupported runtime trace provider to be rejected")
 	}
 }
 
 func TestWriteRuntimeTraceStateAndReuseChecks(t *testing.T) {
 	tracePath := writeTraceFixture(t)
-	if err := writeRuntimeTraceState(tracePath, "  npm test  "); err != nil {
+	if err := writeRuntimeTraceState(tracePath, "  npm test  ", CaptureProviderNode); err != nil {
 		t.Fatalf("write runtime trace state: %v", err)
 	}
 
-	assertRuntimeReuseResult(t, tracePath, npmTestCommand, true)
-	assertRuntimeReuseResult(t, tracePath, "npm run test", false)
+	assertRuntimeReuseResult(t, tracePath, npmTestCommand, CaptureProviderNode, true)
+	assertRuntimeReuseResult(t, tracePath, npmTestCommand, CaptureProviderPython, false)
+	assertRuntimeReuseResult(t, tracePath, "npm run test", CaptureProviderNode, false)
 }
 
 func TestWriteRuntimeTraceStateFailsWhenParentMissing(t *testing.T) {
 	missingParentTrace := filepath.Join(t.TempDir(), "missing", runtimeTraceNDJSON)
-	if err := writeRuntimeTraceState(missingParentTrace, npmTestCommand); err == nil {
+	if err := writeRuntimeTraceState(missingParentTrace, npmTestCommand, CaptureProviderNode); err == nil {
 		t.Fatalf("expected writeRuntimeTraceState to fail when parent directory is missing")
 	}
 }
 
 func TestReuseRuntimeTraceIfPossibleSurfacesStatError(t *testing.T) {
-	reused, err := reuseRuntimeTraceIfPossible(string([]byte{0}), npmTestCommand)
+	reused, err := reuseRuntimeTraceIfPossible(string([]byte{0}), npmTestCommand, CaptureProviderNode)
 	if err == nil || reused {
 		t.Fatalf("expected invalid trace path stat error, reused=%v err=%v", reused, err)
 	}
@@ -347,7 +368,7 @@ func TestReuseRuntimeTraceIfPossibleSurfacesStateReadError(t *testing.T) {
 		t.Fatalf("mkdir trace state dir: %v", err)
 	}
 
-	reused, err := reuseRuntimeTraceIfPossible(tracePath, npmTestCommand)
+	reused, err := reuseRuntimeTraceIfPossible(tracePath, npmTestCommand, CaptureProviderNode)
 	if err == nil || reused {
 		t.Fatalf("expected runtime trace state read error, reused=%v err=%v", reused, err)
 	}
@@ -410,10 +431,16 @@ func writeTraceFixture(t *testing.T) string {
 	return tracePath
 }
 
-func assertRuntimeReuseResult(t *testing.T, tracePath, command string, wantReused bool) {
+func assertDefaultRuntimeReuseResult(t *testing.T, tracePath, command string, wantReused bool) {
 	t.Helper()
 
-	reused, err := reuseRuntimeTraceIfPossible(tracePath, command)
+	assertRuntimeReuseResult(t, tracePath, command, CaptureProviderNode, wantReused)
+}
+
+func assertRuntimeReuseResult(t *testing.T, tracePath, command string, provider CaptureProvider, wantReused bool) {
+	t.Helper()
+
+	reused, err := reuseRuntimeTraceIfPossible(tracePath, command, provider)
 	if err != nil {
 		t.Fatalf("reuse runtime trace: %v", err)
 	}

--- a/internal/runtime/capture_command.go
+++ b/internal/runtime/capture_command.go
@@ -17,18 +17,21 @@ const defaultWindowsPathExt = ".COM;.EXE;.BAT;.CMD"
 var runtimeOS = goruntime.GOOS
 
 var runtimeExecutableAllowlist = map[string]struct{}{
-	"npm":    {},
-	"pnpm":   {},
-	"yarn":   {},
-	"bun":    {},
-	"npx":    {},
-	"node":   {},
-	"vitest": {},
-	"jest":   {},
-	"mocha":  {},
-	"ava":    {},
-	"deno":   {},
-	"make":   {},
+	"npm":     {},
+	"pnpm":    {},
+	"yarn":    {},
+	"bun":     {},
+	"npx":     {},
+	"node":    {},
+	"vitest":  {},
+	"jest":    {},
+	"mocha":   {},
+	"ava":     {},
+	"deno":    {},
+	"make":    {},
+	"pytest":  {},
+	"python":  {},
+	"python3": {},
 }
 
 func buildRuntimeCommand(ctx context.Context, command string) (*exec.Cmd, error) {
@@ -52,6 +55,7 @@ func buildRuntimeCommand(ctx context.Context, command string) (*exec.Cmd, error)
 		return nil, err
 	}
 	cmd.Path = executablePath
+	cmd.Err = nil
 	cmd.Args = append([]string{executablePath}, args...)
 	return cmd, nil
 }
@@ -192,6 +196,10 @@ func nextRuntimeCommandRune(runes []rune, index int) rune {
 }
 
 func rejectRuntimeCommandUnsafeFlags(executable string, args []string) error {
+	if isPythonRuntimeExecutable(executable) {
+		return rejectUnsafePythonRuntimeCommand(executable, args)
+	}
+
 	flags, ok := runtimeCommandUnsafeFlags[executable]
 	if !ok {
 		return nil
@@ -203,6 +211,28 @@ func rejectRuntimeCommandUnsafeFlags(executable string, args []string) error {
 				return fmt.Errorf("runtime test command uses unsafe executable flag %q for %q", arg, executable)
 			}
 		}
+	}
+	return nil
+}
+
+func IsPythonTestCommand(command string) bool {
+	fields, err := parseRuntimeCommand(command)
+	if err != nil || len(fields) == 0 {
+		return false
+	}
+	if fields[0] == "pytest" {
+		return true
+	}
+	return isPythonRuntimeExecutable(fields[0]) && len(fields) >= 2 && fields[1] == "-m" && len(fields) >= 3 && fields[2] == "pytest"
+}
+
+func isPythonRuntimeExecutable(executable string) bool {
+	return executable == "python" || executable == "python3"
+}
+
+func rejectUnsafePythonRuntimeCommand(executable string, args []string) error {
+	if len(args) < 2 || args[0] != "-m" || args[1] != "pytest" {
+		return fmt.Errorf("runtime test command for %q may only run '-m pytest'", executable)
 	}
 	return nil
 }

--- a/internal/runtime/capture_command_test.go
+++ b/internal/runtime/capture_command_test.go
@@ -25,6 +25,10 @@ func TestBuildRuntimeCommandAllowlist(t *testing.T) {
 		"ava",
 		"deno test",
 		"make test",
+		"pytest",
+		"pytest tests -q",
+		"python -m pytest",
+		"python3 -m pytest tests",
 	}
 
 	for _, command := range commands {
@@ -131,6 +135,9 @@ func TestBuildRuntimeCommandRejectsUnsafeSyntaxAndFlags(t *testing.T) {
 
 	checkRejects(`npm test && echo bad`, "indirect command execution operators")
 	checkRejects(`node -e 'console.log("hi")'`, "unsafe executable flag")
+	checkRejects(`python -c 'print("hi")'`, "may only run '-m pytest'")
+	checkRejects(`python -m pip install pytest`, "may only run '-m pytest'")
+	checkRejects(`python3 -m unittest`, "may only run '-m pytest'")
 }
 
 func TestValidateCommand(t *testing.T) {
@@ -140,10 +147,34 @@ func TestValidateCommand(t *testing.T) {
 	if err := ValidateCommand("npm test"); err != nil {
 		t.Fatalf("expected safe command to validate, got %v", err)
 	}
+	if err := ValidateCommand("python3 -m pytest tests"); err != nil {
+		t.Fatalf("expected python pytest command to validate, got %v", err)
+	}
 
 	err := ValidateCommand(`node -e 'console.log("hi")'`)
 	if err == nil || !strings.Contains(err.Error(), "unsafe executable flag") {
 		t.Fatalf("expected unsafe executable flag rejection, got %v", err)
+	}
+}
+
+func TestIsPythonTestCommand(t *testing.T) {
+	testCases := []struct {
+		command string
+		want    bool
+	}{
+		{command: "pytest", want: true},
+		{command: "pytest tests -q", want: true},
+		{command: "python -m pytest", want: true},
+		{command: "python3 -m pytest tests", want: true},
+		{command: "npm test", want: false},
+		{command: "python -m pip", want: false},
+		{command: `python -m "pytest`, want: false},
+	}
+
+	for _, tc := range testCases {
+		if got := IsPythonTestCommand(tc.command); got != tc.want {
+			t.Fatalf("IsPythonTestCommand(%q) = %v, want %v", tc.command, got, tc.want)
+		}
 	}
 }
 
@@ -324,7 +355,7 @@ func TestRuntimeSearchDirsDefaultOnWindowsKeepsProgramFilesNodejsDir(t *testing.
 }
 
 func TestNewAllowlistedRuntimeCommandRejectsUnsupportedExecutable(t *testing.T) {
-	if _, err := newAllowlistedRuntimeCommand(context.Background(), "python"); err == nil {
+	if _, err := newAllowlistedRuntimeCommand(context.Background(), "ruby"); err == nil {
 		t.Fatalf("expected unsupported executable error")
 	}
 }

--- a/internal/runtime/capture_cov_branches_test.go
+++ b/internal/runtime/capture_cov_branches_test.go
@@ -63,7 +63,7 @@ func TestRuntimeHookErrorsPropagate(t *testing.T) {
 		t.Fatalf("expected runtime hook options error %v, got %v", sentinel, err)
 	}
 
-	_, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, "/tmp/runtime.ndjson")
+	_, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, "/tmp/runtime.ndjson", CaptureProviderNode)
 	if err == nil || !strings.Contains(err.Error(), "resolve runtime node hooks") {
 		t.Fatalf("expected wrapped runtime hook error, got %v", err)
 	}
@@ -74,6 +74,14 @@ func TestRuntimeHookErrorsPropagate(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "resolve runtime node hooks") {
 		t.Fatalf("expected capture to surface hook resolution error, got %v", err)
+	}
+}
+
+func TestLocateRuntimePythonHookDirectoryInRootsErrorsWhenHookMissing(t *testing.T) {
+	root := t.TempDir()
+	_, err := locateRuntimePythonHookDirectoryInRoots([]string{root})
+	if err == nil || !strings.Contains(err.Error(), "could not locate runtime python hook") {
+		t.Fatalf("expected missing python hook error, got %v", err)
 	}
 }
 

--- a/internal/runtime/capture_env.go
+++ b/internal/runtime/capture_env.go
@@ -11,18 +11,34 @@ import (
 
 const runtimeRequireHookRelPath = "scripts/runtime/require-hook.cjs"
 const runtimeLoaderHookRelPath = "scripts/runtime/loader.mjs"
+const runtimePythonHookRelPath = "scripts/runtime/sitecustomize.py"
 
 var (
 	runtimeHookPathsOnce   sync.Once
 	runtimeRequireHookPath string
 	runtimeLoaderHookPath  string
 	runtimeHookPathsErr    error
+
+	runtimePythonHookDirOnce sync.Once
+	runtimePythonHookDirPath string
+	runtimePythonHookDirErr  error
 )
 
 var runtimeExecutablePath = os.Executable
 var runtimeCaller = goruntime.Caller
 
-func withRuntimeTraceEnv(base []string, tracePath string) ([]string, error) {
+func withRuntimeTraceEnv(base []string, tracePath string, provider CaptureProvider) ([]string, error) {
+	switch normalizeCaptureProvider(provider) {
+	case CaptureProviderNode:
+		return withNodeRuntimeTraceEnv(base, tracePath)
+	case CaptureProviderPython:
+		return withPythonRuntimeTraceEnv(base, tracePath)
+	default:
+		return nil, fmt.Errorf("unsupported runtime capture provider %q", provider)
+	}
+}
+
+func withNodeRuntimeTraceEnv(base []string, tracePath string) ([]string, error) {
 	required, err := runtimeNodeHookOptions()
 	if err != nil {
 		return nil, fmt.Errorf("resolve runtime node hooks: %w", err)
@@ -39,6 +55,22 @@ func withRuntimeTraceEnv(base []string, tracePath string) ([]string, error) {
 		updates["NODE_OPTIONS"] = nodeOptions + " " + required
 	}
 	return mergeEnv(base, updates), nil
+}
+
+func withPythonRuntimeTraceEnv(base []string, tracePath string) ([]string, error) {
+	hookDir, err := runtimePythonHookDirectory()
+	if err != nil {
+		return nil, fmt.Errorf("resolve runtime python hook: %w", err)
+	}
+
+	pythonPath := hookDir
+	if existing := strings.TrimSpace(readEnvValue(base, "PYTHONPATH")); existing != "" {
+		pythonPath += string(os.PathListSeparator) + existing
+	}
+	return mergeEnv(base, map[string]string{
+		"LOPPER_RUNTIME_TRACE": tracePath,
+		"PYTHONPATH":           pythonPath,
+	}), nil
 }
 
 func mergeEnv(base []string, updates map[string]string) []string {
@@ -98,8 +130,19 @@ func runtimeHookPaths() (string, string, error) {
 	return runtimeRequireHookPath, runtimeLoaderHookPath, runtimeHookPathsErr
 }
 
+func runtimePythonHookDirectory() (string, error) {
+	runtimePythonHookDirOnce.Do(func() {
+		runtimePythonHookDirPath, runtimePythonHookDirErr = locateRuntimePythonHookDirectory()
+	})
+	return runtimePythonHookDirPath, runtimePythonHookDirErr
+}
+
 func locateRuntimeHookPaths() (string, string, error) {
 	return locateRuntimeHookPathsInRoots(runtimeHookSearchRoots())
+}
+
+func locateRuntimePythonHookDirectory() (string, error) {
+	return locateRuntimePythonHookDirectoryInRoots(runtimeHookSearchRoots())
 }
 
 func locateRuntimeHookPathsInRoots(roots []string) (string, string, error) {
@@ -113,6 +156,18 @@ func locateRuntimeHookPathsInRoots(roots []string) (string, string, error) {
 	}
 
 	return "", "", fmt.Errorf("could not locate runtime hooks %q and %q", runtimeRequireHookRelPath, runtimeLoaderHookRelPath)
+}
+
+func locateRuntimePythonHookDirectoryInRoots(roots []string) (string, error) {
+	for _, root := range roots {
+		hookPath := filepath.Join(root, runtimePythonHookRelPath)
+		if !isRegularFile(hookPath) {
+			continue
+		}
+		return filepath.Dir(hookPath), nil
+	}
+
+	return "", fmt.Errorf("could not locate runtime python hook %q", runtimePythonHookRelPath)
 }
 
 func runtimeHookSearchRoots() []string {
@@ -139,6 +194,7 @@ func runtimeHookSearchRoots() []string {
 
 	if executablePath, err := runtimeExecutablePath(); err == nil {
 		executableDir := filepath.Dir(executablePath)
+		addSearchPath(filepath.Join(executableDir, "share", "lopper"))
 		addSearchPath(filepath.Join(executableDir, "..", "share", "lopper"))
 	}
 	if _, filename, _, ok := runtimeCaller(0); ok {

--- a/internal/runtime/capture_env_test.go
+++ b/internal/runtime/capture_env_test.go
@@ -52,6 +52,41 @@ func TestWithPythonRuntimeTraceEnv(t *testing.T) {
 	}
 }
 
+func TestWithPythonRuntimeTraceEnvWithoutExistingPythonPath(t *testing.T) {
+	tracePath := "/tmp/python-runtime.ndjson"
+	hookDir, err := runtimePythonHookDirectory()
+	if err != nil {
+		t.Fatalf("runtime python hook directory: %v", err)
+	}
+
+	env, err := withPythonRuntimeTraceEnv([]string{"PATH=/usr/bin"}, tracePath)
+	if err != nil {
+		t.Fatalf("with python runtime trace env: %v", err)
+	}
+
+	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
+	assertEnvEntryValue(t, env, "PYTHONPATH", hookDir)
+}
+
+func TestRuntimeCaptureProviderValidationBranches(t *testing.T) {
+	if got := normalizeCaptureProvider(""); got != CaptureProviderNode {
+		t.Fatalf("expected default provider to normalize to node, got %q", got)
+	}
+	if got := normalizeCaptureProvider(CaptureProviderPython); got != CaptureProviderPython {
+		t.Fatalf("expected python provider to normalize to python, got %q", got)
+	}
+	if got := normalizeCaptureProvider("ruby"); got != "" {
+		t.Fatalf("expected unsupported provider to normalize empty, got %q", got)
+	}
+
+	if _, err := withRuntimeTraceEnv(nil, "/tmp/runtime.ndjson", "ruby"); err == nil || !strings.Contains(err.Error(), "unsupported runtime capture provider") {
+		t.Fatalf("expected unsupported provider env error, got %v", err)
+	}
+	if _, err := resolveCapturePlan(CaptureRequest{RepoPath: t.TempDir(), Command: "npm test", Provider: "ruby"}); err == nil || !strings.Contains(err.Error(), "unsupported runtime capture provider") {
+		t.Fatalf("expected unsupported provider plan error, got %v", err)
+	}
+}
+
 func assertEnvEntryValue(t *testing.T, env []string, key, want string) {
 	t.Helper()
 

--- a/internal/runtime/capture_env_test.go
+++ b/internal/runtime/capture_env_test.go
@@ -17,13 +17,39 @@ func TestWithRuntimeTraceEnv(t *testing.T) {
 		t.Fatalf("runtime hook paths: %v", err)
 	}
 
-	env, err := withRuntimeTraceEnv([]string{"NODE_OPTIONS=--max-old-space-size=4096", "PATH=/usr/bin"}, tracePath)
+	env, err := withRuntimeTraceEnv([]string{"NODE_OPTIONS=--max-old-space-size=4096", "PATH=/usr/bin"}, tracePath, CaptureProviderNode)
 	if err != nil {
 		t.Fatalf("with runtime trace env: %v", err)
 	}
 
 	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
 	assertNodeOptionsEntry(t, env, requirePath, loaderPath)
+}
+
+func TestWithPythonRuntimeTraceEnv(t *testing.T) {
+	tracePath := "/tmp/python-runtime.ndjson"
+	hookDir, err := runtimePythonHookDirectory()
+	if err != nil {
+		t.Fatalf("runtime python hook directory: %v", err)
+	}
+
+	env, err := withRuntimeTraceEnv([]string{"PYTHONPATH=/existing/path", "NODE_OPTIONS=--max-old-space-size=4096"}, tracePath, CaptureProviderPython)
+	if err != nil {
+		t.Fatalf("with python runtime trace env: %v", err)
+	}
+
+	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
+	pythonPath, ok := lookupEnvEntry(env, "PYTHONPATH")
+	if !ok {
+		t.Fatalf("expected PYTHONPATH to be set")
+	}
+	wantPythonPath := hookDir + string(os.PathListSeparator) + "/existing/path"
+	if pythonPath != wantPythonPath {
+		t.Fatalf("expected PYTHONPATH %q, got %q", wantPythonPath, pythonPath)
+	}
+	if nodeOptions, ok := lookupEnvEntry(env, "NODE_OPTIONS"); !ok || nodeOptions != "--max-old-space-size=4096" {
+		t.Fatalf("expected NODE_OPTIONS to be preserved without Python changes, got %q", nodeOptions)
+	}
 }
 
 func assertEnvEntryValue(t *testing.T, env []string, key, want string) {
@@ -124,6 +150,7 @@ func TestRuntimeHookSearchRootsAreAnchored(t *testing.T) {
 
 	roots := runtimeHookSearchRoots()
 	want := []string{
+		filepath.Clean(filepath.Join("/tmp", "plant", "bin", "share", "lopper")),
 		filepath.Clean(filepath.Join("/tmp", "plant", "bin", "..", "share", "lopper")),
 		filepath.Clean(filepath.Join("/tmp", "source", "internal", "runtime", "..", "..")),
 	}
@@ -148,6 +175,7 @@ func TestRuntimeHookSearchRootsResolveRelativeCallerPaths(t *testing.T) {
 		t.Fatalf("abs repo root: %v", err)
 	}
 	want := []string{
+		filepath.Clean(filepath.Join("/tmp", "plant", "bin", "share", "lopper")),
 		filepath.Clean(filepath.Join("/tmp", "plant", "bin", "..", "share", "lopper")),
 		wantRepoRoot,
 	}

--- a/internal/runtime/capture_state.go
+++ b/internal/runtime/capture_state.go
@@ -4,19 +4,19 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	"strconv"
 	"strings"
 )
 
-const runtimeTraceStateSchema = "v1"
+const runtimeTraceStateSchema = "v2"
 const runtimeTraceStateSuffix = ".state.json"
 
 type runtimeTraceState struct {
-	Schema  string `json:"schema"`
-	Command string `json:"command"`
+	Schema   string          `json:"schema"`
+	Command  string          `json:"command"`
+	Provider CaptureProvider `json:"provider"`
 }
 
-func reuseRuntimeTraceIfPossible(tracePath, command string) (bool, error) {
+func reuseRuntimeTraceIfPossible(tracePath, command string, provider CaptureProvider) (bool, error) {
 	info, err := os.Stat(tracePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -39,7 +39,8 @@ func reuseRuntimeTraceIfPossible(tracePath, command string) (bool, error) {
 	if !ok {
 		return false, nil
 	}
-	return strings.TrimSpace(state.Command) == strings.TrimSpace(command), nil
+	return strings.TrimSpace(state.Command) == strings.TrimSpace(command) &&
+		normalizeCaptureProvider(state.Provider) == normalizeCaptureProvider(provider), nil
 }
 
 func runtimeTraceStatePath(tracePath string) string {
@@ -57,10 +58,20 @@ func parseRuntimeTraceState(stateData []byte) (runtimeTraceState, bool) {
 	if strings.TrimSpace(state.Command) == "" {
 		return runtimeTraceState{}, false
 	}
+	if normalizeCaptureProvider(state.Provider) == "" {
+		return runtimeTraceState{}, false
+	}
 	return state, true
 }
 
-func writeRuntimeTraceState(tracePath, command string) error {
-	payload := []byte(`{"schema":"` + runtimeTraceStateSchema + `","command":` + strconv.Quote(strings.TrimSpace(command)) + `}`)
+func writeRuntimeTraceState(tracePath, command string, provider CaptureProvider) error {
+	payload, err := json.Marshal(runtimeTraceState{
+		Schema:   runtimeTraceStateSchema,
+		Command:  strings.TrimSpace(command),
+		Provider: normalizeCaptureProvider(provider),
+	})
+	if err != nil {
+		return err
+	}
 	return os.WriteFile(runtimeTraceStatePath(tracePath), payload, 0o600)
 }

--- a/internal/runtime/capture_state.go
+++ b/internal/runtime/capture_state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -65,13 +66,8 @@ func parseRuntimeTraceState(stateData []byte) (runtimeTraceState, bool) {
 }
 
 func writeRuntimeTraceState(tracePath, command string, provider CaptureProvider) error {
-	payload, err := json.Marshal(runtimeTraceState{
-		Schema:   runtimeTraceStateSchema,
-		Command:  strings.TrimSpace(command),
-		Provider: normalizeCaptureProvider(provider),
-	})
-	if err != nil {
-		return err
-	}
+	payload := []byte(`{"schema":"` + runtimeTraceStateSchema +
+		`","command":` + strconv.Quote(strings.TrimSpace(command)) +
+		`,"provider":` + strconv.Quote(string(normalizeCaptureProvider(provider))) + `}`)
 	return os.WriteFile(runtimeTraceStatePath(tracePath), payload, 0o600)
 }

--- a/internal/runtime/capture_test_helpers_test.go
+++ b/internal/runtime/capture_test_helpers_test.go
@@ -43,6 +43,9 @@ func setupFakeRuntimeTools(t *testing.T) string {
 		"ava",
 		"deno",
 		"make",
+		"pytest",
+		"python",
+		"python3",
 	}
 	for _, tool := range tools {
 		path := filepath.Join(toolDir, tool)

--- a/internal/runtime/runtime_helpers_test.go
+++ b/internal/runtime/runtime_helpers_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRuntimeAdditionalHelperBranches(t *testing.T) {
 	tracePath := "/tmp/runtime.ndjson"
-	env, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, tracePath)
+	env, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, tracePath, CaptureProviderNode)
 	if err != nil {
 		t.Fatalf("with runtime trace env: %v", err)
 	}

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -311,6 +311,30 @@ func TestDarwinReleaseJobsAssertHostArchitecture(t *testing.T) {
 	}
 }
 
+func TestMakefileReleasePackagesRuntimeHooks(t *testing.T) {
+	t.Parallel()
+
+	makefile := readConfig(t, "Makefile")
+	for _, want := range []string{
+		`mkdir -p "$$output_dir/share/lopper/scripts"`,
+		`cp -R scripts/runtime "$$output_dir/share/lopper/scripts/"`,
+	} {
+		if !strings.Contains(makefile, want) {
+			t.Fatalf("release target must package runtime hook assets with %q", want)
+		}
+	}
+
+	for _, path := range []string{
+		"scripts/runtime/require-hook.cjs",
+		"scripts/runtime/loader.mjs",
+		"scripts/runtime/sitecustomize.py",
+	} {
+		if _, err := os.Stat(repoPath(t, path)); err != nil {
+			t.Fatalf("runtime hook asset %s must exist: %v", path, err)
+		}
+	}
+}
+
 func TestReleaseImageTagScriptSanitizesAndValidatesTags(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/runtime/sitecustomize.py
+++ b/scripts/runtime/sitecustomize.py
@@ -1,0 +1,163 @@
+"""Lopper Python runtime import capture hook."""
+
+from __future__ import annotations
+
+import builtins
+import json
+import os
+import sys
+import threading
+
+try:
+    from importlib import metadata as importlib_metadata
+except Exception:  # pragma: no cover - older or constrained Python runtimes.
+    importlib_metadata = None
+
+
+TRACE_PATH = os.environ.get("LOPPER_RUNTIME_TRACE", "").strip()
+ORIGINAL_IMPORT = builtins.__import__
+SITE_MARKERS = ("/site-packages/", "/dist-packages/")
+WRITE_LOCK = threading.Lock()
+STATE = threading.local()
+PACKAGE_DISTRIBUTIONS = None
+
+
+def _entrypoint() -> str:
+    if not sys.argv:
+        return ""
+    entry = sys.argv[0]
+    if not entry:
+        return ""
+    return _abs_path(entry)
+
+
+def _patched_import(name, globals=None, locals=None, fromlist=(), level=0):
+    module = ORIGINAL_IMPORT(name, globals, locals, fromlist, level)
+    if TRACE_PATH and level == 0:
+        caller = _caller_frame()
+        _record_import(name, caller)
+        for item in fromlist or ():
+            if item == "*":
+                continue
+            _record_import(f"{name}.{item}", caller)
+    return module
+
+
+def _caller_frame():
+    try:
+        return sys._getframe(2)
+    except ValueError:
+        return None
+
+
+def _record_import(name: str, caller) -> None:
+    module_name = (name or "").strip()
+    if not module_name:
+        return
+    module = sys.modules.get(module_name)
+    if module is None and "." in module_name:
+        module = sys.modules.get(module_name.split(".", 1)[0])
+    if module is None:
+        return
+
+    resolved = _module_path(module)
+    if not _is_third_party_path(resolved):
+        return
+
+    event = {
+        "language": "python",
+        "dependency": _dependency_for_module(module_name),
+        "module": module_name,
+        "resolved": _abs_path(resolved),
+        "parent": _parent_from_frame(caller),
+        "entrypoint": ENTRYPOINT,
+        "kind": "import",
+    }
+    _append_event(event)
+
+
+def _module_path(module) -> str:
+    spec = getattr(module, "__spec__", None)
+    origin = getattr(spec, "origin", "") if spec is not None else ""
+    if not origin or origin in {"built-in", "frozen", "namespace"}:
+        origin = getattr(module, "__file__", "")
+    return str(origin or "")
+
+
+def _is_third_party_path(path: str) -> bool:
+    normalized = _slash_path(path)
+    return any(marker in normalized for marker in SITE_MARKERS)
+
+
+def _dependency_for_module(module_name: str) -> str:
+    top_level = module_name.split(".", 1)[0]
+    if not top_level:
+        return ""
+    distributions = _package_distributions().get(top_level, ())
+    if distributions:
+        return sorted(distributions, key=str.lower)[0]
+    return top_level
+
+
+def _package_distributions():
+    global PACKAGE_DISTRIBUTIONS
+    if PACKAGE_DISTRIBUTIONS is not None:
+        return PACKAGE_DISTRIBUTIONS
+    PACKAGE_DISTRIBUTIONS = {}
+    if importlib_metadata is None or not hasattr(importlib_metadata, "packages_distributions"):
+        return PACKAGE_DISTRIBUTIONS
+    try:
+        PACKAGE_DISTRIBUTIONS = importlib_metadata.packages_distributions()
+    except Exception:
+        PACKAGE_DISTRIBUTIONS = {}
+    return PACKAGE_DISTRIBUTIONS
+
+
+def _parent_from_frame(frame) -> str:
+    if frame is None:
+        return ""
+    filename = frame.f_globals.get("__file__", "")
+    if filename:
+        return _abs_path(str(filename))
+    module_name = frame.f_globals.get("__name__", "")
+    return str(module_name or "")
+
+
+def _append_event(event) -> None:
+    if getattr(STATE, "active", False):
+        return
+    STATE.active = True
+    try:
+        parent_dir = os.path.dirname(TRACE_PATH)
+        if parent_dir:
+            os.makedirs(parent_dir, exist_ok=True)
+        payload = json.dumps(event, separators=(",", ":"), sort_keys=True).encode("utf-8") + b"\n"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        with WRITE_LOCK:
+            fd = os.open(TRACE_PATH, flags, 0o600)
+            try:
+                os.write(fd, payload)
+            finally:
+                os.close(fd)
+    except Exception:
+        return
+    finally:
+        STATE.active = False
+
+
+def _abs_path(path: str) -> str:
+    if not path:
+        return ""
+    try:
+        return os.path.abspath(path)
+    except Exception:
+        return path
+
+
+def _slash_path(path: str) -> str:
+    return _abs_path(path).replace(os.sep, "/")
+
+
+if TRACE_PATH:
+    ENTRYPOINT = _entrypoint()
+    builtins.__import__ = _patched_import

--- a/scripts/runtime/sitecustomize.py
+++ b/scripts/runtime/sitecustomize.py
@@ -10,7 +10,7 @@ import threading
 
 try:
     from importlib import metadata as importlib_metadata
-except Exception:  # pragma: no cover - older or constrained Python runtimes.
+except Exception:
     importlib_metadata = None
 
 
@@ -95,7 +95,7 @@ def _dependency_for_module(module_name: str) -> str:
         return ""
     distributions = _package_distributions().get(top_level, ())
     if distributions:
-        return sorted(distributions, key=str.lower)[0]
+        return min(distributions, key=str.lower)
     return top_level
 
 


### PR DESCRIPTION
## Summary

Adds first-party Python runtime import capture for `--runtime-test-command` behind `python-runtime-capture-preview`, so Python test runs can produce runtime trace annotations without a hand-written NDJSON trace.

Closes #1091

## Changes

- Adds a Python capture provider that injects a shipped `sitecustomize.py` hook through `PYTHONPATH` only for the runtime command.
- Supports conservative Python commands: `pytest`, `python -m pytest`, and `python3 -m pytest`, while keeping unsafe shell syntax and arbitrary Python module execution rejected.
- Emits Python NDJSON events with `language`, `dependency`, `module`, `resolved`, `parent`, and `entrypoint`, filtering to third-party imports from `site-packages` and `dist-packages`.
- Keeps explicit `--runtime-trace` consumption compatible and lets the new capture flag enable Python annotation for captured traces.
- Packages runtime hook assets into release archives and documents Python capture setup/caveats.

## Validation

Commands and checks run:

```bash
make format-check
go test ./internal/runtime ./internal/analysis ./internal/app ./internal/cli ./cmd/lopper
go test ./internal/runtime -run 'Python|Capture|Command|Env|Trace'
go test ./internal/analysis -run 'RuntimeCapture|RuntimeTrace|Python'
make feature-flag-check
make lint
make test
git diff --check
python3 -m py_compile scripts/runtime/sitecustomize.py
```

Additional manual validation:

- Temporary Python fixture with `go run ./cmd/lopper analyse --repo <fixture> --language python --top 10 --runtime-test-command "pytest" --format json --enable-feature python-runtime-capture-preview`.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Python import tracing adds runtime hook overhead only while the explicit runtime capture command is running.
- Memory benchmark impact: None expected.
- Python capture remains preview-gated by `python-runtime-capture-preview`; JS/TS runtime capture remains the default provider for existing JS commands.
- Explicit `--runtime-trace` still works without running capture.
- Python capture uses `sitecustomize.py`, so an existing project `sitecustomize.py` can be affected while the runtime command is running.
- Subprocesses and pytest workers inherit tracing when they inherit the parent environment; concurrent writers append NDJSON lines to the shared trace file.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
