### PR TITLE
feat(dashboard): add remediation queue

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -27,6 +27,15 @@ lopper dashboard \
   --enable-feature dashboard-remote-repos
 ```
 
+With the remediation queue preview enabled:
+
+```bash
+lopper dashboard \
+  --repos "./api,./frontend,./worker" \
+  --format html \
+  --enable-feature dashboard-remediation-queue-preview
+```
+
 Supported output formats:
 
 - `json`
@@ -85,6 +94,7 @@ Notes:
 - Remote repos are materialized under the user cache at `<cache-dir>/lopper/dashboard/repos/<repo-name>-<hash>`. Set `LOPPER_DASHBOARD_REPO_CACHE` to an absolute path to override the cache root in CI.
 - The checkout lifecycle is deterministic: unpinned `repoUrl` entries continue to track remote `HEAD`; pinned entries fetch the requested branch, tag, or commit and reset to that revision. Cache paths include the requested pin, so the same `repoUrl` at different pins uses separate checkouts.
 - Dashboard JSON, CSV, HTML, and saved dashboard baselines include the resolved commit SHA for materialized remote repos. JSON repo rows also include `repo_url` and the requested `revision` when present.
+- When `dashboard-remediation-queue-preview` is enabled, dashboard JSON, CSV, HTML, and saved dashboard baselines include org-level remediation queue items derived from per-repo errors, vulnerability findings, denied licenses, dependency recommendations, risk cues, runtime regressions, and cross-repo duplicate dependencies. The queue is sorted by highest severity/priority first.
 - Fetch, clone, checkout, reset, or clean failures are reported in the affected repo's dashboard `error` field and in top-level dashboard warnings, while other repos continue to analyze.
 - `baseline_store` enables dashboard baseline snapshots and compare mode. Relative values are resolved against the config file directory.
 - `baseline_key` selects a stored baseline snapshot when comparing. `baseline_label` is used when saving a labeled snapshot.
@@ -98,6 +108,16 @@ Dashboard JSON emits:
 - `generated_at`
 - `repos[]` (per-repo metrics, remote `repo_url`, requested `revision`, `resolved_commit`, runtime trace/regression counts, vulnerability finding counts, and any analysis errors)
 - `baseline_comparison` when a dashboard baseline is loaded and compared
+- `remediation_items[]` when `dashboard-remediation-queue-preview` is enabled:
+  - `id`: deterministic stable queue item ID
+  - `repo`: repo label, or a comma-separated repo set for cross-repo duplicate dependency items
+  - `repo_path`: local repo path when available
+  - `dependency`: affected dependency when applicable
+  - `category`: one of the emitted remediation categories, such as `repo_error`, `vulnerability`, `license`, `runtime_regression`, `risk`, `waste`, `recommendation`, or `duplicate_dependency`
+  - `severity` and `priority`: normalized triage levels when available
+  - `evidence[]`: compact evidence strings backing the item
+  - `suggested_action`: recommended next action
+  - `baseline_status`: `new`, `regressed`, or `existing` when compared with a dashboard baseline
 - `summary`:
   - `total_repos`
   - `total_deps`
@@ -109,3 +129,22 @@ Dashboard JSON emits:
   - `repos_with_runtime_trace_data`
   - `repos_with_runtime_regressions`
 - `cross_repo_deps[]` (dependencies present in 3+ repos)
+
+## CSV Shape
+
+Dashboard CSV is sectioned. It starts with summary key/value rows, then per-repo rows, and conditionally adds more sections.
+
+When `dashboard-remediation-queue-preview` is enabled and the queue is non-empty, a remediation section is emitted with these columns:
+
+- `remediation_id`
+- `baseline_status`
+- `repo`
+- `repo_path`
+- `dependency`
+- `category`
+- `severity`
+- `priority`
+- `evidence` (`|` delimited)
+- `suggested_action`
+
+When a dashboard baseline is compared, `baseline_comparison` also includes remediation queue deltas split into `new_remediation_items`, `regressed_remediation_items`, `existing_remediation_items`, and `removed_remediation_items`. The CSV baseline section includes a remediation delta subsection with `kind`, current severity/priority, and baseline severity/priority columns.

--- a/internal/app/app_save_baseline_test.go
+++ b/internal/app/app_save_baseline_test.go
@@ -271,10 +271,11 @@ func TestApplyDashboardBaselineIfNeededBranches(t *testing.T) {
 		t.Fatalf("seed dashboard baseline: %v", err)
 	}
 
-	applied, err := application.applyDashboardBaselineIfNeeded(base, ".", resolvedDashboardRequest{
+	nightlyResolved := resolvedDashboardRequest{
 		baselineStorePath: store,
 		baselineKey:       "label:nightly",
-	})
+	}
+	applied, err := application.applyDashboardBaselineIfNeeded(base, ".", nightlyResolved, true)
 	if err != nil {
 		t.Fatalf("apply dashboard baseline: %v", err)
 	}
@@ -283,11 +284,12 @@ func TestApplyDashboardBaselineIfNeededBranches(t *testing.T) {
 	}
 
 	missingStore := t.TempDir()
-	bootstrapped, err := application.applyDashboardBaselineIfNeeded(base, ".", resolvedDashboardRequest{
+	missingResolved := resolvedDashboardRequest{
 		baselineStorePath: missingStore,
 		baselineKey:       "label:missing",
 		saveBaseline:      true,
-	})
+	}
+	bootstrapped, err := application.applyDashboardBaselineIfNeeded(base, ".", missingResolved, true)
 	if err != nil {
 		t.Fatalf("expected missing dashboard baseline to bootstrap when saving: %v", err)
 	}
@@ -295,17 +297,17 @@ func TestApplyDashboardBaselineIfNeededBranches(t *testing.T) {
 		t.Fatalf("expected missing bootstrap baseline to leave report unchanged, got %#v", bootstrapped.BaselineComparison)
 	}
 
-	_, err = application.applyDashboardBaselineIfNeeded(base, filepath.Join(t.TempDir(), "missing", "repo"), resolvedDashboardRequest{
-		baselineStorePath: t.TempDir(),
-	})
+	missingRepoPath := filepath.Join(t.TempDir(), "missing", "repo")
+	_, err = application.applyDashboardBaselineIfNeeded(base, missingRepoPath, resolvedDashboardRequest{baselineStorePath: t.TempDir()}, true)
 	if err == nil || !strings.Contains(err.Error(), "baseline key is required") {
 		t.Fatalf("expected dashboard baseline resolution error, got %v", err)
 	}
 
-	_, err = application.applyDashboardBaselineIfNeeded(base, ".", resolvedDashboardRequest{
+	notFoundResolved := resolvedDashboardRequest{
 		baselineStorePath: t.TempDir(),
 		baselineKey:       "label:not-found",
-	})
+	}
+	_, err = application.applyDashboardBaselineIfNeeded(base, ".", notFoundResolved, true)
 	if err == nil || !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected missing dashboard baseline load error, got %v", err)
 	}

--- a/internal/app/dashboard.go
+++ b/internal/app/dashboard.go
@@ -24,9 +24,12 @@ func (a *App) executeDashboard(ctx context.Context, req Request) (string, error)
 	executionPlan := a.prepareDashboardExecutionPlan(ctx, req.Dashboard, resolved.repos)
 	analyses := a.executeDashboardAnalysisPlan(ctx, executionPlan)
 	now := time.Now()
-	reportData := dashboard.Aggregate(now, analyses)
+	includeRemediationQueue := req.Dashboard.Features.Enabled(DashboardRemediationQueuePreviewFeature)
+	reportData := dashboard.AggregateWithOptions(now, analyses, dashboard.AggregateOptions{
+		IncludeRemediationQueue: includeRemediationQueue,
+	})
 
-	reportData, err = a.applyDashboardBaselineIfNeeded(reportData, req.RepoPath, resolved)
+	reportData, err = a.applyDashboardBaselineIfNeeded(reportData, req.RepoPath, resolved, includeRemediationQueue)
 	if err != nil {
 		return "", err
 	}
@@ -42,7 +45,7 @@ func (a *App) executeDashboard(ctx context.Context, req Request) (string, error)
 	return persistDashboardOutput(formatted, resolved.outputPath)
 }
 
-func (a *App) applyDashboardBaselineIfNeeded(reportData dashboard.Report, repoPath string, resolved resolvedDashboardRequest) (dashboard.Report, error) {
+func (a *App) applyDashboardBaselineIfNeeded(reportData dashboard.Report, repoPath string, resolved resolvedDashboardRequest, includeRemediationQueue bool) (dashboard.Report, error) {
 	baselinePath, baselineKey, currentKey, shouldApply, err := resolveDashboardBaselinePaths(repoPath, resolved)
 	if err != nil {
 		return reportData, err
@@ -60,6 +63,9 @@ func (a *App) applyDashboardBaselineIfNeeded(reportData dashboard.Report, repoPa
 	}
 	if strings.TrimSpace(baselineKey) == "" {
 		baselineKey = loadedKey
+	}
+	if !includeRemediationQueue {
+		baseline.RemediationItems = nil
 	}
 	return dashboard.ApplyBaselineWithKeys(reportData, baseline, baselineKey, currentKey)
 }

--- a/internal/app/dashboard_features.go
+++ b/internal/app/dashboard_features.go
@@ -1,0 +1,3 @@
+package app
+
+const DashboardRemediationQueuePreviewFeature = "dashboard-remediation-queue-preview"

--- a/internal/app/dashboard_rendering_test.go
+++ b/internal/app/dashboard_rendering_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ben-ranford/lopper/internal/dashboard"
+	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/report"
 )
 
@@ -93,6 +94,56 @@ func TestExecuteDashboardJSON(t *testing.T) {
 	}
 }
 
+func TestExecuteDashboardRemediationQueueRequiresPreviewFeature(t *testing.T) {
+	analyzer := &mapAnalyzer{
+		reports: map[string]report.Report{
+			singleRepoPath: {
+				Dependencies: []report.DependencyReport{{
+					Name: "vuln-lib",
+					Vulnerabilities: []report.VulnerabilityFinding{{
+						AdvisoryID: "GHSA-dashboard",
+						Package:    "vuln-lib",
+						Severity:   report.VulnerabilityPriorityHigh,
+						Priority:   report.VulnerabilityPriorityHigh,
+					}},
+				}},
+			},
+		},
+		errs: map[string]error{},
+	}
+	application := &App{Analyzer: analyzer}
+
+	req := DefaultRequest()
+	req.Mode = ModeDashboard
+	req.Dashboard.Format = "json"
+	req.Dashboard.Repos = []DashboardRepo{{Name: "repo", Path: singleRepoPath}}
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute dashboard without remediation feature: %v", err)
+	}
+	disabledReport := dashboard.Report{}
+	if err := json.Unmarshal([]byte(output), &disabledReport); err != nil {
+		t.Fatalf("unmarshal disabled dashboard output: %v", err)
+	}
+	if len(disabledReport.RemediationItems) != 0 {
+		t.Fatalf("expected remediation queue to be disabled by default, got %#v", disabledReport.RemediationItems)
+	}
+
+	req.Dashboard.Features = enabledDashboardRemediationQueueFeatures(t)
+	output, err = application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute dashboard with remediation feature: %v", err)
+	}
+	enabledReport := dashboard.Report{}
+	if err := json.Unmarshal([]byte(output), &enabledReport); err != nil {
+		t.Fatalf("unmarshal enabled dashboard output: %v", err)
+	}
+	if len(enabledReport.RemediationItems) != 1 || enabledReport.RemediationItems[0].Category != "vulnerability" {
+		t.Fatalf("expected vulnerability remediation item when feature is enabled, got %#v", enabledReport.RemediationItems)
+	}
+}
+
 func TestExecuteDashboardJSONDistinguishesSameBasenameRepos(t *testing.T) {
 	const (
 		platformAPI = "./platform/api"
@@ -139,6 +190,27 @@ func TestExecuteDashboardJSONDistinguishesSameBasenameRepos(t *testing.T) {
 	if reportData.CrossRepoDeps[0].Count != 3 || !reflect.DeepEqual(reportData.CrossRepoDeps[0].Repositories, wantRepos) {
 		t.Fatalf("unexpected cross-repo duplicate payload: %#v", reportData.CrossRepoDeps[0])
 	}
+}
+
+func enabledDashboardRemediationQueueFeatures(t *testing.T) featureflags.Set {
+	t.Helper()
+	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
+		Code:        "LOP-FEAT-0017",
+		Name:        DashboardRemediationQueuePreviewFeature,
+		Description: "Dashboard remediation queue preview",
+		Lifecycle:   featureflags.LifecyclePreview,
+	}})
+	if err != nil {
+		t.Fatalf("new remediation queue feature registry: %v", err)
+	}
+	features, err := registry.Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  []string{DashboardRemediationQueuePreviewFeature},
+	})
+	if err != nil {
+		t.Fatalf("resolve remediation queue feature: %v", err)
+	}
+	return features
 }
 
 func TestExecuteDashboardOutputFile(t *testing.T) {
@@ -318,5 +390,52 @@ func TestExecuteDashboardAppliesBaselineComparison(t *testing.T) {
 	}
 	if !strings.Contains(output, "baseline_comparison") {
 		t.Fatalf("expected baseline comparison in dashboard output, got %q", output)
+	}
+}
+
+func TestExecuteDashboardBaselineDoesNotExposeRemediationQueueWhenPreviewDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	baselineStore := filepath.Join(tmp, "baselines")
+	baseline := dashboard.Report{
+		GeneratedAt: time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC),
+		RemediationItems: []dashboard.RemediationItem{{
+			ID:              "rqi-baseline-only",
+			Repo:            "api",
+			Dependency:      "vuln-lib",
+			Category:        "vulnerability",
+			Severity:        report.VulnerabilityPriorityHigh,
+			Priority:        report.VulnerabilityPriorityHigh,
+			SuggestedAction: "Upgrade vuln-lib.",
+		}},
+	}
+	if _, err := dashboard.SaveSnapshot(baselineStore, "label:baseline", baseline, time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("save dashboard baseline snapshot: %v", err)
+	}
+
+	application := &App{Analyzer: &mapAnalyzer{
+		reports: map[string]report.Report{
+			singleRepoPath: {Dependencies: []report.DependencyReport{{Name: "dep"}}},
+		},
+		errs: map[string]error{},
+	}}
+
+	req := DefaultRequest()
+	req.Mode = ModeDashboard
+	req.Dashboard.Format = "csv"
+	req.Dashboard.Repos = []DashboardRepo{{Name: "api", Path: singleRepoPath}}
+	req.Dashboard.BaselineStorePath = baselineStore
+	req.Dashboard.BaselineKey = "label:baseline"
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute dashboard baseline compare: %v", err)
+	}
+	if !strings.Contains(output, "baseline_key,label:baseline") {
+		t.Fatalf("expected ordinary baseline comparison to remain enabled, got %q", output)
+	}
+	for _, forbidden := range []string{"rqi-baseline-only", "remediation_id,kind", "remediation_id,baseline_status"} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("expected remediation queue data to stay hidden when preview is disabled; found %q in %q", forbidden, output)
+		}
 	}
 }

--- a/internal/dashboard/aggregate.go
+++ b/internal/dashboard/aggregate.go
@@ -14,6 +14,10 @@ type RepoAnalysis struct {
 	Err    error
 }
 
+type AggregateOptions struct {
+	IncludeRemediationQueue bool
+}
+
 type crossRepoRepository struct {
 	Label string
 }
@@ -29,10 +33,15 @@ type repoSummaryContribution struct {
 }
 
 func Aggregate(generatedAt time.Time, analyses []RepoAnalysis) Report {
+	return AggregateWithOptions(generatedAt, analyses, AggregateOptions{})
+}
+
+func AggregateWithOptions(generatedAt time.Time, analyses []RepoAnalysis, options AggregateOptions) Report {
 	results := make([]RepoResult, 0, len(analyses))
 	crossRepoIndex := make(map[string]map[string]crossRepoRepository)
 	repoNameCounts := countRepoNames(analyses)
 	sourceWarnings := make([]string, 0)
+	remediationItems := make([]RemediationItem, 0)
 	summary := Summary{
 		TotalRepos: len(analyses),
 	}
@@ -43,18 +52,30 @@ func Aggregate(generatedAt time.Time, analyses []RepoAnalysis) Report {
 		if warning != "" {
 			sourceWarnings = append(sourceWarnings, warning)
 		}
+		if options.IncludeRemediationQueue {
+			if analysis.Err != nil {
+				remediationItems = append(remediationItems, repoErrorRemediationItem(analysis.Input, repoNameCounts, analysis.Err))
+			} else {
+				remediationItems = append(remediationItems, repoRemediationItems(analysis, repoNameCounts)...)
+			}
+		}
 		results = append(results, repoResult)
 	}
 
 	crossRepoDeps := buildCrossRepoDependencies(crossRepoIndex)
 	summary.CrossRepoDuplicates = len(crossRepoDeps)
+	if options.IncludeRemediationQueue {
+		remediationItems = append(remediationItems, crossRepoRemediationItems(crossRepoDeps)...)
+		remediationItems = dedupeAndSortRemediationItems(remediationItems)
+	}
 
 	return Report{
-		GeneratedAt:    generatedAt.UTC(),
-		Repos:          results,
-		Summary:        summary,
-		CrossRepoDeps:  crossRepoDeps,
-		SourceWarnings: sourceWarnings,
+		GeneratedAt:      generatedAt.UTC(),
+		Repos:            results,
+		Summary:          summary,
+		CrossRepoDeps:    crossRepoDeps,
+		RemediationItems: remediationItems,
+		SourceWarnings:   sourceWarnings,
 	}
 }
 

--- a/internal/dashboard/baseline.go
+++ b/internal/dashboard/baseline.go
@@ -72,6 +72,7 @@ func ApplyBaselineWithKeys(current, baseline Report, baselineKey, currentKey str
 	comparison := ComputeBaselineComparison(current, baseline)
 	comparison.BaselineKey = strings.TrimSpace(baselineKey)
 	comparison.CurrentKey = strings.TrimSpace(currentKey)
+	current.RemediationItems = annotateRemediationItems(current.RemediationItems, comparison)
 	current.BaselineComparison = &comparison
 	return current, nil
 }
@@ -138,6 +139,11 @@ func ComputeBaselineComparison(current, baseline Report) BaselineComparison {
 			comparison.Changed = append(comparison.Changed, delta)
 		}
 	}
+	comparison.RemediationItemDeltas,
+		comparison.NewRemediationItems,
+		comparison.RegressedRemediationItems,
+		comparison.ExistingRemediationItems,
+		comparison.RemovedRemediationItems = compareRemediationItems(current.RemediationItems, baseline.RemediationItems)
 
 	return comparison
 }
@@ -261,6 +267,7 @@ func newBaselineSnapshot(key string, rep Report, now time.Time) BaselineSnapshot
 func normalizeSnapshotReport(rep Report) Report {
 	normalized := rep
 	normalized.Repos = append([]RepoResult(nil), rep.Repos...)
+	normalized.RemediationItems = dedupeAndSortRemediationItems(rep.RemediationItems)
 	sort.Slice(normalized.Repos, func(i, j int) bool {
 		if normalized.Repos[i].Name != normalized.Repos[j].Name {
 			return normalized.Repos[i].Name < normalized.Repos[j].Name

--- a/internal/dashboard/coverage_thresholds_test.go
+++ b/internal/dashboard/coverage_thresholds_test.go
@@ -19,6 +19,10 @@ func (f *failOnCSVWrite) Write(_ []string) error {
 	return nil
 }
 
+func failingCSVWriter(failOn int) func([]string) error {
+	return (&failOnCSVWrite{failOn: failOn}).Write
+}
+
 func TestWriteDashboardCrossRepoRowsCSVHeaderError(t *testing.T) {
 	writer := &failOnCSVWrite{failOn: 2}
 
@@ -62,22 +66,52 @@ func TestRepoRevisionHelpersCoverAllKinds(t *testing.T) {
 	}
 }
 
-func TestDashboardCSVWriterErrorBranches(t *testing.T) {
-	if err := writeDashboardSummaryCSV((&failOnCSVWrite{failOn: 1}).Write, Report{}); err == nil {
-		t.Fatal("expected summary writer error")
+func requireCSVWriterError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected writer error")
 	}
-	if err := writeDashboardRepoRowsCSV((&failOnCSVWrite{failOn: 1}).Write, nil); err == nil {
-		t.Fatal("expected repo header writer error")
-	}
-	if err := writeDashboardRepoRowsCSV((&failOnCSVWrite{failOn: 2}).Write, []RepoResult{{Name: "api"}}); err == nil {
-		t.Fatal("expected repo row writer error")
-	}
-	if err := writeDashboardCrossRepoRowsCSV((&failOnCSVWrite{failOn: 1}).Write, []CrossRepoDependency{{Name: "shared"}}); err == nil {
-		t.Fatal("expected cross-repo separator writer error")
-	}
-	if err := writeDashboardCrossRepoRowsCSV((&failOnCSVWrite{failOn: 3}).Write, []CrossRepoDependency{{Name: "shared"}}); err == nil {
-		t.Fatal("expected cross-repo row writer error")
-	}
+}
+
+func TestDashboardSummaryAndRepoCSVWriterErrorBranches(t *testing.T) {
+	requireCSVWriterError(t, writeDashboardSummaryCSV(failingCSVWriter(1), Report{}))
+	requireCSVWriterError(t, writeDashboardRepoRowsCSV(failingCSVWriter(1), nil))
+	requireCSVWriterError(t, writeDashboardRepoRowsCSV(failingCSVWriter(2), []RepoResult{{Name: "api"}}))
+}
+
+func TestDashboardCrossRepoCSVWriterErrorBranches(t *testing.T) {
+	deps := []CrossRepoDependency{{Name: "shared"}}
+
+	requireCSVWriterError(t, writeDashboardCrossRepoRowsCSV(failingCSVWriter(1), deps))
+	requireCSVWriterError(t, writeDashboardCrossRepoRowsCSV(failingCSVWriter(3), deps))
+}
+
+func TestDashboardRemediationCSVWriterErrorBranches(t *testing.T) {
+	items := []RemediationItem{{ID: "rqi-test"}}
+
+	requireCSVWriterError(t, writeDashboardRemediationRowsCSV(failingCSVWriter(1), items))
+	requireCSVWriterError(t, writeDashboardRemediationRowsCSV(failingCSVWriter(2), items))
+	requireCSVWriterError(t, writeDashboardRemediationRowsCSV(failingCSVWriter(3), items))
+}
+
+func TestDashboardBaselineCSVWriterErrorBranches(t *testing.T) {
+	keys := &BaselineComparison{BaselineKey: "base", CurrentKey: "head"}
+	summary := &BaselineComparison{BaselineKey: "base"}
+	repos := &BaselineComparison{BaselineKey: "base", RepoDeltas: []RepoDelta{{Name: "api"}}}
+
+	requireCSVWriterError(t, writeDashboardBaselineRowsCSV(failingCSVWriter(2), keys))
+	requireCSVWriterError(t, writeDashboardBaselineRowsCSV(failingCSVWriter(3), keys))
+	requireCSVWriterError(t, writeDashboardBaselineRowsCSV(failingCSVWriter(4), summary))
+	requireCSVWriterError(t, writeDashboardBaselineRowsCSV(failingCSVWriter(13), repos))
+	requireCSVWriterError(t, writeDashboardBaselineRowsCSV(failingCSVWriter(14), repos))
+}
+
+func TestDashboardBaselineRemediationCSVWriterErrorBranches(t *testing.T) {
+	items := []RemediationItemDelta{{ID: "rqi-test"}}
+
+	requireCSVWriterError(t, writeDashboardBaselineRemediationRowsCSV(failingCSVWriter(1), items))
+	requireCSVWriterError(t, writeDashboardBaselineRemediationRowsCSV(failingCSVWriter(2), items))
+	requireCSVWriterError(t, writeDashboardBaselineRemediationRowsCSV(failingCSVWriter(3), items))
 }
 
 func TestFormatReportCSVRevisionKinds(t *testing.T) {

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -547,6 +547,10 @@ func TestDashboardCSVHelpersPropagateWriteErrors(t *testing.T) {
 		t.Fatalf("expected repo row CSV writer error")
 	}
 
+	if writeDashboardRemediationRowsCSV(poisonedDashboardCSVWriter(t, &failingDashboardWriter{}).Write, []RemediationItem{{ID: "rqi-test", Repo: "api", Category: remediationCategoryRisk}}) == nil {
+		t.Fatalf("expected remediation CSV writer error")
+	}
+
 	if writeDashboardCrossRepoRowsCSV(poisonedDashboardCSVWriter(t, &failingDashboardWriter{}).Write, reportData.CrossRepoDeps) == nil {
 		t.Fatalf("expected cross-repo CSV writer error")
 	}

--- a/internal/dashboard/format.go
+++ b/internal/dashboard/format.go
@@ -14,6 +14,9 @@ import (
 const (
 	htmlTableBodyOpen  = "</tr></thead><tbody>"
 	htmlTableBodyClose = "</tbody></table>"
+	htmlPriorityCell   = "<td class=\"priority\">"
+	htmlStatusCell     = "<td class=\"status\">"
+	htmlWrapCell       = "<td class=\"wrap\">"
 )
 
 func FormatReport(reportData Report, format Format) (string, error) {
@@ -41,6 +44,9 @@ func formatCSV(reportData Report) (string, error) {
 		return "", err
 	}
 	if err := writeDashboardRepoRowsCSV(writer.Write, reportData.Repos); err != nil {
+		return "", err
+	}
+	if err := writeDashboardRemediationRowsCSV(writer.Write, reportData.RemediationItems); err != nil {
 		return "", err
 	}
 	if err := writeDashboardCrossRepoRowsCSV(writer.Write, reportData.CrossRepoDeps); err != nil {
@@ -129,6 +135,46 @@ func writeDashboardRepoRowsCSV(write func([]string) error, repos []RepoResult) e
 	return nil
 }
 
+func writeDashboardRemediationRowsCSV(write func([]string) error, items []RemediationItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	if err := write(nil); err != nil {
+		return err
+	}
+	if err := write(csvsanitize.EscapeLeadingFormulaRow([]string{
+		"remediation_id",
+		"baseline_status",
+		"repo",
+		"repo_path",
+		"dependency",
+		"category",
+		"severity",
+		"priority",
+		"evidence",
+		"suggested_action",
+	})); err != nil {
+		return err
+	}
+	for _, item := range items {
+		if err := write(csvsanitize.EscapeLeadingFormulaRow([]string{
+			item.ID,
+			item.BaselineStatus,
+			item.Repo,
+			item.RepoPath,
+			item.Dependency,
+			item.Category,
+			item.Severity,
+			item.Priority,
+			joinDashboardCSVValues(item.Evidence),
+			item.SuggestedAction,
+		})); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func writeDashboardCrossRepoRowsCSV(write func([]string) error, dependencies []CrossRepoDependency) error {
 	if len(dependencies) == 0 {
 		return nil
@@ -187,7 +233,7 @@ func writeDashboardBaselineRowsCSV(write func([]string) error, comparison *Basel
 		}
 	}
 	if len(comparison.RepoDeltas) == 0 {
-		return nil
+		return writeDashboardBaselineRemediationRowsCSV(write, comparison.RemediationItemDeltas)
 	}
 	if err := write(nil); err != nil {
 		return err
@@ -230,6 +276,50 @@ func writeDashboardBaselineRowsCSV(write func([]string) error, comparison *Basel
 			return err
 		}
 	}
+	return writeDashboardBaselineRemediationRowsCSV(write, comparison.RemediationItemDeltas)
+}
+
+func writeDashboardBaselineRemediationRowsCSV(write func([]string) error, deltas []RemediationItemDelta) error {
+	if len(deltas) == 0 {
+		return nil
+	}
+	if err := write(nil); err != nil {
+		return err
+	}
+	if err := write(csvsanitize.EscapeLeadingFormulaRow([]string{
+		"remediation_id",
+		"kind",
+		"repo",
+		"repo_path",
+		"dependency",
+		"category",
+		"severity",
+		"priority",
+		"baseline_severity",
+		"baseline_priority",
+		"evidence",
+		"suggested_action",
+	})); err != nil {
+		return err
+	}
+	for _, delta := range deltas {
+		if err := write(csvsanitize.EscapeLeadingFormulaRow([]string{
+			delta.ID,
+			string(delta.Kind),
+			delta.Repo,
+			delta.RepoPath,
+			delta.Dependency,
+			delta.Category,
+			delta.Severity,
+			delta.Priority,
+			delta.BaselineSeverity,
+			delta.BaselinePriority,
+			joinDashboardCSVValues(delta.Evidence),
+			delta.SuggestedAction,
+		})); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -249,6 +339,7 @@ func formatHTML(reportData Report) string {
 	buffer.WriteString(".grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}")
 	buffer.WriteString(".metric{background:#f8fafc;border:1px solid #e2e8f0;padding:12px;border-radius:8px}")
 	buffer.WriteString(".metric strong{display:block;font-size:22px}")
+	buffer.WriteString(".priority{text-transform:capitalize;font-weight:600}.status{text-transform:capitalize;color:#334155}.wrap{max-width:360px;white-space:normal}")
 	buffer.WriteString("</style></head><body>")
 	buffer.WriteString("<h1>Lopper Org Dashboard</h1>")
 	buffer.WriteString("<p class=\"meta\">Generated at ")
@@ -265,6 +356,8 @@ func formatHTML(reportData Report) string {
 	buffer.WriteString(metricHTML("Runtime Trace Repos", fmt.Sprintf("%d", reportData.Summary.ReposWithRuntimeTraceData)))
 	buffer.WriteString(metricHTML("Runtime Regression Repos", fmt.Sprintf("%d", reportData.Summary.ReposWithRuntimeRegressions)))
 	buffer.WriteString("</div></section>")
+
+	buffer.WriteString(formatDashboardRemediationHTML(reportData.RemediationItems))
 
 	buffer.WriteString("<h2>Per-Repo Summary</h2><table><thead><tr>")
 	buffer.WriteString("<th>Repo</th><th>Path</th><th>Repo URL</th><th>Revision</th><th>Resolved Commit</th><th>Language</th><th>Deps</th><th>Waste Candidates</th><th>Waste %</th><th>Top Risk</th><th>Critical CVEs</th><th>Vuln Findings</th><th>Reachable Vulns</th><th>Denied Licenses</th><th>Runtime Trace</th><th>Runtime Regressions</th><th>Runtime Improvements</th><th>Error</th>")
@@ -313,6 +406,30 @@ func formatHTML(reportData Report) string {
 	return buffer.String()
 }
 
+func formatDashboardRemediationHTML(items []RemediationItem) string {
+	if len(items) == 0 {
+		return ""
+	}
+	var buffer strings.Builder
+	buffer.WriteString("<h2>Remediation Queue</h2><table><thead><tr>")
+	buffer.WriteString("<th>Priority</th><th>Category</th><th>Repo</th><th>Dependency</th><th>Evidence</th><th>Suggested Action</th><th>Baseline</th><th>ID</th>")
+	buffer.WriteString(htmlTableBodyOpen)
+	for _, item := range items {
+		buffer.WriteString("<tr>")
+		buffer.WriteString(htmlPriorityCell + html.EscapeString(item.Priority) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(item.Category) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(item.Repo) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(item.Dependency) + "</td>")
+		buffer.WriteString(htmlWrapCell + html.EscapeString(strings.Join(item.Evidence, "; ")) + "</td>")
+		buffer.WriteString(htmlWrapCell + html.EscapeString(item.SuggestedAction) + "</td>")
+		buffer.WriteString(htmlStatusCell + html.EscapeString(item.BaselineStatus) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(item.ID) + "</td>")
+		buffer.WriteString("</tr>")
+	}
+	buffer.WriteString(htmlTableBodyClose)
+	return buffer.String()
+}
+
 func formatDashboardBaselineHTML(comparison *BaselineComparison) string {
 	if comparison == nil {
 		return ""
@@ -357,6 +474,32 @@ func formatDashboardBaselineHTML(comparison *BaselineComparison) string {
 		buffer.WriteString(htmlTableBodyClose)
 	}
 
+	buffer.WriteString(formatDashboardBaselineRemediationHTML(comparison.RemediationItemDeltas))
+
+	return buffer.String()
+}
+
+func formatDashboardBaselineRemediationHTML(deltas []RemediationItemDelta) string {
+	if len(deltas) == 0 {
+		return ""
+	}
+	var buffer strings.Builder
+	buffer.WriteString("<h2>Remediation Queue Baseline</h2><table><thead><tr>")
+	buffer.WriteString("<th>Kind</th><th>Priority</th><th>Baseline Priority</th><th>Category</th><th>Repo</th><th>Dependency</th><th>Suggested Action</th><th>ID</th>")
+	buffer.WriteString(htmlTableBodyOpen)
+	for _, delta := range deltas {
+		buffer.WriteString("<tr>")
+		buffer.WriteString(htmlStatusCell + html.EscapeString(string(delta.Kind)) + "</td>")
+		buffer.WriteString(htmlPriorityCell + html.EscapeString(delta.Priority) + "</td>")
+		buffer.WriteString(htmlPriorityCell + html.EscapeString(delta.BaselinePriority) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(delta.Category) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(delta.Repo) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(delta.Dependency) + "</td>")
+		buffer.WriteString(htmlWrapCell + html.EscapeString(delta.SuggestedAction) + "</td>")
+		buffer.WriteString("<td>" + html.EscapeString(delta.ID) + "</td>")
+		buffer.WriteString("</tr>")
+	}
+	buffer.WriteString(htmlTableBodyClose)
 	return buffer.String()
 }
 
@@ -369,4 +512,12 @@ func formatRepoRevision(revision *RepoRevision) string {
 		return ""
 	}
 	return revision.Kind() + ":" + revision.Value()
+}
+
+func joinDashboardCSVValues(values []string) string {
+	escaped := make([]string, 0, len(values))
+	for _, value := range values {
+		escaped = append(escaped, csvsanitize.EscapeLeadingFormula(value))
+	}
+	return strings.Join(escaped, "|")
 }

--- a/internal/dashboard/remediation.go
+++ b/internal/dashboard/remediation.go
@@ -1,0 +1,575 @@
+package dashboard
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const (
+	remediationCategoryDuplicateDependency = "duplicate_dependency"
+	remediationCategoryLicense             = "license"
+	remediationCategoryRecommendation      = "recommendation"
+	remediationCategoryRepoError           = "repo_error"
+	remediationCategoryRisk                = "risk"
+	remediationCategoryRuntimeRegression   = "runtime_regression"
+	remediationCategoryVulnerability       = "vulnerability"
+	remediationCategoryWaste               = "waste"
+)
+
+func repoRemediationItems(analysis RepoAnalysis, repoNameCounts map[string]int) []RemediationItem {
+	repoLabel := crossRepoRepositoryLabel(analysis.Input, repoNameCounts)
+	repoPath := strings.TrimSpace(analysis.Input.Path)
+	repoID := repoIdentity(analysis.Input)
+	items := make([]RemediationItem, 0)
+
+	for _, dependency := range analysis.Report.Dependencies {
+		dependencyName := strings.TrimSpace(dependency.Name)
+		if dependencyName == "" {
+			continue
+		}
+		items = append(items, vulnerabilityRemediationItems(repoID, repoLabel, repoPath, dependencyName, dependency.Vulnerabilities)...)
+		if item, ok := licenseRemediationItem(repoID, repoLabel, repoPath, dependencyName, dependency.License); ok {
+			items = append(items, item)
+		}
+		items = append(items, recommendationRemediationItems(repoID, repoLabel, repoPath, dependencyName, dependency.Recommendations)...)
+		items = append(items, riskRemediationItems(repoID, repoLabel, repoPath, dependencyName, dependency.RiskCues)...)
+	}
+	items = append(items, runtimeRegressionRemediationItems(repoID, repoLabel, repoPath, analysis.Report.BaselineComparison)...)
+
+	return items
+}
+
+func repoErrorRemediationItem(input RepoInput, repoNameCounts map[string]int, err error) RemediationItem {
+	repoLabel := crossRepoRepositoryLabel(input, repoNameCounts)
+	repoID := repoIdentity(input)
+	return RemediationItem{
+		ID:              stableRemediationID(repoID, remediationCategoryRepoError),
+		Repo:            repoLabel,
+		RepoPath:        strings.TrimSpace(input.Path),
+		Category:        remediationCategoryRepoError,
+		Severity:        report.VulnerabilityPriorityCritical,
+		Priority:        report.VulnerabilityPriorityCritical,
+		Evidence:        []string{strings.TrimSpace(err.Error())},
+		SuggestedAction: "Fix the dashboard analysis failure for this repository and rerun the dashboard.",
+	}
+}
+
+func vulnerabilityRemediationItems(repoID, repoLabel, repoPath, dependencyName string, findings []report.VulnerabilityFinding) []RemediationItem {
+	items := make([]RemediationItem, 0, len(findings))
+	for _, finding := range findings {
+		advisoryID := strings.TrimSpace(finding.AdvisoryID)
+		priority := normalizeRemediationLevel(finding.Priority)
+		severity := normalizeRemediationLevel(finding.Severity)
+		if priority == "" {
+			priority = severity
+		}
+		if severity == "" {
+			severity = priority
+		}
+		var evidence []string
+		if advisoryID != "" {
+			evidence = append(evidence, "advisory: "+advisoryID)
+		}
+		if finding.Source != "" {
+			evidence = append(evidence, "source: "+strings.TrimSpace(finding.Source))
+		}
+		if finding.Reachable {
+			evidence = append(evidence, "reachable: true")
+		}
+		evidence = append(evidence, finding.Evidence...)
+
+		items = append(items, RemediationItem{
+			ID:              stableRemediationID(repoID, dependencyName, remediationCategoryVulnerability, advisoryID, finding.Package),
+			Repo:            repoLabel,
+			RepoPath:        repoPath,
+			Dependency:      dependencyName,
+			Category:        remediationCategoryVulnerability,
+			Severity:        severity,
+			Priority:        priority,
+			Evidence:        compactEvidence(evidence),
+			SuggestedAction: vulnerabilitySuggestedAction(dependencyName, finding),
+		})
+	}
+	return items
+}
+
+func vulnerabilitySuggestedAction(dependencyName string, finding report.VulnerabilityFinding) string {
+	advisoryID := strings.TrimSpace(finding.AdvisoryID)
+	if advisoryID == "" {
+		advisoryID = "the advisory"
+	}
+	fixedVersion := strings.TrimSpace(finding.FixedVersion)
+	if fixedVersion != "" {
+		return fmt.Sprintf("Upgrade %s to %s or later to address %s.", dependencyName, fixedVersion, advisoryID)
+	}
+	return fmt.Sprintf("Triage %s for %s and apply the vendor remediation or document accepted risk.", advisoryID, dependencyName)
+}
+
+func licenseRemediationItem(repoID, repoLabel, repoPath, dependencyName string, license *report.DependencyLicense) (RemediationItem, bool) {
+	if license == nil || !license.Denied {
+		return RemediationItem{}, false
+	}
+	label := firstNonBlank(license.SPDX, license.Raw, "denied license")
+	evidence := []string{"license: " + label}
+	if license.Source != "" {
+		evidence = append(evidence, "source: "+strings.TrimSpace(license.Source))
+	}
+	evidence = append(evidence, license.Evidence...)
+	return RemediationItem{
+		ID:              stableRemediationID(repoID, dependencyName, remediationCategoryLicense, label),
+		Repo:            repoLabel,
+		RepoPath:        repoPath,
+		Dependency:      dependencyName,
+		Category:        remediationCategoryLicense,
+		Severity:        report.VulnerabilityPriorityHigh,
+		Priority:        report.VulnerabilityPriorityHigh,
+		Evidence:        compactEvidence(evidence),
+		SuggestedAction: fmt.Sprintf("Replace %s or add an explicit policy approval for denied license %s.", dependencyName, label),
+	}, true
+}
+
+func recommendationRemediationItems(repoID, repoLabel, repoPath, dependencyName string, recommendations []report.Recommendation) []RemediationItem {
+	items := make([]RemediationItem, 0, len(recommendations))
+	for _, recommendation := range recommendations {
+		code := strings.TrimSpace(recommendation.Code)
+		message := strings.TrimSpace(recommendation.Message)
+		if code == "" && message == "" {
+			continue
+		}
+		category := remediationCategoryRecommendation
+		if isWasteRecommendationCode(code) {
+			category = remediationCategoryWaste
+		}
+		priority := normalizeRemediationLevel(recommendation.Priority)
+		if priority == "" {
+			priority = report.VulnerabilityPriorityMedium
+		}
+		var evidence []string
+		if code != "" {
+			evidence = append(evidence, "recommendation: "+code)
+		}
+		if recommendation.Rationale != "" {
+			evidence = append(evidence, strings.TrimSpace(recommendation.Rationale))
+		}
+		evidence = append(evidence, recommendation.ConfidenceReasonCodes...)
+		action := message
+		if action == "" {
+			action = fmt.Sprintf("Review recommendation %s for %s and apply or document the outcome.", code, dependencyName)
+		}
+		items = append(items, RemediationItem{
+			ID:              stableRemediationID(repoID, dependencyName, category, code, message),
+			Repo:            repoLabel,
+			RepoPath:        repoPath,
+			Dependency:      dependencyName,
+			Category:        category,
+			Severity:        priority,
+			Priority:        priority,
+			Evidence:        compactEvidence(evidence),
+			SuggestedAction: action,
+		})
+	}
+	return items
+}
+
+func riskRemediationItems(repoID, repoLabel, repoPath, dependencyName string, cues []report.RiskCue) []RemediationItem {
+	items := make([]RemediationItem, 0, len(cues))
+	for _, cue := range cues {
+		code := strings.TrimSpace(cue.Code)
+		message := strings.TrimSpace(cue.Message)
+		if code == "" && message == "" {
+			continue
+		}
+		severity := normalizeRemediationLevel(cue.Severity)
+		if severity == "" {
+			severity = report.VulnerabilityPriorityLow
+		}
+		var evidence []string
+		if code != "" {
+			evidence = append(evidence, "risk: "+code)
+		}
+		if message != "" {
+			evidence = append(evidence, message)
+		}
+		evidence = append(evidence, cue.ConfidenceReasonCodes...)
+		items = append(items, RemediationItem{
+			ID:              stableRemediationID(repoID, dependencyName, remediationCategoryRisk, code, message),
+			Repo:            repoLabel,
+			RepoPath:        repoPath,
+			Dependency:      dependencyName,
+			Category:        remediationCategoryRisk,
+			Severity:        severity,
+			Priority:        severity,
+			Evidence:        compactEvidence(evidence),
+			SuggestedAction: fmt.Sprintf("Investigate the %s risk cue for %s and upgrade, replace, or document acceptance.", firstNonBlank(code, "reported"), dependencyName),
+		})
+	}
+	return items
+}
+
+func runtimeRegressionRemediationItems(repoID, repoLabel, repoPath string, comparison *report.BaselineComparison) []RemediationItem {
+	if comparison == nil || len(comparison.RuntimeRegressions) == 0 {
+		return nil
+	}
+	items := make([]RemediationItem, 0, len(comparison.RuntimeRegressions))
+	for _, regression := range comparison.RuntimeRegressions {
+		dependencyName := strings.TrimSpace(regression.Name)
+		if dependencyName == "" {
+			continue
+		}
+		items = append(items, RemediationItem{
+			ID:              stableRemediationID(repoID, dependencyName, remediationCategoryRuntimeRegression),
+			Repo:            repoLabel,
+			RepoPath:        repoPath,
+			Dependency:      dependencyName,
+			Category:        remediationCategoryRuntimeRegression,
+			Severity:        report.VulnerabilityPriorityHigh,
+			Priority:        report.VulnerabilityPriorityHigh,
+			Evidence:        runtimeRegressionEvidence(regression),
+			SuggestedAction: fmt.Sprintf("Inspect new runtime usage for %s and update code, dependency ownership, or the baseline intentionally.", dependencyName),
+		})
+	}
+	return items
+}
+
+func runtimeRegressionEvidence(regression report.DependencyDelta) []string {
+	evidence := []string{"runtime regression detected"}
+	if regression.Language != "" {
+		evidence = append(evidence, "language: "+strings.TrimSpace(regression.Language))
+	}
+	if regression.RuntimeDelta != nil {
+		if regression.RuntimeDelta.NewRuntimeLoads {
+			evidence = append(evidence, "new runtime loads")
+		}
+		if regression.RuntimeDelta.RuntimeOnlyRegression {
+			evidence = append(evidence, "runtime-only regression")
+		}
+		if regression.RuntimeDelta.LoadCountDelta != nil && *regression.RuntimeDelta.LoadCountDelta != 0 {
+			evidence = append(evidence, fmt.Sprintf("load_count_delta: %+d", *regression.RuntimeDelta.LoadCountDelta))
+		}
+	}
+	return compactEvidence(evidence)
+}
+
+func crossRepoRemediationItems(dependencies []CrossRepoDependency) []RemediationItem {
+	items := make([]RemediationItem, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		dependencyName := strings.TrimSpace(dependency.Name)
+		if dependencyName == "" {
+			continue
+		}
+		repoList := strings.Join(dependency.Repositories, ", ")
+		items = append(items, RemediationItem{
+			ID:              stableRemediationID("org", dependencyName, remediationCategoryDuplicateDependency),
+			Repo:            repoList,
+			Dependency:      dependencyName,
+			Category:        remediationCategoryDuplicateDependency,
+			Severity:        report.VulnerabilityPriorityLow,
+			Priority:        report.VulnerabilityPriorityLow,
+			Evidence:        []string{fmt.Sprintf("dependency appears in %d repositories: %s", dependency.Count, repoList)},
+			SuggestedAction: fmt.Sprintf("Review shared ownership for %s and decide whether to consolidate, pin, or govern it centrally.", dependencyName),
+		})
+	}
+	return items
+}
+
+func compareRemediationItems(current, baseline []RemediationItem) ([]RemediationItemDelta, []RemediationItemDelta, []RemediationItemDelta, []RemediationItemDelta, []RemediationItemDelta) {
+	currentByID := remediationItemsByID(current)
+	baselineByID := remediationItemsByID(baseline)
+	keys := make([]string, 0, len(currentByID)+len(baselineByID))
+	seen := make(map[string]struct{}, len(currentByID)+len(baselineByID))
+	for key := range currentByID {
+		keys = append(keys, key)
+		seen[key] = struct{}{}
+	}
+	for key := range baselineByID {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	deltas := make([]RemediationItemDelta, 0, len(keys))
+	newItems := make([]RemediationItemDelta, 0)
+	regressedItems := make([]RemediationItemDelta, 0)
+	existingItems := make([]RemediationItemDelta, 0)
+	removedItems := make([]RemediationItemDelta, 0)
+	for _, key := range keys {
+		currentItem, hasCurrent := currentByID[key]
+		baselineItem, hasBaseline := baselineByID[key]
+		var delta RemediationItemDelta
+		switch {
+		case hasCurrent && !hasBaseline:
+			delta = remediationItemDelta(RemediationItemNew, currentItem, RemediationItem{})
+			newItems = append(newItems, delta)
+		case hasCurrent && hasBaseline:
+			if remediationItemRank(currentItem) > remediationItemRank(baselineItem) {
+				delta = remediationItemDelta(RemediationItemRegressed, currentItem, baselineItem)
+				regressedItems = append(regressedItems, delta)
+			} else {
+				delta = remediationItemDelta(RemediationItemExisting, currentItem, baselineItem)
+				existingItems = append(existingItems, delta)
+			}
+		case !hasCurrent && hasBaseline:
+			delta = remediationItemDelta(RemediationItemRemoved, baselineItem, baselineItem)
+			removedItems = append(removedItems, delta)
+		}
+		deltas = append(deltas, delta)
+	}
+	sortRemediationItemDeltas(deltas)
+	sortRemediationItemDeltas(newItems)
+	sortRemediationItemDeltas(regressedItems)
+	sortRemediationItemDeltas(existingItems)
+	sortRemediationItemDeltas(removedItems)
+	return deltas, newItems, regressedItems, existingItems, removedItems
+}
+
+func annotateRemediationItems(items []RemediationItem, comparison BaselineComparison) []RemediationItem {
+	if len(items) == 0 {
+		return items
+	}
+	statusByID := make(map[string]string, len(comparison.NewRemediationItems)+len(comparison.RegressedRemediationItems)+len(comparison.ExistingRemediationItems))
+	for _, delta := range comparison.NewRemediationItems {
+		statusByID[delta.ID] = string(RemediationItemNew)
+	}
+	for _, delta := range comparison.RegressedRemediationItems {
+		statusByID[delta.ID] = string(RemediationItemRegressed)
+	}
+	for _, delta := range comparison.ExistingRemediationItems {
+		statusByID[delta.ID] = string(RemediationItemExisting)
+	}
+	annotated := append([]RemediationItem(nil), items...)
+	for index := range annotated {
+		annotated[index].BaselineStatus = statusByID[annotated[index].ID]
+	}
+	return annotated
+}
+
+func remediationItemDelta(kind RemediationItemDeltaKind, item, baseline RemediationItem) RemediationItemDelta {
+	return RemediationItemDelta{
+		Kind:             kind,
+		ID:               item.ID,
+		Repo:             item.Repo,
+		RepoPath:         item.RepoPath,
+		Dependency:       item.Dependency,
+		Category:         item.Category,
+		Severity:         item.Severity,
+		Priority:         item.Priority,
+		BaselineSeverity: baseline.Severity,
+		BaselinePriority: baseline.Priority,
+		Evidence:         append([]string(nil), item.Evidence...),
+		SuggestedAction:  item.SuggestedAction,
+	}
+}
+
+func remediationItemsByID(items []RemediationItem) map[string]RemediationItem {
+	byID := make(map[string]RemediationItem, len(items))
+	for _, item := range dedupeAndSortRemediationItems(items) {
+		if item.ID == "" {
+			continue
+		}
+		byID[item.ID] = item
+	}
+	return byID
+}
+
+func dedupeAndSortRemediationItems(items []RemediationItem) []RemediationItem {
+	byID := make(map[string]RemediationItem, len(items))
+	for _, item := range items {
+		item = normalizeRemediationItem(item)
+		if item.ID == "" {
+			continue
+		}
+		existing, ok := byID[item.ID]
+		if !ok {
+			byID[item.ID] = item
+			continue
+		}
+		merged := existing
+		if remediationItemRank(item) > remediationItemRank(existing) {
+			merged = item
+		}
+		merged.Evidence = compactEvidence(append(existing.Evidence, item.Evidence...))
+		byID[item.ID] = merged
+	}
+	deduped := make([]RemediationItem, 0, len(byID))
+	for _, item := range byID {
+		deduped = append(deduped, item)
+	}
+	sortRemediationItems(deduped)
+	return deduped
+}
+
+func normalizeRemediationItem(item RemediationItem) RemediationItem {
+	item.ID = strings.TrimSpace(item.ID)
+	item.Repo = strings.TrimSpace(item.Repo)
+	item.RepoPath = strings.TrimSpace(item.RepoPath)
+	item.Dependency = strings.TrimSpace(item.Dependency)
+	item.Category = strings.TrimSpace(item.Category)
+	item.Severity = normalizeRemediationLevel(item.Severity)
+	item.Priority = normalizeRemediationLevel(item.Priority)
+	item.Evidence = compactEvidence(item.Evidence)
+	item.SuggestedAction = strings.TrimSpace(item.SuggestedAction)
+	item.BaselineStatus = strings.TrimSpace(item.BaselineStatus)
+	return item
+}
+
+func sortRemediationItems(items []RemediationItem) {
+	sort.Slice(items, func(i, j int) bool {
+		leftRank := remediationItemRank(items[i])
+		rightRank := remediationItemRank(items[j])
+		if leftRank != rightRank {
+			return leftRank > rightRank
+		}
+		if categoryRank(items[i].Category) != categoryRank(items[j].Category) {
+			return categoryRank(items[i].Category) < categoryRank(items[j].Category)
+		}
+		if items[i].Repo != items[j].Repo {
+			return items[i].Repo < items[j].Repo
+		}
+		if items[i].Dependency != items[j].Dependency {
+			return items[i].Dependency < items[j].Dependency
+		}
+		if items[i].Category != items[j].Category {
+			return items[i].Category < items[j].Category
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func sortRemediationItemDeltas(items []RemediationItemDelta) {
+	sort.Slice(items, func(i, j int) bool {
+		leftRank := remediationDeltaRank(items[i])
+		rightRank := remediationDeltaRank(items[j])
+		if leftRank != rightRank {
+			return leftRank > rightRank
+		}
+		if items[i].Kind != items[j].Kind {
+			return items[i].Kind < items[j].Kind
+		}
+		if items[i].Repo != items[j].Repo {
+			return items[i].Repo < items[j].Repo
+		}
+		if items[i].Dependency != items[j].Dependency {
+			return items[i].Dependency < items[j].Dependency
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func remediationDeltaRank(item RemediationItemDelta) int {
+	return maxInt(remediationLevelRank(item.Priority), remediationLevelRank(item.Severity))
+}
+
+func remediationItemRank(item RemediationItem) int {
+	return maxInt(remediationLevelRank(item.Priority), remediationLevelRank(item.Severity))
+}
+
+func remediationLevelRank(value string) int {
+	switch normalizeRemediationLevel(value) {
+	case report.VulnerabilityPriorityCritical:
+		return 4
+	case report.VulnerabilityPriorityHigh:
+		return 3
+	case report.VulnerabilityPriorityMedium:
+		return 2
+	case report.VulnerabilityPriorityLow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func normalizeRemediationLevel(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case report.VulnerabilityPriorityCritical:
+		return report.VulnerabilityPriorityCritical
+	case report.VulnerabilityPriorityHigh:
+		return report.VulnerabilityPriorityHigh
+	case "moderate", report.VulnerabilityPriorityMedium:
+		return report.VulnerabilityPriorityMedium
+	case report.VulnerabilityPriorityLow:
+		return report.VulnerabilityPriorityLow
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func categoryRank(category string) int {
+	switch category {
+	case remediationCategoryRepoError:
+		return 0
+	case remediationCategoryVulnerability:
+		return 1
+	case remediationCategoryLicense:
+		return 2
+	case remediationCategoryRuntimeRegression:
+		return 3
+	case remediationCategoryRisk:
+		return 4
+	case remediationCategoryWaste:
+		return 5
+	case remediationCategoryRecommendation:
+		return 6
+	case remediationCategoryDuplicateDependency:
+		return 7
+	default:
+		return 8
+	}
+}
+
+func stableRemediationID(parts ...string) string {
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.ToLower(strings.TrimSpace(part))
+		if trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	sum := sha256.Sum256([]byte(strings.Join(normalized, "\x00")))
+	return "rqi-" + hex.EncodeToString(sum[:8])
+}
+
+func compactEvidence(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func isWasteRecommendationCode(code string) bool {
+	code = strings.ToLower(strings.TrimSpace(code))
+	return strings.HasPrefix(code, "remove-") || strings.Contains(code, "low-usage")
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/dashboard/remediation_test.go
+++ b/internal/dashboard/remediation_test.go
@@ -1,0 +1,408 @@
+package dashboard
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestAggregateWithRemediationQueueBuildsOrderedStableItems(t *testing.T) {
+	const duplicateDependency = "shared-lib"
+	analyses := []RepoAnalysis{
+		{
+			Input: RepoInput{Name: "api", Path: "./api"},
+			Report: report.Report{
+				Dependencies: []report.DependencyReport{
+					{
+						Name: "vuln-lib",
+						Vulnerabilities: []report.VulnerabilityFinding{
+							{
+								AdvisoryID:   "GHSA-dashboard",
+								Package:      "vuln-lib",
+								Severity:     report.VulnerabilityPriorityHigh,
+								Priority:     report.VulnerabilityPriorityCritical,
+								FixedVersion: "2.0.0",
+								Source:       "local-advisory",
+								Reachable:    true,
+								Evidence:     []string{"imported by api"},
+							},
+						},
+					},
+					{
+						Name: "waste-lib",
+						Recommendations: []report.Recommendation{
+							{Code: "remove-unused-dependency", Priority: report.VulnerabilityPriorityMedium, Message: "Remove waste-lib."},
+						},
+					},
+					{Name: duplicateDependency},
+				},
+			},
+		},
+		{
+			Input:  RepoInput{Name: "web", Path: "./web"},
+			Report: report.Report{Dependencies: []report.DependencyReport{{Name: duplicateDependency}}},
+		},
+		{
+			Input:  RepoInput{Name: "worker", Path: "./worker"},
+			Report: report.Report{Dependencies: []report.DependencyReport{{Name: duplicateDependency}}},
+		},
+		{
+			Input: RepoInput{Name: "broken", Path: "./broken"},
+			Err:   errors.New("analysis failed"),
+		},
+	}
+
+	first := AggregateWithOptions(time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC), analyses, AggregateOptions{IncludeRemediationQueue: true})
+	second := AggregateWithOptions(time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC), analyses, AggregateOptions{IncludeRemediationQueue: true})
+
+	if len(first.RemediationItems) != 4 {
+		t.Fatalf("expected four remediation items, got %#v", first.RemediationItems)
+	}
+	if remediationItemRank(first.RemediationItems[0]) < remediationItemRank(first.RemediationItems[1]) {
+		t.Fatalf("expected remediation items sorted by descending priority, got %#v", first.RemediationItems)
+	}
+	if !reflect.DeepEqual(remediationIDs(first.RemediationItems), remediationIDs(second.RemediationItems)) {
+		t.Fatalf("expected stable remediation IDs, first=%#v second=%#v", remediationIDs(first.RemediationItems), remediationIDs(second.RemediationItems))
+	}
+
+	assertRemediationCategory(t, first.RemediationItems, remediationCategoryRepoError, "")
+	assertRemediationCategory(t, first.RemediationItems, remediationCategoryVulnerability, "vuln-lib")
+	assertRemediationCategory(t, first.RemediationItems, remediationCategoryWaste, "waste-lib")
+	duplicate := assertRemediationCategory(t, first.RemediationItems, remediationCategoryDuplicateDependency, duplicateDependency)
+	if !strings.Contains(duplicate.Repo, "api") || !strings.Contains(duplicate.Repo, "web") || !strings.Contains(duplicate.Repo, "worker") {
+		t.Fatalf("expected duplicate item repo list to include all repos, got %#v", duplicate)
+	}
+}
+
+func TestAggregateWithRemediationQueueDedupeDuplicateDependencyItems(t *testing.T) {
+	generatedAt := time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC)
+	analyses := []RepoAnalysis{{
+		Input: RepoInput{Name: "api", Path: "./api"},
+		Report: report.Report{
+			Dependencies: []report.DependencyReport{
+				{Name: "denied-lib", License: &report.DependencyLicense{SPDX: "GPL-3.0", Denied: true, Evidence: []string{"policy"}}},
+				{Name: "denied-lib", License: &report.DependencyLicense{SPDX: "GPL-3.0", Denied: true, Evidence: []string{"duplicate row"}}},
+			},
+		},
+	}}
+	reportData := AggregateWithOptions(generatedAt, analyses, AggregateOptions{IncludeRemediationQueue: true})
+
+	count := 0
+	var item RemediationItem
+	for _, candidate := range reportData.RemediationItems {
+		if candidate.Category == remediationCategoryLicense && candidate.Dependency == "denied-lib" {
+			count++
+			item = candidate
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected duplicate dependency license items to dedupe, got %#v", reportData.RemediationItems)
+	}
+	if !reflect.DeepEqual(item.Evidence, []string{"license: GPL-3.0", "policy", "duplicate row"}) {
+		t.Fatalf("expected duplicate evidence to merge, got %#v", item)
+	}
+}
+
+func TestDashboardBaselineComparisonRemediationItems(t *testing.T) {
+	regressedID := stableRemediationID("api", "vuln-lib", "vulnerability", "GHSA-regressed")
+	existingID := stableRemediationID("api", "old-lib", "waste", "remove-unused-dependency")
+	removedID := stableRemediationID("api", "removed-lib", "license")
+	newID := stableRemediationID("api", "new-lib", "risk")
+
+	current := Report{
+		RemediationItems: []RemediationItem{
+			{ID: regressedID, Repo: "api", Dependency: "vuln-lib", Category: remediationCategoryVulnerability, Priority: report.VulnerabilityPriorityCritical, Severity: report.VulnerabilityPriorityCritical, SuggestedAction: "upgrade"},
+			{ID: existingID, Repo: "api", Dependency: "old-lib", Category: remediationCategoryWaste, Priority: report.VulnerabilityPriorityLow, Severity: report.VulnerabilityPriorityLow, SuggestedAction: "remove"},
+			{ID: newID, Repo: "api", Dependency: "new-lib", Category: remediationCategoryRisk, Priority: report.VulnerabilityPriorityMedium, Severity: report.VulnerabilityPriorityMedium, SuggestedAction: "triage"},
+		},
+	}
+	baseline := Report{
+		RemediationItems: []RemediationItem{
+			{ID: regressedID, Repo: "api", Dependency: "vuln-lib", Category: remediationCategoryVulnerability, Priority: report.VulnerabilityPriorityHigh, Severity: report.VulnerabilityPriorityHigh, SuggestedAction: "upgrade"},
+			{ID: existingID, Repo: "api", Dependency: "old-lib", Category: remediationCategoryWaste, Priority: report.VulnerabilityPriorityLow, Severity: report.VulnerabilityPriorityLow, SuggestedAction: "remove"},
+			{ID: removedID, Repo: "api", Dependency: "removed-lib", Category: remediationCategoryLicense, Priority: report.VulnerabilityPriorityHigh, Severity: report.VulnerabilityPriorityHigh, SuggestedAction: "replace"},
+		},
+	}
+
+	comparison := ComputeBaselineComparison(current, baseline)
+	if len(comparison.NewRemediationItems) != 1 || comparison.NewRemediationItems[0].ID != newID {
+		t.Fatalf("expected new remediation item, got %#v", comparison.NewRemediationItems)
+	}
+	if len(comparison.RegressedRemediationItems) != 1 || comparison.RegressedRemediationItems[0].ID != regressedID {
+		t.Fatalf("expected regressed remediation item, got %#v", comparison.RegressedRemediationItems)
+	}
+	if len(comparison.ExistingRemediationItems) != 1 || comparison.ExistingRemediationItems[0].ID != existingID {
+		t.Fatalf("expected existing remediation item, got %#v", comparison.ExistingRemediationItems)
+	}
+	if len(comparison.RemovedRemediationItems) != 1 || comparison.RemovedRemediationItems[0].ID != removedID {
+		t.Fatalf("expected removed remediation item, got %#v", comparison.RemovedRemediationItems)
+	}
+
+	updated, err := ApplyBaselineWithKeys(current, baseline, "label:baseline", "commit:head")
+	if err != nil {
+		t.Fatalf("apply baseline: %v", err)
+	}
+	statuses := map[string]string{}
+	for _, item := range updated.RemediationItems {
+		statuses[item.ID] = item.BaselineStatus
+	}
+	if statuses[newID] != string(RemediationItemNew) || statuses[regressedID] != string(RemediationItemRegressed) || statuses[existingID] != string(RemediationItemExisting) {
+		t.Fatalf("expected current remediation items to be annotated by baseline status, got %#v", statuses)
+	}
+}
+
+func TestFormatReportRemediationQueueCSVAndHTML(t *testing.T) {
+	item := RemediationItem{
+		ID:              "rqi-test",
+		Repo:            "<api>",
+		RepoPath:        "./api",
+		Dependency:      "vuln-lib",
+		Category:        remediationCategoryVulnerability,
+		Severity:        report.VulnerabilityPriorityHigh,
+		Priority:        report.VulnerabilityPriorityCritical,
+		Evidence:        []string{"<evidence>"},
+		SuggestedAction: "Upgrade <vuln-lib>.",
+		BaselineStatus:  string(RemediationItemNew),
+	}
+	reportData := Report{
+		GeneratedAt:      time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC),
+		Summary:          Summary{TotalRepos: 1},
+		Repos:            []RepoResult{{Name: "api", Path: "./api"}},
+		RemediationItems: []RemediationItem{item},
+		BaselineComparison: &BaselineComparison{
+			BaselineKey:           "label:baseline",
+			RemediationItemDeltas: []RemediationItemDelta{remediationItemDelta(RemediationItemNew, item, RemediationItem{})},
+		},
+	}
+
+	csvOutput, err := FormatReport(reportData, FormatCSV)
+	if err != nil {
+		t.Fatalf("format remediation csv: %v", err)
+	}
+	for _, want := range []string{"remediation_id,baseline_status,repo,repo_path,dependency,category,severity,priority,evidence,suggested_action", "rqi-test,new,<api>,./api,vuln-lib,vulnerability,high,critical,<evidence>,Upgrade <vuln-lib>.", "remediation_id,kind,repo,repo_path,dependency,category"} {
+		if !strings.Contains(csvOutput, want) {
+			t.Fatalf("expected csv output to contain %q, got %q", want, csvOutput)
+		}
+	}
+
+	htmlOutput, err := FormatReport(reportData, FormatHTML)
+	if err != nil {
+		t.Fatalf("format remediation html: %v", err)
+	}
+	for _, want := range []string{"Remediation Queue", "Remediation Queue Baseline", "&lt;api&gt;", "Upgrade &lt;vuln-lib&gt;."} {
+		if !strings.Contains(htmlOutput, want) {
+			t.Fatalf("expected html output to contain %q, got %q", want, htmlOutput)
+		}
+	}
+}
+
+func TestRemediationHelperBranchCoverage(t *testing.T) {
+	loadDelta := 3
+	analysis := RepoAnalysis{
+		Input: RepoInput{Name: "api", Path: "./api"},
+		Report: report.Report{
+			Dependencies: []report.DependencyReport{
+				{
+					Name: "",
+					Vulnerabilities: []report.VulnerabilityFinding{{
+						AdvisoryID: "GHSA-skipped",
+						Severity:   report.VulnerabilityPriorityHigh,
+					}},
+				},
+				{
+					Name: "fallback-vuln",
+					Vulnerabilities: []report.VulnerabilityFinding{{
+						Severity: "moderate",
+					}},
+				},
+				{
+					Name:    "permitted-lib",
+					License: &report.DependencyLicense{SPDX: "MIT", Denied: false},
+				},
+				{
+					Name:    "custom-license-lib",
+					License: &report.DependencyLicense{Raw: "Custom", Denied: true, Source: "policy", Evidence: []string{"approval needed"}},
+				},
+				{
+					Name: "recommend-lib",
+					Recommendations: []report.Recommendation{
+						{Code: "", Message: ""},
+						{Code: "review-ownership", Rationale: "low ownership", ConfidenceReasonCodes: []string{"stale"}},
+					},
+				},
+				{
+					Name: "risk-lib",
+					RiskCues: []report.RiskCue{
+						{Code: "", Message: ""},
+						{Code: "CVE-signal", Message: "Investigate", ConfidenceReasonCodes: []string{"low-confidence"}},
+					},
+				},
+			},
+			BaselineComparison: &report.BaselineComparison{
+				RuntimeRegressions: []report.DependencyDelta{
+					{
+						Name:     "runtime-lib",
+						Language: "python",
+						RuntimeDelta: &report.RuntimeDelta{
+							NewRuntimeLoads:       true,
+							RuntimeOnlyRegression: true,
+							LoadCountDelta:        &loadDelta,
+						},
+					},
+					{Name: "   "},
+				},
+			},
+		},
+	}
+	items := repoRemediationItems(analysis, map[string]int{"api": 1})
+
+	fallback := assertRemediationCategory(t, items, remediationCategoryVulnerability, "fallback-vuln")
+	if fallback.Priority != report.VulnerabilityPriorityMedium || !strings.Contains(fallback.SuggestedAction, "the advisory") {
+		t.Fatalf("expected fallback vulnerability item to normalize moderate priority and action, got %#v", fallback)
+	}
+	license := assertRemediationCategory(t, items, remediationCategoryLicense, "custom-license-lib")
+	if !reflect.DeepEqual(license.Evidence, []string{"license: Custom", "source: policy", "approval needed"}) {
+		t.Fatalf("expected license evidence to include source and policy evidence, got %#v", license.Evidence)
+	}
+	recommendation := assertRemediationCategory(t, items, remediationCategoryRecommendation, "recommend-lib")
+	if !strings.Contains(recommendation.SuggestedAction, "review-ownership") || !reflect.DeepEqual(recommendation.Evidence, []string{"recommendation: review-ownership", "low ownership", "stale"}) {
+		t.Fatalf("expected default recommendation action and evidence, got %#v", recommendation)
+	}
+	risk := assertRemediationCategory(t, items, remediationCategoryRisk, "risk-lib")
+	if risk.Priority != report.VulnerabilityPriorityLow || !reflect.DeepEqual(risk.Evidence, []string{"risk: CVE-signal", "Investigate", "low-confidence"}) {
+		t.Fatalf("expected default risk severity and evidence, got %#v", risk)
+	}
+	runtime := assertRemediationCategory(t, items, remediationCategoryRuntimeRegression, "runtime-lib")
+	for _, want := range []string{"runtime regression detected", "language: python", "new runtime loads", "runtime-only regression", "load_count_delta: +3"} {
+		if !containsString(runtime.Evidence, want) {
+			t.Fatalf("expected runtime evidence %q in %#v", want, runtime.Evidence)
+		}
+	}
+
+	if item, ok := licenseRemediationItem("repo", "repo", "./repo", "nil-license", nil); ok || item.ID != "" {
+		t.Fatalf("expected nil license to produce no item, got %#v", item)
+	}
+	if len(runtimeRegressionEvidence(report.DependencyDelta{})) != 1 {
+		t.Fatalf("expected bare runtime regression evidence to keep only the base marker")
+	}
+	if got := crossRepoRemediationItems([]CrossRepoDependency{{Name: "   "}, {Name: "shared", Count: 3, Repositories: []string{"api", "web", "worker"}}}); len(got) != 1 {
+		t.Fatalf("expected blank cross-repo dependency to be skipped, got %#v", got)
+	}
+}
+
+func TestRemediationOrderingAndNormalizationBranches(t *testing.T) {
+	items := []RemediationItem{
+		{ID: "z", Repo: "web", Dependency: "dep", Category: remediationCategoryDuplicateDependency, Priority: "unknown"},
+		{ID: "a", Repo: "api", Dependency: "dep", Category: remediationCategoryVulnerability, Priority: report.VulnerabilityPriorityHigh},
+		{ID: "b", Repo: "api", Dependency: "dep", Category: remediationCategoryRisk, Priority: report.VulnerabilityPriorityHigh},
+		{ID: "c", Repo: "api", Dependency: "zzz", Category: remediationCategoryRisk, Priority: report.VulnerabilityPriorityHigh},
+	}
+	sortRemediationItems(items)
+	if got := remediationIDs(items); !reflect.DeepEqual(got, []string{"a", "b", "c", "z"}) {
+		t.Fatalf("unexpected remediation sort order: %#v", got)
+	}
+
+	deltas := []RemediationItemDelta{
+		{ID: "z", Kind: RemediationItemExisting, Repo: "web", Dependency: "dep", Priority: report.VulnerabilityPriorityLow},
+		{ID: "c", Kind: RemediationItemRegressed, Repo: "api", Dependency: "zzz", Priority: report.VulnerabilityPriorityHigh},
+		{ID: "b", Kind: RemediationItemNew, Repo: "api", Dependency: "dep", Priority: report.VulnerabilityPriorityHigh},
+		{ID: "a", Kind: RemediationItemNew, Repo: "api", Dependency: "dep", Priority: report.VulnerabilityPriorityHigh},
+	}
+	sortRemediationItemDeltas(deltas)
+	if got := []string{deltas[0].ID, deltas[1].ID, deltas[2].ID, deltas[3].ID}; !reflect.DeepEqual(got, []string{"a", "b", "c", "z"}) {
+		t.Fatalf("unexpected remediation delta sort order: %#v", got)
+	}
+
+	for _, category := range []string{
+		remediationCategoryRepoError,
+		remediationCategoryVulnerability,
+		remediationCategoryLicense,
+		remediationCategoryRuntimeRegression,
+		remediationCategoryRisk,
+		remediationCategoryWaste,
+		remediationCategoryRecommendation,
+		remediationCategoryDuplicateDependency,
+		"other",
+	} {
+		if categoryRank(category) < 0 {
+			t.Fatalf("category %q returned invalid rank", category)
+		}
+	}
+	for _, level := range []string{report.VulnerabilityPriorityCritical, report.VulnerabilityPriorityHigh, report.VulnerabilityPriorityMedium, report.VulnerabilityPriorityLow, "other"} {
+		if remediationLevelRank(level) < 0 {
+			t.Fatalf("level %q returned invalid rank", level)
+		}
+	}
+	if normalizeRemediationLevel("  MODERATE ") != report.VulnerabilityPriorityMedium {
+		t.Fatalf("expected moderate to normalize to medium")
+	}
+	if got := firstNonBlank(" ", "\t"); got != "" {
+		t.Fatalf("expected blank values to return empty string, got %q", got)
+	}
+}
+
+func TestRemediationDedupeAndSnapshotNormalizationBranches(t *testing.T) {
+	items := []RemediationItem{
+		{ID: "same", Repo: " api ", Dependency: " dep ", Category: remediationCategoryRisk, Priority: report.VulnerabilityPriorityLow, Evidence: []string{"first", " "}, SuggestedAction: " triage "},
+		{ID: "same", Repo: "api", Dependency: "dep", Category: remediationCategoryRisk, Priority: report.VulnerabilityPriorityCritical, Evidence: []string{"first", "second"}, SuggestedAction: "escalate"},
+		{ID: " ", Repo: "ignored", Priority: report.VulnerabilityPriorityCritical},
+		{ID: "tie-b", Repo: "api", Dependency: "dep", Category: remediationCategoryRisk, Priority: report.VulnerabilityPriorityHigh},
+		{ID: "tie-a", Repo: "api", Dependency: "dep", Category: remediationCategoryRisk, Priority: report.VulnerabilityPriorityHigh},
+	}
+
+	deduped := dedupeAndSortRemediationItems(items)
+	if got := remediationIDs(deduped); !reflect.DeepEqual(got, []string{"same", "tie-a", "tie-b"}) {
+		t.Fatalf("unexpected dedupe order: %#v", got)
+	}
+	if deduped[0].Priority != report.VulnerabilityPriorityCritical || !reflect.DeepEqual(deduped[0].Evidence, []string{"first", "second"}) {
+		t.Fatalf("expected duplicate to keep higher priority and merged evidence, got %#v", deduped[0])
+	}
+
+	byID := remediationItemsByID(items)
+	if len(byID) != 3 || byID["same"].Priority != report.VulnerabilityPriorityCritical {
+		t.Fatalf("expected remediationItemsByID to dedupe and skip blank IDs, got %#v", byID)
+	}
+
+	snapshot := normalizeSnapshotReport(Report{
+		Repos:            []RepoResult{{Name: "web", Path: "./web", DependencyCount: 2}, {Name: "api", Path: "./api", DependencyCount: 1}},
+		RemediationItems: items,
+	})
+	if snapshot.Summary.TotalRepos != 2 || snapshot.Summary.TotalDeps != 3 {
+		t.Fatalf("expected empty summary to be computed during snapshot normalization, got %#v", snapshot.Summary)
+	}
+	if got := []string{snapshot.Repos[0].Name, snapshot.Repos[1].Name}; !reflect.DeepEqual(got, []string{"api", "web"}) {
+		t.Fatalf("expected repos sorted during snapshot normalization, got %#v", got)
+	}
+}
+
+func remediationIDs(items []RemediationItem) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	return ids
+}
+
+func assertRemediationCategory(t *testing.T, items []RemediationItem, category, dependency string) RemediationItem {
+	t.Helper()
+	for _, item := range items {
+		if item.Category == category && (dependency == "" || item.Dependency == dependency) {
+			return item
+		}
+	}
+	t.Fatalf("expected remediation item category=%q dependency=%q in %#v", category, dependency, items)
+	return RemediationItem{}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dashboard/types.go
+++ b/internal/dashboard/types.go
@@ -124,14 +124,32 @@ type Summary struct {
 	ReposWithRuntimeRegressions int `json:"repos_with_runtime_regressions"`
 }
 
+type RemediationItem struct {
+	ID              string   `json:"id"`
+	Repo            string   `json:"repo"`
+	RepoPath        string   `json:"repo_path,omitempty"`
+	Dependency      string   `json:"dependency,omitempty"`
+	Category        string   `json:"category"`
+	Severity        string   `json:"severity,omitempty"`
+	Priority        string   `json:"priority,omitempty"`
+	Evidence        []string `json:"evidence,omitempty"`
+	SuggestedAction string   `json:"suggested_action"`
+	BaselineStatus  string   `json:"baseline_status,omitempty"`
+}
+
 type BaselineComparison struct {
-	BaselineKey  string       `json:"baseline_key"`
-	CurrentKey   string       `json:"current_key,omitempty"`
-	SummaryDelta SummaryDelta `json:"summary_delta"`
-	RepoDeltas   []RepoDelta  `json:"repo_deltas,omitempty"`
-	Added        []RepoDelta  `json:"added,omitempty"`
-	Removed      []RepoDelta  `json:"removed,omitempty"`
-	Changed      []RepoDelta  `json:"changed,omitempty"`
+	BaselineKey               string                 `json:"baseline_key"`
+	CurrentKey                string                 `json:"current_key,omitempty"`
+	SummaryDelta              SummaryDelta           `json:"summary_delta"`
+	RepoDeltas                []RepoDelta            `json:"repo_deltas,omitempty"`
+	Added                     []RepoDelta            `json:"added,omitempty"`
+	Removed                   []RepoDelta            `json:"removed,omitempty"`
+	Changed                   []RepoDelta            `json:"changed,omitempty"`
+	RemediationItemDeltas     []RemediationItemDelta `json:"remediation_item_deltas,omitempty"`
+	NewRemediationItems       []RemediationItemDelta `json:"new_remediation_items,omitempty"`
+	RegressedRemediationItems []RemediationItemDelta `json:"regressed_remediation_items,omitempty"`
+	ExistingRemediationItems  []RemediationItemDelta `json:"existing_remediation_items,omitempty"`
+	RemovedRemediationItems   []RemediationItemDelta `json:"removed_remediation_items,omitempty"`
 }
 
 type SummaryDelta struct {
@@ -171,11 +189,36 @@ type RepoDelta struct {
 	BaselineError                 string        `json:"baseline_error,omitempty"`
 }
 
+type RemediationItemDeltaKind string
+
+const (
+	RemediationItemNew       RemediationItemDeltaKind = "new"
+	RemediationItemRegressed RemediationItemDeltaKind = "regressed"
+	RemediationItemExisting  RemediationItemDeltaKind = "existing"
+	RemediationItemRemoved   RemediationItemDeltaKind = "removed"
+)
+
+type RemediationItemDelta struct {
+	Kind             RemediationItemDeltaKind `json:"kind"`
+	ID               string                   `json:"id"`
+	Repo             string                   `json:"repo"`
+	RepoPath         string                   `json:"repo_path,omitempty"`
+	Dependency       string                   `json:"dependency,omitempty"`
+	Category         string                   `json:"category"`
+	Severity         string                   `json:"severity,omitempty"`
+	Priority         string                   `json:"priority,omitempty"`
+	BaselineSeverity string                   `json:"baseline_severity,omitempty"`
+	BaselinePriority string                   `json:"baseline_priority,omitempty"`
+	Evidence         []string                 `json:"evidence,omitempty"`
+	SuggestedAction  string                   `json:"suggested_action"`
+}
+
 type Report struct {
 	GeneratedAt        time.Time             `json:"generated_at"`
 	Repos              []RepoResult          `json:"repos"`
 	Summary            Summary               `json:"summary"`
 	BaselineComparison *BaselineComparison   `json:"baseline_comparison,omitempty"`
 	CrossRepoDeps      []CrossRepoDependency `json:"cross_repo_deps,omitempty"`
+	RemediationItems   []RemediationItem     `json:"remediation_items,omitempty"`
 	SourceWarnings     []string              `json:"warnings,omitempty"`
 }

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -142,5 +142,11 @@
     "name": "python-codemod-suggestions-preview",
     "description": "Enable preview Python safe remediation suggestions for deterministic unused import cleanup.",
     "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0017",
+    "name": "dashboard-remediation-queue-preview",
+    "description": "Enable org-level dashboard remediation queue items across errors, vulnerabilities, policy findings, recommendations, runtime regressions, and shared dependency hotspots.",
+    "lifecycle": "preview"
   }
 ]


### PR DESCRIPTION
## Summary
Add a preview-gated org-level dashboard remediation queue for #1096, including stable queue items, dashboard rendering/export support, baseline queue deltas, and documentation.

## Changes
- Add `dashboard-remediation-queue-preview` / `LOP-FEAT-0017` as a preview feature flag.
- Derive stable remediation items from repo errors, vulnerabilities, denied licenses, risk cues, recommendations, runtime regressions, and cross-repo duplicate dependencies.
- Render remediation queue data in dashboard JSON, CSV, and HTML, with baseline statuses and queue deltas for new, regressed, existing, and removed items.
- Keep remediation queue output fully hidden when the preview flag is disabled, including saved baseline comparisons.
- Document the JSON and CSV shape in `docs/dashboard.md`.

## Validation
- `go test ./internal/dashboard ./internal/app`
- `go test ./internal/app ./internal/dashboard ./internal/featureflags`
- `go run ./tools/featureflag validate`
- `git diff --check`
- `make test`
- `make cov`
- `make lint`

## Risk and compatibility
- Breaking changes: None. The feature is preview-gated and existing dashboard output remains unchanged unless enabled.
- Migration required: None.
- Performance impact: Expected to be minimal; queue generation is derived from in-memory dashboard analysis results.
- Memory benchmark impact: None expected; memory benchmark gate reported no approval required.

## Checklist
- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #1096
