### PR TITLE
chore(dashboard): pin remote repos by revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Use a dashboard config file:
 lopper dashboard --config lopper-org.yml --format json
 ```
 
+Remote dashboard config entries can use `repoUrl` with the `dashboard-remote-repos-preview` feature and may pin exactly one of `branch`, `tag`, or full `commit` SHA. Unpinned remote entries continue to track remote `HEAD`; dashboard JSON, CSV, HTML, and saved dashboard baselines include the resolved commit SHA for materialized remote repos.
+
 ## Languages
 
 - Supported adapters: `js-ts`, `python`, `cpp`, `jvm`, `kotlin-android`, `go`, `php`, `ruby`, `rust`, `dotnet`, `elixir`, `swift`, `dart`, `powershell`

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -58,14 +58,20 @@ Remote Git repositories can be configured with `repoUrl` when the `dashboard-rem
 dashboard:
   repos:
     - repoUrl: https://github.com/example/api.git
+      branch: release/2.0
       language: go
       name: API Service
     - repoUrl: ssh://git@github.com/example/frontend.git
+      tag: v2.0.0
       language: js-ts
       name: Frontend
-    - path: ./worker
+    - repoUrl: file:///srv/repos/worker.git
+      commit: 0123456789abcdef0123456789abcdef01234567
       language: python
       name: Worker
+    - path: ./worker
+      language: python
+      name: Local Worker
   output: json
 ```
 
@@ -75,8 +81,10 @@ Notes:
 - `path` and `repoUrl` are mutually exclusive on each repo entry.
 - `repoUrl` accepts only `https://`, `ssh://`, and local `file://` URLs. `http://`, `git://`, scp-style URLs such as `git@github.com:org/repo.git`, query strings, fragments, and embedded credentials are rejected.
 - `file://` URLs must use an absolute path and an empty or `localhost` host.
+- Remote `repoUrl` entries can set one of `branch`, `tag`, or `commit`. These fields are mutually exclusive, only apply to `repoUrl` entries, and `commit` must be a full 40- or 64-character hex SHA.
 - Remote repos are materialized under the user cache at `<cache-dir>/lopper/dashboard/repos/<repo-name>-<hash>`. Set `LOPPER_DASHBOARD_REPO_CACHE` to an absolute path to override the cache root in CI.
-- The checkout lifecycle is deterministic: each `repoUrl` maps to a stable hash-based checkout directory, existing checkouts with a matching origin are fetched and reset to remote `HEAD`, and invalid or mismatched cache directories are replaced before analysis.
+- The checkout lifecycle is deterministic: unpinned `repoUrl` entries continue to track remote `HEAD`; pinned entries fetch the requested branch, tag, or commit and reset to that revision. Cache paths include the requested pin, so the same `repoUrl` at different pins uses separate checkouts.
+- Dashboard JSON, CSV, HTML, and saved dashboard baselines include the resolved commit SHA for materialized remote repos. JSON repo rows also include `repo_url` and the requested `revision` when present.
 - Fetch, clone, checkout, reset, or clean failures are reported in the affected repo's dashboard `error` field and in top-level dashboard warnings, while other repos continue to analyze.
 - `baseline_store` enables dashboard baseline snapshots and compare mode. Relative values are resolved against the config file directory.
 - `baseline_key` selects a stored baseline snapshot when comparing. `baseline_label` is used when saving a labeled snapshot.
@@ -88,7 +96,7 @@ Notes:
 Dashboard JSON emits:
 
 - `generated_at`
-- `repos[]` (per-repo metrics and any analysis errors)
+- `repos[]` (per-repo metrics, remote `repo_url`, requested `revision`, `resolved_commit`, and any analysis errors)
 - `baseline_comparison` when a dashboard baseline is loaded and compared
 - `summary`:
   - `total_repos`

--- a/internal/app/dashboard_remote.go
+++ b/internal/app/dashboard_remote.go
@@ -20,6 +20,7 @@ const (
 	DashboardRemoteReposPreviewFeature = "dashboard-remote-repos-preview"
 	dashboardRepoCacheEnv              = "LOPPER_DASHBOARD_REPO_CACHE"
 	dashboardRepoCacheHashLength       = 16
+	dashboardGitShallowDepthArg        = "--depth=1"
 )
 
 type dashboardRepoURLSpec struct {
@@ -162,7 +163,7 @@ func (m *dashboardRepoMaterializer) checkoutUsable(ctx context.Context, checkout
 
 func (m *dashboardRepoMaterializer) cloneCheckout(ctx context.Context, checkoutPath string, spec dashboardRepoURLSpec, revision dashboard.RepoRevision) (string, error) {
 	if revision.IsZero() {
-		if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "clone", "--no-tags", "--depth=1", "--", spec.normalized, checkoutPath)...); err != nil {
+		if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "clone", "--no-tags", dashboardGitShallowDepthArg, "--", spec.normalized, checkoutPath)...); err != nil {
 			return "", fmt.Errorf("clone remote repo: %w", err)
 		}
 		return m.pinCheckout(ctx, checkoutPath, spec, "HEAD", revision)
@@ -181,7 +182,7 @@ func (m *dashboardRepoMaterializer) refreshCheckout(ctx context.Context, checkou
 	if !revision.IsZero() {
 		return m.fetchAndPinCheckout(ctx, checkoutPath, spec, revision)
 	}
-	if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "-C", checkoutPath, "fetch", "--prune", "--depth=1", "origin", "HEAD")...); err != nil {
+	if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "-C", checkoutPath, "fetch", "--prune", dashboardGitShallowDepthArg, "origin", "HEAD")...); err != nil {
 		return "", fmt.Errorf("fetch remote repo: %w", err)
 	}
 	return m.pinCheckout(ctx, checkoutPath, spec, "FETCH_HEAD", revision)
@@ -189,7 +190,7 @@ func (m *dashboardRepoMaterializer) refreshCheckout(ctx context.Context, checkou
 
 func (m *dashboardRepoMaterializer) fetchAndPinCheckout(ctx context.Context, checkoutPath string, spec dashboardRepoURLSpec, revision dashboard.RepoRevision) (string, error) {
 	ref := dashboardFetchRef(revision)
-	if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "-C", checkoutPath, "fetch", "--prune", "--no-tags", "--depth=1", "origin", ref)...); err != nil {
+	if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "-C", checkoutPath, "fetch", "--prune", "--no-tags", dashboardGitShallowDepthArg, "origin", ref)...); err != nil {
 		return "", fmt.Errorf("fetch remote %s %q: %w", revision.Kind(), revision.Value(), err)
 	}
 	return m.pinCheckout(ctx, checkoutPath, spec, "FETCH_HEAD", revision)
@@ -298,32 +299,47 @@ func validateDashboardRevisionName(kind, value string) error {
 	if value == "" {
 		return fmt.Errorf("%s is required", kind)
 	}
-	if strings.HasPrefix(value, "refs/") {
+	if err := validateDashboardRevisionSyntax(kind, value); err != nil {
+		return err
+	}
+	if err := validateDashboardRevisionPathComponents(kind, value); err != nil {
+		return err
+	}
+	return validateDashboardRevisionCharacters(kind, value)
+}
+
+func validateDashboardRevisionSyntax(kind, value string) error {
+	switch {
+	case strings.HasPrefix(value, "refs/"):
 		return fmt.Errorf("%s must be a name, not a full refs/... ref", kind)
-	}
-	if strings.HasPrefix(value, "-") {
+	case strings.HasPrefix(value, "-"):
 		return fmt.Errorf("%s cannot start with '-'", kind)
-	}
-	if value == "@" || strings.Contains(value, "@{") {
+	case value == "@" || strings.Contains(value, "@{"):
 		return fmt.Errorf("%s cannot use git reflog syntax", kind)
-	}
-	if strings.HasPrefix(value, "/") || strings.HasSuffix(value, "/") || strings.Contains(value, "//") {
+	case strings.HasPrefix(value, "/") || strings.HasSuffix(value, "/") || strings.Contains(value, "//"):
 		return fmt.Errorf("%s cannot start, end, or repeat '/'", kind)
-	}
-	if strings.Contains(value, "..") {
+	case strings.Contains(value, ".."):
 		return fmt.Errorf("%s cannot contain dot-dot path segments", kind)
-	}
-	if strings.HasSuffix(value, ".") {
+	case strings.HasSuffix(value, "."):
 		return fmt.Errorf("%s cannot end with a dot", kind)
+	default:
+		return nil
 	}
+}
+
+func validateDashboardRevisionPathComponents(kind, value string) error {
 	for _, component := range strings.Split(value, "/") {
-		if strings.HasPrefix(component, ".") {
+		switch {
+		case strings.HasPrefix(component, "."):
 			return fmt.Errorf("%s cannot contain a path component starting with a dot", kind)
-		}
-		if strings.HasSuffix(component, ".lock") {
+		case strings.HasSuffix(component, ".lock"):
 			return fmt.Errorf("%s cannot contain a path component ending with '.lock'", kind)
 		}
 	}
+	return nil
+}
+
+func validateDashboardRevisionCharacters(kind, value string) error {
 	for _, r := range value {
 		if unicode.IsSpace(r) || unicode.IsControl(r) || r == 0x7f {
 			return fmt.Errorf("%s cannot contain whitespace or control characters", kind)

--- a/internal/app/dashboard_remote.go
+++ b/internal/app/dashboard_remote.go
@@ -28,6 +28,11 @@ type dashboardRepoURLSpec struct {
 	name       string
 }
 
+type dashboardMaterializedRepo struct {
+	CheckoutPath   string
+	ResolvedCommit string
+}
+
 type dashboardRepoMaterializer struct {
 	cacheRoot string
 	gitPath   string
@@ -62,8 +67,9 @@ func (a *App) prepareDashboardExecutionPlan(ctx context.Context, request Dashboa
 			continue
 		}
 
-		checkoutPath, err := materializer.Materialize(ctx, repo.RepoURL)
-		repo.Path = checkoutPath
+		materialized, err := materializer.Materialize(ctx, repo.RepoURL, repo.Revision)
+		repo.Path = materialized.CheckoutPath
+		repo.ResolvedCommit = materialized.ResolvedCommit
 		initialResults[index].Input = repo
 		if err != nil {
 			initialResults[index].Err = fmt.Errorf("materialize repoUrl: %w", err)
@@ -105,36 +111,45 @@ func dashboardRemoteCacheRoot() (string, error) {
 	return filepath.Join(userCacheDir, "lopper", "dashboard", "repos"), nil
 }
 
-func (m *dashboardRepoMaterializer) Materialize(ctx context.Context, repoURL string) (string, error) {
+func (m *dashboardRepoMaterializer) Materialize(ctx context.Context, repoURL string, revision dashboard.RepoRevision) (dashboardMaterializedRepo, error) {
 	spec, err := parseDashboardRepoURL(repoURL)
 	if err != nil {
-		return "", err
+		return dashboardMaterializedRepo{}, err
 	}
-	checkoutPath, err := dashboardCheckoutPath(m.cacheRoot, spec)
+	normalizedRevision, err := normalizeDashboardRepoRevision(revision)
 	if err != nil {
-		return "", err
+		return dashboardMaterializedRepo{}, err
 	}
+	checkoutPath, err := dashboardCheckoutPath(m.cacheRoot, spec, normalizedRevision)
+	if err != nil {
+		return dashboardMaterializedRepo{}, err
+	}
+	materialized := dashboardMaterializedRepo{CheckoutPath: checkoutPath}
 	if err := os.MkdirAll(m.cacheRoot, 0o750); err != nil {
-		return checkoutPath, fmt.Errorf("create dashboard repo cache: %w", err)
+		return materialized, fmt.Errorf("create dashboard repo cache: %w", err)
 	}
 
 	if m.checkoutUsable(ctx, checkoutPath, spec.normalized) {
-		if err := m.refreshCheckout(ctx, checkoutPath, spec); err != nil {
-			return checkoutPath, err
+		resolvedCommit, err := m.refreshCheckout(ctx, checkoutPath, spec, normalizedRevision)
+		materialized.ResolvedCommit = resolvedCommit
+		if err != nil {
+			return materialized, err
 		}
-		return checkoutPath, nil
+		return materialized, nil
 	}
 
 	if err := dashboardRemoveAllFn(checkoutPath); err != nil {
-		return checkoutPath, fmt.Errorf("reset dashboard repo checkout: %w", err)
+		return materialized, fmt.Errorf("reset dashboard repo checkout: %w", err)
 	}
-	if err := m.cloneCheckout(ctx, checkoutPath, spec); err != nil {
+	resolvedCommit, err := m.cloneCheckout(ctx, checkoutPath, spec, normalizedRevision)
+	materialized.ResolvedCommit = resolvedCommit
+	if err != nil {
 		if cleanupErr := dashboardRemoveAllFn(checkoutPath); cleanupErr != nil {
-			return checkoutPath, fmt.Errorf("%w; cleanup failed: %w", err, cleanupErr)
+			return materialized, fmt.Errorf("%w; cleanup failed: %w", err, cleanupErr)
 		}
-		return checkoutPath, err
+		return materialized, err
 	}
-	return checkoutPath, nil
+	return materialized, nil
 }
 
 func (m *dashboardRepoMaterializer) checkoutUsable(ctx context.Context, checkoutPath, repoURL string) bool {
@@ -145,31 +160,71 @@ func (m *dashboardRepoMaterializer) checkoutUsable(ctx context.Context, checkout
 	return err == nil && strings.TrimSpace(string(output)) == repoURL
 }
 
-func (m *dashboardRepoMaterializer) cloneCheckout(ctx context.Context, checkoutPath string, spec dashboardRepoURLSpec) error {
-	if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "clone", "--no-tags", "--depth=1", "--", spec.normalized, checkoutPath)...); err != nil {
-		return fmt.Errorf("clone remote repo: %w", err)
+func (m *dashboardRepoMaterializer) cloneCheckout(ctx context.Context, checkoutPath string, spec dashboardRepoURLSpec, revision dashboard.RepoRevision) (string, error) {
+	if revision.IsZero() {
+		if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "clone", "--no-tags", "--depth=1", "--", spec.normalized, checkoutPath)...); err != nil {
+			return "", fmt.Errorf("clone remote repo: %w", err)
+		}
+		return m.pinCheckout(ctx, checkoutPath, spec, "HEAD", revision)
 	}
-	return m.pinCheckout(ctx, checkoutPath, spec, "HEAD")
+
+	if _, err := m.runGit(ctx, "init", checkoutPath); err != nil {
+		return "", fmt.Errorf("initialize remote repo checkout: %w", err)
+	}
+	if _, err := m.runGit(ctx, "-C", checkoutPath, "remote", "add", "origin", spec.normalized); err != nil {
+		return "", fmt.Errorf("configure remote repo origin: %w", err)
+	}
+	return m.fetchAndPinCheckout(ctx, checkoutPath, spec, revision)
 }
 
-func (m *dashboardRepoMaterializer) refreshCheckout(ctx context.Context, checkoutPath string, spec dashboardRepoURLSpec) error {
+func (m *dashboardRepoMaterializer) refreshCheckout(ctx context.Context, checkoutPath string, spec dashboardRepoURLSpec, revision dashboard.RepoRevision) (string, error) {
+	if !revision.IsZero() {
+		return m.fetchAndPinCheckout(ctx, checkoutPath, spec, revision)
+	}
 	if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "-C", checkoutPath, "fetch", "--prune", "--depth=1", "origin", "HEAD")...); err != nil {
-		return fmt.Errorf("fetch remote repo: %w", err)
+		return "", fmt.Errorf("fetch remote repo: %w", err)
 	}
-	return m.pinCheckout(ctx, checkoutPath, spec, "FETCH_HEAD")
+	return m.pinCheckout(ctx, checkoutPath, spec, "FETCH_HEAD", revision)
 }
 
-func (m *dashboardRepoMaterializer) pinCheckout(ctx context.Context, checkoutPath string, spec dashboardRepoURLSpec, ref string) error {
+func (m *dashboardRepoMaterializer) fetchAndPinCheckout(ctx context.Context, checkoutPath string, spec dashboardRepoURLSpec, revision dashboard.RepoRevision) (string, error) {
+	ref := dashboardFetchRef(revision)
+	if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "-C", checkoutPath, "fetch", "--prune", "--no-tags", "--depth=1", "origin", ref)...); err != nil {
+		return "", fmt.Errorf("fetch remote %s %q: %w", revision.Kind(), revision.Value(), err)
+	}
+	return m.pinCheckout(ctx, checkoutPath, spec, "FETCH_HEAD", revision)
+}
+
+func (m *dashboardRepoMaterializer) pinCheckout(ctx context.Context, checkoutPath string, spec dashboardRepoURLSpec, ref string, revision dashboard.RepoRevision) (string, error) {
 	if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "-C", checkoutPath, "checkout", "--detach", "--force", ref)...); err != nil {
-		return fmt.Errorf("checkout remote repo: %w", err)
+		return "", fmt.Errorf("checkout remote repo: %w", err)
 	}
 	if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "-C", checkoutPath, "reset", "--hard", ref)...); err != nil {
-		return fmt.Errorf("reset remote repo checkout: %w", err)
+		return "", fmt.Errorf("reset remote repo checkout: %w", err)
 	}
 	if _, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "-C", checkoutPath, "clean", "-fdx")...); err != nil {
-		return fmt.Errorf("clean remote repo checkout: %w", err)
+		return "", fmt.Errorf("clean remote repo checkout: %w", err)
 	}
-	return nil
+	resolvedCommit, err := m.resolveCheckoutCommit(ctx, checkoutPath, spec)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(revision.Commit) != "" && !strings.EqualFold(resolvedCommit, revision.Commit) {
+		return "", fmt.Errorf("resolved commit %s does not match requested commit %s", resolvedCommit, revision.Commit)
+	}
+	return resolvedCommit, nil
+}
+
+func (m *dashboardRepoMaterializer) resolveCheckoutCommit(ctx context.Context, checkoutPath string, spec dashboardRepoURLSpec) (string, error) {
+	output, err := m.runGit(ctx, gitArgsForURL(spec.normalized, "-C", checkoutPath, "rev-parse", "--verify", "HEAD")...)
+	if err != nil {
+		return "", fmt.Errorf("resolve remote repo commit: %w", err)
+	}
+	sha := strings.ToLower(strings.TrimSpace(string(output)))
+	if !isFullCommitSHA(sha) {
+		return "", fmt.Errorf("resolve remote repo commit: invalid SHA %q", sha)
+	}
+	return sha, nil
 }
 
 func (m *dashboardRepoMaterializer) runGit(ctx context.Context, args ...string) ([]byte, error) {
@@ -203,6 +258,108 @@ func gitArgsForURL(repoURL string, args ...string) []string {
 	combined := make([]string, 0, len(prefix)+len(args))
 	combined = append(combined, prefix...)
 	return append(combined, args...)
+}
+
+func normalizeDashboardRepoRevision(revision dashboard.RepoRevision) (dashboard.RepoRevision, error) {
+	normalized := dashboard.RepoRevision{
+		Branch: strings.TrimSpace(revision.Branch),
+		Tag:    strings.TrimSpace(revision.Tag),
+		Commit: strings.ToLower(strings.TrimSpace(revision.Commit)),
+	}
+	pinCount := 0
+	for _, value := range []string{normalized.Branch, normalized.Tag, normalized.Commit} {
+		if value != "" {
+			pinCount++
+		}
+	}
+	if pinCount > 1 {
+		return dashboard.RepoRevision{}, fmt.Errorf("define only one of branch, tag, or commit")
+	}
+
+	switch {
+	case normalized.Branch != "":
+		if err := validateDashboardRevisionName("branch", normalized.Branch); err != nil {
+			return dashboard.RepoRevision{}, err
+		}
+	case normalized.Tag != "":
+		if err := validateDashboardRevisionName("tag", normalized.Tag); err != nil {
+			return dashboard.RepoRevision{}, err
+		}
+	case normalized.Commit != "":
+		if !isFullCommitSHA(normalized.Commit) {
+			return dashboard.RepoRevision{}, fmt.Errorf("commit must be a full 40- or 64-character hex SHA")
+		}
+	}
+
+	return normalized, nil
+}
+
+func validateDashboardRevisionName(kind, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", kind)
+	}
+	if strings.HasPrefix(value, "refs/") {
+		return fmt.Errorf("%s must be a name, not a full refs/... ref", kind)
+	}
+	if strings.HasPrefix(value, "-") {
+		return fmt.Errorf("%s cannot start with '-'", kind)
+	}
+	if value == "@" || strings.Contains(value, "@{") {
+		return fmt.Errorf("%s cannot use git reflog syntax", kind)
+	}
+	if strings.HasPrefix(value, "/") || strings.HasSuffix(value, "/") || strings.Contains(value, "//") {
+		return fmt.Errorf("%s cannot start, end, or repeat '/'", kind)
+	}
+	if strings.Contains(value, "..") {
+		return fmt.Errorf("%s cannot contain dot-dot path segments", kind)
+	}
+	if strings.HasSuffix(value, ".") {
+		return fmt.Errorf("%s cannot end with a dot", kind)
+	}
+	for _, component := range strings.Split(value, "/") {
+		if strings.HasPrefix(component, ".") {
+			return fmt.Errorf("%s cannot contain a path component starting with a dot", kind)
+		}
+		if strings.HasSuffix(component, ".lock") {
+			return fmt.Errorf("%s cannot contain a path component ending with '.lock'", kind)
+		}
+	}
+	for _, r := range value {
+		if unicode.IsSpace(r) || unicode.IsControl(r) || r == 0x7f {
+			return fmt.Errorf("%s cannot contain whitespace or control characters", kind)
+		}
+		switch r {
+		case '~', '^', ':', '?', '*', '[', '\\':
+			return fmt.Errorf("%s cannot contain %q", kind, r)
+		}
+	}
+	return nil
+}
+
+func dashboardFetchRef(revision dashboard.RepoRevision) string {
+	switch revision.Kind() {
+	case "branch":
+		return "refs/heads/" + revision.Value()
+	case "tag":
+		return "refs/tags/" + revision.Value()
+	case "commit":
+		return revision.Value()
+	default:
+		return "HEAD"
+	}
+}
+
+func isFullCommitSHA(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func parseDashboardRepoURL(raw string) (dashboardRepoURLSpec, error) {
@@ -298,14 +455,21 @@ func inferDashboardRepoURLName(parsed *url.URL) string {
 	return base
 }
 
-func dashboardCheckoutPath(cacheRoot string, spec dashboardRepoURLSpec) (string, error) {
+func dashboardCheckoutPath(cacheRoot string, spec dashboardRepoURLSpec, revision dashboard.RepoRevision) (string, error) {
 	root := filepath.Clean(cacheRoot)
 	if !filepath.IsAbs(root) {
 		return "", fmt.Errorf("dashboard repo cache root must be absolute")
 	}
-	sum := sha256.Sum256([]byte(spec.normalized))
+	hashInput := spec.normalized
+	checkoutName := sanitizeDashboardCheckoutName(spec.name)
+	if !revision.IsZero() {
+		revisionKey := revision.Kind() + ":" + revision.Value()
+		hashInput += "\x00" + revisionKey
+		checkoutName += "-" + sanitizeDashboardCheckoutName(revisionKey)
+	}
+	sum := sha256.Sum256([]byte(hashInput))
 	hash := hex.EncodeToString(sum[:])[:dashboardRepoCacheHashLength]
-	checkoutPath := filepath.Join(root, sanitizeDashboardCheckoutName(spec.name)+"-"+hash)
+	checkoutPath := filepath.Join(root, checkoutName+"-"+hash)
 	if !pathWithinDir(root, checkoutPath) {
 		return "", fmt.Errorf("dashboard repo checkout path escapes cache root")
 	}

--- a/internal/app/dashboard_remote_test.go
+++ b/internal/app/dashboard_remote_test.go
@@ -120,6 +120,56 @@ func TestReposFromDashboardConfigRemoteRevisionValidation(t *testing.T) {
 	}
 }
 
+func TestValidateDashboardRevisionNameBranches(t *testing.T) {
+	tests := []struct {
+		name  string
+		kind  string
+		value string
+		want  string
+	}{
+		{name: "empty", kind: "branch", value: "", want: "is required"},
+		{name: "dash prefix", kind: "branch", value: "-main", want: "cannot start with '-'"},
+		{name: "at", kind: "tag", value: "@", want: "reflog"},
+		{name: "reflog", kind: "tag", value: "main@{1}", want: "reflog"},
+		{name: "slash prefix", kind: "branch", value: "/main", want: "start, end, or repeat '/'"},
+		{name: "slash suffix", kind: "branch", value: "main/", want: "start, end, or repeat '/'"},
+		{name: "repeated slash", kind: "branch", value: "release//main", want: "start, end, or repeat '/'"},
+		{name: "dot suffix", kind: "tag", value: "v1.", want: "cannot end with a dot"},
+		{name: "dot component", kind: "branch", value: "release/.hidden", want: "component starting with a dot"},
+		{name: "lock component", kind: "branch", value: "release/main.lock", want: "component ending with '.lock'"},
+		{name: "space", kind: "branch", value: "release main", want: "whitespace"},
+		{name: "tilde", kind: "branch", value: "release~main", want: "~"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDashboardRevisionName(tc.kind, tc.value)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected revision validation error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+
+	if err := validateDashboardRevisionName("branch", "release/main"); err != nil {
+		t.Fatalf("expected valid branch revision name, got %v", err)
+	}
+}
+
+func TestDashboardRevisionHelperBranches(t *testing.T) {
+	if got := dashboardFetchRef(dashboard.RepoRevision{}); got != "HEAD" {
+		t.Fatalf("expected empty revision fetch ref HEAD, got %q", got)
+	}
+	if isFullCommitSHA("not-a-sha") {
+		t.Fatalf("expected non-hex commit to be rejected")
+	}
+	if isFullCommitSHA(strings.Repeat("a", 39)) {
+		t.Fatalf("expected short commit to be rejected")
+	}
+	if !isFullCommitSHA(strings.Repeat("A", 64)) {
+		t.Fatalf("expected 64-character uppercase commit to be accepted")
+	}
+}
+
 func TestDashboardRemoteCacheRootRules(t *testing.T) {
 	t.Setenv(dashboardRepoCacheEnv, "relative-cache")
 	if _, err := dashboardRemoteCacheRoot(); err == nil || !strings.Contains(err.Error(), "absolute path") {
@@ -589,6 +639,54 @@ func TestDashboardRepoMaterializerPinCheckoutErrors(t *testing.T) {
 				t.Fatalf("expected %q error, got %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestDashboardRepoMaterializerResolveCommitErrors(t *testing.T) {
+	spec := mustParseDashboardRepoURL(t, testHTTPSRepoURL)
+	tests := []struct {
+		name    string
+		output  string
+		fail    bool
+		wantErr string
+	}{
+		{name: "rev parse failure", fail: true, wantErr: "resolve remote repo commit"},
+		{name: "invalid sha", output: "not-a-sha", wantErr: "invalid SHA"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withFakeDashboardGit(t, func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
+				if tc.fail {
+					return exec.CommandContext(ctx, fixedTestBinary(t, "false")), nil
+				}
+				return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), tc.output), nil
+			})
+
+			materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
+			_, err := materializer.resolveCheckoutCommit(context.Background(), t.TempDir(), spec)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected resolve commit error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestDashboardRepoMaterializerPinnedCommitMismatch(t *testing.T) {
+	spec := mustParseDashboardRepoURL(t, testHTTPSRepoURL)
+	resolvedCommit := strings.Repeat("a", 40)
+	requestedCommit := strings.Repeat("b", 40)
+	withFakeDashboardGit(t, func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
+		if strings.Contains(strings.Join(args, " "), "rev-parse --verify HEAD") {
+			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), resolvedCommit), nil
+		}
+		return exec.CommandContext(ctx, fixedTestBinary(t, "true")), nil
+	})
+
+	materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
+	_, err := materializer.pinCheckout(context.Background(), t.TempDir(), spec, "FETCH_HEAD", dashboard.RepoRevision{Commit: requestedCommit})
+	if err == nil || !strings.Contains(err.Error(), "does not match requested commit") {
+		t.Fatalf("expected pinned commit mismatch error, got %v", err)
 	}
 }
 

--- a/internal/app/dashboard_remote_test.go
+++ b/internal/app/dashboard_remote_test.go
@@ -441,6 +441,30 @@ func TestDashboardRepoMaterializerPinnedHTTPSFetchCommands(t *testing.T) {
 	}
 }
 
+func TestDashboardRepoMaterializerCloneCheckoutSetupErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		failOn  string
+		wantErr string
+	}{
+		{name: "init", failOn: "init ", wantErr: "initialize remote repo checkout"},
+		{name: "remote", failOn: "remote add origin", wantErr: "configure remote repo origin"},
+	}
+	spec := mustParseDashboardRepoURL(t, testHTTPSRepoURL)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withDashboardGitFailingCommand(t, tc.failOn)
+
+			materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
+			_, err := materializer.cloneCheckout(context.Background(), t.TempDir(), spec, dashboard.RepoRevision{Branch: "main"})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected %q error, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestDashboardRepoMaterializerPinnedCommitFailure(t *testing.T) {
 	fixture := initDashboardRemoteGitRepoWithRefs(t)
 	materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: dashboardGitPathForTest(t)}
@@ -449,6 +473,13 @@ func TestDashboardRepoMaterializerPinnedCommitFailure(t *testing.T) {
 	_, err := materializer.Materialize(context.Background(), fileURL(fixture.repoPath), dashboard.RepoRevision{Commit: missingCommit})
 	if err == nil || !strings.Contains(err.Error(), "fetch remote commit") {
 		t.Fatalf("expected unresolved commit fetch error, got %v", err)
+	}
+}
+
+func TestDashboardRepoMaterializerRejectsInvalidMaterializeRevision(t *testing.T) {
+	materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
+	if materialized, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, dashboard.RepoRevision{Branch: "release..main"}); err == nil || materialized.CheckoutPath != "" {
+		t.Fatalf("expected invalid revision without checkout path, materialized=%#v err=%v", materialized, err)
 	}
 }
 
@@ -461,16 +492,7 @@ func TestDashboardRepoMaterializerRefreshesUsableCheckout(t *testing.T) {
 	}
 
 	var commands []string
-	withFakeDashboardGit(t, func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
-		commands = append(commands, strings.Join(args, " "))
-		if strings.Contains(strings.Join(args, " "), "remote get-url origin") {
-			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), testHTTPSRepoURL), nil
-		}
-		if strings.Contains(strings.Join(args, " "), "rev-parse --verify HEAD") {
-			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), testResolvedCommit), nil
-		}
-		return exec.CommandContext(ctx, fixedTestBinary(t, "true")), nil
-	})
+	withDashboardGitRemoteOriginAndCommit(t, testHTTPSRepoURL, testResolvedCommit, &commands)
 
 	materializer := &dashboardRepoMaterializer{cacheRoot: cacheRoot, gitPath: "/usr/bin/git"}
 	got, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, dashboard.RepoRevision{})
@@ -586,17 +608,7 @@ func TestDashboardRepoMaterializerReplacesMismatchedCheckout(t *testing.T) {
 	testutil.MustWriteFile(t, filepath.Join(checkoutPath, "stale.txt"), "stale")
 
 	var commands []string
-	withFakeDashboardGit(t, func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
-		joined := strings.Join(args, " ")
-		commands = append(commands, joined)
-		if strings.Contains(joined, "remote get-url origin") {
-			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), "https://github.com/other/repo.git"), nil
-		}
-		if strings.Contains(joined, "rev-parse --verify HEAD") {
-			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), testResolvedCommit), nil
-		}
-		return exec.CommandContext(ctx, fixedTestBinary(t, "true")), nil
-	})
+	withDashboardGitRemoteOriginAndCommit(t, "https://github.com/other/repo.git", testResolvedCommit, &commands)
 
 	materializer := &dashboardRepoMaterializer{cacheRoot: cacheRoot, gitPath: "/usr/bin/git"}
 	got, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, dashboard.RepoRevision{})
@@ -626,12 +638,7 @@ func TestDashboardRepoMaterializerPinCheckoutErrors(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			withFakeDashboardGit(t, func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
-				if strings.Contains(strings.Join(args, " "), tc.failOn) {
-					return exec.CommandContext(ctx, fixedTestBinary(t, "false")), nil
-				}
-				return exec.CommandContext(ctx, fixedTestBinary(t, "true")), nil
-			})
+			withDashboardGitFailingCommand(t, tc.failOn)
 
 			materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
 			_, err := materializer.pinCheckout(context.Background(), t.TempDir(), spec, "HEAD", dashboard.RepoRevision{})
@@ -687,6 +694,22 @@ func TestDashboardRepoMaterializerPinnedCommitMismatch(t *testing.T) {
 	_, err := materializer.pinCheckout(context.Background(), t.TempDir(), spec, "FETCH_HEAD", dashboard.RepoRevision{Commit: requestedCommit})
 	if err == nil || !strings.Contains(err.Error(), "does not match requested commit") {
 		t.Fatalf("expected pinned commit mismatch error, got %v", err)
+	}
+}
+
+func TestDashboardRepoMaterializerPinCheckoutResolveCommitError(t *testing.T) {
+	spec := mustParseDashboardRepoURL(t, testHTTPSRepoURL)
+	withFakeDashboardGit(t, func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
+		if strings.Contains(strings.Join(args, " "), "rev-parse --verify HEAD") {
+			return exec.CommandContext(ctx, fixedTestBinary(t, "false")), nil
+		}
+		return exec.CommandContext(ctx, fixedTestBinary(t, "true")), nil
+	})
+
+	materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
+	_, err := materializer.pinCheckout(context.Background(), t.TempDir(), spec, "FETCH_HEAD", dashboard.RepoRevision{})
+	if err == nil || !strings.Contains(err.Error(), "resolve remote repo commit") {
+		t.Fatalf("expected resolve commit error, got %v", err)
 	}
 }
 
@@ -772,6 +795,9 @@ func TestDashboardCheckoutHelpers(t *testing.T) {
 	}
 	if pathWithinDir(root, filepath.Dir(root)) {
 		t.Fatalf("expected parent directory to be outside cache root")
+	}
+	if !pathWithinDir(root, filepath.Join(root, "child")) {
+		t.Fatalf("expected child directory to be within cache root")
 	}
 	if !pathWithinDir(root, root) {
 		t.Fatalf("expected cache root to be within itself")
@@ -864,6 +890,31 @@ func withFakeDashboardGit(t *testing.T, fake func(context.Context, string, ...st
 	original := execDashboardGitCommandFn
 	execDashboardGitCommandFn = fake
 	t.Cleanup(func() { execDashboardGitCommandFn = original })
+}
+
+func withDashboardGitFailingCommand(t *testing.T, failOn string) {
+	t.Helper()
+	withFakeDashboardGit(t, func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
+		if strings.Contains(strings.Join(args, " "), failOn) {
+			return exec.CommandContext(ctx, fixedTestBinary(t, "false")), nil
+		}
+		return exec.CommandContext(ctx, fixedTestBinary(t, "true")), nil
+	})
+}
+
+func withDashboardGitRemoteOriginAndCommit(t *testing.T, remoteOrigin, commit string, commands *[]string) {
+	t.Helper()
+	withFakeDashboardGit(t, func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
+		joined := strings.Join(args, " ")
+		*commands = append(*commands, joined)
+		if strings.Contains(joined, "remote get-url origin") {
+			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), remoteOrigin), nil
+		}
+		if strings.Contains(joined, "rev-parse --verify HEAD") {
+			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), commit), nil
+		}
+		return exec.CommandContext(ctx, fixedTestBinary(t, "true")), nil
+	})
 }
 
 func fixedTestBinary(t *testing.T, name string) string {

--- a/internal/app/dashboard_remote_test.go
+++ b/internal/app/dashboard_remote_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	testHTTPSRepoURL = "https://github.com/org/repo.git"
+	testHTTPSRepoURL   = "https://github.com/org/repo.git"
+	testResolvedCommit = "0123456789abcdef0123456789abcdef01234567"
 )
 
 func TestReposFromDashboardConfigRejectsUnsafeRepoURLs(t *testing.T) {
@@ -49,6 +50,73 @@ func TestReposFromDashboardConfigRejectsUnsafeRepoURLs(t *testing.T) {
 				t.Fatalf("expected repoUrl error containing %q, got %v", tc.want, err)
 			}
 		})
+	}
+}
+
+func TestReposFromDashboardConfigRemoteRevisionValidation(t *testing.T) {
+	features := enabledDashboardRemoteReposFeatures(t)
+	tests := []struct {
+		name string
+		repo dashboard.ConfigRepo
+		want string
+	}{
+		{
+			name: "ambiguous branch and tag",
+			repo: dashboard.ConfigRepo{RepoURL: testHTTPSRepoURL, Branch: "main", Tag: "v1.0.0"},
+			want: "define only one of branch, tag, or commit",
+		},
+		{
+			name: "branch full ref",
+			repo: dashboard.ConfigRepo{RepoURL: testHTTPSRepoURL, Branch: "refs/heads/main"},
+			want: "not a full refs/... ref",
+		},
+		{
+			name: "tag invalid ref syntax",
+			repo: dashboard.ConfigRepo{RepoURL: testHTTPSRepoURL, Tag: "release..candidate"},
+			want: "cannot contain dot-dot",
+		},
+		{
+			name: "short commit",
+			repo: dashboard.ConfigRepo{RepoURL: testHTTPSRepoURL, Commit: "abc123"},
+			want: "full 40- or 64-character hex SHA",
+		},
+		{
+			name: "local path pin",
+			repo: dashboard.ConfigRepo{Path: "./api", Branch: "main"},
+			want: "revision fields require repoUrl",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := dashboard.LoadedConfig{
+				ConfigDir: t.TempDir(),
+				Dashboard: dashboard.ConfigDashboard{
+					Repos: []dashboard.ConfigRepo{tc.repo},
+				},
+			}
+			_, err := reposFromDashboardConfig(config, &features)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected revision error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+
+	config := dashboard.LoadedConfig{
+		ConfigDir: t.TempDir(),
+		Dashboard: dashboard.ConfigDashboard{
+			Repos: []dashboard.ConfigRepo{{
+				RepoURL: testHTTPSRepoURL,
+				Branch:  " release/2.0 ",
+			}},
+		},
+	}
+	repos, err := reposFromDashboardConfig(config, &features)
+	if err != nil {
+		t.Fatalf("expected branch revision config to resolve: %v", err)
+	}
+	if len(repos) != 1 || repos[0].Revision.Branch != "release/2.0" {
+		t.Fatalf("unexpected resolved repo revision: %#v", repos)
 	}
 }
 
@@ -159,6 +227,7 @@ func TestExecuteDashboardMaterializesRepoURL(t *testing.T) {
 	cacheRoot := t.TempDir()
 	t.Setenv(dashboardRepoCacheEnv, cacheRoot)
 	remoteRepo := initDashboardRemoteGitRepo(t)
+	remoteHead := gitHead(t, remoteRepo)
 	configPath := filepath.Join(t.TempDir(), "lopper-org.yml")
 	config := "dashboard:\n  repos:\n    - repoUrl: " + fileURL(remoteRepo) + "\n      name: Fixture Remote\n      language: go\n  output: json\n"
 	testutil.MustWriteFile(t, configPath, config)
@@ -195,7 +264,7 @@ func TestExecuteDashboardMaterializesRepoURL(t *testing.T) {
 		t.Fatalf("expected one repo result, got %#v", reportData.Repos)
 	}
 	got := reportData.Repos[0]
-	if got.Name != "Fixture Remote" || got.Language != "go" || got.Path != checkoutPath || got.Error != "" {
+	if got.Name != "Fixture Remote" || got.Language != "go" || got.Path != checkoutPath || got.RepoURL != fileURL(remoteRepo) || got.ResolvedCommit != remoteHead || got.Error != "" {
 		t.Fatalf("unexpected materialized repo result: %#v", got)
 	}
 }
@@ -239,6 +308,100 @@ func TestExecuteDashboardReportsRepoURLCheckoutFailure(t *testing.T) {
 	}
 }
 
+func TestDashboardRepoMaterializerPinsFileRemoteRevisions(t *testing.T) {
+	fixture := initDashboardRemoteGitRepoWithRefs(t)
+	repoURL := fileURL(fixture.repoPath)
+	materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: dashboardGitPathForTest(t)}
+
+	unpinned, err := materializer.Materialize(context.Background(), repoURL, dashboard.RepoRevision{})
+	if err != nil {
+		t.Fatalf("materialize unpinned file remote: %v", err)
+	}
+	branch, err := materializer.Materialize(context.Background(), repoURL, dashboard.RepoRevision{Branch: "stable"})
+	if err != nil {
+		t.Fatalf("materialize branch-pinned file remote: %v", err)
+	}
+	tag, err := materializer.Materialize(context.Background(), repoURL, dashboard.RepoRevision{Tag: "v1.0.0"})
+	if err != nil {
+		t.Fatalf("materialize tag-pinned file remote: %v", err)
+	}
+	commit, err := materializer.Materialize(context.Background(), repoURL, dashboard.RepoRevision{Commit: fixture.initialCommit})
+	if err != nil {
+		t.Fatalf("materialize commit-pinned file remote: %v", err)
+	}
+
+	if unpinned.ResolvedCommit != fixture.headCommit {
+		t.Fatalf("expected unpinned checkout at HEAD %s, got %#v", fixture.headCommit, unpinned)
+	}
+	for name, materialized := range map[string]dashboardMaterializedRepo{
+		"branch": branch,
+		"tag":    tag,
+		"commit": commit,
+	} {
+		if materialized.ResolvedCommit != fixture.initialCommit {
+			t.Fatalf("expected %s pin at %s, got %#v", name, fixture.initialCommit, materialized)
+		}
+	}
+
+	paths := map[string]bool{}
+	for _, materialized := range []dashboardMaterializedRepo{unpinned, branch, tag, commit} {
+		if paths[materialized.CheckoutPath] {
+			t.Fatalf("expected pin-aware cache paths, duplicate %q", materialized.CheckoutPath)
+		}
+		paths[materialized.CheckoutPath] = true
+	}
+}
+
+func TestDashboardRepoMaterializerPinnedHTTPSFetchCommands(t *testing.T) {
+	tests := []struct {
+		name      string
+		revision  dashboard.RepoRevision
+		wantFetch string
+	}{
+		{name: "branch", revision: dashboard.RepoRevision{Branch: "release/2.0"}, wantFetch: "fetch --prune --no-tags --depth=1 origin refs/heads/release/2.0"},
+		{name: "tag", revision: dashboard.RepoRevision{Tag: "v2.0.0"}, wantFetch: "fetch --prune --no-tags --depth=1 origin refs/tags/v2.0.0"},
+		{name: "commit", revision: dashboard.RepoRevision{Commit: testResolvedCommit}, wantFetch: "fetch --prune --no-tags --depth=1 origin " + testResolvedCommit},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var commands []string
+			withFakeDashboardGit(t, func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
+				joined := strings.Join(args, " ")
+				commands = append(commands, joined)
+				if strings.Contains(joined, "rev-parse --verify HEAD") {
+					return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), testResolvedCommit), nil
+				}
+				return exec.CommandContext(ctx, fixedTestBinary(t, "true")), nil
+			})
+
+			materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
+			got, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, tc.revision)
+			if err != nil {
+				t.Fatalf("materialize pinned https remote: %v", err)
+			}
+			if got.ResolvedCommit != testResolvedCommit {
+				t.Fatalf("expected resolved commit %s, got %#v", testResolvedCommit, got)
+			}
+			assertCommandContains(t, commands, "init "+got.CheckoutPath)
+			assertCommandContains(t, commands, "remote add origin "+testHTTPSRepoURL)
+			assertCommandContains(t, commands, tc.wantFetch)
+			assertCommandContains(t, commands, "checkout --detach --force FETCH_HEAD")
+		})
+	}
+}
+
+func TestDashboardRepoMaterializerPinnedCommitFailure(t *testing.T) {
+	fixture := initDashboardRemoteGitRepoWithRefs(t)
+	materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: dashboardGitPathForTest(t)}
+	missingCommit := strings.Repeat("f", 40)
+
+	_, err := materializer.Materialize(context.Background(), fileURL(fixture.repoPath), dashboard.RepoRevision{Commit: missingCommit})
+	if err == nil || !strings.Contains(err.Error(), "fetch remote commit") {
+		t.Fatalf("expected unresolved commit fetch error, got %v", err)
+	}
+}
+
 func TestDashboardRepoMaterializerRefreshesUsableCheckout(t *testing.T) {
 	cacheRoot := t.TempDir()
 	spec := mustParseDashboardRepoURL(t, testHTTPSRepoURL)
@@ -253,16 +416,19 @@ func TestDashboardRepoMaterializerRefreshesUsableCheckout(t *testing.T) {
 		if strings.Contains(strings.Join(args, " "), "remote get-url origin") {
 			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), testHTTPSRepoURL), nil
 		}
+		if strings.Contains(strings.Join(args, " "), "rev-parse --verify HEAD") {
+			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), testResolvedCommit), nil
+		}
 		return exec.CommandContext(ctx, fixedTestBinary(t, "true")), nil
 	})
 
 	materializer := &dashboardRepoMaterializer{cacheRoot: cacheRoot, gitPath: "/usr/bin/git"}
-	got, err := materializer.Materialize(context.Background(), testHTTPSRepoURL)
+	got, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, dashboard.RepoRevision{})
 	if err != nil {
 		t.Fatalf("materialize existing checkout: %v", err)
 	}
-	if got != checkoutPath {
-		t.Fatalf("expected checkout path %q, got %q", checkoutPath, got)
+	if got.CheckoutPath != checkoutPath || got.ResolvedCommit != testResolvedCommit {
+		t.Fatalf("expected checkout %q at %s, got %#v", checkoutPath, testResolvedCommit, got)
 	}
 	assertCommandContains(t, commands, "fetch --prune --depth=1 origin HEAD")
 	assertCommandContains(t, commands, "checkout --detach --force FETCH_HEAD")
@@ -290,9 +456,9 @@ func TestDashboardRepoMaterializerRefreshFailure(t *testing.T) {
 	})
 
 	materializer := &dashboardRepoMaterializer{cacheRoot: cacheRoot, gitPath: "/usr/bin/git"}
-	got, err := materializer.Materialize(context.Background(), testHTTPSRepoURL)
-	if got != checkoutPath {
-		t.Fatalf("expected checkout path on refresh failure, got %q", got)
+	got, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, dashboard.RepoRevision{})
+	if got.CheckoutPath != checkoutPath {
+		t.Fatalf("expected checkout path on refresh failure, got %#v", got)
 	}
 	if err == nil || !strings.Contains(err.Error(), "fetch remote repo") {
 		t.Fatalf("expected fetch failure, got %v", err)
@@ -301,20 +467,20 @@ func TestDashboardRepoMaterializerRefreshFailure(t *testing.T) {
 
 func TestDashboardRepoMaterializerValidationAndCacheErrors(t *testing.T) {
 	materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
-	if checkoutPath, err := materializer.Materialize(context.Background(), "notaurl"); err == nil || checkoutPath != "" {
-		t.Fatalf("expected invalid URL without checkout path, path=%q err=%v", checkoutPath, err)
+	if materialized, err := materializer.Materialize(context.Background(), "notaurl", dashboard.RepoRevision{}); err == nil || materialized.CheckoutPath != "" {
+		t.Fatalf("expected invalid URL without checkout path, materialized=%#v err=%v", materialized, err)
 	}
 
 	materializer.cacheRoot = "relative-cache"
-	if _, err := materializer.Materialize(context.Background(), testHTTPSRepoURL); err == nil || !strings.Contains(err.Error(), "cache root") {
+	if _, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, dashboard.RepoRevision{}); err == nil || !strings.Contains(err.Error(), "cache root") {
 		t.Fatalf("expected relative cache root error, got %v", err)
 	}
 
 	blocker := filepath.Join(t.TempDir(), "blocked-cache")
 	testutil.MustWriteFile(t, blocker, "x")
 	materializer.cacheRoot = blocker
-	checkoutPath, err := materializer.Materialize(context.Background(), testHTTPSRepoURL)
-	if checkoutPath == "" {
+	materialized, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, dashboard.RepoRevision{})
+	if materialized.CheckoutPath == "" {
 		t.Fatalf("expected deterministic checkout path with blocked cache")
 	}
 	if err == nil || !strings.Contains(err.Error(), "create dashboard repo cache") {
@@ -329,7 +495,7 @@ func TestDashboardRepoMaterializerRemoveErrors(t *testing.T) {
 	dashboardRemoveAllFn = func(string) error { return resetErr }
 
 	materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
-	if _, err := materializer.Materialize(context.Background(), testHTTPSRepoURL); !errors.Is(err, resetErr) {
+	if _, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, dashboard.RepoRevision{}); !errors.Is(err, resetErr) {
 		t.Fatalf("expected reset remove error, got %v", err)
 	}
 }
@@ -354,7 +520,7 @@ func TestDashboardRepoMaterializerCloneCleanupError(t *testing.T) {
 	})
 
 	materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
-	_, err := materializer.Materialize(context.Background(), testHTTPSRepoURL)
+	_, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, dashboard.RepoRevision{})
 	if err == nil || !strings.Contains(err.Error(), "clone remote repo") || !strings.Contains(err.Error(), "cleanup failed") || !errors.Is(err, cleanupErr) {
 		t.Fatalf("expected clone and cleanup failure, got %v", err)
 	}
@@ -376,16 +542,19 @@ func TestDashboardRepoMaterializerReplacesMismatchedCheckout(t *testing.T) {
 		if strings.Contains(joined, "remote get-url origin") {
 			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), "https://github.com/other/repo.git"), nil
 		}
+		if strings.Contains(joined, "rev-parse --verify HEAD") {
+			return exec.CommandContext(ctx, fixedTestBinary(t, "printf"), testResolvedCommit), nil
+		}
 		return exec.CommandContext(ctx, fixedTestBinary(t, "true")), nil
 	})
 
 	materializer := &dashboardRepoMaterializer{cacheRoot: cacheRoot, gitPath: "/usr/bin/git"}
-	got, err := materializer.Materialize(context.Background(), testHTTPSRepoURL)
+	got, err := materializer.Materialize(context.Background(), testHTTPSRepoURL, dashboard.RepoRevision{})
 	if err != nil {
 		t.Fatalf("materialize mismatched checkout: %v", err)
 	}
-	if got != checkoutPath {
-		t.Fatalf("expected checkout path %q, got %q", checkoutPath, got)
+	if got.CheckoutPath != checkoutPath || got.ResolvedCommit != testResolvedCommit {
+		t.Fatalf("expected checkout %q at %s, got %#v", checkoutPath, testResolvedCommit, got)
 	}
 	if _, err := os.Stat(filepath.Join(checkoutPath, "stale.txt")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected stale checkout to be removed before clone, stat err=%v", err)
@@ -415,7 +584,7 @@ func TestDashboardRepoMaterializerPinCheckoutErrors(t *testing.T) {
 			})
 
 			materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
-			err := materializer.pinCheckout(context.Background(), t.TempDir(), spec, "HEAD")
+			_, err := materializer.pinCheckout(context.Background(), t.TempDir(), spec, "HEAD", dashboard.RepoRevision{})
 			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 				t.Fatalf("expected %q error, got %v", tc.wantErr, err)
 			}
@@ -492,6 +661,11 @@ func TestDashboardCheckoutHelpers(t *testing.T) {
 	if first != second || !strings.HasPrefix(first, root+string(filepath.Separator)) {
 		t.Fatalf("expected deterministic checkout path under root, first=%q second=%q root=%q", first, second, root)
 	}
+	branchCheckout := mustDashboardCheckoutPath(t, root, spec, dashboard.RepoRevision{Branch: "main"})
+	tagCheckout := mustDashboardCheckoutPath(t, root, spec, dashboard.RepoRevision{Tag: "main"})
+	if branchCheckout == first || tagCheckout == first || branchCheckout == tagCheckout {
+		t.Fatalf("expected distinct checkout paths for unpinned, branch, and tag pins: %q %q %q", first, branchCheckout, tagCheckout)
+	}
 	if sanitized := sanitizeDashboardCheckoutName(" ../repo name:with/slash "); sanitized != "repo-name-with-slash" {
 		t.Fatalf("unexpected sanitized checkout name: %q", sanitized)
 	}
@@ -504,7 +678,7 @@ func TestDashboardCheckoutHelpers(t *testing.T) {
 	if !pathWithinDir(root, root) {
 		t.Fatalf("expected cache root to be within itself")
 	}
-	if _, err := dashboardCheckoutPath("relative", spec); err == nil || !strings.Contains(err.Error(), "absolute") {
+	if _, err := dashboardCheckoutPath("relative", spec, dashboard.RepoRevision{}); err == nil || !strings.Contains(err.Error(), "absolute") {
 		t.Fatalf("expected relative checkout root error, got %v", err)
 	}
 
@@ -540,6 +714,47 @@ func initDashboardRemoteGitRepo(t *testing.T) string {
 	testutil.RunGit(t, repo, "add", ".")
 	testutil.RunGit(t, repo, "-c", "user.name=Lopper Test", "-c", "user.email=lopper@example.invalid", "commit", "-m", "initial")
 	return repo
+}
+
+type dashboardRemoteGitFixture struct {
+	repoPath      string
+	initialCommit string
+	headCommit    string
+}
+
+func initDashboardRemoteGitRepoWithRefs(t *testing.T) dashboardRemoteGitFixture {
+	t.Helper()
+	repo := initDashboardRemoteGitRepo(t)
+	initialCommit := gitHead(t, repo)
+	testutil.RunGit(t, repo, "branch", "stable", initialCommit)
+	testutil.RunGit(t, repo, "tag", "v1.0.0", initialCommit)
+	testutil.MustWriteFile(t, filepath.Join(repo, "main.go"), "package main\n")
+	testutil.RunGit(t, repo, "add", ".")
+	testutil.RunGit(t, repo, "-c", "user.name=Lopper Test", "-c", "user.email=lopper@example.invalid", "commit", "-m", "head")
+	return dashboardRemoteGitFixture{
+		repoPath:      repo,
+		initialCommit: initialCommit,
+		headCommit:    gitHead(t, repo),
+	}
+}
+
+func gitHead(t *testing.T, repo string) string {
+	t.Helper()
+	command := exec.Command("git", "-C", repo, "rev-parse", "--verify", "HEAD")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v\n%s", err, string(output))
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func dashboardGitPathForTest(t *testing.T) string {
+	t.Helper()
+	gitPath, err := resolveDashboardGitBinaryFn()
+	if err != nil {
+		t.Fatalf("resolve git path: %v", err)
+	}
+	return gitPath
 }
 
 func fileURL(path string) string {
@@ -578,9 +793,13 @@ func mustParseDashboardRepoURL(t *testing.T, repoURL string) dashboardRepoURLSpe
 	return spec
 }
 
-func mustDashboardCheckoutPath(t *testing.T, cacheRoot string, spec dashboardRepoURLSpec) string {
+func mustDashboardCheckoutPath(t *testing.T, cacheRoot string, spec dashboardRepoURLSpec, revision ...dashboard.RepoRevision) string {
 	t.Helper()
-	checkoutPath, err := dashboardCheckoutPath(cacheRoot, spec)
+	resolvedRevision := dashboard.RepoRevision{}
+	if len(revision) > 0 {
+		resolvedRevision = revision[0]
+	}
+	checkoutPath, err := dashboardCheckoutPath(cacheRoot, spec, resolvedRevision)
 	if err != nil {
 		t.Fatalf("dashboard checkout path: %v", err)
 	}

--- a/internal/app/dashboard_request.go
+++ b/internal/app/dashboard_request.go
@@ -126,19 +126,30 @@ func reposFromDashboardConfig(config dashboard.LoadedConfig, features *featurefl
 func dashboardRepoInputFromConfig(configDir string, repo dashboard.ConfigRepo, features *featureflags.Set) (dashboard.RepoInput, error) {
 	repoPath := strings.TrimSpace(repo.Path)
 	repoURL := strings.TrimSpace(repo.RepoURL)
+	revision, err := normalizeDashboardRepoRevision(dashboard.RepoRevision{
+		Branch: repo.Branch,
+		Tag:    repo.Tag,
+		Commit: repo.Commit,
+	})
+	if err != nil {
+		return dashboard.RepoInput{}, fmt.Errorf("dashboard config repo revision is invalid: %w", err)
+	}
+	if repoPath != "" && !revision.IsZero() {
+		return dashboard.RepoInput{}, fmt.Errorf("dashboard config repo revision fields require repoUrl")
+	}
 	switch {
 	case repoPath != "" && repoURL != "":
 		return dashboard.RepoInput{}, fmt.Errorf("dashboard config repo cannot define both path and repoUrl")
 	case repoPath == "" && repoURL == "":
 		return dashboard.RepoInput{}, fmt.Errorf("dashboard config repo is missing path or repoUrl")
 	case repoURL != "":
-		return dashboardRepoInputFromURL(repo, repoURL, features)
+		return dashboardRepoInputFromURL(repo, repoURL, revision, features)
 	default:
 		return dashboardRepoInputFromPath(configDir, repo, repoPath), nil
 	}
 }
 
-func dashboardRepoInputFromURL(repo dashboard.ConfigRepo, repoURL string, features *featureflags.Set) (dashboard.RepoInput, error) {
+func dashboardRepoInputFromURL(repo dashboard.ConfigRepo, repoURL string, revision dashboard.RepoRevision, features *featureflags.Set) (dashboard.RepoInput, error) {
 	if features == nil || !features.Enabled(DashboardRemoteReposPreviewFeature) {
 		return dashboard.RepoInput{}, fmt.Errorf("dashboard config repoUrl requires feature %s", DashboardRemoteReposPreviewFeature)
 	}
@@ -153,6 +164,7 @@ func dashboardRepoInputFromURL(repo dashboard.ConfigRepo, repoURL string, featur
 	return dashboard.RepoInput{
 		Name:     name,
 		RepoURL:  spec.normalized,
+		Revision: revision,
 		Language: strings.TrimSpace(repo.Language),
 	}, nil
 }

--- a/internal/dashboard/aggregate.go
+++ b/internal/dashboard/aggregate.go
@@ -29,9 +29,15 @@ func Aggregate(generatedAt time.Time, analyses []RepoAnalysis) Report {
 
 	for _, analysis := range analyses {
 		repoResult := RepoResult{
-			Name:     analysis.Input.Name,
-			Path:     analysis.Input.Path,
-			Language: analysis.Input.Language,
+			Name:           analysis.Input.Name,
+			Path:           analysis.Input.Path,
+			RepoURL:        analysis.Input.RepoURL,
+			ResolvedCommit: analysis.Input.ResolvedCommit,
+			Language:       analysis.Input.Language,
+		}
+		if !analysis.Input.Revision.IsZero() {
+			revision := analysis.Input.Revision
+			repoResult.Revision = &revision
 		}
 		if analysis.Err != nil {
 			repoResult.Error = analysis.Err.Error()

--- a/internal/dashboard/baseline_loading_comparison_test.go
+++ b/internal/dashboard/baseline_loading_comparison_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestDashboardBaselineLoadBranches(t *testing.T) {
+func TestDashboardBaselineLoadPreservesRemoteMetadata(t *testing.T) {
 	t.Parallel()
 
 	tmp := t.TempDir()
@@ -44,7 +44,12 @@ func TestDashboardBaselineLoadBranches(t *testing.T) {
 	if got := BaselineSnapshotPath(tmp, " label:load "); got != path {
 		t.Fatalf("BaselineSnapshotPath() = %q, want %q", got, path)
 	}
+}
 
+func TestDashboardBaselineLoadLegacyRemoteFieldsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
 	legacyPath := filepath.Join(tmp, "legacy.json")
 	legacyJSON := `{"generated_at":"2026-03-12T00:00:00Z","repos":[{"name":"api","path":"./api","dependency_count":3,"waste_candidate_count":2,"critical_cves":1}]}`
 	if err := os.WriteFile(legacyPath, []byte(legacyJSON), 0o600); err != nil {
@@ -60,7 +65,12 @@ func TestDashboardBaselineLoadBranches(t *testing.T) {
 	if legacy.Repos[0].RepoURL != "" || legacy.Repos[0].Revision != nil || legacy.Repos[0].ResolvedCommit != "" {
 		t.Fatalf("expected legacy baseline remote metadata fields to remain empty, got %#v", legacy.Repos[0])
 	}
+}
 
+func TestDashboardBaselineLoadRejectsUnsupportedSchema(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
 	badPath := filepath.Join(tmp, "bad-schema.json")
 	badJSON := `{"baselineSchemaVersion":"9.9.9","key":"label:bad","report":{"repos":[]}}`
 	if err := os.WriteFile(badPath, []byte(badJSON), 0o600); err != nil {
@@ -69,7 +79,12 @@ func TestDashboardBaselineLoadBranches(t *testing.T) {
 	if _, _, err := LoadWithKey(badPath); err == nil || !strings.Contains(err.Error(), "unsupported dashboard baseline schema version") {
 		t.Fatalf("expected unsupported schema error, got %v", err)
 	}
+}
 
+func TestDashboardBaselineLoadReportsReadErrors(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
 	if _, err := Load(filepath.Join(tmp, "missing.json")); err == nil {
 		t.Fatalf("expected Load to return missing file error")
 	}

--- a/internal/dashboard/baseline_loading_comparison_test.go
+++ b/internal/dashboard/baseline_loading_comparison_test.go
@@ -15,7 +15,16 @@ func TestDashboardBaselineLoadBranches(t *testing.T) {
 	snapshot := Report{
 		GeneratedAt: time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC),
 		Repos: []RepoResult{
-			{Name: "web", Path: "./web", DependencyCount: 2, WasteCandidateCount: 1, CriticalCVEs: 1},
+			{
+				Name:                "web",
+				Path:                "./web",
+				RepoURL:             "https://github.com/example/web.git",
+				Revision:            &RepoRevision{Branch: "release/2.0"},
+				ResolvedCommit:      "0123456789abcdef0123456789abcdef01234567",
+				DependencyCount:     2,
+				WasteCandidateCount: 1,
+				CriticalCVEs:        1,
+			},
 		},
 	}
 	path, err := SaveSnapshot(tmp, " label:load ", snapshot, time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC))
@@ -24,6 +33,13 @@ func TestDashboardBaselineLoadBranches(t *testing.T) {
 	}
 	if loaded, err := Load(path); err != nil || loaded.Summary.TotalRepos != 1 {
 		t.Fatalf("Load() = summary=%+v err=%v", loaded.Summary, err)
+	}
+	loaded, key, err := LoadWithKey(path)
+	if err != nil {
+		t.Fatalf("LoadWithKey(snapshot) error = %v", err)
+	}
+	if key != "label:load" || loaded.Repos[0].RepoURL != "https://github.com/example/web.git" || loaded.Repos[0].Revision == nil || loaded.Repos[0].Revision.Branch != "release/2.0" || loaded.Repos[0].ResolvedCommit != "0123456789abcdef0123456789abcdef01234567" {
+		t.Fatalf("expected snapshot to preserve remote revision metadata, key=%q repo=%#v", key, loaded.Repos[0])
 	}
 	if got := BaselineSnapshotPath(tmp, " label:load "); got != path {
 		t.Fatalf("BaselineSnapshotPath() = %q, want %q", got, path)
@@ -40,6 +56,9 @@ func TestDashboardBaselineLoadBranches(t *testing.T) {
 	}
 	if key != "" || legacy.Summary.TotalRepos != 1 || legacy.Summary.TotalDeps != 3 || legacy.Summary.CriticalCVEs != 1 {
 		t.Fatalf("unexpected legacy load result: key=%q summary=%+v", key, legacy.Summary)
+	}
+	if legacy.Repos[0].RepoURL != "" || legacy.Repos[0].Revision != nil || legacy.Repos[0].ResolvedCommit != "" {
+		t.Fatalf("expected legacy baseline remote metadata fields to remain empty, got %#v", legacy.Repos[0])
 	}
 
 	badPath := filepath.Join(tmp, "bad-schema.json")

--- a/internal/dashboard/config.go
+++ b/internal/dashboard/config.go
@@ -24,6 +24,9 @@ type ConfigRepo struct {
 	Name     string `yaml:"name"`
 	Language string `yaml:"language"`
 	RepoURL  string `yaml:"repoUrl"`
+	Branch   string `yaml:"branch"`
+	Tag      string `yaml:"tag"`
+	Commit   string `yaml:"commit"`
 }
 
 type LoadedConfig struct {

--- a/internal/dashboard/coverage_thresholds_test.go
+++ b/internal/dashboard/coverage_thresholds_test.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -28,5 +29,72 @@ func TestWriteDashboardCrossRepoRowsCSVHeaderError(t *testing.T) {
 	}})
 	if err == nil {
 		t.Fatal("expected cross-repo header write to fail")
+	}
+}
+
+func TestRepoRevisionHelpersCoverAllKinds(t *testing.T) {
+	tests := []struct {
+		name     string
+		revision *RepoRevision
+		wantZero bool
+		wantKind string
+		wantVal  string
+	}{
+		{name: "nil", revision: nil, wantZero: true},
+		{name: "empty", revision: &RepoRevision{Branch: " ", Tag: "\t", Commit: "\n"}, wantZero: true},
+		{name: "branch", revision: &RepoRevision{Branch: " release/2.0 "}, wantKind: "branch", wantVal: "release/2.0"},
+		{name: "tag", revision: &RepoRevision{Tag: " v2.0.0 "}, wantKind: "tag", wantVal: "v2.0.0"},
+		{name: "commit", revision: &RepoRevision{Commit: " 0123456789abcdef0123456789abcdef01234567 "}, wantKind: "commit", wantVal: "0123456789abcdef0123456789abcdef01234567"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.revision.IsZero(); got != tc.wantZero {
+				t.Fatalf("IsZero() = %v, want %v", got, tc.wantZero)
+			}
+			if got := tc.revision.Kind(); got != tc.wantKind {
+				t.Fatalf("Kind() = %q, want %q", got, tc.wantKind)
+			}
+			if got := tc.revision.Value(); got != tc.wantVal {
+				t.Fatalf("Value() = %q, want %q", got, tc.wantVal)
+			}
+		})
+	}
+}
+
+func TestDashboardCSVWriterErrorBranches(t *testing.T) {
+	if err := writeDashboardSummaryCSV((&failOnCSVWrite{failOn: 1}).Write, Report{}); err == nil {
+		t.Fatal("expected summary writer error")
+	}
+	if err := writeDashboardRepoRowsCSV((&failOnCSVWrite{failOn: 1}).Write, nil); err == nil {
+		t.Fatal("expected repo header writer error")
+	}
+	if err := writeDashboardRepoRowsCSV((&failOnCSVWrite{failOn: 2}).Write, []RepoResult{{Name: "api"}}); err == nil {
+		t.Fatal("expected repo row writer error")
+	}
+	if err := writeDashboardCrossRepoRowsCSV((&failOnCSVWrite{failOn: 1}).Write, []CrossRepoDependency{{Name: "shared"}}); err == nil {
+		t.Fatal("expected cross-repo separator writer error")
+	}
+	if err := writeDashboardCrossRepoRowsCSV((&failOnCSVWrite{failOn: 3}).Write, []CrossRepoDependency{{Name: "shared"}}); err == nil {
+		t.Fatal("expected cross-repo row writer error")
+	}
+}
+
+func TestFormatReportCSVRevisionKinds(t *testing.T) {
+	reportData := Report{
+		Repos: []RepoResult{
+			{Name: "branch", Revision: &RepoRevision{Branch: "release/2.0"}},
+			{Name: "commit", Revision: &RepoRevision{Commit: "0123456789abcdef0123456789abcdef01234567"}},
+			{Name: "unpinned"},
+		},
+	}
+	output, err := FormatReport(reportData, FormatCSV)
+	if err != nil {
+		t.Fatalf("format dashboard csv: %v", err)
+	}
+	for _, want := range []string{"branch:release/2.0", "commit:0123456789abcdef0123456789abcdef01234567", "unpinned"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected csv output to contain %q, got %q", want, output)
+		}
 	}
 }

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -179,27 +179,60 @@ func TestAggregateCrossRepoDuplicatesDistinguishesSameInferredRepoNames(t *testi
 	}
 }
 
+func TestAggregateCopiesRemoteRevisionMetadata(t *testing.T) {
+	reportData := Aggregate(time.Date(2026, time.March, 10, 1, 2, 3, 0, time.UTC), []RepoAnalysis{
+		{
+			Input: RepoInput{
+				Name:           "api",
+				Path:           "/cache/api",
+				RepoURL:        "https://github.com/example/api.git",
+				Revision:       RepoRevision{Branch: "release/2.0"},
+				ResolvedCommit: "0123456789abcdef0123456789abcdef01234567",
+				Language:       "go",
+			},
+			Report: report.Report{
+				Dependencies: []report.DependencyReport{{Name: "dep"}},
+			},
+		},
+	})
+
+	if len(reportData.Repos) != 1 {
+		t.Fatalf("expected one repo result, got %#v", reportData.Repos)
+	}
+	got := reportData.Repos[0]
+	if got.RepoURL != "https://github.com/example/api.git" || got.ResolvedCommit != "0123456789abcdef0123456789abcdef01234567" || got.Revision == nil || got.Revision.Branch != "release/2.0" {
+		t.Fatalf("expected remote revision metadata to be copied, got %#v", got)
+	}
+}
+
 func TestFormatReport(t *testing.T) {
 	reportData := Report{
 		GeneratedAt: time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC),
 		Repos: []RepoResult{
-			{Name: testRepoA, Path: "./a", DependencyCount: 1},
+			{
+				Name:            testRepoA,
+				Path:            "./a",
+				RepoURL:         "https://github.com/example/a.git",
+				Revision:        &RepoRevision{Tag: "v1.0.0"},
+				ResolvedCommit:  "0123456789abcdef0123456789abcdef01234567",
+				DependencyCount: 1,
+			},
 		},
 		Summary: Summary{TotalRepos: 1, TotalDeps: 1},
 	}
 
 	jsonOutput, err := FormatReport(reportData, FormatJSON)
-	if err != nil || !strings.Contains(jsonOutput, "\"total_repos\": 1") {
+	if err != nil || !strings.Contains(jsonOutput, "\"total_repos\": 1") || !strings.Contains(jsonOutput, "\"resolved_commit\": \"0123456789abcdef0123456789abcdef01234567\"") {
 		t.Fatalf("expected json output, err=%v output=%q", err, jsonOutput)
 	}
 
 	csvOutput, err := FormatReport(reportData, FormatCSV)
-	if err != nil || !strings.Contains(csvOutput, "total_repos,1") {
+	if err != nil || !strings.Contains(csvOutput, "total_repos,1") || !strings.Contains(csvOutput, "tag:v1.0.0,0123456789abcdef0123456789abcdef01234567") {
 		t.Fatalf("expected csv output, err=%v output=%q", err, csvOutput)
 	}
 
 	htmlOutput, err := FormatReport(reportData, FormatHTML)
-	if err != nil || !strings.Contains(strings.ToLower(htmlOutput), "<html") {
+	if err != nil || !strings.Contains(strings.ToLower(htmlOutput), "<html") || !strings.Contains(htmlOutput, "0123456789abcdef0123456789abcdef01234567") {
 		t.Fatalf("expected html output, err=%v output=%q", err, htmlOutput)
 	}
 }
@@ -279,7 +312,7 @@ func TestFormatReportCSVSanitizesCrossRepoAndRepoFormulaPrefixes(t *testing.T) {
 	repoRow := dashboardCSVRowAfterHeader(rows, "repo_name")
 	crossRepoRow := dashboardCSVRowAfterHeader(rows, "dependency_name")
 
-	if len(repoRow) != 10 || repoRow[0] != "'+repo" || repoRow[1] != "'@path" || repoRow[2] != "go" {
+	if len(repoRow) != 13 || repoRow[0] != "'+repo" || repoRow[1] != "'@path" || repoRow[5] != "go" {
 		t.Fatalf("expected sanitized repo csv row, got %#v", repoRow)
 	}
 	if len(crossRepoRow) != 3 || crossRepoRow[0] != "'-shared" || !strings.Contains(crossRepoRow[2], "'\trepo-d") {
@@ -524,7 +557,7 @@ func dashboardCSVRowAfterHeader(rows [][]string, header string) []string {
 
 func dashboardCSVContainsRepoRow(rows [][]string, name, path string) bool {
 	for _, row := range rows {
-		if len(row) == 10 && row[0] == name && row[1] == path {
+		if len(row) == 13 && row[0] == name && row[1] == path {
 			return true
 		}
 	}

--- a/internal/dashboard/format.go
+++ b/internal/dashboard/format.go
@@ -78,6 +78,9 @@ func writeDashboardRepoRowsCSV(write func([]string) error, repos []RepoResult) e
 	if err := write(csvsanitize.EscapeLeadingFormulaRow([]string{
 		"repo_name",
 		"repo_path",
+		"repo_url",
+		"revision",
+		"resolved_commit",
 		"language",
 		"dependency_count",
 		"waste_candidate_count",
@@ -94,6 +97,9 @@ func writeDashboardRepoRowsCSV(write func([]string) error, repos []RepoResult) e
 		if err := write(csvsanitize.EscapeLeadingFormulaRow([]string{
 			repoResult.Name,
 			repoResult.Path,
+			repoResult.RepoURL,
+			formatRepoRevision(repoResult.Revision),
+			repoResult.ResolvedCommit,
 			repoResult.Language,
 			fmt.Sprintf("%d", repoResult.DependencyCount),
 			fmt.Sprintf("%d", repoResult.WasteCandidateCount),
@@ -231,12 +237,15 @@ func formatHTML(reportData Report) string {
 	buffer.WriteString("</div></section>")
 
 	buffer.WriteString("<h2>Per-Repo Summary</h2><table><thead><tr>")
-	buffer.WriteString("<th>Repo</th><th>Path</th><th>Language</th><th>Deps</th><th>Waste Candidates</th><th>Waste %</th><th>Top Risk</th><th>Critical CVEs</th><th>Denied Licenses</th><th>Error</th>")
+	buffer.WriteString("<th>Repo</th><th>Path</th><th>Repo URL</th><th>Revision</th><th>Resolved Commit</th><th>Language</th><th>Deps</th><th>Waste Candidates</th><th>Waste %</th><th>Top Risk</th><th>Critical CVEs</th><th>Denied Licenses</th><th>Error</th>")
 	buffer.WriteString("</tr></thead><tbody>")
 	for _, repoResult := range reportData.Repos {
 		buffer.WriteString("<tr>")
 		buffer.WriteString("<td>" + html.EscapeString(repoResult.Name) + "</td>")
 		buffer.WriteString("<td>" + html.EscapeString(repoResult.Path) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(repoResult.RepoURL) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(formatRepoRevision(repoResult.Revision)) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(repoResult.ResolvedCommit) + "</td>")
 		buffer.WriteString("<td>" + html.EscapeString(repoResult.Language) + "</td>")
 		buffer.WriteString("<td>" + fmt.Sprintf("%d", repoResult.DependencyCount) + "</td>")
 		buffer.WriteString("<td>" + fmt.Sprintf("%d", repoResult.WasteCandidateCount) + "</td>")
@@ -310,4 +319,11 @@ func formatDashboardBaselineHTML(comparison *BaselineComparison) string {
 
 func metricHTML(label, value string) string {
 	return "<div class=\"metric\"><span>" + html.EscapeString(label) + "</span><strong>" + html.EscapeString(value) + "</strong></div>"
+}
+
+func formatRepoRevision(revision *RepoRevision) string {
+	if revision == nil || revision.IsZero() {
+		return ""
+	}
+	return revision.Kind() + ":" + revision.Value()
 }

--- a/internal/dashboard/types.go
+++ b/internal/dashboard/types.go
@@ -31,24 +31,74 @@ func ParseFormat(value string) (Format, error) {
 }
 
 type RepoInput struct {
-	Name     string `json:"name"`
-	Path     string `json:"path"`
-	RepoURL  string `json:"repo_url,omitempty"`
-	Language string `json:"language,omitempty"`
+	Name           string       `json:"name"`
+	Path           string       `json:"path"`
+	RepoURL        string       `json:"repo_url,omitempty"`
+	Revision       RepoRevision `json:"revision,omitempty"`
+	ResolvedCommit string       `json:"resolved_commit,omitempty"`
+	Language       string       `json:"language,omitempty"`
+}
+
+type RepoRevision struct {
+	Branch string `json:"branch,omitempty"`
+	Tag    string `json:"tag,omitempty"`
+	Commit string `json:"commit,omitempty"`
+}
+
+func (r *RepoRevision) IsZero() bool {
+	if r == nil {
+		return true
+	}
+	return strings.TrimSpace(r.Branch) == "" && strings.TrimSpace(r.Tag) == "" && strings.TrimSpace(r.Commit) == ""
+}
+
+func (r *RepoRevision) Kind() string {
+	if r == nil {
+		return ""
+	}
+	switch {
+	case strings.TrimSpace(r.Branch) != "":
+		return "branch"
+	case strings.TrimSpace(r.Tag) != "":
+		return "tag"
+	case strings.TrimSpace(r.Commit) != "":
+		return "commit"
+	default:
+		return ""
+	}
+}
+
+func (r *RepoRevision) Value() string {
+	if r == nil {
+		return ""
+	}
+	switch {
+	case strings.TrimSpace(r.Branch) != "":
+		return strings.TrimSpace(r.Branch)
+	case strings.TrimSpace(r.Tag) != "":
+		return strings.TrimSpace(r.Tag)
+	case strings.TrimSpace(r.Commit) != "":
+		return strings.TrimSpace(r.Commit)
+	default:
+		return ""
+	}
 }
 
 type RepoResult struct {
-	Name                  string   `json:"name"`
-	Path                  string   `json:"path"`
-	Language              string   `json:"language,omitempty"`
-	DependencyCount       int      `json:"dependency_count"`
-	WasteCandidateCount   int      `json:"waste_candidate_count"`
-	WasteCandidatePercent float64  `json:"waste_candidate_percent"`
-	TopRiskSeverity       string   `json:"top_risk_severity,omitempty"`
-	CriticalCVEs          int      `json:"critical_cves"`
-	DeniedLicenseCount    int      `json:"denied_license_count"`
-	Warnings              []string `json:"warnings,omitempty"`
-	Error                 string   `json:"error,omitempty"`
+	Name                  string        `json:"name"`
+	Path                  string        `json:"path"`
+	RepoURL               string        `json:"repo_url,omitempty"`
+	Revision              *RepoRevision `json:"revision,omitempty"`
+	ResolvedCommit        string        `json:"resolved_commit,omitempty"`
+	Language              string        `json:"language,omitempty"`
+	DependencyCount       int           `json:"dependency_count"`
+	WasteCandidateCount   int           `json:"waste_candidate_count"`
+	WasteCandidatePercent float64       `json:"waste_candidate_percent"`
+	TopRiskSeverity       string        `json:"top_risk_severity,omitempty"`
+	CriticalCVEs          int           `json:"critical_cves"`
+	DeniedLicenseCount    int           `json:"denied_license_count"`
+	Warnings              []string      `json:"warnings,omitempty"`
+	Error                 string        `json:"error,omitempty"`
 }
 
 type CrossRepoDependency struct {


### PR DESCRIPTION
## Summary

Extends dashboard `repoUrl` entries so org dashboard runs can pin remote repositories by branch, tag, or full commit SHA while preserving existing unpinned remote HEAD behavior.

Closes #1086

## Changes

- Adds mutually exclusive `branch`, `tag`, and `commit` dashboard config fields for remote repos under the existing `dashboard-remote-repos-preview` gate.
- Makes remote checkout cache paths pin-aware and fetches exact branch/tag refs or full commit SHAs for pinned entries.
- Resolves and records the materialized commit SHA in dashboard JSON, CSV, HTML, and saved dashboard baselines.
- Adds fail-closed validation for ambiguous pins, unsafe branch/tag names, short commits, and unresolved commit fetches.
- Documents remote pinning and resolved commit metadata in `docs/dashboard.md` and `README.md`.
- Refactors the new validation/test helpers to keep Sonar complexity and duplication checks clean.

## Validation

Commands and checks run:

```bash
make format-check
go test ./internal/app -run 'Test(ResolveDashboardRequestConfigRepoURL|DashboardRepoMaterializer|ExecuteDashboard|Remote)'
go test ./internal/dashboard
go test ./internal/app ./internal/dashboard ./internal/cli
make feature-flag-check
make lint
make test
git diff --check
```

Additional validation after Sonar cleanup:

```bash
gofmt -w internal/app/dashboard_remote.go internal/dashboard/baseline_loading_comparison_test.go
git diff --check
```

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Remote pinned entries may perform a shallow fetch for the requested ref; unpinned `repoUrl` entries still track remote `HEAD`.
- Memory benchmark impact: None expected.
- This uses the existing stable `dashboard-remote-repos-preview` gate because pinning only extends the already-gated remote repo materialization surface.
- Legacy dashboard baselines without remote metadata still load with empty remote fields.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
