### PR TITLE
fix(report): handle empty baseline snapshot summaries

### DIFF
--- a/internal/report/baseline_catalog.go
+++ b/internal/report/baseline_catalog.go
@@ -130,6 +130,10 @@ func decodeBaselineSnapshotMetadata(name string, data []byte) (BaselineSnapshotM
 		return BaselineSnapshotMetadata{}, fmt.Errorf("missing baseline repository identity")
 	}
 	reportData := normalizeSnapshotReport(snapshot.Report)
+	summary := reportData.Summary
+	if summary == nil {
+		summary = &Summary{}
+	}
 	keyType, value := baselineKeyType(key)
 	metadata := BaselineSnapshotMetadata{
 		Key:                   key,
@@ -138,7 +142,7 @@ func decodeBaselineSnapshotMetadata(name string, data []byte) (BaselineSnapshotM
 		BaselineSchemaVersion: snapshot.BaselineSchemaVersion,
 		ReportSchemaVersion:   reportData.SchemaVersion,
 		RepoIdentity:          repoIdentity,
-		Summary:               *reportData.Summary,
+		Summary:               *summary,
 		File:                  name,
 	}
 	if keyType == "label" {

--- a/internal/report/baseline_catalog_test.go
+++ b/internal/report/baseline_catalog_test.go
@@ -99,12 +99,13 @@ func TestListAndInspectBaselineSnapshotsHandlesEmptyReportSummary(t *testing.T) 
 
 	dir := t.TempDir()
 	now := time.Date(2026, time.July, 10, 1, 0, 0, 0, time.UTC)
-	if _, err := SaveSnapshot(dir, "label:empty", Report{
+	report := Report{
 		SchemaVersion: SchemaVersion,
 		GeneratedAt:   now,
 		RepoPath:      "/repo/empty",
 		Dependencies:  []DependencyReport{},
-	}, now); err != nil {
+	}
+	if _, err := SaveSnapshot(dir, "label:empty", report, now); err != nil {
 		t.Fatalf("save empty snapshot: %v", err)
 	}
 

--- a/internal/report/baseline_catalog_test.go
+++ b/internal/report/baseline_catalog_test.go
@@ -94,6 +94,40 @@ func TestListBaselineSnapshotsReturnsSafePerEntryDiagnostics(t *testing.T) {
 	}
 }
 
+func TestListAndInspectBaselineSnapshotsHandlesEmptyReportSummary(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2026, time.July, 10, 1, 0, 0, 0, time.UTC)
+	if _, err := SaveSnapshot(dir, "label:empty", Report{
+		SchemaVersion: SchemaVersion,
+		GeneratedAt:   now,
+		RepoPath:      "/repo/empty",
+		Dependencies:  []DependencyReport{},
+	}, now); err != nil {
+		t.Fatalf("save empty snapshot: %v", err)
+	}
+
+	catalog, err := ListBaselineSnapshots(dir, 10)
+	if err != nil {
+		t.Fatalf("list empty snapshot: %v", err)
+	}
+	if len(catalog.Snapshots) != 1 || len(catalog.Diagnostics) != 0 {
+		t.Fatalf("unexpected empty catalog: %#v", catalog)
+	}
+	if catalog.Snapshots[0].Summary.DependencyCount != 0 {
+		t.Fatalf("expected zero-value summary for empty snapshot, got %#v", catalog.Snapshots[0].Summary)
+	}
+
+	shown, err := InspectBaselineSnapshot(dir, "label:empty")
+	if err != nil {
+		t.Fatalf("inspect empty snapshot: %v", err)
+	}
+	if shown.Summary.DependencyCount != 0 || shown.RepoIdentity != "/repo/empty" {
+		t.Fatalf("unexpected empty snapshot metadata: %#v", shown)
+	}
+}
+
 func TestBaselineSnapshotLegacyFallbackRejectsCollidingKey(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Prevent baseline snapshot discovery from panicking when saved report metadata contains an empty `dependencies` array and therefore a nil `Report.Summary`.

## Changes

- Fall back to `&Summary{}` in `internal/report/baseline_catalog.go` when decoded snapshot data has a nil summary before populating `BaselineSnapshotMetadata.Summary`.
- Add `TestListAndInspectBaselineSnapshotsHandlesEmptyReportSummary` to cover snapshots with empty dependencies and no stored summary.

## Validation

Commands and checks run:

```bash
go test ./internal/report
go test ./...
```

Additional manual validation:

- `go test ./internal/report` passed successfully.
- `go test ./...` reported unrelated environment-specific permission/unreadable-file failures outside the `report` package.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: Not measured.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
