### PR TITLE
fix(shared): count Unicode import aliases as used

### DIFF
--- a/internal/lang/dotnet/adapter_test.go
+++ b/internal/lang/dotnet/adapter_test.go
@@ -115,6 +115,35 @@ public class Program {
 	}
 }
 
+func TestAdapterAnalyseUnicodeUsingAliasAsUsed(t *testing.T) {
+	repo := t.TempDir()
+	writeManifestFixture(t, filepath.Join(repo, "Api.csproj"), newtonsoftProjectManifest)
+	testutil.MustWriteFile(t, filepath.Join(repo, programSourceFileName), `
+using føø = Newtonsoft.Json.JsonConvert;
+
+public class Program {
+  public static void Main() {
+    _ = føø.SerializeObject(new { Name = "demo" });
+  }
+}
+`)
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath:   repo,
+		Dependency: newtonsoftDependencyName,
+	})
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	dep := expectSingleDotNetDependency(t, reportData.Dependencies)
+	if dep.UsedExportsCount != 1 || dep.TotalExportsCount != 1 {
+		t.Fatalf("expected unicode alias usage 1/1, got %d/%d", dep.UsedExportsCount, dep.TotalExportsCount)
+	}
+	if len(dep.UnusedImports) != 0 {
+		t.Fatalf("expected unicode alias to stay out of unused imports, got %#v", dep.UnusedImports)
+	}
+}
+
 func TestAdapterAnalyseTopNWithCentralPackages(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, centralPackagesFileName), `

--- a/internal/lang/python/adapter_test.go
+++ b/internal/lang/python/adapter_test.go
@@ -47,6 +47,21 @@ func TestAdapterAnalyseDependency(t *testing.T) {
 	assertDependencyReport(t, dep, dependencyReportExpectation{language: "python", used: 1, total: 2})
 }
 
+func TestAdapterAnalyseUnicodeImportAliasAsUsed(t *testing.T) {
+	source := "import requests as føø\nprint(føø.__name__)\n"
+	dep := analysePythonDependency(t, source, "requests")
+
+	assertDependencyReport(t, dep, dependencyReportExpectation{name: "requests", language: "python", used: 1, total: 1})
+	if len(dep.UnusedImports) != 0 {
+		t.Fatalf("expected unicode alias to stay out of unused imports, got %#v", dep.UnusedImports)
+	}
+	for _, recommendation := range dep.Recommendations {
+		if recommendation.Code == "remove-unused-dependency" {
+			t.Fatalf("did not expect removal recommendation for used unicode alias, got %#v", dep.Recommendations)
+		}
+	}
+}
+
 func TestAdapterAnalyseSuggestOnlyPythonUnusedImportCodemod(t *testing.T) {
 	source := "import requests as rq\n" +
 		"from requests import get, post\n" +

--- a/internal/lang/shared/dependency_usage_scan.go
+++ b/internal/lang/shared/dependency_usage_scan.go
@@ -3,20 +3,28 @@ package shared
 import (
 	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 func CountUsage(content []byte, imports []ImportRecord) map[string]int {
 	importCount := make(map[string]int)
+	hasUnicodeLocal := false
 	for _, imported := range imports {
 		if imported.Wildcard || imported.Local == "" {
 			continue
 		}
 		importCount[imported.Local]++
+		hasUnicodeLocal = hasUnicodeLocal || containsNonASCII(imported.Local)
 	}
 
 	usage := make(map[string]int, len(importCount))
 	scannable := MaskCommentsAndStringsWithProfile(content, inferMaskProfile(imports))
-	scanTokenUsage(scannable, importCount, usage)
+	if hasUnicodeLocal {
+		scanUnicodeTokenUsage(scannable, importCount, usage)
+	} else {
+		scanTokenUsage(scannable, importCount, usage)
+	}
 	subtractDeclarationTokenHits(scannable, imports, usage)
 	clampUsageCounts(importCount, usage)
 	return usage
@@ -36,6 +44,19 @@ func scanTokenUsage(content []byte, importCount map[string]int, usage map[string
 		if _, ok := importCount[token]; ok {
 			usage[token]++
 		}
+	}
+}
+
+func scanUnicodeTokenUsage(content []byte, importCount map[string]int, usage map[string]int) {
+	for index := 0; index < len(content); {
+		start, end, ok := nextUnicodeIdentifier(content, index)
+		if !ok {
+			return
+		}
+		if token := string(content[start:end]); importCount[token] > 0 {
+			usage[token]++
+		}
+		index = end
 	}
 }
 
@@ -80,6 +101,9 @@ func declarationLineContainsToken(content []byte, lineStarts []int, line int, to
 	if lineStart < 0 || lineStart >= lineEnd || lineEnd > len(content) {
 		return false
 	}
+	if containsNonASCII(token) {
+		return containsUnicodeIdentifierToken(content[lineStart:lineEnd], token)
+	}
 	return containsWordToken(content[lineStart:lineEnd], token)
 }
 
@@ -105,6 +129,61 @@ func containsWordToken(content []byte, token string) bool {
 			i++
 		}
 		if string(content[start:i]) == token {
+			return true
+		}
+	}
+	return false
+}
+
+func containsUnicodeIdentifierToken(content []byte, token string) bool {
+	for index := 0; index < len(content); {
+		start, end, ok := nextUnicodeIdentifier(content, index)
+		if !ok {
+			return false
+		}
+		if string(content[start:end]) == token {
+			return true
+		}
+		index = end
+	}
+	return false
+}
+
+func nextUnicodeIdentifier(content []byte, index int) (int, int, bool) {
+	for index < len(content) {
+		current, size := utf8.DecodeRune(content[index:])
+		if isUnicodeIdentifierRune(current) {
+			break
+		}
+		index += size
+	}
+	if index >= len(content) {
+		return 0, 0, false
+	}
+
+	start := index
+	for index < len(content) {
+		current, size := utf8.DecodeRune(content[index:])
+		if !isUnicodeIdentifierRune(current) {
+			break
+		}
+		index += size
+	}
+	return start, index, true
+}
+
+func isUnicodeIdentifierRune(value rune) bool {
+	if value < utf8.RuneSelf {
+		return isWordByte(byte(value))
+	}
+	return unicode.IsLetter(value) ||
+		unicode.IsDigit(value) ||
+		unicode.In(value, unicode.Mn, unicode.Mc, unicode.Pc, unicode.Nl, unicode.Other_ID_Start, unicode.Other_ID_Continue)
+}
+
+func containsNonASCII(value string) bool {
+	for index := 0; index < len(value); index++ {
+		if value[index] >= utf8.RuneSelf {
 			return true
 		}
 	}
@@ -320,10 +399,9 @@ func maskNonNewline(content []byte, index int) {
 	content[index] = ' '
 }
 
-// isWordByte implements an ASCII-only token scanner for import local names.
-// It intentionally treats '$' as part of identifiers (common in JS/PHP), so
-// tokens such as "$foo" and "foo$bar" can be matched. Non-ASCII bytes are not
-// considered word characters and therefore split/ignore Unicode identifiers.
+// isWordByte implements the fast path for ASCII-only import local names. It
+// intentionally treats '$' as part of identifiers (common in JS/PHP), so
+// tokens such as "$foo" and "foo$bar" can be matched.
 func isWordByte(ch byte) bool {
 	return ch == '$' || ch == '_' || (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
 }

--- a/internal/lang/shared/dependency_usage_test.go
+++ b/internal/lang/shared/dependency_usage_test.go
@@ -127,29 +127,32 @@ func TestCountUsageHonorsWordBoundaries(t *testing.T) {
 	if usage[testLocalDollarFoo] != 1 {
 		t.Fatalf("expected $foo usage 1, got %d", usage[testLocalDollarFoo])
 	}
-	if usage[testLocalUnicode] != 0 {
-		t.Fatalf("expected føø usage 0 to match regexp word-boundary behavior, got %d", usage[testLocalUnicode])
+	if usage[testLocalUnicode] != 1 {
+		t.Fatalf("expected føø usage 1, got %d", usage[testLocalUnicode])
 	}
 }
 
-func TestCountUsageUnicodeIdentifierPositionsAreIgnored(t *testing.T) {
-	imports := []ImportRecord{{Local: testLocalUnicode}}
-	cases := []struct {
-		name    string
-		content string
-	}{
-		{name: "standalone", content: "føø"},
-		{name: "prefix", content: "føøalpha"},
-		{name: "suffix", content: "alphaføø"},
-		{name: "middle", content: "al føø ph"},
-		{name: "adjacent punctuation", content: "(føø),[føø]"},
+func TestCountUsageUnicodeIdentifierBoundaries(t *testing.T) {
+	imports := []ImportRecord{{
+		Local:    testLocalUnicode,
+		Location: report.Location{File: "main.py", Line: 1, Column: 1},
+	}}
+	cases := map[string]int{
+		"føø":         1,
+		"føøalpha":    0,
+		"alphaføø":    0,
+		"al føø ph":   1,
+		"(føø),[føø]": 2,
 	}
 
-	for _, tc := range cases {
-		usage := CountUsage([]byte(tc.content), imports)
-		if usage[testLocalUnicode] != 0 {
-			t.Fatalf("%s: expected unicode identifier usage 0 with ASCII scanner, got %d", tc.name, usage[testLocalUnicode])
-		}
+	for source, want := range cases {
+		t.Run(source, func(t *testing.T) {
+			content := []byte("import module as føø\n" + source + "\n")
+			usage := CountUsage(content, imports)
+			if usage[testLocalUnicode] != want {
+				t.Fatalf("expected unicode identifier usage %d, got %d", want, usage[testLocalUnicode])
+			}
+		})
 	}
 }
 
@@ -218,6 +221,12 @@ func TestDeclarationAndMaskingHelpers(t *testing.T) {
 	if declarationLineContainsToken([]byte("x"), []int{1, 1}, 1, "x") {
 		t.Fatalf("expected malformed line offsets to be rejected")
 	}
+	if !containsUnicodeIdentifierToken([]byte("call(føø)"), testLocalUnicode) {
+		t.Fatalf("expected unicode token helper to find an exact identifier")
+	}
+	if containsUnicodeIdentifierToken([]byte("føøalpha alphaføø"), testLocalUnicode) {
+		t.Fatalf("expected unicode token helper to honor identifier boundaries")
+	}
 
 	escaped := []byte("\\\"")
 	next, state := scanQuoted(escaped, 0, '"', scannerStateDoubleQuote)
@@ -238,6 +247,16 @@ func TestDeclarationAndMaskingHelpers(t *testing.T) {
 
 func BenchmarkCountUsage(b *testing.B) {
 	imports, content := benchmarkImportsAndContent()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = CountUsage(content, imports)
+	}
+}
+
+func BenchmarkCountUsageUnicode(b *testing.B) {
+	imports, content := benchmarkUnicodeImportsAndContent()
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = CountUsage(content, imports)
@@ -264,6 +283,12 @@ func benchmarkImportsAndContent() ([]ImportRecord, []byte) {
 		source.WriteString("();otherToken();")
 	}
 	return imports, []byte(source.String())
+}
+
+func benchmarkUnicodeImportsAndContent() ([]ImportRecord, []byte) {
+	imports, content := benchmarkImportsAndContent()
+	imports = append(imports, ImportRecord{Local: testLocalUnicode})
+	return imports, append(content, []byte("føø();føø();otherToken();")...)
 }
 
 func countUsageRegexPerIdentifier(content []byte, imports []ImportRecord) map[string]int {


### PR DESCRIPTION
## Summary

Fix shared dependency-usage accounting for valid non-ASCII local import aliases. Python and C# projects could reference an imported dependency through an alias such as `føø`, yet Lopper reported zero usage, marked the import unused, and could recommend removing the dependency.

The root cause was an ASCII-only byte scanner in `shared.CountUsage`. The fix keeps that scanner as the unchanged fast path for all-ASCII import sets and dispatches to a Unicode identifier scanner only when at least one import local contains non-ASCII bytes.

Fixes #1103.

## Changes

- Detect non-ASCII import locals and scan Unicode identifier letters, digits, marks, connector punctuation, letter numbers, and Unicode identifier compatibility properties with exact token boundaries.
- Use the same Unicode-aware boundary logic when subtracting declaration-line hits, preserving usage counts outside the import declaration.
- Preserve the existing ASCII byte-scanner path, including `$` and `_` behavior used by JS/PHP-style identifiers.
- Add shared boundary coverage plus end-to-end Python and C# regressions proving Unicode aliases are counted as used and do not trigger unused-import/removal findings.
- Retain the existing ASCII benchmark as the release memory guard and add a Unicode benchmark for the new path.

## Validation

Commands and checks run:

```bash
GOTOOLCHAIN=go1.26.5 go test ./internal/lang/shared ./internal/lang/python ./internal/lang/dotnet -run 'Unicode|TestCountUsageHonorsWordBoundaries' -count=1
GOTOOLCHAIN=go1.26.5 go test ./internal/lang/shared -run '^$' -bench '^BenchmarkCountUsage($|Unicode$)' -benchmem -count=5
make ci
make demos-check
```

Additional manual validation:

- Rebased onto `origin/main` at `f8051d1` before the final full run.
- `make ci` passed formatting, module/feature-flag validation, lint, actionlint, shellcheck, suppression, gosec, govulncheck, unit, leak, race, memory, build, and coverage gates.
- New-code duplication: 0.00%; gosec issues: 0; govulncheck vulnerabilities: 0.
- Coverage: 98.2% total; `internal/lang/shared`: 98.0%; every measured package meets the 98% floor.
- ASCII `BenchmarkCountUsage`: 25,632 B/op and 375 allocs/op, a -0.0% bytes / +0.0% allocations delta against `origin/main`. The Unicode path is isolated behind non-ASCII import detection.
- Demo asset freshness check passed.

## Risk and compatibility

- Breaking changes: None. Existing report fields and ASCII identifier behavior are unchanged.
- Migration required: None.
- Performance impact: No allocation regression on the normal ASCII path. Files with non-ASCII import locals use a rune-aware linear scan instead of the byte scanner.
- Memory benchmark impact: None. The gated ASCII benchmark remained at 25,632 B/op and 375 allocs/op, so `memory-approved` is not required.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
