### PR TITLE
chore(report): add runtime trace baseline diffs

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -96,7 +96,7 @@ Notes:
 Dashboard JSON emits:
 
 - `generated_at`
-- `repos[]` (per-repo metrics, remote `repo_url`, requested `revision`, `resolved_commit`, and any analysis errors)
+- `repos[]` (per-repo metrics, remote `repo_url`, requested `revision`, `resolved_commit`, runtime trace/regression counts, and any analysis errors)
 - `baseline_comparison` when a dashboard baseline is loaded and compared
 - `summary`:
   - `total_repos`
@@ -104,4 +104,6 @@ Dashboard JSON emits:
   - `total_waste_candidates`
   - `cross_repo_duplicates`
   - `critical_cves`
+  - `repos_with_runtime_trace_data`
+  - `repos_with_runtime_regressions`
 - `cross_repo_deps[]` (dependencies present in 3+ repos)

--- a/docs/report-schema.json
+++ b/docs/report-schema.json
@@ -553,6 +553,14 @@
           "type": "array",
           "items": { "$ref": "#/$defs/dependencyDelta" }
         },
+        "runtimeRegressions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/dependencyDelta" }
+        },
+        "runtimeImprovements": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/dependencyDelta" }
+        },
         "added": {
           "type": "array",
           "items": { "$ref": "#/$defs/dependencyDelta" }
@@ -615,7 +623,97 @@
         "usedPercentDelta": { "type": "number" },
         "estimatedUnusedBytesDelta": { "type": "integer" },
         "wastePercentDelta": { "type": "number" },
+        "runtimeDelta": { "$ref": "#/$defs/runtimeDelta" },
         "deniedIntroduced": { "type": "boolean" }
+      }
+    },
+    "runtimeDelta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["comparable", "baselinePresent", "currentPresent"],
+      "properties": {
+        "comparable": { "type": "boolean" },
+        "baselinePresent": { "type": "boolean" },
+        "currentPresent": { "type": "boolean" },
+        "baselineLoadCount": { "type": "integer", "minimum": 0 },
+        "currentLoadCount": { "type": "integer", "minimum": 0 },
+        "loadCountDelta": { "type": "integer" },
+        "baselineCorrelation": {
+          "type": "string",
+          "enum": ["static-only", "runtime-only", "overlap"]
+        },
+        "currentCorrelation": {
+          "type": "string",
+          "enum": ["static-only", "runtime-only", "overlap"]
+        },
+        "changeTypes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "load-count",
+              "new-runtime-loads",
+              "removed-runtime-loads",
+              "correlation",
+              "runtime-only-regression",
+              "runtime-only-improvement",
+              "modules",
+              "parent-modules",
+              "entrypoints"
+            ]
+          }
+        },
+        "newRuntimeLoads": { "type": "boolean" },
+        "removedRuntimeLoads": { "type": "boolean" },
+        "runtimeOnlyRegression": { "type": "boolean" },
+        "runtimeOnlyImprovement": { "type": "boolean" },
+        "modulesAdded": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/runtimeModuleDelta" }
+        },
+        "modulesRemoved": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/runtimeModuleDelta" }
+        },
+        "modulesChanged": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/runtimeModuleDelta" }
+        },
+        "parentModulesAdded": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/runtimeModuleDelta" }
+        },
+        "parentModulesRemoved": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/runtimeModuleDelta" }
+        },
+        "parentModulesChanged": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/runtimeModuleDelta" }
+        },
+        "entrypointsAdded": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/runtimeModuleDelta" }
+        },
+        "entrypointsRemoved": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/runtimeModuleDelta" }
+        },
+        "entrypointsChanged": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/runtimeModuleDelta" }
+        }
+      }
+    },
+    "runtimeModuleDelta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["module", "baselineCount", "currentCount", "countDelta"],
+      "properties": {
+        "module": { "type": "string" },
+        "baselineCount": { "type": "integer", "minimum": 0 },
+        "currentCount": { "type": "integer", "minimum": 0 },
+        "countDelta": { "type": "integer" }
       }
     },
     "deniedLicenseDelta": {

--- a/docs/report-schema.md
+++ b/docs/report-schema.md
@@ -98,7 +98,8 @@ CycloneDX characteristics:
 - `dependencies[].usedImports[].provenance`: optional attribution chain for barrel/re-export resolution in detailed views.
 - `summary.reachability`: repo-level v2 confidence rollup (`model`, `averageScore`, `lowestScore`, `highestScore`).
 - `wasteIncreasePercent`: present when `--baseline` was supplied and compared.
-- `baselineComparison`: deterministic dependency-level deltas between baseline and current run, including `summaryDelta`, `dependencies`, `added`, `removed`, `regressions`, `progressions`, and `newDeniedLicenses`.
+- `baselineComparison`: deterministic dependency-level deltas between baseline and current run, including `summaryDelta`, `dependencies`, `added`, `removed`, `regressions`, `progressions`, `runtimeRegressions`, `runtimeImprovements`, and `newDeniedLicenses`.
+- `baselineComparison.dependencies[].runtimeDelta`: runtime trace comparison for dependencies present in both baseline and current reports when at least one side has runtime data. Comparable deltas include load-count changes, correlation transitions, new/removed runtime loads, runtime-only regressions/improvements, and module/parent/entrypoint changes.
 
 ## Notes
 
@@ -111,6 +112,8 @@ CycloneDX characteristics:
 - `runtimeUsage.modules` lists runtime-loaded module paths seen for a dependency.
 - `runtimeUsage.topSymbols` lists best-effort runtime symbol hits derived from module subpaths.
 - Runtime annotations use the same report fields across supported languages; adapter differences are confined to trace-to-dependency mapping.
+- Runtime baseline deltas are comparable only when both reports contain `runtimeUsage` for the same dependency. If one side lacks runtime data, `runtimeDelta.comparable` is `false`, and load deltas are omitted instead of treating the missing side as zero loads.
+- Added and removed dependencies do not produce `runtimeDelta` or runtime regression/improvement entries; their runtime data remains on the dependency row in the source report, while `baselineComparison.added` and `baselineComparison.removed` describe dependency presence changes.
 - `cache.invalidations` entries identify deterministic invalidation reasons (for example `input-changed`).
 - `usedPercent` values are adapter best-effort based on static analysis signals.
 - `summary.knownLicenseCount`, `summary.unknownLicenseCount`, and `summary.deniedLicenseCount` are mutually exclusive license buckets across dependency rows. Denied dependencies count only as denied, even when they also have an SPDX value or unknown license metadata.

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -35,6 +35,7 @@ import type {
   LopperImportUse,
   LopperLocation,
   LopperReachabilityConfidence,
+  LopperRuntimeDelta,
   LopperRuntimeUsage,
   LopperScopeMode,
 } from "./types";
@@ -2290,8 +2291,71 @@ function dependencyBaselineSummary(
   }
   if (dependencyDelta) {
     parts.push(`dep ${dependencyDelta.usedPercentDelta > 0 ? "+" : ""}${dependencyDelta.usedPercentDelta.toFixed(1)}%`);
+    const runtimeDelta = runtimeDeltaSummary(dependencyDelta.runtimeDelta);
+    if (runtimeDelta) {
+      parts.push(runtimeDelta);
+    }
   }
   return parts.length > 0 ? parts.join(" • ") : undefined;
+}
+
+function runtimeDeltaSummary(runtimeDelta?: LopperRuntimeDelta): string | undefined {
+  if (!runtimeDelta) {
+    return undefined;
+  }
+  if (!runtimeDelta.comparable) {
+    return runtimeDeltaNotComparableSummary(runtimeDelta);
+  }
+  const parts: string[] = [];
+  appendRuntimeDeltaSummaryPart(parts, runtimeLoadCountDeltaSummary(runtimeDelta));
+  appendRuntimeDeltaSummaryPart(parts, runtimeDelta.newRuntimeLoads ? "new runtime loads" : undefined);
+  appendRuntimeDeltaSummaryPart(parts, runtimeDelta.removedRuntimeLoads ? "removed runtime loads" : undefined);
+  appendRuntimeDeltaSummaryPart(parts, runtimeCorrelationDeltaSummary(runtimeDelta));
+  appendRuntimeDeltaSummaryPart(parts, runtimeDelta.runtimeOnlyRegression ? "runtime-only regression" : undefined);
+  appendRuntimeDeltaSummaryPart(parts, runtimeDelta.runtimeOnlyImprovement ? "runtime-only improvement" : undefined);
+  appendRuntimeDeltaSummaryPart(parts, runtimeModuleGroupDeltaSummary("modules", runtimeDelta.modulesAdded, runtimeDelta.modulesRemoved, runtimeDelta.modulesChanged));
+  appendRuntimeDeltaSummaryPart(parts, runtimeModuleGroupDeltaSummary("parent modules", runtimeDelta.parentModulesAdded, runtimeDelta.parentModulesRemoved, runtimeDelta.parentModulesChanged));
+  appendRuntimeDeltaSummaryPart(parts, runtimeModuleGroupDeltaSummary("entrypoints", runtimeDelta.entrypointsAdded, runtimeDelta.entrypointsRemoved, runtimeDelta.entrypointsChanged));
+  return parts.length > 0 ? parts.join(" • ") : "runtime unchanged";
+}
+
+function runtimeDeltaNotComparableSummary(runtimeDelta: LopperRuntimeDelta): string {
+  if (!runtimeDelta.baselinePresent && runtimeDelta.currentPresent) {
+    return "runtime baseline missing";
+  }
+  if (runtimeDelta.baselinePresent && !runtimeDelta.currentPresent) {
+    return "runtime current missing";
+  }
+  return "runtime not comparable";
+}
+
+function runtimeLoadCountDeltaSummary(runtimeDelta: LopperRuntimeDelta): string | undefined {
+  if (typeof runtimeDelta.loadCountDelta !== "number" || runtimeDelta.loadCountDelta === 0) {
+    return undefined;
+  }
+  return `runtime loads ${runtimeDelta.loadCountDelta > 0 ? "+" : ""}${runtimeDelta.loadCountDelta}`;
+}
+
+function runtimeCorrelationDeltaSummary(runtimeDelta: LopperRuntimeDelta): string | undefined {
+  if (runtimeDelta.baselineCorrelation === runtimeDelta.currentCorrelation) {
+    return undefined;
+  }
+  return `runtime ${runtimeDelta.baselineCorrelation ?? "n/a"} -> ${runtimeDelta.currentCorrelation ?? "n/a"}`;
+}
+
+function runtimeModuleGroupDeltaSummary(
+  label: string,
+  added?: NonNullable<LopperRuntimeDelta["modulesAdded"]>,
+  removed?: NonNullable<LopperRuntimeDelta["modulesAdded"]>,
+  changed?: NonNullable<LopperRuntimeDelta["modulesAdded"]>,
+): string | undefined {
+  return added?.length || removed?.length || changed?.length ? `${label} changed` : undefined;
+}
+
+function appendRuntimeDeltaSummaryPart(parts: string[], value?: string): void {
+  if (value) {
+    parts.push(value);
+  }
 }
 
 function renderDependencyDetailHtml(
@@ -2523,9 +2587,56 @@ function renderBaselineHtml(baseline: LopperBaselineComparison, dependencyDelta?
       ["Dependency waste delta", `${dependencyDelta.wastePercentDelta.toFixed(1)}%`],
       ["Dependency used delta", `${dependencyDelta.usedPercentDelta.toFixed(1)}%`],
     ]) : "",
+    dependencyDelta?.runtimeDelta ? renderRuntimeDeltaHtml(dependencyDelta.runtimeDelta) : "",
     baseline.newDeniedLicenses?.length ? `<p><strong>New denied licenses:</strong> ${escapeHtml(baseline.newDeniedLicenses.map((item) => item.name).join(", "))}</p>` : "",
   ];
   return lines.join("");
+}
+
+function renderRuntimeDeltaHtml(runtimeDelta: LopperRuntimeDelta): string {
+  const entries: Array<[string, string]> = [
+    ["Runtime comparable", runtimeDelta.comparable ? "yes" : "no"],
+    ["Baseline runtime data", runtimeDelta.baselinePresent ? "yes" : "no"],
+    ["Current runtime data", runtimeDelta.currentPresent ? "yes" : "no"],
+  ];
+  if (typeof runtimeDelta.baselineLoadCount === "number") {
+    entries.push(["Baseline loads", String(runtimeDelta.baselineLoadCount)]);
+  }
+  if (typeof runtimeDelta.currentLoadCount === "number") {
+    entries.push(["Current loads", String(runtimeDelta.currentLoadCount)]);
+  }
+  if (typeof runtimeDelta.loadCountDelta === "number") {
+    entries.push(["Load delta", `${runtimeDelta.loadCountDelta > 0 ? "+" : ""}${runtimeDelta.loadCountDelta}`]);
+  }
+  if (runtimeDelta.baselineCorrelation || runtimeDelta.currentCorrelation) {
+    entries.push(["Correlation", `${runtimeDelta.baselineCorrelation ?? "n/a"} -> ${runtimeDelta.currentCorrelation ?? "n/a"}`]);
+  }
+  const parts = [renderHtmlSection("Runtime baseline delta", renderKeyValueList(entries))];
+  if (runtimeDelta.changeTypes?.length) {
+    parts.push(renderHtmlSection("Runtime change types", renderHtmlList(runtimeDelta.changeTypes.map((item) => renderListItem(escapeHtml(item))))));
+  }
+  appendRuntimeModuleDeltaSection(parts, "Modules added", runtimeDelta.modulesAdded);
+  appendRuntimeModuleDeltaSection(parts, "Modules removed", runtimeDelta.modulesRemoved);
+  appendRuntimeModuleDeltaSection(parts, "Modules changed", runtimeDelta.modulesChanged);
+  appendRuntimeModuleDeltaSection(parts, "Parent modules added", runtimeDelta.parentModulesAdded);
+  appendRuntimeModuleDeltaSection(parts, "Parent modules removed", runtimeDelta.parentModulesRemoved);
+  appendRuntimeModuleDeltaSection(parts, "Parent modules changed", runtimeDelta.parentModulesChanged);
+  appendRuntimeModuleDeltaSection(parts, "Entrypoints added", runtimeDelta.entrypointsAdded);
+  appendRuntimeModuleDeltaSection(parts, "Entrypoints removed", runtimeDelta.entrypointsRemoved);
+  appendRuntimeModuleDeltaSection(parts, "Entrypoints changed", runtimeDelta.entrypointsChanged);
+  return parts.join("");
+}
+
+function appendRuntimeModuleDeltaSection(parts: string[], title: string, deltas?: NonNullable<LopperRuntimeDelta["modulesAdded"]>): void {
+  if (!deltas?.length) {
+    return;
+  }
+  parts.push(renderHtmlSection(title, renderHtmlList(deltas.map(renderRuntimeModuleDeltaItem))));
+}
+
+function renderRuntimeModuleDeltaItem(delta: { module: string; baselineCount: number; currentCount: number; countDelta: number }): string {
+  const signed = delta.countDelta > 0 ? `+${delta.countDelta}` : String(delta.countDelta);
+  return renderListItem(`<code>${escapeHtml(delta.module)}</code> ${delta.baselineCount} -> ${delta.currentCount} (${signed})`);
 }
 
 function renderRuntimeUsage(runtime: LopperRuntimeUsage): string {
@@ -2538,6 +2649,12 @@ function renderRuntimeUsage(runtime: LopperRuntimeUsage): string {
   ];
   if (runtime.modules?.length) {
     parts.push(renderHtmlSection("Modules", renderHtmlList(runtime.modules.map(renderRuntimeModuleItem))));
+  }
+  if (runtime.parentModules?.length) {
+    parts.push(renderHtmlSection("Parent modules", renderHtmlList(runtime.parentModules.map(renderRuntimeModuleItem))));
+  }
+  if (runtime.entrypoints?.length) {
+    parts.push(renderHtmlSection("Entrypoints", renderHtmlList(runtime.entrypoints.map(renderRuntimeModuleItem))));
   }
   if (runtime.topSymbols?.length) {
     parts.push(renderHtmlSection("Top symbols", renderHtmlList(runtime.topSymbols.map(renderRuntimeTopSymbolItem))));

--- a/extensions/vscode-lopper/src/types.ts
+++ b/extensions/vscode-lopper/src/types.ts
@@ -207,9 +207,11 @@ export interface LopperSymbolRef {
 
 export interface LopperRuntimeUsage {
   loadCount: number;
-  correlation?: "static-only" | "runtime-only" | "overlap";
+  correlation?: LopperRuntimeCorrelation;
   runtimeOnly?: boolean;
   modules?: LopperRuntimeModuleUsage[];
+  parentModules?: LopperRuntimeModuleUsage[];
+  entrypoints?: LopperRuntimeModuleUsage[];
   topSymbols?: LopperRuntimeSymbolUsage[];
 }
 
@@ -255,6 +257,8 @@ export interface LopperBaselineComparison {
   dependencies?: LopperDependencyDelta[];
   regressions?: LopperDependencyDelta[];
   progressions?: LopperDependencyDelta[];
+  runtimeRegressions?: LopperDependencyDelta[];
+  runtimeImprovements?: LopperDependencyDelta[];
   added?: LopperDependencyDelta[];
   removed?: LopperDependencyDelta[];
   newDeniedLicenses?: LopperDeniedLicenseDelta[];
@@ -282,7 +286,53 @@ export interface LopperDependencyDelta {
   usedPercentDelta: number;
   estimatedUnusedBytesDelta: number;
   wastePercentDelta: number;
+  runtimeDelta?: LopperRuntimeDelta;
   deniedIntroduced?: boolean;
+}
+
+export type LopperRuntimeChangeType =
+  | "load-count"
+  | "new-runtime-loads"
+  | "removed-runtime-loads"
+  | "correlation"
+  | "runtime-only-regression"
+  | "runtime-only-improvement"
+  | "modules"
+  | "parent-modules"
+  | "entrypoints";
+
+export type LopperRuntimeCorrelation = "static-only" | "runtime-only" | "overlap";
+
+export interface LopperRuntimeDelta {
+  comparable: boolean;
+  baselinePresent: boolean;
+  currentPresent: boolean;
+  baselineLoadCount?: number;
+  currentLoadCount?: number;
+  loadCountDelta?: number;
+  baselineCorrelation?: LopperRuntimeCorrelation;
+  currentCorrelation?: LopperRuntimeCorrelation;
+  changeTypes?: LopperRuntimeChangeType[];
+  newRuntimeLoads?: boolean;
+  removedRuntimeLoads?: boolean;
+  runtimeOnlyRegression?: boolean;
+  runtimeOnlyImprovement?: boolean;
+  modulesAdded?: LopperRuntimeModuleDelta[];
+  modulesRemoved?: LopperRuntimeModuleDelta[];
+  modulesChanged?: LopperRuntimeModuleDelta[];
+  parentModulesAdded?: LopperRuntimeModuleDelta[];
+  parentModulesRemoved?: LopperRuntimeModuleDelta[];
+  parentModulesChanged?: LopperRuntimeModuleDelta[];
+  entrypointsAdded?: LopperRuntimeModuleDelta[];
+  entrypointsRemoved?: LopperRuntimeModuleDelta[];
+  entrypointsChanged?: LopperRuntimeModuleDelta[];
+}
+
+export interface LopperRuntimeModuleDelta {
+  module: string;
+  baselineCount: number;
+  currentCount: number;
+  countDelta: number;
 }
 
 export interface LopperDeniedLicenseDelta {

--- a/internal/dashboard/aggregate.go
+++ b/internal/dashboard/aggregate.go
@@ -18,6 +18,14 @@ type crossRepoRepository struct {
 	Label string
 }
 
+type repoSummaryContribution struct {
+	TotalDeps              int
+	TotalWasteCandidates   int
+	CriticalCVEs           int
+	RuntimeTraceData       bool
+	RuntimeRegressionCount int
+}
+
 func Aggregate(generatedAt time.Time, analyses []RepoAnalysis) Report {
 	results := make([]RepoResult, 0, len(analyses))
 	crossRepoIndex := make(map[string]map[string]crossRepoRepository)
@@ -28,56 +36,11 @@ func Aggregate(generatedAt time.Time, analyses []RepoAnalysis) Report {
 	}
 
 	for _, analysis := range analyses {
-		repoResult := RepoResult{
-			Name:           analysis.Input.Name,
-			Path:           analysis.Input.Path,
-			RepoURL:        analysis.Input.RepoURL,
-			ResolvedCommit: analysis.Input.ResolvedCommit,
-			Language:       analysis.Input.Language,
+		repoResult, contribution, warning := aggregateRepoAnalysis(analysis, repoNameCounts, crossRepoIndex)
+		addSummaryContribution(&summary, contribution)
+		if warning != "" {
+			sourceWarnings = append(sourceWarnings, warning)
 		}
-		if !analysis.Input.Revision.IsZero() {
-			revision := analysis.Input.Revision
-			repoResult.Revision = &revision
-		}
-		if analysis.Err != nil {
-			repoResult.Error = analysis.Err.Error()
-			sourceWarnings = append(sourceWarnings, analysis.Input.Name+": "+analysis.Err.Error())
-			results = append(results, repoResult)
-			continue
-		}
-
-		dependencyCount := len(analysis.Report.Dependencies)
-		wasteCandidateCount := countWasteCandidates(analysis.Report.Dependencies)
-		topRiskSeverity, criticalCVEs := scanRiskSignals(analysis.Report.Dependencies)
-		deniedLicenseCount := countDeniedLicenses(analysis.Report)
-
-		repoResult.DependencyCount = dependencyCount
-		repoResult.WasteCandidateCount = wasteCandidateCount
-		if dependencyCount > 0 {
-			repoResult.WasteCandidatePercent = (float64(wasteCandidateCount) / float64(dependencyCount)) * 100
-		}
-		repoResult.TopRiskSeverity = topRiskSeverity
-		repoResult.CriticalCVEs = criticalCVEs
-		repoResult.DeniedLicenseCount = deniedLicenseCount
-		repoResult.Warnings = append(repoResult.Warnings, analysis.Report.Warnings...)
-
-		summary.TotalDeps += dependencyCount
-		summary.TotalWasteCandidates += wasteCandidateCount
-		summary.CriticalCVEs += criticalCVEs
-
-		repoID := repoIdentity(analysis.Input)
-		repoLabel := crossRepoRepositoryLabel(analysis.Input, repoNameCounts)
-		for _, dependency := range analysis.Report.Dependencies {
-			name := strings.TrimSpace(dependency.Name)
-			if name == "" {
-				continue
-			}
-			if _, ok := crossRepoIndex[name]; !ok {
-				crossRepoIndex[name] = make(map[string]crossRepoRepository)
-			}
-			crossRepoIndex[name][repoID] = crossRepoRepository{Label: repoLabel}
-		}
-
 		results = append(results, repoResult)
 	}
 
@@ -90,6 +53,88 @@ func Aggregate(generatedAt time.Time, analyses []RepoAnalysis) Report {
 		Summary:        summary,
 		CrossRepoDeps:  crossRepoDeps,
 		SourceWarnings: sourceWarnings,
+	}
+}
+
+func aggregateRepoAnalysis(analysis RepoAnalysis, repoNameCounts map[string]int, crossRepoIndex map[string]map[string]crossRepoRepository) (RepoResult, repoSummaryContribution, string) {
+	repoResult := baseRepoResult(analysis.Input)
+	if analysis.Err != nil {
+		repoResult.Error = analysis.Err.Error()
+		return repoResult, repoSummaryContribution{}, analysis.Input.Name + ": " + analysis.Err.Error()
+	}
+
+	contribution := summarizeRepo(analysis.Report)
+	populateRepoResult(&repoResult, analysis.Report, contribution)
+	indexCrossRepoDependencies(crossRepoIndex, analysis.Input, repoNameCounts, analysis.Report.Dependencies)
+	return repoResult, contribution, ""
+}
+
+func baseRepoResult(input RepoInput) RepoResult {
+	result := RepoResult{
+		Name:           input.Name,
+		Path:           input.Path,
+		RepoURL:        input.RepoURL,
+		ResolvedCommit: input.ResolvedCommit,
+		Language:       input.Language,
+	}
+	if !input.Revision.IsZero() {
+		revision := input.Revision
+		result.Revision = &revision
+	}
+	return result
+}
+
+func summarizeRepo(reportData report.Report) repoSummaryContribution {
+	_, criticalCVEs := scanRiskSignals(reportData.Dependencies)
+	return repoSummaryContribution{
+		TotalDeps:              len(reportData.Dependencies),
+		TotalWasteCandidates:   countWasteCandidates(reportData.Dependencies),
+		CriticalCVEs:           criticalCVEs,
+		RuntimeTraceData:       reportHasRuntimeUsage(reportData),
+		RuntimeRegressionCount: runtimeRegressionCount(reportData),
+	}
+}
+
+func populateRepoResult(result *RepoResult, reportData report.Report, contribution repoSummaryContribution) {
+	topRiskSeverity, _ := scanRiskSignals(reportData.Dependencies)
+	result.DependencyCount = contribution.TotalDeps
+	result.WasteCandidateCount = contribution.TotalWasteCandidates
+	if contribution.TotalDeps > 0 {
+		result.WasteCandidatePercent = (float64(contribution.TotalWasteCandidates) / float64(contribution.TotalDeps)) * 100
+	}
+	result.TopRiskSeverity = topRiskSeverity
+	result.CriticalCVEs = contribution.CriticalCVEs
+	result.DeniedLicenseCount = countDeniedLicenses(reportData)
+	result.RuntimeTraceData = contribution.RuntimeTraceData
+	result.RuntimeRegressionCount = contribution.RuntimeRegressionCount
+	result.RuntimeImprovementCount = runtimeImprovementCount(reportData)
+	result.Warnings = append(result.Warnings, reportData.Warnings...)
+}
+
+func addSummaryContribution(summary *Summary, contribution repoSummaryContribution) {
+	summary.TotalDeps += contribution.TotalDeps
+	summary.TotalWasteCandidates += contribution.TotalWasteCandidates
+	summary.CriticalCVEs += contribution.CriticalCVEs
+	if contribution.RuntimeTraceData {
+		summary.ReposWithRuntimeTraceData++
+	}
+	if contribution.RuntimeTraceData && contribution.RuntimeRegressionCount > 0 {
+		summary.ReposWithRuntimeRegressions++
+	}
+}
+
+func indexCrossRepoDependencies(index map[string]map[string]crossRepoRepository, input RepoInput, repoNameCounts map[string]int, dependencies []report.DependencyReport) {
+	repoID := repoIdentity(input)
+	repoLabel := crossRepoRepositoryLabel(input, repoNameCounts)
+	for _, dependency := range dependencies {
+		name := strings.TrimSpace(dependency.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := index[name]; !ok {
+			index[name] = make(map[string]crossRepoRepository)
+		}
+		index[name][repoID] = crossRepoRepository{Label: repoLabel}
 	}
 }
 
@@ -170,6 +215,29 @@ func countDeniedLicenses(reportData report.Report) int {
 		}
 	}
 	return count
+}
+
+func reportHasRuntimeUsage(reportData report.Report) bool {
+	for _, dependency := range reportData.Dependencies {
+		if dependency.RuntimeUsage != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func runtimeRegressionCount(reportData report.Report) int {
+	if reportData.BaselineComparison == nil {
+		return 0
+	}
+	return len(reportData.BaselineComparison.RuntimeRegressions)
+}
+
+func runtimeImprovementCount(reportData report.Report) int {
+	if reportData.BaselineComparison == nil {
+		return 0
+	}
+	return len(reportData.BaselineComparison.RuntimeImprovements)
 }
 
 func countRepoNames(analyses []RepoAnalysis) map[string]int {

--- a/internal/dashboard/baseline.go
+++ b/internal/dashboard/baseline.go
@@ -109,11 +109,13 @@ func ComputeBaselineComparison(current, baseline Report) BaselineComparison {
 
 	comparison := BaselineComparison{
 		SummaryDelta: SummaryDelta{
-			TotalReposDelta:           current.Summary.TotalRepos - baseline.Summary.TotalRepos,
-			TotalDepsDelta:            current.Summary.TotalDeps - baseline.Summary.TotalDeps,
-			TotalWasteCandidatesDelta: current.Summary.TotalWasteCandidates - baseline.Summary.TotalWasteCandidates,
-			CrossRepoDuplicatesDelta:  current.Summary.CrossRepoDuplicates - baseline.Summary.CrossRepoDuplicates,
-			CriticalCVEsDelta:         current.Summary.CriticalCVEs - baseline.Summary.CriticalCVEs,
+			TotalReposDelta:                  current.Summary.TotalRepos - baseline.Summary.TotalRepos,
+			TotalDepsDelta:                   current.Summary.TotalDeps - baseline.Summary.TotalDeps,
+			TotalWasteCandidatesDelta:        current.Summary.TotalWasteCandidates - baseline.Summary.TotalWasteCandidates,
+			CrossRepoDuplicatesDelta:         current.Summary.CrossRepoDuplicates - baseline.Summary.CrossRepoDuplicates,
+			CriticalCVEsDelta:                current.Summary.CriticalCVEs - baseline.Summary.CriticalCVEs,
+			ReposWithRuntimeTraceDataDelta:   current.Summary.ReposWithRuntimeTraceData - baseline.Summary.ReposWithRuntimeTraceData,
+			ReposWithRuntimeRegressionsDelta: current.Summary.ReposWithRuntimeRegressions - baseline.Summary.ReposWithRuntimeRegressions,
 		},
 	}
 
@@ -159,6 +161,8 @@ func computeRepoDelta(curr RepoResult, hasCurrent bool, base RepoResult, hasBase
 		delta.WasteCandidatePercentDelta = curr.WasteCandidatePercent
 		delta.CriticalCVEsDelta = curr.CriticalCVEs
 		delta.DeniedLicenseCountDelta = curr.DeniedLicenseCount
+		delta.RuntimeRegressionCountDelta = curr.RuntimeRegressionCount
+		delta.RuntimeImprovementCountDelta = curr.RuntimeImprovementCount
 		delta.CurrentError = curr.Error
 		return delta, true
 	case !hasCurrent && hasBaseline:
@@ -168,6 +172,8 @@ func computeRepoDelta(curr RepoResult, hasCurrent bool, base RepoResult, hasBase
 		delta.WasteCandidatePercentDelta = -base.WasteCandidatePercent
 		delta.CriticalCVEsDelta = -base.CriticalCVEs
 		delta.DeniedLicenseCountDelta = -base.DeniedLicenseCount
+		delta.RuntimeRegressionCountDelta = -base.RuntimeRegressionCount
+		delta.RuntimeImprovementCountDelta = -base.RuntimeImprovementCount
 		delta.BaselineError = base.Error
 		return delta, true
 	default:
@@ -177,6 +183,8 @@ func computeRepoDelta(curr RepoResult, hasCurrent bool, base RepoResult, hasBase
 		delta.WasteCandidatePercentDelta = curr.WasteCandidatePercent - base.WasteCandidatePercent
 		delta.CriticalCVEsDelta = curr.CriticalCVEs - base.CriticalCVEs
 		delta.DeniedLicenseCountDelta = curr.DeniedLicenseCount - base.DeniedLicenseCount
+		delta.RuntimeRegressionCountDelta = curr.RuntimeRegressionCount - base.RuntimeRegressionCount
+		delta.RuntimeImprovementCountDelta = curr.RuntimeImprovementCount - base.RuntimeImprovementCount
 		delta.CurrentError = curr.Error
 		delta.BaselineError = base.Error
 		if delta.DependencyCountDelta == 0 &&
@@ -184,6 +192,8 @@ func computeRepoDelta(curr RepoResult, hasCurrent bool, base RepoResult, hasBase
 			delta.WasteCandidatePercentDelta == 0 &&
 			delta.CriticalCVEsDelta == 0 &&
 			delta.DeniedLicenseCountDelta == 0 &&
+			delta.RuntimeRegressionCountDelta == 0 &&
+			delta.RuntimeImprovementCountDelta == 0 &&
 			strings.TrimSpace(curr.Error) == strings.TrimSpace(base.Error) {
 			return RepoDelta{}, false
 		}
@@ -197,11 +207,15 @@ func repoKey(repo RepoResult) string {
 
 func computeSummary(rep Report) Summary {
 	return Summary{
-		TotalRepos:           len(rep.Repos),
-		TotalDeps:            sumRepoField(rep.Repos, func(repo RepoResult) int { return repo.DependencyCount }),
-		TotalWasteCandidates: sumRepoField(rep.Repos, func(repo RepoResult) int { return repo.WasteCandidateCount }),
-		CrossRepoDuplicates:  len(rep.CrossRepoDeps),
-		CriticalCVEs:         sumRepoField(rep.Repos, func(repo RepoResult) int { return repo.CriticalCVEs }),
+		TotalRepos:                len(rep.Repos),
+		TotalDeps:                 sumRepoField(rep.Repos, func(repo RepoResult) int { return repo.DependencyCount }),
+		TotalWasteCandidates:      sumRepoField(rep.Repos, func(repo RepoResult) int { return repo.WasteCandidateCount }),
+		CrossRepoDuplicates:       len(rep.CrossRepoDeps),
+		CriticalCVEs:              sumRepoField(rep.Repos, func(repo RepoResult) int { return repo.CriticalCVEs }),
+		ReposWithRuntimeTraceData: countRepoField(rep.Repos, func(repo RepoResult) bool { return repo.RuntimeTraceData }),
+		ReposWithRuntimeRegressions: countRepoField(rep.Repos, func(repo RepoResult) bool {
+			return repo.RuntimeTraceData && repo.RuntimeRegressionCount > 0
+		}),
 	}
 }
 
@@ -209,6 +223,16 @@ func sumRepoField(repos []RepoResult, selector func(RepoResult) int) int {
 	total := 0
 	for _, repo := range repos {
 		total += selector(repo)
+	}
+	return total
+}
+
+func countRepoField(repos []RepoResult, selector func(RepoResult) bool) int {
+	total := 0
+	for _, repo := range repos {
+		if selector(repo) {
+			total++
+		}
 	}
 	return total
 }

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -89,6 +89,10 @@ func TestAggregate(t *testing.T) {
 		Dependencies: []report.DependencyReport{
 			{
 				Name: "shared",
+				RuntimeUsage: &report.RuntimeUsage{
+					LoadCount:   2,
+					Correlation: report.RuntimeCorrelationOverlap,
+				},
 				Recommendations: []report.Recommendation{
 					{Code: "remove-unused-dependency"},
 				},
@@ -99,10 +103,23 @@ func TestAggregate(t *testing.T) {
 			{Name: "a-only"},
 		},
 		Summary: &report.Summary{DeniedLicenseCount: 2},
+		BaselineComparison: &report.BaselineComparison{
+			RuntimeRegressions: []report.DependencyDelta{{
+				Kind:     report.DependencyDeltaChanged,
+				Name:     "shared",
+				Language: "js-ts",
+				RuntimeDelta: &report.RuntimeDelta{
+					Comparable:      true,
+					BaselinePresent: true,
+					CurrentPresent:  true,
+					NewRuntimeLoads: true,
+				},
+			}},
+		},
 	}
 	reportB := report.Report{
 		Dependencies: []report.DependencyReport{
-			{Name: "shared"},
+			{Name: "shared", RuntimeUsage: &report.RuntimeUsage{LoadCount: 1, Correlation: report.RuntimeCorrelationOverlap}},
 			{Name: "b-only"},
 		},
 	}
@@ -134,6 +151,15 @@ func TestAggregate(t *testing.T) {
 	}
 	if data.Summary.CriticalCVEs != 1 {
 		t.Fatalf("expected one critical CVE signal, got %+v", data.Summary)
+	}
+	if data.Summary.ReposWithRuntimeTraceData != 2 {
+		t.Fatalf("expected two repos with runtime trace data, got %+v", data.Summary)
+	}
+	if data.Summary.ReposWithRuntimeRegressions != 1 {
+		t.Fatalf("expected one repo with runtime regressions, got %+v", data.Summary)
+	}
+	if !data.Repos[0].RuntimeTraceData || data.Repos[0].RuntimeRegressionCount != 1 {
+		t.Fatalf("expected first repo runtime regression counts, got %+v", data.Repos[0])
 	}
 	if len(data.CrossRepoDeps) != 1 || data.CrossRepoDeps[0].Name != "shared" || data.CrossRepoDeps[0].Count != 3 {
 		t.Fatalf("unexpected cross-repo dependency set: %#v", data.CrossRepoDeps)
@@ -179,6 +205,23 @@ func TestAggregateCrossRepoDuplicatesDistinguishesSameInferredRepoNames(t *testi
 	}
 }
 
+func TestComputeSummaryCountsRuntimeTraceAndRegressionRepos(t *testing.T) {
+	summary := computeSummary(Report{
+		Repos: []RepoResult{
+			{Name: "with-regression", DependencyCount: 1, RuntimeTraceData: true, RuntimeRegressionCount: 1},
+			{Name: "trace-only", DependencyCount: 1, RuntimeTraceData: true},
+			{Name: "no-trace", DependencyCount: 1, RuntimeRegressionCount: 1},
+		},
+	})
+
+	if summary.ReposWithRuntimeTraceData != 2 {
+		t.Fatalf("expected two repos with runtime trace data, got %+v", summary)
+	}
+	if summary.ReposWithRuntimeRegressions != 1 {
+		t.Fatalf("expected one trace-backed runtime regression repo, got %+v", summary)
+	}
+}
+
 func TestAggregateCopiesRemoteRevisionMetadata(t *testing.T) {
 	reportData := Aggregate(time.Date(2026, time.March, 10, 1, 2, 3, 0, time.UTC), []RepoAnalysis{
 		{
@@ -210,29 +253,31 @@ func TestFormatReport(t *testing.T) {
 		GeneratedAt: time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC),
 		Repos: []RepoResult{
 			{
-				Name:            testRepoA,
-				Path:            "./a",
-				RepoURL:         "https://github.com/example/a.git",
-				Revision:        &RepoRevision{Tag: "v1.0.0"},
-				ResolvedCommit:  "0123456789abcdef0123456789abcdef01234567",
-				DependencyCount: 1,
+				Name:                   testRepoA,
+				Path:                   "./a",
+				RepoURL:                "https://github.com/example/a.git",
+				Revision:               &RepoRevision{Tag: "v1.0.0"},
+				ResolvedCommit:         "0123456789abcdef0123456789abcdef01234567",
+				DependencyCount:        1,
+				RuntimeTraceData:       true,
+				RuntimeRegressionCount: 1,
 			},
 		},
-		Summary: Summary{TotalRepos: 1, TotalDeps: 1},
+		Summary: Summary{TotalRepos: 1, TotalDeps: 1, ReposWithRuntimeTraceData: 1, ReposWithRuntimeRegressions: 1},
 	}
 
 	jsonOutput, err := FormatReport(reportData, FormatJSON)
-	if err != nil || !strings.Contains(jsonOutput, "\"total_repos\": 1") || !strings.Contains(jsonOutput, "\"resolved_commit\": \"0123456789abcdef0123456789abcdef01234567\"") {
+	if err != nil || !strings.Contains(jsonOutput, "\"total_repos\": 1") || !strings.Contains(jsonOutput, "\"repos_with_runtime_regressions\": 1") || !strings.Contains(jsonOutput, "\"resolved_commit\": \"0123456789abcdef0123456789abcdef01234567\"") {
 		t.Fatalf("expected json output, err=%v output=%q", err, jsonOutput)
 	}
 
 	csvOutput, err := FormatReport(reportData, FormatCSV)
-	if err != nil || !strings.Contains(csvOutput, "total_repos,1") || !strings.Contains(csvOutput, "tag:v1.0.0,0123456789abcdef0123456789abcdef01234567") {
+	if err != nil || !strings.Contains(csvOutput, "total_repos,1") || !strings.Contains(csvOutput, "repos_with_runtime_regressions,1") || !strings.Contains(csvOutput, "tag:v1.0.0,0123456789abcdef0123456789abcdef01234567") {
 		t.Fatalf("expected csv output, err=%v output=%q", err, csvOutput)
 	}
 
 	htmlOutput, err := FormatReport(reportData, FormatHTML)
-	if err != nil || !strings.Contains(strings.ToLower(htmlOutput), "<html") || !strings.Contains(htmlOutput, "0123456789abcdef0123456789abcdef01234567") {
+	if err != nil || !strings.Contains(strings.ToLower(htmlOutput), "<html") || !strings.Contains(htmlOutput, "Runtime Regression Repos") || !strings.Contains(htmlOutput, "0123456789abcdef0123456789abcdef01234567") {
 		t.Fatalf("expected html output, err=%v output=%q", err, htmlOutput)
 	}
 }
@@ -312,7 +357,7 @@ func TestFormatReportCSVSanitizesCrossRepoAndRepoFormulaPrefixes(t *testing.T) {
 	repoRow := dashboardCSVRowAfterHeader(rows, "repo_name")
 	crossRepoRow := dashboardCSVRowAfterHeader(rows, "dependency_name")
 
-	if len(repoRow) != 13 || repoRow[0] != "'+repo" || repoRow[1] != "'@path" || repoRow[5] != "go" {
+	if len(repoRow) != 16 || repoRow[0] != "'+repo" || repoRow[1] != "'@path" || repoRow[5] != "go" {
 		t.Fatalf("expected sanitized repo csv row, got %#v", repoRow)
 	}
 	if len(crossRepoRow) != 3 || crossRepoRow[0] != "'-shared" || !strings.Contains(crossRepoRow[2], "'\trepo-d") {
@@ -557,7 +602,7 @@ func dashboardCSVRowAfterHeader(rows [][]string, header string) []string {
 
 func dashboardCSVContainsRepoRow(rows [][]string, name, path string) bool {
 	for _, row := range rows {
-		if len(row) == 13 && row[0] == name && row[1] == path {
+		if len(row) == 16 && row[0] == name && row[1] == path {
 			return true
 		}
 	}

--- a/internal/dashboard/format.go
+++ b/internal/dashboard/format.go
@@ -65,6 +65,8 @@ func writeDashboardSummaryCSV(write func([]string) error, reportData Report) err
 		{"total_waste_candidates", fmt.Sprintf("%d", reportData.Summary.TotalWasteCandidates)},
 		{"cross_repo_duplicates", fmt.Sprintf("%d", reportData.Summary.CrossRepoDuplicates)},
 		{"critical_cves", fmt.Sprintf("%d", reportData.Summary.CriticalCVEs)},
+		{"repos_with_runtime_trace_data", fmt.Sprintf("%d", reportData.Summary.ReposWithRuntimeTraceData)},
+		{"repos_with_runtime_regressions", fmt.Sprintf("%d", reportData.Summary.ReposWithRuntimeRegressions)},
 	}
 	for _, row := range summaryRows {
 		if err := write(csvsanitize.EscapeLeadingFormulaRow(row)); err != nil {
@@ -88,6 +90,9 @@ func writeDashboardRepoRowsCSV(write func([]string) error, repos []RepoResult) e
 		"top_risk_severity",
 		"critical_cves",
 		"denied_license_count",
+		"runtime_trace_data",
+		"runtime_regression_count",
+		"runtime_improvement_count",
 		"error",
 	})); err != nil {
 		return err
@@ -107,6 +112,9 @@ func writeDashboardRepoRowsCSV(write func([]string) error, repos []RepoResult) e
 			repoResult.TopRiskSeverity,
 			fmt.Sprintf("%d", repoResult.CriticalCVEs),
 			fmt.Sprintf("%d", repoResult.DeniedLicenseCount),
+			fmt.Sprintf("%t", repoResult.RuntimeTraceData),
+			fmt.Sprintf("%d", repoResult.RuntimeRegressionCount),
+			fmt.Sprintf("%d", repoResult.RuntimeImprovementCount),
 			repoResult.Error,
 		})); err != nil {
 			return err
@@ -162,6 +170,8 @@ func writeDashboardBaselineRowsCSV(write func([]string) error, comparison *Basel
 		{"total_waste_candidates_delta", fmt.Sprintf("%d", comparison.SummaryDelta.TotalWasteCandidatesDelta)},
 		{"cross_repo_duplicates_delta", fmt.Sprintf("%d", comparison.SummaryDelta.CrossRepoDuplicatesDelta)},
 		{"critical_cves_delta", fmt.Sprintf("%d", comparison.SummaryDelta.CriticalCVEsDelta)},
+		{"repos_with_runtime_trace_data_delta", fmt.Sprintf("%d", comparison.SummaryDelta.ReposWithRuntimeTraceDataDelta)},
+		{"repos_with_runtime_regressions_delta", fmt.Sprintf("%d", comparison.SummaryDelta.ReposWithRuntimeRegressionsDelta)},
 	}
 	for _, row := range summaryRows {
 		if err := write(csvsanitize.EscapeLeadingFormulaRow(row)); err != nil {
@@ -183,6 +193,8 @@ func writeDashboardBaselineRowsCSV(write func([]string) error, comparison *Basel
 		"waste_candidate_percent_delta",
 		"critical_cves_delta",
 		"denied_license_count_delta",
+		"runtime_regression_count_delta",
+		"runtime_improvement_count_delta",
 		"current_error",
 		"baseline_error",
 	})); err != nil {
@@ -198,6 +210,8 @@ func writeDashboardBaselineRowsCSV(write func([]string) error, comparison *Basel
 			fmt.Sprintf("%.2f", delta.WasteCandidatePercentDelta),
 			fmt.Sprintf("%d", delta.CriticalCVEsDelta),
 			fmt.Sprintf("%d", delta.DeniedLicenseCountDelta),
+			fmt.Sprintf("%d", delta.RuntimeRegressionCountDelta),
+			fmt.Sprintf("%d", delta.RuntimeImprovementCountDelta),
 			delta.CurrentError,
 			delta.BaselineError,
 		})); err != nil {
@@ -234,10 +248,12 @@ func formatHTML(reportData Report) string {
 	buffer.WriteString(metricHTML("Waste Candidates", fmt.Sprintf("%d", reportData.Summary.TotalWasteCandidates)))
 	buffer.WriteString(metricHTML("Cross-Repo Duplicates", fmt.Sprintf("%d", reportData.Summary.CrossRepoDuplicates)))
 	buffer.WriteString(metricHTML("Critical CVEs", fmt.Sprintf("%d", reportData.Summary.CriticalCVEs)))
+	buffer.WriteString(metricHTML("Runtime Trace Repos", fmt.Sprintf("%d", reportData.Summary.ReposWithRuntimeTraceData)))
+	buffer.WriteString(metricHTML("Runtime Regression Repos", fmt.Sprintf("%d", reportData.Summary.ReposWithRuntimeRegressions)))
 	buffer.WriteString("</div></section>")
 
 	buffer.WriteString("<h2>Per-Repo Summary</h2><table><thead><tr>")
-	buffer.WriteString("<th>Repo</th><th>Path</th><th>Repo URL</th><th>Revision</th><th>Resolved Commit</th><th>Language</th><th>Deps</th><th>Waste Candidates</th><th>Waste %</th><th>Top Risk</th><th>Critical CVEs</th><th>Denied Licenses</th><th>Error</th>")
+	buffer.WriteString("<th>Repo</th><th>Path</th><th>Repo URL</th><th>Revision</th><th>Resolved Commit</th><th>Language</th><th>Deps</th><th>Waste Candidates</th><th>Waste %</th><th>Top Risk</th><th>Critical CVEs</th><th>Denied Licenses</th><th>Runtime Trace</th><th>Runtime Regressions</th><th>Runtime Improvements</th><th>Error</th>")
 	buffer.WriteString("</tr></thead><tbody>")
 	for _, repoResult := range reportData.Repos {
 		buffer.WriteString("<tr>")
@@ -253,6 +269,9 @@ func formatHTML(reportData Report) string {
 		buffer.WriteString("<td>" + html.EscapeString(repoResult.TopRiskSeverity) + "</td>")
 		buffer.WriteString("<td>" + fmt.Sprintf("%d", repoResult.CriticalCVEs) + "</td>")
 		buffer.WriteString("<td>" + fmt.Sprintf("%d", repoResult.DeniedLicenseCount) + "</td>")
+		buffer.WriteString("<td>" + fmt.Sprintf("%t", repoResult.RuntimeTraceData) + "</td>")
+		buffer.WriteString("<td>" + fmt.Sprintf("%d", repoResult.RuntimeRegressionCount) + "</td>")
+		buffer.WriteString("<td>" + fmt.Sprintf("%d", repoResult.RuntimeImprovementCount) + "</td>")
 		buffer.WriteString("<td>" + html.EscapeString(repoResult.Error) + "</td>")
 		buffer.WriteString("</tr>")
 	}
@@ -291,11 +310,13 @@ func formatDashboardBaselineHTML(comparison *BaselineComparison) string {
 	buffer.WriteString(metricHTML("Waste Candidates Delta", fmt.Sprintf("%+d", comparison.SummaryDelta.TotalWasteCandidatesDelta)))
 	buffer.WriteString(metricHTML("Cross-Repo Delta", fmt.Sprintf("%+d", comparison.SummaryDelta.CrossRepoDuplicatesDelta)))
 	buffer.WriteString(metricHTML("Critical CVEs Delta", fmt.Sprintf("%+d", comparison.SummaryDelta.CriticalCVEsDelta)))
+	buffer.WriteString(metricHTML("Runtime Trace Repos Delta", fmt.Sprintf("%+d", comparison.SummaryDelta.ReposWithRuntimeTraceDataDelta)))
+	buffer.WriteString(metricHTML("Runtime Regression Repos Delta", fmt.Sprintf("%+d", comparison.SummaryDelta.ReposWithRuntimeRegressionsDelta)))
 	buffer.WriteString("</div></section>")
 
 	if len(comparison.RepoDeltas) > 0 {
 		buffer.WriteString("<table><thead><tr>")
-		buffer.WriteString("<th>Repo</th><th>Path</th><th>Kind</th><th>Deps Δ</th><th>Waste Δ</th><th>Waste % Δ</th><th>Critical CVEs Δ</th><th>Denied Licenses Δ</th><th>Current Error</th><th>Baseline Error</th>")
+		buffer.WriteString("<th>Repo</th><th>Path</th><th>Kind</th><th>Deps Δ</th><th>Waste Δ</th><th>Waste % Δ</th><th>Critical CVEs Δ</th><th>Denied Licenses Δ</th><th>Runtime Regressions Δ</th><th>Runtime Improvements Δ</th><th>Current Error</th><th>Baseline Error</th>")
 		buffer.WriteString(htmlTableBodyOpen)
 		for _, delta := range comparison.RepoDeltas {
 			buffer.WriteString("<tr>")
@@ -307,6 +328,8 @@ func formatDashboardBaselineHTML(comparison *BaselineComparison) string {
 			buffer.WriteString("<td>" + fmt.Sprintf("%+0.2f%%", delta.WasteCandidatePercentDelta) + "</td>")
 			buffer.WriteString("<td>" + fmt.Sprintf("%+d", delta.CriticalCVEsDelta) + "</td>")
 			buffer.WriteString("<td>" + fmt.Sprintf("%+d", delta.DeniedLicenseCountDelta) + "</td>")
+			buffer.WriteString("<td>" + fmt.Sprintf("%+d", delta.RuntimeRegressionCountDelta) + "</td>")
+			buffer.WriteString("<td>" + fmt.Sprintf("%+d", delta.RuntimeImprovementCountDelta) + "</td>")
 			buffer.WriteString("<td>" + html.EscapeString(delta.CurrentError) + "</td>")
 			buffer.WriteString("<td>" + html.EscapeString(delta.BaselineError) + "</td>")
 			buffer.WriteString("</tr>")

--- a/internal/dashboard/types.go
+++ b/internal/dashboard/types.go
@@ -85,20 +85,23 @@ func (r *RepoRevision) Value() string {
 }
 
 type RepoResult struct {
-	Name                  string        `json:"name"`
-	Path                  string        `json:"path"`
-	RepoURL               string        `json:"repo_url,omitempty"`
-	Revision              *RepoRevision `json:"revision,omitempty"`
-	ResolvedCommit        string        `json:"resolved_commit,omitempty"`
-	Language              string        `json:"language,omitempty"`
-	DependencyCount       int           `json:"dependency_count"`
-	WasteCandidateCount   int           `json:"waste_candidate_count"`
-	WasteCandidatePercent float64       `json:"waste_candidate_percent"`
-	TopRiskSeverity       string        `json:"top_risk_severity,omitempty"`
-	CriticalCVEs          int           `json:"critical_cves"`
-	DeniedLicenseCount    int           `json:"denied_license_count"`
-	Warnings              []string      `json:"warnings,omitempty"`
-	Error                 string        `json:"error,omitempty"`
+	Name                    string        `json:"name"`
+	Path                    string        `json:"path"`
+	RepoURL                 string        `json:"repo_url,omitempty"`
+	Revision                *RepoRevision `json:"revision,omitempty"`
+	ResolvedCommit          string        `json:"resolved_commit,omitempty"`
+	Language                string        `json:"language,omitempty"`
+	DependencyCount         int           `json:"dependency_count"`
+	WasteCandidateCount     int           `json:"waste_candidate_count"`
+	WasteCandidatePercent   float64       `json:"waste_candidate_percent"`
+	TopRiskSeverity         string        `json:"top_risk_severity,omitempty"`
+	CriticalCVEs            int           `json:"critical_cves"`
+	DeniedLicenseCount      int           `json:"denied_license_count"`
+	RuntimeTraceData        bool          `json:"runtime_trace_data,omitempty"`
+	RuntimeRegressionCount  int           `json:"runtime_regression_count,omitempty"`
+	RuntimeImprovementCount int           `json:"runtime_improvement_count,omitempty"`
+	Warnings                []string      `json:"warnings,omitempty"`
+	Error                   string        `json:"error,omitempty"`
 }
 
 type CrossRepoDependency struct {
@@ -108,11 +111,13 @@ type CrossRepoDependency struct {
 }
 
 type Summary struct {
-	TotalRepos           int `json:"total_repos"`
-	TotalDeps            int `json:"total_deps"`
-	TotalWasteCandidates int `json:"total_waste_candidates"`
-	CrossRepoDuplicates  int `json:"cross_repo_duplicates"`
-	CriticalCVEs         int `json:"critical_cves"`
+	TotalRepos                  int `json:"total_repos"`
+	TotalDeps                   int `json:"total_deps"`
+	TotalWasteCandidates        int `json:"total_waste_candidates"`
+	CrossRepoDuplicates         int `json:"cross_repo_duplicates"`
+	CriticalCVEs                int `json:"critical_cves"`
+	ReposWithRuntimeTraceData   int `json:"repos_with_runtime_trace_data"`
+	ReposWithRuntimeRegressions int `json:"repos_with_runtime_regressions"`
 }
 
 type BaselineComparison struct {
@@ -126,11 +131,13 @@ type BaselineComparison struct {
 }
 
 type SummaryDelta struct {
-	TotalReposDelta           int `json:"total_repos_delta"`
-	TotalDepsDelta            int `json:"total_deps_delta"`
-	TotalWasteCandidatesDelta int `json:"total_waste_candidates_delta"`
-	CrossRepoDuplicatesDelta  int `json:"cross_repo_duplicates_delta"`
-	CriticalCVEsDelta         int `json:"critical_cves_delta"`
+	TotalReposDelta                  int `json:"total_repos_delta"`
+	TotalDepsDelta                   int `json:"total_deps_delta"`
+	TotalWasteCandidatesDelta        int `json:"total_waste_candidates_delta"`
+	CrossRepoDuplicatesDelta         int `json:"cross_repo_duplicates_delta"`
+	CriticalCVEsDelta                int `json:"critical_cves_delta"`
+	ReposWithRuntimeTraceDataDelta   int `json:"repos_with_runtime_trace_data_delta"`
+	ReposWithRuntimeRegressionsDelta int `json:"repos_with_runtime_regressions_delta"`
 }
 
 type RepoDeltaKind string
@@ -142,16 +149,18 @@ const (
 )
 
 type RepoDelta struct {
-	Kind                       RepoDeltaKind `json:"kind"`
-	Name                       string        `json:"name"`
-	Path                       string        `json:"path,omitempty"`
-	DependencyCountDelta       int           `json:"dependency_count_delta"`
-	WasteCandidateCountDelta   int           `json:"waste_candidate_count_delta"`
-	WasteCandidatePercentDelta float64       `json:"waste_candidate_percent_delta"`
-	CriticalCVEsDelta          int           `json:"critical_cves_delta"`
-	DeniedLicenseCountDelta    int           `json:"denied_license_count_delta"`
-	CurrentError               string        `json:"current_error,omitempty"`
-	BaselineError              string        `json:"baseline_error,omitempty"`
+	Kind                         RepoDeltaKind `json:"kind"`
+	Name                         string        `json:"name"`
+	Path                         string        `json:"path,omitempty"`
+	DependencyCountDelta         int           `json:"dependency_count_delta"`
+	WasteCandidateCountDelta     int           `json:"waste_candidate_count_delta"`
+	WasteCandidatePercentDelta   float64       `json:"waste_candidate_percent_delta"`
+	CriticalCVEsDelta            int           `json:"critical_cves_delta"`
+	DeniedLicenseCountDelta      int           `json:"denied_license_count_delta"`
+	RuntimeRegressionCountDelta  int           `json:"runtime_regression_count_delta"`
+	RuntimeImprovementCountDelta int           `json:"runtime_improvement_count_delta"`
+	CurrentError                 string        `json:"current_error,omitempty"`
+	BaselineError                string        `json:"baseline_error,omitempty"`
 }
 
 type Report struct {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -828,6 +828,9 @@ func summarizeReport(kind analysisToolKind, reportData report.Report) string {
 	summary := fmt.Sprintf("%s completed: %d dependencies, %.1f%% used exports, %.1f%% waste.", label, reportData.Summary.DependencyCount, reportData.Summary.UsedPercent, waste)
 	if reportData.BaselineComparison != nil {
 		summary += fmt.Sprintf(" Waste delta: %.1f%%.", reportData.BaselineComparison.SummaryDelta.WastePercentDelta)
+		if len(reportData.BaselineComparison.RuntimeRegressions) > 0 || len(reportData.BaselineComparison.RuntimeImprovements) > 0 {
+			summary += fmt.Sprintf(" Runtime regressions: %d. Runtime improvements: %d.", len(reportData.BaselineComparison.RuntimeRegressions), len(reportData.BaselineComparison.RuntimeImprovements))
+		}
 	}
 	return summary
 }

--- a/internal/report/baseline_diff.go
+++ b/internal/report/baseline_diff.go
@@ -126,6 +126,12 @@ func appendDependencyDelta(comparison *BaselineComparison, delta DependencyDelta
 		} else if delta.WastePercentDelta < 0 {
 			comparison.Progressions = append(comparison.Progressions, delta)
 		}
+		if runtimeDeltaIsRegression(delta.RuntimeDelta) {
+			comparison.RuntimeRegressions = append(comparison.RuntimeRegressions, delta)
+		}
+		if runtimeDeltaIsImprovement(delta.RuntimeDelta) {
+			comparison.RuntimeImprovements = append(comparison.RuntimeImprovements, delta)
+		}
 	}
 }
 
@@ -200,16 +206,181 @@ func dependencyDelta(curr DependencyReport, hasCurrent bool, base DependencyRepo
 		delta.UsedPercentDelta = curr.UsedPercent - base.UsedPercent
 		delta.EstimatedUnusedBytesDelta = curr.EstimatedUnusedBytes - base.EstimatedUnusedBytes
 		delta.WastePercentDelta = wasteFromDependency(curr) - wasteFromDependency(base)
+		runtimeDelta, runtimeChanged := dependencyRuntimeDelta(curr.RuntimeUsage, base.RuntimeUsage)
+		delta.RuntimeDelta = runtimeDelta
 		delta.DeniedIntroduced = isDenied(curr) && !isDenied(base)
 		if delta.UsedExportsCountDelta == 0 &&
 			delta.TotalExportsCountDelta == 0 &&
 			delta.UsedPercentDelta == 0 &&
 			delta.EstimatedUnusedBytesDelta == 0 &&
+			!runtimeChanged &&
 			!delta.DeniedIntroduced {
 			return DependencyDelta{}, false
 		}
 		return delta, true
 	}
+}
+
+func dependencyRuntimeDelta(currentUsage, baselineUsage *RuntimeUsage) (*RuntimeDelta, bool) {
+	if currentUsage == nil && baselineUsage == nil {
+		return nil, false
+	}
+
+	delta := runtimePresenceDelta(currentUsage, baselineUsage)
+	if currentUsage == nil || baselineUsage == nil {
+		return delta, false
+	}
+
+	delta.Comparable = true
+	appendRuntimeLoadCountChanges(delta, currentUsage, baselineUsage)
+	appendRuntimeCorrelationChange(delta, currentUsage, baselineUsage)
+	appendRuntimeOnlyChange(delta, currentUsage, baselineUsage)
+	appendRuntimeCollectionChanges(delta, currentUsage, baselineUsage)
+	return delta, len(delta.ChangeTypes) > 0
+}
+
+func runtimePresenceDelta(currentUsage, baselineUsage *RuntimeUsage) *RuntimeDelta {
+	delta := &RuntimeDelta{
+		BaselinePresent: baselineUsage != nil,
+		CurrentPresent:  currentUsage != nil,
+	}
+	if baselineUsage != nil {
+		delta.BaselineLoadCount = intPointer(baselineUsage.LoadCount)
+	}
+	if currentUsage != nil {
+		delta.CurrentLoadCount = intPointer(currentUsage.LoadCount)
+	}
+	return delta
+}
+
+func appendRuntimeLoadCountChanges(delta *RuntimeDelta, currentUsage, baselineUsage *RuntimeUsage) {
+	loadCountDelta := currentUsage.LoadCount - baselineUsage.LoadCount
+	delta.LoadCountDelta = intPointer(loadCountDelta)
+	if loadCountDelta != 0 {
+		delta.ChangeTypes = append(delta.ChangeTypes, RuntimeChangeLoadCount)
+	}
+	if baselineUsage.LoadCount == 0 && currentUsage.LoadCount > 0 {
+		delta.NewRuntimeLoads = true
+		delta.ChangeTypes = append(delta.ChangeTypes, RuntimeChangeNewRuntimeLoads)
+	}
+	if baselineUsage.LoadCount > 0 && currentUsage.LoadCount == 0 {
+		delta.RemovedRuntimeLoads = true
+		delta.ChangeTypes = append(delta.ChangeTypes, RuntimeChangeRemovedRuntimeLoads)
+	}
+}
+
+func appendRuntimeCorrelationChange(delta *RuntimeDelta, currentUsage, baselineUsage *RuntimeUsage) {
+	delta.BaselineCorrelation = runtimeUsageCorrelation(baselineUsage)
+	delta.CurrentCorrelation = runtimeUsageCorrelation(currentUsage)
+	if delta.BaselineCorrelation != delta.CurrentCorrelation {
+		delta.ChangeTypes = append(delta.ChangeTypes, RuntimeChangeCorrelation)
+	}
+}
+
+func appendRuntimeOnlyChange(delta *RuntimeDelta, currentUsage, baselineUsage *RuntimeUsage) {
+	baselineRuntimeOnly := isRuntimeOnlyUsage(baselineUsage)
+	currentRuntimeOnly := isRuntimeOnlyUsage(currentUsage)
+	if currentRuntimeOnly && !baselineRuntimeOnly {
+		delta.RuntimeOnlyRegression = true
+		delta.ChangeTypes = append(delta.ChangeTypes, RuntimeChangeRuntimeOnlyRegression)
+	}
+	if baselineRuntimeOnly && !currentRuntimeOnly {
+		delta.RuntimeOnlyImprovement = true
+		delta.ChangeTypes = append(delta.ChangeTypes, RuntimeChangeRuntimeOnlyImprovement)
+	}
+}
+
+func appendRuntimeCollectionChanges(delta *RuntimeDelta, currentUsage, baselineUsage *RuntimeUsage) {
+	delta.ModulesAdded, delta.ModulesRemoved, delta.ModulesChanged = compareRuntimeModuleUsage(currentUsage.Modules, baselineUsage.Modules)
+	appendRuntimeCollectionChangeType(delta, RuntimeChangeModules, delta.ModulesAdded, delta.ModulesRemoved, delta.ModulesChanged)
+	delta.ParentModulesAdded, delta.ParentModulesRemoved, delta.ParentModulesChanged = compareRuntimeModuleUsage(currentUsage.ParentModules, baselineUsage.ParentModules)
+	appendRuntimeCollectionChangeType(delta, RuntimeChangeParentModules, delta.ParentModulesAdded, delta.ParentModulesRemoved, delta.ParentModulesChanged)
+	delta.EntrypointsAdded, delta.EntrypointsRemoved, delta.EntrypointsChanged = compareRuntimeModuleUsage(currentUsage.Entrypoints, baselineUsage.Entrypoints)
+	appendRuntimeCollectionChangeType(delta, RuntimeChangeEntrypoints, delta.EntrypointsAdded, delta.EntrypointsRemoved, delta.EntrypointsChanged)
+}
+
+func appendRuntimeCollectionChangeType(delta *RuntimeDelta, changeType RuntimeChangeType, added, removed, changed []RuntimeModuleDelta) {
+	if len(added) > 0 || len(removed) > 0 || len(changed) > 0 {
+		delta.ChangeTypes = append(delta.ChangeTypes, changeType)
+	}
+}
+
+func compareRuntimeModuleUsage(current, baseline []RuntimeModuleUsage) ([]RuntimeModuleDelta, []RuntimeModuleDelta, []RuntimeModuleDelta) {
+	currentByModule := runtimeModuleCounts(current)
+	baselineByModule := runtimeModuleCounts(baseline)
+	keys := make([]string, 0, len(currentByModule)+len(baselineByModule))
+	seen := make(map[string]struct{}, len(currentByModule)+len(baselineByModule))
+	for module := range currentByModule {
+		keys = append(keys, module)
+		seen[module] = struct{}{}
+	}
+	for module := range baselineByModule {
+		if _, ok := seen[module]; ok {
+			continue
+		}
+		keys = append(keys, module)
+	}
+	sort.Strings(keys)
+
+	added := make([]RuntimeModuleDelta, 0)
+	removed := make([]RuntimeModuleDelta, 0)
+	changed := make([]RuntimeModuleDelta, 0)
+	for _, module := range keys {
+		currentCount, hasCurrent := currentByModule[module]
+		baselineCount, hasBaseline := baselineByModule[module]
+		moduleDelta := RuntimeModuleDelta{
+			Module:        module,
+			BaselineCount: baselineCount,
+			CurrentCount:  currentCount,
+			CountDelta:    currentCount - baselineCount,
+		}
+		switch {
+		case hasCurrent && !hasBaseline:
+			added = append(added, moduleDelta)
+		case !hasCurrent && hasBaseline:
+			removed = append(removed, moduleDelta)
+		case moduleDelta.CountDelta != 0:
+			changed = append(changed, moduleDelta)
+		}
+	}
+	return added, removed, changed
+}
+
+func runtimeModuleCounts(items []RuntimeModuleUsage) map[string]int {
+	counts := make(map[string]int, len(items))
+	for _, item := range items {
+		counts[item.Module] += item.Count
+	}
+	return counts
+}
+
+func runtimeDeltaIsRegression(delta *RuntimeDelta) bool {
+	if delta == nil || !delta.Comparable {
+		return false
+	}
+	return delta.NewRuntimeLoads || delta.RuntimeOnlyRegression || runtimeDeltaLoadCount(delta) > 0
+}
+
+func runtimeDeltaIsImprovement(delta *RuntimeDelta) bool {
+	if delta == nil || !delta.Comparable {
+		return false
+	}
+	return delta.RemovedRuntimeLoads || delta.RuntimeOnlyImprovement || runtimeDeltaLoadCount(delta) < 0
+}
+
+func runtimeDeltaLoadCount(delta *RuntimeDelta) int {
+	if delta == nil || delta.LoadCountDelta == nil {
+		return 0
+	}
+	return *delta.LoadCountDelta
+}
+
+func isRuntimeOnlyUsage(usage *RuntimeUsage) bool {
+	return usage != nil && (usage.RuntimeOnly || runtimeUsageCorrelation(usage) == RuntimeCorrelationRuntimeOnly)
+}
+
+func intPointer(value int) *int {
+	return &value
 }
 
 func wasteFromDependency(dep DependencyReport) float64 {

--- a/internal/report/baseline_diff_test.go
+++ b/internal/report/baseline_diff_test.go
@@ -208,6 +208,174 @@ func TestComputeBaselineComparisonTracksNewDeniedLicenses(t *testing.T) {
 	}
 }
 
+func TestComputeBaselineComparisonRuntimeMissingBaselineDataIsNotZeroLoads(t *testing.T) {
+	current := Report{
+		Dependencies: []DependencyReport{{
+			Name:              "alpha",
+			Language:          "js-ts",
+			UsedExportsCount:  1,
+			TotalExportsCount: 4,
+			UsedPercent:       25,
+			RuntimeUsage: &RuntimeUsage{
+				LoadCount:   3,
+				Correlation: RuntimeCorrelationOverlap,
+			},
+		}},
+	}
+	baseline := Report{
+		Dependencies: []DependencyReport{{
+			Name:              "alpha",
+			Language:          "js-ts",
+			UsedExportsCount:  2,
+			TotalExportsCount: 4,
+			UsedPercent:       50,
+		}},
+	}
+
+	comparison := ComputeBaselineComparison(current, baseline)
+	if len(comparison.RuntimeRegressions) != 0 {
+		t.Fatalf("missing baseline runtime data must not create runtime regressions: %#v", comparison.RuntimeRegressions)
+	}
+	if len(comparison.Dependencies) != 1 {
+		t.Fatalf("expected export delta to keep dependency row, got %#v", comparison.Dependencies)
+	}
+	runtimeDelta := comparison.Dependencies[0].RuntimeDelta
+	if runtimeDelta == nil {
+		t.Fatalf("expected runtime availability context on changed dependency")
+	}
+	if runtimeDelta.Comparable {
+		t.Fatalf("expected runtime delta with missing baseline to be non-comparable")
+	}
+	if runtimeDelta.BaselinePresent || !runtimeDelta.CurrentPresent {
+		t.Fatalf("unexpected runtime availability flags: %#v", runtimeDelta)
+	}
+	if runtimeDelta.LoadCountDelta != nil {
+		t.Fatalf("missing baseline runtime data must not produce load delta, got %d", *runtimeDelta.LoadCountDelta)
+	}
+}
+
+func TestComputeBaselineComparisonRuntimeOnlyChangesDoNotPolluteAddedRemovedDependencies(t *testing.T) {
+	current := Report{
+		Dependencies: []DependencyReport{{
+			Name:              "new-runtime",
+			Language:          "js-ts",
+			UsedExportsCount:  1,
+			TotalExportsCount: 1,
+			UsedPercent:       100,
+			RuntimeUsage:      &RuntimeUsage{LoadCount: 3, Correlation: RuntimeCorrelationRuntimeOnly, RuntimeOnly: true},
+		}},
+	}
+	baseline := Report{
+		Dependencies: []DependencyReport{{
+			Name:              "removed-runtime",
+			Language:          "js-ts",
+			UsedExportsCount:  1,
+			TotalExportsCount: 1,
+			UsedPercent:       100,
+			RuntimeUsage:      &RuntimeUsage{LoadCount: 2, Correlation: RuntimeCorrelationOverlap},
+		}},
+	}
+
+	comparison := ComputeBaselineComparison(current, baseline)
+	if len(comparison.Added) != 1 || comparison.Added[0].RuntimeDelta != nil {
+		t.Fatalf("added dependencies should not produce runtime baseline deltas: %#v", comparison.Added)
+	}
+	if len(comparison.Removed) != 1 || comparison.Removed[0].RuntimeDelta != nil {
+		t.Fatalf("removed dependencies should not produce runtime baseline deltas: %#v", comparison.Removed)
+	}
+	if len(comparison.RuntimeRegressions) != 0 || len(comparison.RuntimeImprovements) != 0 {
+		t.Fatalf("new/removed dependencies should not be classified as runtime regressions/improvements: %#v %#v", comparison.RuntimeRegressions, comparison.RuntimeImprovements)
+	}
+}
+
+func TestComputeBaselineComparisonRuntimeCorrelationTransitions(t *testing.T) {
+	current := Report{
+		Dependencies: []DependencyReport{
+			{
+				Name:              "regression",
+				Language:          "js-ts",
+				UsedExportsCount:  1,
+				TotalExportsCount: 2,
+				UsedPercent:       50,
+				RuntimeUsage: &RuntimeUsage{
+					LoadCount:     2,
+					Correlation:   RuntimeCorrelationRuntimeOnly,
+					RuntimeOnly:   true,
+					Modules:       []RuntimeModuleUsage{{Module: "regression/runtime", Count: 2}},
+					ParentModules: []RuntimeModuleUsage{{Module: "src/new-parent.js", Count: 2}},
+					Entrypoints:   []RuntimeModuleUsage{{Module: "src/new-entry.js", Count: 2}},
+				},
+			},
+			{
+				Name:              "improvement",
+				Language:          "js-ts",
+				UsedExportsCount:  1,
+				TotalExportsCount: 2,
+				UsedPercent:       50,
+				RuntimeUsage: &RuntimeUsage{
+					LoadCount:   0,
+					Correlation: RuntimeCorrelationStaticOnly,
+				},
+			},
+		},
+	}
+	baseline := Report{
+		Dependencies: []DependencyReport{
+			{
+				Name:              "regression",
+				Language:          "js-ts",
+				UsedExportsCount:  1,
+				TotalExportsCount: 2,
+				UsedPercent:       50,
+				RuntimeUsage: &RuntimeUsage{
+					LoadCount:     0,
+					Correlation:   RuntimeCorrelationStaticOnly,
+					ParentModules: []RuntimeModuleUsage{{Module: "src/old-parent.js", Count: 1}},
+					Entrypoints:   []RuntimeModuleUsage{{Module: "src/old-entry.js", Count: 1}},
+				},
+			},
+			{
+				Name:              "improvement",
+				Language:          "js-ts",
+				UsedExportsCount:  1,
+				TotalExportsCount: 2,
+				UsedPercent:       50,
+				RuntimeUsage: &RuntimeUsage{
+					LoadCount:   3,
+					Correlation: RuntimeCorrelationRuntimeOnly,
+					RuntimeOnly: true,
+				},
+			},
+		},
+	}
+
+	comparison := ComputeBaselineComparison(current, baseline)
+	if len(comparison.RuntimeRegressions) != 1 || comparison.RuntimeRegressions[0].Name != "regression" {
+		t.Fatalf("expected one runtime regression, got %#v", comparison.RuntimeRegressions)
+	}
+	regressionDelta := comparison.RuntimeRegressions[0].RuntimeDelta
+	if regressionDelta == nil || !regressionDelta.NewRuntimeLoads || !regressionDelta.RuntimeOnlyRegression {
+		t.Fatalf("expected new runtime load and runtime-only regression flags, got %#v", regressionDelta)
+	}
+	if regressionDelta.BaselineCorrelation != RuntimeCorrelationStaticOnly || regressionDelta.CurrentCorrelation != RuntimeCorrelationRuntimeOnly {
+		t.Fatalf("expected correlation transition, got %#v", regressionDelta)
+	}
+	if len(regressionDelta.ParentModulesAdded) != 1 || len(regressionDelta.ParentModulesRemoved) != 1 {
+		t.Fatalf("expected parent module changes, got %#v", regressionDelta)
+	}
+	if len(regressionDelta.EntrypointsAdded) != 1 || len(regressionDelta.EntrypointsRemoved) != 1 {
+		t.Fatalf("expected entrypoint changes, got %#v", regressionDelta)
+	}
+
+	if len(comparison.RuntimeImprovements) != 1 || comparison.RuntimeImprovements[0].Name != "improvement" {
+		t.Fatalf("expected one runtime improvement, got %#v", comparison.RuntimeImprovements)
+	}
+	improvementDelta := comparison.RuntimeImprovements[0].RuntimeDelta
+	if improvementDelta == nil || !improvementDelta.RemovedRuntimeLoads || !improvementDelta.RuntimeOnlyImprovement {
+		t.Fatalf("expected removed runtime load and runtime-only improvement flags, got %#v", improvementDelta)
+	}
+}
+
 func TestBaselineDiffAdditionalBranches(t *testing.T) {
 	current := Report{
 		Dependencies: []DependencyReport{

--- a/internal/report/format_cyclonedx.go
+++ b/internal/report/format_cyclonedx.go
@@ -278,6 +278,7 @@ func appendCycloneDXBaselineDeltaProperties(props *[]cycloneDXProperty, delta De
 	appendCycloneDXProperty(props, "lopper:baseline:used-percent-delta", formatCycloneDXFloat(delta.UsedPercentDelta))
 	appendCycloneDXProperty(props, "lopper:baseline:waste-percent-delta", formatCycloneDXFloat(delta.WastePercentDelta))
 	appendCycloneDXProperty(props, "lopper:baseline:estimated-unused-bytes-delta", strconv.FormatInt(delta.EstimatedUnusedBytesDelta, 10))
+	appendCycloneDXJSONProperty(props, "lopper:baseline:runtime-delta", delta.RuntimeDelta)
 	appendCycloneDXProperty(props, "lopper:baseline:denied-introduced", strconv.FormatBool(delta.DeniedIntroduced))
 }
 

--- a/internal/report/format_cyclonedx_test.go
+++ b/internal/report/format_cyclonedx_test.go
@@ -129,6 +129,7 @@ func TestFormatCycloneDXJSONDeterministicOrdering(t *testing.T) {
 }
 
 func TestFormatCycloneDXJSONPreservesDependencySurfaceMetadata(t *testing.T) {
+	loadDelta := 3
 	reportData := Report{
 		SchemaVersion: SchemaVersion,
 		RepoPath:      ".",
@@ -148,7 +149,14 @@ func TestFormatCycloneDXJSONPreservesDependencySurfaceMetadata(t *testing.T) {
 				UsedPercentDelta:          -5,
 				WastePercentDelta:         5,
 				EstimatedUnusedBytesDelta: 128,
-				DeniedIntroduced:          true,
+				RuntimeDelta: &RuntimeDelta{
+					Comparable:      true,
+					BaselinePresent: true,
+					CurrentPresent:  true,
+					LoadCountDelta:  &loadDelta,
+					NewRuntimeLoads: true,
+				},
+				DeniedIntroduced: true,
 			}},
 		},
 		Dependencies: []DependencyReport{{
@@ -216,6 +224,10 @@ func TestFormatCycloneDXJSONPreservesDependencySurfaceMetadata(t *testing.T) {
 	requireCycloneDXProperty(t, component.Properties, "lopper:removal-candidate:score", "71")
 	requireCycloneDXProperty(t, component.Properties, "lopper:baseline:kind", "changed")
 	requireCycloneDXProperty(t, component.Properties, "lopper:baseline:denied-introduced", "true")
+	runtimeDelta, ok := cycloneDXPropertyValue(component.Properties, "lopper:baseline:runtime-delta")
+	if !ok || !strings.Contains(runtimeDelta, `"newRuntimeLoads":true`) {
+		t.Fatalf("expected CycloneDX runtime baseline delta, got %q", runtimeDelta)
+	}
 	requireCycloneDXProperty(t, bom.Properties, "lopper:baseline:key", "commit:base")
 
 	provenanceSignals, ok := cycloneDXPropertyValue(component.Properties, "lopper:provenance:signals")

--- a/internal/report/format_pr_comment.go
+++ b/internal/report/format_pr_comment.go
@@ -28,6 +28,12 @@ func formatPRComment(report Report) string {
 	buffer.WriteString("| Changed | Regressions | Progressions | Added | Removed | Unchanged |\n")
 	buffer.WriteString("| --- | --- | --- | --- | --- | --- |\n")
 	buffer.WriteString(fmt.Sprintf("| %d | %d | %d | %d | %d | %d |\n", len(comparison.Dependencies), len(comparison.Regressions), len(comparison.Progressions), len(comparison.Added), len(comparison.Removed), comparison.UnchangedRows))
+	if len(comparison.RuntimeRegressions) > 0 || len(comparison.RuntimeImprovements) > 0 {
+		buffer.WriteString("\n| Runtime trace deltas | Count |\n")
+		buffer.WriteString("| --- | --- |\n")
+		buffer.WriteString(fmt.Sprintf("| Runtime regressions | %d |\n", len(comparison.RuntimeRegressions)))
+		buffer.WriteString(fmt.Sprintf("| Runtime improvements | %d |\n", len(comparison.RuntimeImprovements)))
+	}
 
 	if len(comparison.NewDeniedLicenses) > 0 {
 		buffer.WriteString("\n### Newly denied licenses\n\n")
@@ -37,6 +43,9 @@ func formatPRComment(report Report) string {
 			buffer.WriteString(fmt.Sprintf("| %d | `%s` | %s | %s |\n", i+1, escapeMarkdownTable(denied.Name), escapeMarkdownTable(denied.Language), escapeMarkdownTable(denied.SPDX)))
 		}
 	}
+
+	appendRuntimePRCommentSection(&buffer, "Runtime regressions", comparison.RuntimeRegressions)
+	appendRuntimePRCommentSection(&buffer, "Runtime improvements", comparison.RuntimeImprovements)
 
 	top := topDependencyDeltas(comparison.Dependencies, 10)
 	if len(top) == 0 {
@@ -64,6 +73,27 @@ func formatPRComment(report Report) string {
 	return buffer.String()
 }
 
+func appendRuntimePRCommentSection(buffer *strings.Builder, title string, deltas []DependencyDelta) {
+	top := topRuntimeDeltas(deltas, 10)
+	if len(top) == 0 {
+		return
+	}
+	buffer.WriteString("\n### ")
+	buffer.WriteString(title)
+	buffer.WriteString("\n\n")
+	buffer.WriteString("| # | Dependency | Language | Runtime delta |\n")
+	buffer.WriteString("| --- | --- | --- | --- |\n")
+	for i, delta := range top {
+		row := []string{
+			fmt.Sprintf("%d", i+1),
+			"`" + escapeMarkdownTable(delta.Name) + "`",
+			escapeMarkdownTable(delta.Language),
+			escapeMarkdownTable(formatRuntimeDelta(delta.RuntimeDelta)),
+		}
+		buffer.WriteString("| " + strings.Join(row, " | ") + " |\n")
+	}
+}
+
 func topDependencyDeltas(deltas []DependencyDelta, limit int) []DependencyDelta {
 	if len(deltas) == 0 || limit <= 0 {
 		return make([]DependencyDelta, 0)
@@ -75,6 +105,34 @@ func topDependencyDeltas(deltas []DependencyDelta, limit int) []DependencyDelta 
 			leftMagnitude = -leftMagnitude
 		}
 		rightMagnitude := copied[j].EstimatedUnusedBytesDelta
+		if rightMagnitude < 0 {
+			rightMagnitude = -rightMagnitude
+		}
+		if leftMagnitude != rightMagnitude {
+			return leftMagnitude > rightMagnitude
+		}
+		if copied[i].Language != copied[j].Language {
+			return copied[i].Language < copied[j].Language
+		}
+		return copied[i].Name < copied[j].Name
+	})
+	if len(copied) < limit {
+		return copied
+	}
+	return copied[:limit]
+}
+
+func topRuntimeDeltas(deltas []DependencyDelta, limit int) []DependencyDelta {
+	if len(deltas) == 0 || limit <= 0 {
+		return make([]DependencyDelta, 0)
+	}
+	copied := append([]DependencyDelta(nil), deltas...)
+	sort.Slice(copied, func(i, j int) bool {
+		leftMagnitude := runtimeDeltaLoadCount(copied[i].RuntimeDelta)
+		if leftMagnitude < 0 {
+			leftMagnitude = -leftMagnitude
+		}
+		rightMagnitude := runtimeDeltaLoadCount(copied[j].RuntimeDelta)
 		if rightMagnitude < 0 {
 			rightMagnitude = -rightMagnitude
 		}

--- a/internal/report/format_table_sections.go
+++ b/internal/report/format_table_sections.go
@@ -215,6 +215,9 @@ func appendBaselineComparison(buffer *bytes.Buffer, comparison *BaselineComparis
 	writef(buffer, "- summary_delta: deps %+d, used %% %+0.1f, waste %% %+0.1f, unused bytes %+d\n", comparison.SummaryDelta.DependencyCountDelta, comparison.SummaryDelta.UsedPercentDelta, comparison.SummaryDelta.WastePercentDelta, comparison.SummaryDelta.UnusedBytesDelta)
 	writef(buffer, "- license_delta: known %+d, unknown %+d, denied %+d\n", comparison.SummaryDelta.KnownLicenseCountDelta, comparison.SummaryDelta.UnknownLicenseCountDelta, comparison.SummaryDelta.DeniedLicenseCountDelta)
 	writef(buffer, "- changed: %d, regressions: %d, progressions: %d, added: %d, removed: %d, unchanged: %d\n", len(comparison.Dependencies), len(comparison.Regressions), len(comparison.Progressions), len(comparison.Added), len(comparison.Removed), comparison.UnchangedRows)
+	if len(comparison.RuntimeRegressions) > 0 || len(comparison.RuntimeImprovements) > 0 {
+		writef(buffer, "- runtime_trace_delta: regressions %d, improvements %d\n", len(comparison.RuntimeRegressions), len(comparison.RuntimeImprovements))
+	}
 	if len(comparison.NewDeniedLicenses) > 0 {
 		for _, denied := range comparison.NewDeniedLicenses {
 			writef(buffer, "  new denied license %s/%s (%s)\n", denied.Language, denied.Name, denied.SPDX)
@@ -226,6 +229,12 @@ func appendBaselineComparison(buffer *bytes.Buffer, comparison *BaselineComparis
 	}
 	for _, delta := range topWasteDeltas(comparison.Progressions, 3) {
 		writef(buffer, "  progression %s/%s waste %+0.1f%% used %+0.1f%%\n", delta.Language, delta.Name, delta.WastePercentDelta, delta.UsedPercentDelta)
+	}
+	for _, delta := range topRuntimeDeltas(comparison.RuntimeRegressions, 3) {
+		writef(buffer, "  runtime regression %s/%s %s\n", delta.Language, delta.Name, formatRuntimeDelta(delta.RuntimeDelta))
+	}
+	for _, delta := range topRuntimeDeltas(comparison.RuntimeImprovements, 3) {
+		writef(buffer, "  runtime improvement %s/%s %s\n", delta.Language, delta.Name, formatRuntimeDelta(delta.RuntimeDelta))
 	}
 	buffer.WriteString("\n")
 }

--- a/internal/report/format_table_values.go
+++ b/internal/report/format_table_values.go
@@ -63,6 +63,75 @@ func formatRuntimeUsage(usage *RuntimeUsage) string {
 	return sanitizeTerminalString(strings.Join(parts, "; "))
 }
 
+func formatRuntimeDelta(delta *RuntimeDelta) string {
+	if delta == nil {
+		return "-"
+	}
+	if !delta.Comparable {
+		return formatRuntimeDeltaNotComparable(delta)
+	}
+
+	parts := make([]string, 0, 6)
+	appendRuntimeDeltaPart(&parts, formatRuntimeLoadDelta(delta))
+	appendRuntimeDeltaPart(&parts, runtimeDeltaFlag(delta.NewRuntimeLoads, "new runtime loads"))
+	appendRuntimeDeltaPart(&parts, runtimeDeltaFlag(delta.RemovedRuntimeLoads, "removed runtime loads"))
+	appendRuntimeDeltaPart(&parts, formatRuntimeCorrelationDelta(delta))
+	appendRuntimeDeltaPart(&parts, runtimeDeltaFlag(delta.RuntimeOnlyRegression, "runtime-only regression"))
+	appendRuntimeDeltaPart(&parts, runtimeDeltaFlag(delta.RuntimeOnlyImprovement, "runtime-only improvement"))
+	appendRuntimeDeltaPart(&parts, runtimeModuleGroupDelta("modules", delta.ModulesAdded, delta.ModulesRemoved, delta.ModulesChanged))
+	appendRuntimeDeltaPart(&parts, runtimeModuleGroupDelta("parent modules", delta.ParentModulesAdded, delta.ParentModulesRemoved, delta.ParentModulesChanged))
+	appendRuntimeDeltaPart(&parts, runtimeModuleGroupDelta("entrypoints", delta.EntrypointsAdded, delta.EntrypointsRemoved, delta.EntrypointsChanged))
+	if len(parts) == 0 {
+		return "no runtime delta"
+	}
+	return sanitizeTerminalString(strings.Join(parts, "; "))
+}
+
+func formatRuntimeDeltaNotComparable(delta *RuntimeDelta) string {
+	switch {
+	case !delta.BaselinePresent && delta.CurrentPresent:
+		return "not comparable (baseline runtime data missing)"
+	case delta.BaselinePresent && !delta.CurrentPresent:
+		return "not comparable (current runtime data missing)"
+	default:
+		return "not comparable"
+	}
+}
+
+func formatRuntimeLoadDelta(delta *RuntimeDelta) string {
+	if delta.LoadCountDelta == nil || *delta.LoadCountDelta == 0 {
+		return ""
+	}
+	return fmt.Sprintf("loads %+d", *delta.LoadCountDelta)
+}
+
+func formatRuntimeCorrelationDelta(delta *RuntimeDelta) string {
+	if delta.BaselineCorrelation == delta.CurrentCorrelation {
+		return ""
+	}
+	return fmt.Sprintf("correlation %s -> %s", delta.BaselineCorrelation, delta.CurrentCorrelation)
+}
+
+func runtimeDeltaFlag(enabled bool, label string) string {
+	if !enabled {
+		return ""
+	}
+	return label
+}
+
+func runtimeModuleGroupDelta(label string, added, removed, changed []RuntimeModuleDelta) string {
+	if len(added) == 0 && len(removed) == 0 && len(changed) == 0 {
+		return ""
+	}
+	return label + " changed"
+}
+
+func appendRuntimeDeltaPart(parts *[]string, value string) {
+	if value != "" {
+		*parts = append(*parts, value)
+	}
+}
+
 func formatDependencyLicense(license *DependencyLicense) string {
 	if license == nil {
 		return "unknown"

--- a/internal/report/format_test.go
+++ b/internal/report/format_test.go
@@ -195,6 +195,19 @@ func TestFormatSARIF(t *testing.T) {
 }
 
 func TestFormatPRComment(t *testing.T) {
+	runtimeDelta := &RuntimeDelta{
+		Comparable:            true,
+		BaselinePresent:       true,
+		CurrentPresent:        true,
+		BaselineLoadCount:     intPointer(0),
+		CurrentLoadCount:      intPointer(2),
+		LoadCountDelta:        intPointer(2),
+		BaselineCorrelation:   RuntimeCorrelationStaticOnly,
+		CurrentCorrelation:    RuntimeCorrelationRuntimeOnly,
+		NewRuntimeLoads:       true,
+		RuntimeOnlyRegression: true,
+	}
+	runtimeRegression := DependencyDelta{Kind: DependencyDeltaChanged, Name: "runtime-only", Language: "js-ts", RuntimeDelta: runtimeDelta}
 	reportData := Report{
 		BaselineComparison: &BaselineComparison{
 			SummaryDelta: SummaryDelta{
@@ -209,14 +222,15 @@ func TestFormatPRComment(t *testing.T) {
 			Regressions: []DependencyDelta{
 				{Kind: DependencyDeltaChanged, Name: "lodash", Language: "js-ts", WastePercentDelta: 2.5},
 			},
-			UnchangedRows: 3,
+			RuntimeRegressions: []DependencyDelta{runtimeRegression},
+			UnchangedRows:      3,
 		},
 	}
 	output, err := NewFormatter().Format(reportData, FormatPRComment)
 	if err != nil {
 		t.Fatalf("format pr-comment: %v", err)
 	}
-	assertOutputContains(t, output, "## Lopper (Delta)", "| Dependency count | +2 |", "| Estimated unused bytes | +1.0 KB |", "### Dependency deltas", "`lodash`", "+512.0 B")
+	assertOutputContains(t, output, "## Lopper (Delta)", "| Dependency count | +2 |", "| Estimated unused bytes | +1.0 KB |", "| Runtime regressions | 1 |", "### Runtime regressions", "runtime-only regression", "### Dependency deltas", "`lodash`", "+512.0 B")
 }
 
 func TestFormatPRCommentZeroDeltasAreUnsigned(t *testing.T) {
@@ -666,6 +680,32 @@ func TestFormatTableIncludesCacheMetadata(t *testing.T) {
 }
 
 func TestFormatTableIncludesBaselineComparison(t *testing.T) {
+	runtimeRegression := DependencyDelta{
+		Kind:     DependencyDeltaChanged,
+		Language: "js-ts",
+		Name:     "lodash",
+		RuntimeDelta: &RuntimeDelta{
+			Comparable:            true,
+			BaselinePresent:       true,
+			CurrentPresent:        true,
+			LoadCountDelta:        intPointer(2),
+			NewRuntimeLoads:       true,
+			RuntimeOnlyRegression: true,
+		},
+	}
+	runtimeImprovement := DependencyDelta{
+		Kind:     DependencyDeltaChanged,
+		Language: "go",
+		Name:     "zap",
+		RuntimeDelta: &RuntimeDelta{
+			Comparable:             true,
+			BaselinePresent:        true,
+			CurrentPresent:         true,
+			LoadCountDelta:         intPointer(-1),
+			RemovedRuntimeLoads:    true,
+			RuntimeOnlyImprovement: true,
+		},
+	}
 	reportData := Report{
 		BaselineComparison: &BaselineComparison{
 			BaselineKey: "commit:abc123",
@@ -679,6 +719,8 @@ func TestFormatTableIncludesBaselineComparison(t *testing.T) {
 			Regressions: []DependencyDelta{
 				{Kind: DependencyDeltaChanged, Language: "js-ts", Name: "lodash", WastePercentDelta: 3.5, UsedPercentDelta: -3.5},
 			},
+			RuntimeRegressions:  []DependencyDelta{runtimeRegression},
+			RuntimeImprovements: []DependencyDelta{runtimeImprovement},
 		},
 		Dependencies: []DependencyReport{
 			{Name: "lodash", Language: "js-ts", UsedExportsCount: 2, TotalExportsCount: 10, UsedPercent: 20},
@@ -697,6 +739,7 @@ func TestFormatTableIncludesBaselineComparison(t *testing.T) {
 	if !strings.Contains(output, "regression js-ts/lodash") {
 		t.Fatalf("expected regression line in output, got %q", output)
 	}
+	assertOutputContains(t, output, "runtime_trace_delta: regressions 1, improvements 1", "runtime regression js-ts/lodash", "runtime improvement go/zap")
 }
 
 func TestFormatTableIncludesDeniedLicenseBaselineLines(t *testing.T) {
@@ -775,6 +818,74 @@ func TestFormatRuntimeUsageFallbacks(t *testing.T) {
 	}
 	if got := formatRuntimeUsage(&RuntimeUsage{LoadCount: 0}); !strings.Contains(got, "- (0 loads)") {
 		t.Fatalf("expected missing correlation placeholder, got %q", got)
+	}
+	if got := formatRuntimeDelta(&RuntimeDelta{BaselinePresent: false, CurrentPresent: true}); !strings.Contains(got, "baseline runtime data missing") {
+		t.Fatalf("expected missing baseline runtime delta message, got %q", got)
+	}
+	if got := formatRuntimeDelta(nil); got != "-" {
+		t.Fatalf("expected nil runtime delta placeholder, got %q", got)
+	}
+	if got := formatRuntimeDelta(&RuntimeDelta{BaselinePresent: true, CurrentPresent: false}); !strings.Contains(got, "current runtime data missing") {
+		t.Fatalf("expected missing current runtime delta message, got %q", got)
+	}
+	if got := formatRuntimeDelta(&RuntimeDelta{}); got != "not comparable" {
+		t.Fatalf("expected generic non-comparable runtime delta message, got %q", got)
+	}
+	if got := formatRuntimeDelta(&RuntimeDelta{
+		Comparable:          true,
+		BaselinePresent:     true,
+		CurrentPresent:      true,
+		LoadCountDelta:      intPointer(1),
+		BaselineCorrelation: RuntimeCorrelationStaticOnly,
+		CurrentCorrelation:  RuntimeCorrelationOverlap,
+		ModulesChanged:      []RuntimeModuleDelta{{Module: "module", BaselineCount: 1, CurrentCount: 2, CountDelta: 1}},
+		ParentModulesAdded:  []RuntimeModuleDelta{{Module: "parent", CurrentCount: 1, CountDelta: 1}},
+		EntrypointsChanged:  []RuntimeModuleDelta{{Module: "entry", BaselineCount: 1, CurrentCount: 2, CountDelta: 1}},
+	}); !strings.Contains(got, "loads +1") || !strings.Contains(got, "correlation static-only -> overlap") || !strings.Contains(got, "modules changed") || !strings.Contains(got, "parent modules changed") || !strings.Contains(got, "entrypoints changed") {
+		t.Fatalf("expected formatted runtime delta details, got %q", got)
+	}
+	if got := formatRuntimeDelta(&RuntimeDelta{
+		Comparable:             true,
+		BaselinePresent:        true,
+		CurrentPresent:         true,
+		RemovedRuntimeLoads:    true,
+		RuntimeOnlyImprovement: true,
+	}); !strings.Contains(got, "removed runtime loads") || !strings.Contains(got, "runtime-only improvement") {
+		t.Fatalf("expected removed/improvement runtime delta details, got %q", got)
+	}
+	if got := formatRuntimeDelta(&RuntimeDelta{Comparable: true, BaselinePresent: true, CurrentPresent: true}); got != "no runtime delta" {
+		t.Fatalf("expected no runtime delta message, got %q", got)
+	}
+}
+
+func TestRuntimeDeltaSortingAndHelperBranches(t *testing.T) {
+	if got := topRuntimeDeltas(nil, 3); len(got) != 0 {
+		t.Fatalf("expected empty top runtime deltas for nil input, got %#v", got)
+	}
+	if got := topRuntimeDeltas([]DependencyDelta{{Name: "x"}}, 0); len(got) != 0 {
+		t.Fatalf("expected empty top runtime deltas for zero limit, got %#v", got)
+	}
+
+	input := []DependencyDelta{
+		{Name: "b", Language: "go", RuntimeDelta: &RuntimeDelta{LoadCountDelta: intPointer(-5)}},
+		{Name: "a", Language: "go", RuntimeDelta: &RuntimeDelta{LoadCountDelta: intPointer(5)}},
+		{Name: "c", Language: "js-ts", RuntimeDelta: &RuntimeDelta{LoadCountDelta: intPointer(1)}},
+	}
+	got := topRuntimeDeltas(input, 2)
+	if len(got) != 2 || got[0].Name != "a" || got[1].Name != "b" {
+		t.Fatalf("expected runtime delta sorting by magnitude then name, got %#v", got)
+	}
+	if got := runtimeDeltaLoadCount(nil); got != 0 {
+		t.Fatalf("expected nil runtime delta load count to be zero, got %d", got)
+	}
+	if runtimeDeltaIsRegression(nil) || runtimeDeltaIsImprovement(&RuntimeDelta{}) {
+		t.Fatalf("nil/non-comparable runtime deltas should not classify")
+	}
+	currentModules := []RuntimeModuleUsage{{Module: "added", Count: 1}, {Module: "changed", Count: 3}}
+	baselineModules := []RuntimeModuleUsage{{Module: "removed", Count: 2}, {Module: "changed", Count: 1}}
+	added, removed, changed := compareRuntimeModuleUsage(currentModules, baselineModules)
+	if len(added) != 1 || len(removed) != 1 || len(changed) != 1 {
+		t.Fatalf("expected added/removed/changed module deltas, got added=%#v removed=%#v changed=%#v", added, removed, changed)
 	}
 }
 

--- a/internal/report/model/metadata.go
+++ b/internal/report/model/metadata.go
@@ -6,16 +6,18 @@ type ScopeMetadata struct {
 }
 
 type BaselineComparison struct {
-	BaselineKey       string               `json:"baselineKey"`
-	CurrentKey        string               `json:"currentKey,omitempty"`
-	SummaryDelta      SummaryDelta         `json:"summaryDelta"`
-	Dependencies      []DependencyDelta    `json:"dependencies,omitempty"`
-	Regressions       []DependencyDelta    `json:"regressions,omitempty"`
-	Progressions      []DependencyDelta    `json:"progressions,omitempty"`
-	Added             []DependencyDelta    `json:"added,omitempty"`
-	Removed           []DependencyDelta    `json:"removed,omitempty"`
-	NewDeniedLicenses []DeniedLicenseDelta `json:"newDeniedLicenses,omitempty"`
-	UnchangedRows     int                  `json:"unchangedRows,omitempty"`
+	BaselineKey         string               `json:"baselineKey"`
+	CurrentKey          string               `json:"currentKey,omitempty"`
+	SummaryDelta        SummaryDelta         `json:"summaryDelta"`
+	Dependencies        []DependencyDelta    `json:"dependencies,omitempty"`
+	Regressions         []DependencyDelta    `json:"regressions,omitempty"`
+	Progressions        []DependencyDelta    `json:"progressions,omitempty"`
+	RuntimeRegressions  []DependencyDelta    `json:"runtimeRegressions,omitempty"`
+	RuntimeImprovements []DependencyDelta    `json:"runtimeImprovements,omitempty"`
+	Added               []DependencyDelta    `json:"added,omitempty"`
+	Removed             []DependencyDelta    `json:"removed,omitempty"`
+	NewDeniedLicenses   []DeniedLicenseDelta `json:"newDeniedLicenses,omitempty"`
+	UnchangedRows       int                  `json:"unchangedRows,omitempty"`
 }
 
 type SummaryDelta struct {
@@ -47,6 +49,7 @@ type DependencyDelta struct {
 	UsedPercentDelta          float64             `json:"usedPercentDelta"`
 	EstimatedUnusedBytesDelta int64               `json:"estimatedUnusedBytesDelta"`
 	WastePercentDelta         float64             `json:"wastePercentDelta"`
+	RuntimeDelta              *RuntimeDelta       `json:"runtimeDelta,omitempty"`
 	DeniedIntroduced          bool                `json:"deniedIntroduced,omitempty"`
 }
 
@@ -54,6 +57,52 @@ type DeniedLicenseDelta struct {
 	Language string `json:"language,omitempty"`
 	Name     string `json:"name"`
 	SPDX     string `json:"spdx,omitempty"`
+}
+
+type RuntimeChangeType string
+
+const (
+	RuntimeChangeLoadCount              RuntimeChangeType = "load-count"
+	RuntimeChangeNewRuntimeLoads        RuntimeChangeType = "new-runtime-loads"
+	RuntimeChangeRemovedRuntimeLoads    RuntimeChangeType = "removed-runtime-loads"
+	RuntimeChangeCorrelation            RuntimeChangeType = "correlation"
+	RuntimeChangeRuntimeOnlyRegression  RuntimeChangeType = "runtime-only-regression"
+	RuntimeChangeRuntimeOnlyImprovement RuntimeChangeType = "runtime-only-improvement"
+	RuntimeChangeModules                RuntimeChangeType = "modules"
+	RuntimeChangeParentModules          RuntimeChangeType = "parent-modules"
+	RuntimeChangeEntrypoints            RuntimeChangeType = "entrypoints"
+)
+
+type RuntimeDelta struct {
+	Comparable             bool                 `json:"comparable"`
+	BaselinePresent        bool                 `json:"baselinePresent"`
+	CurrentPresent         bool                 `json:"currentPresent"`
+	BaselineLoadCount      *int                 `json:"baselineLoadCount,omitempty"`
+	CurrentLoadCount       *int                 `json:"currentLoadCount,omitempty"`
+	LoadCountDelta         *int                 `json:"loadCountDelta,omitempty"`
+	BaselineCorrelation    RuntimeCorrelation   `json:"baselineCorrelation,omitempty"`
+	CurrentCorrelation     RuntimeCorrelation   `json:"currentCorrelation,omitempty"`
+	ChangeTypes            []RuntimeChangeType  `json:"changeTypes,omitempty"`
+	NewRuntimeLoads        bool                 `json:"newRuntimeLoads,omitempty"`
+	RemovedRuntimeLoads    bool                 `json:"removedRuntimeLoads,omitempty"`
+	RuntimeOnlyRegression  bool                 `json:"runtimeOnlyRegression,omitempty"`
+	RuntimeOnlyImprovement bool                 `json:"runtimeOnlyImprovement,omitempty"`
+	ModulesAdded           []RuntimeModuleDelta `json:"modulesAdded,omitempty"`
+	ModulesRemoved         []RuntimeModuleDelta `json:"modulesRemoved,omitempty"`
+	ModulesChanged         []RuntimeModuleDelta `json:"modulesChanged,omitempty"`
+	ParentModulesAdded     []RuntimeModuleDelta `json:"parentModulesAdded,omitempty"`
+	ParentModulesRemoved   []RuntimeModuleDelta `json:"parentModulesRemoved,omitempty"`
+	ParentModulesChanged   []RuntimeModuleDelta `json:"parentModulesChanged,omitempty"`
+	EntrypointsAdded       []RuntimeModuleDelta `json:"entrypointsAdded,omitempty"`
+	EntrypointsRemoved     []RuntimeModuleDelta `json:"entrypointsRemoved,omitempty"`
+	EntrypointsChanged     []RuntimeModuleDelta `json:"entrypointsChanged,omitempty"`
+}
+
+type RuntimeModuleDelta struct {
+	Module        string `json:"module"`
+	BaselineCount int    `json:"baselineCount"`
+	CurrentCount  int    `json:"currentCount"`
+	CountDelta    int    `json:"countDelta"`
 }
 
 type CacheMetadata struct {

--- a/internal/report/model/model_contract_test.go
+++ b/internal/report/model/model_contract_test.go
@@ -102,10 +102,16 @@ func TestReportJSONContractShape(t *testing.T) {
 		"dependencies",
 		"newDeniedLicenses",
 		"regressions",
+		"runtimeRegressions",
 		"summaryDelta",
 		"unchangedRows",
 	}
 	assertKeys(t, baselineComparison, baselineComparisonKeys...)
+	dependencyDeltas := jsonArray(t, baselineComparison, "dependencies")
+	dependencyDelta := jsonObjectValue(t, dependencyDeltas[0], "baselineComparison.dependencies[0]")
+	assertKeys(t, dependencyDelta, "deniedIntroduced", "estimatedUnusedBytesDelta", "kind", "language", "name", "runtimeDelta", "totalExportsCountDelta", "usedExportsCountDelta", "usedPercentDelta", "wastePercentDelta")
+	runtimeDelta := jsonObject(t, dependencyDelta, "runtimeDelta")
+	assertKeys(t, runtimeDelta, "baselineCorrelation", "baselineLoadCount", "baselinePresent", "changeTypes", "comparable", "currentCorrelation", "currentLoadCount", "currentPresent", "loadCountDelta", "modulesAdded", "newRuntimeLoads", "runtimeOnlyRegression")
 
 	reachability := jsonObject(t, dependency, "reachabilityConfidence")
 	assertKeys(t, reachability, "model", "rationaleCodes", "score", "signals", "summary")
@@ -117,6 +123,9 @@ func TestReportJSONContractShape(t *testing.T) {
 
 func representativeReport() Report {
 	wasteIncreasePercent := 12.5
+	baselineLoadCount := 2
+	currentLoadCount := 4
+	loadCountDelta := 2
 	delta := DependencyDelta{
 		Kind:                      DependencyDeltaChanged,
 		Language:                  "js",
@@ -126,7 +135,21 @@ func representativeReport() Report {
 		UsedPercentDelta:          -20,
 		EstimatedUnusedBytesDelta: 1024,
 		WastePercentDelta:         20,
-		DeniedIntroduced:          true,
+		RuntimeDelta: &RuntimeDelta{
+			Comparable:            true,
+			BaselinePresent:       true,
+			CurrentPresent:        true,
+			BaselineLoadCount:     &baselineLoadCount,
+			CurrentLoadCount:      &currentLoadCount,
+			LoadCountDelta:        &loadCountDelta,
+			BaselineCorrelation:   RuntimeCorrelationStaticOnly,
+			CurrentCorrelation:    RuntimeCorrelationRuntimeOnly,
+			ChangeTypes:           []RuntimeChangeType{RuntimeChangeLoadCount, RuntimeChangeNewRuntimeLoads, RuntimeChangeCorrelation, RuntimeChangeRuntimeOnlyRegression, RuntimeChangeModules},
+			NewRuntimeLoads:       true,
+			RuntimeOnlyRegression: true,
+			ModulesAdded:          []RuntimeModuleDelta{{Module: "lodash/runtime", BaselineCount: 0, CurrentCount: 2, CountDelta: 2}},
+		},
+		DeniedIntroduced: true,
 	}
 
 	return Report{
@@ -290,10 +313,11 @@ func representativeReport() Report {
 				KnownLicenseCountDelta:  -1,
 				DeniedLicenseCountDelta: 1,
 			},
-			Dependencies:      []DependencyDelta{delta},
-			Regressions:       []DependencyDelta{delta},
-			NewDeniedLicenses: []DeniedLicenseDelta{{Language: "js", Name: "lodash", SPDX: "MIT"}},
-			UnchangedRows:     1,
+			Dependencies:       []DependencyDelta{delta},
+			Regressions:        []DependencyDelta{delta},
+			RuntimeRegressions: []DependencyDelta{delta},
+			NewDeniedLicenses:  []DeniedLicenseDelta{{Language: "js", Name: "lodash", SPDX: "MIT"}},
+			UnchangedRows:      1,
 		},
 	}
 }

--- a/internal/report/model_aliases.go
+++ b/internal/report/model_aliases.go
@@ -43,6 +43,9 @@ type SummaryDelta = model.SummaryDelta
 type DependencyDeltaKind = model.DependencyDeltaKind
 type DependencyDelta = model.DependencyDelta
 type DeniedLicenseDelta = model.DeniedLicenseDelta
+type RuntimeChangeType = model.RuntimeChangeType
+type RuntimeDelta = model.RuntimeDelta
+type RuntimeModuleDelta = model.RuntimeModuleDelta
 type CacheMetadata = model.CacheMetadata
 type CacheInvalidation = model.CacheInvalidation
 type EffectiveThresholds = model.EffectiveThresholds
@@ -57,4 +60,14 @@ const (
 	DependencyDeltaAdded   = model.DependencyDeltaAdded
 	DependencyDeltaRemoved = model.DependencyDeltaRemoved
 	DependencyDeltaChanged = model.DependencyDeltaChanged
+
+	RuntimeChangeLoadCount              = model.RuntimeChangeLoadCount
+	RuntimeChangeNewRuntimeLoads        = model.RuntimeChangeNewRuntimeLoads
+	RuntimeChangeRemovedRuntimeLoads    = model.RuntimeChangeRemovedRuntimeLoads
+	RuntimeChangeCorrelation            = model.RuntimeChangeCorrelation
+	RuntimeChangeRuntimeOnlyRegression  = model.RuntimeChangeRuntimeOnlyRegression
+	RuntimeChangeRuntimeOnlyImprovement = model.RuntimeChangeRuntimeOnlyImprovement
+	RuntimeChangeModules                = model.RuntimeChangeModules
+	RuntimeChangeParentModules          = model.RuntimeChangeParentModules
+	RuntimeChangeEntrypoints            = model.RuntimeChangeEntrypoints
 )

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -249,7 +249,7 @@ func sarifDependencyProperties(dep DependencyReport, baselineDelta *DependencyDe
 		}
 	}
 	if baselineDelta != nil {
-		props["baselineContext"] = map[string]any{
+		baselineContext := map[string]any{
 			"kind":                      baselineDelta.Kind,
 			"usedExportsCountDelta":     baselineDelta.UsedExportsCountDelta,
 			"totalExportsCountDelta":    baselineDelta.TotalExportsCountDelta,
@@ -258,6 +258,10 @@ func sarifDependencyProperties(dep DependencyReport, baselineDelta *DependencyDe
 			"wastePercentDelta":         baselineDelta.WastePercentDelta,
 			"deniedIntroduced":          baselineDelta.DeniedIntroduced,
 		}
+		if baselineDelta.RuntimeDelta != nil {
+			baselineContext["runtimeDelta"] = baselineDelta.RuntimeDelta
+		}
+		props["baselineContext"] = baselineContext
 	}
 	for key, value := range extra {
 		props[key] = value

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -160,6 +160,9 @@ func TestNormalizeRuleToken(t *testing.T) {
 
 func sampleSARIFRuntimeAndBaselineReport() Report {
 	wasteIncrease := 1.5
+	baselineLoads := 0
+	currentLoads := 4
+	loadDelta := 4
 	return Report{
 		Dependencies: []DependencyReport{
 			{
@@ -204,7 +207,19 @@ func sampleSARIFRuntimeAndBaselineReport() Report {
 					UsedPercentDelta:          -10,
 					EstimatedUnusedBytesDelta: 512,
 					WastePercentDelta:         10,
-					DeniedIntroduced:          true,
+					RuntimeDelta: &RuntimeDelta{
+						Comparable:            true,
+						BaselinePresent:       true,
+						CurrentPresent:        true,
+						BaselineLoadCount:     &baselineLoads,
+						CurrentLoadCount:      &currentLoads,
+						LoadCountDelta:        &loadDelta,
+						BaselineCorrelation:   RuntimeCorrelationStaticOnly,
+						CurrentCorrelation:    RuntimeCorrelationOverlap,
+						NewRuntimeLoads:       true,
+						RuntimeOnlyRegression: true,
+					},
+					DeniedIntroduced: true,
 				},
 			},
 		},
@@ -272,6 +287,12 @@ func assertSARIFBaselineContext(t *testing.T, baselineValue any, wantDeniedIntro
 	}
 	if baselineContext["deniedIntroduced"] != wantDeniedIntroduced {
 		t.Fatalf("expected deniedIntroduced=%v, got %#v", wantDeniedIntroduced, baselineContext["deniedIntroduced"])
+	}
+	if wantDeniedIntroduced {
+		runtimeDelta, ok := baselineContext["runtimeDelta"].(map[string]any)
+		if !ok || runtimeDelta["newRuntimeLoads"] != true {
+			t.Fatalf("expected runtime delta context, got %#v", baselineContext["runtimeDelta"])
+		}
 	}
 }
 

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -132,6 +132,7 @@ func printDependencySections(out io.Writer, dep detailDependencyView) error {
 		func(w io.Writer) error { return printReachabilityConfidence(w, dep.ReachabilityConfidence) },
 		func(w io.Writer) error { return printRemovalCandidate(w, dep.RemovalCandidate) },
 		func(w io.Writer) error { return printRuntimeUsage(w, dep.RuntimeUsage) },
+		func(w io.Writer) error { return printRuntimeDelta(w, dep.RuntimeDelta) },
 		func(w io.Writer) error { return printRiskCues(w, dep.RiskCues) },
 		func(w io.Writer) error { return printRecommendations(w, dep.Recommendations) },
 		func(w io.Writer) error { return printCodemod(w, dep.Codemod) },
@@ -297,6 +298,64 @@ func printRuntimeUsage(out io.Writer, usage *detailRuntimeUsageView) error {
 	return writeln(out, "")
 }
 
+func printRuntimeDelta(out io.Writer, delta *detailRuntimeDeltaView) error {
+	if delta == nil {
+		return nil
+	}
+	if err := writeln(out, "Runtime baseline delta"); err != nil {
+		return err
+	}
+	lines := []string{
+		fmt.Sprintf("  - comparable: %t", delta.Comparable),
+		fmt.Sprintf("  - baseline runtime data: %t", delta.BaselinePresent),
+		fmt.Sprintf("  - current runtime data: %t", delta.CurrentPresent),
+	}
+	if delta.BaselineLoadCount != nil {
+		lines = append(lines, fmt.Sprintf("  - baseline load count: %d", *delta.BaselineLoadCount))
+	}
+	if delta.CurrentLoadCount != nil {
+		lines = append(lines, fmt.Sprintf("  - current load count: %d", *delta.CurrentLoadCount))
+	}
+	if delta.LoadCountDelta != nil {
+		lines = append(lines, fmt.Sprintf("  - load count delta: %+d", *delta.LoadCountDelta))
+	}
+	if delta.BaselineCorrelation != "" || delta.CurrentCorrelation != "" {
+		lines = append(lines, fmt.Sprintf("  - correlation: %s -> %s", delta.BaselineCorrelation, delta.CurrentCorrelation))
+	}
+	if len(delta.ChangeTypes) > 0 {
+		changeTypes := make([]string, 0, len(delta.ChangeTypes))
+		for _, changeType := range delta.ChangeTypes {
+			changeTypes = append(changeTypes, string(changeType))
+		}
+		lines = append(lines, fmt.Sprintf("  - change types: %s", strings.Join(changeTypes, ", ")))
+	}
+	if delta.NewRuntimeLoads {
+		lines = append(lines, "  - new runtime loads: true")
+	}
+	if delta.RemovedRuntimeLoads {
+		lines = append(lines, "  - removed runtime loads: true")
+	}
+	if delta.RuntimeOnlyRegression {
+		lines = append(lines, "  - runtime-only regression: true")
+	}
+	if delta.RuntimeOnlyImprovement {
+		lines = append(lines, "  - runtime-only improvement: true")
+	}
+	appendRuntimeModuleDeltaLine(&lines, "modules added", delta.ModulesAdded)
+	appendRuntimeModuleDeltaLine(&lines, "modules removed", delta.ModulesRemoved)
+	appendRuntimeModuleDeltaLine(&lines, "modules changed", delta.ModulesChanged)
+	appendRuntimeModuleDeltaLine(&lines, "parent modules added", delta.ParentModulesAdded)
+	appendRuntimeModuleDeltaLine(&lines, "parent modules removed", delta.ParentModulesRemoved)
+	appendRuntimeModuleDeltaLine(&lines, "parent modules changed", delta.ParentModulesChanged)
+	appendRuntimeModuleDeltaLine(&lines, "entrypoints added", delta.EntrypointsAdded)
+	appendRuntimeModuleDeltaLine(&lines, "entrypoints removed", delta.EntrypointsRemoved)
+	appendRuntimeModuleDeltaLine(&lines, "entrypoints changed", delta.EntrypointsChanged)
+	if err := writeLines(out, lines); err != nil {
+		return err
+	}
+	return writeln(out, "")
+}
+
 func printReachabilityConfidence(out io.Writer, confidence *detailReachabilityConfidenceView) error {
 	if err := writeln(out, "Reachability confidence"); err != nil {
 		return err
@@ -441,6 +500,17 @@ func formatRuntimeSymbols(symbols []detailRuntimeSymbolView) string {
 		items = append(items, fmt.Sprintf("%s (%d)", symbol.Symbol, symbol.Count))
 	}
 	return strings.Join(items, ", ")
+}
+
+func appendRuntimeModuleDeltaLine(lines *[]string, label string, deltas []detailRuntimeModuleDeltaView) {
+	if len(deltas) == 0 {
+		return
+	}
+	items := make([]string, 0, len(deltas))
+	for _, delta := range deltas {
+		items = append(items, fmt.Sprintf("%s (%d -> %d, %+d)", delta.Module, delta.BaselineCount, delta.CurrentCount, delta.CountDelta))
+	}
+	*lines = append(*lines, fmt.Sprintf("  - %s: %s", label, strings.Join(items, ", ")))
 }
 
 func isDetailCommand(input string) (string, bool) {

--- a/internal/ui/detail_test.go
+++ b/internal/ui/detail_test.go
@@ -311,6 +311,30 @@ func TestDetailRationaleAndRuntimeOnlyOutput(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("print runtime usage: %v", err)
 	}
+	baselineLoads := 0
+	currentLoads := 2
+	loadDelta := 2
+	if err := printRuntimeDelta(&out, &detailRuntimeDeltaView{
+		Comparable:            true,
+		BaselinePresent:       true,
+		CurrentPresent:        true,
+		BaselineLoadCount:     &baselineLoads,
+		CurrentLoadCount:      &currentLoads,
+		LoadCountDelta:        &loadDelta,
+		BaselineCorrelation:   report.RuntimeCorrelationStaticOnly,
+		CurrentCorrelation:    report.RuntimeCorrelationRuntimeOnly,
+		ChangeTypes:           []report.RuntimeChangeType{report.RuntimeChangeNewRuntimeLoads, report.RuntimeChangeRuntimeOnlyRegression, report.RuntimeChangeParentModules, report.RuntimeChangeEntrypoints},
+		NewRuntimeLoads:       true,
+		RuntimeOnlyRegression: true,
+		ParentModulesAdded: []detailRuntimeModuleDeltaView{
+			{Module: "pkg/parent", BaselineCount: 0, CurrentCount: 1, CountDelta: 1},
+		},
+		EntrypointsAdded: []detailRuntimeModuleDeltaView{
+			{Module: "pkg/main", BaselineCount: 0, CurrentCount: 1, CountDelta: 1},
+		},
+	}); err != nil {
+		t.Fatalf("print runtime delta: %v", err)
+	}
 	text := out.String()
 	if !strings.Contains(text, "rationale: because") {
 		t.Fatalf("expected rationale output, got %q", text)
@@ -323,6 +347,99 @@ func TestDetailRationaleAndRuntimeOnlyOutput(t *testing.T) {
 	}
 	if !strings.Contains(text, "parent modules: pkg/parent (1)") || !strings.Contains(text, "entrypoints: pkg/main (1)") {
 		t.Fatalf("expected runtime parent and entrypoint output, got %q", text)
+	}
+	if !strings.Contains(text, "Runtime baseline delta") || !strings.Contains(text, "load count delta: +2") || !strings.Contains(text, "correlation: static-only -> runtime-only") {
+		t.Fatalf("expected runtime delta output, got %q", text)
+	}
+	if !strings.Contains(text, "parent modules added: pkg/parent (0 -> 1, +1)") || !strings.Contains(text, "entrypoints added: pkg/main (0 -> 1, +1)") {
+		t.Fatalf("expected runtime delta parent and entrypoint output, got %q", text)
+	}
+}
+
+func TestSummaryDetailIncludesRuntimeBaselineDelta(t *testing.T) {
+	loadDelta := 1
+	reportView := mapSummaryReportView(report.Report{
+		Dependencies: []report.DependencyReport{{
+			Name:              "alpha",
+			Language:          "js-ts",
+			UsedExportsCount:  1,
+			TotalExportsCount: 2,
+			UsedPercent:       50,
+		}},
+		BaselineComparison: &report.BaselineComparison{
+			Dependencies: []report.DependencyDelta{{
+				Kind:     report.DependencyDeltaChanged,
+				Name:     "alpha",
+				Language: "js-ts",
+				RuntimeDelta: &report.RuntimeDelta{
+					Comparable:      true,
+					BaselinePresent: true,
+					CurrentPresent:  true,
+					LoadCountDelta:  &loadDelta,
+					NewRuntimeLoads: true,
+					ChangeTypes:     []report.RuntimeChangeType{report.RuntimeChangeNewRuntimeLoads},
+					ModulesChanged:  []report.RuntimeModuleDelta{{Module: "alpha/runtime", BaselineCount: 1, CurrentCount: 2, CountDelta: 1}},
+				},
+			}},
+		},
+	})
+
+	detail, ok := findSummaryDependencyDetail(reportView.Dependencies, "js-ts", "alpha")
+	if !ok {
+		t.Fatalf("expected mapped dependency detail")
+	}
+	if detail.RuntimeDelta == nil || detail.RuntimeDelta.LoadCountDelta == nil || *detail.RuntimeDelta.LoadCountDelta != 1 {
+		t.Fatalf("expected runtime baseline delta to be mapped into detail view, got %#v", detail.RuntimeDelta)
+	}
+	if len(detail.RuntimeDelta.ModulesChanged) != 1 {
+		t.Fatalf("expected runtime module deltas to be mapped into detail view, got %#v", detail.RuntimeDelta)
+	}
+	if got := mapDetailRuntimeDelta(nil); got != nil {
+		t.Fatalf("expected nil runtime delta to map to nil, got %#v", got)
+	}
+}
+
+func TestPrintRuntimeDeltaBranches(t *testing.T) {
+	var out bytes.Buffer
+	if err := printRuntimeDelta(&out, nil); err != nil {
+		t.Fatalf("print nil runtime delta: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected nil runtime delta to produce no output, got %q", out.String())
+	}
+
+	if err := printRuntimeDelta(&out, &detailRuntimeDeltaView{
+		Comparable:             false,
+		BaselinePresent:        true,
+		CurrentPresent:         false,
+		RemovedRuntimeLoads:    true,
+		RuntimeOnlyImprovement: true,
+		ModulesAdded:           []detailRuntimeModuleDeltaView{{Module: "added", BaselineCount: 0, CurrentCount: 1, CountDelta: 1}},
+		ModulesRemoved:         []detailRuntimeModuleDeltaView{{Module: "removed", BaselineCount: 1, CurrentCount: 0, CountDelta: -1}},
+		ModulesChanged:         []detailRuntimeModuleDeltaView{{Module: "changed", BaselineCount: 1, CurrentCount: 2, CountDelta: 1}},
+		ParentModulesRemoved:   []detailRuntimeModuleDeltaView{{Module: "old-parent", BaselineCount: 1, CurrentCount: 0, CountDelta: -1}},
+		ParentModulesChanged:   []detailRuntimeModuleDeltaView{{Module: "same-parent", BaselineCount: 1, CurrentCount: 2, CountDelta: 1}},
+		EntrypointsRemoved:     []detailRuntimeModuleDeltaView{{Module: "old-entry", BaselineCount: 1, CurrentCount: 0, CountDelta: -1}},
+		EntrypointsChanged:     []detailRuntimeModuleDeltaView{{Module: "same-entry", BaselineCount: 1, CurrentCount: 2, CountDelta: 1}},
+	}); err != nil {
+		t.Fatalf("print runtime delta branches: %v", err)
+	}
+	text := out.String()
+	for _, want := range []string{
+		"comparable: false",
+		"removed runtime loads: true",
+		"runtime-only improvement: true",
+		"modules added: added (0 -> 1, +1)",
+		"modules removed: removed (1 -> 0, -1)",
+		"modules changed: changed (1 -> 2, +1)",
+		"parent modules removed: old-parent (1 -> 0, -1)",
+		"parent modules changed: same-parent (1 -> 2, +1)",
+		"entrypoints removed: old-entry (1 -> 0, -1)",
+		"entrypoints changed: same-entry (1 -> 2, +1)",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected runtime delta output to contain %q, got %q", want, text)
+		}
 	}
 }
 

--- a/internal/ui/view_model.go
+++ b/internal/ui/view_model.go
@@ -11,6 +11,7 @@ type summaryDependencyView struct {
 	EstimatedUnusedBytes   int64
 	TopUsedSymbols         []report.SymbolUsage
 	RuntimeUsage           *report.RuntimeUsage
+	RuntimeDelta           *report.RuntimeDelta
 	ReachabilityConfidence *report.ReachabilityConfidence
 	RemovalCandidate       *report.RemovalCandidate
 	License                *report.DependencyLicense
@@ -63,13 +64,17 @@ func mapSummaryReportView(reportData report.Report) summaryReportView {
 		EffectivePolicy:     reportData.EffectivePolicy,
 		BaselineComparison:  reportData.BaselineComparison,
 		Warnings:            append([]string(nil), reportData.Warnings...),
-		Dependencies:        mapSummaryDependencies(reportData.Dependencies),
+		Dependencies:        mapSummaryDependencies(reportData.Dependencies, reportData.BaselineComparison),
 	}
 }
 
-func mapSummaryDependencies(dependencies []report.DependencyReport) []summaryDependencyView {
+func mapSummaryDependencies(dependencies []report.DependencyReport, comparison *report.BaselineComparison) []summaryDependencyView {
 	views := make([]summaryDependencyView, 0, len(dependencies))
+	runtimeDeltas := baselineRuntimeDeltasByDependency(comparison)
 	for _, dep := range dependencies {
+		runtimeDelta := runtimeDeltas[summaryDependencyKey(dep.Language, dep.Name)]
+		detail := mapDetailDependencyView(dep)
+		detail.RuntimeDelta = mapDetailRuntimeDelta(runtimeDelta)
 		views = append(views, summaryDependencyView{
 			Language:               dep.Language,
 			Name:                   dep.Name,
@@ -79,15 +84,35 @@ func mapSummaryDependencies(dependencies []report.DependencyReport) []summaryDep
 			EstimatedUnusedBytes:   dep.EstimatedUnusedBytes,
 			TopUsedSymbols:         append([]report.SymbolUsage(nil), dep.TopUsedSymbols...),
 			RuntimeUsage:           dep.RuntimeUsage,
+			RuntimeDelta:           runtimeDelta,
 			ReachabilityConfidence: dep.ReachabilityConfidence,
 			RemovalCandidate:       dep.RemovalCandidate,
 			License:                dep.License,
 			Provenance:             dep.Provenance,
 			CodemodApply:           summaryCodemodApplyView(dep.Codemod),
-			detail:                 mapDetailDependencyView(dep),
+			detail:                 detail,
 		})
 	}
 	return views
+}
+
+func baselineRuntimeDeltasByDependency(comparison *report.BaselineComparison) map[string]*report.RuntimeDelta {
+	deltas := make(map[string]*report.RuntimeDelta)
+	if comparison == nil {
+		return deltas
+	}
+	for i := range comparison.Dependencies {
+		delta := comparison.Dependencies[i]
+		if delta.RuntimeDelta == nil {
+			continue
+		}
+		deltas[summaryDependencyKey(delta.Language, delta.Name)] = delta.RuntimeDelta
+	}
+	return deltas
+}
+
+func summaryDependencyKey(language, name string) string {
+	return language + "\x00" + name
 }
 
 func summaryDependencyDetailView(dep summaryDependencyView) detailDependencyView {
@@ -181,6 +206,7 @@ type detailDependencyView struct {
 	Recommendations        []detailRecommendationView
 	Codemod                *detailCodemodView
 	RuntimeUsage           *detailRuntimeUsageView
+	RuntimeDelta           *detailRuntimeDeltaView
 	ReachabilityConfidence *detailReachabilityConfidenceView
 	RemovalCandidate       *detailRemovalCandidateView
 }
@@ -255,6 +281,10 @@ type detailRuntimeSymbolView struct {
 	Module string
 	Count  int
 }
+
+type detailRuntimeDeltaView = report.RuntimeDelta
+
+type detailRuntimeModuleDeltaView = report.RuntimeModuleDelta
 
 type detailReachabilityConfidenceView struct {
 	Model          string
@@ -425,6 +455,10 @@ func mapDetailRuntimeSymbols(symbols []report.RuntimeSymbolUsage) []detailRuntim
 		})
 	}
 	return views
+}
+
+func mapDetailRuntimeDelta(delta *report.RuntimeDelta) *detailRuntimeDeltaView {
+	return delta
 }
 
 func mapDetailReachabilityConfidence(confidence *report.ReachabilityConfidence) *detailReachabilityConfidenceView {


### PR DESCRIPTION
## Summary

Add runtime trace baseline comparison support for dependency reports so comparable dependencies can show runtime load, correlation, runtime-only, parent, entrypoint, and module deltas without treating missing historical trace data as zero.

## Changes

- Add backward-compatible runtime delta fields to the report model and baseline comparison output.
- Surface runtime regressions and improvements in PR comments, table/detail output, SARIF/CycloneDX metadata, MCP summaries, dashboard aggregates, and VS Code dependency detail.
- Document schema behavior for missing runtime data plus added/removed dependencies, and cover the new output surfaces with tests.

## Validation

Commands and checks run:

```bash
GOTOOLCHAIN=go1.26.4 go test ./internal/report ./internal/ui ./internal/dashboard ./internal/mcp
GOTOOLCHAIN=go1.26.4 go test ./internal/runtime ./internal/analysis
GOTOOLCHAIN=go1.26.4 go test ./cmd/lopper
make vscode-extension-compile
make vscode-extension-test
make lint
make test
make cov
git diff --check
```

Additional manual validation:

- Confirmed PR head SHA and branch after push.
- Re-ran focused report/UI/dashboard/MCP package tests and `git diff --check` after PR creation.

## Risk and compatibility

- Breaking changes: None. Runtime deltas are additive JSON fields and older baselines without `runtimeUsage` remain non-comparable rather than being treated as zero runtime loads.
- Migration required: None.
- Performance impact: Minimal; runtime diffing is bounded to dependencies already present in both baseline and current reports.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #1098
