### PR TITLE
feat(baseline): add safe snapshot discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,20 @@ lopper analyse --top 20 \
   --threshold-fail-on-increase 2
 ```
 
+List the newest saved snapshots, or inspect one without printing its full report payload. Baseline discovery is preview-gated in v1.8.x:
+
+```bash
+lopper baseline list \
+  --store .artifacts/lopper-baselines \
+  --limit 20 \
+  --enable-feature baseline-store-discovery-preview
+
+lopper baseline show label:release-candidate \
+  --store .artifacts/lopper-baselines \
+  --format json \
+  --enable-feature baseline-store-discovery-preview
+```
+
 Attach local vulnerability advisories for reachability-weighted security triage:
 
 ```bash

--- a/docs/man/lopper.1
+++ b/docs/man/lopper.1
@@ -8,6 +8,8 @@ lopper tui [--repo PATH] [--language auto|all|js-ts|python|cpp|jvm|kotlin-androi
 lopper analyse --top N [options]
 lopper analyse <dependency> [options]
 lopper dashboard [--repos PATH1,PATH2 | --config PATH]
+lopper baseline list [options]
+lopper baseline show KEY [options]
 lopper profile apply strict|balanced|noise-reduction [options]
 lopper mcp
 .fi
@@ -22,6 +24,8 @@ Usage and options:
   lopper analyse --top N [--repo PATH] [--scope-mode repo|package|changed-packages] [--format table|csv|json|sarif|pr-comment|cyclonedx-json] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--cache=true|false] [--cache-path PATH] [--cache-readonly] [--runtime-profile node-import|node-require|browser-import|browser-require] [--baseline PATH] [--baseline-store DIR] [--baseline-key KEY] [--save-baseline] [--baseline-label LABEL] [--runtime-trace PATH] [--runtime-test-command CMD] [--advisory-source PATH] [--config PATH] [--include GLOBS] [--exclude GLOBS] [--lockfile-drift-policy off|warn|fail] [--license-deny SPDXS] [--license-fail-on-deny] [--license-provenance-registry] [--notify-on always|breach|regression|improvement] [--notify-slack URL] [--notify-teams URL] [--enable-feature NAME] [--disable-feature NAME] [--fail-on-increase PERCENT]
   lopper dashboard --repos PATH1,PATH2 [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline] [--enable-feature NAME] [--disable-feature NAME]
   lopper dashboard --config lopper-org.yml [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline] [--enable-feature NAME] [--disable-feature NAME]
+  lopper baseline list [--store DIR] [--format table|json] [--limit N] [--enable-feature baseline-store-discovery-preview]
+  lopper baseline show KEY [--store DIR] [--format table|json] [--enable-feature baseline-store-discovery-preview]
   lopper features [--format table|json] [--channel dev|rolling|release] [--release VERSION]
   lopper profile apply strict|balanced|noise-reduction [--output PATH] [--force] [--enable-feature threshold-profiles]
   lopper mcp
@@ -59,6 +63,8 @@ Options:
   --baseline-key KEY         Baseline snapshot key for dashboard comparison
   --baseline-label LABEL     Label key to use when saving dashboard baselines
   --save-baseline            Save current dashboard run as an immutable baseline snapshot
+  --store DIR                Baseline discovery store (default: .artifacts/lopper-baselines)
+  --limit N                  Maximum snapshots returned by baseline list (default: 50)
   --include GLOBS            Comma-separated include path globs (repeatable; CLI overrides config scope.include)
   --exclude GLOBS            Comma-separated exclude path globs (repeatable; CLI overrides config scope.exclude)
   --suggest-only             Generate deterministic patch previews for safe remediation suggestions

--- a/docs/report-schema.md
+++ b/docs/report-schema.md
@@ -159,4 +159,4 @@ CycloneDX characteristics:
   findings under `baselineComparison.newReachableVulnerabilities`.
 - Stored reports or baselines created before the mutually exclusive license-bucket summary should be regenerated, or consumers should recompute `summary` from `dependencies`, before comparing license deltas.
 - `schemaVersion` is currently pinned to `0.1.0`.
-- Baseline snapshots created with `--save-baseline --baseline-store DIR` are stored as immutable files keyed by `commit:<sha>` (default) or `label:<name>` when `--baseline-label` is passed.
+- Baseline snapshots created with `--save-baseline --baseline-store DIR` are stored as immutable files keyed by `commit:<sha>` (default) or `label:<name>` when `--baseline-label` is passed. `lopper baseline list` and `lopper baseline show KEY` expose bounded snapshot metadata when `baseline-store-discovery-preview` is enabled; they do not print dependency rows from the stored report.

--- a/internal/app/analyse_postprocess.go
+++ b/internal/app/analyse_postprocess.go
@@ -21,7 +21,13 @@ func (a *App) applyBaselineIfNeeded(reportData report.Report, repoPath string, r
 		return reportData, nil
 	}
 
-	baseline, loadedKey, err := report.LoadWithKey(baselinePath)
+	var baseline report.Report
+	var loadedKey string
+	if strings.TrimSpace(baselineKey) != "" {
+		baseline, loadedKey, _, err = report.LoadSnapshot(req.BaselineStorePath, baselineKey)
+	} else {
+		baseline, loadedKey, err = report.LoadWithKey(baselinePath)
+	}
 	if err != nil && isBootstrapableMissingBaseline(req, err) {
 		return reportData, nil
 	}
@@ -60,7 +66,7 @@ func resolveBaselineComparisonPaths(repoPath string, req AnalyseRequest) (string
 		return strings.TrimSpace(req.BaselinePath), "", resolveCurrentBaselineKey(repoPath), true, nil
 	}
 
-	return resolveBaselineStoreComparisonPaths(repoPath, baselineKeyRequestFromAnalyse(req), report.BaselineSnapshotPath)
+	return resolveBaselineStoreComparisonPaths(repoPath, baselineKeyRequestFromAnalyse(req), report.ResolveBaselineSnapshotPath)
 }
 
 func (a *App) saveBaselineIfNeeded(reportData report.Report, repoPath string, req AnalyseRequest, now time.Time) (report.Report, error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,6 +26,7 @@ var (
 	ErrCodemodApplyFailed           = errors.New("codemod apply failed")
 	ErrMCPFeatureDisabled           = errors.New("mcp server feature is disabled")
 	ErrProfileFeatureDisabled       = errors.New("threshold profile command feature is disabled; enable threshold-profiles with --enable-feature")
+	ErrBaselineFeatureDisabled      = errors.New("baseline discovery feature is disabled; enable baseline-store-discovery-preview with --enable-feature")
 )
 
 type App struct {
@@ -66,6 +67,8 @@ func (a *App) Execute(ctx context.Context, req Request) (string, error) {
 		return a.executeAnalyse(ctx, req)
 	case ModeDashboard:
 		return a.executeDashboard(ctx, req)
+	case ModeBaseline:
+		return a.executeBaseline(req)
 	case ModeFeatures:
 		return a.executeFeatures(req)
 	case ModeProfile:

--- a/internal/app/app_save_baseline_test.go
+++ b/internal/app/app_save_baseline_test.go
@@ -95,7 +95,7 @@ func TestResolveBaselineComparisonPathsBranches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("baseline store branch: %v", err)
 	}
-	if !shouldApply || key != "label:weekly" || !strings.HasSuffix(path, "label_weekly.json") {
+	if !shouldApply || key != "label:weekly" || path != report.ResolveBaselineSnapshotPath(baselineStorePath, key) {
 		t.Fatalf("unexpected baseline-store resolution: path=%q key=%q shouldApply=%v", path, key, shouldApply)
 	}
 	if currentKey == "" {

--- a/internal/app/baseline.go
+++ b/internal/app/baseline.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/terminal"
+)
+
+const BaselineStoreDiscoveryPreviewFeature = "baseline-store-discovery-preview"
+
+func (a *App) executeBaseline(req Request) (string, error) {
+	if !req.Baseline.Features.Enabled(BaselineStoreDiscoveryPreviewFeature) {
+		return "", ErrBaselineFeatureDisabled
+	}
+	format := strings.ToLower(strings.TrimSpace(req.Baseline.Format))
+	if format != "table" && format != "json" {
+		return "", fmt.Errorf("invalid baseline format: %s", req.Baseline.Format)
+	}
+	switch req.Baseline.Action {
+	case "list":
+		catalog, err := report.ListBaselineSnapshots(req.Baseline.StorePath, req.Baseline.Limit)
+		if err != nil {
+			return "", err
+		}
+		if format == "json" {
+			return formatBaselineJSON(catalog)
+		}
+		return formatBaselineCatalog(catalog), nil
+	case "show":
+		metadata, err := report.InspectBaselineSnapshot(req.Baseline.StorePath, req.Baseline.Key)
+		if err != nil {
+			return "", err
+		}
+		if format == "json" {
+			return formatBaselineJSON(metadata)
+		}
+		return formatBaselineMetadata(metadata), nil
+	default:
+		return "", fmt.Errorf("unknown baseline action: %s", req.Baseline.Action)
+	}
+}
+
+func formatBaselineJSON(value any) (string, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data) + "\n", nil
+}
+
+func formatBaselineCatalog(catalog report.BaselineCatalog) string {
+	var output strings.Builder
+	if len(catalog.Snapshots) == 0 {
+		fmt.Fprintf(&output, "No baseline snapshots found in %s.\n", terminal.SanitizeString(catalog.Store))
+	} else {
+		output.WriteString("TYPE\tKEY\tCREATED\tBASELINE SCHEMA\tREPORT SCHEMA\tREPO\tDEPS\tUSED\n")
+		for _, snapshot := range catalog.Snapshots {
+			fmt.Fprintf(&output, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d/%d\n", snapshot.KeyType, terminal.SanitizeString(snapshot.Key), snapshot.CreatedAt.Format("2006-01-02T15:04:05Z"), terminal.SanitizeString(snapshot.BaselineSchemaVersion), terminal.SanitizeString(snapshot.ReportSchemaVersion), terminal.SanitizeString(snapshot.RepoIdentity), snapshot.Summary.DependencyCount, snapshot.Summary.UsedExportsCount, snapshot.Summary.TotalExportsCount)
+		}
+	}
+	if len(catalog.Diagnostics) > 0 {
+		output.WriteString("Diagnostics:\n")
+		for _, diagnostic := range catalog.Diagnostics {
+			fmt.Fprintf(&output, "- %s: %s\n", terminal.SanitizeString(diagnostic.File), terminal.SanitizeString(diagnostic.Error))
+		}
+	}
+	return output.String()
+}
+
+func formatBaselineMetadata(snapshot report.BaselineSnapshotMetadata) string {
+	var output strings.Builder
+	fmt.Fprintf(&output, "Key: %s\n", terminal.SanitizeString(snapshot.Key))
+	fmt.Fprintf(&output, "Type: %s\n", snapshot.KeyType)
+	if snapshot.Label != "" {
+		fmt.Fprintf(&output, "Label: %s\n", terminal.SanitizeString(snapshot.Label))
+	}
+	if snapshot.Commit != "" {
+		fmt.Fprintf(&output, "Commit: %s\n", terminal.SanitizeString(snapshot.Commit))
+	}
+	fmt.Fprintf(&output, "Created: %s\n", snapshot.CreatedAt.Format("2006-01-02T15:04:05Z"))
+	fmt.Fprintf(&output, "Baseline schema: %s\n", terminal.SanitizeString(snapshot.BaselineSchemaVersion))
+	fmt.Fprintf(&output, "Report schema: %s\n", terminal.SanitizeString(snapshot.ReportSchemaVersion))
+	fmt.Fprintf(&output, "Repository: %s\n", terminal.SanitizeString(snapshot.RepoIdentity))
+	fmt.Fprintf(&output, "Dependencies: %d\n", snapshot.Summary.DependencyCount)
+	fmt.Fprintf(&output, "Used exports: %d/%d (%.2f%%)\n", snapshot.Summary.UsedExportsCount, snapshot.Summary.TotalExportsCount, snapshot.Summary.UsedPercent)
+	fmt.Fprintf(&output, "Licenses: %d known, %d unknown, %d denied\n", snapshot.Summary.KnownLicenseCount, snapshot.Summary.UnknownLicenseCount, snapshot.Summary.DeniedLicenseCount)
+	return output.String()
+}

--- a/internal/app/baseline_test.go
+++ b/internal/app/baseline_test.go
@@ -1,0 +1,230 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	baselineutil "github.com/ben-ranford/lopper/internal/baseline"
+	"github.com/ben-ranford/lopper/internal/featureflags"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestExecuteBaselineList(t *testing.T) {
+	t.Parallel()
+
+	dir := saveBaselineDiscoveryFixtures(t)
+	application := &App{}
+	req := baselineDiscoveryRequest(t, dir)
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute baseline list: %v", err)
+	}
+	if !strings.Contains(output, "TYPE") || !strings.Contains(output, "label:nightly") || strings.Contains(output, "commit:abc123") {
+		t.Fatalf("unexpected newest-first limited table: %s", output)
+	}
+
+	req.Baseline.Format = "json"
+	output, err = application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute baseline JSON list: %v", err)
+	}
+	if !strings.Contains(output, `"keyType": "label"`) || !strings.Contains(output, `"dependencyCount": 1`) {
+		t.Fatalf("missing JSON metadata: %s", output)
+	}
+	if strings.Contains(output, "private-dependency-row") {
+		t.Fatalf("baseline list dumped dependency report content: %s", output)
+	}
+}
+
+func TestExecuteBaselineShow(t *testing.T) {
+	t.Parallel()
+
+	dir := saveBaselineDiscoveryFixtures(t)
+	application := &App{}
+	req := baselineDiscoveryRequest(t, dir)
+	req.Baseline.Action = "show"
+	req.Baseline.Key = "commit:abc123"
+	req.Baseline.Format = "table"
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute baseline show: %v", err)
+	}
+	for _, want := range []string{"Key: commit:abc123", "Type: commit", "Commit: abc123", "Repository: /repo/app", "Dependencies: 1"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("show output missing %q: %s", want, output)
+		}
+	}
+	if strings.Contains(output, "old-dependency") {
+		t.Fatalf("baseline show dumped dependency report content: %s", output)
+	}
+
+	req.Baseline.Key = "label:nightly"
+	req.Baseline.Format = "json"
+	output, err = application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute baseline JSON show: %v", err)
+	}
+	if !strings.Contains(output, `"label": "nightly"`) || strings.Contains(output, "private-dependency-row") {
+		t.Fatalf("unexpected JSON show output: %s", output)
+	}
+}
+
+func saveBaselineDiscoveryFixtures(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	older := time.Date(2026, time.July, 10, 1, 0, 0, 0, time.UTC)
+	if _, err := report.SaveSnapshot(dir, "commit:abc123", appBaselineReport(older, "old-dependency"), older); err != nil {
+		t.Fatalf("save commit baseline: %v", err)
+	}
+	newer := older.Add(time.Hour)
+	if _, err := report.SaveSnapshot(dir, "label:nightly", appBaselineReport(newer, "private-dependency-row"), newer); err != nil {
+		t.Fatalf("save label baseline: %v", err)
+	}
+	return dir
+}
+
+func baselineDiscoveryRequest(t *testing.T, dir string) Request {
+	t.Helper()
+	req := DefaultRequest()
+	req.Mode = ModeBaseline
+	req.Baseline.Action = "list"
+	req.Baseline.StorePath = dir
+	req.Baseline.Limit = 1
+	req.Baseline.Features = enabledBaselineDiscovery(t)
+	return req
+}
+
+func TestExecuteBaselineValidationAndEmptyStore(t *testing.T) {
+	t.Parallel()
+
+	application := &App{}
+	req := DefaultRequest()
+	req.Mode = ModeBaseline
+	req.Baseline.Action = "list"
+	req.Baseline.StorePath = filepath.Join(t.TempDir(), "missing")
+
+	if _, err := application.Execute(context.Background(), req); !errors.Is(err, ErrBaselineFeatureDisabled) {
+		t.Fatalf("expected disabled preview error, got %v", err)
+	}
+	req.Baseline.Features = enabledBaselineDiscovery(t)
+	output, err := application.Execute(context.Background(), req)
+	if err != nil || !strings.Contains(output, "No baseline snapshots found") {
+		t.Fatalf("expected safe empty-store output, output=%q err=%v", output, err)
+	}
+
+	req.Baseline.Format = "yaml"
+	if _, err := application.Execute(context.Background(), req); err == nil || !strings.Contains(err.Error(), "invalid baseline format") {
+		t.Fatalf("expected invalid format error, got %v", err)
+	}
+	req.Baseline.Format = "table"
+	req.Baseline.Limit = 0
+	if _, err := application.Execute(context.Background(), req); err == nil || !strings.Contains(err.Error(), "limit must be greater than zero") {
+		t.Fatalf("expected invalid list limit error, got %v", err)
+	}
+	req.Baseline.Limit = 50
+	req.Baseline.Action = "unknown"
+	if _, err := application.Execute(context.Background(), req); err == nil || !strings.Contains(err.Error(), "unknown baseline action") {
+		t.Fatalf("expected unknown action error, got %v", err)
+	}
+	req.Baseline.Action = "show"
+	req.Baseline.Key = "label:missing"
+	if _, err := application.Execute(context.Background(), req); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected safe missing snapshot error, got %v", err)
+	}
+	if _, err := formatBaselineJSON(make(chan int)); err == nil {
+		t.Fatalf("expected unsupported JSON value error")
+	}
+}
+
+func TestFormatBaselineCatalogDiagnosticsAndCustomMetadata(t *testing.T) {
+	t.Parallel()
+
+	catalog := report.BaselineCatalog{
+		Store:     "store\x1b",
+		Snapshots: []report.BaselineSnapshotMetadata{},
+		Diagnostics: []report.BaselineStoreDiagnostic{
+			{File: "bad\x1b.json", Error: "corrupt\x1b"},
+		},
+	}
+	output := formatBaselineCatalog(catalog)
+	if !strings.Contains(output, "No baseline snapshots") || !strings.Contains(output, "Diagnostics:") || !strings.Contains(output, `bad\x1b.json: corrupt\x1b`) || strings.ContainsRune(output, '\x1b') {
+		t.Fatalf("unexpected diagnostic catalog output: %s", output)
+	}
+	metadata := report.BaselineSnapshotMetadata{
+		Key: "owner:nightly", KeyType: "custom", CreatedAt: time.Date(2026, time.July, 10, 1, 0, 0, 0, time.UTC),
+		Summary: report.Summary{},
+	}
+	output = formatBaselineMetadata(metadata)
+	if !strings.Contains(output, "Type: custom") || strings.Contains(output, "Label:") || strings.Contains(output, "Commit:") {
+		t.Fatalf("unexpected custom metadata output: %s", output)
+	}
+	metadata.Key = "label:nightly\x1b"
+	metadata.KeyType = "label"
+	metadata.Label = "nightly\x1b"
+	output = formatBaselineMetadata(metadata)
+	if !strings.Contains(output, `Label: nightly\x1b`) || strings.ContainsRune(output, '\x1b') {
+		t.Fatalf("expected human label metadata: %s", output)
+	}
+}
+
+func TestAnalyseBaselineStoreRejectsLegacyKeyCollision(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2026, time.July, 10, 1, 0, 0, 0, time.UTC)
+	newPath, err := report.SaveSnapshot(dir, "label:a/b", appBaselineReport(now, "dep"), now)
+	if err != nil {
+		t.Fatalf("save collision fixture: %v", err)
+	}
+	legacyPath := baselineutil.LegacySnapshotPath(dir, "label:a/b")
+	if err := os.Rename(newPath, legacyPath); err != nil {
+		t.Fatalf("move fixture to legacy path: %v", err)
+	}
+
+	current := appBaselineReport(now.Add(time.Hour), "dep")
+	application := &App{Formatter: report.NewFormatter()}
+	if _, err := application.applyBaselineIfNeeded(current, ".", AnalyseRequest{
+		BaselineStorePath: dir,
+		BaselineKey:       "label:a?b",
+		Format:            report.FormatJSON,
+	}); !errors.Is(err, report.ErrBaselineKeyMismatch) {
+		t.Fatalf("expected legacy filename collision mismatch, got %v", err)
+	}
+	if _, err := application.applyBaselineIfNeeded(current, ".", AnalyseRequest{
+		BaselineStorePath: dir,
+		BaselineKey:       "label:a/b",
+		Format:            report.FormatJSON,
+	}); err != nil {
+		t.Fatalf("expected matching legacy key comparison to remain compatible, got %v", err)
+	}
+}
+
+func enabledBaselineDiscovery(t *testing.T) featureflags.Set {
+	t.Helper()
+	features, err := featureflags.DefaultRegistry().Resolve(featureflags.ResolveOptions{Enable: []string{BaselineStoreDiscoveryPreviewFeature}})
+	if err != nil {
+		t.Fatalf("resolve baseline discovery feature: %v", err)
+	}
+	return features
+}
+
+func appBaselineReport(generatedAt time.Time, dependency string) report.Report {
+	return report.Report{
+		SchemaVersion: report.SchemaVersion,
+		GeneratedAt:   generatedAt,
+		RepoPath:      "/repo/app",
+		Dependencies: []report.DependencyReport{{
+			Language:          "go",
+			Name:              dependency,
+			UsedExportsCount:  1,
+			TotalExportsCount: 2,
+			UsedPercent:       50,
+		}},
+	}
+}

--- a/internal/app/dashboard.go
+++ b/internal/app/dashboard.go
@@ -46,7 +46,7 @@ func (a *App) executeDashboard(ctx context.Context, req Request) (string, error)
 }
 
 func (a *App) applyDashboardBaselineIfNeeded(reportData dashboard.Report, repoPath string, resolved resolvedDashboardRequest, includeRemediationQueue bool) (dashboard.Report, error) {
-	baselinePath, baselineKey, currentKey, shouldApply, err := resolveDashboardBaselinePaths(repoPath, resolved)
+	_, baselineKey, currentKey, shouldApply, err := resolveDashboardBaselinePaths(repoPath, resolved)
 	if err != nil {
 		return reportData, err
 	}
@@ -54,7 +54,7 @@ func (a *App) applyDashboardBaselineIfNeeded(reportData dashboard.Report, repoPa
 		return reportData, nil
 	}
 
-	baseline, loadedKey, err := dashboard.LoadWithKey(baselinePath)
+	baseline, loadedKey, _, err := dashboard.LoadSnapshot(resolved.baselineStorePath, baselineKey)
 	if err != nil {
 		if resolved.saveBaseline && errors.Is(err, os.ErrNotExist) {
 			return reportData, nil
@@ -83,7 +83,7 @@ func (a *App) saveDashboardBaselineIfNeeded(reportData dashboard.Report, repoPat
 }
 
 func resolveDashboardBaselinePaths(repoPath string, resolved resolvedDashboardRequest) (string, string, string, bool, error) {
-	return resolveBaselineStoreComparisonPaths(repoPath, baselineKeyRequestFromDashboard(resolved), dashboard.BaselineSnapshotPath)
+	return resolveBaselineStoreComparisonPaths(repoPath, baselineKeyRequestFromDashboard(resolved), dashboard.ResolveBaselineSnapshotPath)
 }
 
 func appendDashboardBaselineSaveWarning(reportData dashboard.Report, savedPath string) dashboard.Report {

--- a/internal/app/tui_actions_test.go
+++ b/internal/app/tui_actions_test.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/report"
@@ -53,7 +52,7 @@ func TestTUIActionRunnerSavesBaselineWithLabel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("save baseline action: %v", err)
 	}
-	if !strings.Contains(savedPath, "label_nightly.json") {
+	if savedPath != report.BaselineSnapshotPath(store, "label:nightly") {
 		t.Fatalf("expected label-based snapshot path, got %q", savedPath)
 	}
 	if _, err := os.Stat(savedPath); err != nil {

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -14,6 +14,7 @@ const (
 	ModeTUI       Mode = "tui"
 	ModeAnalyse   Mode = "analyse"
 	ModeDashboard Mode = "dashboard"
+	ModeBaseline  Mode = "baseline"
 	ModeFeatures  Mode = "features"
 	ModeProfile   Mode = "profile"
 	ModeMCP       Mode = "mcp"
@@ -29,6 +30,7 @@ type Request struct {
 	Analyse   AnalyseRequest
 	TUI       TUIRequest
 	Dashboard DashboardRequest
+	Baseline  BaselineRequest
 	Features  FeaturesRequest
 	Profile   ProfileRequest
 	MCP       MCPRequest
@@ -98,6 +100,15 @@ type DashboardRequest struct {
 	Features          featureflags.Set
 }
 
+type BaselineRequest struct {
+	Action    string
+	StorePath string
+	Key       string
+	Format    string
+	Limit     int
+	Features  featureflags.Set
+}
+
 type FeaturesRequest struct {
 	Format     string
 	OutputPath string
@@ -138,6 +149,11 @@ func DefaultRequest() Request {
 		Dashboard: DashboardRequest{
 			TopN:            20,
 			DefaultLanguage: "auto",
+		},
+		Baseline: BaselineRequest{
+			StorePath: ".artifacts/lopper-baselines",
+			Format:    "table",
+			Limit:     50,
 		},
 		Features: FeaturesRequest{
 			Format: "table",

--- a/internal/baseline/store.go
+++ b/internal/baseline/store.go
@@ -1,16 +1,53 @@
 package baseline
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
+const (
+	maxSnapshotSlugLength = 80
+	MaxSnapshotBytes      = 64 * 1024 * 1024
+)
+
+var ErrSnapshotTooLarge = errors.New("baseline snapshot exceeds size limit")
+
 func SnapshotPath(dir, key string) string {
-	return filepath.Join(strings.TrimSpace(dir), SanitizeKey(strings.TrimSpace(key))+".json")
+	return filepath.Join(strings.TrimSpace(dir), SnapshotFileName(key))
+}
+
+func SnapshotFileName(key string) string {
+	trimmedKey := strings.TrimSpace(key)
+	slug := SanitizeKey(trimmedKey)
+	if len(slug) > maxSnapshotSlugLength {
+		slug = strings.TrimRight(slug[:maxSnapshotSlugLength], "._-")
+	}
+	digest := sha256.Sum256([]byte(trimmedKey))
+	return fmt.Sprintf("%s--%x.json", slug, digest)
+}
+
+func LegacySnapshotPath(dir, key string) string {
+	return filepath.Join(strings.TrimSpace(dir), LegacySnapshotFileName(key))
+}
+
+func LegacySnapshotFileName(key string) string {
+	return SanitizeKey(strings.TrimSpace(key)) + ".json"
+}
+
+func ResolveSnapshotPath(dir, key string) string {
+	path := SnapshotPath(dir, key)
+	if _, err := os.Lstat(path); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return path
+	}
+	return LegacySnapshotPath(dir, key)
 }
 
 func SaveJSON[T any](dir, key string, existsErr error, build func(trimmedKey string) T) (path string, err error) {
@@ -18,7 +55,10 @@ func SaveJSON[T any](dir, key string, existsErr error, build func(trimmedKey str
 	if err != nil {
 		return "", err
 	}
-	if err := rejectStoreDirSymlink(trimmedDir); err != nil {
+	if err := ValidateStorePath(trimmedDir); err != nil {
+		return "", err
+	}
+	if err := rejectMatchingLegacySnapshot(trimmedDir, trimmedKey, existsErr); err != nil {
 		return "", err
 	}
 
@@ -84,27 +124,65 @@ func validateInputs(dir, key string) (string, string, error) {
 	return trimmedDir, trimmedKey, nil
 }
 
-func rejectStoreDirSymlink(dir string) error {
-	if info, err := os.Lstat(dir); err == nil && info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("baseline store directory must not be a symlink: %s", dir)
+func ValidateStorePath(dir string) error {
+	_, err := resolveStorePath(dir)
+	return err
+}
+
+func resolveStorePath(dir string) (string, error) {
+	trimmedDir := strings.TrimSpace(dir)
+	if trimmedDir == "" {
+		return "", fmt.Errorf("baseline store directory is required")
 	}
-	return nil
+	absDir, err := filepath.Abs(trimmedDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve baseline store directory: %w", err)
+	}
+
+	paths := make([]string, 0, 8)
+	for current := filepath.Clean(absDir); ; current = filepath.Dir(current) {
+		paths = append(paths, current)
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+	}
+	for index := len(paths) - 1; index >= 0; index-- {
+		path := paths[index]
+		info, statErr := os.Lstat(path)
+		if errors.Is(statErr, os.ErrNotExist) {
+			return absDir, nil
+		}
+		if statErr != nil {
+			return "", fmt.Errorf("inspect baseline store path %s: %w", path, statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			if isAllowedSystemRootSymlink(path) {
+				continue
+			}
+			return "", fmt.Errorf("baseline store path component must not be a symlink: %s", path)
+		}
+	}
+	return absDir, nil
 }
 
 func openSnapshotWriter(dir, key string, existsErr error) (*os.Root, *os.File, string, error) {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return nil, nil, "", err
 	}
+	if err := ValidateStorePath(dir); err != nil {
+		return nil, nil, "", err
+	}
 
-	sanitizedFileName := SanitizeKey(key) + ".json"
-	snapshotPath := filepath.Join(dir, sanitizedFileName)
+	fileName := SnapshotFileName(key)
+	snapshotPath := filepath.Join(dir, fileName)
 
 	root, err := os.OpenRoot(dir)
 	if err != nil {
 		return nil, nil, "", err
 	}
 
-	file, err := root.OpenFile(sanitizedFileName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	file, err := root.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		err = errors.Join(err, root.Close())
 		if errors.Is(err, os.ErrExist) && existsErr != nil {
@@ -114,4 +192,79 @@ func openSnapshotWriter(dir, key string, existsErr error) (*os.Root, *os.File, s
 	}
 
 	return root, file, snapshotPath, nil
+}
+
+func rejectMatchingLegacySnapshot(dir, key string, existsErr error) error {
+	legacyName := LegacySnapshotFileName(key)
+	data, err := ReadStoreEntry(dir, legacyName, MaxSnapshotBytes)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var identity struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal(data, &identity); err != nil || strings.TrimSpace(identity.Key) != key {
+		return nil
+	}
+	if existsErr == nil {
+		return fmt.Errorf("baseline snapshot already exists: key %q (%s)", key, filepath.Join(dir, legacyName))
+	}
+	return fmt.Errorf("%w: key %q (%s)", existsErr, key, filepath.Join(dir, legacyName))
+}
+
+func ListStoreEntries(dir string) ([]string, error) {
+	absDir, err := resolveStorePath(dir)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(absDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list baseline store: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func ReadStoreEntry(dir, name string, maxBytes int64) (data []byte, err error) {
+	absDir, err := resolveStorePath(dir)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateStoreEntryName(name); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(absDir, name)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("baseline snapshot must not be a symlink: %s", path)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("baseline snapshot must be a regular file: %s", path)
+	}
+	data, err = safeio.ReadFileUnderLimit(absDir, path, maxBytes)
+	if errors.Is(err, safeio.ErrFileTooLarge) {
+		return nil, fmt.Errorf("%w: %s", ErrSnapshotTooLarge, path)
+	}
+	return data, err
+}
+
+func validateStoreEntryName(name string) error {
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" || trimmedName == "." || filepath.Base(trimmedName) != trimmedName {
+		return fmt.Errorf("invalid baseline store entry name: %q", name)
+	}
+	return nil
 }

--- a/internal/baseline/store_symlink_darwin.go
+++ b/internal/baseline/store_symlink_darwin.go
@@ -1,0 +1,27 @@
+//go:build darwin
+
+package baseline
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func isAllowedSystemRootSymlink(path string) bool {
+	expectedTarget, ok := map[string]string{
+		"/etc": "/private/etc",
+		"/tmp": "/private/tmp",
+		"/var": "/private/var",
+	}[filepath.Clean(path)]
+	if !ok {
+		return false
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		return false
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(path), target)
+	}
+	return filepath.Clean(target) == expectedTarget
+}

--- a/internal/baseline/store_symlink_darwin_test.go
+++ b/internal/baseline/store_symlink_darwin_test.go
@@ -1,0 +1,15 @@
+//go:build darwin
+
+package baseline
+
+import "testing"
+
+func TestAllowsVerifiedDarwinSystemRootSymlinks(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{"/etc", "/tmp", "/var"} {
+		if !isAllowedSystemRootSymlink(path) {
+			t.Errorf("expected verified Darwin system alias %s to be allowed", path)
+		}
+	}
+}

--- a/internal/baseline/store_symlink_other.go
+++ b/internal/baseline/store_symlink_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package baseline
+
+func isAllowedSystemRootSymlink(string) bool {
+	return false
+}

--- a/internal/baseline/store_test.go
+++ b/internal/baseline/store_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 func TestSaveJSONWritesImmutableSnapshot(t *testing.T) {
@@ -22,7 +24,7 @@ func TestSaveJSONWritesImmutableSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SaveJSON() error = %v", err)
 	}
-	if wantSuffix := filepath.Join(dir, "label_weekly_1.json"); path != wantSuffix {
+	if wantSuffix := SnapshotPath(dir, "label:weekly/1"); path != wantSuffix {
 		t.Fatalf("SaveJSON() path = %q, want %q", path, wantSuffix)
 	}
 
@@ -146,5 +148,269 @@ func TestSanitizeKey(t *testing.T) {
 				t.Fatalf("SanitizeKey(%q) = %q, want %q", tc.key, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestSnapshotPathIsCollisionResistantAndBounded(t *testing.T) {
+	t.Parallel()
+
+	first := SnapshotPath("store", "label:a/b")
+	second := SnapshotPath("store", "label:a?b")
+	if first == second {
+		t.Fatalf("distinct keys resolved to the same snapshot path: %q", first)
+	}
+	if !strings.HasPrefix(filepath.Base(first), "label_a_b--") || !strings.HasPrefix(filepath.Base(second), "label_a_b--") {
+		t.Fatalf("expected readable slugs with digests, got %q and %q", first, second)
+	}
+
+	longKey := "label:" + strings.Repeat("a", 300)
+	if got := len(SnapshotFileName(longKey)); got > maxSnapshotSlugLength+2+64+len(".json") {
+		t.Fatalf("snapshot filename exceeded bounded length: %d", got)
+	}
+}
+
+func TestSaveJSONRejectsSymlinkedAncestorBeforeCreatingStore(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "actual")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	store := filepath.Join(link, "nested", "store")
+	if _, err := SaveJSON(store, "label:nightly", nil, func(key string) map[string]string {
+		return map[string]string{"key": key}
+	}); err == nil || !strings.Contains(err.Error(), "path component must not be a symlink") {
+		t.Fatalf("expected ancestor symlink rejection, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "nested")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("save wrote through symlinked ancestor, stat err=%v", err)
+	}
+}
+
+func TestLegacySnapshotCompatibilityAndCollisionMigration(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	legacyPath := LegacySnapshotPath(dir, "label:a/b")
+	if err := os.WriteFile(legacyPath, []byte(`{"key":"label:a/b"}`), 0o600); err != nil {
+		t.Fatalf("write legacy snapshot: %v", err)
+	}
+	if got := ResolveSnapshotPath(dir, "label:a/b"); got != legacyPath {
+		t.Fatalf("expected legacy fallback %q, got %q", legacyPath, got)
+	}
+
+	existsErr := errors.New("snapshot exists")
+	if _, err := SaveJSON(dir, "label:a/b", existsErr, func(key string) map[string]string {
+		return map[string]string{"key": key}
+	}); !errors.Is(err, existsErr) {
+		t.Fatalf("expected legacy snapshot to preserve immutability, got %v", err)
+	}
+	newPath, err := SaveJSON(dir, "label:a?b", existsErr, func(key string) map[string]string {
+		return map[string]string{"key": key}
+	})
+	if err != nil {
+		t.Fatalf("save colliding logical key with new mapping: %v", err)
+	}
+	if newPath == legacyPath || ResolveSnapshotPath(dir, "label:a?b") != newPath {
+		t.Fatalf("expected colliding key to use unique new path, legacy=%q new=%q", legacyPath, newPath)
+	}
+}
+
+func TestStoreListingAndRegularEntryRead(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "missing")
+	if names, err := ListStoreEntries(missing); err != nil || len(names) != 0 {
+		t.Fatalf("missing store should list safely, names=%v err=%v", names, err)
+	}
+
+	dir := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(dir, "b.json"), "bb")
+	testutil.MustWriteFile(t, filepath.Join(dir, "a.json"), "a")
+	if err := os.Mkdir(filepath.Join(dir, "directory.json"), 0o700); err != nil {
+		t.Fatalf("create directory entry: %v", err)
+	}
+	names, err := ListStoreEntries(dir)
+	if err != nil || len(names) != 3 || names[0] != "a.json" || names[1] != "b.json" {
+		t.Fatalf("unexpected deterministic listing: names=%v err=%v", names, err)
+	}
+	if data, err := ReadStoreEntry(dir, "a.json", 0); err != nil || string(data) != "a" {
+		t.Fatalf("read regular entry: data=%q err=%v", data, err)
+	}
+}
+
+func TestStoreEntryReadRejectsInvalidTargets(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(dir, "oversized.json"), "bb")
+	if err := os.Mkdir(filepath.Join(dir, "directory.json"), 0o700); err != nil {
+		t.Fatalf("create directory entry: %v", err)
+	}
+	if _, err := ReadStoreEntry(dir, "oversized.json", 1); !errors.Is(err, ErrSnapshotTooLarge) {
+		t.Fatalf("expected oversized entry error, got %v", err)
+	}
+	if _, err := ReadStoreEntry(dir, "directory.json", 10); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("expected directory entry rejection, got %v", err)
+	}
+	if _, err := ReadStoreEntry(dir, "../outside.json", 10); err == nil || !strings.Contains(err.Error(), "invalid baseline store entry") {
+		t.Fatalf("expected out-of-root entry rejection, got %v", err)
+	}
+}
+
+func TestStoreEntryReadRejectsSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.json")
+	testutil.MustWriteFile(t, target, "a")
+	link := filepath.Join(dir, "outside.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if _, err := ReadStoreEntry(dir, "outside.json", 10); err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("expected entry symlink rejection, got %v", err)
+	}
+}
+
+func TestStoreValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	if err := ValidateStorePath(" "); err == nil || !strings.Contains(err.Error(), "directory is required") {
+		t.Fatalf("expected empty store validation error, got %v", err)
+	}
+
+	root := t.TempDir()
+	blockingFile := filepath.Join(root, "store-file")
+	testutil.MustWriteFile(t, blockingFile, "x")
+	if _, err := ListStoreEntries(blockingFile); err == nil || !strings.Contains(err.Error(), "list baseline store") {
+		t.Fatalf("expected regular-file store listing error, got %v", err)
+	}
+	if _, err := ReadStoreEntry(filepath.Join(root, "missing"), "snapshot.json", 10); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing store entry error, got %v", err)
+	}
+	if _, err := ReadStoreEntry(root, "missing.json", 10); err == nil || strings.Count(err.Error(), "lstat") != 1 {
+		t.Fatalf("expected one lstat layer for missing entry, got %v", err)
+	}
+	if _, err := ReadStoreEntry(root, " ", 10); err == nil || !strings.Contains(err.Error(), "invalid baseline store entry") {
+		t.Fatalf("expected empty entry name error, got %v", err)
+	}
+}
+
+func TestSystemRootSymlinkAllowanceIsNarrow(t *testing.T) {
+	t.Parallel()
+
+	if isAllowedSystemRootSymlink(string(filepath.Separator) + "link") {
+		t.Fatal("arbitrary direct-root symlink must not be allowed")
+	}
+}
+
+func TestStoreValidationRejectsSymlink(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	linkedTarget := filepath.Join(root, "linked-target")
+	if err := os.Mkdir(linkedTarget, 0o700); err != nil {
+		t.Fatalf("create linked target: %v", err)
+	}
+	linkedStore := filepath.Join(root, "linked-store")
+	if err := os.Symlink(linkedTarget, linkedStore); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if _, err := ListStoreEntries(linkedStore); err == nil || !strings.Contains(err.Error(), "path component must not be a symlink") {
+		t.Fatalf("expected linked store listing rejection, got %v", err)
+	}
+	if _, err := ReadStoreEntry(linkedStore, "snapshot.json", 10); err == nil || !strings.Contains(err.Error(), "path component must not be a symlink") {
+		t.Fatalf("expected linked store read rejection, got %v", err)
+	}
+}
+
+func TestCorruptLegacyFileDoesNotBlockUniqueMapping(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	testutil.MustWriteFile(t, LegacySnapshotPath(dir, "label:corrupt"), "{")
+	if _, err := SaveJSON(dir, "label:corrupt", nil, baselineKeyPayload); err != nil {
+		t.Fatalf("corrupt legacy file should not collide with new mapping: %v", err)
+	}
+}
+
+func TestMatchingLegacyKeyReportsDefaultImmutabilityError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	testutil.MustWriteFile(t, LegacySnapshotPath(dir, "label:weekly"), `{"key":"label:weekly"}`)
+	if _, err := SaveJSON(dir, "label:weekly", nil, baselineKeyPayload); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected default immutable snapshot error, got %v", err)
+	}
+}
+
+func TestSymlinkedLegacyCandidateIsRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(t.TempDir(), "outside.json")
+	testutil.MustWriteFile(t, target, `{"key":"label:linked"}`)
+	if err := os.Symlink(target, LegacySnapshotPath(dir, "label:linked")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if _, err := SaveJSON(dir, "label:linked", nil, baselineKeyPayload); err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("expected symlinked legacy rejection, got %v", err)
+	}
+}
+
+func TestDuplicateNewPathReportsRawExistsError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if _, err := SaveJSON(dir, "label:new", nil, baselineKeyPayload); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if _, err := SaveJSON(dir, "label:new", nil, baselineKeyPayload); !errors.Is(err, os.ErrExist) {
+		t.Fatalf("expected raw exists error, got %v", err)
+	}
+}
+
+func baselineKeyPayload(key string) map[string]string {
+	return map[string]string{"key": key}
+}
+
+func TestResolveStorePathReportsAbsolutePathFailure(t *testing.T) {
+	testutil.ChdirRemovedDir(t)
+
+	_, err := resolveStorePath("relative")
+	if err == nil {
+		t.Skip("platform retains an absolute path for a removed working directory")
+	}
+	if !strings.Contains(err.Error(), "resolve baseline store directory") {
+		t.Fatalf("expected absolute path resolution error, got %v", err)
+	}
+}
+
+func TestOpenSnapshotWriterRejectsInvalidStoreTargets(t *testing.T) {
+	root := t.TempDir()
+	blockingFile := filepath.Join(root, "blocking")
+	if err := os.WriteFile(blockingFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocking file: %v", err)
+	}
+	if _, _, _, err := openSnapshotWriter(filepath.Join(blockingFile, "nested"), "label:x", nil); err == nil {
+		t.Fatalf("expected mkdir failure below regular file")
+	}
+
+	target := filepath.Join(root, "actual")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("create symlink target: %v", err)
+	}
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if _, _, _, err := openSnapshotWriter(link, "label:x", nil); err == nil || !strings.Contains(err.Error(), "path component must not be a symlink") {
+		t.Fatalf("expected post-mkdir symlink validation error, got %v", err)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -75,6 +75,8 @@ func featureDeprecationWarnings(req app.Request) []string {
 		return req.Analyse.Features.DeprecationWarnings()
 	case app.ModeDashboard:
 		return req.Dashboard.Features.DeprecationWarnings()
+	case app.ModeBaseline:
+		return req.Baseline.Features.DeprecationWarnings()
 	case app.ModeProfile:
 		return req.Profile.Features.DeprecationWarnings()
 	case app.ModeMCP:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -110,6 +110,7 @@ func TestFeatureDeprecationWarningsByMode(t *testing.T) {
 	cases := []app.Request{
 		{Mode: app.ModeAnalyse, Analyse: app.AnalyseRequest{Features: features}},
 		{Mode: app.ModeDashboard, Dashboard: app.DashboardRequest{Features: features}},
+		{Mode: app.ModeBaseline, Baseline: app.BaselineRequest{Features: features}},
 		{Mode: app.ModeProfile, Profile: app.ProfileRequest{Features: features}},
 		{Mode: app.ModeMCP, MCP: app.MCPRequest{Features: features}},
 	}
@@ -278,6 +279,9 @@ func TestUsageReturnsText(t *testing.T) {
 	}
 	if !strings.Contains(Usage(), "lopper mcp") {
 		t.Fatalf("expected usage text to include mcp command")
+	}
+	if !strings.Contains(Usage(), "lopper baseline list") || !strings.Contains(Usage(), "lopper baseline show KEY") {
+		t.Fatalf("expected usage text to include baseline discovery commands")
 	}
 	if !strings.Contains(Usage(), "--format table|csv|json|sarif|pr-comment|cyclonedx-json") {
 		t.Fatalf("expected usage text to include analyse csv format")

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -33,6 +33,8 @@ func ParseArgs(args []string) (app.Request, error) {
 		return parseAnalyse(args[1:], req)
 	case "dashboard":
 		return parseDashboard(args[1:], req)
+	case "baseline":
+		return parseBaseline(args[1:], req)
 	case "features":
 		return parseFeatures(args[1:], req)
 	case "profile":

--- a/internal/cli/parse_baseline.go
+++ b/internal/cli/parse_baseline.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/app"
+)
+
+func parseBaseline(args []string, req app.Request) (app.Request, error) {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		return req, ErrHelpRequested
+	}
+	switch strings.ToLower(strings.TrimSpace(args[0])) {
+	case "list":
+		return parseBaselineList(args[1:], req)
+	case "show":
+		return parseBaselineShow(args[1:], req)
+	default:
+		return req, fmt.Errorf("unknown baseline command: %s", args[0])
+	}
+}
+
+func parseBaselineList(args []string, req app.Request) (app.Request, error) {
+	fs, values, err := newBaselineFlagSet("baseline list", args, req)
+	if err != nil {
+		return req, err
+	}
+	limit := fs.Int("limit", req.Baseline.Limit, "maximum number of snapshots to return")
+	if err := parseFlagSet(fs, values.args); err != nil {
+		return req, err
+	}
+	if len(fs.Args()) > 0 {
+		return req, fmt.Errorf("too many arguments for baseline list")
+	}
+	if *limit <= 0 {
+		return req, fmt.Errorf("--limit must be greater than zero")
+	}
+	return finishBaselineParse(req, "list", "", *limit, values)
+}
+
+func parseBaselineShow(args []string, req app.Request) (app.Request, error) {
+	fs, values, err := newBaselineFlagSet("baseline show", args, req)
+	if err != nil {
+		return req, err
+	}
+	if err := parseFlagSet(fs, values.args); err != nil {
+		return req, err
+	}
+	positionals := fs.Args()
+	if len(positionals) == 0 {
+		return req, fmt.Errorf("baseline show requires a snapshot key")
+	}
+	if len(positionals) > 1 {
+		return req, fmt.Errorf("too many arguments for baseline show")
+	}
+	key := strings.TrimSpace(positionals[0])
+	if key == "" {
+		return req, fmt.Errorf("baseline show requires a snapshot key")
+	}
+	return finishBaselineParse(req, "show", key, req.Baseline.Limit, values)
+}
+
+type baselineFlagValues struct {
+	args            []string
+	format          *string
+	store           *string
+	baselineStore   *string
+	enableFeatures  *patternListFlag
+	disableFeatures *patternListFlag
+}
+
+func newBaselineFlagSet(name string, args []string, req app.Request) (*flag.FlagSet, baselineFlagValues, error) {
+	normalizedArgs, err := normalizeArgs(args)
+	if err != nil {
+		return nil, baselineFlagValues{}, err
+	}
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	values := baselineFlagValues{
+		args:            normalizedArgs,
+		format:          fs.String("format", req.Baseline.Format, "output format (table or json)"),
+		store:           fs.String("store", "", "baseline snapshot directory"),
+		baselineStore:   fs.String("baseline-store", "", "baseline snapshot directory"),
+		enableFeatures:  newPatternListFlag(nil),
+		disableFeatures: newPatternListFlag(nil),
+	}
+	fs.Var(values.enableFeatures, "enable-feature", "comma-separated feature flag names to enable (repeatable)")
+	fs.Var(values.disableFeatures, "disable-feature", "comma-separated feature flag names to disable (repeatable)")
+	return fs, values, nil
+}
+
+func finishBaselineParse(req app.Request, action, key string, limit int, values baselineFlagValues) (app.Request, error) {
+	storePath, err := resolveMatchingPath(*values.store, *values.baselineStore, "--store", "--baseline-store")
+	if err != nil {
+		return req, err
+	}
+	if storePath == "" {
+		storePath = req.Baseline.StorePath
+	}
+	format := strings.ToLower(strings.TrimSpace(*values.format))
+	if format != "table" && format != "json" {
+		return req, fmt.Errorf("invalid baseline format: %s", *values.format)
+	}
+	features, err := resolveFeatureRefs(values.enableFeatures.Values(), values.disableFeatures.Values())
+	if err != nil {
+		return req, err
+	}
+	req.Mode = app.ModeBaseline
+	req.Baseline = app.BaselineRequest{
+		Action:    action,
+		StorePath: strings.TrimSpace(storePath),
+		Key:       key,
+		Format:    format,
+		Limit:     limit,
+		Features:  features,
+	}
+	return req, nil
+}

--- a/internal/cli/parse_baseline_test.go
+++ b/internal/cli/parse_baseline_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/app"
+)
+
+func TestParseBaselineList(t *testing.T) {
+	t.Parallel()
+
+	req := mustParseArgs(t, []string{
+		"baseline", "list",
+		"--store", "./snapshots",
+		"--baseline-store", "./snapshots",
+		"--format", "json",
+		"--limit", "7",
+		"--enable-feature", app.BaselineStoreDiscoveryPreviewFeature,
+	})
+	if req.Mode != app.ModeBaseline || req.Baseline.Action != "list" {
+		t.Fatalf("unexpected baseline mode/action: %#v", req.Baseline)
+	}
+	if req.Baseline.StorePath != "./snapshots" || req.Baseline.Format != "json" || req.Baseline.Limit != 7 {
+		t.Fatalf("unexpected baseline list options: %#v", req.Baseline)
+	}
+	if !req.Baseline.Features.Enabled(app.BaselineStoreDiscoveryPreviewFeature) {
+		t.Fatalf("expected explicit preview feature enablement")
+	}
+}
+
+func TestParseBaselineShowAndDefaults(t *testing.T) {
+	t.Parallel()
+
+	req := mustParseArgs(t, []string{"baseline", "show", "label:nightly", "--format", "table"})
+	if req.Mode != app.ModeBaseline || req.Baseline.Action != "show" || req.Baseline.Key != "label:nightly" {
+		t.Fatalf("unexpected baseline show request: %#v", req.Baseline)
+	}
+	if req.Baseline.StorePath != ".artifacts/lopper-baselines" || req.Baseline.Limit != 50 {
+		t.Fatalf("unexpected baseline defaults: %#v", req.Baseline)
+	}
+}
+
+func TestParseBaselineValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{args: []string{"baseline", "unknown"}, want: "unknown baseline command"},
+		{args: []string{"baseline", "list", "extra"}, want: "too many arguments"},
+		{args: []string{"baseline", "list", "--limit", "0"}, want: "--limit must be greater than zero"},
+		{args: []string{"baseline", "list", "--format", "yaml"}, want: "invalid baseline format"},
+		{args: []string{"baseline", "list", "--store", "one", "--baseline-store", "two"}, want: "must match"},
+		{args: []string{"baseline", "show"}, want: "requires a snapshot key"},
+		{args: []string{"baseline", "show", "  "}, want: "requires a snapshot key"},
+		{args: []string{"baseline", "show", "one", "two"}, want: "too many arguments"},
+		{args: []string{"baseline", "show", "key", "--store"}, want: "flag needs an argument"},
+	}
+	for _, tc := range tests {
+		if _, err := ParseArgs(tc.args); err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("ParseArgs(%v) error=%v, want %q", tc.args, err, tc.want)
+		}
+	}
+}
+
+func TestParseBaselineHelp(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{{"baseline"}, {"baseline", "help"}, {"baseline", "list", "--help"}, {"baseline", "show", "--help"}} {
+		if _, err := ParseArgs(args); !errors.Is(err, ErrHelpRequested) {
+			t.Fatalf("ParseArgs(%v) error=%v, want help", args, err)
+		}
+	}
+}

--- a/internal/cli/parse_shared.go
+++ b/internal/cli/parse_shared.go
@@ -209,7 +209,7 @@ func flagNeedsValue(arg string) bool {
 		return false
 	}
 	switch arg {
-	case "--repo", "--top", "--scope-mode", "--format", "--channel", "--release", "--cache-path", "--fail-on-increase", "--threshold-fail-on-increase", "--threshold-low-confidence-warning", "--threshold-min-usage-percent", "--threshold-max-uncertain-imports", "--threshold-reachable-vuln-priority", "--score-weight-usage", "--score-weight-impact", "--score-weight-confidence", "--license-deny", "--language", "--runtime-profile", "--baseline", "--baseline-store", "--baseline-key", "--baseline-label", "--runtime-trace", "--runtime-test-command", "--advisory-source", "--config", "--enable-feature", "--disable-feature", "--include", "--exclude", "--lockfile-drift-policy", "--notify-on", "--notify-slack", "--notify-teams", "--snapshot", "--filter", "--sort", "--page-size", "--repos", "--output", "-o":
+	case "--repo", "--top", "--scope-mode", "--format", "--channel", "--release", "--cache-path", "--fail-on-increase", "--threshold-fail-on-increase", "--threshold-low-confidence-warning", "--threshold-min-usage-percent", "--threshold-max-uncertain-imports", "--threshold-reachable-vuln-priority", "--score-weight-usage", "--score-weight-impact", "--score-weight-confidence", "--license-deny", "--language", "--runtime-profile", "--baseline", "--baseline-store", "--baseline-key", "--baseline-label", "--runtime-trace", "--runtime-test-command", "--advisory-source", "--config", "--enable-feature", "--disable-feature", "--include", "--exclude", "--lockfile-drift-policy", "--notify-on", "--notify-slack", "--notify-teams", "--snapshot", "--filter", "--sort", "--page-size", "--repos", "--store", "--limit", "--output", "-o":
 		return true
 	default:
 		return false

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -7,6 +7,8 @@ const usage = `Usage:
   lopper analyse --top N [--repo PATH] [--scope-mode repo|package|changed-packages] [--format table|csv|json|sarif|pr-comment|cyclonedx-json] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--cache=true|false] [--cache-path PATH] [--cache-readonly] [--runtime-profile node-import|node-require|browser-import|browser-require] [--baseline PATH] [--baseline-store DIR] [--baseline-key KEY] [--save-baseline] [--baseline-label LABEL] [--runtime-trace PATH] [--runtime-test-command CMD] [--advisory-source PATH] [--config PATH] [--include GLOBS] [--exclude GLOBS] [--lockfile-drift-policy off|warn|fail] [--license-deny SPDXS] [--license-fail-on-deny] [--license-provenance-registry] [--notify-on always|breach|regression|improvement] [--notify-slack URL] [--notify-teams URL] [--enable-feature NAME] [--disable-feature NAME] [--fail-on-increase PERCENT]
   lopper dashboard --repos PATH1,PATH2 [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline] [--enable-feature NAME] [--disable-feature NAME]
   lopper dashboard --config lopper-org.yml [--format json|csv|html] [--top N] [--language auto|all|js-ts|python|cpp|jvm|kotlin-android|go|php|ruby|rust|dotnet|elixir|swift|dart|powershell] [--output PATH] [--baseline-store DIR] [--baseline-key KEY] [--baseline-label LABEL] [--save-baseline] [--enable-feature NAME] [--disable-feature NAME]
+  lopper baseline list [--store DIR] [--format table|json] [--limit N] [--enable-feature baseline-store-discovery-preview]
+  lopper baseline show KEY [--store DIR] [--format table|json] [--enable-feature baseline-store-discovery-preview]
   lopper features [--format table|json] [--channel dev|rolling|release] [--release VERSION]
   lopper profile apply strict|balanced|noise-reduction [--output PATH] [--force] [--enable-feature threshold-profiles]
   lopper mcp
@@ -44,6 +46,8 @@ Options:
   --baseline-key KEY         Baseline snapshot key for dashboard comparison
   --baseline-label LABEL     Label key to use when saving dashboard baselines
   --save-baseline            Save current dashboard run as an immutable baseline snapshot
+  --store DIR                Baseline discovery store (default: .artifacts/lopper-baselines)
+  --limit N                  Maximum snapshots returned by baseline list (default: 50)
   --include GLOBS            Comma-separated include path globs (repeatable; CLI overrides config scope.include)
   --exclude GLOBS            Comma-separated exclude path globs (repeatable; CLI overrides config scope.exclude)
   --suggest-only             Generate deterministic patch previews for safe remediation suggestions

--- a/internal/dashboard/baseline.go
+++ b/internal/dashboard/baseline.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -15,6 +16,8 @@ import (
 const BaselineSnapshotSchemaVersion = "1.0.0"
 
 var ErrBaselineAlreadyExists = errors.New("dashboard baseline snapshot already exists")
+
+var ErrBaselineKeyMismatch = errors.New("dashboard baseline snapshot key does not match requested key")
 
 type BaselineSnapshot struct {
 	BaselineSchemaVersion string    `json:"baselineSchemaVersion"`
@@ -36,7 +39,10 @@ func LoadWithKey(path string) (Report, string, error) {
 	if err != nil {
 		return Report{}, "", err
 	}
+	return decodeBaselineSnapshot(data)
+}
 
+func decodeBaselineSnapshot(data []byte) (Report, string, error) {
 	var snapshot BaselineSnapshot
 	if err := json.Unmarshal(data, &snapshot); err == nil && strings.TrimSpace(snapshot.BaselineSchemaVersion) != "" {
 		if snapshot.BaselineSchemaVersion != BaselineSnapshotSchemaVersion {
@@ -58,6 +64,23 @@ func LoadWithKey(path string) (Report, string, error) {
 	return rep, "", nil
 }
 
+func LoadSnapshot(dir, key string) (Report, string, string, error) {
+	trimmedKey := strings.TrimSpace(key)
+	path := ResolveBaselineSnapshotPath(dir, trimmedKey)
+	data, err := baselineutil.ReadStoreEntry(dir, filepath.Base(path), baselineutil.MaxSnapshotBytes)
+	if err != nil {
+		return Report{}, "", path, err
+	}
+	rep, loadedKey, err := decodeBaselineSnapshot(data)
+	if err != nil {
+		return Report{}, "", path, err
+	}
+	if loadedKey != trimmedKey || trimmedKey == "" {
+		return Report{}, loadedKey, path, fmt.Errorf("%w: requested %q, stored %q", ErrBaselineKeyMismatch, trimmedKey, loadedKey)
+	}
+	return rep, loadedKey, path, nil
+}
+
 func SaveSnapshot(dir string, key string, rep Report, now time.Time) (string, error) {
 	return baselineutil.SaveJSON(dir, key, ErrBaselineAlreadyExists, func(trimmedKey string) BaselineSnapshot {
 		return newBaselineSnapshot(trimmedKey, rep, now)
@@ -66,6 +89,10 @@ func SaveSnapshot(dir string, key string, rep Report, now time.Time) (string, er
 
 func BaselineSnapshotPath(dir, key string) string {
 	return baselineutil.SnapshotPath(dir, key)
+}
+
+func ResolveBaselineSnapshotPath(dir, key string) string {
+	return baselineutil.ResolveSnapshotPath(dir, key)
 }
 
 func ApplyBaselineWithKeys(current, baseline Report, baselineKey, currentKey string) (Report, error) {

--- a/internal/dashboard/baseline_loading_comparison_test.go
+++ b/internal/dashboard/baseline_loading_comparison_test.go
@@ -1,11 +1,15 @@
 package dashboard
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	baselineutil "github.com/ben-ranford/lopper/internal/baseline"
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 func TestDashboardBaselineLoadPreservesRemoteMetadata(t *testing.T) {
@@ -67,6 +71,20 @@ func TestDashboardBaselineLoadLegacyRemoteFieldsEmpty(t *testing.T) {
 	}
 }
 
+func TestDashboardLoadWithKeyPreservesOversizedExplicitBaselineCompatibility(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oversized-explicit.json")
+	content := `{"generated_at":"2026-03-12T00:00:00Z","repos":[{"name":"api","path":"./api","dependency_count":3}]}`
+	testutil.MustWritePaddedFile(t, path, content, baselineutil.MaxSnapshotBytes+1)
+
+	rep, key, err := LoadWithKey(path)
+	if err != nil {
+		t.Fatalf("load oversized explicit dashboard baseline: %v", err)
+	}
+	if key != "" || rep.Summary.TotalDeps != 3 {
+		t.Fatalf("unexpected oversized explicit dashboard baseline: key=%q report=%#v", key, rep)
+	}
+}
+
 func TestDashboardBaselineLoadRejectsUnsupportedSchema(t *testing.T) {
 	t.Parallel()
 
@@ -94,6 +112,51 @@ func TestDashboardBaselineLoadReportsReadErrors(t *testing.T) {
 	}
 	if _, _, err := LoadWithKey(invalidPath); err == nil {
 		t.Fatalf("expected invalid dashboard json error")
+	}
+}
+
+func TestDashboardKeyedBaselineLoadCompatibilityAndIdentity(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC)
+	path, err := SaveSnapshot(dir, "label:current", Report{GeneratedAt: now, Repos: []RepoResult{{Name: "api"}}}, now)
+	if err != nil {
+		t.Fatalf("save current snapshot: %v", err)
+	}
+	loaded, key, resolvedPath, err := LoadSnapshot(dir, "label:current")
+	if err != nil || key != "label:current" || resolvedPath != path || loaded.Summary.TotalRepos != 1 {
+		t.Fatalf("keyed load failed: key=%q path=%q report=%#v err=%v", key, resolvedPath, loaded, err)
+	}
+	if ResolveBaselineSnapshotPath(dir, "label:current") != path {
+		t.Fatalf("expected current snapshot path resolution")
+	}
+	if _, _, _, err := LoadSnapshot(dir, "label:missing"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing keyed snapshot error, got %v", err)
+	}
+
+	legacyDir := t.TempDir()
+	newPath, err := SaveSnapshot(legacyDir, "label:a/b", Report{GeneratedAt: now}, now)
+	if err != nil {
+		t.Fatalf("save legacy fixture: %v", err)
+	}
+	legacyPath := baselineutil.LegacySnapshotPath(legacyDir, "label:a/b")
+	if err := os.Rename(newPath, legacyPath); err != nil {
+		t.Fatalf("move snapshot to legacy path: %v", err)
+	}
+	if _, key, resolvedPath, err := LoadSnapshot(legacyDir, "label:a/b"); err != nil || key != "label:a/b" || resolvedPath != legacyPath {
+		t.Fatalf("legacy keyed load failed: key=%q path=%q err=%v", key, resolvedPath, err)
+	}
+	if _, _, _, err := LoadSnapshot(legacyDir, "label:a?b"); !errors.Is(err, ErrBaselineKeyMismatch) {
+		t.Fatalf("expected colliding dashboard key mismatch, got %v", err)
+	}
+
+	corruptName := baselineutil.SnapshotFileName("label:corrupt")
+	if err := os.WriteFile(filepath.Join(legacyDir, corruptName), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write corrupt keyed snapshot: %v", err)
+	}
+	if _, _, _, err := LoadSnapshot(legacyDir, "label:corrupt"); err == nil {
+		t.Fatalf("expected corrupt keyed snapshot error")
 	}
 }
 

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -165,5 +165,11 @@
     "name": "python-runner-profiles",
     "description": "Enable safe unittest and uv profiles for Python runtime capture.",
     "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0019",
+    "name": "baseline-store-discovery-preview",
+    "description": "Enable safe listing and inspection of immutable local baseline snapshots.",
+    "lifecycle": "preview"
   }
 ]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -666,7 +667,7 @@ func resolveBaselineComparison(repoPath string, args analysisToolArguments) (str
 		if baselineKey == "" {
 			return "", "", "", errors.New("baselineKey is required with baselineStorePath")
 		}
-		baselinePath = report.BaselineSnapshotPath(baselineStorePath, baselineKey)
+		baselinePath = report.ResolveBaselineSnapshotPath(baselineStorePath, baselineKey)
 	}
 	if baselinePath == "" {
 		return "", "", "", nil
@@ -679,7 +680,14 @@ func resolveBaselineComparison(repoPath string, args analysisToolArguments) (str
 }
 
 func applyBaseline(current report.Report, baselinePath, requestedKey, currentKey string) (report.Report, error) {
-	baseline, loadedKey, err := report.LoadWithKey(baselinePath)
+	var baseline report.Report
+	var loadedKey string
+	var err error
+	if strings.TrimSpace(requestedKey) != "" {
+		baseline, loadedKey, _, err = report.LoadSnapshot(filepath.Dir(baselinePath), requestedKey)
+	} else {
+		baseline, loadedKey, err = report.LoadWithKey(baselinePath)
+	}
 	if err != nil {
 		return current, err
 	}

--- a/internal/report/baseline_catalog.go
+++ b/internal/report/baseline_catalog.go
@@ -1,0 +1,168 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	baselineutil "github.com/ben-ranford/lopper/internal/baseline"
+)
+
+type BaselineSnapshotMetadata struct {
+	Key                   string    `json:"key"`
+	KeyType               string    `json:"keyType"`
+	Label                 string    `json:"label,omitempty"`
+	Commit                string    `json:"commit,omitempty"`
+	CreatedAt             time.Time `json:"createdAt"`
+	BaselineSchemaVersion string    `json:"baselineSchemaVersion"`
+	ReportSchemaVersion   string    `json:"reportSchemaVersion"`
+	RepoIdentity          string    `json:"repoIdentity"`
+	Summary               Summary   `json:"summary"`
+	File                  string    `json:"file"`
+}
+
+type BaselineStoreDiagnostic struct {
+	File  string `json:"file"`
+	Error string `json:"error"`
+}
+
+type BaselineCatalog struct {
+	Store       string                     `json:"store"`
+	Snapshots   []BaselineSnapshotMetadata `json:"snapshots"`
+	Diagnostics []BaselineStoreDiagnostic  `json:"diagnostics"`
+}
+
+func ListBaselineSnapshots(dir string, limit int) (BaselineCatalog, error) {
+	if limit <= 0 {
+		return BaselineCatalog{}, fmt.Errorf("baseline list limit must be greater than zero")
+	}
+	catalog := BaselineCatalog{
+		Store:       strings.TrimSpace(dir),
+		Snapshots:   []BaselineSnapshotMetadata{},
+		Diagnostics: []BaselineStoreDiagnostic{},
+	}
+	names, err := baselineutil.ListStoreEntries(dir)
+	if err != nil {
+		return BaselineCatalog{}, err
+	}
+	for _, name := range names {
+		if !strings.EqualFold(filepath.Ext(name), ".json") {
+			continue
+		}
+		data, readErr := baselineutil.ReadStoreEntry(dir, name, baselineutil.MaxSnapshotBytes)
+		if readErr != nil {
+			catalog.Diagnostics = append(catalog.Diagnostics, baselineDiagnostic(name, readErr))
+			continue
+		}
+		metadata, decodeErr := decodeBaselineSnapshotMetadata(name, data)
+		if decodeErr != nil {
+			catalog.Diagnostics = append(catalog.Diagnostics, baselineDiagnostic(name, decodeErr))
+			continue
+		}
+		catalog.Snapshots = append(catalog.Snapshots, metadata)
+	}
+	sort.Slice(catalog.Snapshots, func(i, j int) bool {
+		left, right := catalog.Snapshots[i], catalog.Snapshots[j]
+		if !left.CreatedAt.Equal(right.CreatedAt) {
+			return left.CreatedAt.After(right.CreatedAt)
+		}
+		if left.Key != right.Key {
+			return left.Key < right.Key
+		}
+		return left.File < right.File
+	})
+	if len(catalog.Snapshots) > limit {
+		catalog.Snapshots = catalog.Snapshots[:limit]
+	}
+	return catalog, nil
+}
+
+func InspectBaselineSnapshot(dir, key string) (BaselineSnapshotMetadata, error) {
+	trimmedKey := strings.TrimSpace(key)
+	path := ResolveBaselineSnapshotPath(dir, trimmedKey)
+	name := filepath.Base(path)
+	data, err := baselineutil.ReadStoreEntry(dir, name, baselineutil.MaxSnapshotBytes)
+	if err != nil {
+		return BaselineSnapshotMetadata{}, err
+	}
+	metadata, err := decodeBaselineSnapshotMetadata(name, data)
+	if err != nil {
+		return BaselineSnapshotMetadata{}, err
+	}
+	if err := ValidateBaselineSnapshotKey(trimmedKey, metadata.Key); err != nil {
+		return BaselineSnapshotMetadata{}, err
+	}
+	return metadata, nil
+}
+
+func decodeBaselineSnapshotMetadata(name string, data []byte) (BaselineSnapshotMetadata, error) {
+	var snapshot BaselineSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return BaselineSnapshotMetadata{}, fmt.Errorf("decode baseline snapshot: %w", err)
+	}
+	if snapshot.BaselineSchemaVersion == "" {
+		return BaselineSnapshotMetadata{}, fmt.Errorf("missing baseline schema version")
+	}
+	if snapshot.BaselineSchemaVersion != BaselineSnapshotSchemaVersion {
+		return BaselineSnapshotMetadata{}, fmt.Errorf("unsupported baseline schema version: %s", snapshot.BaselineSchemaVersion)
+	}
+	key := strings.TrimSpace(snapshot.Key)
+	if key == "" {
+		return BaselineSnapshotMetadata{}, fmt.Errorf("missing baseline snapshot key")
+	}
+	if name != baselineutil.SnapshotFileName(key) && name != baselineutil.LegacySnapshotFileName(key) {
+		return BaselineSnapshotMetadata{}, fmt.Errorf("snapshot filename does not match embedded key %q", key)
+	}
+	if snapshot.SavedAt.IsZero() {
+		return BaselineSnapshotMetadata{}, fmt.Errorf("missing baseline creation time")
+	}
+	if strings.TrimSpace(snapshot.Report.SchemaVersion) == "" {
+		return BaselineSnapshotMetadata{}, fmt.Errorf("missing baseline report schema version")
+	}
+	if snapshot.Report.GeneratedAt.IsZero() {
+		return BaselineSnapshotMetadata{}, fmt.Errorf("missing baseline report generation time")
+	}
+	repoIdentity := strings.TrimSpace(snapshot.Report.RepoPath)
+	if repoIdentity == "" {
+		return BaselineSnapshotMetadata{}, fmt.Errorf("missing baseline repository identity")
+	}
+	reportData := normalizeSnapshotReport(snapshot.Report)
+	keyType, value := baselineKeyType(key)
+	metadata := BaselineSnapshotMetadata{
+		Key:                   key,
+		KeyType:               keyType,
+		CreatedAt:             snapshot.SavedAt.UTC(),
+		BaselineSchemaVersion: snapshot.BaselineSchemaVersion,
+		ReportSchemaVersion:   reportData.SchemaVersion,
+		RepoIdentity:          repoIdentity,
+		Summary:               *reportData.Summary,
+		File:                  name,
+	}
+	if keyType == "label" {
+		metadata.Label = value
+	}
+	if keyType == "commit" {
+		metadata.Commit = value
+	}
+	return metadata, nil
+}
+
+func baselineKeyType(key string) (string, string) {
+	prefix, value, found := strings.Cut(key, ":")
+	if found {
+		switch strings.ToLower(strings.TrimSpace(prefix)) {
+		case "label":
+			return "label", strings.TrimSpace(value)
+		case "commit":
+			return "commit", strings.TrimSpace(value)
+		}
+	}
+	return "custom", key
+}
+
+func baselineDiagnostic(name string, err error) BaselineStoreDiagnostic {
+	return BaselineStoreDiagnostic{File: name, Error: err.Error()}
+}

--- a/internal/report/baseline_catalog_test.go
+++ b/internal/report/baseline_catalog_test.go
@@ -1,0 +1,258 @@
+package report
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	baselineutil "github.com/ben-ranford/lopper/internal/baseline"
+)
+
+func TestListAndInspectBaselineSnapshots(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	older := time.Date(2026, time.July, 10, 1, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Hour)
+	if _, err := SaveSnapshot(dir, "commit:abc123", baselineCatalogReport(older, 1), older); err != nil {
+		t.Fatalf("save older snapshot: %v", err)
+	}
+	if _, err := SaveSnapshot(dir, "label:release-candidate", baselineCatalogReport(newer, 2), newer); err != nil {
+		t.Fatalf("save newer snapshot: %v", err)
+	}
+
+	catalog, err := ListBaselineSnapshots(dir, 1)
+	if err != nil {
+		t.Fatalf("list snapshots: %v", err)
+	}
+	if catalog.Store != dir || len(catalog.Snapshots) != 1 || len(catalog.Diagnostics) != 0 {
+		t.Fatalf("unexpected limited catalog: %#v", catalog)
+	}
+	listed := catalog.Snapshots[0]
+	if listed.Key != "label:release-candidate" || listed.KeyType != "label" || listed.Label != "release-candidate" || listed.Commit != "" {
+		t.Fatalf("unexpected label metadata: %#v", listed)
+	}
+	if listed.RepoIdentity != "/repo/example" || listed.Summary.DependencyCount != 2 || listed.ReportSchemaVersion != SchemaVersion {
+		t.Fatalf("missing report metadata: %#v", listed)
+	}
+
+	shown, err := InspectBaselineSnapshot(dir, "commit:abc123")
+	if err != nil {
+		t.Fatalf("inspect snapshot: %v", err)
+	}
+	if shown.KeyType != "commit" || shown.Commit != "abc123" || shown.Label != "" || shown.CreatedAt != older {
+		t.Fatalf("unexpected commit metadata: %#v", shown)
+	}
+	if _, _, _, err := LoadSnapshot(dir, "commit:abc123"); err != nil {
+		t.Fatalf("load keyed snapshot: %v", err)
+	}
+}
+
+func TestListBaselineSnapshotsReturnsSafePerEntryDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "corrupt.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write corrupt snapshot: %v", err)
+	}
+	oversized := filepath.Join(dir, "oversized.json")
+	if err := os.WriteFile(oversized, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write oversized snapshot: %v", err)
+	}
+	if err := os.Truncate(oversized, baselineutil.MaxSnapshotBytes+1); err != nil {
+		t.Fatalf("grow oversized snapshot: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.json")
+	if err := os.WriteFile(outside, []byte(`{"doNotRead":true}`), 0o600); err != nil {
+		t.Fatalf("write outside fixture: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "symlink.json")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ignored"), 0o600); err != nil {
+		t.Fatalf("write non-snapshot: %v", err)
+	}
+
+	catalog, err := ListBaselineSnapshots(dir, 10)
+	if err != nil {
+		t.Fatalf("list diagnostic catalog: %v", err)
+	}
+	if len(catalog.Snapshots) != 0 || len(catalog.Diagnostics) != 3 {
+		t.Fatalf("expected three safe diagnostics, got %#v", catalog)
+	}
+	got := catalog.Diagnostics[0].File + " " + catalog.Diagnostics[0].Error + "\n" +
+		catalog.Diagnostics[1].File + " " + catalog.Diagnostics[1].Error + "\n" +
+		catalog.Diagnostics[2].File + " " + catalog.Diagnostics[2].Error
+	for _, want := range []string{"corrupt.json", "oversized.json", "exceeds size limit", "symlink.json", "must not be a symlink"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("diagnostics missing %q: %s", want, got)
+		}
+	}
+}
+
+func TestBaselineSnapshotLegacyFallbackRejectsCollidingKey(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2026, time.July, 10, 1, 0, 0, 0, time.UTC)
+	legacyPath := baselineutil.LegacySnapshotPath(dir, "label:a/b")
+	snapshot := newBaselineSnapshot("label:a/b", baselineCatalogReport(now, 1), now)
+	data, err := jsonMarshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal legacy snapshot: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, data, 0o600); err != nil {
+		t.Fatalf("write legacy snapshot: %v", err)
+	}
+
+	loaded, key, path, err := LoadSnapshot(dir, "label:a/b")
+	if err != nil || key != "label:a/b" || path != legacyPath || loaded.Summary == nil {
+		t.Fatalf("legacy fallback failed: key=%q path=%q report=%#v err=%v", key, path, loaded, err)
+	}
+	if _, err := InspectBaselineSnapshot(dir, "label:a?b"); !errors.Is(err, ErrBaselineKeyMismatch) {
+		t.Fatalf("expected colliding requested key mismatch, got %v", err)
+	}
+	if _, _, _, err := LoadSnapshot(dir, "label:a?b"); !errors.Is(err, ErrBaselineKeyMismatch) {
+		t.Fatalf("expected keyed load mismatch, got %v", err)
+	}
+}
+
+func TestBaselineCatalogValidationBranches(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ListBaselineSnapshots(t.TempDir(), 0); err == nil {
+		t.Fatalf("expected non-positive limit error")
+	}
+	if kind, value := baselineKeyType("owner:nightly"); kind != "custom" || value != "owner:nightly" {
+		t.Fatalf("unexpected custom key classification: %q %q", kind, value)
+	}
+
+	now := time.Date(2026, time.July, 10, 1, 0, 0, 0, time.UTC)
+	valid := newBaselineSnapshot("label:valid", baselineCatalogReport(now, 1), now)
+	tests := []struct {
+		name     string
+		fileName string
+		mutate   func(*BaselineSnapshot)
+		want     string
+	}{
+		{name: "missing schema", fileName: baselineutil.SnapshotFileName("label:valid"), mutate: func(snapshot *BaselineSnapshot) { snapshot.BaselineSchemaVersion = "" }, want: "missing baseline schema"},
+		{name: "unsupported schema", fileName: baselineutil.SnapshotFileName("label:valid"), mutate: func(snapshot *BaselineSnapshot) { snapshot.BaselineSchemaVersion = "9.9.9" }, want: "unsupported baseline schema"},
+		{name: "missing key", fileName: baselineutil.SnapshotFileName("label:valid"), mutate: func(snapshot *BaselineSnapshot) { snapshot.Key = "" }, want: "missing baseline snapshot key"},
+		{name: "wrong filename", fileName: "wrong.json", mutate: func(*BaselineSnapshot) {}, want: "filename does not match"},
+		{name: "missing creation time", fileName: baselineutil.SnapshotFileName("label:valid"), mutate: func(snapshot *BaselineSnapshot) { snapshot.SavedAt = time.Time{} }, want: "missing baseline creation time"},
+		{name: "missing report schema", fileName: baselineutil.SnapshotFileName("label:valid"), mutate: func(snapshot *BaselineSnapshot) { snapshot.Report.SchemaVersion = "" }, want: "missing baseline report schema"},
+		{name: "missing report generation", fileName: baselineutil.SnapshotFileName("label:valid"), mutate: func(snapshot *BaselineSnapshot) { snapshot.Report.GeneratedAt = time.Time{} }, want: "missing baseline report generation"},
+		{name: "missing repo identity", fileName: baselineutil.SnapshotFileName("label:valid"), mutate: func(snapshot *BaselineSnapshot) { snapshot.Report.RepoPath = "" }, want: "missing baseline repository identity"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot := valid
+			tc.mutate(&snapshot)
+			data, err := jsonMarshal(snapshot)
+			if err != nil {
+				t.Fatalf("marshal fixture: %v", err)
+			}
+			if _, err := decodeBaselineSnapshotMetadata(tc.fileName, data); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+	if _, err := decodeBaselineSnapshotMetadata("bad.json", []byte("{")); err == nil || !strings.Contains(err.Error(), "decode baseline snapshot") {
+		t.Fatalf("expected corrupt JSON error, got %v", err)
+	}
+}
+
+func TestBaselineCatalogLoadAndStoreErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if _, _, _, err := LoadSnapshot(dir, "label:missing"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing keyed snapshot error, got %v", err)
+	}
+	if _, err := InspectBaselineSnapshot(dir, "label:missing"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing inspection error, got %v", err)
+	}
+	corruptName := baselineutil.SnapshotFileName("label:corrupt")
+	if err := os.WriteFile(filepath.Join(dir, corruptName), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write corrupt keyed snapshot: %v", err)
+	}
+	if _, _, _, err := LoadSnapshot(dir, "label:corrupt"); err == nil || !strings.Contains(err.Error(), "unexpected end of JSON") {
+		t.Fatalf("expected corrupt keyed load error, got %v", err)
+	}
+	if _, err := InspectBaselineSnapshot(dir, "label:corrupt"); err == nil || !strings.Contains(err.Error(), "decode baseline snapshot") {
+		t.Fatalf("expected corrupt inspection error, got %v", err)
+	}
+
+	target := filepath.Join(t.TempDir(), "actual")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("create target store: %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "linked-store")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if _, err := ListBaselineSnapshots(link, 10); err == nil || !strings.Contains(err.Error(), "path component must not be a symlink") {
+		t.Fatalf("expected symlinked store rejection, got %v", err)
+	}
+}
+
+func TestBaselineCatalogDeterministicTieBreaks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2026, time.July, 10, 1, 0, 0, 0, time.UTC)
+	for _, key := range []string{"label:zeta", "label:alpha"} {
+		if _, err := SaveSnapshot(dir, key, baselineCatalogReport(now, 1), now); err != nil {
+			t.Fatalf("save %s: %v", key, err)
+		}
+	}
+	duplicateKey := "label:duplicate"
+	newPath, err := SaveSnapshot(dir, duplicateKey, baselineCatalogReport(now, 1), now)
+	if err != nil {
+		t.Fatalf("save duplicate fixture: %v", err)
+	}
+	data, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("read duplicate fixture: %v", err)
+	}
+	if err := os.WriteFile(baselineutil.LegacySnapshotPath(dir, duplicateKey), data, 0o600); err != nil {
+		t.Fatalf("write compatible legacy duplicate: %v", err)
+	}
+
+	catalog, err := ListBaselineSnapshots(dir, 10)
+	if err != nil {
+		t.Fatalf("list tied snapshots: %v", err)
+	}
+	if len(catalog.Snapshots) != 4 {
+		t.Fatalf("expected four tied snapshots, got %#v", catalog.Snapshots)
+	}
+	keys := []string{catalog.Snapshots[0].Key, catalog.Snapshots[1].Key, catalog.Snapshots[2].Key, catalog.Snapshots[3].Key}
+	if keys[0] != "label:alpha" || keys[1] != duplicateKey || keys[2] != duplicateKey || keys[3] != "label:zeta" {
+		t.Fatalf("unexpected deterministic key order: %v", keys)
+	}
+	if catalog.Snapshots[1].File >= catalog.Snapshots[2].File {
+		t.Fatalf("expected filename tie-break order, got %q then %q", catalog.Snapshots[1].File, catalog.Snapshots[2].File)
+	}
+}
+
+func baselineCatalogReport(generatedAt time.Time, dependencyCount int) Report {
+	dependencies := make([]DependencyReport, dependencyCount)
+	for index := range dependencies {
+		dependencies[index] = DependencyReport{
+			Name:              "dep-" + string(rune('a'+index)),
+			Language:          "go",
+			UsedExportsCount:  1,
+			TotalExportsCount: 2,
+			UsedPercent:       50,
+		}
+	}
+	return Report{SchemaVersion: SchemaVersion, GeneratedAt: generatedAt, RepoPath: "/repo/example", Dependencies: dependencies}
+}
+
+func jsonMarshal(value any) ([]byte, error) {
+	return json.Marshal(value)
+}

--- a/internal/report/baseline_snapshot.go
+++ b/internal/report/baseline_snapshot.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -15,6 +16,8 @@ import (
 const BaselineSnapshotSchemaVersion = "1.0.0"
 
 var ErrBaselineAlreadyExists = errors.New("baseline snapshot already exists")
+
+var ErrBaselineKeyMismatch = errors.New("baseline snapshot key does not match requested key")
 
 type BaselineSnapshot struct {
 	BaselineSchemaVersion string    `json:"baselineSchemaVersion"`
@@ -36,7 +39,10 @@ func LoadWithKey(path string) (Report, string, error) {
 	if err != nil {
 		return Report{}, "", err
 	}
+	return decodeBaselineSnapshot(data)
+}
 
+func decodeBaselineSnapshot(data []byte) (Report, string, error) {
 	var snapshot BaselineSnapshot
 	if err := json.Unmarshal(data, &snapshot); err == nil && strings.TrimSpace(snapshot.BaselineSchemaVersion) != "" {
 		if snapshot.BaselineSchemaVersion != BaselineSnapshotSchemaVersion {
@@ -64,6 +70,32 @@ func LoadWithKey(path string) (Report, string, error) {
 	return rep, "", nil
 }
 
+func LoadSnapshot(dir, key string) (Report, string, string, error) {
+	trimmedKey := strings.TrimSpace(key)
+	path := ResolveBaselineSnapshotPath(dir, trimmedKey)
+	data, err := baselineutil.ReadStoreEntry(dir, filepath.Base(path), baselineutil.MaxSnapshotBytes)
+	if err != nil {
+		return Report{}, "", path, err
+	}
+	rep, loadedKey, err := decodeBaselineSnapshot(data)
+	if err != nil {
+		return Report{}, "", path, err
+	}
+	if err := ValidateBaselineSnapshotKey(trimmedKey, loadedKey); err != nil {
+		return Report{}, loadedKey, path, err
+	}
+	return rep, loadedKey, path, nil
+}
+
+func ValidateBaselineSnapshotKey(requestedKey, storedKey string) error {
+	requestedKey = strings.TrimSpace(requestedKey)
+	storedKey = strings.TrimSpace(storedKey)
+	if requestedKey == storedKey && requestedKey != "" {
+		return nil
+	}
+	return fmt.Errorf("%w: requested %q, stored %q", ErrBaselineKeyMismatch, requestedKey, storedKey)
+}
+
 func SaveSnapshot(dir string, key string, rep Report, now time.Time) (string, error) {
 	return baselineutil.SaveJSON(dir, key, ErrBaselineAlreadyExists, func(trimmedKey string) BaselineSnapshot {
 		return newBaselineSnapshot(trimmedKey, rep, now)
@@ -72,6 +104,10 @@ func SaveSnapshot(dir string, key string, rep Report, now time.Time) (string, er
 
 func BaselineSnapshotPath(dir, key string) string {
 	return baselineutil.SnapshotPath(dir, key)
+}
+
+func ResolveBaselineSnapshotPath(dir, key string) string {
+	return baselineutil.ResolveSnapshotPath(dir, key)
 }
 
 func newBaselineSnapshot(key string, rep Report, now time.Time) BaselineSnapshot {

--- a/internal/report/baseline_snapshot_test.go
+++ b/internal/report/baseline_snapshot_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	baselineutil "github.com/ben-ranford/lopper/internal/baseline"
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 const testLabelX = "label:x"
@@ -125,6 +126,20 @@ func TestLoadWithKeySupportsLegacyReportFile(t *testing.T) {
 	}
 }
 
+func TestLoadWithKeyPreservesOversizedExplicitBaselineCompatibility(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oversized-explicit.json")
+	content := `{"schemaVersion":"0.1.0","generatedAt":"2026-01-01T00:00:00Z","repoPath":".","dependencies":[]}`
+	testutil.MustWritePaddedFile(t, path, content, baselineutil.MaxSnapshotBytes+1)
+
+	rep, key, err := LoadWithKey(path)
+	if err != nil {
+		t.Fatalf("load oversized explicit baseline: %v", err)
+	}
+	if key != "" || rep.RepoPath != "." {
+		t.Fatalf("unexpected oversized explicit baseline: key=%q report=%#v", key, rep)
+	}
+}
+
 func TestLoadWithKeyUnsupportedSnapshotSchema(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "snapshot.json")
@@ -149,7 +164,7 @@ func TestSaveSnapshotValidationErrors(t *testing.T) {
 
 func TestBaselineSnapshotPathSanitizesKey(t *testing.T) {
 	path := BaselineSnapshotPath("/tmp/baselines", " label:release candidate/1 ")
-	if !strings.HasSuffix(path, "label_release_candidate_1.json") {
+	if filepath.Base(path) != baselineutil.SnapshotFileName("label:release candidate/1") {
 		t.Fatalf("expected sanitized snapshot path, got %q", path)
 	}
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -32,6 +32,49 @@ func MustWriteFileMode(t *testing.T, path string, content string, perm os.FileMo
 	}
 }
 
+func MustWritePaddedFile(t *testing.T, path string, content string, minBytes int64) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	root, err := os.OpenRoot(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("open root for %s: %v", path, err)
+	}
+	file, err := root.OpenFile(filepath.Base(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		closeErr := root.Close()
+		t.Fatalf("open %s: %v (close root: %v)", path, err, closeErr)
+	}
+	written, err := file.WriteString(content)
+	if err != nil || written != len(content) {
+		closeErr := file.Close()
+		rootCloseErr := root.Close()
+		t.Fatalf("write %s: wrote %d of %d bytes: %v (close: %v; close root: %v)", path, written, len(content), err, closeErr, rootCloseErr)
+	}
+	padding := strings.Repeat(" ", 1<<20)
+	for remaining := minBytes - int64(len(content)); remaining > 0; {
+		chunk := padding
+		if int64(len(chunk)) > remaining {
+			chunk = chunk[:remaining]
+		}
+		written, writeErr := file.WriteString(chunk)
+		if writeErr != nil || written != len(chunk) {
+			closeErr := file.Close()
+			rootCloseErr := root.Close()
+			t.Fatalf("pad %s: wrote %d of %d bytes: %v (close: %v; close root: %v)", path, written, len(chunk), writeErr, closeErr, rootCloseErr)
+		}
+		remaining -= int64(written)
+	}
+	if err := file.Close(); err != nil {
+		rootCloseErr := root.Close()
+		t.Fatalf("close %s: %v (close root: %v)", path, err, rootCloseErr)
+	}
+	if err := root.Close(); err != nil {
+		t.Fatalf("close root for %s: %v", path, err)
+	}
+}
+
 func WriteNumberedTextFiles(t *testing.T, dir string, count int) {
 	t.Helper()
 	for i := 0; i < count; i++ {

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -522,7 +522,13 @@ func applySummaryBaselineIfNeeded(reportData report.Report, opts Options) (repor
 		return reportData, nil
 	}
 
-	baseline, loadedKey, err := report.LoadWithKey(baselinePath)
+	var baseline report.Report
+	var loadedKey string
+	if strings.TrimSpace(baselineKey) != "" {
+		baseline, loadedKey, _, err = report.LoadSnapshot(opts.BaselineStorePath, baselineKey)
+	} else {
+		baseline, loadedKey, err = report.LoadWithKey(baselinePath)
+	}
 	if err != nil {
 		return reportData, err
 	}
@@ -550,7 +556,7 @@ func resolveSummaryBaselinePaths(repoPath string, opts Options) (string, string,
 		return "", "", "", false, fmt.Errorf("baseline key is required when using --baseline-store")
 	}
 
-	return report.BaselineSnapshotPath(storePath, baselineKey), baselineKey, resolveSummaryCurrentBaselineKey(repoPath), true, nil
+	return report.ResolveBaselineSnapshotPath(storePath, baselineKey), baselineKey, resolveSummaryCurrentBaselineKey(repoPath), true, nil
 }
 
 func resolveSummaryCurrentBaselineKey(repoPath string) string {

--- a/internal/ui/summary_actions_test.go
+++ b/internal/ui/summary_actions_test.go
@@ -496,7 +496,7 @@ func TestSummaryBaselineActionMessagesAndErrors(t *testing.T) {
 	if err := summary.runSummaryBaselineSave(context.Background(), &opts, nil, summaryAction{kind: summaryActionSaveBaseline, baselineLabel: "nightly", baselineStorePath: "store"}); err != nil {
 		t.Fatalf("save with fallback path: %v", err)
 	}
-	if !strings.Contains(out.String(), "store/label_nightly.json") {
+	if !strings.Contains(out.String(), report.BaselineSnapshotPath("store", "label:nightly")) {
 		t.Fatalf("expected fallback saved path in output, got %q", out.String())
 	}
 }

--- a/scripts/generate-manpage.sh
+++ b/scripts/generate-manpage.sh
@@ -42,6 +42,8 @@ escape_roff() {
 	printf "lopper analyse --top N [options]\n"
 	printf "lopper analyse <dependency> [options]\n"
 	printf "lopper dashboard [--repos PATH1,PATH2 | --config PATH]\n"
+	printf "lopper baseline list [options]\n"
+	printf "lopper baseline show KEY [options]\n"
 	printf "lopper profile apply strict|balanced|noise-reduction [options]\n"
 	printf "lopper mcp\n"
 	printf ".fi\n"


### PR DESCRIPTION
## Summary

The local baseline workflow could save and compare immutable snapshots, but users could not discover or inspect stored keys. The store also accepted a symlink in an ancestor of a not-yet-created directory and mapped distinct keys such as `label:a/b` and `label:a?b` to the same filename.

This adds preview-gated, metadata-only baseline discovery and hardens existing save/compare behavior without exposing dependency rows or following store symlinks.

Closes #1133
Closes #1156

## Changes

- add `lopper baseline list` and `lopper baseline show KEY` with table/JSON output, newest-first ordering, explicit limits, safe per-entry diagnostics, and `LOP-FEAT-0019` `baseline-store-discovery-preview`
- replace lossy-only filenames with readable slugs plus full SHA-256 key digests while preserving verified fallback loading for legacy filenames
- reject symlinked store ancestry and symlinked/non-regular entries, bound snapshot reads to 64 MiB, and require exact requested/stored key identity
- expose only snapshot identity, timestamps, schema versions, repository identity, and summary metadata; sanitize terminal controls in human output
- update parser/help, README, report-schema docs, generated manpage, and regression coverage across report/dashboard/app/TUI/MCP paths

## Validation

Commands and checks run:

```bash
make ci
make ci BUILD_CHANNEL=rolling
make demos-check
make dup-check
make suppression-check
make manpage
go run ./tools/featureflag validate
```

Additional manual validation:

- built the CLI and verified preview-gated list/show table and JSON output against saved commit/label snapshots
- verified `show` omits dependency rows
- reproduced the nested symlink-parent case and confirmed exit 1 with no write through the link
- reproduced a legacy sanitized-filename collision and confirmed an explicit requested/stored key mismatch
- verified malformed, oversized, non-regular, and out-of-root symlink entries remain per-entry diagnostics

## Risk and compatibility

- Breaking changes: None; discovery is preview-gated and existing CLI flags remain compatible.
- Migration required: None; new saves use collision-resistant names and legacy sanitized filenames load through a verified fallback.
- Performance impact: Local-only listing reads candidate JSON snapshots sequentially with a 64 MiB per-entry ceiling; output is explicitly limited.
- Memory benchmark impact: No intentional regression; the enforced memory benchmark gate passed within thresholds.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
