### PR TITLE
fix(ci): avoid persisting release credentials

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -647,13 +647,10 @@ jobs:
           provenance: false
           sbom: true
 
-  publish-ghcr-manifest:
-    needs:
-      - publish-ghcr-images
+  prepare-ghcr-manifest:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -666,6 +663,136 @@ jobs:
         run: |
           owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           echo "name=ghcr.io/${owner}/lopper" >> "$GITHUB_OUTPUT"
+
+      - name: Compute manifest image tags
+        shell: bash
+        env:
+          IMAGE_TAGS: ${{ inputs.image_tags }}
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+        run: |
+          set -euo pipefail
+          bash scripts/release-image-tags.sh > image-tags.txt
+
+      - name: Prepare manifest publication payload
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          payload_root="${RUNNER_TEMP}/ghcr-manifest-publication"
+          mkdir -p "${payload_root}"
+          install -m 0600 image-tags.txt "${payload_root}/image-tags.txt"
+          jq -n \
+            --arg source_sha "${SOURCE_SHA}" \
+            --arg image_name "${IMAGE_NAME}" \
+            --arg tag "${RELEASE_TAG}" \
+            '{source_sha: $source_sha, image_name: $image_name, tag: $tag}' \
+            > "${payload_root}/publication.json"
+
+      - name: Upload manifest publication payload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ghcr-manifest-publication-payload
+          path: ${{ runner.temp }}/ghcr-manifest-publication
+
+  publish-ghcr-manifest:
+    needs:
+      - publish-ghcr-images
+      - prepare-ghcr-manifest
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Download manifest publication payload
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: ghcr-manifest-publication-payload
+          path: ${{ runner.temp }}/ghcr-manifest-publication
+
+      - name: Validate manifest publication payload
+        shell: bash
+        env:
+          EXPECTED_SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+          EXPECTED_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          payload_root="${RUNNER_TEMP}/ghcr-manifest-publication"
+          metadata_file="${payload_root}/publication.json"
+          tags_file="${payload_root}/image-tags.txt"
+          expected_source_sha="${EXPECTED_SOURCE_SHA}"
+          owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          expected_image_name="ghcr.io/${owner}/lopper"
+
+          if [[ ! "${expected_source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Invalid immutable source SHA in manifest publication payload."
+            exit 1
+          fi
+          if [ ! -f "${metadata_file}" ] || [ ! -f "${tags_file}" ] \
+            || find -P "${payload_root}" ! -type d ! -type f -print -quit | grep -q .; then
+            echo "::error::Manifest publication payload is missing files or contains unsupported paths."
+            exit 1
+          fi
+          directory_count="$(find -P "${payload_root}" -type d | wc -l | tr -d '[:space:]')"
+          if [ "${directory_count}" -ne 1 ]; then
+            echo "::error::Manifest publication payload contains unexpected directories."
+            exit 1
+          fi
+          file_count="$(find -P "${payload_root}" -type f | wc -l | tr -d '[:space:]')"
+          total_bytes="$(find -P "${payload_root}" -type f -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }')"
+          if [ "${file_count}" -ne 2 ] || [ "${total_bytes}" -gt 32768 ]; then
+            echo "::error::Manifest artifact payload exceeds file-count or size bounds."
+            exit 1
+          fi
+          while IFS= read -r payload_file; do
+            relative_path="${payload_file#"${payload_root}/"}"
+            case "${relative_path}" in
+              publication.json|image-tags.txt) ;;
+              *)
+                echo "::error::Unexpected manifest publication payload path."
+                exit 1
+                ;;
+            esac
+          done < <(find -P "${payload_root}" -type f -print)
+          if ! jq -e \
+            --arg source_sha "${expected_source_sha}" \
+            --arg image_name "${expected_image_name}" \
+            --arg tag "${EXPECTED_TAG}" \
+            'type == "object"
+              and length == 3
+              and .source_sha == $source_sha
+              and .image_name == $image_name
+              and .tag == $tag' "${metadata_file}" >/dev/null; then
+            echo "::error::Manifest publication metadata does not match immutable release inputs."
+            exit 1
+          fi
+
+          tag_count=0
+          declare -A seen_tags=()
+          while IFS= read -r image_ref; do
+            if [[ "${image_ref}" != "${expected_image_name}:"* ]]; then
+              echo "::error::unexpected image reference in manifest publication payload."
+              exit 1
+            fi
+            image_tag="${image_ref#"${expected_image_name}:"}"
+            if [[ ! "${image_tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] \
+              || [[ "${image_tag}" == *-amd64 ]] || [[ "${image_tag}" == *-arm64 ]]; then
+              echo "::error::unexpected image reference in manifest publication payload."
+              exit 1
+            fi
+            if [[ -n "${seen_tags[${image_ref}]:-}" ]]; then
+              echo "::error::Duplicate manifest publication image reference."
+              exit 1
+            fi
+            seen_tags["${image_ref}"]=1
+            tag_count=$((tag_count + 1))
+          done < "${tags_file}"
+          if [ "${tag_count}" -lt 1 ] || [ "${tag_count}" -gt 16 ]; then
+            echo "::error::Manifest publication tag count is outside bounds."
+            exit 1
+          fi
+          chmod -R a-w "${payload_root}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -680,15 +807,13 @@ jobs:
       - name: Publish multi-arch manifests
         shell: bash
         env:
-          IMAGE_TAGS: ${{ inputs.image_tags }}
-          IMAGE_NAME: ${{ steps.image.outputs.name }}
+          IMAGE_TAGS_FILE: ${{ runner.temp }}/ghcr-manifest-publication/image-tags.txt
         run: |
           set -euo pipefail
-          bash scripts/release-image-tags.sh > image-tags.txt
           while IFS= read -r image_ref; do
             docker buildx imagetools create \
               -t "${image_ref}" \
               "${image_ref}-amd64" \
               "${image_ref}-arm64"
             docker buildx imagetools inspect "${image_ref}"
-          done < image-tags.txt
+          done < "${IMAGE_TAGS_FILE}"

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -157,17 +157,16 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
 
-  publish-ghcr-amd64:
+  prepare-ghcr-amd64:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          persist-credentials: false
           ref: ${{ inputs.source_sha || github.sha }}
+          persist-credentials: false
 
       - name: Compute image metadata
         id: image_meta
@@ -200,14 +199,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Log in to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push amd64 release image
+      - name: Build amd64 OCI publication payload
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -221,23 +214,66 @@ jobs:
             org.opencontainers.image.created=${{ steps.image_meta.outputs.build_date }}
             org.opencontainers.image.revision=${{ inputs.source_sha || github.sha }}
             org.opencontainers.image.version=${{ inputs.tag }}
-          push: true
+          push: false
           platforms: linux/amd64
           tags: ${{ steps.image_tags.outputs.tags }}
+          outputs: type=oci,dest=${{ runner.temp }}/ghcr-amd64-publication/layout,tar=false
           provenance: false
-          sbom: true
+          sbom: false
 
-  publish-ghcr-arm64:
+      - name: Prepare amd64 publication metadata
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          BUILD_COMMIT: ${{ steps.image_meta.outputs.commit }}
+          BUILD_DATE: ${{ steps.image_meta.outputs.build_date }}
+          BUILD_CHANNEL: ${{ inputs.build_channel }}
+        run: |
+          set -euo pipefail
+          payload_root="${RUNNER_TEMP}/ghcr-amd64-publication"
+          install -m 0600 image-tags.txt "${payload_root}/image-tags.txt"
+          jq -n \
+            --arg source_sha "${SOURCE_SHA}" \
+            --arg image_name "${IMAGE_NAME}" \
+            --arg platform "linux/amd64" \
+            --arg tag "${RELEASE_TAG}" \
+            --arg build_commit "${BUILD_COMMIT}" \
+            --arg build_date "${BUILD_DATE}" \
+            --arg build_channel "${BUILD_CHANNEL}" \
+            '{
+              source_sha: $source_sha,
+              image_name: $image_name,
+              platform: $platform,
+              tag: $tag,
+              build_commit: $build_commit,
+              build_date: $build_date,
+              build_channel: $build_channel
+            }' > "${payload_root}/publication.json"
+          (
+            cd "${payload_root}"
+            find -P . -type f ! -path './SHA256SUMS' -print0 \
+              | LC_ALL=C sort -z \
+              | xargs -0 -r sha256sum
+          ) > "${payload_root}/SHA256SUMS"
+
+      - name: Upload amd64 OCI publication payload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ghcr-amd64-publication-payload
+          path: ${{ runner.temp }}/ghcr-amd64-publication
+
+  prepare-ghcr-arm64:
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          persist-credentials: false
           ref: ${{ inputs.source_sha || github.sha }}
+          persist-credentials: false
 
       - name: Compute image metadata
         id: image_meta
@@ -270,14 +306,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Log in to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push arm64 release image
+      - name: Build arm64 OCI publication payload
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -291,16 +321,335 @@ jobs:
             org.opencontainers.image.created=${{ steps.image_meta.outputs.build_date }}
             org.opencontainers.image.revision=${{ inputs.source_sha || github.sha }}
             org.opencontainers.image.version=${{ inputs.tag }}
-          push: true
+          push: false
           platforms: linux/arm64
           tags: ${{ steps.image_tags.outputs.tags }}
+          outputs: type=oci,dest=${{ runner.temp }}/ghcr-arm64-publication/layout,tar=false
+          provenance: false
+          sbom: false
+
+      - name: Prepare arm64 publication metadata
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          BUILD_COMMIT: ${{ steps.image_meta.outputs.commit }}
+          BUILD_DATE: ${{ steps.image_meta.outputs.build_date }}
+          BUILD_CHANNEL: ${{ inputs.build_channel }}
+        run: |
+          set -euo pipefail
+          payload_root="${RUNNER_TEMP}/ghcr-arm64-publication"
+          install -m 0600 image-tags.txt "${payload_root}/image-tags.txt"
+          jq -n \
+            --arg source_sha "${SOURCE_SHA}" \
+            --arg image_name "${IMAGE_NAME}" \
+            --arg platform "linux/arm64" \
+            --arg tag "${RELEASE_TAG}" \
+            --arg build_commit "${BUILD_COMMIT}" \
+            --arg build_date "${BUILD_DATE}" \
+            --arg build_channel "${BUILD_CHANNEL}" \
+            '{
+              source_sha: $source_sha,
+              image_name: $image_name,
+              platform: $platform,
+              tag: $tag,
+              build_commit: $build_commit,
+              build_date: $build_date,
+              build_channel: $build_channel
+            }' > "${payload_root}/publication.json"
+          (
+            cd "${payload_root}"
+            find -P . -type f ! -path './SHA256SUMS' -print0 \
+              | LC_ALL=C sort -z \
+              | xargs -0 -r sha256sum
+          ) > "${payload_root}/SHA256SUMS"
+
+      - name: Upload arm64 OCI publication payload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ghcr-arm64-publication-payload
+          path: ${{ runner.temp }}/ghcr-arm64-publication
+
+  publish-ghcr-images:
+    needs:
+      - prepare-ghcr-amd64
+      - prepare-ghcr-arm64
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Download amd64 OCI publication payload
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: ghcr-amd64-publication-payload
+          path: ${{ runner.temp }}/ghcr-amd64-publication
+
+      - name: Download arm64 OCI publication payload
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: ghcr-arm64-publication-payload
+          path: ${{ runner.temp }}/ghcr-arm64-publication
+
+      - name: Validate OCI publication payloads
+        id: validate
+        shell: bash
+        env:
+          EXPECTED_SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+          EXPECTED_TAG: ${{ inputs.tag }}
+          EXPECTED_BUILD_CHANNEL: ${{ inputs.build_channel }}
+        run: |
+          set -euo pipefail
+          expected_source_sha="${EXPECTED_SOURCE_SHA}"
+          owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          expected_image_name="ghcr.io/${owner}/lopper"
+
+          if [[ ! "${expected_source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Invalid immutable source SHA in OCI publication payloads."
+            exit 1
+          fi
+
+          validate_payload() {
+            local architecture="$1"
+            local platform="$2"
+            local tag_suffix="-$1"
+            local payload_root="${RUNNER_TEMP}/ghcr-${architecture}-publication"
+            local layout_root="${payload_root}/layout"
+            local metadata_file="${payload_root}/publication.json"
+            local tags_file="${payload_root}/image-tags.txt"
+            local checksums_file="${payload_root}/SHA256SUMS"
+            local required
+            for required in \
+              "${layout_root}" \
+              "${layout_root}/blobs/sha256" \
+              "${layout_root}/oci-layout" \
+              "${layout_root}/index.json" \
+              "${metadata_file}" \
+              "${tags_file}" \
+              "${checksums_file}"; do
+              if [ ! -e "${required}" ]; then
+                echo "::error::Missing ${architecture} publication payload path: ${required}."
+                exit 1
+              fi
+            done
+            if find -P "${payload_root}" ! -type d ! -type f -print -quit | grep -q .; then
+              echo "::error::${architecture} publication payload must contain only regular files and directories."
+              exit 1
+            fi
+
+            local file_count
+            local total_bytes
+            file_count="$(find -P "${payload_root}" -type f | wc -l | tr -d '[:space:]')"
+            total_bytes="$(find -P "${payload_root}" -type f -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }')"
+            if [ "${file_count}" -lt 6 ] || [ "${file_count}" -gt 256 ] || [ "${total_bytes}" -gt 536870912 ]; then
+              echo "::error::${architecture} artifact payload exceeds file-count or size bounds."
+              exit 1
+            fi
+
+            local payload_path
+            local relative_path
+            while IFS= read -r payload_path; do
+              relative_path="${payload_path#"${payload_root}/"}"
+              case "${relative_path}" in
+                SHA256SUMS|publication.json|image-tags.txt|layout/oci-layout|layout/index.json|layout/manifest.json) ;;
+                layout/blobs/sha256/*)
+                  if [[ ! "${relative_path##*/}" =~ ^[0-9a-f]{64}$ ]]; then
+                    echo "::error::Unexpected ${architecture} OCI blob path: ${relative_path}."
+                    exit 1
+                  fi
+                  ;;
+                *)
+                  echo "::error::Unexpected ${architecture} publication payload path: ${relative_path}."
+                  exit 1
+                  ;;
+              esac
+            done < <(find -P "${payload_root}" -type f -print)
+            while IFS= read -r payload_path; do
+              relative_path="${payload_path#"${payload_root}/"}"
+              case "${relative_path}" in
+                "${payload_root}"|layout|layout/blobs|layout/blobs/sha256) ;;
+                *)
+                  echo "::error::Unexpected ${architecture} publication payload directory: ${relative_path}."
+                  exit 1
+                  ;;
+              esac
+            done < <(find -P "${payload_root}" -type d -print)
+
+            if [ "$(stat -c '%s' "${metadata_file}")" -gt 16384 ] \
+              || [ "$(stat -c '%s' "${tags_file}")" -gt 16384 ] \
+              || [ "$(stat -c '%s' "${checksums_file}")" -gt 32768 ]; then
+              echo "::error::${architecture} publication metadata exceeds size bounds."
+              exit 1
+            fi
+            local computed_checksums="${RUNNER_TEMP}/ghcr-${architecture}-computed-SHA256SUMS"
+            (
+              cd "${payload_root}"
+              find -P . -type f ! -path './SHA256SUMS' -print0 \
+                | LC_ALL=C sort -z \
+                | xargs -0 -r sha256sum
+            ) > "${computed_checksums}"
+            if ! cmp -s "${checksums_file}" "${computed_checksums}" \
+              || ! (cd "${payload_root}" && sha256sum --check --strict SHA256SUMS >/dev/null); then
+              echo "::error::${architecture} publication payload checksum validation failed."
+              exit 1
+            fi
+            rm -f "${computed_checksums}"
+            if ! jq -e \
+              --arg source_sha "${expected_source_sha}" \
+              --arg image_name "${expected_image_name}" \
+              --arg platform "${platform}" \
+              --arg tag "${EXPECTED_TAG}" \
+              --arg build_channel "${EXPECTED_BUILD_CHANNEL}" \
+              'type == "object"
+                and length == 7
+                and .source_sha == $source_sha
+                and .image_name == $image_name
+                and .platform == $platform
+                and .tag == $tag
+                and .build_commit == ($source_sha[0:12])
+                and (.build_date | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+                and .build_channel == $build_channel' "${metadata_file}" >/dev/null; then
+              echo "::error::${architecture} publication metadata does not match immutable release inputs."
+              exit 1
+            fi
+
+            local image_ref
+            local image_tag
+            local tag_count=0
+            local -A seen_tags=()
+            while IFS= read -r image_ref; do
+              if [[ "${image_ref}" != "${expected_image_name}:"* ]]; then
+                echo "::error::unexpected image reference in ${architecture} publication payload."
+                exit 1
+              fi
+              image_tag="${image_ref#"${expected_image_name}:"}"
+              if [[ ! "${image_tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || [[ "${image_tag}" != *"${tag_suffix}" ]]; then
+                echo "::error::unexpected image reference in ${architecture} publication payload."
+                exit 1
+              fi
+              if [[ -n "${seen_tags[${image_ref}]:-}" ]]; then
+                echo "::error::Duplicate ${architecture} publication image reference."
+                exit 1
+              fi
+              seen_tags["${image_ref}"]=1
+              tag_count=$((tag_count + 1))
+            done < "${tags_file}"
+            if [ "${tag_count}" -lt 1 ] || [ "${tag_count}" -gt 16 ]; then
+              echo "::error::${architecture} publication tag count is outside bounds."
+              exit 1
+            fi
+
+            if ! jq -e '.imageLayoutVersion == "1.0.0"' "${layout_root}/oci-layout" >/dev/null \
+              || ! jq -e '.schemaVersion == 2 and (.manifests | type == "array")' "${layout_root}/index.json" >/dev/null; then
+              echo "::error::Invalid ${architecture} OCI image layout."
+              exit 1
+            fi
+            local blob
+            local expected_digest
+            local actual_digest
+            while IFS= read -r blob; do
+              expected_digest="$(basename "${blob}")"
+              actual_digest="$(sha256sum "${blob}" | cut -d ' ' -f 1)"
+              if [ "${actual_digest}" != "${expected_digest}" ]; then
+                echo "::error::${architecture} OCI blob digest mismatch."
+                exit 1
+              fi
+            done < <(find -P "${layout_root}/blobs/sha256" -type f -print)
+
+            local -a image_digests
+            mapfile -t image_digests < <(jq -r \
+              --arg architecture "${architecture}" \
+              '.manifests[]
+                | select(.platform.os == "linux" and .platform.architecture == $architecture)
+                | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
+                | .digest' "${layout_root}/index.json")
+            if [ "${#image_digests[@]}" -ne 1 ] || [[ ! "${image_digests[0]}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::${architecture} OCI layout must contain exactly one ${platform} image."
+              exit 1
+            fi
+
+            local image_digest="${image_digests[0]}"
+            local manifest_file="${layout_root}/blobs/sha256/${image_digest#sha256:}"
+            local config_digest
+            config_digest="$(jq -r '.config.digest // empty' "${manifest_file}")"
+            if [[ ! "${config_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::${architecture} OCI image config digest is invalid."
+              exit 1
+            fi
+            local config_file="${layout_root}/blobs/sha256/${config_digest#sha256:}"
+            if ! jq -e \
+              --arg source_sha "${expected_source_sha}" \
+              --arg release_tag "${EXPECTED_TAG}" \
+              --arg architecture "${architecture}" \
+              '.architecture == $architecture
+                and .os == "linux"
+                and .config.Labels["org.opencontainers.image.revision"] == $source_sha
+                and .config.Labels["org.opencontainers.image.version"] == $release_tag
+                and ((.config.OnBuild // []) | length == 0)' "${config_file}" >/dev/null; then
+              echo "::error::${architecture} OCI image identity or OnBuild policy is invalid."
+              exit 1
+            fi
+
+            chmod -R a-w "${payload_root}"
+            {
+              echo "${architecture}_digest=${image_digest}"
+              echo "${architecture}_tags<<EOF_${architecture}"
+              cat "${tags_file}"
+              echo "EOF_${architecture}"
+            } >> "${GITHUB_OUTPUT}"
+          }
+
+          validate_payload amd64 linux/amd64
+          validate_payload arm64 linux/arm64
+
+      - name: Prepare trusted image promotion Dockerfiles
+        shell: bash
+        run: |
+          set -euo pipefail
+          for architecture in amd64 arm64; do
+            promotion_root="${RUNNER_TEMP}/ghcr-${architecture}-promotion"
+            mkdir -p "${promotion_root}"
+            printf '%s\n' 'FROM prepared' > "${promotion_root}/Dockerfile"
+            chmod 0444 "${promotion_root}/Dockerfile"
+          done
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish amd64 release image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ runner.temp }}/ghcr-amd64-promotion
+          file: ${{ runner.temp }}/ghcr-amd64-promotion/Dockerfile
+          build-contexts: prepared=oci-layout://${{ runner.temp }}/ghcr-amd64-publication/layout@${{ steps.validate.outputs.amd64_digest }}
+          platforms: linux/amd64
+          tags: ${{ steps.validate.outputs.amd64_tags }}
+          push: true
+          provenance: false
+          sbom: true
+
+      - name: Publish arm64 release image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ runner.temp }}/ghcr-arm64-promotion
+          file: ${{ runner.temp }}/ghcr-arm64-promotion/Dockerfile
+          build-contexts: prepared=oci-layout://${{ runner.temp }}/ghcr-arm64-publication/layout@${{ steps.validate.outputs.arm64_digest }}
+          platforms: linux/arm64
+          tags: ${{ steps.validate.outputs.arm64_tags }}
+          push: true
           provenance: false
           sbom: true
 
   publish-ghcr-manifest:
     needs:
-      - publish-ghcr-amd64
-      - publish-ghcr-arm64
+      - publish-ghcr-images
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -309,8 +658,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          persist-credentials: false
           ref: ${{ inputs.source_sha || github.sha }}
+          persist-credentials: false
 
       - name: Compute image name
         id: image

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -606,9 +606,9 @@ jobs:
               '.manifests[]
                 | select(.platform.os == "linux" and .platform.architecture == $architecture)
                 | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
-                | .digest' "${layout_root}/index.json")
+                | .digest' "${layout_root}/index.json" | sort -u)
             if [ "${#image_digests[@]}" -ne 1 ] || [[ ! "${image_digests[0]}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-              echo "::error::${architecture} OCI layout must contain exactly one ${platform} image."
+              echo "::error::${architecture} OCI layout must contain exactly one unique ${platform} image digest."
               exit 1
             fi
 

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -401,9 +401,11 @@ jobs:
           EXPECTED_SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
           EXPECTED_TAG: ${{ inputs.tag }}
           EXPECTED_BUILD_CHANNEL: ${{ inputs.build_channel }}
+          EXPECTED_IMAGE_TAGS: ${{ inputs.image_tags }}
         run: |
           set -euo pipefail
           expected_source_sha="${EXPECTED_SOURCE_SHA}"
+          expected_image_tags="${EXPECTED_IMAGE_TAGS}"
           owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           expected_image_name="ghcr.io/${owner}/lopper"
 
@@ -541,6 +543,45 @@ jobs:
               echo "::error::${architecture} publication tag count is outside bounds."
               exit 1
             fi
+
+            local expected_tags_file="${RUNNER_TEMP}/ghcr-${architecture}-expected-image-tags.txt"
+            : > "${expected_tags_file}"
+            local expected_tag_count=0
+            local -A expected_seen_tags=()
+            local raw_tag
+            local tag
+            local expected_image_ref
+            while IFS= read -r raw_tag || [[ -n "${raw_tag}" ]]; do
+              tag="${raw_tag}"
+              tag="${tag%$'\r'}"
+              tag="${tag#"${tag%%[![:space:]]*}"}"
+              tag="${tag%"${tag##*[![:space:]]}"}"
+              if [[ -z "${tag}" ]]; then
+                continue
+              fi
+              if [[ ! "${tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] \
+                || [[ "${tag}" == *-amd64 ]] || [[ "${tag}" == *-arm64 ]]; then
+                echo "::error::unexpected image reference in immutable architecture inputs."
+                exit 1
+              fi
+              expected_image_ref="${expected_image_name}:${tag}-${architecture}"
+              if [[ -n "${expected_seen_tags[${expected_image_ref}]:-}" ]]; then
+                echo "::error::Duplicate immutable architecture image reference."
+                exit 1
+              fi
+              expected_seen_tags["${expected_image_ref}"]=1
+              printf '%s\n' "${expected_image_ref}" >> "${expected_tags_file}"
+              expected_tag_count=$((expected_tag_count + 1))
+            done <<< "${expected_image_tags}"
+            if [ "${expected_tag_count}" -lt 1 ] || [ "${expected_tag_count}" -gt 16 ]; then
+              echo "::error::Immutable architecture input tag count is outside bounds."
+              exit 1
+            fi
+            if ! cmp -s "${tags_file}" "${expected_tags_file}"; then
+              echo "::error::${architecture} publication image references do not match immutable release inputs."
+              exit 1
+            fi
+            rm -f "${expected_tags_file}"
 
             if ! jq -e '.imageLayoutVersion == "1.0.0"' "${layout_root}/oci-layout" >/dev/null \
               || ! jq -e '.schemaVersion == 2 and (.manifests | type == "array")' "${layout_root}/index.json" >/dev/null; then

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -690,6 +690,12 @@ jobs:
             --arg tag "${RELEASE_TAG}" \
             '{source_sha: $source_sha, image_name: $image_name, tag: $tag}' \
             > "${payload_root}/publication.json"
+          (
+            cd "${payload_root}"
+            find -P . -type f ! -path './SHA256SUMS' -print0 \
+              | LC_ALL=C sort -z \
+              | xargs -0 -r sha256sum
+          ) > "${payload_root}/SHA256SUMS"
 
       - name: Upload manifest publication payload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -716,12 +722,15 @@ jobs:
         env:
           EXPECTED_SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
           EXPECTED_TAG: ${{ inputs.tag }}
+          EXPECTED_IMAGE_TAGS: ${{ inputs.image_tags }}
         run: |
           set -euo pipefail
           payload_root="${RUNNER_TEMP}/ghcr-manifest-publication"
           metadata_file="${payload_root}/publication.json"
           tags_file="${payload_root}/image-tags.txt"
+          checksums_file="${payload_root}/SHA256SUMS"
           expected_source_sha="${EXPECTED_SOURCE_SHA}"
+          expected_image_tags="${EXPECTED_IMAGE_TAGS}"
           owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           expected_image_name="ghcr.io/${owner}/lopper"
 
@@ -729,7 +738,7 @@ jobs:
             echo "::error::Invalid immutable source SHA in manifest publication payload."
             exit 1
           fi
-          if [ ! -f "${metadata_file}" ] || [ ! -f "${tags_file}" ] \
+          if [ ! -f "${metadata_file}" ] || [ ! -f "${tags_file}" ] || [ ! -f "${checksums_file}" ] \
             || find -P "${payload_root}" ! -type d ! -type f -print -quit | grep -q .; then
             echo "::error::Manifest publication payload is missing files or contains unsupported paths."
             exit 1
@@ -741,20 +750,58 @@ jobs:
           fi
           file_count="$(find -P "${payload_root}" -type f | wc -l | tr -d '[:space:]')"
           total_bytes="$(find -P "${payload_root}" -type f -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }')"
-          if [ "${file_count}" -ne 2 ] || [ "${total_bytes}" -gt 32768 ]; then
+          if [ "${file_count}" -ne 3 ] || [ "${total_bytes}" -gt 33280 ] \
+            || [ "$(stat -c '%s' "${metadata_file}")" -gt 16384 ] \
+            || [ "$(stat -c '%s' "${tags_file}")" -gt 16384 ] \
+            || [ "$(stat -c '%s' "${checksums_file}")" -gt 512 ]; then
             echo "::error::Manifest artifact payload exceeds file-count or size bounds."
             exit 1
           fi
           while IFS= read -r payload_file; do
             relative_path="${payload_file#"${payload_root}/"}"
             case "${relative_path}" in
-              publication.json|image-tags.txt) ;;
+              SHA256SUMS|publication.json|image-tags.txt) ;;
               *)
                 echo "::error::Unexpected manifest publication payload path."
                 exit 1
                 ;;
-            esac
+              esac
           done < <(find -P "${payload_root}" -type f -print)
+
+          checksum_pattern='^[0-9a-f]{64}  (\./(image-tags\.txt|publication\.json))$'
+          checksum_count=0
+          declare -A seen_checksum_paths=()
+          while IFS= read -r checksum_line || [[ -n "${checksum_line}" ]]; do
+            if [[ ! "${checksum_line}" =~ ${checksum_pattern} ]]; then
+              echo "::error::Manifest publication checksum syntax is invalid."
+              exit 1
+            fi
+            checksum_path="${BASH_REMATCH[1]}"
+            if [[ -n "${seen_checksum_paths[${checksum_path}]:-}" ]]; then
+              echo "::error::Manifest publication checksum paths must be unique."
+              exit 1
+            fi
+            seen_checksum_paths["${checksum_path}"]=1
+            checksum_count=$((checksum_count + 1))
+          done < "${checksums_file}"
+          if [ "${checksum_count}" -ne 2 ]; then
+            echo "::error::Manifest publication checksum count is invalid."
+            exit 1
+          fi
+          computed_checksums="${RUNNER_TEMP}/ghcr-manifest-computed-SHA256SUMS"
+          (
+            cd "${payload_root}"
+            find -P . -type f ! -path './SHA256SUMS' -print0 \
+              | LC_ALL=C sort -z \
+              | xargs -0 -r sha256sum
+          ) > "${computed_checksums}"
+          if ! cmp -s "${checksums_file}" "${computed_checksums}" \
+            || ! (cd "${payload_root}" && sha256sum --check --strict SHA256SUMS >/dev/null); then
+            echo "::error::Manifest publication payload checksum validation failed."
+            exit 1
+          fi
+          rm -f "${computed_checksums}"
+
           if ! jq -e \
             --arg source_sha "${expected_source_sha}" \
             --arg image_name "${expected_image_name}" \
@@ -767,6 +814,42 @@ jobs:
             echo "::error::Manifest publication metadata does not match immutable release inputs."
             exit 1
           fi
+
+          expected_tags_file="${RUNNER_TEMP}/ghcr-manifest-expected-image-tags.txt"
+          : > "${expected_tags_file}"
+          expected_tag_count=0
+          declare -A expected_seen_tags=()
+          while IFS= read -r raw_tag || [[ -n "${raw_tag}" ]]; do
+            tag="${raw_tag}"
+            tag="${tag%$'\r'}"
+            tag="${tag#"${tag%%[![:space:]]*}"}"
+            tag="${tag%"${tag##*[![:space:]]}"}"
+            if [[ -z "${tag}" ]]; then
+              continue
+            fi
+            if [[ ! "${tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] \
+              || [[ "${tag}" == *-amd64 ]] || [[ "${tag}" == *-arm64 ]]; then
+              echo "::error::unexpected image reference in immutable manifest inputs."
+              exit 1
+            fi
+            expected_image_ref="${expected_image_name}:${tag}"
+            if [[ -n "${expected_seen_tags[${expected_image_ref}]:-}" ]]; then
+              echo "::error::Duplicate manifest publication image reference."
+              exit 1
+            fi
+            expected_seen_tags["${expected_image_ref}"]=1
+            printf '%s:%s\n' "${expected_image_name}" "${tag}" >> "${expected_tags_file}"
+            expected_tag_count=$((expected_tag_count + 1))
+          done <<< "${expected_image_tags}"
+          if [ "${expected_tag_count}" -lt 1 ] || [ "${expected_tag_count}" -gt 16 ]; then
+            echo "::error::Immutable manifest input tag count is outside bounds."
+            exit 1
+          fi
+          if ! cmp -s "${tags_file}" "${expected_tags_file}"; then
+            echo "::error::Manifest publication image references do not match immutable release inputs."
+            exit 1
+          fi
+          rm -f "${expected_tags_file}"
 
           tag_count=0
           declare -A seen_tags=()

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -375,6 +375,9 @@ jobs:
     needs:
       - prepare-ghcr-amd64
       - prepare-ghcr-arm64
+    outputs:
+      amd64_digest: ${{ steps.publish_amd64.outputs.digest }}
+      arm64_digest: ${{ steps.publish_arm64.outputs.digest }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -624,6 +627,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish amd64 release image
+        id: publish_amd64
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ runner.temp }}/ghcr-amd64-promotion
@@ -636,6 +640,7 @@ jobs:
           sbom: true
 
       - name: Publish arm64 release image
+        id: publish_arm64
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ runner.temp }}/ghcr-arm64-promotion
@@ -723,6 +728,8 @@ jobs:
           EXPECTED_SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
           EXPECTED_TAG: ${{ inputs.tag }}
           EXPECTED_IMAGE_TAGS: ${{ inputs.image_tags }}
+          EXPECTED_AMD64_DIGEST: ${{ needs.publish-ghcr-images.outputs.amd64_digest }}
+          EXPECTED_ARM64_DIGEST: ${{ needs.publish-ghcr-images.outputs.arm64_digest }}
         run: |
           set -euo pipefail
           payload_root="${RUNNER_TEMP}/ghcr-manifest-publication"
@@ -731,11 +738,18 @@ jobs:
           checksums_file="${payload_root}/SHA256SUMS"
           expected_source_sha="${EXPECTED_SOURCE_SHA}"
           expected_image_tags="${EXPECTED_IMAGE_TAGS}"
+          amd64_digest="${EXPECTED_AMD64_DIGEST}"
+          arm64_digest="${EXPECTED_ARM64_DIGEST}"
           owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           expected_image_name="ghcr.io/${owner}/lopper"
 
           if [[ ! "${expected_source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::Invalid immutable source SHA in manifest publication payload."
+            exit 1
+          fi
+          if [[ ! "${amd64_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+            || [[ ! "${arm64_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Published architecture image digests are invalid."
             exit 1
           fi
           if [ ! -f "${metadata_file}" ] || [ ! -f "${tags_file}" ] || [ ! -f "${checksums_file}" ] \
@@ -765,7 +779,7 @@ jobs:
                 echo "::error::Unexpected manifest publication payload path."
                 exit 1
                 ;;
-              esac
+            esac
           done < <(find -P "${payload_root}" -type f -print)
 
           checksum_pattern='^[0-9a-f]{64}  (\./(image-tags\.txt|publication\.json))$'
@@ -891,12 +905,18 @@ jobs:
         shell: bash
         env:
           IMAGE_TAGS_FILE: ${{ runner.temp }}/ghcr-manifest-publication/image-tags.txt
+          AMD64_DIGEST: ${{ needs.publish-ghcr-images.outputs.amd64_digest }}
+          ARM64_DIGEST: ${{ needs.publish-ghcr-images.outputs.arm64_digest }}
         run: |
           set -euo pipefail
+          amd64_digest="${AMD64_DIGEST}"
+          arm64_digest="${ARM64_DIGEST}"
+          owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          expected_image_name="ghcr.io/${owner}/lopper"
           while IFS= read -r image_ref; do
             docker buildx imagetools create \
               -t "${image_ref}" \
-              "${image_ref}-amd64" \
-              "${image_ref}-arm64"
+              "${expected_image_name}@${amd64_digest}" \
+              "${expected_image_name}@${arm64_digest}"
             docker buildx imagetools inspect "${image_ref}"
           done < "${IMAGE_TAGS_FILE}"

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Compute build metadata
@@ -95,6 +96,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Compute build metadata
@@ -164,6 +166,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Compute image metadata
@@ -233,6 +236,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Compute image metadata
@@ -305,6 +309,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Compute image name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,27 @@ jobs:
       tag: ${{ steps.release.outputs.tag_name || steps.manual.outputs.tag }}
       version: ${{ steps.release.outputs.version || steps.manual.outputs.version }}
       sha: ${{ steps.release.outputs.sha || steps.manual.outputs.sha }}
+      trusted_main_sha: ${{ steps.trusted_main.outputs.trusted_main_sha }}
     steps:
+      - name: Resolve trusted main workflow revision
+        id: trusted_main
+        env:
+          PATH: /usr/bin:/bin
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          expected_workflow_ref="${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/heads/main"
+          if [ "${WORKFLOW_REF}" != "${expected_workflow_ref}" ]; then
+            echo "::error::Release workflow must come from ${expected_workflow_ref}; got ${WORKFLOW_REF}." >&2
+            exit 1
+          fi
+          if [[ ! "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Release workflow SHA must be a lowercase full 40-character commit SHA; got ${WORKFLOW_SHA}." >&2
+            exit 1
+          fi
+          /usr/bin/printf 'trusted_main_sha=%s\n' "${WORKFLOW_SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Run release-please
         if: ${{ github.event_name != 'workflow_dispatch' }}
         id: release
@@ -431,7 +451,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-          ref: main
+          ref: ${{ needs.prepare-release.outputs.trusted_main_sha }}
 
       - name: Setup Node for Marketplace tooling
         if: ${{ steps.gate.outputs.configured == 'true' }}
@@ -1426,7 +1446,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: main
+          ref: ${{ needs.prepare-release.outputs.trusted_main_sha }}
 
       - name: Checkout validated release data
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -613,25 +613,43 @@ jobs:
           go-version-file: go.mod
 
       - name: Stamp first stable release history
+        id: stamp_history
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
-          PUSH_TOKEN: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          go run ./tools/featureflag stamp-release --release "${RELEASE_TAG}"
+          go run ./tools/featureflag validate
+
+          if git diff --quiet -- internal/featureflags/features.json; then
+            echo "No feature release history changes to commit"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit stamped feature release history
+        if: ${{ steps.stamp_history.outputs.changed == 'true' }}
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          go run ./tools/featureflag stamp-release --release "${RELEASE_TAG}"
-          go run ./tools/featureflag validate
-
           git add internal/featureflags/features.json
-          if git diff --cached --quiet; then
-            echo "No feature release history changes to commit"
-            exit 0
-          fi
-
           git commit -m "chore(flags): stamp ${RELEASE_TAG} feature release history"
-          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - name: Push stamped feature release history
+        if: ${{ steps.stamp_history.outputs.changed == 'true' }}
+        env:
+          PUSH_TOKEN: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          push_url="https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} for feature release history"
             if ! git fetch origin main:refs/remotes/origin/main; then
@@ -645,7 +663,7 @@ jobs:
               sleep 2
               continue
             fi
-            if git push origin HEAD:main; then
+            if git push "${push_url}" HEAD:main; then
               exit 0
             fi
             sleep 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,58 +478,81 @@ jobs:
           git tag --force "${minor_tag}" "${RELEASE_SHA}"
           git push --force "${push_url}" "refs/tags/${major_tag}" "refs/tags/${minor_tag}"
 
-  update-homebrew-tap:
+  homebrew-tap-token-gate:
     needs:
       - prepare-release
       - publish
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
-    concurrency:
-      group: homebrew-tap-main
-      cancel-in-progress: false
-    permissions:
-      contents: read
+    permissions: {}
+    outputs:
+      configured: ${{ steps.gate.outputs.configured }}
     steps:
       - name: Detect tap token
-        id: tap_token
+        id: gate
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
-          if [ -n "${HOMEBREW_TAP_TOKEN}" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
+          if [ -n "${HOMEBREW_TAP_TOKEN:-}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
           else
-            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "configured=false" >> "$GITHUB_OUTPUT"
           fi
 
+  validate-homebrew-tap:
+    needs:
+      - prepare-release
+      - publish
+      - homebrew-tap-token-gate
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' && needs.homebrew-tap-token-gate.outputs.configured == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      FORMULA_VERSION: ${{ needs.prepare-release.outputs.version }}
+      SOURCE_SHA: ${{ needs.prepare-release.outputs.sha }}
+      SOURCE_REPO: ${{ github.repository }}
+    steps:
       - name: Set up Homebrew
-        if: ${{ steps.tap_token.outputs.available == 'true' }}
         uses: Homebrew/actions/setup-homebrew@fc695c54c2032716dd4cedd007489c8e32fc8a5d
 
-      - name: Checkout tap repository
-        if: ${{ steps.tap_token.outputs.available == 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-          repository: ben-ranford/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-tap
-          fetch-depth: 0
+      - name: Clone tap repository anonymously
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          git_bin=/usr/bin/git
+          mktemp_bin=/usr/bin/mktemp
+          if [ ! -x "${git_bin}" ] || [ ! -x "${mktemp_bin}" ]; then
+            echo "::error::Trusted binaries are not available for anonymous Homebrew tap validation" >&2
+            exit 1
+          fi
+          export PATH=/usr/bin:/bin
 
-      - name: Update lopper formula
-        if: ${{ steps.tap_token.outputs.available == 'true' }}
+          git_home="$("${mktemp_bin}" -d)"
+          trap 'rm -rf "${git_home}"' EXIT
+
+          env -i \
+            HOME="${git_home}" \
+            PATH="${PATH}" \
+            GIT_TERMINAL_PROMPT=0 \
+            GIT_CONFIG_NOSYSTEM=1 \
+            "${git_bin}" \
+            -c core.hooksPath=/dev/null \
+            -c protocol.file.allow=never \
+            -c protocol.ext.allow=never \
+            clone --origin origin --branch main --single-branch \
+            https://github.com/ben-ranford/homebrew-tap.git homebrew-tap
+
+      - name: Regenerate lopper formula
         working-directory: homebrew-tap
-        env:
-          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
-          SOURCE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          source_url="https://github.com/${SOURCE_REPO}/archive/refs/tags/${RELEASE_TAG}.tar.gz"
+          source_url="https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz"
           curl --fail --show-error --silent --location \
             --retry 5 --retry-all-errors --retry-delay 2 \
             --connect-timeout 20 --max-time 180 \
             "$source_url" -o /tmp/lopper-source.tar.gz
-          source_sha="$(sha256sum /tmp/lopper-source.tar.gz | awk '{print $1}')"
+          read -r source_sha _ < <(sha256sum /tmp/lopper-source.tar.gz)
 
           mkdir -p Formula
           cat > Formula/lopper.rb <<RUBY
@@ -537,6 +560,7 @@ jobs:
             desc "Local-first CLI/TUI for measuring dependency surface area"
             homepage "https://github.com/ben-ranford/lopper"
             url "${source_url}"
+            version "${FORMULA_VERSION}"
             sha256 "${source_sha}"
             license "MIT"
 
@@ -562,7 +586,6 @@ jobs:
           RUBY
 
       - name: Validate formula
-        if: ${{ steps.tap_token.outputs.available == 'true' }}
         working-directory: homebrew-tap
         run: |
           set -euo pipefail
@@ -574,49 +597,156 @@ jobs:
           brew install --build-from-source ben-ranford/tap/lopper
           brew test ben-ranford/tap/lopper
 
-      - name: Commit and push formula changes
-        if: ${{ steps.tap_token.outputs.available == 'true' }}
-        working-directory: homebrew-tap
+  update-homebrew-tap:
+    needs:
+      - prepare-release
+      - publish
+      - validate-homebrew-tap
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: homebrew-tap-main
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+      FORMULA_VERSION: ${{ needs.prepare-release.outputs.version }}
+      SOURCE_SHA: ${{ needs.prepare-release.outputs.sha }}
+      SOURCE_REPO: ${{ github.repository }}
+    steps:
+      - name: Regenerate and push formula changes
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         run: |
-          set -euo pipefail
-          push_url="https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ben-ranford/homebrew-tap.git"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git_bin=/usr/bin/git
+          curl_bin=/usr/bin/curl
+          sha256sum_bin=/usr/bin/sha256sum
+          base64_bin=/usr/bin/base64
+          tr_bin=/usr/bin/tr
+          mktemp_bin=/usr/bin/mktemp
+          if [ ! -x "${git_bin}" ] || [ ! -x "${curl_bin}" ] || [ ! -x "${sha256sum_bin}" ] || [ ! -x "${base64_bin}" ] || [ ! -x "${tr_bin}" ] || [ ! -x "${mktemp_bin}" ]; then
+            echo "::error::Trusted binaries are not available for the isolated Homebrew tap update step" >&2
+            exit 1
+          fi
+          export PATH=/usr/bin:/bin
 
-          git add Formula/lopper.rb
-          if git diff --cached --quiet; then
+          git_home="$("${mktemp_bin}" -d)"
+          work_root="$("${mktemp_bin}" -d)"
+          tap_repo="${work_root}/homebrew-tap"
+          source_archive="${work_root}/lopper-source.tar.gz"
+          trap 'rm -rf "${git_home}" "${work_root}"' EXIT
+
+          git_safe() {
+            env -i \
+              HOME="${git_home}" \
+              PATH="${PATH}" \
+              GIT_TERMINAL_PROMPT=0 \
+              GIT_CONFIG_NOSYSTEM=1 \
+              "${git_bin}" \
+              -c core.hooksPath=/dev/null \
+              -c credential.helper= \
+              -c protocol.file.allow=never \
+              -c protocol.ext.allow=never \
+              "$@"
+          }
+
+          git_network() {
+            env -i \
+              HOME="${git_home}" \
+              PATH="${PATH}" \
+              GIT_TERMINAL_PROMPT=0 \
+              GIT_CONFIG_NOSYSTEM=1 \
+              GIT_CONFIG_COUNT=5 \
+              GIT_CONFIG_KEY_0=core.hooksPath \
+              GIT_CONFIG_VALUE_0=/dev/null \
+              GIT_CONFIG_KEY_1=credential.helper \
+              GIT_CONFIG_VALUE_1= \
+              GIT_CONFIG_KEY_2=protocol.file.allow \
+              GIT_CONFIG_VALUE_2=never \
+              GIT_CONFIG_KEY_3=protocol.ext.allow \
+              GIT_CONFIG_VALUE_3=never \
+              GIT_CONFIG_KEY_4=http.https://github.com/.extraheader \
+              GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}" \
+              "${git_bin}" \
+              "$@"
+          }
+
+          git_safe clone --origin origin --branch main --single-branch https://github.com/ben-ranford/homebrew-tap.git "${tap_repo}"
+
+          source_url="https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz"
+          "${curl_bin}" --fail --show-error --silent --location \
+            --retry 5 --retry-all-errors --retry-delay 2 \
+            --connect-timeout 20 --max-time 180 \
+            "${source_url}" -o "${source_archive}"
+          read -r source_sha _ < <("${sha256sum_bin}" "${source_archive}")
+
+          mkdir -p "${tap_repo}/Formula"
+          cat > "${tap_repo}/Formula/lopper.rb" <<RUBY
+          class Lopper < Formula
+            desc "Local-first CLI/TUI for measuring dependency surface area"
+            homepage "https://github.com/ben-ranford/lopper"
+            url "${source_url}"
+            version "${FORMULA_VERSION}"
+            sha256 "${source_sha}"
+            license "MIT"
+
+            depends_on "go" => :build
+            conflicts_with "ben-ranford/tap/lopper-rolling", because: "both install the lopper executable"
+
+            def install
+              ldflags = %W[
+                -s
+                -w
+                -X github.com/ben-ranford/lopper/internal/version.version=#{version}
+                -X github.com/ben-ranford/lopper/internal/version.buildChannel=release
+              ]
+              system "go", "build", *std_go_args(output: bin/"lopper", ldflags: ldflags.join(" ")), "./cmd/lopper"
+              system "bash", "scripts/generate-manpage.sh", "docs/man/lopper.1"
+              man1.install "docs/man/lopper.1"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/lopper --version")
+            end
+          end
+          RUBY
+
+          git_safe -C "${tap_repo}" config user.name "github-actions[bot]"
+          git_safe -C "${tap_repo}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git_safe -C "${tap_repo}" add Formula/lopper.rb
+          if git_safe -C "${tap_repo}" diff --cached --quiet; then
             echo "No formula changes to commit"
             exit 0
           fi
 
-          git commit -m "lopper ${{ needs.prepare-release.outputs.tag }}"
+          git_safe -C "${tap_repo}" commit --no-verify -m "lopper ${RELEASE_TAG}"
+
+          auth_header="$(printf 'x-access-token:%s' "${HOMEBREW_TAP_TOKEN}" | "${base64_bin}" | "${tr_bin}" -d '\n')"
+          unset HOMEBREW_TAP_TOKEN
+
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} for Homebrew formula"
-            if ! git fetch origin main:refs/remotes/origin/main; then
+            if ! git_network -C "${tap_repo}" fetch origin main:refs/remotes/origin/main; then
               echo "git fetch failed on attempt ${attempt}" >&2
-              sleep 2
+              /bin/sleep 2
               continue
             fi
-            if ! git rebase origin/main; then
+            if ! git_safe -C "${tap_repo}" rebase origin/main; then
               echo "git rebase failed on attempt ${attempt}; aborting rebase and retrying" >&2
-              git rebase --abort || true
-              sleep 2
+              git_safe -C "${tap_repo}" rebase --abort || true
+              /bin/sleep 2
               continue
             fi
-            if git push "${push_url}" HEAD:main; then
+            if git_network -C "${tap_repo}" push origin HEAD:main; then
               exit 0
             fi
-            sleep 2
+            /bin/sleep 2
           done
 
           echo "Failed to push Homebrew formula after retries" >&2
           exit 1
-
-      - name: Skip tap update when token is missing
-        if: ${{ steps.tap_token.outputs.available != 'true' }}
-        run: echo "HOMEBREW_TAP_TOKEN not configured; skipping tap update."
 
   stamp-feature-release-history:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ inputs.source_sha || github.sha }}
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
@@ -134,6 +135,7 @@ jobs:
       - name: Checkout release source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare-release.outputs.sha }}
 
       - name: Setup Go
@@ -188,6 +190,7 @@ jobs:
       - name: Checkout release source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare-release.outputs.sha }}
 
       - name: Compute build metadata
@@ -256,6 +259,7 @@ jobs:
       - name: Checkout release source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ needs.prepare-release.outputs.sha }}
 
@@ -424,6 +428,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
           RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
+          PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -437,6 +442,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git tag --force "${major_tag}" "${RELEASE_SHA}"
           git tag --force "${minor_tag}" "${RELEASE_SHA}"
           git push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"
@@ -472,6 +478,7 @@ jobs:
         if: ${{ steps.tap_token.outputs.available == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           repository: ben-ranford/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
@@ -539,6 +546,8 @@ jobs:
       - name: Commit and push formula changes
         if: ${{ steps.tap_token.outputs.available == 'true' }}
         working-directory: homebrew-tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -551,6 +560,7 @@ jobs:
           fi
 
           git commit -m "lopper ${{ needs.prepare-release.outputs.tag }}"
+          git remote set-url origin "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ben-ranford/homebrew-tap.git"
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} for Homebrew formula"
             if ! git fetch origin main:refs/remotes/origin/main; then
@@ -592,6 +602,7 @@ jobs:
       - name: Checkout release source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ needs.prepare-release.outputs.sha }}
           token: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
@@ -604,6 +615,7 @@ jobs:
       - name: Stamp first stable release history
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          PUSH_TOKEN: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -619,6 +631,7 @@ jobs:
           fi
 
           git commit -m "chore(flags): stamp ${RELEASE_TAG} feature release history"
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} for feature release history"
             if ! git fetch origin main:refs/remotes/origin/main; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,35 +73,55 @@ jobs:
           resolved_sha="$(git rev-parse HEAD)"
           encoded_tag="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$tag")"
           release_json="$(mktemp)"
-          if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" >"${release_json}" 2>/dev/null; then
+          release_lookup_error="$(mktemp)"
+          trap 'rm -f "${release_json}" "${release_lookup_error}"' EXIT
+          if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" >"${release_json}" 2>"${release_lookup_error}"; then
             echo "Reusing existing GitHub release ${tag}."
+            tag_fetched="true"
             if ! fetch_error="$(git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}" 2>&1)"; then
               if [[ "${fetch_error}" == *"couldn't find remote ref refs/tags/${tag}"* ]]; then
                 echo "Remote tag ${tag} does not exist; validating the release target instead."
+                tag_fetched="false"
               else
                 echo "::error::Failed to fetch existing release tag ${tag}." >&2
                 printf '%s\n' "${fetch_error}" >&2
-                rm -f "${release_json}"
                 exit 1
               fi
             fi
 
-            existing_commit=""
-            if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
-              existing_commit="$(git rev-list -n 1 "${tag}")"
+            if [ "${tag_fetched}" = "true" ]; then
+              if ! existing_commit="$(git rev-parse "refs/tags/${tag}^{commit}")"; then
+                echo "::error::Failed to resolve fetched release tag ${tag} to a commit." >&2
+                exit 1
+              fi
             else
               existing_target="$(jq -r '.target_commitish // empty' "${release_json}")"
-              if [ -n "${existing_target}" ] && git rev-parse -q --verify "${existing_target}^{commit}" >/dev/null 2>&1; then
-                existing_commit="$(git rev-parse "${existing_target}^{commit}")"
+              if [ -z "${existing_target}" ]; then
+                echo "::error::Existing release ${tag} has no target_commitish to validate." >&2
+                exit 1
+              fi
+              encoded_target="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$existing_target")"
+              if ! existing_commit="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_target}" --jq '.sha')"; then
+                echo "::error::Failed to resolve existing release ${tag} target ${existing_target}." >&2
+                exit 1
               fi
             fi
 
-            if [ -n "${existing_commit}" ] && [ "${existing_commit}" != "${resolved_sha}" ]; then
+            if [[ ! "${existing_commit}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::Existing release ${tag} resolved to invalid commit SHA ${existing_commit}." >&2
+              exit 1
+            fi
+            if [ "${existing_commit}" != "${resolved_sha}" ]; then
               echo "::error::Existing release ${tag} points to ${existing_commit}, but this run resolved ${resolved_sha}." >&2
-              rm -f "${release_json}"
               exit 1
             fi
           else
+            release_lookup_status=$?
+            if ! grep -q "HTTP 404" "${release_lookup_error}"; then
+              cat "${release_lookup_error}" >&2
+              echo "::error::Failed to look up GitHub release ${tag}." >&2
+              exit "${release_lookup_status}"
+            fi
             gh release create "${tag}" \
               --repo "${GITHUB_REPOSITORY}" \
               --target "${resolved_sha}" \
@@ -109,7 +129,6 @@ jobs:
               --title "Release ${tag}" \
               --notes ""
           fi
-          rm -f "${release_json}"
 
           {
             echo "release_created=true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -810,8 +810,8 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PUBLISH }}
         run: |
           if [ -z "${VSCE_PAT:-}" ]; then
-            echo "VSCE publish token not configured; skipping marketplace publish."
-            exit 0
+            echo "::error::VSCE publish token became unavailable after Marketplace publication was enabled." >&2
+            exit 1
           fi
 
           vsce_bin="${RUNNER_TEMP}/vsce-toolchain/node_modules/.bin/vsce"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,19 +406,41 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      configured: ${{ steps.gate.outputs.configured }}
     steps:
+      - name: Detect Marketplace token
+        id: gate
+        env:
+          VSCE_PUBLISH: ${{ secrets.VSCE_PUBLISH }}
+          PATH: /usr/bin:/bin
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          if [ -n "${VSCE_PUBLISH:-}" ]; then
+            /usr/bin/printf '%s\n' 'configured=true' >> "$GITHUB_OUTPUT"
+          else
+            /usr/bin/printf '%s\n' 'configured=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip Marketplace toolchain prep when token is missing
+        if: ${{ steps.gate.outputs.configured != 'true' }}
+        run: echo "VSCE publish token not configured; skipping Marketplace toolchain preparation."
+
       - name: Checkout trusted main Marketplace manifests
+        if: ${{ steps.gate.outputs.configured == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           ref: main
 
       - name: Setup Node for Marketplace tooling
+        if: ${{ steps.gate.outputs.configured == 'true' }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
 
       - name: Validate Marketplace tooling lockfile
+        if: ${{ steps.gate.outputs.configured == 'true' }}
         run: |
           set -euo pipefail
           lockfile="extensions/vscode-lopper/package-lock.json"
@@ -442,6 +464,7 @@ jobs:
           esac
 
       - name: Prepare integrity-bound Marketplace toolchain
+        if: ${{ steps.gate.outputs.configured == 'true' }}
         run: |
           set -euo pipefail
           source_dir="extensions/vscode-lopper"
@@ -476,6 +499,7 @@ jobs:
           fi
 
       - name: Archive Marketplace toolchain
+        if: ${{ steps.gate.outputs.configured == 'true' }}
         run: |
           set -euo pipefail
           scratch_dir="${RUNNER_TEMP}/marketplace-toolchain"
@@ -495,6 +519,7 @@ jobs:
           )
 
       - name: Upload Marketplace toolchain
+        if: ${{ steps.gate.outputs.configured == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: marketplace-toolchain
@@ -515,24 +540,32 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
+      - name: Skip Marketplace publish when token is missing
+        if: ${{ needs.prepare-marketplace-toolchain.outputs.configured != 'true' }}
+        run: echo "VSCE publish token not configured; skipping Marketplace publish."
+
       - name: Setup Node for Marketplace tooling
+        if: ${{ needs.prepare-marketplace-toolchain.outputs.configured == 'true' }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
 
       - name: Download release publication inputs
+        if: ${{ needs.prepare-marketplace-toolchain.outputs.configured == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: release-publication-inputs
           path: publication-inputs
 
       - name: Download Marketplace toolchain
+        if: ${{ needs.prepare-marketplace-toolchain.outputs.configured == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: marketplace-toolchain
           path: marketplace-toolchain-input
 
       - name: Validate Marketplace publication inputs
+        if: ${{ needs.prepare-marketplace-toolchain.outputs.configured == 'true' }}
         shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         env:
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
@@ -750,6 +783,7 @@ jobs:
           test -x "${node_bin}"
 
       - name: Publish VS Code extension to Marketplace
+        if: ${{ needs.prepare-marketplace-toolchain.outputs.configured == 'true' }}
         shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         env:
           VSCE_PAT: ${{ secrets.VSCE_PUBLISH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,13 +439,13 @@ jobs:
 
           major_tag="v${BASH_REMATCH[1]}"
           minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+          push_url="https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git tag --force "${major_tag}" "${RELEASE_SHA}"
           git tag --force "${minor_tag}" "${RELEASE_SHA}"
-          git push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"
+          git push --force "${push_url}" "refs/tags/${major_tag}" "refs/tags/${minor_tag}"
 
   update-homebrew-tap:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1440,6 +1440,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$ ]]; then
+            echo "::notice::Skipping feature release history for non-stable semver release ${RELEASE_TAG}."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           "${RUNNER_TEMP}/featureflag" stamp-release --release "${RELEASE_TAG}"
           "${RUNNER_TEMP}/featureflag" validate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,6 +534,13 @@ jobs:
         with:
           node-version: 24
 
+      - name: Prepare VS Code Marketplace tooling
+        run: |
+          set -euo pipefail
+          toolchain_dir="${RUNNER_TEMP}/vsce-toolchain"
+          npm install --prefix "${toolchain_dir}" --no-audit --no-fund @vscode/vsce@3.9.2
+          test -x "${toolchain_dir}/node_modules/.bin/vsce"
+
       - name: Publish VS Code extension to Marketplace
         env:
           VSCE_PAT: ${{ secrets.VSCE_PUBLISH }}
@@ -544,9 +551,11 @@ jobs:
             exit 0
           fi
 
+          vsce_bin="${RUNNER_TEMP}/vsce-toolchain/node_modules/.bin/vsce"
+          test -x "$vsce_bin"
           vsix_path="$(find publication-inputs/dist -maxdepth 1 -name 'lopper-vscode-*.vsix' | head -n1)"
           test -n "$vsix_path"
-          npx --yes @vscode/vsce@3.9.2 publish --packagePath "$vsix_path"
+          "$vsce_bin" publish --packagePath "$vsix_path"
 
       - name: Publish GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,6 +508,7 @@ jobs:
   publish-marketplace:
     needs:
       - prepare-release
+      - publish
       - prepare-release-publication
       - prepare-marketplace-toolchain
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
@@ -766,7 +767,6 @@ jobs:
     needs:
       - prepare-release
       - prepare-release-publication
-      - publish-marketplace
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,13 +455,66 @@ jobs:
             -f make_latest=true >/dev/null
 
       - name: Update GitHub Action floating tags
-        shell: bash
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
           RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
           PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
+          git_bin=/usr/bin/git
+          env_bin=/usr/bin/env
+          base64_bin=/usr/bin/base64
+          tr_bin=/usr/bin/tr
+          mktemp_bin=/usr/bin/mktemp
+          if [ ! -x "${git_bin}" ] || [ ! -x "${env_bin}" ] || [ ! -x "${base64_bin}" ] || [ ! -x "${tr_bin}" ] || [ ! -x "${mktemp_bin}" ]; then
+            echo "::error::Trusted binaries are unavailable for the floating tag update step." >&2
+            exit 1
+          fi
+          push_token="${PUSH_TOKEN}"
+          unset PUSH_TOKEN
+          if [ -z "${push_token}" ]; then
+            echo "::error::No token is available to update floating tags." >&2
+            exit 1
+          fi
+          git_home="$("${mktemp_bin}" -d)"
+          trap '/bin/rm -rf "${git_home}"' EXIT
+
+          git_safe() {
+            "${env_bin}" -i \
+              HOME="${git_home}" \
+              PATH=/usr/bin:/bin \
+              GIT_TERMINAL_PROMPT=0 \
+              GIT_CONFIG_NOSYSTEM=1 \
+              GIT_CONFIG_GLOBAL=/dev/null \
+              "${git_bin}" \
+              -c core.hooksPath=/dev/null \
+              -c credential.helper= \
+              -c protocol.file.allow=never \
+              -c protocol.ext.allow=never \
+              "$@"
+          }
+
+          git_network() {
+            "${env_bin}" -i \
+              HOME="${git_home}" \
+              PATH=/usr/bin:/bin \
+              GIT_TERMINAL_PROMPT=0 \
+              GIT_CONFIG_NOSYSTEM=1 \
+              GIT_CONFIG_GLOBAL=/dev/null \
+              GIT_CONFIG_COUNT=5 \
+              GIT_CONFIG_KEY_0=core.hooksPath \
+              GIT_CONFIG_VALUE_0=/dev/null \
+              GIT_CONFIG_KEY_1=credential.helper \
+              GIT_CONFIG_VALUE_1= \
+              GIT_CONFIG_KEY_2=protocol.file.allow \
+              GIT_CONFIG_VALUE_2=never \
+              GIT_CONFIG_KEY_3=protocol.ext.allow \
+              GIT_CONFIG_VALUE_3=never \
+              GIT_CONFIG_KEY_4=http.https://github.com/.extraheader \
+              GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}" \
+              "${git_bin}" \
+              "$@"
+          }
 
           if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$ ]]; then
             echo "::notice::Skipping GitHub Action floating tags for non-stable semver release ${RELEASE_TAG}."
@@ -470,13 +523,22 @@ jobs:
 
           major_tag="v${BASH_REMATCH[1]}"
           minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-          push_url="https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          expected_origin="https://github.com/${GITHUB_REPOSITORY}"
+          origin_fetch_urls="$(git_safe remote get-url --all origin)"
+          origin_push_urls="$(git_safe remote get-url --push --all origin)"
+          if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then
+            echo "::error::Refusing to update floating tags through an unexpected origin." >&2
+            exit 1
+          fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag --force "${major_tag}" "${RELEASE_SHA}"
-          git tag --force "${minor_tag}" "${RELEASE_SHA}"
-          git push --force "${push_url}" "refs/tags/${major_tag}" "refs/tags/${minor_tag}"
+          git_safe config user.name "github-actions[bot]"
+          git_safe config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git_safe tag --force "${major_tag}" "${RELEASE_SHA}"
+          git_safe tag --force "${minor_tag}" "${RELEASE_SHA}"
+
+          auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"
+          unset push_token
+          git_network push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"
 
   homebrew-tap-token-gate:
     needs:
@@ -842,29 +904,93 @@ jobs:
       - name: Push stamped feature release history
         if: ${{ steps.stamp_history.outputs.changed == 'true' }}
         working-directory: release-source
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         env:
           PUSH_TOKEN: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
-          push_url="https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git_bin=/usr/bin/git
+          env_bin=/usr/bin/env
+          base64_bin=/usr/bin/base64
+          tr_bin=/usr/bin/tr
+          mktemp_bin=/usr/bin/mktemp
+          if [ ! -x "${git_bin}" ] || [ ! -x "${env_bin}" ] || [ ! -x "${base64_bin}" ] || [ ! -x "${tr_bin}" ] || [ ! -x "${mktemp_bin}" ]; then
+            echo "::error::Trusted binaries are unavailable for the feature history push step." >&2
+            exit 1
+          fi
+          push_token="${PUSH_TOKEN}"
+          unset PUSH_TOKEN
+          if [ -z "${push_token}" ]; then
+            echo "::error::No token is available to push feature release history." >&2
+            exit 1
+          fi
+          git_home="$("${mktemp_bin}" -d)"
+          trap '/bin/rm -rf "${git_home}"' EXIT
+
+          git_safe() {
+            "${env_bin}" -i \
+              HOME="${git_home}" \
+              PATH=/usr/bin:/bin \
+              GIT_TERMINAL_PROMPT=0 \
+              GIT_CONFIG_NOSYSTEM=1 \
+              GIT_CONFIG_GLOBAL=/dev/null \
+              "${git_bin}" \
+              -c core.hooksPath=/dev/null \
+              -c credential.helper= \
+              -c protocol.file.allow=never \
+              -c protocol.ext.allow=never \
+              "$@"
+          }
+
+          git_network() {
+            "${env_bin}" -i \
+              HOME="${git_home}" \
+              PATH=/usr/bin:/bin \
+              GIT_TERMINAL_PROMPT=0 \
+              GIT_CONFIG_NOSYSTEM=1 \
+              GIT_CONFIG_GLOBAL=/dev/null \
+              GIT_CONFIG_COUNT=5 \
+              GIT_CONFIG_KEY_0=core.hooksPath \
+              GIT_CONFIG_VALUE_0=/dev/null \
+              GIT_CONFIG_KEY_1=credential.helper \
+              GIT_CONFIG_VALUE_1= \
+              GIT_CONFIG_KEY_2=protocol.file.allow \
+              GIT_CONFIG_VALUE_2=never \
+              GIT_CONFIG_KEY_3=protocol.ext.allow \
+              GIT_CONFIG_VALUE_3=never \
+              GIT_CONFIG_KEY_4=http.https://github.com/.extraheader \
+              GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}" \
+              "${git_bin}" \
+              "$@"
+          }
+
+          expected_origin="https://github.com/${GITHUB_REPOSITORY}"
+          origin_fetch_urls="$(git_safe remote get-url --all origin)"
+          origin_push_urls="$(git_safe remote get-url --push --all origin)"
+          if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then
+            echo "::error::Refusing to push feature release history through an unexpected origin." >&2
+            exit 1
+          fi
+
+          auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"
+          unset push_token
 
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} for feature release history"
-            if ! git fetch origin main:refs/remotes/origin/main; then
+            if ! git_network fetch origin main:refs/remotes/origin/main; then
               echo "git fetch failed on attempt ${attempt}" >&2
-              sleep 2
+              /bin/sleep 2
               continue
             fi
-            if ! git rebase origin/main; then
+            if ! git_safe rebase origin/main; then
               echo "git rebase failed on attempt ${attempt}; aborting rebase and retrying" >&2
-              git rebase --abort || true
-              sleep 2
+              git_safe rebase --abort || true
+              /bin/sleep 2
               continue
             fi
-            if git push "${push_url}" HEAD:main; then
+            if git_network push origin HEAD:main; then
               exit 0
             fi
-            sleep 2
+            /bin/sleep 2
           done
 
           echo "Failed to push feature release history after retries" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -806,6 +806,7 @@ jobs:
         if: ${{ needs.prepare-marketplace-toolchain.outputs.configured == 'true' }}
         shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         env:
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
           VSCE_PAT: ${{ secrets.VSCE_PUBLISH }}
         run: |
           if [ -z "${VSCE_PAT:-}" ]; then
@@ -814,7 +815,7 @@ jobs:
           fi
 
           vsce_bin="${RUNNER_TEMP}/vsce-toolchain/node_modules/.bin/vsce"
-          vsix_path="${GITHUB_WORKSPACE}/publication-inputs/dist/lopper-vscode-${{ needs.prepare-release.outputs.version }}.vsix"
+          vsix_path="${GITHUB_WORKSPACE}/publication-inputs/dist/lopper-vscode-${RELEASE_VERSION}.vsix"
           "${vsce_bin}" publish --packagePath "${vsix_path}"
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1031,18 +1031,17 @@ jobs:
           echo "Failed to push Homebrew formula after retries" >&2
           exit 1
 
-  stamp-feature-release-history:
+  prepare-feature-release-history:
     needs:
       - prepare-release
       - publish
       - update-floating-tags
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
-    concurrency:
-      group: feature-release-history-main
-      cancel-in-progress: false
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      changed: ${{ steps.stamp_history.outputs.changed }}
     steps:
       - name: Checkout trusted main tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -1050,7 +1049,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           ref: main
-          token: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout validated release data
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -1059,7 +1057,6 @@ jobs:
           fetch-depth: 0
           path: release-source
           ref: ${{ needs.prepare-release.outputs.sha }}
-          token: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -1110,24 +1107,183 @@ jobs:
 
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit stamped feature release history
+      - name: Validate and stage feature history patch
         if: ${{ steps.stamp_history.outputs.changed == 'true' }}
         working-directory: release-source
-        env:
-          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add internal/featureflags/features.json
-          git commit -m "chore(flags): stamp ${RELEASE_TAG} feature release history"
+          mapfile -t changed_files < <(git diff --name-only)
+          if [ "${#changed_files[@]}" -ne 1 ] || [ "${changed_files[0]}" != "internal/featureflags/features.json" ]; then
+            echo "::error::Feature history generation changed an unexpected file set." >&2
+            printf '%s\n' "${changed_files[@]}" >&2
+            exit 1
+          fi
+          if [ -n "$(git ls-files --others --exclude-standard)" ]; then
+            echo "::error::Feature history generation created unexpected untracked files." >&2
+            exit 1
+          fi
+          git diff --check -- internal/featureflags/features.json
 
-      - name: Push stamped feature release history
+          artifact_dir="${GITHUB_WORKSPACE}/.artifacts"
+          patch_file="${artifact_dir}/feature-history.patch"
+          mkdir -p "${artifact_dir}"
+          git diff --binary --full-index -- internal/featureflags/features.json > "${patch_file}"
+          if [ ! -s "${patch_file}" ] || [ -L "${patch_file}" ] || [ "$(stat --format=%s "${patch_file}")" -gt 1048576 ]; then
+            echo "::error::Feature history patch is missing, invalid, or larger than 1 MiB." >&2
+            exit 1
+          fi
+          git apply --check --reverse "${patch_file}"
+          (
+            cd "${artifact_dir}"
+            sha256sum feature-history.patch > SHA256SUMS
+          )
+
+      - name: Upload feature history patch
         if: ${{ steps.stamp_history.outputs.changed == 'true' }}
-        working-directory: release-source
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: feature-history-patch
+          path: |
+            .artifacts/feature-history.patch
+            .artifacts/SHA256SUMS
+          if-no-files-found: error
+          include-hidden-files: true
+          overwrite: true
+
+  push-feature-release-history:
+    needs:
+      - prepare-release
+      - prepare-feature-release-history
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' && needs.prepare-feature-release-history.outputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: feature-release-history-main
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    steps:
+      - name: Download feature history patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: feature-history-patch
+          path: feature-history-input
+
+      - name: Prepare trusted feature history commit
         shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
+        run: |
+          git_bin=/usr/bin/git
+          env_bin=/usr/bin/env
+          mktemp_bin=/usr/bin/mktemp
+          rm_bin=/bin/rm
+          if [ ! -x "${git_bin}" ] || [ ! -x "${env_bin}" ] || [ ! -x "${mktemp_bin}" ] || [ ! -x "${rm_bin}" ]; then
+            echo "::error::Trusted binaries are unavailable for feature history commit preparation." >&2
+            exit 1
+          fi
+          git_home="$("${mktemp_bin}" -d)"
+          trap '/bin/rm -rf "${git_home}"' EXIT
+          repo_dir="${RUNNER_TEMP}/feature-history-push"
+          input_dir="${GITHUB_WORKSPACE}/feature-history-input"
+          patch_file="${input_dir}/feature-history.patch"
+
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "::error::Feature history commit requires a stable semver release tag." >&2
+            exit 1
+          fi
+          if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Release source must be an immutable commit SHA." >&2
+            exit 1
+          fi
+          if find "${input_dir}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "::error::Feature history artifact contains a non-regular entry." >&2
+            exit 1
+          fi
+          if [ "$(find "${input_dir}" -maxdepth 1 -type f | wc -l)" -ne 2 ]; then
+            echo "::error::Feature history artifact must contain exactly the patch and checksum manifest." >&2
+            exit 1
+          fi
+          if [ ! -s "${patch_file}" ] || [ ! -f "${input_dir}/SHA256SUMS" ] || [ "$(stat --format=%s "${patch_file}")" -gt 1048576 ]; then
+            echo "::error::Feature history patch artifact is missing, empty, or larger than 1 MiB." >&2
+            exit 1
+          fi
+          (
+            cd "${input_dir}"
+            sha256sum --check --strict SHA256SUMS
+          )
+
+          git_safe() {
+            "${env_bin}" -i \
+              HOME="${git_home}" \
+              PATH=/usr/bin:/bin \
+              GIT_TERMINAL_PROMPT=0 \
+              GIT_CONFIG_NOSYSTEM=1 \
+              GIT_CONFIG_GLOBAL=/dev/null \
+              "${git_bin}" \
+              -c core.hooksPath=/dev/null \
+              -c credential.helper= \
+              -c protocol.file.allow=never \
+              -c protocol.ext.allow=never \
+              "$@"
+          }
+
+          expected_origin="https://github.com/${GITHUB_REPOSITORY}"
+          "${rm_bin}" -rf "${repo_dir}"
+          git_safe init "${repo_dir}"
+          git_safe -C "${repo_dir}" remote add origin "${expected_origin}"
+          origin_fetch_urls="$(git_safe -C "${repo_dir}" remote get-url --all origin)"
+          origin_push_urls="$(git_safe -C "${repo_dir}" remote get-url --push --all origin)"
+          if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then
+            echo "::error::Refusing to prepare feature history through an unexpected origin." >&2
+            exit 1
+          fi
+
+          git_safe -C "${repo_dir}" fetch --no-tags --depth=1 origin "${RELEASE_SHA}"
+          git_safe -C "${repo_dir}" checkout -b feature-history FETCH_HEAD
+          resolved_sha="$(git_safe -C "${repo_dir}" rev-parse HEAD)"
+          if [ "${resolved_sha}" != "${RELEASE_SHA}" ]; then
+            echo "::error::Feature history worktree resolved ${resolved_sha}, expected ${RELEASE_SHA}." >&2
+            exit 1
+          fi
+
+          git_safe -C "${repo_dir}" apply --index --whitespace=error-all "${patch_file}"
+          mapfile -t staged_files < <(git_safe -C "${repo_dir}" diff --cached --name-only)
+          if [ "${#staged_files[@]}" -ne 1 ] || [ "${staged_files[0]}" != "internal/featureflags/features.json" ]; then
+            echo "::error::Feature history patch staged an unexpected file set." >&2
+            printf '%s\n' "${staged_files[@]}" >&2
+            exit 1
+          fi
+          git_safe -C "${repo_dir}" diff --cached --check
+          git_safe -C "${repo_dir}" config user.name "github-actions[bot]"
+          git_safe -C "${repo_dir}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          expected_subject="chore(flags): stamp ${RELEASE_TAG} feature release history"
+          git_safe -C "${repo_dir}" commit -m "${expected_subject}"
+
+          commit_count="$(git_safe -C "${repo_dir}" rev-list --count "${RELEASE_SHA}..HEAD")"
+          parent_sha="$(git_safe -C "${repo_dir}" rev-parse HEAD^)"
+          commit_subject="$(git_safe -C "${repo_dir}" log -1 --format=%s)"
+          mapfile -t committed_files < <(git_safe -C "${repo_dir}" diff-tree --no-commit-id --name-only -r HEAD)
+          if [ "${commit_count}" -ne 1 ] || [ "${parent_sha}" != "${RELEASE_SHA}" ] || [ "${commit_subject}" != "${expected_subject}" ]; then
+            echo "::error::Feature history preparation did not create exactly the expected commit." >&2
+            exit 1
+          fi
+          if [ "${#committed_files[@]}" -ne 1 ] || [ "${committed_files[0]}" != "internal/featureflags/features.json" ]; then
+            echo "::error::Feature history commit changed an unexpected file set." >&2
+            printf '%s\n' "${committed_files[@]}" >&2
+            exit 1
+          fi
+          if [ -n "$(git_safe -C "${repo_dir}" status --porcelain --untracked-files=all)" ]; then
+            echo "::error::Feature history worktree is not clean after commit preparation." >&2
+            exit 1
+          fi
+
+      - name: Push feature history commit
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
           PUSH_TOKEN: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
         run: |
           git_bin=/usr/bin/git
@@ -1139,14 +1295,9 @@ jobs:
             echo "::error::Trusted binaries are unavailable for the feature history push step." >&2
             exit 1
           fi
-          push_token="${PUSH_TOKEN}"
-          unset PUSH_TOKEN
-          if [ -z "${push_token}" ]; then
-            echo "::error::No token is available to push feature release history." >&2
-            exit 1
-          fi
           git_home="$("${mktemp_bin}" -d)"
           trap '/bin/rm -rf "${git_home}"' EXIT
+          repo_dir="${RUNNER_TEMP}/feature-history-push"
 
           git_safe() {
             "${env_bin}" -i \
@@ -1185,31 +1336,91 @@ jobs:
               "$@"
           }
 
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "::error::Feature history push requires a stable semver release tag." >&2
+            exit 1
+          fi
+          if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Release source must be an immutable commit SHA." >&2
+            exit 1
+          fi
+          expected_subject="chore(flags): stamp ${RELEASE_TAG} feature release history"
           expected_origin="https://github.com/${GITHUB_REPOSITORY}"
-          origin_fetch_urls="$(git_safe remote get-url --all origin)"
-          origin_push_urls="$(git_safe remote get-url --push --all origin)"
+          origin_fetch_urls="$(git_safe -C "${repo_dir}" remote get-url --all origin)"
+          origin_push_urls="$(git_safe -C "${repo_dir}" remote get-url --push --all origin)"
           if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then
             echo "::error::Refusing to push feature release history through an unexpected origin." >&2
             exit 1
           fi
 
+          prepared_commit_count="$(git_safe -C "${repo_dir}" rev-list --count "${RELEASE_SHA}..HEAD")"
+          prepared_parent="$(git_safe -C "${repo_dir}" rev-parse HEAD^)"
+          prepared_subject="$(git_safe -C "${repo_dir}" log -1 --format=%s)"
+          mapfile -t prepared_files < <(git_safe -C "${repo_dir}" diff-tree --no-commit-id --name-only -r HEAD)
+          if [ "${prepared_commit_count}" -ne 1 ] || [ "${prepared_parent}" != "${RELEASE_SHA}" ] || [ "${prepared_subject}" != "${expected_subject}" ]; then
+            echo "::error::Feature history push did not receive exactly the expected commit." >&2
+            exit 1
+          fi
+          if [ "${#prepared_files[@]}" -ne 1 ] || [ "${prepared_files[0]}" != "internal/featureflags/features.json" ]; then
+            echo "::error::Feature history push received an unexpected committed file set." >&2
+            printf '%s\n' "${prepared_files[@]}" >&2
+            exit 1
+          fi
+          if [ -n "$(git_safe -C "${repo_dir}" status --porcelain --untracked-files=all)" ]; then
+            echo "::error::Feature history push worktree is not clean." >&2
+            exit 1
+          fi
+
+          push_token="${PUSH_TOKEN}"
+          unset PUSH_TOKEN
+          if [ -z "${push_token}" ]; then
+            echo "::error::No token is available to push feature release history." >&2
+            exit 1
+          fi
           auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"
           unset push_token
 
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} for feature release history"
-            if ! git_network fetch origin main:refs/remotes/origin/main; then
+            if ! git_network -C "${repo_dir}" fetch origin main:refs/remotes/origin/main; then
               echo "git fetch failed on attempt ${attempt}" >&2
               /bin/sleep 2
               continue
             fi
-            if ! git_safe rebase origin/main; then
+            if git_safe -C "${repo_dir}" diff --quiet origin/main HEAD -- internal/featureflags/features.json; then
+              echo "No feature release history changes to push"
+              exit 0
+            fi
+            if ! git_safe -C "${repo_dir}" rebase origin/main; then
               echo "git rebase failed on attempt ${attempt}; aborting rebase and retrying" >&2
-              git_safe rebase --abort || true
+              git_safe -C "${repo_dir}" rebase --abort || true
               /bin/sleep 2
               continue
             fi
-            if git_network push origin HEAD:main; then
+
+            main_sha="$(git_safe -C "${repo_dir}" rev-parse origin/main)"
+            ahead_count="$(git_safe -C "${repo_dir}" rev-list --count origin/main..HEAD)"
+            if [ "${ahead_count}" -eq 0 ] && git_safe -C "${repo_dir}" diff --quiet origin/main HEAD; then
+              echo "No feature release history changes to push"
+              exit 0
+            fi
+            push_parent="$(git_safe -C "${repo_dir}" rev-parse HEAD^)"
+            push_subject="$(git_safe -C "${repo_dir}" log -1 --format=%s)"
+            mapfile -t pushed_files < <(git_safe -C "${repo_dir}" diff-tree --no-commit-id --name-only -r HEAD)
+            if [ "${ahead_count}" -ne 1 ] || [ "${push_parent}" != "${main_sha}" ] || [ "${push_subject}" != "${expected_subject}" ]; then
+              echo "::error::Rebased feature history is not exactly one expected commit ahead of main." >&2
+              exit 1
+            fi
+            if [ "${#pushed_files[@]}" -ne 1 ] || [ "${pushed_files[0]}" != "internal/featureflags/features.json" ]; then
+              echo "::error::Rebased feature history changed an unexpected file set." >&2
+              printf '%s\n' "${pushed_files[@]}" >&2
+              exit 1
+            fi
+            if [ -n "$(git_safe -C "${repo_dir}" status --porcelain --untracked-files=all)" ]; then
+              echo "::error::Rebased feature history worktree is not clean." >&2
+              exit 1
+            fi
+            if git_network -C "${repo_dir}" push origin HEAD:main; then
               exit 0
             fi
             /bin/sleep 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -550,6 +550,7 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           set -euo pipefail
+          push_url="https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ben-ranford/homebrew-tap.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -560,7 +561,6 @@ jobs:
           fi
 
           git commit -m "lopper ${{ needs.prepare-release.outputs.tag }}"
-          git remote set-url origin "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ben-ranford/homebrew-tap.git"
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} for Homebrew formula"
             if ! git fetch origin main:refs/remotes/origin/main; then
@@ -574,7 +574,7 @@ jobs:
               sleep 2
               continue
             fi
-            if git push origin HEAD:main; then
+            if git push "${push_url}" HEAD:main; then
               exit 0
             fi
             sleep 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,16 @@ jobs:
           release_json="$(mktemp)"
           if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" >"${release_json}" 2>/dev/null; then
             echo "Reusing existing GitHub release ${tag}."
-            git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}" >/dev/null 2>&1 || true
+            if ! fetch_error="$(git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}" 2>&1)"; then
+              if [[ "${fetch_error}" == *"couldn't find remote ref refs/tags/${tag}"* ]]; then
+                echo "Remote tag ${tag} does not exist; validating the release target instead."
+              else
+                echo "::error::Failed to fetch existing release tag ${tag}." >&2
+                printf '%s\n' "${fetch_error}" >&2
+                rm -f "${release_json}"
+                exit 1
+              fi
+            fi
 
             existing_commit=""
             if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,7 +274,7 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
 
-  publish:
+  prepare-release-publication:
     needs:
       - prepare-release
       - orchestrate-release
@@ -283,9 +283,7 @@ jobs:
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      contents: read
     steps:
       - name: Checkout release source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -345,7 +343,140 @@ jobs:
           fi
           go run ./tools/featureflag "${args[@]}" > feature-flags.md
 
+      - name: Stage bounded release publication inputs
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          expected_vsix="lopper-vscode-${version}.vsix"
+
+          if [ ! -f feature-flags.md ] || [ -L feature-flags.md ]; then
+            echo "Feature flag release report must be a regular file" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s feature-flags.md)" -gt 1048576 ]; then
+            echo "Feature flag release report exceeds the 1 MiB publication limit" >&2
+            exit 1
+          fi
+          if find dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Release publication inputs must contain only regular files" >&2
+            exit 1
+          fi
+
+          mapfile -t assets < <(find dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.vsix' \) -print | sort)
+          if [ "${#assets[@]}" -eq 0 ] || [ "${#assets[@]}" -gt 32 ]; then
+            echo "Expected between 1 and 32 release assets, found ${#assets[@]}" >&2
+            exit 1
+          fi
+          if [ "$(find dist -maxdepth 1 -type f | wc -l)" -ne "${#assets[@]}" ]; then
+            echo "Release publication inputs contain an unsupported file type" >&2
+            exit 1
+          fi
+          if [ "$(find dist -maxdepth 1 -type f -name 'lopper-vscode-*.vsix' | wc -l)" -ne 1 ] || [ ! -f "dist/${expected_vsix}" ]; then
+            echo "Expected exactly one VSIX asset named ${expected_vsix}" >&2
+            exit 1
+          fi
+          for asset in "${assets[@]}"; do
+            if [ "$(stat --format=%s "${asset}")" -gt 1073741824 ]; then
+              echo "Release asset ${asset} exceeds the 1 GiB publication limit" >&2
+              exit 1
+            fi
+          done
+
+          mkdir -p publication-inputs/dist
+          cp -- "${assets[@]}" publication-inputs/dist/
+          cp -- feature-flags.md publication-inputs/feature-flags.md
+          (
+            cd publication-inputs
+            mapfile -d '' checksum_files < <(find . -type f -print0 | sort -z)
+            sha256sum "${checksum_files[@]}" > SHA256SUMS
+          )
+
+      - name: Upload release publication inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: release-publication-inputs
+          path: publication-inputs
+          if-no-files-found: error
+
+  publish:
+    needs:
+      - prepare-release
+      - prepare-release-publication
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release publication inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-publication-inputs
+          path: publication-inputs
+
+      - name: Validate release publication inputs
+        working-directory: publication-inputs
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          expected_vsix="lopper-vscode-${version}.vsix"
+
+          if find . -mindepth 1 ! -type f ! -type d -print -quit | grep -q .; then
+            echo "Release publication inputs contain a non-regular entry" >&2
+            exit 1
+          fi
+          if [ ! -f SHA256SUMS ] || [ -L SHA256SUMS ]; then
+            echo "Release publication checksum manifest is missing or invalid" >&2
+            exit 1
+          fi
+          sha256sum --check --strict SHA256SUMS
+          if [ ! -f feature-flags.md ] || [ -L feature-flags.md ]; then
+            echo "Feature flag release report must be a regular file" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s feature-flags.md)" -gt 1048576 ]; then
+            echo "Feature flag release report exceeds the 1 MiB publication limit" >&2
+            exit 1
+          fi
+          if find dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Release asset directory must contain only regular files" >&2
+            exit 1
+          fi
+
+          mapfile -t assets < <(find dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.vsix' \) -print | sort)
+          if [ "${#assets[@]}" -eq 0 ] || [ "${#assets[@]}" -gt 32 ]; then
+            echo "Expected between 1 and 32 release assets, found ${#assets[@]}" >&2
+            exit 1
+          fi
+          if [ "$(find dist -maxdepth 1 -type f | wc -l)" -ne "${#assets[@]}" ]; then
+            echo "Release publication inputs contain an unsupported file type" >&2
+            exit 1
+          fi
+          if [ "$(find dist -maxdepth 1 -type f -name 'lopper-vscode-*.vsix' | wc -l)" -ne 1 ] || [ ! -f "dist/${expected_vsix}" ]; then
+            echo "Expected exactly one VSIX asset named ${expected_vsix}" >&2
+            exit 1
+          fi
+          for asset in "${assets[@]}"; do
+            if [ "$(stat --format=%s "${asset}")" -gt 1073741824 ]; then
+              echo "Release asset ${asset} exceeds the 1 GiB publication limit" >&2
+              exit 1
+            fi
+          done
+          if ! find dist -maxdepth 1 -type f -name '*_darwin_amd64.tar.gz' | grep -q .; then
+            echo "Expected darwin/amd64 artifact is missing from release publication inputs" >&2
+            exit 1
+          fi
+          if ! find dist -maxdepth 1 -type f -name '*_darwin_arm64.tar.gz' | grep -q .; then
+            echo "Expected darwin/arm64 artifact is missing from release publication inputs" >&2
+            exit 1
+          fi
+
       - name: Update GitHub Release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           tag="${{ needs.prepare-release.outputs.tag }}"
@@ -366,8 +497,8 @@ jobs:
           ghcr_package_url="https://github.com/${GITHUB_REPOSITORY}/pkgs/container/lopper"
 
           {
-            if [ -s feature-flags.md ]; then
-              cat feature-flags.md
+            if [ -s publication-inputs/feature-flags.md ]; then
+              cat publication-inputs/feature-flags.md
               echo
             fi
             echo "<!-- lopper-release-assets:start -->"
@@ -386,12 +517,14 @@ jobs:
           gh release edit "$tag" --repo "$GITHUB_REPOSITORY" --title "Release $tag" --notes-file release-body.md
 
       - name: Upload GitHub Release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           tag="${{ needs.prepare-release.outputs.tag }}"
-          mapfile -t assets < <(find dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.vsix' \) | sort)
+          mapfile -t assets < <(find publication-inputs/dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.vsix' \) | sort)
           if [ "${#assets[@]}" -eq 0 ]; then
-            echo "No release assets found in dist" >&2
+            echo "No release assets found in publication inputs" >&2
             exit 1
           fi
           gh release upload "$tag" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
@@ -411,13 +544,13 @@ jobs:
             exit 0
           fi
 
-          make vscode-extension-install
-
-          vsix_path="$(find dist -maxdepth 1 -name 'lopper-vscode-*.vsix' | head -n1)"
+          vsix_path="$(find publication-inputs/dist -maxdepth 1 -name 'lopper-vscode-*.vsix' | head -n1)"
           test -n "$vsix_path"
-          ./extensions/vscode-lopper/node_modules/.bin/vsce publish --packagePath "$vsix_path"
+          npx --yes @vscode/vsce@3.9.2 publish --packagePath "$vsix_path"
 
       - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           tag="${{ needs.prepare-release.outputs.tag }}"
@@ -453,6 +586,22 @@ jobs:
           gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
             -F draft=false \
             -f make_latest=true >/dev/null
+
+  update-floating-tags:
+    needs:
+      - prepare-release
+      - publish
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ needs.prepare-release.outputs.sha }}
 
       - name: Update GitHub Action floating tags
         shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,10 +400,373 @@ jobs:
           path: publication-inputs
           if-no-files-found: error
 
+  prepare-marketplace-toolchain:
+    needs: prepare-release
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted main Marketplace manifests
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          ref: main
+
+      - name: Setup Node for Marketplace tooling
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+
+      - name: Validate Marketplace tooling lockfile
+        run: |
+          set -euo pipefail
+          lockfile="extensions/vscode-lopper/package-lock.json"
+          if [ ! -f "${lockfile}" ] || [ -L "${lockfile}" ]; then
+            echo "Marketplace tooling lockfile is missing or invalid" >&2
+            exit 1
+          fi
+
+          vsce_version="$(jq -er '.packages["node_modules/@vscode/vsce"].version' "${lockfile}")"
+          vsce_integrity="$(jq -er '.packages["node_modules/@vscode/vsce"].integrity' "${lockfile}")"
+          if [ "${vsce_version}" != "3.9.2" ]; then
+            echo "Marketplace tooling lockfile must pin @vscode/vsce 3.9.2" >&2
+            exit 1
+          fi
+          case "${vsce_integrity}" in
+            sha512-?*) ;;
+            *)
+              echo "Marketplace tooling lockfile must pin @vscode/vsce integrity" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Prepare integrity-bound Marketplace toolchain
+        run: |
+          set -euo pipefail
+          source_dir="extensions/vscode-lopper"
+          scratch_dir="${RUNNER_TEMP}/marketplace-toolchain"
+          rm -rf "${scratch_dir}"
+          mkdir -p "${scratch_dir}"
+          chmod 0700 "${scratch_dir}"
+          cp -- "${source_dir}/package.json" "${source_dir}/package-lock.json" "${scratch_dir}/"
+
+          if [ "$(find "${scratch_dir}" -mindepth 1 -maxdepth 1 -type f | wc -l)" -ne 2 ]; then
+            echo "Marketplace scratch directory must contain exactly two package manifests" >&2
+            exit 1
+          fi
+          if find "${scratch_dir}" -mindepth 1 -maxdepth 1 \( ! -type f -o \( ! -name package.json ! -name package-lock.json \) \) -print -quit | grep -q .; then
+            echo "Marketplace scratch directory contains an unexpected path" >&2
+            exit 1
+          fi
+
+          (
+            cd "${scratch_dir}"
+            npm ci --ignore-scripts --include=dev --audit=false --fund=false
+          )
+          if ! cmp --silent "${source_dir}/package.json" "${scratch_dir}/package.json" ||
+            ! cmp --silent "${source_dir}/package-lock.json" "${scratch_dir}/package-lock.json"; then
+            echo "Marketplace package manifests changed during preparation" >&2
+            exit 1
+          fi
+          test -x "${scratch_dir}/node_modules/.bin/vsce"
+          if [ "$(realpath -e "${scratch_dir}/node_modules/.bin/vsce")" != "$(realpath -e "${scratch_dir}/node_modules/@vscode/vsce/vsce")" ]; then
+            echo "Marketplace VSCE launcher resolves outside the locked package" >&2
+            exit 1
+          fi
+
+      - name: Archive Marketplace toolchain
+        run: |
+          set -euo pipefail
+          scratch_dir="${RUNNER_TEMP}/marketplace-toolchain"
+          archive_dir="${GITHUB_WORKSPACE}/.artifacts/marketplace-toolchain"
+          archive_file="${archive_dir}/vsce-toolchain.tar.gz"
+          rm -rf "${archive_dir}"
+          mkdir -p "${archive_dir}"
+          chmod 0700 "${archive_dir}"
+          tar --create --gzip --file "${archive_file}" --directory "${scratch_dir}" package.json package-lock.json node_modules
+          if [ ! -s "${archive_file}" ] || [ -L "${archive_file}" ] || [ "$(stat --format=%s "${archive_file}")" -gt 268435456 ]; then
+            echo "Marketplace toolchain archive is missing, invalid, or larger than 256 MiB" >&2
+            exit 1
+          fi
+          (
+            cd "${archive_dir}"
+            sha256sum vsce-toolchain.tar.gz > SHA256SUMS
+          )
+
+      - name: Upload Marketplace toolchain
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: marketplace-toolchain
+          path: |
+            .artifacts/marketplace-toolchain/vsce-toolchain.tar.gz
+            .artifacts/marketplace-toolchain/SHA256SUMS
+          if-no-files-found: error
+          include-hidden-files: true
+          overwrite: true
+
+  publish-marketplace:
+    needs:
+      - prepare-release
+      - prepare-release-publication
+      - prepare-marketplace-toolchain
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Setup Node for Marketplace tooling
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+
+      - name: Download release publication inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-publication-inputs
+          path: publication-inputs
+
+      - name: Download Marketplace toolchain
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: marketplace-toolchain
+          path: marketplace-toolchain-input
+
+      - name: Validate Marketplace publication inputs
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        env:
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          publication_dir="${GITHUB_WORKSPACE}/publication-inputs"
+          artifact_dir="${GITHUB_WORKSPACE}/marketplace-toolchain-input"
+          archive_file="${artifact_dir}/vsce-toolchain.tar.gz"
+          toolchain_dir="${RUNNER_TEMP}/vsce-toolchain"
+          expected_vsix="lopper-vscode-${RELEASE_VERSION}.vsix"
+
+          if find "${publication_dir}" -mindepth 1 ! -type f ! -type d -print -quit | grep -q .; then
+            echo "Marketplace publication inputs contain a symlink or special file" >&2
+            exit 1
+          fi
+          if [ "$(find "${publication_dir}" -mindepth 1 -maxdepth 1 | wc -l)" -ne 3 ] ||
+            [ ! -d "${publication_dir}/dist" ] || [ -L "${publication_dir}/dist" ] ||
+            [ ! -f "${publication_dir}/feature-flags.md" ] || [ -L "${publication_dir}/feature-flags.md" ] ||
+            [ ! -f "${publication_dir}/SHA256SUMS" ] || [ -L "${publication_dir}/SHA256SUMS" ]; then
+            echo "Marketplace publication inputs have an unexpected top-level layout" >&2
+            exit 1
+          fi
+          if find "${publication_dir}" -mindepth 1 -maxdepth 1 ! -name dist ! -name feature-flags.md ! -name SHA256SUMS -print -quit | grep -q .; then
+            echo "Marketplace publication inputs contain an unexpected path" >&2
+            exit 1
+          fi
+          if find "${publication_dir}/dist" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Marketplace publication asset directory contains an unexpected path" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s "${publication_dir}/feature-flags.md")" -gt 1048576 ] ||
+            [ "$(stat --format=%s "${publication_dir}/SHA256SUMS")" -gt 65536 ]; then
+            echo "Marketplace publication metadata exceeds its size limit" >&2
+            exit 1
+          fi
+
+          mapfile -t assets < <(find "${publication_dir}/dist" -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.vsix' \) -print | sort)
+          if [ "${#assets[@]}" -eq 0 ] || [ "${#assets[@]}" -gt 32 ]; then
+            echo "Expected between 1 and 32 Marketplace publication assets, found ${#assets[@]}" >&2
+            exit 1
+          fi
+          if [ "$(find "${publication_dir}/dist" -maxdepth 1 -type f | wc -l)" -ne "${#assets[@]}" ] ||
+            [ "$(find "${publication_dir}" -type f | wc -l)" -ne "$(( ${#assets[@]} + 2 ))" ]; then
+            echo "Marketplace publication inputs contain an unexpected file" >&2
+            exit 1
+          fi
+          if find "${publication_dir}/dist" -maxdepth 1 -type f -printf '%f\n' | grep -q '[[:space:]]'; then
+            echo "Marketplace publication asset names must not contain whitespace" >&2
+            exit 1
+          fi
+          if [ "$(find "${publication_dir}/dist" -maxdepth 1 -type f -name 'lopper-vscode-*.vsix' | wc -l)" -ne 1 ] ||
+            [ ! -f "${publication_dir}/dist/${expected_vsix}" ]; then
+            echo "Expected exactly one VSIX asset named ${expected_vsix}" >&2
+            exit 1
+          fi
+          for asset in "${assets[@]}"; do
+            if [ ! -s "${asset}" ]; then
+              echo "Marketplace publication asset ${asset} is empty" >&2
+              exit 1
+            fi
+            if [ "$(stat --format=%s "${asset}")" -gt 1073741824 ]; then
+              echo "Marketplace publication asset ${asset} exceeds the 1 GiB limit" >&2
+              exit 1
+            fi
+          done
+
+          expected_paths="$(mktemp)"
+          manifest_paths="$(mktemp)"
+          trap 'rm -f "${expected_paths}" "${manifest_paths}"' EXIT
+          (
+            cd "${publication_dir}"
+            {
+              printf '%s\n' ./feature-flags.md
+              find ./dist -maxdepth 1 -type f -print
+            } | sort > "${expected_paths}"
+            if grep -Ev '^[0-9a-f]{64}  [.]\/(feature-flags[.]md|dist\/[A-Za-z0-9._+-]+([.]tar[.]gz|[.]zip|[.]vsix))$' SHA256SUMS | grep -q .; then
+              echo "Marketplace publication checksum manifest contains an unexpected path" >&2
+              exit 1
+            fi
+            awk '{print $2}' SHA256SUMS | sort > "${manifest_paths}"
+            if ! cmp --silent "${expected_paths}" "${manifest_paths}"; then
+              echo "Marketplace publication checksum manifest does not cover the exact file set" >&2
+              exit 1
+            fi
+            sha256sum --check --strict SHA256SUMS
+          )
+
+          if find "${artifact_dir}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Marketplace toolchain artifact contains a symlink or unexpected path" >&2
+            exit 1
+          fi
+          if [ "$(find "${artifact_dir}" -maxdepth 1 -type f | wc -l)" -ne 2 ]; then
+            echo "Marketplace toolchain artifact must contain exactly an archive and checksum manifest" >&2
+            exit 1
+          fi
+          if [ ! -s "${archive_file}" ] || [ ! -f "${artifact_dir}/SHA256SUMS" ]; then
+            echo "Marketplace toolchain artifact is missing or empty" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s "${archive_file}")" -gt 268435456 ]; then
+            echo "Marketplace toolchain archive exceeds the 256 MiB limit" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s "${artifact_dir}/SHA256SUMS")" -gt 1024 ]; then
+            echo "Marketplace toolchain checksum manifest exceeds its size limit" >&2
+            exit 1
+          fi
+          if [ "$(wc -l < "${artifact_dir}/SHA256SUMS")" -ne 1 ] ||
+            ! grep -Eq '^[0-9a-f]{64}  vsce-toolchain[.]tar[.]gz$' "${artifact_dir}/SHA256SUMS"; then
+            echo "Marketplace toolchain checksum manifest is invalid" >&2
+            exit 1
+          fi
+          (
+            cd "${artifact_dir}"
+            sha256sum --check --strict SHA256SUMS
+          )
+
+          python3 - "${archive_file}" <<'PY'
+          from pathlib import PurePosixPath
+          import sys
+          import tarfile
+
+          archive_path = sys.argv[1]
+          allowed_roots = {"package.json", "package-lock.json", "node_modules"}
+          required_regular = {
+              "package.json",
+              "package-lock.json",
+              "node_modules/@vscode/vsce/vsce",
+          }
+
+          def normalize(parts):
+              resolved = []
+              for part in parts:
+                  if part in ("", "."):
+                      continue
+                  if part == "..":
+                      if not resolved:
+                          return None
+                      resolved.pop()
+                      continue
+                  resolved.append(part)
+              return tuple(resolved)
+
+          with tarfile.open(archive_path, "r:gz") as archive:
+              members = archive.getmembers()
+
+          member_count = len(members)
+          total_size = 0
+          names = set()
+          regular_files = set()
+          symlinks = {}
+          for member in members:
+              if "\\" in member.name:
+                  raise SystemExit("Marketplace toolchain archive contains a backslash path")
+              path = PurePosixPath(member.name)
+              if path.is_absolute() or not path.parts or ".." in path.parts:
+                  raise SystemExit("Marketplace toolchain archive contains an unsafe path")
+              name = str(path)
+              if name in names or path.parts[0] not in allowed_roots:
+                  raise SystemExit("Marketplace toolchain archive contains a duplicate or unexpected path")
+              names.add(name)
+
+              if member.isfile():
+                  total_size += member.size
+                  regular_files.add(name)
+                  continue
+              if member.isdir():
+                  continue
+              if member.issym():
+                  if ".bin" not in path.parts or "\\" in member.linkname:
+                      raise SystemExit("Marketplace toolchain archive contains an unexpected symlink")
+                  link = PurePosixPath(member.linkname)
+                  if link.is_absolute():
+                      raise SystemExit("Marketplace toolchain archive contains an absolute symlink")
+                  resolved = normalize(path.parent.parts + link.parts)
+                  if not resolved or resolved[0] != "node_modules":
+                      raise SystemExit("Marketplace toolchain symlink escapes node_modules")
+                  symlinks[name] = "/".join(resolved)
+                  continue
+              if member.islnk() or not (member.isfile() or member.isdir()):
+                  raise SystemExit("Marketplace toolchain archive contains an unsupported file type")
+
+          if member_count < 3 or member_count > 65536:
+              raise SystemExit("Marketplace toolchain archive has an invalid entry count")
+          if total_size > 1073741824:
+              raise SystemExit("Marketplace toolchain archive exceeds the 1 GiB expanded size limit")
+          if not required_regular.issubset(regular_files):
+              raise SystemExit("Marketplace toolchain archive is missing a required regular file")
+          if symlinks.get("node_modules/.bin/vsce") != "node_modules/@vscode/vsce/vsce":
+              raise SystemExit("Marketplace VSCE launcher does not target the locked package")
+          PY
+
+          rm -rf "${toolchain_dir}"
+          mkdir -p "${toolchain_dir}"
+          chmod 0700 "${toolchain_dir}"
+          tar --extract --gzip --file "${archive_file}" --directory "${toolchain_dir}" --no-same-owner
+          while IFS= read -r -d '' link; do
+            resolved="$(realpath -e "${link}")"
+            case "${resolved}" in
+              "${toolchain_dir}"/node_modules/*) ;;
+              *)
+                echo "Marketplace toolchain symlink resolves outside node_modules" >&2
+                exit 1
+                ;;
+            esac
+          done < <(find "${toolchain_dir}" -type l -print0)
+
+          test -x "${toolchain_dir}/node_modules/.bin/vsce"
+          if [ "$(realpath -e "${toolchain_dir}/node_modules/.bin/vsce")" != "$(realpath -e "${toolchain_dir}/node_modules/@vscode/vsce/vsce")" ]; then
+            echo "Extracted Marketplace VSCE launcher resolves outside the locked package" >&2
+            exit 1
+          fi
+          jq -e '.packages["node_modules/@vscode/vsce"] | .version == "3.9.2" and (.integrity | startswith("sha512-"))' "${toolchain_dir}/package-lock.json" >/dev/null
+          jq -e '.version == "3.9.2"' "${toolchain_dir}/node_modules/@vscode/vsce/package.json" >/dev/null
+          node_bin="$(command -v node)"
+          test -x "${node_bin}"
+
+      - name: Publish VS Code extension to Marketplace
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PUBLISH }}
+        run: |
+          if [ -z "${VSCE_PAT:-}" ]; then
+            echo "VSCE publish token not configured; skipping marketplace publish."
+            exit 0
+          fi
+
+          vsce_bin="${RUNNER_TEMP}/vsce-toolchain/node_modules/.bin/vsce"
+          vsix_path="${GITHUB_WORKSPACE}/publication-inputs/dist/lopper-vscode-${{ needs.prepare-release.outputs.version }}.vsix"
+          "${vsce_bin}" publish --packagePath "${vsix_path}"
+
   publish:
     needs:
       - prepare-release
       - prepare-release-publication
+      - publish-marketplace
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
@@ -528,34 +891,6 @@ jobs:
             exit 1
           fi
           gh release upload "$tag" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
-
-      - name: Setup Node for VSIX publish
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 24
-
-      - name: Prepare VS Code Marketplace tooling
-        run: |
-          set -euo pipefail
-          toolchain_dir="${RUNNER_TEMP}/vsce-toolchain"
-          npm install --prefix "${toolchain_dir}" --no-audit --no-fund @vscode/vsce@3.9.2
-          test -x "${toolchain_dir}/node_modules/.bin/vsce"
-
-      - name: Publish VS Code extension to Marketplace
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PUBLISH }}
-        run: |
-          set -euo pipefail
-          if [ -z "${VSCE_PAT:-}" ]; then
-            echo "VSCE publish token not configured; skipping marketplace publish."
-            exit 0
-          fi
-
-          vsce_bin="${RUNNER_TEMP}/vsce-toolchain/node_modules/.bin/vsce"
-          test -x "$vsce_bin"
-          vsix_path="$(find publication-inputs/dist -maxdepth 1 -name 'lopper-vscode-*.vsix' | head -n1)"
-          test -n "$vsix_path"
-          "$vsce_bin" publish --packagePath "$vsix_path"
 
       - name: Publish GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,12 +96,11 @@ jobs:
               fi
             else
               existing_target="$(jq -r '.target_commitish // empty' "${release_json}")"
-              if [ -z "${existing_target}" ]; then
-                echo "::error::Existing release ${tag} has no target_commitish to validate." >&2
+              if [[ ! "${existing_target}" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "::error::Existing release ${tag} target_commitish must be a full 40-character hexadecimal commit SHA; got '${existing_target}'." >&2
                 exit 1
               fi
-              encoded_target="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$existing_target")"
-              if ! existing_commit="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_target}" --jq '.sha')"; then
+              if ! existing_commit="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${existing_target}" --jq '.sha')"; then
                 echo "::error::Failed to resolve existing release ${tag} target ${existing_target}." >&2
                 exit 1
               fi
@@ -109,6 +108,10 @@ jobs:
 
             if [[ ! "${existing_commit}" =~ ^[0-9a-f]{40}$ ]]; then
               echo "::error::Existing release ${tag} resolved to invalid commit SHA ${existing_commit}." >&2
+              exit 1
+            fi
+            if [ "${tag_fetched}" = "false" ] && [ "${existing_commit}" != "${existing_target}" ]; then
+              echo "::error::Existing release ${tag} commit lookup returned ${existing_commit}, expected immutable target ${existing_target}." >&2
               exit 1
             fi
             if [ "${existing_commit}" != "${resolved_sha}" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -627,11 +627,20 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout release source
+      - name: Checkout trusted main tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: main
+          token: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Checkout validated release data
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          path: release-source
           ref: ${{ needs.prepare-release.outputs.sha }}
           token: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
 
@@ -640,15 +649,41 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Validate release data against trusted main
+        env:
+          RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Release source must be an immutable commit SHA." >&2
+            exit 1
+          fi
+          release_commit="$(git -C release-source rev-parse HEAD)"
+          if [ "${release_commit}" != "${RELEASE_SHA}" ]; then
+            echo "::error::Release data checkout resolved ${release_commit}, expected ${RELEASE_SHA}." >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${release_commit}" HEAD; then
+            echo "::error::Release source ${release_commit} is not in trusted main history." >&2
+            exit 1
+          fi
+
+      - name: Build trusted feature flag tool
+        run: |
+          set -euo pipefail
+          go build -o "${RUNNER_TEMP}/featureflag" ./tools/featureflag
+
       - name: Stamp first stable release history
         id: stamp_history
+        working-directory: release-source
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
 
-          go run ./tools/featureflag stamp-release --release "${RELEASE_TAG}"
-          go run ./tools/featureflag validate
+          "${RUNNER_TEMP}/featureflag" stamp-release --release "${RELEASE_TAG}"
+          "${RUNNER_TEMP}/featureflag" validate
 
           if git diff --quiet -- internal/featureflags/features.json; then
             echo "No feature release history changes to commit"
@@ -660,6 +695,7 @@ jobs:
 
       - name: Commit stamped feature release history
         if: ${{ steps.stamp_history.outputs.changed == 'true' }}
+        working-directory: release-source
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
@@ -672,6 +708,7 @@ jobs:
 
       - name: Push stamped feature release history
         if: ${{ steps.stamp_history.outputs.changed == 'true' }}
+        working-directory: release-source
         env:
           PUSH_TOKEN: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,7 +416,7 @@ jobs:
       - name: Upload release publication inputs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: release-publication-inputs
+          name: publication-inputs
           path: publication-inputs
           if-no-files-found: error
 
@@ -574,7 +574,7 @@ jobs:
         if: ${{ needs.prepare-marketplace-toolchain.outputs.configured == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: release-publication-inputs
+          name: publication-inputs
           path: publication-inputs
 
       - name: Download Marketplace toolchain
@@ -830,7 +830,7 @@ jobs:
       - name: Download release publication inputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: release-publication-inputs
+          name: publication-inputs
           path: publication-inputs
 
       - name: Validate release publication inputs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -596,14 +596,77 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout release source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ needs.prepare-release.outputs.sha }}
+      - name: Prepare GitHub Action floating tags
+        id: prepare_tags
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
+        run: |
+          git_bin=/usr/bin/git
+          env_bin=/usr/bin/env
+          mktemp_bin=/usr/bin/mktemp
+          rm_bin=/bin/rm
+          if [ ! -x "${git_bin}" ] || [ ! -x "${env_bin}" ] || [ ! -x "${mktemp_bin}" ] || [ ! -x "${rm_bin}" ]; then
+            echo "::error::Trusted binaries are unavailable for floating tag preparation." >&2
+            exit 1
+          fi
+          git_home="$("${mktemp_bin}" -d)"
+          trap '/bin/rm -rf "${git_home}"' EXIT
+          repo_dir="${RUNNER_TEMP}/floating-tags"
 
-      - name: Update GitHub Action floating tags
+          git_safe() {
+            "${env_bin}" -i \
+              HOME="${git_home}" \
+              PATH=/usr/bin:/bin \
+              GIT_TERMINAL_PROMPT=0 \
+              GIT_CONFIG_NOSYSTEM=1 \
+              GIT_CONFIG_GLOBAL=/dev/null \
+              "${git_bin}" \
+              -c core.hooksPath=/dev/null \
+              -c credential.helper= \
+              -c protocol.file.allow=never \
+              -c protocol.ext.allow=never \
+              "$@"
+          }
+
+          if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$ ]]; then
+            echo "::notice::Skipping GitHub Action floating tags for non-stable semver release ${RELEASE_TAG}."
+            echo "push=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          major_tag="v${BASH_REMATCH[1]}"
+          minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+
+          if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Release source must be an immutable commit SHA." >&2
+            exit 1
+          fi
+
+          expected_origin="https://github.com/${GITHUB_REPOSITORY}"
+          "${rm_bin}" -rf "${repo_dir}"
+          git_safe init "${repo_dir}"
+          git_safe -C "${repo_dir}" remote add origin "${expected_origin}"
+          origin_fetch_urls="$(git_safe -C "${repo_dir}" remote get-url --all origin)"
+          origin_push_urls="$(git_safe -C "${repo_dir}" remote get-url --push --all origin)"
+          if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then
+            echo "::error::Refusing to prepare floating tags through an unexpected origin." >&2
+            exit 1
+          fi
+
+          git_safe -C "${repo_dir}" fetch --no-tags --depth=1 origin "${RELEASE_SHA}"
+          git_safe -C "${repo_dir}" checkout --detach FETCH_HEAD
+          resolved_sha="$(git_safe -C "${repo_dir}" rev-parse HEAD)"
+          if [ "${resolved_sha}" != "${RELEASE_SHA}" ]; then
+            echo "::error::Floating tag worktree resolved ${resolved_sha}, expected ${RELEASE_SHA}." >&2
+            exit 1
+          fi
+          git_safe -C "${repo_dir}" tag --force "${major_tag}" "${RELEASE_SHA}"
+          git_safe -C "${repo_dir}" tag --force "${minor_tag}" "${RELEASE_SHA}"
+          echo "push=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push GitHub Action floating tags
+        if: ${{ steps.prepare_tags.outputs.push == 'true' }}
         shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
@@ -616,17 +679,12 @@ jobs:
           tr_bin=/usr/bin/tr
           mktemp_bin=/usr/bin/mktemp
           if [ ! -x "${git_bin}" ] || [ ! -x "${env_bin}" ] || [ ! -x "${base64_bin}" ] || [ ! -x "${tr_bin}" ] || [ ! -x "${mktemp_bin}" ]; then
-            echo "::error::Trusted binaries are unavailable for the floating tag update step." >&2
-            exit 1
-          fi
-          push_token="${PUSH_TOKEN}"
-          unset PUSH_TOKEN
-          if [ -z "${push_token}" ]; then
-            echo "::error::No token is available to update floating tags." >&2
+            echo "::error::Trusted binaries are unavailable for the floating tag push step." >&2
             exit 1
           fi
           git_home="$("${mktemp_bin}" -d)"
           trap '/bin/rm -rf "${git_home}"' EXIT
+          repo_dir="${RUNNER_TEMP}/floating-tags"
 
           git_safe() {
             "${env_bin}" -i \
@@ -666,33 +724,47 @@ jobs:
           }
 
           if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$ ]]; then
-            echo "::notice::Skipping GitHub Action floating tags for non-stable semver release ${RELEASE_TAG}."
-            exit 0
+            echo "::error::Floating tag push received an invalid stable semver tag ${RELEASE_TAG}." >&2
+            exit 1
           fi
-
           major_tag="v${BASH_REMATCH[1]}"
           minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+          if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Release source must be an immutable commit SHA." >&2
+            exit 1
+          fi
+
           expected_origin="https://github.com/${GITHUB_REPOSITORY}"
-          origin_fetch_urls="$(git_safe remote get-url --all origin)"
-          origin_push_urls="$(git_safe remote get-url --push --all origin)"
+          origin_fetch_urls="$(git_safe -C "${repo_dir}" remote get-url --all origin)"
+          origin_push_urls="$(git_safe -C "${repo_dir}" remote get-url --push --all origin)"
           if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then
             echo "::error::Refusing to update floating tags through an unexpected origin." >&2
             exit 1
           fi
 
-          git_safe config user.name "github-actions[bot]"
-          git_safe config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git_safe tag --force "${major_tag}" "${RELEASE_SHA}"
-          git_safe tag --force "${minor_tag}" "${RELEASE_SHA}"
+          resolved_sha="$(git_safe -C "${repo_dir}" rev-parse HEAD)"
+          major_target="$(git_safe -C "${repo_dir}" rev-parse "refs/tags/${major_tag}^{commit}")"
+          minor_target="$(git_safe -C "${repo_dir}" rev-parse "refs/tags/${minor_tag}^{commit}")"
+          if [ "${resolved_sha}" != "${RELEASE_SHA}" ] || [ "${major_target}" != "${RELEASE_SHA}" ] || [ "${minor_target}" != "${RELEASE_SHA}" ]; then
+            echo "::error::Floating tag worktree or tag targets do not match ${RELEASE_SHA}." >&2
+            exit 1
+          fi
 
+          push_token="${PUSH_TOKEN}"
+          unset PUSH_TOKEN
+          if [ -z "${push_token}" ]; then
+            echo "::error::No token is available to update floating tags." >&2
+            exit 1
+          fi
           auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"
           unset push_token
-          git_network push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"
+          git_network -C "${repo_dir}" push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"
 
   homebrew-tap-token-gate:
     needs:
       - prepare-release
       - publish
+      - update-floating-tags
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions: {}
@@ -963,6 +1035,7 @@ jobs:
     needs:
       - prepare-release
       - publish
+      - update-floating-tags
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     concurrency:

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -33,13 +33,39 @@ type workflowConfig struct {
 }
 
 type workflowJobConfig struct {
-	Steps []workflowStepConfig `yaml:"steps"`
+	If          string               `yaml:"if"`
+	Env         map[string]string    `yaml:"env"`
+	Needs       workflowJobNeeds     `yaml:"needs"`
+	Outputs     map[string]string    `yaml:"outputs"`
+	Permissions map[string]string    `yaml:"permissions"`
+	Steps       []workflowStepConfig `yaml:"steps"`
+}
+
+type workflowJobNeeds []string
+
+func (n *workflowJobNeeds) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		var need string
+		if err := node.Decode(&need); err != nil {
+			return err
+		}
+		*n = []string{need}
+		return nil
+	}
+
+	var decoded []string
+	if err := node.Decode(&decoded); err != nil {
+		return err
+	}
+	*n = decoded
+	return nil
 }
 
 type workflowStepConfig struct {
 	Name             string            `yaml:"name"`
 	ID               string            `yaml:"id"`
 	If               string            `yaml:"if"`
+	Uses             string            `yaml:"uses"`
 	Run              string            `yaml:"run"`
 	Shell            string            `yaml:"shell"`
 	WorkingDirectory string            `yaml:"working-directory"`
@@ -324,27 +350,207 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowHomebrewPushUsesEphemeralAuthenticatedRemote(t *testing.T) {
+func TestReleaseWorkflowHomebrewUsesGatedThreeJobGraph(t *testing.T) {
 	t.Parallel()
 
-	var workflow struct {
-		Jobs map[string]workflowJobConfig `yaml:"jobs"`
-	}
+	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+	workflowText := readConfig(t, ".github/workflows/release.yml")
 
-	step := workflowStepByName(t, workflow.Jobs, "update-homebrew-tap", "Commit and push formula changes")
-	for _, want := range []string{
-		`push_url="https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ben-ranford/homebrew-tap.git"`,
-		`git fetch origin main:refs/remotes/origin/main`,
-		`git rebase origin/main`,
-		`git push "${push_url}" HEAD:main`,
-	} {
-		if !strings.Contains(step.Run, want) {
-			t.Fatalf("homebrew push step must contain %q", want)
+	gate := workflow.Jobs["homebrew-tap-token-gate"]
+	if !slices.Equal(gate.Needs, workflowJobNeeds{"prepare-release", "publish"}) {
+		t.Fatalf("tap token gate needs = %v", gate.Needs)
+	}
+	if gate.If != "${{ needs.prepare-release.outputs.release_created == 'true' }}" {
+		t.Fatalf("tap token gate if = %q", gate.If)
+	}
+	if gate.Permissions == nil || len(gate.Permissions) != 0 {
+		t.Fatalf("tap token gate permissions = %#v, want explicit empty permissions", gate.Permissions)
+	}
+	if gate.Outputs["configured"] != "${{ steps.gate.outputs.configured }}" {
+		t.Fatalf("tap token gate configured output = %q", gate.Outputs["configured"])
+	}
+	gateStep := workflowStepByName(t, workflow.Jobs, "homebrew-tap-token-gate", "Detect tap token")
+	if gateStep.ID != "gate" {
+		t.Fatalf("tap token gate step id = %q", gateStep.ID)
+	}
+	if gateStep.Env["HOMEBREW_TAP_TOKEN"] != "${{ secrets.HOMEBREW_TAP_TOKEN }}" {
+		t.Fatalf("tap token gate secret = %q", gateStep.Env["HOMEBREW_TAP_TOKEN"])
+	}
+	assertWorkflowStepRunContainsAll(t, gateStep, "tap token gate step", []string{
+		`if [ -n "${HOMEBREW_TAP_TOKEN:-}" ]; then`,
+		`echo "configured=true" >> "$GITHUB_OUTPUT"`,
+		`echo "configured=false" >> "$GITHUB_OUTPUT"`,
+	})
+
+	validation := workflow.Jobs["validate-homebrew-tap"]
+	if !slices.Equal(validation.Needs, workflowJobNeeds{"prepare-release", "publish", "homebrew-tap-token-gate"}) {
+		t.Fatalf("tap validation needs = %v", validation.Needs)
+	}
+	if validation.If != "${{ needs.prepare-release.outputs.release_created == 'true' && needs.homebrew-tap-token-gate.outputs.configured == 'true' }}" {
+		t.Fatalf("tap validation if = %q", validation.If)
+	}
+	if len(validation.Permissions) != 1 || validation.Permissions["contents"] != "read" {
+		t.Fatalf("tap validation permissions = %#v", validation.Permissions)
+	}
+
+	publication := workflow.Jobs["update-homebrew-tap"]
+	if !slices.Equal(publication.Needs, workflowJobNeeds{"prepare-release", "publish", "validate-homebrew-tap"}) {
+		t.Fatalf("tap publication needs = %v", publication.Needs)
+	}
+	if publication.If != "${{ needs.prepare-release.outputs.release_created == 'true' }}" {
+		t.Fatalf("tap publication if = %q", publication.If)
+	}
+	if len(publication.Permissions) != 1 || publication.Permissions["contents"] != "read" {
+		t.Fatalf("tap publication permissions = %#v", publication.Permissions)
+	}
+	if count := strings.Count(workflowText, "${{ secrets.HOMEBREW_TAP_TOKEN }}"); count != 2 {
+		t.Fatalf("release workflow tap secret references = %d, want gate and publication only", count)
+	}
+}
+
+func TestReleaseWorkflowHomebrewValidationIsTokenlessAndImmutable(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+	validation := workflow.Jobs["validate-homebrew-tap"]
+	assertWorkflowJobOmitsText(t, validation, "HOMEBREW_TAP_TOKEN", "tap validation job must not receive the tap token")
+	assertWorkflowJobOmitsText(t, validation, "secrets.", "tap validation job must use only public read-only inputs")
+
+	if validation.Env["SOURCE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
+		t.Fatalf("tap validation SOURCE_SHA = %q", validation.Env["SOURCE_SHA"])
+	}
+	if validation.Env["FORMULA_VERSION"] != "${{ needs.prepare-release.outputs.version }}" {
+		t.Fatalf("tap validation FORMULA_VERSION = %q", validation.Env["FORMULA_VERSION"])
+	}
+	if validation.Env["SOURCE_REPO"] != "${{ github.repository }}" {
+		t.Fatalf("tap validation SOURCE_REPO = %q", validation.Env["SOURCE_REPO"])
+	}
+
+	cloneStep := workflowStepByName(t, workflow.Jobs, "validate-homebrew-tap", "Clone tap repository anonymously")
+	if cloneStep.Uses != "" {
+		t.Fatalf("anonymous tap clone must be a run step, got uses %q", cloneStep.Uses)
+	}
+	assertWorkflowStepRunContainsAll(t, cloneStep, "anonymous tap clone step", []string{
+		"git_bin=/usr/bin/git",
+		"mktemp_bin=/usr/bin/mktemp",
+		"env -i",
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_CONFIG_NOSYSTEM=1",
+		`-c core.hooksPath=/dev/null`,
+		`-c protocol.file.allow=never`,
+		`-c protocol.ext.allow=never`,
+		`clone --origin origin --branch main --single-branch`,
+		`https://github.com/ben-ranford/homebrew-tap.git homebrew-tap`,
+	})
+	for _, forbidden := range []string{"actions/checkout", "persist-credentials", "credential.helper", "extraheader", "x-access-token:", "AUTHORIZATION: basic"} {
+		if strings.Contains(cloneStep.Run, forbidden) {
+			t.Fatalf("anonymous tap clone must not contain %q", forbidden)
 		}
 	}
-	if strings.Contains(step.Run, "git remote set-url origin") {
-		t.Fatal("homebrew push step must not persist tap credentials in .git/config")
+
+	regenerateStep := workflowStepByName(t, workflow.Jobs, "validate-homebrew-tap", "Regenerate lopper formula")
+	assertWorkflowStepRunContainsAll(t, regenerateStep, "tokenless formula regeneration step", []string{
+		`source_url="https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz"`,
+		`read -r source_sha _ < <(sha256sum /tmp/lopper-source.tar.gz)`,
+		`version "${FORMULA_VERSION}"`,
+	})
+	for _, forbidden := range []string{"archive/refs/tags/", "RELEASE_TAG", "target_commitish"} {
+		if strings.Contains(regenerateStep.Run, forbidden) {
+			t.Fatalf("tokenless formula regeneration must not contain %q", forbidden)
+		}
+	}
+
+	validateStep := workflowStepByName(t, workflow.Jobs, "validate-homebrew-tap", "Validate formula")
+	assertWorkflowStepRunContainsAll(t, validateStep, "tokenless formula validation step", []string{
+		"brew audit --strict --online ben-ranford/tap/lopper",
+		"brew install --build-from-source ben-ranford/tap/lopper",
+		"brew test ben-ranford/tap/lopper",
+	})
+}
+
+func TestReleaseWorkflowHomebrewPublicationUsesFreshCredentialScopedClone(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+	publication := workflow.Jobs["update-homebrew-tap"]
+	if publication.Env["SOURCE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
+		t.Fatalf("tap publication SOURCE_SHA = %q", publication.Env["SOURCE_SHA"])
+	}
+	if publication.Env["FORMULA_VERSION"] != "${{ needs.prepare-release.outputs.version }}" {
+		t.Fatalf("tap publication FORMULA_VERSION = %q", publication.Env["FORMULA_VERSION"])
+	}
+	if len(publication.Steps) != 1 {
+		t.Fatalf("privileged tap publication steps = %d, want one isolated host-tool step", len(publication.Steps))
+	}
+
+	step := workflowStepByName(t, workflow.Jobs, "update-homebrew-tap", "Regenerate and push formula changes")
+	if len(step.Env) != 1 || step.Env["HOMEBREW_TAP_TOKEN"] != "${{ secrets.HOMEBREW_TAP_TOKEN }}" {
+		t.Fatalf("privileged tap step env = %#v", step.Env)
+	}
+	if step.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
+		t.Fatalf("privileged tap step shell = %q", step.Shell)
+	}
+	assertWorkflowStepRunContainsAll(t, step, "privileged tap publication step", []string{
+		"git_bin=/usr/bin/git",
+		"curl_bin=/usr/bin/curl",
+		"sha256sum_bin=/usr/bin/sha256sum",
+		"base64_bin=/usr/bin/base64",
+		"tr_bin=/usr/bin/tr",
+		"mktemp_bin=/usr/bin/mktemp",
+		`git_home="$("${mktemp_bin}" -d)"`,
+		`work_root="$("${mktemp_bin}" -d)"`,
+		`tap_repo="${work_root}/homebrew-tap"`,
+		`git_safe clone --origin origin --branch main --single-branch https://github.com/ben-ranford/homebrew-tap.git "${tap_repo}"`,
+		`source_url="https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz"`,
+		`version "${FORMULA_VERSION}"`,
+		`git_safe -C "${tap_repo}" diff --cached --quiet`,
+		`git_safe -C "${tap_repo}" commit --no-verify -m "lopper ${RELEASE_TAG}"`,
+		`auth_header="$(printf 'x-access-token:%s' "${HOMEBREW_TAP_TOKEN}" | "${base64_bin}" | "${tr_bin}" -d '\n')"`,
+		"unset HOMEBREW_TAP_TOKEN",
+		"GIT_CONFIG_KEY_4=http.https://github.com/.extraheader",
+		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
+		`git_network -C "${tap_repo}" fetch origin main:refs/remotes/origin/main`,
+		`git_safe -C "${tap_repo}" rebase origin/main`,
+		`git_network -C "${tap_repo}" push origin HEAD:main`,
+		"Failed to push Homebrew formula after retries",
+	})
+
+	commitIndex := strings.Index(step.Run, `git_safe -C "${tap_repo}" commit`)
+	authIndex := strings.Index(step.Run, `auth_header="$(printf`)
+	fetchIndex := strings.Index(step.Run, `git_network -C "${tap_repo}" fetch`)
+	if commitIndex < 0 || authIndex < 0 || fetchIndex < 0 || !(commitIndex < authIndex && authIndex < fetchIndex) {
+		t.Fatal("tap publication must finish regeneration and commit before constructing command-scoped GitHub authentication")
+	}
+	for _, forbidden := range []string{
+		"brew audit --strict --online",
+		"brew install --build-from-source",
+		"brew test ben-ranford/tap/",
+		"actions/checkout",
+		"git remote set-url",
+		"push_url=",
+		"https://x-access-token:",
+		`x-access-token:${HOMEBREW_TAP_TOKEN}@`,
+		`-c "http.https://github.com/.extraheader=`,
+		"credential.helper store",
+	} {
+		if strings.Contains(step.Run, forbidden) {
+			t.Fatalf("privileged tap publication must not contain %q", forbidden)
+		}
+	}
+}
+
+func assertWorkflowJobOmitsText(t *testing.T, job workflowJobConfig, forbidden string, message string) {
+	t.Helper()
+
+	data, err := yaml.Marshal(job)
+	if err != nil {
+		t.Fatalf("marshal workflow job: %v", err)
+	}
+	if strings.Contains(string(data), forbidden) {
+		t.Fatal(message)
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -338,7 +338,6 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	})
 
 	publication := workflowJobByName(t, workflow.Jobs, "publish")
-	assertWorkflowJobNeeds(t, publication, "fresh release publication", workflowJobNeeds{"prepare-release", "prepare-release-publication", "publish-marketplace"})
 	assertWorkflowJobPermissions(t, publication, "fresh release publication", map[string]string{"contents": "write"})
 	assertWorkflowJobEnvEmpty(t, publication, "fresh release publication")
 	assertReleasePublicationCredentialScope(t, publication)
@@ -440,7 +439,6 @@ func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T)
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
 	marketplace := workflowJobByName(t, workflow.Jobs, "publish-marketplace")
-	assertWorkflowJobNeeds(t, marketplace, "Marketplace publication", workflowJobNeeds{"prepare-release", "prepare-release-publication", "prepare-marketplace-toolchain"})
 	assertWorkflowJobPermissions(t, marketplace, "Marketplace publication", nil)
 	assertWorkflowJobEnvEmpty(t, marketplace, "Marketplace publication")
 	assertWorkflowStringValues(t, []workflowStringValue{
@@ -522,6 +520,22 @@ func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T)
 	workflowText := readConfig(t, ".github/workflows/release.yml")
 	if count := strings.Count(workflowText, "${{ secrets.VSCE_PUBLISH }}"); count != 1 {
 		t.Fatalf("Marketplace secret references = %d, want final publish step only", count)
+	}
+}
+
+func TestReleaseWorkflowPublishesMarketplaceAfterGitHubReleaseBoundary(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	marketplace := workflowJobByName(t, workflow.Jobs, "publish-marketplace")
+	assertWorkflowJobNeeds(t, marketplace, "Marketplace publication", workflowJobNeeds{"prepare-release", "publish", "prepare-release-publication", "prepare-marketplace-toolchain"})
+
+	publication := workflowJobByName(t, workflow.Jobs, "publish")
+	assertWorkflowJobNeeds(t, publication, "fresh release publication", workflowJobNeeds{"prepare-release", "prepare-release-publication"})
+	if slices.Contains(publication.Needs, "publish-marketplace") {
+		t.Fatalf("GitHub release publication must not wait for Marketplace publication: %v", publication.Needs)
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -916,12 +916,7 @@ func TestReleaseWorkflowSkipsPrereleaseFeatureHistoryBeforeStamping(t *testing.T
 	githubOutput := filepath.Join(runnerTemp, "github-output")
 	cmd := exec.Command("bash", "-c", stampStep.Run)
 	cmd.Dir = t.TempDir()
-	cmd.Env = append(os.Environ(),
-		"FEATUREFLAG_INVOCATION="+invocationPath,
-		"GITHUB_OUTPUT="+githubOutput,
-		"RELEASE_TAG=v1.8.2-rc.1",
-		"RUNNER_TEMP="+runnerTemp,
-	)
+	cmd.Env = append(os.Environ(), "FEATUREFLAG_INVOCATION="+invocationPath, "GITHUB_OUTPUT="+githubOutput, "RELEASE_TAG=v1.8.2-rc.1", "RUNNER_TEMP="+runnerTemp)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("run prerelease feature history step: %v\n%s", err, output)

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -215,23 +215,10 @@ func TestReleaseWorkflowPinsTrustedMainToWorkflowRevision(t *testing.T) {
 	if strings.Count(resolver.Run, `>> "$GITHUB_OUTPUT"`) != 1 {
 		t.Fatal("trusted main workflow resolver must output only the validated workflow SHA")
 	}
-	assertTextAppearsBefore(t, resolver.Run,
-		`if [ "${WORKFLOW_REF}" != "${expected_workflow_ref}" ]; then`,
-		`/usr/bin/printf 'trusted_main_sha=%s\n' "${WORKFLOW_SHA}" >> "$GITHUB_OUTPUT"`,
-		"trusted main workflow ref must be validated before output",
-	)
-	assertTextAppearsBefore(t, resolver.Run,
-		`if [[ ! "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then`,
-		`/usr/bin/printf 'trusted_main_sha=%s\n' "${WORKFLOW_SHA}" >> "$GITHUB_OUTPUT"`,
-		"trusted main workflow SHA must be validated before output",
-	)
+	assertTextAppearsBefore(t, resolver.Run, `if [ "${WORKFLOW_REF}" != "${expected_workflow_ref}" ]; then`, `/usr/bin/printf 'trusted_main_sha=%s\n' "${WORKFLOW_SHA}" >> "$GITHUB_OUTPUT"`, "trusted main workflow ref must be validated before output")
+	assertTextAppearsBefore(t, resolver.Run, `if [[ ! "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then`, `/usr/bin/printf 'trusted_main_sha=%s\n' "${WORKFLOW_SHA}" >> "$GITHUB_OUTPUT"`, "trusted main workflow SHA must be validated before output")
 	assertWorkflowStepRunOmitsAll(t, resolver, "trusted main workflow resolver", []string{"git ", "gh ", "curl ", "wget ", "secrets.", "token"})
-	assertWorkflowStepOrder(t, preparation,
-		"Resolve trusted main workflow revision",
-		"Run release-please",
-		"Checkout manual release source",
-		"Prepare manual release",
-	)
+	assertWorkflowStepOrder(t, preparation, "Resolve trusted main workflow revision", "Run release-please", "Checkout manual release source", "Prepare manual release")
 
 	wantTrustedMain := "${{ needs.prepare-release.outputs.trusted_main_sha }}"
 	marketplaceCheckout := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Checkout trusted main Marketplace manifests")

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -732,137 +732,229 @@ func assertWorkflowJobOmitsText(t *testing.T, job workflowJobConfig, forbidden s
 	}
 }
 
-func TestReleaseWorkflowStampsFeatureHistoryBeforeInjectingPushToken(t *testing.T) {
+func TestReleaseWorkflowTransportsFeatureHistoryPatchAcrossJobs(t *testing.T) {
 	t.Parallel()
 
-	var workflow struct {
-		Jobs map[string]workflowJobConfig `yaml:"jobs"`
-	}
+	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	stampStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Stamp first stable release history")
-	if stampStep.ID != "stamp_history" {
-		t.Fatalf("stamp history step id = %q, want stamp_history", stampStep.ID)
+	preparation, ok := workflow.Jobs["prepare-feature-release-history"]
+	if !ok {
+		t.Fatal("release workflow must prepare feature history changes in a separate job")
 	}
-	assertWorkflowStepEnvMissing(t, stampStep, "PUSH_TOKEN", "stamp history step must not expose PUSH_TOKEN to repository-controlled featureflag tooling")
-	assertWorkflowStepRunContainsAll(t, stampStep, "stamp history step", []string{
-		`"${RUNNER_TEMP}/featureflag" stamp-release --release "${RELEASE_TAG}"`,
-		`"${RUNNER_TEMP}/featureflag" validate`,
-		`echo "changed=true" >> "$GITHUB_OUTPUT"`,
-	})
-	if strings.Contains(stampStep.Run, "git push") {
-		t.Fatal("stamp history step must not push while running repository-controlled tools")
+	if !slices.Equal(preparation.Needs, workflowJobNeeds{"prepare-release", "publish", "update-floating-tags"}) {
+		t.Fatalf("feature history preparation needs = %v", preparation.Needs)
+	}
+	if len(preparation.Permissions) != 1 || preparation.Permissions["contents"] != "read" {
+		t.Fatalf("feature history preparation permissions = %#v", preparation.Permissions)
+	}
+	if preparation.Outputs["changed"] != "${{ steps.stamp_history.outputs.changed }}" {
+		t.Fatalf("feature history preparation changed output = %q", preparation.Outputs["changed"])
+	}
+	assertWorkflowJobOmitsText(t, preparation, "PUSH_TOKEN", "feature history preparation must not receive a push token")
+	assertWorkflowJobOmitsText(t, preparation, "secrets.", "feature history preparation must not receive secrets")
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, preparation, "prepare-feature-release-history")
+
+	trustedCheckout := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Checkout trusted main tooling")
+	if trustedCheckout.With["ref"] != "main" || trustedCheckout.With["path"] != "" {
+		t.Fatalf("trusted tooling checkout config = %#v", trustedCheckout.With)
+	}
+	releaseCheckout := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Checkout validated release data")
+	if releaseCheckout.With["ref"] != "${{ needs.prepare-release.outputs.sha }}" || releaseCheckout.With["path"] != "release-source" {
+		t.Fatalf("validated release data checkout config = %#v", releaseCheckout.With)
 	}
 
-	commitStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Commit stamped feature release history")
-	if commitStep.If != "${{ steps.stamp_history.outputs.changed == 'true' }}" {
-		t.Fatalf("commit stamped history step if = %q", commitStep.If)
-	}
-	if commitStep.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" {
-		t.Fatalf("commit stamped history step RELEASE_TAG env = %q", commitStep.Env["RELEASE_TAG"])
-	}
-	if !strings.Contains(commitStep.Run, `git commit -m "chore(flags): stamp ${RELEASE_TAG} feature release history"`) {
-		t.Fatal("commit stamped history step must create the release history commit without a push token")
-	}
-	assertWorkflowStepEnvMissing(t, commitStep, "PUSH_TOKEN", "commit stamped history step must not expose PUSH_TOKEN")
-
-	pushStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Push stamped feature release history")
-	if pushStep.If != "${{ steps.stamp_history.outputs.changed == 'true' }}" {
-		t.Fatalf("push stamped history step if = %q", pushStep.If)
-	}
-	if pushStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
-		t.Fatalf("push stamped history step shell = %q", pushStep.Shell)
-	}
-	if pushStep.Env["PUSH_TOKEN"] != "${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}" {
-		t.Fatalf("push stamped history step PUSH_TOKEN env = %q", pushStep.Env["PUSH_TOKEN"])
-	}
-	assertWorkflowStepRunContainsAll(t, pushStep, "push stamped history step", []string{
-		"git_bin=/usr/bin/git",
-		"env_bin=/usr/bin/env",
-		`git_home="$("${mktemp_bin}" -d)"`,
-		`"${env_bin}" -i`,
-		"GIT_CONFIG_NOSYSTEM=1",
-		"GIT_CONFIG_GLOBAL=/dev/null",
-		`push_token="${PUSH_TOKEN}"`,
-		"unset PUSH_TOKEN",
-		`auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"`,
-		"unset push_token",
-		`expected_origin="https://github.com/${GITHUB_REPOSITORY}"`,
-		`origin_fetch_urls="$(git_safe remote get-url --all origin)"`,
-		`origin_push_urls="$(git_safe remote get-url --push --all origin)"`,
-		`if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then`,
-		"GIT_CONFIG_KEY_1=credential.helper",
-		"GIT_CONFIG_VALUE_1=",
-		"GIT_CONFIG_KEY_4=http.https://github.com/.extraheader",
-		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
-		`git_network fetch origin main:refs/remotes/origin/main`,
-		`git_safe rebase origin/main`,
-		`git_network push origin HEAD:main`,
-	})
-	assertWorkflowStepKeepsGitCredentialsCommandScoped(t, pushStep, "push stamped history step")
-	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, workflow.Jobs["stamp-feature-release-history"], "stamp-feature-release-history")
-}
-
-func TestReleaseWorkflowBuildsFeatureHistoryPatchWithTrustedMainTooling(t *testing.T) {
-	t.Parallel()
-
-	var workflow struct {
-		Jobs map[string]workflowJobConfig `yaml:"jobs"`
-	}
-	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
-
-	trustedCheckout := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Checkout trusted main tooling")
-	if trustedCheckout.With["ref"] != "main" {
-		t.Fatalf("trusted tooling checkout ref = %q, want main", trustedCheckout.With["ref"])
-	}
-	if trustedCheckout.With["path"] != "" {
-		t.Fatalf("trusted tooling checkout path = %q, want repository root", trustedCheckout.With["path"])
-	}
-
-	releaseCheckout := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Checkout validated release data")
-	if releaseCheckout.With["ref"] != "${{ needs.prepare-release.outputs.sha }}" {
-		t.Fatalf("release data checkout ref = %q", releaseCheckout.With["ref"])
-	}
-	if releaseCheckout.With["path"] != "release-source" {
-		t.Fatalf("release data checkout path = %q, want release-source", releaseCheckout.With["path"])
-	}
-
-	validateStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Validate release data against trusted main")
-	if validateStep.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
-		t.Fatalf("release data validation RELEASE_SHA env = %q", validateStep.Env["RELEASE_SHA"])
-	}
+	validateStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Validate release data against trusted main")
 	assertWorkflowStepRunContainsAll(t, validateStep, "release data validation step", []string{
 		`release_commit="$(git -C release-source rev-parse HEAD)"`,
 		`if [ "${release_commit}" != "${RELEASE_SHA}" ]; then`,
 		`if ! git merge-base --is-ancestor "${release_commit}" HEAD; then`,
 	})
-
-	buildStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Build trusted feature flag tool")
-	if buildStep.WorkingDirectory != "" {
-		t.Fatalf("trusted feature flag build working directory = %q, want trusted repository root", buildStep.WorkingDirectory)
-	}
-	if !strings.Contains(buildStep.Run, `go build -o "${RUNNER_TEMP}/featureflag" ./tools/featureflag`) {
-		t.Fatal("feature history job must build featureflag from trusted main")
+	buildStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Build trusted feature flag tool")
+	if buildStep.WorkingDirectory != "" || !strings.Contains(buildStep.Run, `go build -o "${RUNNER_TEMP}/featureflag" ./tools/featureflag`) {
+		t.Fatalf("trusted feature flag build config = %#v", buildStep)
 	}
 
-	stampStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Stamp first stable release history")
+	stampStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Stamp first stable release history")
+	if stampStep.ID != "stamp_history" {
+		t.Fatalf("stamp history step id = %q, want stamp_history", stampStep.ID)
+	}
 	if stampStep.WorkingDirectory != "release-source" {
 		t.Fatalf("stamp history working directory = %q, want release-source", stampStep.WorkingDirectory)
 	}
+	assertWorkflowStepEnvMissing(t, stampStep, "PUSH_TOKEN", "stamp history step must not expose PUSH_TOKEN to repository-controlled featureflag tooling")
 	assertWorkflowStepRunContainsAll(t, stampStep, "stamp history step", []string{
 		`"${RUNNER_TEMP}/featureflag" stamp-release --release "${RELEASE_TAG}"`,
 		`"${RUNNER_TEMP}/featureflag" validate`,
+		`echo "changed=false" >> "$GITHUB_OUTPUT"`,
+		`echo "changed=true" >> "$GITHUB_OUTPUT"`,
 	})
-	if strings.Contains(stampStep.Run, "go run ./tools/featureflag") {
-		t.Fatal("release-source changes must not control the feature history executable")
-	}
-
-	for _, stepName := range []string{"Commit stamped feature release history", "Push stamped feature release history"} {
-		step := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", stepName)
-		if step.WorkingDirectory != "release-source" {
-			t.Fatalf("%s working directory = %q, want release-source", stepName, step.WorkingDirectory)
+	for _, forbidden := range []string{"git commit", "git push", "PUSH_TOKEN"} {
+		if strings.Contains(stampStep.Run, forbidden) {
+			t.Fatalf("stamp history step must not contain %q", forbidden)
 		}
 	}
+
+	patchStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Validate and stage feature history patch")
+	if patchStep.If != "${{ steps.stamp_history.outputs.changed == 'true' }}" {
+		t.Fatalf("feature history patch step if = %q", patchStep.If)
+	}
+	if patchStep.WorkingDirectory != "release-source" {
+		t.Fatalf("feature history patch working directory = %q, want release-source", patchStep.WorkingDirectory)
+	}
+	assertWorkflowStepRunContainsAll(t, patchStep, "feature history patch step", []string{
+		`mapfile -t changed_files < <(git diff --name-only)`,
+		`if [ "${#changed_files[@]}" -ne 1 ] || [ "${changed_files[0]}" != "internal/featureflags/features.json" ]; then`,
+		`git diff --binary --full-index -- internal/featureflags/features.json > "${patch_file}"`,
+		`git apply --check "${patch_file}"`,
+		`sha256sum feature-history.patch > SHA256SUMS`,
+	})
+	assertWorkflowStepEnvMissing(t, patchStep, "PUSH_TOKEN", "feature history patch staging must be tokenless")
+
+	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Upload feature history patch")
+	if uploadStep.If != "${{ steps.stamp_history.outputs.changed == 'true' }}" {
+		t.Fatalf("feature history patch upload if = %q", uploadStep.If)
+	}
+	if uploadStep.With["name"] != "feature-history-patch" || !strings.Contains(uploadStep.With["path"], ".artifacts/feature-history.patch") || !strings.Contains(uploadStep.With["path"], ".artifacts/SHA256SUMS") {
+		t.Fatalf("feature history patch artifact config = %#v", uploadStep.With)
+	}
+	if uploadStep.With["if-no-files-found"] != "error" {
+		t.Fatalf("feature history patch artifact missing-file behavior = %q", uploadStep.With["if-no-files-found"])
+	}
+
+	for _, step := range preparation.Steps {
+		if strings.Contains(step.Name, "Push") || strings.Contains(step.Run, "git push") {
+			t.Fatalf("feature history preparation must not push from release-source: %q", step.Name)
+		}
+	}
+
+	publication, ok := workflow.Jobs["push-feature-release-history"]
+	if !ok {
+		t.Fatal("release workflow must push feature history from a separate fresh job")
+	}
+	if !slices.Equal(publication.Needs, workflowJobNeeds{"prepare-release", "prepare-feature-release-history"}) {
+		t.Fatalf("feature history publication needs = %v", publication.Needs)
+	}
+	if publication.If != "${{ needs.prepare-release.outputs.release_created == 'true' && needs.prepare-feature-release-history.outputs.changed == 'true' }}" {
+		t.Fatalf("feature history publication if = %q", publication.If)
+	}
+	if len(publication.Permissions) != 1 || publication.Permissions["contents"] != "write" {
+		t.Fatalf("feature history publication permissions = %#v", publication.Permissions)
+	}
+	if len(publication.Env) != 0 {
+		t.Fatalf("feature history publication job env = %#v, want no job-scoped credentials", publication.Env)
+	}
+	for _, step := range publication.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") {
+			t.Fatalf("feature history publication must use a fresh host-Git clone, found checkout step %q", step.Name)
+		}
+		if step.WorkingDirectory == "release-source" || strings.Contains(step.Run, "release-source") {
+			t.Fatalf("feature history publication must not reuse release-source: %q", step.Name)
+		}
+	}
+
+	downloadStep := workflowStepByName(t, workflow.Jobs, "push-feature-release-history", "Download feature history patch")
+	if downloadStep.With["name"] != "feature-history-patch" || downloadStep.With["path"] != "feature-history-input" {
+		t.Fatalf("feature history patch download config = %#v", downloadStep.With)
+	}
+}
+
+func TestReleaseWorkflowPushesFeatureHistoryFromFreshValidatedCommit(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	prepareStep := workflowStepByName(t, workflow.Jobs, "push-feature-release-history", "Prepare trusted feature history commit")
+	if prepareStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
+		t.Fatalf("feature history commit preparation shell = %q", prepareStep.Shell)
+	}
+	if len(prepareStep.Env) != 2 || prepareStep.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" || prepareStep.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
+		t.Fatalf("feature history commit preparation env = %#v", prepareStep.Env)
+	}
+	assertWorkflowStepEnvMissing(t, prepareStep, "PUSH_TOKEN", "feature history commit preparation must be tokenless")
+	assertWorkflowStepRunContainsAll(t, prepareStep, "feature history commit preparation", []string{
+		"git_bin=/usr/bin/git",
+		"env_bin=/usr/bin/env",
+		`repo_dir="${RUNNER_TEMP}/feature-history-push"`,
+		`input_dir="${GITHUB_WORKSPACE}/feature-history-input"`,
+		`sha256sum --check --strict SHA256SUMS`,
+		`if [ "$(find "${input_dir}" -maxdepth 1 -type f | wc -l)" -ne 2 ]; then`,
+		`expected_origin="https://github.com/${GITHUB_REPOSITORY}"`,
+		`git_safe init "${repo_dir}"`,
+		`git_safe -C "${repo_dir}" remote add origin "${expected_origin}"`,
+		`git_safe -C "${repo_dir}" fetch --no-tags --depth=1 origin "${RELEASE_SHA}"`,
+		`git_safe -C "${repo_dir}" checkout -b feature-history FETCH_HEAD`,
+		`git_safe -C "${repo_dir}" apply --index --whitespace=error-all "${patch_file}"`,
+		`mapfile -t staged_files < <(git_safe -C "${repo_dir}" diff --cached --name-only)`,
+		`if [ "${#staged_files[@]}" -ne 1 ] || [ "${staged_files[0]}" != "internal/featureflags/features.json" ]; then`,
+		`expected_subject="chore(flags): stamp ${RELEASE_TAG} feature release history"`,
+		`git_safe -C "${repo_dir}" commit -m "${expected_subject}"`,
+		`commit_count="$(git_safe -C "${repo_dir}" rev-list --count "${RELEASE_SHA}..HEAD")"`,
+		`parent_sha="$(git_safe -C "${repo_dir}" rev-parse HEAD^)"`,
+		`commit_subject="$(git_safe -C "${repo_dir}" log -1 --format=%s)"`,
+		`mapfile -t committed_files < <(git_safe -C "${repo_dir}" diff-tree --no-commit-id --name-only -r HEAD)`,
+		`if [ "${commit_count}" -ne 1 ] || [ "${parent_sha}" != "${RELEASE_SHA}" ] || [ "${commit_subject}" != "${expected_subject}" ]; then`,
+		`if [ "${#committed_files[@]}" -ne 1 ] || [ "${committed_files[0]}" != "internal/featureflags/features.json" ]; then`,
+	})
+	for _, forbidden := range []string{"PUSH_TOKEN", "secrets.", "AUTHORIZATION: basic", "extraheader"} {
+		if strings.Contains(prepareStep.Run, forbidden) {
+			t.Fatalf("feature history commit preparation must not contain %q", forbidden)
+		}
+	}
+
+	pushStep := workflowStepByName(t, workflow.Jobs, "push-feature-release-history", "Push feature history commit")
+	if pushStep.Shell != prepareStep.Shell {
+		t.Fatalf("feature history push shell = %q", pushStep.Shell)
+	}
+	if len(pushStep.Env) != 3 || pushStep.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" || pushStep.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" || pushStep.Env["PUSH_TOKEN"] != "${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}" {
+		t.Fatalf("feature history push env = %#v", pushStep.Env)
+	}
+	assertWorkflowStepRunContainsAll(t, pushStep, "feature history push", []string{
+		"git_bin=/usr/bin/git",
+		"env_bin=/usr/bin/env",
+		`git_home="$("${mktemp_bin}" -d)"`,
+		`repo_dir="${RUNNER_TEMP}/feature-history-push"`,
+		`"${env_bin}" -i`,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		`expected_origin="https://github.com/${GITHUB_REPOSITORY}"`,
+		`origin_fetch_urls="$(git_safe -C "${repo_dir}" remote get-url --all origin)"`,
+		`origin_push_urls="$(git_safe -C "${repo_dir}" remote get-url --push --all origin)"`,
+		`prepared_commit_count="$(git_safe -C "${repo_dir}" rev-list --count "${RELEASE_SHA}..HEAD")"`,
+		`prepared_parent="$(git_safe -C "${repo_dir}" rev-parse HEAD^)"`,
+		`mapfile -t prepared_files < <(git_safe -C "${repo_dir}" diff-tree --no-commit-id --name-only -r HEAD)`,
+		`if [ "${prepared_commit_count}" -ne 1 ] || [ "${prepared_parent}" != "${RELEASE_SHA}" ] || [ "${prepared_subject}" != "${expected_subject}" ]; then`,
+		`if [ "${#prepared_files[@]}" -ne 1 ] || [ "${prepared_files[0]}" != "internal/featureflags/features.json" ]; then`,
+		`push_token="${PUSH_TOKEN}"`,
+		"unset PUSH_TOKEN",
+		`auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"`,
+		"unset push_token",
+		"GIT_CONFIG_KEY_1=credential.helper",
+		"GIT_CONFIG_VALUE_1=",
+		"GIT_CONFIG_KEY_4=http.https://github.com/.extraheader",
+		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
+		`for attempt in 1 2 3; do`,
+		`git_network -C "${repo_dir}" fetch origin main:refs/remotes/origin/main`,
+		`git_safe -C "${repo_dir}" diff --quiet origin/main HEAD -- internal/featureflags/features.json`,
+		`echo "No feature release history changes to push"`,
+		`git_safe -C "${repo_dir}" rebase origin/main`,
+		`ahead_count="$(git_safe -C "${repo_dir}" rev-list --count origin/main..HEAD)"`,
+		`mapfile -t pushed_files < <(git_safe -C "${repo_dir}" diff-tree --no-commit-id --name-only -r HEAD)`,
+		`if [ "${ahead_count}" -ne 1 ] || [ "${push_parent}" != "${main_sha}" ] || [ "${push_subject}" != "${expected_subject}" ]; then`,
+		`if [ "${#pushed_files[@]}" -ne 1 ] || [ "${pushed_files[0]}" != "internal/featureflags/features.json" ]; then`,
+		`git_network -C "${repo_dir}" push origin HEAD:main`,
+		"Failed to push feature release history after retries",
+	})
+	validationIndex := strings.Index(pushStep.Run, `if [ "${prepared_commit_count}" -ne 1 ]`)
+	tokenIndex := strings.Index(pushStep.Run, `push_token="${PUSH_TOKEN}"`)
+	if validationIndex < 0 || tokenIndex < 0 || validationIndex >= tokenIndex {
+		t.Fatal("feature history publication must validate the exact commit and file set before reading the push token")
+	}
+	if strings.Count(pushStep.Run, "git_network ") != 2 {
+		t.Fatal("feature history authentication must be exposed only to fetch and push network commands")
+	}
+	assertWorkflowStepKeepsGitCredentialsCommandScoped(t, pushStep, "feature history push")
 }
 
 func TestRenovateDoesNotAutomergeMajorUpdates(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -386,7 +386,7 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	})
 	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
 	assertWorkflowStringValues(t, []workflowStringValue{
-		{label: "release publication input artifact name", got: uploadStep.With["name"], want: "release-publication-inputs"},
+		{label: "release publication input artifact name", got: uploadStep.With["name"], want: "publication-inputs"},
 		{label: "release publication input artifact path", got: uploadStep.With["path"], want: "publication-inputs"},
 		{label: "release publication input artifact missing-file behavior", got: uploadStep.With["if-no-files-found"], want: "error"},
 	})
@@ -582,7 +582,7 @@ func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T)
 	downloadStep := workflowStepByName(t, workflow.Jobs, "publish-marketplace", "Download release publication inputs")
 	toolchainDownload := workflowStepByName(t, workflow.Jobs, "publish-marketplace", "Download Marketplace toolchain")
 	assertWorkflowStringValues(t, []workflowStringValue{
-		{label: "Marketplace release input artifact name", got: downloadStep.With["name"], want: "release-publication-inputs"},
+		{label: "Marketplace release input artifact name", got: downloadStep.With["name"], want: "publication-inputs"},
 		{label: "Marketplace release input artifact path", got: downloadStep.With["path"], want: "publication-inputs"},
 		{label: "Marketplace toolchain artifact name", got: toolchainDownload.With["name"], want: "marketplace-toolchain"},
 		{label: "Marketplace toolchain artifact path", got: toolchainDownload.With["path"], want: "marketplace-toolchain-input"},

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -37,12 +37,14 @@ type workflowJobConfig struct {
 }
 
 type workflowStepConfig struct {
-	Name  string            `yaml:"name"`
-	ID    string            `yaml:"id"`
-	If    string            `yaml:"if"`
-	Run   string            `yaml:"run"`
-	Shell string            `yaml:"shell"`
-	Env   map[string]string `yaml:"env"`
+	Name             string            `yaml:"name"`
+	ID               string            `yaml:"id"`
+	If               string            `yaml:"if"`
+	Run              string            `yaml:"run"`
+	Shell            string            `yaml:"shell"`
+	WorkingDirectory string            `yaml:"working-directory"`
+	Env              map[string]string `yaml:"env"`
+	With             map[string]string `yaml:"with"`
 }
 
 func TestReleasePleaseWritesRootChangelog(t *testing.T) {
@@ -317,8 +319,8 @@ func TestReleaseWorkflowStampsFeatureHistoryBeforeInjectingPushToken(t *testing.
 	}
 	assertWorkflowStepEnvMissing(t, stampStep, "PUSH_TOKEN", "stamp history step must not expose PUSH_TOKEN to repository-controlled featureflag tooling")
 	assertWorkflowStepRunContainsAll(t, stampStep, "stamp history step", []string{
-		`go run ./tools/featureflag stamp-release --release "${RELEASE_TAG}"`,
-		`go run ./tools/featureflag validate`,
+		`"${RUNNER_TEMP}/featureflag" stamp-release --release "${RELEASE_TAG}"`,
+		`"${RUNNER_TEMP}/featureflag" validate`,
 		`echo "changed=true" >> "$GITHUB_OUTPUT"`,
 	})
 	if strings.Contains(stampStep.Run, "git push") {
@@ -352,6 +354,68 @@ func TestReleaseWorkflowStampsFeatureHistoryBeforeInjectingPushToken(t *testing.
 	})
 	if strings.Contains(pushStep.Run, "git remote set-url origin") {
 		t.Fatal("push stamped history step must not persist push credentials in .git/config")
+	}
+}
+
+func TestReleaseWorkflowBuildsFeatureHistoryPatchWithTrustedMainTooling(t *testing.T) {
+	t.Parallel()
+
+	var workflow struct {
+		Jobs map[string]workflowJobConfig `yaml:"jobs"`
+	}
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	trustedCheckout := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Checkout trusted main tooling")
+	if trustedCheckout.With["ref"] != "main" {
+		t.Fatalf("trusted tooling checkout ref = %q, want main", trustedCheckout.With["ref"])
+	}
+	if trustedCheckout.With["path"] != "" {
+		t.Fatalf("trusted tooling checkout path = %q, want repository root", trustedCheckout.With["path"])
+	}
+
+	releaseCheckout := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Checkout validated release data")
+	if releaseCheckout.With["ref"] != "${{ needs.prepare-release.outputs.sha }}" {
+		t.Fatalf("release data checkout ref = %q", releaseCheckout.With["ref"])
+	}
+	if releaseCheckout.With["path"] != "release-source" {
+		t.Fatalf("release data checkout path = %q, want release-source", releaseCheckout.With["path"])
+	}
+
+	validateStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Validate release data against trusted main")
+	if validateStep.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
+		t.Fatalf("release data validation RELEASE_SHA env = %q", validateStep.Env["RELEASE_SHA"])
+	}
+	assertWorkflowStepRunContainsAll(t, validateStep, "release data validation step", []string{
+		`release_commit="$(git -C release-source rev-parse HEAD)"`,
+		`if [ "${release_commit}" != "${RELEASE_SHA}" ]; then`,
+		`if ! git merge-base --is-ancestor "${release_commit}" HEAD; then`,
+	})
+
+	buildStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Build trusted feature flag tool")
+	if buildStep.WorkingDirectory != "" {
+		t.Fatalf("trusted feature flag build working directory = %q, want trusted repository root", buildStep.WorkingDirectory)
+	}
+	if !strings.Contains(buildStep.Run, `go build -o "${RUNNER_TEMP}/featureflag" ./tools/featureflag`) {
+		t.Fatal("feature history job must build featureflag from trusted main")
+	}
+
+	stampStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Stamp first stable release history")
+	if stampStep.WorkingDirectory != "release-source" {
+		t.Fatalf("stamp history working directory = %q, want release-source", stampStep.WorkingDirectory)
+	}
+	assertWorkflowStepRunContainsAll(t, stampStep, "stamp history step", []string{
+		`"${RUNNER_TEMP}/featureflag" stamp-release --release "${RELEASE_TAG}"`,
+		`"${RUNNER_TEMP}/featureflag" validate`,
+	})
+	if strings.Contains(stampStep.Run, "go run ./tools/featureflag") {
+		t.Fatal("release-source changes must not control the feature history executable")
+	}
+
+	for _, stepName := range []string{"Commit stamped feature release history", "Push stamped feature release history"} {
+		step := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", stepName)
+		if step.WorkingDirectory != "release-source" {
+			t.Fatalf("%s working directory = %q, want release-source", stepName, step.WorkingDirectory)
+		}
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -1436,6 +1436,52 @@ func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
 	})
 }
 
+func TestReleaseOrchestrationRequiresIntegrityBoundManifestPayload(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
+
+	manifestPayload := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Prepare manifest publication payload")
+	assertWorkflowStepRunContainsAll(t, manifestPayload, "manifest payload preparation", []string{
+		`find -P . -type f ! -path './SHA256SUMS'`,
+		`> "${payload_root}/SHA256SUMS"`,
+	})
+
+	publishManifest := workflowJobByName(t, workflow.Jobs, "publish-ghcr-manifest")
+	manifestValidation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Validate manifest publication payload")
+	if manifestValidation.Env["EXPECTED_IMAGE_TAGS"] != "${{ inputs.image_tags }}" {
+		t.Fatalf("manifest validation EXPECTED_IMAGE_TAGS = %q, want immutable workflow input", manifestValidation.Env["EXPECTED_IMAGE_TAGS"])
+	}
+	validationIndex := workflowStepIndexByName(t, workflow.Jobs, "publish-ghcr-manifest", "Validate manifest publication payload")
+	loginIndex := workflowStepIndexByName(t, workflow.Jobs, "publish-ghcr-manifest", "Log in to GHCR")
+	if validationIndex >= loginIndex {
+		t.Fatal("manifest publication inputs must be validated before GHCR login")
+	}
+	assertWorkflowStepRunContainsAll(t, manifestValidation, "integrity-bound manifest validation", []string{
+		`expected_source_sha="${EXPECTED_SOURCE_SHA}"`,
+		`expected_image_tags="${EXPECTED_IMAGE_TAGS}"`,
+		`expected_image_name="ghcr.io/${owner}/lopper"`,
+		`checksums_file="${payload_root}/SHA256SUMS"`,
+		`find -P "${payload_root}" ! -type d ! -type f`,
+		`directory_count`,
+		`[ "${file_count}" -ne 3 ]`,
+		`SHA256SUMS|publication.json|image-tags.txt`,
+		`computed_checksums=`,
+		`cmp -s "${checksums_file}" "${computed_checksums}"`,
+		`sha256sum --check --strict SHA256SUMS`,
+		`while IFS= read -r raw_tag || [[ -n "${raw_tag}" ]]; do`,
+		`tag="${tag%$'\r'}"`,
+		`printf '%s:%s\n' "${expected_image_name}" "${tag}" >> "${expected_tags_file}"`,
+		`cmp -s "${tags_file}" "${expected_tags_file}"`,
+		`unexpected image reference`,
+	})
+
+	if len(publishManifest.Permissions) != 1 || publishManifest.Permissions["packages"] != "write" {
+		t.Fatalf("publish-ghcr-manifest permissions = %#v, want packages: write", publishManifest.Permissions)
+	}
+}
+
 func assertGHCRJobDoesNotReference(t *testing.T, job workflowJobConfig, needle string, jobLabel string) {
 	t.Helper()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -1814,6 +1814,19 @@ func TestReleaseOrchestrationRequiresDigestPinnedGHCRManifests(t *testing.T) {
 	})
 }
 
+func TestReleaseOrchestrationDedupesPlatformOCIManifestDescriptorsByDigest(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
+
+	validation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Validate OCI publication payloads")
+	assertWorkflowStepRunContainsAll(t, validation, "unique OCI image digest validation", []string{
+		`| .digest' "${layout_root}/index.json" | sort -u)`,
+		`OCI layout must contain exactly one unique ${platform} image digest.`,
+	})
+}
+
 func TestReleaseOrchestrationRequiresExactTrustedArchitectureTags(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -213,7 +213,7 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowManualDispatchStrictlyResolvesExistingReleaseCommit(t *testing.T) {
+func TestReleaseWorkflowManualDispatchStrictlyValidatesExistingReleaseCommit(t *testing.T) {
 	t.Parallel()
 
 	var workflow struct {
@@ -226,16 +226,59 @@ func TestReleaseWorkflowManualDispatchStrictlyResolvesExistingReleaseCommit(t *t
 		`release_lookup_error="$(mktemp)"`,
 		`if ! grep -q "HTTP 404" "${release_lookup_error}"; then`,
 		`tag_fetched="false"`,
-		`encoded_target="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$existing_target")"`,
-		`existing_commit="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_target}" --jq '.sha')"`,
+		`if [[ ! "${existing_target}" =~ ^[0-9a-f]{40}$ ]]; then`,
+		`existing_commit="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${existing_target}" --jq '.sha')"`,
 		`if [[ ! "${existing_commit}" =~ ^[0-9a-f]{40}$ ]]; then`,
+		`if [ "${tag_fetched}" = "false" ] && [ "${existing_commit}" != "${existing_target}" ]; then`,
 		`if [ "${existing_commit}" != "${resolved_sha}" ]; then`,
 	})
+	guardIndex := strings.Index(manualStep.Run, `if [[ ! "${existing_target}" =~ ^[0-9a-f]{40}$ ]]; then`)
+	lookupIndex := strings.Index(manualStep.Run, `existing_commit="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${existing_target}" --jq '.sha')"`)
+	if guardIndex < 0 || lookupIndex < 0 || guardIndex > lookupIndex {
+		t.Fatal("manual release flow must validate target_commitish as a full commit SHA before the commits API lookup")
+	}
 	if strings.Contains(manualStep.Run, `git rev-parse -q --verify "${existing_target}^{commit}"`) {
 		t.Fatal("manual release flow must resolve a release target that is absent from the local checkout")
 	}
 	if strings.Contains(manualStep.Run, `[ -n "${existing_commit}" ] &&`) {
 		t.Fatal("manual release flow must never skip existing release mismatch validation")
+	}
+}
+
+func TestReleaseWorkflowRejectsBranchValuedMissingTagFallback(t *testing.T) {
+	t.Parallel()
+
+	var workflow struct {
+		Jobs map[string]workflowJobConfig `yaml:"jobs"`
+	}
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	manualStep := workflowStepByName(t, workflow.Jobs, "prepare-release", "Prepare manual release")
+	const guardLine = `if [[ ! "${existing_target}" =~ ^[0-9a-f]{40}$ ]]; then`
+	guardIndex := strings.Index(manualStep.Run, guardLine)
+	if guardIndex < 0 {
+		t.Fatal("manual release flow must guard target_commitish with a full-SHA check")
+	}
+
+	var guardLines []string
+	for _, line := range strings.Split(manualStep.Run[guardIndex:], "\n") {
+		guardLines = append(guardLines, line)
+		if strings.TrimSpace(line) == "fi" {
+			break
+		}
+	}
+	guardScript := strings.Join(guardLines, "\n")
+	cmd := exec.Command("bash", "-c", "set -euo pipefail\n"+guardScript+"\nprintf 'guard-bypassed\\n'")
+	cmd.Env = append(os.Environ(), "existing_target=main", "tag=v1.2.3")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("branch-valued target_commitish passed the missing-tag guard: %s", output)
+	}
+	if !strings.Contains(string(output), "Existing release v1.2.3 target_commitish must be a full 40-character hexadecimal commit SHA; got 'main'.") {
+		t.Fatalf("branch-valued target_commitish error = %q", output)
+	}
+	if strings.Contains(string(output), "guard-bypassed") {
+		t.Fatalf("branch-valued target_commitish bypassed the guard: %s", output)
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -220,14 +220,18 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 		`major_tag="v${BASH_REMATCH[1]}"`,
 		`minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"`,
 		`git tag --force "${major_tag}" "${RELEASE_SHA}"`,
+		`push_url="https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"`,
 		`git tag --force "${minor_tag}" "${RELEASE_SHA}"`,
-		`git push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"`,
+		`git push --force "${push_url}" "refs/tags/${major_tag}" "refs/tags/${minor_tag}"`,
 	} {
 		if !strings.Contains(step.Run, want) {
 			t.Fatalf("action floating tag step must contain %q", want)
 		}
 	}
 
+	if strings.Contains(step.Run, "git remote set-url origin") {
+		t.Fatal("action floating tag step must not persist push credentials in .git/config")
+	}
 	workflowText := readConfig(t, ".github/workflows/release.yml")
 	if !strings.Contains(workflowText, "- GitHub Action: \\`${GITHUB_REPOSITORY}@${tag}\\`") {
 		t.Fatal("release notes must include the concrete GitHub Action ref")

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -1299,8 +1299,10 @@ func TestReleaseOrchestrationImageTagStepsUseSanitizer(t *testing.T) {
 		})
 	}
 
-	manifestStep := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Compute manifest image tags")
-	assertManifestImageTagStep(t, manifestStep)
+	t.Run("manifest", func(t *testing.T) {
+		manifestStep := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Compute manifest image tags")
+		assertManifestImageTagStep(t, manifestStep)
+	})
 }
 
 func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
@@ -1333,6 +1335,8 @@ func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
 			build := workflowStepByName(t, workflow.Jobs, prepareJobName, "Build "+architecture.name+" OCI publication payload")
 			assertWorkflowStringValues(t, []workflowStringValue{
 				{label: prepareJobName + " registry push", got: build.With["push"], want: "false"},
+				{label: prepareJobName + " deferred provenance", got: build.With["provenance"], want: "false"},
+				{label: prepareJobName + " deferred SBOM", got: build.With["sbom"], want: "false"},
 				{label: prepareJobName + " platform", got: build.With["platforms"], want: architecture.platform},
 			})
 			for _, want := range []string{"type=oci", "tar=false", "${{ runner.temp }}/ghcr-" + architecture.name + "-publication/layout"} {
@@ -1340,83 +1344,93 @@ func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
 					t.Fatalf("%s OCI output = %q, want %q", prepareJobName, build.With["outputs"], want)
 				}
 			}
-			workflowStepByName(t, workflow.Jobs, prepareJobName, "Prepare "+architecture.name+" publication metadata")
+			metadata := workflowStepByName(t, workflow.Jobs, prepareJobName, "Prepare "+architecture.name+" publication metadata")
+			assertWorkflowStepRunContainsAll(t, metadata, prepareJobName+" metadata", []string{
+				`find -P . -type f ! -path './SHA256SUMS'`,
+				`> "${payload_root}/SHA256SUMS"`,
+			})
 			upload := workflowStepByName(t, workflow.Jobs, prepareJobName, "Upload "+architecture.name+" OCI publication payload")
 			assertWorkflowStringValues(t, []workflowStringValue{
 				{label: prepareJobName + " artifact name", got: upload.With["name"], want: "ghcr-" + architecture.name + "-publication-payload"},
 				{label: prepareJobName + " artifact path", got: upload.With["path"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-publication"},
 			})
-
-			publishJobName := "publish-ghcr-" + architecture.name
-			publish := workflowJobByName(t, workflow.Jobs, publishJobName)
-			assertWorkflowJobNeeds(t, publish, publishJobName, workflowJobNeeds{prepareJobName})
-			assertWorkflowJobPermissions(t, publish, publishJobName, map[string]string{"packages": "write"})
-			assertFreshGHCRPublisher(t, publish, "Log in to GHCR")
-
-			download := workflowStepByName(t, workflow.Jobs, publishJobName, "Download "+architecture.name+" OCI publication payload")
-			assertWorkflowStringValues(t, []workflowStringValue{
-				{label: publishJobName + " artifact name", got: download.With["name"], want: "ghcr-" + architecture.name + "-publication-payload"},
-				{label: publishJobName + " artifact path", got: download.With["path"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-publication"},
-			})
-			validation := workflowStepByName(t, workflow.Jobs, publishJobName, "Validate "+architecture.name+" OCI publication payload")
-			assertWorkflowStepRunContainsAll(t, validation, publishJobName+" validation", []string{
-				`expected_source_sha="${EXPECTED_SOURCE_SHA}"`,
-				`expected_image_name="ghcr.io/${owner}/lopper"`,
-				`find -P "${payload_root}" -type l`,
-				`sha256sum`,
-				`org.opencontainers.image.revision`,
-				`OnBuild`,
-				`artifact payload exceeds`,
-				`unexpected image reference`,
-			})
-			workflowStepByName(t, workflow.Jobs, publishJobName, "Prepare trusted image promotion Dockerfile")
-			publishImage := workflowStepByName(t, workflow.Jobs, publishJobName, "Publish "+architecture.name+" release image")
-			assertWorkflowStringValues(t, []workflowStringValue{
-				{label: publishJobName + " trusted context", got: publishImage.With["context"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-promotion"},
-				{label: publishJobName + " trusted Dockerfile", got: publishImage.With["file"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-promotion/Dockerfile"},
-				{label: publishJobName + " validated tags", got: publishImage.With["tags"], want: "${{ steps.validate.outputs.tags }}"},
-				{label: publishJobName + " push", got: publishImage.With["push"], want: "true"},
-				{label: publishJobName + " provenance", got: publishImage.With["provenance"], want: "false"},
-				{label: publishJobName + " SBOM", got: publishImage.With["sbom"], want: "true"},
-			})
-			wantBuildContext := "prepared=oci-layout://${{ runner.temp }}/ghcr-" + architecture.name + "-publication/layout@${{ steps.validate.outputs.digest }}"
-			if !strings.Contains(publishImage.With["build-contexts"], wantBuildContext) {
-				t.Fatalf("%s build contexts = %q, want validated OCI digest", publishJobName, publishImage.With["build-contexts"])
-			}
 		})
 	}
 
-	prepareManifest := workflowJobByName(t, workflow.Jobs, "prepare-ghcr-manifest")
-	assertWorkflowJobPermissions(t, prepareManifest, "prepare-ghcr-manifest", map[string]string{"contents": "read"})
-	assertGHCRJobDoesNotReference(t, prepareManifest, "secrets.GITHUB_TOKEN", "prepare-ghcr-manifest")
-	manifestCheckout := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Checkout")
-	if manifestCheckout.With["persist-credentials"] != "false" {
-		t.Fatalf("prepare-ghcr-manifest checkout persist-credentials = %q, want false", manifestCheckout.With["persist-credentials"])
-	}
-	manifestUpload := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Upload manifest publication payload")
-	if manifestUpload.With["name"] != "ghcr-manifest-publication-payload" {
-		t.Fatalf("manifest artifact name = %q", manifestUpload.With["name"])
-	}
-
-	publishManifest := workflowJobByName(t, workflow.Jobs, "publish-ghcr-manifest")
-	assertWorkflowJobNeeds(t, publishManifest, "publish-ghcr-manifest", workflowJobNeeds{"publish-ghcr-amd64", "publish-ghcr-arm64", "prepare-ghcr-manifest"})
-	assertWorkflowJobPermissions(t, publishManifest, "publish-ghcr-manifest", map[string]string{"packages": "write"})
-	assertFreshGHCRPublisher(t, publishManifest, "Log in to GHCR")
-	manifestValidation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Validate manifest publication payload")
-	assertWorkflowStepRunContainsAll(t, manifestValidation, "manifest validation", []string{
+	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
+	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"prepare-ghcr-amd64", "prepare-ghcr-arm64"})
+	assertWorkflowJobPermissions(t, publishImages, "publish-ghcr-images", map[string]string{"packages": "write"})
+	assertFreshGHCRPublisher(t, publishImages, "Log in to GHCR")
+	validation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Validate OCI publication payloads")
+	assertWorkflowStepRunContainsAll(t, validation, "publish-ghcr-images validation", []string{
 		`expected_source_sha="${EXPECTED_SOURCE_SHA}"`,
 		`expected_image_name="ghcr.io/${owner}/lopper"`,
+		`find -P "${payload_root}" ! -type d ! -type f`,
+		`SHA256SUMS`,
+		`sha256sum --check --strict SHA256SUMS`,
+		`org.opencontainers.image.revision`,
+		`OnBuild`,
 		`artifact payload exceeds`,
 		`unexpected image reference`,
+		`validate_payload amd64 linux/amd64`,
+		`validate_payload arm64 linux/arm64`,
 	})
-	manifestPublish := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Publish multi-arch manifests")
-	if strings.Contains(manifestPublish.Run, "scripts/") {
-		t.Fatal("trusted manifest publisher must not run repository scripts")
+	workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Prepare trusted image promotion Dockerfiles")
+	for _, architecture := range architectures {
+		download := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Download "+architecture.name+" OCI publication payload")
+		assertWorkflowStringValues(t, []workflowStringValue{
+			{label: "publish-ghcr-images artifact name", got: download.With["name"], want: "ghcr-" + architecture.name + "-publication-payload"},
+			{label: "publish-ghcr-images artifact path", got: download.With["path"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-publication"},
+		})
+
+		publishImage := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Publish "+architecture.name+" release image")
+		assertWorkflowStringValues(t, []workflowStringValue{
+			{label: "publish-ghcr-images trusted context", got: publishImage.With["context"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-promotion"},
+			{label: "publish-ghcr-images trusted Dockerfile", got: publishImage.With["file"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-promotion/Dockerfile"},
+			{label: "publish-ghcr-images validated tags", got: publishImage.With["tags"], want: "${{ steps.validate.outputs." + architecture.name + "_tags }}"},
+			{label: "publish-ghcr-images push", got: publishImage.With["push"], want: "true"},
+			{label: "publish-ghcr-images provenance", got: publishImage.With["provenance"], want: "false"},
+			{label: "publish-ghcr-images SBOM", got: publishImage.With["sbom"], want: "true"},
+		})
+		wantBuildContext := "prepared=oci-layout://${{ runner.temp }}/ghcr-" + architecture.name + "-publication/layout@${{ steps.validate.outputs." + architecture.name + "_digest }}"
+		if !strings.Contains(publishImage.With["build-contexts"], wantBuildContext) {
+			t.Fatalf("publish-ghcr-images %s build contexts = %q, want validated OCI digest", architecture.name, publishImage.With["build-contexts"])
+		}
 	}
-	assertWorkflowStepRunContainsAll(t, manifestPublish, "trusted manifest publication", []string{
-		`done < "${IMAGE_TAGS_FILE}"`,
-		`docker buildx imagetools create`,
-		`docker buildx imagetools inspect`,
+
+	t.Run("manifest", func(t *testing.T) {
+		prepareManifest := workflowJobByName(t, workflow.Jobs, "prepare-ghcr-manifest")
+		assertWorkflowJobPermissions(t, prepareManifest, "prepare-ghcr-manifest", map[string]string{"contents": "read"})
+		assertGHCRJobDoesNotReference(t, prepareManifest, "secrets.GITHUB_TOKEN", "prepare-ghcr-manifest")
+		manifestCheckout := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Checkout")
+		if manifestCheckout.With["persist-credentials"] != "false" {
+			t.Fatalf("prepare-ghcr-manifest checkout persist-credentials = %q, want false", manifestCheckout.With["persist-credentials"])
+		}
+		manifestUpload := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Upload manifest publication payload")
+		if manifestUpload.With["name"] != "ghcr-manifest-publication-payload" {
+			t.Fatalf("manifest artifact name = %q", manifestUpload.With["name"])
+		}
+
+		publishManifest := workflowJobByName(t, workflow.Jobs, "publish-ghcr-manifest")
+		assertWorkflowJobNeeds(t, publishManifest, "publish-ghcr-manifest", workflowJobNeeds{"publish-ghcr-images"})
+		assertWorkflowJobPermissions(t, publishManifest, "publish-ghcr-manifest", map[string]string{"packages": "write"})
+		assertFreshGHCRPublisher(t, publishManifest, "Log in to GHCR")
+		manifestValidation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Validate manifest publication payload")
+		assertWorkflowStepRunContainsAll(t, manifestValidation, "manifest validation", []string{
+			`expected_source_sha="${EXPECTED_SOURCE_SHA}"`,
+			`expected_image_name="ghcr.io/${owner}/lopper"`,
+			`artifact payload exceeds`,
+			`unexpected image reference`,
+		})
+		manifestPublish := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Publish multi-arch manifests")
+		if strings.Contains(manifestPublish.Run, "scripts/") {
+			t.Fatal("trusted manifest publisher must not run repository scripts")
+		}
+		assertWorkflowStepRunContainsAll(t, manifestPublish, "trusted manifest publication", []string{
+			`done < "${IMAGE_TAGS_FILE}"`,
+			`docker buildx imagetools create`,
+			`docker buildx imagetools inspect`,
+		})
 	})
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -175,6 +175,73 @@ func TestGraduateFeatureWorkflowCreatesTemplateCompatiblePRBody(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowPinsTrustedMainToWorkflowRevision(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	preparation := workflowJobByName(t, workflow.Jobs, "prepare-release")
+	if preparation.Outputs["trusted_main_sha"] != "${{ steps.trusted_main.outputs.trusted_main_sha }}" {
+		t.Fatalf("prepare-release trusted_main_sha output = %q", preparation.Outputs["trusted_main_sha"])
+	}
+	if len(preparation.Steps) == 0 || preparation.Steps[0].Name != "Resolve trusted main workflow revision" {
+		t.Fatal("trusted main workflow revision must be resolved before release side effects")
+	}
+	resolver := preparation.Steps[0]
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "trusted main resolver id", got: resolver.ID, want: "trusted_main"},
+		{label: "trusted main resolver shell", got: resolver.Shell, want: "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"},
+		{label: "trusted main resolver action", got: resolver.Uses, want: ""},
+		{label: "trusted main resolver condition", got: resolver.If, want: ""},
+		{label: "trusted main resolver working directory", got: resolver.WorkingDirectory, want: ""},
+	})
+	assertWorkflowStepEnv(t, resolver, "trusted main workflow resolver", map[string]string{
+		"PATH":         "/usr/bin:/bin",
+		"WORKFLOW_REF": "${{ github.workflow_ref }}",
+		"WORKFLOW_SHA": "${{ github.workflow_sha }}",
+	})
+	assertWorkflowStepRunContainsAll(t, resolver, "trusted main workflow resolver", []string{
+		`expected_workflow_ref="${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/heads/main"`,
+		`if [ "${WORKFLOW_REF}" != "${expected_workflow_ref}" ]; then`,
+		`echo "::error::Release workflow must come from ${expected_workflow_ref}; got ${WORKFLOW_REF}." >&2`,
+		`if [[ ! "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then`,
+		`echo "::error::Release workflow SHA must be a lowercase full 40-character commit SHA; got ${WORKFLOW_SHA}." >&2`,
+		`/usr/bin/printf 'trusted_main_sha=%s\n' "${WORKFLOW_SHA}" >> "$GITHUB_OUTPUT"`,
+	})
+	if strings.Count(resolver.Run, "exit 1") != 2 {
+		t.Fatal("trusted main workflow resolver must fail closed on ref or SHA mismatch")
+	}
+	if strings.Count(resolver.Run, `>> "$GITHUB_OUTPUT"`) != 1 {
+		t.Fatal("trusted main workflow resolver must output only the validated workflow SHA")
+	}
+	assertTextAppearsBefore(t, resolver.Run,
+		`if [ "${WORKFLOW_REF}" != "${expected_workflow_ref}" ]; then`,
+		`/usr/bin/printf 'trusted_main_sha=%s\n' "${WORKFLOW_SHA}" >> "$GITHUB_OUTPUT"`,
+		"trusted main workflow ref must be validated before output",
+	)
+	assertTextAppearsBefore(t, resolver.Run,
+		`if [[ ! "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then`,
+		`/usr/bin/printf 'trusted_main_sha=%s\n' "${WORKFLOW_SHA}" >> "$GITHUB_OUTPUT"`,
+		"trusted main workflow SHA must be validated before output",
+	)
+	assertWorkflowStepRunOmitsAll(t, resolver, "trusted main workflow resolver", []string{"git ", "gh ", "curl ", "wget ", "secrets.", "token"})
+	assertWorkflowStepOrder(t, preparation,
+		"Resolve trusted main workflow revision",
+		"Run release-please",
+		"Checkout manual release source",
+		"Prepare manual release",
+	)
+
+	wantTrustedMain := "${{ needs.prepare-release.outputs.trusted_main_sha }}"
+	marketplaceCheckout := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Checkout trusted main Marketplace manifests")
+	featureHistoryCheckout := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Checkout trusted main tooling")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "trusted Marketplace checkout ref", got: marketplaceCheckout.With["ref"], want: wantTrustedMain},
+		{label: "trusted feature history checkout ref", got: featureHistoryCheckout.With["ref"], want: wantTrustedMain},
+	})
+}
+
 func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	t.Parallel()
 
@@ -386,7 +453,7 @@ func TestReleaseWorkflowPreparesIntegrityBoundMarketplaceTooling(t *testing.T) {
 	checkoutStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Checkout trusted main Marketplace manifests")
 	setupStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Setup Node for Marketplace tooling")
 	assertWorkflowStringValues(t, []workflowStringValue{
-		{label: "trusted Marketplace checkout ref", got: checkoutStep.With["ref"], want: "main"},
+		{label: "trusted Marketplace checkout ref", got: checkoutStep.With["ref"], want: "${{ needs.prepare-release.outputs.trusted_main_sha }}"},
 		{label: "trusted Marketplace checkout path", got: checkoutStep.With["path"], want: ""},
 		{label: "Marketplace tooling Node version", got: setupStep.With["node-version"], want: "24"},
 	})
@@ -985,7 +1052,7 @@ func TestReleaseWorkflowTransportsFeatureHistoryPatchAcrossJobs(t *testing.T) {
 	trustedCheckout := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Checkout trusted main tooling")
 	releaseCheckout := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Checkout validated release data")
 	assertWorkflowStringValues(t, []workflowStringValue{
-		{label: "trusted tooling checkout ref", got: trustedCheckout.With["ref"], want: "main"},
+		{label: "trusted tooling checkout ref", got: trustedCheckout.With["ref"], want: "${{ needs.prepare-release.outputs.trusted_main_sha }}"},
 		{label: "trusted tooling checkout path", got: trustedCheckout.With["path"], want: ""},
 		{label: "validated release data checkout ref", got: releaseCheckout.With["ref"], want: "${{ needs.prepare-release.outputs.sha }}"},
 		{label: "validated release data checkout path", got: releaseCheckout.With["path"], want: "release-source"},

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -192,7 +192,6 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 		`echo "Remote tag ${tag} does not exist; validating the release target instead."`,
 		`echo "::error::Failed to fetch existing release tag ${tag}." >&2
       printf '%s\n' "${fetch_error}" >&2
-      rm -f "${release_json}"
       exit 1`,
 	})
 	if strings.Contains(manualStep.Run, `git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}" >/dev/null 2>&1 || true`) {
@@ -209,6 +208,32 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	}
 	if strings.Contains(workflowText, "Release Please did not create a release; the release PR was created or updated instead.") {
 		t.Fatal("skip-release log must not use the stale message that also appears during manual tag dispatches")
+	}
+}
+
+func TestReleaseWorkflowManualDispatchStrictlyResolvesExistingReleaseCommit(t *testing.T) {
+	t.Parallel()
+
+	var workflow struct {
+		Jobs map[string]workflowJobConfig `yaml:"jobs"`
+	}
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	manualStep := workflowStepByName(t, workflow.Jobs, "prepare-release", "Prepare manual release")
+	assertWorkflowStepRunContainsAll(t, manualStep, "manual release preparation step", []string{
+		`release_lookup_error="$(mktemp)"`,
+		`if ! grep -q "HTTP 404" "${release_lookup_error}"; then`,
+		`tag_fetched="false"`,
+		`encoded_target="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$existing_target")"`,
+		`existing_commit="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_target}" --jq '.sha')"`,
+		`if [[ ! "${existing_commit}" =~ ^[0-9a-f]{40}$ ]]; then`,
+		`if [ "${existing_commit}" != "${resolved_sha}" ]; then`,
+	})
+	if strings.Contains(manualStep.Run, `git rev-parse -q --verify "${existing_target}^{commit}"`) {
+		t.Fatal("manual release flow must resolve a release target that is absent from the local checkout")
+	}
+	if strings.Contains(manualStep.Run, `[ -n "${existing_commit}" ] &&`) {
+		t.Fatal("manual release flow must never skip existing release mismatch validation")
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -317,8 +317,8 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
 	step := workflowStepByName(t, workflow.Jobs, "publish", "Update GitHub Action floating tags")
-	if step.Shell != "bash" {
-		t.Fatalf("action floating tag step shell = %q, want bash", step.Shell)
+	if step.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
+		t.Fatalf("action floating tag step shell = %q", step.Shell)
 	}
 	if step.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" {
 		t.Fatalf("action floating tag step RELEASE_TAG env = %q", step.Env["RELEASE_TAG"])
@@ -326,23 +326,32 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 	if step.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
 		t.Fatalf("action floating tag step RELEASE_SHA env = %q", step.Env["RELEASE_SHA"])
 	}
+	if step.Env["PUSH_TOKEN"] != "${{ secrets.GITHUB_TOKEN }}" {
+		t.Fatalf("action floating tag step PUSH_TOKEN env = %q", step.Env["PUSH_TOKEN"])
+	}
 
-	for _, want := range []string{
+	assertWorkflowStepRunContainsAll(t, step, "action floating tag step", []string{
+		"git_bin=/usr/bin/git",
+		`push_token="${PUSH_TOKEN}"`,
+		"unset PUSH_TOKEN",
+		`auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"`,
+		"unset push_token",
+		`expected_origin="https://github.com/${GITHUB_REPOSITORY}"`,
+		`origin_fetch_urls="$(git_safe remote get-url --all origin)"`,
+		`origin_push_urls="$(git_safe remote get-url --push --all origin)"`,
+		"GIT_CONFIG_KEY_1=credential.helper",
+		"GIT_CONFIG_VALUE_1=",
+		"GIT_CONFIG_KEY_4=http.https://github.com/.extraheader",
+		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
 		`^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$`,
 		`major_tag="v${BASH_REMATCH[1]}"`,
 		`minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"`,
-		`push_url="https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"`,
-		`git tag --force "${major_tag}" "${RELEASE_SHA}"`,
-		`git tag --force "${minor_tag}" "${RELEASE_SHA}"`,
-		`git push --force "${push_url}" "refs/tags/${major_tag}" "refs/tags/${minor_tag}"`,
-	} {
-		if !strings.Contains(step.Run, want) {
-			t.Fatalf("action floating tag step must contain %q", want)
-		}
-	}
-	if strings.Contains(step.Run, "git remote set-url origin") {
-		t.Fatal("action floating tag step must not persist push credentials in .git/config")
-	}
+		`git_safe tag --force "${major_tag}" "${RELEASE_SHA}"`,
+		`git_safe tag --force "${minor_tag}" "${RELEASE_SHA}"`,
+		`git_network push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"`,
+	})
+	assertWorkflowStepKeepsGitCredentialsCommandScoped(t, step, "action floating tag step")
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, workflow.Jobs["publish"], "publish")
 
 	workflowText := readConfig(t, ".github/workflows/release.yml")
 	if !strings.Contains(workflowText, "- GitHub Action: \\`${GITHUB_REPOSITORY}@${tag}\\`") {
@@ -592,18 +601,31 @@ func TestReleaseWorkflowStampsFeatureHistoryBeforeInjectingPushToken(t *testing.
 	if pushStep.If != "${{ steps.stamp_history.outputs.changed == 'true' }}" {
 		t.Fatalf("push stamped history step if = %q", pushStep.If)
 	}
+	if pushStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
+		t.Fatalf("push stamped history step shell = %q", pushStep.Shell)
+	}
 	if pushStep.Env["PUSH_TOKEN"] != "${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}" {
 		t.Fatalf("push stamped history step PUSH_TOKEN env = %q", pushStep.Env["PUSH_TOKEN"])
 	}
 	assertWorkflowStepRunContainsAll(t, pushStep, "push stamped history step", []string{
-		`push_url="https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"`,
-		`git fetch origin main:refs/remotes/origin/main`,
-		`git rebase origin/main`,
-		`git push "${push_url}" HEAD:main`,
+		"git_bin=/usr/bin/git",
+		`push_token="${PUSH_TOKEN}"`,
+		"unset PUSH_TOKEN",
+		`auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"`,
+		"unset push_token",
+		`expected_origin="https://github.com/${GITHUB_REPOSITORY}"`,
+		`origin_fetch_urls="$(git_safe remote get-url --all origin)"`,
+		`origin_push_urls="$(git_safe remote get-url --push --all origin)"`,
+		"GIT_CONFIG_KEY_1=credential.helper",
+		"GIT_CONFIG_VALUE_1=",
+		"GIT_CONFIG_KEY_4=http.https://github.com/.extraheader",
+		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
+		`git_network fetch origin main:refs/remotes/origin/main`,
+		`git_safe rebase origin/main`,
+		`git_network push origin HEAD:main`,
 	})
-	if strings.Contains(pushStep.Run, "git remote set-url origin") {
-		t.Fatal("push stamped history step must not persist push credentials in .git/config")
-	}
+	assertWorkflowStepKeepsGitCredentialsCommandScoped(t, pushStep, "push stamped history step")
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, workflow.Jobs["stamp-feature-release-history"], "stamp-feature-release-history")
 }
 
 func TestReleaseWorkflowBuildsFeatureHistoryPatchWithTrustedMainTooling(t *testing.T) {
@@ -1062,6 +1084,52 @@ func assertWorkflowStepEnvMissing(t *testing.T, step workflowStepConfig, key str
 
 	if _, ok := step.Env[key]; ok {
 		t.Fatal(message)
+	}
+}
+
+func assertWorkflowStepKeepsGitCredentialsCommandScoped(t *testing.T, step workflowStepConfig, stepLabel string) {
+	t.Helper()
+
+	for _, forbidden := range []string{
+		"push_url=",
+		"https://x-access-token:",
+		"@github.com",
+		"git remote set-url",
+		"credential.helper store",
+		"persist-credentials: true",
+	} {
+		if strings.Contains(step.Run, forbidden) {
+			t.Fatalf("%s must not contain %q", stepLabel, forbidden)
+		}
+	}
+
+	for _, line := range strings.Split(step.Run, "\n") {
+		isGitCommand := strings.Contains(line, `"${git_bin}"`) ||
+			strings.Contains(line, "git_safe ") ||
+			strings.Contains(line, "git_network ")
+		if isGitCommand && (strings.Contains(line, "PUSH_TOKEN") ||
+			strings.Contains(line, "push_token") ||
+			strings.Contains(line, "auth_header")) {
+			t.Fatalf("%s must not place secret text in git argv: %q", stepLabel, strings.TrimSpace(line))
+		}
+	}
+}
+
+func assertWorkflowJobCheckoutsDisablePersistedCredentials(t *testing.T, job workflowJobConfig, jobLabel string) {
+	t.Helper()
+
+	checkoutCount := 0
+	for _, step := range job.Steps {
+		if !strings.HasPrefix(step.Uses, "actions/checkout@") {
+			continue
+		}
+		checkoutCount++
+		if step.With["persist-credentials"] != "false" {
+			t.Fatalf("%s checkout %q must set persist-credentials: false", jobLabel, step.Name)
+		}
+	}
+	if checkoutCount == 0 {
+		t.Fatalf("%s must contain a checkout step", jobLabel)
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -2,6 +2,7 @@ package scripts
 
 import (
 	"encoding/json"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -413,34 +414,28 @@ func TestReleaseWorkflowPreparesIntegrityBoundMarketplaceTooling(t *testing.T) {
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	preparation, ok := workflow.Jobs["prepare-marketplace-toolchain"]
-	if !ok {
-		t.Fatal("release workflow must prepare Marketplace tooling in a separate trusted-main job")
-	}
-	if !slices.Equal(preparation.Needs, workflowJobNeeds{"prepare-release"}) {
-		t.Fatalf("Marketplace tooling preparation needs = %v", preparation.Needs)
-	}
-	if preparation.If != "${{ needs.prepare-release.outputs.release_created == 'true' }}" {
-		t.Fatalf("Marketplace tooling preparation if = %q", preparation.If)
-	}
-	if len(preparation.Permissions) != 1 || preparation.Permissions["contents"] != "read" {
-		t.Fatalf("Marketplace tooling preparation permissions = %#v", preparation.Permissions)
-	}
-	if len(preparation.Env) != 0 {
-		t.Fatalf("Marketplace tooling preparation env = %#v, want no job-scoped credentials", preparation.Env)
-	}
+	preparation := workflowJobByName(t, workflow.Jobs, "prepare-marketplace-toolchain")
+	assertWorkflowJobNeeds(t, preparation, "Marketplace tooling preparation", workflowJobNeeds{"prepare-release"})
+	assertWorkflowJobPermissions(t, preparation, "Marketplace tooling preparation", map[string]string{"contents": "read"})
+	assertWorkflowJobEnvEmpty(t, preparation, "Marketplace tooling preparation")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{
+			label: "Marketplace tooling preparation if",
+			got:   preparation.If,
+			want:  "${{ needs.prepare-release.outputs.release_created == 'true' }}",
+		},
+	})
 	assertWorkflowJobOmitsText(t, preparation, "VSCE_PAT", "Marketplace tooling preparation must not receive VSCE_PAT")
 	assertWorkflowJobOmitsText(t, preparation, "secrets.", "Marketplace tooling preparation must not receive secrets")
 	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, preparation, "prepare-marketplace-toolchain")
 
 	checkoutStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Checkout trusted main Marketplace manifests")
-	if checkoutStep.With["ref"] != "main" || checkoutStep.With["path"] != "" {
-		t.Fatalf("trusted Marketplace checkout config = %#v", checkoutStep.With)
-	}
 	setupStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Setup Node for Marketplace tooling")
-	if setupStep.With["node-version"] != "24" {
-		t.Fatalf("Marketplace tooling Node version = %q", setupStep.With["node-version"])
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "trusted Marketplace checkout ref", got: checkoutStep.With["ref"], want: "main"},
+		{label: "trusted Marketplace checkout path", got: checkoutStep.With["path"], want: ""},
+		{label: "Marketplace tooling Node version", got: setupStep.With["node-version"], want: "24"},
+	})
 
 	lockStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Validate Marketplace tooling lockfile")
 	assertWorkflowStepRunContainsAll(t, lockStep, "Marketplace lockfile validation step", []string{
@@ -476,14 +471,14 @@ func TestReleaseWorkflowPreparesIntegrityBoundMarketplaceTooling(t *testing.T) {
 	})
 
 	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Upload Marketplace toolchain")
-	if uploadStep.With["name"] != "marketplace-toolchain" ||
-		!strings.Contains(uploadStep.With["path"], ".artifacts/marketplace-toolchain/vsce-toolchain.tar.gz") ||
-		!strings.Contains(uploadStep.With["path"], ".artifacts/marketplace-toolchain/SHA256SUMS") {
-		t.Fatalf("Marketplace toolchain artifact config = %#v", uploadStep.With)
-	}
-	if uploadStep.With["if-no-files-found"] != "error" {
-		t.Fatalf("Marketplace toolchain artifact missing-file behavior = %q", uploadStep.With["if-no-files-found"])
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "Marketplace toolchain artifact name", got: uploadStep.With["name"], want: "marketplace-toolchain"},
+		{label: "Marketplace toolchain artifact missing-file behavior", got: uploadStep.With["if-no-files-found"], want: "error"},
+	})
+	assertTextContainsAll(t, uploadStep.With["path"], "Marketplace toolchain artifact path", []string{
+		".artifacts/marketplace-toolchain/vsce-toolchain.tar.gz",
+		".artifacts/marketplace-toolchain/SHA256SUMS",
+	})
 }
 
 func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T) {
@@ -492,51 +487,39 @@ func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T)
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	marketplace, ok := workflow.Jobs["publish-marketplace"]
-	if !ok {
-		t.Fatal("release workflow must publish Marketplace inputs from a fresh job")
-	}
-	if !slices.Equal(marketplace.Needs, workflowJobNeeds{"prepare-release", "prepare-release-publication", "prepare-marketplace-toolchain"}) {
-		t.Fatalf("Marketplace publication needs = %v", marketplace.Needs)
-	}
-	if marketplace.If != "${{ needs.prepare-release.outputs.release_created == 'true' }}" {
-		t.Fatalf("Marketplace publication if = %q", marketplace.If)
-	}
-	if len(marketplace.Permissions) != 0 {
-		t.Fatalf("Marketplace publication permissions = %#v, want none", marketplace.Permissions)
-	}
-	if len(marketplace.Env) != 0 {
-		t.Fatalf("Marketplace publication job env = %#v, want no job-scoped credentials", marketplace.Env)
-	}
+	marketplace := workflowJobByName(t, workflow.Jobs, "publish-marketplace")
+	assertWorkflowJobNeeds(t, marketplace, "Marketplace publication", workflowJobNeeds{"prepare-release", "prepare-release-publication", "prepare-marketplace-toolchain"})
+	assertWorkflowJobPermissions(t, marketplace, "Marketplace publication", nil)
+	assertWorkflowJobEnvEmpty(t, marketplace, "Marketplace publication")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{
+			label: "Marketplace publication if",
+			got:   marketplace.If,
+			want:  "${{ needs.prepare-release.outputs.release_created == 'true' }}",
+		},
+	})
 	assertWorkflowEnvKeyOnlyOnStep(t, workflow.Jobs, "VSCE_PAT", "publish-marketplace", "Publish VS Code extension to Marketplace")
-
-	for _, step := range marketplace.Steps {
-		if strings.HasPrefix(step.Uses, "actions/checkout@") {
-			t.Fatalf("Marketplace publication must not checkout repository code: %q", step.Name)
-		}
-		for _, forbidden := range []string{"npm ", "npx ", "git ", "go run ./", "make ", "scripts/", "./extensions/"} {
-			if strings.Contains(strings.ToLower(step.Run), forbidden) {
-				t.Fatalf("Marketplace publication step %q must not execute %q", step.Name, forbidden)
-			}
-		}
-	}
+	assertWorkflowJobOmitsCheckout(t, marketplace, "Marketplace publication")
+	assertWorkflowJobStepRunsOmitAllFold(t, marketplace, "Marketplace publication", []string{"npm ", "npx ", "git ", "go run ./", "make ", "scripts/", "./extensions/"})
 
 	downloadStep := workflowStepByName(t, workflow.Jobs, "publish-marketplace", "Download release publication inputs")
-	if downloadStep.With["name"] != "release-publication-inputs" || downloadStep.With["path"] != "publication-inputs" {
-		t.Fatalf("Marketplace release input download config = %#v", downloadStep.With)
-	}
 	toolchainDownload := workflowStepByName(t, workflow.Jobs, "publish-marketplace", "Download Marketplace toolchain")
-	if toolchainDownload.With["name"] != "marketplace-toolchain" || toolchainDownload.With["path"] != "marketplace-toolchain-input" {
-		t.Fatalf("Marketplace toolchain download config = %#v", toolchainDownload.With)
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "Marketplace release input artifact name", got: downloadStep.With["name"], want: "release-publication-inputs"},
+		{label: "Marketplace release input artifact path", got: downloadStep.With["path"], want: "publication-inputs"},
+		{label: "Marketplace toolchain artifact name", got: toolchainDownload.With["name"], want: "marketplace-toolchain"},
+		{label: "Marketplace toolchain artifact path", got: toolchainDownload.With["path"], want: "marketplace-toolchain-input"},
+	})
 
 	validateStep := workflowStepByName(t, workflow.Jobs, "publish-marketplace", "Validate Marketplace publication inputs")
-	if validateStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
-		t.Fatalf("Marketplace input validation shell = %q", validateStep.Shell)
-	}
-	if len(validateStep.Env) != 1 || validateStep.Env["RELEASE_VERSION"] != "${{ needs.prepare-release.outputs.version }}" {
-		t.Fatalf("Marketplace input validation env = %#v", validateStep.Env)
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{{
+		label: "Marketplace input validation shell",
+		got:   validateStep.Shell,
+		want:  "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}",
+	}})
+	assertWorkflowStepEnv(t, validateStep, "Marketplace input validation", map[string]string{
+		"RELEASE_VERSION": "${{ needs.prepare-release.outputs.version }}",
+	})
 	assertWorkflowStepRunContainsAll(t, validateStep, "Marketplace input validation step", []string{
 		`publication_dir="${GITHUB_WORKSPACE}/publication-inputs"`,
 		`artifact_dir="${GITHUB_WORKSPACE}/marketplace-toolchain-input"`,
@@ -579,14 +562,10 @@ func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T)
 		`vsix_path="${GITHUB_WORKSPACE}/publication-inputs/dist/lopper-vscode-${{ needs.prepare-release.outputs.version }}.vsix"`,
 		`"${vsce_bin}" publish --packagePath "${vsix_path}"`,
 	})
-	for _, forbidden := range []string{
+	assertWorkflowStepRunOmitsAllFold(t, marketplaceStep, "Marketplace publication", []string{
 		"npx ", "npm ", "find ", "test -x", "sha256sum ", "tar ", "python", "node ",
 		"curl ", "wget ", "git ", "go ", "make ", "scripts/", "./extensions/",
-	} {
-		if strings.Contains(strings.ToLower(marketplaceStep.Run), forbidden) {
-			t.Fatalf("Marketplace publication must not execute %q while VSCE_PAT is in scope", forbidden)
-		}
-	}
+	})
 
 	workflowText := readConfig(t, ".github/workflows/release.yml")
 	if count := strings.Count(workflowText, "${{ secrets.VSCE_PUBLISH }}"); count != 1 {
@@ -1505,6 +1484,16 @@ func workflowStepByName(t *testing.T, jobs map[string]workflowJobConfig, jobName
 	return jobs[jobName].Steps[workflowStepIndexByName(t, jobs, jobName, stepName)]
 }
 
+func workflowJobByName(t *testing.T, jobs map[string]workflowJobConfig, jobName string) workflowJobConfig {
+	t.Helper()
+
+	job, ok := jobs[jobName]
+	if !ok {
+		t.Fatalf("workflow must define job %s", jobName)
+	}
+	return job
+}
+
 func workflowStepIndexByName(t *testing.T, jobs map[string]workflowJobConfig, jobName string, stepName string) int {
 	t.Helper()
 
@@ -1544,12 +1533,102 @@ func assertWorkflowEnvKeyOnlyOnStep(t *testing.T, jobs map[string]workflowJobCon
 	}
 }
 
+type workflowStringValue struct {
+	label string
+	got   string
+	want  string
+}
+
+func assertWorkflowStringValues(t *testing.T, values []workflowStringValue) {
+	t.Helper()
+
+	for _, value := range values {
+		if value.got != value.want {
+			t.Fatalf("%s = %q", value.label, value.got)
+		}
+	}
+}
+
+func assertWorkflowJobNeeds(t *testing.T, job workflowJobConfig, jobLabel string, want workflowJobNeeds) {
+	t.Helper()
+
+	if !slices.Equal(job.Needs, want) {
+		t.Fatalf("%s needs = %v", jobLabel, job.Needs)
+	}
+}
+
+func assertWorkflowJobPermissions(t *testing.T, job workflowJobConfig, jobLabel string, want map[string]string) {
+	t.Helper()
+
+	if !maps.Equal(job.Permissions, want) {
+		t.Fatalf("%s permissions = %#v", jobLabel, job.Permissions)
+	}
+}
+
+func assertWorkflowJobEnvEmpty(t *testing.T, job workflowJobConfig, jobLabel string) {
+	t.Helper()
+
+	if len(job.Env) != 0 {
+		t.Fatalf("%s env = %#v, want no job-scoped credentials", jobLabel, job.Env)
+	}
+}
+
+func assertWorkflowStepEnv(t *testing.T, step workflowStepConfig, stepLabel string, want map[string]string) {
+	t.Helper()
+
+	if !maps.Equal(step.Env, want) {
+		t.Fatalf("%s env = %#v", stepLabel, step.Env)
+	}
+}
+
+func assertWorkflowJobOmitsCheckout(t *testing.T, job workflowJobConfig, jobLabel string) {
+	t.Helper()
+
+	for _, step := range job.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") {
+			t.Fatalf("%s must not checkout repository code: %q", jobLabel, step.Name)
+		}
+	}
+}
+
+func assertWorkflowJobStepRunsOmitAllFold(t *testing.T, job workflowJobConfig, jobLabel string, forbiddenValues []string) {
+	t.Helper()
+
+	for _, step := range job.Steps {
+		for _, forbidden := range forbiddenValues {
+			if strings.Contains(strings.ToLower(step.Run), forbidden) {
+				t.Fatalf("%s step %q must not execute %q", jobLabel, step.Name, forbidden)
+			}
+		}
+	}
+}
+
+func assertWorkflowStepRunOmitsAllFold(t *testing.T, step workflowStepConfig, stepLabel string, forbiddenValues []string) {
+	t.Helper()
+
+	for _, forbidden := range forbiddenValues {
+		if strings.Contains(strings.ToLower(step.Run), forbidden) {
+			t.Fatalf("%s must not execute %q while credential is in scope", stepLabel, forbidden)
+		}
+	}
+}
+
 func assertWorkflowStepRunContainsAll(t *testing.T, step workflowStepConfig, stepLabel string, wants []string) {
 	t.Helper()
 
 	for _, want := range wants {
 		if !strings.Contains(step.Run, want) {
 			t.Fatalf("%s must contain %q", stepLabel, want)
+		}
+	}
+}
+
+func assertTextContainsAll(t *testing.T, text string, textLabel string, wants []string) {
+	t.Helper()
+
+	for _, want := range wants {
+		if !strings.Contains(text, want) {
+			t.Fatalf("%s must contain %q", textLabel, want)
 		}
 	}
 }

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -390,6 +390,18 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 			t.Fatalf("fresh release publication must define GitHub API step %q", stepName)
 		}
 	}
+}
+
+func TestReleaseWorkflowPreparesMarketplaceToolingBeforeCredentialedPublish(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	publication, ok := workflow.Jobs["publish"]
+	if !ok {
+		t.Fatal("release workflow must define the fresh publication job")
+	}
 
 	downloadStep := workflowStepByName(t, workflow.Jobs, "publish", "Download release publication inputs")
 	if downloadStep.With["name"] != "release-publication-inputs" || downloadStep.With["path"] != "publication-inputs" {
@@ -405,14 +417,79 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	})
 	assertWorkflowStepEnvMissing(t, validateStep, "GH_TOKEN", "release publication validation must be tokenless")
 
-	marketplaceStep := workflowStepByName(t, workflow.Jobs, "publish", "Publish VS Code extension to Marketplace")
+	prepareIndex := -1
+	publishIndex := -1
+	credentialedSteps := 0
+	for jobName, job := range workflow.Jobs {
+		if _, present := job.Env["VSCE_PAT"]; present {
+			t.Fatalf("Marketplace token must not be scoped to job %q", jobName)
+		}
+		for stepIndex, step := range job.Steps {
+			if jobName == "publish" && step.Name == "Prepare VS Code Marketplace tooling" {
+				prepareIndex = stepIndex
+			}
+			if _, present := step.Env["VSCE_PAT"]; !present {
+				continue
+			}
+			credentialedSteps++
+			if jobName != "publish" || step.Name != "Publish VS Code extension to Marketplace" {
+				t.Fatalf("Marketplace token is exposed to unexpected step %q in job %q", step.Name, jobName)
+			}
+			publishIndex = stepIndex
+		}
+	}
+	if credentialedSteps != 1 {
+		t.Fatalf("Marketplace token-bearing steps = %d, want exactly one", credentialedSteps)
+	}
+	if prepareIndex < 0 {
+		t.Fatal("release workflow must prepare pinned Marketplace tooling without a token")
+	}
+	if publishIndex != prepareIndex+1 {
+		t.Fatalf("Marketplace preparation index = %d, publish index = %d; preparation must be immediately before credentialed publication", prepareIndex, publishIndex)
+	}
+
+	prepareStep := publication.Steps[prepareIndex]
+	if len(prepareStep.Env) != 0 {
+		t.Fatalf("Marketplace tooling preparation env = %#v, want no step-scoped credentials", prepareStep.Env)
+	}
+	assertWorkflowStepRunContainsAll(t, prepareStep, "Marketplace tooling preparation step", []string{
+		`toolchain_dir="${RUNNER_TEMP}/vsce-toolchain"`,
+		`npm install --prefix "${toolchain_dir}" --no-audit --no-fund @vscode/vsce@3.9.2`,
+		`test -x "${toolchain_dir}/node_modules/.bin/vsce"`,
+	})
+	if strings.Count(prepareStep.Run, "@vscode/vsce@") != 1 || !strings.Contains(prepareStep.Run, "@vscode/vsce@3.9.2") {
+		t.Fatal("Marketplace tooling preparation must install exactly VSCE 3.9.2")
+	}
+
+	marketplaceStep := publication.Steps[publishIndex]
 	if len(marketplaceStep.Env) != 1 || marketplaceStep.Env["VSCE_PAT"] != "${{ secrets.VSCE_PUBLISH }}" {
 		t.Fatalf("Marketplace publication env = %#v", marketplaceStep.Env)
 	}
+	if marketplaceStep.Uses != "" {
+		t.Fatalf("Marketplace publication must invoke the prepared toolchain directly, found action %q", marketplaceStep.Uses)
+	}
 	assertWorkflowStepRunContainsAll(t, marketplaceStep, "Marketplace publication step", []string{
 		`if [ -z "${VSCE_PAT:-}" ]; then`,
-		`npx --yes @vscode/vsce@3.9.2 publish --packagePath "$vsix_path"`,
+		`vsce_bin="${RUNNER_TEMP}/vsce-toolchain/node_modules/.bin/vsce"`,
+		`test -x "$vsce_bin"`,
+		`vsix_path="$(find publication-inputs/dist -maxdepth 1 -name 'lopper-vscode-*.vsix' | head -n1)"`,
+		`test -n "$vsix_path"`,
+		`"$vsce_bin" publish --packagePath "$vsix_path"`,
 	})
+	for _, forbidden := range []string{
+		"npx ", "npm install", "npm exec", "pnpm ", "yarn ", "corepack ", "bunx ",
+		"curl ", "wget ", "go install ", "pip install ", "pipx install ", "cargo install ",
+		"actions/checkout", "git clone", "git checkout", "go run ./", "make ", "scripts/", "./",
+	} {
+		if strings.Contains(strings.ToLower(marketplaceStep.Run), forbidden) {
+			t.Fatalf("Marketplace publication must not execute %q while VSCE_PAT is in scope", forbidden)
+		}
+	}
+
+	workflowText := readConfig(t, ".github/workflows/release.yml")
+	if count := strings.Count(workflowText, "${{ secrets.VSCE_PUBLISH }}"); count != 1 {
+		t.Fatalf("Marketplace secret references = %d, want final publish step only", count)
+	}
 }
 
 func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -333,7 +333,8 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`find dist -maxdepth 1 -type f`,
 		`lopper-vscode-${version}.vsix`,
 		`publication-inputs/feature-flags.md`,
-		`sha256sum > SHA256SUMS`,
+		`mapfile -d '' checksum_files`,
+		`sha256sum "${checksum_files[@]}" > SHA256SUMS`,
 	})
 	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
 	if uploadStep.With["name"] != "release-publication-inputs" {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -1482,6 +1482,76 @@ func TestReleaseOrchestrationRequiresIntegrityBoundManifestPayload(t *testing.T)
 	}
 }
 
+func TestReleaseOrchestrationRequiresDigestPinnedGHCRManifests(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
+
+	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
+	architectures := []struct {
+		name     string
+		platform string
+	}{
+		{name: "amd64", platform: "linux/amd64"},
+		{name: "arm64", platform: "linux/arm64"},
+	}
+	for _, architecture := range architectures {
+		publishImage := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Publish "+architecture.name+" release image")
+		if publishImage.ID != "publish_"+architecture.name {
+			t.Fatalf("publish-ghcr-images %s step ID = %q, want stable digest source", architecture.name, publishImage.ID)
+		}
+		if publishImage.With["platforms"] != architecture.platform {
+			t.Fatalf("publish-ghcr-images %s platform = %q, want %q", architecture.name, publishImage.With["platforms"], architecture.platform)
+		}
+	}
+	for _, output := range []struct {
+		name string
+		want string
+	}{
+		{name: "amd64_digest", want: "${{ steps.publish_amd64.outputs.digest }}"},
+		{name: "arm64_digest", want: "${{ steps.publish_arm64.outputs.digest }}"},
+	} {
+		if publishImages.Outputs[output.name] != output.want {
+			t.Fatalf("publish-ghcr-images output %s = %q, want %q", output.name, publishImages.Outputs[output.name], output.want)
+		}
+	}
+
+	manifestValidation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Validate manifest publication payload")
+	for _, digest := range []struct {
+		name string
+		want string
+	}{
+		{name: "EXPECTED_AMD64_DIGEST", want: "${{ needs.publish-ghcr-images.outputs.amd64_digest }}"},
+		{name: "EXPECTED_ARM64_DIGEST", want: "${{ needs.publish-ghcr-images.outputs.arm64_digest }}"},
+	} {
+		if manifestValidation.Env[digest.name] != digest.want {
+			t.Fatalf("manifest validation %s = %q, want %q", digest.name, manifestValidation.Env[digest.name], digest.want)
+		}
+	}
+	assertWorkflowStepRunContainsAll(t, manifestValidation, "manifest digest validation", []string{
+		`amd64_digest="${EXPECTED_AMD64_DIGEST}"`,
+		`arm64_digest="${EXPECTED_ARM64_DIGEST}"`,
+		`[[ ! "${amd64_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]`,
+		`[[ ! "${arm64_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]`,
+	})
+
+	manifestPublish := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Publish multi-arch manifests")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "manifest publication AMD64_DIGEST", got: manifestPublish.Env["AMD64_DIGEST"], want: "${{ needs.publish-ghcr-images.outputs.amd64_digest }}"},
+		{label: "manifest publication ARM64_DIGEST", got: manifestPublish.Env["ARM64_DIGEST"], want: "${{ needs.publish-ghcr-images.outputs.arm64_digest }}"},
+	})
+	for _, mutableSource := range []string{`"${image_ref}-amd64"`, `"${image_ref}-arm64"`} {
+		if strings.Contains(manifestPublish.Run, mutableSource) {
+			t.Fatalf("trusted manifest publication must not use mutable source %s", mutableSource)
+		}
+	}
+	assertWorkflowStepRunContainsAll(t, manifestPublish, "digest-pinned manifest publication", []string{
+		`"${expected_image_name}@${amd64_digest}"`,
+		`"${expected_image_name}@${arm64_digest}"`,
+	})
+}
+
 func assertGHCRJobDoesNotReference(t *testing.T, job workflowJobConfig, needle string, jobLabel string) {
 	t.Helper()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -418,57 +418,109 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 	t.Parallel()
 
-	var workflow struct {
-		Jobs map[string]workflowJobConfig `yaml:"jobs"`
-	}
+	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
 	job := workflow.Jobs["update-floating-tags"]
 	if !slices.Equal(job.Needs, workflowJobNeeds{"prepare-release", "publish"}) {
 		t.Fatalf("action floating tag job needs = %v", job.Needs)
 	}
-	step := workflowStepByName(t, workflow.Jobs, "update-floating-tags", "Update GitHub Action floating tags")
-	if step.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
-		t.Fatalf("action floating tag step shell = %q", step.Shell)
+	if len(job.Permissions) != 1 || job.Permissions["contents"] != "write" {
+		t.Fatalf("action floating tag job permissions = %#v", job.Permissions)
 	}
-	if step.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" {
-		t.Fatalf("action floating tag step RELEASE_TAG env = %q", step.Env["RELEASE_TAG"])
+	if len(job.Env) != 0 {
+		t.Fatalf("action floating tag job env = %#v, want no job-scoped credentials", job.Env)
 	}
-	if step.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
-		t.Fatalf("action floating tag step RELEASE_SHA env = %q", step.Env["RELEASE_SHA"])
-	}
-	if step.Env["PUSH_TOKEN"] != "${{ secrets.GITHUB_TOKEN }}" {
-		t.Fatalf("action floating tag step PUSH_TOKEN env = %q", step.Env["PUSH_TOKEN"])
+	for _, step := range job.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") {
+			t.Fatalf("action floating tag job must use a fresh host-Git worktree, found checkout step %q", step.Name)
+		}
 	}
 
-	assertWorkflowStepRunContainsAll(t, step, "action floating tag step", []string{
+	prepareStep := workflowStepByName(t, workflow.Jobs, "update-floating-tags", "Prepare GitHub Action floating tags")
+	if prepareStep.ID != "prepare_tags" {
+		t.Fatalf("action floating tag preparation id = %q", prepareStep.ID)
+	}
+	if prepareStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
+		t.Fatalf("action floating tag preparation shell = %q", prepareStep.Shell)
+	}
+	if len(prepareStep.Env) != 2 || prepareStep.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" || prepareStep.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
+		t.Fatalf("action floating tag preparation env = %#v", prepareStep.Env)
+	}
+	assertWorkflowStepEnvMissing(t, prepareStep, "PUSH_TOKEN", "action floating tag preparation must be tokenless")
+	assertWorkflowStepRunContainsAll(t, prepareStep, "action floating tag preparation", []string{
 		"git_bin=/usr/bin/git",
 		"env_bin=/usr/bin/env",
 		`git_home="$("${mktemp_bin}" -d)"`,
+		`repo_dir="${RUNNER_TEMP}/floating-tags"`,
 		`"${env_bin}" -i`,
 		"GIT_CONFIG_NOSYSTEM=1",
 		"GIT_CONFIG_GLOBAL=/dev/null",
+		`^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$`,
+		`echo "push=false" >> "$GITHUB_OUTPUT"`,
+		`if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then`,
+		`expected_origin="https://github.com/${GITHUB_REPOSITORY}"`,
+		`git_safe init "${repo_dir}"`,
+		`git_safe -C "${repo_dir}" remote add origin "${expected_origin}"`,
+		`origin_fetch_urls="$(git_safe -C "${repo_dir}" remote get-url --all origin)"`,
+		`origin_push_urls="$(git_safe -C "${repo_dir}" remote get-url --push --all origin)"`,
+		`if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then`,
+		`git_safe -C "${repo_dir}" fetch --no-tags --depth=1 origin "${RELEASE_SHA}"`,
+		`git_safe -C "${repo_dir}" checkout --detach FETCH_HEAD`,
+		`resolved_sha="$(git_safe -C "${repo_dir}" rev-parse HEAD)"`,
+		`if [ "${resolved_sha}" != "${RELEASE_SHA}" ]; then`,
+		`major_tag="v${BASH_REMATCH[1]}"`,
+		`minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"`,
+		`git_safe -C "${repo_dir}" tag --force "${major_tag}" "${RELEASE_SHA}"`,
+		`git_safe -C "${repo_dir}" tag --force "${minor_tag}" "${RELEASE_SHA}"`,
+		`echo "push=true" >> "$GITHUB_OUTPUT"`,
+	})
+	for _, forbidden := range []string{"PUSH_TOKEN", "secrets.", "AUTHORIZATION: basic", "extraheader"} {
+		if strings.Contains(prepareStep.Run, forbidden) {
+			t.Fatalf("action floating tag preparation must not contain %q", forbidden)
+		}
+	}
+
+	pushStep := workflowStepByName(t, workflow.Jobs, "update-floating-tags", "Push GitHub Action floating tags")
+	if pushStep.If != "${{ steps.prepare_tags.outputs.push == 'true' }}" {
+		t.Fatalf("action floating tag push if = %q", pushStep.If)
+	}
+	if pushStep.Shell != prepareStep.Shell {
+		t.Fatalf("action floating tag push shell = %q", pushStep.Shell)
+	}
+	if len(pushStep.Env) != 3 || pushStep.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" || pushStep.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" || pushStep.Env["PUSH_TOKEN"] != "${{ secrets.GITHUB_TOKEN }}" {
+		t.Fatalf("action floating tag push env = %#v", pushStep.Env)
+	}
+	assertWorkflowStepRunContainsAll(t, pushStep, "action floating tag push", []string{
+		"git_bin=/usr/bin/git",
+		"env_bin=/usr/bin/env",
+		`repo_dir="${RUNNER_TEMP}/floating-tags"`,
+		`expected_origin="https://github.com/${GITHUB_REPOSITORY}"`,
+		`origin_fetch_urls="$(git_safe -C "${repo_dir}" remote get-url --all origin)"`,
+		`origin_push_urls="$(git_safe -C "${repo_dir}" remote get-url --push --all origin)"`,
+		`resolved_sha="$(git_safe -C "${repo_dir}" rev-parse HEAD)"`,
+		`major_target="$(git_safe -C "${repo_dir}" rev-parse "refs/tags/${major_tag}^{commit}")"`,
+		`minor_target="$(git_safe -C "${repo_dir}" rev-parse "refs/tags/${minor_tag}^{commit}")"`,
+		`if [ "${resolved_sha}" != "${RELEASE_SHA}" ] || [ "${major_target}" != "${RELEASE_SHA}" ] || [ "${minor_target}" != "${RELEASE_SHA}" ]; then`,
 		`push_token="${PUSH_TOKEN}"`,
 		"unset PUSH_TOKEN",
 		`auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"`,
 		"unset push_token",
-		`expected_origin="https://github.com/${GITHUB_REPOSITORY}"`,
-		`origin_fetch_urls="$(git_safe remote get-url --all origin)"`,
-		`origin_push_urls="$(git_safe remote get-url --push --all origin)"`,
-		`if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then`,
 		"GIT_CONFIG_KEY_1=credential.helper",
 		"GIT_CONFIG_VALUE_1=",
 		"GIT_CONFIG_KEY_4=http.https://github.com/.extraheader",
 		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
-		`^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$`,
-		`major_tag="v${BASH_REMATCH[1]}"`,
-		`minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"`,
-		`git_safe tag --force "${major_tag}" "${RELEASE_SHA}"`,
-		`git_safe tag --force "${minor_tag}" "${RELEASE_SHA}"`,
-		`git_network push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"`,
+		`git_network -C "${repo_dir}" push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"`,
 	})
-	assertWorkflowStepKeepsGitCredentialsCommandScoped(t, step, "action floating tag step")
-	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, job, "update-floating-tags")
+	validationIndex := strings.Index(pushStep.Run, `if [ "${resolved_sha}" != "${RELEASE_SHA}" ]`)
+	tokenIndex := strings.Index(pushStep.Run, `push_token="${PUSH_TOKEN}"`)
+	if validationIndex < 0 || tokenIndex < 0 || validationIndex >= tokenIndex {
+		t.Fatal("action floating tag push must validate origin, SHA, and tag targets before reading the push token")
+	}
+	if strings.Count(pushStep.Run, "git_network ") != 1 {
+		t.Fatal("action floating tag authentication must be exposed only to the single network push command")
+	}
+	assertWorkflowStepKeepsGitCredentialsCommandScoped(t, pushStep, "action floating tag push")
 
 	workflowText := readConfig(t, ".github/workflows/release.yml")
 	if !strings.Contains(workflowText, "- GitHub Action: \\`${GITHUB_REPOSITORY}@${tag}\\`") {
@@ -484,7 +536,7 @@ func TestReleaseWorkflowHomebrewUsesGatedThreeJobGraph(t *testing.T) {
 	workflowText := readConfig(t, ".github/workflows/release.yml")
 
 	gate := workflow.Jobs["homebrew-tap-token-gate"]
-	if !slices.Equal(gate.Needs, workflowJobNeeds{"prepare-release", "publish"}) {
+	if !slices.Equal(gate.Needs, workflowJobNeeds{"prepare-release", "publish", "update-floating-tags"}) {
 		t.Fatalf("tap token gate needs = %v", gate.Needs)
 	}
 	if gate.If != "${{ needs.prepare-release.outputs.release_created == 'true' }}" {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -351,7 +351,7 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	if !ok {
 		t.Fatal("release workflow must define the fresh publication job")
 	}
-	if !slices.Equal(publication.Needs, workflowJobNeeds{"prepare-release", "prepare-release-publication"}) {
+	if !slices.Equal(publication.Needs, workflowJobNeeds{"prepare-release", "prepare-release-publication", "publish-marketplace"}) {
 		t.Fatalf("fresh release publication needs = %v", publication.Needs)
 	}
 	if len(publication.Permissions) != 1 || publication.Permissions["contents"] != "write" {
@@ -392,76 +392,181 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowPreparesMarketplaceToolingBeforeCredentialedPublish(t *testing.T) {
+func TestReleaseWorkflowPreparesIntegrityBoundMarketplaceTooling(t *testing.T) {
+	t.Parallel()
+
+	var lockfile struct {
+		Packages map[string]struct {
+			Version   string `json:"version"`
+			Integrity string `json:"integrity"`
+		} `json:"packages"`
+	}
+	readJSONConfig(t, "extensions/vscode-lopper/package-lock.json", &lockfile)
+	vsce, ok := lockfile.Packages["node_modules/@vscode/vsce"]
+	if !ok {
+		t.Fatal("VS Code extension lockfile must contain node_modules/@vscode/vsce")
+	}
+	if vsce.Version != "3.9.2" || !strings.HasPrefix(vsce.Integrity, "sha512-") {
+		t.Fatalf("locked Marketplace tool = version %q, integrity %q", vsce.Version, vsce.Integrity)
+	}
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	preparation, ok := workflow.Jobs["prepare-marketplace-toolchain"]
+	if !ok {
+		t.Fatal("release workflow must prepare Marketplace tooling in a separate trusted-main job")
+	}
+	if !slices.Equal(preparation.Needs, workflowJobNeeds{"prepare-release"}) {
+		t.Fatalf("Marketplace tooling preparation needs = %v", preparation.Needs)
+	}
+	if preparation.If != "${{ needs.prepare-release.outputs.release_created == 'true' }}" {
+		t.Fatalf("Marketplace tooling preparation if = %q", preparation.If)
+	}
+	if len(preparation.Permissions) != 1 || preparation.Permissions["contents"] != "read" {
+		t.Fatalf("Marketplace tooling preparation permissions = %#v", preparation.Permissions)
+	}
+	if len(preparation.Env) != 0 {
+		t.Fatalf("Marketplace tooling preparation env = %#v, want no job-scoped credentials", preparation.Env)
+	}
+	assertWorkflowJobOmitsText(t, preparation, "VSCE_PAT", "Marketplace tooling preparation must not receive VSCE_PAT")
+	assertWorkflowJobOmitsText(t, preparation, "secrets.", "Marketplace tooling preparation must not receive secrets")
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, preparation, "prepare-marketplace-toolchain")
+
+	checkoutStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Checkout trusted main Marketplace manifests")
+	if checkoutStep.With["ref"] != "main" || checkoutStep.With["path"] != "" {
+		t.Fatalf("trusted Marketplace checkout config = %#v", checkoutStep.With)
+	}
+	setupStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Setup Node for Marketplace tooling")
+	if setupStep.With["node-version"] != "24" {
+		t.Fatalf("Marketplace tooling Node version = %q", setupStep.With["node-version"])
+	}
+
+	lockStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Validate Marketplace tooling lockfile")
+	assertWorkflowStepRunContainsAll(t, lockStep, "Marketplace lockfile validation step", []string{
+		`lockfile="extensions/vscode-lopper/package-lock.json"`,
+		`vsce_version="$(jq -er '.packages["node_modules/@vscode/vsce"].version' "${lockfile}")"`,
+		`vsce_integrity="$(jq -er '.packages["node_modules/@vscode/vsce"].integrity' "${lockfile}")"`,
+		`if [ "${vsce_version}" != "3.9.2" ]; then`,
+		`case "${vsce_integrity}" in`,
+		`sha512-?*)`,
+	})
+
+	prepareStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Prepare integrity-bound Marketplace toolchain")
+	assertWorkflowStepRunContainsAll(t, prepareStep, "Marketplace tooling preparation step", []string{
+		`source_dir="extensions/vscode-lopper"`,
+		`scratch_dir="${RUNNER_TEMP}/marketplace-toolchain"`,
+		`cp -- "${source_dir}/package.json" "${source_dir}/package-lock.json" "${scratch_dir}/"`,
+		`if [ "$(find "${scratch_dir}" -mindepth 1 -maxdepth 1 -type f | wc -l)" -ne 2 ]; then`,
+		`npm ci --ignore-scripts --include=dev --audit=false --fund=false`,
+		`test -x "${scratch_dir}/node_modules/.bin/vsce"`,
+	})
+	for _, forbidden := range []string{"npm install", "npm exec", "npx "} {
+		if strings.Contains(prepareStep.Run, forbidden) {
+			t.Fatalf("Marketplace tooling preparation must not contain %q", forbidden)
+		}
+	}
+
+	archiveStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Archive Marketplace toolchain")
+	assertWorkflowStepRunContainsAll(t, archiveStep, "Marketplace toolchain archive step", []string{
+		`archive_dir="${GITHUB_WORKSPACE}/.artifacts/marketplace-toolchain"`,
+		`archive_file="${archive_dir}/vsce-toolchain.tar.gz"`,
+		`tar --create --gzip --file "${archive_file}" --directory "${scratch_dir}" package.json package-lock.json node_modules`,
+		`sha256sum vsce-toolchain.tar.gz > SHA256SUMS`,
+	})
+
+	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Upload Marketplace toolchain")
+	if uploadStep.With["name"] != "marketplace-toolchain" ||
+		!strings.Contains(uploadStep.With["path"], ".artifacts/marketplace-toolchain/vsce-toolchain.tar.gz") ||
+		!strings.Contains(uploadStep.With["path"], ".artifacts/marketplace-toolchain/SHA256SUMS") {
+		t.Fatalf("Marketplace toolchain artifact config = %#v", uploadStep.With)
+	}
+	if uploadStep.With["if-no-files-found"] != "error" {
+		t.Fatalf("Marketplace toolchain artifact missing-file behavior = %q", uploadStep.With["if-no-files-found"])
+	}
+}
+
+func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T) {
 	t.Parallel()
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	publication, ok := workflow.Jobs["publish"]
+	marketplace, ok := workflow.Jobs["publish-marketplace"]
 	if !ok {
-		t.Fatal("release workflow must define the fresh publication job")
+		t.Fatal("release workflow must publish Marketplace inputs from a fresh job")
+	}
+	if !slices.Equal(marketplace.Needs, workflowJobNeeds{"prepare-release", "prepare-release-publication", "prepare-marketplace-toolchain"}) {
+		t.Fatalf("Marketplace publication needs = %v", marketplace.Needs)
+	}
+	if marketplace.If != "${{ needs.prepare-release.outputs.release_created == 'true' }}" {
+		t.Fatalf("Marketplace publication if = %q", marketplace.If)
+	}
+	if len(marketplace.Permissions) != 0 {
+		t.Fatalf("Marketplace publication permissions = %#v, want none", marketplace.Permissions)
+	}
+	if len(marketplace.Env) != 0 {
+		t.Fatalf("Marketplace publication job env = %#v, want no job-scoped credentials", marketplace.Env)
+	}
+	assertWorkflowEnvKeyOnlyOnStep(t, workflow.Jobs, "VSCE_PAT", "publish-marketplace", "Publish VS Code extension to Marketplace")
+
+	for _, step := range marketplace.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") {
+			t.Fatalf("Marketplace publication must not checkout repository code: %q", step.Name)
+		}
+		for _, forbidden := range []string{"npm ", "npx ", "git ", "go run ./", "make ", "scripts/", "./extensions/"} {
+			if strings.Contains(strings.ToLower(step.Run), forbidden) {
+				t.Fatalf("Marketplace publication step %q must not execute %q", step.Name, forbidden)
+			}
+		}
 	}
 
-	downloadStep := workflowStepByName(t, workflow.Jobs, "publish", "Download release publication inputs")
+	downloadStep := workflowStepByName(t, workflow.Jobs, "publish-marketplace", "Download release publication inputs")
 	if downloadStep.With["name"] != "release-publication-inputs" || downloadStep.With["path"] != "publication-inputs" {
-		t.Fatalf("fresh release publication download config = %#v", downloadStep.With)
+		t.Fatalf("Marketplace release input download config = %#v", downloadStep.With)
 	}
-	validateStep := workflowStepByName(t, workflow.Jobs, "publish", "Validate release publication inputs")
-	assertWorkflowStepRunContainsAll(t, validateStep, "release publication input validation step", []string{
-		`sha256sum --check --strict SHA256SUMS`,
-		`find dist -maxdepth 1 -type f`,
-		`lopper-vscode-${version}.vsix`,
-		`Expected darwin/amd64 artifact is missing`,
-		`Expected darwin/arm64 artifact is missing`,
-	})
-	assertWorkflowStepEnvMissing(t, validateStep, "GH_TOKEN", "release publication validation must be tokenless")
-
-	prepareIndex := -1
-	publishIndex := -1
-	credentialedSteps := 0
-	for jobName, job := range workflow.Jobs {
-		if _, present := job.Env["VSCE_PAT"]; present {
-			t.Fatalf("Marketplace token must not be scoped to job %q", jobName)
-		}
-		for stepIndex, step := range job.Steps {
-			if jobName == "publish" && step.Name == "Prepare VS Code Marketplace tooling" {
-				prepareIndex = stepIndex
-			}
-			if _, present := step.Env["VSCE_PAT"]; !present {
-				continue
-			}
-			credentialedSteps++
-			if jobName != "publish" || step.Name != "Publish VS Code extension to Marketplace" {
-				t.Fatalf("Marketplace token is exposed to unexpected step %q in job %q", step.Name, jobName)
-			}
-			publishIndex = stepIndex
-		}
-	}
-	if credentialedSteps != 1 {
-		t.Fatalf("Marketplace token-bearing steps = %d, want exactly one", credentialedSteps)
-	}
-	if prepareIndex < 0 {
-		t.Fatal("release workflow must prepare pinned Marketplace tooling without a token")
-	}
-	if publishIndex != prepareIndex+1 {
-		t.Fatalf("Marketplace preparation index = %d, publish index = %d; preparation must be immediately before credentialed publication", prepareIndex, publishIndex)
+	toolchainDownload := workflowStepByName(t, workflow.Jobs, "publish-marketplace", "Download Marketplace toolchain")
+	if toolchainDownload.With["name"] != "marketplace-toolchain" || toolchainDownload.With["path"] != "marketplace-toolchain-input" {
+		t.Fatalf("Marketplace toolchain download config = %#v", toolchainDownload.With)
 	}
 
-	prepareStep := publication.Steps[prepareIndex]
-	if len(prepareStep.Env) != 0 {
-		t.Fatalf("Marketplace tooling preparation env = %#v, want no step-scoped credentials", prepareStep.Env)
+	validateStep := workflowStepByName(t, workflow.Jobs, "publish-marketplace", "Validate Marketplace publication inputs")
+	if validateStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
+		t.Fatalf("Marketplace input validation shell = %q", validateStep.Shell)
 	}
-	assertWorkflowStepRunContainsAll(t, prepareStep, "Marketplace tooling preparation step", []string{
-		`toolchain_dir="${RUNNER_TEMP}/vsce-toolchain"`,
-		`npm install --prefix "${toolchain_dir}" --no-audit --no-fund @vscode/vsce@3.9.2`,
+	if len(validateStep.Env) != 1 || validateStep.Env["RELEASE_VERSION"] != "${{ needs.prepare-release.outputs.version }}" {
+		t.Fatalf("Marketplace input validation env = %#v", validateStep.Env)
+	}
+	assertWorkflowStepRunContainsAll(t, validateStep, "Marketplace input validation step", []string{
+		`publication_dir="${GITHUB_WORKSPACE}/publication-inputs"`,
+		`artifact_dir="${GITHUB_WORKSPACE}/marketplace-toolchain-input"`,
+		`archive_file="${artifact_dir}/vsce-toolchain.tar.gz"`,
+		`if find "${publication_dir}" -mindepth 1 ! -type f ! -type d -print -quit | grep -q .; then`,
+		`if find "${artifact_dir}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then`,
+		`if [ "$(find "${artifact_dir}" -maxdepth 1 -type f | wc -l)" -ne 2 ]; then`,
+		`if [ "$(stat --format=%s "${archive_file}")" -gt 268435456 ]; then`,
+		`expected_vsix="lopper-vscode-${RELEASE_VERSION}.vsix"`,
+		`if [ "${#assets[@]}" -eq 0 ] || [ "${#assets[@]}" -gt 32 ]; then`,
+		`if [ "$(stat --format=%s "${asset}")" -gt 1073741824 ]; then`,
+		`allowed_roots = {"package.json", "package-lock.json", "node_modules"}`,
+		`if member.issym():`,
+		`if member.islnk() or not (member.isfile() or member.isdir()):`,
+		`if member_count < 3 or member_count > 65536:`,
+		`if total_size > 1073741824:`,
+		`tar --extract --gzip --file "${archive_file}" --directory "${toolchain_dir}"`,
 		`test -x "${toolchain_dir}/node_modules/.bin/vsce"`,
+		`node_bin="$(command -v node)"`,
 	})
-	if strings.Count(prepareStep.Run, "@vscode/vsce@") != 1 || !strings.Contains(prepareStep.Run, "@vscode/vsce@3.9.2") {
-		t.Fatal("Marketplace tooling preparation must install exactly VSCE 3.9.2")
+	if count := strings.Count(validateStep.Run, "sha256sum --check --strict SHA256SUMS"); count != 2 {
+		t.Fatalf("Marketplace input checksum validations = %d, want publication and toolchain artifacts", count)
 	}
+	assertWorkflowStepEnvMissing(t, validateStep, "VSCE_PAT", "Marketplace validation must be tokenless")
 
-	marketplaceStep := publication.Steps[publishIndex]
+	publishIndex := workflowStepIndexByName(t, workflow.Jobs, "publish-marketplace", "Publish VS Code extension to Marketplace")
+	if publishIndex != len(marketplace.Steps)-1 {
+		t.Fatalf("Marketplace credentialed step index = %d, want final step", publishIndex)
+	}
+	marketplaceStep := marketplace.Steps[publishIndex]
 	if len(marketplaceStep.Env) != 1 || marketplaceStep.Env["VSCE_PAT"] != "${{ secrets.VSCE_PUBLISH }}" {
 		t.Fatalf("Marketplace publication env = %#v", marketplaceStep.Env)
 	}
@@ -471,15 +576,12 @@ func TestReleaseWorkflowPreparesMarketplaceToolingBeforeCredentialedPublish(t *t
 	assertWorkflowStepRunContainsAll(t, marketplaceStep, "Marketplace publication step", []string{
 		`if [ -z "${VSCE_PAT:-}" ]; then`,
 		`vsce_bin="${RUNNER_TEMP}/vsce-toolchain/node_modules/.bin/vsce"`,
-		`test -x "$vsce_bin"`,
-		`vsix_path="$(find publication-inputs/dist -maxdepth 1 -name 'lopper-vscode-*.vsix' | head -n1)"`,
-		`test -n "$vsix_path"`,
-		`"$vsce_bin" publish --packagePath "$vsix_path"`,
+		`vsix_path="${GITHUB_WORKSPACE}/publication-inputs/dist/lopper-vscode-${{ needs.prepare-release.outputs.version }}.vsix"`,
+		`"${vsce_bin}" publish --packagePath "${vsix_path}"`,
 	})
 	for _, forbidden := range []string{
-		"npx ", "npm install", "npm exec", "pnpm ", "yarn ", "corepack ", "bunx ",
-		"curl ", "wget ", "go install ", "pip install ", "pipx install ", "cargo install ",
-		"actions/checkout", "git clone", "git checkout", "go run ./", "make ", "scripts/", "./",
+		"npx ", "npm ", "find ", "test -x", "sha256sum ", "tar ", "python", "node ",
+		"curl ", "wget ", "git ", "go ", "make ", "scripts/", "./extensions/",
 	} {
 		if strings.Contains(strings.ToLower(marketplaceStep.Run), forbidden) {
 			t.Fatalf("Marketplace publication must not execute %q while VSCE_PAT is in scope", forbidden)
@@ -1400,17 +1502,46 @@ func releaseImageTagScriptCommand(t *testing.T, imageTags string, suffix string)
 func workflowStepByName(t *testing.T, jobs map[string]workflowJobConfig, jobName string, stepName string) workflowStepConfig {
 	t.Helper()
 
+	return jobs[jobName].Steps[workflowStepIndexByName(t, jobs, jobName, stepName)]
+}
+
+func workflowStepIndexByName(t *testing.T, jobs map[string]workflowJobConfig, jobName string, stepName string) int {
+	t.Helper()
+
 	job, ok := jobs[jobName]
 	if !ok {
 		t.Fatalf("workflow must define job %s", jobName)
 	}
-	for _, step := range job.Steps {
+	for index, step := range job.Steps {
 		if step.Name == stepName {
-			return step
+			return index
 		}
 	}
 	t.Fatalf("%s must define step %q", jobName, stepName)
-	return workflowStepConfig{}
+	return -1
+}
+
+func assertWorkflowEnvKeyOnlyOnStep(t *testing.T, jobs map[string]workflowJobConfig, key string, wantJob string, wantStep string) {
+	t.Helper()
+
+	credentialedSteps := 0
+	for jobName, job := range jobs {
+		if _, present := job.Env[key]; present {
+			t.Fatalf("%s must not be scoped to job %q", key, jobName)
+		}
+		for _, step := range job.Steps {
+			if _, present := step.Env[key]; !present {
+				continue
+			}
+			credentialedSteps++
+			if jobName != wantJob || step.Name != wantStep {
+				t.Fatalf("%s is exposed to unexpected step %q in job %q", key, step.Name, jobName)
+			}
+		}
+	}
+	if credentialedSteps != 1 {
+		t.Fatalf("%s-bearing steps = %d, want exactly one", key, credentialedSteps)
+	}
 }
 
 func assertWorkflowStepRunContainsAll(t *testing.T, step workflowStepConfig, stepLabel string, wants []string) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -275,18 +275,12 @@ func TestReleaseWorkflowStampsFeatureHistoryBeforeInjectingPushToken(t *testing.
 	if stampStep.ID != "stamp_history" {
 		t.Fatalf("stamp history step id = %q, want stamp_history", stampStep.ID)
 	}
-	if _, ok := stampStep.Env["PUSH_TOKEN"]; ok {
-		t.Fatal("stamp history step must not expose PUSH_TOKEN to repository-controlled featureflag tooling")
-	}
-	for _, want := range []string{
+	assertWorkflowStepEnvMissing(t, stampStep, "PUSH_TOKEN", "stamp history step must not expose PUSH_TOKEN to repository-controlled featureflag tooling")
+	assertWorkflowStepRunContainsAll(t, stampStep, "stamp history step", []string{
 		`go run ./tools/featureflag stamp-release --release "${RELEASE_TAG}"`,
 		`go run ./tools/featureflag validate`,
 		`echo "changed=true" >> "$GITHUB_OUTPUT"`,
-	} {
-		if !strings.Contains(stampStep.Run, want) {
-			t.Fatalf("stamp history step must contain %q", want)
-		}
-	}
+	})
 	if strings.Contains(stampStep.Run, "git push") {
 		t.Fatal("stamp history step must not push while running repository-controlled tools")
 	}
@@ -301,9 +295,7 @@ func TestReleaseWorkflowStampsFeatureHistoryBeforeInjectingPushToken(t *testing.
 	if !strings.Contains(commitStep.Run, `git commit -m "chore(flags): stamp ${RELEASE_TAG} feature release history"`) {
 		t.Fatal("commit stamped history step must create the release history commit without a push token")
 	}
-	if _, ok := commitStep.Env["PUSH_TOKEN"]; ok {
-		t.Fatal("commit stamped history step must not expose PUSH_TOKEN")
-	}
+	assertWorkflowStepEnvMissing(t, commitStep, "PUSH_TOKEN", "commit stamped history step must not expose PUSH_TOKEN")
 
 	pushStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Push stamped feature release history")
 	if pushStep.If != "${{ steps.stamp_history.outputs.changed == 'true' }}" {
@@ -312,16 +304,12 @@ func TestReleaseWorkflowStampsFeatureHistoryBeforeInjectingPushToken(t *testing.
 	if pushStep.Env["PUSH_TOKEN"] != "${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}" {
 		t.Fatalf("push stamped history step PUSH_TOKEN env = %q", pushStep.Env["PUSH_TOKEN"])
 	}
-	for _, want := range []string{
+	assertWorkflowStepRunContainsAll(t, pushStep, "push stamped history step", []string{
 		`push_url="https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"`,
 		`git fetch origin main:refs/remotes/origin/main`,
 		`git rebase origin/main`,
 		`git push "${push_url}" HEAD:main`,
-	} {
-		if !strings.Contains(pushStep.Run, want) {
-			t.Fatalf("push stamped history step must contain %q", want)
-		}
-	}
+	})
 	if strings.Contains(pushStep.Run, "git remote set-url origin") {
 		t.Fatal("push stamped history step must not persist push credentials in .git/config")
 	}
@@ -704,6 +692,24 @@ func workflowStepByName(t *testing.T, jobs map[string]workflowJobConfig, jobName
 	}
 	t.Fatalf("%s must define step %q", jobName, stepName)
 	return workflowStepConfig{}
+}
+
+func assertWorkflowStepRunContainsAll(t *testing.T, step workflowStepConfig, stepLabel string, wants []string) {
+	t.Helper()
+
+	for _, want := range wants {
+		if !strings.Contains(step.Run, want) {
+			t.Fatalf("%s must contain %q", stepLabel, want)
+		}
+	}
+}
+
+func assertWorkflowStepEnvMissing(t *testing.T, step workflowStepConfig, key string, message string) {
+	t.Helper()
+
+	if _, ok := step.Env[key]; ok {
+		t.Fatal(message)
+	}
 }
 
 func readJSONConfig(t *testing.T, path string, target any) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -308,6 +308,112 @@ func TestReleaseWorkflowRejectsBranchValuedMissingTagFallback(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	preparation, ok := workflow.Jobs["prepare-release-publication"]
+	if !ok {
+		t.Fatal("release workflow must prepare bounded publication inputs in a separate job")
+	}
+	if !slices.Equal(preparation.Needs, workflowJobNeeds{"prepare-release", "orchestrate-release", "build-vscode-extension", "build-darwin-amd64"}) {
+		t.Fatalf("release publication preparation needs = %v", preparation.Needs)
+	}
+	if len(preparation.Permissions) != 1 || preparation.Permissions["contents"] != "read" {
+		t.Fatalf("release publication preparation permissions = %#v", preparation.Permissions)
+	}
+	assertWorkflowJobOmitsText(t, preparation, "GH_TOKEN", "release publication preparation must not receive GH_TOKEN")
+	assertWorkflowJobOmitsText(t, preparation, "secrets.", "release publication preparation must not receive secrets")
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, preparation, "prepare-release-publication")
+
+	stageStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Stage bounded release publication inputs")
+	assertWorkflowStepRunContainsAll(t, stageStep, "release publication staging step", []string{
+		`find dist -maxdepth 1 -type f`,
+		`lopper-vscode-${version}.vsix`,
+		`publication-inputs/feature-flags.md`,
+		`sha256sum > SHA256SUMS`,
+	})
+	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
+	if uploadStep.With["name"] != "release-publication-inputs" {
+		t.Fatalf("release publication input artifact name = %q", uploadStep.With["name"])
+	}
+	if uploadStep.With["path"] != "publication-inputs" {
+		t.Fatalf("release publication input artifact path = %q", uploadStep.With["path"])
+	}
+	if uploadStep.With["if-no-files-found"] != "error" {
+		t.Fatalf("release publication input artifact missing-file behavior = %q", uploadStep.With["if-no-files-found"])
+	}
+
+	publication, ok := workflow.Jobs["publish"]
+	if !ok {
+		t.Fatal("release workflow must define the fresh publication job")
+	}
+	if !slices.Equal(publication.Needs, workflowJobNeeds{"prepare-release", "prepare-release-publication"}) {
+		t.Fatalf("fresh release publication needs = %v", publication.Needs)
+	}
+	if len(publication.Permissions) != 1 || publication.Permissions["contents"] != "write" {
+		t.Fatalf("fresh release publication permissions = %#v", publication.Permissions)
+	}
+	if len(publication.Env) != 0 {
+		t.Fatalf("fresh release publication job env = %#v, want no job-scoped credentials", publication.Env)
+	}
+
+	apiSteps := map[string]bool{
+		"Update GitHub Release notes":  false,
+		"Upload GitHub Release assets": false,
+		"Publish GitHub Release":       false,
+	}
+	for _, step := range publication.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") {
+			t.Fatalf("fresh release publication must not checkout repository code: %q", step.Name)
+		}
+		if _, isAPIStep := apiSteps[step.Name]; isAPIStep {
+			apiSteps[step.Name] = true
+			if len(step.Env) != 1 || step.Env["GH_TOKEN"] != "${{ secrets.GITHUB_TOKEN }}" {
+				t.Fatalf("GitHub API step %q env = %#v", step.Name, step.Env)
+			}
+		} else if _, ok := step.Env["GH_TOKEN"]; ok {
+			t.Fatalf("non-API publication step %q must not receive GH_TOKEN", step.Name)
+		}
+
+		for _, repositoryCommand := range []string{"go run ./", "make ", "./extensions/", "scripts/"} {
+			if strings.Contains(step.Run, repositoryCommand) {
+				t.Fatalf("fresh release publication step %q must not execute repository-controlled command %q", step.Name, repositoryCommand)
+			}
+		}
+	}
+	for stepName, found := range apiSteps {
+		if !found {
+			t.Fatalf("fresh release publication must define GitHub API step %q", stepName)
+		}
+	}
+
+	downloadStep := workflowStepByName(t, workflow.Jobs, "publish", "Download release publication inputs")
+	if downloadStep.With["name"] != "release-publication-inputs" || downloadStep.With["path"] != "publication-inputs" {
+		t.Fatalf("fresh release publication download config = %#v", downloadStep.With)
+	}
+	validateStep := workflowStepByName(t, workflow.Jobs, "publish", "Validate release publication inputs")
+	assertWorkflowStepRunContainsAll(t, validateStep, "release publication input validation step", []string{
+		`sha256sum --check --strict SHA256SUMS`,
+		`find dist -maxdepth 1 -type f`,
+		`lopper-vscode-${version}.vsix`,
+		`Expected darwin/amd64 artifact is missing`,
+		`Expected darwin/arm64 artifact is missing`,
+	})
+	assertWorkflowStepEnvMissing(t, validateStep, "GH_TOKEN", "release publication validation must be tokenless")
+
+	marketplaceStep := workflowStepByName(t, workflow.Jobs, "publish", "Publish VS Code extension to Marketplace")
+	if len(marketplaceStep.Env) != 1 || marketplaceStep.Env["VSCE_PAT"] != "${{ secrets.VSCE_PUBLISH }}" {
+		t.Fatalf("Marketplace publication env = %#v", marketplaceStep.Env)
+	}
+	assertWorkflowStepRunContainsAll(t, marketplaceStep, "Marketplace publication step", []string{
+		`if [ -z "${VSCE_PAT:-}" ]; then`,
+		`npx --yes @vscode/vsce@3.9.2 publish --packagePath "$vsix_path"`,
+	})
+}
+
 func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 	t.Parallel()
 
@@ -316,7 +422,11 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 	}
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	step := workflowStepByName(t, workflow.Jobs, "publish", "Update GitHub Action floating tags")
+	job := workflow.Jobs["update-floating-tags"]
+	if !slices.Equal(job.Needs, workflowJobNeeds{"prepare-release", "publish"}) {
+		t.Fatalf("action floating tag job needs = %v", job.Needs)
+	}
+	step := workflowStepByName(t, workflow.Jobs, "update-floating-tags", "Update GitHub Action floating tags")
 	if step.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
 		t.Fatalf("action floating tag step shell = %q", step.Shell)
 	}
@@ -357,7 +467,7 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 		`git_network push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"`,
 	})
 	assertWorkflowStepKeepsGitCredentialsCommandScoped(t, step, "action floating tag step")
-	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, workflow.Jobs["publish"], "publish")
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, job, "update-floating-tags")
 
 	workflowText := readConfig(t, ".github/workflows/release.yml")
 	if !strings.Contains(workflowText, "- GitHub Action: \\`${GITHUB_REPOSITORY}@${tag}\\`") {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -332,6 +332,11 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 
 	assertWorkflowStepRunContainsAll(t, step, "action floating tag step", []string{
 		"git_bin=/usr/bin/git",
+		"env_bin=/usr/bin/env",
+		`git_home="$("${mktemp_bin}" -d)"`,
+		`"${env_bin}" -i`,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=/dev/null",
 		`push_token="${PUSH_TOKEN}"`,
 		"unset PUSH_TOKEN",
 		`auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"`,
@@ -339,6 +344,7 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 		`expected_origin="https://github.com/${GITHUB_REPOSITORY}"`,
 		`origin_fetch_urls="$(git_safe remote get-url --all origin)"`,
 		`origin_push_urls="$(git_safe remote get-url --push --all origin)"`,
+		`if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then`,
 		"GIT_CONFIG_KEY_1=credential.helper",
 		"GIT_CONFIG_VALUE_1=",
 		"GIT_CONFIG_KEY_4=http.https://github.com/.extraheader",
@@ -609,6 +615,11 @@ func TestReleaseWorkflowStampsFeatureHistoryBeforeInjectingPushToken(t *testing.
 	}
 	assertWorkflowStepRunContainsAll(t, pushStep, "push stamped history step", []string{
 		"git_bin=/usr/bin/git",
+		"env_bin=/usr/bin/env",
+		`git_home="$("${mktemp_bin}" -d)"`,
+		`"${env_bin}" -i`,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=/dev/null",
 		`push_token="${PUSH_TOKEN}"`,
 		"unset PUSH_TOKEN",
 		`auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"`,
@@ -616,6 +627,7 @@ func TestReleaseWorkflowStampsFeatureHistoryBeforeInjectingPushToken(t *testing.
 		`expected_origin="https://github.com/${GITHUB_REPOSITORY}"`,
 		`origin_fetch_urls="$(git_safe remote get-url --all origin)"`,
 		`origin_push_urls="$(git_safe remote get-url --push --all origin)"`,
+		`if [ "${origin_fetch_urls}" != "${expected_origin}" ] || [ "${origin_push_urls}" != "${expected_origin}" ]; then`,
 		"GIT_CONFIG_KEY_1=credential.helper",
 		"GIT_CONFIG_VALUE_1=",
 		"GIT_CONFIG_KEY_4=http.https://github.com/.extraheader",
@@ -1104,13 +1116,16 @@ func assertWorkflowStepKeepsGitCredentialsCommandScoped(t *testing.T, step workf
 	}
 
 	for _, line := range strings.Split(step.Run, "\n") {
-		isGitCommand := strings.Contains(line, `"${git_bin}"`) ||
+		trimmed := strings.TrimSpace(line)
+		isGitCommand := strings.HasPrefix(trimmed, "git ") ||
+			strings.Contains(trimmed, " git ") ||
+			strings.Contains(line, `"${git_bin}"`) ||
 			strings.Contains(line, "git_safe ") ||
 			strings.Contains(line, "git_network ")
 		if isGitCommand && (strings.Contains(line, "PUSH_TOKEN") ||
 			strings.Contains(line, "push_token") ||
 			strings.Contains(line, "auth_header")) {
-			t.Fatalf("%s must not place secret text in git argv: %q", stepLabel, strings.TrimSpace(line))
+			t.Fatalf("%s must not place secret text in git argv: %q", stepLabel, trimmed)
 		}
 	}
 }

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -398,6 +398,26 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	assertReleasePublicationOmitsCheckoutAndCommands(t, publication)
 }
 
+func TestReleaseWorkflowPublicationArtifactNameAvoidsReleaseArtifactWildcard(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	downloadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Download release artifacts")
+	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
+
+	pattern := downloadStep.With["pattern"]
+	artifactName := uploadStep.With["name"]
+	matched, err := filepath.Match(pattern, artifactName)
+	if err != nil {
+		t.Fatalf("release artifact download pattern %q is invalid: %v", pattern, err)
+	}
+	if matched {
+		t.Fatalf("release publication input artifact %q must not match release artifact download pattern %q", artifactName, pattern)
+	}
+}
+
 func TestReleaseWorkflowPreparesIntegrityBoundMarketplaceTooling(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -626,53 +626,34 @@ func TestReleaseWorkflowHomebrewUsesGatedThreeJobGraph(t *testing.T) {
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 	workflowText := readConfig(t, ".github/workflows/release.yml")
 
-	gate := workflow.Jobs["homebrew-tap-token-gate"]
-	if !slices.Equal(gate.Needs, workflowJobNeeds{"prepare-release", "publish", "update-floating-tags"}) {
-		t.Fatalf("tap token gate needs = %v", gate.Needs)
-	}
-	if gate.If != "${{ needs.prepare-release.outputs.release_created == 'true' }}" {
-		t.Fatalf("tap token gate if = %q", gate.If)
-	}
-	if gate.Permissions == nil || len(gate.Permissions) != 0 {
-		t.Fatalf("tap token gate permissions = %#v, want explicit empty permissions", gate.Permissions)
-	}
-	if gate.Outputs["configured"] != "${{ steps.gate.outputs.configured }}" {
-		t.Fatalf("tap token gate configured output = %q", gate.Outputs["configured"])
-	}
+	gate := workflowJobByName(t, workflow.Jobs, "homebrew-tap-token-gate")
+	assertWorkflowJobNeeds(t, gate, "tap token gate", workflowJobNeeds{"prepare-release", "publish", "update-floating-tags"})
+	assertWorkflowJobHasExplicitEmptyPermissions(t, gate, "tap token gate")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "tap token gate if", got: gate.If, want: "${{ needs.prepare-release.outputs.release_created == 'true' }}"},
+		{label: "tap token gate configured output", got: gate.Outputs["configured"], want: "${{ steps.gate.outputs.configured }}"},
+	})
 	gateStep := workflowStepByName(t, workflow.Jobs, "homebrew-tap-token-gate", "Detect tap token")
-	if gateStep.ID != "gate" {
-		t.Fatalf("tap token gate step id = %q", gateStep.ID)
-	}
-	if gateStep.Env["HOMEBREW_TAP_TOKEN"] != "${{ secrets.HOMEBREW_TAP_TOKEN }}" {
-		t.Fatalf("tap token gate secret = %q", gateStep.Env["HOMEBREW_TAP_TOKEN"])
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "tap token gate step id", got: gateStep.ID, want: "gate"},
+		{label: "tap token gate secret", got: gateStep.Env["HOMEBREW_TAP_TOKEN"], want: "${{ secrets.HOMEBREW_TAP_TOKEN }}"},
+	})
 	assertWorkflowStepRunContainsAll(t, gateStep, "tap token gate step", []string{
 		`if [ -n "${HOMEBREW_TAP_TOKEN:-}" ]; then`,
 		`echo "configured=true" >> "$GITHUB_OUTPUT"`,
 		`echo "configured=false" >> "$GITHUB_OUTPUT"`,
 	})
 
-	validation := workflow.Jobs["validate-homebrew-tap"]
-	if !slices.Equal(validation.Needs, workflowJobNeeds{"prepare-release", "publish", "homebrew-tap-token-gate"}) {
-		t.Fatalf("tap validation needs = %v", validation.Needs)
-	}
-	if validation.If != "${{ needs.prepare-release.outputs.release_created == 'true' && needs.homebrew-tap-token-gate.outputs.configured == 'true' }}" {
-		t.Fatalf("tap validation if = %q", validation.If)
-	}
-	if len(validation.Permissions) != 1 || validation.Permissions["contents"] != "read" {
-		t.Fatalf("tap validation permissions = %#v", validation.Permissions)
-	}
-
-	publication := workflow.Jobs["update-homebrew-tap"]
-	if !slices.Equal(publication.Needs, workflowJobNeeds{"prepare-release", "publish", "validate-homebrew-tap"}) {
-		t.Fatalf("tap publication needs = %v", publication.Needs)
-	}
-	if publication.If != "${{ needs.prepare-release.outputs.release_created == 'true' }}" {
-		t.Fatalf("tap publication if = %q", publication.If)
-	}
-	if len(publication.Permissions) != 1 || publication.Permissions["contents"] != "read" {
-		t.Fatalf("tap publication permissions = %#v", publication.Permissions)
-	}
+	validation := workflowJobByName(t, workflow.Jobs, "validate-homebrew-tap")
+	assertWorkflowJobNeeds(t, validation, "tap validation", workflowJobNeeds{"prepare-release", "publish", "homebrew-tap-token-gate"})
+	assertWorkflowJobPermissions(t, validation, "tap validation", map[string]string{"contents": "read"})
+	publication := workflowJobByName(t, workflow.Jobs, "update-homebrew-tap")
+	assertWorkflowJobNeeds(t, publication, "tap publication", workflowJobNeeds{"prepare-release", "publish", "validate-homebrew-tap"})
+	assertWorkflowJobPermissions(t, publication, "tap publication", map[string]string{"contents": "read"})
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "tap validation if", got: validation.If, want: "${{ needs.prepare-release.outputs.release_created == 'true' && needs.homebrew-tap-token-gate.outputs.configured == 'true' }}"},
+		{label: "tap publication if", got: publication.If, want: "${{ needs.prepare-release.outputs.release_created == 'true' }}"},
+	})
 	if count := strings.Count(workflowText, "${{ secrets.HOMEBREW_TAP_TOKEN }}"); count != 2 {
 		t.Fatalf("release workflow tap secret references = %d, want gate and publication only", count)
 	}
@@ -829,31 +810,26 @@ func TestReleaseWorkflowTransportsFeatureHistoryPatchAcrossJobs(t *testing.T) {
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	preparation, ok := workflow.Jobs["prepare-feature-release-history"]
-	if !ok {
-		t.Fatal("release workflow must prepare feature history changes in a separate job")
-	}
-	if !slices.Equal(preparation.Needs, workflowJobNeeds{"prepare-release", "publish", "update-floating-tags"}) {
-		t.Fatalf("feature history preparation needs = %v", preparation.Needs)
-	}
-	if len(preparation.Permissions) != 1 || preparation.Permissions["contents"] != "read" {
-		t.Fatalf("feature history preparation permissions = %#v", preparation.Permissions)
-	}
-	if preparation.Outputs["changed"] != "${{ steps.stamp_history.outputs.changed }}" {
-		t.Fatalf("feature history preparation changed output = %q", preparation.Outputs["changed"])
-	}
+	preparation := workflowJobByName(t, workflow.Jobs, "prepare-feature-release-history")
+	assertWorkflowJobNeeds(t, preparation, "feature history preparation", workflowJobNeeds{"prepare-release", "publish", "update-floating-tags"})
+	assertWorkflowJobPermissions(t, preparation, "feature history preparation", map[string]string{"contents": "read"})
+	assertWorkflowStringValues(t, []workflowStringValue{{
+		label: "feature history preparation changed output",
+		got:   preparation.Outputs["changed"],
+		want:  "${{ steps.stamp_history.outputs.changed }}",
+	}})
 	assertWorkflowJobOmitsText(t, preparation, "PUSH_TOKEN", "feature history preparation must not receive a push token")
 	assertWorkflowJobOmitsText(t, preparation, "secrets.", "feature history preparation must not receive secrets")
 	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, preparation, "prepare-feature-release-history")
 
 	trustedCheckout := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Checkout trusted main tooling")
-	if trustedCheckout.With["ref"] != "main" || trustedCheckout.With["path"] != "" {
-		t.Fatalf("trusted tooling checkout config = %#v", trustedCheckout.With)
-	}
 	releaseCheckout := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Checkout validated release data")
-	if releaseCheckout.With["ref"] != "${{ needs.prepare-release.outputs.sha }}" || releaseCheckout.With["path"] != "release-source" {
-		t.Fatalf("validated release data checkout config = %#v", releaseCheckout.With)
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "trusted tooling checkout ref", got: trustedCheckout.With["ref"], want: "main"},
+		{label: "trusted tooling checkout path", got: trustedCheckout.With["path"], want: ""},
+		{label: "validated release data checkout ref", got: releaseCheckout.With["ref"], want: "${{ needs.prepare-release.outputs.sha }}"},
+		{label: "validated release data checkout path", got: releaseCheckout.With["path"], want: "release-source"},
+	})
 
 	validateStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Validate release data against trusted main")
 	assertWorkflowStepRunContainsAll(t, validateStep, "release data validation step", []string{
@@ -862,17 +838,14 @@ func TestReleaseWorkflowTransportsFeatureHistoryPatchAcrossJobs(t *testing.T) {
 		`if ! git merge-base --is-ancestor "${release_commit}" HEAD; then`,
 	})
 	buildStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Build trusted feature flag tool")
-	if buildStep.WorkingDirectory != "" || !strings.Contains(buildStep.Run, `go build -o "${RUNNER_TEMP}/featureflag" ./tools/featureflag`) {
-		t.Fatalf("trusted feature flag build config = %#v", buildStep)
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{{label: "trusted feature flag build working directory", got: buildStep.WorkingDirectory, want: ""}})
+	assertTextContainsAll(t, buildStep.Run, "trusted feature flag build step", []string{`go build -o "${RUNNER_TEMP}/featureflag" ./tools/featureflag`})
 
 	stampStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Stamp first stable release history")
-	if stampStep.ID != "stamp_history" {
-		t.Fatalf("stamp history step id = %q, want stamp_history", stampStep.ID)
-	}
-	if stampStep.WorkingDirectory != "release-source" {
-		t.Fatalf("stamp history working directory = %q, want release-source", stampStep.WorkingDirectory)
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "stamp history step id", got: stampStep.ID, want: "stamp_history"},
+		{label: "stamp history working directory", got: stampStep.WorkingDirectory, want: "release-source"},
+	})
 	assertWorkflowStepEnvMissing(t, stampStep, "PUSH_TOKEN", "stamp history step must not expose PUSH_TOKEN to repository-controlled featureflag tooling")
 	assertWorkflowStepRunContainsAll(t, stampStep, "stamp history step", []string{
 		`"${RUNNER_TEMP}/featureflag" stamp-release --release "${RELEASE_TAG}"`,
@@ -880,19 +853,13 @@ func TestReleaseWorkflowTransportsFeatureHistoryPatchAcrossJobs(t *testing.T) {
 		`echo "changed=false" >> "$GITHUB_OUTPUT"`,
 		`echo "changed=true" >> "$GITHUB_OUTPUT"`,
 	})
-	for _, forbidden := range []string{"git commit", "git push", "PUSH_TOKEN"} {
-		if strings.Contains(stampStep.Run, forbidden) {
-			t.Fatalf("stamp history step must not contain %q", forbidden)
-		}
-	}
+	assertWorkflowStepRunOmitsAll(t, stampStep, "stamp history step", []string{"git commit", "git push", "PUSH_TOKEN"})
 
 	patchStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Validate and stage feature history patch")
-	if patchStep.If != "${{ steps.stamp_history.outputs.changed == 'true' }}" {
-		t.Fatalf("feature history patch step if = %q", patchStep.If)
-	}
-	if patchStep.WorkingDirectory != "release-source" {
-		t.Fatalf("feature history patch working directory = %q, want release-source", patchStep.WorkingDirectory)
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "feature history patch step if", got: patchStep.If, want: "${{ steps.stamp_history.outputs.changed == 'true' }}"},
+		{label: "feature history patch working directory", got: patchStep.WorkingDirectory, want: "release-source"},
+	})
 	assertWorkflowStepRunContainsAll(t, patchStep, "feature history patch step", []string{
 		`mapfile -t changed_files < <(git diff --name-only)`,
 		`if [ "${#changed_files[@]}" -ne 1 ] || [ "${changed_files[0]}" != "internal/featureflags/features.json" ]; then`,
@@ -903,51 +870,30 @@ func TestReleaseWorkflowTransportsFeatureHistoryPatchAcrossJobs(t *testing.T) {
 	assertWorkflowStepEnvMissing(t, patchStep, "PUSH_TOKEN", "feature history patch staging must be tokenless")
 
 	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Upload feature history patch")
-	if uploadStep.If != "${{ steps.stamp_history.outputs.changed == 'true' }}" {
-		t.Fatalf("feature history patch upload if = %q", uploadStep.If)
-	}
-	if uploadStep.With["name"] != "feature-history-patch" || !strings.Contains(uploadStep.With["path"], ".artifacts/feature-history.patch") || !strings.Contains(uploadStep.With["path"], ".artifacts/SHA256SUMS") {
-		t.Fatalf("feature history patch artifact config = %#v", uploadStep.With)
-	}
-	if uploadStep.With["if-no-files-found"] != "error" {
-		t.Fatalf("feature history patch artifact missing-file behavior = %q", uploadStep.With["if-no-files-found"])
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "feature history patch upload if", got: uploadStep.If, want: "${{ steps.stamp_history.outputs.changed == 'true' }}"},
+		{label: "feature history patch artifact name", got: uploadStep.With["name"], want: "feature-history-patch"},
+		{label: "feature history patch artifact missing-file behavior", got: uploadStep.With["if-no-files-found"], want: "error"},
+	})
+	assertTextContainsAll(t, uploadStep.With["path"], "feature history patch artifact path", []string{".artifacts/feature-history.patch", ".artifacts/SHA256SUMS"})
+	assertFeatureHistoryPreparationDoesNotPush(t, preparation)
 
-	for _, step := range preparation.Steps {
-		if strings.Contains(step.Name, "Push") || strings.Contains(step.Run, "git push") {
-			t.Fatalf("feature history preparation must not push from release-source: %q", step.Name)
-		}
-	}
-
-	publication, ok := workflow.Jobs["push-feature-release-history"]
-	if !ok {
-		t.Fatal("release workflow must push feature history from a separate fresh job")
-	}
-	if !slices.Equal(publication.Needs, workflowJobNeeds{"prepare-release", "prepare-feature-release-history"}) {
-		t.Fatalf("feature history publication needs = %v", publication.Needs)
-	}
-	if publication.If != "${{ needs.prepare-release.outputs.release_created == 'true' && needs.prepare-feature-release-history.outputs.changed == 'true' }}" {
-		t.Fatalf("feature history publication if = %q", publication.If)
-	}
-	if len(publication.Permissions) != 1 || publication.Permissions["contents"] != "write" {
-		t.Fatalf("feature history publication permissions = %#v", publication.Permissions)
-	}
-	if len(publication.Env) != 0 {
-		t.Fatalf("feature history publication job env = %#v, want no job-scoped credentials", publication.Env)
-	}
-	for _, step := range publication.Steps {
-		if strings.HasPrefix(step.Uses, "actions/checkout@") {
-			t.Fatalf("feature history publication must use a fresh host-Git clone, found checkout step %q", step.Name)
-		}
-		if step.WorkingDirectory == "release-source" || strings.Contains(step.Run, "release-source") {
-			t.Fatalf("feature history publication must not reuse release-source: %q", step.Name)
-		}
-	}
+	publication := workflowJobByName(t, workflow.Jobs, "push-feature-release-history")
+	assertWorkflowJobNeeds(t, publication, "feature history publication", workflowJobNeeds{"prepare-release", "prepare-feature-release-history"})
+	assertWorkflowJobPermissions(t, publication, "feature history publication", map[string]string{"contents": "write"})
+	assertWorkflowJobEnvEmpty(t, publication, "feature history publication")
+	assertWorkflowStringValues(t, []workflowStringValue{{
+		label: "feature history publication if",
+		got:   publication.If,
+		want:  "${{ needs.prepare-release.outputs.release_created == 'true' && needs.prepare-feature-release-history.outputs.changed == 'true' }}",
+	}})
+	assertFeatureHistoryPublicationUsesFreshInputs(t, publication)
 
 	downloadStep := workflowStepByName(t, workflow.Jobs, "push-feature-release-history", "Download feature history patch")
-	if downloadStep.With["name"] != "feature-history-patch" || downloadStep.With["path"] != "feature-history-input" {
-		t.Fatalf("feature history patch download config = %#v", downloadStep.With)
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "feature history patch download artifact name", got: downloadStep.With["name"], want: "feature-history-patch"},
+		{label: "feature history patch download artifact path", got: downloadStep.With["path"], want: "feature-history-input"},
+	})
 }
 
 func TestReleaseWorkflowPushesFeatureHistoryFromFreshValidatedCommit(t *testing.T) {
@@ -1498,6 +1444,14 @@ func assertWorkflowJobPermissions(t *testing.T, job workflowJobConfig, jobLabel 
 	}
 }
 
+func assertWorkflowJobHasExplicitEmptyPermissions(t *testing.T, job workflowJobConfig, jobLabel string) {
+	t.Helper()
+
+	if job.Permissions == nil || len(job.Permissions) != 0 {
+		t.Fatalf("%s permissions = %#v, want explicit empty permissions", jobLabel, job.Permissions)
+	}
+}
+
 func assertWorkflowJobEnvEmpty(t *testing.T, job workflowJobConfig, jobLabel string) {
 	t.Helper()
 
@@ -1540,6 +1494,29 @@ func assertReleasePublicationOmitsCheckoutAndCommands(t *testing.T, publication 
 			if strings.Contains(step.Run, repositoryCommand) {
 				t.Fatalf("fresh release publication step %q must not execute repository-controlled command %q", step.Name, repositoryCommand)
 			}
+		}
+	}
+}
+
+func assertFeatureHistoryPreparationDoesNotPush(t *testing.T, preparation workflowJobConfig) {
+	t.Helper()
+
+	for _, step := range preparation.Steps {
+		if strings.Contains(step.Name, "Push") || strings.Contains(step.Run, "git push") {
+			t.Fatalf("feature history preparation must not push from release-source: %q", step.Name)
+		}
+	}
+}
+
+func assertFeatureHistoryPublicationUsesFreshInputs(t *testing.T, publication workflowJobConfig) {
+	t.Helper()
+
+	for _, step := range publication.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") {
+			t.Fatalf("feature history publication must use a fresh host-Git clone, found checkout step %q", step.Name)
+		}
+		if step.WorkingDirectory == "release-source" || strings.Contains(step.Run, "release-source") {
+			t.Fatalf("feature history publication must not reuse release-source: %q", step.Name)
 		}
 	}
 }

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -654,6 +654,24 @@ func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T)
 	}
 }
 
+func TestReleaseWorkflowFailsClosedWhenConfiguredMarketplaceTokenDisappears(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	publishStep := workflowStepByName(t, workflow.Jobs, "publish-marketplace", "Publish VS Code extension to Marketplace")
+	cmd := exec.Command("bash", "-c", publishStep.Run)
+	cmd.Env = append(os.Environ(), "RELEASE_VERSION=1.8.0", "VSCE_PAT=")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("configured Marketplace publication succeeded after its token disappeared: %s", output)
+	}
+	if !strings.Contains(string(output), "::error::VSCE publish token became unavailable after Marketplace publication was enabled.") {
+		t.Fatalf("configured Marketplace missing-token error = %q", output)
+	}
+}
+
 func assertMarketplacePublicationGate(t *testing.T, jobs map[string]workflowJobConfig) {
 	t.Helper()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -38,6 +38,7 @@ type workflowJobConfig struct {
 type workflowStepConfig struct {
 	Name  string            `yaml:"name"`
 	ID    string            `yaml:"id"`
+	If    string            `yaml:"if"`
 	Run   string            `yaml:"run"`
 	Shell string            `yaml:"shell"`
 	Env   map[string]string `yaml:"env"`
@@ -219,8 +220,8 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 		`^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$`,
 		`major_tag="v${BASH_REMATCH[1]}"`,
 		`minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"`,
-		`git tag --force "${major_tag}" "${RELEASE_SHA}"`,
 		`push_url="https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"`,
+		`git tag --force "${major_tag}" "${RELEASE_SHA}"`,
 		`git tag --force "${minor_tag}" "${RELEASE_SHA}"`,
 		`git push --force "${push_url}" "refs/tags/${major_tag}" "refs/tags/${minor_tag}"`,
 	} {
@@ -228,17 +229,16 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 			t.Fatalf("action floating tag step must contain %q", want)
 		}
 	}
-
 	if strings.Contains(step.Run, "git remote set-url origin") {
 		t.Fatal("action floating tag step must not persist push credentials in .git/config")
 	}
+
 	workflowText := readConfig(t, ".github/workflows/release.yml")
 	if !strings.Contains(workflowText, "- GitHub Action: \\`${GITHUB_REPOSITORY}@${tag}\\`") {
 		t.Fatal("release notes must include the concrete GitHub Action ref")
 	}
 }
 
-func TestRenovateDoesNotAutomergeMajorUpdates(t *testing.T) {
 func TestReleaseWorkflowHomebrewPushUsesEphemeralAuthenticatedRemote(t *testing.T) {
 	t.Parallel()
 
@@ -261,6 +261,73 @@ func TestReleaseWorkflowHomebrewPushUsesEphemeralAuthenticatedRemote(t *testing.
 	if strings.Contains(step.Run, "git remote set-url origin") {
 		t.Fatal("homebrew push step must not persist tap credentials in .git/config")
 	}
+}
+
+func TestReleaseWorkflowStampsFeatureHistoryBeforeInjectingPushToken(t *testing.T) {
+	t.Parallel()
+
+	var workflow struct {
+		Jobs map[string]workflowJobConfig `yaml:"jobs"`
+	}
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	stampStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Stamp first stable release history")
+	if stampStep.ID != "stamp_history" {
+		t.Fatalf("stamp history step id = %q, want stamp_history", stampStep.ID)
+	}
+	if _, ok := stampStep.Env["PUSH_TOKEN"]; ok {
+		t.Fatal("stamp history step must not expose PUSH_TOKEN to repository-controlled featureflag tooling")
+	}
+	for _, want := range []string{
+		`go run ./tools/featureflag stamp-release --release "${RELEASE_TAG}"`,
+		`go run ./tools/featureflag validate`,
+		`echo "changed=true" >> "$GITHUB_OUTPUT"`,
+	} {
+		if !strings.Contains(stampStep.Run, want) {
+			t.Fatalf("stamp history step must contain %q", want)
+		}
+	}
+	if strings.Contains(stampStep.Run, "git push") {
+		t.Fatal("stamp history step must not push while running repository-controlled tools")
+	}
+
+	commitStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Commit stamped feature release history")
+	if commitStep.If != "${{ steps.stamp_history.outputs.changed == 'true' }}" {
+		t.Fatalf("commit stamped history step if = %q", commitStep.If)
+	}
+	if commitStep.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" {
+		t.Fatalf("commit stamped history step RELEASE_TAG env = %q", commitStep.Env["RELEASE_TAG"])
+	}
+	if !strings.Contains(commitStep.Run, `git commit -m "chore(flags): stamp ${RELEASE_TAG} feature release history"`) {
+		t.Fatal("commit stamped history step must create the release history commit without a push token")
+	}
+	if _, ok := commitStep.Env["PUSH_TOKEN"]; ok {
+		t.Fatal("commit stamped history step must not expose PUSH_TOKEN")
+	}
+
+	pushStep := workflowStepByName(t, workflow.Jobs, "stamp-feature-release-history", "Push stamped feature release history")
+	if pushStep.If != "${{ steps.stamp_history.outputs.changed == 'true' }}" {
+		t.Fatalf("push stamped history step if = %q", pushStep.If)
+	}
+	if pushStep.Env["PUSH_TOKEN"] != "${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}" {
+		t.Fatalf("push stamped history step PUSH_TOKEN env = %q", pushStep.Env["PUSH_TOKEN"])
+	}
+	for _, want := range []string{
+		`push_url="https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"`,
+		`git fetch origin main:refs/remotes/origin/main`,
+		`git rebase origin/main`,
+		`git push "${push_url}" HEAD:main`,
+	} {
+		if !strings.Contains(pushStep.Run, want) {
+			t.Fatalf("push stamped history step must contain %q", want)
+		}
+	}
+	if strings.Contains(pushStep.Run, "git remote set-url origin") {
+		t.Fatal("push stamped history step must not persist push credentials in .git/config")
+	}
+}
+
+func TestRenovateDoesNotAutomergeMajorUpdates(t *testing.T) {
 	t.Parallel()
 
 	var config struct {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -1412,13 +1412,15 @@ func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
 		}
 
 		publishManifest := workflowJobByName(t, workflow.Jobs, "publish-ghcr-manifest")
-		assertWorkflowJobNeeds(t, publishManifest, "publish-ghcr-manifest", workflowJobNeeds{"publish-ghcr-images"})
+		assertWorkflowJobNeeds(t, publishManifest, "publish-ghcr-manifest", workflowJobNeeds{"publish-ghcr-images", "prepare-ghcr-manifest"})
 		assertWorkflowJobPermissions(t, publishManifest, "publish-ghcr-manifest", map[string]string{"packages": "write"})
 		assertFreshGHCRPublisher(t, publishManifest, "Log in to GHCR")
 		manifestValidation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Validate manifest publication payload")
 		assertWorkflowStepRunContainsAll(t, manifestValidation, "manifest validation", []string{
 			`expected_source_sha="${EXPECTED_SOURCE_SHA}"`,
 			`expected_image_name="ghcr.io/${owner}/lopper"`,
+			`find -P "${payload_root}" ! -type d ! -type f`,
+			`directory_count`,
 			`artifact payload exceeds`,
 			`unexpected image reference`,
 		})

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -607,17 +607,21 @@ func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T)
 		t.Fatalf("Marketplace credentialed step index = %d, want final step", publishIndex)
 	}
 	marketplaceStep := marketplace.Steps[publishIndex]
-	if len(marketplaceStep.Env) != 1 || marketplaceStep.Env["VSCE_PAT"] != "${{ secrets.VSCE_PUBLISH }}" {
-		t.Fatalf("Marketplace publication env = %#v", marketplaceStep.Env)
-	}
+	assertWorkflowStepEnv(t, marketplaceStep, "Marketplace publication", map[string]string{
+		"RELEASE_VERSION": "${{ needs.prepare-release.outputs.version }}",
+		"VSCE_PAT":        "${{ secrets.VSCE_PUBLISH }}",
+	})
 	if marketplaceStep.Uses != "" {
 		t.Fatalf("Marketplace publication must invoke the prepared toolchain directly, found action %q", marketplaceStep.Uses)
 	}
 	assertWorkflowStepRunContainsAll(t, marketplaceStep, "Marketplace publication step", []string{
 		`if [ -z "${VSCE_PAT:-}" ]; then`,
 		`vsce_bin="${RUNNER_TEMP}/vsce-toolchain/node_modules/.bin/vsce"`,
-		`vsix_path="${GITHUB_WORKSPACE}/publication-inputs/dist/lopper-vscode-${{ needs.prepare-release.outputs.version }}.vsix"`,
+		`vsix_path="${GITHUB_WORKSPACE}/publication-inputs/dist/lopper-vscode-${RELEASE_VERSION}.vsix"`,
 		`"${vsce_bin}" publish --packagePath "${vsix_path}"`,
+	})
+	assertWorkflowStepRunOmitsAll(t, marketplaceStep, "Marketplace publication", []string{
+		"${{ needs.prepare-release.outputs.version }}",
 	})
 	assertWorkflowStepRunOmitsAllFold(t, marketplaceStep, "Marketplace publication", []string{
 		"npx ", "npm ", "find ", "test -x", "sha256sum ", "tar ", "python", "node ",

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -369,6 +369,9 @@ func TestReleaseWorkflowPreparesIntegrityBoundMarketplaceTooling(t *testing.T) {
 	assertWorkflowJobNeeds(t, preparation, "Marketplace tooling preparation", workflowJobNeeds{"prepare-release"})
 	assertWorkflowJobPermissions(t, preparation, "Marketplace tooling preparation", map[string]string{"contents": "read"})
 	assertWorkflowJobEnvEmpty(t, preparation, "Marketplace tooling preparation")
+	if len(preparation.Outputs) != 1 || preparation.Outputs["configured"] != "${{ steps.gate.outputs.configured }}" {
+		t.Fatalf("Marketplace tooling preparation outputs = %#v, want only the token configuration boolean", preparation.Outputs)
+	}
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{
 			label: "Marketplace tooling preparation if",
@@ -377,7 +380,7 @@ func TestReleaseWorkflowPreparesIntegrityBoundMarketplaceTooling(t *testing.T) {
 		},
 	})
 	assertWorkflowJobOmitsText(t, preparation, "VSCE_PAT", "Marketplace tooling preparation must not receive VSCE_PAT")
-	assertWorkflowJobOmitsText(t, preparation, "secrets.", "Marketplace tooling preparation must not receive secrets")
+	assertMarketplacePreparationGate(t, preparation)
 	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, preparation, "prepare-marketplace-toolchain")
 
 	checkoutStep := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Checkout trusted main Marketplace manifests")
@@ -432,6 +435,54 @@ func TestReleaseWorkflowPreparesIntegrityBoundMarketplaceTooling(t *testing.T) {
 	})
 }
 
+func assertMarketplacePreparationGate(t *testing.T, preparation workflowJobConfig) {
+	t.Helper()
+
+	if len(preparation.Steps) == 0 || preparation.Steps[0].Name != "Detect Marketplace token" {
+		t.Fatal("Marketplace token detection must be the first fresh-runner step")
+	}
+	gate := preparation.Steps[0]
+	if gate.ID != "gate" {
+		t.Fatalf("Marketplace token detector id = %q, want gate", gate.ID)
+	}
+	if len(gate.Env) != 2 || gate.Env["VSCE_PUBLISH"] != "${{ secrets.VSCE_PUBLISH }}" || gate.Env["PATH"] != "/usr/bin:/bin" {
+		t.Fatalf("Marketplace token detector env = %#v, want only the scoped token and trusted PATH", gate.Env)
+	}
+	wantShell := "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"
+	if gate.Shell != wantShell {
+		t.Fatalf("Marketplace token detector shell = %q, want sanitized shell", gate.Shell)
+	}
+	assertWorkflowStepRunContainsAll(t, gate, "Marketplace token detector", []string{
+		`if [ -n "${VSCE_PUBLISH:-}" ]; then`,
+		`/usr/bin/printf '%s\n' 'configured=true' >> "$GITHUB_OUTPUT"`,
+		`/usr/bin/printf '%s\n' 'configured=false' >> "$GITHUB_OUTPUT"`,
+	})
+	if strings.Count(gate.Run, `>> "$GITHUB_OUTPUT"`) != 2 {
+		t.Fatal("Marketplace token detector must write only configured=true|false to GITHUB_OUTPUT")
+	}
+
+	skip := workflowStepByName(t, map[string]workflowJobConfig{"prepare-marketplace-toolchain": preparation}, "prepare-marketplace-toolchain", "Skip Marketplace toolchain prep when token is missing")
+	if skip.If != "${{ steps.gate.outputs.configured != 'true' }}" || !strings.Contains(skip.Run, "VSCE publish token not configured; skipping Marketplace toolchain preparation.") {
+		t.Fatal("Marketplace tooling preparation must preserve an explicit no-token skip message")
+	}
+	assertWorkflowStepOrder(t, preparation, "Detect Marketplace token", "Skip Marketplace toolchain prep when token is missing", "Checkout trusted main Marketplace manifests")
+
+	configuredCondition := "${{ steps.gate.outputs.configured == 'true' }}"
+	for _, stepName := range []string{
+		"Checkout trusted main Marketplace manifests",
+		"Setup Node for Marketplace tooling",
+		"Validate Marketplace tooling lockfile",
+		"Prepare integrity-bound Marketplace toolchain",
+		"Archive Marketplace toolchain",
+		"Upload Marketplace toolchain",
+	} {
+		step := workflowStepByName(t, map[string]workflowJobConfig{"prepare-marketplace-toolchain": preparation}, "prepare-marketplace-toolchain", stepName)
+		if step.If != configuredCondition {
+			t.Fatalf("Marketplace preparation step %q condition = %q, want %q", stepName, step.If, configuredCondition)
+		}
+	}
+}
+
 func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T) {
 	t.Parallel()
 
@@ -449,6 +500,8 @@ func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T)
 		},
 	})
 	assertWorkflowEnvKeyOnlyOnStep(t, workflow.Jobs, "VSCE_PAT", "publish-marketplace", "Publish VS Code extension to Marketplace")
+	assertMarketplacePublicationGate(t, workflow.Jobs)
+	assertMarketplaceSecretBoundary(t, workflow.Jobs)
 	assertWorkflowJobOmitsCheckout(t, marketplace, "Marketplace publication")
 	assertWorkflowJobStepRunsOmitAllFold(t, marketplace, "Marketplace publication", []string{"npm ", "npx ", "git ", "go run ./", "make ", "scripts/", "./extensions/"})
 
@@ -518,9 +571,102 @@ func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T)
 	})
 
 	workflowText := readConfig(t, ".github/workflows/release.yml")
-	if count := strings.Count(workflowText, "${{ secrets.VSCE_PUBLISH }}"); count != 1 {
-		t.Fatalf("Marketplace secret references = %d, want final publish step only", count)
+	if count := strings.Count(workflowText, "${{ secrets.VSCE_PUBLISH }}"); count != 2 {
+		t.Fatalf("Marketplace secret references = %d, want isolated detection and final publication only", count)
 	}
+}
+
+func assertMarketplacePublicationGate(t *testing.T, jobs map[string]workflowJobConfig) {
+	t.Helper()
+
+	marketplace := workflowJobByName(t, jobs, "publish-marketplace")
+	assertWorkflowJobEnvEmpty(t, marketplace, "Marketplace publication")
+	skip := workflowStepByName(t, jobs, "publish-marketplace", "Skip Marketplace publish when token is missing")
+	if skip.If != "${{ needs.prepare-marketplace-toolchain.outputs.configured != 'true' }}" || !strings.Contains(skip.Run, "VSCE publish token not configured; skipping Marketplace publish.") {
+		t.Fatal("Marketplace publication must preserve an explicit no-token skip message")
+	}
+	assertWorkflowStepOrder(t, marketplace, "Skip Marketplace publish when token is missing", "Setup Node for Marketplace tooling")
+
+	configuredCondition := "${{ needs.prepare-marketplace-toolchain.outputs.configured == 'true' }}"
+	for _, stepName := range []string{
+		"Setup Node for Marketplace tooling",
+		"Download release publication inputs",
+		"Download Marketplace toolchain",
+		"Validate Marketplace publication inputs",
+		"Publish VS Code extension to Marketplace",
+	} {
+		step := workflowStepByName(t, jobs, "publish-marketplace", stepName)
+		if step.If != configuredCondition {
+			t.Fatalf("Marketplace publication step %q condition = %q, want %q", stepName, step.If, configuredCondition)
+		}
+	}
+}
+
+func assertMarketplaceSecretBoundary(t *testing.T, jobs map[string]workflowJobConfig) {
+	t.Helper()
+
+	credentialedSteps := 0
+	for jobName, job := range jobs {
+		credentialedSteps += marketplaceTokenBindingsInJob(t, jobName, job)
+	}
+	if credentialedSteps != 2 {
+		t.Fatalf("Marketplace token-bearing steps = %d, want isolated detection and final publication only", credentialedSteps)
+	}
+}
+
+func marketplaceTokenBindingsInJob(t *testing.T, jobName string, job workflowJobConfig) int {
+	t.Helper()
+
+	const secretReference = "secrets.VSCE_PUBLISH"
+	if strings.Contains(job.If, secretReference) {
+		t.Fatalf("Marketplace token must not reach job %q through its condition", jobName)
+	}
+	for key, value := range job.Env {
+		if strings.Contains(value, secretReference) {
+			t.Fatalf("Marketplace token must not reach job %q through env.%s", jobName, key)
+		}
+	}
+	for key, value := range job.Outputs {
+		if strings.Contains(value, secretReference) {
+			t.Fatalf("Marketplace token must not reach job %q through outputs.%s", jobName, key)
+		}
+	}
+
+	credentialedSteps := 0
+	for _, step := range job.Steps {
+		credentialedSteps += marketplaceTokenBindingsInStep(t, jobName, step)
+	}
+	return credentialedSteps
+}
+
+func marketplaceTokenBindingsInStep(t *testing.T, jobName string, step workflowStepConfig) int {
+	t.Helper()
+
+	const secretReference = "secrets.VSCE_PUBLISH"
+	for _, value := range []string{step.If, step.Run, step.Shell, step.Uses, step.WorkingDirectory} {
+		if strings.Contains(value, secretReference) {
+			t.Fatalf("Marketplace token reaches unexpected %s step %q", jobName, step.Name)
+		}
+	}
+	for key, value := range step.With {
+		if strings.Contains(value, secretReference) {
+			t.Fatalf("Marketplace token reaches unexpected %s step %q with.%s", jobName, step.Name, key)
+		}
+	}
+
+	credentialedSteps := 0
+	for key, value := range step.Env {
+		if !strings.Contains(value, secretReference) {
+			continue
+		}
+		credentialedSteps++
+		detectorBinding := jobName == "prepare-marketplace-toolchain" && step.Name == "Detect Marketplace token" && key == "VSCE_PUBLISH" && value == "${{ secrets.VSCE_PUBLISH }}"
+		publishBinding := jobName == "publish-marketplace" && step.Name == "Publish VS Code extension to Marketplace" && key == "VSCE_PAT" && value == "${{ secrets.VSCE_PUBLISH }}"
+		if !detectorBinding && !publishBinding {
+			t.Fatalf("Marketplace token reaches unexpected %s step %q env.%s", jobName, step.Name, key)
+		}
+	}
+	return credentialedSteps
 }
 
 func TestReleaseWorkflowPublishesMarketplaceAfterGitHubReleaseBoundary(t *testing.T) {
@@ -2060,6 +2206,28 @@ func assertTextAppearsBefore(t *testing.T, text string, earlier string, later st
 	laterIndex := strings.Index(text, later)
 	if earlierIndex < 0 || laterIndex < 0 || earlierIndex >= laterIndex {
 		t.Fatal(message)
+	}
+}
+
+func assertWorkflowStepOrder(t *testing.T, job workflowJobConfig, stepNames ...string) {
+	t.Helper()
+
+	previousIndex := -1
+	for _, stepName := range stepNames {
+		stepIndex := -1
+		for index, step := range job.Steps {
+			if step.Name == stepName {
+				stepIndex = index
+				break
+			}
+		}
+		if stepIndex < 0 {
+			t.Fatalf("workflow job must define step %q", stepName)
+		}
+		if stepIndex <= previousIndex {
+			t.Fatalf("workflow step %q is out of order", stepName)
+		}
+		previousIndex = stepIndex
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -1278,12 +1278,12 @@ func TestReleaseOrchestrationImageTagStepsUseSanitizer(t *testing.T) {
 		suffix   string
 	}{
 		{
-			jobName:  "publish-ghcr-amd64",
+			jobName:  "prepare-ghcr-amd64",
 			stepName: "Compute amd64 image tags",
 			suffix:   "-amd64",
 		},
 		{
-			jobName:  "publish-ghcr-arm64",
+			jobName:  "prepare-ghcr-arm64",
 			stepName: "Compute arm64 image tags",
 			suffix:   "-arm64",
 		},
@@ -1299,8 +1299,205 @@ func TestReleaseOrchestrationImageTagStepsUseSanitizer(t *testing.T) {
 		})
 	}
 
-	manifestStep := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Publish multi-arch manifests")
+	manifestStep := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Compute manifest image tags")
 	assertManifestImageTagStep(t, manifestStep)
+}
+
+func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
+
+	architectures := []struct {
+		name     string
+		platform string
+	}{
+		{name: "amd64", platform: "linux/amd64"},
+		{name: "arm64", platform: "linux/arm64"},
+	}
+	for _, architecture := range architectures {
+		architecture := architecture
+		t.Run(architecture.name, func(t *testing.T) {
+			t.Parallel()
+
+			prepareJobName := "prepare-ghcr-" + architecture.name
+			prepare := workflowJobByName(t, workflow.Jobs, prepareJobName)
+			assertWorkflowJobPermissions(t, prepare, prepareJobName, map[string]string{"contents": "read"})
+			assertGHCRJobDoesNotReference(t, prepare, "secrets.GITHUB_TOKEN", prepareJobName)
+			checkout := workflowStepByName(t, workflow.Jobs, prepareJobName, "Checkout")
+			if checkout.With["persist-credentials"] != "false" {
+				t.Fatalf("%s checkout persist-credentials = %q, want false", prepareJobName, checkout.With["persist-credentials"])
+			}
+
+			build := workflowStepByName(t, workflow.Jobs, prepareJobName, "Build "+architecture.name+" OCI publication payload")
+			assertWorkflowStringValues(t, []workflowStringValue{
+				{label: prepareJobName + " registry push", got: build.With["push"], want: "false"},
+				{label: prepareJobName + " platform", got: build.With["platforms"], want: architecture.platform},
+			})
+			for _, want := range []string{"type=oci", "tar=false", "${{ runner.temp }}/ghcr-" + architecture.name + "-publication/layout"} {
+				if !strings.Contains(build.With["outputs"], want) {
+					t.Fatalf("%s OCI output = %q, want %q", prepareJobName, build.With["outputs"], want)
+				}
+			}
+			workflowStepByName(t, workflow.Jobs, prepareJobName, "Prepare "+architecture.name+" publication metadata")
+			upload := workflowStepByName(t, workflow.Jobs, prepareJobName, "Upload "+architecture.name+" OCI publication payload")
+			assertWorkflowStringValues(t, []workflowStringValue{
+				{label: prepareJobName + " artifact name", got: upload.With["name"], want: "ghcr-" + architecture.name + "-publication-payload"},
+				{label: prepareJobName + " artifact path", got: upload.With["path"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-publication"},
+			})
+
+			publishJobName := "publish-ghcr-" + architecture.name
+			publish := workflowJobByName(t, workflow.Jobs, publishJobName)
+			assertWorkflowJobNeeds(t, publish, publishJobName, workflowJobNeeds{prepareJobName})
+			assertWorkflowJobPermissions(t, publish, publishJobName, map[string]string{"packages": "write"})
+			assertFreshGHCRPublisher(t, publish, "Log in to GHCR")
+
+			download := workflowStepByName(t, workflow.Jobs, publishJobName, "Download "+architecture.name+" OCI publication payload")
+			assertWorkflowStringValues(t, []workflowStringValue{
+				{label: publishJobName + " artifact name", got: download.With["name"], want: "ghcr-" + architecture.name + "-publication-payload"},
+				{label: publishJobName + " artifact path", got: download.With["path"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-publication"},
+			})
+			validation := workflowStepByName(t, workflow.Jobs, publishJobName, "Validate "+architecture.name+" OCI publication payload")
+			assertWorkflowStepRunContainsAll(t, validation, publishJobName+" validation", []string{
+				`expected_source_sha="${EXPECTED_SOURCE_SHA}"`,
+				`expected_image_name="ghcr.io/${owner}/lopper"`,
+				`find -P "${payload_root}" -type l`,
+				`sha256sum`,
+				`org.opencontainers.image.revision`,
+				`OnBuild`,
+				`artifact payload exceeds`,
+				`unexpected image reference`,
+			})
+			workflowStepByName(t, workflow.Jobs, publishJobName, "Prepare trusted image promotion Dockerfile")
+			publishImage := workflowStepByName(t, workflow.Jobs, publishJobName, "Publish "+architecture.name+" release image")
+			assertWorkflowStringValues(t, []workflowStringValue{
+				{label: publishJobName + " trusted context", got: publishImage.With["context"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-promotion"},
+				{label: publishJobName + " trusted Dockerfile", got: publishImage.With["file"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-promotion/Dockerfile"},
+				{label: publishJobName + " validated tags", got: publishImage.With["tags"], want: "${{ steps.validate.outputs.tags }}"},
+				{label: publishJobName + " push", got: publishImage.With["push"], want: "true"},
+				{label: publishJobName + " provenance", got: publishImage.With["provenance"], want: "false"},
+				{label: publishJobName + " SBOM", got: publishImage.With["sbom"], want: "true"},
+			})
+			wantBuildContext := "prepared=oci-layout://${{ runner.temp }}/ghcr-" + architecture.name + "-publication/layout@${{ steps.validate.outputs.digest }}"
+			if !strings.Contains(publishImage.With["build-contexts"], wantBuildContext) {
+				t.Fatalf("%s build contexts = %q, want validated OCI digest", publishJobName, publishImage.With["build-contexts"])
+			}
+		})
+	}
+
+	prepareManifest := workflowJobByName(t, workflow.Jobs, "prepare-ghcr-manifest")
+	assertWorkflowJobPermissions(t, prepareManifest, "prepare-ghcr-manifest", map[string]string{"contents": "read"})
+	assertGHCRJobDoesNotReference(t, prepareManifest, "secrets.GITHUB_TOKEN", "prepare-ghcr-manifest")
+	manifestCheckout := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Checkout")
+	if manifestCheckout.With["persist-credentials"] != "false" {
+		t.Fatalf("prepare-ghcr-manifest checkout persist-credentials = %q, want false", manifestCheckout.With["persist-credentials"])
+	}
+	manifestUpload := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Upload manifest publication payload")
+	if manifestUpload.With["name"] != "ghcr-manifest-publication-payload" {
+		t.Fatalf("manifest artifact name = %q", manifestUpload.With["name"])
+	}
+
+	publishManifest := workflowJobByName(t, workflow.Jobs, "publish-ghcr-manifest")
+	assertWorkflowJobNeeds(t, publishManifest, "publish-ghcr-manifest", workflowJobNeeds{"publish-ghcr-amd64", "publish-ghcr-arm64", "prepare-ghcr-manifest"})
+	assertWorkflowJobPermissions(t, publishManifest, "publish-ghcr-manifest", map[string]string{"packages": "write"})
+	assertFreshGHCRPublisher(t, publishManifest, "Log in to GHCR")
+	manifestValidation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Validate manifest publication payload")
+	assertWorkflowStepRunContainsAll(t, manifestValidation, "manifest validation", []string{
+		`expected_source_sha="${EXPECTED_SOURCE_SHA}"`,
+		`expected_image_name="ghcr.io/${owner}/lopper"`,
+		`artifact payload exceeds`,
+		`unexpected image reference`,
+	})
+	manifestPublish := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Publish multi-arch manifests")
+	if strings.Contains(manifestPublish.Run, "scripts/") {
+		t.Fatal("trusted manifest publisher must not run repository scripts")
+	}
+	assertWorkflowStepRunContainsAll(t, manifestPublish, "trusted manifest publication", []string{
+		`done < "${IMAGE_TAGS_FILE}"`,
+		`docker buildx imagetools create`,
+		`docker buildx imagetools inspect`,
+	})
+}
+
+func assertGHCRJobDoesNotReference(t *testing.T, job workflowJobConfig, needle string, jobLabel string) {
+	t.Helper()
+
+	for key, value := range job.Env {
+		if strings.Contains(key, needle) || strings.Contains(value, needle) {
+			t.Fatalf("%s job env must not reference %q", jobLabel, needle)
+		}
+	}
+	for _, step := range job.Steps {
+		for _, value := range []string{step.Uses, step.Run, step.Shell, step.WorkingDirectory} {
+			if strings.Contains(value, needle) {
+				t.Fatalf("%s step %q must not reference %q", jobLabel, step.Name, needle)
+			}
+		}
+		for key, value := range step.Env {
+			if strings.Contains(key, needle) || strings.Contains(value, needle) {
+				t.Fatalf("%s step %q env must not reference %q", jobLabel, step.Name, needle)
+			}
+		}
+		for key, value := range step.With {
+			if strings.Contains(key, needle) || strings.Contains(value, needle) {
+				t.Fatalf("%s step %q inputs must not reference %q", jobLabel, step.Name, needle)
+			}
+		}
+	}
+}
+
+func assertFreshGHCRPublisher(t *testing.T, job workflowJobConfig, loginStepName string) {
+	t.Helper()
+
+	if len(job.Env) != 0 {
+		t.Fatalf("fresh GHCR publisher job env = %#v, want empty", job.Env)
+	}
+	loginIndex := -1
+	for index, step := range job.Steps {
+		if step.Name == loginStepName {
+			loginIndex = index
+			if step.With["password"] != "${{ secrets.GITHUB_TOKEN }}" {
+				t.Fatalf("%s password = %q, want step-local GITHUB_TOKEN", step.Name, step.With["password"])
+			}
+			continue
+		}
+		if strings.Contains(step.Uses, "actions/checkout@") || strings.HasPrefix(step.Uses, "./") {
+			t.Fatalf("fresh GHCR publisher must not execute repository action %q", step.Uses)
+		}
+		if strings.Contains(step.Run, "scripts/") || strings.Contains(step.Run, "make ") || step.WorkingDirectory != "" {
+			t.Fatalf("fresh GHCR publisher step %q must not execute repository code", step.Name)
+		}
+		if step.With["context"] == "." || strings.HasPrefix(step.With["file"], "./") {
+			t.Fatalf("fresh GHCR publisher step %q must not use repository build context", step.Name)
+		}
+		for _, value := range append([]string{step.Run, step.Shell, step.Uses}, mapValues(step.Env)...) {
+			if strings.Contains(value, "secrets.GITHUB_TOKEN") || strings.Contains(value, "github.token") {
+				t.Fatalf("fresh GHCR publisher step %q must not receive GitHub credentials", step.Name)
+			}
+		}
+		for _, value := range step.With {
+			if strings.Contains(value, "secrets.GITHUB_TOKEN") || strings.Contains(value, "github.token") {
+				t.Fatalf("fresh GHCR publisher step %q must not receive GitHub credentials", step.Name)
+			}
+		}
+	}
+	if loginIndex < 0 {
+		t.Fatalf("fresh GHCR publisher is missing %q", loginStepName)
+	}
+	for _, step := range job.Steps[loginIndex+1:] {
+		if strings.Contains(step.Run, "scripts/") || strings.Contains(step.Run, "./Dockerfile") || strings.Contains(step.Run, "make ") || step.WorkingDirectory != "" || step.With["context"] == "." || strings.HasPrefix(step.With["file"], "./") {
+			t.Fatalf("fresh GHCR publisher step %q executes repository code after login", step.Name)
+		}
+	}
+}
+
+func mapValues(values map[string]string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, value)
+	}
+	return result
 }
 
 func assertArchImageTagStep(t *testing.T, step workflowStepConfig, stepName string, suffix string) {
@@ -1326,22 +1523,11 @@ func assertArchImageTagStep(t *testing.T, step workflowStepConfig, stepName stri
 func assertManifestImageTagStep(t *testing.T, manifestStep workflowStepConfig) {
 	t.Helper()
 
-	sanitizerIndex := strings.Index(manifestStep.Run, "bash scripts/release-image-tags.sh > image-tags.txt")
-	dockerIndex := strings.Index(manifestStep.Run, "docker buildx imagetools create")
-	if sanitizerIndex < 0 {
-		t.Fatal("manifest publish step must sanitize image tags before use")
+	if !strings.Contains(manifestStep.Run, "bash scripts/release-image-tags.sh > image-tags.txt") {
+		t.Fatal("manifest preparation step must sanitize image tags before publication")
 	}
-	if dockerIndex < 0 {
-		t.Fatal("manifest publish step must create Docker manifests")
-	}
-	if sanitizerIndex > dockerIndex {
-		t.Fatal("manifest publish step must validate tags before Docker manifest operations")
-	}
-	if !strings.Contains(manifestStep.Run, "done < image-tags.txt") {
-		t.Fatal("manifest publish step must consume sanitized image tags")
-	}
-	if strings.Contains(manifestStep.Run, "done <<< \"$IMAGE_TAGS\"") {
-		t.Fatal("manifest publish step must not use the stale unsanitized image tag input loop")
+	if strings.Contains(manifestStep.Run, "docker ") {
+		t.Fatal("manifest preparation step must not publish Docker manifests")
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -896,6 +896,71 @@ func TestReleaseWorkflowTransportsFeatureHistoryPatchAcrossJobs(t *testing.T) {
 	})
 }
 
+func TestReleaseWorkflowSkipsPrereleaseFeatureHistoryBeforeStamping(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	stampStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Stamp first stable release history")
+	runnerTemp := t.TempDir()
+	invocationPath := filepath.Join(runnerTemp, "featureflag-invoked")
+	featureFlagStub := "#!/bin/sh\n" +
+		"printf 'featureflag invoked for %s\\n' \"$*\" >&2\n" +
+		"printf '%s\\n' \"$*\" > \"$FEATUREFLAG_INVOCATION\"\n" +
+		"exit 99\n"
+	if err := os.WriteFile(filepath.Join(runnerTemp, "featureflag"), []byte(featureFlagStub), 0o755); err != nil {
+		t.Fatalf("write featureflag stub: %v", err)
+	}
+
+	githubOutput := filepath.Join(runnerTemp, "github-output")
+	cmd := exec.Command("bash", "-c", stampStep.Run)
+	cmd.Dir = t.TempDir()
+	cmd.Env = append(os.Environ(),
+		"FEATUREFLAG_INVOCATION="+invocationPath,
+		"GITHUB_OUTPUT="+githubOutput,
+		"RELEASE_TAG=v1.8.2-rc.1",
+		"RUNNER_TEMP="+runnerTemp,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run prerelease feature history step: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(invocationPath); !os.IsNotExist(err) {
+		t.Fatalf("prerelease feature history invoked featureflag: %v", err)
+	}
+	if !strings.Contains(string(output), "::notice::Skipping feature release history for non-stable semver release v1.8.2-rc.1.") {
+		t.Fatalf("prerelease feature history notice = %q", output)
+	}
+	changedOutput, err := os.ReadFile(githubOutput)
+	if err != nil {
+		t.Fatalf("read prerelease feature history output: %v", err)
+	}
+	if string(changedOutput) != "changed=false\n" {
+		t.Fatalf("prerelease feature history output = %q, want changed=false", changedOutput)
+	}
+
+	const stableSemverGate = `if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]+)[.]([0-9]+)[.]([0-9]+)$ ]]; then`
+	floatingTagStep := workflowStepByName(t, workflow.Jobs, "update-floating-tags", "Prepare GitHub Action floating tags")
+	if !strings.Contains(floatingTagStep.Run, stableSemverGate) {
+		t.Fatal("floating tag preparation must retain the stable semver gate")
+	}
+	gateIndex := strings.Index(stampStep.Run, stableSemverGate)
+	stampIndex := strings.Index(stampStep.Run, `"${RUNNER_TEMP}/featureflag" stamp-release --release "${RELEASE_TAG}"`)
+	if gateIndex < 0 || stampIndex < 0 || gateIndex >= stampIndex {
+		t.Fatal("feature history preparation must apply the floating-tag stable semver gate before stamp-release")
+	}
+
+	patchStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Validate and stage feature history patch")
+	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history", "Upload feature history patch")
+	publication := workflowJobByName(t, workflow.Jobs, "push-feature-release-history")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "feature history patch step prerelease guard", got: patchStep.If, want: "${{ steps.stamp_history.outputs.changed == 'true' }}"},
+		{label: "feature history patch upload prerelease guard", got: uploadStep.If, want: "${{ steps.stamp_history.outputs.changed == 'true' }}"},
+		{label: "feature history push prerelease guard", got: publication.If, want: "${{ needs.prepare-release.outputs.release_created == 'true' && needs.prepare-feature-release-history.outputs.changed == 'true' }}"},
+	})
+}
+
 func TestReleaseWorkflowPushesFeatureHistoryFromFreshValidatedCommit(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -806,7 +806,7 @@ func TestReleaseWorkflowTransportsFeatureHistoryPatchAcrossJobs(t *testing.T) {
 		`mapfile -t changed_files < <(git diff --name-only)`,
 		`if [ "${#changed_files[@]}" -ne 1 ] || [ "${changed_files[0]}" != "internal/featureflags/features.json" ]; then`,
 		`git diff --binary --full-index -- internal/featureflags/features.json > "${patch_file}"`,
-		`git apply --check "${patch_file}"`,
+		`git apply --check --reverse "${patch_file}"`,
 		`sha256sum feature-history.patch > SHA256SUMS`,
 	})
 	assertWorkflowStepEnvMissing(t, patchStep, "PUSH_TOKEN", "feature history patch staging must be tokenless")

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -521,7 +521,7 @@ func TestReleaseWorkflowHomebrewPublicationUsesFreshCredentialScopedClone(t *tes
 	commitIndex := strings.Index(step.Run, `git_safe -C "${tap_repo}" commit`)
 	authIndex := strings.Index(step.Run, `auth_header="$(printf`)
 	fetchIndex := strings.Index(step.Run, `git_network -C "${tap_repo}" fetch`)
-	if commitIndex < 0 || authIndex < 0 || fetchIndex < 0 || !(commitIndex < authIndex && authIndex < fetchIndex) {
+	if commitIndex < 0 || authIndex < 0 || fetchIndex < 0 || commitIndex >= authIndex || authIndex >= fetchIndex {
 		t.Fatal("tap publication must finish regeneration and commit before constructing command-scoped GitHub authentication")
 	}
 	for _, forbidden := range []string{

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -239,6 +239,28 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 }
 
 func TestRenovateDoesNotAutomergeMajorUpdates(t *testing.T) {
+func TestReleaseWorkflowHomebrewPushUsesEphemeralAuthenticatedRemote(t *testing.T) {
+	t.Parallel()
+
+	var workflow struct {
+		Jobs map[string]workflowJobConfig `yaml:"jobs"`
+	}
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	step := workflowStepByName(t, workflow.Jobs, "update-homebrew-tap", "Commit and push formula changes")
+	for _, want := range []string{
+		`push_url="https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ben-ranford/homebrew-tap.git"`,
+		`git fetch origin main:refs/remotes/origin/main`,
+		`git rebase origin/main`,
+		`git push "${push_url}" HEAD:main`,
+	} {
+		if !strings.Contains(step.Run, want) {
+			t.Fatalf("homebrew push step must contain %q", want)
+		}
+	}
+	if strings.Contains(step.Run, "git remote set-url origin") {
+		t.Fatal("homebrew push step must not persist tap credentials in .git/config")
+	}
 	t.Parallel()
 
 	var config struct {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -315,16 +315,9 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	preparation, ok := workflow.Jobs["prepare-release-publication"]
-	if !ok {
-		t.Fatal("release workflow must prepare bounded publication inputs in a separate job")
-	}
-	if !slices.Equal(preparation.Needs, workflowJobNeeds{"prepare-release", "orchestrate-release", "build-vscode-extension", "build-darwin-amd64"}) {
-		t.Fatalf("release publication preparation needs = %v", preparation.Needs)
-	}
-	if len(preparation.Permissions) != 1 || preparation.Permissions["contents"] != "read" {
-		t.Fatalf("release publication preparation permissions = %#v", preparation.Permissions)
-	}
+	preparation := workflowJobByName(t, workflow.Jobs, "prepare-release-publication")
+	assertWorkflowJobNeeds(t, preparation, "release publication preparation", workflowJobNeeds{"prepare-release", "orchestrate-release", "build-vscode-extension", "build-darwin-amd64"})
+	assertWorkflowJobPermissions(t, preparation, "release publication preparation", map[string]string{"contents": "read"})
 	assertWorkflowJobOmitsText(t, preparation, "GH_TOKEN", "release publication preparation must not receive GH_TOKEN")
 	assertWorkflowJobOmitsText(t, preparation, "secrets.", "release publication preparation must not receive secrets")
 	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, preparation, "prepare-release-publication")
@@ -338,59 +331,18 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`sha256sum "${checksum_files[@]}" > SHA256SUMS`,
 	})
 	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
-	if uploadStep.With["name"] != "release-publication-inputs" {
-		t.Fatalf("release publication input artifact name = %q", uploadStep.With["name"])
-	}
-	if uploadStep.With["path"] != "publication-inputs" {
-		t.Fatalf("release publication input artifact path = %q", uploadStep.With["path"])
-	}
-	if uploadStep.With["if-no-files-found"] != "error" {
-		t.Fatalf("release publication input artifact missing-file behavior = %q", uploadStep.With["if-no-files-found"])
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "release publication input artifact name", got: uploadStep.With["name"], want: "release-publication-inputs"},
+		{label: "release publication input artifact path", got: uploadStep.With["path"], want: "publication-inputs"},
+		{label: "release publication input artifact missing-file behavior", got: uploadStep.With["if-no-files-found"], want: "error"},
+	})
 
-	publication, ok := workflow.Jobs["publish"]
-	if !ok {
-		t.Fatal("release workflow must define the fresh publication job")
-	}
-	if !slices.Equal(publication.Needs, workflowJobNeeds{"prepare-release", "prepare-release-publication", "publish-marketplace"}) {
-		t.Fatalf("fresh release publication needs = %v", publication.Needs)
-	}
-	if len(publication.Permissions) != 1 || publication.Permissions["contents"] != "write" {
-		t.Fatalf("fresh release publication permissions = %#v", publication.Permissions)
-	}
-	if len(publication.Env) != 0 {
-		t.Fatalf("fresh release publication job env = %#v, want no job-scoped credentials", publication.Env)
-	}
-
-	apiSteps := map[string]bool{
-		"Update GitHub Release notes":  false,
-		"Upload GitHub Release assets": false,
-		"Publish GitHub Release":       false,
-	}
-	for _, step := range publication.Steps {
-		if strings.HasPrefix(step.Uses, "actions/checkout@") {
-			t.Fatalf("fresh release publication must not checkout repository code: %q", step.Name)
-		}
-		if _, isAPIStep := apiSteps[step.Name]; isAPIStep {
-			apiSteps[step.Name] = true
-			if len(step.Env) != 1 || step.Env["GH_TOKEN"] != "${{ secrets.GITHUB_TOKEN }}" {
-				t.Fatalf("GitHub API step %q env = %#v", step.Name, step.Env)
-			}
-		} else if _, ok := step.Env["GH_TOKEN"]; ok {
-			t.Fatalf("non-API publication step %q must not receive GH_TOKEN", step.Name)
-		}
-
-		for _, repositoryCommand := range []string{"go run ./", "make ", "./extensions/", "scripts/"} {
-			if strings.Contains(step.Run, repositoryCommand) {
-				t.Fatalf("fresh release publication step %q must not execute repository-controlled command %q", step.Name, repositoryCommand)
-			}
-		}
-	}
-	for stepName, found := range apiSteps {
-		if !found {
-			t.Fatalf("fresh release publication must define GitHub API step %q", stepName)
-		}
-	}
+	publication := workflowJobByName(t, workflow.Jobs, "publish")
+	assertWorkflowJobNeeds(t, publication, "fresh release publication", workflowJobNeeds{"prepare-release", "prepare-release-publication", "publish-marketplace"})
+	assertWorkflowJobPermissions(t, publication, "fresh release publication", map[string]string{"contents": "write"})
+	assertWorkflowJobEnvEmpty(t, publication, "fresh release publication")
+	assertReleasePublicationCredentialScope(t, publication)
+	assertReleasePublicationOmitsCheckoutAndCommands(t, publication)
 }
 
 func TestReleaseWorkflowPreparesIntegrityBoundMarketplaceTooling(t *testing.T) {
@@ -579,32 +531,21 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	job := workflow.Jobs["update-floating-tags"]
-	if !slices.Equal(job.Needs, workflowJobNeeds{"prepare-release", "publish"}) {
-		t.Fatalf("action floating tag job needs = %v", job.Needs)
-	}
-	if len(job.Permissions) != 1 || job.Permissions["contents"] != "write" {
-		t.Fatalf("action floating tag job permissions = %#v", job.Permissions)
-	}
-	if len(job.Env) != 0 {
-		t.Fatalf("action floating tag job env = %#v, want no job-scoped credentials", job.Env)
-	}
-	for _, step := range job.Steps {
-		if strings.HasPrefix(step.Uses, "actions/checkout@") {
-			t.Fatalf("action floating tag job must use a fresh host-Git worktree, found checkout step %q", step.Name)
-		}
-	}
+	job := workflowJobByName(t, workflow.Jobs, "update-floating-tags")
+	assertWorkflowJobNeeds(t, job, "action floating tag job", workflowJobNeeds{"prepare-release", "publish"})
+	assertWorkflowJobPermissions(t, job, "action floating tag job", map[string]string{"contents": "write"})
+	assertWorkflowJobEnvEmpty(t, job, "action floating tag job")
+	assertWorkflowJobOmitsCheckout(t, job, "action floating tag job")
 
 	prepareStep := workflowStepByName(t, workflow.Jobs, "update-floating-tags", "Prepare GitHub Action floating tags")
-	if prepareStep.ID != "prepare_tags" {
-		t.Fatalf("action floating tag preparation id = %q", prepareStep.ID)
-	}
-	if prepareStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
-		t.Fatalf("action floating tag preparation shell = %q", prepareStep.Shell)
-	}
-	if len(prepareStep.Env) != 2 || prepareStep.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" || prepareStep.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
-		t.Fatalf("action floating tag preparation env = %#v", prepareStep.Env)
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "action floating tag preparation id", got: prepareStep.ID, want: "prepare_tags"},
+		{label: "action floating tag preparation shell", got: prepareStep.Shell, want: "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"},
+	})
+	assertWorkflowStepEnv(t, prepareStep, "action floating tag preparation", map[string]string{
+		"RELEASE_TAG": "${{ needs.prepare-release.outputs.tag }}",
+		"RELEASE_SHA": "${{ needs.prepare-release.outputs.sha }}",
+	})
 	assertWorkflowStepEnvMissing(t, prepareStep, "PUSH_TOKEN", "action floating tag preparation must be tokenless")
 	assertWorkflowStepRunContainsAll(t, prepareStep, "action floating tag preparation", []string{
 		"git_bin=/usr/bin/git",
@@ -633,22 +574,18 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 		`git_safe -C "${repo_dir}" tag --force "${minor_tag}" "${RELEASE_SHA}"`,
 		`echo "push=true" >> "$GITHUB_OUTPUT"`,
 	})
-	for _, forbidden := range []string{"PUSH_TOKEN", "secrets.", "AUTHORIZATION: basic", "extraheader"} {
-		if strings.Contains(prepareStep.Run, forbidden) {
-			t.Fatalf("action floating tag preparation must not contain %q", forbidden)
-		}
-	}
+	assertWorkflowStepRunOmitsAll(t, prepareStep, "action floating tag preparation", []string{"PUSH_TOKEN", "secrets.", "AUTHORIZATION: basic", "extraheader"})
 
 	pushStep := workflowStepByName(t, workflow.Jobs, "update-floating-tags", "Push GitHub Action floating tags")
-	if pushStep.If != "${{ steps.prepare_tags.outputs.push == 'true' }}" {
-		t.Fatalf("action floating tag push if = %q", pushStep.If)
-	}
-	if pushStep.Shell != prepareStep.Shell {
-		t.Fatalf("action floating tag push shell = %q", pushStep.Shell)
-	}
-	if len(pushStep.Env) != 3 || pushStep.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" || pushStep.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" || pushStep.Env["PUSH_TOKEN"] != "${{ secrets.GITHUB_TOKEN }}" {
-		t.Fatalf("action floating tag push env = %#v", pushStep.Env)
-	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "action floating tag push if", got: pushStep.If, want: "${{ steps.prepare_tags.outputs.push == 'true' }}"},
+		{label: "action floating tag push shell", got: pushStep.Shell, want: prepareStep.Shell},
+	})
+	assertWorkflowStepEnv(t, pushStep, "action floating tag push", map[string]string{
+		"RELEASE_TAG": "${{ needs.prepare-release.outputs.tag }}",
+		"RELEASE_SHA": "${{ needs.prepare-release.outputs.sha }}",
+		"PUSH_TOKEN":  "${{ secrets.GITHUB_TOKEN }}",
+	})
 	assertWorkflowStepRunContainsAll(t, pushStep, "action floating tag push", []string{
 		"git_bin=/usr/bin/git",
 		"env_bin=/usr/bin/env",
@@ -670,11 +607,7 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
 		`git_network -C "${repo_dir}" push --force origin "refs/tags/${major_tag}" "refs/tags/${minor_tag}"`,
 	})
-	validationIndex := strings.Index(pushStep.Run, `if [ "${resolved_sha}" != "${RELEASE_SHA}" ]`)
-	tokenIndex := strings.Index(pushStep.Run, `push_token="${PUSH_TOKEN}"`)
-	if validationIndex < 0 || tokenIndex < 0 || validationIndex >= tokenIndex {
-		t.Fatal("action floating tag push must validate origin, SHA, and tag targets before reading the push token")
-	}
+	assertTextAppearsBefore(t, pushStep.Run, `if [ "${resolved_sha}" != "${RELEASE_SHA}" ]`, `push_token="${PUSH_TOKEN}"`, "action floating tag push must validate origin, SHA, and tag targets before reading the push token")
 	if strings.Count(pushStep.Run, "git_network ") != 1 {
 		t.Fatal("action floating tag authentication must be exposed only to the single network push command")
 	}
@@ -1573,6 +1506,44 @@ func assertWorkflowJobEnvEmpty(t *testing.T, job workflowJobConfig, jobLabel str
 	}
 }
 
+func assertReleasePublicationCredentialScope(t *testing.T, publication workflowJobConfig) {
+	t.Helper()
+
+	apiSteps := map[string]bool{
+		"Update GitHub Release notes":  false,
+		"Upload GitHub Release assets": false,
+		"Publish GitHub Release":       false,
+	}
+	for _, step := range publication.Steps {
+		if _, isAPIStep := apiSteps[step.Name]; isAPIStep {
+			apiSteps[step.Name] = true
+			assertWorkflowStepEnv(t, step, "GitHub API step "+step.Name, map[string]string{"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}"})
+		} else if _, ok := step.Env["GH_TOKEN"]; ok {
+			t.Fatalf("non-API publication step %q must not receive GH_TOKEN", step.Name)
+		}
+	}
+	for stepName, found := range apiSteps {
+		if !found {
+			t.Fatalf("fresh release publication must define GitHub API step %q", stepName)
+		}
+	}
+}
+
+func assertReleasePublicationOmitsCheckoutAndCommands(t *testing.T, publication workflowJobConfig) {
+	t.Helper()
+
+	for _, step := range publication.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") {
+			t.Fatalf("fresh release publication must not checkout repository code: %q", step.Name)
+		}
+		for _, repositoryCommand := range []string{"go run ./", "make ", "./extensions/", "scripts/"} {
+			if strings.Contains(step.Run, repositoryCommand) {
+				t.Fatalf("fresh release publication step %q must not execute repository-controlled command %q", step.Name, repositoryCommand)
+			}
+		}
+	}
+}
+
 func assertWorkflowStepEnv(t *testing.T, step workflowStepConfig, stepLabel string, want map[string]string) {
 	t.Helper()
 
@@ -1610,6 +1581,26 @@ func assertWorkflowStepRunOmitsAllFold(t *testing.T, step workflowStepConfig, st
 		if strings.Contains(strings.ToLower(step.Run), forbidden) {
 			t.Fatalf("%s must not execute %q while credential is in scope", stepLabel, forbidden)
 		}
+	}
+}
+
+func assertWorkflowStepRunOmitsAll(t *testing.T, step workflowStepConfig, stepLabel string, forbiddenValues []string) {
+	t.Helper()
+
+	for _, forbidden := range forbiddenValues {
+		if strings.Contains(step.Run, forbidden) {
+			t.Fatalf("%s must not contain %q", stepLabel, forbidden)
+		}
+	}
+}
+
+func assertTextAppearsBefore(t *testing.T, text string, earlier string, later string, message string) {
+	t.Helper()
+
+	earlierIndex := strings.Index(text, earlier)
+	laterIndex := strings.Index(text, later)
+	if earlierIndex < 0 || laterIndex < 0 || earlierIndex >= laterIndex {
+		t.Fatal(message)
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -1311,10 +1311,7 @@ func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
 
-	architectures := []struct {
-		name     string
-		platform string
-	}{
+	architectures := []ghcrArchitecture{
 		{name: "amd64", platform: "linux/amd64"},
 		{name: "arm64", platform: "linux/arm64"},
 	}
@@ -1322,40 +1319,59 @@ func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
 		architecture := architecture
 		t.Run(architecture.name, func(t *testing.T) {
 			t.Parallel()
-
-			prepareJobName := "prepare-ghcr-" + architecture.name
-			prepare := workflowJobByName(t, workflow.Jobs, prepareJobName)
-			assertWorkflowJobPermissions(t, prepare, prepareJobName, map[string]string{"contents": "read"})
-			assertGHCRJobDoesNotReference(t, prepare, "secrets.GITHUB_TOKEN", prepareJobName)
-			checkout := workflowStepByName(t, workflow.Jobs, prepareJobName, "Checkout")
-			if checkout.With["persist-credentials"] != "false" {
-				t.Fatalf("%s checkout persist-credentials = %q, want false", prepareJobName, checkout.With["persist-credentials"])
-			}
-
-			build := workflowStepByName(t, workflow.Jobs, prepareJobName, "Build "+architecture.name+" OCI publication payload")
-			assertWorkflowStringValues(t, []workflowStringValue{
-				{label: prepareJobName + " registry push", got: build.With["push"], want: "false"},
-				{label: prepareJobName + " deferred provenance", got: build.With["provenance"], want: "false"},
-				{label: prepareJobName + " deferred SBOM", got: build.With["sbom"], want: "false"},
-				{label: prepareJobName + " platform", got: build.With["platforms"], want: architecture.platform},
-			})
-			for _, want := range []string{"type=oci", "tar=false", "${{ runner.temp }}/ghcr-" + architecture.name + "-publication/layout"} {
-				if !strings.Contains(build.With["outputs"], want) {
-					t.Fatalf("%s OCI output = %q, want %q", prepareJobName, build.With["outputs"], want)
-				}
-			}
-			metadata := workflowStepByName(t, workflow.Jobs, prepareJobName, "Prepare "+architecture.name+" publication metadata")
-			assertWorkflowStepRunContainsAll(t, metadata, prepareJobName+" metadata", []string{
-				`find -P . -type f ! -path './SHA256SUMS'`,
-				`> "${payload_root}/SHA256SUMS"`,
-			})
-			upload := workflowStepByName(t, workflow.Jobs, prepareJobName, "Upload "+architecture.name+" OCI publication payload")
-			assertWorkflowStringValues(t, []workflowStringValue{
-				{label: prepareJobName + " artifact name", got: upload.With["name"], want: "ghcr-" + architecture.name + "-publication-payload"},
-				{label: prepareJobName + " artifact path", got: upload.With["path"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-publication"},
-			})
+			assertTrustedGHCRPreparation(t, workflow, architecture)
 		})
 	}
+	assertTrustedGHCRImagePublisher(t, workflow, architectures)
+
+	t.Run("manifest", func(t *testing.T) {
+		assertTrustedGHCRManifestPublisher(t, workflow)
+	})
+}
+
+type ghcrArchitecture struct {
+	name     string
+	platform string
+}
+
+func assertTrustedGHCRPreparation(t *testing.T, workflow workflowConfig, architecture ghcrArchitecture) {
+	t.Helper()
+
+	prepareJobName := "prepare-ghcr-" + architecture.name
+	prepare := workflowJobByName(t, workflow.Jobs, prepareJobName)
+	assertWorkflowJobPermissions(t, prepare, prepareJobName, map[string]string{"contents": "read"})
+	assertGHCRJobDoesNotReference(t, prepare, "secrets.GITHUB_TOKEN", prepareJobName)
+	checkout := workflowStepByName(t, workflow.Jobs, prepareJobName, "Checkout")
+	if checkout.With["persist-credentials"] != "false" {
+		t.Fatalf("%s checkout persist-credentials = %q, want false", prepareJobName, checkout.With["persist-credentials"])
+	}
+
+	build := workflowStepByName(t, workflow.Jobs, prepareJobName, "Build "+architecture.name+" OCI publication payload")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: prepareJobName + " registry push", got: build.With["push"], want: "false"},
+		{label: prepareJobName + " deferred provenance", got: build.With["provenance"], want: "false"},
+		{label: prepareJobName + " deferred SBOM", got: build.With["sbom"], want: "false"},
+		{label: prepareJobName + " platform", got: build.With["platforms"], want: architecture.platform},
+	})
+	assertTextContainsAll(t, build.With["outputs"], prepareJobName+" OCI output", []string{
+		"type=oci",
+		"tar=false",
+		"${{ runner.temp }}/ghcr-" + architecture.name + "-publication/layout",
+	})
+	metadata := workflowStepByName(t, workflow.Jobs, prepareJobName, "Prepare "+architecture.name+" publication metadata")
+	assertWorkflowStepRunContainsAll(t, metadata, prepareJobName+" metadata", []string{
+		`find -P . -type f ! -path './SHA256SUMS'`,
+		`> "${payload_root}/SHA256SUMS"`,
+	})
+	upload := workflowStepByName(t, workflow.Jobs, prepareJobName, "Upload "+architecture.name+" OCI publication payload")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: prepareJobName + " artifact name", got: upload.With["name"], want: "ghcr-" + architecture.name + "-publication-payload"},
+		{label: prepareJobName + " artifact path", got: upload.With["path"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-publication"},
+	})
+}
+
+func assertTrustedGHCRImagePublisher(t *testing.T, workflow workflowConfig, architectures []ghcrArchitecture) {
+	t.Helper()
 
 	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
 	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"prepare-ghcr-amd64", "prepare-ghcr-arm64"})
@@ -1377,62 +1393,70 @@ func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
 	})
 	workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Prepare trusted image promotion Dockerfiles")
 	for _, architecture := range architectures {
-		download := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Download "+architecture.name+" OCI publication payload")
-		assertWorkflowStringValues(t, []workflowStringValue{
-			{label: "publish-ghcr-images artifact name", got: download.With["name"], want: "ghcr-" + architecture.name + "-publication-payload"},
-			{label: "publish-ghcr-images artifact path", got: download.With["path"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-publication"},
-		})
+		assertTrustedGHCRArchitecturePublication(t, workflow, architecture)
+	}
+}
 
-		publishImage := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Publish "+architecture.name+" release image")
-		assertWorkflowStringValues(t, []workflowStringValue{
-			{label: "publish-ghcr-images trusted context", got: publishImage.With["context"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-promotion"},
-			{label: "publish-ghcr-images trusted Dockerfile", got: publishImage.With["file"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-promotion/Dockerfile"},
-			{label: "publish-ghcr-images validated tags", got: publishImage.With["tags"], want: "${{ steps.validate.outputs." + architecture.name + "_tags }}"},
-			{label: "publish-ghcr-images push", got: publishImage.With["push"], want: "true"},
-			{label: "publish-ghcr-images provenance", got: publishImage.With["provenance"], want: "false"},
-			{label: "publish-ghcr-images SBOM", got: publishImage.With["sbom"], want: "true"},
-		})
-		wantBuildContext := "prepared=oci-layout://${{ runner.temp }}/ghcr-" + architecture.name + "-publication/layout@${{ steps.validate.outputs." + architecture.name + "_digest }}"
-		if !strings.Contains(publishImage.With["build-contexts"], wantBuildContext) {
-			t.Fatalf("publish-ghcr-images %s build contexts = %q, want validated OCI digest", architecture.name, publishImage.With["build-contexts"])
-		}
+func assertTrustedGHCRArchitecturePublication(t *testing.T, workflow workflowConfig, architecture ghcrArchitecture) {
+	t.Helper()
+
+	download := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Download "+architecture.name+" OCI publication payload")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "publish-ghcr-images artifact name", got: download.With["name"], want: "ghcr-" + architecture.name + "-publication-payload"},
+		{label: "publish-ghcr-images artifact path", got: download.With["path"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-publication"},
+	})
+
+	publishImage := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Publish "+architecture.name+" release image")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "publish-ghcr-images trusted context", got: publishImage.With["context"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-promotion"},
+		{label: "publish-ghcr-images trusted Dockerfile", got: publishImage.With["file"], want: "${{ runner.temp }}/ghcr-" + architecture.name + "-promotion/Dockerfile"},
+		{label: "publish-ghcr-images validated tags", got: publishImage.With["tags"], want: "${{ steps.validate.outputs." + architecture.name + "_tags }}"},
+		{label: "publish-ghcr-images push", got: publishImage.With["push"], want: "true"},
+		{label: "publish-ghcr-images provenance", got: publishImage.With["provenance"], want: "false"},
+		{label: "publish-ghcr-images SBOM", got: publishImage.With["sbom"], want: "true"},
+	})
+	wantBuildContext := "prepared=oci-layout://${{ runner.temp }}/ghcr-" + architecture.name + "-publication/layout@${{ steps.validate.outputs." + architecture.name + "_digest }}"
+	if !strings.Contains(publishImage.With["build-contexts"], wantBuildContext) {
+		t.Fatalf("publish-ghcr-images %s build contexts = %q, want validated OCI digest", architecture.name, publishImage.With["build-contexts"])
+	}
+}
+
+func assertTrustedGHCRManifestPublisher(t *testing.T, workflow workflowConfig) {
+	t.Helper()
+
+	prepareManifest := workflowJobByName(t, workflow.Jobs, "prepare-ghcr-manifest")
+	assertWorkflowJobPermissions(t, prepareManifest, "prepare-ghcr-manifest", map[string]string{"contents": "read"})
+	assertGHCRJobDoesNotReference(t, prepareManifest, "secrets.GITHUB_TOKEN", "prepare-ghcr-manifest")
+	manifestCheckout := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Checkout")
+	if manifestCheckout.With["persist-credentials"] != "false" {
+		t.Fatalf("prepare-ghcr-manifest checkout persist-credentials = %q, want false", manifestCheckout.With["persist-credentials"])
+	}
+	manifestUpload := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Upload manifest publication payload")
+	if manifestUpload.With["name"] != "ghcr-manifest-publication-payload" {
+		t.Fatalf("manifest artifact name = %q", manifestUpload.With["name"])
 	}
 
-	t.Run("manifest", func(t *testing.T) {
-		prepareManifest := workflowJobByName(t, workflow.Jobs, "prepare-ghcr-manifest")
-		assertWorkflowJobPermissions(t, prepareManifest, "prepare-ghcr-manifest", map[string]string{"contents": "read"})
-		assertGHCRJobDoesNotReference(t, prepareManifest, "secrets.GITHUB_TOKEN", "prepare-ghcr-manifest")
-		manifestCheckout := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Checkout")
-		if manifestCheckout.With["persist-credentials"] != "false" {
-			t.Fatalf("prepare-ghcr-manifest checkout persist-credentials = %q, want false", manifestCheckout.With["persist-credentials"])
-		}
-		manifestUpload := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Upload manifest publication payload")
-		if manifestUpload.With["name"] != "ghcr-manifest-publication-payload" {
-			t.Fatalf("manifest artifact name = %q", manifestUpload.With["name"])
-		}
-
-		publishManifest := workflowJobByName(t, workflow.Jobs, "publish-ghcr-manifest")
-		assertWorkflowJobNeeds(t, publishManifest, "publish-ghcr-manifest", workflowJobNeeds{"publish-ghcr-images", "prepare-ghcr-manifest"})
-		assertWorkflowJobPermissions(t, publishManifest, "publish-ghcr-manifest", map[string]string{"packages": "write"})
-		assertFreshGHCRPublisher(t, publishManifest, "Log in to GHCR")
-		manifestValidation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Validate manifest publication payload")
-		assertWorkflowStepRunContainsAll(t, manifestValidation, "manifest validation", []string{
-			`expected_source_sha="${EXPECTED_SOURCE_SHA}"`,
-			`expected_image_name="ghcr.io/${owner}/lopper"`,
-			`find -P "${payload_root}" ! -type d ! -type f`,
-			`directory_count`,
-			`artifact payload exceeds`,
-			`unexpected image reference`,
-		})
-		manifestPublish := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Publish multi-arch manifests")
-		if strings.Contains(manifestPublish.Run, "scripts/") {
-			t.Fatal("trusted manifest publisher must not run repository scripts")
-		}
-		assertWorkflowStepRunContainsAll(t, manifestPublish, "trusted manifest publication", []string{
-			`done < "${IMAGE_TAGS_FILE}"`,
-			`docker buildx imagetools create`,
-			`docker buildx imagetools inspect`,
-		})
+	publishManifest := workflowJobByName(t, workflow.Jobs, "publish-ghcr-manifest")
+	assertWorkflowJobNeeds(t, publishManifest, "publish-ghcr-manifest", workflowJobNeeds{"publish-ghcr-images", "prepare-ghcr-manifest"})
+	assertWorkflowJobPermissions(t, publishManifest, "publish-ghcr-manifest", map[string]string{"packages": "write"})
+	assertFreshGHCRPublisher(t, publishManifest, "Log in to GHCR")
+	manifestValidation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Validate manifest publication payload")
+	assertWorkflowStepRunContainsAll(t, manifestValidation, "manifest validation", []string{
+		`expected_source_sha="${EXPECTED_SOURCE_SHA}"`,
+		`expected_image_name="ghcr.io/${owner}/lopper"`,
+		`find -P "${payload_root}" ! -type d ! -type f`,
+		`directory_count`,
+		`artifact payload exceeds`,
+		`unexpected image reference`,
+	})
+	manifestPublish := workflowStepByName(t, workflow.Jobs, "publish-ghcr-manifest", "Publish multi-arch manifests")
+	if strings.Contains(manifestPublish.Run, "scripts/") {
+		t.Fatal("trusted manifest publisher must not run repository scripts")
+	}
+	assertWorkflowStepRunContainsAll(t, manifestPublish, "trusted manifest publication", []string{
+		`done < "${IMAGE_TAGS_FILE}"`,
+		`docker buildx imagetools create`,
+		`docker buildx imagetools inspect`,
 	})
 }
 
@@ -1617,27 +1641,12 @@ func TestReleaseOrchestrationRequiresExactTrustedArchitectureTags(t *testing.T) 
 func assertGHCRJobDoesNotReference(t *testing.T, job workflowJobConfig, needle string, jobLabel string) {
 	t.Helper()
 
-	for key, value := range job.Env {
-		if strings.Contains(key, needle) || strings.Contains(value, needle) {
-			t.Fatalf("%s job env must not reference %q", jobLabel, needle)
-		}
-	}
+	assertStringMapDoesNotContain(t, job.Env, needle, jobLabel+" job env")
 	for _, step := range job.Steps {
-		for _, value := range []string{step.Uses, step.Run, step.Shell, step.WorkingDirectory} {
-			if strings.Contains(value, needle) {
-				t.Fatalf("%s step %q must not reference %q", jobLabel, step.Name, needle)
-			}
-		}
-		for key, value := range step.Env {
-			if strings.Contains(key, needle) || strings.Contains(value, needle) {
-				t.Fatalf("%s step %q env must not reference %q", jobLabel, step.Name, needle)
-			}
-		}
-		for key, value := range step.With {
-			if strings.Contains(key, needle) || strings.Contains(value, needle) {
-				t.Fatalf("%s step %q inputs must not reference %q", jobLabel, step.Name, needle)
-			}
-		}
+		stepLabel := jobLabel + " step " + step.Name
+		assertStringsDoNotContain(t, []string{step.Uses, step.Run, step.Shell, step.WorkingDirectory}, needle, stepLabel)
+		assertStringMapDoesNotContain(t, step.Env, needle, stepLabel+" env")
+		assertStringMapDoesNotContain(t, step.With, needle, stepLabel+" inputs")
 	}
 }
 
@@ -1656,32 +1665,51 @@ func assertFreshGHCRPublisher(t *testing.T, job workflowJobConfig, loginStepName
 			}
 			continue
 		}
-		if strings.Contains(step.Uses, "actions/checkout@") || strings.HasPrefix(step.Uses, "./") {
-			t.Fatalf("fresh GHCR publisher must not execute repository action %q", step.Uses)
-		}
-		if strings.Contains(step.Run, "scripts/") || strings.Contains(step.Run, "make ") || step.WorkingDirectory != "" {
-			t.Fatalf("fresh GHCR publisher step %q must not execute repository code", step.Name)
-		}
-		if step.With["context"] == "." || strings.HasPrefix(step.With["file"], "./") {
-			t.Fatalf("fresh GHCR publisher step %q must not use repository build context", step.Name)
-		}
-		for _, value := range append([]string{step.Run, step.Shell, step.Uses}, mapValues(step.Env)...) {
-			if strings.Contains(value, "secrets.GITHUB_TOKEN") || strings.Contains(value, "github.token") {
-				t.Fatalf("fresh GHCR publisher step %q must not receive GitHub credentials", step.Name)
-			}
-		}
-		for _, value := range step.With {
-			if strings.Contains(value, "secrets.GITHUB_TOKEN") || strings.Contains(value, "github.token") {
-				t.Fatalf("fresh GHCR publisher step %q must not receive GitHub credentials", step.Name)
-			}
-		}
+		assertFreshGHCRPublisherStep(t, step)
 	}
 	if loginIndex < 0 {
 		t.Fatalf("fresh GHCR publisher is missing %q", loginStepName)
 	}
 	for _, step := range job.Steps[loginIndex+1:] {
-		if strings.Contains(step.Run, "scripts/") || strings.Contains(step.Run, "./Dockerfile") || strings.Contains(step.Run, "make ") || step.WorkingDirectory != "" || step.With["context"] == "." || strings.HasPrefix(step.With["file"], "./") {
-			t.Fatalf("fresh GHCR publisher step %q executes repository code after login", step.Name)
+		assertStringsDoNotContain(t, []string{step.Run}, "./Dockerfile", "fresh GHCR publisher step "+step.Name)
+	}
+}
+
+func assertFreshGHCRPublisherStep(t *testing.T, step workflowStepConfig) {
+	t.Helper()
+
+	if strings.Contains(step.Uses, "actions/checkout@") || strings.HasPrefix(step.Uses, "./") {
+		t.Fatalf("fresh GHCR publisher must not execute repository action %q", step.Uses)
+	}
+	assertStringsDoNotContain(t, []string{step.Run}, "scripts/", "fresh GHCR publisher step "+step.Name)
+	assertStringsDoNotContain(t, []string{step.Run}, "make ", "fresh GHCR publisher step "+step.Name)
+	if step.WorkingDirectory != "" {
+		t.Fatalf("fresh GHCR publisher step %q must not set a repository working directory", step.Name)
+	}
+	if step.With["context"] == "." || strings.HasPrefix(step.With["file"], "./") {
+		t.Fatalf("fresh GHCR publisher step %q must not use repository build context", step.Name)
+	}
+	credentialValues := append([]string{step.Run, step.Shell, step.Uses}, mapValues(step.Env)...)
+	credentialValues = append(credentialValues, mapValues(step.With)...)
+	for _, credentialMarker := range []string{"secrets.GITHUB_TOKEN", "github.token"} {
+		assertStringsDoNotContain(t, credentialValues, credentialMarker, "fresh GHCR publisher step "+step.Name)
+	}
+}
+
+func assertStringMapDoesNotContain(t *testing.T, values map[string]string, needle string, label string) {
+	t.Helper()
+
+	for key, value := range values {
+		assertStringsDoNotContain(t, []string{key, value}, needle, label)
+	}
+}
+
+func assertStringsDoNotContain(t *testing.T, values []string, needle string, label string) {
+	t.Helper()
+
+	for _, value := range values {
+		if strings.Contains(value, needle) {
+			t.Fatalf("%s must not reference %q", label, needle)
 		}
 	}
 }

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -1552,6 +1552,68 @@ func TestReleaseOrchestrationRequiresDigestPinnedGHCRManifests(t *testing.T) {
 	})
 }
 
+func TestReleaseOrchestrationRequiresExactTrustedArchitectureTags(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
+
+	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
+	validation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Validate OCI publication payloads")
+	if validation.Env["EXPECTED_IMAGE_TAGS"] != "${{ inputs.image_tags }}" {
+		t.Fatalf("architecture tag validation EXPECTED_IMAGE_TAGS = %q, want immutable workflow input", validation.Env["EXPECTED_IMAGE_TAGS"])
+	}
+	if strings.Contains(validation.Run, "scripts/") {
+		t.Fatal("trusted architecture tag validation must not execute repository scripts")
+	}
+	validationIndex := workflowStepIndexByName(t, workflow.Jobs, "publish-ghcr-images", "Validate OCI publication payloads")
+	loginIndex := workflowStepIndexByName(t, workflow.Jobs, "publish-ghcr-images", "Log in to GHCR")
+	if validationIndex >= loginIndex {
+		t.Fatal("architecture publication tags must be validated before GHCR login")
+	}
+	assertWorkflowStepRunContainsAll(t, validation, "exact trusted architecture tag validation", []string{
+		`expected_image_tags="${EXPECTED_IMAGE_TAGS}"`,
+		`local expected_tags_file="${RUNNER_TEMP}/ghcr-${architecture}-expected-image-tags.txt"`,
+		`: > "${expected_tags_file}"`,
+		`local expected_tag_count=0`,
+		`local -A expected_seen_tags=()`,
+		`while IFS= read -r raw_tag || [[ -n "${raw_tag}" ]]; do`,
+		`tag="${tag%$'\r'}"`,
+		`tag="${tag#"${tag%%[![:space:]]*}"}"`,
+		`tag="${tag%"${tag##*[![:space:]]}"}"`,
+		`[[ "${tag}" == *-amd64 ]]`,
+		`[[ "${tag}" == *-arm64 ]]`,
+		`expected_image_ref="${expected_image_name}:${tag}-${architecture}"`,
+		`expected_seen_tags["${expected_image_ref}"]=1`,
+		`printf '%s\n' "${expected_image_ref}" >> "${expected_tags_file}"`,
+		`done <<< "${expected_image_tags}"`,
+		`[ "${expected_tag_count}" -lt 1 ]`,
+		`[ "${expected_tag_count}" -gt 16 ]`,
+		`cmp -s "${tags_file}" "${expected_tags_file}"`,
+		`rm -f "${expected_tags_file}"`,
+	})
+
+	shapeValidation := strings.Index(validation.Run, `if [ "${tag_count}" -lt 1 ] || [ "${tag_count}" -gt 16 ]; then`)
+	expectedDerivation := strings.Index(validation.Run, `local expected_tags_file="${RUNNER_TEMP}/ghcr-${architecture}-expected-image-tags.txt"`)
+	exactComparison := strings.Index(validation.Run, `cmp -s "${tags_file}" "${expected_tags_file}"`)
+	outputPublication := strings.Index(validation.Run, `cat "${tags_file}"`)
+	if shapeValidation < 0 || expectedDerivation < shapeValidation || exactComparison < expectedDerivation || outputPublication < exactComparison {
+		t.Fatal("architecture tags must pass existing shape checks, exact immutable-input comparison, then publication")
+	}
+	for _, insufficientValidation := range []string{
+		`sort -u "${tags_file}"`,
+		`comm -3`,
+		`diff -q`,
+	} {
+		if strings.Contains(validation.Run, insufficientValidation) {
+			t.Fatalf("trusted architecture tags must use deterministic byte equality, not %q", insufficientValidation)
+		}
+	}
+	if len(publishImages.Permissions) != 1 || publishImages.Permissions["packages"] != "write" {
+		t.Fatalf("publish-ghcr-images permissions = %#v, want packages: write", publishImages.Permissions)
+	}
+}
+
 func assertGHCRJobDoesNotReference(t *testing.T, job workflowJobConfig, needle string, jobLabel string) {
 	t.Helper()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -28,7 +28,8 @@ type workflowOnConfig struct {
 }
 
 type workflowConfig struct {
-	On workflowOnConfig `yaml:"on"`
+	On   workflowOnConfig             `yaml:"on"`
+	Jobs map[string]workflowJobConfig `yaml:"jobs"`
 }
 
 type workflowJobConfig struct {
@@ -182,6 +183,20 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	}
 	if !strings.Contains(workflowText, "Existing release ${tag} points to ${existing_commit}, but this run resolved ${resolved_sha}.") {
 		t.Fatal("manual release flow must fail when an existing release tag points to a different commit")
+	}
+	manualStep := workflowStepByName(t, workflow.Jobs, "prepare-release", "Prepare manual release")
+	assertWorkflowStepRunContainsAll(t, manualStep, "manual release preparation step", []string{
+		`existing_target="$(jq -r '.target_commitish // empty' "${release_json}")"`,
+		`if ! fetch_error="$(git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}" 2>&1)"; then`,
+		`if [[ "${fetch_error}" == *"couldn't find remote ref refs/tags/${tag}"* ]]; then`,
+		`echo "Remote tag ${tag} does not exist; validating the release target instead."`,
+		`echo "::error::Failed to fetch existing release tag ${tag}." >&2
+      printf '%s\n' "${fetch_error}" >&2
+      rm -f "${release_json}"
+      exit 1`,
+	})
+	if strings.Contains(manualStep.Run, `git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}" >/dev/null 2>&1 || true`) {
+		t.Fatal("manual release flow must not swallow operational failures while fetching an existing release tag")
 	}
 	if !strings.Contains(workflowText, "needs.prepare-release.outputs.sha") {
 		t.Fatal("downstream release jobs must use the resolved prepare-release SHA")


### PR DESCRIPTION
## Summary

Confine release and Homebrew write credentials to trusted publication boundaries while keeping release identity immutable and fail closed.

## Changes

- Prepare release notes and assets without write credentials, then perform GitHub release mutations in a fresh publication job with step-scoped API authentication.
- Skip Marketplace checkout and toolchain setup when `VSCE_PUBLISH` is absent; when configured, prepare the pinned toolchain without the token, confine it to a final no-checkout publication job, and fail closed if it disappears at that privileged boundary.
- Require the release workflow to come from `refs/heads/main`, then bind trusted-tooling and feature-history checkouts to that immutable workflow commit through `github.workflow_sha` instead of a moving `main` ref.
- Move floating-tag and feature-history pushes into fresh trusted lanes that validate origin, immutable release identity, and the bounded history patch before command-scoped authentication is exposed.
- Keep prepared publication inputs outside the `release-*` build-artifact namespace so workflow reruns cannot merge control files into the release asset directory.
- Accept OCI indexes with multiple image names by deduplicating platform descriptors by digest before enforcing a single immutable image digest.
- Require existing releases to resolve through an immutable tag or full commit SHA, rejecting mutable fallback targets and identity mismatches.
- Split Homebrew handling into a secret gate, tokenless formula validation, and a fresh isolated privileged publication job.

## Validation

Commands and checks run:

```bash
make ci
```

Additional validation:

- Workflow contract tests cover immutable release identity, workflow-pinned trusted tooling, token-gated Marketplace preparation, fail-closed privileged token loss, fresh GitHub/tag/history publication lanes, rerun-safe publication artifacts, multi-name OCI indexes, credential reachability, tokenless Homebrew validation, and isolated publication.
- The final PR head is required to pass hosted checks, Sonar analysis, and review-thread verification before handoff.

## Risk and compatibility

- Breaking changes: Release dispatches whose workflow revision is not the `main`-hosted `release.yml` now fail closed; tokenless runs skip Marketplace toolchain preparation and publication.
- Migration required: Mutable existing-release targets are no longer accepted, and release automation must dispatch the workflow from `refs/heads/main`.
- Performance impact: Release publication uses additional isolated jobs and artifact handoffs.
- Memory benchmark impact: Not measured.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
