### PR TITLE
fix(swift): bound unqualified usage generic scan

### DIFF
--- a/internal/lang/swift/adapter_detection_manifest_paths_test.go
+++ b/internal/lang/swift/adapter_detection_manifest_paths_test.go
@@ -510,6 +510,9 @@ func testSwiftUsageHeuristicGenericSpecializations(t *testing.T) {
 	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value: UnknownResponse<Value>"), singleDep, map[string]int{}); len(got) != 0 {
 		t.Fatalf("expected a generic type annotation to lack attribution evidence, got %#v", got)
 	}
+	if got := applyUnqualifiedUsageHeuristic([]byte("import Alamofire\nlet value = UnknownResponse <Value>()"), singleDep, map[string]int{}); len(got) != 0 {
+		t.Fatalf("expected whitespace before a comparison-like generic expression to lack attribution evidence, got %#v", got)
+	}
 }
 
 func testSwiftUsageHeuristicEvidenceShapes(t *testing.T) {
@@ -527,27 +530,6 @@ func testSwiftUsageHeuristicEvidenceShapes(t *testing.T) {
 	}
 	if hasPotentialUnqualifiedSymbolUsage([]byte("import Alamofire\nlet value: UnknownResponse"), singleDep) {
 		t.Fatalf("expected a bare unknown identifier to require stronger usage evidence")
-	}
-	if hasUnqualifiedUsageEvidence("<Value") {
-		t.Fatalf("expected an unterminated generic specialization to lack usage evidence")
-	}
-	if hasUnqualifiedUsageEvidence(" <Value>()") {
-		t.Fatalf("expected whitespace before a comparison-like generic expression to lack usage evidence")
-	}
-	if !hasUnqualifiedUsageEvidence("<Result<Value, Error>>.success") {
-		t.Fatalf("expected nested generic specializations to preserve static-member evidence")
-	}
-	if !hasUnqualifiedUsageEvidence("<(Value) -> Result>()") {
-		t.Fatalf("expected function-type generics to preserve call evidence")
-	}
-	if after, ok := trimSwiftGenericSpecialization("<Result<Value, Error>>.success"); !ok || after != ".success" {
-		t.Fatalf("expected nested generic specialization to trim to member access, got after=%q ok=%v", after, ok)
-	}
-	if after, ok := trimSwiftGenericSpecialization("<(Value) -> Result>()"); !ok || after != "()" {
-		t.Fatalf("expected function-type generic specialization to trim to call site, got after=%q ok=%v", after, ok)
-	}
-	if after, ok := trimSwiftGenericSpecialization("<Result<Value, Error>"); ok || after != "" {
-		t.Fatalf("expected unterminated generic specialization trim to fail, got after=%q ok=%v", after, ok)
 	}
 }
 

--- a/internal/lang/swift/adapter_detection_manifest_paths_test.go
+++ b/internal/lang/swift/adapter_detection_manifest_paths_test.go
@@ -444,6 +444,7 @@ func TestSwiftUsageHeuristicBranches(t *testing.T) {
 	t.Run("generic specializations provide usage evidence", testSwiftUsageHeuristicGenericSpecializations)
 	t.Run("symbol shapes require strong usage evidence", testSwiftUsageHeuristicEvidenceShapes)
 	t.Run("symbol collection detects local declarations", testSwiftUsageHeuristicCollectsLocalSymbols)
+	t.Run("context collection stays bounded to attributable files", testSwiftUsageHeuristicContextCollection)
 	t.Run("candidate attribution excludes known declarations", testSwiftUsageCandidateAttribution)
 	t.Run("unterminated generic candidate scan stays bounded", testSwiftUsageHeuristicUnterminatedGenericScan)
 	t.Run("declaration scopes follow Swift targets", testSwiftDeclarationScopes)
@@ -533,6 +534,21 @@ func testSwiftUsageHeuristicEvidenceShapes(t *testing.T) {
 	if hasUnqualifiedUsageEvidence(" <Value>()") {
 		t.Fatalf("expected whitespace before a comparison-like generic expression to lack usage evidence")
 	}
+	if !hasUnqualifiedUsageEvidence("<Result<Value, Error>>.success") {
+		t.Fatalf("expected nested generic specializations to preserve static-member evidence")
+	}
+	if !hasUnqualifiedUsageEvidence("<(Value) -> Result>()") {
+		t.Fatalf("expected function-type generics to preserve call evidence")
+	}
+	if after, ok := trimSwiftGenericSpecialization("<Result<Value, Error>>.success"); !ok || after != ".success" {
+		t.Fatalf("expected nested generic specialization to trim to member access, got after=%q ok=%v", after, ok)
+	}
+	if after, ok := trimSwiftGenericSpecialization("<(Value) -> Result>()"); !ok || after != "()" {
+		t.Fatalf("expected function-type generic specialization to trim to call site, got after=%q ok=%v", after, ok)
+	}
+	if after, ok := trimSwiftGenericSpecialization("<Result<Value, Error>"); ok || after != "" {
+		t.Fatalf("expected unterminated generic specialization trim to fail, got after=%q ok=%v", after, ok)
+	}
 }
 
 func testSwiftUsageHeuristicCollectsLocalSymbols(t *testing.T) {
@@ -544,6 +560,61 @@ func testSwiftUsageHeuristicCollectsLocalSymbols(t *testing.T) {
 	}
 	if _, ok := symbols[lookupKey("Runner")]; !ok {
 		t.Fatalf("expected Runner to be collected, got %#v", symbols)
+	}
+}
+
+func testSwiftUsageHeuristicContextCollection(t *testing.T) {
+	t.Helper()
+
+	singleDep := []importBinding{{Dependency: "alamofire", Module: "Alamofire", Local: "Session"}}
+	multipleDeps := append([]importBinding{}, singleDep...)
+	multipleDeps = append(multipleDeps, importBinding{Dependency: "kingfisher", Module: "Kingfisher", Local: "KingfisherManager"})
+
+	if shouldCollectUnqualifiedUsageCandidates(nil, map[string]int{}) {
+		t.Fatalf("expected empty imports to skip candidate collection")
+	}
+	if shouldCollectUnqualifiedUsageCandidates(multipleDeps, map[string]int{}) {
+		t.Fatalf("expected multi-dependency imports to skip candidate collection")
+	}
+	if shouldCollectUnqualifiedUsageCandidates([]importBinding{{Module: "Alamofire", Local: "Session"}}, map[string]int{}) {
+		t.Fatalf("expected imports without a dependency key to skip candidate collection")
+	}
+	if shouldCollectUnqualifiedUsageCandidates(singleDep, map[string]int{"Session": 1}) {
+		t.Fatalf("expected existing qualified usage to skip candidate collection")
+	}
+	if !shouldCollectUnqualifiedUsageCandidates(singleDep, map[string]int{}) {
+		t.Fatalf("expected a single dependency without qualified usage to collect candidates")
+	}
+
+	scanner := repoScanner{}
+	scanner.recordUnqualifiedUsageContext(fileScan{Path: "Sources/App/main.swift", Imports: singleDep, Usage: map[string]int{"Session": 1}}, []byte("import Alamofire\nlet value = SharedModel()\n"))
+	if len(scanner.unqualifiedUsageContexts) != 1 {
+		t.Fatalf("expected one recorded context, got %#v", scanner.unqualifiedUsageContexts)
+	}
+	if len(scanner.unqualifiedUsageContexts[0].candidates) != 0 {
+		t.Fatalf("expected qualified usage to avoid candidate collection, got %#v", scanner.unqualifiedUsageContexts[0].candidates)
+	}
+
+	scanner = repoScanner{
+		scan: scanResult{
+			Files: []fileScan{
+				{Path: "Sources/App/main.swift", Imports: singleDep, Usage: map[string]int{}},
+				{Path: "Sources/App/other.swift", Imports: singleDep, Usage: map[string]int{}},
+			},
+		},
+		declaredSymbolsByScope: map[string]map[string]struct{}{
+			"Sources/App": {},
+		},
+		unqualifiedUsageContexts: []unqualifiedUsageContext{
+			{scope: "Sources/App", candidates: []string{lookupKey("SharedModel")}},
+		},
+	}
+	scanner.applyUnqualifiedUsageHeuristics()
+	if scanner.scan.Files[0].Usage["Session"] != 1 {
+		t.Fatalf("expected first file to receive inferred usage, got %#v", scanner.scan.Files[0].Usage)
+	}
+	if len(scanner.scan.Files[1].Usage) != 0 {
+		t.Fatalf("expected files without a matching recorded context to remain unchanged, got %#v", scanner.scan.Files[1].Usage)
 	}
 }
 

--- a/internal/lang/swift/adapter_detection_manifest_paths_test.go
+++ b/internal/lang/swift/adapter_detection_manifest_paths_test.go
@@ -445,6 +445,7 @@ func TestSwiftUsageHeuristicBranches(t *testing.T) {
 	t.Run("symbol shapes require strong usage evidence", testSwiftUsageHeuristicEvidenceShapes)
 	t.Run("symbol collection detects local declarations", testSwiftUsageHeuristicCollectsLocalSymbols)
 	t.Run("candidate attribution excludes known declarations", testSwiftUsageCandidateAttribution)
+	t.Run("unterminated generic candidate scan stays bounded", testSwiftUsageHeuristicUnterminatedGenericScan)
 	t.Run("declaration scopes follow Swift targets", testSwiftDeclarationScopes)
 }
 
@@ -561,6 +562,16 @@ func testSwiftUsageCandidateAttribution(t *testing.T) {
 	}
 	if got := applyUnqualifiedUsageCandidates(imports, map[string]int{}, candidates, nil); got["Alamofire"] != 1 {
 		t.Fatalf("expected unknown candidate to seed usage, got %#v", got)
+	}
+}
+
+func testSwiftUsageHeuristicUnterminatedGenericScan(t *testing.T) {
+	t.Helper()
+
+	imports := []importBinding{{Dependency: "alamofire", Module: "Alamofire", Local: "Session"}}
+	content := []byte("import Alamofire\nlet value = A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<\n")
+	if candidates := collectPotentialUnqualifiedSymbols(content, imports); len(candidates) != 0 {
+		t.Fatalf("expected unterminated generic chain to lack usage candidates, got %#v", candidates)
 	}
 }
 

--- a/internal/lang/swift/usage_heuristics.go
+++ b/internal/lang/swift/usage_heuristics.go
@@ -165,41 +165,6 @@ func swiftGenericSpecializationEnds(line string) map[int]int {
 	return ends
 }
 
-func hasUnqualifiedUsageEvidence(afterSymbol string) bool {
-	trimmed := strings.TrimLeft(afterSymbol, " \t")
-	if strings.HasPrefix(trimmed, ".") || strings.HasPrefix(trimmed, "(") {
-		return true
-	}
-	if !strings.HasPrefix(afterSymbol, "<") {
-		return false
-	}
-	afterSpecialization, ok := trimSwiftGenericSpecialization(afterSymbol)
-	if !ok {
-		return false
-	}
-	afterSpecialization = strings.TrimLeft(afterSpecialization, " \t")
-	return strings.HasPrefix(afterSpecialization, ".") || strings.HasPrefix(afterSpecialization, "(")
-}
-
-func trimSwiftGenericSpecialization(value string) (string, bool) {
-	depth := 0
-	for index, symbol := range value {
-		switch symbol {
-		case '<':
-			depth++
-		case '>':
-			if index > 0 && value[index-1] == '-' {
-				continue
-			}
-			depth--
-			if depth == 0 {
-				return value[index+1:], true
-			}
-		}
-	}
-	return "", false
-}
-
 func isIgnoredUnqualifiedSymbol(key string, importModules map[string]struct{}, localDeclaredSymbols map[string]struct{}) bool {
 	if key == "" {
 		return true

--- a/internal/lang/swift/usage_heuristics.go
+++ b/internal/lang/swift/usage_heuristics.go
@@ -51,8 +51,9 @@ func collectPotentialUnqualifiedSymbolsWithDeclarations(content []byte, imports 
 		if line == "" || swiftImportPattern.MatchString(line) {
 			continue
 		}
+		genericEnds := swiftGenericSpecializationEnds(line)
 		for _, location := range swiftUpperIdentifierPattern.FindAllStringIndex(line, -1) {
-			if !hasUnqualifiedUsageEvidence(line[location[1]:]) {
+			if !hasUnqualifiedUsageEvidenceInLine(line, location[1], genericEnds) {
 				continue
 			}
 			key := lookupKey(line[location[0]:location[1]])
@@ -111,8 +112,9 @@ func importedModuleSet(imports []importBinding) map[string]struct{} {
 
 func lineHasPotentialUnqualifiedSymbolUsage(line string, importModules map[string]struct{}, localDeclaredSymbols map[string]struct{}) bool {
 	locations := swiftUpperIdentifierPattern.FindAllStringIndex(line, -1)
+	genericEnds := swiftGenericSpecializationEnds(line)
 	for _, location := range locations {
-		if !hasUnqualifiedUsageEvidence(line[location[1]:]) {
+		if !hasUnqualifiedUsageEvidenceInLine(line, location[1], genericEnds) {
 			continue
 		}
 		key := lookupKey(line[location[0]:location[1]])
@@ -122,6 +124,45 @@ func lineHasPotentialUnqualifiedSymbolUsage(line string, importModules map[strin
 		return true
 	}
 	return false
+}
+
+func hasUnqualifiedUsageEvidenceInLine(line string, symbolEnd int, genericEnds map[int]int) bool {
+	afterSymbol := line[symbolEnd:]
+	trimmed := strings.TrimLeft(afterSymbol, " \t")
+	if strings.HasPrefix(trimmed, ".") || strings.HasPrefix(trimmed, "(") {
+		return true
+	}
+	if symbolEnd >= len(line) || line[symbolEnd] != '<' {
+		return false
+	}
+	afterSpecializationStart, ok := genericEnds[symbolEnd]
+	if !ok {
+		return false
+	}
+	afterSpecialization := strings.TrimLeft(line[afterSpecializationStart:], " \t")
+	return strings.HasPrefix(afterSpecialization, ".") || strings.HasPrefix(afterSpecialization, "(")
+}
+
+func swiftGenericSpecializationEnds(line string) map[int]int {
+	ends := make(map[int]int)
+	stack := make([]int, 0)
+	for index, symbol := range line {
+		switch symbol {
+		case '<':
+			stack = append(stack, index)
+		case '>':
+			if index > 0 && line[index-1] == '-' {
+				continue
+			}
+			if len(stack) == 0 {
+				continue
+			}
+			openIndex := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			ends[openIndex] = index + 1
+		}
+	}
+	return ends
 }
 
 func hasUnqualifiedUsageEvidence(afterSymbol string) bool {
@@ -198,6 +239,20 @@ func collectLocalDeclaredSymbols(content []byte) map[string]struct{} {
 	return localDeclaredSymbols
 }
 
+func shouldCollectUnqualifiedUsageCandidates(imports []importBinding, usage map[string]int) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	byDependency := importsByDependency(imports)
+	if len(byDependency) != 1 {
+		return false
+	}
+	for _, importsForDependency := range byDependency {
+		return !hasQualifiedImportUsage(importsForDependency, usage)
+	}
+	return false
+}
+
 func (s *repoScanner) recordUnqualifiedUsageContext(file fileScan, content []byte) {
 	if s.declaredSymbolsByScope == nil {
 		s.declaredSymbolsByScope = make(map[string]map[string]struct{})
@@ -212,9 +267,13 @@ func (s *repoScanner) recordUnqualifiedUsageContext(file fileScan, content []byt
 	for symbol := range localDeclaredSymbols {
 		declared[symbol] = struct{}{}
 	}
+	candidates := []string(nil)
+	if shouldCollectUnqualifiedUsageCandidates(file.Imports, file.Usage) {
+		candidates = collectPotentialUnqualifiedSymbolsWithDeclarations(content, file.Imports, localDeclaredSymbols)
+	}
 	s.unqualifiedUsageContexts = append(s.unqualifiedUsageContexts, unqualifiedUsageContext{
 		scope:      scope,
-		candidates: collectPotentialUnqualifiedSymbolsWithDeclarations(content, file.Imports, localDeclaredSymbols),
+		candidates: candidates,
 	})
 }
 


### PR DESCRIPTION
## Summary

Bound the Swift unqualified-usage heuristic so attacker-controlled unterminated generic specializations cannot drive repeated rescans and quadratic CPU use during source analysis.

## Changes

- Precompute generic specialization bounds per line with `swiftGenericSpecializationEnds` and reuse them through `hasUnqualifiedUsageEvidenceInLine` instead of rescanning suffixes for each identifier.
- Limit expensive unqualified-usage candidate collection to files where the heuristic can actually apply while still recording local declarations for cross-file exclusion.
- Add `testSwiftUsageHeuristicUnterminatedGenericScan` to verify unterminated generic chains do not produce unqualified usage candidates.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/swift
go test ./...
```

Additional manual validation:

- `go test ./internal/lang/swift` passed.
- `go test ./...` reported unrelated existing failures in other packages caused by unreadable-permission tests in this environment; the Swift package remained green.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Reduces pathological CPU work and unnecessary candidate collection when the heuristic cannot apply.
- Memory benchmark impact: Not measured.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
