### PR TITLE
fix(sonar): exclude intentional dependency fixtures

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=testdata/js/cjs/index.cjs,testdata/js/esm/index.js

--- a/scripts/sonarcloud_config_test.go
+++ b/scripts/sonarcloud_config_test.go
@@ -2,14 +2,17 @@ package scripts
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
 func TestSonarCloudAutomaticAnalysisExcludesOnlyIntentionalJSFixtures(t *testing.T) {
 	t.Parallel()
 
-	const want = "sonar.exclusions=testdata/js/cjs/index.cjs,testdata/js/esm/index.js\n"
-	if got := readConfig(t, ".sonarcloud.properties"); got != want {
+	const want = "sonar.exclusions=testdata/js/cjs/index.cjs,testdata/js/esm/index.js"
+	got := strings.ReplaceAll(readConfig(t, ".sonarcloud.properties"), "\r\n", "\n")
+	got = strings.TrimSuffix(got, "\n")
+	if got != want {
 		t.Fatalf(".sonarcloud.properties = %q, want %q", got, want)
 	}
 

--- a/scripts/sonarcloud_config_test.go
+++ b/scripts/sonarcloud_config_test.go
@@ -1,0 +1,24 @@
+package scripts
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSonarCloudAutomaticAnalysisExcludesOnlyIntentionalJSFixtures(t *testing.T) {
+	t.Parallel()
+
+	const want = "sonar.exclusions=testdata/js/cjs/index.cjs,testdata/js/esm/index.js\n"
+	if got := readConfig(t, ".sonarcloud.properties"); got != want {
+		t.Fatalf(".sonarcloud.properties = %q, want %q", got, want)
+	}
+
+	for _, path := range []string{
+		"testdata/js/cjs/index.cjs",
+		"testdata/js/esm/index.js",
+	} {
+		if _, err := os.Stat(repoPath(t, path)); err != nil {
+			t.Fatalf("stat excluded fixture %s: %v", path, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Keep SonarQube Cloud automatic analysis focused on product code by excluding the two exact JavaScript dependency-analysis fixtures that intentionally call lodash. Production analysis remains strict, and a policy test locks the exclusion to those files.

Closes #1181

## Changes

- Add a repository-root `.sonarcloud.properties` with exact exclusions for the CommonJS and ESM lodash fixtures.
- Add a policy test that requires the exact configuration and verifies both excluded fixtures still exist.
- Leave the intentional fixture source unchanged; no inline suppression or wildcard exclusion is introduced.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/js -run 'TestScanRepoFixtures|TestReportFormatContainsDependency'
go test ./scripts -run TestSonarCloudAutomaticAnalysisExcludesOnlyIntentionalJSFixtures
make suppression-check
make ci
make ci BUILD_CHANNEL=rolling
make demos-check
```

Results:

- Dev and rolling CI passed with lint 0, duplication 0, gosec issues 0 / Nosec 0, vulnerabilities 0, race/leak gates green, total coverage 98.3%, every package at least 98%, and memory checks within threshold.
- Targeted JavaScript fixture tests, exact Sonar configuration policy test, suppression policy, and demo checks passed.
- The branch changes only the two-file analysis configuration and its policy test.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None; runtime behavior is unchanged.
- Analysis scope: Only the two named dependency-analysis fixtures are excluded; no wildcard, directory-wide exclusion, or inline suppression is used.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
