### PR TITLE
chore(tui): add apply and baseline actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,24 @@ lopper tui \
   --baseline-key commit:abc123
 ```
 
+Inside the TUI, open a dependency to inspect codemod suggestions and apply safe suggestions without leaving the session:
+
+```text
+open js-ts:lodash
+apply-codemod --confirm
+```
+
+`apply-codemod` refuses dirty git worktrees by default; add `--allow-dirty` only when you intentionally want to apply into a dirty tree. The action prints applied, skipped, and failed files plus the rollback backup path. Baselines can also be saved and compared in-session:
+
+```text
+save-baseline
+save-baseline release-candidate
+compare-baseline label:release-candidate
+compare-baseline --file baseline.json
+```
+
+In-session baseline commands default to `.artifacts/lopper-baselines` and `commit:<HEAD>` when no store or label/key is provided.
+
 ## Runtime trace annotations
 
 ### JS/TS

--- a/docs/man/lopper.1
+++ b/docs/man/lopper.1
@@ -89,6 +89,13 @@ Options:
   --baseline PATH            Baseline report (JSON) for TUI comparison
   --baseline-store DIR       Directory for immutable keyed TUI baseline snapshots
   --baseline-key KEY         Baseline snapshot key for TUI comparison
+  TUI commands:
+    apply-codemod [dep] --confirm [--allow-dirty]
+                              Apply safe codemod suggestions shown in dependency detail
+    save-baseline [label] [--store DIR] [--key KEY]
+                              Save the current TUI report; defaults to .artifacts/lopper-baselines and commit:<HEAD>
+    compare-baseline <key|file> [--store DIR]
+                              Refresh TUI summary/detail views with baseline deltas
   --fail-on-increase PERCENT Legacy alias for --threshold-fail-on-increase
   --version                  Show CLI version metadata
   mcp                        Run a local stdio MCP server with read-only dependency analysis tools

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -42,16 +42,19 @@ func New(out io.Writer, in io.Reader) *App {
 	analyzer := analysis.NewService()
 	formatter := report.NewFormatter()
 
-	return &App{
+	app := &App{
 		Analyzer:  analyzer,
 		In:        in,
 		Out:       out,
 		Formatter: formatter,
-		TUI:       ui.NewSummary(out, in, analyzer, formatter),
 		Notify:    notify.NewDefaultDispatcher(),
 		Features:  featureflags.DefaultRegistry(),
 		Languages: analyzer.Registry,
 	}
+	summary := ui.NewSummary(out, in, analyzer, formatter)
+	summary.Actions = app.tuiActionRunner()
+	app.TUI = summary
+	return app
 }
 
 func (a *App) Execute(ctx context.Context, req Request) (string, error) {

--- a/internal/app/tui_actions.go
+++ b/internal/app/tui_actions.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/ui"
+)
+
+type appTUIActionRunner struct {
+	app *App
+}
+
+func (a *App) tuiActionRunner() ui.ActionRunner {
+	if a == nil {
+		return nil
+	}
+	a.ensureMCPMutationDefaults()
+	return &appTUIActionRunner{app: a}
+}
+
+func (r *appTUIActionRunner) ApplyCodemod(ctx context.Context, req ui.CodemodApplyRequest) (report.Report, error) {
+	appReq := newTUIAnalyseRequest(req.RepoPath, req.TopN, req.Language)
+	appReq.Analyse.Dependency = strings.TrimSpace(req.Dependency)
+	appReq.Analyse.ApplyCodemod = true
+	appReq.Analyse.AllowDirty = req.AllowDirty
+	return r.runAnalyseReport(ctx, appReq)
+}
+
+func (r *appTUIActionRunner) SaveBaseline(ctx context.Context, req ui.BaselineSaveRequest) (report.Report, string, error) {
+	appReq := newTUIAnalyseRequest(req.RepoPath, req.TopN, req.Language)
+	appReq.Analyse.SaveBaseline = true
+	appReq.Analyse.BaselineStorePath = strings.TrimSpace(req.BaselineStorePath)
+	if strings.TrimSpace(req.BaselineLabel) == "" {
+		appReq.Analyse.BaselineKey = strings.TrimSpace(req.BaselineKey)
+	}
+	appReq.Analyse.BaselineLabel = strings.TrimSpace(req.BaselineLabel)
+
+	reportData, err := r.runAnalyseReport(ctx, appReq)
+	return reportData, savedSnapshotPath(reportData.Warnings, baselineSaveWarningPrefix), err
+}
+
+func newTUIAnalyseRequest(repoPath string, topN int, language string) Request {
+	appReq := DefaultRequest()
+	appReq.Mode = ModeAnalyse
+	appReq.RepoPath = repoPath
+	appReq.Analyse.TopN = topN
+	appReq.Analyse.Format = report.FormatJSON
+	if trimmedLanguage := strings.TrimSpace(language); trimmedLanguage != "" {
+		appReq.Analyse.Language = trimmedLanguage
+	}
+	return appReq
+}
+
+func (r *appTUIActionRunner) runAnalyseReport(ctx context.Context, req Request) (report.Report, error) {
+	output, err := r.app.executeAnalyse(ctx, req)
+	return decodeMCPCommandReport[report.Report](output, err)
+}

--- a/internal/app/tui_actions_test.go
+++ b/internal/app/tui_actions_test.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/ui"
+)
+
+func TestTUIActionRunnerUsesAnalysePipelineForCodemodApply(t *testing.T) {
+	analyzer := &fakeAnalyzer{
+		report: report.Report{
+			Dependencies: []report.DependencyReport{{Name: "lodash", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+		},
+	}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+	runner := application.tuiActionRunner()
+
+	if _, err := runner.ApplyCodemod(context.Background(), ui.CodemodApplyRequest{
+		RepoPath:   t.TempDir(),
+		Dependency: "lodash",
+		TopN:       7,
+		Language:   "js-ts",
+	}); err != nil {
+		t.Fatalf("apply codemod action: %v", err)
+	}
+	if !analyzer.lastReq.SuggestOnly || analyzer.lastReq.Dependency != "lodash" || analyzer.lastReq.TopN != 7 || analyzer.lastReq.Language != "js-ts" {
+		t.Fatalf("expected TUI codemod action to use analyse apply pipeline, got %#v", analyzer.lastReq)
+	}
+}
+
+func TestTUIActionRunnerSavesBaselineWithLabel(t *testing.T) {
+	analyzer := &fakeAnalyzer{
+		report: report.Report{
+			SchemaVersion: report.SchemaVersion,
+			Dependencies:  []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+		},
+	}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+	runner := application.tuiActionRunner()
+
+	store := t.TempDir()
+	_, savedPath, err := runner.SaveBaseline(context.Background(), ui.BaselineSaveRequest{
+		RepoPath:          ".",
+		TopN:              5,
+		Language:          "all",
+		BaselineStorePath: store,
+		BaselineLabel:     "nightly",
+	})
+	if err != nil {
+		t.Fatalf("save baseline action: %v", err)
+	}
+	if !strings.Contains(savedPath, "label_nightly.json") {
+		t.Fatalf("expected label-based snapshot path, got %q", savedPath)
+	}
+	if _, err := os.Stat(savedPath); err != nil {
+		t.Fatalf("expected saved snapshot to exist: %v", err)
+	}
+	if analyzer.lastReq.TopN != 5 || analyzer.lastReq.Language != "all" {
+		t.Fatalf("expected TUI baseline save to forward summary options, got %#v", analyzer.lastReq)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -280,4 +280,7 @@ func TestUsageReturnsText(t *testing.T) {
 	if !strings.Contains(Usage(), "powershell") {
 		t.Fatalf("expected usage text to include powershell adapter id")
 	}
+	if !strings.Contains(Usage(), "apply-codemod [dep] --confirm") || !strings.Contains(Usage(), "compare-baseline <key|file>") {
+		t.Fatalf("expected usage text to include TUI action commands")
+	}
 }

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -74,6 +74,13 @@ Options:
   --baseline PATH            Baseline report (JSON) for TUI comparison
   --baseline-store DIR       Directory for immutable keyed TUI baseline snapshots
   --baseline-key KEY         Baseline snapshot key for TUI comparison
+  TUI commands:
+    apply-codemod [dep] --confirm [--allow-dirty]
+                              Apply safe codemod suggestions shown in dependency detail
+    save-baseline [label] [--store DIR] [--key KEY]
+                              Save the current TUI report; defaults to .artifacts/lopper-baselines and commit:<HEAD>
+    compare-baseline <key|file> [--store DIR]
+                              Refresh TUI summary/detail views with baseline deltas
   --fail-on-increase PERCENT Legacy alias for --threshold-fail-on-increase
   --version                  Show CLI version metadata
   mcp                        Run a local stdio MCP server with read-only dependency analysis tools

--- a/internal/ui/actions.go
+++ b/internal/ui/actions.go
@@ -1,0 +1,29 @@
+package ui
+
+import (
+	"context"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+type ActionRunner interface {
+	ApplyCodemod(context.Context, CodemodApplyRequest) (report.Report, error)
+	SaveBaseline(context.Context, BaselineSaveRequest) (report.Report, string, error)
+}
+
+type CodemodApplyRequest struct {
+	RepoPath   string
+	Dependency string
+	TopN       int
+	Language   string
+	AllowDirty bool
+}
+
+type BaselineSaveRequest struct {
+	RepoPath          string
+	TopN              int
+	Language          string
+	BaselineStorePath string
+	BaselineKey       string
+	BaselineLabel     string
+}

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/analysis"
+	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/terminal"
 )
 
@@ -135,7 +136,7 @@ func printDependencySections(out io.Writer, dep detailDependencyView) error {
 		func(w io.Writer) error { return printRuntimeDelta(w, dep.RuntimeDelta) },
 		func(w io.Writer) error { return printRiskCues(w, dep.RiskCues) },
 		func(w io.Writer) error { return printRecommendations(w, dep.Recommendations) },
-		func(w io.Writer) error { return printCodemod(w, dep.Codemod) },
+		func(w io.Writer) error { return printCodemod(w, dep.Codemod, detailCodemodActionTarget(dep)) },
 		func(w io.Writer) error { return printImportList(w, "Used imports", dep.UsedImports) },
 		func(w io.Writer) error { return printImportList(w, "Unused imports", dep.UnusedImports) },
 		func(w io.Writer) error { return printExportsList(w, "Unused exports", dep.UnusedExports) },
@@ -230,7 +231,7 @@ func printRecommendations(out io.Writer, recommendations []detailRecommendationV
 	})
 }
 
-func printCodemod(out io.Writer, codemod *detailCodemodView) error {
+func printCodemod(out io.Writer, codemod *detailCodemodView, actionTargets ...string) error {
 	if err := writeln(out, "Codemod preview"); err != nil {
 		return err
 	}
@@ -261,7 +262,60 @@ func printCodemod(out io.Writer, codemod *detailCodemodView) error {
 			return err
 		}
 	}
+	if len(codemod.Suggestions) > 0 {
+		actionTarget := firstNonEmpty(actionTargets...)
+		if actionTarget != "" {
+			if err := writef(out, "  - action: apply-codemod %s --confirm\n", actionTarget); err != nil {
+				return err
+			}
+		}
+	}
+	if err := printDetailCodemodApply(out, codemod.Apply); err != nil {
+		return err
+	}
 	return writeln(out, "")
+}
+
+func detailCodemodActionTarget(dep detailDependencyView) string {
+	if strings.TrimSpace(dep.Name) == "" {
+		return ""
+	}
+	if strings.TrimSpace(dep.Language) == "" {
+		return dep.Name
+	}
+	return dep.Language + ":" + dep.Name
+}
+
+func printDetailCodemodApply(out io.Writer, apply *report.CodemodApplyReport) error {
+	if apply == nil {
+		return nil
+	}
+	if err := writeln(out, "  - apply results:"); err != nil {
+		return err
+	}
+	lines := []string{
+		fmt.Sprintf("    applied: %d file(s), %d patch(es)", apply.AppliedFiles, apply.AppliedPatches),
+		fmt.Sprintf("    skipped: %d file(s), %d patch(es)", apply.SkippedFiles, apply.SkippedPatches),
+		fmt.Sprintf("    failed: %d file(s), %d patch(es)", apply.FailedFiles, apply.FailedPatches),
+	}
+	if apply.BackupPath != "" {
+		lines = append(lines, fmt.Sprintf("    backup: %s", apply.BackupPath))
+	}
+	for _, line := range lines {
+		if err := writeln(out, line); err != nil {
+			return err
+		}
+	}
+	for _, result := range apply.Results {
+		line := fmt.Sprintf("    - %s %s (%d patch(es))", result.Status, result.File, result.PatchCount)
+		if strings.TrimSpace(result.Message) != "" {
+			line += ": " + result.Message
+		}
+		if err := writeln(out, line); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func printRuntimeUsage(out io.Writer, usage *detailRuntimeUsageView) error {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -241,39 +241,65 @@ func printCodemod(out io.Writer, codemod *detailCodemodView, actionTargets ...st
 		}
 		return writeln(out, "")
 	}
-	if codemod.Mode != "" {
-		if err := writef(out, "  - mode: %s\n", codemod.Mode); err != nil {
-			return err
-		}
-	}
-	if err := writef(out, "  - suggestions: %d\n", len(codemod.Suggestions)); err != nil {
+
+	if err := printCodemodMode(out, codemod.Mode); err != nil {
 		return err
 	}
-	for _, suggestion := range codemod.Suggestions {
-		if err := writef(out, "    - %s:%d %s -> %s\n", suggestion.File, suggestion.Line, suggestion.FromModule, suggestion.ToModule); err != nil {
-			return err
-		}
-	}
-	if err := writef(out, "  - skips: %d\n", len(codemod.Skips)); err != nil {
+	if err := printCodemodSuggestions(out, codemod.Suggestions); err != nil {
 		return err
 	}
-	for _, skip := range codemod.Skips {
-		if err := writef(out, "    - %s:%d [%s] %s\n", skip.File, skip.Line, skip.ReasonCode, skip.Message); err != nil {
-			return err
-		}
+	if err := printCodemodSkips(out, codemod.Skips); err != nil {
+		return err
 	}
-	if len(codemod.Suggestions) > 0 {
-		actionTarget := firstNonEmpty(actionTargets...)
-		if actionTarget != "" {
-			if err := writef(out, "  - action: apply-codemod %s --confirm\n", actionTarget); err != nil {
-				return err
-			}
-		}
+	if err := printCodemodActionHint(out, codemod.Suggestions, actionTargets...); err != nil {
+		return err
 	}
 	if err := printDetailCodemodApply(out, codemod.Apply); err != nil {
 		return err
 	}
 	return writeln(out, "")
+}
+
+func printCodemodMode(out io.Writer, mode string) error {
+	if mode == "" {
+		return nil
+	}
+	return writef(out, "  - mode: %s\n", mode)
+}
+
+func printCodemodSuggestions(out io.Writer, suggestions []detailCodemodSuggestionView) error {
+	if err := writef(out, "  - suggestions: %d\n", len(suggestions)); err != nil {
+		return err
+	}
+	for _, suggestion := range suggestions {
+		if err := writef(out, "    - %s:%d %s -> %s\n", suggestion.File, suggestion.Line, suggestion.FromModule, suggestion.ToModule); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printCodemodSkips(out io.Writer, skips []detailCodemodSkipView) error {
+	if err := writef(out, "  - skips: %d\n", len(skips)); err != nil {
+		return err
+	}
+	for _, skip := range skips {
+		if err := writef(out, "    - %s:%d [%s] %s\n", skip.File, skip.Line, skip.ReasonCode, skip.Message); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printCodemodActionHint(out io.Writer, suggestions []detailCodemodSuggestionView, actionTargets ...string) error {
+	if len(suggestions) == 0 {
+		return nil
+	}
+	actionTarget := firstNonEmpty(actionTargets...)
+	if actionTarget == "" {
+		return nil
+	}
+	return writef(out, "  - action: apply-codemod %s --confirm\n", actionTarget)
 }
 
 func detailCodemodActionTarget(dep detailDependencyView) string {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -268,23 +268,27 @@ func printCodemodMode(out io.Writer, mode string) error {
 }
 
 func printCodemodSuggestions(out io.Writer, suggestions []detailCodemodSuggestionView) error {
-	if err := writef(out, "  - suggestions: %d\n", len(suggestions)); err != nil {
-		return err
-	}
+	lines := make([]string, 0, len(suggestions))
 	for _, suggestion := range suggestions {
-		if err := writef(out, "    - %s:%d %s -> %s\n", suggestion.File, suggestion.Line, suggestion.FromModule, suggestion.ToModule); err != nil {
-			return err
-		}
+		lines = append(lines, fmt.Sprintf("%s:%d %s -> %s", suggestion.File, suggestion.Line, suggestion.FromModule, suggestion.ToModule))
 	}
-	return nil
+	return printCodemodLineCollection(out, "suggestions", lines)
 }
 
 func printCodemodSkips(out io.Writer, skips []detailCodemodSkipView) error {
-	if err := writef(out, "  - skips: %d\n", len(skips)); err != nil {
+	lines := make([]string, 0, len(skips))
+	for _, skip := range skips {
+		lines = append(lines, fmt.Sprintf("%s:%d [%s] %s", skip.File, skip.Line, skip.ReasonCode, skip.Message))
+	}
+	return printCodemodLineCollection(out, "skips", lines)
+}
+
+func printCodemodLineCollection(out io.Writer, label string, lines []string) error {
+	if err := writef(out, "  - %s: %d\n", label, len(lines)); err != nil {
 		return err
 	}
-	for _, skip := range skips {
-		if err := writef(out, "    - %s:%d [%s] %s\n", skip.File, skip.Line, skip.ReasonCode, skip.Message); err != nil {
+	for _, line := range lines {
+		if err := writef(out, "    - %s\n", line); err != nil {
 			return err
 		}
 	}

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -18,6 +18,7 @@ import (
 
 type Summary struct {
 	Analyzer  analysis.Analyser
+	Actions   ActionRunner
 	Formatter summaryFormatter
 	Out       io.Writer
 	In        io.Reader
@@ -63,7 +64,7 @@ func (s *Summary) Start(ctx context.Context, opts Options) error {
 		if err != nil {
 			return err
 		}
-		quit, err := s.handleSummaryInput(ctx, opts, reportView, &state, input)
+		quit, err := s.handleSummaryInputMutable(ctx, &opts, &reportView, &state, input)
 		if err != nil {
 			return err
 		}
@@ -101,7 +102,10 @@ func readSummaryInput(reader *bufio.Reader) (string, error) {
 }
 
 func (s *Summary) handleSummaryInput(ctx context.Context, opts Options, reportView summaryReportView, state *summaryState, input string) (bool, error) {
-	_ = ctx
+	return s.handleSummaryInputMutable(ctx, &opts, &reportView, state, input)
+}
+
+func (s *Summary) handleSummaryInputMutable(ctx context.Context, opts *Options, reportView *summaryReportView, state *summaryState, input string) (bool, error) {
 	if input == "" || input == "refresh" {
 		return false, nil
 	}
@@ -110,7 +114,19 @@ func (s *Summary) handleSummaryInput(ctx context.Context, opts Options, reportVi
 	}
 	if dependency, ok := isDetailCommand(input); ok {
 		detail := NewDetail(s.Out, s.Analyzer, opts.RepoPath, opts.Language)
-		if err := detail.showLoadedSummary(dependency, reportView); err != nil {
+		if err := detail.showLoadedSummary(dependency, *reportView); err != nil {
+			return false, err
+		}
+		if state != nil {
+			state.selectedDependency = dependency
+		}
+		return false, nil
+	}
+	if action, ok, err := parseSummaryAction(input, state); ok {
+		if err != nil {
+			return false, writeSummaryActionError(s.Out, err)
+		}
+		if err := s.runSummaryAction(ctx, opts, reportView, state, action); err != nil {
 			return false, err
 		}
 		return false, nil
@@ -120,7 +136,7 @@ func (s *Summary) handleSummaryInput(ctx context.Context, opts Options, reportVi
 			return false, err
 		}
 	} else {
-		clampSummaryPage(reportView, state)
+		clampSummaryPage(*reportView, state)
 	}
 	return false, nil
 }
@@ -149,11 +165,12 @@ const (
 )
 
 type summaryState struct {
-	filter   string
-	sortMode sortMode
-	page     int
-	pageSize int
-	showHelp bool
+	filter             string
+	sortMode           sortMode
+	page               int
+	pageSize           int
+	showHelp           bool
+	selectedDependency string
 }
 
 func applySummaryCommand(state *summaryState, input string, out io.Writer) bool {
@@ -301,6 +318,12 @@ func summaryHelpText() string {
 		"  size <n>             Change page size\n" +
 		"  open <dependency>    Show dependency detail\n" +
 		"  open <lang>:<dep>    Detail in multi-language mode\n" +
+		"  apply-codemod [dep] --confirm [--allow-dirty]\n" +
+		"                       Apply safe codemod suggestions from detail\n" +
+		"  save-baseline [label] [--store DIR] [--key KEY]\n" +
+		"                       Save current report as an immutable baseline\n" +
+		"  compare-baseline <key|file> [--store DIR]\n" +
+		"                       Refresh summary/detail with baseline deltas\n" +
 		"  refresh              Re-render the current view\n" +
 		"  q                    Quit\n\n"
 }
@@ -575,7 +598,7 @@ func renderSummaryFrame(formatted string, state summaryState, totalPages int, to
 	if state.showHelp {
 		builder.WriteString(summaryHelpText())
 	} else {
-		builder.WriteString("Commands: help | open <dependency> | q\n")
+		builder.WriteString("Commands: help | open <dependency> | apply-codemod | save-baseline | compare-baseline | q\n")
 	}
 	return builder.String()
 }

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -112,33 +112,50 @@ func (s *Summary) handleSummaryInputMutable(ctx context.Context, opts *Options, 
 	if input == "q" || input == "quit" {
 		return true, nil
 	}
-	if dependency, ok := isDetailCommand(input); ok {
-		detail := NewDetail(s.Out, s.Analyzer, opts.RepoPath, opts.Language)
-		if err := detail.showLoadedSummary(dependency, *reportView); err != nil {
-			return false, err
-		}
-		if state != nil {
-			state.selectedDependency = dependency
-		}
+	if handled, err := s.handleSummaryDetailInput(opts, reportView, state, input); handled || err != nil {
+		return false, err
+	}
+	if handled, err := s.handleSummaryActionInput(ctx, opts, reportView, state, input); handled || err != nil {
+		return false, err
+	}
+	return false, s.handleSummaryCommandInput(reportView, state, input)
+}
+
+func (s *Summary) handleSummaryDetailInput(opts *Options, reportView *summaryReportView, state *summaryState, input string) (bool, error) {
+	dependency, ok := isDetailCommand(input)
+	if !ok {
 		return false, nil
 	}
-	if action, ok, err := parseSummaryAction(input, state); ok {
-		if err != nil {
-			return false, writeSummaryActionError(s.Out, err)
-		}
-		if err := s.runSummaryAction(ctx, opts, reportView, state, action); err != nil {
-			return false, err
-		}
+	detail := NewDetail(s.Out, s.Analyzer, opts.RepoPath, opts.Language)
+	if err := detail.showLoadedSummary(dependency, *reportView); err != nil {
+		return true, err
+	}
+	if state != nil {
+		state.selectedDependency = dependency
+	}
+	return true, nil
+}
+
+func (s *Summary) handleSummaryActionInput(ctx context.Context, opts *Options, reportView *summaryReportView, state *summaryState, input string) (bool, error) {
+	action, ok, err := parseSummaryAction(input, state)
+	if !ok {
 		return false, nil
 	}
+	if err != nil {
+		return true, writeSummaryActionError(s.Out, err)
+	}
+	return true, s.runSummaryAction(ctx, opts, reportView, state, action)
+}
+
+func (s *Summary) handleSummaryCommandInput(reportView *summaryReportView, state *summaryState, input string) error {
 	if !applySummaryCommand(state, input, s.Out) {
 		if _, err := fmt.Fprintln(s.Out, "Unknown command. Type 'help' for options."); err != nil {
-			return false, err
+			return err
 		}
 	} else {
 		clampSummaryPage(*reportView, state)
 	}
-	return false, nil
+	return nil
 }
 
 func filterDependencies(deps []summaryDependencyView, filter string) []summaryDependencyView {

--- a/internal/ui/summary_actions.go
+++ b/internal/ui/summary_actions.go
@@ -1,0 +1,438 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const defaultTUIBaselineStorePath = ".artifacts/lopper-baselines"
+
+type summaryActionKind string
+
+const (
+	summaryActionApplyCodemod    summaryActionKind = "apply-codemod"
+	summaryActionSaveBaseline    summaryActionKind = "save-baseline"
+	summaryActionCompareBaseline summaryActionKind = "compare-baseline"
+)
+
+type summaryAction struct {
+	kind              summaryActionKind
+	dependency        string
+	confirm           bool
+	allowDirty        bool
+	baselineStorePath string
+	baselineKey       string
+	baselineLabel     string
+	baselinePath      string
+	baselineTarget    string
+}
+
+func parseSummaryAction(input string, state *summaryState) (summaryAction, bool, error) {
+	fields := strings.Fields(input)
+	if len(fields) == 0 {
+		return summaryAction{}, false, nil
+	}
+
+	command := fields[0]
+	args := fields[1:]
+	if command == "baseline" && len(args) > 0 {
+		command = "baseline-" + args[0]
+		args = args[1:]
+	}
+
+	switch command {
+	case "apply-codemod", "codemod-apply":
+		return parseSummaryCodemodApplyAction(args, state)
+	case "save-baseline", "baseline-save":
+		return parseSummaryBaselineSaveAction(args)
+	case "compare-baseline", "baseline-compare":
+		return parseSummaryBaselineCompareAction(args)
+	default:
+		return summaryAction{}, false, nil
+	}
+}
+
+func parseSummaryCodemodApplyAction(args []string, state *summaryState) (summaryAction, bool, error) {
+	action := summaryAction{kind: summaryActionApplyCodemod}
+	dependencyParts := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--confirm", "-y":
+			action.confirm = true
+		case "--allow-dirty":
+			action.allowDirty = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return action, true, fmt.Errorf("unknown apply-codemod option: %s", arg)
+			}
+			dependencyParts = append(dependencyParts, arg)
+		}
+	}
+	if len(dependencyParts) > 0 {
+		action.dependency = strings.Join(dependencyParts, " ")
+	} else if state != nil {
+		action.dependency = state.selectedDependency
+	}
+	return action, true, nil
+}
+
+func parseSummaryBaselineSaveAction(args []string) (summaryAction, bool, error) {
+	action := summaryAction{kind: summaryActionSaveBaseline}
+	labelParts, err := parseSummaryBaselineArguments(args, &action, summaryActionSaveBaseline)
+	if err != nil {
+		return action, true, err
+	}
+	if action.baselineLabel == "" && len(labelParts) > 0 {
+		action.baselineLabel = strings.Join(labelParts, " ")
+	}
+	if action.baselineKey != "" && action.baselineLabel != "" {
+		return action, true, fmt.Errorf("save-baseline accepts either --key or a label, not both")
+	}
+	return action, true, nil
+}
+
+func parseSummaryBaselineCompareAction(args []string) (summaryAction, bool, error) {
+	action := summaryAction{kind: summaryActionCompareBaseline}
+	targetParts, err := parseSummaryBaselineArguments(args, &action, summaryActionCompareBaseline)
+	if err != nil {
+		return action, true, err
+	}
+	if len(targetParts) > 0 {
+		action.baselineTarget = strings.Join(targetParts, " ")
+	}
+	return action, true, nil
+}
+
+func parseSummaryBaselineArguments(args []string, action *summaryAction, kind summaryActionKind) ([]string, error) {
+	positionals := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--store":
+			value, next, err := readSummaryActionValue(args, i, arg)
+			if err != nil {
+				return nil, err
+			}
+			action.baselineStorePath = value
+			i = next
+		case "--key":
+			value, next, err := readSummaryActionValue(args, i, arg)
+			if err != nil {
+				return nil, err
+			}
+			action.baselineKey = value
+			i = next
+		case "--label":
+			if kind != summaryActionSaveBaseline {
+				return nil, fmt.Errorf("unknown %s option: %s", kind, arg)
+			}
+			value, next, err := readSummaryActionValue(args, i, arg)
+			if err != nil {
+				return nil, err
+			}
+			action.baselineLabel = value
+			i = next
+		case "--file":
+			if kind != summaryActionCompareBaseline {
+				return nil, fmt.Errorf("unknown %s option: %s", kind, arg)
+			}
+			value, next, err := readSummaryActionValue(args, i, arg)
+			if err != nil {
+				return nil, err
+			}
+			action.baselinePath = value
+			i = next
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return nil, fmt.Errorf("unknown %s option: %s", kind, arg)
+			}
+			positionals = append(positionals, arg)
+		}
+	}
+	return positionals, nil
+}
+
+func readSummaryActionValue(args []string, index int, option string) (string, int, error) {
+	next := index + 1
+	if next >= len(args) || strings.TrimSpace(args[next]) == "" {
+		return "", index, fmt.Errorf("%s requires a value", option)
+	}
+	return strings.TrimSpace(args[next]), next, nil
+}
+
+func (s *Summary) runSummaryAction(ctx context.Context, opts *Options, reportView *summaryReportView, state *summaryState, action summaryAction) error {
+	switch action.kind {
+	case summaryActionApplyCodemod:
+		return s.runSummaryCodemodApply(ctx, opts, reportView, action)
+	case summaryActionSaveBaseline:
+		return s.runSummaryBaselineSave(ctx, opts, reportView, action)
+	case summaryActionCompareBaseline:
+		return s.runSummaryBaselineCompare(ctx, opts, reportView, state, action)
+	default:
+		return nil
+	}
+}
+
+func (s *Summary) runSummaryCodemodApply(ctx context.Context, opts *Options, reportView *summaryReportView, action summaryAction) error {
+	if strings.TrimSpace(action.dependency) == "" {
+		return writeSummaryActionMessage(s.Out, "Open a dependency detail first or pass a dependency to apply-codemod.\n")
+	}
+	if !action.confirm {
+		return writeSummaryActionMessage(s.Out, "Codemod apply requires --confirm.\n")
+	}
+	if s.Actions == nil {
+		return writeSummaryActionMessage(s.Out, "Codemod apply is unavailable in this TUI instance.\n")
+	}
+
+	languageID, dependencyName := parseDependencyLanguage(opts.Language, action.dependency)
+	reportData, runErr := s.Actions.ApplyCodemod(ctx, CodemodApplyRequest{
+		RepoPath:   opts.RepoPath,
+		Dependency: dependencyName,
+		TopN:       opts.TopN,
+		Language:   languageID,
+		AllowDirty: action.allowDirty,
+	})
+	applyReport := findCodemodApplyReport(reportData, action.dependency)
+	if applyReport != nil && reportView != nil {
+		mergeCodemodApplyReport(reportView, action.dependency, applyReport)
+	}
+	if applyReport != nil {
+		if err := writeCodemodApplyReport(s.Out, action.dependency, applyReport); err != nil {
+			return err
+		}
+	} else if runErr == nil {
+		if err := writeSummaryActionMessage(s.Out, fmt.Sprintf("No safe codemod apply results for %s.\n", sanitizeTerminalString(action.dependency))); err != nil {
+			return err
+		}
+	}
+	if runErr != nil {
+		return writeSummaryActionMessage(s.Out, fmt.Sprintf("Codemod apply failed: %s\n", sanitizeTerminalString(runErr.Error())))
+	}
+	return nil
+}
+
+func (s *Summary) runSummaryBaselineSave(ctx context.Context, opts *Options, reportView *summaryReportView, action summaryAction) error {
+	if s.Actions == nil {
+		return writeSummaryActionMessage(s.Out, "Baseline save is unavailable in this TUI instance.\n")
+	}
+	request, displayKey, err := buildSummaryBaselineSaveRequest(*opts, action)
+	if err != nil {
+		return writeSummaryActionError(s.Out, err)
+	}
+
+	reportData, savedPath, runErr := s.Actions.SaveBaseline(ctx, request)
+	if runErr != nil {
+		return writeSummaryActionMessage(s.Out, fmt.Sprintf("Baseline save failed: %s\n", sanitizeTerminalString(runErr.Error())))
+	}
+	if savedPath == "" {
+		savedPath = report.BaselineSnapshotPath(request.BaselineStorePath, displayKey)
+	}
+	*opts = updateOptionsAfterBaselineSave(*opts, request.BaselineStorePath)
+	if reportView != nil {
+		*reportView = mapSummaryReportView(reportData)
+	}
+	return writeSummaryActionMessage(s.Out, fmt.Sprintf("Saved baseline %s to %s\n", sanitizeTerminalString(displayKey), sanitizeTerminalString(savedPath)))
+}
+
+func (s *Summary) runSummaryBaselineCompare(ctx context.Context, opts *Options, reportView *summaryReportView, state *summaryState, action summaryAction) error {
+	nextOpts, target, err := buildSummaryBaselineCompareOptions(*opts, action)
+	if err != nil {
+		return writeSummaryActionError(s.Out, err)
+	}
+	nextReportView, err := s.analyseSummaryView(ctx, nextOpts)
+	if err != nil {
+		return writeSummaryActionMessage(s.Out, fmt.Sprintf("Baseline compare failed: %s\n", sanitizeTerminalString(err.Error())))
+	}
+	*opts = nextOpts
+	if reportView != nil {
+		*reportView = nextReportView
+		clampSummaryPage(*reportView, state)
+	}
+	return writeBaselineCompareResult(s.Out, target, nextReportView.BaselineComparison)
+}
+
+func buildSummaryBaselineSaveRequest(opts Options, action summaryAction) (BaselineSaveRequest, string, error) {
+	storePath := firstNonEmpty(action.baselineStorePath, opts.BaselineStorePath, defaultTUIBaselineStorePath)
+	label := normalizeSummaryBaselineLabel(action.baselineLabel)
+	key := strings.TrimSpace(action.baselineKey)
+	displayKey := key
+	if label != "" {
+		displayKey = "label:" + label
+		key = ""
+	} else if key == "" {
+		key = resolveSummaryCurrentBaselineKey(opts.RepoPath)
+		displayKey = key
+	}
+	if displayKey == "" {
+		return BaselineSaveRequest{}, "", fmt.Errorf("unable to resolve git commit for baseline key; pass --label or --key")
+	}
+
+	return BaselineSaveRequest{
+		RepoPath:          opts.RepoPath,
+		TopN:              opts.TopN,
+		Language:          opts.Language,
+		BaselineStorePath: storePath,
+		BaselineKey:       key,
+		BaselineLabel:     label,
+	}, displayKey, nil
+}
+
+func updateOptionsAfterBaselineSave(opts Options, storePath string) Options {
+	opts.BaselineStorePath = storePath
+	return opts
+}
+
+func buildSummaryBaselineCompareOptions(opts Options, action summaryAction) (Options, string, error) {
+	nextOpts := opts
+	baselinePath := strings.TrimSpace(action.baselinePath)
+	target := strings.TrimSpace(action.baselineTarget)
+	key := strings.TrimSpace(action.baselineKey)
+	if baselinePath == "" && key == "" && target != "" && summaryBaselineTargetLooksLikeFile(target) {
+		baselinePath = target
+	}
+	if baselinePath != "" {
+		nextOpts.BaselinePath = baselinePath
+		nextOpts.BaselineStorePath = ""
+		nextOpts.BaselineKey = ""
+		return nextOpts, baselinePath, nil
+	}
+
+	if key == "" && target != "" {
+		key = target
+	}
+	if key == "" {
+		key = strings.TrimSpace(opts.BaselineKey)
+	}
+	if key == "" {
+		return Options{}, "", fmt.Errorf("baseline key or file is required")
+	}
+	storePath := firstNonEmpty(action.baselineStorePath, opts.BaselineStorePath, defaultTUIBaselineStorePath)
+	nextOpts.BaselinePath = ""
+	nextOpts.BaselineStorePath = storePath
+	nextOpts.BaselineKey = key
+	return nextOpts, key, nil
+}
+
+func normalizeSummaryBaselineLabel(label string) string {
+	label = strings.TrimSpace(label)
+	return strings.TrimSpace(strings.TrimPrefix(label, "label:"))
+}
+
+func summaryBaselineTargetLooksLikeFile(target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return false
+	}
+	return filepath.IsAbs(target) ||
+		strings.ContainsAny(target, `/\`) ||
+		strings.EqualFold(filepath.Ext(target), ".json")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func findCodemodApplyReport(reportData report.Report, dependency string) *report.CodemodApplyReport {
+	languageID, dependencyName := parseDependencyLanguage("", dependency)
+	for i := range reportData.Dependencies {
+		dep := reportData.Dependencies[i]
+		if dep.Codemod == nil || dep.Codemod.Apply == nil {
+			continue
+		}
+		if dep.Name == dependencyName && summaryDependencyLanguageMatches(languageID, dep.Language) {
+			return dep.Codemod.Apply
+		}
+	}
+	for i := range reportData.Dependencies {
+		if reportData.Dependencies[i].Codemod != nil && reportData.Dependencies[i].Codemod.Apply != nil {
+			return reportData.Dependencies[i].Codemod.Apply
+		}
+	}
+	return nil
+}
+
+func mergeCodemodApplyReport(reportView *summaryReportView, dependency string, applyReport *report.CodemodApplyReport) {
+	if reportView == nil || applyReport == nil {
+		return
+	}
+	languageID, dependencyName := parseDependencyLanguage("", dependency)
+	for i := range reportView.Dependencies {
+		dep := &reportView.Dependencies[i]
+		if dep.Name != dependencyName || !summaryDependencyLanguageMatches(languageID, dep.Language) {
+			continue
+		}
+		dep.CodemodApply = applyReport
+		if dep.detail.Codemod == nil {
+			dep.detail.Codemod = &detailCodemodView{Mode: "apply"}
+		}
+		dep.detail.Codemod.Apply = applyReport
+		return
+	}
+}
+
+func writeSummaryActionError(out io.Writer, err error) error {
+	return writeSummaryActionMessage(out, fmt.Sprintf("Invalid command: %s\n", sanitizeTerminalString(err.Error())))
+}
+
+func writeSummaryActionMessage(out io.Writer, message string) error {
+	_, err := io.WriteString(out, message)
+	return err
+}
+
+func writeCodemodApplyReport(out io.Writer, dependency string, applyReport *report.CodemodApplyReport) error {
+	if applyReport == nil {
+		return nil
+	}
+	if err := writeSummaryActionMessage(out, fmt.Sprintf("Codemod apply results for %s\n", sanitizeTerminalString(dependency))); err != nil {
+		return err
+	}
+	lines := []string{
+		fmt.Sprintf("  applied: %d file(s), %d patch(es)\n", applyReport.AppliedFiles, applyReport.AppliedPatches),
+		fmt.Sprintf("  skipped: %d file(s), %d patch(es)\n", applyReport.SkippedFiles, applyReport.SkippedPatches),
+		fmt.Sprintf("  failed: %d file(s), %d patch(es)\n", applyReport.FailedFiles, applyReport.FailedPatches),
+	}
+	if applyReport.BackupPath != "" {
+		lines = append(lines, fmt.Sprintf("  backup: %s\n", sanitizeTerminalString(applyReport.BackupPath)))
+	}
+	for _, result := range applyReport.Results {
+		line := fmt.Sprintf("  - %s %s (%d patch(es))", sanitizeTerminalString(result.Status), sanitizeTerminalString(result.File), result.PatchCount)
+		if strings.TrimSpace(result.Message) != "" {
+			line += ": " + sanitizeTerminalString(result.Message)
+		}
+		lines = append(lines, line+"\n")
+	}
+	for _, line := range lines {
+		if err := writeSummaryActionMessage(out, line); err != nil {
+			return err
+		}
+	}
+	return writeSummaryActionMessage(out, "\n")
+}
+
+func writeBaselineCompareResult(out io.Writer, target string, comparison *report.BaselineComparison) error {
+	if comparison == nil {
+		return writeSummaryActionMessage(out, fmt.Sprintf("Baseline comparison refreshed for %s\n", sanitizeTerminalString(target)))
+	}
+	lines := []string{
+		fmt.Sprintf("Baseline comparison refreshed for %s\n", sanitizeTerminalString(target)),
+		fmt.Sprintf("  changed: %d, regressions: %d, progressions: %d, added: %d, removed: %d\n", len(comparison.Dependencies), len(comparison.Regressions), len(comparison.Progressions), len(comparison.Added), len(comparison.Removed)),
+		fmt.Sprintf("  summary_delta: deps %+d, used %% %+0.1f, waste %% %+0.1f, unused bytes %+d\n", comparison.SummaryDelta.DependencyCountDelta, comparison.SummaryDelta.UsedPercentDelta, comparison.SummaryDelta.WastePercentDelta, comparison.SummaryDelta.UnusedBytesDelta),
+	}
+	for _, line := range lines {
+		if err := writeSummaryActionMessage(out, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/ui/summary_actions.go
+++ b/internal/ui/summary_actions.go
@@ -113,49 +113,77 @@ func parseSummaryBaselineArguments(args []string, action *summaryAction, kind su
 	positionals := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		switch arg {
-		case "--store":
-			value, next, err := readSummaryActionValue(args, i, arg)
-			if err != nil {
-				return nil, err
-			}
-			action.baselineStorePath = value
-			i = next
-		case "--key":
-			value, next, err := readSummaryActionValue(args, i, arg)
-			if err != nil {
-				return nil, err
-			}
-			action.baselineKey = value
-			i = next
-		case "--label":
-			if kind != summaryActionSaveBaseline {
-				return nil, fmt.Errorf("unknown %s option: %s", kind, arg)
-			}
-			value, next, err := readSummaryActionValue(args, i, arg)
-			if err != nil {
-				return nil, err
-			}
-			action.baselineLabel = value
-			i = next
-		case "--file":
-			if kind != summaryActionCompareBaseline {
-				return nil, fmt.Errorf("unknown %s option: %s", kind, arg)
-			}
-			value, next, err := readSummaryActionValue(args, i, arg)
-			if err != nil {
-				return nil, err
-			}
-			action.baselinePath = value
-			i = next
-		default:
-			if strings.HasPrefix(arg, "-") {
-				return nil, fmt.Errorf("unknown %s option: %s", kind, arg)
-			}
-			positionals = append(positionals, arg)
+		next, handled, err := parseSummaryBaselineOption(args, i, action, kind)
+		if err != nil {
+			return nil, err
 		}
+		if handled {
+			i = next
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			return nil, fmt.Errorf("unknown %s option: %s", kind, arg)
+		}
+		positionals = append(positionals, arg)
 	}
 	return positionals, nil
+}
+
+func parseSummaryBaselineOption(args []string, index int, action *summaryAction, kind summaryActionKind) (int, bool, error) {
+	switch args[index] {
+	case "--store":
+		return readSummaryBaselineStoreOption(args, index, action)
+	case "--key":
+		return readSummaryBaselineKeyOption(args, index, action)
+	case "--label":
+		return readSummaryBaselineLabelOption(args, index, action, kind)
+	case "--file":
+		return readSummaryBaselineFileOption(args, index, action, kind)
+	default:
+		return index, false, nil
+	}
+}
+
+func readSummaryBaselineStoreOption(args []string, index int, action *summaryAction) (int, bool, error) {
+	value, next, err := readSummaryActionValue(args, index, args[index])
+	if err != nil {
+		return index, true, err
+	}
+	action.baselineStorePath = value
+	return next, true, nil
+}
+
+func readSummaryBaselineKeyOption(args []string, index int, action *summaryAction) (int, bool, error) {
+	value, next, err := readSummaryActionValue(args, index, args[index])
+	if err != nil {
+		return index, true, err
+	}
+	action.baselineKey = value
+	return next, true, nil
+}
+
+func readSummaryBaselineLabelOption(args []string, index int, action *summaryAction, kind summaryActionKind) (int, bool, error) {
+	if kind != summaryActionSaveBaseline {
+		return index, true, fmt.Errorf("unknown %s option: %s", kind, args[index])
+	}
+	value, next, err := readSummaryActionValue(args, index, args[index])
+	if err != nil {
+		return index, true, err
+	}
+	action.baselineLabel = value
+	return next, true, nil
+}
+
+func readSummaryBaselineFileOption(args []string, index int, action *summaryAction, kind summaryActionKind) (int, bool, error) {
+	if kind != summaryActionCompareBaseline {
+		return index, true, fmt.Errorf("unknown %s option: %s", kind, args[index])
+	}
+	value, next, err := readSummaryActionValue(args, index, args[index])
+	if err != nil {
+		return index, true, err
+	}
+	action.baselinePath = value
+	return next, true, nil
 }
 
 func readSummaryActionValue(args []string, index int, option string) (string, int, error) {

--- a/internal/ui/summary_actions.go
+++ b/internal/ui/summary_actions.go
@@ -163,26 +163,26 @@ func readSummaryBaselineKeyOption(args []string, index int, action *summaryActio
 }
 
 func readSummaryBaselineLabelOption(args []string, index int, action *summaryAction, kind summaryActionKind) (int, bool, error) {
-	if kind != summaryActionSaveBaseline {
-		return index, true, fmt.Errorf("unknown %s option: %s", kind, args[index])
-	}
-	value, next, err := readSummaryActionValue(args, index, args[index])
-	if err != nil {
-		return index, true, err
-	}
-	action.baselineLabel = value
-	return next, true, nil
+	return readSummaryBaselineScopedOption(args, index, kind, summaryActionSaveBaseline, func(value string) {
+		action.baselineLabel = value
+	})
 }
 
 func readSummaryBaselineFileOption(args []string, index int, action *summaryAction, kind summaryActionKind) (int, bool, error) {
-	if kind != summaryActionCompareBaseline {
-		return index, true, fmt.Errorf("unknown %s option: %s", kind, args[index])
+	return readSummaryBaselineScopedOption(args, index, kind, summaryActionCompareBaseline, func(value string) {
+		action.baselinePath = value
+	})
+}
+
+func readSummaryBaselineScopedOption(args []string, index int, actual summaryActionKind, allowed summaryActionKind, assign func(string)) (int, bool, error) {
+	if actual != allowed {
+		return index, true, fmt.Errorf("unknown %s option: %s", actual, args[index])
 	}
 	value, next, err := readSummaryActionValue(args, index, args[index])
 	if err != nil {
 		return index, true, err
 	}
-	action.baselinePath = value
+	assign(value)
 	return next, true, nil
 }
 

--- a/internal/ui/summary_actions_test.go
+++ b/internal/ui/summary_actions_test.go
@@ -1,0 +1,229 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+type stubSummaryActionRunner struct {
+	applyCalls  int
+	applyReq    CodemodApplyRequest
+	applyReport report.Report
+	applyErr    error
+
+	saveCalls  int
+	saveReq    BaselineSaveRequest
+	saveReport report.Report
+	savePath   string
+	saveErr    error
+}
+
+func (s *stubSummaryActionRunner) ApplyCodemod(_ context.Context, req CodemodApplyRequest) (report.Report, error) {
+	s.applyCalls++
+	s.applyReq = req
+	return s.applyReport, s.applyErr
+}
+
+func (s *stubSummaryActionRunner) SaveBaseline(_ context.Context, req BaselineSaveRequest) (report.Report, string, error) {
+	s.saveCalls++
+	s.saveReq = req
+	return s.saveReport, s.savePath, s.saveErr
+}
+
+func TestSummaryCodemodApplyCommandRequiresConfirmationAndMergesResults(t *testing.T) {
+	applyReport := &report.CodemodApplyReport{
+		AppliedFiles:   1,
+		AppliedPatches: 2,
+		SkippedFiles:   1,
+		SkippedPatches: 1,
+		BackupPath:     ".artifacts/lopper-codemod-backups/lodash.json",
+		Results: []report.CodemodApplyResult{
+			{File: "src/index.js", Status: "applied", PatchCount: 2},
+			{File: "src/skip.js", Status: "skipped", PatchCount: 1, Message: "reason codes: namespace-import"},
+		},
+	}
+	actions := &stubSummaryActionRunner{
+		applyReport: report.Report{
+			Dependencies: []report.DependencyReport{
+				{Name: "lodash", Language: "js-ts", Codemod: &report.CodemodReport{Apply: applyReport}},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{}, report.NewFormatter())
+	summary.Actions = actions
+	reportView := mapSummaryReportView(report.Report{
+		Dependencies: []report.DependencyReport{
+			{
+				Name:     "lodash",
+				Language: "js-ts",
+				Codemod: &report.CodemodReport{
+					Mode: "suggest-only",
+					Suggestions: []report.CodemodSuggestion{
+						{File: "src/index.js", Line: 1, FromModule: "lodash", ToModule: "lodash/map"},
+					},
+				},
+			},
+		},
+	})
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all"}
+	state := summaryState{page: 1, pageSize: 10, sortMode: sortByWaste, selectedDependency: "js-ts:lodash"}
+
+	if quit, err := summary.handleSummaryInputMutable(context.Background(), &opts, &reportView, &state, "apply-codemod"); err != nil || quit {
+		t.Fatalf("expected unconfirmed apply to continue, quit=%v err=%v", quit, err)
+	}
+	if actions.applyCalls != 0 {
+		t.Fatalf("expected unconfirmed apply to avoid mutation, got %d calls", actions.applyCalls)
+	}
+	if !strings.Contains(out.String(), "requires --confirm") {
+		t.Fatalf("expected confirmation message, got %q", out.String())
+	}
+
+	out.Reset()
+	if quit, err := summary.handleSummaryInputMutable(context.Background(), &opts, &reportView, &state, "apply-codemod --confirm --allow-dirty"); err != nil || quit {
+		t.Fatalf("expected confirmed apply to continue, quit=%v err=%v", quit, err)
+	}
+	if actions.applyCalls != 1 {
+		t.Fatalf("expected one apply call, got %d", actions.applyCalls)
+	}
+	if actions.applyReq.Dependency != "lodash" || actions.applyReq.Language != "js-ts" || !actions.applyReq.AllowDirty {
+		t.Fatalf("unexpected apply request: %#v", actions.applyReq)
+	}
+	if reportView.Dependencies[0].CodemodApply != applyReport {
+		t.Fatalf("expected apply report to merge into current view, got %#v", reportView.Dependencies[0].CodemodApply)
+	}
+	output := out.String()
+	if !strings.Contains(output, "Codemod apply results for js-ts:lodash") ||
+		!strings.Contains(output, "backup: .artifacts/lopper-codemod-backups/lodash.json") ||
+		!strings.Contains(output, "applied src/index.js") ||
+		!strings.Contains(output, "skipped src/skip.js") {
+		t.Fatalf("expected codemod apply details in output, got %q", output)
+	}
+}
+
+func TestSummarySaveBaselineCommandSupportsLabelAndDefaultCommitKey(t *testing.T) {
+	actions := &stubSummaryActionRunner{
+		saveReport: report.Report{
+			Dependencies: []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+		},
+		savePath: ".artifacts/lopper-baselines/label_nightly.json",
+	}
+
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{}, report.NewFormatter())
+	summary.Actions = actions
+	reportView := summaryReportView{}
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all"}
+	state := summaryState{page: 1, pageSize: 10, sortMode: sortByWaste}
+
+	if quit, err := summary.handleSummaryInputMutable(context.Background(), &opts, &reportView, &state, "save-baseline nightly"); err != nil || quit {
+		t.Fatalf("expected save label to continue, quit=%v err=%v", quit, err)
+	}
+	if actions.saveReq.BaselineStorePath != defaultTUIBaselineStorePath || actions.saveReq.BaselineLabel != "nightly" {
+		t.Fatalf("unexpected label save request: %#v", actions.saveReq)
+	}
+	if opts.BaselineStorePath != defaultTUIBaselineStorePath {
+		t.Fatalf("expected options to remember baseline store, got %q", opts.BaselineStorePath)
+	}
+	if !strings.Contains(out.String(), "Saved baseline label:nightly") {
+		t.Fatalf("expected saved baseline message, got %q", out.String())
+	}
+
+	out.Reset()
+	if quit, err := summary.handleSummaryInputMutable(context.Background(), &opts, &reportView, &state, "save-baseline --store custom-baselines"); err != nil || quit {
+		t.Fatalf("expected default-key save to continue, quit=%v err=%v", quit, err)
+	}
+	if !strings.HasPrefix(actions.saveReq.BaselineKey, "commit:") || actions.saveReq.BaselineLabel != "" {
+		t.Fatalf("expected default commit key save request, got %#v", actions.saveReq)
+	}
+	if actions.saveReq.BaselineStorePath != "custom-baselines" {
+		t.Fatalf("expected explicit store to win, got %q", actions.saveReq.BaselineStorePath)
+	}
+}
+
+func TestSummaryCompareBaselineCommandRefreshesReportAndDetailDeltas(t *testing.T) {
+	tmp := t.TempDir()
+	baselineReport := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		GeneratedAt:   mustParseTime(t, "2024-01-01T00:00:00Z"),
+		RepoPath:      "/repo",
+		Dependencies: []report.DependencyReport{
+			{
+				Name:              "alpha",
+				UsedExportsCount:  1,
+				TotalExportsCount: 10,
+				UsedPercent:       10,
+				RuntimeUsage:      &report.RuntimeUsage{LoadCount: 1, Correlation: report.RuntimeCorrelationStaticOnly},
+			},
+		},
+	}
+	baselinePath, err := report.SaveSnapshot(tmp, "label:base", baselineReport, mustParseTime(t, "2024-01-02T00:00:00Z"))
+	if err != nil {
+		t.Fatalf("save baseline snapshot: %v", err)
+	}
+
+	currentReport := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		GeneratedAt:   mustParseTime(t, "2024-02-01T00:00:00Z"),
+		RepoPath:      "/repo",
+		Dependencies: []report.DependencyReport{
+			{
+				Name:              "alpha",
+				UsedExportsCount:  3,
+				TotalExportsCount: 10,
+				UsedPercent:       30,
+				RuntimeUsage:      &report.RuntimeUsage{LoadCount: 3, Correlation: report.RuntimeCorrelationRuntimeOnly, RuntimeOnly: true},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{report: currentReport}, report.NewFormatter())
+	reportView := mapSummaryReportView(currentReport)
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all"}
+	state := summaryState{page: 1, pageSize: 10, sortMode: sortByWaste}
+
+	if quit, err := summary.handleSummaryInputMutable(context.Background(), &opts, &reportView, &state, "compare-baseline --file "+baselinePath); err != nil || quit {
+		t.Fatalf("expected compare to continue, quit=%v err=%v", quit, err)
+	}
+	if reportView.BaselineComparison == nil {
+		t.Fatalf("expected baseline comparison to refresh current view")
+	}
+	if !strings.Contains(out.String(), "Baseline comparison refreshed") {
+		t.Fatalf("expected compare refresh message, got %q", out.String())
+	}
+
+	out.Reset()
+	detail := NewDetail(&out, nil, ".", "auto")
+	if err := detail.showLoadedSummary("alpha", reportView); err != nil {
+		t.Fatalf("show refreshed detail: %v", err)
+	}
+	if !strings.Contains(out.String(), "Runtime baseline delta") || !strings.Contains(out.String(), "load count delta: +2") {
+		t.Fatalf("expected refreshed detail to include runtime baseline delta, got %q", out.String())
+	}
+}
+
+func TestSummaryDetailShowsCodemodAction(t *testing.T) {
+	dep := detailDependencyView{
+		Name:     "lodash",
+		Language: "js-ts",
+		Codemod: &detailCodemodView{
+			Mode: "suggest-only",
+			Suggestions: []detailCodemodSuggestionView{
+				{File: "src/index.js", Line: 1, FromModule: "lodash", ToModule: "lodash/map"},
+			},
+		},
+	}
+	var out bytes.Buffer
+	if err := printCodemod(&out, dep.Codemod, detailCodemodActionTarget(dep)); err != nil {
+		t.Fatalf("print codemod: %v", err)
+	}
+	if !strings.Contains(out.String(), "action: apply-codemod js-ts:lodash --confirm") {
+		t.Fatalf("expected explicit codemod apply action, got %q", out.String())
+	}
+}

--- a/internal/ui/summary_actions_test.go
+++ b/internal/ui/summary_actions_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"bytes"
 	"context"
+	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -225,5 +227,423 @@ func TestSummaryDetailShowsCodemodAction(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "action: apply-codemod js-ts:lodash --confirm") {
 		t.Fatalf("expected explicit codemod apply action, got %q", out.String())
+	}
+}
+
+func TestParseSummaryActionVariantsAndErrors(t *testing.T) {
+	if _, ok, err := parseSummaryAction("", nil); ok || err != nil {
+		t.Fatalf("expected empty input to be ignored, ok=%t err=%v", ok, err)
+	}
+	if _, ok, err := parseSummaryAction("noop", nil); ok || err != nil {
+		t.Fatalf("expected unknown input to be ignored, ok=%t err=%v", ok, err)
+	}
+
+	action, ok, err := parseSummaryAction("codemod-apply selected dep --confirm", nil)
+	if !ok || err != nil || action.kind != summaryActionApplyCodemod || action.dependency != "selected dep" || !action.confirm {
+		t.Fatalf("unexpected codemod alias parse: action=%#v ok=%t err=%v", action, ok, err)
+	}
+	action, ok, err = parseSummaryAction("apply-codemod --confirm", &summaryState{selectedDependency: "js-ts:lodash"})
+	if !ok || err != nil || action.dependency != "js-ts:lodash" {
+		t.Fatalf("expected selected dependency fallback, action=%#v ok=%t err=%v", action, ok, err)
+	}
+	if _, ok, err := parseSummaryAction("apply-codemod --bad", nil); !ok || err == nil {
+		t.Fatalf("expected unknown apply option error, ok=%t err=%v", ok, err)
+	}
+
+	action, ok, err = parseSummaryAction("baseline save --label nightly --store baselines", nil)
+	if !ok || err != nil || action.kind != summaryActionSaveBaseline || action.baselineLabel != "nightly" || action.baselineStorePath != "baselines" {
+		t.Fatalf("unexpected baseline save parse: action=%#v ok=%t err=%v", action, ok, err)
+	}
+	action, ok, err = parseSummaryAction("baseline compare --key commit:abc --store baselines", nil)
+	if !ok || err != nil || action.kind != summaryActionCompareBaseline || action.baselineKey != "commit:abc" || action.baselineStorePath != "baselines" {
+		t.Fatalf("unexpected baseline compare parse: action=%#v ok=%t err=%v", action, ok, err)
+	}
+	if _, ok, err := parseSummaryAction("baseline compare --label nope", nil); !ok || err == nil {
+		t.Fatalf("expected compare label error, ok=%t err=%v", ok, err)
+	}
+	action, ok, err = parseSummaryAction("compare-baseline label base", nil)
+	if !ok || err != nil || action.baselineTarget != "label base" {
+		t.Fatalf("unexpected compare positional parse: action=%#v ok=%t err=%v", action, ok, err)
+	}
+	if _, ok, err := parseSummaryAction("save-baseline --key commit:abc release", nil); !ok || err == nil {
+		t.Fatalf("expected key plus label conflict, ok=%t err=%v", ok, err)
+	}
+	if _, ok, err := parseSummaryAction("save-baseline --store", nil); !ok || err == nil {
+		t.Fatalf("expected missing store value error, ok=%t err=%v", ok, err)
+	}
+}
+
+func TestSummaryCodemodApplyCommandUnavailableAndFailureMessages(t *testing.T) {
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{}, report.NewFormatter())
+	reportView := summaryReportView{}
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all"}
+
+	if err := summary.runSummaryCodemodApply(context.Background(), &opts, &reportView, summaryAction{kind: summaryActionApplyCodemod, confirm: true}); err != nil {
+		t.Fatalf("empty dependency message: %v", err)
+	}
+	if !strings.Contains(out.String(), "Open a dependency detail first") {
+		t.Fatalf("expected empty dependency guidance, got %q", out.String())
+	}
+
+	out.Reset()
+	if err := summary.runSummaryCodemodApply(context.Background(), &opts, &reportView, summaryAction{kind: summaryActionApplyCodemod, dependency: "lodash", confirm: true}); err != nil {
+		t.Fatalf("unavailable action message: %v", err)
+	}
+	if !strings.Contains(out.String(), "unavailable") {
+		t.Fatalf("expected unavailable message, got %q", out.String())
+	}
+
+	out.Reset()
+	summary.Actions = &stubSummaryActionRunner{applyErr: errors.New("dirty worktree")}
+	if err := summary.runSummaryCodemodApply(context.Background(), &opts, &reportView, summaryAction{kind: summaryActionApplyCodemod, dependency: "lodash", confirm: true}); err != nil {
+		t.Fatalf("failed action message: %v", err)
+	}
+	output := out.String()
+	if strings.Contains(output, "No safe codemod apply results") || !strings.Contains(output, "dirty worktree") {
+		t.Fatalf("expected failure message without no-result text, got %q", output)
+	}
+}
+
+func TestSummaryCodemodApplyUsesFallbackReportWhenDependencyDoesNotMatch(t *testing.T) {
+	applyReport := &report.CodemodApplyReport{
+		FailedFiles:   1,
+		FailedPatches: 1,
+		Results: []report.CodemodApplyResult{
+			{File: "src/index.js", Status: "failed", PatchCount: 1, Message: "manual follow-up required"},
+		},
+	}
+	actions := &stubSummaryActionRunner{
+		applyReport: report.Report{
+			Dependencies: []report.DependencyReport{
+				{Name: "other", Codemod: &report.CodemodReport{Apply: applyReport}},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{}, report.NewFormatter())
+	summary.Actions = actions
+	reportView := mapSummaryReportView(report.Report{Dependencies: []report.DependencyReport{{Name: "lodash"}}})
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all"}
+
+	if err := summary.runSummaryCodemodApply(context.Background(), &opts, &reportView, summaryAction{kind: summaryActionApplyCodemod, dependency: "lodash", confirm: true}); err != nil {
+		t.Fatalf("fallback apply report: %v", err)
+	}
+	if reportView.Dependencies[0].CodemodApply != applyReport {
+		t.Fatalf("expected fallback report to merge into selected dependency, got %#v", reportView.Dependencies[0].CodemodApply)
+	}
+	if !strings.Contains(out.String(), "failed src/index.js") {
+		t.Fatalf("expected fallback apply details in output, got %q", out.String())
+	}
+}
+
+func TestSummaryCodemodApplyReportsNoSafeResults(t *testing.T) {
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{}, report.NewFormatter())
+	summary.Actions = &stubSummaryActionRunner{applyReport: report.Report{}}
+	reportView := summaryReportView{}
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all"}
+
+	if err := summary.runSummaryCodemodApply(context.Background(), &opts, &reportView, summaryAction{kind: summaryActionApplyCodemod, dependency: "lodash", confirm: true}); err != nil {
+		t.Fatalf("no safe codemod result message: %v", err)
+	}
+	if !strings.Contains(out.String(), "No safe codemod apply results for lodash") {
+		t.Fatalf("expected no-result message, got %q", out.String())
+	}
+}
+
+func TestBuildSummaryBaselineCompareOptions(t *testing.T) {
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all", BaselineStorePath: "existing", BaselineKey: "commit:prev"}
+
+	nextOpts, target, err := buildSummaryBaselineCompareOptions(opts, summaryAction{kind: summaryActionCompareBaseline, baselineTarget: "/tmp/base.json"})
+	if err != nil {
+		t.Fatalf("absolute file target: %v", err)
+	}
+	if target != "/tmp/base.json" || nextOpts.BaselinePath != "/tmp/base.json" || nextOpts.BaselineStorePath != "" || nextOpts.BaselineKey != "" {
+		t.Fatalf("unexpected file compare options: target=%q opts=%#v", target, nextOpts)
+	}
+
+	nextOpts, target, err = buildSummaryBaselineCompareOptions(opts, summaryAction{kind: summaryActionCompareBaseline, baselineKey: "label:nightly", baselineStorePath: "custom"})
+	if err != nil {
+		t.Fatalf("key target: %v", err)
+	}
+	if target != "label:nightly" || nextOpts.BaselineStorePath != "custom" || nextOpts.BaselineKey != "label:nightly" || nextOpts.BaselinePath != "" {
+		t.Fatalf("unexpected key compare options: target=%q opts=%#v", target, nextOpts)
+	}
+
+	nextOpts, target, err = buildSummaryBaselineCompareOptions(opts, summaryAction{kind: summaryActionCompareBaseline, baselinePath: "explicit.json"})
+	if err != nil {
+		t.Fatalf("explicit file option: %v", err)
+	}
+	if target != "explicit.json" || nextOpts.BaselinePath != "explicit.json" || nextOpts.BaselineStorePath != "" || nextOpts.BaselineKey != "" {
+		t.Fatalf("unexpected explicit file options: target=%q opts=%#v", target, nextOpts)
+	}
+
+	nextOpts, target, err = buildSummaryBaselineCompareOptions(opts, summaryAction{kind: summaryActionCompareBaseline})
+	if err != nil {
+		t.Fatalf("stored key fallback: %v", err)
+	}
+	if target != "commit:prev" || nextOpts.BaselineStorePath != "existing" || nextOpts.BaselineKey != "commit:prev" {
+		t.Fatalf("unexpected stored key fallback: target=%q opts=%#v", target, nextOpts)
+	}
+
+	if _, _, err := buildSummaryBaselineCompareOptions(Options{}, summaryAction{kind: summaryActionCompareBaseline}); err == nil {
+		t.Fatalf("expected missing compare target to fail")
+	}
+
+	if summaryBaselineTargetLooksLikeFile("") {
+		t.Fatalf("empty compare target should not look like a file")
+	}
+	if summaryBaselineTargetLooksLikeFile("commit:abc") {
+		t.Fatalf("baseline key should not look like a file")
+	}
+	if !summaryBaselineTargetLooksLikeFile("baseline.json") {
+		t.Fatalf("json target should look like a file")
+	}
+}
+
+func TestPrintCodemodApplyResultsInDetail(t *testing.T) {
+	codemod := &detailCodemodView{
+		Apply: &report.CodemodApplyReport{
+			AppliedFiles:   1,
+			AppliedPatches: 2,
+			SkippedFiles:   1,
+			SkippedPatches: 1,
+			FailedFiles:    1,
+			FailedPatches:  1,
+			BackupPath:     ".artifacts/backups/lodash.json",
+			Results: []report.CodemodApplyResult{
+				{File: "src/index.js", Status: "applied", PatchCount: 2},
+				{File: "src/manual.js", Status: "failed", PatchCount: 1, Message: "manual follow-up required"},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	if err := printCodemod(&out, codemod); err != nil {
+		t.Fatalf("print codemod apply: %v", err)
+	}
+	output := out.String()
+	for _, expected := range []string{
+		"apply results",
+		"backup: .artifacts/backups/lodash.json",
+		"applied src/index.js",
+		"failed src/manual.js",
+		"manual follow-up required",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected detail output to contain %q, got %q", expected, output)
+		}
+	}
+}
+
+func TestSummaryBaselineActionMessagesAndErrors(t *testing.T) {
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{}, report.NewFormatter())
+	reportView := summaryReportView{}
+	opts := Options{RepoPath: t.TempDir(), TopN: 20, Language: "all"}
+
+	if err := summary.runSummaryAction(context.Background(), &opts, &reportView, nil, summaryAction{kind: "unknown"}); err != nil {
+		t.Fatalf("unknown summary action should be ignored: %v", err)
+	}
+
+	if err := summary.runSummaryBaselineSave(context.Background(), &opts, &reportView, summaryAction{kind: summaryActionSaveBaseline, baselineLabel: "nightly"}); err != nil {
+		t.Fatalf("unavailable save message: %v", err)
+	}
+	if !strings.Contains(out.String(), "Baseline save is unavailable") {
+		t.Fatalf("expected unavailable baseline save message, got %q", out.String())
+	}
+
+	out.Reset()
+	summary.Actions = &stubSummaryActionRunner{}
+	if err := summary.runSummaryBaselineSave(context.Background(), &opts, &reportView, summaryAction{kind: summaryActionSaveBaseline}); err != nil {
+		t.Fatalf("invalid save message: %v", err)
+	}
+	if !strings.Contains(out.String(), "Invalid command") || !strings.Contains(out.String(), "unable to resolve git commit") {
+		t.Fatalf("expected invalid save message, got %q", out.String())
+	}
+
+	out.Reset()
+	summary.Actions = &stubSummaryActionRunner{saveErr: errors.New("disk full")}
+	if err := summary.runSummaryBaselineSave(context.Background(), &opts, &reportView, summaryAction{kind: summaryActionSaveBaseline, baselineLabel: "nightly"}); err != nil {
+		t.Fatalf("failed save message: %v", err)
+	}
+	if !strings.Contains(out.String(), "Baseline save failed: disk full") {
+		t.Fatalf("expected save failure message, got %q", out.String())
+	}
+
+	out.Reset()
+	actions := &stubSummaryActionRunner{
+		saveReport: report.Report{Dependencies: []report.DependencyReport{{Name: "dep"}}},
+	}
+	summary.Actions = actions
+	if err := summary.runSummaryBaselineSave(context.Background(), &opts, nil, summaryAction{kind: summaryActionSaveBaseline, baselineLabel: "nightly", baselineStorePath: "store"}); err != nil {
+		t.Fatalf("save with fallback path: %v", err)
+	}
+	if !strings.Contains(out.String(), "store/label_nightly.json") {
+		t.Fatalf("expected fallback saved path in output, got %q", out.String())
+	}
+}
+
+func TestSummaryBaselineCompareErrorMessages(t *testing.T) {
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{}, report.NewFormatter())
+	reportView := summaryReportView{}
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all"}
+	state := summaryState{page: 1, pageSize: 10, sortMode: sortByWaste}
+
+	if err := summary.runSummaryBaselineCompare(context.Background(), &opts, &reportView, &state, summaryAction{kind: summaryActionCompareBaseline}); err != nil {
+		t.Fatalf("invalid compare message: %v", err)
+	}
+	if !strings.Contains(out.String(), "Invalid command") || !strings.Contains(out.String(), "baseline key or file is required") {
+		t.Fatalf("expected invalid compare message, got %q", out.String())
+	}
+
+	out.Reset()
+	summary.Analyzer = &stubAnalyzer{err: errors.New("analysis failed")}
+	if err := summary.runSummaryBaselineCompare(context.Background(), &opts, &reportView, &state, summaryAction{kind: summaryActionCompareBaseline, baselineKey: "label:base"}); err != nil {
+		t.Fatalf("failed compare message: %v", err)
+	}
+	if !strings.Contains(out.String(), "Baseline compare failed: analysis failed") {
+		t.Fatalf("expected compare failure message, got %q", out.String())
+	}
+
+	out.Reset()
+	if err := writeBaselineCompareResult(&out, "label:base", nil); err != nil {
+		t.Fatalf("write nil baseline comparison: %v", err)
+	}
+	if !strings.Contains(out.String(), "Baseline comparison refreshed for label:base") {
+		t.Fatalf("expected nil comparison refresh message, got %q", out.String())
+	}
+}
+
+func TestSummaryActionParserMissingValues(t *testing.T) {
+	testCases := []string{
+		"save-baseline --label",
+		"compare-baseline --key",
+		"compare-baseline --file",
+		"save-baseline --file baseline.json",
+	}
+	for _, input := range testCases {
+		if _, ok, err := parseSummaryAction(input, nil); !ok || err == nil {
+			t.Fatalf("expected parse error for %q, ok=%t err=%v", input, ok, err)
+		}
+	}
+}
+
+func TestDetailCodemodActionTargetFallbacks(t *testing.T) {
+	if got := detailCodemodActionTarget(detailDependencyView{}); got != "" {
+		t.Fatalf("expected empty action target, got %q", got)
+	}
+	if got := detailCodemodActionTarget(detailDependencyView{Name: "lodash"}); got != "lodash" {
+		t.Fatalf("expected dependency-only action target, got %q", got)
+	}
+}
+
+func TestSummaryActionInputInvalidCommandUsesActionError(t *testing.T) {
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{}, report.NewFormatter())
+	reportView := summaryReportView{}
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all"}
+	state := summaryState{page: 1, pageSize: 10, sortMode: sortByWaste}
+
+	quit, err := summary.handleSummaryInputMutable(context.Background(), &opts, &reportView, &state, "apply-codemod --bad")
+	if err != nil || quit {
+		t.Fatalf("expected invalid action to continue, quit=%t err=%v", quit, err)
+	}
+	if !strings.Contains(out.String(), "Invalid command: unknown apply-codemod option") {
+		t.Fatalf("expected invalid action message, got %q", out.String())
+	}
+}
+
+func TestSummaryDetailInputStoresSelectedDependency(t *testing.T) {
+	var out bytes.Buffer
+	summary := NewSummary(&out, strings.NewReader(""), &stubAnalyzer{}, report.NewFormatter())
+	reportView := mapSummaryReportView(report.Report{
+		Dependencies: []report.DependencyReport{{Name: "lodash", Language: "js-ts", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+	})
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all"}
+	state := summaryState{page: 1, pageSize: 10, sortMode: sortByWaste}
+
+	quit, err := summary.handleSummaryInputMutable(context.Background(), &opts, &reportView, &state, "open js-ts:lodash")
+	if err != nil || quit {
+		t.Fatalf("expected detail open to continue, quit=%t err=%v", quit, err)
+	}
+	if state.selectedDependency != "js-ts:lodash" {
+		t.Fatalf("expected selected dependency to be stored, got %q", state.selectedDependency)
+	}
+	if !strings.Contains(out.String(), "Dependency detail: lodash") {
+		t.Fatalf("expected detail output, got %q", out.String())
+	}
+}
+
+func TestSummaryBaselinePathResolutionBranches(t *testing.T) {
+	reportData := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		Dependencies:  []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+	}
+	unchanged, err := applySummaryBaselineIfNeeded(reportData, Options{})
+	if err != nil {
+		t.Fatalf("no baseline should not fail: %v", err)
+	}
+	if len(unchanged.Dependencies) != 1 || unchanged.Dependencies[0].Name != "dep" {
+		t.Fatalf("expected report to remain unchanged, got %#v", unchanged)
+	}
+
+	baselinePath := filepath.Join(t.TempDir(), "baseline.json")
+	path, key, _, shouldApply, err := resolveSummaryBaselinePaths(".", Options{BaselinePath: baselinePath})
+	if err != nil || !shouldApply || path != baselinePath || key != "" {
+		t.Fatalf("unexpected explicit baseline path resolution: path=%q key=%q apply=%t err=%v", path, key, shouldApply, err)
+	}
+
+	if _, _, _, _, err := resolveSummaryBaselinePaths(t.TempDir(), Options{BaselineStorePath: "store"}); err == nil {
+		t.Fatalf("expected baseline store without key in non-git repo to fail")
+	}
+	if _, err := applySummaryBaselineIfNeeded(reportData, Options{BaselinePath: filepath.Join(t.TempDir(), "missing.json")}); err == nil {
+		t.Fatalf("expected missing baseline file to fail")
+	}
+
+	baselineStore := t.TempDir()
+	baselineReport := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		Dependencies:  []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50}},
+	}
+	savedPath, err := report.SaveSnapshot(baselineStore, "label:base", baselineReport, mustParseTime(t, "2024-01-01T00:00:00Z"))
+	if err != nil {
+		t.Fatalf("save baseline snapshot: %v", err)
+	}
+	currentReport := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		Dependencies:  []report.DependencyReport{{Name: "dep", UsedExportsCount: 2, TotalExportsCount: 2, UsedPercent: 100}},
+	}
+	applied, err := applySummaryBaselineIfNeeded(currentReport, Options{BaselinePath: savedPath})
+	if err != nil {
+		t.Fatalf("apply explicit baseline snapshot: %v", err)
+	}
+	if applied.BaselineComparison == nil || applied.BaselineComparison.BaselineKey != "label:base" {
+		t.Fatalf("expected loaded baseline key to be applied, got %#v", applied.BaselineComparison)
+	}
+}
+
+func TestSummaryActionHelpersNoOps(t *testing.T) {
+	if got := findCodemodApplyReport(report.Report{}, "lodash"); got != nil {
+		t.Fatalf("expected no apply report, got %#v", got)
+	}
+
+	reportView := mapSummaryReportView(report.Report{Dependencies: []report.DependencyReport{{Name: "lodash"}}})
+	mergeCodemodApplyReport(nil, "lodash", &report.CodemodApplyReport{})
+	mergeCodemodApplyReport(&reportView, "lodash", nil)
+	mergeCodemodApplyReport(&reportView, "react", &report.CodemodApplyReport{AppliedFiles: 1})
+	if reportView.Dependencies[0].CodemodApply != nil {
+		t.Fatalf("expected no-op merges to leave dependency unchanged")
+	}
+
+	var out bytes.Buffer
+	if err := writeCodemodApplyReport(&out, "lodash", nil); err != nil {
+		t.Fatalf("nil codemod apply report should not fail: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected nil codemod apply report to write nothing, got %q", out.String())
 	}
 }

--- a/internal/ui/summary_actions_test.go
+++ b/internal/ui/summary_actions_test.go
@@ -230,14 +230,16 @@ func TestSummaryDetailShowsCodemodAction(t *testing.T) {
 	}
 }
 
-func TestParseSummaryActionVariantsAndErrors(t *testing.T) {
+func TestParseSummaryActionIgnoresEmptyAndUnknown(t *testing.T) {
 	if _, ok, err := parseSummaryAction("", nil); ok || err != nil {
 		t.Fatalf("expected empty input to be ignored, ok=%t err=%v", ok, err)
 	}
 	if _, ok, err := parseSummaryAction("noop", nil); ok || err != nil {
 		t.Fatalf("expected unknown input to be ignored, ok=%t err=%v", ok, err)
 	}
+}
 
+func TestParseSummaryCodemodApplyActionVariants(t *testing.T) {
 	action, ok, err := parseSummaryAction("codemod-apply selected dep --confirm", nil)
 	if !ok || err != nil || action.kind != summaryActionApplyCodemod || action.dependency != "selected dep" || !action.confirm {
 		t.Fatalf("unexpected codemod alias parse: action=%#v ok=%t err=%v", action, ok, err)
@@ -249,12 +251,23 @@ func TestParseSummaryActionVariantsAndErrors(t *testing.T) {
 	if _, ok, err := parseSummaryAction("apply-codemod --bad", nil); !ok || err == nil {
 		t.Fatalf("expected unknown apply option error, ok=%t err=%v", ok, err)
 	}
+}
 
-	action, ok, err = parseSummaryAction("baseline save --label nightly --store baselines", nil)
+func TestParseSummaryBaselineSaveActionVariants(t *testing.T) {
+	action, ok, err := parseSummaryAction("baseline save --label nightly --store baselines", nil)
 	if !ok || err != nil || action.kind != summaryActionSaveBaseline || action.baselineLabel != "nightly" || action.baselineStorePath != "baselines" {
 		t.Fatalf("unexpected baseline save parse: action=%#v ok=%t err=%v", action, ok, err)
 	}
-	action, ok, err = parseSummaryAction("baseline compare --key commit:abc --store baselines", nil)
+	if _, ok, err := parseSummaryAction("save-baseline --key commit:abc release", nil); !ok || err == nil {
+		t.Fatalf("expected key plus label conflict, ok=%t err=%v", ok, err)
+	}
+	if _, ok, err := parseSummaryAction("save-baseline --store", nil); !ok || err == nil {
+		t.Fatalf("expected missing store value error, ok=%t err=%v", ok, err)
+	}
+}
+
+func TestParseSummaryBaselineCompareActionVariants(t *testing.T) {
+	action, ok, err := parseSummaryAction("baseline compare --key commit:abc --store baselines", nil)
 	if !ok || err != nil || action.kind != summaryActionCompareBaseline || action.baselineKey != "commit:abc" || action.baselineStorePath != "baselines" {
 		t.Fatalf("unexpected baseline compare parse: action=%#v ok=%t err=%v", action, ok, err)
 	}
@@ -264,12 +277,6 @@ func TestParseSummaryActionVariantsAndErrors(t *testing.T) {
 	action, ok, err = parseSummaryAction("compare-baseline label base", nil)
 	if !ok || err != nil || action.baselineTarget != "label base" {
 		t.Fatalf("unexpected compare positional parse: action=%#v ok=%t err=%v", action, ok, err)
-	}
-	if _, ok, err := parseSummaryAction("save-baseline --key commit:abc release", nil); !ok || err == nil {
-		t.Fatalf("expected key plus label conflict, ok=%t err=%v", ok, err)
-	}
-	if _, ok, err := parseSummaryAction("save-baseline --store", nil); !ok || err == nil {
-		t.Fatalf("expected missing store value error, ok=%t err=%v", ok, err)
 	}
 }
 
@@ -353,7 +360,7 @@ func TestSummaryCodemodApplyReportsNoSafeResults(t *testing.T) {
 	}
 }
 
-func TestBuildSummaryBaselineCompareOptions(t *testing.T) {
+func TestBuildSummaryBaselineCompareFileOptions(t *testing.T) {
 	opts := Options{RepoPath: ".", TopN: 20, Language: "all", BaselineStorePath: "existing", BaselineKey: "commit:prev"}
 
 	nextOpts, target, err := buildSummaryBaselineCompareOptions(opts, summaryAction{kind: summaryActionCompareBaseline, baselineTarget: "/tmp/base.json"})
@@ -364,20 +371,24 @@ func TestBuildSummaryBaselineCompareOptions(t *testing.T) {
 		t.Fatalf("unexpected file compare options: target=%q opts=%#v", target, nextOpts)
 	}
 
-	nextOpts, target, err = buildSummaryBaselineCompareOptions(opts, summaryAction{kind: summaryActionCompareBaseline, baselineKey: "label:nightly", baselineStorePath: "custom"})
-	if err != nil {
-		t.Fatalf("key target: %v", err)
-	}
-	if target != "label:nightly" || nextOpts.BaselineStorePath != "custom" || nextOpts.BaselineKey != "label:nightly" || nextOpts.BaselinePath != "" {
-		t.Fatalf("unexpected key compare options: target=%q opts=%#v", target, nextOpts)
-	}
-
 	nextOpts, target, err = buildSummaryBaselineCompareOptions(opts, summaryAction{kind: summaryActionCompareBaseline, baselinePath: "explicit.json"})
 	if err != nil {
 		t.Fatalf("explicit file option: %v", err)
 	}
 	if target != "explicit.json" || nextOpts.BaselinePath != "explicit.json" || nextOpts.BaselineStorePath != "" || nextOpts.BaselineKey != "" {
 		t.Fatalf("unexpected explicit file options: target=%q opts=%#v", target, nextOpts)
+	}
+}
+
+func TestBuildSummaryBaselineCompareKeyOptions(t *testing.T) {
+	opts := Options{RepoPath: ".", TopN: 20, Language: "all", BaselineStorePath: "existing", BaselineKey: "commit:prev"}
+
+	nextOpts, target, err := buildSummaryBaselineCompareOptions(opts, summaryAction{kind: summaryActionCompareBaseline, baselineKey: "label:nightly", baselineStorePath: "custom"})
+	if err != nil {
+		t.Fatalf("key target: %v", err)
+	}
+	if target != "label:nightly" || nextOpts.BaselineStorePath != "custom" || nextOpts.BaselineKey != "label:nightly" || nextOpts.BaselinePath != "" {
+		t.Fatalf("unexpected key compare options: target=%q opts=%#v", target, nextOpts)
 	}
 
 	nextOpts, target, err = buildSummaryBaselineCompareOptions(opts, summaryAction{kind: summaryActionCompareBaseline})
@@ -387,11 +398,15 @@ func TestBuildSummaryBaselineCompareOptions(t *testing.T) {
 	if target != "commit:prev" || nextOpts.BaselineStorePath != "existing" || nextOpts.BaselineKey != "commit:prev" {
 		t.Fatalf("unexpected stored key fallback: target=%q opts=%#v", target, nextOpts)
 	}
+}
 
+func TestBuildSummaryBaselineCompareRequiresTarget(t *testing.T) {
 	if _, _, err := buildSummaryBaselineCompareOptions(Options{}, summaryAction{kind: summaryActionCompareBaseline}); err == nil {
 		t.Fatalf("expected missing compare target to fail")
 	}
+}
 
+func TestSummaryBaselineTargetLooksLikeFile(t *testing.T) {
 	if summaryBaselineTargetLooksLikeFile("") {
 		t.Fatalf("empty compare target should not look like a file")
 	}

--- a/internal/ui/summary_commands_test.go
+++ b/internal/ui/summary_commands_test.go
@@ -34,6 +34,9 @@ func TestSummaryCommandHandlersHelpAndFiltering(t *testing.T) {
 	if !strings.Contains(summaryHelpText(), "sort name|alpha|waste") {
 		t.Fatalf("expected help text to list alpha sort alias")
 	}
+	if !strings.Contains(summaryHelpText(), "apply-codemod") || !strings.Contains(summaryHelpText(), "save-baseline") || !strings.Contains(summaryHelpText(), "compare-baseline") {
+		t.Fatalf("expected help text to list action commands")
+	}
 	if !applySummaryCommand(state, "filter lodash", io.Discard) || state.filter != "lodash" || state.page != 1 {
 		t.Fatalf("expected filter command to set filter and reset page")
 	}

--- a/internal/ui/summary_commands_test.go
+++ b/internal/ui/summary_commands_test.go
@@ -21,8 +21,8 @@ func newSummaryCommandState() *summaryState {
 	return &summaryState{page: 2, pageSize: 10, sortMode: sortByWaste}
 }
 
-func TestSummaryCommandHandlersHelpAndFiltering(t *testing.T) {
-	state := &summaryState{page: 2, pageSize: 10, sortMode: sortByWaste}
+func TestSummaryCommandHandlersHelp(t *testing.T) {
+	state := newSummaryCommandState()
 	var out bytes.Buffer
 
 	if !applySummaryCommand(state, "help", &out) || !state.showHelp {
@@ -31,18 +31,26 @@ func TestSummaryCommandHandlersHelpAndFiltering(t *testing.T) {
 	if out.Len() != 0 {
 		t.Fatalf("expected help command to rely on re-render instead of direct output")
 	}
-	if !strings.Contains(summaryHelpText(), "sort name|alpha|waste") {
-		t.Fatalf("expected help text to list alpha sort alias")
-	}
-	if !strings.Contains(summaryHelpText(), "apply-codemod") || !strings.Contains(summaryHelpText(), "save-baseline") || !strings.Contains(summaryHelpText(), "compare-baseline") {
-		t.Fatalf("expected help text to list action commands")
-	}
+	assertSummaryHelpContains(t, "sort name|alpha|waste")
+	assertSummaryHelpContains(t, "apply-codemod")
+	assertSummaryHelpContains(t, "save-baseline")
+	assertSummaryHelpContains(t, "compare-baseline")
+}
+
+func TestSummaryCommandHandlersFiltering(t *testing.T) {
+	state := newSummaryCommandState()
+
 	if !applySummaryCommand(state, "filter lodash", io.Discard) || state.filter != "lodash" || state.page != 1 {
 		t.Fatalf("expected filter command to set filter and reset page")
 	}
 	if !applySummaryCommand(state, "filter", io.Discard) || state.filter != "" {
 		t.Fatalf("expected bare filter command to clear filter")
 	}
+}
+
+func TestSummaryCommandHandlersSorting(t *testing.T) {
+	state := newSummaryCommandState()
+
 	if !applySummaryCommand(state, "sort name", io.Discard) || state.sortMode != sortByName {
 		t.Fatalf("expected sort name to apply")
 	}
@@ -54,6 +62,14 @@ func TestSummaryCommandHandlersHelpAndFiltering(t *testing.T) {
 	}
 	if applySummaryCommand(state, "sort nope", io.Discard) {
 		t.Fatalf("expected invalid sort command to fail")
+	}
+}
+
+func assertSummaryHelpContains(t *testing.T, expected string) {
+	t.Helper()
+
+	if !strings.Contains(summaryHelpText(), expected) {
+		t.Fatalf("expected help text to include %q", expected)
 	}
 }
 

--- a/internal/ui/summary_detail_rendering_test.go
+++ b/internal/ui/summary_detail_rendering_test.go
@@ -82,7 +82,7 @@ func TestRenderSummaryOutputHelpIsOneShot(t *testing.T) {
 	if strings.Contains(out.String(), "Commands:\n  filter <text>") {
 		t.Fatalf("expected second render to omit expanded help, got %q", out.String())
 	}
-	if !strings.Contains(out.String(), "Commands: help | open <dependency> | q") {
+	if !strings.Contains(out.String(), "Commands: help | open <dependency> | apply-codemod | save-baseline | compare-baseline | q") {
 		t.Fatalf("expected second render to include compact command hint, got %q", out.String())
 	}
 }

--- a/internal/ui/summary_test.go
+++ b/internal/ui/summary_test.go
@@ -15,9 +15,13 @@ import (
 
 type stubAnalyzer struct {
 	report report.Report
+	err    error
 }
 
 func (s *stubAnalyzer) Analyse(ctx context.Context, req analysis.Request) (report.Report, error) {
+	if s.err != nil {
+		return report.Report{}, s.err
+	}
 	return s.report, nil
 }
 

--- a/internal/ui/view_model.go
+++ b/internal/ui/view_model.go
@@ -245,6 +245,7 @@ type detailCodemodView struct {
 	Mode        string
 	Suggestions []detailCodemodSuggestionView
 	Skips       []detailCodemodSkipView
+	Apply       *report.CodemodApplyReport
 }
 
 type detailCodemodSuggestionView struct {
@@ -389,6 +390,7 @@ func mapDetailCodemod(codemod *report.CodemodReport) *detailCodemodView {
 		Mode:        codemod.Mode,
 		Suggestions: mapDetailCodemodSuggestions(codemod.Suggestions),
 		Skips:       mapDetailCodemodSkips(codemod.Skips),
+		Apply:       codemod.Apply,
 	}
 }
 

--- a/testdata/ui/summary.golden
+++ b/testdata/ui/summary.golden
@@ -8,4 +8,4 @@ Licenses: known=0, unknown=2, denied=0
 Dependency  Used/Total  Used%  License  Provenance  Est. Unused Size  Candidate Score  Score Components  Top Symbols
 alpha       1/10        10.0   unknown  -           0 B               -                -                 foo (2)
 beta        0/5         0.0    unknown  -           0 B               -                -                 -
-Commands: help | open <dependency> | q
+Commands: help | open <dependency> | apply-codemod | save-baseline | compare-baseline | q


### PR DESCRIPTION
## Summary

Adds in-session TUI actions for GitHub issue #1089 so users can apply safe codemods from dependency detail, save immutable baselines, and compare the current report against a stored baseline without leaving the TUI.

## Changes

- Added an app-backed TUI action runner that reuses existing analyse codemod apply and baseline save behavior.
- Added `apply-codemod`, `save-baseline`, and `compare-baseline` TUI commands with confirmation, dirty-worktree default refusal through the app pipeline, result output, and summary/detail refresh for baseline deltas.
- Updated dependency detail, TUI help, README, generated man page, golden output, and focused UI/app/CLI tests.

## Validation

Commands and checks run:

```bash
GOTOOLCHAIN=go1.26.4 go test ./internal/ui ./internal/app ./internal/cli
make lint
make test
make dup-check
git diff --check
git diff HEAD^..HEAD --check
```

Additional manual validation:

- Focused tests cover apply confirmation, language-prefixed detail action targets, baseline save label/default key behavior, and compare refresh with runtime baseline deltas in detail.

## Risk and compatibility

- Breaking changes: none
- Migration required: none
- Performance impact: explicit TUI baseline compare/save actions rerun analysis; no read-only behavior changes unless users run write commands
- Memory benchmark impact: not measured; change is command/event flow and small app/UI adapters

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #1089
