### PR TITLE
feat(vscode): add preview capability parity

### DIFF
--- a/extensions/vscode-lopper/CHANGELOG.md
+++ b/extensions/vscode-lopper/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## 1.8.0 (Unreleased)
+## 1.8.1 (Unreleased)
+
+- Added safe per-workspace preview capability controls, CycloneDX JSON export, and Python runtime-aware refresh.
+- Added selected-binary capability preflight before Python runtime and CycloneDX file-selection UI.
+- Fixed refresh invalidation and request ordering so stale cached or in-flight analysis cannot replace explicit runtime or configuration-driven work.
+- Fixed binary freshness and multi-root Workspace Trust checks for configured, linked, and discovered executables.
+- Fixed runtime test commands and baseline saves repeating during focused codemod discovery.
+- Fixed transient runtime and baseline actions reusing or replacing static cached and in-flight analysis.
+- Fixed cancelling the Save Baseline label prompt still writing an unlabelled snapshot.
+
+## 1.8.0 (2026-07-11)
 
 - Added explicit VS Code actions to preview and apply safe dependency codemods with confirmation and rollback reporting.
 - Added local advisory and reachability-priority settings for the v1.8 vulnerability workflow.

--- a/extensions/vscode-lopper/README.md
+++ b/extensions/vscode-lopper/README.md
@@ -31,8 +31,9 @@ The extension shells out to `lopper`.
 - If your repo contains `bin/lopper`, the extension will use that first after you trust the workspace.
 - If no local binary is available, the extension can download a matching GitHub release into extension-managed storage.
 - You can always override detection with `lopper.binaryPath` or `LOPPER_BINARY_PATH`.
-- Workspace-local binaries, including `bin/lopper` and `lopper.binaryPath` values inside the repo, are blocked until the workspace is trusted.
+- Workspace-local binaries, including `bin/lopper`, configured paths, PATH entries, and symlinks resolving under any open workspace root, are blocked until the workspace is trusted.
 - Codemod apply actions are disabled until the workspace is trusted and keep the CLI's clean-worktree protection unless you explicitly retry with the dirty-worktree override.
+- Runtime trace files can be analysed without executing workspace code. Runtime test commands remain unavailable until the workspace is trusted and run only from the explicit runtime refresh command.
 
 ## Install
 
@@ -57,8 +58,10 @@ code --install-extension lopper-vscode-<version>.vsix
 - `lopper.autoRefresh`: refresh on saves that match the selected adapter mode
 - `lopper.autoDownloadBinary`: enable or disable managed binary downloads
 - `lopper.managedBinaryTag`: optional release tag override for managed installs
-- `lopper.runtimeTracePath`: optional runtime trace file for JS/TS runtime-aware analysis
-- `lopper.runtimeTestCommand`: optional command to run while capturing a runtime trace
+- `lopper.runtimeTracePath`: optional runtime trace file for JS/TS or Python runtime-aware analysis
+- `lopper.runtimeTestCommand`: optional allowlisted JS/TS or Python test command; execution requires Workspace Trust and an explicit runtime refresh
+- `lopper.enableFeatures`: per-workspace allowlist of safe CLI preview features to enable
+- `lopper.disableFeatures`: per-workspace allowlist of safe CLI features to disable; disable entries take precedence
 - `lopper.advisorySourcePath`: optional local JSON or YAML advisory file for vulnerability findings
 - `lopper.thresholdFailOnIncreasePercent`: waste increase gate threshold, default `-1`
 - `lopper.thresholdLowConfidenceWarningPercent`: warning threshold for low-confidence dependencies
@@ -73,21 +76,25 @@ Setting `lopper.advisorySourcePath` or a non-`off` reachable vulnerability
 threshold automatically enables the
 `reachability-vulnerability-prioritization-preview` feature for VS Code runs.
 
-Python codemod suggestions use the stable `python-codemod-suggestions` default in Lopper v1.8. First-party Python runtime capture is stable in the CLI but remains outside the extension's JS/TS-only runtime-aware refresh workflow.
+The extension queries the selected binary's `features --format json` catalog before forwarding an explicit feature setting. Only `python-runner-profiles`, `reachability-vulnerability-prioritization-preview`, and `sbom-attestation-exports-preview` are exposed because their VS Code operations are local and explicitly bounded. Dashboard, MCP mutation, and remote-repository capabilities are not accepted by these settings.
+
+Command discoverability is global because each folder in a multi-root window can select a different binary. Execution availability is folder-specific: Python runtime and CycloneDX actions preflight the selected folder's CLI manifest before opening file or input UI, and the `vscode-preview-capability-parity` tracker remains required while this surface is in preview.
+
+Python codemod suggestions and first-party Python runtime capture use their stable Lopper v1.8 defaults. The preview `python-runner-profiles` feature adds the CLI's safe `unittest` and `uv` forms when enabled for a trusted, explicit runtime refresh.
 
 ## Commands
 
 - `Lopper: Refresh Diagnostics`: refresh using the configured scope and session cache.
 - `Lopper: Refresh Diagnostics (Force Fresh)`: bypass cache and re-run analysis.
-- `Lopper: Refresh Diagnostics (Runtime Trace)`: run runtime-aware analysis for JS/TS workspaces.
+- `Lopper: Refresh Diagnostics (Runtime Trace)`: run runtime-aware analysis for JS/TS or Python workspaces.
 - `Lopper: Refresh Diagnostics (Scope: package|repo|changed-packages)`: run using an explicit scope mode.
 - `Lopper: Save Baseline Snapshot`: save the current workspace analysis as a baseline snapshot.
 - `Lopper: Compare Baseline`: compare the current workspace analysis against a saved baseline key or file.
 - `Lopper: Analyse Dependency...`: open a focused dependency analysis and detail view.
 - `Lopper: Apply Codemod`: apply an available safe codemod for a dependency and print applied, skipped, failed, and rollback artifact details.
-- `Lopper: Export Analysis as JSON|CSV|SARIF|PR Comment`: export the current analysis in a machine-readable format.
+- `Lopper: Export Analysis as JSON|CSV|SARIF|PR Comment|CycloneDX JSON`: export the current analysis. CycloneDX defaults to `lopper-analysis.cdx.json` and requests its preview capability only when the selected CLI does not enable it by default.
 
-The extension deduplicates in-flight refreshes per folder/language/scope, prevents stale runs from overwriting newer diagnostics, and logs refresh lifecycle states to the `Lopper` output channel.
+The extension deduplicates ordinary in-flight refreshes per folder/language/scope, prevents stale runs from overwriting newer diagnostics, and logs refresh lifecycle states to the `Lopper` output channel. Explicit runtime and baseline actions always execute fresh and do not replace the ordinary analysis cache.
 
 ## Development
 

--- a/extensions/vscode-lopper/package.json
+++ b/extensions/vscode-lopper/package.json
@@ -20,7 +20,10 @@
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",
-      "description": "Lopper does not execute workspace-local binaries until the workspace is trusted."
+      "description": "Lopper does not execute workspace-local binaries until the workspace is trusted.",
+      "restrictedConfigurations": [
+        "lopper.binaryPath"
+      ]
     }
   },
   "categories": [
@@ -56,6 +59,7 @@
     "onCommand:lopper.exportAnalysis.csv",
     "onCommand:lopper.exportAnalysis.sarif",
     "onCommand:lopper.exportAnalysis.prComment",
+    "onCommand:lopper.exportAnalysis.cyclonedx",
     "onCommand:lopper.openLocation",
     "onView:lopperExplorer"
   ],
@@ -123,6 +127,10 @@
         "title": "Lopper: Export Analysis as PR Comment"
       },
       {
+        "command": "lopper.exportAnalysis.cyclonedx",
+        "title": "Lopper: Export Analysis as CycloneDX JSON"
+      },
+      {
         "command": "lopper.openLocation",
         "title": "Lopper: Open Location"
       }
@@ -150,6 +158,7 @@
       "properties": {
         "lopper.language": {
           "type": "string",
+          "scope": "resource",
           "default": "auto",
           "enum": [
             "auto",
@@ -238,13 +247,55 @@
         },
         "lopper.runtimeTracePath": {
           "type": "string",
+          "scope": "resource",
           "default": "",
-          "description": "Optional runtime trace file to use for JS/TS runtime-aware analysis."
+          "description": "Optional runtime trace file to use for JS/TS or Python runtime-aware analysis."
         },
         "lopper.runtimeTestCommand": {
           "type": "string",
+          "scope": "resource",
           "default": "",
-          "description": "Optional command to run while capturing a runtime trace for JS/TS analysis."
+          "markdownDescription": "Optional allowlisted command to run while capturing a runtime trace for JS/TS or Python analysis. Test execution occurs only from the explicit runtime refresh command and requires Workspace Trust."
+        },
+        "lopper.enableFeatures": {
+          "type": "array",
+          "scope": "resource",
+          "default": [],
+          "uniqueItems": true,
+          "markdownDescription": "Safe CLI feature names to enable for this workspace folder. Lopper validates each name against the selected CLI's feature catalog and forwards it only to its allowlisted VS Code operation.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "python-runner-profiles",
+              "reachability-vulnerability-prioritization-preview",
+              "sbom-attestation-exports-preview"
+            ],
+            "enumDescriptions": [
+              "Enable safe unittest and uv Python runtime runner profiles for an explicit trusted runtime refresh.",
+              "Enable local advisory ingestion and reachability-weighted vulnerability prioritization.",
+              "Enable preview CycloneDX JSON export when the selected CLI still requires the flag."
+            ]
+          }
+        },
+        "lopper.disableFeatures": {
+          "type": "array",
+          "scope": "resource",
+          "default": [],
+          "uniqueItems": true,
+          "markdownDescription": "Safe CLI feature names to disable for this workspace folder. Disable entries take precedence over enable entries; an operation that requires a disabled feature is rejected before Lopper runs.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "python-runner-profiles",
+              "reachability-vulnerability-prioritization-preview",
+              "sbom-attestation-exports-preview"
+            ],
+            "enumDescriptions": [
+              "Disable safe unittest and uv Python runtime runner profiles.",
+              "Disable local advisory ingestion and reachability-weighted vulnerability prioritization.",
+              "Disable preview CycloneDX JSON export while this feature remains required by the CLI."
+            ]
+          }
         },
         "lopper.advisorySourcePath": {
           "type": "string",

--- a/extensions/vscode-lopper/src/binaryIdentity.ts
+++ b/extensions/vscode-lopper/src/binaryIdentity.ts
@@ -1,0 +1,22 @@
+import { realpath, stat } from "node:fs/promises";
+
+export async function binaryFileSignature(binaryPath: string): Promise<string> {
+  const resolvedPath = await realpath(binaryPath);
+  const details = await stat(resolvedPath, { bigint: true });
+  return [
+    resolvedPath,
+    details.dev,
+    details.ino,
+    details.size,
+    details.mtimeNs,
+    details.ctimeNs,
+  ].join("\0");
+}
+
+export async function tryBinaryFileSignature(binaryPath: string): Promise<string | undefined> {
+  try {
+    return await binaryFileSignature(binaryPath);
+  } catch {
+    return undefined;
+  }
+}

--- a/extensions/vscode-lopper/src/extension.ts
+++ b/extensions/vscode-lopper/src/extension.ts
@@ -1,8 +1,14 @@
 import { realpathSync } from "node:fs";
-import { mkdir, realpath, stat, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import * as vscode from "vscode";
 
+import { tryBinaryFileSignature } from "./binaryIdentity";
+import {
+  operationRequiresExplicitUserAction,
+  operationRequiresWorkspaceTrust,
+  type LopperFeatureOperation,
+} from "./featureCapabilities";
 import {
   configuredLopperLanguage,
   clearAndroidModuleSignalCache,
@@ -81,6 +87,11 @@ export interface RefreshWorkspaceOptions {
 interface LopperControllerContract extends vscode.Disposable {
   initialize(): Promise<void>;
   refreshWorkspace(options?: RefreshWorkspaceOptions): Promise<void>;
+  refreshRuntimeWorkspace(folderPath?: string): Promise<void>;
+  saveBaselineSnapshot(folderPath?: string): Promise<void>;
+  compareBaselineSnapshot(folderPath?: string): Promise<void>;
+  exportAnalysis(format: LopperOutputFormat, folderPath?: string): Promise<void>;
+  handleConfigurationChange(event: Pick<vscode.ConfigurationChangeEvent, "affectsConfiguration">): Promise<void>;
   cancelRefresh(reason?: string): void;
   applyCodemod(dependencyName?: string, folderPath?: string, options?: ApplyCodemodCommandOptions): Promise<void>;
   getLatestSummary(): string;
@@ -98,6 +109,15 @@ class DefaultLopperControllerFactory implements LopperControllerFactory {
 
 interface LopperControllerOptions {
   registerWithVSCode?: boolean;
+  isWorkspaceTrusted?: () => boolean;
+  binarySignature?: (binaryPath: string) => Promise<string | undefined>;
+  resolveLanguage?: typeof resolveLopperLanguage;
+}
+
+interface ExportTargetDescriptor {
+  readonly defaultFileName: string;
+  readonly filterLabel: string;
+  readonly extensions: readonly string[];
 }
 
 interface RefreshAbortHandle {
@@ -112,6 +132,7 @@ interface FreshRefreshOptions {
   workspaceKey: string;
   sessionKey: string;
   runId: number;
+  inputVersion: number;
   revealErrors: boolean;
   scopeMode: LopperScopeMode;
   document?: vscode.TextDocument;
@@ -149,6 +170,9 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   private latestSummary = "Lopper: idle";
   private missingBinaryWarningShown = false;
   private readonly disposable: vscode.Disposable;
+  private readonly isWorkspaceTrusted: () => boolean;
+  private readonly binarySignatureProvider: (binaryPath: string) => Promise<string | undefined>;
+  private readonly resolveLanguage: typeof resolveLopperLanguage;
 
   constructor(
     context: vscode.ExtensionContext,
@@ -156,6 +180,9 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     options: LopperControllerOptions = {},
   ) {
     const registerWithVSCode = options.registerWithVSCode ?? true;
+    this.isWorkspaceTrusted = options.isWorkspaceTrusted ?? (() => vscode.workspace.isTrusted);
+    this.binarySignatureProvider = options.binarySignature ?? tryBinaryFileSignature;
+    this.resolveLanguage = options.resolveLanguage ?? resolveLopperLanguage;
     this.runner = runner ?? new LopperRunner(this.output, context);
     this.explorer = new LopperExplorerTreeDataProvider(
       () => vscode.workspace.workspaceFolders ?? [],
@@ -234,6 +261,9 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
         vscode.commands.registerCommand("lopper.exportAnalysis.prComment", async (folderPath?: string) => {
           await this.exportAnalysis("pr-comment", folderPath);
         }),
+        vscode.commands.registerCommand("lopper.exportAnalysis.cyclonedx", async (folderPath?: string) => {
+          await this.exportAnalysis("cyclonedx-json", folderPath);
+        }),
         vscode.commands.registerCommand("lopper.openLocation", async (filePath: string, line = 1, column = 1) => {
           await this.openLocation(filePath, line, column);
         }),
@@ -246,21 +276,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
           void this.handleDidSaveTextDocument(document);
         }),
         vscode.workspace.onDidChangeConfiguration((event) => {
-          for (const folder of vscode.workspace.workspaceFolders ?? []) {
-            if (!event.affectsConfiguration("lopper", folder.uri)) {
-              continue;
-            }
-            this.invalidateWorkspaceSession(folder, "lopper settings changed");
-            if (!vscode.workspace.getConfiguration("lopper", folder.uri).get<boolean>("autoRefresh", true)) {
-              continue;
-            }
-            void this.refreshWorkspace({
-              folder,
-              revealErrors: false,
-              document: this.activeDocumentForFolder(folder),
-              trigger: "config-change",
-            });
-          }
+          void this.handleConfigurationChange(event);
         }),
         vscode.workspace.onDidChangeWorkspaceFolders((event) => {
           for (const removedFolder of event.removed) {
@@ -330,6 +346,26 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     }
   }
 
+  async handleConfigurationChange(event: Pick<vscode.ConfigurationChangeEvent, "affectsConfiguration">): Promise<void> {
+    const refreshes: Promise<void>[] = [];
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+      if (!event.affectsConfiguration("lopper", folder.uri)) {
+        continue;
+      }
+      this.invalidateWorkspaceSession(folder, "lopper settings changed");
+      if (!vscode.workspace.getConfiguration("lopper", folder.uri).get<boolean>("autoRefresh", true)) {
+        continue;
+      }
+      refreshes.push(this.refreshWorkspace({
+        folder,
+        revealErrors: false,
+        document: this.activeDocumentForFolder(folder),
+        trigger: "config-change",
+      }));
+    }
+    await Promise.all(refreshes);
+  }
+
   async refreshWorkspace(options: RefreshWorkspaceOptions = {}): Promise<void> {
     const folder = options.folder ?? await this.resolveWorkspaceFolder();
     const revealErrors = options.revealErrors ?? true;
@@ -350,9 +386,18 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       return;
     }
 
-    const scopeMode = this.requestedScopeMode(folder, options.scopeModeOverride);
-    const requestedLanguage = await resolveLopperLanguage(configuredLopperLanguage(folder), document, folder.uri.fsPath);
     const workspaceKey = folder.uri.toString();
+    const requestId = this.refreshSessions.reserveRequest(workspaceKey);
+    const inputVersion = this.refreshSessions.inputVersion(workspaceKey);
+    const scopeMode = this.requestedScopeMode(folder, options.scopeModeOverride);
+    const requestedLanguage = await this.resolveLanguage(configuredLopperLanguage(folder), document, folder.uri.fsPath);
+    if (
+      !this.refreshSessions.isLatestRequest(workspaceKey, requestId)
+      || !this.refreshSessions.isCurrentInputVersion(workspaceKey, inputVersion)
+    ) {
+      this.output.appendLine(`[refresh:stale] ${folder.name} request=${requestId} superseded before session lookup`);
+      return;
+    }
     const sessionKey = this.sessionKey(workspaceKey, requestedLanguage, scopeMode);
 
     const reuse = this.tryReuseAnalysis({
@@ -363,8 +408,17 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       scopeMode,
       forceFresh,
       trigger,
+      requestId,
+      inputVersion,
     });
     if (reuse === true || (reuse instanceof Promise && await reuse)) {
+      return;
+    }
+    if (
+      !this.refreshSessions.isLatestRequest(workspaceKey, requestId)
+      || !this.refreshSessions.isCurrentInputVersion(workspaceKey, inputVersion)
+    ) {
+      this.output.appendLine(`[refresh:stale] ${folder.name} request=${requestId} superseded during cache validation`);
       return;
     }
 
@@ -392,6 +446,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       workspaceKey,
       sessionKey,
       runId,
+      inputVersion,
       revealErrors,
       scopeMode,
       document,
@@ -406,7 +461,9 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       signal: abortController.signal,
       abortKey,
     });
-    this.refreshSessions.setInFlight(workspaceKey, sessionKey, runId, refreshPromise);
+    if (isStaticAnalysisRefresh(options)) {
+      this.refreshSessions.setInFlight(workspaceKey, sessionKey, runId, refreshPromise);
+    }
     await refreshPromise;
   }
 
@@ -418,13 +475,15 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     scopeMode: LopperScopeMode;
     forceFresh: boolean;
     trigger: RefreshTrigger;
+    requestId: number;
+    inputVersion: number;
   }): boolean | Promise<boolean> {
     if (options.forceFresh) {
       return false;
     }
 
     const inFlight = this.refreshSessions.inFlight(options.workspaceKey, options.sessionKey);
-    if (inFlight) {
+    if (inFlight && this.refreshSessions.isLatestRun(options.workspaceKey, inFlight.runId)) {
       this.output.appendLine(
         `[refresh:reused-running] ${options.folder.name} (${options.requestedLanguage}, ${options.scopeMode}) trigger=${options.trigger}`,
       );
@@ -439,6 +498,13 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     const cached = this.refreshSessions.getCache(options.workspaceKey, options.sessionKey);
     if (cached) {
       return this.canReuseCachedAnalysis(cached.value).then((canReuse) => {
+        if (
+          !this.refreshSessions.isLatestRequest(options.workspaceKey, options.requestId)
+          || !this.refreshSessions.isCurrentInputVersion(options.workspaceKey, options.inputVersion)
+          || !this.refreshSessions.isCurrentInputVersion(options.workspaceKey, cached.inputVersion)
+        ) {
+          return true;
+        }
         if (canReuse) {
           const runId = this.refreshSessions.reserveRun(options.workspaceKey);
           this.abortSupersededRefreshes(options.workspaceKey, runId);
@@ -487,8 +553,8 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   }
 
   private completeFreshRefresh(options: FreshRefreshOptions, analysis: WorkspaceAnalysis): void {
-    const { folder, workspaceKey, sessionKey, runId, requestedLanguage, scopeMode, signal } = options;
-    if (!this.refreshSessions.isLatestRun(workspaceKey, runId)) {
+    const { folder, workspaceKey, sessionKey, runId, inputVersion, requestedLanguage, scopeMode, signal } = options;
+    if (!this.isCurrentRefresh(workspaceKey, runId, inputVersion)) {
       this.output.appendLine(
         `[refresh:stale] ${folder.name} (${requestedLanguage}, ${scopeMode}) run=${runId} ignored in favor of run=${this.refreshSessions.latestRunId(workspaceKey)}`,
       );
@@ -499,14 +565,18 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       this.restoreStatusAfterCancellation(folder, workspaceKey, scopeMode, runId);
       return;
     }
-    this.refreshSessions.setCache(workspaceKey, sessionKey, analysis);
+    if (isStaticAnalysisRefresh(options)) {
+      this.refreshSessions.setCache(workspaceKey, sessionKey, analysis);
+    } else {
+      this.output.appendLine(`[refresh:cache-skipped] ${folder.name} transient analysis result`);
+    }
     this.renderAnalysis(analysis, "fresh");
     this.missingBinaryWarningShown = false;
   }
 
   private async handleFreshRefreshError(options: FreshRefreshOptions, error: unknown): Promise<void> {
-    const { folder, workspaceKey, runId, requestedLanguage, scopeMode, signal, revealErrors } = options;
-    if (!this.refreshSessions.isLatestRun(workspaceKey, runId)) {
+    const { folder, workspaceKey, runId, inputVersion, requestedLanguage, scopeMode, signal, revealErrors } = options;
+    if (!this.isCurrentRefresh(workspaceKey, runId, inputVersion)) {
       this.output.appendLine(
         `[refresh:stale] ${folder.name} (${requestedLanguage}, ${scopeMode}) run=${runId} failed after supersession`,
       );
@@ -566,8 +636,15 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   }
 
   private invalidateWorkspaceSession(folder: vscode.WorkspaceFolder, reason: string): void {
-    this.refreshSessions.bumpInputVersion(folder.uri.toString());
+    const workspaceKey = folder.uri.toString();
+    this.refreshSessions.bumpInputVersion(workspaceKey);
+    this.abortWorkspaceRefreshes(workspaceKey, reason);
     this.output.appendLine(`[refresh:invalidate] ${folder.name}: ${reason}`);
+  }
+
+  private isCurrentRefresh(workspaceKey: string, runId: number, inputVersion: number): boolean {
+    return this.refreshSessions.isLatestRun(workspaceKey, runId)
+      && this.refreshSessions.isCurrentInputVersion(workspaceKey, inputVersion);
   }
 
   private async canReuseCachedAnalysis(analysis: WorkspaceAnalysis): Promise<boolean> {
@@ -576,13 +653,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   }
 
   private async binarySignature(binaryPath: string): Promise<string | undefined> {
-    try {
-      const resolvedPath = await realpath(binaryPath);
-      const details = await stat(resolvedPath);
-      return `${resolvedPath}:${Math.floor(details.mtimeMs)}`;
-    } catch {
-      return undefined;
-    }
+    return this.binarySignatureProvider(binaryPath);
   }
 
   getLatestSummary(): string {
@@ -769,7 +840,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     invalidateAndroidModuleSignalCacheForPath(uri.fsPath, folder?.uri.fsPath);
   }
 
-  private async refreshRuntimeWorkspace(folderPath?: string): Promise<void> {
+  async refreshRuntimeWorkspace(folderPath?: string): Promise<void> {
     const folder = await this.resolveDependencyWorkspaceFolder(folderPath);
     if (!folder) {
       await vscode.window.showInformationMessage("Open a folder before running Lopper runtime analysis.");
@@ -781,13 +852,22 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       this.activeDocumentForFolder(folder),
       folder.uri.fsPath,
     );
-    if (requestedLanguage !== "js-ts") {
-      await vscode.window.showInformationMessage("Runtime-aware analysis is currently intended for JS/TS workspaces.");
+    if (!isRuntimeLanguageSupported(requestedLanguage)) {
+      await vscode.window.showInformationMessage("Runtime-aware analysis is available for JS/TS and Python workspaces.");
+      return;
+    }
+    if (requestedLanguage === "python" && !await this.preflightExplicitOperation(folder, "python-runtime")) {
       return;
     }
 
     const runtimeTracePath = await this.resolveRuntimeTracePath(folder);
-    const runtimeTestCommand = runtimeTracePath ? undefined : await this.resolveRuntimeTestCommand(folder);
+    if (!runtimeTracePath && operationRequiresWorkspaceTrust("runtime-test") && !this.isWorkspaceTrusted()) {
+      await vscode.window.showWarningMessage("Trust this workspace before running a Lopper runtime test command.");
+      return;
+    }
+    const runtimeTestCommand = runtimeTracePath
+      ? undefined
+      : await this.resolveRuntimeTestCommand(folder, requestedLanguage);
     if (!runtimeTracePath && !runtimeTestCommand) {
       await vscode.window.showInformationMessage("Provide a runtime trace file or test command to run runtime-aware analysis.");
       return;
@@ -797,13 +877,14 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       folder,
       document: this.activeDocumentForFolder(folder),
       revealErrors: true,
+      forceFresh: true,
       trigger: "command",
       runtimeTracePath,
       runtimeTestCommand,
     });
   }
 
-  private async saveBaselineSnapshot(folderPath?: string): Promise<void> {
+  async saveBaselineSnapshot(folderPath?: string): Promise<void> {
     const folder = await this.resolveDependencyWorkspaceFolder(folderPath);
     if (!folder) {
       await vscode.window.showInformationMessage("Open a folder before saving a baseline snapshot.");
@@ -816,11 +897,15 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       prompt: "Optional label for the saved baseline snapshot.",
       placeHolder: "release-candidate",
     });
+    if (baselineLabel === undefined) {
+      return;
+    }
 
     await this.refreshWorkspace({
       folder,
       document: this.activeDocumentForFolder(folder),
       revealErrors: true,
+      forceFresh: true,
       trigger: "command",
       baselineStorePath,
       baselineLabel: baselineLabel?.trim().length ? baselineLabel.trim() : undefined,
@@ -828,7 +913,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     });
   }
 
-  private async compareBaselineSnapshot(folderPath?: string): Promise<void> {
+  async compareBaselineSnapshot(folderPath?: string): Promise<void> {
     const folder = await this.resolveDependencyWorkspaceFolder(folderPath);
     if (!folder) {
       await vscode.window.showInformationMessage("Open a folder before comparing against a baseline.");
@@ -868,6 +953,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
         folder,
         document: this.activeDocumentForFolder(folder),
         revealErrors: true,
+        forceFresh: true,
         trigger: "command",
         baselinePath,
       });
@@ -887,6 +973,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       folder,
       document: this.activeDocumentForFolder(folder),
       revealErrors: true,
+      forceFresh: true,
       trigger: "command",
       baselineStorePath: this.defaultBaselineStorePath(folder),
       baselineKey: baselineKey.trim(),
@@ -935,7 +1022,7 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
       await vscode.window.showInformationMessage("Open a folder before applying a Lopper codemod.");
       return;
     }
-    if (!vscode.workspace.isTrusted) {
+    if (!this.isWorkspaceTrusted()) {
       await vscode.window.showWarningMessage("Trust this workspace before applying Lopper codemods.");
       return;
     }
@@ -970,10 +1057,13 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     }
   }
 
-  private async exportAnalysis(format: LopperOutputFormat, folderPath?: string): Promise<void> {
+  async exportAnalysis(format: LopperOutputFormat, folderPath?: string): Promise<void> {
     const folder = await this.resolveDependencyWorkspaceFolder(folderPath);
     if (!folder) {
       await vscode.window.showInformationMessage("Open a folder before exporting analysis results.");
+      return;
+    }
+    if (format === "cyclonedx-json" && !await this.preflightExplicitOperation(folder, "cyclonedx-export")) {
       return;
     }
 
@@ -1033,7 +1123,32 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     return selected?.[0]?.fsPath;
   }
 
-  private async resolveRuntimeTestCommand(folder: vscode.WorkspaceFolder): Promise<string | undefined> {
+  private async preflightExplicitOperation(
+    folder: vscode.WorkspaceFolder,
+    operation: LopperFeatureOperation,
+  ): Promise<boolean> {
+    if (!operationRequiresExplicitUserAction(operation)) {
+      throw new Error(`Lopper operation ${operation} is not declared as an explicit user action.`);
+    }
+    if (!this.runner.preflightOperation) {
+      return true;
+    }
+    try {
+      await this.runner.preflightOperation(folder, operation);
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const unavailable = `Lopper ${operation} is unavailable for ${folder.name}: ${message}`;
+      this.output.appendLine(`[capability:unavailable] ${unavailable}`);
+      await vscode.window.showErrorMessage(unavailable);
+      return false;
+    }
+  }
+
+  private async resolveRuntimeTestCommand(
+    folder: vscode.WorkspaceFolder,
+    requestedLanguage: "js-ts" | "python",
+  ): Promise<string | undefined> {
     const configured = vscode.workspace.getConfiguration("lopper", folder.uri).get<string>("runtimeTestCommand", "");
     if (configured.trim().length > 0) {
       return configured.trim();
@@ -1041,8 +1156,8 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
 
     const command = await vscode.window.showInputBox({
       title: "Runtime test command",
-      prompt: "Command to run while capturing the runtime trace.",
-      placeHolder: "npm test",
+      prompt: "Allowlisted command to run while capturing the runtime trace.",
+      placeHolder: requestedLanguage === "python" ? "pytest" : "npm test",
     });
     return command?.trim().length ? command.trim() : undefined;
   }
@@ -1052,13 +1167,12 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
   }
 
   private async pickExportTarget(folder: vscode.WorkspaceFolder, format: LopperOutputFormat): Promise<string | undefined> {
-    const defaultExtension = format === "pr-comment" ? "md" : format;
-    const defaultFileName = `lopper-analysis.${defaultExtension}`;
+    const descriptor = exportTargetDescriptor(format);
     const target = await vscode.window.showSaveDialog({
       title: `Export Lopper ${format.toUpperCase()} output`,
-      defaultUri: vscode.Uri.file(path.join(folder.uri.fsPath, defaultFileName)),
+      defaultUri: vscode.Uri.file(path.join(folder.uri.fsPath, descriptor.defaultFileName)),
       filters: {
-        [format.toUpperCase()]: [defaultExtension],
+        [descriptor.filterLabel]: [...descriptor.extensions],
       },
     });
     return target?.fsPath;
@@ -1481,6 +1595,16 @@ class LopperController implements LopperControllerContract, vscode.HoverProvider
     }
   }
 
+  private abortWorkspaceRefreshes(workspaceKey: string, reason: string): void {
+    for (const handle of this.refreshAbortHandles.values()) {
+      if (handle.workspaceKey !== workspaceKey || handle.controller.signal.aborted) {
+        continue;
+      }
+      this.output.appendLine(`[refresh:abort] ${handle.folderName} run=${handle.runId}: ${reason}`);
+      handle.controller.abort();
+    }
+  }
+
   private cancelActiveRefreshes(reason: string): void {
     let cancelled = 0;
     for (const handle of this.refreshAbortHandles.values()) {
@@ -1623,8 +1747,16 @@ class LopperExtensionBootstrap implements vscode.Disposable {
 }
 
 export const __testing = {
-  createController: (runner: WorkspaceAnalysisRunner): LopperControllerContract =>
-    new LopperController({} as vscode.ExtensionContext, runner, { registerWithVSCode: false }),
+  createController: (
+    runner: WorkspaceAnalysisRunner,
+    options: Pick<
+      LopperControllerOptions,
+      "isWorkspaceTrusted" | "registerWithVSCode" | "binarySignature" | "resolveLanguage"
+    > = {},
+  ): LopperControllerContract =>
+    new LopperController({} as vscode.ExtensionContext, runner, { registerWithVSCode: false, ...options }),
+  exportTargetDescriptor,
+  isRuntimeLanguageSupported,
   formatCodemodApplySummary,
   formatCodemodApplyNotification,
   isDirtyWorktreeApplyError,
@@ -1642,12 +1774,54 @@ export function deactivate(): void {
   bootstrap.dispose();
 }
 
+function isStaticAnalysisRefresh(options: Pick<
+  RefreshWorkspaceOptions,
+  | "runtimeTracePath"
+  | "runtimeTestCommand"
+  | "baselinePath"
+  | "baselineStorePath"
+  | "baselineKey"
+  | "baselineLabel"
+  | "saveBaseline"
+>): boolean {
+  return options.runtimeTracePath === undefined
+    && options.runtimeTestCommand === undefined
+    && options.baselinePath === undefined
+    && options.baselineStorePath === undefined
+    && options.baselineKey === undefined
+    && options.baselineLabel === undefined
+    && options.saveBaseline !== true;
+}
+
 function normalizeScopeMode(value: string | undefined): LopperScopeMode {
   const normalized = value?.trim().toLowerCase() as LopperScopeMode | undefined;
   if (normalized && (lopperScopeModeValues as readonly string[]).includes(normalized)) {
     return normalized;
   }
   return "package";
+}
+
+function isRuntimeLanguageSupported(value: string): value is "js-ts" | "python" {
+  return value === "js-ts" || value === "python";
+}
+
+function exportTargetDescriptor(format: LopperOutputFormat): ExportTargetDescriptor {
+  switch (format) {
+    case "pr-comment":
+      return { defaultFileName: "lopper-analysis.md", filterLabel: "PR Comment", extensions: ["md"] };
+    case "cyclonedx-json":
+      return {
+        defaultFileName: "lopper-analysis.cdx.json",
+        filterLabel: "CycloneDX JSON",
+        extensions: ["cdx.json", "json"],
+      };
+    default:
+      return {
+        defaultFileName: `lopper-analysis.${format}`,
+        filterLabel: format.toUpperCase(),
+        extensions: [format],
+      };
+  }
 }
 
 type LopperExplorerNodeKind = "folder" | "summary" | "dependency" | "group" | "import" | "metric";

--- a/extensions/vscode-lopper/src/featureCapabilities.ts
+++ b/extensions/vscode-lopper/src/featureCapabilities.ts
@@ -1,0 +1,260 @@
+export const sbomAttestationExportsFeature = "sbom-attestation-exports-preview";
+export const reachabilityVulnerabilityFeature = "reachability-vulnerability-prioritization-preview";
+export const pythonRunnerProfilesFeature = "python-runner-profiles";
+export const vscodePreviewCapabilityParityFeature = "vscode-preview-capability-parity";
+
+export type LopperFeatureOperation = "analysis" | "cyclonedx-export" | "python-runtime" | "runtime-test";
+export type LopperFeatureLifecycle = "preview" | "stable";
+
+export interface LopperFeatureManifestEntry {
+  code: string;
+  name: string;
+  description: string;
+  lifecycle: LopperFeatureLifecycle;
+  enabledByDefault: boolean;
+}
+
+export interface LopperFeatureSettings {
+  enable: readonly string[];
+  disable: readonly string[];
+}
+
+export interface LopperFeatureResolutionRequest extends LopperFeatureSettings {
+  operations: readonly LopperFeatureOperation[];
+  required: readonly string[];
+}
+
+export interface LopperFeatureOverrides {
+  enable: string[];
+  disable: string[];
+}
+
+interface LopperFeatureCapability {
+  readonly name: string;
+  readonly operations: readonly LopperFeatureOperation[];
+  readonly configurable: boolean;
+}
+
+interface LopperOperationCapability {
+  readonly requiredFeatures: readonly string[];
+  readonly requiresWorkspaceTrust: boolean;
+  readonly explicitUserAction: boolean;
+}
+
+const featureCapabilities: readonly LopperFeatureCapability[] = [
+  {
+    name: reachabilityVulnerabilityFeature,
+    operations: ["analysis"],
+    configurable: true,
+  },
+  {
+    name: sbomAttestationExportsFeature,
+    operations: ["cyclonedx-export"],
+    configurable: true,
+  },
+  {
+    name: pythonRunnerProfilesFeature,
+    operations: ["runtime-test"],
+    configurable: true,
+  },
+  {
+    name: vscodePreviewCapabilityParityFeature,
+    operations: ["cyclonedx-export", "python-runtime"],
+    configurable: false,
+  },
+];
+
+const operationCapabilities: Readonly<Record<LopperFeatureOperation, LopperOperationCapability>> = {
+  analysis: {
+    requiredFeatures: [],
+    requiresWorkspaceTrust: false,
+    explicitUserAction: false,
+  },
+  "cyclonedx-export": {
+    requiredFeatures: [vscodePreviewCapabilityParityFeature, sbomAttestationExportsFeature],
+    requiresWorkspaceTrust: false,
+    explicitUserAction: true,
+  },
+  "python-runtime": {
+    requiredFeatures: [vscodePreviewCapabilityParityFeature],
+    requiresWorkspaceTrust: false,
+    explicitUserAction: true,
+  },
+  "runtime-test": {
+    requiredFeatures: [],
+    requiresWorkspaceTrust: true,
+    explicitUserAction: true,
+  },
+};
+
+const featureCapabilityByName = new Map(featureCapabilities.map((capability) => [capability.name, capability]));
+
+export const vscodeFeatureNames = featureCapabilities
+  .filter((capability) => capability.configurable)
+  .map((capability) => capability.name);
+
+export function operationRequiresWorkspaceTrust(operation: LopperFeatureOperation): boolean {
+  return operationCapabilities[operation].requiresWorkspaceTrust;
+}
+
+export function operationRequiresExplicitUserAction(operation: LopperFeatureOperation): boolean {
+  return operationCapabilities[operation].explicitUserAction;
+}
+
+export function requiredFeaturesForOperation(operation: LopperFeatureOperation): readonly string[] {
+  return operationCapabilities[operation].requiredFeatures;
+}
+
+export function parseFeatureManifest(output: string): LopperFeatureManifestEntry[] {
+  let value: unknown;
+  try {
+    value = JSON.parse(output);
+  } catch (error) {
+    throw new Error(`invalid feature catalog JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!Array.isArray(value)) {
+    throw new TypeError("invalid feature catalog JSON: expected an array");
+  }
+
+  const codes = new Set<string>();
+  const names = new Set<string>();
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new TypeError(`invalid feature catalog entry at index ${index}: expected an object`);
+    }
+    const code = requiredString(entry, "code", index);
+    const name = requiredString(entry, "name", index);
+    const description = optionalString(entry, "description", index);
+    const lifecycle = entry.lifecycle;
+    if (lifecycle !== "preview" && lifecycle !== "stable") {
+      throw new TypeError(`invalid feature catalog entry ${name}: lifecycle must be preview or stable`);
+    }
+    if (typeof entry.enabledByDefault !== "boolean") {
+      throw new TypeError(`invalid feature catalog entry ${name}: enabledByDefault must be boolean`);
+    }
+    if (codes.has(code)) {
+      throw new Error(`invalid feature catalog JSON: duplicate feature code ${code}`);
+    }
+    if (names.has(name)) {
+      throw new Error(`invalid feature catalog JSON: duplicate feature name ${name}`);
+    }
+    codes.add(code);
+    names.add(name);
+    return {
+      code,
+      name,
+      description,
+      lifecycle,
+      enabledByDefault: entry.enabledByDefault,
+    };
+  });
+}
+
+export function resolveFeatureOverrides(
+  manifest: readonly LopperFeatureManifestEntry[],
+  request: LopperFeatureResolutionRequest,
+): LopperFeatureOverrides {
+  const enabledNames = normalizeFeatureNames(request.enable);
+  const disabledNames = normalizeFeatureNames(request.disable);
+  const requiredNames = normalizeFeatureNames(request.required);
+  const manifestByName = new Map(manifest.map((entry) => [entry.name, entry]));
+
+  validateConfiguredFeatureNames(enabledNames, manifestByName);
+  validateConfiguredFeatureNames(disabledNames, manifestByName);
+  validateRequiredFeatureNames(requiredNames, manifestByName);
+
+  const activeOperations = new Set(request.operations);
+  const disabled = new Set(disabledNames.filter((name) => appliesToOperation(name, activeOperations)));
+  const enabled = new Set(
+    enabledNames.filter((name) => appliesToOperation(name, activeOperations) && !disabled.has(name)),
+  );
+
+  for (const name of requiredNames) {
+    if (disabled.has(name)) {
+      throw new Error(`Lopper feature ${name} is disabled but required for this operation.`);
+    }
+    if (!manifestByName.get(name)?.enabledByDefault) {
+      enabled.add(name);
+    }
+  }
+
+  return {
+    enable: [...enabled].sort((a, b) => a.localeCompare(b, "en")),
+    disable: [...disabled].sort((a, b) => a.localeCompare(b, "en")),
+  };
+}
+
+function normalizeFeatureNames(values: readonly string[]): string[] {
+  const names = new Set<string>();
+  for (const value of values) {
+    const name = value.trim();
+    if (name.length > 0) {
+      names.add(name);
+    }
+  }
+  return [...names];
+}
+
+function validateConfiguredFeatureNames(
+  names: readonly string[],
+  manifestByName: ReadonlyMap<string, LopperFeatureManifestEntry>,
+): void {
+  for (const name of names) {
+    if (featureCapabilityByName.get(name)?.configurable !== true) {
+      throw new Error(
+        `Lopper feature ${name} is not available to VS Code. Choose an allowlisted feature from the workspace settings UI.`,
+      );
+    }
+    if (!manifestByName.has(name)) {
+      throw staleBinaryFeatureError(name);
+    }
+  }
+}
+
+function validateRequiredFeatureNames(
+  names: readonly string[],
+  manifestByName: ReadonlyMap<string, LopperFeatureManifestEntry>,
+): void {
+  for (const name of names) {
+    if (!featureCapabilityByName.has(name)) {
+      throw new Error(`Lopper operation requires an unregistered VS Code feature capability: ${name}.`);
+    }
+    if (!manifestByName.has(name)) {
+      throw staleBinaryFeatureError(name);
+    }
+  }
+}
+
+function staleBinaryFeatureError(name: string): Error {
+  return new Error(
+    `The selected lopper binary does not report feature ${name}. Update lopper.binaryPath or lopper.managedBinaryTag, or remove the unsupported setting.`,
+  );
+}
+
+function appliesToOperation(name: string, activeOperations: ReadonlySet<LopperFeatureOperation>): boolean {
+  const capability = featureCapabilityByName.get(name);
+  return capability?.operations.some((operation) => activeOperations.has(operation)) === true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function requiredString(entry: Record<string, unknown>, field: string, index: number): string {
+  const value = entry[field];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError(`invalid feature catalog entry at index ${index}: ${field} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function optionalString(entry: Record<string, unknown>, field: string, index: number): string {
+  const value = entry[field];
+  if (value === undefined) {
+    return "";
+  }
+  if (typeof value !== "string") {
+    throw new TypeError(`invalid feature catalog entry at index ${index}: ${field} must be a string`);
+  }
+  return value.trim();
+}

--- a/extensions/vscode-lopper/src/lopperRunner.ts
+++ b/extensions/vscode-lopper/src/lopperRunner.ts
@@ -1,8 +1,17 @@
 import { execFile } from "node:child_process";
-import { realpath, stat } from "node:fs/promises";
 import { promisify } from "node:util";
 import * as vscode from "vscode";
 
+import { tryBinaryFileSignature } from "./binaryIdentity";
+import {
+  parseFeatureManifest,
+  reachabilityVulnerabilityFeature,
+  requiredFeaturesForOperation,
+  resolveFeatureOverrides,
+  type LopperFeatureManifestEntry,
+  type LopperFeatureOperation,
+  type LopperFeatureSettings,
+} from "./featureCapabilities";
 import { configuredLopperLanguage, resolveLopperLanguage, type LopperLanguage } from "./languageConfiguration";
 import {
   BinaryResolutionError,
@@ -21,11 +30,10 @@ import {
   type LopperScopeMode,
 } from "./types";
 
-export type LopperOutputFormat = "json" | "csv" | "sarif" | "pr-comment";
+export type LopperOutputFormat = "json" | "csv" | "sarif" | "pr-comment" | "cyclonedx-json";
 
 export const defaultLopperRunTimeoutMs = 120_000;
 export const defaultCodemodAnalysisConcurrency = 4;
-const reachabilityVulnerabilityFeature = "reachability-vulnerability-prioritization-preview";
 
 const execFileAsync = promisify(execFile);
 
@@ -40,6 +48,11 @@ export interface WorkspaceAnalysis {
 }
 
 export interface WorkspaceAnalysisRunner {
+  preflightOperation?(
+    folder: vscode.WorkspaceFolder,
+    operation: LopperFeatureOperation,
+    options?: LopperExecutionOptions,
+  ): Promise<void>;
   analyseWorkspace(folder: vscode.WorkspaceFolder, options?: WorkspaceAnalysisRequest): Promise<WorkspaceAnalysis>;
   exportWorkspace(folder: vscode.WorkspaceFolder, format: LopperOutputFormat, options?: WorkspaceExportRequest): Promise<string>;
   applyCodemod(
@@ -117,6 +130,8 @@ export interface ReportCommandExecutor {
 export interface LopperRunnerDeps {
   binaryLifecycle?: BinaryLifecycleManager;
   reportExecutor?: ReportCommandExecutor;
+  featureSettings?: (folder: vscode.WorkspaceFolder) => LopperFeatureSettings;
+  binarySignature?: (binaryPath: string) => Promise<string>;
 }
 
 export interface LopperExecutionOptions {
@@ -252,6 +267,10 @@ export class LopperCliReportExecutor implements ReportCommandExecutor {
 export class LopperRunner implements WorkspaceAnalysisRunner {
   private readonly binaryLifecycle: BinaryLifecycleManager;
   private readonly reportExecutor: ReportCommandExecutor;
+  private readonly featureSettings: (folder: vscode.WorkspaceFolder) => LopperFeatureSettings;
+  private readonly binarySignatureProvider: (binaryPath: string) => Promise<string>;
+  private readonly featureManifestByBinarySignature = new Map<string, LopperFeatureManifestEntry[]>();
+  private readonly featureManifestSignatureByBinaryPath = new Map<string, string>();
 
   constructor(
     private readonly output: Pick<vscode.OutputChannel, "appendLine">,
@@ -291,6 +310,23 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       },
     );
     this.reportExecutor = deps.reportExecutor ?? new LopperCliReportExecutor(output);
+    this.featureSettings = deps.featureSettings ?? configuredFeatureSettings;
+    this.binarySignatureProvider = deps.binarySignature ?? ((binaryPath) => this.readBinarySignature(binaryPath));
+  }
+
+  async preflightOperation(
+    folder: vscode.WorkspaceFolder,
+    operation: LopperFeatureOperation,
+    options: LopperExecutionOptions = {},
+  ): Promise<void> {
+    const binaryPath = await this.resolveBinaryPath(folder);
+    await this.featureArgs(
+      binaryPath,
+      folder,
+      [operation],
+      requiredFeaturesForOperation(operation),
+      { signal: options.signal, timeoutMs: options.timeoutMs ?? this.runTimeoutMs(folder) },
+    );
   }
 
   async analyseWorkspace(
@@ -410,6 +446,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     const configuration = vscode.workspace.getConfiguration("lopper", folder.uri);
     const request: BinaryResolutionRequest = {
       workspaceRoot: folder.uri.fsPath,
+      workspaceRoots: (vscode.workspace.workspaceFolders ?? [folder]).map((workspaceFolder) => workspaceFolder.uri.fsPath),
       workspaceTrusted,
       autoDownloadBinary: configuration.get<boolean>("autoDownloadBinary", true),
       envBinaryPath: process.env.LOPPER_BINARY_PATH,
@@ -441,7 +478,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     folder: vscode.WorkspaceFolder,
     options: AnalysisArgsOptions,
   ): Promise<LopperReport> {
-    const args = this.buildAnalysisArgs(folder, options);
+    const args = await this.buildAnalysisArgs(binaryPath, folder, options);
     return this.reportExecutor.runReport(binaryPath, args, folder.uri.fsPath, {
       signal: options.signal,
       timeoutMs: options.timeoutMs,
@@ -453,17 +490,18 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     folder: vscode.WorkspaceFolder,
     options: AnalysisArgsOptions,
   ): Promise<string> {
-    const args = this.buildAnalysisArgs(folder, options);
+    const args = await this.buildAnalysisArgs(binaryPath, folder, options);
     return this.reportExecutor.runCommand(binaryPath, args, folder.uri.fsPath, {
       signal: options.signal,
       timeoutMs: options.timeoutMs,
     });
   }
 
-  private buildAnalysisArgs(
+  private async buildAnalysisArgs(
+    binaryPath: string,
     folder: vscode.WorkspaceFolder,
     options: AnalysisArgsOptions,
-  ): string[] {
+  ): Promise<string[]> {
     const args = ["analyse"];
     const dependencyName = normalizeDependencyArgument(options.dependencyName);
     if (!dependencyName) {
@@ -480,7 +518,24 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       options.format,
     );
 
-    this.appendThresholdArgs(folder, args);
+    const requiredFeatures = this.appendThresholdArgs(folder, args);
+    const operations: LopperFeatureOperation[] = ["analysis"];
+    if (options.format === "cyclonedx-json") {
+      operations.push("cyclonedx-export");
+    }
+    if (
+      options.requestedLanguage === "python"
+      && (hasValue(options.runtimeTracePath) || hasValue(options.runtimeTestCommand))
+    ) {
+      operations.push("python-runtime");
+    }
+    if (hasValue(options.runtimeTestCommand)) {
+      operations.push("runtime-test");
+    }
+    for (const operation of operations) {
+      requiredFeatures.push(...requiredFeaturesForOperation(operation));
+    }
+    args.push(...await this.featureArgs(binaryPath, folder, operations, requiredFeatures, options));
     this.appendRuntimeArgs(args, options.runtimeTracePath, options.runtimeTestCommand);
     this.appendBaselineArgs(args, options.baselinePath, options.baselineStorePath, options.baselineKey, options.baselineLabel, options.saveBaseline);
     if (options.suggestOnly) {
@@ -498,7 +553,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     return args;
   }
 
-  private appendThresholdArgs(folder: vscode.WorkspaceFolder, args: string[]): void {
+  private appendThresholdArgs(folder: vscode.WorkspaceFolder, args: string[]): string[] {
     const configuration = vscode.workspace.getConfiguration("lopper", folder.uri);
     const thresholdFailOnIncrease = configuration.get<number>("thresholdFailOnIncreasePercent", -1);
     const lowConfidenceWarning = configuration.get<number>("thresholdLowConfidenceWarningPercent", 40);
@@ -523,13 +578,71 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
       String(maxUncertainImports),
       "--threshold-reachable-vuln-priority",
       reachableVulnerabilityPriority,
-      ...(enableVulnerabilityFeature ? ["--enable-feature", reachabilityVulnerabilityFeature] : []),
       ...(advisorySourcePath.trim().length > 0 ? ["--advisory-source", advisorySourcePath.trim()] : []),
       ...(licenseDeny.length > 0 ? ["--license-deny", licenseDeny.join(",")] : []),
       ...(licenseFailOnDeny ? ["--license-fail-on-deny"] : []),
       ...(licenseIncludeRegistryProvenance ? ["--license-provenance-registry"] : []),
     ];
     args.push(...thresholdArgs);
+    return enableVulnerabilityFeature ? [reachabilityVulnerabilityFeature] : [];
+  }
+
+  private async featureArgs(
+    binaryPath: string,
+    folder: vscode.WorkspaceFolder,
+    operations: readonly LopperFeatureOperation[],
+    requiredFeatures: readonly string[],
+    options: Pick<AnalysisArgsOptions, "signal" | "timeoutMs">,
+  ): Promise<string[]> {
+    const settings = this.featureSettings(folder);
+    if (settings.enable.length === 0 && settings.disable.length === 0 && requiredFeatures.length === 0) {
+      return [];
+    }
+
+    const manifest = await this.featureManifest(binaryPath, folder, options);
+    const overrides = resolveFeatureOverrides(manifest, {
+      ...settings,
+      operations,
+      required: requiredFeatures,
+    });
+    return [
+      ...overrides.enable.flatMap((name) => ["--enable-feature", name]),
+      ...overrides.disable.flatMap((name) => ["--disable-feature", name]),
+    ];
+  }
+
+  private async featureManifest(
+    binaryPath: string,
+    folder: vscode.WorkspaceFolder,
+    options: Pick<AnalysisArgsOptions, "signal" | "timeoutMs">,
+  ): Promise<LopperFeatureManifestEntry[]> {
+    const binarySignature = await this.binarySignature(binaryPath);
+    const previousSignature = this.featureManifestSignatureByBinaryPath.get(binaryPath);
+    if (previousSignature && previousSignature !== binarySignature) {
+      this.featureManifestByBinarySignature.delete(previousSignature);
+    }
+    this.featureManifestSignatureByBinaryPath.set(binaryPath, binarySignature);
+    const cached = this.featureManifestByBinarySignature.get(binarySignature);
+    if (cached) {
+      return cached;
+    }
+
+    try {
+      const output = await this.reportExecutor.runCommand(
+        binaryPath,
+        ["features", "--format", "json"],
+        folder.uri.fsPath,
+        options,
+      );
+      const manifest = parseFeatureManifest(output);
+      if (this.featureManifestSignatureByBinaryPath.get(binaryPath) === binarySignature) {
+        this.featureManifestByBinarySignature.set(binarySignature, manifest);
+      }
+      return manifest;
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Unable to read features from the selected lopper binary: ${message}`);
+    }
   }
 
   private appendRuntimeArgs(args: string[], runtimeTracePath?: string, runtimeTestCommand?: string): void {
@@ -581,7 +694,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     try {
       const report = await this.reportExecutor.runReport(
         binaryPath,
-        this.buildAnalysisArgs(folder, {
+        await this.buildAnalysisArgs(binaryPath, folder, {
           format: "json",
           requestedLanguage: language,
           scopeMode,
@@ -618,6 +731,11 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     options: WorkspaceAnalysisRequest,
     context: CodemodFetchContext,
   ): Promise<Map<string, LopperCodemodReport>> {
+    if (hasSideEffectingAnalysis(options)) {
+      this.output.appendLine("focused codemod analysis skipped for a side-effecting primary analysis");
+      return new Map();
+    }
+
     const { binarySignature, requestedLanguage, scopeMode, timeoutMs } = context;
     const dependencyByCacheKey = new Map<string, { dependency: LopperDependencyReport; language: LopperLanguage }>();
     const cacheKeys: string[] = [];
@@ -637,7 +755,7 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
     }
 
     const codemodByCacheKey = new Map<string, LopperCodemodReport | undefined>();
-    await runWithConcurrency(cacheKeys, codemodAnalysisConcurrency(options), async (cacheKey) => {
+    await runWithConcurrency(cacheKeys, defaultCodemodAnalysisConcurrency, async (cacheKey) => {
       const item = dependencyByCacheKey.get(cacheKey);
       if (!item) {
         return;
@@ -664,29 +782,39 @@ export class LopperRunner implements WorkspaceAnalysisRunner {
   }
 
   private async binarySignature(binaryPath: string): Promise<string> {
-    try {
-      const resolvedPath = await realpath(binaryPath);
-      const details = await stat(resolvedPath);
-      return `${resolvedPath}:${Math.floor(details.mtimeMs)}`;
-    } catch {
-      return `${binaryPath}:unknown`;
-    }
+    return this.binarySignatureProvider(binaryPath);
   }
+
+  private async readBinarySignature(binaryPath: string): Promise<string> {
+    return await tryBinaryFileSignature(binaryPath) ?? `${binaryPath}:unknown`;
+  }
+}
+
+function configuredFeatureSettings(folder: vscode.WorkspaceFolder): LopperFeatureSettings {
+  const configuration = vscode.workspace.getConfiguration("lopper", folder.uri);
+  return {
+    enable: configuredFeatureNames(configuration.get<unknown>("enableFeatures", []), "lopper.enableFeatures"),
+    disable: configuredFeatureNames(configuration.get<unknown>("disableFeatures", []), "lopper.disableFeatures"),
+  };
+}
+
+function configuredFeatureNames(value: unknown, settingName: string): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new Error(`${settingName} must be an array of feature names.`);
+  }
+  return value;
 }
 
 function codemodCacheKey(binarySignature: string, scopeMode: LopperScopeMode, language: LopperLanguage, dependencyName: string): string {
   return [binarySignature, scopeMode, language, dependencyName].join("\0");
 }
 
-function codemodAnalysisConcurrency(options: WorkspaceAnalysisRequest): number {
-  if (hasValue(options.runtimeTestCommand) || options.saveBaseline) {
-    return 1;
-  }
-  return defaultCodemodAnalysisConcurrency;
-}
-
 function hasValue(value: string | undefined): boolean {
   return value !== undefined && value.trim().length > 0;
+}
+
+function hasSideEffectingAnalysis(options: WorkspaceAnalysisRequest): boolean {
+  return hasValue(options.runtimeTestCommand) || options.saveBaseline === true;
 }
 
 async function runWithConcurrency<T>(

--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -55,6 +55,7 @@ interface LopperBinaryLifecycleDeps {
 
 export interface BinaryResolutionRequest {
   workspaceRoot: string;
+  workspaceRoots?: readonly string[];
   workspaceTrusted: boolean;
   autoDownloadBinary: boolean;
   envBinaryPath?: string;
@@ -254,7 +255,12 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
     const envBinaryPath = request.envBinaryPath?.trim();
     if (envBinaryPath) {
       const binaryPath = await this.ensureConfiguredBinaryExists(envBinaryPath, "LOPPER_BINARY_PATH");
-      await this.ensureWorkspaceTrustedForBinary(binaryPath, request.workspaceRoot, "LOPPER_BINARY_PATH", request.workspaceTrusted);
+      await this.ensureWorkspaceTrustedForBinary(
+        binaryPath,
+        workspaceRootsForRequest(request),
+        "LOPPER_BINARY_PATH",
+        request.workspaceTrusted,
+      );
       return binaryPath;
     }
 
@@ -267,7 +273,12 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
       ? configuredBinaryPath
       : path.join(request.workspaceRoot, configuredBinaryPath);
     const binaryPath = await this.ensureConfiguredBinaryExists(resolvedPath, "lopper.binaryPath");
-    await this.ensureWorkspaceTrustedForBinary(binaryPath, request.workspaceRoot, "lopper.binaryPath", request.workspaceTrusted);
+    await this.ensureWorkspaceTrustedForBinary(
+      binaryPath,
+      workspaceRootsForRequest(request),
+      "lopper.binaryPath",
+      request.workspaceTrusted,
+    );
     return binaryPath;
   }
 
@@ -298,7 +309,7 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
     }
 
     return findExecutableInPath(binaryFileName(this.platform), this.platform, async (candidatePath) => {
-      if (!(await this.isWorkspaceLocalBinary(candidatePath, request.workspaceRoot))) {
+      if (!(await this.isWorkspaceLocalBinary(candidatePath, workspaceRootsForRequest(request)))) {
         return true;
       }
 
@@ -383,11 +394,11 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
 
   private async ensureWorkspaceTrustedForBinary(
     binaryPath: string,
-    workspaceRoot: string,
+    workspaceRoots: readonly string[],
     source: string,
     workspaceTrusted: boolean,
   ): Promise<void> {
-    if (workspaceTrusted || !(await this.isWorkspaceLocalBinary(binaryPath, workspaceRoot))) {
+    if (workspaceTrusted || !(await this.isWorkspaceLocalBinary(binaryPath, workspaceRoots))) {
       return;
     }
 
@@ -396,21 +407,25 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
     );
   }
 
-  private async isWorkspaceLocalBinary(binaryPath: string, workspaceRoot: string): Promise<boolean> {
+  private async isWorkspaceLocalBinary(binaryPath: string, workspaceRoots: readonly string[]): Promise<boolean> {
     try {
-      const [canonicalBinaryPath, canonicalWorkspaceRoot] = await Promise.all([
+      const [canonicalBinaryPath, ...canonicalWorkspaceRoots] = await Promise.all([
         this.canonicalizePath(binaryPath),
-        this.canonicalizePath(workspaceRoot),
+        ...workspaceRoots.map((workspaceRoot) => this.canonicalizePath(workspaceRoot)),
       ]);
-      return isPathInsideWorkspace(canonicalBinaryPath, canonicalWorkspaceRoot);
+      return canonicalWorkspaceRoots.some((workspaceRoot) => isPathInsideWorkspace(canonicalBinaryPath, workspaceRoot));
     } catch (error) {
       const detail = error instanceof Error && error.message ? `: ${error.message}` : "";
       this.output.appendLine(
-        `treating lopper binary as workspace-local because path canonicalization failed while checking ${binaryPath} against workspace ${workspaceRoot}${detail}`,
+        `treating lopper binary as workspace-local because path canonicalization failed while checking ${binaryPath} against open workspace roots ${workspaceRoots.join(", ")}${detail}`,
       );
       return true;
     }
   }
+}
+
+function workspaceRootsForRequest(request: BinaryResolutionRequest): string[] {
+  return Array.from(new Set([request.workspaceRoot, ...(request.workspaceRoots ?? [])]));
 }
 
 export async function findExecutableInPath(

--- a/extensions/vscode-lopper/src/refreshSession.ts
+++ b/extensions/vscode-lopper/src/refreshSession.ts
@@ -15,6 +15,8 @@ interface FolderRefreshSession<TCachedValue, TInFlightValue> {
   inputVersion: number;
   latestRunId: number;
   nextRunId: number;
+  latestRequestId: number;
+  nextRequestId: number;
   inFlightByKey: Map<string, InFlightRefresh<TInFlightValue>>;
   cacheByKey: Map<string, CachedRefresh<TCachedValue>>;
 }
@@ -25,8 +27,29 @@ export class RefreshSessionStore<TCachedValue, TInFlightValue = void> {
   bumpInputVersion(folderKey: string): number {
     const session = this.session(folderKey);
     session.inputVersion += 1;
+    session.inFlightByKey.clear();
     session.cacheByKey.clear();
     return session.inputVersion;
+  }
+
+  inputVersion(folderKey: string): number {
+    return this.session(folderKey).inputVersion;
+  }
+
+  isCurrentInputVersion(folderKey: string, inputVersion: number): boolean {
+    return this.inputVersion(folderKey) === inputVersion;
+  }
+
+  reserveRequest(folderKey: string): number {
+    const session = this.session(folderKey);
+    const requestId = session.nextRequestId + 1;
+    session.nextRequestId = requestId;
+    session.latestRequestId = requestId;
+    return requestId;
+  }
+
+  isLatestRequest(folderKey: string, requestId: number): boolean {
+    return this.session(folderKey).latestRequestId === requestId;
   }
 
   reserveRun(folderKey: string): number {
@@ -101,6 +124,8 @@ export class RefreshSessionStore<TCachedValue, TInFlightValue = void> {
         inputVersion: 0,
         latestRunId: 0,
         nextRunId: 0,
+        latestRequestId: 0,
+        nextRequestId: 0,
         inFlightByKey: new Map<string, InFlightRefresh<TInFlightValue>>(),
         cacheByKey: new Map<string, CachedRefresh<TCachedValue>>(),
       };

--- a/extensions/vscode-lopper/src/test/runTest.mjs
+++ b/extensions/vscode-lopper/src/test/runTest.mjs
@@ -29,6 +29,7 @@ async function main() {
     await rm(path.join(workspacePathTwo, ".lopper-cache"), { recursive: true, force: true });
     await mkdir(path.join(workspacePath, "src"), { recursive: true });
     await mkdir(path.join(workspacePathTwo, "src"), { recursive: true });
+    await mkdir(path.join(workspacePathTwo, ".artifacts"), { recursive: true });
     await mkdir(outsideLocationPath, { recursive: true });
     await writeFile(
       path.join(workspacePath, "src", "index.ts"),
@@ -52,6 +53,9 @@ async function main() {
       ].join("\n"),
       "utf8",
     );
+    const pythonTracePath = path.join(workspacePathTwo, ".artifacts", "python-runtime.ndjson");
+    await writeFile(path.join(workspacePathTwo, "src", "runtime.py"), "import scope_lib\n", "utf8");
+    await writeFile(pythonTracePath, "", "utf8");
     await writeFile(path.join(outsideLocationPath, "escape.ts"), 'export const escaped = "outside";\n', "utf8");
     await symlink(outsideLocationPath, path.join(workspacePath, "linked-outside"));
 

--- a/extensions/vscode-lopper/src/test/suite/featureCapabilities.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/featureCapabilities.test.ts
@@ -1,0 +1,212 @@
+import * as assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { suite, test } from "mocha";
+
+import {
+  operationRequiresExplicitUserAction,
+  operationRequiresWorkspaceTrust,
+  parseFeatureManifest,
+  pythonRunnerProfilesFeature,
+  reachabilityVulnerabilityFeature,
+  requiredFeaturesForOperation,
+  resolveFeatureOverrides,
+  sbomAttestationExportsFeature,
+  vscodePreviewCapabilityParityFeature,
+  vscodeFeatureNames,
+  type LopperFeatureManifestEntry,
+} from "../../featureCapabilities";
+
+suite("feature capabilities", () => {
+  test("parses the CLI feature manifest strictly", () => {
+    const manifest = parseFeatureManifest(JSON.stringify(featureManifest()));
+    assert.deepEqual(manifest.map((entry) => entry.name), [
+      sbomAttestationExportsFeature,
+      reachabilityVulnerabilityFeature,
+      pythonRunnerProfilesFeature,
+      vscodePreviewCapabilityParityFeature,
+    ]);
+
+    assert.throws(() => parseFeatureManifest("{}"), {
+      name: "TypeError",
+      message: /expected an array/,
+    });
+    assert.throws(() => parseFeatureManifest("[null]"), {
+      name: "TypeError",
+      message: /expected an object/,
+    });
+    assert.throws(
+      () => parseFeatureManifest(JSON.stringify([{ ...featureManifest()[0], code: "" }])),
+      { name: "TypeError", message: /code must be a non-empty string/ },
+    );
+    assert.throws(
+      () => parseFeatureManifest(JSON.stringify([{ ...featureManifest()[0], description: false }])),
+      { name: "TypeError", message: /description must be a string/ },
+    );
+    assert.throws(
+      () => parseFeatureManifest(JSON.stringify([{ ...featureManifest()[0], lifecycle: "experimental" }])),
+      { name: "TypeError", message: /lifecycle must be preview or stable/ },
+    );
+    assert.throws(
+      () => parseFeatureManifest(JSON.stringify([...featureManifest(), featureManifest()[0]])),
+      /duplicate feature code/,
+    );
+    assert.throws(
+      () => parseFeatureManifest(JSON.stringify([{ ...featureManifest()[0], enabledByDefault: "no" }])),
+      { name: "TypeError", message: /enabledByDefault must be boolean/ },
+    );
+  });
+
+  test("applies deterministic disable precedence and operation scoping", () => {
+    const overrides = resolveFeatureOverrides(featureManifest(), {
+      enable: [
+        pythonRunnerProfilesFeature,
+        reachabilityVulnerabilityFeature,
+        sbomAttestationExportsFeature,
+        pythonRunnerProfilesFeature,
+      ],
+      disable: [reachabilityVulnerabilityFeature, reachabilityVulnerabilityFeature],
+      operations: ["analysis", "runtime-test", "cyclonedx-export"],
+      required: [sbomAttestationExportsFeature],
+    });
+
+    assert.deepEqual(overrides, {
+      enable: [pythonRunnerProfilesFeature, sbomAttestationExportsFeature],
+      disable: [reachabilityVulnerabilityFeature],
+    });
+
+    assert.deepEqual(resolveFeatureOverrides(featureManifest(), {
+      enable: [pythonRunnerProfilesFeature],
+      disable: [],
+      operations: ["analysis"],
+      required: [],
+    }), { enable: [], disable: [] });
+  });
+
+  test("does not redundantly enable a required feature already enabled by the CLI", () => {
+    const manifest = featureManifest().map((entry) => entry.name === sbomAttestationExportsFeature
+      ? { ...entry, lifecycle: "stable" as const, enabledByDefault: true }
+      : entry);
+    assert.deepEqual(resolveFeatureOverrides(manifest, {
+      enable: [],
+      disable: [],
+      operations: ["analysis", "cyclonedx-export"],
+      required: [sbomAttestationExportsFeature],
+    }), { enable: [], disable: [] });
+  });
+
+  test("rejects disabled requirements, arbitrary flags, and stale binaries", () => {
+    assert.throws(() => resolveFeatureOverrides(featureManifest(), {
+      enable: [],
+      disable: [sbomAttestationExportsFeature],
+      operations: ["analysis", "cyclonedx-export"],
+      required: [sbomAttestationExportsFeature],
+    }), /disabled but required/);
+
+    assert.throws(() => resolveFeatureOverrides(featureManifest(), {
+      enable: ["mcp-mutation-tools"],
+      disable: [],
+      operations: ["analysis"],
+      required: [],
+    }), /not available to VS Code/);
+
+    assert.throws(() => resolveFeatureOverrides(featureManifest().slice(1), {
+      enable: [sbomAttestationExportsFeature],
+      disable: [],
+      operations: ["cyclonedx-export"],
+      required: [],
+    }), /selected lopper binary does not report feature/);
+  });
+
+  test("marks only explicit test execution as trust-requiring", () => {
+    assert.equal(operationRequiresWorkspaceTrust("analysis"), false);
+    assert.equal(operationRequiresWorkspaceTrust("cyclonedx-export"), false);
+    assert.equal(operationRequiresWorkspaceTrust("python-runtime"), false);
+    assert.equal(operationRequiresWorkspaceTrust("runtime-test"), true);
+    assert.equal(operationRequiresExplicitUserAction("cyclonedx-export"), true);
+    assert.equal(operationRequiresExplicitUserAction("python-runtime"), true);
+    assert.equal(operationRequiresExplicitUserAction("runtime-test"), true);
+    assert.deepEqual(requiredFeaturesForOperation("cyclonedx-export"), [
+      vscodePreviewCapabilityParityFeature,
+      sbomAttestationExportsFeature,
+    ]);
+    assert.deepEqual(requiredFeaturesForOperation("python-runtime"), [vscodePreviewCapabilityParityFeature]);
+  });
+
+  test("gates VS Code parity in dev, rolling, and release manifests", () => {
+    for (const channel of ["dev", "release"] as const) {
+      const overrides = resolveFeatureOverrides(featureManifest(false), {
+        enable: [],
+        disable: [],
+        operations: ["cyclonedx-export"],
+        required: requiredFeaturesForOperation("cyclonedx-export"),
+      });
+      assert.deepEqual(overrides.enable, [sbomAttestationExportsFeature, vscodePreviewCapabilityParityFeature], channel);
+    }
+
+    const rollingOverrides = resolveFeatureOverrides(featureManifest(true), {
+      enable: [],
+      disable: [],
+      operations: ["cyclonedx-export"],
+      required: requiredFeaturesForOperation("cyclonedx-export"),
+    });
+    assert.deepEqual(rollingOverrides.enable, []);
+  });
+
+  test("keeps package setting enums aligned with the capability allowlist", async () => {
+    const extensionRoot = path.resolve(__dirname, "../../..");
+    const packageJson = JSON.parse(await readFile(path.join(extensionRoot, "package.json"), "utf8")) as {
+      capabilities: {
+        untrustedWorkspaces: {
+          restrictedConfigurations?: string[];
+        };
+      };
+      contributes: {
+        configuration: {
+          properties: Record<string, { items?: { enum?: string[] } }>;
+        };
+      };
+    };
+    const properties = packageJson.contributes.configuration.properties;
+    const expected = [...vscodeFeatureNames].sort();
+    assert.deepEqual([...(properties["lopper.enableFeatures"].items?.enum ?? [])].sort(), expected);
+    assert.deepEqual([...(properties["lopper.disableFeatures"].items?.enum ?? [])].sort(), expected);
+    assert.ok(
+      packageJson.capabilities.untrustedWorkspaces.restrictedConfigurations?.includes("lopper.binaryPath"),
+      "workspace-selected executable path must be declared restricted",
+    );
+  });
+});
+
+function featureManifest(previewEnabledByDefault = false): LopperFeatureManifestEntry[] {
+  return [
+    {
+      code: "LOP-FEAT-0013",
+      name: sbomAttestationExportsFeature,
+      description: "CycloneDX",
+      lifecycle: "preview",
+      enabledByDefault: previewEnabledByDefault,
+    },
+    {
+      code: "LOP-FEAT-0015",
+      name: reachabilityVulnerabilityFeature,
+      description: "Vulnerability priority",
+      lifecycle: "preview",
+      enabledByDefault: previewEnabledByDefault,
+    },
+    {
+      code: "LOP-FEAT-0018",
+      name: pythonRunnerProfilesFeature,
+      description: "Python runners",
+      lifecycle: "preview",
+      enabledByDefault: previewEnabledByDefault,
+    },
+    {
+      code: "LOP-FEAT-0020",
+      name: vscodePreviewCapabilityParityFeature,
+      description: "VS Code parity",
+      lifecycle: "preview",
+      enabledByDefault: previewEnabledByDefault,
+    },
+  ];
+}

--- a/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/lopperRunner.test.ts
@@ -1,10 +1,16 @@
 import * as assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { suite, test } from "mocha";
 import * as vscode from "vscode";
 
+import {
+  pythonRunnerProfilesFeature,
+  reachabilityVulnerabilityFeature,
+  sbomAttestationExportsFeature,
+  vscodePreviewCapabilityParityFeature,
+} from "../../featureCapabilities";
 import type { BinaryResolutionRequest } from "../../managedBinary";
 import {
   BinaryResolutionError,
@@ -398,11 +404,12 @@ suite("lopper runner", () => {
     ]);
   });
 
-  test("keeps side-effecting codemod refreshes serial", async () => {
+  test("runs a runtime test command exactly once per analysis", async () => {
     const folder = workspaceFolder();
     const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
     let activeCodemods = 0;
     let maxActiveCodemods = 0;
+    let runtimeCommandCalls = 0;
 
     const runner = new LopperRunner(
       { appendLine: () => undefined },
@@ -414,6 +421,9 @@ suite("lopper runner", () => {
         reportExecutor: {
           runCommand: async () => "",
           runReport: async (_binaryPath, args): Promise<LopperReport> => {
+            if (args.includes("--runtime-test-command")) {
+              runtimeCommandCalls += 1;
+            }
             if (args.includes("--suggest-only")) {
               activeCodemods += 1;
               maxActiveCodemods = Math.max(maxActiveCodemods, activeCodemods);
@@ -452,7 +462,113 @@ suite("lopper runner", () => {
 
     await runner.analyseWorkspace(folder, { runtimeTestCommand: "npm test" });
 
-    assert.equal(maxActiveCodemods, 1);
+    assert.equal(runtimeCommandCalls, 1, "an authorized runtime test command must execute once");
+    assert.equal(maxActiveCodemods, 0, "command-backed analysis must not start focused codemod runs");
+  });
+
+  test("keeps focused codemod discovery for trace-file-only runtime analysis", async () => {
+    const folder = workspaceFolder();
+    const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
+    const reportCalls: string[][] = [];
+
+    const runner = new LopperRunner(
+      { appendLine: () => undefined },
+      context,
+      {
+        binaryLifecycle: {
+          resolveBinaryPath: async () => path.join(folder.uri.fsPath, ".lopper-managed", "lopper"),
+        },
+        reportExecutor: {
+          runCommand: async () => "",
+          runReport: async (_binaryPath, args): Promise<LopperReport> => {
+            reportCalls.push(args);
+            if (args.includes("--suggest-only")) {
+              return {
+                dependencies: [{
+                  name: "scope-lib",
+                  usedExportsCount: 1,
+                  totalExportsCount: 2,
+                  usedPercent: 50,
+                  codemod: { mode: "suggest-only", suggestions: [] },
+                }],
+              };
+            }
+            return {
+              dependencies: [{
+                name: "scope-lib",
+                language: "js-ts",
+                usedExportsCount: 1,
+                totalExportsCount: 2,
+                usedPercent: 50,
+              }],
+            };
+          },
+        },
+      },
+    );
+
+    const analysis = await runner.analyseWorkspace(folder, { runtimeTracePath: "trace.ndjson" });
+
+    assert.equal(reportCalls.length, 2, "trace-only analysis should run primary and focused codemod reports");
+    assert.ok(!reportCalls[0]?.includes("--suggest-only"));
+    assert.ok(reportCalls[1]?.includes("--suggest-only"));
+    for (const args of reportCalls) {
+      assert.ok(args.includes("--runtime-trace"));
+      assert.equal(args[args.indexOf("--runtime-trace") + 1], "trace.ndjson");
+    }
+    assert.ok(analysis.codemodsByDependency.has("scope-lib"));
+  });
+
+  test("saves a baseline exactly once per analysis", async () => {
+    const folder = workspaceFolder();
+    const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
+    let baselineSaveCalls = 0;
+
+    const runner = new LopperRunner(
+      { appendLine: () => undefined },
+      context,
+      {
+        binaryLifecycle: {
+          resolveBinaryPath: async () => path.join(folder.uri.fsPath, ".lopper-managed", "lopper"),
+        },
+        reportExecutor: {
+          runCommand: async () => "",
+          runReport: async (_binaryPath, args): Promise<LopperReport> => {
+            if (args.includes("--save-baseline")) {
+              baselineSaveCalls += 1;
+            }
+            if (args.includes("--suggest-only")) {
+              return {
+                dependencies: [{
+                  name: args.at(-1) ?? "unknown",
+                  usedExportsCount: 1,
+                  totalExportsCount: 2,
+                  usedPercent: 50,
+                  codemod: { mode: "suggest-only", suggestions: [] },
+                }],
+              };
+            }
+            return {
+              dependencies: ["scope-a", "scope-b", "scope-c"].map((name) => ({
+                name,
+                language: "js-ts",
+                usedExportsCount: 1,
+                totalExportsCount: 2,
+                usedPercent: 50,
+              })),
+            };
+          },
+        },
+      },
+    );
+
+    await runner.analyseWorkspace(folder, {
+      baselineStorePath: ".artifacts/lopper-baselines",
+      baselineLabel: "release-candidate",
+      saveBaseline: true,
+    });
+
+    assert.equal(baselineSaveCalls, 1, "an explicit baseline save must execute once");
   });
 
   test("skips codemod analysis for flag-shaped dependency names", async () => {
@@ -628,6 +744,295 @@ suite("lopper runner", () => {
     assert.ok(exportArgs.includes("--baseline-key"));
   });
 
+  test("keeps allowlisted feature settings scoped per workspace folder", async () => {
+    const folders = vscode.workspace.workspaceFolders ?? [];
+    assert.ok(folders.length >= 2, "expected a multi-root workspace");
+    const [enabledFolder, disabledFolder] = folders;
+    assert.ok(enabledFolder);
+    assert.ok(disabledFolder);
+    const context = { globalStorageUri: vscode.Uri.file(enabledFolder.uri.fsPath) } as vscode.ExtensionContext;
+    const analysisCalls: Array<{ cwd: string; args: string[] }> = [];
+    let featureCalls = 0;
+
+    const runner = new LopperRunner(
+      { appendLine: () => undefined },
+      context,
+      {
+        binaryLifecycle: { resolveBinaryPath: async () => "/managed/lopper" },
+        binarySignature: async () => "/managed/lopper:1",
+        featureSettings: (folder) => folder.uri.toString() === enabledFolder.uri.toString()
+          ? { enable: [reachabilityVulnerabilityFeature], disable: [] }
+          : { enable: [], disable: [reachabilityVulnerabilityFeature] },
+        reportExecutor: {
+          runCommand: async (_binaryPath, args): Promise<string> => {
+            assert.deepEqual(args, ["features", "--format", "json"]);
+            featureCalls += 1;
+            return featureManifestOutput();
+          },
+          runReport: async (_binaryPath, args, cwd): Promise<LopperReport> => {
+            analysisCalls.push({ cwd, args });
+            return { dependencies: [] };
+          },
+        },
+      },
+    );
+
+    await runner.analyseWorkspace(enabledFolder);
+    await runner.analyseWorkspace(disabledFolder);
+
+    assert.equal(featureCalls, 1, "same binary signature should share one catalog lookup");
+    assert.deepEqual(featureFlagValues(analysisCalls[0]?.args ?? [], "--enable-feature"), [
+      reachabilityVulnerabilityFeature,
+    ]);
+    assert.deepEqual(featureFlagValues(analysisCalls[1]?.args ?? [], "--disable-feature"), [
+      reachabilityVulnerabilityFeature,
+    ]);
+    assert.equal(analysisCalls[0]?.cwd, enabledFolder.uri.fsPath);
+    assert.equal(analysisCalls[1]?.cwd, disabledFolder.uri.fsPath);
+  });
+
+  test("forwards Python runner profiles only for explicit runtime-test analysis", async () => {
+    const folder = workspaceFolder();
+    const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
+    const analysisCalls: string[][] = [];
+
+    const runner = new LopperRunner(
+      { appendLine: () => undefined },
+      context,
+      {
+        binaryLifecycle: { resolveBinaryPath: async () => "/managed/lopper" },
+        binarySignature: async () => "/managed/lopper:1",
+        featureSettings: () => ({ enable: [pythonRunnerProfilesFeature], disable: [] }),
+        reportExecutor: {
+          runCommand: async (): Promise<string> => featureManifestOutput(),
+          runReport: async (_binaryPath, args): Promise<LopperReport> => {
+            analysisCalls.push(args);
+            return { dependencies: [] };
+          },
+        },
+      },
+    );
+
+    await runner.analyseWorkspace(folder);
+    await runner.analyseWorkspace(folder, {
+      document: {
+        fileName: path.join(folder.uri.fsPath, "src", "runtime.py"),
+        isUntitled: false,
+        languageId: "python",
+      } as vscode.TextDocument,
+      runtimeTestCommand: "python -m unittest",
+    });
+
+    assert.deepEqual(featureFlagValues(analysisCalls[0] ?? [], "--enable-feature"), []);
+    assert.deepEqual(featureFlagValues(analysisCalls[1] ?? [], "--enable-feature"), [
+      pythonRunnerProfilesFeature,
+      vscodePreviewCapabilityParityFeature,
+    ]);
+  });
+
+  test("refreshes the feature catalog when the selected binary signature changes", async () => {
+    const folder = workspaceFolder();
+    const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
+    let signature = "/managed/lopper:1";
+    let featureCalls = 0;
+    const exportCalls: string[][] = [];
+
+    const runner = new LopperRunner(
+      { appendLine: () => undefined },
+      context,
+      {
+        binaryLifecycle: { resolveBinaryPath: async () => "/managed/lopper" },
+        binarySignature: async () => signature,
+        featureSettings: () => ({ enable: [], disable: [] }),
+        reportExecutor: {
+          runCommand: async (_binaryPath, args): Promise<string> => {
+            if (args[0] === "features") {
+              featureCalls += 1;
+              return featureCalls === 1
+                ? featureManifestOutput()
+                : JSON.stringify(JSON.parse(featureManifestOutput()).slice(1));
+            }
+            exportCalls.push(args);
+            return "{}";
+          },
+          runReport: async (): Promise<LopperReport> => ({ dependencies: [] }),
+        },
+      },
+    );
+
+    await runner.exportWorkspace(folder, "cyclonedx-json");
+    await runner.exportWorkspace(folder, "cyclonedx-json");
+    assert.equal(featureCalls, 1);
+    assert.equal(exportCalls.length, 2);
+    for (const args of exportCalls) {
+      assert.deepEqual(featureFlagValues(args, "--enable-feature"), [
+        sbomAttestationExportsFeature,
+        vscodePreviewCapabilityParityFeature,
+      ]);
+    }
+
+    signature = "/managed/lopper:2";
+    await assert.rejects(
+      runner.exportWorkspace(folder, "cyclonedx-json"),
+      /selected lopper binary does not report feature/,
+    );
+    assert.equal(featureCalls, 2);
+    assert.equal(exportCalls.length, 2, "stale binary must be rejected before export execution");
+  });
+
+  test("refreshes the feature catalog after same-path binary replacement with restored mtime", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    const folder = workspaceFolder();
+    const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-feature-signature-"));
+    const binaryPath = path.join(tempRoot, "lopper");
+    const fixedTime = new Date(1_700_000_000_000);
+    let featureCalls = 0;
+    let exportCalls = 0;
+
+    try {
+      await writeFile(binaryPath, "first", "utf8");
+      await chmod(binaryPath, 0o755);
+      await utimes(binaryPath, fixedTime, fixedTime);
+      const runner = new LopperRunner(
+        { appendLine: () => undefined },
+        context,
+        {
+          binaryLifecycle: { resolveBinaryPath: async () => binaryPath },
+          featureSettings: () => ({ enable: [], disable: [] }),
+          reportExecutor: {
+            runCommand: async (_binaryPath, args): Promise<string> => {
+              if (args[0] === "features") {
+                featureCalls += 1;
+                return featureCalls === 1
+                  ? featureManifestOutput()
+                  : JSON.stringify(JSON.parse(featureManifestOutput()).slice(1));
+              }
+              exportCalls += 1;
+              return "{}";
+            },
+            runReport: async (): Promise<LopperReport> => ({ dependencies: [] }),
+          },
+        },
+      );
+
+      await runner.exportWorkspace(folder, "cyclonedx-json");
+      assert.equal(featureCalls, 1);
+      assert.equal(exportCalls, 1);
+
+      await writeFile(binaryPath, "other", "utf8");
+      await utimes(binaryPath, fixedTime, fixedTime);
+      await assert.rejects(
+        runner.exportWorkspace(folder, "cyclonedx-json"),
+        /selected lopper binary does not report feature/,
+      );
+      assert.equal(featureCalls, 2, "replaced binary must refresh its catalog");
+      assert.equal(exportCalls, 1, "stale catalog must fail before export execution");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("isolates concurrent feature catalog cancellation across workspace folders", async () => {
+    const folders = vscode.workspace.workspaceFolders ?? [];
+    assert.ok(folders.length >= 2, "expected a multi-root workspace");
+    const [cancelledFolder, successfulFolder] = folders;
+    assert.ok(cancelledFolder);
+    assert.ok(successfulFolder);
+    const context = { globalStorageUri: vscode.Uri.file(cancelledFolder.uri.fsPath) } as vscode.ExtensionContext;
+    const cancelledController = new AbortController();
+    let featureCalls = 0;
+    let signatureCalls = 0;
+    let resolveFirstCatalogStarted!: () => void;
+    let resolveSecondSignatureRequested!: () => void;
+    const firstCatalogStarted = new Promise<void>((resolve) => {
+      resolveFirstCatalogStarted = resolve;
+    });
+    const secondSignatureRequested = new Promise<void>((resolve) => {
+      resolveSecondSignatureRequested = resolve;
+    });
+
+    const runner = new LopperRunner(
+      { appendLine: () => undefined },
+      context,
+      {
+        binaryLifecycle: { resolveBinaryPath: async () => "/managed/lopper" },
+        binarySignature: async () => {
+          signatureCalls += 1;
+          if (signatureCalls === 2) {
+            resolveSecondSignatureRequested();
+          }
+          return "/managed/lopper:1";
+        },
+        featureSettings: () => ({ enable: [reachabilityVulnerabilityFeature], disable: [] }),
+        reportExecutor: {
+          runCommand: async (_binaryPath, args, _cwd, options): Promise<string> => {
+            assert.deepEqual(args, ["features", "--format", "json"]);
+            featureCalls += 1;
+            if (featureCalls > 1) {
+              return featureManifestOutput();
+            }
+
+            resolveFirstCatalogStarted();
+            const signal = options?.signal;
+            assert.ok(signal, "expected the first catalog lookup to carry its caller's cancellation signal");
+            return new Promise<string>((_resolve, reject) => {
+              const abort = () => reject(new Error("catalog query aborted"));
+              if (signal.aborted) {
+                abort();
+                return;
+              }
+              signal.addEventListener("abort", abort, { once: true });
+            });
+          },
+          runReport: async (): Promise<LopperReport> => ({ dependencies: [] }),
+        },
+      },
+    );
+
+    const cancelledAnalysis = runner.analyseWorkspace(cancelledFolder, { signal: cancelledController.signal });
+    await firstCatalogStarted;
+    const successfulAnalysis = runner.analyseWorkspace(successfulFolder);
+    await secondSignatureRequested;
+    await delay(0);
+    cancelledController.abort();
+
+    await assert.rejects(cancelledAnalysis, /catalog query aborted/);
+    const analysis = await successfulAnalysis;
+    assert.equal(analysis.folder.uri.toString(), successfulFolder.uri.toString());
+    assert.equal(featureCalls, 2, "each in-flight caller must own its cancellable catalog lookup");
+    await runner.analyseWorkspace(cancelledFolder);
+    assert.equal(featureCalls, 2, "an aborted lookup must not evict a concurrently successful catalog");
+  });
+
+  test("rejects arbitrary feature settings before analysis", async () => {
+    const folder = workspaceFolder();
+    const context = { globalStorageUri: vscode.Uri.file(folder.uri.fsPath) } as vscode.ExtensionContext;
+    let analysisCalls = 0;
+    const runner = new LopperRunner(
+      { appendLine: () => undefined },
+      context,
+      {
+        binaryLifecycle: { resolveBinaryPath: async () => "/managed/lopper" },
+        binarySignature: async () => "/managed/lopper:1",
+        featureSettings: () => ({ enable: ["mcp-mutation-tools"], disable: [] }),
+        reportExecutor: {
+          runCommand: async (): Promise<string> => featureManifestOutput(),
+          runReport: async (): Promise<LopperReport> => {
+            analysisCalls += 1;
+            return { dependencies: [] };
+          },
+        },
+      },
+    );
+
+    await assert.rejects(runner.analyseWorkspace(folder), /not available to VS Code/);
+    assert.equal(analysisCalls, 0);
+  });
+
   test("times out hung lopper commands", async function () {
     if (process.platform === "win32") {
       this.skip();
@@ -724,4 +1129,47 @@ function restoreEnv(name: string, value: string | undefined): void {
     return;
   }
   process.env[name] = value;
+}
+
+function featureManifestOutput(): string {
+  return JSON.stringify([
+    {
+      code: "LOP-FEAT-0013",
+      name: sbomAttestationExportsFeature,
+      description: "CycloneDX",
+      lifecycle: "preview",
+      enabledByDefault: false,
+    },
+    {
+      code: "LOP-FEAT-0015",
+      name: reachabilityVulnerabilityFeature,
+      description: "Vulnerability priority",
+      lifecycle: "preview",
+      enabledByDefault: false,
+    },
+    {
+      code: "LOP-FEAT-0018",
+      name: pythonRunnerProfilesFeature,
+      description: "Python runners",
+      lifecycle: "preview",
+      enabledByDefault: false,
+    },
+    {
+      code: "LOP-FEAT-0020",
+      name: vscodePreviewCapabilityParityFeature,
+      description: "VS Code parity",
+      lifecycle: "preview",
+      enabledByDefault: false,
+    },
+  ]);
+}
+
+function featureFlagValues(args: readonly string[], flag: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === flag && args[index + 1]) {
+      values.push(args[index + 1]);
+    }
+  }
+  return values;
 }

--- a/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
@@ -1,7 +1,7 @@
 import AdmZip from "adm-zip";
 import * as assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { suite, test } from "mocha";
@@ -524,6 +524,72 @@ suite("managed binary installer", () => {
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true });
       await rm(binaryRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects configured binaries under any open root in an untrusted multi-root workspace", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-multiroot-"));
+    const currentRoot = path.join(tempRoot, "current");
+    const siblingRoot = path.join(tempRoot, "sibling");
+    const siblingBinary = path.join(siblingRoot, platformBinaryName());
+
+    try {
+      await mkdir(currentRoot, { recursive: true });
+      await mkdir(siblingRoot, { recursive: true });
+      await writeExecutable(siblingBinary);
+      const lifecycle = createPathFallbackLifecycle();
+
+      await assert.rejects(
+        lifecycle.resolveBinaryPath({
+          workspaceRoot: currentRoot,
+          workspaceRoots: [currentRoot, siblingRoot],
+          workspaceTrusted: false,
+          autoDownloadBinary: false,
+          configuredBinaryPath: siblingBinary,
+        }),
+        (error: unknown) =>
+          error instanceof BinaryResolutionError
+          && error.message.includes("workspace-local binary in an untrusted workspace"),
+      );
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects configured symlinks resolving under a sibling root in an untrusted workspace", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-multiroot-link-"));
+    const currentRoot = path.join(tempRoot, "current");
+    const siblingRoot = path.join(tempRoot, "sibling");
+    const outsideRoot = path.join(tempRoot, "outside");
+    const siblingBinary = path.join(siblingRoot, platformBinaryName());
+    const outsideLink = path.join(outsideRoot, platformBinaryName());
+
+    try {
+      await mkdir(currentRoot, { recursive: true });
+      await mkdir(siblingRoot, { recursive: true });
+      await mkdir(outsideRoot, { recursive: true });
+      await writeExecutable(siblingBinary);
+      await symlink(siblingBinary, outsideLink);
+      const lifecycle = createPathFallbackLifecycle();
+
+      await assert.rejects(
+        lifecycle.resolveBinaryPath({
+          workspaceRoot: currentRoot,
+          workspaceRoots: [currentRoot, siblingRoot],
+          workspaceTrusted: false,
+          autoDownloadBinary: false,
+          configuredBinaryPath: outsideLink,
+        }),
+        (error: unknown) =>
+          error instanceof BinaryResolutionError
+          && error.message.includes("workspace-local binary in an untrusted workspace"),
+      );
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
     }
   });
 

--- a/extensions/vscode-lopper/src/test/suite/previewCapabilities.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/previewCapabilities.test.ts
@@ -1,0 +1,496 @@
+import * as assert from "node:assert/strict";
+import { realpath } from "node:fs/promises";
+import * as path from "node:path";
+import { suite, test } from "mocha";
+import * as vscode from "vscode";
+
+import { binaryFileSignature } from "../../binaryIdentity";
+import { __testing } from "../../extension";
+import type {
+  WorkspaceAnalysis,
+  WorkspaceAnalysisRequest,
+  WorkspaceAnalysisRunner,
+  WorkspaceCodemodApplyResult,
+} from "../../lopperRunner";
+
+suite("VS Code preview capabilities", () => {
+  test("uses a CycloneDX-specific default target", () => {
+    const descriptor = __testing.exportTargetDescriptor("cyclonedx-json");
+    assert.equal(descriptor.defaultFileName, "lopper-analysis.cdx.json");
+    assert.equal(descriptor.filterLabel, "CycloneDX JSON");
+    assert.deepEqual(descriptor.extensions, ["cdx.json", "json"]);
+  });
+
+  test("rejects stale CycloneDX capability before opening the save dialog", async () => {
+    const folder = primaryWorkspaceFolder();
+    let saveDialogCalls = 0;
+    let exportCalls = 0;
+    let errorMessage = "";
+    const runner: WorkspaceAnalysisRunner = {
+      preflightOperation: async () => {
+        throw new Error("The selected lopper binary does not report feature vscode-preview-capability-parity.");
+      },
+      analyseWorkspace: async () => emptyAnalysis(folder, "js-ts"),
+      exportWorkspace: async () => {
+        exportCalls += 1;
+        return "{}";
+      },
+      applyCodemod: async (): Promise<WorkspaceCodemodApplyResult> => {
+        throw new Error("unexpected codemod apply");
+      },
+    };
+    const controller = __testing.createController(runner);
+    const originalSaveDialog = vscode.window.showSaveDialog;
+    const originalShowError = vscode.window.showErrorMessage;
+    (vscode.window as typeof vscode.window & { showSaveDialog: typeof vscode.window.showSaveDialog }).showSaveDialog =
+      (async () => {
+        saveDialogCalls += 1;
+        return undefined;
+      }) as typeof vscode.window.showSaveDialog;
+    (vscode.window as typeof vscode.window & { showErrorMessage: typeof vscode.window.showErrorMessage }).showErrorMessage =
+      (async (message: string) => {
+        errorMessage = message;
+        return undefined;
+      }) as typeof vscode.window.showErrorMessage;
+    try {
+      await controller.exportAnalysis("cyclonedx-json", folder.uri.fsPath);
+    } finally {
+      (vscode.window as typeof vscode.window & { showSaveDialog: typeof vscode.window.showSaveDialog }).showSaveDialog = originalSaveDialog;
+      (vscode.window as typeof vscode.window & { showErrorMessage: typeof vscode.window.showErrorMessage }).showErrorMessage = originalShowError;
+      controller.dispose();
+    }
+
+    assert.equal(saveDialogCalls, 0);
+    assert.equal(exportCalls, 0);
+    assert.match(errorMessage, new RegExp(folder.name));
+    assert.match(errorMessage, /selected lopper binary does not report feature/);
+  });
+
+  test("accepts JS/TS and Python runtime languages only", () => {
+    assert.equal(__testing.isRuntimeLanguageSupported("js-ts"), true);
+    assert.equal(__testing.isRuntimeLanguageSupported("python"), true);
+    assert.equal(__testing.isRuntimeLanguageSupported("ruby"), false);
+    assert.equal(__testing.isRuntimeLanguageSupported("auto"), false);
+  });
+
+  test("blocks runtime test-command prompting in an untrusted workspace", async () => {
+    const folder = primaryWorkspaceFolder();
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(folder.uri.fsPath, "src", "index.ts")));
+    await vscode.window.showTextDocument(document);
+    let analyseCalls = 0;
+    let warning = "";
+    const runner = testRunner(async () => {
+      analyseCalls += 1;
+      return emptyAnalysis(folder, "js-ts");
+    });
+    const controller = __testing.createController(runner, { isWorkspaceTrusted: () => false });
+    const restore = stubRuntimeDialogs({
+      showOpenDialog: async () => undefined,
+      showWarningMessage: async (message) => {
+        warning = message;
+        return undefined;
+      },
+    });
+    try {
+      await controller.refreshRuntimeWorkspace(folder.uri.fsPath);
+    } finally {
+      restore();
+      controller.dispose();
+    }
+
+    assert.equal(analyseCalls, 0);
+    assert.match(warning, /Trust this workspace/);
+  });
+
+  test("allows an existing Python trace without workspace test execution", async () => {
+    const folder = secondaryWorkspaceFolder();
+    const pythonUri = vscode.Uri.file(path.join(folder.uri.fsPath, "src", "runtime.py"));
+    const pythonTracePath = path.join(folder.uri.fsPath, ".artifacts", "python-runtime.ndjson");
+    const configuration = vscode.workspace.getConfiguration("lopper", folder.uri);
+    await configuration.update("language", "python", vscode.ConfigurationTarget.WorkspaceFolder);
+    await configuration.update("runtimeTracePath", pythonTracePath, vscode.ConfigurationTarget.WorkspaceFolder);
+    const document = await vscode.workspace.openTextDocument(pythonUri);
+    await vscode.window.showTextDocument(document);
+    let request: WorkspaceAnalysisRequest | undefined;
+    const runner = testRunner(async (_folder, options) => {
+      request = options;
+      return emptyAnalysis(folder, "python");
+    });
+    const controller = __testing.createController(runner, { isWorkspaceTrusted: () => false });
+    try {
+      await controller.refreshRuntimeWorkspace(folder.uri.fsPath);
+    } finally {
+      controller.dispose();
+      await configuration.update("language", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      await configuration.update("runtimeTracePath", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+    }
+
+    assert.ok(request, "expected the Python runtime refresh to reach the runner");
+    assert.match(request?.runtimeTracePath ?? "", /python-runtime\.ndjson$/);
+    assert.equal(request?.runtimeTestCommand, undefined);
+  });
+
+  test("forces runtime refresh past a matching static-analysis cache entry", async () => {
+    const folder = secondaryWorkspaceFolder();
+    const binaryPath = process.env.LOPPER_BINARY_PATH;
+    assert.ok(binaryPath, "expected the smoke binary path");
+    const resolvedBinaryPath = await realpath(binaryPath);
+    const binarySignature = await binaryFileSignature(resolvedBinaryPath);
+    const pythonTracePath = path.join(folder.uri.fsPath, ".artifacts", "python-runtime.ndjson");
+    const configuration = vscode.workspace.getConfiguration("lopper", folder.uri);
+    await configuration.update("language", "python", vscode.ConfigurationTarget.WorkspaceFolder);
+    await configuration.update("runtimeTracePath", pythonTracePath, vscode.ConfigurationTarget.WorkspaceFolder);
+    const requests: WorkspaceAnalysisRequest[] = [];
+    const runner = testRunner(async (_folder, options = {}) => {
+      requests.push(options);
+      return {
+        ...emptyAnalysis(folder, "python"),
+        binaryPath: resolvedBinaryPath,
+        binarySignature,
+      };
+    });
+    const controller = __testing.createController(runner, { isWorkspaceTrusted: () => false });
+    try {
+      await controller.refreshWorkspace({ folder, revealErrors: false, trigger: "command" });
+      await controller.refreshRuntimeWorkspace(folder.uri.fsPath);
+    } finally {
+      controller.dispose();
+      await configuration.update("language", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      await configuration.update("runtimeTracePath", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+    }
+
+    assert.equal(requests.length, 2, "explicit runtime refresh must not reuse static cached analysis");
+    assert.equal(requests[0]?.runtimeTracePath, undefined);
+    assert.equal(requests[1]?.runtimeTracePath, pythonTracePath);
+  });
+
+  test("does not reuse runtime analysis as an ordinary static refresh", async () => {
+    const folder = secondaryWorkspaceFolder();
+    const binaryPath = process.env.LOPPER_BINARY_PATH;
+    assert.ok(binaryPath, "expected the smoke binary path");
+    const resolvedBinaryPath = await realpath(binaryPath);
+    const binarySignature = await binaryFileSignature(resolvedBinaryPath);
+    const pythonTracePath = path.join(folder.uri.fsPath, ".artifacts", "python-runtime.ndjson");
+    const configuration = vscode.workspace.getConfiguration("lopper", folder.uri);
+    await configuration.update("language", "python", vscode.ConfigurationTarget.WorkspaceFolder);
+    await configuration.update("runtimeTracePath", pythonTracePath, vscode.ConfigurationTarget.WorkspaceFolder);
+    const requests: WorkspaceAnalysisRequest[] = [];
+    const runner = testRunner(async (_folder, options = {}) => {
+      requests.push(options);
+      return {
+        ...emptyAnalysis(folder, "python"),
+        binaryPath: resolvedBinaryPath,
+        binarySignature,
+      };
+    });
+    const controller = __testing.createController(runner, { isWorkspaceTrusted: () => false });
+    try {
+      await controller.refreshRuntimeWorkspace(folder.uri.fsPath);
+      await controller.refreshWorkspace({ folder, revealErrors: false, trigger: "command" });
+    } finally {
+      controller.dispose();
+      await configuration.update("language", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      await configuration.update("runtimeTracePath", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+    }
+
+    assert.equal(requests.length, 2, "ordinary refresh must not reuse a transient runtime result");
+    assert.equal(requests[0]?.runtimeTracePath, pythonTracePath);
+    assert.equal(requests[1]?.runtimeTracePath, undefined);
+  });
+
+  test("does not deduplicate an ordinary refresh against in-flight runtime analysis", async () => {
+    const folder = secondaryWorkspaceFolder();
+    const binaryPath = process.env.LOPPER_BINARY_PATH;
+    assert.ok(binaryPath, "expected the smoke binary path");
+    const resolvedBinaryPath = await realpath(binaryPath);
+    const binarySignature = await binaryFileSignature(resolvedBinaryPath);
+    const pythonTracePath = path.join(folder.uri.fsPath, ".artifacts", "python-runtime.ndjson");
+    const configuration = vscode.workspace.getConfiguration("lopper", folder.uri);
+    await configuration.update("language", "python", vscode.ConfigurationTarget.WorkspaceFolder);
+    await configuration.update("runtimeTracePath", pythonTracePath, vscode.ConfigurationTarget.WorkspaceFolder);
+
+    const requests: WorkspaceAnalysisRequest[] = [];
+    let resolveRuntime!: (analysis: WorkspaceAnalysis) => void;
+    let markRuntimeStarted!: () => void;
+    const runtimeStarted = new Promise<void>((resolve) => {
+      markRuntimeStarted = resolve;
+    });
+    const pendingRuntime = new Promise<WorkspaceAnalysis>((resolve) => {
+      resolveRuntime = resolve;
+    });
+    const runner = testRunner(async (_folder, options = {}) => {
+      requests.push(options);
+      if (options.runtimeTracePath) {
+        markRuntimeStarted();
+        return pendingRuntime;
+      }
+      return {
+        ...emptyAnalysis(folder, "python"),
+        binaryPath: resolvedBinaryPath,
+        binarySignature,
+      };
+    });
+    const controller = __testing.createController(runner, { isWorkspaceTrusted: () => false });
+    const runtimeRefresh = controller.refreshRuntimeWorkspace(folder.uri.fsPath);
+    await runtimeStarted;
+    const ordinaryRefresh = controller.refreshWorkspace({ folder, revealErrors: false, trigger: "command" });
+    try {
+      await waitForPromise(ordinaryRefresh, "ordinary static refresh");
+      assert.equal(requests.length, 2, "ordinary refresh must start distinct work while runtime analysis is pending");
+      assert.equal(requests[1]?.runtimeTracePath, undefined);
+    } finally {
+      resolveRuntime({
+        ...emptyAnalysis(folder, "python"),
+        binaryPath: resolvedBinaryPath,
+        binarySignature,
+      });
+      await Promise.all([runtimeRefresh, ordinaryRefresh]);
+      controller.dispose();
+      await configuration.update("language", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      await configuration.update("runtimeTracePath", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+    }
+  });
+
+  test("does not reuse a baseline save result as an ordinary static refresh", async () => {
+    const folder = primaryWorkspaceFolder();
+    const binaryPath = process.env.LOPPER_BINARY_PATH;
+    assert.ok(binaryPath, "expected the smoke binary path");
+    const resolvedBinaryPath = await realpath(binaryPath);
+    const binarySignature = await binaryFileSignature(resolvedBinaryPath);
+    const requests: WorkspaceAnalysisRequest[] = [];
+    const runner = testRunner(async (_folder, options = {}) => {
+      requests.push(options);
+      return {
+        ...emptyAnalysis(folder, "js-ts"),
+        binaryPath: resolvedBinaryPath,
+        binarySignature,
+      };
+    });
+    const controller = __testing.createController(runner);
+    const originalInputBox = vscode.window.showInputBox;
+    (vscode.window as typeof vscode.window & { showInputBox: typeof vscode.window.showInputBox }).showInputBox =
+      (async () => "release-candidate") as typeof vscode.window.showInputBox;
+    try {
+      await controller.saveBaselineSnapshot(folder.uri.fsPath);
+      await controller.refreshWorkspace({ folder, revealErrors: false, trigger: "command" });
+    } finally {
+      (vscode.window as typeof vscode.window & { showInputBox: typeof vscode.window.showInputBox }).showInputBox = originalInputBox;
+      controller.dispose();
+    }
+
+    assert.equal(requests.length, 2, "ordinary refresh must not reuse a baseline save result");
+    assert.equal(requests[0]?.saveBaseline, true);
+    assert.equal(requests[1]?.saveBaseline, undefined);
+    assert.equal(requests[1]?.baselineStorePath, undefined);
+  });
+
+  test("does not reuse baseline comparison results as ordinary static refreshes", async () => {
+    const folder = primaryWorkspaceFolder();
+    const binaryPath = process.env.LOPPER_BINARY_PATH;
+    assert.ok(binaryPath, "expected the smoke binary path");
+    const resolvedBinaryPath = await realpath(binaryPath);
+    const binarySignature = await binaryFileSignature(resolvedBinaryPath);
+
+    for (const mode of ["Stored baseline key", "Baseline file"] as const) {
+      const requests: WorkspaceAnalysisRequest[] = [];
+      const runner = testRunner(async (_folder, options = {}) => {
+        requests.push(options);
+        return {
+          ...emptyAnalysis(folder, "js-ts"),
+          binaryPath: resolvedBinaryPath,
+          binarySignature,
+        };
+      });
+      const controller = __testing.createController(runner);
+      const originalInputBox = vscode.window.showInputBox;
+      const originalQuickPick = vscode.window.showQuickPick;
+      const originalOpenDialog = vscode.window.showOpenDialog;
+      (vscode.window as typeof vscode.window & { showInputBox: typeof vscode.window.showInputBox }).showInputBox =
+        (async () => "commit:abc123") as typeof vscode.window.showInputBox;
+      (vscode.window as typeof vscode.window & { showQuickPick: typeof vscode.window.showQuickPick }).showQuickPick =
+        (async () => ({ label: mode })) as unknown as typeof vscode.window.showQuickPick;
+      (vscode.window as typeof vscode.window & { showOpenDialog: typeof vscode.window.showOpenDialog }).showOpenDialog =
+        (async () => [vscode.Uri.file(path.join(folder.uri.fsPath, "baseline.json"))]) as typeof vscode.window.showOpenDialog;
+      try {
+        await controller.compareBaselineSnapshot(folder.uri.fsPath);
+        await controller.refreshWorkspace({ folder, revealErrors: false, trigger: "command" });
+      } finally {
+        (vscode.window as typeof vscode.window & { showInputBox: typeof vscode.window.showInputBox }).showInputBox = originalInputBox;
+        (vscode.window as typeof vscode.window & { showQuickPick: typeof vscode.window.showQuickPick }).showQuickPick = originalQuickPick;
+        (vscode.window as typeof vscode.window & { showOpenDialog: typeof vscode.window.showOpenDialog }).showOpenDialog = originalOpenDialog;
+        controller.dispose();
+      }
+
+      assert.equal(requests.length, 2, `${mode} result must not satisfy an ordinary refresh`);
+      assert.ok(requests[0]?.baselineKey || requests[0]?.baselinePath);
+      assert.equal(requests[1]?.baselineKey, undefined);
+      assert.equal(requests[1]?.baselinePath, undefined);
+      assert.equal(requests[1]?.baselineStorePath, undefined);
+    }
+  });
+
+  test("forces Save and both Compare baseline actions past a matching static cache", async () => {
+    const folder = primaryWorkspaceFolder();
+    const binaryPath = process.env.LOPPER_BINARY_PATH;
+    assert.ok(binaryPath, "expected the smoke binary path");
+    const resolvedBinaryPath = await realpath(binaryPath);
+    const binarySignature = await binaryFileSignature(resolvedBinaryPath);
+    const requests: WorkspaceAnalysisRequest[] = [];
+    const runner = testRunner(async (_folder, options = {}) => {
+      requests.push(options);
+      return {
+        ...emptyAnalysis(folder, "js-ts"),
+        binaryPath: resolvedBinaryPath,
+        binarySignature,
+      };
+    });
+    const controller = __testing.createController(runner);
+    const originalInputBox = vscode.window.showInputBox;
+    const originalQuickPick = vscode.window.showQuickPick;
+    const originalOpenDialog = vscode.window.showOpenDialog;
+    const originalInformation = vscode.window.showInformationMessage;
+    const compareModes = ["Stored baseline key", "Baseline file"];
+    (vscode.window as typeof vscode.window & { showInputBox: typeof vscode.window.showInputBox }).showInputBox =
+      ((async (options?: vscode.InputBoxOptions) => options?.title === "Save Lopper baseline"
+        ? "release-candidate"
+        : "commit:abc123") as typeof vscode.window.showInputBox);
+    (vscode.window as typeof vscode.window & { showQuickPick: typeof vscode.window.showQuickPick }).showQuickPick =
+      (async () => ({ label: compareModes.shift() ?? "" })) as unknown as typeof vscode.window.showQuickPick;
+    (vscode.window as typeof vscode.window & { showOpenDialog: typeof vscode.window.showOpenDialog }).showOpenDialog =
+      (async () => [vscode.Uri.file(path.join(folder.uri.fsPath, "baseline.json"))]) as typeof vscode.window.showOpenDialog;
+    (vscode.window as typeof vscode.window & { showInformationMessage: typeof vscode.window.showInformationMessage }).showInformationMessage =
+      (async () => undefined) as typeof vscode.window.showInformationMessage;
+    try {
+      await controller.refreshWorkspace({ folder, revealErrors: false, trigger: "command" });
+      await controller.saveBaselineSnapshot(folder.uri.fsPath);
+      await controller.compareBaselineSnapshot(folder.uri.fsPath);
+      await controller.compareBaselineSnapshot(folder.uri.fsPath);
+    } finally {
+      (vscode.window as typeof vscode.window & { showInputBox: typeof vscode.window.showInputBox }).showInputBox = originalInputBox;
+      (vscode.window as typeof vscode.window & { showQuickPick: typeof vscode.window.showQuickPick }).showQuickPick = originalQuickPick;
+      (vscode.window as typeof vscode.window & { showOpenDialog: typeof vscode.window.showOpenDialog }).showOpenDialog = originalOpenDialog;
+      (vscode.window as typeof vscode.window & { showInformationMessage: typeof vscode.window.showInformationMessage }).showInformationMessage = originalInformation;
+      controller.dispose();
+    }
+
+    assert.equal(requests.length, 4, "each explicit baseline action must execute after the static prime");
+    assert.equal(requests[1]?.saveBaseline, true);
+    assert.match(requests[1]?.baselineStorePath ?? "", /lopper-baselines$/);
+    assert.equal(requests[2]?.baselineKey, "commit:abc123");
+    assert.match(requests[2]?.baselineStorePath ?? "", /lopper-baselines$/);
+    assert.match(requests[3]?.baselinePath ?? "", /baseline\.json$/);
+  });
+
+  test("cancels Save Baseline when the label prompt is dismissed", async () => {
+    const folder = primaryWorkspaceFolder();
+    let analyseCalls = 0;
+    const controller = __testing.createController(testRunner(async () => {
+      analyseCalls += 1;
+      return emptyAnalysis(folder, "js-ts");
+    }));
+    const originalInputBox = vscode.window.showInputBox;
+    (vscode.window as typeof vscode.window & { showInputBox: typeof vscode.window.showInputBox }).showInputBox =
+      (async () => undefined) as typeof vscode.window.showInputBox;
+    try {
+      await controller.saveBaselineSnapshot(folder.uri.fsPath);
+    } finally {
+      (vscode.window as typeof vscode.window & { showInputBox: typeof vscode.window.showInputBox }).showInputBox = originalInputBox;
+      controller.dispose();
+    }
+
+    assert.equal(analyseCalls, 0, "dismissing the label prompt must not save a baseline");
+  });
+
+  test("saves an unlabelled baseline when an empty label is submitted", async () => {
+    const folder = primaryWorkspaceFolder();
+    let request: WorkspaceAnalysisRequest | undefined;
+    const controller = __testing.createController(testRunner(async (_folder, options) => {
+      request = options;
+      return emptyAnalysis(folder, "js-ts");
+    }));
+    const originalInputBox = vscode.window.showInputBox;
+    (vscode.window as typeof vscode.window & { showInputBox: typeof vscode.window.showInputBox }).showInputBox =
+      (async () => "") as typeof vscode.window.showInputBox;
+    try {
+      await controller.saveBaselineSnapshot(folder.uri.fsPath);
+    } finally {
+      (vscode.window as typeof vscode.window & { showInputBox: typeof vscode.window.showInputBox }).showInputBox = originalInputBox;
+      controller.dispose();
+    }
+
+    assert.equal(request?.saveBaseline, true);
+    assert.equal(request?.baselineLabel, undefined);
+  });
+});
+
+function testRunner(
+  analyseWorkspace: WorkspaceAnalysisRunner["analyseWorkspace"],
+): WorkspaceAnalysisRunner {
+  return {
+    analyseWorkspace,
+    exportWorkspace: async (): Promise<string> => "",
+    applyCodemod: async (): Promise<WorkspaceCodemodApplyResult> => {
+      throw new Error("unexpected codemod apply");
+    },
+  };
+}
+
+function emptyAnalysis(folder: vscode.WorkspaceFolder, language: "js-ts" | "python"): WorkspaceAnalysis {
+  return {
+    folder,
+    binaryPath: "/managed/lopper",
+    binarySignature: "/managed/lopper:1",
+    requestedLanguage: language,
+    scopeMode: "package",
+    report: { dependencies: [], summary: { dependencyCount: 0, usedPercent: 0 } },
+    codemodsByDependency: new Map(),
+  };
+}
+
+function primaryWorkspaceFolder(): vscode.WorkspaceFolder {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  assert.ok(folder);
+  return folder;
+}
+
+function secondaryWorkspaceFolder(): vscode.WorkspaceFolder {
+  const folder = vscode.workspace.workspaceFolders?.[1];
+  assert.ok(folder);
+  return folder;
+}
+
+async function waitForPromise<T>(promise: Promise<T>, label: string, timeoutMs = 2_000): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function stubRuntimeDialogs(options: {
+  showOpenDialog: () => Promise<readonly vscode.Uri[] | undefined>;
+  showWarningMessage: (message: string) => Promise<string | undefined>;
+}): () => void {
+  const originalOpenDialog = vscode.window.showOpenDialog;
+  const originalWarning = vscode.window.showWarningMessage;
+  const originalInformation = vscode.window.showInformationMessage;
+  (vscode.window as typeof vscode.window & { showOpenDialog: typeof vscode.window.showOpenDialog }).showOpenDialog =
+    options.showOpenDialog as typeof vscode.window.showOpenDialog;
+  (vscode.window as typeof vscode.window & { showWarningMessage: typeof vscode.window.showWarningMessage }).showWarningMessage =
+    options.showWarningMessage as typeof vscode.window.showWarningMessage;
+  (vscode.window as typeof vscode.window & { showInformationMessage: typeof vscode.window.showInformationMessage }).showInformationMessage =
+    (async () => undefined) as typeof vscode.window.showInformationMessage;
+  return () => {
+    (vscode.window as typeof vscode.window & { showOpenDialog: typeof vscode.window.showOpenDialog }).showOpenDialog = originalOpenDialog;
+    (vscode.window as typeof vscode.window & { showWarningMessage: typeof vscode.window.showWarningMessage }).showWarningMessage = originalWarning;
+    (vscode.window as typeof vscode.window & { showInformationMessage: typeof vscode.window.showInformationMessage }).showInformationMessage = originalInformation;
+  };
+}

--- a/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshLifecycle.test.ts
@@ -1,11 +1,13 @@
 import * as assert from "node:assert/strict";
-import { chmod, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { setup, suite, test } from "mocha";
 import * as vscode from "vscode";
 
+import { binaryFileSignature } from "../../binaryIdentity";
 import { __testing, deactivate } from "../../extension";
+import { reachabilityVulnerabilityFeature } from "../../featureCapabilities";
 import type { RefreshWorkspaceOptions } from "../../extension";
 import type { WorkspaceAnalysis, WorkspaceAnalysisRunner, WorkspaceCodemodApplyResult } from "../../lopperRunner";
 
@@ -82,6 +84,44 @@ suite("refresh lifecycle", () => {
     });
   });
 
+  test("invalidates cached analysis after same-path binary replacement with restored mtime", async function () {
+    this.timeout(30_000);
+
+    await withHarness(async (harness) => {
+      const fixedTime = new Date(1_700_000_000_000);
+      await utimes(harness.binaryPath, fixedTime, fixedTime);
+      let analyseCalls = 0;
+
+      await withController(
+        {
+          analyseWorkspace: async (): Promise<WorkspaceAnalysis> => {
+            analyseCalls += 1;
+            return makeWorkspaceAnalysis({
+              folder: harness.folder,
+              binaryPath: harness.binaryPath,
+              binarySignature: await binaryFileSignature(harness.binaryPath),
+              dependencyCount: analyseCalls,
+              usedPercent: 50,
+            });
+          },
+          exportWorkspace: async (): Promise<string> => "",
+        },
+        async (controller) => {
+          await refresh(controller, harness);
+          await refresh(controller, harness);
+          assert.equal(analyseCalls, 1, "unchanged binary should retain the analysis cache");
+
+          await writeFile(harness.binaryPath, "change", "utf8");
+          await utimes(harness.binaryPath, fixedTime, fixedTime);
+          await refresh(controller, harness);
+
+          assert.equal(analyseCalls, 2, "binary replacement must invalidate cached analysis");
+          assert.doesNotMatch(controller.getLatestSummary(), /cached/);
+        },
+      );
+    });
+  });
+
   test("suppresses stale runs so older completions cannot overwrite latest state", async function () {
     this.timeout(30_000);
 
@@ -99,6 +139,7 @@ suite("refresh lifecycle", () => {
         },
         async (controller) => {
           const firstRefresh = refresh(controller, harness, { forceFresh: true });
+          await waitForAssertion(() => assert.equal(deferredAnalyses.length, 1));
           const secondRefresh = refresh(controller, harness, { forceFresh: true });
 
           await waitForAssertion(() => {
@@ -150,6 +191,7 @@ suite("refresh lifecycle", () => {
         },
         async (controller) => {
           const firstRefresh = refresh(controller, harness, { forceFresh: true });
+          await waitForAssertion(() => assert.equal(deferredAnalyses.length, 1));
           const secondRefresh = refresh(controller, harness, { forceFresh: true });
 
           await waitForAssertion(() => {
@@ -231,6 +273,257 @@ suite("refresh lifecycle", () => {
           assert.doesNotMatch(controller.getLatestSummary(), /cached/);
         },
       );
+    });
+  });
+
+  test("older cache validation cannot supersede a newer force-fresh runtime request", async function () {
+    this.timeout(30_000);
+
+    await withHarness(async (harness) => {
+      const cacheValidationStarted = deferred<void>();
+      const cacheValidationResult = deferred<string | undefined>();
+      const runtimeAnalysis = deferred<WorkspaceAnalysis>();
+      let analyseCalls = 0;
+      let runtimeSignal: AbortSignal | undefined;
+      let runtimeTracePath: string | undefined;
+      const runner: WorkspaceAnalysisRunner = {
+        analyseWorkspace: async (_folder, options): Promise<WorkspaceAnalysis> => {
+          analyseCalls += 1;
+          if (analyseCalls === 1) {
+            return makeAnalysis(harness, { dependencyCount: 2, usedPercent: 50 });
+          }
+          runtimeSignal = options?.signal;
+          runtimeTracePath = options?.runtimeTracePath;
+          return runtimeAnalysis.promise;
+        },
+        exportWorkspace: async (): Promise<string> => "",
+        applyCodemod: async (): Promise<WorkspaceCodemodApplyResult> => {
+          throw new Error("unexpected codemod apply");
+        },
+      };
+      const controller = __testing.createController(runner, {
+        binarySignature: async () => {
+          cacheValidationStarted.resolve(undefined);
+          return cacheValidationResult.promise;
+        },
+      });
+
+      try {
+        await refresh(controller, harness);
+        const ordinaryRefresh = refresh(controller, harness);
+        await cacheValidationStarted.promise;
+
+        const runtimeRefresh = refresh(controller, harness, {
+          forceFresh: true,
+          runtimeTracePath: "runtime.ndjson",
+        });
+        await waitForAssertion(() => assert.equal(analyseCalls, 2));
+        assert.equal(runtimeTracePath, "runtime.ndjson");
+
+        cacheValidationResult.resolve(harness.signature);
+        await ordinaryRefresh;
+        assert.equal(runtimeSignal?.aborted, false, "older cache validation must not cancel the runtime request");
+
+        runtimeAnalysis.resolve(makeAnalysis(harness, {
+          dependencyCount: 0,
+          usedPercent: 0,
+          withUnusedImport: false,
+        }));
+        await runtimeRefresh;
+
+        assert.equal(analyseCalls, 2);
+        assert.match(controller.getLatestSummary(), /0 deps/);
+        assert.doesNotMatch(controller.getLatestSummary(), /cached/);
+      } finally {
+        controller.dispose();
+      }
+    });
+  });
+
+  test("folder configuration invalidation starts fresh work without disturbing siblings", async function () {
+    this.timeout(30_000);
+
+    const folders = vscode.workspace.workspaceFolders ?? [];
+    assert.ok(folders.length >= 2, "expected a multi-root workspace");
+    const [changedFolder, siblingFolder] = folders;
+    assert.ok(changedFolder);
+    assert.ok(siblingFolder);
+    const changedDocument = await workspaceDocument(changedFolder);
+    const siblingDocument = await workspaceDocument(siblingFolder);
+    const changedConfiguration = vscode.workspace.getConfiguration("lopper", changedFolder.uri);
+    const siblingConfiguration = vscode.workspace.getConfiguration("lopper", siblingFolder.uri);
+    await changedConfiguration.update("enableFeatures", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+    await siblingConfiguration.update("enableFeatures", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+    await changedConfiguration.update("language", "js-ts", vscode.ConfigurationTarget.WorkspaceFolder);
+    await siblingConfiguration.update("language", "js-ts", vscode.ConfigurationTarget.WorkspaceFolder);
+    const { binaryPath, signature, cleanup } = await createBinaryFixture();
+    const calls: Array<{
+      folder: vscode.WorkspaceFolder;
+      enabledFeatures: readonly string[];
+      pending: Deferred<WorkspaceAnalysis>;
+      signal: AbortSignal | undefined;
+    }> = [];
+    const runner: WorkspaceAnalysisRunner = {
+      analyseWorkspace: async (folder, options): Promise<WorkspaceAnalysis> => {
+        const pending = deferred<WorkspaceAnalysis>();
+        calls.push({
+          folder,
+          enabledFeatures: vscode.workspace.getConfiguration("lopper", folder.uri).get<string[]>("enableFeatures", []),
+          pending,
+          signal: options?.signal,
+        });
+        return pending.promise;
+      },
+      exportWorkspace: async (): Promise<string> => "",
+      applyCodemod: async (): Promise<WorkspaceCodemodApplyResult> => {
+        throw new Error("unexpected codemod apply");
+      },
+    };
+    const controller = __testing.createController(runner);
+
+    try {
+      const changedRefresh = controller.refreshWorkspace({
+        folder: changedFolder,
+        document: changedDocument,
+        revealErrors: false,
+        trigger: "command",
+      });
+      const siblingRefresh = controller.refreshWorkspace({
+        folder: siblingFolder,
+        document: siblingDocument,
+        revealErrors: false,
+        trigger: "command",
+      });
+      await waitForAssertion(() => assert.equal(calls.length, 2));
+
+      const siblingCall = calls.find((call) => call.folder.uri.toString() === siblingFolder.uri.toString());
+      assert.ok(siblingCall);
+      siblingCall.pending.resolve(makeWorkspaceAnalysis({
+        folder: siblingFolder,
+        binaryPath,
+        binarySignature: signature,
+        dependencyCount: 1,
+        usedPercent: 75,
+      }));
+      await waitForPromise(siblingRefresh, "sibling refresh");
+
+      await waitForPromise(changedConfiguration.update(
+        "enableFeatures",
+        [reachabilityVulnerabilityFeature],
+        vscode.ConfigurationTarget.WorkspaceFolder,
+      ), "folder configuration update");
+      const configurationRefresh = controller.handleConfigurationChange({
+        affectsConfiguration: (_section, resource) => resource?.toString() === changedFolder.uri.toString(),
+      });
+      await waitForAssertion(() => {
+        const changedCalls = calls.filter((call) => call.folder.uri.toString() === changedFolder.uri.toString());
+        assert.equal(changedCalls.length, 2, "changed folder must start a post-invalidation run");
+      });
+
+      const changedCalls = calls.filter((call) => call.folder.uri.toString() === changedFolder.uri.toString());
+      assert.deepEqual(changedCalls.map((call) => call.enabledFeatures), [[], [reachabilityVulnerabilityFeature]]);
+      assert.equal(changedCalls[0]?.signal?.aborted, true, "pre-change work should be cancelled");
+      assert.equal(siblingCall.signal?.aborted, false, "sibling work must not be cancelled");
+      assert.equal(
+        calls.filter((call) => call.folder.uri.toString() === siblingFolder.uri.toString()).length,
+        1,
+        "sibling configuration is unchanged",
+      );
+
+      changedCalls[1]?.pending.resolve(makeWorkspaceAnalysis({
+        folder: changedFolder,
+        binaryPath,
+        binarySignature: signature,
+        dependencyCount: 0,
+        usedPercent: 0,
+        withUnusedImport: false,
+      }));
+      await waitForPromise(configurationRefresh, "post-change configuration refresh");
+      await waitForAssertion(() => assert.match(controller.getLatestSummary(), /0 deps/));
+
+      changedCalls[0]?.pending.resolve(makeWorkspaceAnalysis({
+        folder: changedFolder,
+        binaryPath,
+        binarySignature: signature,
+        dependencyCount: 3,
+        usedPercent: 10,
+        withUnusedImport: true,
+      }));
+      await waitForPromise(changedRefresh, "pre-change refresh completion");
+      await waitForPromise(controller.refreshWorkspace({
+        folder: changedFolder,
+        document: changedDocument,
+        revealErrors: false,
+        trigger: "command",
+      }), "post-change cache refresh");
+
+      assert.equal(
+        calls.filter((call) => call.folder.uri.toString() === changedFolder.uri.toString()).length,
+        2,
+        "post-change refresh should reuse only the post-change cache",
+      );
+      assert.match(controller.getLatestSummary(), /0 deps.*cached/);
+      assert.equal(
+        vscode.languages.getDiagnostics(changedDocument.uri).filter((item) => item.source === "lopper").length,
+        0,
+        "stale pre-change analysis must not render",
+      );
+    } finally {
+      controller.dispose();
+      await changedConfiguration.update("enableFeatures", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      await siblingConfiguration.update("enableFeatures", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      await changedConfiguration.update("language", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      await siblingConfiguration.update("language", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+      await cleanup();
+    }
+  });
+
+  test("configuration invalidation supersedes refreshes still resolving their language", async function () {
+    this.timeout(30_000);
+
+    await withHarness(async (harness) => {
+      const configuration = vscode.workspace.getConfiguration("lopper", harness.folder.uri);
+      await configuration.update("autoRefresh", false, vscode.ConfigurationTarget.Workspace);
+      await configuration.update("scopeMode", "package", vscode.ConfigurationTarget.Workspace);
+
+      const pendingLanguage = deferred<"js-ts">();
+      let languageResolutionCalls = 0;
+      let analyseCalls = 0;
+      const runner: WorkspaceAnalysisRunner = {
+        analyseWorkspace: async (): Promise<WorkspaceAnalysis> => {
+          analyseCalls += 1;
+          return makeAnalysis(harness, { dependencyCount: 1, usedPercent: 50 });
+        },
+        exportWorkspace: async (): Promise<string> => "",
+        applyCodemod: async (): Promise<WorkspaceCodemodApplyResult> => {
+          throw new Error("unexpected codemod apply");
+        },
+      };
+      const controller = __testing.createController(runner, {
+        resolveLanguage: async () => {
+          languageResolutionCalls += 1;
+          return pendingLanguage.promise;
+        },
+      });
+
+      try {
+        const staleRefresh = refresh(controller, harness);
+        await waitForAssertion(() => assert.equal(languageResolutionCalls, 1));
+
+        await configuration.update("scopeMode", "repo", vscode.ConfigurationTarget.Workspace);
+        await controller.handleConfigurationChange({
+          affectsConfiguration: (_section, resource) => resource?.toString() === harness.folder.uri.toString(),
+        });
+
+        pendingLanguage.resolve("js-ts");
+        await waitForPromise(staleRefresh, "invalidated language resolution");
+
+        assert.equal(analyseCalls, 0, "configuration changes must cancel pre-invalidation refresh requests");
+      } finally {
+        controller.dispose();
+        await configuration.update("autoRefresh", undefined, vscode.ConfigurationTarget.Workspace);
+        await configuration.update("scopeMode", undefined, vscode.ConfigurationTarget.Workspace);
+      }
     });
   });
 
@@ -610,18 +903,12 @@ async function createBinaryFixture(): Promise<{
   if (process.platform !== "win32") {
     await chmod(binaryPath, 0o755);
   }
-  const signature = await binarySignature(binaryPath);
+  const signature = await binaryFileSignature(binaryPath);
   return {
     binaryPath,
     signature,
     cleanup: async () => rm(tempRoot, { recursive: true, force: true }),
   };
-}
-
-async function binarySignature(binaryPath: string): Promise<string> {
-  const resolvedPath = await realpath(binaryPath);
-  const details = await stat(resolvedPath);
-  return `${resolvedPath}:${Math.floor(details.mtimeMs)}`;
 }
 
 function deferred<T>(): Deferred<T> {
@@ -651,6 +938,22 @@ async function waitForAssertion(assertion: () => void, timeoutMs = 1_000): Promi
   }
   assertion();
 	}
+
+async function waitForPromise<T>(promise: PromiseLike<T>, label: string, timeoutMs = 2_000): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 function attachScopeLibCodemod(analysis: WorkspaceAnalysis): void {
 	analysis.codemodsByDependency = new Map([

--- a/extensions/vscode-lopper/src/test/suite/refreshSession.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/refreshSession.test.ts
@@ -41,15 +41,33 @@ suite("refresh session store", () => {
     assert.equal(sessions.inFlight(folderKey, sessionKey), undefined);
   });
 
-  test("invalidates cache when input version changes", () => {
+  test("invalidates cache and in-flight work when input version changes", () => {
     const sessions = new RefreshSessionStore<{ id: string }, void>();
     const folderKey = "workspace://one";
     const sessionKey = "workspace://one|js-ts|repo";
 
+    const runId = sessions.reserveRun(folderKey);
+    sessions.setInFlight(folderKey, sessionKey, runId, Promise.resolve());
     sessions.setCache(folderKey, sessionKey, { id: "report-1" });
+    assert.ok(sessions.inFlight(folderKey, sessionKey));
     assert.equal(sessions.getCache(folderKey, sessionKey)?.value.id, "report-1");
 
-    sessions.bumpInputVersion(folderKey);
+    const inputVersion = sessions.bumpInputVersion(folderKey);
+    assert.equal(inputVersion, 1);
+    assert.equal(sessions.isCurrentInputVersion(folderKey, 0), false);
+    assert.equal(sessions.isCurrentInputVersion(folderKey, 1), true);
+    assert.equal(sessions.inFlight(folderKey, sessionKey), undefined);
     assert.equal(sessions.getCache(folderKey, sessionKey), undefined);
+  });
+
+  test("orders asynchronous cache decisions by refresh request", () => {
+    const sessions = new RefreshSessionStore<string, void>();
+    const folderKey = "workspace://one";
+
+    const ordinaryRequest = sessions.reserveRequest(folderKey);
+    const explicitRuntimeRequest = sessions.reserveRequest(folderKey);
+
+    assert.equal(sessions.isLatestRequest(folderKey, ordinaryRequest), false);
+    assert.equal(sessions.isLatestRequest(folderKey, explicitRuntimeRequest), true);
   });
 });

--- a/extensions/vscode-lopper/src/test/suite/smoke.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/smoke.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import * as path from "node:path";
 import * as vscode from "vscode";
 import { suite, teardown, test } from "mocha";
@@ -46,8 +47,23 @@ suite("vscode-lopper smoke", () => {
     assert.ok(commands.includes("lopper.refreshWorkspace.repo"), "expected repo-scope refresh command");
     assert.ok(commands.includes("lopper.saveBaseline"), "expected baseline save command");
     assert.ok(commands.includes("lopper.exportAnalysis.csv"), "expected CSV export command");
+    assert.ok(commands.includes("lopper.exportAnalysis.cyclonedx"), "expected CycloneDX export command");
     assert.ok(commands.includes("lopper.refreshWorkspace.runtime"), "expected runtime refresh command");
     assert.ok(commands.includes("lopper.applyCodemod"), "expected codemod apply command");
+
+    const cyclonedxPath = path.join(primaryFolder.uri.fsPath, ".artifacts", "lopper-analysis.cdx.json");
+    const restoreSaveDialog = stubSaveDialog(cyclonedxPath);
+    try {
+      await vscode.commands.executeCommand("lopper.exportAnalysis.cyclonedx", primaryFolder.uri.fsPath);
+    } finally {
+      restoreSaveDialog();
+    }
+    const cyclonedx = JSON.parse(await readFile(cyclonedxPath, "utf8")) as {
+      bomFormat?: string;
+      specVersion?: string;
+    };
+    assert.equal(cyclonedx.bomFormat, "CycloneDX");
+    assert.equal(cyclonedx.specVersion, "1.6");
 
     const primaryDiagnostics = await waitForDiagnostics(primaryFixtureUri, 2);
     const unusedImportDiagnostic = primaryDiagnostics.find((item) => item.message.includes("unused"));
@@ -80,6 +96,16 @@ suite("vscode-lopper smoke", () => {
     assert.match(normalizedHoverText, /Provenance:/);
     assert.match(normalizedHoverText, /unknown/i);
 
+    const pythonFixtureUri = vscode.Uri.file(path.join(secondaryFolder.uri.fsPath, "src", "runtime.py"));
+    const pythonTracePath = path.join(secondaryFolder.uri.fsPath, ".artifacts", "python-runtime.ndjson");
+    const pythonConfiguration = vscode.workspace.getConfiguration("lopper", secondaryFolder.uri);
+    await pythonConfiguration.update("language", "python", vscode.ConfigurationTarget.WorkspaceFolder);
+    await pythonConfiguration.update("runtimeTracePath", pythonTracePath, vscode.ConfigurationTarget.WorkspaceFolder);
+    const pythonDocument = await vscode.workspace.openTextDocument(pythonFixtureUri);
+    await vscode.window.showTextDocument(pythonDocument);
+    await vscode.commands.executeCommand("lopper.refreshWorkspace.runtime", secondaryFolder.uri.fsPath);
+    assert.match(api.getLatestSummary(), /package/);
+
     const quickFixes = await waitForCodeActions(primaryFixtureUri, new vscode.Range(0, 0, 0, 10));
     assert.ok(quickFixes && quickFixes.length > 0, "expected quick fixes");
     const codeAction = quickFixes.find(
@@ -95,6 +121,19 @@ suite("vscode-lopper smoke", () => {
     assert.match(updatedText, /import chunk from "scope-lib\/chunk";/);
   });
 });
+
+function stubSaveDialog(filePath: string): () => void {
+  const original = vscode.window.showSaveDialog;
+  const originalInformation = vscode.window.showInformationMessage;
+  (vscode.window as typeof vscode.window & { showSaveDialog: typeof vscode.window.showSaveDialog }).showSaveDialog =
+    (async () => vscode.Uri.file(filePath)) as typeof vscode.window.showSaveDialog;
+  (vscode.window as typeof vscode.window & { showInformationMessage: typeof vscode.window.showInformationMessage }).showInformationMessage =
+    (async () => undefined) as typeof vscode.window.showInformationMessage;
+  return () => {
+    (vscode.window as typeof vscode.window & { showSaveDialog: typeof vscode.window.showSaveDialog }).showSaveDialog = original;
+    (vscode.window as typeof vscode.window & { showInformationMessage: typeof vscode.window.showInformationMessage }).showInformationMessage = originalInformation;
+  };
+}
 
 async function waitForDiagnostics(uri: vscode.Uri, minimumCount: number): Promise<readonly vscode.Diagnostic[]> {
   const timeoutAt = Date.now() + 20_000;

--- a/extensions/vscode-lopper/test-fixtures/lopper-smoke-binary.mjs
+++ b/extensions/vscode-lopper/test-fixtures/lopper-smoke-binary.mjs
@@ -8,9 +8,23 @@ const options = parseArgs(args.slice(1));
 const cwd = process.cwd();
 const format = options.format ?? "json";
 
+if (command === "features") {
+  process.stdout.write(JSON.stringify(featureManifest(), null, 2));
+  process.exit(0);
+}
+
 if (command !== "analyse") {
   process.stdout.write(renderExport(command, options, cwd));
   process.exit(0);
+}
+
+if (
+  options.language === "python"
+  && (options["runtime-trace"] || options["runtime-test-command"])
+  && !(options["enable-feature"] ?? []).includes("vscode-preview-capability-parity")
+) {
+  process.stderr.write("python runtime parity requires vscode-preview-capability-parity\n");
+  process.exit(2);
 }
 
 if (format !== "json") {
@@ -36,7 +50,11 @@ function parseArgs(tokens) {
       const key = token.slice(2);
       const next = tokens[index + 1];
       if (next !== undefined && !next.startsWith("--")) {
-        parsed[key] = next;
+        if (key === "enable-feature" || key === "disable-feature") {
+          parsed[key] = [...(parsed[key] ?? []), next];
+        } else {
+          parsed[key] = next;
+        }
         index += 1;
       } else {
         parsed[key] = "";
@@ -329,6 +347,40 @@ function renderExport(commandName, parsedOptions, workspaceRoot) {
     ].join("\n");
   }
 
+  if (format === "cyclonedx-json") {
+    const enabledFeatures = parsedOptions["enable-feature"] ?? [];
+    if (
+      !enabledFeatures.includes("sbom-attestation-exports-preview")
+      || !enabledFeatures.includes("vscode-preview-capability-parity")
+    ) {
+      process.stderr.write("cyclonedx-json requires SBOM and VS Code parity capabilities\n");
+      process.exit(2);
+    }
+    return JSON.stringify(
+      {
+        bomFormat: "CycloneDX",
+        specVersion: "1.6",
+        serialNumber: "urn:uuid:00000000-0000-4000-8000-000000000001",
+        version: 1,
+        metadata: {
+          component: {
+            type: "application",
+            name: path.basename(workspaceRoot),
+          },
+        },
+        components: [
+          {
+            type: "library",
+            name: "scope-lib",
+            properties: [{ name: "lopper:usedPercent", value: "50.0" }],
+          },
+        ],
+      },
+      null,
+      2,
+    );
+  }
+
   return JSON.stringify(
     {
       command: commandName,
@@ -338,6 +390,39 @@ function renderExport(commandName, parsedOptions, workspaceRoot) {
     null,
     2,
   );
+}
+
+function featureManifest() {
+  return [
+    {
+      code: "LOP-FEAT-0013",
+      name: "sbom-attestation-exports-preview",
+      description: "Enable preview CycloneDX SBOM exports with Lopper dependency-surface metadata.",
+      lifecycle: "preview",
+      enabledByDefault: false,
+    },
+    {
+      code: "LOP-FEAT-0015",
+      name: "reachability-vulnerability-prioritization-preview",
+      description: "Enable local advisory ingestion and reachability-weighted vulnerability prioritization.",
+      lifecycle: "preview",
+      enabledByDefault: false,
+    },
+    {
+      code: "LOP-FEAT-0018",
+      name: "python-runner-profiles",
+      description: "Enable safe unittest and uv profiles for Python runtime capture.",
+      lifecycle: "preview",
+      enabledByDefault: false,
+    },
+    {
+      code: "LOP-FEAT-0020",
+      name: "vscode-preview-capability-parity",
+      description: "Enable VS Code controls for safe CLI preview capabilities.",
+      lifecycle: "preview",
+      enabledByDefault: false,
+    },
+  ];
 }
 
 function escapeCsv(value) {

--- a/internal/featureflags/features.json
+++ b/internal/featureflags/features.json
@@ -171,5 +171,11 @@
     "name": "baseline-store-discovery-preview",
     "description": "Enable safe listing and inspection of immutable local baseline snapshots.",
     "lifecycle": "preview"
+  },
+  {
+    "code": "LOP-FEAT-0020",
+    "name": "vscode-preview-capability-parity",
+    "description": "Enable VS Code controls for safe CLI preview capabilities, CycloneDX export, and Python runtime refresh parity.",
+    "lifecycle": "preview"
   }
 ]


### PR DESCRIPTION
## Summary

Bring the VS Code extension to safe parity with the v1.8 CLI preview surface while keeping capability selection folder-specific, explicit, and fail-closed. This adds CycloneDX export and Python runtime workflows, then hardens the refresh, cache, binary, trust, and side-effect boundaries found during regression missions.

Closes #1131
Closes #1172
Closes #1173
Closes #1174
Closes #1175
Closes #1176
Closes #1177
Closes #1178
Closes #1179

## Changes

- Register `LOP-FEAT-0020` (`vscode-preview-capability-parity`) after mainline `LOP-FEAT-0019`, query the selected CLI manifest lazily, and forward only operation-scoped allowlisted feature flags.
- Add folder-specific CycloneDX JSON export preflight and Python runtime refresh, retaining Workspace Trust and explicit-action requirements for test execution.
- Prevent runtime commands and baseline saves from repeating during focused codemod discovery while retaining safe trace-file-only codemod discovery.
- Make refresh invalidation, asynchronous cache checks, transient action caching, and in-flight request ordering reject stale work deterministically.
- Strengthen selected-binary identity and multi-root Workspace Trust checks across configured, linked, PATH, and managed executables.
- Document the public command, setting, capability, and cache behavior.

## Validation

Commands and checks run:

```bash
make feature-flag-check
npm run test:e2e
npx @vscode/vsce ls --tree
make vscode-extension-package
make ci
make ci BUILD_CHANNEL=rolling
make demos-check
```

Additional manual validation:

- VS Code 1.90.0 Electron suite: 98 passing.
- Deterministic pre-fix controls reproduced the #1172-#1179 regressions twice before their fixes; corresponding regressions now pass.
- Dev and rolling CI: lint 0, gosec issues 0 / Nosec 0 across 313 files and 55,514 lines, vulnerabilities 0, race/leak gates green, total coverage 98.3%, per-package coverage at least 98%, and memory benchmark delta within threshold.
- VSIX manifest inspected: only intended public package files, runtime output, and production dependencies are included.
- `act pull_request -W .github/workflows/ci.yml --job verify` was attempted, but the local Docker daemon was unavailable before the container started; the equivalent `make ci` gate passed and remote Actions remain authoritative.

## Risk and compatibility

- Breaking changes: None; existing commands and settings remain compatible.
- Migration required: None.
- Performance impact: Selected-binary feature manifests are queried lazily and cached by robust binary identity; transient actions do not pollute static refresh caches.
- Memory benchmark impact: No material change; measured deltas remained within the gate.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

