### PR TITLE
chore(featureflags): add v2 stable feature aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2.0.0 (Unreleased)
+
+### Feature Flag Migration
+
+Stable v2 feature names no longer use the `-preview` suffix. The legacy preview names remain accepted in v2.0.0 for compatibility and explicit rollback commands, but new docs, examples, manifests, and release reports use the stable names.
+
+| Legacy preview name | Stable name |
+| --- | --- |
+| `dart-source-attribution-preview` | `dart-source-attribution` |
+| `lockfile-drift-ecosystem-expansion-preview` | `lockfile-drift-ecosystem-expansion` |
+| `swift-carthage-preview` | `swift-carthage` |
+| `powershell-adapter-preview` | `powershell-adapter` |
+| `go-vendored-provenance-preview` | `go-vendored-provenance` |
+| `baseline-provenance-runtime-context-preview` | `baseline-provenance-runtime-context` |
+| `vscode-multi-root-workflows-preview` | `vscode-multi-root-workflows` |
+| `mcp-server-preview` | `mcp-server` |
+| `threshold-profiles-preview` | `threshold-profiles` |
+| `dashboard-remote-repos-preview` | `dashboard-remote-repos` |
+| `python-runtime-trace-preview` | `python-runtime-trace` |
+| `mcp-mutation-tools-preview` | `mcp-mutation-tools` |
+
 ## [1.7.0](https://github.com/ben-ranford/lopper/compare/v1.6.1...v1.7.0) (2026-06-25)
 
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Use a dashboard config file:
 lopper dashboard --config lopper-org.yml --format json
 ```
 
-Remote dashboard config entries can use `repoUrl` with the `dashboard-remote-repos-preview` feature and may pin exactly one of `branch`, `tag`, or full `commit` SHA. Unpinned remote entries continue to track remote `HEAD`; dashboard JSON, CSV, HTML, and saved dashboard baselines include the resolved commit SHA for materialized remote repos.
+Remote dashboard config entries can use `repoUrl` with the `dashboard-remote-repos` feature and may pin exactly one of `branch`, `tag`, or full `commit` SHA. Unpinned remote entries continue to track remote `HEAD`; dashboard JSON, CSV, HTML, and saved dashboard baselines include the resolved commit SHA for materialized remote repos.
 
 ## Languages
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -24,7 +24,7 @@ From config with remote repositories enabled:
 ```bash
 lopper dashboard \
   --config lopper-org.yml \
-  --enable-feature dashboard-remote-repos-preview
+  --enable-feature dashboard-remote-repos
 ```
 
 Supported output formats:
@@ -52,7 +52,7 @@ dashboard:
   output: html
 ```
 
-Remote Git repositories can be configured with `repoUrl` when the `dashboard-remote-repos-preview` feature is enabled:
+Remote Git repositories can be configured with `repoUrl` when the `dashboard-remote-repos` feature is enabled:
 
 ```yaml
 dashboard:

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -48,7 +48,7 @@ Codes are stable identifiers for config, release reports, and release locks:
 ```
 
 Do not renumber or recycle a feature code after it has shipped in any rolling or stable artifact.
-Avoid renaming shipped features; if a name must change, keep the code and update the description.
+Avoid renaming shipped features; if a name must change, keep the code and record the old name in `deprecatedNames`.
 
 Validate the registry and release locks before opening a PR:
 
@@ -89,6 +89,9 @@ features:
 The same flag cannot be enabled and disabled in one resolved run.
 Unknown feature names or codes fail parsing so stale config is visible.
 
+Stable features may keep deprecated legacy names for one major release boundary.
+When a stable feature drops a `-preview` suffix, use the stable name in docs, examples, release reports, and manifests; keep the old preview name in `deprecatedNames` so existing config and explicit rollback commands continue to resolve.
+
 Use `lopper features` to inspect the resolved defaults for a channel:
 
 ```bash
@@ -96,6 +99,25 @@ lopper features --format table
 lopper features --format json --channel rolling
 lopper features --format json --channel release --release v1.4.2
 ```
+
+## v2 Stable Alias Migration
+
+Use these stable names for v2.0.0 and later. The legacy preview names remain accepted in v2.0.0 and emit deprecation guidance when used as explicit CLI feature overrides.
+
+| Legacy preview name | Stable name |
+| --- | --- |
+| `dart-source-attribution-preview` | `dart-source-attribution` |
+| `lockfile-drift-ecosystem-expansion-preview` | `lockfile-drift-ecosystem-expansion` |
+| `swift-carthage-preview` | `swift-carthage` |
+| `powershell-adapter-preview` | `powershell-adapter` |
+| `go-vendored-provenance-preview` | `go-vendored-provenance` |
+| `baseline-provenance-runtime-context-preview` | `baseline-provenance-runtime-context` |
+| `vscode-multi-root-workflows-preview` | `vscode-multi-root-workflows` |
+| `mcp-server-preview` | `mcp-server` |
+| `threshold-profiles-preview` | `threshold-profiles` |
+| `dashboard-remote-repos-preview` | `dashboard-remote-repos` |
+| `python-runtime-trace-preview` | `python-runtime-trace` |
+| `mcp-mutation-tools-preview` | `mcp-mutation-tools` |
 
 ## Build Channels
 

--- a/docs/man/lopper.1
+++ b/docs/man/lopper.1
@@ -23,7 +23,7 @@ Usage and options:
   lopper dashboard --repos PATH1,PATH2 [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline] [--enable-feature NAME] [--disable-feature NAME]
   lopper dashboard --config lopper-org.yml [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline] [--enable-feature NAME] [--disable-feature NAME]
   lopper features [--format table|json] [--channel dev|rolling|release] [--release VERSION]
-  lopper profile apply strict|balanced|noise-reduction [--output PATH] [--force] [--enable-feature threshold-profiles-preview]
+  lopper profile apply strict|balanced|noise-reduction [--output PATH] [--force] [--enable-feature threshold-profiles]
   lopper mcp
 
 Options:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -19,16 +19,16 @@ Example MCP client entry:
 }
 ```
 
-`mcp-server-preview` is now a stable feature flag and is enabled by default in every build channel. The original flag name remains available for compatibility and explicit rollback testing via `--disable-feature mcp-server-preview`. During `initialize`, the server advertises tool support and returns Lopper version metadata. Use `tools/list` to inspect tool schemas at runtime.
+`mcp-server` is a stable feature flag and is enabled by default in every build channel. The legacy `mcp-server-preview` name remains available for compatibility and explicit rollback testing via `--disable-feature mcp-server-preview`. During `initialize`, the server advertises tool support and returns Lopper version metadata. Use `tools/list` to inspect tool schemas at runtime.
 
-Mutation tools are behind the preview flag `mcp-mutation-tools-preview` and are not advertised unless the MCP server is started with that flag enabled, for example:
+Mutation tools are behind the stable flag `mcp-mutation-tools` and are not advertised unless the MCP server is started with that flag enabled, for example:
 
 ```json
 {
   "mcpServers": {
     "lopper": {
       "command": "lopper",
-      "args": ["mcp", "--enable-feature", "mcp-mutation-tools-preview"]
+      "args": ["mcp", "--enable-feature", "mcp-mutation-tools"]
     }
   }
 }
@@ -194,7 +194,7 @@ The MCP server is local-first and read-only by default:
 
 Explicit mutation tools add these guardrails:
 
-- The MCP process must be started with `mcp-mutation-tools-preview` enabled; per-call `enableFeatures` cannot turn on hidden mutation tools after startup.
+- The MCP process must be started with `mcp-mutation-tools` enabled; per-call `enableFeatures` cannot turn on hidden mutation tools after startup. The legacy `mcp-mutation-tools-preview` name remains accepted for v2.0.0 compatibility.
 - Mutations require a dedicated tool name plus `confirmApply: true` or `confirmSave: true`.
 - Mutation store paths and dashboard repo paths must be local filesystem paths. Relative `baselineStorePath` values resolve under `repoPath`.
 - `baselineKey` and `baselineLabel` are mutually exclusive.

--- a/docs/threshold-tuning.md
+++ b/docs/threshold-tuning.md
@@ -40,14 +40,14 @@ Use a built-in profile to generate a loader-ready config without copying YAML fr
 
 ```bash
 lopper profile apply balanced \
-  --enable-feature threshold-profiles-preview
+  --enable-feature threshold-profiles
 ```
 
 Write a starter repo config:
 
 ```bash
 lopper profile apply strict \
-  --enable-feature threshold-profiles-preview \
+  --enable-feature threshold-profiles \
   --output .lopper.yml
 ```
 
@@ -55,12 +55,12 @@ lopper profile apply strict \
 
 ```bash
 lopper profile apply noise-reduction \
-  --enable-feature threshold-profiles-preview \
+  --enable-feature threshold-profiles \
   --output .lopper.yml \
   --force
 ```
 
-`threshold-profiles-preview` is a preview feature flag. Rolling builds enable preview features by default; dev and release builds require `--enable-feature threshold-profiles-preview` until the command graduates.
+`threshold-profiles` is a stable feature flag and is enabled by default in every build channel. The legacy `threshold-profiles-preview` name remains accepted in v2.0.0 for compatibility and rollback testing.
 
 Use CLI flags for per-run overrides:
 
@@ -133,7 +133,7 @@ Policy precedence is deterministic:
 | `balanced` | You want stable signal without over-triggering. | 2 | 40 | 40 | 0.50 | 0.30 | 0.20 |
 | `noise-reduction` | Your repository currently produces too many warnings or recommendations. | 5 | 25 | 25 | 0.35 | 0.25 | 0.40 |
 
-Use `lopper profile apply NAME --enable-feature threshold-profiles-preview` to print the exact YAML for any profile.
+Use `lopper profile apply NAME --enable-feature threshold-profiles` to print the exact YAML for any profile.
 
 ## How to verify effective values
 

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -425,7 +425,7 @@ func mustResolveFeatureSet(t *testing.T, enabled bool) featureflags.Set {
 	t.Helper()
 	options := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
 	if !enabled {
-		options.Disable = []string{"swift-carthage-preview"}
+		options.Disable = []string{"swift-carthage"}
 	}
 	resolved, err := featureflags.DefaultRegistry().Resolve(options)
 	if err != nil {

--- a/internal/analysis/feature_gates.go
+++ b/internal/analysis/feature_gates.go
@@ -32,11 +32,14 @@ func adapterFeatureFlags(registry *featureflags.Registry) map[string]string {
 	flags := registry.Flags()
 	features := make(map[string]string, len(flags))
 	for _, flag := range flags {
-		adapterID, ok := previewAdapterID(flag.Name)
-		if !ok {
-			continue
+		for _, featureName := range append([]string{flag.Name}, flag.DeprecatedNames...) {
+			adapterID, ok := previewAdapterID(featureName)
+			if !ok {
+				continue
+			}
+			features[adapterID] = flag.Name
+			break
 		}
-		features[adapterID] = flag.Name
 	}
 	return features
 }

--- a/internal/analysis/feature_gates_test.go
+++ b/internal/analysis/feature_gates_test.go
@@ -18,7 +18,7 @@ func TestPowerShellPreviewFeatureUsesShippedCode(t *testing.T) {
 
 func TestAdapterFeatureFlagsUsesRegistryPattern(t *testing.T) {
 	registry, err := featureflags.NewRegistry([]featureflags.Flag{
-		{Code: "LOP-FEAT-0001", Name: "powershell-adapter-preview", Lifecycle: featureflags.LifecyclePreview},
+		{Code: "LOP-FEAT-0001", Name: "powershell-adapter", DeprecatedNames: []string{"powershell-adapter-preview"}, Lifecycle: featureflags.LifecyclePreview},
 		{Code: "LOP-FEAT-0002", Name: "swift-carthage-preview", Lifecycle: featureflags.LifecyclePreview},
 		{Code: "LOP-FEAT-0003", Name: "ruby-adapter-preview", Lifecycle: featureflags.LifecycleStable},
 	})
@@ -30,7 +30,7 @@ func TestAdapterFeatureFlagsUsesRegistryPattern(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("expected adapter feature flags, got %#v", got)
 	}
-	if got["powershell"] != "powershell-adapter-preview" {
+	if got["powershell"] != "powershell-adapter" {
 		t.Fatalf("expected powershell adapter feature mapping, got %#v", got)
 	}
 	if _, ok := got["swift-carthage"]; ok {

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	pythonRuntimeTracePreviewFeature   = "python-runtime-trace-preview"
+	pythonRuntimeTracePreviewFeature   = "python-runtime-trace"
 	pythonRuntimeCapturePreviewFeature = "python-runtime-capture-preview"
 )
 

--- a/internal/analysis/powershell_feature_gate_test.go
+++ b/internal/analysis/powershell_feature_gate_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ben-ranford/lopper/internal/language"
 )
 
-const powerShellFeatureName = "powershell-adapter-preview"
+const powerShellFeatureName = "powershell-adapter"
 
 func TestServicePowerShellFeatureGateCanBeDisabled(t *testing.T) {
 	repo := t.TempDir()

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -379,7 +379,7 @@ func mustResolveSwiftCarthagePreviewSet(t *testing.T, enabled bool) featureflags
 	t.Helper()
 	options := featureflags.ResolveOptions{Channel: featureflags.ChannelDev}
 	if enabled {
-		options.Enable = []string{"swift-carthage-preview"}
+		options.Enable = []string{"swift-carthage"}
 	}
 	resolved, err := featureflags.DefaultRegistry().Resolve(options)
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,7 +24,7 @@ var (
 	ErrDirtyWorktree                = errors.New("codemod apply requires a clean git worktree")
 	ErrCodemodApplyFailed           = errors.New("codemod apply failed")
 	ErrMCPFeatureDisabled           = errors.New("mcp server feature is disabled")
-	ErrProfileFeatureDisabled       = errors.New("threshold profile command feature is disabled; enable threshold-profiles-preview with --enable-feature")
+	ErrProfileFeatureDisabled       = errors.New("threshold profile command feature is disabled; enable threshold-profiles with --enable-feature")
 )
 
 type App struct {

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -47,7 +47,7 @@ func TestExecuteAnalyseEmitsEffectiveThresholds(t *testing.T) {
 	}
 	featureRegistry, err := featureflags.NewRegistry([]featureflags.Flag{{
 		Code:      "LOP-FEAT-0001",
-		Name:      "powershell-adapter-preview",
+		Name:      "powershell-adapter",
 		Lifecycle: featureflags.LifecyclePreview,
 	}})
 	if err != nil {
@@ -55,7 +55,7 @@ func TestExecuteAnalyseEmitsEffectiveThresholds(t *testing.T) {
 	}
 	resolvedFeatures, err := featureRegistry.Resolve(featureflags.ResolveOptions{
 		Channel: featureflags.ChannelDev,
-		Enable:  []string{"powershell-adapter-preview"},
+		Enable:  []string{"powershell-adapter"},
 	})
 	if err != nil {
 		t.Fatalf("resolve feature set: %v", err)
@@ -68,7 +68,7 @@ func TestExecuteAnalyseEmitsEffectiveThresholds(t *testing.T) {
 	}
 	assertContainsAll(t, output, []string{`"effectiveThresholds"`, `"effectivePolicy"`, `"sources": [`, `"cli"`, `"lowConfidenceWarningPercent": 33`})
 	assertForwardedAnalyseRequest(t, analyzer.lastReq)
-	if !analyzer.lastReq.Features.Enabled("powershell-adapter-preview") {
+	if !analyzer.lastReq.Features.Enabled("powershell-adapter") {
 		t.Fatalf("expected feature set to be forwarded to analysis request")
 	}
 }
@@ -165,7 +165,7 @@ func TestExecuteAnalyseForwardsFeatureFlags(t *testing.T) {
 
 	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
 		Code:      "LOP-FEAT-0001",
-		Name:      "swift-carthage-preview",
+		Name:      "swift-carthage",
 		Lifecycle: featureflags.LifecyclePreview,
 	}})
 	if err != nil {
@@ -173,7 +173,7 @@ func TestExecuteAnalyseForwardsFeatureFlags(t *testing.T) {
 	}
 	resolved, err := registry.Resolve(featureflags.ResolveOptions{
 		Channel: featureflags.ChannelDev,
-		Enable:  []string{"swift-carthage-preview"},
+		Enable:  []string{"swift-carthage"},
 	})
 	if err != nil {
 		t.Fatalf("resolve feature set: %v", err)
@@ -188,7 +188,7 @@ func TestExecuteAnalyseForwardsFeatureFlags(t *testing.T) {
 	if _, err := application.Execute(context.Background(), req); err != nil {
 		t.Fatalf(executeAnalyseErrFmt, err)
 	}
-	if !analyzer.lastReq.Features.Enabled("swift-carthage-preview") {
+	if !analyzer.lastReq.Features.Enabled("swift-carthage") {
 		t.Fatalf("expected analyse request features to be forwarded, got %#v", analyzer.lastReq.Features)
 	}
 }

--- a/internal/app/app_test_helpers_test.go
+++ b/internal/app/app_test_helpers_test.go
@@ -91,7 +91,7 @@ func assertForwardedAnalyseRequest(t *testing.T, got analysis.Request) {
 		{"runtime profile", got.RuntimeProfile == "browser-import"},
 		{"scope mode", got.ScopeMode == ScopeModeChangedPackages},
 		{"cache options", got.Cache != nil && !got.Cache.Enabled && got.Cache.Path == "/tmp/lopper-cache" && got.Cache.ReadOnly},
-		{"features", got.Features.Enabled("powershell-adapter-preview")},
+		{"features", got.Features.Enabled("powershell-adapter")},
 		{"suggest only", got.SuggestOnly},
 		{"removal candidate weights", got.RemovalCandidateWeights != nil && got.RemovalCandidateWeights.Usage == 0.6 && got.RemovalCandidateWeights.Impact == 0.2 && got.RemovalCandidateWeights.Confidence == 0.2},
 	}
@@ -110,7 +110,7 @@ func mustEnabledPreviewFeatureSet(t *testing.T) featureflags.Set {
 	t.Helper()
 	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
 		Code:      "LOP-FEAT-0001",
-		Name:      "dart-source-attribution-preview",
+		Name:      "dart-source-attribution",
 		Lifecycle: featureflags.LifecyclePreview,
 	}})
 	if err != nil {
@@ -118,7 +118,7 @@ func mustEnabledPreviewFeatureSet(t *testing.T) featureflags.Set {
 	}
 	features, err := registry.Resolve(featureflags.ResolveOptions{
 		Channel: featureflags.ChannelDev,
-		Enable:  []string{"dart-source-attribution-preview"},
+		Enable:  []string{"dart-source-attribution"},
 	})
 	if err != nil {
 		t.Fatalf("resolve feature set: %v", err)

--- a/internal/app/dashboard_execution_plan_test.go
+++ b/internal/app/dashboard_execution_plan_test.go
@@ -76,7 +76,7 @@ func TestRunDashboardAnalysesForwardsFeatures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve release features: %v", err)
 	}
-	if !features.Enabled("powershell-adapter-preview") {
+	if !features.Enabled("powershell-adapter") {
 		t.Fatalf("expected release default features to include powershell adapter")
 	}
 
@@ -93,7 +93,7 @@ func TestRunDashboardAnalysesForwardsFeatures(t *testing.T) {
 	if len(analyzer.calls) != 1 {
 		t.Fatalf("expected one analyzer call, got %#v", analyzer.calls)
 	}
-	if !analyzer.calls[0].Features.Enabled("powershell-adapter-preview") {
+	if !analyzer.calls[0].Features.Enabled("powershell-adapter") {
 		t.Fatalf("expected dashboard analysis request to forward powershell feature flag")
 	}
 }

--- a/internal/app/dashboard_remote.go
+++ b/internal/app/dashboard_remote.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	DashboardRemoteReposPreviewFeature = "dashboard-remote-repos-preview"
+	DashboardRemoteReposPreviewFeature = "dashboard-remote-repos"
 	dashboardRepoCacheEnv              = "LOPPER_DASHBOARD_REPO_CACHE"
 	dashboardRepoCacheHashLength       = 16
 	dashboardGitShallowDepthArg        = "--depth=1"

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -93,16 +93,19 @@ func TestExecuteFeaturesReleaseChannelAndEmptyRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute empty features: %v", err)
 	}
-	if !strings.Contains(emptyOutput, "dart-source-attribution-preview") ||
-		!strings.Contains(emptyOutput, "lockfile-drift-ecosystem-expansion-preview") ||
-		!strings.Contains(emptyOutput, "swift-carthage-preview") ||
-		!strings.Contains(emptyOutput, "powershell-adapter-preview") ||
-		!strings.Contains(emptyOutput, "go-vendored-provenance-preview") ||
-		!strings.Contains(emptyOutput, "baseline-provenance-runtime-context-preview") ||
-		!strings.Contains(emptyOutput, "vscode-multi-root-workflows-preview") ||
-		!strings.Contains(emptyOutput, "mcp-server-preview") ||
+	if !strings.Contains(emptyOutput, "dart-source-attribution") ||
+		!strings.Contains(emptyOutput, "lockfile-drift-ecosystem-expansion") ||
+		!strings.Contains(emptyOutput, "swift-carthage") ||
+		!strings.Contains(emptyOutput, "powershell-adapter") ||
+		!strings.Contains(emptyOutput, "go-vendored-provenance") ||
+		!strings.Contains(emptyOutput, "baseline-provenance-runtime-context") ||
+		!strings.Contains(emptyOutput, "vscode-multi-root-workflows") ||
+		!strings.Contains(emptyOutput, "mcp-server") ||
 		!strings.Contains(emptyOutput, "true") {
 		t.Fatalf("expected default feature table to include embedded graduated flags enabled by default, got %q", emptyOutput)
+	}
+	if strings.Contains(emptyOutput, "dart-source-attribution-preview") || strings.Contains(emptyOutput, "mcp-server-preview") {
+		t.Fatalf("expected default feature table to use stable aliases, got %q", emptyOutput)
 	}
 }
 

--- a/internal/app/lockfile_drift_ruleset.go
+++ b/internal/app/lockfile_drift_ruleset.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	pyprojectManifestName                          = "pyproject.toml"
-	lockfileDriftEcosystemExpansionPreviewFlagName = "lockfile-drift-ecosystem-expansion-preview"
+	lockfileDriftEcosystemExpansionPreviewFlagName = "lockfile-drift-ecosystem-expansion"
 	dotnetCSharpProjectManifestExt                 = ".csproj"
 	dotnetFSharpProjectManifestExt                 = ".fsproj"
 	pyprojectPoetrySection                         = "tool.poetry"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -36,6 +36,9 @@ func (c *CommandLine) Run(ctx context.Context, args []string) int {
 	if err != nil {
 		return c.handleParseError(err)
 	}
+	if err := c.writeFeatureDeprecationWarnings(req); err != nil {
+		return 1
+	}
 
 	output, runErr := c.Executor.Execute(ctx, req)
 	writeErr := c.writeOutput(output)
@@ -55,6 +58,30 @@ func (c *CommandLine) Run(ctx context.Context, args []string) int {
 	}
 
 	return 0
+}
+
+func (c *CommandLine) writeFeatureDeprecationWarnings(req app.Request) error {
+	for _, warning := range featureDeprecationWarnings(req) {
+		if err := c.writeErrln("warning: " + warning); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func featureDeprecationWarnings(req app.Request) []string {
+	switch req.Mode {
+	case app.ModeAnalyse:
+		return req.Analyse.Features.DeprecationWarnings()
+	case app.ModeDashboard:
+		return req.Dashboard.Features.DeprecationWarnings()
+	case app.ModeProfile:
+		return req.Profile.Features.DeprecationWarnings()
+	case app.ModeMCP:
+		return req.MCP.Features.DeprecationWarnings()
+	default:
+		return nil
+	}
 }
 
 func (c *CommandLine) handleParseError(parseErr error) int {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/app"
+	"github.com/ben-ranford/lopper/internal/featureflags"
 )
 
 type fakeRunner struct {
@@ -82,6 +83,46 @@ func TestRunVersion(t *testing.T) {
 	}
 }
 
+func TestRunWarnsOnDeprecatedFeatureName(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	c := New(&fakeRunner{}, &out, &errOut)
+
+	code := c.Run(context.Background(), []string{"dashboard", "--repos", ".", "--enable-feature", "mcp-server-preview"})
+	if code != 0 {
+		t.Fatalf("expected code 0, got %d stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), `feature flag "mcp-server-preview" is deprecated; use "mcp-server" instead`) {
+		t.Fatalf("expected feature deprecation warning, got %q", errOut.String())
+	}
+}
+
+func TestFeatureDeprecationWarningsByMode(t *testing.T) {
+	features := mustDeprecatedFeatureSet(t)
+	cases := []app.Request{
+		{Mode: app.ModeAnalyse, Analyse: app.AnalyseRequest{Features: features}},
+		{Mode: app.ModeDashboard, Dashboard: app.DashboardRequest{Features: features}},
+		{Mode: app.ModeProfile, Profile: app.ProfileRequest{Features: features}},
+		{Mode: app.ModeMCP, MCP: app.MCPRequest{Features: features}},
+	}
+	for _, req := range cases {
+		if warnings := featureDeprecationWarnings(req); len(warnings) != 1 {
+			t.Fatalf("expected warning for mode %s, got %#v", req.Mode, warnings)
+		}
+	}
+	if warnings := featureDeprecationWarnings(app.Request{Mode: app.ModeFeatures}); len(warnings) != 0 {
+		t.Fatalf("expected no feature warnings for features mode, got %#v", warnings)
+	}
+}
+
+func TestWriteFeatureDeprecationWarningsReturnsWriterError(t *testing.T) {
+	c := New(&fakeRunner{}, &bytes.Buffer{}, &failWriter{})
+	req := app.Request{Mode: app.ModeMCP, MCP: app.MCPRequest{Features: mustDeprecatedFeatureSet(t)}}
+	if err := c.writeFeatureDeprecationWarnings(req); err == nil {
+		t.Fatalf("expected warning writer error")
+	}
+}
+
 func TestRunVersionAliasAndExtraArgs(t *testing.T) {
 	var out bytes.Buffer
 	var errOut bytes.Buffer
@@ -101,6 +142,24 @@ func TestRunVersionAliasAndExtraArgs(t *testing.T) {
 	if errOut.Len() != 0 {
 		t.Fatalf("expected no stderr output for version requests, got %q", errOut.String())
 	}
+}
+
+func mustDeprecatedFeatureSet(t *testing.T) featureflags.Set {
+	t.Helper()
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
+		Code:            "LOP-FEAT-0001",
+		Name:            "stable-flag",
+		DeprecatedNames: []string{"stable-flag-preview"},
+		Lifecycle:       featureflags.LifecycleStable,
+	}})
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	features, err := registry.Resolve(featureflags.ResolveOptions{Enable: []string{"stable-flag-preview"}})
+	if err != nil {
+		t.Fatalf("resolve feature set: %v", err)
+	}
+	return features
 }
 
 func TestRunVersionWriterFailure(t *testing.T) {

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -8,7 +8,7 @@ const usage = `Usage:
   lopper dashboard --repos PATH1,PATH2 [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline] [--enable-feature NAME] [--disable-feature NAME]
   lopper dashboard --config lopper-org.yml [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline] [--enable-feature NAME] [--disable-feature NAME]
   lopper features [--format table|json] [--channel dev|rolling|release] [--release VERSION]
-  lopper profile apply strict|balanced|noise-reduction [--output PATH] [--force] [--enable-feature threshold-profiles-preview]
+  lopper profile apply strict|balanced|noise-reduction [--output PATH] [--force] [--enable-feature threshold-profiles]
   lopper mcp
 
 Options:

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -15,6 +15,8 @@ func TestNewRegistryValidatesEntries(t *testing.T) {
 	assertNewRegistryErrorContains(t, []Flag{{Code: "LOP-FEAT-001", Name: "alpha", Lifecycle: LifecyclePreview}}, "must use LOP-FEAT-NNNN", "short code")
 	assertNewRegistryErrorContains(t, []Flag{{Code: "LOP-FEAT-00A1", Name: "alpha", Lifecycle: LifecyclePreview}}, "suffix must be numeric", "nonnumeric code")
 	assertNewRegistryErrorContains(t, []Flag{{Code: "LOP-FEAT-0001", Name: "", Lifecycle: LifecyclePreview}}, "feature name is required", "missing name")
+	assertNewRegistryErrorContains(t, []Flag{{Code: "LOP-FEAT-0001", Name: "alpha", DeprecatedNames: []string{"bad name"}, Lifecycle: LifecyclePreview}}, "invalid feature name", "invalid deprecated name")
+	assertNewRegistryErrorContains(t, []Flag{{Code: "LOP-FEAT-0001", Name: "alpha", DeprecatedNames: []string{"alpha"}, Lifecycle: LifecyclePreview}}, "duplicates canonical name", "canonical deprecated name")
 	assertNewRegistryErrorContains(t, []Flag{{Code: "LOP-FEAT-0001", Name: "alpha", Lifecycle: "unknown"}}, "invalid feature lifecycle", "invalid lifecycle")
 	assertNewRegistryErrorContains(t, []Flag{{Code: "LOP-FEAT-0001", Name: "alpha", Lifecycle: LifecyclePreview, FirstStableRelease: "nope"}}, "invalid first stable release", "invalid first stable release")
 }
@@ -24,17 +26,20 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 		t.Fatalf("expected embedded default registry to be valid, got %v", err)
 	}
 	defaultFlags := DefaultRegistry().Flags()
-	assertDefaultFlag(t, defaultFlags, "dart-source-attribution-preview", "LOP-FEAT-0001")
-	assertDefaultFlag(t, defaultFlags, "lockfile-drift-ecosystem-expansion-preview", "LOP-FEAT-0002")
-	assertDefaultFlag(t, defaultFlags, "swift-carthage-preview", "LOP-FEAT-0003")
-	assertDefaultFlag(t, defaultFlags, "powershell-adapter-preview", "LOP-FEAT-0004")
-	assertDefaultFlag(t, defaultFlags, "go-vendored-provenance-preview", "LOP-FEAT-0005")
-	assertDefaultFlagRelease(t, defaultFlags, "baseline-provenance-runtime-context-preview", "LOP-FEAT-0006", "v1.6.0")
-	assertDefaultFlagRelease(t, defaultFlags, "vscode-multi-root-workflows-preview", "LOP-FEAT-0007", "v1.6.0")
-	assertDefaultFlagRelease(t, defaultFlags, "mcp-server-preview", "LOP-FEAT-0008", "v1.6.0")
+	assertDefaultFlag(t, defaultFlags, "dart-source-attribution", "LOP-FEAT-0001")
+	assertDefaultFlag(t, defaultFlags, "lockfile-drift-ecosystem-expansion", "LOP-FEAT-0002")
+	assertDefaultFlag(t, defaultFlags, "swift-carthage", "LOP-FEAT-0003")
+	assertDefaultFlag(t, defaultFlags, "powershell-adapter", "LOP-FEAT-0004")
+	assertDefaultFlag(t, defaultFlags, "go-vendored-provenance", "LOP-FEAT-0005")
+	assertDefaultFlagRelease(t, defaultFlags, "baseline-provenance-runtime-context", "LOP-FEAT-0006", "v1.6.0")
+	assertDefaultFlagRelease(t, defaultFlags, "vscode-multi-root-workflows", "LOP-FEAT-0007", "v1.6.0")
+	assertDefaultFlagRelease(t, defaultFlags, "mcp-server", "LOP-FEAT-0008", "v1.6.0")
 	if defaultFlags[0].FirstStableRelease != "v1.5.0" {
 		t.Fatalf("expected default flags to retain first stable release history, got %#v", defaultFlags[0])
 	}
+	assertDefaultLookup(t, "LOP-FEAT-0001", "dart-source-attribution", false)
+	assertDefaultLookup(t, "dart-source-attribution", "dart-source-attribution", false)
+	assertDefaultLookup(t, "dart-source-attribution-preview", "dart-source-attribution", true)
 	if flags := (*Registry)(nil).Flags(); len(flags) != 0 {
 		t.Fatalf("expected nil registry flags to be empty, got %#v", flags)
 	}
@@ -51,8 +56,12 @@ func TestDefaultRegistryAndLookup(t *testing.T) {
 	}
 	copiedFlags := registry.Flags()
 	copiedFlags[0].Name = "mutated"
+	copiedFlags[1].DeprecatedNames[0] = "mutated"
 	if got, _ := registry.Lookup("LOP-FEAT-0001"); got.Name != "preview-flag" {
 		t.Fatalf("expected Flags to return a defensive copy, got %#v", got)
+	}
+	if got, _ := registry.Lookup("legacy-stable-flag"); got.DeprecatedNames[0] != "legacy-stable-flag" {
+		t.Fatalf("expected deprecated names to be defensively copied, got %#v", got)
 	}
 }
 
@@ -140,6 +149,14 @@ func TestNewRegistryRejectsDuplicates(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "duplicate feature name") {
 		t.Fatalf("expected duplicate name error, got %v", err)
+	}
+
+	_, err = NewRegistry([]Flag{
+		{Code: "LOP-FEAT-0001", Name: "alpha", DeprecatedNames: []string{"legacy-alpha"}, Lifecycle: LifecycleStable},
+		{Code: "LOP-FEAT-0002", Name: "legacy-alpha", Lifecycle: LifecyclePreview},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate feature name") {
+		t.Fatalf("expected duplicate deprecated name error, got %v", err)
 	}
 }
 
@@ -500,14 +517,14 @@ func TestManifestReportsDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil registry manifest to defer to defaults, manifest=%#v err=%v", manifest, err)
 	}
-	assertManifestFlag(t, manifest, "dart-source-attribution-preview", true)
-	assertManifestFlag(t, manifest, "lockfile-drift-ecosystem-expansion-preview", true)
-	assertManifestFlag(t, manifest, "swift-carthage-preview", true)
-	assertManifestFlag(t, manifest, "powershell-adapter-preview", true)
-	assertManifestFlag(t, manifest, "go-vendored-provenance-preview", true)
-	assertManifestFlag(t, manifest, "baseline-provenance-runtime-context-preview", true)
-	assertManifestFlag(t, manifest, "vscode-multi-root-workflows-preview", true)
-	assertManifestFlag(t, manifest, "mcp-server-preview", true)
+	assertManifestFlag(t, manifest, "dart-source-attribution", true)
+	assertManifestFlag(t, manifest, "lockfile-drift-ecosystem-expansion", true)
+	assertManifestFlag(t, manifest, "swift-carthage", true)
+	assertManifestFlag(t, manifest, "powershell-adapter", true)
+	assertManifestFlag(t, manifest, "go-vendored-provenance", true)
+	assertManifestFlag(t, manifest, "baseline-provenance-runtime-context", true)
+	assertManifestFlag(t, manifest, "vscode-multi-root-workflows", true)
+	assertManifestFlag(t, manifest, "mcp-server", true)
 }
 
 func TestFormatManifest(t *testing.T) {
@@ -526,19 +543,52 @@ func TestEnabledFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if got := resolved.EnabledCodes(); len(got) != 2 || got[0] != "LOP-FEAT-0001" || got[1] != "LOP-FEAT-0002" {
-		t.Fatalf("expected enabled codes for rolling defaults, got %#v", got)
+	assertEnabledCodes(t, resolved, "LOP-FEAT-0001", "LOP-FEAT-0002")
+	assertEnabledFlag(t, resolved, " preview-flag ")
+	assertEnabledFlag(t, resolved, " legacy-stable-flag ")
+	assertUnknownFeatureDisabled(t, resolved, "missing")
+	assertFeatureSnapshot(t, resolved, "LOP-FEAT-0001", "LOP-FEAT-0002")
+	assertNilFeatureSet(t)
+}
+
+func assertEnabledFlag(t *testing.T, set Set, ref string) {
+	t.Helper()
+	enabled, err := set.EnabledFlag(ref)
+	if err != nil || !enabled {
+		t.Fatalf("expected %q enabled, enabled=%v err=%v", ref, enabled, err)
 	}
-	if enabled, err := resolved.EnabledFlag(" preview-flag "); err != nil || !enabled {
-		t.Fatalf("expected preview flag enabled in rolling, enabled=%v err=%v", enabled, err)
+}
+
+func assertUnknownFeatureDisabled(t *testing.T, set Set, ref string) {
+	t.Helper()
+	enabled, err := set.EnabledFlag(ref)
+	if err == nil || enabled {
+		t.Fatalf("expected unknown feature error for %q, enabled=%v err=%v", ref, enabled, err)
 	}
-	if enabled, err := resolved.EnabledFlag("missing"); err == nil || enabled {
-		t.Fatalf("expected unknown feature error, enabled=%v err=%v", enabled, err)
+}
+
+func assertEnabledCodes(t *testing.T, set Set, want ...string) {
+	t.Helper()
+	if got := set.EnabledCodes(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected enabled codes %#v, got %#v", want, got)
 	}
-	snapshot := resolved.Snapshot()
-	if len(snapshot) != 2 || !snapshot["LOP-FEAT-0001"] || !snapshot["LOP-FEAT-0002"] {
-		t.Fatalf("unexpected feature snapshot: %#v", snapshot)
+}
+
+func assertFeatureSnapshot(t *testing.T, set Set, want ...string) {
+	t.Helper()
+	snapshot := set.Snapshot()
+	if len(snapshot) != len(want) {
+		t.Fatalf("expected feature snapshot keys %#v, got %#v", want, snapshot)
 	}
+	for _, code := range want {
+		if !snapshot[code] {
+			t.Fatalf("expected feature snapshot to enable %s, got %#v", code, snapshot)
+		}
+	}
+}
+
+func assertNilFeatureSet(t *testing.T) {
+	t.Helper()
 	var empty *Set
 	if empty.Enabled("preview-flag") {
 		t.Fatalf("expected nil set to report disabled")
@@ -549,48 +599,22 @@ func TestEnabledFlag(t *testing.T) {
 	if snapshot := empty.Snapshot(); len(snapshot) != 0 {
 		t.Fatalf("expected nil set snapshot to be empty, got %#v", snapshot)
 	}
+	if refs := empty.DeprecatedReferences(); len(refs) != 0 {
+		t.Fatalf("expected nil set deprecated refs to be empty, got %#v", refs)
+	}
+	if warnings := empty.DeprecationWarnings(); len(warnings) != 0 {
+		t.Fatalf("expected nil set deprecation warnings to be empty, got %#v", warnings)
+	}
 }
 
 func TestDefaultRegistryGraduatedDefaultsAndDisable(t *testing.T) {
 	registry := DefaultRegistry()
-	dev, err := registry.Resolve(ResolveOptions{Channel: ChannelDev})
-	if err != nil {
-		t.Fatalf("resolve dev defaults: %v", err)
-	}
-	for _, name := range []string{
-		"dart-source-attribution-preview",
-		"lockfile-drift-ecosystem-expansion-preview",
-		"swift-carthage-preview",
-		"powershell-adapter-preview",
-		"go-vendored-provenance-preview",
-		"baseline-provenance-runtime-context-preview",
-		"vscode-multi-root-workflows-preview",
-		"mcp-server-preview",
-	} {
-		if !dev.Enabled(name) {
-			t.Fatalf("expected %s default-on in dev channel", name)
-		}
-	}
+	assertGraduatedDefaults(t, registry, ChannelDev)
+	assertGraduatedDefaults(t, registry, ChannelRelease)
+}
 
-	release, err := registry.Resolve(ResolveOptions{Channel: ChannelRelease})
-	if err != nil {
-		t.Fatalf("resolve release defaults: %v", err)
-	}
-	for _, name := range []string{
-		"dart-source-attribution-preview",
-		"lockfile-drift-ecosystem-expansion-preview",
-		"swift-carthage-preview",
-		"powershell-adapter-preview",
-		"go-vendored-provenance-preview",
-		"baseline-provenance-runtime-context-preview",
-		"vscode-multi-root-workflows-preview",
-		"mcp-server-preview",
-	} {
-		if !release.Enabled(name) {
-			t.Fatalf("expected %s default-on in release channel", name)
-		}
-	}
-
+func TestDefaultRegistryLegacyPreviewDisable(t *testing.T) {
+	registry := DefaultRegistry()
 	disabled, err := registry.Resolve(ResolveOptions{
 		Channel: ChannelRelease,
 		Disable: []string{"swift-carthage-preview"},
@@ -600,6 +624,70 @@ func TestDefaultRegistryGraduatedDefaultsAndDisable(t *testing.T) {
 	}
 	if disabled.Enabled("swift-carthage-preview") {
 		t.Fatalf("expected explicit disable to turn off swift-carthage-preview")
+	}
+	if disabled.Enabled("swift-carthage") {
+		t.Fatalf("expected explicit legacy disable to turn off swift-carthage")
+	}
+	if warnings := disabled.DeprecationWarnings(); len(warnings) != 1 || !strings.Contains(warnings[0], `"swift-carthage-preview"`) || !strings.Contains(warnings[0], `"swift-carthage"`) {
+		t.Fatalf("expected legacy disable deprecation warning, got %#v", warnings)
+	}
+}
+
+func TestDefaultRegistryDedupesDeprecatedReferences(t *testing.T) {
+	registry := DefaultRegistry()
+	duplicateLegacy, err := registry.Resolve(ResolveOptions{
+		Channel: ChannelRelease,
+		Enable:  []string{"swift-carthage-preview", "swift-carthage-preview"},
+	})
+	if err != nil {
+		t.Fatalf("resolve duplicate legacy enable: %v", err)
+	}
+	refs := duplicateLegacy.DeprecatedReferences()
+	if len(refs) != 1 || refs[0].Code != "LOP-FEAT-0003" || refs[0].Name != "swift-carthage-preview" || refs[0].Replacement != "swift-carthage" {
+		t.Fatalf("expected duplicate legacy refs to be deduped, got %#v", refs)
+	}
+	refs[0].Name = "mutated"
+	if got := duplicateLegacy.DeprecatedReferences(); got[0].Name != "swift-carthage-preview" {
+		t.Fatalf("expected deprecated refs to return a copy, got %#v", got)
+	}
+}
+
+func assertGraduatedDefaults(t *testing.T, registry *Registry, channel Channel) {
+	t.Helper()
+	resolved, err := registry.Resolve(ResolveOptions{Channel: channel})
+	if err != nil {
+		t.Fatalf("resolve %s defaults: %v", channel, err)
+	}
+	for _, name := range defaultGraduatedFeatureNames() {
+		if !resolved.Enabled(name) {
+			t.Fatalf("expected %s default-on in %s channel", name, channel)
+		}
+	}
+}
+
+func defaultGraduatedFeatureNames() []string {
+	return []string{
+		"dart-source-attribution",
+		"lockfile-drift-ecosystem-expansion",
+		"swift-carthage",
+		"powershell-adapter",
+		"go-vendored-provenance",
+		"baseline-provenance-runtime-context",
+		"vscode-multi-root-workflows",
+		"mcp-server",
+	}
+}
+
+func TestDefaultRegistryLegacyPreviewNamesResolve(t *testing.T) {
+	registry := DefaultRegistry()
+	dev, err := registry.Resolve(ResolveOptions{Channel: ChannelDev})
+	if err != nil {
+		t.Fatalf("resolve dev defaults: %v", err)
+	}
+	for _, name := range []string{"dart-source-attribution-preview", "swift-carthage-preview", "mcp-server-preview"} {
+		if !dev.Enabled(name) {
+			t.Fatalf("expected legacy name %s to resolve in dev channel", name)
+		}
 	}
 }
 
@@ -645,6 +733,7 @@ func testRegistry(t *testing.T) *Registry {
 		{
 			Code:               "LOP-FEAT-0002",
 			Name:               "stable-flag",
+			DeprecatedNames:    []string{"legacy-stable-flag"},
 			Description:        "Stable behavior",
 			Lifecycle:          LifecycleStable,
 			FirstStableRelease: "v1.5.0",
@@ -683,6 +772,20 @@ func assertDefaultFlagRelease(t *testing.T, flags []Flag, name, code, release st
 		}
 	}
 	t.Fatalf("expected default registry to include %s, got %#v", name, flags)
+}
+
+func assertDefaultLookup(t *testing.T, ref, canonicalName string, deprecated bool) {
+	t.Helper()
+	result, ok := DefaultRegistry().LookupReference(ref)
+	if !ok {
+		t.Fatalf("expected default registry lookup for %s to succeed", ref)
+	}
+	if result.Flag.Name != canonicalName || result.Deprecated != deprecated {
+		t.Fatalf("unexpected lookup for %s: %#v", ref, result)
+	}
+	if deprecated && result.ReplacementRef != canonicalName {
+		t.Fatalf("expected deprecated lookup for %s to point at %s, got %#v", ref, canonicalName, result)
+	}
 }
 
 func assertManifestFlag(t *testing.T, manifest []ManifestEntry, name string, enabled bool) {

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -1,84 +1,120 @@
 [
   {
     "code": "LOP-FEAT-0001",
-    "name": "dart-source-attribution-preview",
+    "name": "dart-source-attribution",
+    "deprecatedNames": [
+      "dart-source-attribution-preview"
+    ],
     "description": "Enable richer Dart and Flutter dependency source attribution and federated plugin relationship reporting.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.5.0"
   },
   {
     "code": "LOP-FEAT-0002",
-    "name": "lockfile-drift-ecosystem-expansion-preview",
-    "description": "Preview expansion of shared lockfile drift checks for .NET, Dart, Elixir, and SwiftPM ecosystems.",
+    "name": "lockfile-drift-ecosystem-expansion",
+    "deprecatedNames": [
+      "lockfile-drift-ecosystem-expansion-preview"
+    ],
+    "description": "Enable shared lockfile drift checks for .NET, Dart, Elixir, and SwiftPM ecosystems.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.5.0"
   },
   {
     "code": "LOP-FEAT-0003",
-    "name": "swift-carthage-preview",
+    "name": "swift-carthage",
+    "deprecatedNames": [
+      "swift-carthage-preview"
+    ],
     "description": "Enable Carthage dependency parsing for the Swift adapter.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.5.0"
   },
   {
     "code": "LOP-FEAT-0004",
-    "name": "powershell-adapter-preview",
-    "description": "Enable preview support for the PowerShell language adapter.",
+    "name": "powershell-adapter",
+    "deprecatedNames": [
+      "powershell-adapter-preview"
+    ],
+    "description": "Enable support for the PowerShell language adapter.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.5.0"
   },
   {
     "code": "LOP-FEAT-0005",
-    "name": "go-vendored-provenance-preview",
+    "name": "go-vendored-provenance",
+    "deprecatedNames": [
+      "go-vendored-provenance-preview"
+    ],
     "description": "Enable vendored dependency provenance for Go using vendor/modules.txt metadata.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.5.0"
   },
   {
     "code": "LOP-FEAT-0006",
-    "name": "baseline-provenance-runtime-context-preview",
+    "name": "baseline-provenance-runtime-context",
+    "deprecatedNames": [
+      "baseline-provenance-runtime-context-preview"
+    ],
     "description": "Enable baseline comparison, policy provenance, and runtime parent/entrypoint context in reports and dashboard views.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.6.0"
   },
   {
     "code": "LOP-FEAT-0007",
-    "name": "vscode-multi-root-workflows-preview",
+    "name": "vscode-multi-root-workflows",
+    "deprecatedNames": [
+      "vscode-multi-root-workflows-preview"
+    ],
     "description": "Enable multi-root VS Code analysis workflows, dependency explorer detail views, baseline commands, and export commands.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.6.0"
   },
   {
     "code": "LOP-FEAT-0008",
-    "name": "mcp-server-preview",
+    "name": "mcp-server",
+    "deprecatedNames": [
+      "mcp-server-preview"
+    ],
     "description": "Enable the local stdio MCP server for read-only dependency analysis workflows.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.6.0"
   },
   {
     "code": "LOP-FEAT-0009",
-    "name": "threshold-profiles-preview",
+    "name": "threshold-profiles",
+    "deprecatedNames": [
+      "threshold-profiles-preview"
+    ],
     "description": "Enable built-in threshold profile config scaffolding through the profile command.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.7.0"
   },
   {
     "code": "LOP-FEAT-0010",
-    "name": "dashboard-remote-repos-preview",
+    "name": "dashboard-remote-repos",
+    "deprecatedNames": [
+      "dashboard-remote-repos-preview"
+    ],
     "description": "Enable dashboard repoUrl entries by materializing remote Git repositories into a deterministic local checkout cache.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.7.0"
   },
   {
     "code": "LOP-FEAT-0011",
-    "name": "python-runtime-trace-preview",
-    "description": "Enable preview runtime trace annotations for Python dependencies using shared runtimeUsage report fields.",
+    "name": "python-runtime-trace",
+    "deprecatedNames": [
+      "python-runtime-trace-preview"
+    ],
+    "description": "Enable runtime trace annotations for Python dependencies using shared runtimeUsage report fields.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.7.0"
   },
   {
     "code": "LOP-FEAT-0012",
-    "name": "mcp-mutation-tools-preview",
+    "name": "mcp-mutation-tools",
+    "deprecatedNames": [
+      "mcp-mutation-tools-preview"
+    ],
     "description": "Enable explicit MCP mutation tools for codemod apply and baseline snapshot save workflows.",
     "lifecycle": "stable",
     "firstStableRelease": "v1.7.0"

--- a/internal/featureflags/registry.go
+++ b/internal/featureflags/registry.go
@@ -30,15 +30,24 @@ const (
 type Flag struct {
 	Code               string    `json:"code" yaml:"code"`
 	Name               string    `json:"name" yaml:"name"`
+	DeprecatedNames    []string  `json:"deprecatedNames,omitempty" yaml:"deprecatedNames,omitempty"`
 	Description        string    `json:"description" yaml:"description"`
 	Lifecycle          Lifecycle `json:"lifecycle" yaml:"lifecycle"`
 	FirstStableRelease string    `json:"firstStableRelease,omitempty" yaml:"firstStableRelease,omitempty"`
 }
 
+type LookupResult struct {
+	Flag           Flag
+	Reference      string
+	Deprecated     bool
+	ReplacementRef string
+}
+
 type Registry struct {
-	flags  []Flag
-	byCode map[string]Flag
-	byName map[string]Flag
+	flags            []Flag
+	byCode           map[string]Flag
+	byName           map[string]Flag
+	deprecatedByName map[string]Flag
 }
 
 func DefaultRegistry() *Registry {
@@ -54,9 +63,10 @@ func ValidateDefaultRegistry() error {
 
 func NewRegistry(flags []Flag) (*Registry, error) {
 	registry := &Registry{
-		flags:  make([]Flag, 0, len(flags)),
-		byCode: make(map[string]Flag, len(flags)),
-		byName: make(map[string]Flag, len(flags)),
+		flags:            make([]Flag, 0, len(flags)),
+		byCode:           make(map[string]Flag, len(flags)),
+		byName:           make(map[string]Flag, len(flags)),
+		deprecatedByName: make(map[string]Flag),
 	}
 	for _, flag := range flags {
 		normalized, err := normalizeFlag(flag)
@@ -66,12 +76,16 @@ func NewRegistry(flags []Flag) (*Registry, error) {
 		if _, exists := registry.byCode[normalized.Code]; exists {
 			return nil, fmt.Errorf("duplicate feature code: %s", normalized.Code)
 		}
-		if _, exists := registry.byName[normalized.Name]; exists {
-			return nil, fmt.Errorf("duplicate feature name: %s", normalized.Name)
+		if err := registry.registerFeatureName(normalized.Name, normalized, false); err != nil {
+			return nil, err
 		}
 		registry.flags = append(registry.flags, normalized)
 		registry.byCode[normalized.Code] = normalized
-		registry.byName[normalized.Name] = normalized
+		for _, deprecatedName := range normalized.DeprecatedNames {
+			if err := registry.registerFeatureName(deprecatedName, normalized, true); err != nil {
+				return nil, err
+			}
+		}
 	}
 	sort.Slice(registry.flags, func(i, j int) bool {
 		return registry.flags[i].Code < registry.flags[j].Code
@@ -79,11 +93,24 @@ func NewRegistry(flags []Flag) (*Registry, error) {
 	return registry, nil
 }
 
+func (r *Registry) registerFeatureName(name string, flag Flag, deprecated bool) error {
+	if _, exists := r.byName[name]; exists {
+		return fmt.Errorf("duplicate feature name: %s", name)
+	}
+	copied := cloneFlag(flag)
+	r.byName[name] = copied
+	if deprecated {
+		r.deprecatedByName[name] = copied
+	}
+	return nil
+}
+
 func emptyRegistry() *Registry {
 	return &Registry{
-		flags:  []Flag{},
-		byCode: map[string]Flag{},
-		byName: map[string]Flag{},
+		flags:            []Flag{},
+		byCode:           map[string]Flag{},
+		byName:           map[string]Flag{},
+		deprecatedByName: map[string]Flag{},
 	}
 }
 
@@ -92,23 +119,41 @@ func (r *Registry) Flags() []Flag {
 		return nil
 	}
 	flags := make([]Flag, len(r.flags))
-	copy(flags, r.flags)
+	for i, flag := range r.flags {
+		flags[i] = cloneFlag(flag)
+	}
 	return flags
 }
 
 func (r *Registry) Lookup(ref string) (Flag, bool) {
-	if r == nil {
+	result, ok := r.LookupReference(ref)
+	if !ok {
 		return Flag{}, false
+	}
+	return result.Flag, true
+}
+
+func (r *Registry) LookupReference(ref string) (LookupResult, bool) {
+	if r == nil {
+		return LookupResult{}, false
 	}
 	normalized := strings.TrimSpace(ref)
 	if normalized == "" {
-		return Flag{}, false
+		return LookupResult{}, false
 	}
 	if flag, ok := r.byCode[normalized]; ok {
-		return flag, true
+		return LookupResult{Flag: cloneFlag(flag), Reference: normalized}, true
 	}
 	flag, ok := r.byName[normalized]
-	return flag, ok
+	if !ok {
+		return LookupResult{}, false
+	}
+	result := LookupResult{Flag: cloneFlag(flag), Reference: normalized}
+	if _, deprecated := r.deprecatedByName[normalized]; deprecated {
+		result.Deprecated = true
+		result.ReplacementRef = flag.Name
+	}
+	return result, true
 }
 
 func (r *Registry) NextCode() (string, error) {
@@ -165,6 +210,11 @@ func normalizeFlag(flag Flag) (Flag, error) {
 	if err := validateFeatureName(flag.Name); err != nil {
 		return Flag{}, err
 	}
+	deprecatedNames, err := normalizeDeprecatedFeatureNames(flag.Name, flag.DeprecatedNames)
+	if err != nil {
+		return Flag{}, err
+	}
+	flag.DeprecatedNames = deprecatedNames
 	lifecycle, err := NormalizeLifecycle(string(flag.Lifecycle))
 	if err != nil {
 		return Flag{}, fmt.Errorf("feature %s: %w", flag.Code, err)
@@ -176,6 +226,35 @@ func normalizeFlag(flag Flag) (Flag, error) {
 	}
 	flag.FirstStableRelease = firstStableRelease
 	return flag, nil
+}
+
+func normalizeDeprecatedFeatureNames(canonicalName string, names []string) ([]string, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if err := validateFeatureName(name); err != nil {
+			return nil, err
+		}
+		if name == canonicalName {
+			return nil, fmt.Errorf("deprecated feature name %q duplicates canonical name", name)
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		normalized = append(normalized, name)
+	}
+	if len(normalized) == 0 {
+		return nil, nil
+	}
+	return normalized, nil
 }
 
 func normalizeStableReleaseVersion(value string) (string, error) {
@@ -231,4 +310,11 @@ func validateFeatureName(name string) error {
 		return fmt.Errorf("invalid feature name %q: use lowercase letters, digits, and hyphens", name)
 	}
 	return nil
+}
+
+func cloneFlag(flag Flag) Flag {
+	if len(flag.DeprecatedNames) > 0 {
+		flag.DeprecatedNames = append([]string{}, flag.DeprecatedNames...)
+	}
+	return flag
 }

--- a/internal/featureflags/resolver.go
+++ b/internal/featureflags/resolver.go
@@ -15,9 +15,16 @@ type ResolveOptions struct {
 }
 
 type Set struct {
-	enabled map[string]bool
-	byCode  map[string]Flag
-	byName  map[string]Flag
+	enabled      map[string]bool
+	byCode       map[string]Flag
+	byName       map[string]Flag
+	deprecations []DeprecatedReference
+}
+
+type DeprecatedReference struct {
+	Code        string
+	Name        string
+	Replacement string
 }
 
 type ManifestEntry struct {
@@ -42,14 +49,16 @@ func (r *Registry) Resolve(opts ResolveOptions) (Set, error) {
 
 	enabled := r.channelDefaults(channel)
 	r.applyReleaseLockDefaults(channel, opts.Lock, enabled)
-	if err := r.applyExplicitOverrides(enabled, opts.Enable, opts.Disable); err != nil {
+	deprecations, err := r.applyExplicitOverrides(enabled, opts.Enable, opts.Disable)
+	if err != nil {
 		return Set{}, err
 	}
 
 	return Set{
-		enabled: enabled,
-		byCode:  copyFlagMap(r.byCode),
-		byName:  copyFlagMap(r.byName),
+		enabled:      enabled,
+		byCode:       copyFlagMap(r.byCode),
+		byName:       copyFlagMap(r.byName),
+		deprecations: deprecations,
 	}, nil
 }
 
@@ -72,25 +81,25 @@ func (r *Registry) applyReleaseLockDefaults(channel Channel, lock *ReleaseLock, 
 	}
 }
 
-func (r *Registry) applyExplicitOverrides(enabled map[string]bool, enable []string, disable []string) error {
-	explicitEnable, err := r.resolveRefs(enable)
+func (r *Registry) applyExplicitOverrides(enabled map[string]bool, enable []string, disable []string) ([]DeprecatedReference, error) {
+	explicitEnable, enableDeprecations, err := r.resolveRefs(enable)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	explicitDisable, err := r.resolveRefs(disable)
+	explicitDisable, disableDeprecations, err := r.resolveRefs(disable)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for code := range explicitEnable {
 		if _, disabled := explicitDisable[code]; disabled {
-			return fmt.Errorf("feature %s is both enabled and disabled", code)
+			return nil, fmt.Errorf("feature %s is both enabled and disabled", code)
 		}
 		enabled[code] = true
 	}
 	for code := range explicitDisable {
 		enabled[code] = false
 	}
-	return nil
+	return mergeDeprecatedReferences(enableDeprecations, disableDeprecations), nil
 }
 
 func (r *Registry) Manifest(opts ResolveOptions) ([]ManifestEntry, error) {
@@ -166,34 +175,80 @@ func (s *Set) Snapshot() map[string]bool {
 	return snapshot
 }
 
+func (s *Set) DeprecatedReferences() []DeprecatedReference {
+	if s == nil || len(s.deprecations) == 0 {
+		return nil
+	}
+	return append([]DeprecatedReference{}, s.deprecations...)
+}
+
+func (s *Set) DeprecationWarnings() []string {
+	if s == nil || len(s.deprecations) == 0 {
+		return nil
+	}
+	warnings := make([]string, 0, len(s.deprecations))
+	for _, ref := range s.deprecations {
+		warnings = append(warnings, fmt.Sprintf("feature flag %q is deprecated; use %q instead", ref.Name, ref.Replacement))
+	}
+	return warnings
+}
+
 func (s *Set) lookup(ref string) (Flag, bool) {
 	ref = strings.TrimSpace(ref)
 	if s == nil {
 		return Flag{}, false
 	}
 	if flag, ok := s.byCode[ref]; ok {
-		return flag, true
+		return cloneFlag(flag), true
 	}
 	flag, ok := s.byName[ref]
-	return flag, ok
+	if !ok {
+		return Flag{}, false
+	}
+	return cloneFlag(flag), true
 }
 
-func (r *Registry) resolveRefs(refs []string) (map[string]struct{}, error) {
+func (r *Registry) resolveRefs(refs []string) (map[string]struct{}, []DeprecatedReference, error) {
 	resolved := map[string]struct{}{}
+	var deprecations []DeprecatedReference
 	for _, ref := range normalizeRefs(refs) {
-		flag, ok := r.Lookup(ref)
+		result, ok := r.LookupReference(ref)
 		if !ok {
-			return nil, fmt.Errorf("unknown feature: %s", ref)
+			return nil, nil, fmt.Errorf("unknown feature: %s", ref)
 		}
+		flag := result.Flag
 		resolved[flag.Code] = struct{}{}
+		if result.Deprecated {
+			deprecations = append(deprecations, DeprecatedReference{
+				Code:        flag.Code,
+				Name:        result.Reference,
+				Replacement: result.ReplacementRef,
+			})
+		}
 	}
-	return resolved, nil
+	return resolved, deprecations, nil
 }
 
 func copyFlagMap(source map[string]Flag) map[string]Flag {
 	copied := make(map[string]Flag, len(source))
 	for key, value := range source {
-		copied[key] = value
+		copied[key] = cloneFlag(value)
 	}
 	return copied
+}
+
+func mergeDeprecatedReferences(groups ...[]DeprecatedReference) []DeprecatedReference {
+	seen := map[string]struct{}{}
+	var merged []DeprecatedReference
+	for _, group := range groups {
+		for _, ref := range group {
+			key := ref.Code + "\x00" + ref.Name
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			merged = append(merged, ref)
+		}
+	}
+	return merged
 }

--- a/internal/lang/dart/types.go
+++ b/internal/lang/dart/types.go
@@ -15,7 +15,7 @@ const (
 	pubspecYAMLName                     = "pubspec.yaml"
 	pubspecYMLName                      = "pubspec.yml"
 	pubspecLockName                     = "pubspec.lock"
-	dartSourceAttributionPreviewFeature = "dart-source-attribution-preview"
+	dartSourceAttributionPreviewFeature = "dart-source-attribution"
 	maxDetectionEntries                 = 2048
 	maxManifestCount                    = 256
 	maxScanFiles                        = 4096

--- a/internal/lang/golang/constants.go
+++ b/internal/lang/golang/constants.go
@@ -3,7 +3,7 @@ package golang
 const (
 	goModName                          = "go.mod"
 	goWorkName                         = "go.work"
-	goVendoredProvenancePreviewFeature = "go-vendored-provenance-preview"
+	goVendoredProvenancePreviewFeature = "go-vendored-provenance"
 	vendorModulesTxtName               = "vendor/modules.txt"
 	maxScannableGoFile                 = 2 * 1024 * 1024
 )

--- a/internal/lang/swift/types.go
+++ b/internal/lang/swift/types.go
@@ -4,7 +4,7 @@ import "github.com/ben-ranford/lopper/internal/lang/shared"
 
 const (
 	swiftAdapterID               = "swift"
-	swiftCarthagePreviewFlagName = "swift-carthage-preview"
+	swiftCarthagePreviewFlagName = "swift-carthage"
 	packageManifestName          = "Package.swift"
 	packageResolvedName          = "Package.resolved"
 	podManifestName              = "Podfile"

--- a/internal/mcp/mutations.go
+++ b/internal/mcp/mutations.go
@@ -17,7 +17,7 @@ import (
 
 // MutationToolsFeature gates explicit MCP mutation tools. Read-only MCP tools
 // stay available under ServerPreviewFeature and do not use this flag.
-const MutationToolsFeature = "mcp-mutation-tools-preview"
+const MutationToolsFeature = "mcp-mutation-tools"
 
 type MutationRunner interface {
 	ApplyCodemod(context.Context, AnalysisMutationRequest) (report.Report, error)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// ServerPreviewFeature is the feature flag name that enables MCP server startup.
-	ServerPreviewFeature   = "mcp-server-preview"
+	ServerPreviewFeature   = "mcp-server"
 	jsonrpcVersion         = "2.0"
 	defaultProtocolVersion = "2024-11-05"
 	methodInitialize       = "initialize"

--- a/internal/thresholds/profiles.go
+++ b/internal/thresholds/profiles.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const ProfilesPreviewFeature = "threshold-profiles-preview"
+const ProfilesPreviewFeature = "threshold-profiles"
 
 type Profile struct {
 	Name        string

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -413,14 +413,14 @@ func TestManifestEntries(t *testing.T) {
 	if len(manifest) < 4 {
 		t.Fatalf("expected embedded manifest entries, got %#v", manifest)
 	}
-	assertManifestEntryDefault(t, manifest, "dart-source-attribution-preview", true)
-	assertManifestEntryDefault(t, manifest, "lockfile-drift-ecosystem-expansion-preview", true)
-	assertManifestEntryDefault(t, manifest, "swift-carthage-preview", true)
-	assertManifestEntryDefault(t, manifest, "powershell-adapter-preview", true)
-	assertManifestEntryDefault(t, manifest, "go-vendored-provenance-preview", true)
-	assertManifestEntryDefault(t, manifest, "baseline-provenance-runtime-context-preview", true)
-	assertManifestEntryDefault(t, manifest, "vscode-multi-root-workflows-preview", true)
-	assertManifestEntryDefault(t, manifest, "mcp-server-preview", true)
+	assertManifestEntryDefault(t, manifest, "dart-source-attribution", true)
+	assertManifestEntryDefault(t, manifest, "lockfile-drift-ecosystem-expansion", true)
+	assertManifestEntryDefault(t, manifest, "swift-carthage", true)
+	assertManifestEntryDefault(t, manifest, "powershell-adapter", true)
+	assertManifestEntryDefault(t, manifest, "go-vendored-provenance", true)
+	assertManifestEntryDefault(t, manifest, "baseline-provenance-runtime-context", true)
+	assertManifestEntryDefault(t, manifest, "vscode-multi-root-workflows", true)
+	assertManifestEntryDefault(t, manifest, "mcp-server", true)
 }
 
 func TestRunManifestAndReportUseChannels(t *testing.T) {


### PR DESCRIPTION
## Summary
Adds v2 stable feature aliases while keeping legacy preview-suffixed names accepted for compatibility.

## Changes
- Added stable canonical v2 feature names with deprecated preview-name aliases instead of duplicating flags.
- Kept feature codes unchanged and preserved explicit enable/disable rollback paths through legacy preview names.
- Updated CLI warnings, generated/public feature docs, MCP docs, README/dashboard examples, manpage, and release migration notes to use stable names.

## Risk and compatibility
- Breaking changes: None; legacy `*-preview` names remain accepted for compatibility and rollback testing.
- Migration required: None for v2.0.0; users can move from legacy preview names to the documented stable aliases.
- Performance impact: None expected; feature resolution adds alias lookup only.
- Memory benchmark impact: N/A; no runtime memory-sensitive path changed.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

## Validation
- `GOTOOLCHAIN=go1.26.4 go test ./internal/featureflags ./internal/cli ./internal/app ./internal/analysis ./internal/mcp ./internal/lang/dart ./internal/lang/golang ./internal/lang/swift ./tools/featureflag`
- `go run ./tools/featureflag validate`
- `go run ./tools/featureflag manifest --channel release --release v2.0.0`
- `make manpage`
- `make feature-flag-check`
- `make lint`
- `make test`
- `make cov`
- `git diff --check`

Closes #1090
