### PR TITLE
fix(vscode): preserve diagnostics when refresh is cancelled

### DIFF
--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -107,6 +107,26 @@ interface RefreshAbortHandle {
   controller: AbortController;
 }
 
+interface FreshRefreshOptions {
+  folder: vscode.WorkspaceFolder;
+  workspaceKey: string;
+  sessionKey: string;
+  runId: number;
+  revealErrors: boolean;
+  scopeMode: LopperScopeMode;
+  document?: vscode.TextDocument;
+  requestedLanguage: string;
+  runtimeTracePath?: string;
+  runtimeTestCommand?: string;
+  baselinePath?: string;
+  baselineStorePath?: string;
+  baselineKey?: string;
+  baselineLabel?: string;
+  saveBaseline?: boolean;
+  signal?: AbortSignal;
+  abortKey?: string;
+}
+
 interface ApplyCodemodCommandOptions {
   allowDirty?: boolean;
   skipConfirmation?: boolean;
@@ -439,108 +459,81 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     return false;
   }
 
-  private async executeFreshRefresh(options: {
-    folder: vscode.WorkspaceFolder;
-    workspaceKey: string;
-    sessionKey: string;
-    runId: number;
-    revealErrors: boolean;
-    scopeMode: LopperScopeMode;
-    document?: vscode.TextDocument;
-    requestedLanguage: string;
-    runtimeTracePath?: string;
-    runtimeTestCommand?: string;
-    baselinePath?: string;
-    baselineStorePath?: string;
-    baselineKey?: string;
-    baselineLabel?: string;
-    saveBaseline?: boolean;
-    signal?: AbortSignal;
-    abortKey?: string;
-  }): Promise<void> {
-    const {
-      folder,
-      workspaceKey,
-      sessionKey,
-      runId,
-      revealErrors,
-      scopeMode,
-      document,
-      requestedLanguage,
-      runtimeTracePath,
-      runtimeTestCommand,
-      baselinePath,
-      baselineStorePath,
-      baselineKey,
-      baselineLabel,
-      saveBaseline,
-      signal,
-      abortKey,
-    } = options;
+  private async executeFreshRefresh(options: FreshRefreshOptions): Promise<void> {
+    const { folder, workspaceKey, sessionKey, runId, abortKey } = options;
     try {
       const request: WorkspaceAnalysisRequest = {
-        document,
-        scopeMode,
-        runtimeTracePath,
-        runtimeTestCommand,
-        baselinePath,
-        baselineStorePath,
-        baselineKey,
-        baselineLabel,
-        saveBaseline,
-        signal,
+        document: options.document,
+        scopeMode: options.scopeMode,
+        runtimeTracePath: options.runtimeTracePath,
+        runtimeTestCommand: options.runtimeTestCommand,
+        baselinePath: options.baselinePath,
+        baselineStorePath: options.baselineStorePath,
+        baselineKey: options.baselineKey,
+        baselineLabel: options.baselineLabel,
+        saveBaseline: options.saveBaseline,
+        signal: options.signal,
       };
       const analysis = await this.runner.analyseWorkspace(folder, request);
-      if (signal?.aborted) {
-        this.restoreStatusAfterCancellation(folder, workspaceKey, scopeMode, runId);
-        return;
-      }
-      if (!this.refreshSessions.isLatestRun(workspaceKey, runId)) {
-        this.output.appendLine(
-          `[refresh:stale] ${folder.name} (${requestedLanguage}, ${scopeMode}) run=${runId} ignored in favor of run=${this.refreshSessions.latestRunId(workspaceKey)}`,
-        );
-        this.output.appendLine(`[refresh:cancelled] stale run ${runId} did not update diagnostics`);
-        return;
-      }
-      this.refreshSessions.setCache(workspaceKey, sessionKey, analysis);
-      this.renderAnalysis(analysis, "fresh");
-      this.missingBinaryWarningShown = false;
+      this.completeFreshRefresh(options, analysis);
     } catch (error) {
-      if (!this.refreshSessions.isLatestRun(workspaceKey, runId)) {
-        this.output.appendLine(
-          `[refresh:stale] ${folder.name} (${requestedLanguage}, ${scopeMode}) run=${runId} failed after supersession`,
-        );
-        this.output.appendLine(`[refresh:cancelled] stale run ${runId} failure ignored`);
-        return;
-      }
-
-      if (signal?.aborted) {
-        this.restoreStatusAfterCancellation(folder, workspaceKey, scopeMode, runId);
-        return;
-      }
-
-      const message = error instanceof Error ? error.message : String(error);
-      this.clearWorkspaceDiagnostics(folder);
-      this.analysisByWorkspace.delete(workspaceKey);
-      this.successfulStatusByWorkspace.delete(workspaceKey);
-      this.explorer.refresh();
-      this.updateStatus(`Lopper: unavailable (${scopeMode})`, message);
-      this.output.appendLine(`[refresh:error] ${message}`);
-      if (error instanceof BinaryResolutionError) {
-        if (revealErrors && !this.missingBinaryWarningShown) {
-          this.missingBinaryWarningShown = true;
-          await vscode.window.showWarningMessage(message);
-        }
-        return;
-      }
-      if (revealErrors) {
-        await vscode.window.showErrorMessage(`Lopper refresh failed: ${message}`);
-      }
+      await this.handleFreshRefreshError(options, error);
     } finally {
       this.refreshSessions.clearInFlight(workspaceKey, sessionKey, runId);
       if (abortKey) {
         this.refreshAbortHandles.delete(abortKey);
       }
+    }
+  }
+
+  private completeFreshRefresh(options: FreshRefreshOptions, analysis: WorkspaceAnalysis): void {
+    const { folder, workspaceKey, sessionKey, runId, requestedLanguage, scopeMode, signal } = options;
+    if (!this.refreshSessions.isLatestRun(workspaceKey, runId)) {
+      this.output.appendLine(
+        `[refresh:stale] ${folder.name} (${requestedLanguage}, ${scopeMode}) run=${runId} ignored in favor of run=${this.refreshSessions.latestRunId(workspaceKey)}`,
+      );
+      this.output.appendLine(`[refresh:cancelled] stale run ${runId} did not update diagnostics`);
+      return;
+    }
+    if (signal?.aborted) {
+      this.restoreStatusAfterCancellation(folder, workspaceKey, scopeMode, runId);
+      return;
+    }
+    this.refreshSessions.setCache(workspaceKey, sessionKey, analysis);
+    this.renderAnalysis(analysis, "fresh");
+    this.missingBinaryWarningShown = false;
+  }
+
+  private async handleFreshRefreshError(options: FreshRefreshOptions, error: unknown): Promise<void> {
+    const { folder, workspaceKey, runId, requestedLanguage, scopeMode, signal, revealErrors } = options;
+    if (!this.refreshSessions.isLatestRun(workspaceKey, runId)) {
+      this.output.appendLine(
+        `[refresh:stale] ${folder.name} (${requestedLanguage}, ${scopeMode}) run=${runId} failed after supersession`,
+      );
+      this.output.appendLine(`[refresh:cancelled] stale run ${runId} failure ignored`);
+      return;
+    }
+    if (signal?.aborted) {
+      this.restoreStatusAfterCancellation(folder, workspaceKey, scopeMode, runId);
+      return;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    this.clearWorkspaceDiagnostics(folder);
+    this.analysisByWorkspace.delete(workspaceKey);
+    this.successfulStatusByWorkspace.delete(workspaceKey);
+    this.explorer.refresh();
+    this.updateStatus(`Lopper: unavailable (${scopeMode})`, message);
+    this.output.appendLine(`[refresh:error] ${message}`);
+    if (error instanceof BinaryResolutionError) {
+      if (revealErrors && !this.missingBinaryWarningShown) {
+        this.missingBinaryWarningShown = true;
+        await vscode.window.showWarningMessage(message);
+      }
+      return;
+    }
+    if (revealErrors) {
+      await vscode.window.showErrorMessage(`Lopper refresh failed: ${message}`);
     }
   }
 

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -81,6 +81,7 @@ export interface RefreshWorkspaceOptions {
 interface LopperControllerContract extends vscode.Disposable {
   initialize(): Promise<void>;
   refreshWorkspace(options?: RefreshWorkspaceOptions): Promise<void>;
+  cancelRefresh(reason?: string): void;
   applyCodemod(dependencyName?: string, folderPath?: string, options?: ApplyCodemodCommandOptions): Promise<void>;
   getLatestSummary(): string;
 }
@@ -122,6 +123,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   private readonly refreshSessions = new RefreshSessionStore<WorkspaceAnalysis>();
   private readonly refreshAbortHandles = new Map<string, RefreshAbortHandle>();
   private readonly analysisByWorkspace = new Map<string, WorkspaceAnalysis>();
+  private readonly successfulStatusByWorkspace = new Map<string, { text: string; tooltip: string }>();
   private readonly detailPanels = new Map<string, vscode.WebviewPanel>();
   private readonly explorer: LopperExplorerTreeDataProvider;
   private latestSummary = "Lopper: idle";
@@ -161,7 +163,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
           });
         }),
         vscode.commands.registerCommand("lopper.cancelRefresh", () => {
-          this.cancelActiveRefreshes("user requested cancellation");
+          this.cancelRefresh();
         }),
         vscode.commands.registerCommand("lopper.refreshWorkspace.runtime", async (folderPath?: string) => {
           await this.refreshRuntimeWorkspace(folderPath);
@@ -247,6 +249,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
             this.clearWorkspaceDiagnostics(removedFolder);
             this.refreshSessions.clearFolder(folderKey);
             this.analysisByWorkspace.delete(folderKey);
+            this.successfulStatusByWorkspace.delete(folderKey);
           }
           for (const addedFolder of event.added) {
             if (!vscode.workspace.getConfiguration("lopper", addedFolder.uri).get<boolean>("autoRefresh", true)) {
@@ -488,6 +491,10 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
         signal,
       };
       const analysis = await this.runner.analyseWorkspace(folder, request);
+      if (signal?.aborted) {
+        this.restoreStatusAfterCancellation(folder, workspaceKey, scopeMode, runId);
+        return;
+      }
       if (!this.refreshSessions.isLatestRun(workspaceKey, runId)) {
         this.output.appendLine(
           `[refresh:stale] ${folder.name} (${requestedLanguage}, ${scopeMode}) run=${runId} ignored in favor of run=${this.refreshSessions.latestRunId(workspaceKey)}`,
@@ -507,9 +514,15 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
         return;
       }
 
+      if (signal?.aborted) {
+        this.restoreStatusAfterCancellation(folder, workspaceKey, scopeMode, runId);
+        return;
+      }
+
       const message = error instanceof Error ? error.message : String(error);
       this.clearWorkspaceDiagnostics(folder);
       this.analysisByWorkspace.delete(workspaceKey);
+      this.successfulStatusByWorkspace.delete(workspaceKey);
       this.explorer.refresh();
       this.updateStatus(`Lopper: unavailable (${scopeMode})`, message);
       this.output.appendLine(`[refresh:error] ${message}`);
@@ -672,6 +685,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   dispose(): void {
     this.cancelActiveRefreshes("extension disposed");
     this.refreshAbortHandles.clear();
+    this.successfulStatusByWorkspace.clear();
     clearAndroidModuleSignalCache();
     for (const timer of this.refreshTimers.values()) {
       clearTimeout(timer);
@@ -1290,11 +1304,14 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     const warningCount = analysis.report.warnings?.length ?? 0;
     const sourceSummary = source === "cache" ? "cached" : "fresh";
     const warningSummary = warningCount > 0 ? ` | Warnings: ${warningCount}` : "";
-    this.updateStatus(
-      `Lopper: ${dependencyCount} deps | ${usedPercent.toFixed(1)}% used | ${analysis.scopeMode}${source === "cache" ? " | cached" : ""}`,
-      `Folder: ${analysis.folder.name} | Scope: ${analysis.scopeMode} | Adapter: ${analysis.requestedLanguage} | Source: ${sourceSummary} | Binary: ${path.basename(analysis.binaryPath)}${warningSummary}`,
-    );
-    this.analysisByWorkspace.set(analysis.folder.uri.toString(), analysis);
+    const workspaceKey = analysis.folder.uri.toString();
+    const status = {
+      text: `Lopper: ${dependencyCount} deps | ${usedPercent.toFixed(1)}% used | ${analysis.scopeMode}${source === "cache" ? " | cached" : ""}`,
+      tooltip: `Folder: ${analysis.folder.name} | Scope: ${analysis.scopeMode} | Adapter: ${analysis.requestedLanguage} | Source: ${sourceSummary} | Binary: ${path.basename(analysis.binaryPath)}${warningSummary}`,
+    };
+    this.updateStatus(status.text, status.tooltip);
+    this.successfulStatusByWorkspace.set(workspaceKey, status);
+    this.analysisByWorkspace.set(workspaceKey, analysis);
     this.explorer.refresh();
     for (const warning of analysis.report.warnings ?? []) {
       this.output.appendLine(`[refresh:warning] ${analysis.folder.name} (${analysis.scopeMode}): ${warning}`);
@@ -1484,6 +1501,27 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     if (cancelled > 0) {
       this.updateStatus("Lopper: cancelling", "Cancelling active Lopper analysis.");
     }
+  }
+
+  cancelRefresh(reason = "user requested cancellation"): void {
+    this.cancelActiveRefreshes(reason);
+  }
+
+  private restoreStatusAfterCancellation(
+    folder: vscode.WorkspaceFolder,
+    workspaceKey: string,
+    scopeMode: LopperScopeMode,
+    runId: number,
+  ): void {
+    const previousStatus = this.successfulStatusByWorkspace.get(workspaceKey);
+    if (previousStatus) {
+      this.updateStatus(previousStatus.text, previousStatus.tooltip);
+    } else {
+      this.updateStatus("Lopper: idle", `Refresh cancelled for ${folder.name}.`);
+    }
+    this.output.appendLine(
+      `[refresh:cancelled] ${folder.name} (${scopeMode}) run=${runId} kept previous diagnostics`,
+    );
   }
 
   private refreshAbortKey(workspaceKey: string, runId: number): string {

--- a/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
@@ -170,6 +170,45 @@ suite("refresh lifecycle", () => {
     });
   });
 
+  test("does not let a superseded cancellation overwrite a newer running status", async function () {
+    this.timeout(30_000);
+
+    await withHarness(async (harness) => {
+      const deferredAnalyses: Array<Deferred<WorkspaceAnalysis>> = [];
+      const signals: AbortSignal[] = [];
+
+      await withController(
+        {
+          analyseWorkspace: async (_folder, options): Promise<WorkspaceAnalysis> => {
+            const next = deferred<WorkspaceAnalysis>();
+            deferredAnalyses.push(next);
+            assert.ok(options?.signal, "expected refresh signal to be forwarded");
+            signals.push(options.signal);
+            return next.promise;
+          },
+          exportWorkspace: async (): Promise<string> => "",
+        },
+        async (controller) => {
+          const firstRefresh = refresh(controller, harness, { forceFresh: true });
+          await waitForAssertion(() => assert.equal(deferredAnalyses.length, 1));
+          const secondRefresh = refresh(controller, harness, { forceFresh: true });
+          await waitForAssertion(() => assert.equal(deferredAnalyses.length, 2));
+
+          deferredAnalyses[0].resolve(makeAnalysis(harness, { dependencyCount: 3, usedPercent: 25 }));
+          await firstRefresh;
+          const statusWhileLatestRunIsPending = controller.getLatestSummary();
+
+          deferredAnalyses[1].resolve(makeAnalysis(harness, { dependencyCount: 0, usedPercent: 0 }));
+          await secondRefresh;
+
+          assert.equal(signals[0].aborted, true, "superseded run should be aborted");
+          assert.match(statusWhileLatestRunIsPending, /analysing/);
+          assert.match(controller.getLatestSummary(), /0 deps/);
+        },
+      );
+    });
+  });
+
   test("forceFresh bypasses cache and starts a new analysis run", async function () {
     this.timeout(30_000);
 

--- a/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
@@ -195,6 +195,135 @@ suite("refresh lifecycle", () => {
     });
   });
 
+  test("preserves the last successful analysis when a fresh refresh is cancelled", async function () {
+    this.timeout(30_000);
+
+    await withHarness(async (harness) => {
+      let analyseCalls = 0;
+      let activeSignal: AbortSignal | undefined;
+
+      await withController(
+        {
+          analyseWorkspace: async (_folder, options): Promise<WorkspaceAnalysis> => {
+            analyseCalls += 1;
+            if (analyseCalls === 1) {
+              return makeAnalysis(harness, { dependencyCount: 1, usedPercent: 50 });
+            }
+
+            assert.ok(options?.signal, "expected fresh refresh signal");
+            activeSignal = options.signal;
+            return new Promise<WorkspaceAnalysis>((_resolve, reject) => {
+              options.signal?.addEventListener(
+                "abort",
+                () => reject(new Error("lopper command was cancelled")),
+                { once: true },
+              );
+            });
+          },
+          exportWorkspace: async (): Promise<string> => "",
+        },
+        async (controller) => {
+          await refresh(controller, harness);
+          const previousSummary = controller.getLatestSummary();
+          const previousDiagnostics = vscode.languages
+            .getDiagnostics(harness.document.uri)
+            .filter((item) => item.source === "lopper");
+          assert.equal(previousDiagnostics.length, 1);
+
+          const pendingRefresh = refresh(controller, harness, { forceFresh: true });
+          await waitForAssertion(() => assert.ok(activeSignal, "expected fresh refresh to start"));
+          controller.cancelRefresh();
+          await pendingRefresh;
+
+          const currentDiagnostics = vscode.languages
+            .getDiagnostics(harness.document.uri)
+            .filter((item) => item.source === "lopper");
+          assert.equal(activeSignal?.aborted, true);
+          assert.equal(controller.getLatestSummary(), previousSummary);
+          assert.equal(currentDiagnostics.length, previousDiagnostics.length);
+          assert.deepEqual(
+            currentDiagnostics.map((item) => item.message),
+            previousDiagnostics.map((item) => item.message),
+          );
+        },
+      );
+    });
+  });
+
+  test("returns to idle when the first refresh is cancelled", async function () {
+    this.timeout(30_000);
+
+    await withHarness(async (harness) => {
+      let activeSignal: AbortSignal | undefined;
+
+      await withController(
+        {
+          analyseWorkspace: async (_folder, options): Promise<WorkspaceAnalysis> => {
+            assert.ok(options?.signal, "expected refresh signal");
+            activeSignal = options.signal;
+            return new Promise<WorkspaceAnalysis>((_resolve, reject) => {
+              options.signal?.addEventListener(
+                "abort",
+                () => reject(new Error("lopper command was cancelled")),
+                { once: true },
+              );
+            });
+          },
+          exportWorkspace: async (): Promise<string> => "",
+        },
+        async (controller) => {
+          const pendingRefresh = refresh(controller, harness, { forceFresh: true });
+          await waitForAssertion(() => assert.ok(activeSignal, "expected refresh to start"));
+          controller.cancelRefresh();
+          await pendingRefresh;
+
+          assert.equal(activeSignal?.aborted, true);
+          assert.equal(controller.getLatestSummary(), "Lopper: idle");
+          assert.equal(
+            vscode.languages.getDiagnostics(harness.document.uri).filter((item) => item.source === "lopper").length,
+            0,
+          );
+        },
+      );
+    });
+  });
+
+  test("still clears stale state for genuine refresh failures", async function () {
+    this.timeout(30_000);
+
+    await withHarness(async (harness) => {
+      let analyseCalls = 0;
+
+      await withController(
+        {
+          analyseWorkspace: async (): Promise<WorkspaceAnalysis> => {
+            analyseCalls += 1;
+            if (analyseCalls === 1) {
+              return makeAnalysis(harness, { dependencyCount: 1, usedPercent: 50 });
+            }
+            throw new Error("analysis exploded");
+          },
+          exportWorkspace: async (): Promise<string> => "",
+        },
+        async (controller) => {
+          await refresh(controller, harness);
+          assert.equal(
+            vscode.languages.getDiagnostics(harness.document.uri).filter((item) => item.source === "lopper").length,
+            1,
+          );
+
+          await refresh(controller, harness, { forceFresh: true });
+
+          assert.match(controller.getLatestSummary(), /unavailable/);
+          assert.equal(
+            vscode.languages.getDiagnostics(harness.document.uri).filter((item) => item.source === "lopper").length,
+            0,
+          );
+        },
+      );
+    });
+  });
+
   test("skips unused import diagnostics for out-of-workspace file paths", async function () {
     this.timeout(30_000);
 


### PR DESCRIPTION
## Summary

Closes #1161.

Canceling a fresh VS Code analysis currently routes the runner's abort error through the same cleanup path as a genuine failure. That erases the last successful diagnostics/cache and replaces its summary with `Lopper: unavailable`. This change gives user cancellation an explicit terminal path that restores the last successful status while leaving the displayed analysis untouched.

## Changes

- Detect an aborted refresh both when the runner rejects and when a runner ignores the signal and resolves after cancellation.
- Preserve per-workspace successful status metadata and restore it after cancellation without deleting diagnostics or cached analysis.
- Return a first canceled refresh to the neutral `Lopper: idle` state.
- Keep the genuine-error cleanup path unchanged and clear saved status when that path runs or a workspace is removed.
- Add extension lifecycle regressions for cancellation after success, cancellation before any result, and a real refresh failure.

## Validation

Commands and checks run:

```bash
make vscode-extension-install
cd extensions/vscode-lopper && npm run compile && npm run test:e2e
make vscode-extension-package
make ci
make demos-check
```

Additional manual validation:

- The VS Code Electron suite passes with 62 tests, including all three new lifecycle cases.
- The extension packages successfully as `dist/vscode-lopper.vsix`.

## Risk and compatibility

- Breaking changes: None; the command and extension API remain compatible.
- Migration required: None.
- Performance impact: Negligible; one small status record is retained per workspace with a successful analysis.
- Memory benchmark impact: None; the repository memory gate passes and the status records are removed with workspace/controller lifecycle cleanup.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
