### PR TITLE
chore(renovate): tidy Go updates before automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,15 @@
         "major"
       ],
       "automerge": false
+    },
+    {
+      "description": "Keep Go module updates tidy for CI and automerge",
+      "matchManagers": [
+        "gomod"
+      ],
+      "postUpdateOptions": [
+        "gomodTidy"
+      ]
     }
   ]
 }

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -267,6 +268,25 @@ func TestRenovateDoesNotAutomergeMajorUpdates(t *testing.T) {
 			t.Fatalf("%s updates should retain Renovate automerge=true", updateType)
 		}
 	}
+}
+
+func TestRenovateTidiesGoModuleUpdates(t *testing.T) {
+	t.Parallel()
+
+	var config struct {
+		PackageRules []struct {
+			MatchManagers     []string `json:"matchManagers"`
+			PostUpdateOptions []string `json:"postUpdateOptions"`
+		} `json:"packageRules"`
+	}
+	readJSONConfig(t, "renovate.json", &config)
+
+	for _, rule := range config.PackageRules {
+		if slices.Contains(rule.MatchManagers, "gomod") && slices.Contains(rule.PostUpdateOptions, "gomodTidy") {
+			return
+		}
+	}
+	t.Fatal("Go module updates must run gomodTidy before CI and automerge")
 }
 
 func TestDarwinReleaseJobsAssertHostArchitecture(t *testing.T) {


### PR DESCRIPTION
## Summary

Renovate already uses GitHub-native automerge for minor, patch, pin, and digest updates, but Go module update PRs can remain blocked even when the dependency change itself is valid. PRs #1124 and #1126 retained obsolete prior-version checksums, so the repository's deterministic `go mod tidy -diff` gate rejected them before queued automerge could run.

The root cause is a policy mismatch: this repository requires a tidy module graph, while Renovate's final `go mod tidy` pass is opt-in and was not configured. This change connects those policies without weakening the existing rule that major updates remain manual.

## Changes

- Add a `gomod`-scoped Renovate rule that runs `gomodTidy` after every Go module update.
- Preserve automerge for minor, patch, pin, and digest updates while leaving major updates explicitly excluded.
- Add a regression test requiring the Go module post-update rule to retain `gomodTidy`.

## Validation

Commands and checks run:

```bash
jq empty renovate.json
GOTOOLCHAIN=go1.26.5 go test ./scripts -run '^TestRenovate' -count=1
git diff --check
make ci
```

Additional manual validation:

- Full pre-commit CI passed module verification, feature-flag validation, lint, workflow and shell checks, duplication and inline-suppression gates, gosec, govulncheck, tests, goleak, race, memory benchmarks, build, and coverage.
- Total coverage was 98.3%, with every measured package at or above 98%.
- Confirmed the rule is manager-scoped and does not enable automerge for major updates.

## Risk and compatibility

- Breaking changes: None. Application and extension runtime behavior are unchanged.
- Migration required: None. The rule applies to future Renovate-generated Go module branches.
- Performance impact: Renovate will spend additional time running `go mod tidy` for Go updates; repository builds are unaffected.
- Memory benchmark impact: None; all benchmark deltas remained within thresholds.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
