### PR TITLE
feat(runtime): support safe Python runner profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,14 +343,47 @@ If `--runtime-trace` points to a missing file, analysis continues with static re
 
 ### Python
 
-First-party Python runtime capture is stable for conservative pytest-family commands:
+First-party Python runtime capture is stable for these conservative pytest-family command forms (runner arguments may follow):
+
+```text
+pytest
+python -m pytest
+python3 -m pytest
+```
 
 ```bash
 lopper analyse --top 20 --repo . --language python \
   --runtime-test-command "pytest"
 ```
 
-`python -m pytest` and `python3 -m pytest` are also supported. Lopper injects its import hook only into the runtime command environment by prepending the shipped `scripts/runtime/sitecustomize.py` directory to `PYTHONPATH`; it does not install project dependencies or run Python outside the user-provided command. Use `--disable-feature python-runtime-capture` for rollback. Additional runner profiles remain separately preview-gated work.
+Enable `python-runner-profiles` to opt into these additional direct-exec forms:
+
+```text
+python -m unittest
+python3 -m unittest
+uv run pytest
+uv run -- pytest
+uv run python -m pytest
+uv run python3 -m pytest
+uv run -- python -m pytest
+uv run -- python3 -m pytest
+uv run python -m unittest
+uv run python3 -m unittest
+uv run -- python -m unittest
+uv run -- python3 -m unittest
+```
+
+For example:
+
+```bash
+lopper analyse --top 20 --repo . --language python \
+  --runtime-test-command "uv run -- python -m unittest discover -s tests" \
+  --enable-feature python-runner-profiles
+```
+
+The optional `--` immediately after `uv run` is the only accepted uv wrapper delimiter. Arguments after the selected `pytest` command or `python[3] -m pytest|unittest` module are forwarded verbatim, including a later `--`; uv wrapper flags, arbitrary uv tools, Python interpreter flags, inline environment assignments, and shell operators are rejected.
+
+Lopper resolves supported executables from trusted absolute `PATH` entries in order, then from its fixed system fallback directories. It rejects writable search directories, writable/non-executable tools, and executables outside the allowlist. Lopper injects its import hook only into the runtime command environment by prepending the shipped `scripts/runtime/sitecustomize.py` directory to `PYTHONPATH`; an existing project `sitecustomize.py` is chained exactly once. It does not install project dependencies or invoke a shell. Use `--disable-feature python-runtime-capture` for rollback.
 
 Explicit Python trace consumption remains compatible through `--runtime-trace`.
 
@@ -377,7 +410,7 @@ Python caveats:
 - Runtime module names map to the top-level import package, with common aliases such as `bs4` -> `beautifulsoup4`.
 - The first-party hook emits third-party imports resolved from `site-packages` or `dist-packages` and filters local modules and stdlib imports.
 - Subprocesses and pytest workers inherit the trace environment when they inherit the parent process environment; concurrent writers append NDJSON lines to the same trace file.
-- Existing project `sitecustomize.py` behavior can be affected while the runtime command is running because Python imports only one `sitecustomize` module from `PYTHONPATH`.
+- Project `sitecustomize.py` runs once before Lopper installs its import wrapper; imports performed only during that startup hook are not included in the trace.
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ inputs:
     required: false
     default: ''
   runtime-test-command:
-    description: Optional test command to run with runtime tracing.
+    description: Optional allowlisted test command to run with runtime tracing. unittest and uv forms require enable-feature=python-runner-profiles.
     required: false
     default: ''
   advisory-source:

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -89,4 +89,6 @@ its annotation logic. The implementation keeps runtime annotations in the shared
 `runtimeUsage` report fields; JS/TS and Python trace consumption are supported
 by default, and first-party Python capture is stable under
 `python-runtime-capture` for the documented pytest-family command profiles.
-Additional runner profiles should use a separate preview flag.
+The separately preview-gated `python-runner-profiles` capability adds the
+documented unittest and uv direct-exec profiles without widening the arbitrary
+command boundary.

--- a/docs/man/lopper.1
+++ b/docs/man/lopper.1
@@ -1,4 +1,4 @@
-.TH LOPPER 1 "2026-07-11" "lopper" "User Commands"
+.TH LOPPER 1 "2026-07-12" "lopper" "User Commands"
 .SH NAME
 lopper \- local-first CLI/TUI for dependency surface analysis
 .SH SYNOPSIS
@@ -45,7 +45,14 @@ Options:
   --save-baseline            Save current run as immutable baseline snapshot
   --baseline-label LABEL     Label key to use when saving baseline snapshots
   --runtime-trace PATH       Runtime import trace (NDJSON) for annotations
-  --runtime-test-command CMD Run command with JS/TS or Python runtime hooks to capture trace before analysis
+  --runtime-test-command CMD Run an allowlisted command with runtime hooks before analysis
+                             Stable Python forms: pytest; python -m pytest; python3 -m pytest
+                             With python-runner-profiles enabled: python -m unittest; python3 -m unittest;
+                             uv run pytest; uv run -- pytest; uv run python -m pytest;
+                             uv run python3 -m pytest; uv run -- python -m pytest;
+                             uv run -- python3 -m pytest; uv run python -m unittest;
+                             uv run python3 -m unittest; uv run -- python -m unittest;
+                             uv run -- python3 -m unittest (runner arguments may follow each form)
   --advisory-source PATH     Local vulnerability advisory source (preview-gated by reachability-vulnerability-prioritization-preview)
   --repos PATH1,PATH2        Comma-separated repo paths for org dashboard input
   --baseline-store DIR       Directory for immutable keyed dashboard baseline snapshots

--- a/internal/analysis/runtime_capture.go
+++ b/internal/analysis/runtime_capture.go
@@ -21,12 +21,14 @@ func captureRuntimeTraceIfNeeded(ctx context.Context, req Request, repoPath stri
 	}
 
 	provider := captureProviderForRequest(req, command, candidates)
+	pythonRunnerProfiles := req.Features.Enabled(runtime.PythonRunnerProfilesFeature)
 	if err := runtime.Capture(ctx, runtime.CaptureRequest{
-		RepoPath:         repoPath,
-		TracePath:        tracePath,
-		Command:          command,
-		Provider:         provider,
-		ReuseIfUnchanged: shouldReuseRuntimeTrace(cache),
+		RepoPath:             repoPath,
+		TracePath:            tracePath,
+		Command:              command,
+		Provider:             provider,
+		ReuseIfUnchanged:     shouldReuseRuntimeTrace(cache),
+		PythonRunnerProfiles: pythonRunnerProfiles,
 	}); err != nil {
 		warning := runtimeTraceCommandWarningPrefix + err.Error()
 		if req.RuntimeTracePathExplicit {
@@ -41,7 +43,8 @@ func captureProviderForRequest(req Request, command string, candidates []languag
 	if !req.Features.Enabled(pythonRuntimeCaptureFeature) || !hasPythonRuntimeCandidate(req.Language, candidates) {
 		return runtime.CaptureProviderNode
 	}
-	if isExplicitPythonLanguage(req.Language) || runtime.IsPythonTestCommand(command) || hasOnlyPythonRuntimeCandidate(candidates) {
+	commandOptions := runtime.CommandOptions{PythonRunnerProfiles: req.Features.Enabled(runtime.PythonRunnerProfilesFeature)}
+	if isExplicitPythonLanguage(req.Language) || runtime.IsPythonTestCommand(command, commandOptions) || hasOnlyPythonRuntimeCandidate(candidates) {
 		return runtime.CaptureProviderPython
 	}
 	return runtime.CaptureProviderNode

--- a/internal/analysis/runtime_capture_test.go
+++ b/internal/analysis/runtime_capture_test.go
@@ -170,6 +170,7 @@ func TestCaptureRuntimeTraceIfNeededWarningAndReuseBranches(t *testing.T) {
 
 func TestCaptureProviderForPythonRuntimeRequests(t *testing.T) {
 	features := mustResolvePythonRuntimeCaptureFeatureSet(t, true)
+	previewFeatures := mustResolvePythonRuntimeCaptureAndRunnerProfiles(t)
 	pythonCandidate := language.Candidate{Adapter: &stubAdapter{id: "python"}}
 	jsCandidate := language.Candidate{Adapter: &stubAdapter{id: "js-ts"}}
 
@@ -192,6 +193,20 @@ func TestCaptureProviderForPythonRuntimeRequests(t *testing.T) {
 			command:    "pytest",
 			candidates: []language.Candidate{pythonCandidate},
 			want:       runtime.CaptureProviderPython,
+		},
+		{
+			name:       "auto uv command with preview profile and python candidate",
+			req:        Request{Language: "auto", Features: previewFeatures},
+			command:    "uv run pytest",
+			candidates: []language.Candidate{pythonCandidate, jsCandidate},
+			want:       runtime.CaptureProviderPython,
+		},
+		{
+			name:       "auto uv command without preview profile stays on node provider",
+			req:        Request{Language: "auto", Features: features},
+			command:    "uv run pytest",
+			candidates: []language.Candidate{pythonCandidate, jsCandidate},
+			want:       runtime.CaptureProviderNode,
 		},
 		{
 			name:       "python only candidate with make command",
@@ -221,6 +236,18 @@ func TestCaptureProviderForPythonRuntimeRequests(t *testing.T) {
 			t.Fatalf("%s: expected provider %q, got %q", tc.name, tc.want, got)
 		}
 	}
+}
+
+func mustResolvePythonRuntimeCaptureAndRunnerProfiles(t *testing.T) featureflags.Set {
+	t.Helper()
+	resolved, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{
+		Channel: featureflags.ChannelDev,
+		Enable:  []string{runtime.PythonRunnerProfilesFeature},
+	})
+	if err != nil {
+		t.Fatalf("resolve Python runner profiles feature set: %v", err)
+	}
+	return resolved
 }
 
 func mustResolvePythonRuntimeCaptureFeatureSet(t *testing.T, enabled bool) featureflags.Set {

--- a/internal/cli/parse_analyse.go
+++ b/internal/cli/parse_analyse.go
@@ -60,10 +60,6 @@ func parseAnalyseState(fs *flag.FlagSet, flags analyseFlagValues) (analyseParseS
 	if err := validateCodemodApplyFlags(*flags.suggestOnly, *flags.applyCodemod, *flags.applyCodemodConfirm, *flags.allowDirty, dependency, *flags.top); err != nil {
 		return analyseParseState{}, err
 	}
-	if err := runtime.ValidateCommand(*flags.runtimeTestCommand); err != nil {
-		return analyseParseState{}, err
-	}
-
 	format, err := report.ParseFormat(*flags.formatFlag)
 	if err != nil {
 		return analyseParseState{}, err
@@ -84,6 +80,10 @@ func parseAnalyseState(fs *flag.FlagSet, flags analyseFlagValues) (analyseParseS
 	}
 	resolvedFeatures, err := resolveAnalyseFeatures(visited, flags, configFeatures)
 	if err != nil {
+		return analyseParseState{}, err
+	}
+	commandOptions := runtime.CommandOptions{PythonRunnerProfiles: resolvedFeatures.Enabled(runtime.PythonRunnerProfilesFeature)}
+	if err := runtime.ValidateCommand(*flags.runtimeTestCommand, commandOptions); err != nil {
 		return analyseParseState{}, err
 	}
 	resolvedNotifications, err := resolveAnalyseNotifications(visited, flags, resolvedConfigPath)

--- a/internal/cli/parse_analyse_flags.go
+++ b/internal/cli/parse_analyse_flags.go
@@ -97,7 +97,7 @@ func newAnalyseFlagSet(req app.Request) (*flag.FlagSet, analyseFlagValues) {
 		baselineLabel:                  fs.String("baseline-label", req.Analyse.BaselineLabel, "label to use when saving a baseline snapshot"),
 		saveBaseline:                   fs.Bool("save-baseline", req.Analyse.SaveBaseline, "save current run as immutable baseline snapshot"),
 		runtimeTracePath:               fs.String("runtime-trace", req.Analyse.RuntimeTracePath, "runtime trace file path"),
-		runtimeTestCommand:             fs.String("runtime-test-command", req.Analyse.RuntimeTestCommand, "optional command to execute tests with JS/TS or Python runtime tracing"),
+		runtimeTestCommand:             fs.String("runtime-test-command", req.Analyse.RuntimeTestCommand, "optional allowlisted command to execute tests with JS/TS or Python runtime tracing"),
 		advisorySourcePath:             fs.String("advisory-source", req.Analyse.AdvisorySourcePath, "local vulnerability advisory source file"),
 		configPath:                     fs.String("config", req.Analyse.ConfigPath, "config file path"),
 		enableFeatures:                 enableFeatures,

--- a/internal/cli/parse_analyse_test.go
+++ b/internal/cli/parse_analyse_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/notify"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/runtime"
 	"github.com/ben-ranford/lopper/internal/testutil"
 	"github.com/ben-ranford/lopper/internal/thresholds"
 )
@@ -299,6 +300,24 @@ func TestParseArgsAnalyseRuntimeTestCommand(t *testing.T) {
 	if req.Analyse.RuntimeTestCommand != "python3 -m pytest tests" {
 		t.Fatalf("expected python runtime test command, got %q", req.Analyse.RuntimeTestCommand)
 	}
+
+	req = mustParseArgs(t, []string{
+		"analyse", "--top", "5",
+		"--runtime-test-command", "python3 -m unittest discover -s tests",
+		"--enable-feature", runtime.PythonRunnerProfilesFeature,
+	})
+	if req.Analyse.RuntimeTestCommand != "python3 -m unittest discover -s tests" {
+		t.Fatalf("expected unittest runtime test command, got %q", req.Analyse.RuntimeTestCommand)
+	}
+
+	req = mustParseArgs(t, []string{
+		"analyse", "--top", "5",
+		"--runtime-test-command", "uv run -- python -m pytest tests -- -k smoke",
+		"--enable-feature", runtime.PythonRunnerProfilesFeature,
+	})
+	if req.Analyse.RuntimeTestCommand != "uv run -- python -m pytest tests -- -k smoke" {
+		t.Fatalf("expected uv runtime test command, got %q", req.Analyse.RuntimeTestCommand)
+	}
 }
 
 func TestParseArgsAnalyseRuntimeTestCommandRejectsUnsafeShape(t *testing.T) {
@@ -315,6 +334,30 @@ func TestParseArgsAnalyseRuntimeTestCommandRejectsUnsafeShape(t *testing.T) {
 	err = expectParseArgsError(t, []string{"analyse", "--top", "5", "--runtime-test-command", "python -m pip install pytest"}, "expected unsafe python module rejection")
 	if !strings.Contains(err.Error(), "may only run '-m pytest'") {
 		t.Fatalf("expected unsafe python module rejection, got %v", err)
+	}
+
+	err = expectParseArgsError(t, []string{"analyse", "--top", "5", "--runtime-test-command", "python -m unittest"}, "expected disabled runner profile rejection")
+	if !strings.Contains(err.Error(), runtime.PythonRunnerProfilesFeature) {
+		t.Fatalf("expected runner profile feature guidance, got %v", err)
+	}
+
+	unsafeUVArgs := []string{
+		"analyse", "--top", "5",
+		"--runtime-test-command", "uv run --isolated pytest",
+		"--enable-feature", runtime.PythonRunnerProfilesFeature,
+	}
+	err = expectParseArgsError(t, unsafeUVArgs, "expected unsafe uv wrapper rejection")
+	if !strings.Contains(err.Error(), "without uv wrapper flags") {
+		t.Fatalf("expected uv wrapper boundary rejection, got %v", err)
+	}
+
+	inlineEnvironmentArgs := []string{
+		"analyse", "--top", "5",
+		"--runtime-test-command", "PYTHONPATH=/tmp python -m pytest",
+	}
+	err = expectParseArgsError(t, inlineEnvironmentArgs, "expected inline environment rejection")
+	if !strings.Contains(err.Error(), "inline environment assignment") {
+		t.Fatalf("expected inline environment rejection, got %v", err)
 	}
 }
 

--- a/internal/cli/parse_analyse_test.go
+++ b/internal/cli/parse_analyse_test.go
@@ -336,7 +336,12 @@ func TestParseArgsAnalyseRuntimeTestCommandRejectsUnsafeShape(t *testing.T) {
 		t.Fatalf("expected unsafe python module rejection, got %v", err)
 	}
 
-	err = expectParseArgsError(t, []string{"analyse", "--top", "5", "--runtime-test-command", "python -m unittest"}, "expected disabled runner profile rejection")
+	disabledProfileArgs := []string{
+		"analyse", "--top", "5",
+		"--runtime-test-command", "python -m unittest",
+		"--disable-feature", runtime.PythonRunnerProfilesFeature,
+	}
+	err = expectParseArgsError(t, disabledProfileArgs, "expected disabled runner profile rejection")
 	if !strings.Contains(err.Error(), runtime.PythonRunnerProfilesFeature) {
 		t.Fatalf("expected runner profile feature guidance, got %v", err)
 	}

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -30,7 +30,14 @@ Options:
   --save-baseline            Save current run as immutable baseline snapshot
   --baseline-label LABEL     Label key to use when saving baseline snapshots
   --runtime-trace PATH       Runtime import trace (NDJSON) for annotations
-  --runtime-test-command CMD Run command with JS/TS or Python runtime hooks to capture trace before analysis
+  --runtime-test-command CMD Run an allowlisted command with runtime hooks before analysis
+                             Stable Python forms: pytest; python -m pytest; python3 -m pytest
+                             With python-runner-profiles enabled: python -m unittest; python3 -m unittest;
+                             uv run pytest; uv run -- pytest; uv run python -m pytest;
+                             uv run python3 -m pytest; uv run -- python -m pytest;
+                             uv run -- python3 -m pytest; uv run python -m unittest;
+                             uv run python3 -m unittest; uv run -- python -m unittest;
+                             uv run -- python3 -m unittest (runner arguments may follow each form)
   --advisory-source PATH     Local vulnerability advisory source (preview-gated by reachability-vulnerability-prioritization-preview)
   --repos PATH1,PATH2        Comma-separated repo paths for org dashboard input
   --baseline-store DIR       Directory for immutable keyed dashboard baseline snapshots

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -159,5 +159,11 @@
     "description": "Enable org-level dashboard remediation queue items across errors, vulnerabilities, policy findings, recommendations, runtime regressions, and shared dependency hotspots.",
     "lifecycle": "preview",
     "firstStableRelease": "v1.8.0"
+  },
+  {
+    "code": "LOP-FEAT-0018",
+    "name": "python-runner-profiles",
+    "description": "Enable safe unittest and uv profiles for Python runtime capture.",
+    "lifecycle": "preview"
   }
 ]

--- a/internal/runtime/capture.go
+++ b/internal/runtime/capture.go
@@ -11,11 +11,12 @@ import (
 const defaultTraceRelPath = ".artifacts/lopper-runtime.ndjson"
 
 type CaptureRequest struct {
-	RepoPath         string
-	TracePath        string
-	Command          string
-	Provider         CaptureProvider
-	ReuseIfUnchanged bool
+	RepoPath             string
+	TracePath            string
+	Command              string
+	Provider             CaptureProvider
+	ReuseIfUnchanged     bool
+	PythonRunnerProfiles bool
 }
 
 type CaptureProvider string
@@ -26,10 +27,11 @@ const (
 )
 
 type capturePlan struct {
-	repoPath  string
-	tracePath string
-	command   string
-	provider  CaptureProvider
+	repoPath             string
+	tracePath            string
+	command              string
+	provider             CaptureProvider
+	pythonRunnerProfiles bool
 }
 
 func DefaultTracePath(repoPath string) string {
@@ -39,6 +41,10 @@ func DefaultTracePath(repoPath string) string {
 func Capture(ctx context.Context, req CaptureRequest) error {
 	plan, err := resolveCapturePlan(req)
 	if err != nil {
+		return err
+	}
+	commandOptions := CommandOptions{PythonRunnerProfiles: plan.pythonRunnerProfiles}
+	if err := ValidateCommand(plan.command, commandOptions); err != nil {
 		return err
 	}
 
@@ -53,7 +59,7 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 		return err
 	}
 
-	cmd, err := buildRuntimeCommand(ctx, plan.command)
+	cmd, err := buildRuntimeCommand(ctx, plan.command, commandOptions)
 	if err != nil {
 		return err
 	}
@@ -63,9 +69,12 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 		return err
 	}
 
-	output, err := cmd.CombinedOutput()
+	output := newRuntimeCommandOutput()
+	cmd.Stdout = output
+	cmd.Stderr = output
+	err = cmd.Run()
 	if err != nil {
-		return formatRuntimeCommandError(err, output)
+		return formatRuntimeCommandError(err, output.diagnostic())
 	}
 	if err := writeRuntimeTraceState(plan.tracePath, plan.command, plan.provider); err != nil {
 		return fmt.Errorf("write runtime trace state: %w", err)
@@ -76,10 +85,11 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 
 func resolveCapturePlan(req CaptureRequest) (capturePlan, error) {
 	plan := capturePlan{
-		repoPath:  strings.TrimSpace(req.RepoPath),
-		tracePath: strings.TrimSpace(req.TracePath),
-		command:   strings.TrimSpace(req.Command),
-		provider:  normalizeCaptureProvider(req.Provider),
+		repoPath:             strings.TrimSpace(req.RepoPath),
+		tracePath:            strings.TrimSpace(req.TracePath),
+		command:              strings.TrimSpace(req.Command),
+		provider:             normalizeCaptureProvider(req.Provider),
+		pythonRunnerProfiles: req.PythonRunnerProfiles,
 	}
 	if plan.repoPath == "" {
 		return capturePlan{}, fmt.Errorf("repo path is required")

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -217,30 +217,98 @@ func TestCaptureCommandFailureWithoutOutput(t *testing.T) {
 }
 
 func TestCaptureHonorsContextCancellation(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		tool                 string
+		command              string
+		provider             CaptureProvider
+		pythonRunnerProfiles bool
+	}{
+		{name: "existing command", tool: "make", command: "make test"},
+		{name: "preview uv profile", tool: "uv", command: "uv run pytest", provider: CaptureProviderPython, pythonRunnerProfiles: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			markerPath := filepath.Join(repo, "started.txt")
+			t.Setenv("LOPPER_CAPTURE_MARKER", markerPath)
+			t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, tc.tool, "#!/bin/sh\nsleep 5\nprintf started > \"$LOPPER_CAPTURE_MARKER\"\n"))
+
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+
+			start := time.Now()
+			err := Capture(ctx, CaptureRequest{
+				RepoPath:             repo,
+				Command:              tc.command,
+				Provider:             tc.provider,
+				PythonRunnerProfiles: tc.pythonRunnerProfiles,
+			})
+			if err == nil {
+				t.Fatalf("expected capture cancellation error")
+			}
+			if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "signal: killed") {
+				t.Fatalf("expected context cancellation error, got %v", err)
+			}
+			if elapsed := time.Since(start); elapsed >= time.Second {
+				t.Fatalf("expected cancelled command to stop quickly, took %v", elapsed)
+			}
+			if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
+				t.Fatalf("expected cancelled command to stop before creating marker, stat err = %v", statErr)
+			}
+		})
+	}
+}
+
+func TestCapturePreviewRunnerUsesRepoWorkingDirectory(t *testing.T) {
 	repo := t.TempDir()
-	markerPath := filepath.Join(repo, "started.txt")
-	t.Setenv("LOPPER_CAPTURE_MARKER", markerPath)
-	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "make", "#!/bin/sh\nsleep 5\nprintf started > \"$LOPPER_CAPTURE_MARKER\"\n"))
+	workingDirectoryPath := filepath.Join(t.TempDir(), "working-directory.txt")
+	t.Setenv("LOPPER_CAPTURE_WORKING_DIRECTORY", workingDirectoryPath)
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "uv", "#!/bin/sh\npwd > \"$LOPPER_CAPTURE_WORKING_DIRECTORY\"\n"))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-
-	start := time.Now()
-	err := Capture(ctx, CaptureRequest{
-		RepoPath: repo,
-		Command:  "make test",
+	err := Capture(context.Background(), CaptureRequest{
+		RepoPath:             repo,
+		Command:              "uv run pytest",
+		Provider:             CaptureProviderPython,
+		PythonRunnerProfiles: true,
 	})
-	if err == nil {
-		t.Fatalf("expected capture cancellation error")
+	if err != nil {
+		t.Fatalf("capture preview runner: %v", err)
 	}
-	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "signal: killed") {
-		t.Fatalf("expected context cancellation error, got %v", err)
+	content, err := os.ReadFile(workingDirectoryPath)
+	if err != nil {
+		t.Fatalf("read captured working directory: %v", err)
 	}
-	if elapsed := time.Since(start); elapsed >= time.Second {
-		t.Fatalf("expected cancelled command to stop quickly, took %v", elapsed)
+	got := strings.TrimSpace(string(content))
+	wantInfo, wantErr := os.Stat(repo)
+	gotInfo, gotErr := os.Stat(got)
+	if wantErr != nil || gotErr != nil || !os.SameFile(wantInfo, gotInfo) {
+		t.Fatalf("expected preview runner working directory %q, got %q (want err=%v, got err=%v)", repo, got, wantErr, gotErr)
 	}
-	if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
-		t.Fatalf("expected cancelled command to stop before creating marker, stat err = %v", statErr)
+}
+
+func TestCaptureReuseDoesNotBypassPreviewGate(t *testing.T) {
+	repo := t.TempDir()
+	tracePath := filepath.Join(repo, ".artifacts", runtimeTraceNDJSON)
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "python", "#!/bin/sh\n: > \"$LOPPER_RUNTIME_TRACE\"\n"))
+
+	request := CaptureRequest{
+		RepoPath:             repo,
+		TracePath:            tracePath,
+		Command:              "python -m unittest",
+		Provider:             CaptureProviderPython,
+		PythonRunnerProfiles: true,
+	}
+	if err := Capture(context.Background(), request); err != nil {
+		t.Fatalf("capture enabled preview profile: %v", err)
+	}
+
+	request.PythonRunnerProfiles = false
+	request.ReuseIfUnchanged = true
+	err := Capture(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), PythonRunnerProfilesFeature) {
+		t.Fatalf("expected disabled preview gate to reject cached trace reuse, got %v", err)
 	}
 }
 

--- a/internal/runtime/capture_command.go
+++ b/internal/runtime/capture_command.go
@@ -14,6 +14,12 @@ import (
 const runtimeBinDirsEnvKey = "LOPPER_RUNTIME_BIN_DIRS"
 const defaultWindowsPathExt = ".COM;.EXE;.BAT;.CMD"
 
+const PythonRunnerProfilesFeature = "python-runner-profiles"
+
+type CommandOptions struct {
+	PythonRunnerProfiles bool
+}
+
 var runtimeOS = goruntime.GOOS
 
 var runtimeExecutableAllowlist = map[string]struct{}{
@@ -32,15 +38,14 @@ var runtimeExecutableAllowlist = map[string]struct{}{
 	"pytest":  {},
 	"python":  {},
 	"python3": {},
+	"uv":      {},
 }
 
-func buildRuntimeCommand(ctx context.Context, command string) (*exec.Cmd, error) {
-	fields, err := parseValidatedCommand(command)
+func buildRuntimeCommand(ctx context.Context, command string, requestedOptions ...CommandOptions) (*exec.Cmd, error) {
+	options := resolveCommandOptions(requestedOptions)
+	fields, err := parseValidatedCommand(command, options)
 	if err != nil {
 		return nil, err
-	}
-	if len(fields) == 0 {
-		return nil, fmt.Errorf("runtime test command is required")
 	}
 
 	executable := fields[0]
@@ -60,12 +65,19 @@ func buildRuntimeCommand(ctx context.Context, command string) (*exec.Cmd, error)
 	return cmd, nil
 }
 
-func ValidateCommand(command string) error {
+func ValidateCommand(command string, requestedOptions ...CommandOptions) error {
 	if strings.TrimSpace(command) == "" {
 		return nil
 	}
-	_, err := parseValidatedCommand(command)
+	_, err := parseValidatedCommand(command, resolveCommandOptions(requestedOptions))
 	return err
+}
+
+func resolveCommandOptions(options []CommandOptions) CommandOptions {
+	if len(options) == 0 {
+		return CommandOptions{}
+	}
+	return options[0]
 }
 
 type runtimeCommandParser struct {
@@ -78,6 +90,13 @@ type runtimeCommandParser struct {
 }
 
 func parseRuntimeCommand(command string) ([]string, error) {
+	if isWindowsRuntime() {
+		return parseWindowsRuntimeCommand(command)
+	}
+	return parseUnixRuntimeCommand(command)
+}
+
+func parseUnixRuntimeCommand(command string) ([]string, error) {
 	var parser runtimeCommandParser
 	for _, ch := range command {
 		parser.consume(ch)
@@ -94,18 +113,18 @@ func parseRuntimeCommand(command string) ([]string, error) {
 	return parser.fields, nil
 }
 
-func parseValidatedCommand(command string) ([]string, error) {
+func parseValidatedCommand(command string, options CommandOptions) ([]string, error) {
 	fields, err := parseRuntimeCommand(command)
 	if err != nil {
 		return nil, err
 	}
-	if err := validateRuntimeCommand(command, fields); err != nil {
+	if err := validateRuntimeCommand(command, fields, options); err != nil {
 		return nil, err
 	}
 	return fields, nil
 }
 
-func validateRuntimeCommand(command string, fields []string) error {
+func validateRuntimeCommand(command string, fields []string, options CommandOptions) error {
 	if containsUnsafeRuntimeCommandSyntax(command) {
 		return fmt.Errorf("runtime test command uses indirect command execution operators; pass a direct executable and arguments instead")
 	}
@@ -113,12 +132,29 @@ func validateRuntimeCommand(command string, fields []string) error {
 	if len(fields) == 0 {
 		return fmt.Errorf("runtime test command is required")
 	}
+	if isInlineEnvironmentAssignment(fields[0]) {
+		return fmt.Errorf("runtime test command uses inline environment assignment %q; configure the environment separately", fields[0])
+	}
 
-	return rejectRuntimeCommandUnsafeFlags(fields[0], fields[1:])
+	return rejectRuntimeCommandUnsafeFlags(fields[0], fields[1:], options)
+}
+
+func isInlineEnvironmentAssignment(token string) bool {
+	name, _, found := strings.Cut(token, "=")
+	if !found || name == "" {
+		return false
+	}
+	for index, ch := range name {
+		if ch == '_' || unicode.IsLetter(ch) || (index > 0 && unicode.IsDigit(ch)) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func containsUnsafeRuntimeCommandSyntax(command string) bool {
-	var parser runtimeCommandUnsafeSyntaxParser
+	parser := runtimeCommandUnsafeSyntaxParser{windows: isWindowsRuntime()}
 	runes := []rune(command)
 
 	for i, ch := range runes {
@@ -134,6 +170,7 @@ type runtimeCommandUnsafeSyntaxParser struct {
 	inSingleQuote bool
 	inDoubleQuote bool
 	escaped       bool
+	windows       bool
 }
 
 func (p *runtimeCommandUnsafeSyntaxParser) consume(ch, next rune) bool {
@@ -144,12 +181,18 @@ func (p *runtimeCommandUnsafeSyntaxParser) consume(ch, next rune) bool {
 
 	switch ch {
 	case '\\':
+		if p.windows {
+			return false
+		}
 		if p.inSingleQuote {
 			return false
 		}
 		p.escaped = true
 		return false
 	case '\'':
+		if p.windows {
+			return false
+		}
 		if p.inDoubleQuote {
 			return false
 		}
@@ -195,9 +238,9 @@ func nextRuntimeCommandRune(runes []rune, index int) rune {
 	return runes[index+1]
 }
 
-func rejectRuntimeCommandUnsafeFlags(executable string, args []string) error {
-	if isPythonRuntimeExecutable(executable) {
-		return rejectUnsafePythonRuntimeCommand(executable, args)
+func rejectRuntimeCommandUnsafeFlags(executable string, args []string, options CommandOptions) error {
+	if isPythonRuntimeExecutable(executable) || executable == "uv" {
+		return validatePythonRuntimeProfile(executable, args, options)
 	}
 
 	flags, ok := runtimeCommandUnsafeFlags[executable]
@@ -215,7 +258,7 @@ func rejectRuntimeCommandUnsafeFlags(executable string, args []string) error {
 	return nil
 }
 
-func IsPythonTestCommand(command string) bool {
+func IsPythonTestCommand(command string, requestedOptions ...CommandOptions) bool {
 	fields, err := parseRuntimeCommand(command)
 	if err != nil || len(fields) == 0 {
 		return false
@@ -223,18 +266,11 @@ func IsPythonTestCommand(command string) bool {
 	if fields[0] == "pytest" {
 		return true
 	}
-	return isPythonRuntimeExecutable(fields[0]) && len(fields) >= 2 && fields[1] == "-m" && len(fields) >= 3 && fields[2] == "pytest"
+	return validatePythonRuntimeProfile(fields[0], fields[1:], resolveCommandOptions(requestedOptions)) == nil
 }
 
 func isPythonRuntimeExecutable(executable string) bool {
 	return executable == "python" || executable == "python3"
-}
-
-func rejectUnsafePythonRuntimeCommand(executable string, args []string) error {
-	if len(args) < 2 || args[0] != "-m" || args[1] != "pytest" {
-		return fmt.Errorf("runtime test command for %q may only run '-m pytest'", executable)
-	}
-	return nil
 }
 
 var runtimeCommandUnsafeFlags = map[string][]string{
@@ -351,10 +387,14 @@ func runtimeExecutableCandidates(executable, dir string) []string {
 }
 
 func isTrustedRuntimeExecutable(info os.FileInfo) bool {
+	if !info.Mode().IsRegular() {
+		return false
+	}
 	if isWindowsRuntime() {
 		return true
 	}
-	return info.Mode().Perm()&0o111 != 0
+	permissions := info.Mode().Perm()
+	return permissions&0o111 != 0 && permissions&0o022 == 0
 }
 
 func newAllowlistedRuntimeCommand(ctx context.Context, executable string) (*exec.Cmd, error) {
@@ -372,8 +412,25 @@ func runtimeSearchDirs() []string {
 	if configured != "" {
 		return trustedSearchDirs(configured)
 	}
+
+	pathDirs := trustedSearchDirs(os.Getenv("PATH"))
 	defaults := strings.Join(defaultTrustedRuntimeBinDirEntries(), string(os.PathListSeparator))
-	return trustedSearchDirs(defaults)
+	return appendUniqueRuntimeSearchDirs(pathDirs, trustedSearchDirs(defaults))
+}
+
+func appendUniqueRuntimeSearchDirs(groups ...[]string) []string {
+	seen := make(map[string]struct{})
+	var dirs []string
+	for _, group := range groups {
+		for _, dir := range group {
+			if _, ok := seen[dir]; ok {
+				continue
+			}
+			seen[dir] = struct{}{}
+			dirs = append(dirs, dir)
+		}
+	}
+	return dirs
 }
 
 func defaultTrustedRuntimeBinDirEntries() []string {

--- a/internal/runtime/capture_command_python.go
+++ b/internal/runtime/capture_command_python.go
@@ -1,0 +1,76 @@
+package runtime
+
+import "fmt"
+
+func validatePythonRuntimeProfile(executable string, args []string, options CommandOptions) error {
+	switch {
+	case isPythonRuntimeExecutable(executable):
+		return validatePythonModuleProfile(executable, args, options)
+	case executable == "uv":
+		return validateUVRuntimeProfile(args, options)
+	default:
+		return fmt.Errorf("runtime test command %q is not a Python test profile", executable)
+	}
+}
+
+func validatePythonModuleProfile(executable string, args []string, options CommandOptions) error {
+	if len(args) < 2 || args[0] != "-m" {
+		return unsupportedPythonModuleProfileError(executable, options)
+	}
+
+	switch args[1] {
+	case "pytest":
+		return nil
+	case "unittest":
+		if options.PythonRunnerProfiles {
+			return nil
+		}
+		return pythonRunnerProfilesDisabledError(executable + " -m unittest")
+	default:
+		return unsupportedPythonModuleProfileError(executable, options)
+	}
+}
+
+func validateUVRuntimeProfile(args []string, options CommandOptions) error {
+	if !options.PythonRunnerProfiles {
+		return pythonRunnerProfilesDisabledError("uv run")
+	}
+	if len(args) < 2 || args[0] != "run" {
+		return unsupportedUVRuntimeProfileError()
+	}
+
+	runnerIndex := 1
+	if args[runnerIndex] == "--" {
+		runnerIndex++
+	}
+	if runnerIndex >= len(args) {
+		return unsupportedUVRuntimeProfileError()
+	}
+
+	switch runner := args[runnerIndex]; runner {
+	case "pytest":
+		return nil
+	case "python", "python3":
+		if err := validatePythonModuleProfile(runner, args[runnerIndex+1:], options); err != nil {
+			return unsupportedUVRuntimeProfileError()
+		}
+		return nil
+	default:
+		return unsupportedUVRuntimeProfileError()
+	}
+}
+
+func pythonRunnerProfilesDisabledError(profile string) error {
+	return fmt.Errorf("runtime test command profile %q requires --enable-feature %s", profile, PythonRunnerProfilesFeature)
+}
+
+func unsupportedPythonModuleProfileError(executable string, options CommandOptions) error {
+	if options.PythonRunnerProfiles {
+		return fmt.Errorf("runtime test command for %q may only run '-m pytest' or '-m unittest'", executable)
+	}
+	return fmt.Errorf("runtime test command for %q may only run '-m pytest'", executable)
+}
+
+func unsupportedUVRuntimeProfileError() error {
+	return fmt.Errorf("runtime test command for %q may only use 'uv run [--] pytest' or 'uv run [--] python[3] -m pytest|unittest' without uv wrapper flags", "uv")
+}

--- a/internal/runtime/capture_command_test.go
+++ b/internal/runtime/capture_command_test.go
@@ -42,6 +42,31 @@ func TestBuildRuntimeCommandAllowlist(t *testing.T) {
 	}
 }
 
+func TestBuildRuntimeCommandAllowsPreviewPythonRunnerProfiles(t *testing.T) {
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeTools(t))
+	options := CommandOptions{PythonRunnerProfiles: true}
+	commands := []string{
+		"python -m unittest",
+		"python3 -m unittest discover -s tests",
+		"uv run pytest",
+		"uv run -- pytest tests -q",
+		"uv run python -m pytest tests",
+		"uv run python3 -m pytest tests",
+		"uv run python -m unittest discover",
+		"uv run -- python3 -m unittest tests.test_api",
+	}
+
+	for _, command := range commands {
+		cmd, err := buildRuntimeCommand(context.Background(), command, options)
+		if err != nil {
+			t.Fatalf("expected preview profile %q to be allowlisted: %v", command, err)
+		}
+		if cmd.Path == "" || !filepath.IsAbs(cmd.Path) {
+			t.Fatalf("expected executable path for command %q", command)
+		}
+	}
+}
+
 func TestBuildRuntimeCommandPreservesParsedArgs(t *testing.T) {
 	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeTools(t))
 
@@ -65,11 +90,16 @@ func TestBuildRuntimeCommandPreservesParsedArgs(t *testing.T) {
 			command: `make test\ target`,
 			want:    []string{"make", "test target"},
 		},
+		{
+			name:    "forwarded separator",
+			command: `uv run -- pytest "tests/integration suite" -- -k smoke`,
+			want:    []string{"uv", "run", "--", "pytest", "tests/integration suite", "--", "-k", "smoke"},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd, err := buildRuntimeCommand(context.Background(), tc.command)
+			cmd, err := buildRuntimeCommand(context.Background(), tc.command, CommandOptions{PythonRunnerProfiles: true})
 			if err != nil {
 				t.Fatalf("build runtime command: %v", err)
 			}
@@ -137,7 +167,33 @@ func TestBuildRuntimeCommandRejectsUnsafeSyntaxAndFlags(t *testing.T) {
 	checkRejects(`node -e 'console.log("hi")'`, "unsafe executable flag")
 	checkRejects(`python -c 'print("hi")'`, "may only run '-m pytest'")
 	checkRejects(`python -m pip install pytest`, "may only run '-m pytest'")
-	checkRejects(`python3 -m unittest`, "may only run '-m pytest'")
+	checkRejects(`python3 -m unittest`, PythonRunnerProfilesFeature)
+	checkRejects(`PYTHONPATH=/tmp python -m pytest`, "inline environment assignment")
+}
+
+func TestBuildRuntimeCommandRejectsUnsafePreviewProfileShapes(t *testing.T) {
+	options := CommandOptions{PythonRunnerProfiles: true}
+	commands := []string{
+		"uv --directory /tmp run pytest",
+		"uv run --isolated pytest",
+		"uv run --python 3.13 pytest",
+		"uv run ruff check",
+		"uv tool run pytest",
+		"uv run python -c 'print(1)'",
+		"uv run python -m pip install pytest",
+		"uv run --",
+		"python -I -m unittest",
+	}
+
+	for _, command := range commands {
+		_, err := buildRuntimeCommand(context.Background(), command, options)
+		if err == nil {
+			t.Fatalf("expected unsafe preview profile %q to be rejected", command)
+		}
+		if !strings.Contains(err.Error(), "may only") {
+			t.Fatalf("expected profile-boundary error for %q, got %v", command, err)
+		}
+	}
 }
 
 func TestValidateCommand(t *testing.T) {
@@ -150,6 +206,15 @@ func TestValidateCommand(t *testing.T) {
 	if err := ValidateCommand("python3 -m pytest tests"); err != nil {
 		t.Fatalf("expected python pytest command to validate, got %v", err)
 	}
+	if err := ValidateCommand("python3 -m unittest tests"); err == nil || !strings.Contains(err.Error(), PythonRunnerProfilesFeature) {
+		t.Fatalf("expected disabled preview profile error, got %v", err)
+	}
+	if err := ValidateCommand("python3 -m unittest tests", CommandOptions{PythonRunnerProfiles: true}); err != nil {
+		t.Fatalf("expected enabled unittest profile to validate, got %v", err)
+	}
+	if err := ValidateCommand("uv run pytest -- -k smoke", CommandOptions{PythonRunnerProfiles: true}); err != nil {
+		t.Fatalf("expected enabled uv profile to validate, got %v", err)
+	}
 
 	err := ValidateCommand(`node -e 'console.log("hi")'`)
 	if err == nil || !strings.Contains(err.Error(), "unsafe executable flag") {
@@ -160,20 +225,95 @@ func TestValidateCommand(t *testing.T) {
 func TestIsPythonTestCommand(t *testing.T) {
 	testCases := []struct {
 		command string
+		preview bool
 		want    bool
 	}{
 		{command: "pytest", want: true},
 		{command: "pytest tests -q", want: true},
 		{command: "python -m pytest", want: true},
 		{command: "python3 -m pytest tests", want: true},
+		{command: "python -m unittest", preview: true, want: true},
+		{command: "python3 -m unittest discover", preview: true, want: true},
+		{command: "uv run pytest", preview: true, want: true},
+		{command: "uv run -- python -m unittest", preview: true, want: true},
+		{command: "python -m unittest", want: false},
+		{command: "uv run pytest", want: false},
 		{command: "npm test", want: false},
 		{command: "python -m pip", want: false},
 		{command: `python -m "pytest`, want: false},
 	}
 
 	for _, tc := range testCases {
-		if got := IsPythonTestCommand(tc.command); got != tc.want {
+		options := CommandOptions{PythonRunnerProfiles: tc.preview}
+		if got := IsPythonTestCommand(tc.command, options); got != tc.want {
 			t.Fatalf("IsPythonTestCommand(%q) = %v, want %v", tc.command, got, tc.want)
+		}
+	}
+}
+
+func TestParseRuntimeCommandUnixArgumentConventions(t *testing.T) {
+	setRuntimeOSTest(t, "linux")
+	got, err := parseRuntimeCommand(`uv run pytest 'tests/integration suite' -- -k smoke`)
+	if err != nil {
+		t.Fatalf("parse Unix runtime command: %v", err)
+	}
+	want := []string{"uv", "run", "pytest", "tests/integration suite", "--", "-k", "smoke"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected Unix args %q, got %q", want, got)
+	}
+}
+
+func TestParseRuntimeCommandWindowsArgumentConventions(t *testing.T) {
+	setRuntimeOSTest(t, "windows")
+	testCases := []struct {
+		command string
+		want    []string
+	}{
+		{
+			command: `python -m unittest C:\repo\tests`,
+			want:    []string{"python", "-m", "unittest", `C:\repo\tests`},
+		},
+		{
+			command: `uv run pytest "C:\repo\tests suite" -- -k smoke`,
+			want:    []string{"uv", "run", "pytest", `C:\repo\tests suite`, "--", "-k", "smoke"},
+		},
+		{
+			command: `uv run pytest "C:\repo\quoted\\\"name.py"`,
+			want:    []string{"uv", "run", "pytest", `C:\repo\quoted\"name.py`},
+		},
+		{
+			command: `uv run pytest ""`,
+			want:    []string{"uv", "run", "pytest", ""},
+		},
+	}
+
+	for _, tc := range testCases {
+		got, err := parseRuntimeCommand(tc.command)
+		if err != nil {
+			t.Fatalf("parse Windows runtime command %q: %v", tc.command, err)
+		}
+		if !slices.Equal(got, tc.want) {
+			t.Fatalf("expected Windows args %q, got %q", tc.want, got)
+		}
+	}
+
+	if _, err := parseRuntimeCommand(`uv run pytest "C:\repo\tests`); err == nil || !strings.Contains(err.Error(), "unterminated quote") {
+		t.Fatalf("expected unterminated Windows quote error, got %v", err)
+	}
+	if fields, err := parseRuntimeCommand("   "); err != nil || len(fields) != 0 {
+		t.Fatalf("expected blank Windows command to produce no fields, fields=%v err=%v", fields, err)
+	}
+}
+
+func TestInlineEnvironmentAssignmentShape(t *testing.T) {
+	for _, token := range []string{"PYTHONPATH=/tmp", "_LOPPER_2=value"} {
+		if !isInlineEnvironmentAssignment(token) {
+			t.Fatalf("expected %q to be recognized as an environment assignment", token)
+		}
+	}
+	for _, token := range []string{"=value", "2PYTHON=value", "python3"} {
+		if isInlineEnvironmentAssignment(token) {
+			t.Fatalf("expected %q not to be recognized as an environment assignment", token)
 		}
 	}
 }
@@ -190,6 +330,16 @@ func TestContainsUnsafeRuntimeCommandSyntax(t *testing.T) {
 	}
 	if !containsUnsafeRuntimeCommandSyntax(`node -r $(pwd)`) {
 		t.Fatalf("expected subshell syntax outside quotes to be rejected")
+	}
+}
+
+func TestContainsUnsafeRuntimeCommandSyntaxUsesWindowsQuoting(t *testing.T) {
+	setRuntimeOSTest(t, "windows")
+	if containsUnsafeRuntimeCommandSyntax(`python -m unittest C:\repo\tests`) {
+		t.Fatal("expected Windows path backslashes to remain literal")
+	}
+	if !containsUnsafeRuntimeCommandSyntax(`python -m unittest 'tests & more'`) {
+		t.Fatal("expected Windows single quotes not to hide indirect operators")
 	}
 }
 
@@ -216,6 +366,72 @@ func TestResolveRuntimeExecutablePathSkipsNonExecutableCandidate(t *testing.T) {
 	}
 	if got != secondPath {
 		t.Fatalf("expected executable path %q, got %q", secondPath, got)
+	}
+}
+
+func TestResolveRuntimeExecutablePathSkipsWritableCandidate(t *testing.T) {
+	if isWindowsRuntime() {
+		t.Skip("writable mode checks are Unix-specific")
+	}
+
+	firstDir := t.TempDir()
+	secondDir := t.TempDir()
+	firstPath := filepath.Join(firstDir, "python3")
+	if err := os.WriteFile(firstPath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write writable tool: %v", err)
+	}
+	if err := os.Chmod(firstPath, 0o777); err != nil {
+		t.Fatalf("make tool writable: %v", err)
+	}
+	secondPath := filepath.Join(secondDir, "python3")
+	if err := os.WriteFile(secondPath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write trusted tool: %v", err)
+	}
+
+	got, err := resolveRuntimeExecutablePath("python3", []string{firstDir, secondDir})
+	if err != nil {
+		t.Fatalf("resolve runtime executable path: %v", err)
+	}
+	if got != secondPath {
+		t.Fatalf("expected trusted executable path %q, got %q", secondPath, got)
+	}
+}
+
+func TestRuntimeSearchDirsPrefersTrustedPATHSelection(t *testing.T) {
+	if isWindowsRuntime() {
+		t.Skip("Unix PATH trust checks are covered here")
+	}
+
+	selectedDir := t.TempDir()
+	fallbackDir := t.TempDir()
+	t.Setenv(runtimeBinDirsEnvKey, "")
+	t.Setenv("PATH", strings.Join([]string{selectedDir, fallbackDir}, string(os.PathListSeparator)))
+
+	got := runtimeSearchDirs()
+	if len(got) < 2 || got[0] != selectedDir || got[1] != fallbackDir {
+		t.Fatalf("expected PATH order to lead runtime search dirs, got %v", got)
+	}
+}
+
+func TestBuildRuntimeCommandUsesPATHSelectedPython(t *testing.T) {
+	if isWindowsRuntime() {
+		t.Skip("Unix PATH-selected executable behavior is covered here")
+	}
+
+	selectedDir := t.TempDir()
+	selectedPython := filepath.Join(selectedDir, "python3")
+	if err := os.WriteFile(selectedPython, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write PATH-selected python: %v", err)
+	}
+	t.Setenv(runtimeBinDirsEnvKey, "")
+	t.Setenv("PATH", selectedDir+string(os.PathListSeparator)+"/usr/bin:/bin")
+
+	cmd, err := buildRuntimeCommand(context.Background(), "python3 -m pytest")
+	if err != nil {
+		t.Fatalf("build PATH-selected Python command: %v", err)
+	}
+	if cmd.Path != selectedPython {
+		t.Fatalf("expected PATH-selected Python %q, got %q", selectedPython, cmd.Path)
 	}
 }
 
@@ -297,6 +513,16 @@ func TestIsTrustedRuntimeExecutableOnWindowsIgnoresModeBits(t *testing.T) {
 	}
 	if !isTrustedRuntimeExecutable(info) {
 		t.Fatalf("expected windows executable trust check to accept regular files")
+	}
+}
+
+func TestIsTrustedRuntimeExecutableRejectsNonRegularFile(t *testing.T) {
+	info, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat directory: %v", err)
+	}
+	if isTrustedRuntimeExecutable(info) {
+		t.Fatal("expected non-regular executable candidate to be rejected")
 	}
 }
 

--- a/internal/runtime/capture_command_test.go
+++ b/internal/runtime/capture_command_test.go
@@ -282,6 +282,14 @@ func TestParseRuntimeCommandWindowsArgumentConventions(t *testing.T) {
 			want:    []string{"uv", "run", "pytest", `C:\repo\quoted\"name.py`},
 		},
 		{
+			command: `uv run pytest "C:\repo\\"`,
+			want:    []string{"uv", "run", "pytest", `C:\repo\`},
+		},
+		{
+			command: `uv run pytest C:\repo\\tests`,
+			want:    []string{"uv", "run", "pytest", `C:\repo\\tests`},
+		},
+		{
 			command: `uv run pytest ""`,
 			want:    []string{"uv", "run", "pytest", ""},
 		},

--- a/internal/runtime/capture_command_windows_parse.go
+++ b/internal/runtime/capture_command_windows_parse.go
@@ -1,0 +1,76 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+func parseWindowsRuntimeCommand(command string) ([]string, error) {
+	runes := []rune(command)
+	fields := make([]string, 0)
+
+	for index := 0; index < len(runes); {
+		for index < len(runes) && unicode.IsSpace(runes[index]) {
+			index++
+		}
+		if index >= len(runes) {
+			break
+		}
+
+		var current strings.Builder
+		inDoubleQuote := false
+		tokenStarted := false
+		for index < len(runes) {
+			ch := runes[index]
+			if unicode.IsSpace(ch) && !inDoubleQuote {
+				break
+			}
+			tokenStarted = true
+
+			if ch == '\\' {
+				backslashStart := index
+				for index < len(runes) && runes[index] == '\\' {
+					index++
+				}
+				backslashCount := index - backslashStart
+				if index < len(runes) && runes[index] == '"' {
+					writeRepeatedRune(&current, '\\', backslashCount/2)
+					if backslashCount%2 == 0 {
+						inDoubleQuote = !inDoubleQuote
+					} else {
+						current.WriteRune('"')
+					}
+					index++
+					continue
+				}
+				writeRepeatedRune(&current, '\\', backslashCount)
+				continue
+			}
+
+			if ch == '"' {
+				inDoubleQuote = !inDoubleQuote
+				index++
+				continue
+			}
+
+			current.WriteRune(ch)
+			index++
+		}
+
+		if inDoubleQuote {
+			return nil, fmt.Errorf("runtime test command contains an unterminated quote")
+		}
+		if tokenStarted {
+			fields = append(fields, current.String())
+		}
+	}
+
+	return fields, nil
+}
+
+func writeRepeatedRune(builder *strings.Builder, value rune, count int) {
+	for range count {
+		builder.WriteRune(value)
+	}
+}

--- a/internal/runtime/capture_command_windows_parse.go
+++ b/internal/runtime/capture_command_windows_parse.go
@@ -9,64 +9,71 @@ import (
 func parseWindowsRuntimeCommand(command string) ([]string, error) {
 	runes := []rune(command)
 	fields := make([]string, 0)
-
-	for index := 0; index < len(runes); {
-		for index < len(runes) && unicode.IsSpace(runes[index]) {
-			index++
+	index := skipWindowsRuntimeSpaces(runes, 0)
+	for index < len(runes) {
+		field, next, err := parseWindowsRuntimeField(runes, index)
+		if err != nil {
+			return nil, err
 		}
-		if index >= len(runes) {
-			break
-		}
-
-		var current strings.Builder
-		inDoubleQuote := false
-		tokenStarted := false
-		for index < len(runes) {
-			ch := runes[index]
-			if unicode.IsSpace(ch) && !inDoubleQuote {
-				break
-			}
-			tokenStarted = true
-
-			if ch == '\\' {
-				backslashStart := index
-				for index < len(runes) && runes[index] == '\\' {
-					index++
-				}
-				backslashCount := index - backslashStart
-				if index < len(runes) && runes[index] == '"' {
-					writeRepeatedRune(&current, '\\', backslashCount/2)
-					if backslashCount%2 == 0 {
-						inDoubleQuote = !inDoubleQuote
-					} else {
-						current.WriteRune('"')
-					}
-					index++
-					continue
-				}
-				writeRepeatedRune(&current, '\\', backslashCount)
-				continue
-			}
-
-			if ch == '"' {
-				inDoubleQuote = !inDoubleQuote
-				index++
-				continue
-			}
-
-			current.WriteRune(ch)
-			index++
-		}
-
-		if inDoubleQuote {
-			return nil, fmt.Errorf("runtime test command contains an unterminated quote")
-		}
-		if tokenStarted {
-			fields = append(fields, current.String())
-		}
+		fields = append(fields, field)
+		index = skipWindowsRuntimeSpaces(runes, next)
 	}
 
 	return fields, nil
+}
+
+func skipWindowsRuntimeSpaces(runes []rune, index int) int {
+	for index < len(runes) && unicode.IsSpace(runes[index]) {
+		index++
+	}
+	return index
+}
+
+func parseWindowsRuntimeField(runes []rune, index int) (string, int, error) {
+	var current strings.Builder
+	inDoubleQuote := false
+	for index < len(runes) && !windowsRuntimeFieldBoundary(runes[index], inDoubleQuote) {
+		index, inDoubleQuote = appendWindowsRuntimeRune(&current, runes, index, inDoubleQuote)
+	}
+	if inDoubleQuote {
+		return "", index, fmt.Errorf("runtime test command contains an unterminated quote")
+	}
+	return current.String(), index, nil
+}
+
+func windowsRuntimeFieldBoundary(value rune, inDoubleQuote bool) bool {
+	return unicode.IsSpace(value) && !inDoubleQuote
+}
+
+func appendWindowsRuntimeRune(builder *strings.Builder, runes []rune, index int, inDoubleQuote bool) (int, bool) {
+	switch runes[index] {
+	case '\\':
+		return appendWindowsRuntimeBackslashes(builder, runes, index, inDoubleQuote)
+	case '"':
+		return index + 1, !inDoubleQuote
+	default:
+		builder.WriteRune(runes[index])
+		return index + 1, inDoubleQuote
+	}
+}
+
+func appendWindowsRuntimeBackslashes(builder *strings.Builder, runes []rune, index int, inDoubleQuote bool) (int, bool) {
+	next := index
+	for next < len(runes) && runes[next] == '\\' {
+		next++
+	}
+	count := next - index
+	if next >= len(runes) || runes[next] != '"' {
+		writeRepeatedRune(builder, '\\', count)
+		return next, inDoubleQuote
+	}
+
+	writeRepeatedRune(builder, '\\', count/2)
+	if count%2 == 0 {
+		return next + 1, !inDoubleQuote
+	}
+	builder.WriteRune('"')
+	return next + 1, inDoubleQuote
 }
 
 func writeRepeatedRune(builder *strings.Builder, value rune, count int) {

--- a/internal/runtime/capture_output.go
+++ b/internal/runtime/capture_output.go
@@ -1,0 +1,69 @@
+package runtime
+
+import (
+	"fmt"
+	"sync"
+)
+
+const runtimeCommandOutputLimit = 64 * 1024
+
+type boundedRuntimeCommandOutput struct {
+	mu        sync.Mutex
+	data      []byte
+	start     int
+	size      int
+	truncated bool
+}
+
+func newRuntimeCommandOutput() *boundedRuntimeCommandOutput {
+	return &boundedRuntimeCommandOutput{data: make([]byte, runtimeCommandOutputLimit)}
+}
+
+func (b *boundedRuntimeCommandOutput) Write(p []byte) (int, error) {
+	written := len(p)
+	if written == 0 {
+		return 0, nil
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if written >= len(b.data) {
+		b.truncated = b.truncated || b.size > 0 || written > len(b.data)
+		copy(b.data, p[written-len(b.data):])
+		b.start = 0
+		b.size = len(b.data)
+		return written, nil
+	}
+
+	if overflow := b.size + written - len(b.data); overflow > 0 {
+		b.truncated = true
+		b.start = (b.start + overflow) % len(b.data)
+		b.size -= overflow
+	}
+	b.append(p)
+	return written, nil
+}
+
+func (b *boundedRuntimeCommandOutput) append(p []byte) {
+	end := (b.start + b.size) % len(b.data)
+	first := min(len(p), len(b.data)-end)
+	copy(b.data[end:], p[:first])
+	copy(b.data, p[first:])
+	b.size += len(p)
+}
+
+func (b *boundedRuntimeCommandOutput) diagnostic() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	output := make([]byte, b.size)
+	first := min(b.size, len(b.data)-b.start)
+	copy(output, b.data[b.start:b.start+first])
+	copy(output[first:], b.data[:b.size-first])
+	if !b.truncated {
+		return output
+	}
+
+	notice := []byte(fmt.Sprintf("[runtime test command output truncated to last %d bytes]\n", len(b.data)))
+	return append(notice, output...)
+}

--- a/internal/runtime/capture_output_test.go
+++ b/internal/runtime/capture_output_test.go
@@ -1,0 +1,60 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestBoundedRuntimeCommandOutputKeepsTail(t *testing.T) {
+	output := &boundedRuntimeCommandOutput{data: make([]byte, 5)}
+	if written, err := output.Write(nil); err != nil || written != 0 {
+		t.Fatalf("expected empty write to be ignored, written=%d err=%v", written, err)
+	}
+	for _, value := range []string{"ab", "cdef"} {
+		if _, err := output.Write([]byte(value)); err != nil {
+			t.Fatalf("write bounded output: %v", err)
+		}
+	}
+	diagnostic := output.diagnostic()
+	if !strings.Contains(string(diagnostic), "truncated") {
+		t.Fatalf("expected truncation notice, got %q", diagnostic)
+	}
+	if !bytes.HasSuffix(diagnostic, []byte("bcdef")) {
+		t.Fatalf("expected newest output tail, got %q", diagnostic)
+	}
+}
+
+func TestBoundedRuntimeCommandOutputHandlesOversizedWrite(t *testing.T) {
+	output := &boundedRuntimeCommandOutput{data: make([]byte, 4)}
+	if _, err := output.Write([]byte("abcdefgh")); err != nil {
+		t.Fatalf("write oversized output: %v", err)
+	}
+	if diagnostic := output.diagnostic(); !bytes.HasSuffix(diagnostic, []byte("efgh")) {
+		t.Fatalf("expected oversized write tail, got %q", diagnostic)
+	}
+}
+
+func TestCaptureBoundsFailureOutput(t *testing.T) {
+	repo := t.TempDir()
+	padding := strconv.Itoa(runtimeCommandOutputLimit + 1024)
+	script := "#!/bin/sh\nprintf prefix-marker\nhead -c " + padding + " /dev/zero | tr '\\000' x\nprintf tail-marker\nexit 2\n"
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "make", script))
+
+	err := Capture(context.Background(), CaptureRequest{RepoPath: repo, Command: "make test"})
+	if err == nil {
+		t.Fatal("expected runtime command failure")
+	}
+	message := err.Error()
+	if !strings.Contains(message, "output truncated") || !strings.Contains(message, "tail-marker") {
+		t.Fatalf("expected bounded tail diagnostics, got %q", message)
+	}
+	if strings.Contains(message, "prefix-marker") {
+		t.Fatalf("expected oldest command output to be discarded, got %q", message)
+	}
+	if len(message) > runtimeCommandOutputLimit+256 {
+		t.Fatalf("expected bounded failure message, got %d bytes", len(message))
+	}
+}

--- a/internal/runtime/capture_python_profiles_test.go
+++ b/internal/runtime/capture_python_profiles_test.go
@@ -1,0 +1,179 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCapturePythonRunnerProfilesMatchPytestDependencyTrace(t *testing.T) {
+	pythonPath, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+
+	repo := t.TempDir()
+	sitePackages := filepath.Join(t.TempDir(), "lib", "python3.12", "site-packages")
+	if err := os.MkdirAll(filepath.Join(sitePackages, "thirdparty"), 0o750); err != nil {
+		t.Fatalf("create third-party package: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sitePackages, "thirdparty", "__init__.py"), []byte("VALUE = 1\n"), 0o600); err != nil {
+		t.Fatalf("write third-party package: %v", err)
+	}
+	testModule := "import unittest\nimport thirdparty\n\nclass ImportTest(unittest.TestCase):\n    def test_import(self):\n        self.assertEqual(thirdparty.VALUE, 1)\n"
+	if err := os.WriteFile(filepath.Join(repo, "test_imports.py"), []byte(testModule), 0o600); err != nil {
+		t.Fatalf("write unittest module: %v", err)
+	}
+
+	toolDir := setupFakeRuntimeTools(t)
+	writeRuntimeProfileTool(t, toolDir, "pytest", "#!/bin/sh\nexec \"$LOPPER_TEST_PYTHON\" -c 'import thirdparty'\n")
+	writeRuntimeProfileTool(t, toolDir, "python3", "#!/bin/sh\nexec \"$LOPPER_TEST_PYTHON\" \"$@\"\n")
+	writeRuntimeProfileTool(t, toolDir, "uv", "#!/bin/sh\nshift\nif [ \"${1:-}\" = -- ]; then shift; fi\nif [ \"${1:-}\" = pytest ]; then exec \"$LOPPER_TEST_PYTHON\" -c 'import thirdparty'; fi\nif [ \"${1:-}\" = python3 ]; then shift; exec \"$LOPPER_TEST_PYTHON\" \"$@\"; fi\nexit 64\n")
+	t.Setenv("LOPPER_TEST_PYTHON", pythonPath)
+	t.Setenv("PYTHONPATH", sitePackages)
+	t.Setenv(runtimeBinDirsEnvKey, toolDir)
+
+	commands := []string{
+		"pytest",
+		"python3 -m unittest test_imports",
+		"uv run pytest",
+		"uv run -- python3 -m unittest test_imports",
+	}
+	dependency := DependencyKey{Language: runtimeLanguagePython, Name: "thirdparty"}
+	for index, command := range commands {
+		tracePath := filepath.Join(repo, ".artifacts", "profile-"+string(rune('a'+index))+".ndjson")
+		err := Capture(context.Background(), CaptureRequest{
+			RepoPath:             repo,
+			TracePath:            tracePath,
+			Command:              command,
+			Provider:             CaptureProviderPython,
+			PythonRunnerProfiles: true,
+		})
+		if err != nil {
+			t.Fatalf("capture %q: %v", command, err)
+		}
+		trace, err := Load(tracePath)
+		if err != nil {
+			t.Fatalf("load trace for %q: %v", command, err)
+		}
+		if trace.DependencyLoadsByLanguage[dependency] == 0 {
+			t.Fatalf("expected %q to capture the same thirdparty dependency as pytest, got %#v", command, trace.DependencyLoadsByLanguage)
+		}
+	}
+}
+
+func TestCaptureUsesPATHSelectedPythonExecutable(t *testing.T) {
+	if isWindowsRuntime() {
+		t.Skip("PATH-selected wrapper fixture uses a Unix shell script")
+	}
+	pythonPath, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+
+	repo := t.TempDir()
+	selectedBin := t.TempDir()
+	sitePackages := filepath.Join(t.TempDir(), "site-packages")
+	if err := os.MkdirAll(sitePackages, 0o750); err != nil {
+		t.Fatalf("create selected site-packages: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sitePackages, "specialdep.py"), []byte("VALUE = 1\n"), 0o600); err != nil {
+		t.Fatalf("write selected dependency: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "pytest.py"), []byte("import specialdep\nassert specialdep.VALUE == 1\n"), 0o600); err != nil {
+		t.Fatalf("write pytest module fixture: %v", err)
+	}
+
+	markerPath := filepath.Join(t.TempDir(), "selected-python.txt")
+	wrapper := "#!/bin/sh\nprintf selected > \"$LOPPER_SELECTED_PYTHON_MARKER\"\nexport PYTHONPATH=\"$LOPPER_SELECTED_SITE_PACKAGES${PYTHONPATH:+:$PYTHONPATH}\"\nexec \"$LOPPER_TEST_PYTHON\" \"$@\"\n"
+	writeRuntimeProfileTool(t, selectedBin, "python3", wrapper)
+	t.Setenv(runtimeBinDirsEnvKey, "")
+	t.Setenv("PATH", selectedBin+string(os.PathListSeparator)+"/usr/bin:/bin")
+	t.Setenv("PYTHONPATH", "")
+	t.Setenv("LOPPER_SELECTED_PYTHON_MARKER", markerPath)
+	t.Setenv("LOPPER_SELECTED_SITE_PACKAGES", sitePackages)
+	t.Setenv("LOPPER_TEST_PYTHON", pythonPath)
+
+	tracePath := filepath.Join(repo, ".artifacts", "selected-python.ndjson")
+	err = Capture(context.Background(), CaptureRequest{
+		RepoPath:  repo,
+		TracePath: tracePath,
+		Command:   "python3 -m pytest",
+		Provider:  CaptureProviderPython,
+	})
+	if err != nil {
+		t.Fatalf("capture with PATH-selected Python: %v", err)
+	}
+	if content, err := os.ReadFile(markerPath); err != nil || string(content) != "selected" {
+		t.Fatalf("expected selected Python wrapper marker, content=%q err=%v", content, err)
+	}
+	trace, err := Load(tracePath)
+	if err != nil {
+		t.Fatalf("load PATH-selected Python trace: %v", err)
+	}
+	dependency := DependencyKey{Language: runtimeLanguagePython, Name: "specialdep"}
+	if trace.DependencyLoadsByLanguage[dependency] == 0 {
+		t.Fatalf("expected selected Python dependency trace, got %#v", trace.DependencyLoadsByLanguage)
+	}
+}
+
+func TestCaptureChainsProjectSitecustomizeExactlyOnce(t *testing.T) {
+	pythonPath, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+
+	repo := t.TempDir()
+	sitePackages := filepath.Join(t.TempDir(), "site-packages")
+	if err := os.MkdirAll(sitePackages, 0o750); err != nil {
+		t.Fatalf("create site-packages: %v", err)
+	}
+	dependencySource := "import os\nif os.environ.get('SPECIALDEP_OK') != '1':\n    raise RuntimeError('project sitecustomize did not run')\nVALUE = 1\n"
+	if err := os.WriteFile(filepath.Join(sitePackages, "specialdep.py"), []byte(dependencySource), 0o600); err != nil {
+		t.Fatalf("write sitecustomize-dependent module: %v", err)
+	}
+	counterPath := filepath.Join(t.TempDir(), "sitecustomize-count.txt")
+	projectHook := "import os\npath = os.environ['LOPPER_PROJECT_SITECUSTOMIZE_COUNT']\ncount = 0\ntry:\n    with open(path, 'r', encoding='utf-8') as handle:\n        count = int(handle.read() or '0')\nexcept FileNotFoundError:\n    pass\nwith open(path, 'w', encoding='utf-8') as handle:\n    handle.write(str(count + 1))\nos.environ['SPECIALDEP_OK'] = '1'\n"
+	if err := os.WriteFile(filepath.Join(repo, "sitecustomize.py"), []byte(projectHook), 0o600); err != nil {
+		t.Fatalf("write project sitecustomize: %v", err)
+	}
+
+	toolDir := setupFakeRuntimeTools(t)
+	writeRuntimeProfileTool(t, toolDir, "pytest", "#!/bin/sh\nexec \"$LOPPER_TEST_PYTHON\" -c 'import specialdep'\n")
+	t.Setenv("LOPPER_TEST_PYTHON", pythonPath)
+	t.Setenv("LOPPER_PROJECT_SITECUSTOMIZE_COUNT", counterPath)
+	t.Setenv("PYTHONPATH", strings.Join([]string{repo, sitePackages}, string(os.PathListSeparator)))
+	t.Setenv(runtimeBinDirsEnvKey, toolDir)
+
+	tracePath := filepath.Join(repo, ".artifacts", "sitecustomize.ndjson")
+	err = Capture(context.Background(), CaptureRequest{
+		RepoPath:  repo,
+		TracePath: tracePath,
+		Command:   "pytest",
+		Provider:  CaptureProviderPython,
+	})
+	if err != nil {
+		t.Fatalf("capture with project sitecustomize: %v", err)
+	}
+	if content, err := os.ReadFile(counterPath); err != nil || string(content) != "1" {
+		t.Fatalf("expected project sitecustomize to run exactly once, content=%q err=%v", content, err)
+	}
+	trace, err := Load(tracePath)
+	if err != nil {
+		t.Fatalf("load project sitecustomize trace: %v", err)
+	}
+	dependency := DependencyKey{Language: runtimeLanguagePython, Name: "specialdep"}
+	if trace.DependencyLoadsByLanguage[dependency] == 0 {
+		t.Fatalf("expected tracing to remain active after project sitecustomize, got %#v", trace.DependencyLoadsByLanguage)
+	}
+}
+
+func writeRuntimeProfileTool(t *testing.T, dir, name, script string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake runtime profile tool %q: %v", name, err)
+	}
+}

--- a/internal/runtime/capture_test_helpers_test.go
+++ b/internal/runtime/capture_test_helpers_test.go
@@ -46,6 +46,7 @@ func setupFakeRuntimeTools(t *testing.T) string {
 		"pytest",
 		"python",
 		"python3",
+		"uv",
 	}
 	for _, tool := range tools {
 		path := filepath.Join(toolDir, tool)

--- a/scripts/runtime/sitecustomize.py
+++ b/scripts/runtime/sitecustomize.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import builtins
+import importlib.machinery
+import importlib.util
 import json
 import os
 import sys
@@ -158,6 +160,25 @@ def _slash_path(path: str) -> str:
     return _abs_path(path).replace(os.sep, "/")
 
 
+def _chain_project_sitecustomize() -> None:
+    hook_dir = _real_path(os.path.dirname(__file__))
+    search_path = [entry for entry in sys.path if _real_path(entry) != hook_dir]
+    spec = importlib.machinery.PathFinder.find_spec("sitecustomize", search_path)
+    if spec is None or spec.loader is None:
+        return
+    if _real_path(getattr(spec, "origin", "")) == _real_path(__file__):
+        return
+    project_hook = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(project_hook)
+
+
+def _real_path(path: str) -> str:
+    candidate = path or os.getcwd()
+    return os.path.normcase(os.path.realpath(os.path.abspath(candidate)))
+
+
 if TRACE_PATH:
     ENTRYPOINT = _entrypoint()
+    _chain_project_sitecustomize()
+    ORIGINAL_IMPORT = builtins.__import__
     builtins.__import__ = _patched_import


### PR DESCRIPTION
## Summary

Python runtime capture only accepted direct pytest entrypoints, so repositories using the standard-library unittest runner or uv could not collect runtime evidence. Executable lookup also needed to preserve trusted project environments, including their Python startup hooks, without weakening the direct-exec safety boundary.

This change adds preview-gated, explicitly enumerated Python runner profiles, uses trusted PATH-selected tools, chains a project sitecustomize hook exactly once, and keeps runtime capture output bounded. Stable behavior remains unchanged until the preview feature is enabled.

Closes #1132
Closes #1160

## Changes

- Add preview feature flag `LOP-FEAT-0018` / `python-runner-profiles`.
- Accept only direct `python/python3 -m unittest`, `uv run pytest`, and `uv run python/python3 -m pytest|unittest` profiles when enabled.
- Preserve documented runner argument forwarding, including `--`, while rejecting shell syntax, inline environment assignments, uv wrapper flags, arbitrary uv tools, and Python interpreter/module variants outside the allowlist.
- Parse command lines with Unix and Windows-specific quoting and backslash rules.
- Resolve Python, pytest, and uv from trusted PATH directories; reject writable, non-regular, or non-executable candidates.
- Chain a project `sitecustomize.py` exactly once before installing the Lopper import tracer.
- Cap failed runtime-command diagnostics to the most recent 64 KiB and preserve cancellation, working-directory, cache, trace, and path protections.
- Document every stable and preview command form in README, CLI help, the action input, extensibility docs, and the generated manpage.
- Add unit and real-Python integration coverage for profiles, safety rejection, PATH selection, startup-hook chaining, cancellation, cache gating, bounded output, and Unix/Windows parsing.

## Validation

Commands and checks run:

```bash
make ci
make demos-check
make feature-flag-check
make format-check
go test -cover ./internal/runtime ./internal/analysis ./internal/cli
```

Additional manual validation:

- Confirmed the feature catalog reports `LOP-FEAT-0018` as preview and disabled by default.
- Confirmed CLI help renders each supported stable and preview command form and its forwarding boundary.
- Confirmed real pytest, unittest, uv, PATH-selected Python, and project-sitecustomize integration cases retain runtime tracing.
- `make ci` reports zero lint, duplication, suppression, gosec, and vulnerability findings; normal, leak, and race tests pass; total coverage is 98.3% and every covered package meets the 98% minimum.

## Risk and compatibility

- Breaking changes: None. Existing stable pytest profiles and safety rejection remain unchanged; new profiles require an explicit preview feature.
- Migration required: None.
- Performance impact: Runtime failure output is now bounded to a 64 KiB tail; profile parsing and trusted PATH checks occur only when runtime capture is requested.
- Memory benchmark impact: None. The repository memory benchmark gate passed without a regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
