### PR TITLE
fix(rust): ignore multiline alias declaration hits

### DIFF
--- a/internal/lang/rust/multiline_use_alias_test.go
+++ b/internal/lang/rust/multiline_use_alias_test.go
@@ -1,0 +1,280 @@
+package rust
+
+import (
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
+)
+
+type multilineAliasUsageCase struct {
+	name    string
+	suffix  string
+	wantUse map[string]int
+}
+
+func TestMultilineUseAliasDeclarationHits(t *testing.T) {
+	const declaration = `use serde::{
+    Deserialize as De,
+    de::{
+        Visitor as Visit,
+        value::BorrowedStrDeserializer as Borrowed,
+    },
+};
+`
+	tests := []multilineAliasUsageCase{
+		{
+			name:    "declaration only",
+			wantUse: map[string]int{"De": 0, "Visit": 0, "Borrowed": 0},
+		},
+		{
+			name:    "referenced alias",
+			suffix:  "\nfn decode(_: De) {}\n",
+			wantUse: map[string]int{"De": 1, "Visit": 0, "Borrowed": 0},
+		},
+	}
+	wantLines := map[string]int{"De": 2, "Visit": 4, "Borrowed": 5}
+	wantColumns := map[string]int{"De": 20, "Visit": 20, "Borrowed": 43}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertMultilineAliasUsage(t, declaration, test, wantLines, wantColumns)
+		})
+	}
+}
+
+func assertMultilineAliasUsage(t *testing.T, declaration string, test multilineAliasUsageCase, wantLines, wantColumns map[string]int) {
+	t.Helper()
+	content := []byte(declaration + test.suffix)
+	imports := parseRustImportsBytes(content, "src/lib.rs", "", multilineAliasDependencyLookup(), nil)
+	if len(imports) != len(test.wantUse) {
+		t.Fatalf("expected %d imports, got %#v", len(test.wantUse), imports)
+	}
+
+	usage := shared.CountUsage(content, imports)
+	for _, imported := range imports {
+		assertMultilineAliasImport(t, imported, usage[imported.Local], test.wantUse[imported.Local], wantLines[imported.Local], wantColumns[imported.Local])
+	}
+}
+
+func assertMultilineAliasImport(t *testing.T, imported importBinding, gotUsage, wantUsage, wantLine, wantColumn int) {
+	t.Helper()
+	if gotUsage != wantUsage {
+		t.Errorf("usage[%q] = %d, want %d", imported.Local, gotUsage, wantUsage)
+	}
+	if got := imported.Location.Line; got != wantLine {
+		t.Errorf("location line for %q = %d, want %d", imported.Local, got, wantLine)
+	}
+	if got := imported.Location.Column; got != wantColumn {
+		t.Errorf("location column for %q = %d, want %d", imported.Local, got, wantColumn)
+	}
+}
+
+func TestMultilineUseAliasMatchingPathIdentifier(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantUsage int
+	}{
+		{
+			name: "declaration only",
+			content: `use serde::{
+    de::Deserialize as de,
+};
+`,
+		},
+		{
+			name: "same line reference after declaration",
+			content: `use serde::{
+    de::Deserialize as de}; fn decode(_: de) {}
+`,
+			wantUsage: 1,
+		},
+		{
+			name: "comment token does not hide real reference",
+			content: `use serde::{
+    de::Deserialize as de,
+    // de is not a declaration token or a use
+}; fn decode(_: de) {}
+`,
+			wantUsage: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertMultilinePathAliasUsage(t, test.content, test.wantUsage)
+		})
+	}
+}
+
+func assertMultilinePathAliasUsage(t *testing.T, source string, wantUsage int) {
+	t.Helper()
+	content := []byte(source)
+	imports := parseRustImportsBytes(content, "src/lib.rs", "", multilineAliasDependencyLookup(), nil)
+	imported := findMultilinePathAliasImport(t, imports)
+	if imported.DeclarationTokenHits != 2 {
+		t.Errorf("declaration token hits = %d, want 2", imported.DeclarationTokenHits)
+	}
+	assertMultilineAliasImport(t, imported, shared.CountUsage(content, imports)["de"], wantUsage, 2, 24)
+}
+
+func findMultilinePathAliasImport(t *testing.T, imports []importBinding) importBinding {
+	t.Helper()
+	var matches []importBinding
+	for _, imported := range imports {
+		if imported.Local == "de" {
+			matches = append(matches, imported)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected one de alias import, got %#v", imports)
+	}
+	return matches[0]
+}
+
+func TestSingleLineUseAliasKeepsStatementLocation(t *testing.T) {
+	const content = "use serde::Deserialize as De;\nfn decode(_: De) {}\n"
+	imports := parseRustImports(content, "src/lib.rs", "", multilineAliasDependencyLookup(), nil)
+	if len(imports) != 1 {
+		t.Fatalf("expected one import, got %#v", imports)
+	}
+	if got := imports[0].Location; got.Line != 1 || got.Column != 5 {
+		t.Fatalf("single-line import location = %#v, want line 1 column 5", got)
+	}
+}
+
+func TestSingleLineUseAliasDeclarationHits(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantUsage int
+	}{
+		{
+			name:    "declaration only",
+			content: "use serde::de as de;\n",
+		},
+		{
+			name:      "genuine use on declaration line",
+			content:   "use serde::de as de; fn decode(_: de) {}\n",
+			wantUsage: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			imports := parseRustImports(test.content, "src/lib.rs", "", multilineAliasDependencyLookup(), nil)
+			if len(imports) != 1 {
+				t.Fatalf("expected one import, got %#v", imports)
+			}
+			imported := imports[0]
+			if got := imported.Location; got.Line != 1 || got.Column != 5 {
+				t.Errorf("single-line import location = %#v, want line 1 column 5", got)
+			}
+			if imported.DeclarationTokenHits != 2 {
+				t.Errorf("declaration token hits = %d, want 2", imported.DeclarationTokenHits)
+			}
+			if got := shared.CountUsage([]byte(test.content), imports)["de"]; got != test.wantUsage {
+				t.Errorf("usage[de] = %d, want %d", got, test.wantUsage)
+			}
+		})
+	}
+}
+
+func TestMultilineUseWildcardAdvancesLaterBindingLocation(t *testing.T) {
+	const content = `use serde::{
+    de::*,
+    de,
+};
+`
+	imports := parseRustImports(content, "src/lib.rs", "", multilineAliasDependencyLookup(), nil)
+	for _, imported := range imports {
+		if imported.Wildcard || imported.Local != "de" {
+			continue
+		}
+		if got := imported.Location; got.Line != 3 || got.Column != 5 {
+			t.Fatalf("later de binding location = %#v, want line 3 column 5", got)
+		}
+		return
+	}
+	t.Fatalf("later de binding missing from %#v", imports)
+}
+
+func TestLocateMultilineUseEntryPaths(t *testing.T) {
+	base := useImportContext{Line: 10, Column: 7}
+	clause := "serde::Thing,\nOther as Alias"
+
+	first, next := locateMultilineUseEntry(clause, usePathEntry{Symbol: "serde"}, base, 0)
+	if first.Line != 10 || first.Column != 7 || next != len("serde") {
+		t.Fatalf("unexpected first-line location: context=%#v next=%d", first, next)
+	}
+	alias, next := locateMultilineUseEntry(clause, usePathEntry{Symbol: "Other", Local: "Alias"}, base, next)
+	if alias.Line != 11 || alias.Column != 10 || next != len(clause) {
+		t.Fatalf("unexpected alias location: context=%#v next=%d", alias, next)
+	}
+
+	wildcard, wildcardNext := locateMultilineUseEntry(clause, usePathEntry{Wildcard: true}, base, next)
+	if wildcard.Line != base.Line || wildcard.Column != base.Column || wildcardNext != next {
+		t.Fatalf("wildcard location changed: context=%#v next=%d", wildcard, wildcardNext)
+	}
+	missing, missingNext := locateMultilineUseEntry(clause, usePathEntry{Symbol: "Missing"}, base, 0)
+	if missing.Line != base.Line || missing.Column != base.Column || missingNext != 0 {
+		t.Fatalf("missing token location changed: context=%#v next=%d", missing, missingNext)
+	}
+	empty, emptyNext := locateMultilineUseEntry(clause, usePathEntry{}, base, 0)
+	if empty.Line != base.Line || empty.Column != base.Column || emptyNext != 0 {
+		t.Fatalf("empty token location changed: context=%#v next=%d", empty, emptyNext)
+	}
+}
+
+func TestFindRustIdentifierTokenBoundaries(t *testing.T) {
+	const content = "Deserialize De"
+	if got := findRustIdentifierToken(content, "Deserialize", 0); got != 0 {
+		t.Fatalf("full token offset = %d, want 0", got)
+	}
+	if got := findRustIdentifierToken(content, "De", 0); got != len("Deserialize ") {
+		t.Fatalf("alias token offset = %d, want %d", got, len("Deserialize "))
+	}
+	if got := findRustIdentifierToken("Deserialize", "De", 0); got != -1 {
+		t.Fatalf("substring offset = %d, want -1", got)
+	}
+	const collidingAlias = "de::Deserialize as de"
+	if got := findRustAliasToken(collidingAlias, "de", 0); got != len("de::Deserialize as ") {
+		t.Fatalf("alias token offset = %d, want %d", got, len("de::Deserialize as "))
+	}
+	if got := findRustAliasToken("de::Deserialize as other", "de", 0); got != -1 {
+		t.Fatalf("mismatched alias token offset = %d, want -1", got)
+	}
+	if got := countRustIdentifierTokens(collidingAlias, "de"); got != 2 {
+		t.Fatalf("declaration token count = %d, want 2", got)
+	}
+	for _, test := range []struct {
+		token string
+		start int
+	}{
+		{token: "", start: 0},
+		{token: "De", start: -1},
+		{token: "De", start: len(content)},
+	} {
+		if got := findRustIdentifierToken(content, test.token, test.start); got != -1 {
+			t.Errorf("findRustIdentifierToken(%q, %d) = %d, want -1", test.token, test.start, got)
+		}
+	}
+	for _, test := range []struct {
+		content string
+		token   string
+		offset  int
+	}{
+		{content: content, token: "", offset: 0},
+		{content: content, token: "De", offset: -1},
+		{content: content, token: "De", offset: len(content)},
+		{content: content, token: "Other", offset: 0},
+	} {
+		if rustIdentifierTokenAt(test.content, test.token, test.offset) {
+			t.Errorf("rustIdentifierTokenAt(%q, %q, %d) unexpectedly matched", test.content, test.token, test.offset)
+		}
+	}
+}
+
+func multilineAliasDependencyLookup() map[string]dependencyInfo {
+	return map[string]dependencyInfo{"serde": {Canonical: "serde"}}
+}

--- a/internal/lang/rust/scan_use.go
+++ b/internal/lang/rust/scan_use.go
@@ -3,6 +3,7 @@ package rust
 import (
 	"strings"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/report"
 )
 
@@ -21,14 +22,132 @@ func parseUseStatementIndex(content string, idx []int) (string, int, int, bool) 
 
 func appendUseClauseImports(imports []importBinding, clause string, ctx useImportContext) []importBinding {
 	entries := parseUseClause(clause)
+	nextToken := 0
+	multiline := strings.ContainsRune(clause, '\n')
+	declarationClause := string(shared.MaskCommentsAndStringsForFile([]byte(clause), ctx.FilePath))
 	for _, entry := range entries {
-		binding, ok := makeUseImportBinding(entry, ctx)
+		entryContext := ctx
+		entryContext.DeclarationTokenHits = countRustUseEntryDeclarationTokens(declarationClause, entry)
+		if multiline {
+			entryContext, nextToken = locateMultilineUseEntry(declarationClause, entry, entryContext, nextToken)
+		}
+		binding, ok := makeUseImportBinding(entry, entryContext)
 		if !ok {
 			continue
 		}
 		imports = append(imports, binding)
 	}
 	return imports
+}
+
+func locateMultilineUseEntry(clause string, entry usePathEntry, ctx useImportContext, searchStart int) (useImportContext, int) {
+	if entry.Wildcard {
+		return ctx, advancePastRustUseWildcard(clause, searchStart)
+	}
+	token := useEntryLocalToken(entry)
+	offset := findRustUseEntryToken(clause, entry, token, searchStart)
+	if offset < 0 {
+		return ctx, searchStart
+	}
+	line, column := lineColumn(clause, offset)
+	ctx.Line += line - 1
+	if line == 1 {
+		ctx.Column += column - 1
+	} else {
+		ctx.Column = column
+	}
+	return ctx, offset + len(token)
+}
+
+func countRustUseEntryDeclarationTokens(clause string, entry usePathEntry) int {
+	if entry.Wildcard {
+		return 0
+	}
+	return countRustIdentifierTokens(clause, useEntryLocalToken(entry))
+}
+
+func advancePastRustUseWildcard(clause string, searchStart int) int {
+	if searchStart < 0 || searchStart >= len(clause) {
+		return searchStart
+	}
+	relative := strings.IndexByte(clause[searchStart:], '*')
+	if relative < 0 {
+		return searchStart
+	}
+	return searchStart + relative + 1
+}
+
+func useEntryLocalToken(entry usePathEntry) string {
+	if entry.Local != "" {
+		return entry.Local
+	}
+	return entry.Symbol
+}
+
+func findRustUseEntryToken(clause string, entry usePathEntry, token string, searchStart int) int {
+	if entry.Local != "" {
+		return findRustAliasToken(clause, token, searchStart)
+	}
+	return findRustIdentifierToken(clause, token, searchStart)
+}
+
+func findRustAliasToken(content, alias string, searchStart int) int {
+	for searchStart < len(content) {
+		asOffset := findRustIdentifierToken(content, "as", searchStart)
+		if asOffset < 0 {
+			return -1
+		}
+		aliasOffset := asOffset + len("as")
+		for aliasOffset < len(content) && isRustWhitespace(content[aliasOffset]) {
+			aliasOffset++
+		}
+		if rustIdentifierTokenAt(content, alias, aliasOffset) {
+			return aliasOffset
+		}
+		searchStart = asOffset + len("as")
+	}
+	return -1
+}
+
+func countRustIdentifierTokens(content, token string) int {
+	count := 0
+	for searchStart := 0; searchStart < len(content); {
+		offset := findRustIdentifierToken(content, token, searchStart)
+		if offset < 0 {
+			return count
+		}
+		count++
+		searchStart = offset + len(token)
+	}
+	return count
+}
+
+func findRustIdentifierToken(content, token string, searchStart int) int {
+	if token == "" || searchStart < 0 || searchStart >= len(content) {
+		return -1
+	}
+	for searchStart < len(content) {
+		relative := strings.Index(content[searchStart:], token)
+		if relative < 0 {
+			return -1
+		}
+		offset := searchStart + relative
+		if rustIdentifierTokenAt(content, token, offset) {
+			return offset
+		}
+		searchStart = offset + 1
+	}
+	return -1
+}
+
+func rustIdentifierTokenAt(content, token string, offset int) bool {
+	end := offset + len(token)
+	if token == "" || offset < 0 || end > len(content) || content[offset:end] != token {
+		return false
+	}
+	leftBoundary := offset == 0 || !isRustIdentifierContinue(content[offset-1])
+	rightBoundary := end == len(content) || !isRustIdentifierContinue(content[end])
+	return leftBoundary && rightBoundary
 }
 
 func makeUseImportBinding(entry usePathEntry, ctx useImportContext) (importBinding, bool) {
@@ -52,6 +171,7 @@ func makeUseImportBinding(entry usePathEntry, ctx useImportContext) (importBindi
 			Line:   ctx.Line,
 			Column: ctx.Column,
 		},
+		DeclarationTokenHits: ctx.DeclarationTokenHits,
 	}, true
 }
 

--- a/internal/lang/rust/types.go
+++ b/internal/lang/rust/types.go
@@ -50,12 +50,13 @@ type scanResult struct {
 }
 
 type useImportContext struct {
-	FilePath  string
-	Line      int
-	Column    int
-	CrateRoot string
-	DepLookup map[string]dependencyInfo
-	Scan      *scanResult
+	FilePath             string
+	Line                 int
+	Column               int
+	DeclarationTokenHits int
+	CrateRoot            string
+	DepLookup            map[string]dependencyInfo
+	Scan                 *scanResult
 }
 
 type usePathEntry struct {

--- a/internal/lang/shared/dependency_usage.go
+++ b/internal/lang/shared/dependency_usage.go
@@ -9,12 +9,13 @@ import (
 )
 
 type ImportRecord struct {
-	Dependency string
-	Module     string
-	Name       string
-	Local      string
-	Location   report.Location
-	Wildcard   bool
+	Dependency           string
+	Module               string
+	Name                 string
+	Local                string
+	Location             report.Location
+	Wildcard             bool
+	DeclarationTokenHits int
 }
 
 type FileUsage struct {

--- a/internal/lang/shared/dependency_usage_scan.go
+++ b/internal/lang/shared/dependency_usage_scan.go
@@ -67,8 +67,12 @@ func subtractDeclarationTokenHits(content []byte, imports []ImportRecord, usage 
 		if imported.Wildcard || imported.Local == "" {
 			continue
 		}
+		declarationHits := imported.DeclarationTokenHits
+		if declarationHits <= 0 {
+			declarationHits = 1
+		}
 		if imported.Location.Line <= 0 {
-			usage[imported.Local]--
+			usage[imported.Local] -= declarationHits
 			continue
 		}
 		if !haveLineStarts {
@@ -76,7 +80,7 @@ func subtractDeclarationTokenHits(content []byte, imports []ImportRecord, usage 
 			haveLineStarts = true
 		}
 		if declarationLineContainsToken(content, lineStarts, imported.Location.Line, imported.Local) {
-			usage[imported.Local]--
+			usage[imported.Local] -= declarationHits
 		}
 	}
 }

--- a/internal/lang/shared/dependency_usage_test.go
+++ b/internal/lang/shared/dependency_usage_test.go
@@ -69,6 +69,23 @@ func TestCountUsage(t *testing.T) {
 	}
 }
 
+func TestCountUsageSubtractsKnownDeclarationTokenHits(t *testing.T) {
+	imports := []ImportRecord{{
+		Local:                "de",
+		Location:             report.Location{File: "lib.rs", Line: 1, Column: 31},
+		DeclarationTokenHits: 2,
+	}}
+	tests := map[string]int{
+		"use serde::{de::Deserialize as de};":                     0,
+		"use serde::{de::Deserialize as de}; fn decode(_: de) {}": 1,
+	}
+	for content, want := range tests {
+		if got := CountUsage([]byte(content), imports)["de"]; got != want {
+			t.Errorf("countUsage(%q) = %d, want %d", content, got, want)
+		}
+	}
+}
+
 func TestCountUsageIgnoresCommentsAndStrings(t *testing.T) {
 	imports := []ImportRecord{{Local: testLocalFoo}, {Local: "bar"}}
 	content := []byte("import foo\nimport bar\nfoo()\n\"foo bar\"\n'foo'\n`foo`\n// foo bar\n# foo bar\n/* foo\nbar\n*/\n")


### PR DESCRIPTION
## Summary

Fix Rust dependency-usage accounting for aliases declared on later lines of a grouped `use`. The Rust parser previously assigned every expanded binding to the statement's first line, while shared declaration-hit subtraction only inspects each binding's reported line. A declaration-only alias such as `Deserialize as De` therefore survived subtraction and made an unused dependency appear 100% used.

Fixes #1159.

## Changes

- map each non-wildcard entry in a multiline Rust `use` clause back to the local token after its own `as`, with identifier-boundary checks and a monotonic source-order search
- mask comments and strings before locating or counting declaration tokens on both single- and multiline clauses, preserving source offsets while preventing comment text from suppressing real usage
- carry the exact declaration-token multiplicity into shared usage accounting so aliases that repeat an earlier path identifier subtract every declaration hit, while retaining the legacy one-hit fallback for other adapters
- advance the multiline source cursor past wildcard entries so a later same-named local binding cannot inherit the wildcard path's position
- report multiline alias locations at their actual line and column while preserving statement-level locations for single-line imports
- cover declaration-only aliases, genuine post-declaration references, alias/path collisions, single-line token collisions, wildcard ordering, comment collisions, nested aliases, identifier boundaries, fallback paths, and unchanged single-line locations

## Validation

Commands and checks run:

```bash
GOTOOLCHAIN=go1.26.5 go test ./internal/lang/rust ./internal/lang/shared -count=1
GOTOOLCHAIN=go1.26.5 go test -race ./internal/lang/rust -count=1
GOTOOLCHAIN=go1.26.5 go test -coverprofile=/tmp/lopper-1159-rust-cover.out ./internal/lang/rust -count=1
make ci
make ci BUILD_CHANNEL=rolling
make demos-check
```

Additional manual validation:

- ran the documented `repro_gate.py` fixture twice on exact main `2d613501ccb83f020c921bfc2d19e8102076b66c`; both runs reproduced `usedExportsCount: 1`
- rebuilt the CLI with this fix and ran the corrected original repro gate twice; both runs reported `usedExportsCount: 0`, no used imports, and the unused alias at line 2, column 20
- separately reproduced the alias/path-collision edge twice, then ran its fixed regression gate twice, including a same-line genuine-use control
- reproduced the wildcard-order and single-line declaration-multiplicity edges twice each, then ran both fixed parser/usage regression gates twice
- rebased and consolidated to one commit on exact main `98ad74e3e5338ae763e3a63be9f02733caf55b16`
- Rust package coverage is 98.3%; repository coverage is 98.3%, with every measured package at or above 98%
- the pre-commit hook independently reran the complete `make ci` gate over the staged snapshot and passed
- the final dev and rolling channel matrices both passed, including lint, security, leak, race, duplication, memory, build, and coverage gates
- `act pull_request -W .github/workflows/ci.yml --job verify` was not run; the complete native gate passed and the remote PR matrix will exercise the workflow

## Risk and compatibility

- Breaking changes: none; report structure is unchanged and single-line Rust import locations retain their existing statement-level position
- Migration required: none
- Performance impact: multiline `use` clauses receive one bounded, forward-only token-location pass; single-line clauses keep the existing path
- Memory benchmark impact: none; all gated bytes/op and allocs/op measurements passed against exact main

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
