### PR TITLE
fix(swift): exclude cross-file local types from usage

### DIFF
--- a/internal/lang/swift/adapter_detection_manifest_paths_test.go
+++ b/internal/lang/swift/adapter_detection_manifest_paths_test.go
@@ -485,8 +485,20 @@ func testSwiftUsageHeuristicSingleDependencyBranches(t *testing.T) {
 	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value = NetworkSession()"), singleDep, map[string]int{}); got["Session"] != 1 {
 		t.Fatalf("expected inferred unqualified usage, got %#v", got)
 	}
+	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value = NetworkResponse<Result<Value, Error>>()"), singleDep, map[string]int{}); got["Session"] != 1 {
+		t.Fatalf("expected generic constructor usage to remain attributable, got %#v", got)
+	}
+	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value = NetworkResponse<Result<Value, Error>>.success"), singleDep, map[string]int{}); got["Session"] != 1 {
+		t.Fatalf("expected generic static-member usage to remain attributable, got %#v", got)
+	}
+	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value = NetworkResponse<(Value) -> Result>()"), singleDep, map[string]int{}); got["Session"] != 1 {
+		t.Fatalf("expected generic function-type usage to remain attributable, got %#v", got)
+	}
 	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nfunc render(_ value: UnknownResponse) {}"), singleDep, map[string]int{}); len(got) != 0 {
 		t.Fatalf("expected a bare unknown type annotation to lack attribution evidence, got %#v", got)
+	}
+	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value: UnknownResponse<Value>"), singleDep, map[string]int{}); len(got) != 0 {
+		t.Fatalf("expected a generic type annotation to lack attribution evidence, got %#v", got)
 	}
 
 	if hasPotentialUnqualifiedSymbolUsage([]byte("import Alamofire\nlet value: URL? = nil"), singleDep) {
@@ -500,6 +512,12 @@ func testSwiftUsageHeuristicSingleDependencyBranches(t *testing.T) {
 	}
 	if hasPotentialUnqualifiedSymbolUsage([]byte("import Alamofire\nlet value: UnknownResponse"), singleDep) {
 		t.Fatalf("expected a bare unknown identifier to require stronger usage evidence")
+	}
+	if hasUnqualifiedUsageEvidence("<Value") {
+		t.Fatalf("expected an unterminated generic specialization to lack usage evidence")
+	}
+	if hasUnqualifiedUsageEvidence(" <Value>()") {
+		t.Fatalf("expected whitespace before a comparison-like generic expression to lack usage evidence")
 	}
 }
 

--- a/internal/lang/swift/adapter_detection_manifest_paths_test.go
+++ b/internal/lang/swift/adapter_detection_manifest_paths_test.go
@@ -441,6 +441,8 @@ func TestSwiftUsageHeuristicBranches(t *testing.T) {
 	t.Run("empty imports preserve usage", testSwiftUsageHeuristicPreservesExistingUsage)
 	t.Run("multiple dependencies avoid attribution", testSwiftUsageHeuristicAvoidsAttributionWithMultipleDeps)
 	t.Run("single dependency handles usage heuristics", testSwiftUsageHeuristicSingleDependencyBranches)
+	t.Run("generic specializations provide usage evidence", testSwiftUsageHeuristicGenericSpecializations)
+	t.Run("symbol shapes require strong usage evidence", testSwiftUsageHeuristicEvidenceShapes)
 	t.Run("symbol collection detects local declarations", testSwiftUsageHeuristicCollectsLocalSymbols)
 	t.Run("candidate attribution excludes known declarations", testSwiftUsageCandidateAttribution)
 	t.Run("declaration scopes follow Swift targets", testSwiftDeclarationScopes)
@@ -485,6 +487,12 @@ func testSwiftUsageHeuristicSingleDependencyBranches(t *testing.T) {
 	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value = NetworkSession()"), singleDep, map[string]int{}); got["Session"] != 1 {
 		t.Fatalf("expected inferred unqualified usage, got %#v", got)
 	}
+}
+
+func testSwiftUsageHeuristicGenericSpecializations(t *testing.T) {
+	t.Helper()
+
+	singleDep := []importBinding{{Dependency: "alamofire", Module: "Alamofire", Local: "Session"}}
 	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value = NetworkResponse<Result<Value, Error>>()"), singleDep, map[string]int{}); got["Session"] != 1 {
 		t.Fatalf("expected generic constructor usage to remain attributable, got %#v", got)
 	}
@@ -500,7 +508,12 @@ func testSwiftUsageHeuristicSingleDependencyBranches(t *testing.T) {
 	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value: UnknownResponse<Value>"), singleDep, map[string]int{}); len(got) != 0 {
 		t.Fatalf("expected a generic type annotation to lack attribution evidence, got %#v", got)
 	}
+}
 
+func testSwiftUsageHeuristicEvidenceShapes(t *testing.T) {
+	t.Helper()
+
+	singleDep := []importBinding{{Dependency: "alamofire", Module: "Alamofire", Local: "Session"}}
 	if hasPotentialUnqualifiedSymbolUsage([]byte("import Alamofire\nlet value: URL? = nil"), singleDep) {
 		t.Fatalf("expected standard Swift symbols to be ignored")
 	}

--- a/internal/lang/swift/adapter_detection_manifest_paths_test.go
+++ b/internal/lang/swift/adapter_detection_manifest_paths_test.go
@@ -442,6 +442,8 @@ func TestSwiftUsageHeuristicBranches(t *testing.T) {
 	t.Run("multiple dependencies avoid attribution", testSwiftUsageHeuristicAvoidsAttributionWithMultipleDeps)
 	t.Run("single dependency handles usage heuristics", testSwiftUsageHeuristicSingleDependencyBranches)
 	t.Run("symbol collection detects local declarations", testSwiftUsageHeuristicCollectsLocalSymbols)
+	t.Run("candidate attribution excludes known declarations", testSwiftUsageCandidateAttribution)
+	t.Run("declaration scopes follow Swift targets", testSwiftDeclarationScopes)
 }
 
 func testSwiftUsageHeuristicPreservesExistingUsage(t *testing.T) {
@@ -483,6 +485,9 @@ func testSwiftUsageHeuristicSingleDependencyBranches(t *testing.T) {
 	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value = NetworkSession()"), singleDep, map[string]int{}); got["Session"] != 1 {
 		t.Fatalf("expected inferred unqualified usage, got %#v", got)
 	}
+	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nfunc render(_ value: UnknownResponse) {}"), singleDep, map[string]int{}); len(got) != 0 {
+		t.Fatalf("expected a bare unknown type annotation to lack attribution evidence, got %#v", got)
+	}
 
 	if hasPotentialUnqualifiedSymbolUsage([]byte("import Alamofire\nlet value: URL? = nil"), singleDep) {
 		t.Fatalf("expected standard Swift symbols to be ignored")
@@ -492,6 +497,9 @@ func testSwiftUsageHeuristicSingleDependencyBranches(t *testing.T) {
 	}
 	if !hasPotentialUnqualifiedSymbolUsage([]byte("import Alamofire\nlet value = NetworkSession()"), singleDep) {
 		t.Fatalf("expected non-standard symbol usage to be detected")
+	}
+	if hasPotentialUnqualifiedSymbolUsage([]byte("import Alamofire\nlet value: UnknownResponse"), singleDep) {
+		t.Fatalf("expected a bare unknown identifier to require stronger usage evidence")
 	}
 }
 
@@ -504,6 +512,42 @@ func testSwiftUsageHeuristicCollectsLocalSymbols(t *testing.T) {
 	}
 	if _, ok := symbols[lookupKey("Runner")]; !ok {
 		t.Fatalf("expected Runner to be collected, got %#v", symbols)
+	}
+}
+
+func testSwiftUsageCandidateAttribution(t *testing.T) {
+	t.Helper()
+
+	imports := []importBinding{{Dependency: "alamofire", Module: "Alamofire", Local: "Alamofire"}}
+	candidates := collectPotentialUnqualifiedSymbols([]byte("import Alamofire\nlet first = SharedModel()\nlet second = SharedModel()\n"), imports)
+	if len(candidates) != 1 || candidates[0] != lookupKey("SharedModel") {
+		t.Fatalf("expected one deduplicated candidate, got %#v", candidates)
+	}
+
+	declared := map[string]struct{}{lookupKey("SharedModel"): {}}
+	if got := applyUnqualifiedUsageCandidates(imports, map[string]int{}, candidates, declared); len(got) != 0 {
+		t.Fatalf("expected known declaration to prevent attribution, got %#v", got)
+	}
+	if got := applyUnqualifiedUsageCandidates(imports, map[string]int{}, candidates, nil); got["Alamofire"] != 1 {
+		t.Fatalf("expected unknown candidate to seed usage, got %#v", got)
+	}
+}
+
+func testSwiftDeclarationScopes(t *testing.T) {
+	t.Helper()
+
+	tests := map[string]string{
+		"Sources/App/main.swift":      "Sources/App",
+		"Tests/AppTests/Test.swift":   "Tests/AppTests",
+		"Plugins/Build/main.swift":    "Plugins/Build",
+		"Scripts/Generate/main.swift": "Scripts/Generate",
+		"standalone.swift":            ".",
+		`Sources\Windows\main.swift`:  "Sources/Windows",
+	}
+	for filePath, want := range tests {
+		if got := swiftDeclarationScope(filePath); got != want {
+			t.Fatalf("swiftDeclarationScope(%q) = %q, want %q", filePath, got, want)
+		}
 	}
 }
 

--- a/internal/lang/swift/adapter_test.go
+++ b/internal/lang/swift/adapter_test.go
@@ -123,6 +123,37 @@ func run() {
 	}
 }
 
+func TestSwiftAdapterDoesNotCountCrossFileLocalTypeUsageAsDependencyUsage(t *testing.T) {
+	repo := t.TempDir()
+	writeSwiftDemoPackage(t, repo, []swiftFixtureDependency{swiftNIOFixtureDependency()}, `import NIO
+func render(_ model: SharedModel) {
+  print(model)
+}
+func buildModel() -> SharedModel {
+  SharedModel()
+}`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "Sources", "Demo", "SharedModel.swift"), "struct SharedModel {}\n")
+
+	reportData := mustSingleSwiftDependencyReport(t, language.Request{RepoPath: repo, Dependency: swiftNIOID})
+	if reportData.UsedExportsCount != 0 {
+		t.Fatalf("expected cross-file local symbols to not count as dependency usage, got %#v", reportData)
+	}
+}
+
+func TestSwiftAdapterKeepsUnqualifiedUsageWhenDeclarationIsInAnotherTarget(t *testing.T) {
+	repo := t.TempDir()
+	writeSwiftDemoPackage(t, repo, []swiftFixtureDependency{alamofireFixtureDependency()}, `import Alamofire
+func run() {
+  _ = Session.default
+}`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "Sources", "Other", "Session.swift"), "struct Session {}\n")
+
+	reportData := mustSingleSwiftDependencyReport(t, language.Request{RepoPath: repo, Dependency: "alamofire"})
+	if reportData.UsedExportsCount == 0 {
+		t.Fatalf("expected declarations in another target to preserve inferred dependency usage, got %#v", reportData)
+	}
+}
+
 func TestSwiftAdapterParsesResolvedVariants(t *testing.T) {
 	t.Run("v1_object_pins", func(t *testing.T) {
 		repo := t.TempDir()

--- a/internal/lang/swift/scan.go
+++ b/internal/lang/swift/scan.go
@@ -24,14 +24,16 @@ func newRepoScanner(repoPath string, catalog dependencyCatalog) *repoScanner {
 		scan.KnownDependencies[dependency] = struct{}{}
 	}
 	return &repoScanner{
-		repoPath:          repoPath,
-		catalog:           catalog,
-		scan:              scan,
-		unresolvedImports: make(map[string]int),
+		repoPath:               repoPath,
+		catalog:                catalog,
+		scan:                   scan,
+		unresolvedImports:      make(map[string]int),
+		declaredSymbolsByScope: make(map[string]map[string]struct{}),
 	}
 }
 
 func (s *repoScanner) finalize() {
+	s.applyUnqualifiedUsageHeuristics()
 	if !s.foundSwift {
 		s.scan.Warnings = append(s.scan.Warnings, "no Swift files found for analysis")
 	}

--- a/internal/lang/swift/scan_walk.go
+++ b/internal/lang/swift/scan_walk.go
@@ -52,7 +52,9 @@ func (s *repoScanner) scanSwiftFile(path string, entry fs.DirEntry) error {
 	if err != nil {
 		return err
 	}
-	s.scan.Files = append(s.scan.Files, s.buildFileScan(path, entry.Name(), content))
+	file := s.buildFileScan(path, entry.Name(), content)
+	s.scan.Files = append(s.scan.Files, file)
+	s.recordUnqualifiedUsageContext(file, content)
 	return nil
 }
 
@@ -67,7 +69,7 @@ func (s *repoScanner) buildFileScan(path string, fallback string, content []byte
 	return fileScan{
 		Path:    relPath,
 		Imports: mappedImports,
-		Usage:   applyUnqualifiedUsageHeuristic(content, mappedImports, shared.CountUsage(content, mappedImports)),
+		Usage:   shared.CountUsage(content, mappedImports),
 	}
 }
 

--- a/internal/lang/swift/types.go
+++ b/internal/lang/swift/types.go
@@ -63,14 +63,21 @@ type scanResult struct {
 	ImportedDependencies map[string]struct{}
 }
 
+type unqualifiedUsageContext struct {
+	scope      string
+	candidates []string
+}
+
 type repoScanner struct {
-	repoPath          string
-	catalog           dependencyCatalog
-	scan              scanResult
-	unresolvedImports map[string]int
-	foundSwift        bool
-	skippedLargeFiles int
-	visited           int
+	repoPath                 string
+	catalog                  dependencyCatalog
+	scan                     scanResult
+	unresolvedImports        map[string]int
+	declaredSymbolsByScope   map[string]map[string]struct{}
+	unqualifiedUsageContexts []unqualifiedUsageContext
+	foundSwift               bool
+	skippedLargeFiles        int
+	visited                  int
 }
 
 type swiftStringScanState struct {

--- a/internal/lang/swift/usage_heuristics.go
+++ b/internal/lang/swift/usage_heuristics.go
@@ -125,8 +125,38 @@ func lineHasPotentialUnqualifiedSymbolUsage(line string, importModules map[strin
 }
 
 func hasUnqualifiedUsageEvidence(afterSymbol string) bool {
-	afterSymbol = strings.TrimLeft(afterSymbol, " \t")
-	return strings.HasPrefix(afterSymbol, ".") || strings.HasPrefix(afterSymbol, "(")
+	trimmed := strings.TrimLeft(afterSymbol, " \t")
+	if strings.HasPrefix(trimmed, ".") || strings.HasPrefix(trimmed, "(") {
+		return true
+	}
+	if !strings.HasPrefix(afterSymbol, "<") {
+		return false
+	}
+	afterSpecialization, ok := trimSwiftGenericSpecialization(afterSymbol)
+	if !ok {
+		return false
+	}
+	afterSpecialization = strings.TrimLeft(afterSpecialization, " \t")
+	return strings.HasPrefix(afterSpecialization, ".") || strings.HasPrefix(afterSpecialization, "(")
+}
+
+func trimSwiftGenericSpecialization(value string) (string, bool) {
+	depth := 0
+	for index, symbol := range value {
+		switch symbol {
+		case '<':
+			depth++
+		case '>':
+			if index > 0 && value[index-1] == '-' {
+				continue
+			}
+			depth--
+			if depth == 0 {
+				return value[index+1:], true
+			}
+		}
+	}
+	return "", false
 }
 
 func isIgnoredUnqualifiedSymbol(key string, importModules map[string]struct{}, localDeclaredSymbols map[string]struct{}) bool {

--- a/internal/lang/swift/usage_heuristics.go
+++ b/internal/lang/swift/usage_heuristics.go
@@ -3,6 +3,10 @@ package swift
 import "strings"
 
 func applyUnqualifiedUsageHeuristic(content []byte, imports []importBinding, usage map[string]int) map[string]int {
+	return applyUnqualifiedUsageCandidates(imports, usage, collectPotentialUnqualifiedSymbols(content, imports), nil)
+}
+
+func applyUnqualifiedUsageCandidates(imports []importBinding, usage map[string]int, candidates []string, declaredSymbols map[string]struct{}) map[string]int {
 	if len(imports) == 0 {
 		return usage
 	}
@@ -18,28 +22,51 @@ func applyUnqualifiedUsageHeuristic(content []byte, imports []importBinding, usa
 		if hasQualifiedImportUsage(importsForDependency, usage) {
 			return usage
 		}
-		if !hasPotentialUnqualifiedSymbolUsage(content, importsForDependency) {
+		for _, candidate := range candidates {
+			if _, locallyDeclared := declaredSymbols[candidate]; locallyDeclared {
+				continue
+			}
+			seedUnqualifiedUsage(importsForDependency, usage)
 			return usage
 		}
-		seedUnqualifiedUsage(importsForDependency, usage)
 	}
 	return usage
 }
 
 func hasPotentialUnqualifiedSymbolUsage(content []byte, imports []importBinding) bool {
+	return len(collectPotentialUnqualifiedSymbols(content, imports)) > 0
+}
+
+func collectPotentialUnqualifiedSymbols(content []byte, imports []importBinding) []string {
+	return collectPotentialUnqualifiedSymbolsWithDeclarations(content, imports, collectLocalDeclaredSymbols(content))
+}
+
+func collectPotentialUnqualifiedSymbolsWithDeclarations(content []byte, imports []importBinding, localDeclaredSymbols map[string]struct{}) []string {
 	importModules := importedModuleSet(imports)
-	localDeclaredSymbols := collectLocalDeclaredSymbols(content)
+	seen := make(map[string]struct{})
+	potential := make([]string, 0)
 	lines := swiftSymbolScanLines(content)
 	for _, rawLine := range lines {
 		line := strings.TrimSpace(rawLine)
 		if line == "" || swiftImportPattern.MatchString(line) {
 			continue
 		}
-		if lineHasPotentialUnqualifiedSymbolUsage(line, importModules, localDeclaredSymbols) {
-			return true
+		for _, location := range swiftUpperIdentifierPattern.FindAllStringIndex(line, -1) {
+			if !hasUnqualifiedUsageEvidence(line[location[1]:]) {
+				continue
+			}
+			key := lookupKey(line[location[0]:location[1]])
+			if isIgnoredUnqualifiedSymbol(key, importModules, localDeclaredSymbols) {
+				continue
+			}
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+			potential = append(potential, key)
 		}
 	}
-	return false
+	return potential
 }
 
 func importsByDependency(imports []importBinding) map[string][]importBinding {
@@ -83,15 +110,23 @@ func importedModuleSet(imports []importBinding) map[string]struct{} {
 }
 
 func lineHasPotentialUnqualifiedSymbolUsage(line string, importModules map[string]struct{}, localDeclaredSymbols map[string]struct{}) bool {
-	symbols := swiftUpperIdentifierPattern.FindAllString(line, -1)
-	for _, symbol := range symbols {
-		key := lookupKey(symbol)
+	locations := swiftUpperIdentifierPattern.FindAllStringIndex(line, -1)
+	for _, location := range locations {
+		if !hasUnqualifiedUsageEvidence(line[location[1]:]) {
+			continue
+		}
+		key := lookupKey(line[location[0]:location[1]])
 		if isIgnoredUnqualifiedSymbol(key, importModules, localDeclaredSymbols) {
 			continue
 		}
 		return true
 	}
 	return false
+}
+
+func hasUnqualifiedUsageEvidence(afterSymbol string) bool {
+	afterSymbol = strings.TrimLeft(afterSymbol, " \t")
+	return strings.HasPrefix(afterSymbol, ".") || strings.HasPrefix(afterSymbol, "(")
 }
 
 func isIgnoredUnqualifiedSymbol(key string, importModules map[string]struct{}, localDeclaredSymbols map[string]struct{}) bool {
@@ -131,4 +166,46 @@ func collectLocalDeclaredSymbols(content []byte) map[string]struct{} {
 		}
 	}
 	return localDeclaredSymbols
+}
+
+func (s *repoScanner) recordUnqualifiedUsageContext(file fileScan, content []byte) {
+	if s.declaredSymbolsByScope == nil {
+		s.declaredSymbolsByScope = make(map[string]map[string]struct{})
+	}
+	scope := swiftDeclarationScope(file.Path)
+	declared := s.declaredSymbolsByScope[scope]
+	if declared == nil {
+		declared = make(map[string]struct{})
+		s.declaredSymbolsByScope[scope] = declared
+	}
+	localDeclaredSymbols := collectLocalDeclaredSymbols(content)
+	for symbol := range localDeclaredSymbols {
+		declared[symbol] = struct{}{}
+	}
+	s.unqualifiedUsageContexts = append(s.unqualifiedUsageContexts, unqualifiedUsageContext{
+		scope:      scope,
+		candidates: collectPotentialUnqualifiedSymbolsWithDeclarations(content, file.Imports, localDeclaredSymbols),
+	})
+}
+
+func (s *repoScanner) applyUnqualifiedUsageHeuristics() {
+	for i := range s.scan.Files {
+		if i >= len(s.unqualifiedUsageContexts) {
+			return
+		}
+		file := &s.scan.Files[i]
+		context := s.unqualifiedUsageContexts[i]
+		file.Usage = applyUnqualifiedUsageCandidates(file.Imports, file.Usage, context.candidates, s.declaredSymbolsByScope[context.scope])
+	}
+}
+
+func swiftDeclarationScope(filePath string) string {
+	parts := strings.Split(strings.ReplaceAll(filePath, "\\", "/"), "/")
+	if len(parts) >= 2 && (parts[0] == "Sources" || parts[0] == "Tests" || parts[0] == "Plugins") {
+		return strings.Join(parts[:2], "/")
+	}
+	if len(parts) <= 1 {
+		return "."
+	}
+	return strings.Join(parts[:len(parts)-1], "/")
 }


### PR DESCRIPTION
## Summary

Prevent Swift package-local types declared in another source file from being misattributed to a third-party import, while retaining conservative evidence for real unqualified dependency usage.

Closes #1162.

## Changes

- collect local Swift type declarations by target-like scope before applying unqualified usage inference
- require constructor-call or static-member syntax before an otherwise unknown capitalized identifier can seed dependency usage
- preserve inference when a same-named declaration belongs to another Swift target
- cover cross-file constructors, bare type annotations, same-file declarations, and genuine static-member usage with regression tests

## Validation

Commands and checks run:

```bash
GOTOOLCHAIN=go1.26.5 go test ./internal/lang/swift -count=1 -coverprofile=/tmp/swift-1162.cover
make lint
make ci
make demos-check
```

Additional manual validation:

- reproduced the reported two-file Swift package before the fix and confirmed `usedExportsCount` changed from `1` to `0` after the fix
- verified an Alamofire `Session.default` reference remains attributed when a same-named declaration exists in another target

## Risk and compatibility

- Breaking changes: none; this removes false-positive Swift dependency usage only
- Migration required: none
- Performance impact: one deferred target-scope declaration pass over already-sanitized per-file symbol metadata; no source contents are retained
- Memory benchmark impact: no regression; the repository memory benchmark gate passed on the final rebased head

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
