### PR TITLE
refactor(report): make PR-comment formatter lint-clean

### DIFF
--- a/internal/report/format_pr_comment.go
+++ b/internal/report/format_pr_comment.go
@@ -17,23 +17,23 @@ func formatPRComment(report Report) string {
 	buffer.WriteString("## Lopper (Delta)\n\n")
 	buffer.WriteString("| Metric delta | Value |\n")
 	buffer.WriteString("| --- | --- |\n")
-	buffer.WriteString(fmt.Sprintf("| Dependency count | %s |\n", signedInt(comparison.SummaryDelta.DependencyCountDelta)))
-	buffer.WriteString(fmt.Sprintf("| Used percent | %s |\n", signedPct(comparison.SummaryDelta.UsedPercentDelta)))
-	buffer.WriteString(fmt.Sprintf("| Waste percent | %s |\n", signedPct(comparison.SummaryDelta.WastePercentDelta)))
-	buffer.WriteString(fmt.Sprintf("| Estimated unused bytes | %s |\n", signedBytes(comparison.SummaryDelta.UnusedBytesDelta)))
-	buffer.WriteString(fmt.Sprintf("| Known licenses | %s |\n", signedInt(comparison.SummaryDelta.KnownLicenseCountDelta)))
-	buffer.WriteString(fmt.Sprintf("| Unknown licenses | %s |\n", signedInt(comparison.SummaryDelta.UnknownLicenseCountDelta)))
-	buffer.WriteString(fmt.Sprintf("| Denied licenses | %s |\n", signedInt(comparison.SummaryDelta.DeniedLicenseCountDelta)))
-	buffer.WriteString(fmt.Sprintf("| Reachable vulnerabilities | %s |\n", signedInt(comparison.SummaryDelta.ReachableVulnerabilityCountDelta)))
+	fmt.Fprintf(&buffer, "| Dependency count | %s |\n", signedInt(comparison.SummaryDelta.DependencyCountDelta))
+	fmt.Fprintf(&buffer, "| Used percent | %s |\n", signedPct(comparison.SummaryDelta.UsedPercentDelta))
+	fmt.Fprintf(&buffer, "| Waste percent | %s |\n", signedPct(comparison.SummaryDelta.WastePercentDelta))
+	fmt.Fprintf(&buffer, "| Estimated unused bytes | %s |\n", signedBytes(comparison.SummaryDelta.UnusedBytesDelta))
+	fmt.Fprintf(&buffer, "| Known licenses | %s |\n", signedInt(comparison.SummaryDelta.KnownLicenseCountDelta))
+	fmt.Fprintf(&buffer, "| Unknown licenses | %s |\n", signedInt(comparison.SummaryDelta.UnknownLicenseCountDelta))
+	fmt.Fprintf(&buffer, "| Denied licenses | %s |\n", signedInt(comparison.SummaryDelta.DeniedLicenseCountDelta))
+	fmt.Fprintf(&buffer, "| Reachable vulnerabilities | %s |\n", signedInt(comparison.SummaryDelta.ReachableVulnerabilityCountDelta))
 	buffer.WriteString("\n")
 	buffer.WriteString("| Changed | Regressions | Progressions | Added | Removed | Unchanged |\n")
 	buffer.WriteString("| --- | --- | --- | --- | --- | --- |\n")
-	buffer.WriteString(fmt.Sprintf("| %d | %d | %d | %d | %d | %d |\n", len(comparison.Dependencies), len(comparison.Regressions), len(comparison.Progressions), len(comparison.Added), len(comparison.Removed), comparison.UnchangedRows))
+	fmt.Fprintf(&buffer, "| %d | %d | %d | %d | %d | %d |\n", len(comparison.Dependencies), len(comparison.Regressions), len(comparison.Progressions), len(comparison.Added), len(comparison.Removed), comparison.UnchangedRows)
 	if len(comparison.RuntimeRegressions) > 0 || len(comparison.RuntimeImprovements) > 0 {
 		buffer.WriteString("\n| Runtime trace deltas | Count |\n")
 		buffer.WriteString("| --- | --- |\n")
-		buffer.WriteString(fmt.Sprintf("| Runtime regressions | %d |\n", len(comparison.RuntimeRegressions)))
-		buffer.WriteString(fmt.Sprintf("| Runtime improvements | %d |\n", len(comparison.RuntimeImprovements)))
+		fmt.Fprintf(&buffer, "| Runtime regressions | %d |\n", len(comparison.RuntimeRegressions))
+		fmt.Fprintf(&buffer, "| Runtime improvements | %d |\n", len(comparison.RuntimeImprovements))
 	}
 
 	if len(comparison.NewDeniedLicenses) > 0 {
@@ -41,7 +41,7 @@ func formatPRComment(report Report) string {
 		buffer.WriteString("| # | Dependency | Language | SPDX |\n")
 		buffer.WriteString("| --- | --- | --- | --- |\n")
 		for i, denied := range comparison.NewDeniedLicenses {
-			buffer.WriteString(fmt.Sprintf("| %d | `%s` | %s | %s |\n", i+1, escapeMarkdownTable(denied.Name), escapeMarkdownTable(denied.Language), escapeMarkdownTable(denied.SPDX)))
+			fmt.Fprintf(&buffer, "| %d | `%s` | %s | %s |\n", i+1, escapeMarkdownTable(denied.Name), escapeMarkdownTable(denied.Language), escapeMarkdownTable(denied.SPDX))
 		}
 	}
 


### PR DESCRIPTION
## Summary

Closes #1105.

The PR-comment formatter retained a two-step `fmt.Sprintf` plus `strings.Builder.WriteString` pattern throughout its generated Markdown rows. That pattern creates avoidable temporary strings and was the root cause recorded by the formatter lint-cleanup issue. This change writes the same rows directly to the builder so the formatter remains behaviorally identical and lint-clean.

## Changes

- Replaced every `buffer.WriteString(fmt.Sprintf(...))` row in `formatPRComment` with `fmt.Fprintf(&buffer, ...)`.
- Kept all Markdown templates, value formatting, ordering, and escaping unchanged.
- Retained the existing PR-comment regression coverage that asserts the rendered Markdown.

## Validation

Commands and checks run:

```bash
GOTOOLCHAIN=go1.26.5 go test ./internal/report
make lint
make ci
make demos-check
```

Additional manual validation:

- Confirmed `make lint` reports `0 issues`.
- Confirmed the full coverage gate remains at 98.3% and the memory benchmark gate reports no regression.

## Risk and compatibility

- Breaking changes: None; output bytes and public behavior are unchanged.
- Migration required: None.
- Performance impact: Neutral to slightly positive because formatted rows no longer allocate an intermediate string.
- Memory benchmark impact: None; the full memory gate passed with no measured regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
