### PR TITLE
fix(git): harden lockfile drift invocations

### DIFF
--- a/internal/app/codemod_apply.go
+++ b/internal/app/codemod_apply.go
@@ -178,7 +178,11 @@ func ensureCleanWorktreeForCodemod(ctx context.Context, repoPath string, allowDi
 }
 
 func gitChangedFilesForCodemod(ctx context.Context, repoPath string) (map[string]struct{}, bool, error) {
-	if !isGitWorktree(ctx, repoPath) {
+	isWorktree, err := isGitWorktree(ctx, repoPath)
+	if err != nil {
+		return nil, false, err
+	}
+	if !isWorktree {
 		return nil, false, nil
 	}
 

--- a/internal/app/codemod_apply.go
+++ b/internal/app/codemod_apply.go
@@ -208,14 +208,14 @@ func gitTrackedChangesForCodemod(ctx context.Context, repoPath string) ([]string
 		return nil, err
 	}
 	if hasHead {
-		return gitDiffNameOnlyWithFilterDrivers(ctx, repoPath, nil, nil, "HEAD")
+		return gitDiffNameOnly(ctx, repoPath, nil, "HEAD")
 	}
 
-	staged, err := gitDiffNameOnlyWithFilterDrivers(ctx, repoPath, nil, nil, gitCachedFlag)
+	staged, err := gitDiffNameOnly(ctx, repoPath, nil, gitCachedFlag)
 	if err != nil {
 		return nil, err
 	}
-	unstaged, err := gitDiffNameOnlyWithFilterDrivers(ctx, repoPath, nil, nil)
+	unstaged, err := gitDiffNameOnly(ctx, repoPath, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/codemod_apply.go
+++ b/internal/app/codemod_apply.go
@@ -158,7 +158,7 @@ func ensureCleanWorktreeForCodemod(ctx context.Context, repoPath string, allowDi
 	if allowDirty {
 		return nil
 	}
-	changed, hasGitContext, err := gitChangedFiles(ctx, repoPath)
+	changed, hasGitContext, err := gitChangedFilesForCodemod(ctx, repoPath)
 	if err != nil {
 		return err
 	}
@@ -175,6 +175,51 @@ func ensureCleanWorktreeForCodemod(ctx context.Context, repoPath string, allowDi
 		files = append(files[:5], fmt.Sprintf("+%d more", len(files)-5))
 	}
 	return fmt.Errorf("%w: detected uncommitted changes in %s; commit/stash them first or pass --allow-dirty", ErrDirtyWorktree, strings.Join(files, ", "))
+}
+
+func gitChangedFilesForCodemod(ctx context.Context, repoPath string) (map[string]struct{}, bool, error) {
+	if !isGitWorktree(ctx, repoPath) {
+		return nil, false, nil
+	}
+
+	changed := map[string]struct{}{}
+	tracked, err := gitTrackedChangesForCodemod(ctx, repoPath)
+	if err != nil {
+		return nil, true, err
+	}
+	for _, path := range tracked {
+		changed[path] = struct{}{}
+	}
+
+	untracked, err := gitUntrackedFiles(ctx, repoPath)
+	if err != nil {
+		return nil, true, err
+	}
+	for _, path := range untracked {
+		changed[path] = struct{}{}
+	}
+
+	return changed, true, nil
+}
+
+func gitTrackedChangesForCodemod(ctx context.Context, repoPath string) ([]string, error) {
+	hasHead, err := gitHasVerifiedHead(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+	if hasHead {
+		return gitDiffNameOnlyWithFilterDrivers(ctx, repoPath, nil, nil, "HEAD")
+	}
+
+	staged, err := gitDiffNameOnlyWithFilterDrivers(ctx, repoPath, nil, nil, gitCachedFlag)
+	if err != nil {
+		return nil, err
+	}
+	unstaged, err := gitDiffNameOnlyWithFilterDrivers(ctx, repoPath, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return mergeGitPaths(staged, unstaged), nil
 }
 
 func findCodemodReport(reportData *report.Report, dependency string) *report.CodemodReport {

--- a/internal/app/codemod_apply_test.go
+++ b/internal/app/codemod_apply_test.go
@@ -300,7 +300,10 @@ func TestGitChangedFilesForCodemodPropagatesWorktreeDetectionError(t *testing.T)
 	resolveGitBinaryPathFn = func() (string, error) { return "", forcedErr }
 	t.Cleanup(func() { resolveGitBinaryPathFn = originalResolve })
 
-	_, _, err := gitChangedFilesForCodemod(context.Background(), t.TempDir())
+	repo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(repo, ".git"))
+	writeTextFile(t, filepath.Join(repo, ".git", "HEAD"), "ref: refs/heads/main\n", 0o600)
+	_, _, err := gitChangedFilesForCodemod(context.Background(), repo)
 	if !errors.Is(err, forcedErr) {
 		t.Fatalf("expected codemod worktree detection error, got %v", err)
 	}

--- a/internal/app/codemod_apply_test.go
+++ b/internal/app/codemod_apply_test.go
@@ -3,12 +3,14 @@ package app
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ben-ranford/lopper/internal/gitexec"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
@@ -266,6 +268,65 @@ func TestEnsureCleanWorktreeForCodemodPropagatesGitErrors(t *testing.T) {
 	err := ensureCleanWorktreeForCodemod(context.Background(), t.TempDir(), false)
 	if err == nil || !strings.Contains(err.Error(), "run git rev-parse --verify --quiet HEAD") {
 		t.Fatalf("expected git helper error to be returned, got %v", err)
+	}
+}
+
+func TestGitChangedFilesForCodemodPropagatesGitErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		mode    string
+		wantSub string
+	}{
+		{name: "untracked files", mode: "lsfail", wantSub: "ls-files"},
+		{name: "unborn HEAD staged changes", mode: "difffail-cached", wantSub: "run git"},
+		{name: "unborn HEAD unstaged changes", mode: "difffail-unstaged", wantSub: "run git"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := configureFakeGitRepo(t, tc.mode)
+
+			_, _, err := gitChangedFilesForCodemod(context.Background(), repo)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantSub, err)
+			}
+		})
+	}
+}
+
+func TestEnsureCleanWorktreeForCodemodPreservesBenignCleanFilterSemantics(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo := t.TempDir()
+	initCodemodGitRepo(t, repo)
+
+	helperPath := filepath.Join(t.TempDir(), "normalize-clean.sh")
+	writeTextFile(t, helperPath, "#!/bin/sh\ntr -d '\\r'\n", 0o700)
+	if err := os.Chmod(helperPath, 0o700); err != nil {
+		t.Fatalf("chmod clean filter helper: %v", err)
+	}
+
+	writeTextFile(t, filepath.Join(repo, ".gitattributes"), "tracked.txt filter=normalize\n", 0o644)
+	writeTextFile(t, filepath.Join(repo, "tracked.txt"), "line one\r\n", 0o644)
+	testutil.RunGit(t, repo, "config", "filter.normalize.clean", helperPath)
+	testutil.RunGit(t, repo, "config", "filter.normalize.required", "true")
+	testutil.RunGit(t, repo, "add", ".gitattributes", "tracked.txt")
+	testutil.RunGit(t, repo, "commit", "-m", "tracked")
+
+	if err := ensureCleanWorktreeForCodemod(context.Background(), repo, false); err != nil {
+		t.Fatalf("expected benign clean filter to keep worktree clean, got %v", err)
+	}
+
+	writeTextFile(t, filepath.Join(repo, "tracked.txt"), "line two\r\n", 0o644)
+
+	err := ensureCleanWorktreeForCodemod(context.Background(), repo, false)
+	if !errors.Is(err, ErrDirtyWorktree) {
+		t.Fatalf("expected tracked content change to be reported, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "tracked.txt") {
+		t.Fatalf("expected tracked dirty path in error, got %v", err)
 	}
 }
 

--- a/internal/app/codemod_apply_test.go
+++ b/internal/app/codemod_apply_test.go
@@ -294,6 +294,18 @@ func TestGitChangedFilesForCodemodPropagatesGitErrors(t *testing.T) {
 	}
 }
 
+func TestGitChangedFilesForCodemodPropagatesWorktreeDetectionError(t *testing.T) {
+	originalResolve := resolveGitBinaryPathFn
+	forcedErr := errors.New("forced codemod worktree detection failure")
+	resolveGitBinaryPathFn = func() (string, error) { return "", forcedErr }
+	t.Cleanup(func() { resolveGitBinaryPathFn = originalResolve })
+
+	_, _, err := gitChangedFilesForCodemod(context.Background(), t.TempDir())
+	if !errors.Is(err, forcedErr) {
+		t.Fatalf("expected codemod worktree detection error, got %v", err)
+	}
+}
+
 func TestEnsureCleanWorktreeForCodemodPreservesBenignCleanFilterSemantics(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -39,9 +39,10 @@ func detectLockfileDriftWithFeatures(ctx context.Context, repoPath string, stopO
 	if err != nil {
 		return nil, err
 	}
-	gitContext, err := collectLockfileGitContextFn(ctx, normalizedPath)
+	rules := activeLockfileRules(features)
+	gitContext, err := collectLockfileGitContextFn(ctx, normalizedPath, rules)
 	if err != nil {
 		return nil, err
 	}
-	return scanLockfileDrift(ctx, normalizedPath, gitContext, stopOnFirst, activeLockfileRules(features))
+	return scanLockfileDrift(ctx, normalizedPath, gitContext, stopOnFirst, rules)
 }

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -40,9 +40,12 @@ func detectLockfileDriftWithFeatures(ctx context.Context, repoPath string, stopO
 		return nil, err
 	}
 	rules := activeLockfileRules(features)
+	if stopOnFirst {
+		return scanLockfileDriftStopOnFirst(ctx, normalizedPath, rules)
+	}
 	gitContext, err := collectLockfileGitContextFn(ctx, normalizedPath, rules)
 	if err != nil {
 		return nil, err
 	}
-	return scanLockfileDrift(ctx, normalizedPath, gitContext, stopOnFirst, rules)
+	return scanLockfileDrift(ctx, normalizedPath, gitContext, false, rules)
 }

--- a/internal/app/lockfile_drift_candidate_paths_test.go
+++ b/internal/app/lockfile_drift_candidate_paths_test.go
@@ -1,0 +1,184 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func mustLockfileRule(t *testing.T, manager, manifest string) lockfileRule {
+	t.Helper()
+	for _, rule := range lockfileRules {
+		if rule.manager == manager && rule.manifest == manifest {
+			return rule
+		}
+	}
+	t.Fatalf("missing lockfile rule for manager %q manifest %q", manager, manifest)
+	return lockfileRule{}
+}
+
+func assertCandidatePaths(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("expected %d candidate paths, got %#v", len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected candidate %q at index %d, got %#v", want[i], i, got)
+		}
+	}
+}
+
+func TestLockfileManifestChangeCandidatePathsRuleRelevance(t *testing.T) {
+	t.Run("requires a matching lockfile", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+
+		snapshot, err := readLockfileDirSnapshot(repo, repo)
+		if err != nil {
+			t.Fatalf("read lockfile snapshot: %v", err)
+		}
+		got, err := lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{mustLockfileRule(t, "npm", manifestFileName)})
+		if err != nil {
+			t.Fatalf("lockfileManifestChangeCandidatePaths: %v", err)
+		}
+		assertCandidatePaths(t, got, nil)
+	})
+
+	t.Run("matches only relevant pyproject sections", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			content string
+			want    []string
+		}{
+			{name: "non matching section", content: "[project]\nname = \"demo\"\n", want: nil},
+			{name: "matching poetry section", content: "[tool.poetry]\nname = \"demo\"\n", want: []string{poetryLockName, pyprojectManifestName}},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				repo := t.TempDir()
+				writeFile(t, filepath.Join(repo, pyprojectManifestName), tc.content)
+				writeFile(t, filepath.Join(repo, poetryLockName), "# lock\n")
+
+				snapshot, err := readLockfileDirSnapshot(repo, repo)
+				if err != nil {
+					t.Fatalf("read lockfile snapshot: %v", err)
+				}
+				got, err := lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{mustLockfileRule(t, "Poetry", pyprojectManifestName)})
+				if err != nil {
+					t.Fatalf("lockfileManifestChangeCandidatePaths: %v", err)
+				}
+				assertCandidatePaths(t, got, tc.want)
+			})
+		}
+	})
+
+	t.Run("includes distributed dotnet lockfiles", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{}\n")
+
+		snapshot, err := readLockfileDirSnapshot(repo, repo)
+		if err != nil {
+			t.Fatalf("read lockfile snapshot: %v", err)
+		}
+		got, err := lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{mustLockfileRule(t, ".NET", dotnetCentralManifest)})
+		if err != nil {
+			t.Fatalf("lockfileManifestChangeCandidatePaths: %v", err)
+		}
+		assertCandidatePaths(t, got, []string{dotnetCentralManifest, filepath.ToSlash(filepath.Join("src", "App", dotnetLockfileName))})
+	})
+}
+
+func TestLockfileManifestChangeCandidatePathsDeduplicatesAndPropagatesErrors(t *testing.T) {
+	t.Run("deduplicates repeated rules and lockfiles", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+
+		snapshot, err := readLockfileDirSnapshot(repo, repo)
+		if err != nil {
+			t.Fatalf("read lockfile snapshot: %v", err)
+		}
+		rule := lockfileRule{
+			manager:   "npm",
+			manifest:  manifestFileName,
+			lockfiles: []string{lockfileName, lockfileName},
+		}
+		got, err := lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{rule, rule})
+		if err != nil {
+			t.Fatalf("lockfileManifestChangeCandidatePaths: %v", err)
+		}
+		assertCandidatePaths(t, got, []string{lockfileName, manifestFileName})
+	})
+
+	t.Run("propagates manifest matcher failures", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+
+		snapshot, err := readLockfileDirSnapshot(repo, repo)
+		if err != nil {
+			t.Fatalf("read lockfile snapshot: %v", err)
+		}
+		_, err = lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{{
+			manager:   "custom",
+			manifest:  manifestFileName,
+			lockfiles: []string{lockfileName},
+			manifestMatcher: func(string, string) (bool, error) {
+				return false, errors.New("boom")
+			},
+		}})
+		if err == nil || err.Error() != "boom" {
+			t.Fatalf("expected matcher error, got %v", err)
+		}
+	})
+}
+
+func TestCollectLockfileManifestChangeCandidatePathsWalksRepoAndHonorsContext(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, "nested", manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, "nested", lockfileName), "{}\n")
+
+	got, err := collectLockfileManifestChangeCandidatePaths(context.Background(), repo, []lockfileRule{mustLockfileRule(t, "npm", manifestFileName)})
+	if err != nil {
+		t.Fatalf("collectLockfileManifestChangeCandidatePaths: %v", err)
+	}
+	assertCandidatePaths(t, got, []string{"nested/package-lock.json", "nested/package.json", "package-lock.json", "package.json"})
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := collectLockfileManifestChangeCandidatePaths(cancelledCtx, repo, []lockfileRule{mustLockfileRule(t, "npm", manifestFileName)}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}
+
+func TestCollectLockfileManifestChangeCandidatePathsHandlesWalkErrorsAndDistributedDeduplication(t *testing.T) {
+	t.Run("missing root propagates walk error", func(t *testing.T) {
+		if _, err := collectLockfileManifestChangeCandidatePaths(context.Background(), filepath.Join(t.TempDir(), "missing"), []lockfileRule{mustLockfileRule(t, "npm", manifestFileName)}); err == nil {
+			t.Fatal("expected missing root to fail candidate collection")
+		}
+	})
+
+	t.Run("distributed dotnet walk returns unique candidates", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project></Project>\n")
+		writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{}\n")
+
+		got, err := collectLockfileManifestChangeCandidatePaths(context.Background(), repo, []lockfileRule{mustLockfileRule(t, ".NET", dotnetCentralManifest)})
+		if err != nil {
+			t.Fatalf("collectLockfileManifestChangeCandidatePaths: %v", err)
+		}
+		assertCandidatePaths(t, got, []string{
+			dotnetCentralManifest,
+			filepath.ToSlash(filepath.Join("src", "App", dotnetProjectManifest)),
+			filepath.ToSlash(filepath.Join("src", "App", dotnetLockfileName)),
+		})
+	})
+}

--- a/internal/app/lockfile_drift_candidate_paths_test.go
+++ b/internal/app/lockfile_drift_candidate_paths_test.go
@@ -30,67 +30,65 @@ func assertCandidatePaths(t *testing.T, got, want []string) {
 	}
 }
 
-func TestLockfileManifestChangeCandidatePathsRuleRelevance(t *testing.T) {
-	t.Run("requires a matching lockfile", func(t *testing.T) {
-		repo := t.TempDir()
-		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+func TestLockfileManifestChangeCandidatePathsRequiresMatchingLockfile(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
 
-		snapshot, err := readLockfileDirSnapshot(repo, repo)
-		if err != nil {
-			t.Fatalf("read lockfile snapshot: %v", err)
-		}
-		got, err := lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{mustLockfileRule(t, "npm", manifestFileName)})
-		if err != nil {
-			t.Fatalf("lockfileManifestChangeCandidatePaths: %v", err)
-		}
-		assertCandidatePaths(t, got, nil)
-	})
+	snapshot, err := readLockfileDirSnapshot(repo, repo)
+	if err != nil {
+		t.Fatalf("read lockfile snapshot: %v", err)
+	}
+	got, err := lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{mustLockfileRule(t, "npm", manifestFileName)})
+	if err != nil {
+		t.Fatalf("lockfileManifestChangeCandidatePaths: %v", err)
+	}
+	assertCandidatePaths(t, got, nil)
+}
 
-	t.Run("matches only relevant pyproject sections", func(t *testing.T) {
-		cases := []struct {
-			name    string
-			content string
-			want    []string
-		}{
-			{name: "non matching section", content: "[project]\nname = \"demo\"\n", want: nil},
-			{name: "matching poetry section", content: "[tool.poetry]\nname = \"demo\"\n", want: []string{poetryLockName, pyprojectManifestName}},
-		}
+func TestLockfileManifestChangeCandidatePathsPyprojectSectionRelevance(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{name: "non matching section", content: "[project]\nname = \"demo\"\n", want: nil},
+		{name: "matching poetry section", content: "[tool.poetry]\nname = \"demo\"\n", want: []string{poetryLockName, pyprojectManifestName}},
+	}
 
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				repo := t.TempDir()
-				writeFile(t, filepath.Join(repo, pyprojectManifestName), tc.content)
-				writeFile(t, filepath.Join(repo, poetryLockName), "# lock\n")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, pyprojectManifestName), tc.content)
+			writeFile(t, filepath.Join(repo, poetryLockName), "# lock\n")
 
-				snapshot, err := readLockfileDirSnapshot(repo, repo)
-				if err != nil {
-					t.Fatalf("read lockfile snapshot: %v", err)
-				}
-				got, err := lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{mustLockfileRule(t, "Poetry", pyprojectManifestName)})
-				if err != nil {
-					t.Fatalf("lockfileManifestChangeCandidatePaths: %v", err)
-				}
-				assertCandidatePaths(t, got, tc.want)
-			})
-		}
-	})
+			snapshot, err := readLockfileDirSnapshot(repo, repo)
+			if err != nil {
+				t.Fatalf("read lockfile snapshot: %v", err)
+			}
+			got, err := lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{mustLockfileRule(t, "Poetry", pyprojectManifestName)})
+			if err != nil {
+				t.Fatalf("lockfileManifestChangeCandidatePaths: %v", err)
+			}
+			assertCandidatePaths(t, got, tc.want)
+		})
+	}
+}
 
-	t.Run("includes distributed dotnet lockfiles", func(t *testing.T) {
-		repo := t.TempDir()
-		writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n")
-		writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project></Project>\n")
-		writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{}\n")
+func TestLockfileManifestChangeCandidatePathsIncludesDistributedDotnetLockfiles(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, dotnetCentralManifest), "<Project><ItemGroup><PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" /></ItemGroup></Project>\n")
+	writeFile(t, filepath.Join(repo, "src", "App", dotnetProjectManifest), "<Project></Project>\n")
+	writeFile(t, filepath.Join(repo, "src", "App", dotnetLockfileName), "{}\n")
 
-		snapshot, err := readLockfileDirSnapshot(repo, repo)
-		if err != nil {
-			t.Fatalf("read lockfile snapshot: %v", err)
-		}
-		got, err := lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{mustLockfileRule(t, ".NET", dotnetCentralManifest)})
-		if err != nil {
-			t.Fatalf("lockfileManifestChangeCandidatePaths: %v", err)
-		}
-		assertCandidatePaths(t, got, []string{dotnetCentralManifest, filepath.ToSlash(filepath.Join("src", "App", dotnetLockfileName))})
-	})
+	snapshot, err := readLockfileDirSnapshot(repo, repo)
+	if err != nil {
+		t.Fatalf("read lockfile snapshot: %v", err)
+	}
+	got, err := lockfileManifestChangeCandidatePaths(snapshot, []lockfileRule{mustLockfileRule(t, ".NET", dotnetCentralManifest)})
+	if err != nil {
+		t.Fatalf("lockfileManifestChangeCandidatePaths: %v", err)
+	}
+	assertCandidatePaths(t, got, []string{dotnetCentralManifest, filepath.ToSlash(filepath.Join("src", "App", dotnetLockfileName))})
 }
 
 func TestLockfileManifestChangeCandidatePathsDeduplicatesAndPropagatesErrors(t *testing.T) {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -25,6 +25,7 @@ const (
 	gitExcludeStandardArg = "--exclude-standard"
 	gitCachedFlag         = "--cached"
 	gitLiteralPathPrefix  = ":(literal)"
+	gitFilterProbeMarker  = "__LOPPER_LOCKFILE_FILTER_PROBE__"
 	// Keep aggregate argv comfortably bounded. A single path cannot be split,
 	// but real candidates come from WalkDir and remain filesystem/Git bounded.
 	gitPathspecBatchPaths = 128
@@ -509,20 +510,10 @@ func isGitAttributeStateDriver(driver string) bool {
 func gitPathUsesNamedFilterDriver(ctx context.Context, repoPath string, assignment gitFilterPathDriver) (active bool, err error) {
 	const probeInput = "lopper-lockfile-filter-probe\n"
 
-	rawHashCommand, err := gitCommandContext(ctx, repoPath, "hash-object", "--stdin")
-	if err != nil {
-		return false, err
-	}
-	rawHashCommand.Stdin = strings.NewReader(probeInput)
-	rawHashOutput, err := rawHashCommand.Output()
-	if err != nil {
-		return false, fmt.Errorf("calculate raw git filter probe hash: %w", err)
-	}
-	rawHash := strings.TrimSpace(string(rawHashOutput))
-
+	probeCommand := "git hash-object --stdin --" + gitFilterProbeMarker
 	args := []string{
-		"-c", fmt.Sprintf("filter.%s.clean=git hash-object --stdin", assignment.driver),
-		"-c", fmt.Sprintf("filter.%s.process=git version", assignment.driver),
+		"-c", fmt.Sprintf("filter.%s.clean=%s", assignment.driver, probeCommand),
+		"-c", fmt.Sprintf("filter.%s.process=%s", assignment.driver, probeCommand),
 		"-c", fmt.Sprintf("filter.%s.required=true", assignment.driver),
 		"hash-object", "--path=" + assignment.path, "--stdin",
 	}
@@ -531,15 +522,14 @@ func gitPathUsesNamedFilterDriver(ctx context.Context, repoPath string, assignme
 		return false, err
 	}
 	command.Stdin = strings.NewReader(probeInput)
-	output, err := command.Output()
-	if err == nil {
-		return strings.TrimSpace(string(output)) != rawHash, nil
-	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	output, probeErr := command.CombinedOutput()
+	if bytes.Contains(output, []byte(gitFilterProbeMarker)) {
 		return true, nil
 	}
-	return false, fmt.Errorf("probe git filter driver %q for %q: %w", assignment.driver, assignment.path, err)
+	if probeErr != nil {
+		return false, fmt.Errorf("probe git filter driver %q for %q: %w: %s", assignment.driver, assignment.path, probeErr, strings.TrimSpace(string(output)))
+	}
+	return false, nil
 }
 
 // Git renders explicit drivers named set, unset, or unspecified exactly like

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -24,7 +24,28 @@ type lockfileGitContext struct {
 	hasGitContext bool
 }
 
-func collectLockfileGitContext(ctx context.Context, repoPath string) (lockfileGitContext, error) {
+type gitFilterPathDriver struct {
+	path   string
+	driver string
+}
+
+func collectLockfileGitContext(ctx context.Context, repoPath string, rules []lockfileRule) (lockfileGitContext, error) {
+	if !isGitWorktree(ctx, repoPath) {
+		return lockfileGitContext{}, nil
+	}
+
+	candidatePaths, err := collectLockfileManifestChangeCandidatePaths(ctx, repoPath, rules)
+	if err != nil {
+		return lockfileGitContext{}, err
+	}
+	filteredPaths, err := gitActiveFilterPathDrivers(ctx, repoPath, candidatePaths)
+	if err != nil {
+		return lockfileGitContext{}, err
+	}
+	if len(filteredPaths) > 0 {
+		return lockfileGitContext{}, newLockfileDriftFilterAmbiguityError(filteredPaths)
+	}
+
 	changedFiles, hasGitContext, err := gitChangedFiles(ctx, repoPath)
 	if err != nil {
 		return lockfileGitContext{}, err
@@ -244,6 +265,14 @@ func gitAttributeCandidatePaths(ctx context.Context, repoPath string) ([]string,
 }
 
 func gitActiveFilterDrivers(ctx context.Context, repoPath string, paths []string) ([]string, error) {
+	assignments, err := gitActiveFilterPathDrivers(ctx, repoPath, paths)
+	if err != nil {
+		return nil, err
+	}
+	return uniqueFilterDrivers(assignments), nil
+}
+
+func gitActiveFilterPathDrivers(ctx context.Context, repoPath string, paths []string) ([]gitFilterPathDriver, error) {
 	if len(paths) == 0 {
 		return nil, nil
 	}
@@ -257,14 +286,43 @@ func gitActiveFilterDrivers(ctx context.Context, repoPath string, paths []string
 	if err != nil {
 		return nil, fmt.Errorf("run git check-attr --stdin -z filter: %w", err)
 	}
-	drivers, err := parseGitCheckAttrFilterDrivers(paths, output)
+	assignments, err := parseGitCheckAttrFilterPathDrivers(paths, output)
 	if err != nil {
 		return nil, fmt.Errorf("parse git check-attr --stdin -z filter output: %w", err)
 	}
-	return drivers, nil
+	return assignments, nil
+}
+
+func newLockfileDriftFilterAmbiguityError(assignments []gitFilterPathDriver) error {
+	parts := make([]string, 0, len(assignments))
+	for _, assignment := range assignments {
+		parts = append(parts, fmt.Sprintf("%s (%s)", assignment.path, assignment.driver))
+	}
+	return fmt.Errorf("cannot safely evaluate lockfile drift: active custom git filter drivers on %s", strings.Join(parts, ", "))
 }
 
 func parseGitCheckAttrFilterDrivers(paths []string, output []byte) ([]string, error) {
+	assignments, err := parseGitCheckAttrFilterPathDrivers(paths, output)
+	if err != nil {
+		return nil, err
+	}
+	return uniqueFilterDrivers(assignments), nil
+}
+
+func uniqueFilterDrivers(assignments []gitFilterPathDriver) []string {
+	drivers := make([]string, 0, len(assignments))
+	seen := make(map[string]struct{}, len(assignments))
+	for _, assignment := range assignments {
+		if _, ok := seen[assignment.driver]; ok {
+			continue
+		}
+		seen[assignment.driver] = struct{}{}
+		drivers = append(drivers, assignment.driver)
+	}
+	return drivers
+}
+
+func parseGitCheckAttrFilterPathDrivers(paths []string, output []byte) ([]gitFilterPathDriver, error) {
 	if len(output) == 0 || output[len(output)-1] != 0 {
 		return nil, errors.New("truncated output: missing trailing NUL terminator")
 	}
@@ -275,8 +333,7 @@ func parseGitCheckAttrFilterDrivers(paths []string, output []byte) ([]string, er
 		return nil, fmt.Errorf("expected %d NUL-delimited fields for %d paths, got %d", expectedFields, len(paths), len(fields))
 	}
 
-	drivers := make([]string, 0, len(fields)/3)
-	seen := make(map[string]struct{}, len(fields)/3)
+	assignments := make([]gitFilterPathDriver, 0, len(fields)/3)
 	for index, expectedPath := range paths {
 		fieldIndex := index * 3
 		path := fields[fieldIndex]
@@ -293,13 +350,12 @@ func parseGitCheckAttrFilterDrivers(paths []string, output []byte) ([]string, er
 		case "", "set", "unset", "unspecified":
 			continue
 		}
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		drivers = append(drivers, value)
+		assignments = append(assignments, gitFilterPathDriver{
+			path:   path,
+			driver: value,
+		})
 	}
-	return drivers, nil
+	return assignments, nil
 }
 
 func sanitizedGitEnv() []string {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -25,7 +25,6 @@ const (
 	gitExcludeStandardArg = "--exclude-standard"
 	gitCachedFlag         = "--cached"
 	gitLiteralPathPrefix  = ":(literal)"
-	gitFilterProbeMarker  = "__LOPPER_LOCKFILE_FILTER_PROBE__"
 	// Keep aggregate argv comfortably bounded. A single path cannot be split,
 	// but real candidates come from WalkDir and remain filesystem/Git bounded.
 	gitPathspecBatchPaths = 128
@@ -508,28 +507,22 @@ func isGitAttributeStateDriver(driver string) bool {
 }
 
 func gitPathUsesNamedFilterDriver(ctx context.Context, repoPath string, assignment gitFilterPathDriver) (active bool, err error) {
-	probeDir, err := os.MkdirTemp("", "lopper-lockfile-filter-probe-")
-	if err != nil {
-		return false, fmt.Errorf("create git filter probe dir: %w", err)
-	}
-	defer func() {
-		if removeErr := os.RemoveAll(probeDir); removeErr != nil && err == nil {
-			err = fmt.Errorf("remove git filter probe dir: %w", removeErr)
-		}
-	}()
+	const probeInput = "lopper-lockfile-filter-probe\n"
 
-	probePath := filepath.Join(probeDir, "probe.sh")
-	probeScript := "#!/bin/sh\n" +
-		"echo " + gitFilterProbeMarker + " >&2\n" +
-		"exit 1\n"
-	if err := os.WriteFile(probePath, []byte(probeScript), 0o600); err != nil {
-		return false, fmt.Errorf("write git filter probe: %w", err)
+	rawHashCommand, err := gitCommandContext(ctx, repoPath, "hash-object", "--stdin")
+	if err != nil {
+		return false, err
 	}
-	probeCommand := "/bin/sh " + probePath
+	rawHashCommand.Stdin = strings.NewReader(probeInput)
+	rawHashOutput, err := rawHashCommand.Output()
+	if err != nil {
+		return false, fmt.Errorf("calculate raw git filter probe hash: %w", err)
+	}
+	rawHash := strings.TrimSpace(string(rawHashOutput))
 
 	args := []string{
-		"-c", fmt.Sprintf("filter.%s.clean=%s", assignment.driver, probeCommand),
-		"-c", fmt.Sprintf("filter.%s.process=%s", assignment.driver, probeCommand),
+		"-c", fmt.Sprintf("filter.%s.clean=git hash-object --stdin", assignment.driver),
+		"-c", fmt.Sprintf("filter.%s.process=git version", assignment.driver),
 		"-c", fmt.Sprintf("filter.%s.required=true", assignment.driver),
 		"hash-object", "--path=" + assignment.path, "--stdin",
 	}
@@ -537,15 +530,16 @@ func gitPathUsesNamedFilterDriver(ctx context.Context, repoPath string, assignme
 	if err != nil {
 		return false, err
 	}
-	command.Stdin = strings.NewReader("")
-	output, err := command.CombinedOutput()
+	command.Stdin = strings.NewReader(probeInput)
+	output, err := command.Output()
 	if err == nil {
-		return false, nil
+		return strings.TrimSpace(string(output)) != rawHash, nil
 	}
-	if bytes.Contains(output, []byte(gitFilterProbeMarker)) {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
 		return true, nil
 	}
-	return false, fmt.Errorf("probe git filter driver %q for %q: %w: %s", assignment.driver, assignment.path, err, strings.TrimSpace(string(output)))
+	return false, fmt.Errorf("probe git filter driver %q for %q: %w", assignment.driver, assignment.path, err)
 }
 
 // Git renders explicit drivers named set, unset, or unspecified exactly like

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -13,6 +15,13 @@ import (
 var resolveGitBinaryPathFn = gitexec.ResolveBinaryPath
 var collectLockfileGitContextFn = collectLockfileGitContext
 var execGitCommandContextFn = gitexec.CommandContext
+
+const (
+	gitObjectFormatSHA1   = "sha1"
+	gitObjectFormatSHA256 = "sha256"
+	emptyGitTreeSHA1      = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+	emptyGitTreePayload   = "tree 0\x00"
+)
 
 type lockfileGitContext struct {
 	changedFiles  map[string]struct{}
@@ -103,7 +112,11 @@ func gitHasVerifiedHead(ctx context.Context, repoPath string) (bool, error) {
 }
 
 func gitDiffNameOnly(ctx context.Context, repoPath string, diffArgs ...string) ([]string, error) {
-	args := []string{"-c", "diff.external=", "diff", "--no-ext-diff", "--no-textconv"}
+	attrSourceArg, err := gitEmptyTreeAttrSourceArg(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{attrSourceArg, "-c", "diff.external=", "diff", "--no-ext-diff", "--no-textconv"}
 	args = append(args, diffArgs...)
 	args = append(args, "--name-only", "--")
 	command, err := gitCommandContext(ctx, repoPath, args...)
@@ -171,6 +184,52 @@ func parseGitOutputLines(output []byte) []string {
 		return nil
 	}
 	return lines
+}
+
+func gitEmptyTreeAttrSourceArg(ctx context.Context, repoPath string) (string, error) {
+	objectFormat, err := gitObjectFormat(ctx, repoPath)
+	if err != nil {
+		return "", err
+	}
+	objectID, err := emptyTreeObjectID(objectFormat)
+	if err != nil {
+		return "", err
+	}
+	return "--attr-source=" + objectID, nil
+}
+
+func gitObjectFormat(ctx context.Context, repoPath string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	gitPath, err := resolveGitBinaryPathFn()
+	if err != nil {
+		return "", err
+	}
+	commandArgs := append(gitexec.SafeConfigArgs(), "-C", repoPath, "rev-parse", "--show-object-format")
+	command, err := execGitCommandContextFn(ctx, gitPath, commandArgs...)
+	if err != nil {
+		return "", err
+	}
+	command.Env = sanitizedGitEnv()
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("run git rev-parse --show-object-format: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func emptyTreeObjectID(objectFormat string) (string, error) {
+	payload := []byte(emptyGitTreePayload)
+	switch strings.ToLower(strings.TrimSpace(objectFormat)) {
+	case gitObjectFormatSHA1:
+		return emptyGitTreeSHA1, nil
+	case gitObjectFormatSHA256:
+		sum := sha256.Sum256(payload)
+		return hex.EncodeToString(sum[:]), nil
+	default:
+		return "", fmt.Errorf("unsupported git object format: %q", objectFormat)
+	}
 }
 
 func sanitizedGitEnv() []string {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -43,6 +43,10 @@ func collectLockfileGitContext(ctx context.Context, repoPath string, rules []loc
 	if err != nil {
 		return lockfileGitContext{}, err
 	}
+	return collectLockfileGitContextForPaths(ctx, repoPath, candidatePaths)
+}
+
+func collectLockfileGitContextForPaths(ctx context.Context, repoPath string, candidatePaths []string) (lockfileGitContext, error) {
 	filteredPaths, err := gitActiveFilterPathDrivers(ctx, repoPath, candidatePaths)
 	if err != nil {
 		return lockfileGitContext{}, err

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -99,7 +101,18 @@ func gitChangedFilesForPaths(ctx context.Context, repoPath string, paths []strin
 }
 
 func isGitWorktree(ctx context.Context, repoPath string) (bool, error) {
-	command, err := gitCommandContext(ctx, repoPath, gitRevParseSubcommand, "--is-inside-work-tree")
+	gitPath, err := resolveGitBinaryPathFn()
+	if err != nil {
+		hasGitMetadata, inspectErr := hasGitMetadataInAncestry(repoPath)
+		if inspectErr != nil {
+			return false, errors.Join(fmt.Errorf("resolve git binary: %w", err), fmt.Errorf("inspect git metadata: %w", inspectErr))
+		}
+		if !hasGitMetadata {
+			return false, nil
+		}
+		return false, err
+	}
+	command, err := gitCommandContextWithBinary(ctx, gitPath, repoPath, gitRevParseSubcommand, "--is-inside-work-tree")
 	if err != nil {
 		return false, err
 	}
@@ -119,6 +132,30 @@ func isGitWorktree(ctx context.Context, repoPath string) (bool, error) {
 		return false, nil
 	default:
 		return false, fmt.Errorf("run git rev-parse --is-inside-work-tree: unexpected output %q", strings.TrimSpace(string(output)))
+	}
+}
+
+func hasGitMetadataInAncestry(path string) (bool, error) {
+	searchDir, err := filepath.Abs(path)
+	if err != nil {
+		return false, err
+	}
+	searchDir, err = filepath.EvalSymlinks(searchDir)
+	if err != nil {
+		return false, err
+	}
+
+	for {
+		if _, err := os.Lstat(filepath.Join(searchDir, ".git")); err == nil {
+			return true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		parent := filepath.Dir(searchDir)
+		if parent == searchDir {
+			return false, nil
+		}
+		searchDir = parent
 	}
 }
 
@@ -281,12 +318,16 @@ func gitUntrackedFilesForPaths(ctx context.Context, repoPath string, paths []str
 }
 
 func gitCommandContext(ctx context.Context, repoPath string, args ...string) (*exec.Cmd, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	gitPath, err := resolveGitBinaryPathFn()
 	if err != nil {
 		return nil, err
+	}
+	return gitCommandContextWithBinary(ctx, gitPath, repoPath, args...)
+}
+
+func gitCommandContextWithBinary(ctx context.Context, gitPath, repoPath string, args ...string) (*exec.Cmd, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	commandArgs := append(gitexec.SafeConfigArgs(), "-C", repoPath)
 	commandArgs = append(commandArgs, args...)

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -19,6 +19,7 @@ var execGitCommandContextFn = gitexec.CommandContext
 const (
 	gitObjectFormatSHA1   = "sha1"
 	gitObjectFormatSHA256 = "sha256"
+	gitRevParseSubcommand = "rev-parse"
 	emptyGitTreeSHA1      = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 	emptyGitTreePayload   = "tree 0\x00"
 )
@@ -65,7 +66,7 @@ func gitChangedFiles(ctx context.Context, repoPath string) (map[string]struct{},
 }
 
 func isGitWorktree(ctx context.Context, repoPath string) bool {
-	command, err := gitCommandContext(ctx, repoPath, "rev-parse", "--is-inside-work-tree")
+	command, err := gitCommandContext(ctx, repoPath, gitRevParseSubcommand, "--is-inside-work-tree")
 	if err != nil {
 		return false
 	}
@@ -97,7 +98,7 @@ func gitTrackedChanges(ctx context.Context, repoPath string) ([]string, error) {
 }
 
 func gitHasVerifiedHead(ctx context.Context, repoPath string) (bool, error) {
-	command, err := gitCommandContext(ctx, repoPath, "rev-parse", "--verify", "--quiet", "HEAD")
+	command, err := gitCommandContext(ctx, repoPath, gitRevParseSubcommand, "--verify", "--quiet", "HEAD")
 	if err != nil {
 		return false, err
 	}
@@ -206,7 +207,7 @@ func gitObjectFormat(ctx context.Context, repoPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	commandArgs := append(gitexec.SafeConfigArgs(), "-C", repoPath, "rev-parse", "--show-object-format")
+	commandArgs := append(gitexec.SafeConfigArgs(), "-C", repoPath, gitRevParseSubcommand, "--show-object-format")
 	command, err := execGitCommandContextFn(ctx, gitPath, commandArgs...)
 	if err != nil {
 		return "", err

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -292,18 +292,13 @@ func gitActiveFilterPathDrivers(ctx context.Context, repoPath string, paths []st
 	if err != nil {
 		return nil, fmt.Errorf("parse git check-attr --stdin -z filter output: %w", err)
 	}
-	return filterConfiguredGitAttributeStateDrivers(ctx, repoPath, assignments)
+	return filterConfiguredGitAttributeDrivers(ctx, repoPath, assignments)
 }
 
-func filterConfiguredGitAttributeStateDrivers(ctx context.Context, repoPath string, assignments []gitFilterPathDriver) ([]gitFilterPathDriver, error) {
+func filterConfiguredGitAttributeDrivers(ctx context.Context, repoPath string, assignments []gitFilterPathDriver) ([]gitFilterPathDriver, error) {
 	active := make([]gitFilterPathDriver, 0, len(assignments))
 	configured := make(map[string]bool)
 	for _, assignment := range assignments {
-		if !isGitAttributeStateValue(assignment.driver) {
-			active = append(active, assignment)
-			continue
-		}
-
 		isConfigured, checked := configured[assignment.driver]
 		if !checked {
 			var err error
@@ -321,32 +316,29 @@ func filterConfiguredGitAttributeStateDrivers(ctx context.Context, repoPath stri
 }
 
 // Git renders explicit drivers named set, unset, or unspecified exactly like
-// attribute-state values, so matching executable config must disambiguate them.
+// attribute-state values. Requiring executable config for every returned name
+// disambiguates those states while allowing inert ordinary declarations.
 func gitFilterDriverHasExecutableConfig(ctx context.Context, repoPath, driver string) (bool, error) {
-	keyPattern := fmt.Sprintf(`^filter\.%s\.(clean|process)$`, driver)
-	args := []string{"config", "--includes", "--get-regexp", keyPattern}
-	command, err := gitCommandContext(ctx, repoPath, args...)
-	if err != nil {
-		return false, err
-	}
-	output, err := command.Output()
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-			return false, nil
+	for _, commandName := range []string{"clean", "process"} {
+		key := fmt.Sprintf("filter.%s.%s", driver, commandName)
+		args := []string{"config", "--includes", "--get", key}
+		command, err := gitCommandContext(ctx, repoPath, args...)
+		if err != nil {
+			return false, err
 		}
-		return false, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+		output, err := command.Output()
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+				continue
+			}
+			return false, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+		}
+		if len(strings.TrimSpace(string(output))) > 0 {
+			return true, nil
+		}
 	}
-	return len(strings.TrimSpace(string(output))) > 0, nil
-}
-
-func isGitAttributeStateValue(value string) bool {
-	switch value {
-	case "set", "unset", "unspecified":
-		return true
-	default:
-		return false
-	}
+	return false, nil
 }
 
 func newLockfileDriftFilterAmbiguityError(assignments []gitFilterPathDriver) error {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -1,9 +1,8 @@
 package app
 
 import (
+	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -17,11 +16,7 @@ var collectLockfileGitContextFn = collectLockfileGitContext
 var execGitCommandContextFn = gitexec.CommandContext
 
 const (
-	gitObjectFormatSHA1   = "sha1"
-	gitObjectFormatSHA256 = "sha256"
 	gitRevParseSubcommand = "rev-parse"
-	emptyGitTreeSHA1      = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-	emptyGitTreePayload   = "tree 0\x00"
 )
 
 type lockfileGitContext struct {
@@ -113,11 +108,11 @@ func gitHasVerifiedHead(ctx context.Context, repoPath string) (bool, error) {
 }
 
 func gitDiffNameOnly(ctx context.Context, repoPath string, diffArgs ...string) ([]string, error) {
-	attrSourceArg, err := gitEmptyTreeAttrSourceArg(ctx, repoPath)
+	filterArgs, err := gitFilterDriverConfigArgs(ctx, repoPath)
 	if err != nil {
 		return nil, err
 	}
-	args := []string{attrSourceArg, "-c", "diff.external=", "diff", "--no-ext-diff", "--no-textconv"}
+	args := append(append([]string{}, filterArgs...), "diff", "--no-ext-diff", "--no-textconv")
 	args = append(args, diffArgs...)
 	args = append(args, "--name-only", "--")
 	command, err := gitCommandContext(ctx, repoPath, args...)
@@ -187,50 +182,91 @@ func parseGitOutputLines(output []byte) []string {
 	return lines
 }
 
-func gitEmptyTreeAttrSourceArg(ctx context.Context, repoPath string) (string, error) {
-	objectFormat, err := gitObjectFormat(ctx, repoPath)
-	if err != nil {
-		return "", err
+func parseNULTerminatedGitOutput(output []byte) []string {
+	if len(output) == 0 {
+		return nil
 	}
-	objectID, err := emptyTreeObjectID(objectFormat)
-	if err != nil {
-		return "", err
+
+	fields := bytes.Split(output, []byte{0})
+	if len(fields) > 0 && len(fields[len(fields)-1]) == 0 {
+		fields = fields[:len(fields)-1]
 	}
-	return "--attr-source=" + objectID, nil
+
+	lines := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if len(field) == 0 {
+			continue
+		}
+		lines = append(lines, string(field))
+	}
+	return lines
 }
 
-func gitObjectFormat(ctx context.Context, repoPath string) (string, error) {
+func gitFilterDriverConfigArgs(ctx context.Context, repoPath string) ([]string, error) {
+	paths, err := gitAttributeCandidatePaths(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+	drivers, err := gitActiveFilterDrivers(ctx, repoPath, paths)
+	if err != nil {
+		return nil, err
+	}
+	return gitexec.FilterDriverConfigArgs(drivers), nil
+}
+
+func gitAttributeCandidatePaths(ctx context.Context, repoPath string) ([]string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	gitPath, err := resolveGitBinaryPathFn()
+	command, err := gitCommandContext(ctx, repoPath, "ls-files", "--cached", "--others", "--exclude-standard", "-z")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	commandArgs := append(gitexec.SafeConfigArgs(), "-C", repoPath, gitRevParseSubcommand, "--show-object-format")
-	command, err := execGitCommandContextFn(ctx, gitPath, commandArgs...)
-	if err != nil {
-		return "", err
-	}
-	command.Env = sanitizedGitEnv()
 	output, err := command.Output()
 	if err != nil {
-		return "", fmt.Errorf("run git rev-parse --show-object-format: %w", err)
+		return nil, fmt.Errorf("run git ls-files --cached --others --exclude-standard -z: %w", err)
 	}
-	return strings.TrimSpace(string(output)), nil
+	return parseNULTerminatedGitOutput(output), nil
 }
 
-func emptyTreeObjectID(objectFormat string) (string, error) {
-	payload := []byte(emptyGitTreePayload)
-	switch strings.ToLower(strings.TrimSpace(objectFormat)) {
-	case gitObjectFormatSHA1:
-		return emptyGitTreeSHA1, nil
-	case gitObjectFormatSHA256:
-		sum := sha256.Sum256(payload)
-		return hex.EncodeToString(sum[:]), nil
-	default:
-		return "", fmt.Errorf("unsupported git object format: %q", objectFormat)
+func gitActiveFilterDrivers(ctx context.Context, repoPath string, paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
 	}
+
+	command, err := gitCommandContext(ctx, repoPath, "check-attr", "--stdin", "-z", "filter")
+	if err != nil {
+		return nil, err
+	}
+	command.Stdin = strings.NewReader(strings.Join(paths, "\x00") + "\x00")
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("run git check-attr --stdin -z filter: %w", err)
+	}
+	return parseGitCheckAttrFilterDrivers(output), nil
+}
+
+func parseGitCheckAttrFilterDrivers(output []byte) []string {
+	fields := parseNULTerminatedGitOutput(output)
+	if len(fields) < 3 {
+		return nil
+	}
+
+	drivers := make([]string, 0, len(fields)/3)
+	seen := make(map[string]struct{}, len(fields)/3)
+	for index := 0; index+2 < len(fields); index += 3 {
+		value := strings.TrimSpace(fields[index+2])
+		switch value {
+		case "", "set", "unset", "unspecified":
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		drivers = append(drivers, value)
+	}
+	return drivers
 }
 
 func sanitizedGitEnv() []string {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -477,24 +477,33 @@ func filterConfiguredGitAttributeDrivers(ctx context.Context, repoPath string, a
 	active := make([]gitFilterPathDriver, 0, len(assignments))
 	stateProbeCache := make(map[gitFilterPathDriver]bool)
 	for _, assignment := range assignments {
-		if _, ok := configured[assignment.driver]; ok {
-			if isGitAttributeStateDriver(assignment.driver) {
-				activeStateDriver, ok := stateProbeCache[assignment]
-				if !ok {
-					var err error
-					activeStateDriver, err = gitPathUsesNamedFilterDriver(ctx, repoPath, assignment)
-					if err != nil {
-						return nil, err
-					}
-					stateProbeCache[assignment] = activeStateDriver
-				}
-				if !activeStateDriver {
-					continue
-				}
-			}
+		assignmentActive, err := gitFilterAssignmentIsActive(ctx, repoPath, assignment, configured, stateProbeCache)
+		if err != nil {
+			return nil, err
+		}
+		if assignmentActive {
 			active = append(active, assignment)
 		}
 	}
+	return active, nil
+}
+
+func gitFilterAssignmentIsActive(ctx context.Context, repoPath string, assignment gitFilterPathDriver, configured map[string]struct{}, stateProbeCache map[gitFilterPathDriver]bool) (bool, error) {
+	if _, ok := configured[assignment.driver]; !ok {
+		return false, nil
+	}
+	if !isGitAttributeStateDriver(assignment.driver) {
+		return true, nil
+	}
+	if active, ok := stateProbeCache[assignment]; ok {
+		return active, nil
+	}
+
+	active, err := gitPathUsesNamedFilterDriver(ctx, repoPath, assignment)
+	if err != nil {
+		return false, err
+	}
+	stateProbeCache[assignment] = active
 	return active, nil
 }
 

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -398,14 +398,6 @@ func newLockfileDriftFilterAmbiguityError(assignments []gitFilterPathDriver) err
 	return fmt.Errorf("cannot safely evaluate lockfile drift: active custom git filter drivers on %s", strings.Join(parts, ", "))
 }
 
-func parseGitCheckAttrFilterDrivers(paths []string, output []byte) ([]string, error) {
-	assignments, err := parseGitCheckAttrFilterPathDrivers(paths, output)
-	if err != nil {
-		return nil, err
-	}
-	return uniqueFilterDrivers(assignments), nil
-}
-
 func uniqueFilterDrivers(assignments []gitFilterPathDriver) []string {
 	drivers := make([]string, 0, len(assignments))
 	seen := make(map[string]struct{}, len(assignments))

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -435,18 +435,18 @@ func gitActiveFilterPathDrivers(ctx context.Context, repoPath string, paths []st
 		return nil, nil
 	}
 
-	command, err := gitCommandContext(ctx, repoPath, "check-attr", "--stdin", "-z", "filter")
+	command, err := gitCommandContext(ctx, repoPath, "check-attr", "--stdin", "-z", "--all")
 	if err != nil {
 		return nil, err
 	}
 	command.Stdin = strings.NewReader(strings.Join(paths, "\x00") + "\x00")
 	output, err := command.Output()
 	if err != nil {
-		return nil, fmt.Errorf("run git check-attr --stdin -z filter: %w", err)
+		return nil, fmt.Errorf("run git check-attr --stdin -z --all: %w", err)
 	}
 	assignments, err := parseGitCheckAttrFilterPathDrivers(paths, output)
 	if err != nil {
-		return nil, fmt.Errorf("parse git check-attr --stdin -z filter output: %w", err)
+		return nil, fmt.Errorf("parse git check-attr --stdin -z --all output: %w", err)
 	}
 	return filterConfiguredGitAttributeDrivers(ctx, repoPath, assignments)
 }
@@ -539,26 +539,36 @@ func newLockfileDriftFilterAmbiguityError(assignments []gitFilterPathDriver) err
 }
 
 func parseGitCheckAttrFilterPathDrivers(paths []string, output []byte) ([]gitFilterPathDriver, error) {
-	if len(output) == 0 || output[len(output)-1] != 0 {
+	if len(output) == 0 {
+		return nil, nil
+	}
+	if output[len(output)-1] != 0 {
 		return nil, errors.New("truncated output: missing trailing NUL terminator")
 	}
 
 	fields := parseNULTerminatedGitFields(output)
-	expectedFields := len(paths) * 3
-	if len(fields) != expectedFields {
-		return nil, fmt.Errorf("expected %d NUL-delimited fields for %d paths, got %d", expectedFields, len(paths), len(fields))
+	if len(fields)%3 != 0 {
+		return nil, fmt.Errorf("expected complete NUL-delimited attribute triplets, got %d fields", len(fields))
 	}
 
+	expectedPaths := make(map[string]int, len(paths))
+	for _, path := range paths {
+		expectedPaths[path]++
+	}
+	filterRecords := make(map[string]int, len(paths))
 	assignments := make([]gitFilterPathDriver, 0, len(fields)/3)
-	for index, expectedPath := range paths {
-		fieldIndex := index * 3
+	for fieldIndex := 0; fieldIndex < len(fields); fieldIndex += 3 {
 		path := fields[fieldIndex]
-		if path != expectedPath {
-			return nil, fmt.Errorf("path %d mismatch: expected %q, got %q", index, expectedPath, path)
+		if expectedPaths[path] == 0 {
+			return nil, fmt.Errorf("unexpected attribute path %q", path)
 		}
 		attribute := fields[fieldIndex+1]
 		if attribute != "filter" {
-			return nil, fmt.Errorf("attribute %d mismatch for %q: expected %q, got %q", index, expectedPath, "filter", attribute)
+			continue
+		}
+		filterRecords[path]++
+		if filterRecords[path] > expectedPaths[path] {
+			return nil, fmt.Errorf("too many filter records for %q", path)
 		}
 
 		value := strings.TrimSpace(fields[fieldIndex+2])

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -511,19 +511,25 @@ func parseGitExecutableFilterConfig(output []byte) (map[string]struct{}, error) 
 		return nil, errors.New("truncated output: missing trailing NUL terminator")
 	}
 
-	configured := make(map[string]struct{})
+	effectiveCommands := make(map[string]string)
 	for index, record := range parseNULTerminatedGitFields(output) {
 		key, value, ok := strings.Cut(record, "\n")
 		if !ok {
 			return nil, fmt.Errorf("record %d missing key/value separator", index)
 		}
-		driver, ok := gitFilterDriverFromExecutableConfigKey(key)
-		if !ok {
+		if _, ok := gitFilterDriverFromExecutableConfigKey(key); !ok {
 			return nil, fmt.Errorf("record %d has unexpected filter command key %q", index, key)
 		}
-		if strings.TrimSpace(value) != "" {
-			configured[driver] = struct{}{}
+		effectiveCommands[key] = strings.TrimSpace(value)
+	}
+
+	configured := make(map[string]struct{})
+	for key, value := range effectiveCommands {
+		if value == "" {
+			continue
 		}
+		driver, _ := gitFilterDriverFromExecutableConfigKey(key)
+		configured[driver] = struct{}{}
 	}
 	return configured, nil
 }

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/gitexec"
@@ -22,6 +23,10 @@ const (
 	gitExcludeStandardArg = "--exclude-standard"
 	gitCachedFlag         = "--cached"
 	gitLiteralPathPrefix  = ":(literal)"
+	// Keep aggregate argv comfortably bounded. A single path cannot be split,
+	// but real candidates come from WalkDir and remain filesystem/Git bounded.
+	gitPathspecBatchPaths = 128
+	gitPathspecBatchBytes = 16 * 1024
 )
 
 type lockfileGitContext struct {
@@ -140,7 +145,15 @@ func gitHasVerifiedHead(ctx context.Context, repoPath string) (bool, error) {
 }
 
 func gitDiffNameOnlyForPaths(ctx context.Context, repoPath string, paths []string, diffArgs ...string) ([]string, error) {
-	return gitDiffNameOnly(ctx, repoPath, paths, diffArgs...)
+	groups := make([][]string, 0)
+	for _, batch := range gitPathspecBatches(paths) {
+		changed, err := gitDiffNameOnly(ctx, repoPath, batch, diffArgs...)
+		if err != nil {
+			return nil, err
+		}
+		groups = append(groups, changed)
+	}
+	return mergeSortedGitPaths(groups...), nil
 }
 
 func gitDiffNameOnly(ctx context.Context, repoPath string, paths []string, diffArgs ...string) ([]string, error) {
@@ -178,6 +191,31 @@ func mergeGitPaths(groups ...[]string) []string {
 	return merged
 }
 
+func mergeSortedGitPaths(groups ...[]string) []string {
+	merged := mergeGitPaths(groups...)
+	sort.Strings(merged)
+	return merged
+}
+
+func gitPathspecBatches(paths []string) [][]string {
+	if len(paths) == 0 {
+		return nil
+	}
+	batches := make([][]string, 0, (len(paths)+gitPathspecBatchPaths-1)/gitPathspecBatchPaths)
+	start := 0
+	batchBytes := 0
+	for index, path := range paths {
+		pathBytes := len(gitLiteralPathPrefix) + len(path) + 1
+		if index > start && (index-start >= gitPathspecBatchPaths || batchBytes+pathBytes > gitPathspecBatchBytes) {
+			batches = append(batches, paths[start:index])
+			start = index
+			batchBytes = 0
+		}
+		batchBytes += pathBytes
+	}
+	return append(batches, paths[start:])
+}
+
 func gitLiteralPathspecs(paths []string) []string {
 	if len(paths) == 0 {
 		return nil
@@ -205,18 +243,21 @@ func gitUntrackedFilesForPaths(ctx context.Context, repoPath string, paths []str
 	if len(paths) == 0 {
 		return nil, nil
 	}
-	args := []string{gitLsFilesSubcommand, gitOthersFlag, gitExcludeStandardArg, "-z"}
-	args = append(args, "--")
-	args = append(args, gitLiteralPathspecs(paths)...)
-	command, err := gitCommandContext(ctx, repoPath, args...)
-	if err != nil {
-		return nil, err
+	groups := make([][]string, 0)
+	for _, batch := range gitPathspecBatches(paths) {
+		args := []string{gitLsFilesSubcommand, gitOthersFlag, gitExcludeStandardArg, "-z", "--"}
+		args = append(args, gitLiteralPathspecs(batch)...)
+		command, err := gitCommandContext(ctx, repoPath, args...)
+		if err != nil {
+			return nil, err
+		}
+		output, err := command.Output()
+		if err != nil {
+			return nil, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+		}
+		groups = append(groups, parseNULTerminatedGitOutput(output))
 	}
-	output, err := command.Output()
-	if err != nil {
-		return nil, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
-	}
-	return parseNULTerminatedGitOutput(output), nil
+	return mergeSortedGitPaths(groups...), nil
 }
 
 func gitCommandContext(ctx context.Context, repoPath string, args ...string) (*exec.Cmd, error) {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -429,19 +429,18 @@ func gitActiveFilterPathDrivers(ctx context.Context, repoPath string, paths []st
 }
 
 func filterConfiguredGitAttributeDrivers(ctx context.Context, repoPath string, assignments []gitFilterPathDriver) ([]gitFilterPathDriver, error) {
+	if len(assignments) == 0 {
+		return nil, nil
+	}
+
+	configured, err := gitExecutableFilterDrivers(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+
 	active := make([]gitFilterPathDriver, 0, len(assignments))
-	configured := make(map[string]bool)
 	for _, assignment := range assignments {
-		isConfigured, checked := configured[assignment.driver]
-		if !checked {
-			var err error
-			isConfigured, err = gitFilterDriverHasExecutableConfig(ctx, repoPath, assignment.driver)
-			if err != nil {
-				return nil, err
-			}
-			configured[assignment.driver] = isConfigured
-		}
-		if isConfigured {
+		if _, ok := configured[gitConfigCaseFold(assignment.driver)]; ok {
 			active = append(active, assignment)
 		}
 	}
@@ -451,27 +450,71 @@ func filterConfiguredGitAttributeDrivers(ctx context.Context, repoPath string, a
 // Git renders explicit drivers named set, unset, or unspecified exactly like
 // attribute-state values. Requiring executable config for every returned name
 // disambiguates those states while allowing inert ordinary declarations.
-func gitFilterDriverHasExecutableConfig(ctx context.Context, repoPath, driver string) (bool, error) {
-	for _, commandName := range []string{"clean", "process"} {
-		key := fmt.Sprintf("filter.%s.%s", driver, commandName)
-		args := []string{"config", "--includes", "--get", key}
-		command, err := gitCommandContext(ctx, repoPath, args...)
-		if err != nil {
-			return false, err
+func gitExecutableFilterDrivers(ctx context.Context, repoPath string) (map[string]struct{}, error) {
+	args := []string{"config", "--null", "--includes", "--get-regexp", `^filter\..*\.(clean|process)$`}
+	command, err := gitCommandContext(ctx, repoPath, args...)
+	if err != nil {
+		return nil, err
+	}
+	output, err := command.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return map[string]struct{}{}, nil
 		}
-		output, err := command.Output()
-		if err != nil {
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-				continue
-			}
-			return false, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+		return nil, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+	}
+	configured, err := parseGitExecutableFilterConfig(output)
+	if err != nil {
+		return nil, fmt.Errorf("parse git config --null --includes --get-regexp output: %w", err)
+	}
+	return configured, nil
+}
+
+func parseGitExecutableFilterConfig(output []byte) (map[string]struct{}, error) {
+	if len(output) == 0 || output[len(output)-1] != 0 {
+		return nil, errors.New("truncated output: missing trailing NUL terminator")
+	}
+
+	configured := make(map[string]struct{})
+	for index, record := range parseNULTerminatedGitFields(output) {
+		key, value, ok := strings.Cut(record, "\n")
+		if !ok {
+			return nil, fmt.Errorf("record %d missing key/value separator", index)
 		}
-		if len(strings.TrimSpace(string(output))) > 0 {
-			return true, nil
+		driver, ok := gitFilterDriverFromExecutableConfigKey(key)
+		if !ok {
+			return nil, fmt.Errorf("record %d has unexpected filter command key %q", index, key)
+		}
+		if strings.TrimSpace(value) != "" {
+			configured[gitConfigCaseFold(driver)] = struct{}{}
 		}
 	}
-	return false, nil
+	return configured, nil
+}
+
+func gitFilterDriverFromExecutableConfigKey(key string) (string, bool) {
+	const prefix = "filter."
+	if len(key) <= len(prefix) || !strings.EqualFold(key[:len(prefix)], prefix) {
+		return "", false
+	}
+	for _, suffix := range []string{".clean", ".process"} {
+		if len(key) <= len(prefix)+len(suffix) || !strings.EqualFold(key[len(key)-len(suffix):], suffix) {
+			continue
+		}
+		return key[len(prefix) : len(key)-len(suffix)], true
+	}
+	return "", false
+}
+
+func gitConfigCaseFold(value string) string {
+	folded := []byte(value)
+	for index, char := range folded {
+		if char >= 'A' && char <= 'Z' {
+			folded[index] = char + ('a' - 'A')
+		}
+	}
+	return string(folded)
 }
 
 func newLockfileDriftFilterAmbiguityError(assignments []gitFilterPathDriver) error {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -58,7 +58,11 @@ func collectLockfileGitContext(ctx context.Context, repoPath string, rules []loc
 }
 
 func collectLockfileGitContextForPaths(ctx context.Context, repoPath string, candidatePaths []string) (lockfileGitContext, error) {
-	filteredPaths, err := gitActiveFilterPathDrivers(ctx, repoPath, candidatePaths)
+	trackedPaths, untrackedPaths, err := classifyGitCandidatePaths(ctx, repoPath, candidatePaths)
+	if err != nil {
+		return lockfileGitContext{}, err
+	}
+	filteredPaths, err := gitActiveFilterPathDrivers(ctx, repoPath, trackedPaths)
 	if err != nil {
 		return lockfileGitContext{}, err
 	}
@@ -66,7 +70,7 @@ func collectLockfileGitContextForPaths(ctx context.Context, repoPath string, can
 		return lockfileGitContext{}, newLockfileDriftFilterAmbiguityError(filteredPaths)
 	}
 
-	changedFiles, err := gitChangedFilesForPaths(ctx, repoPath, candidatePaths)
+	changedFiles, err := gitChangedFilesForClassifiedPaths(ctx, repoPath, trackedPaths, untrackedPaths)
 	if err != nil {
 		return lockfileGitContext{}, err
 	}
@@ -77,11 +81,38 @@ func collectLockfileGitContextForPaths(ctx context.Context, repoPath string, can
 }
 
 func gitChangedFilesForPaths(ctx context.Context, repoPath string, paths []string) (map[string]struct{}, error) {
-	if len(paths) == 0 {
-		return map[string]struct{}{}, nil
+	trackedPaths, untrackedPaths, err := classifyGitCandidatePaths(ctx, repoPath, paths)
+	if err != nil {
+		return nil, err
 	}
+	return gitChangedFilesForClassifiedPaths(ctx, repoPath, trackedPaths, untrackedPaths)
+}
+
+func classifyGitCandidatePaths(ctx context.Context, repoPath string, paths []string) ([]string, []string, error) {
+	untrackedPaths, err := gitUntrackedFilesForPaths(ctx, repoPath, paths)
+	if err != nil {
+		return nil, nil, err
+	}
+	return excludeGitPaths(paths, untrackedPaths), untrackedPaths, nil
+}
+
+func excludeGitPaths(paths, excludedPaths []string) []string {
+	excluded := make(map[string]struct{}, len(excludedPaths))
+	for _, path := range excludedPaths {
+		excluded[path] = struct{}{}
+	}
+	remaining := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if _, ok := excluded[path]; !ok {
+			remaining = append(remaining, path)
+		}
+	}
+	return remaining
+}
+
+func gitChangedFilesForClassifiedPaths(ctx context.Context, repoPath string, trackedPaths, untrackedPaths []string) (map[string]struct{}, error) {
 	changed := map[string]struct{}{}
-	tracked, err := gitTrackedChangesForPaths(ctx, repoPath, paths)
+	tracked, err := gitTrackedChangesForPaths(ctx, repoPath, trackedPaths)
 	if err != nil {
 		return nil, err
 	}
@@ -89,11 +120,7 @@ func gitChangedFilesForPaths(ctx context.Context, repoPath string, paths []strin
 		changed[path] = struct{}{}
 	}
 
-	untracked, err := gitUntrackedFilesForPaths(ctx, repoPath, paths)
-	if err != nil {
-		return nil, err
-	}
-	for _, path := range untracked {
+	for _, path := range untrackedPaths {
 		changed[path] = struct{}{}
 	}
 

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -108,17 +108,18 @@ func gitHasVerifiedHead(ctx context.Context, repoPath string) (bool, error) {
 }
 
 func gitDiffNameOnly(ctx context.Context, repoPath string, diffArgs ...string) ([]string, error) {
-	filterArgs, err := gitFilterDriverConfigArgs(ctx, repoPath)
+	filterDrivers, err := gitDiffFilterDrivers(ctx, repoPath)
 	if err != nil {
 		return nil, err
 	}
-	args := append(append([]string{}, filterArgs...), "diff", "--no-ext-diff", "--no-textconv")
+	args := []string{"diff", "--no-ext-diff", "--no-textconv"}
 	args = append(args, diffArgs...)
 	args = append(args, "--name-only", "--")
 	command, err := gitCommandContext(ctx, repoPath, args...)
 	if err != nil {
 		return nil, err
 	}
+	command.Env = gitexec.SanitizedEnvWithFilterDrivers(filterDrivers)
 	output, err := command.Output()
 	if err != nil {
 		return nil, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
@@ -183,6 +184,22 @@ func parseGitOutputLines(output []byte) []string {
 }
 
 func parseNULTerminatedGitOutput(output []byte) []string {
+	fields := parseNULTerminatedGitFields(output)
+	if len(fields) == 0 {
+		return nil
+	}
+
+	lines := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if field == "" {
+			continue
+		}
+		lines = append(lines, field)
+	}
+	return lines
+}
+
+func parseNULTerminatedGitFields(output []byte) []string {
 	if len(output) == 0 {
 		return nil
 	}
@@ -194,15 +211,12 @@ func parseNULTerminatedGitOutput(output []byte) []string {
 
 	lines := make([]string, 0, len(fields))
 	for _, field := range fields {
-		if len(field) == 0 {
-			continue
-		}
 		lines = append(lines, string(field))
 	}
 	return lines
 }
 
-func gitFilterDriverConfigArgs(ctx context.Context, repoPath string) ([]string, error) {
+func gitDiffFilterDrivers(ctx context.Context, repoPath string) ([]string, error) {
 	paths, err := gitAttributeCandidatePaths(ctx, repoPath)
 	if err != nil {
 		return nil, err
@@ -211,7 +225,7 @@ func gitFilterDriverConfigArgs(ctx context.Context, repoPath string) ([]string, 
 	if err != nil {
 		return nil, err
 	}
-	return gitexec.FilterDriverConfigArgs(drivers), nil
+	return drivers, nil
 }
 
 func gitAttributeCandidatePaths(ctx context.Context, repoPath string) ([]string, error) {
@@ -247,7 +261,7 @@ func gitActiveFilterDrivers(ctx context.Context, repoPath string, paths []string
 }
 
 func parseGitCheckAttrFilterDrivers(output []byte) []string {
-	fields := parseNULTerminatedGitOutput(output)
+	fields := parseNULTerminatedGitFields(output)
 	if len(fields) < 3 {
 		return nil
 	}

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -257,19 +257,38 @@ func gitActiveFilterDrivers(ctx context.Context, repoPath string, paths []string
 	if err != nil {
 		return nil, fmt.Errorf("run git check-attr --stdin -z filter: %w", err)
 	}
-	return parseGitCheckAttrFilterDrivers(output), nil
+	drivers, err := parseGitCheckAttrFilterDrivers(paths, output)
+	if err != nil {
+		return nil, fmt.Errorf("parse git check-attr --stdin -z filter output: %w", err)
+	}
+	return drivers, nil
 }
 
-func parseGitCheckAttrFilterDrivers(output []byte) []string {
+func parseGitCheckAttrFilterDrivers(paths []string, output []byte) ([]string, error) {
+	if len(output) == 0 || output[len(output)-1] != 0 {
+		return nil, errors.New("truncated output: missing trailing NUL terminator")
+	}
+
 	fields := parseNULTerminatedGitFields(output)
-	if len(fields) < 3 {
-		return nil
+	expectedFields := len(paths) * 3
+	if len(fields) != expectedFields {
+		return nil, fmt.Errorf("expected %d NUL-delimited fields for %d paths, got %d", expectedFields, len(paths), len(fields))
 	}
 
 	drivers := make([]string, 0, len(fields)/3)
 	seen := make(map[string]struct{}, len(fields)/3)
-	for index := 0; index+2 < len(fields); index += 3 {
-		value := strings.TrimSpace(fields[index+2])
+	for index, expectedPath := range paths {
+		fieldIndex := index * 3
+		path := fields[fieldIndex]
+		if path != expectedPath {
+			return nil, fmt.Errorf("path %d mismatch: expected %q, got %q", index, expectedPath, path)
+		}
+		attribute := fields[fieldIndex+1]
+		if attribute != "filter" {
+			return nil, fmt.Errorf("attribute %d mismatch for %q: expected %q, got %q", index, expectedPath, "filter", attribute)
+		}
+
+		value := strings.TrimSpace(fields[fieldIndex+2])
 		switch value {
 		case "", "set", "unset", "unspecified":
 			continue
@@ -280,7 +299,7 @@ func parseGitCheckAttrFilterDrivers(output []byte) []string {
 		seen[value] = struct{}{}
 		drivers = append(drivers, value)
 	}
-	return drivers
+	return drivers, nil
 }
 
 func sanitizedGitEnv() []string {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -21,6 +21,7 @@ const (
 	gitOthersFlag         = "--others"
 	gitExcludeStandardArg = "--exclude-standard"
 	gitCachedFlag         = "--cached"
+	gitLiteralPathPrefix  = ":(literal)"
 )
 
 type lockfileGitContext struct {
@@ -202,7 +203,7 @@ func gitDiffNameOnlyWithFilterDrivers(ctx context.Context, repoPath string, filt
 	args := []string{"diff", "--no-ext-diff", "--no-textconv"}
 	args = append(args, diffArgs...)
 	args = append(args, "--name-only", "--")
-	args = append(args, paths...)
+	args = append(args, gitLiteralPathspecs(paths)...)
 	command, err := gitCommandContext(ctx, repoPath, args...)
 	if err != nil {
 		return nil, err
@@ -233,6 +234,17 @@ func mergeGitPaths(groups ...[]string) []string {
 	return merged
 }
 
+func gitLiteralPathspecs(paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	literalPaths := make([]string, 0, len(paths))
+	for _, path := range paths {
+		literalPaths = append(literalPaths, gitLiteralPathPrefix+path)
+	}
+	return literalPaths
+}
+
 func gitUntrackedFiles(ctx context.Context, repoPath string) ([]string, error) {
 	command, err := gitCommandContext(ctx, repoPath, gitLsFilesSubcommand, gitOthersFlag, gitExcludeStandardArg)
 	if err != nil {
@@ -251,7 +263,7 @@ func gitUntrackedFilesForPaths(ctx context.Context, repoPath string, paths []str
 	}
 	args := []string{gitLsFilesSubcommand, gitOthersFlag, gitExcludeStandardArg, "-z"}
 	args = append(args, "--")
-	args = append(args, paths...)
+	args = append(args, gitLiteralPathspecs(paths)...)
 	command, err := gitCommandContext(ctx, repoPath, args...)
 	if err != nil {
 		return nil, err

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -61,38 +61,6 @@ func collectLockfileGitContext(ctx context.Context, repoPath string, rules []loc
 	}, nil
 }
 
-func gitChangedFiles(ctx context.Context, repoPath string) (map[string]struct{}, bool, error) {
-	if !isGitWorktree(ctx, repoPath) {
-		return nil, false, nil
-	}
-	changed, err := gitChangedFilesInWorktree(ctx, repoPath)
-	if err != nil {
-		return nil, true, err
-	}
-	return changed, true, nil
-}
-
-func gitChangedFilesInWorktree(ctx context.Context, repoPath string) (map[string]struct{}, error) {
-	changed := map[string]struct{}{}
-	tracked, err := gitTrackedChanges(ctx, repoPath)
-	if err != nil {
-		return nil, err
-	}
-	for _, path := range tracked {
-		changed[path] = struct{}{}
-	}
-
-	untracked, err := gitUntrackedFiles(ctx, repoPath)
-	if err != nil {
-		return nil, err
-	}
-	for _, path := range untracked {
-		changed[path] = struct{}{}
-	}
-
-	return changed, nil
-}
-
 func gitChangedFilesForPaths(ctx context.Context, repoPath string, paths []string) (map[string]struct{}, error) {
 	if len(paths) == 0 {
 		return map[string]struct{}{}, nil
@@ -127,26 +95,6 @@ func isGitWorktree(ctx context.Context, repoPath string) bool {
 		return false
 	}
 	return strings.TrimSpace(string(output)) == "true"
-}
-
-func gitTrackedChanges(ctx context.Context, repoPath string) ([]string, error) {
-	hasHead, err := gitHasVerifiedHead(ctx, repoPath)
-	if err != nil {
-		return nil, err
-	}
-	if hasHead {
-		return gitDiffNameOnly(ctx, repoPath, "HEAD")
-	}
-	// Unborn HEAD: derive tracked changes from staged + working tree diffs.
-	staged, err := gitDiffNameOnly(ctx, repoPath, gitCachedFlag)
-	if err != nil {
-		return nil, err
-	}
-	unstaged, err := gitDiffNameOnly(ctx, repoPath)
-	if err != nil {
-		return nil, err
-	}
-	return mergeGitPaths(staged, unstaged), nil
 }
 
 func gitTrackedChangesForPaths(ctx context.Context, repoPath string, paths []string) ([]string, error) {
@@ -187,19 +135,11 @@ func gitHasVerifiedHead(ctx context.Context, repoPath string) (bool, error) {
 	return true, nil
 }
 
-func gitDiffNameOnly(ctx context.Context, repoPath string, diffArgs ...string) ([]string, error) {
-	filterDrivers, err := gitDiffFilterDrivers(ctx, repoPath)
-	if err != nil {
-		return nil, err
-	}
-	return gitDiffNameOnlyWithFilterDrivers(ctx, repoPath, filterDrivers, nil, diffArgs...)
-}
-
 func gitDiffNameOnlyForPaths(ctx context.Context, repoPath string, paths []string, diffArgs ...string) ([]string, error) {
-	return gitDiffNameOnlyWithFilterDrivers(ctx, repoPath, nil, paths, diffArgs...)
+	return gitDiffNameOnly(ctx, repoPath, paths, diffArgs...)
 }
 
-func gitDiffNameOnlyWithFilterDrivers(ctx context.Context, repoPath string, filterDrivers, paths []string, diffArgs ...string) ([]string, error) {
+func gitDiffNameOnly(ctx context.Context, repoPath string, paths []string, diffArgs ...string) ([]string, error) {
 	args := []string{"diff", "--no-ext-diff", "--no-textconv"}
 	args = append(args, diffArgs...)
 	args = append(args, "--name-only", "--")
@@ -208,7 +148,7 @@ func gitDiffNameOnlyWithFilterDrivers(ctx context.Context, repoPath string, filt
 	if err != nil {
 		return nil, err
 	}
-	command.Env = gitexec.SanitizedEnvWithFilterDrivers(filterDrivers)
+	command.Env = gitexec.SanitizedEnv()
 	output, err := command.Output()
 	if err != nil {
 		return nil, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
@@ -334,41 +274,6 @@ func parseNULTerminatedGitFields(output []byte) []string {
 	return lines
 }
 
-func gitDiffFilterDrivers(ctx context.Context, repoPath string) ([]string, error) {
-	paths, err := gitAttributeCandidatePaths(ctx, repoPath)
-	if err != nil {
-		return nil, err
-	}
-	drivers, err := gitActiveFilterDrivers(ctx, repoPath, paths)
-	if err != nil {
-		return nil, err
-	}
-	return drivers, nil
-}
-
-func gitAttributeCandidatePaths(ctx context.Context, repoPath string) ([]string, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	command, err := gitCommandContext(ctx, repoPath, "ls-files", "--cached", "--others", "--exclude-standard", "-z")
-	if err != nil {
-		return nil, err
-	}
-	output, err := command.Output()
-	if err != nil {
-		return nil, fmt.Errorf("run git ls-files --cached --others --exclude-standard -z: %w", err)
-	}
-	return parseNULTerminatedGitOutput(output), nil
-}
-
-func gitActiveFilterDrivers(ctx context.Context, repoPath string, paths []string) ([]string, error) {
-	assignments, err := gitActiveFilterPathDrivers(ctx, repoPath, paths)
-	if err != nil {
-		return nil, err
-	}
-	return uniqueFilterDrivers(assignments), nil
-}
-
 func gitActiveFilterPathDrivers(ctx context.Context, repoPath string, paths []string) ([]gitFilterPathDriver, error) {
 	if len(paths) == 0 {
 		return nil, nil
@@ -396,19 +301,6 @@ func newLockfileDriftFilterAmbiguityError(assignments []gitFilterPathDriver) err
 		parts = append(parts, fmt.Sprintf("%s (%s)", assignment.path, assignment.driver))
 	}
 	return fmt.Errorf("cannot safely evaluate lockfile drift: active custom git filter drivers on %s", strings.Join(parts, ", "))
-}
-
-func uniqueFilterDrivers(assignments []gitFilterPathDriver) []string {
-	drivers := make([]string, 0, len(assignments))
-	seen := make(map[string]struct{}, len(assignments))
-	for _, assignment := range assignments {
-		if _, ok := seen[assignment.driver]; ok {
-			continue
-		}
-		seen[assignment.driver] = struct{}{}
-		drivers = append(drivers, assignment.driver)
-	}
-	return drivers
 }
 
 func parseGitCheckAttrFilterPathDrivers(paths []string, output []byte) ([]gitFilterPathDriver, error) {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -41,6 +41,18 @@ type gitFilterPathDriver struct {
 	driver string
 }
 
+type lockfileDriftFilterAmbiguityError struct {
+	assignments []gitFilterPathDriver
+}
+
+func (e *lockfileDriftFilterAmbiguityError) Error() string {
+	parts := make([]string, 0, len(e.assignments))
+	for _, assignment := range e.assignments {
+		parts = append(parts, fmt.Sprintf("%s (%s)", assignment.path, assignment.driver))
+	}
+	return fmt.Sprintf("cannot safely evaluate lockfile drift: active custom git filter drivers on %s", strings.Join(parts, ", "))
+}
+
 func collectLockfileGitContext(ctx context.Context, repoPath string, rules []lockfileRule) (lockfileGitContext, error) {
 	isWorktree, err := isGitWorktree(ctx, repoPath)
 	if err != nil {
@@ -531,11 +543,7 @@ func gitFilterDriverFromExecutableConfigKey(key string) (string, bool) {
 }
 
 func newLockfileDriftFilterAmbiguityError(assignments []gitFilterPathDriver) error {
-	parts := make([]string, 0, len(assignments))
-	for _, assignment := range assignments {
-		parts = append(parts, fmt.Sprintf("%s (%s)", assignment.path, assignment.driver))
-	}
-	return fmt.Errorf("cannot safely evaluate lockfile drift: active custom git filter drivers on %s", strings.Join(parts, ", "))
+	return &lockfileDriftFilterAmbiguityError{assignments: assignments}
 }
 
 func parseGitCheckAttrFilterPathDrivers(paths []string, output []byte) ([]gitFilterPathDriver, error) {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -155,7 +155,8 @@ func gitCommandContext(ctx context.Context, repoPath string, args ...string) (*e
 	if err != nil {
 		return nil, err
 	}
-	commandArgs := append([]string{"-C", repoPath}, args...)
+	commandArgs := append(gitexec.SafeConfigArgs(), "-C", repoPath)
+	commandArgs = append(commandArgs, args...)
 	command, err := execGitCommandContextFn(ctx, gitPath, commandArgs...)
 	if err != nil {
 		return nil, err

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -17,6 +17,10 @@ var execGitCommandContextFn = gitexec.CommandContext
 
 const (
 	gitRevParseSubcommand = "rev-parse"
+	gitLsFilesSubcommand  = "ls-files"
+	gitOthersFlag         = "--others"
+	gitExcludeStandardArg = "--exclude-standard"
+	gitCachedFlag         = "--cached"
 )
 
 type lockfileGitContext struct {
@@ -133,7 +137,7 @@ func gitTrackedChanges(ctx context.Context, repoPath string) ([]string, error) {
 		return gitDiffNameOnly(ctx, repoPath, "HEAD")
 	}
 	// Unborn HEAD: derive tracked changes from staged + working tree diffs.
-	staged, err := gitDiffNameOnly(ctx, repoPath, "--cached")
+	staged, err := gitDiffNameOnly(ctx, repoPath, gitCachedFlag)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +160,7 @@ func gitTrackedChangesForPaths(ctx context.Context, repoPath string, paths []str
 		return gitDiffNameOnlyForPaths(ctx, repoPath, paths, "HEAD")
 	}
 	// Unborn HEAD: derive tracked changes from staged + working tree diffs.
-	staged, err := gitDiffNameOnlyForPaths(ctx, repoPath, paths, "--cached")
+	staged, err := gitDiffNameOnlyForPaths(ctx, repoPath, paths, gitCachedFlag)
 	if err != nil {
 		return nil, err
 	}
@@ -230,13 +234,13 @@ func mergeGitPaths(groups ...[]string) []string {
 }
 
 func gitUntrackedFiles(ctx context.Context, repoPath string) ([]string, error) {
-	command, err := gitCommandContext(ctx, repoPath, "ls-files", "--others", "--exclude-standard")
+	command, err := gitCommandContext(ctx, repoPath, gitLsFilesSubcommand, gitOthersFlag, gitExcludeStandardArg)
 	if err != nil {
 		return nil, err
 	}
 	output, err := command.Output()
 	if err != nil {
-		return nil, fmt.Errorf("run git ls-files --others --exclude-standard: %w", err)
+		return nil, fmt.Errorf("run git %s %s %s: %w", gitLsFilesSubcommand, gitOthersFlag, gitExcludeStandardArg, err)
 	}
 	return parseGitOutputLines(output), nil
 }
@@ -245,7 +249,7 @@ func gitUntrackedFilesForPaths(ctx context.Context, repoPath string, paths []str
 	if len(paths) == 0 {
 		return nil, nil
 	}
-	args := []string{"ls-files", "--others", "--exclude-standard", "-z"}
+	args := []string{gitLsFilesSubcommand, gitOthersFlag, gitExcludeStandardArg, "-z"}
 	args = append(args, "--")
 	args = append(args, paths...)
 	command, err := gitCommandContext(ctx, repoPath, args...)

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -40,7 +40,11 @@ type gitFilterPathDriver struct {
 }
 
 func collectLockfileGitContext(ctx context.Context, repoPath string, rules []lockfileRule) (lockfileGitContext, error) {
-	if !isGitWorktree(ctx, repoPath) {
+	isWorktree, err := isGitWorktree(ctx, repoPath)
+	if err != nil {
+		return lockfileGitContext{}, err
+	}
+	if !isWorktree {
 		return lockfileGitContext{}, nil
 	}
 
@@ -94,16 +98,28 @@ func gitChangedFilesForPaths(ctx context.Context, repoPath string, paths []strin
 	return changed, nil
 }
 
-func isGitWorktree(ctx context.Context, repoPath string) bool {
+func isGitWorktree(ctx context.Context, repoPath string) (bool, error) {
 	command, err := gitCommandContext(ctx, repoPath, gitRevParseSubcommand, "--is-inside-work-tree")
 	if err != nil {
-		return false
+		return false, err
 	}
-	output, err := command.Output()
+	command.Env = append(command.Env, "LC_ALL=C")
+	output, err := command.CombinedOutput()
 	if err != nil {
-		return false
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 128 && bytes.Contains(output, []byte("not a git repository")) {
+			return false, nil
+		}
+		return false, fmt.Errorf("run git rev-parse --is-inside-work-tree: %w", err)
 	}
-	return strings.TrimSpace(string(output)) == "true"
+	switch strings.TrimSpace(string(output)) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("run git rev-parse --is-inside-work-tree: unexpected output %q", strings.TrimSpace(string(output)))
+	}
 }
 
 func gitTrackedChangesForPaths(ctx context.Context, repoPath string, paths []string) ([]string, error) {
@@ -205,7 +221,7 @@ func gitPathspecBatches(paths []string) [][]string {
 	start := 0
 	batchBytes := 0
 	for index, path := range paths {
-		pathBytes := len(gitLiteralPathPrefix) + len(path) + 1
+		pathBytes := gitPathspecArgBytes(path)
 		if index > start && (index-start >= gitPathspecBatchPaths || batchBytes+pathBytes > gitPathspecBatchBytes) {
 			batches = append(batches, paths[start:index])
 			start = index
@@ -214,6 +230,10 @@ func gitPathspecBatches(paths []string) [][]string {
 		batchBytes += pathBytes
 	}
 	return append(batches, paths[start:])
+}
+
+func gitPathspecArgBytes(path string) int {
+	return len(gitLiteralPathPrefix) + len(path) + 1
 }
 
 func gitLiteralPathspecs(paths []string) []string {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -89,25 +89,37 @@ func gitChangedFilesForPaths(ctx context.Context, repoPath string, paths []strin
 }
 
 func classifyGitCandidatePaths(ctx context.Context, repoPath string, paths []string) ([]string, []string, error) {
+	visiblePaths, err := gitVisibleFilesForPaths(ctx, repoPath, paths)
+	if err != nil {
+		return nil, nil, err
+	}
 	untrackedPaths, err := gitUntrackedFilesForPaths(ctx, repoPath, paths)
 	if err != nil {
 		return nil, nil, err
 	}
-	return excludeGitPaths(paths, untrackedPaths), untrackedPaths, nil
-}
 
-func excludeGitPaths(paths, excludedPaths []string) []string {
-	excluded := make(map[string]struct{}, len(excludedPaths))
-	for _, path := range excludedPaths {
-		excluded[path] = struct{}{}
+	visible := make(map[string]struct{}, len(visiblePaths))
+	for _, path := range visiblePaths {
+		visible[path] = struct{}{}
 	}
-	remaining := make([]string, 0, len(paths))
+	untracked := make(map[string]struct{}, len(untrackedPaths))
+	for _, path := range untrackedPaths {
+		untracked[path] = struct{}{}
+	}
+
+	trackedPaths := make([]string, 0, len(paths))
+	classifiedUntrackedPaths := make([]string, 0, len(untrackedPaths))
 	for _, path := range paths {
-		if _, ok := excluded[path]; !ok {
-			remaining = append(remaining, path)
+		if _, ok := visible[path]; !ok {
+			continue
+		}
+		if _, ok := untracked[path]; ok {
+			classifiedUntrackedPaths = append(classifiedUntrackedPaths, path)
+		} else {
+			trackedPaths = append(trackedPaths, path)
 		}
 	}
-	return remaining
+	return trackedPaths, classifiedUntrackedPaths, nil
 }
 
 func gitChangedFilesForClassifiedPaths(ctx context.Context, repoPath string, trackedPaths, untrackedPaths []string) (map[string]struct{}, error) {
@@ -324,12 +336,23 @@ func gitUntrackedFiles(ctx context.Context, repoPath string) ([]string, error) {
 }
 
 func gitUntrackedFilesForPaths(ctx context.Context, repoPath string, paths []string) ([]string, error) {
+	return gitFilesForPaths(ctx, repoPath, paths, gitOthersFlag, gitExcludeStandardArg)
+}
+
+func gitVisibleFilesForPaths(ctx context.Context, repoPath string, paths []string) ([]string, error) {
+	return gitFilesForPaths(ctx, repoPath, paths, gitCachedFlag, gitOthersFlag, gitExcludeStandardArg)
+}
+
+func gitFilesForPaths(ctx context.Context, repoPath string, paths []string, flags ...string) ([]string, error) {
 	if len(paths) == 0 {
 		return nil, nil
 	}
 	groups := make([][]string, 0)
 	for _, batch := range gitPathspecBatches(paths) {
-		args := []string{gitLsFilesSubcommand, gitOthersFlag, gitExcludeStandardArg, "-z", "--"}
+		args := make([]string, 0, 3+len(flags)+len(batch))
+		args = append(args, gitLsFilesSubcommand)
+		args = append(args, flags...)
+		args = append(args, "-z", "--")
 		args = append(args, gitLiteralPathspecs(batch)...)
 		command, err := gitCommandContext(ctx, repoPath, args...)
 		if err != nil {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -292,7 +292,61 @@ func gitActiveFilterPathDrivers(ctx context.Context, repoPath string, paths []st
 	if err != nil {
 		return nil, fmt.Errorf("parse git check-attr --stdin -z filter output: %w", err)
 	}
-	return assignments, nil
+	return filterConfiguredGitAttributeStateDrivers(ctx, repoPath, assignments)
+}
+
+func filterConfiguredGitAttributeStateDrivers(ctx context.Context, repoPath string, assignments []gitFilterPathDriver) ([]gitFilterPathDriver, error) {
+	active := make([]gitFilterPathDriver, 0, len(assignments))
+	configured := make(map[string]bool)
+	for _, assignment := range assignments {
+		if !isGitAttributeStateValue(assignment.driver) {
+			active = append(active, assignment)
+			continue
+		}
+
+		isConfigured, checked := configured[assignment.driver]
+		if !checked {
+			var err error
+			isConfigured, err = gitFilterDriverHasExecutableConfig(ctx, repoPath, assignment.driver)
+			if err != nil {
+				return nil, err
+			}
+			configured[assignment.driver] = isConfigured
+		}
+		if isConfigured {
+			active = append(active, assignment)
+		}
+	}
+	return active, nil
+}
+
+// Git renders explicit drivers named set, unset, or unspecified exactly like
+// attribute-state values, so matching executable config must disambiguate them.
+func gitFilterDriverHasExecutableConfig(ctx context.Context, repoPath, driver string) (bool, error) {
+	keyPattern := fmt.Sprintf(`^filter\.%s\.(clean|process)$`, driver)
+	args := []string{"config", "--includes", "--get-regexp", keyPattern}
+	command, err := gitCommandContext(ctx, repoPath, args...)
+	if err != nil {
+		return false, err
+	}
+	output, err := command.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+	}
+	return len(strings.TrimSpace(string(output))) > 0, nil
+}
+
+func isGitAttributeStateValue(value string) bool {
+	switch value {
+	case "set", "unset", "unspecified":
+		return true
+	default:
+		return false
+	}
 }
 
 func newLockfileDriftFilterAmbiguityError(assignments []gitFilterPathDriver) error {
@@ -327,8 +381,7 @@ func parseGitCheckAttrFilterPathDrivers(paths []string, output []byte) ([]gitFil
 		}
 
 		value := strings.TrimSpace(fields[fieldIndex+2])
-		switch value {
-		case "", "set", "unset", "unspecified":
+		if value == "" {
 			continue
 		}
 		assignments = append(assignments, gitFilterPathDriver{

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -46,13 +46,13 @@ func collectLockfileGitContext(ctx context.Context, repoPath string, rules []loc
 		return lockfileGitContext{}, newLockfileDriftFilterAmbiguityError(filteredPaths)
 	}
 
-	changedFiles, hasGitContext, err := gitChangedFiles(ctx, repoPath)
+	changedFiles, err := gitChangedFilesForPaths(ctx, repoPath, candidatePaths)
 	if err != nil {
 		return lockfileGitContext{}, err
 	}
 	return lockfileGitContext{
 		changedFiles:  changedFiles,
-		hasGitContext: hasGitContext,
+		hasGitContext: true,
 	}, nil
 }
 
@@ -60,11 +60,18 @@ func gitChangedFiles(ctx context.Context, repoPath string) (map[string]struct{},
 	if !isGitWorktree(ctx, repoPath) {
 		return nil, false, nil
 	}
+	changed, err := gitChangedFilesInWorktree(ctx, repoPath)
+	if err != nil {
+		return nil, true, err
+	}
+	return changed, true, nil
+}
 
+func gitChangedFilesInWorktree(ctx context.Context, repoPath string) (map[string]struct{}, error) {
 	changed := map[string]struct{}{}
 	tracked, err := gitTrackedChanges(ctx, repoPath)
 	if err != nil {
-		return nil, true, err
+		return nil, err
 	}
 	for _, path := range tracked {
 		changed[path] = struct{}{}
@@ -72,13 +79,37 @@ func gitChangedFiles(ctx context.Context, repoPath string) (map[string]struct{},
 
 	untracked, err := gitUntrackedFiles(ctx, repoPath)
 	if err != nil {
-		return nil, true, err
+		return nil, err
 	}
 	for _, path := range untracked {
 		changed[path] = struct{}{}
 	}
 
-	return changed, true, nil
+	return changed, nil
+}
+
+func gitChangedFilesForPaths(ctx context.Context, repoPath string, paths []string) (map[string]struct{}, error) {
+	if len(paths) == 0 {
+		return map[string]struct{}{}, nil
+	}
+	changed := map[string]struct{}{}
+	tracked, err := gitTrackedChangesForPaths(ctx, repoPath, paths)
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range tracked {
+		changed[path] = struct{}{}
+	}
+
+	untracked, err := gitUntrackedFilesForPaths(ctx, repoPath, paths)
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range untracked {
+		changed[path] = struct{}{}
+	}
+
+	return changed, nil
 }
 
 func isGitWorktree(ctx context.Context, repoPath string) bool {
@@ -113,6 +144,29 @@ func gitTrackedChanges(ctx context.Context, repoPath string) ([]string, error) {
 	return mergeGitPaths(staged, unstaged), nil
 }
 
+func gitTrackedChangesForPaths(ctx context.Context, repoPath string, paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	hasHead, err := gitHasVerifiedHead(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+	if hasHead {
+		return gitDiffNameOnlyForPaths(ctx, repoPath, paths, "HEAD")
+	}
+	// Unborn HEAD: derive tracked changes from staged + working tree diffs.
+	staged, err := gitDiffNameOnlyForPaths(ctx, repoPath, paths, "--cached")
+	if err != nil {
+		return nil, err
+	}
+	unstaged, err := gitDiffNameOnlyForPaths(ctx, repoPath, paths)
+	if err != nil {
+		return nil, err
+	}
+	return mergeGitPaths(staged, unstaged), nil
+}
+
 func gitHasVerifiedHead(ctx context.Context, repoPath string) (bool, error) {
 	command, err := gitCommandContext(ctx, repoPath, gitRevParseSubcommand, "--verify", "--quiet", "HEAD")
 	if err != nil {
@@ -133,9 +187,18 @@ func gitDiffNameOnly(ctx context.Context, repoPath string, diffArgs ...string) (
 	if err != nil {
 		return nil, err
 	}
+	return gitDiffNameOnlyWithFilterDrivers(ctx, repoPath, filterDrivers, nil, diffArgs...)
+}
+
+func gitDiffNameOnlyForPaths(ctx context.Context, repoPath string, paths []string, diffArgs ...string) ([]string, error) {
+	return gitDiffNameOnlyWithFilterDrivers(ctx, repoPath, nil, paths, diffArgs...)
+}
+
+func gitDiffNameOnlyWithFilterDrivers(ctx context.Context, repoPath string, filterDrivers, paths []string, diffArgs ...string) ([]string, error) {
 	args := []string{"diff", "--no-ext-diff", "--no-textconv"}
 	args = append(args, diffArgs...)
 	args = append(args, "--name-only", "--")
+	args = append(args, paths...)
 	command, err := gitCommandContext(ctx, repoPath, args...)
 	if err != nil {
 		return nil, err
@@ -176,6 +239,24 @@ func gitUntrackedFiles(ctx context.Context, repoPath string) ([]string, error) {
 		return nil, fmt.Errorf("run git ls-files --others --exclude-standard: %w", err)
 	}
 	return parseGitOutputLines(output), nil
+}
+
+func gitUntrackedFilesForPaths(ctx context.Context, repoPath string, paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	args := []string{"ls-files", "--others", "--exclude-standard", "-z"}
+	args = append(args, "--")
+	args = append(args, paths...)
+	command, err := gitCommandContext(ctx, repoPath, args...)
+	if err != nil {
+		return nil, err
+	}
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+	}
+	return parseNULTerminatedGitOutput(output), nil
 }
 
 func gitCommandContext(ctx context.Context, repoPath string, args ...string) (*exec.Cmd, error) {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -264,7 +264,7 @@ func gitDiffNameOnlyForPaths(ctx context.Context, repoPath string, paths []strin
 func gitDiffNameOnly(ctx context.Context, repoPath string, paths []string, diffArgs ...string) ([]string, error) {
 	args := []string{"diff", "--no-ext-diff", "--no-textconv"}
 	args = append(args, diffArgs...)
-	args = append(args, "--name-only", "--")
+	args = append(args, "--name-only", "-z", "--")
 	args = append(args, gitLiteralPathspecs(paths)...)
 	command, err := gitCommandContext(ctx, repoPath, args...)
 	if err != nil {
@@ -275,7 +275,7 @@ func gitDiffNameOnly(ctx context.Context, repoPath string, paths []string, diffA
 	if err != nil {
 		return nil, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
 	}
-	return parseGitOutputLines(output), nil
+	return parseNULTerminatedGitOutput(output), nil
 }
 
 func mergeGitPaths(groups ...[]string) []string {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -440,7 +440,7 @@ func filterConfiguredGitAttributeDrivers(ctx context.Context, repoPath string, a
 
 	active := make([]gitFilterPathDriver, 0, len(assignments))
 	for _, assignment := range assignments {
-		if _, ok := configured[gitConfigCaseFold(assignment.driver)]; ok {
+		if _, ok := configured[assignment.driver]; ok {
 			active = append(active, assignment)
 		}
 	}
@@ -487,7 +487,7 @@ func parseGitExecutableFilterConfig(output []byte) (map[string]struct{}, error) 
 			return nil, fmt.Errorf("record %d has unexpected filter command key %q", index, key)
 		}
 		if strings.TrimSpace(value) != "" {
-			configured[gitConfigCaseFold(driver)] = struct{}{}
+			configured[driver] = struct{}{}
 		}
 	}
 	return configured, nil
@@ -505,16 +505,6 @@ func gitFilterDriverFromExecutableConfigKey(key string) (string, bool) {
 		return key[len(prefix) : len(key)-len(suffix)], true
 	}
 	return "", false
-}
-
-func gitConfigCaseFold(value string) string {
-	folded := []byte(value)
-	for index, char := range folded {
-		if char >= 'A' && char <= 'Z' {
-			folded[index] = char + ('a' - 'A')
-		}
-	}
-	return string(folded)
 }
 
 func newLockfileDriftFilterAmbiguityError(assignments []gitFilterPathDriver) error {

--- a/internal/app/lockfile_drift_git.go
+++ b/internal/app/lockfile_drift_git.go
@@ -25,6 +25,7 @@ const (
 	gitExcludeStandardArg = "--exclude-standard"
 	gitCachedFlag         = "--cached"
 	gitLiteralPathPrefix  = ":(literal)"
+	gitFilterProbeMarker  = "__LOPPER_LOCKFILE_FILTER_PROBE__"
 	// Keep aggregate argv comfortably bounded. A single path cannot be split,
 	// but real candidates come from WalkDir and remain filesystem/Git bounded.
 	gitPathspecBatchPaths = 128
@@ -474,12 +475,77 @@ func filterConfiguredGitAttributeDrivers(ctx context.Context, repoPath string, a
 	}
 
 	active := make([]gitFilterPathDriver, 0, len(assignments))
+	stateProbeCache := make(map[gitFilterPathDriver]bool)
 	for _, assignment := range assignments {
 		if _, ok := configured[assignment.driver]; ok {
+			if isGitAttributeStateDriver(assignment.driver) {
+				activeStateDriver, ok := stateProbeCache[assignment]
+				if !ok {
+					var err error
+					activeStateDriver, err = gitPathUsesNamedFilterDriver(ctx, repoPath, assignment)
+					if err != nil {
+						return nil, err
+					}
+					stateProbeCache[assignment] = activeStateDriver
+				}
+				if !activeStateDriver {
+					continue
+				}
+			}
 			active = append(active, assignment)
 		}
 	}
 	return active, nil
+}
+
+func isGitAttributeStateDriver(driver string) bool {
+	switch driver {
+	case "set", "unset", "unspecified":
+		return true
+	default:
+		return false
+	}
+}
+
+func gitPathUsesNamedFilterDriver(ctx context.Context, repoPath string, assignment gitFilterPathDriver) (active bool, err error) {
+	probeDir, err := os.MkdirTemp("", "lopper-lockfile-filter-probe-")
+	if err != nil {
+		return false, fmt.Errorf("create git filter probe dir: %w", err)
+	}
+	defer func() {
+		if removeErr := os.RemoveAll(probeDir); removeErr != nil && err == nil {
+			err = fmt.Errorf("remove git filter probe dir: %w", removeErr)
+		}
+	}()
+
+	probePath := filepath.Join(probeDir, "probe.sh")
+	probeScript := "#!/bin/sh\n" +
+		"echo " + gitFilterProbeMarker + " >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(probePath, []byte(probeScript), 0o600); err != nil {
+		return false, fmt.Errorf("write git filter probe: %w", err)
+	}
+	probeCommand := "/bin/sh " + probePath
+
+	args := []string{
+		"-c", fmt.Sprintf("filter.%s.clean=%s", assignment.driver, probeCommand),
+		"-c", fmt.Sprintf("filter.%s.process=%s", assignment.driver, probeCommand),
+		"-c", fmt.Sprintf("filter.%s.required=true", assignment.driver),
+		"hash-object", "--path=" + assignment.path, "--stdin",
+	}
+	command, err := gitCommandContext(ctx, repoPath, args...)
+	if err != nil {
+		return false, err
+	}
+	command.Stdin = strings.NewReader("")
+	output, err := command.CombinedOutput()
+	if err == nil {
+		return false, nil
+	}
+	if bytes.Contains(output, []byte(gitFilterProbeMarker)) {
+		return true, nil
+	}
+	return false, fmt.Errorf("probe git filter driver %q for %q: %w: %s", assignment.driver, assignment.path, err, strings.TrimSpace(string(output)))
 }
 
 // Git renders explicit drivers named set, unset, or unspecified exactly like

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -2,6 +2,9 @@ package app
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -25,4 +28,101 @@ func TestDetectLockfileDriftPropagatesGitContextErrors(t *testing.T) {
 			t.Fatalf("expected ls-files error with stopOnFirst=%v, got %v", stopOnFirst, err)
 		}
 	}
+}
+
+func TestDetectLockfileDriftStopOnFirstBatchesGitContextAcrossDirectories(t *testing.T) {
+	repo := t.TempDir()
+	const candidateDirs = gitPathspecBatchPaths/2 + 1
+	for index := range candidateDirs {
+		dir := filepath.Join(repo, fmt.Sprintf("pkg-%03d", index))
+		writeFile(t, filepath.Join(dir, manifestFileName), demoPackageJSON)
+		writeFile(t, filepath.Join(dir, lockfileName), "{}\n")
+	}
+	initGitRepo(t, repo)
+
+	commandGroups := captureLockfileGitCommandGroups(t)
+	warnings, err := detectLockfileDrift(context.Background(), repo, true)
+	if err != nil {
+		t.Fatalf("detect lockfile drift: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected clean candidate directories, got %#v", warnings)
+	}
+
+	if got := commandGroups["worktree"]; got != 1 {
+		t.Errorf("expected one worktree detection command, got %d", got)
+	}
+	for _, group := range []string{"check-attr", "head", "diff", "ls-files"} {
+		if got := commandGroups[group]; got != 2 {
+			t.Errorf("expected two bounded %s command groups for %d candidate directories, got %d", group, candidateDirs, got)
+		}
+	}
+}
+
+func TestDetectLockfileDriftStopOnFirstPropagatesGitDetectionErrors(t *testing.T) {
+	t.Run("command construction", func(t *testing.T) {
+		originalResolve := resolveGitBinaryPathFn
+		forcedErr := errors.New("forced git detection construction failure")
+		resolveGitBinaryPathFn = func() (string, error) { return "", forcedErr }
+		t.Cleanup(func() { resolveGitBinaryPathFn = originalResolve })
+
+		_, err := detectLockfileDrift(context.Background(), t.TempDir(), true)
+		if !errors.Is(err, forcedErr) {
+			t.Fatalf("expected git detection construction error, got %v", err)
+		}
+	})
+
+	t.Run("rev-parse execution", func(t *testing.T) {
+		originalResolve := resolveGitBinaryPathFn
+		originalExec := execGitCommandContextFn
+		resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+		execGitCommandContextFn = func(ctx context.Context, _ string, _ ...string) (*exec.Cmd, error) {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 23"), nil
+		}
+		t.Cleanup(func() {
+			resolveGitBinaryPathFn = originalResolve
+			execGitCommandContextFn = originalExec
+		})
+
+		_, err := detectLockfileDrift(context.Background(), t.TempDir(), true)
+		if err == nil || !strings.Contains(err.Error(), "rev-parse --is-inside-work-tree") {
+			t.Fatalf("expected rev-parse worktree detection error, got %v", err)
+		}
+	})
+}
+
+func captureLockfileGitCommandGroups(t *testing.T) map[string]int {
+	t.Helper()
+
+	originalExec := execGitCommandContextFn
+	commandGroups := make(map[string]int)
+	execGitCommandContextFn = func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
+		if group := lockfileGitCommandGroup(args); group != "" {
+			commandGroups[group]++
+		}
+		return originalExec(ctx, gitPath, args...)
+	}
+	t.Cleanup(func() { execGitCommandContextFn = originalExec })
+	return commandGroups
+}
+
+func lockfileGitCommandGroup(args []string) string {
+	for index, arg := range args {
+		if arg != "-C" || index+2 >= len(args) {
+			continue
+		}
+		commandArgs := args[index+2:]
+		switch commandArgs[0] {
+		case "check-attr", "diff", "ls-files":
+			return commandArgs[0]
+		case gitRevParseSubcommand:
+			if len(commandArgs) > 1 && commandArgs[1] == "--verify" {
+				return "head"
+			}
+			return "worktree"
+		default:
+			return ""
+		}
+	}
+	return ""
 }

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -291,6 +291,44 @@ func TestLockfileFailFastBatchScannerPropagatesSnapshotEvaluationErrors(t *testi
 	})
 }
 
+func TestLockfileFailFastBatchScannerReplaysAmbiguousSnapshots(t *testing.T) {
+	t.Run("candidate path error", func(t *testing.T) {
+		repo, snapshot := newPoetrySnapshot(t, true)
+		forcedErr := errors.New("forced candidate path failure")
+		rule := newPoetryLockfileRule(func(string, string) (bool, error) {
+			return false, forcedErr
+		})
+		scanner := lockfileFailFastBatchScanner{repoPath: repo, rules: []lockfileRule{rule}}
+		if err := scanner.flushSnapshotsInOrder(context.Background(), []lockfileDirSnapshot{snapshot}); !errors.Is(err, forcedErr) {
+			t.Fatalf("expected candidate-path error, got %v", err)
+		}
+	})
+
+	t.Run("git context error", func(t *testing.T) {
+		repo, snapshot := newPoetrySnapshot(t, true)
+		forcedErr := errors.New("forced git context failure")
+		originalResolve := resolveGitBinaryPathFn
+		resolveGitBinaryPathFn = func() (string, error) { return "", forcedErr }
+		t.Cleanup(func() { resolveGitBinaryPathFn = originalResolve })
+
+		rule := newPoetryLockfileRule(func(string, string) (bool, error) { return true, nil })
+		scanner := lockfileFailFastBatchScanner{repoPath: repo, rules: []lockfileRule{rule}}
+		if err := scanner.flushSnapshotsInOrder(context.Background(), []lockfileDirSnapshot{snapshot}); !errors.Is(err, forcedErr) {
+			t.Fatalf("expected git-context error, got %v", err)
+		}
+	})
+
+	t.Run("clean snapshot", func(t *testing.T) {
+		repo, snapshot := newPoetrySnapshot(t, true)
+		initGitRepo(t, repo)
+		rule := newPoetryLockfileRule(func(string, string) (bool, error) { return true, nil })
+		scanner := lockfileFailFastBatchScanner{repoPath: repo, rules: []lockfileRule{rule}}
+		if err := scanner.flushSnapshotsInOrder(context.Background(), []lockfileDirSnapshot{snapshot}); err != nil {
+			t.Fatalf("expected clean replay, got %v", err)
+		}
+	})
+}
+
 func captureLockfileGitCommandGroups(t *testing.T) map[string]int {
 	t.Helper()
 

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -14,42 +14,13 @@ func TestDetectLockfileDriftPropagatesGitContextErrors(t *testing.T) {
 	resolveGitBinaryPathFn = func() (string, error) { return writeFakeGitBinary(t), nil }
 	useFakeGitCommandContext(t)
 
-	cases := []struct {
-		name    string
-		mode    string
-		wantSub string
-		run     func(context.Context, string) error
-	}{
-		{
-			name:    "detect lockfile drift propagates git context errors",
-			mode:    "lsfail",
-			wantSub: "ls-files",
-			run: func(ctx context.Context, repo string) error {
-				_, err := detectLockfileDrift(ctx, repo, false)
-				return err
-			},
-		},
-		{
-			name:    "git changed files propagates tracked change failures",
-			mode:    "difffail-head",
-			wantSub: "run git",
-			run: func(ctx context.Context, repo string) error {
-				_, _, err := gitChangedFiles(ctx, repo)
-				return err
-			},
-		},
-	}
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	writeFakeGitMode(t, repo, "lsfail")
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			repo := t.TempDir()
-			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-			writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
-			writeFakeGitMode(t, repo, tc.mode)
-			err := tc.run(context.Background(), repo)
-			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
-				t.Fatalf("expected %q error, got %v", tc.wantSub, err)
-			}
-		})
+	_, err := detectLockfileDrift(context.Background(), repo, false)
+	if err == nil || !strings.Contains(err.Error(), "ls-files") {
+		t.Fatalf("expected ls-files error, got %v", err)
 	}
 }

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -57,6 +57,58 @@ func TestGitWorktreeDetectionMissingBinaryFailsClosedWhenMetadataCannotBeInspect
 	}
 }
 
+func TestGitWorktreeDetectionDubiousOwnershipFailsClosed(t *testing.T) {
+	originalResolve := resolveGitBinaryPathFn
+	originalExec := execGitCommandContextFn
+	resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+	execGitCommandContextFn = func(ctx context.Context, _ string, _ ...string) (*exec.Cmd, error) {
+		return exec.CommandContext(ctx, "/bin/sh", "-c", "printf '%s\\n' \"$1\" >&2; exit 128", "git", "fatal: detected dubious ownership in repository at '/repo'"), nil
+	}
+	t.Cleanup(func() {
+		resolveGitBinaryPathFn = originalResolve
+		execGitCommandContextFn = originalExec
+	})
+
+	repo := t.TempDir()
+	assertRevParseError := func(t *testing.T, err error) {
+		t.Helper()
+		if err == nil || !strings.Contains(err.Error(), "run git rev-parse --is-inside-work-tree") {
+			t.Fatalf("expected hard rev-parse error, got %v", err)
+		}
+	}
+	t.Run("worktree detection", func(t *testing.T) {
+		inside, err := isGitWorktree(context.Background(), repo)
+		if inside {
+			t.Fatal("expected dubious ownership refusal not to report a Git worktree")
+		}
+		assertRevParseError(t, err)
+	})
+
+	consumers := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "lockfile drift",
+			run: func() error {
+				_, err := detectLockfileDrift(context.Background(), repo, false)
+				return err
+			},
+		},
+		{
+			name: "codemod apply",
+			run: func() error {
+				return validateCodemodApplyPreconditions(context.Background(), repo, AnalyseRequest{ApplyCodemod: true})
+			},
+		},
+	}
+	for _, consumer := range consumers {
+		t.Run(consumer.name, func(t *testing.T) {
+			assertRevParseError(t, consumer.run())
+		})
+	}
+}
+
 func TestDetectLockfileDriftStopOnFirstBatchesGitContextAcrossDirectories(t *testing.T) {
 	repo := t.TempDir()
 	const candidateDirs = gitPathspecBatchPaths/2 + 1

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -44,6 +45,18 @@ func TestDetectLockfileDriftPlainDirectoryWithoutGitBinary(t *testing.T) {
 	}
 }
 
+func TestGitWorktreeDetectionMissingBinaryFailsClosedWhenMetadataCannotBeInspected(t *testing.T) {
+	original := resolveGitBinaryPathFn
+	forcedErr := errors.New(gitExecutableNotFoundErr)
+	resolveGitBinaryPathFn = func() (string, error) { return "", forcedErr }
+	t.Cleanup(func() { resolveGitBinaryPathFn = original })
+
+	_, err := isGitWorktree(context.Background(), filepath.Join(t.TempDir(), "missing"))
+	if !errors.Is(err, forcedErr) || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected binary resolution and metadata inspection errors, got %v", err)
+	}
+}
+
 func TestDetectLockfileDriftStopOnFirstBatchesGitContextAcrossDirectories(t *testing.T) {
 	repo := t.TempDir()
 	const candidateDirs = gitPathspecBatchPaths/2 + 1
@@ -80,9 +93,32 @@ func TestDetectLockfileDriftStopOnFirstPropagatesGitDetectionErrors(t *testing.T
 		resolveGitBinaryPathFn = func() (string, error) { return "", forcedErr }
 		t.Cleanup(func() { resolveGitBinaryPathFn = originalResolve })
 
-		_, err := detectLockfileDrift(context.Background(), t.TempDir(), true)
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, ".git", "HEAD"), "ref: refs/heads/main\n")
+		_, err := detectLockfileDrift(context.Background(), repo, true)
 		if !errors.Is(err, forcedErr) {
 			t.Fatalf("expected git detection construction error, got %v", err)
+		}
+	})
+
+	t.Run("command factory", func(t *testing.T) {
+		originalResolve := resolveGitBinaryPathFn
+		originalExec := execGitCommandContextFn
+		forcedErr := errors.New("forced git command factory failure")
+		resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+		execGitCommandContextFn = func(context.Context, string, ...string) (*exec.Cmd, error) {
+			return nil, forcedErr
+		}
+		t.Cleanup(func() {
+			resolveGitBinaryPathFn = originalResolve
+			execGitCommandContextFn = originalExec
+		})
+
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, ".git", "HEAD"), "ref: refs/heads/main\n")
+		_, err := detectLockfileDrift(context.Background(), repo, true)
+		if !errors.Is(err, forcedErr) {
+			t.Fatalf("expected git command factory error, got %v", err)
 		}
 	})
 

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -298,6 +299,29 @@ func TestLockfileFailFastBatchScannerReplaysAmbiguousSnapshots(t *testing.T) {
 		scanner := lockfileFailFastBatchScanner{repoPath: repo, rules: []lockfileRule{rule}}
 		if err := scanner.flushSnapshotsInOrder(context.Background(), []lockfileDirSnapshot{snapshot}); err != nil {
 			t.Fatalf("expected candidate-free replay to continue, got %v", err)
+		}
+	})
+
+	t.Run("later immediate finding after clean candidate", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+		writeFile(t, filepath.Join(repo, pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\n")
+		initGitRepo(t, repo)
+		snapshot, err := readLockfileDirSnapshot(repo, repo)
+		if err != nil {
+			t.Fatalf("read lockfile snapshot: %v", err)
+		}
+		rules := []lockfileRule{
+			mustLockfileRule(t, "npm", manifestFileName),
+			mustLockfileRule(t, "Poetry", pyprojectManifestName),
+		}
+		scanner := lockfileFailFastBatchScanner{repoPath: repo, rules: rules}
+		if err := scanner.flushSnapshotsInOrder(context.Background(), []lockfileDirSnapshot{snapshot}); !errors.Is(err, fs.SkipAll) {
+			t.Fatalf("expected replay to stop on the later immediate finding, got %v", err)
+		}
+		if len(scanner.warnings) != 1 || !strings.Contains(scanner.warnings[0], "Poetry in .") {
+			t.Fatalf("expected replay to preserve the later Poetry finding, got %#v", scanner.warnings)
 		}
 	})
 

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -30,6 +30,20 @@ func TestDetectLockfileDriftPropagatesGitContextErrors(t *testing.T) {
 	}
 }
 
+func TestDetectLockfileDriftPlainDirectoryWithoutGitBinary(t *testing.T) {
+	original := resolveGitBinaryPathFn
+	resolveGitBinaryPathFn = func() (string, error) { return "", errors.New(gitExecutableNotFoundErr) }
+	t.Cleanup(func() { resolveGitBinaryPathFn = original })
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+
+	for _, stopOnFirst := range []bool{false, true} {
+		warnings, err := detectLockfileDrift(context.Background(), repo, stopOnFirst)
+		assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json exists but no matching lockfile", "npm install")
+	}
+}
+
 func TestDetectLockfileDriftStopOnFirstBatchesGitContextAcrossDirectories(t *testing.T) {
 	repo := t.TempDir()
 	const candidateDirs = gitPathspecBatchPaths/2 + 1

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -206,6 +206,36 @@ func TestLockfileGitSnapshotBatchHonorsLimitsAndDeduplicates(t *testing.T) {
 	}
 }
 
+func TestLockfileFailFastBatchScannerPropagatesSnapshotEvaluationErrors(t *testing.T) {
+	repo, snapshot := newPoetrySnapshot(t, true)
+	forcedErr := errors.New("forced snapshot evaluation failure")
+
+	t.Run("record first", func(t *testing.T) {
+		rule := newPoetryLockfileRule(func(string, string) (bool, error) {
+			return false, forcedErr
+		})
+		scanner := lockfileFailFastBatchScanner{repoPath: repo, rules: []lockfileRule{rule}}
+		if err := scanner.recordFirst(snapshot, lockfileGitContext{}); !errors.Is(err, forcedErr) {
+			t.Fatalf("expected record-first evaluation error, got %v", err)
+		}
+	})
+
+	t.Run("candidate paths", func(t *testing.T) {
+		matcherCalls := 0
+		rule := newPoetryLockfileRule(func(string, string) (bool, error) {
+			matcherCalls++
+			if matcherCalls == 2 {
+				return false, forcedErr
+			}
+			return true, nil
+		})
+		scanner := lockfileFailFastBatchScanner{repoPath: repo, rules: []lockfileRule{rule}}
+		if err := scanner.visit(context.Background(), snapshot); !errors.Is(err, forcedErr) {
+			t.Fatalf("expected candidate-path evaluation error, got %v", err)
+		}
+	})
+}
+
 func captureLockfileGitCommandGroups(t *testing.T) map[string]int {
 	t.Helper()
 

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -91,6 +91,71 @@ func TestDetectLockfileDriftStopOnFirstPropagatesGitDetectionErrors(t *testing.T
 	})
 }
 
+func TestGitWorktreeDetectionDistinguishesFalseAndMalformedResults(t *testing.T) {
+	cases := []struct {
+		name    string
+		output  string
+		wantErr bool
+	}{
+		{name: "explicit false", output: "false\n"},
+		{name: "malformed", output: "indeterminate\n", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalResolve := resolveGitBinaryPathFn
+			originalExec := execGitCommandContextFn
+			resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+			execGitCommandContextFn = func(ctx context.Context, _ string, _ ...string) (*exec.Cmd, error) {
+				return exec.CommandContext(ctx, "/bin/sh", "-c", "printf '%s' \"$1\"", "git-output", tc.output), nil
+			}
+			t.Cleanup(func() {
+				resolveGitBinaryPathFn = originalResolve
+				execGitCommandContextFn = originalExec
+			})
+
+			inside, err := isGitWorktree(context.Background(), t.TempDir())
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("isGitWorktree error = %v, wantErr=%v", err, tc.wantErr)
+			}
+			if inside {
+				t.Fatal("expected false worktree result")
+			}
+		})
+	}
+}
+
+func TestLockfileGitSnapshotBatchHonorsLimitsAndDeduplicates(t *testing.T) {
+	if batches := gitPathspecBatches(nil); len(batches) != 0 {
+		t.Fatalf("expected no pathspec batches for an empty input, got %#v", batches)
+	}
+
+	snapshot := lockfileDirSnapshot{relDir: "pkg"}
+	batch := lockfileGitSnapshotBatch{}
+	batch.add(snapshot, []string{"pkg/package.json", "pkg/package.json"})
+	if len(batch.candidatePaths) != 1 {
+		t.Fatalf("expected duplicate candidate to be stored once, got %#v", batch.candidatePaths)
+	}
+	if batch.wouldOverflow([]string{"pkg/package.json"}) {
+		t.Fatal("expected an already-buffered candidate not to consume another batch slot")
+	}
+
+	batch.snapshots = make([]lockfileDirSnapshot, lockfileGitBatchSnapshots)
+	if !batch.wouldOverflow(nil) {
+		t.Fatal("expected snapshot count cap to flush the batch")
+	}
+	batch.snapshots = []lockfileDirSnapshot{snapshot}
+	batch.candidatePaths = make([]string, gitPathspecBatchPaths)
+	if !batch.wouldOverflow([]string{"pkg/package-lock.json"}) {
+		t.Fatal("expected candidate count cap to flush the batch")
+	}
+	batch.candidatePaths = nil
+	batch.candidatePathBytes = gitPathspecBatchBytes
+	if !batch.wouldOverflow([]string{"pkg/package-lock.json"}) {
+		t.Fatal("expected candidate byte cap to flush the batch")
+	}
+}
+
 func captureLockfileGitCommandGroups(t *testing.T) map[string]int {
 	t.Helper()
 

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -292,6 +292,15 @@ func TestLockfileFailFastBatchScannerPropagatesSnapshotEvaluationErrors(t *testi
 }
 
 func TestLockfileFailFastBatchScannerReplaysAmbiguousSnapshots(t *testing.T) {
+	t.Run("rule without candidates", func(t *testing.T) {
+		repo, snapshot := newPoetrySnapshot(t, true)
+		rule := lockfileRule{manager: "missing", manifest: "missing.json", lockfiles: []string{"missing.lock"}}
+		scanner := lockfileFailFastBatchScanner{repoPath: repo, rules: []lockfileRule{rule}}
+		if err := scanner.flushSnapshotsInOrder(context.Background(), []lockfileDirSnapshot{snapshot}); err != nil {
+			t.Fatalf("expected candidate-free replay to continue, got %v", err)
+		}
+	})
+
 	t.Run("candidate path error", func(t *testing.T) {
 		repo, snapshot := newPoetrySnapshot(t, true)
 		forcedErr := errors.New("forced candidate path failure")

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -131,10 +131,13 @@ func TestDetectLockfileDriftStopOnFirstBatchesGitContextAcrossDirectories(t *tes
 	if got := commandGroups["worktree"]; got != 1 {
 		t.Errorf("expected one worktree detection command, got %d", got)
 	}
-	for _, group := range []string{"check-attr", "head", "diff", "ls-files"} {
+	for _, group := range []string{"check-attr", "head", "diff"} {
 		if got := commandGroups[group]; got != 2 {
 			t.Errorf("expected two bounded %s command groups for %d candidate directories, got %d", group, candidateDirs, got)
 		}
+	}
+	if got := commandGroups["ls-files"]; got != 4 {
+		t.Errorf("expected four bounded ls-files command groups for visible and untracked classification across %d candidate directories, got %d", candidateDirs, got)
 	}
 }
 

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -42,6 +43,8 @@ func TestDetectLockfileDriftPropagatesGitContextErrors(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+			writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
 			writeFakeGitMode(t, repo, tc.mode)
 			err := tc.run(context.Background(), repo)
 			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {

--- a/internal/app/lockfile_drift_git_context_errors_test.go
+++ b/internal/app/lockfile_drift_git_context_errors_test.go
@@ -19,8 +19,10 @@ func TestDetectLockfileDriftPropagatesGitContextErrors(t *testing.T) {
 	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
 	writeFakeGitMode(t, repo, "lsfail")
 
-	_, err := detectLockfileDrift(context.Background(), repo, false)
-	if err == nil || !strings.Contains(err.Error(), "ls-files") {
-		t.Fatalf("expected ls-files error, got %v", err)
+	for _, stopOnFirst := range []bool{false, true} {
+		_, err := detectLockfileDrift(context.Background(), repo, stopOnFirst)
+		if err == nil || !strings.Contains(err.Error(), "ls-files") {
+			t.Fatalf("expected ls-files error with stopOnFirst=%v, got %v", stopOnFirst, err)
+		}
 	}
 }

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -217,6 +217,38 @@ func TestCollectLockfileGitContextSkipsIrrelevantPathsAndFailsClosed(t *testing.
 	})
 }
 
+func TestCollectLockfileGitContextScopesTrackedAndUntrackedCommandsToCandidatePaths(t *testing.T) {
+	cases := []struct {
+		name        string
+		mode        string
+		wantChanged []string
+	}{
+		{name: "head", mode: "pathscope-head", wantChanged: []string{"package.json"}},
+		{name: "unborn head", mode: "pathscope-unborn", wantChanged: []string{"package-lock.json", "package.json"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := configureFakeGitRepo(t, tc.mode)
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+			writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+			writeFile(t, filepath.Join(repo, "README.md"), "hello\n")
+
+			gitContext, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
+			if err != nil {
+				t.Fatalf("collectLockfileGitContext: %v", err)
+			}
+			if !gitContext.hasGitContext {
+				t.Fatal("expected git context")
+			}
+			assertChangedPathsPresent(t, gitContext.changedFiles, tc.wantChanged...)
+			if len(gitContext.changedFiles) != len(tc.wantChanged) {
+				t.Fatalf("expected only candidate-path changes %#v, got %#v", tc.wantChanged, gitContext.changedFiles)
+			}
+		})
+	}
+}
+
 func TestGitActiveFilterDriversHandlesEmptyPaths(t *testing.T) {
 	drivers, err := gitActiveFilterDrivers(context.Background(), t.TempDir(), nil)
 	if err != nil {
@@ -265,6 +297,83 @@ func TestGitActiveFilterPathDriversAndParser(t *testing.T) {
 	t.Cleanup(func() { resolveGitBinaryPathFn = original })
 	if _, err := gitActiveFilterPathDrivers(context.Background(), t.TempDir(), []string{"package.json"}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected command construction failure for non-empty path set, got %v", err)
+	}
+}
+
+func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
+	changed, err := gitChangedFilesForPaths(context.Background(), t.TempDir(), nil)
+	if err != nil || len(changed) != 0 {
+		t.Fatalf("expected empty scoped changed set, got %#v err=%v", changed, err)
+	}
+	tracked, err := gitTrackedChangesForPaths(context.Background(), t.TempDir(), nil)
+	if err != nil || len(tracked) != 0 {
+		t.Fatalf("expected empty scoped tracked set, got %#v err=%v", tracked, err)
+	}
+	untracked, err := gitUntrackedFilesForPaths(context.Background(), t.TempDir(), nil)
+	if err != nil || len(untracked) != 0 {
+		t.Fatalf("expected empty scoped untracked set, got %#v err=%v", untracked, err)
+	}
+
+	cases := []struct {
+		name    string
+		mode    string
+		run     func(string) error
+		wantSub string
+	}{
+		{
+			name: "tracked HEAD diff failure",
+			mode: "difffail-head",
+			run: func(repo string) error {
+				_, err := gitTrackedChangesForPaths(context.Background(), repo, []string{"package.json"})
+				return err
+			},
+			wantSub: lockfileRunGitErr,
+		},
+		{
+			name: "tracked cached diff failure",
+			mode: "difffail-cached",
+			run: func(repo string) error {
+				_, err := gitTrackedChangesForPaths(context.Background(), repo, []string{"package.json"})
+				return err
+			},
+			wantSub: lockfileRunGitErr,
+		},
+		{
+			name: "tracked unstaged diff failure",
+			mode: "difffail-unstaged",
+			run: func(repo string) error {
+				_, err := gitTrackedChangesForPaths(context.Background(), repo, []string{"package.json"})
+				return err
+			},
+			wantSub: lockfileRunGitErr,
+		},
+		{
+			name: "untracked ls-files failure",
+			mode: "lsfail",
+			run: func(repo string) error {
+				_, err := gitUntrackedFilesForPaths(context.Background(), repo, []string{"package.json"})
+				return err
+			},
+			wantSub: "ls-files",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(configureFakeGitRepo(t, tc.mode)); err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantSub, err)
+			}
+		})
+	}
+
+	original := resolveGitBinaryPathFn
+	resolveGitBinaryPathFn = func() (string, error) { return "", context.Canceled }
+	t.Cleanup(func() { resolveGitBinaryPathFn = original })
+	if _, err := gitDiffNameOnlyForPaths(context.Background(), t.TempDir(), []string{"package.json"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected scoped diff command construction failure, got %v", err)
+	}
+	if _, err := gitUntrackedFilesForPaths(context.Background(), t.TempDir(), []string{"package.json"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected scoped untracked command construction failure, got %v", err)
 	}
 }
 
@@ -401,12 +510,22 @@ if printf '%s' "$args" | grep -q 'rev-parse --is-inside-work-tree'; then
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'rev-parse --verify --quiet HEAD'; then
-  if [ "$mode" = "difffail-cached" ] || [ "$mode" = "difffail-unstaged" ]; then
+  if [ "$mode" = "difffail-cached" ] || [ "$mode" = "difffail-unstaged" ] || [ "$mode" = "pathscope-unborn" ]; then
     exit 1
   fi
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
+  if [ "$mode" = "pathscope-head" ] || [ "$mode" = "pathscope-unborn" ]; then
+    if ! printf '%s' "$args" | grep -q -- 'ls-files --others --exclude-standard -z -- package-lock.json package.json'; then
+      echo "missing pathspec-scoped untracked args: $args" >&2
+      exit 1
+    fi
+    if [ "$mode" = "pathscope-unborn" ]; then
+      printf 'package-lock.json\000'
+    fi
+    exit 0
+  fi
   if [ "$mode" = "pathscope-filterdriver" ] || [ "$mode" = "checkattrtruncated" ] || [ "$mode" = "checkattrwrongfieldcount" ] || [ "$mode" = "checkattrwrongattr" ] || [ "$mode" = "checkattrwrongorder" ]; then
     echo "scoped untracked listing should not run before filter validation" >&2
     exit 1
@@ -418,7 +537,7 @@ if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'ls-files --cached --others --exclude-standard -z'; then
-  if [ "$mode" = "pathscope-filterdriver" ]; then
+  if [ "$mode" = "pathscope-head" ] || [ "$mode" = "pathscope-unborn" ] || [ "$mode" = "pathscope-filterdriver" ]; then
     echo "repo-wide attribute candidate listing should not run" >&2
     exit 1
   fi
@@ -445,6 +564,11 @@ if printf '%s' "$args" | grep -q 'ls-files --cached --others --exclude-standard 
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
+  if [ "$mode" = "pathscope-head" ] || [ "$mode" = "pathscope-unborn" ]; then
+    cat >/dev/null
+    printf 'package-lock.json\000filter\000unspecified\000package.json\000filter\000unspecified\000'
+    exit 0
+  fi
   if [ "$mode" = "pathscope-filterdriver" ]; then
     cat >/dev/null
     printf 'package-lock.json\000filter\000unspecified\000package.json\000filter\000pwn\000'
@@ -487,6 +611,30 @@ if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
+  if [ "$mode" = "pathscope-head" ]; then
+    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv HEAD --name-only -- package-lock.json package.json'; then
+      echo "missing pathspec-scoped head diff args: $args" >&2
+      exit 1
+    fi
+    printf 'package.json\n'
+    exit 0
+  fi
+  if [ "$mode" = "pathscope-unborn" ]; then
+    if printf '%s' "$args" | grep -q -- '--cached'; then
+      if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --cached --name-only -- package-lock.json package.json'; then
+        echo "missing pathspec-scoped cached diff args: $args" >&2
+        exit 1
+      fi
+      printf 'package.json\n'
+      exit 0
+    fi
+    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --name-only -- package-lock.json package.json'; then
+      echo "missing pathspec-scoped unstaged diff args: $args" >&2
+      exit 1
+    fi
+    printf 'package-lock.json\n'
+    exit 0
+  fi
   if [ "$mode" = "pathscope-filterdriver" ]; then
     echo "scoped git diff should not run after filter ambiguity" >&2
     exit 1

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -320,6 +320,14 @@ func shellEscapedOutputCommand(ctx context.Context, output string) *exec.Cmd {
 }
 
 func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
+	assertScopedGitPathHelpersReturnEmpty(t)
+	assertScopedGitPathHelperExecutionFailures(t)
+	assertScopedGitPathHelperConstructionFailures(t)
+}
+
+func assertScopedGitPathHelpersReturnEmpty(t *testing.T) {
+	t.Helper()
+
 	changed, err := gitChangedFilesForPaths(context.Background(), t.TempDir(), nil)
 	if err != nil || len(changed) != 0 {
 		t.Fatalf("expected empty scoped changed set, got %#v err=%v", changed, err)
@@ -336,6 +344,10 @@ func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
 	if err != nil || len(visible) != 0 {
 		t.Fatalf("expected empty scoped visible set, got %#v err=%v", visible, err)
 	}
+}
+
+func assertScopedGitPathHelperExecutionFailures(t *testing.T) {
+	t.Helper()
 
 	cases := []struct {
 		name    string
@@ -406,6 +418,10 @@ func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
 			}
 		})
 	}
+}
+
+func assertScopedGitPathHelperConstructionFailures(t *testing.T) {
+	t.Helper()
 
 	original := resolveGitBinaryPathFn
 	resolveGitBinaryPathFn = func() (string, error) { return "", context.Canceled }

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -225,7 +225,7 @@ func TestConfiguredGitAttributeDriverErrors(t *testing.T) {
 	})
 }
 
-func TestConfiguredGitAttributeDriversEnumerateCaseFoldedNullConfigRecords(t *testing.T) {
+func TestConfiguredGitAttributeDriversMatchExactNullConfigRecords(t *testing.T) {
 	originalResolve := resolveGitBinaryPathFn
 	originalExec := execGitCommandContextFn
 	resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
@@ -244,16 +244,17 @@ func TestConfiguredGitAttributeDriversEnumerateCaseFoldedNullConfigRecords(t *te
 
 	active, err := filterConfiguredGitAttributeDrivers(context.Background(), t.TempDir(), []gitFilterPathDriver{
 		{path: "a.json", driver: "pwn"},
-		{path: "b.json", driver: "Pwn"},
-		{path: "c.json", driver: "foo/bar"},
-		{path: "d.json", driver: "empty"},
-		{path: "e.json", driver: "pwn.*"},
+		{path: "b.json", driver: "PWN"},
+		{path: "c.json", driver: "Foo/Bar"},
+		{path: "d.json", driver: "foo/bar"},
+		{path: "e.json", driver: "empty"},
+		{path: "f.json", driver: "pwn.*"},
 	})
 	if err != nil {
 		t.Fatalf("filter configured git attribute drivers: %v", err)
 	}
-	if len(active) != 3 || active[0].path != "a.json" || active[1].path != "b.json" || active[2].path != "c.json" {
-		t.Errorf("expected case-folded configured assignments with punctuation in input order, got %#v", active)
+	if len(active) != 2 || active[0].path != "b.json" || active[1].path != "c.json" {
+		t.Errorf("expected exact configured assignments with punctuation in input order, got %#v", active)
 	}
 	if configCalls != 1 {
 		t.Errorf("expected one config-only filter command enumeration, got %d config calls", configCalls)
@@ -565,13 +566,15 @@ func TestParseGitExecutableFilterConfigRecords(t *testing.T) {
 		t.Fatalf("parse executable filter config: %v", err)
 	}
 
-	for _, driver := range []string{"pwn", "PWN.DRV+v1"} {
-		if _, ok := configured[gitConfigCaseFold(driver)]; !ok {
-			t.Errorf("expected case-folded driver %q in %#v", driver, configured)
+	for _, driver := range []string{"PWN", "Pwn.Drv+V1"} {
+		if _, ok := configured[driver]; !ok {
+			t.Errorf("expected exact driver %q in %#v", driver, configured)
 		}
 	}
-	if _, ok := configured["empty"]; ok {
-		t.Errorf("expected empty filter command to remain inert, got %#v", configured)
+	for _, driver := range []string{"pwn", "PWN.DRV+v1", "empty"} {
+		if _, ok := configured[driver]; ok {
+			t.Errorf("expected mismatched or empty driver %q to remain absent from %#v", driver, configured)
+		}
 	}
 	if len(configured) != 2 {
 		t.Errorf("expected only executable filter drivers, got %#v", configured)

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -124,7 +124,7 @@ func TestCollectLockfileGitContextFailsClosedForMalformedCheckAttr(t *testing.T)
 	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
 
 	_, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
-	if err == nil || !strings.Contains(err.Error(), "parse git check-attr --stdin -z filter output") {
+	if err == nil || !strings.Contains(err.Error(), "parse git check-attr --stdin -z --all output") {
 		t.Fatalf("expected malformed check-attr failure, got %v", err)
 	}
 	if strings.Contains(err.Error(), "run git diff") {
@@ -178,7 +178,7 @@ func TestGitActiveFilterPathDriversAndParser(t *testing.T) {
 		t.Fatalf("expected check-attr failure for non-empty path set, got %v", err)
 	}
 
-	assignments, err = parseGitCheckAttrFilterPathDrivers([]string{"package.json", "package-lock.json"}, []byte("package.json\x00filter\x00pwn=drv\x00package-lock.json\x00filter\x00 \x00"))
+	assignments, err = parseGitCheckAttrFilterPathDrivers([]string{"package.json", "package-lock.json"}, []byte("package.json\x00eol\x00lf\x00package.json\x00filter\x00pwn=drv\x00"))
 	if err != nil {
 		t.Fatalf("expected valid path-driver output to parse, got %v", err)
 	}
@@ -620,14 +620,13 @@ func TestParseGitExecutableFilterConfigRecords(t *testing.T) {
 }
 
 func TestParseGitCheckAttrFilterPathDrivers(t *testing.T) {
-	output := []byte("package.json\x00filter\x00foo.bar\x00package-lock.json\x00filter\x00unspecified\x00nested/package.json\x00filter\x00foo/bar\x00package.json\x00filter\x00foo.bar\x00")
+	output := []byte("package.json\x00filter\x00foo.bar\x00package-lock.json\x00eol\x00lf\x00nested/package.json\x00filter\x00foo/bar\x00package.json\x00filter\x00foo.bar\x00")
 	assignments, err := parseGitCheckAttrFilterPathDrivers([]string{"package.json", "package-lock.json", "nested/package.json", "package.json"}, output)
 	if err != nil {
 		t.Fatalf("expected valid check-attr output to parse, got %v", err)
 	}
 	want := []gitFilterPathDriver{
 		{path: "package.json", driver: "foo.bar"},
-		{path: "package-lock.json", driver: "unspecified"},
 		{path: "nested/package.json", driver: "foo/bar"},
 		{path: "package.json", driver: "foo.bar"},
 	}
@@ -683,25 +682,19 @@ func TestParseGitCheckAttrFilterPathDriversRejectsMalformedOutput(t *testing.T) 
 			name:       "wrong field count",
 			paths:      []string{"package.json"},
 			output:     []byte("package.json\x00filter\x00foo.bar\x00extra\x00"),
-			errContain: "expected 3 NUL-delimited fields",
-		},
-		{
-			name:       "wrong attribute name",
-			paths:      []string{"package.json"},
-			output:     []byte("package.json\x00eol\x00lf\x00"),
-			errContain: "attribute 0 mismatch",
+			errContain: "complete NUL-delimited attribute triplets",
 		},
 		{
 			name:       "wrong path",
 			paths:      []string{"package.json"},
 			output:     []byte("package-lock.json\x00filter\x00foo.bar\x00"),
-			errContain: "path 0 mismatch",
+			errContain: "unexpected attribute path",
 		},
 		{
-			name:       "wrong path order",
-			paths:      []string{"package.json", "package-lock.json"},
-			output:     []byte("package-lock.json\x00filter\x00foo.bar\x00package.json\x00filter\x00foo.baz\x00"),
-			errContain: "path 0 mismatch",
+			name:       "duplicate filter record",
+			paths:      []string{"package.json"},
+			output:     []byte("package.json\x00filter\x00foo.bar\x00package.json\x00filter\x00foo.baz\x00"),
+			errContain: "too many filter records",
 		},
 	}
 
@@ -783,25 +776,22 @@ if printf '%s' "$args" | grep -q 'ls-files --cached --others --exclude-standard 
   fi
   exit 0
 fi
-if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
+if printf '%s' "$args" | grep -q 'check-attr --stdin -z --all'; then
   if [ "$mode" = "pathscope-head" ]; then
     cat >/dev/null
-    printf 'package-lock.json\000filter\000unspecified\000package.json\000filter\000unspecified\000'
     exit 0
   fi
   if [ "$mode" = "pathscope-unborn" ]; then
     cat >/dev/null
-    printf 'package.json\000filter\000unspecified\000'
     exit 0
   fi
   if [ "$mode" = "pathscope-filterdriver" ]; then
     cat >/dev/null
-    printf 'package-lock.json\000filter\000unspecified\000package.json\000filter\000pwn\000'
+    printf 'package.json\000filter\000pwn\000'
     exit 0
   fi
   if [ "$mode" = "lsfail" ]; then
     cat >/dev/null
-    printf 'package-lock.json\000filter\000unspecified\000package.json\000filter\000unspecified\000'
     exit 0
   fi
   if [ "$mode" = "checkattrfail" ]; then

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -104,9 +104,13 @@ func writeFakeGitBinary(t *testing.T) string {
 	script := `#!/bin/sh
 args="$*"
 mode="${FAKE_GIT_MODE}"
-if [ "$1" = "-C" ] && [ -f "$2/.fake-git-mode" ]; then
-  mode="$(cat "$2/.fake-git-mode")"
-fi
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-C" ] && [ -n "$2" ] && [ -f "$2/.fake-git-mode" ]; then
+    mode="$(cat "$2/.fake-git-mode")"
+    break
+  fi
+  shift
+done
 if printf '%s' "$args" | grep -q 'rev-parse --is-inside-work-tree'; then
   echo true
   exit 0

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -331,112 +331,91 @@ func TestGitPathUsesNamedFilterDriver(t *testing.T) {
 		t.Skip("git binary not available")
 	}
 
-	t.Run("git command construction failure", func(t *testing.T) {
-		sentinel := errors.New("resolve probe git")
-		originalResolve := resolveGitBinaryPathFn
-		resolveGitBinaryPathFn = func() (string, error) { return "", sentinel }
-		t.Cleanup(func() { resolveGitBinaryPathFn = originalResolve })
-
-		active, err := gitPathUsesNamedFilterDriver(context.Background(), t.TempDir(), gitFilterPathDriver{path: manifestFileName, driver: "set"})
-		if !errors.Is(err, sentinel) {
-			t.Fatalf("expected git resolution failure, got %v", err)
-		}
-		if active {
-			t.Fatal("expected failed probe command construction to remain inactive")
-		}
-	})
-
+	t.Run("git command construction failure", testGitPathUsesNamedFilterDriverCommandConstructionFailure)
 	t.Run("inactive boolean state", func(t *testing.T) {
-		repo := t.TempDir()
-		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-		writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter\n")
-		initGitRepo(t, repo)
-
-		active, err := gitPathUsesNamedFilterDriver(context.Background(), repo, gitFilterPathDriver{path: manifestFileName, driver: "set"})
-		if err != nil {
-			t.Fatalf("gitPathUsesNamedFilterDriver: %v", err)
-		}
-		if active {
-			t.Fatal("expected bare boolean filter state to remain inactive")
-		}
+		assertGitPathUsesNamedFilterDriver(t, ".gitattributes", manifestFileName+" filter\n", false, false)
 	})
-
 	t.Run("explicit special-name clean driver", func(t *testing.T) {
-		repo := t.TempDir()
-		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-		writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=set\n")
-		initGitRepo(t, repo)
-
-		active, err := gitPathUsesNamedFilterDriver(context.Background(), repo, gitFilterPathDriver{path: manifestFileName, driver: "set"})
-		if err != nil {
-			t.Fatalf("gitPathUsesNamedFilterDriver: %v", err)
-		}
-		if !active {
-			t.Fatal("expected explicit state-named clean driver to be classified active")
-		}
+		assertGitPathUsesNamedFilterDriver(t, ".gitattributes", manifestFileName+" filter=set\n", false, true)
 	})
-
 	t.Run("explicit special-name process driver from info attributes", func(t *testing.T) {
-		repo := t.TempDir()
-		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-		initGitRepo(t, repo)
-		writeFile(t, filepath.Join(repo, ".git", "info", "attributes"), manifestFileName+" filter=set\n")
+		assertGitPathUsesNamedFilterDriver(t, filepath.Join(".git", "info", "attributes"), manifestFileName+" filter=set\n", true, true)
+	})
+	t.Run("marker probe failure is active but generic probe failure is not", testGitPathUsesNamedFilterDriverProbeFailures)
+}
 
-		active, err := gitPathUsesNamedFilterDriver(context.Background(), repo, gitFilterPathDriver{path: manifestFileName, driver: "set"})
-		if err != nil {
-			t.Fatalf("gitPathUsesNamedFilterDriver: %v", err)
-		}
-		if !active {
-			t.Fatal("expected explicit state-named process driver to be classified active")
-		}
+func testGitPathUsesNamedFilterDriverCommandConstructionFailure(t *testing.T) {
+	sentinel := errors.New("resolve probe git")
+	originalResolve := resolveGitBinaryPathFn
+	resolveGitBinaryPathFn = func() (string, error) { return "", sentinel }
+	t.Cleanup(func() { resolveGitBinaryPathFn = originalResolve })
+
+	active, err := gitPathUsesNamedFilterDriver(context.Background(), t.TempDir(), gitFilterPathDriver{path: manifestFileName, driver: "set"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected git resolution failure, got %v", err)
+	}
+	if active {
+		t.Fatal("expected failed probe command construction to remain inactive")
+	}
+}
+
+func assertGitPathUsesNamedFilterDriver(t *testing.T, attributePath, attribute string, writeAttributeAfterInit, wantActive bool) {
+	t.Helper()
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	if !writeAttributeAfterInit {
+		writeFile(t, filepath.Join(repo, attributePath), attribute)
+	}
+	initGitRepo(t, repo)
+	if writeAttributeAfterInit {
+		writeFile(t, filepath.Join(repo, attributePath), attribute)
+	}
+
+	active, err := gitPathUsesNamedFilterDriver(context.Background(), repo, gitFilterPathDriver{path: manifestFileName, driver: "set"})
+	if err != nil {
+		t.Fatalf("gitPathUsesNamedFilterDriver: %v", err)
+	}
+	if active != wantActive {
+		t.Fatalf("expected active=%t, got %t", wantActive, active)
+	}
+}
+
+func testGitPathUsesNamedFilterDriverProbeFailures(t *testing.T) {
+	originalResolve := resolveGitBinaryPathFn
+	originalExec := execGitCommandContextFn
+	resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+	t.Cleanup(func() {
+		resolveGitBinaryPathFn = originalResolve
+		execGitCommandContextFn = originalExec
 	})
 
-	t.Run("marker probe failure is active but generic probe failure is not", func(t *testing.T) {
-		originalResolve := resolveGitBinaryPathFn
-		originalExec := execGitCommandContextFn
-		resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
-		execGitCommandContextFn = func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
-			subcommand := gitSubcommandArgs(args)
-			if len(subcommand) >= 2 && subcommand[0] == "hash-object" && subcommand[1] == "--stdin" {
-				return shellEscapedOutputCommand(ctx, "rawhash\n"), nil
-			}
-			if len(subcommand) >= 1 && subcommand[0] == "hash-object" {
-				return exec.CommandContext(ctx, "/bin/sh", "-c", `printf '%s\n' "$1" >&2; exit 2`, "git-probe", "__LOPPER_LOCKFILE_FILTER_PROBE__"), nil
-			}
-			return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 1"), nil
-		}
-		t.Cleanup(func() {
-			resolveGitBinaryPathFn = originalResolve
-			execGitCommandContextFn = originalExec
-		})
+	assertGitFilterProbeClassification(t, gitFilterProbeMarker, true, false)
+	assertGitFilterProbeClassification(t, "generic-probe-failure", false, true)
+}
 
-		active, err := gitPathUsesNamedFilterDriver(context.Background(), t.TempDir(), gitFilterPathDriver{path: manifestFileName, driver: "set"})
-		if err != nil {
-			t.Fatalf("expected marked probe failure to classify active, got %v", err)
-		}
-		if !active {
-			t.Fatal("expected marked probe failure to classify active")
-		}
+func assertGitFilterProbeClassification(t *testing.T, probeFailure string, wantActive, wantErr bool) {
+	t.Helper()
+	execGitCommandContextFn = gitFilterProbeCommandStub(probeFailure)
+	active, err := gitPathUsesNamedFilterDriver(context.Background(), t.TempDir(), gitFilterPathDriver{path: manifestFileName, driver: "set"})
+	if (err != nil) != wantErr {
+		t.Fatalf("expected error=%t for probe output %q, got %v", wantErr, probeFailure, err)
+	}
+	if active != wantActive {
+		t.Fatalf("expected active=%t for probe output %q, got %t", wantActive, probeFailure, active)
+	}
+}
 
-		execGitCommandContextFn = func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
-			subcommand := gitSubcommandArgs(args)
-			if len(subcommand) >= 2 && subcommand[0] == "hash-object" && subcommand[1] == "--stdin" {
-				return shellEscapedOutputCommand(ctx, "rawhash\n"), nil
-			}
-			if len(subcommand) >= 1 && subcommand[0] == "hash-object" {
-				return exec.CommandContext(ctx, "/bin/sh", "-c", `printf '%s\n' "$1" >&2; exit 2`, "git-probe", "generic-probe-failure"), nil
-			}
-			return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 1"), nil
+func gitFilterProbeCommandStub(probeFailure string) func(context.Context, string, ...string) (*exec.Cmd, error) {
+	return func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
+		subcommand := gitSubcommandArgs(args)
+		if len(subcommand) >= 2 && subcommand[0] == "hash-object" && subcommand[1] == "--stdin" {
+			return shellEscapedOutputCommand(ctx, "rawhash\n"), nil
 		}
-
-		active, err = gitPathUsesNamedFilterDriver(context.Background(), t.TempDir(), gitFilterPathDriver{path: manifestFileName, driver: "set"})
-		if err == nil {
-			t.Fatal("expected generic probe failure to return an error")
+		if len(subcommand) >= 1 && subcommand[0] == "hash-object" {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", `printf '%s\n' "$1" >&2; exit 2`, "git-probe", probeFailure), nil
 		}
-		if active {
-			t.Fatal("expected generic probe failure to remain inactive")
-		}
-	})
+		return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 1"), nil
+	}
 }
 
 func gitSubcommandArgs(args []string) []string {

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -564,7 +564,7 @@ func assertScopedGitPathHelperConstructionFailures(t *testing.T) {
 
 func TestGitDiffNameOnlyForPathsUsesBoundedLiteralBatches(t *testing.T) {
 	paths := scopedGitBatchRegressionPaths()
-	commands := captureScopedGitPathspecCommands(t, false)
+	commands := captureScopedGitPathspecCommands(t, true)
 
 	got, err := gitDiffNameOnlyForPaths(context.Background(), t.TempDir(), paths, "HEAD")
 	if err != nil {
@@ -973,23 +973,23 @@ if printf '%s' "$args" | grep -q 'config --null --includes --get-regexp'; then
 fi
 if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
   if [ "$mode" = "pathscope-head" ]; then
-    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv HEAD --name-only -- :(literal)package-lock.json :(literal)package.json'; then
+    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv HEAD --name-only -z -- :(literal)package-lock.json :(literal)package.json'; then
       echo "missing pathspec-scoped head diff args: $args" >&2
       exit 1
     fi
-    printf 'package.json\n'
+    printf 'package.json\000'
     exit 0
   fi
   if [ "$mode" = "pathscope-unborn" ]; then
     if printf '%s' "$args" | grep -q -- '--cached'; then
-      if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --cached --name-only -- :(literal)package.json'; then
+      if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --cached --name-only -z -- :(literal)package.json'; then
         echo "missing pathspec-scoped cached diff args: $args" >&2
         exit 1
       fi
-      printf 'package.json\n'
+      printf 'package.json\000'
       exit 0
     fi
-    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --name-only -- :(literal)package.json'; then
+    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --name-only -z -- :(literal)package.json'; then
       echo "missing pathspec-scoped unstaged diff args: $args" >&2
       exit 1
     fi

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -140,6 +140,25 @@ func TestGitDiffNameOnlyRejectsMalformedCheckAttrOutput(t *testing.T) {
 	}
 }
 
+func TestLockfileDriftFilterAmbiguityErrorNamesAffectedPathsAndDrivers(t *testing.T) {
+	err := newLockfileDriftFilterAmbiguityError([]gitFilterPathDriver{
+		{path: "package.json", driver: "pwn"},
+		{path: "nested/package-lock.json", driver: "drv=with.equals"},
+	})
+	if err == nil {
+		t.Fatal("expected ambiguity error")
+	}
+	for _, want := range []string{
+		"cannot safely evaluate lockfile drift",
+		"package.json (pwn)",
+		"nested/package-lock.json (drv=with.equals)",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected ambiguity error to contain %q, got %v", want, err)
+		}
+	}
+}
+
 func TestGitAttributeCandidatePathsHandlesNilContextAndCommandFailure(t *testing.T) {
 	t.Run("nil context", func(t *testing.T) {
 		repo := configureFakeGitRepo(t, "filterdriver")
@@ -162,6 +181,42 @@ func TestGitAttributeCandidatePathsHandlesNilContextAndCommandFailure(t *testing
 	})
 }
 
+func TestCollectLockfileGitContextSkipsIrrelevantPathsAndFailsClosed(t *testing.T) {
+	t.Run("non git worktree", func(t *testing.T) {
+		gitContext, err := collectLockfileGitContext(context.Background(), t.TempDir(), []lockfileRule{lockfileRules[0]})
+		if err != nil {
+			t.Fatalf("collectLockfileGitContext: %v", err)
+		}
+		if gitContext.hasGitContext || len(gitContext.changedFiles) != 0 {
+			t.Fatalf("expected empty git context, got %#v", gitContext)
+		}
+	})
+
+	t.Run("no relevant candidates", func(t *testing.T) {
+		repo := configureFakeGitRepo(t, "filterdriver")
+		writeFile(t, filepath.Join(repo, "README.md"), "hello\n")
+
+		gitContext, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
+		if err != nil {
+			t.Fatalf("collectLockfileGitContext: %v", err)
+		}
+		if !gitContext.hasGitContext || len(gitContext.changedFiles) != 0 {
+			t.Fatalf("expected empty candidate-only git context, got %#v", gitContext)
+		}
+	})
+
+	t.Run("custom filters on relevant candidates fail closed", func(t *testing.T) {
+		repo := configureFakeGitRepo(t, "pathscope-filterdriver")
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+
+		_, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
+		if err == nil || !strings.Contains(err.Error(), "cannot safely evaluate lockfile drift") || !strings.Contains(err.Error(), "package.json (pwn)") {
+			t.Fatalf("expected relevant filter ambiguity error, got %v", err)
+		}
+	})
+}
+
 func TestGitActiveFilterDriversHandlesEmptyPaths(t *testing.T) {
 	drivers, err := gitActiveFilterDrivers(context.Background(), t.TempDir(), nil)
 	if err != nil {
@@ -169,6 +224,47 @@ func TestGitActiveFilterDriversHandlesEmptyPaths(t *testing.T) {
 	}
 	if len(drivers) != 0 {
 		t.Fatalf("expected no drivers for empty path set, got %#v", drivers)
+	}
+}
+
+func TestGitActiveFilterDriversDeduplicatesAssignments(t *testing.T) {
+	repo := configureFakeGitRepo(t, "filterdriverdupe")
+	drivers, err := gitActiveFilterDrivers(context.Background(), repo, []string{"package.json", "package-lock.json"})
+	if err != nil {
+		t.Fatalf("expected duplicate filter drivers to parse, got %v", err)
+	}
+	if len(drivers) != 1 || drivers[0] != "foo.bar" {
+		t.Fatalf("expected duplicate filter drivers to deduplicate, got %#v", drivers)
+	}
+}
+
+func TestGitActiveFilterPathDriversAndParser(t *testing.T) {
+	assignments, err := gitActiveFilterPathDrivers(context.Background(), t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("expected empty path set to skip git check-attr, got %v", err)
+	}
+	if len(assignments) != 0 {
+		t.Fatalf("expected no assignments for empty path set, got %#v", assignments)
+	}
+
+	repo := configureFakeGitRepo(t, "checkattrfail")
+	if _, err := gitActiveFilterPathDrivers(context.Background(), repo, []string{"package.json"}); err == nil || !strings.Contains(err.Error(), "check-attr") {
+		t.Fatalf("expected check-attr failure for non-empty path set, got %v", err)
+	}
+
+	assignments, err = parseGitCheckAttrFilterPathDrivers([]string{"package.json", "package-lock.json"}, []byte("package.json\x00filter\x00pwn=drv\x00package-lock.json\x00filter\x00 \x00"))
+	if err != nil {
+		t.Fatalf("expected valid path-driver output to parse, got %v", err)
+	}
+	if len(assignments) != 1 || assignments[0].path != "package.json" || assignments[0].driver != "pwn=drv" {
+		t.Fatalf("unexpected parsed assignments %#v", assignments)
+	}
+
+	original := resolveGitBinaryPathFn
+	resolveGitBinaryPathFn = func() (string, error) { return "", context.Canceled }
+	t.Cleanup(func() { resolveGitBinaryPathFn = original })
+	if _, err := gitActiveFilterPathDrivers(context.Background(), t.TempDir(), []string{"package.json"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected command construction failure for non-empty path set, got %v", err)
 	}
 }
 
@@ -311,6 +407,10 @@ if printf '%s' "$args" | grep -q 'rev-parse --verify --quiet HEAD'; then
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
+  if [ "$mode" = "pathscope-filterdriver" ] || [ "$mode" = "checkattrtruncated" ] || [ "$mode" = "checkattrwrongfieldcount" ] || [ "$mode" = "checkattrwrongattr" ] || [ "$mode" = "checkattrwrongorder" ]; then
+    echo "scoped untracked listing should not run before filter validation" >&2
+    exit 1
+  fi
   if [ "$mode" = "lsfail" ]; then
     echo "ls-files failed" >&2
     exit 1
@@ -318,6 +418,10 @@ if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'ls-files --cached --others --exclude-standard -z'; then
+  if [ "$mode" = "pathscope-filterdriver" ]; then
+    echo "repo-wide attribute candidate listing should not run" >&2
+    exit 1
+  fi
   if [ "$mode" = "lsfilescachedfail" ]; then
     echo "ls-files cached failed" >&2
     exit 1
@@ -341,6 +445,11 @@ if printf '%s' "$args" | grep -q 'ls-files --cached --others --exclude-standard 
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
+  if [ "$mode" = "pathscope-filterdriver" ]; then
+    cat >/dev/null
+    printf 'package-lock.json\000filter\000unspecified\000package.json\000filter\000pwn\000'
+    exit 0
+  fi
   if [ "$mode" = "checkattrfail" ]; then
     echo "check-attr failed" >&2
     exit 1
@@ -370,9 +479,18 @@ if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
     printf 'package.json\000filter\000foo.bar\000'
     exit 0
   fi
+  if [ "$mode" = "filterdriverdupe" ]; then
+    cat >/dev/null
+    printf 'package.json\000filter\000foo.bar\000package-lock.json\000filter\000foo.bar\000'
+    exit 0
+  fi
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
+  if [ "$mode" = "pathscope-filterdriver" ]; then
+    echo "scoped git diff should not run after filter ambiguity" >&2
+    exit 1
+  fi
   if [ "$mode" = "filterdriver" ]; then
     if printf '%s' "$args" | grep -q -- '--attr-source='; then
       echo "unexpected attr-source flag" >&2

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -46,46 +46,6 @@ func TestLockfileDriftAdditionalPathAndWalkBranches(t *testing.T) {
 	}
 }
 
-func TestLockfileDriftGitErrorBranches(t *testing.T) {
-	original := resolveGitBinaryPathFn
-	defer func() { resolveGitBinaryPathFn = original }()
-
-	repo := t.TempDir()
-	fakeGit := writeFakeGitBinary(t)
-	resolveGitBinaryPathFn = func() (string, error) { return fakeGit, nil }
-	useFakeGitCommandContext(t)
-
-	writeFakeGitMode(t, repo, "lsfail")
-	if _, _, err := gitChangedFiles(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "ls-files") {
-		t.Fatalf("expected gitChangedFiles to surface ls-files failure, got %v", err)
-	}
-
-	writeFakeGitMode(t, repo, "checkattrfail")
-	if _, err := gitDiffNameOnly(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "check-attr") {
-		t.Fatalf("expected gitDiffNameOnly to surface check-attr failure, got %v", err)
-	}
-
-	writeFakeGitMode(t, repo, "difffail-head")
-	if _, err := gitTrackedChanges(context.Background(), repo); err == nil || !strings.Contains(err.Error(), lockfileRunGitErr) {
-		t.Fatalf("expected gitTrackedChanges HEAD diff failure, got %v", err)
-	}
-
-	writeFakeGitMode(t, repo, "difffail-unstaged")
-	if _, err := gitTrackedChanges(context.Background(), repo); err == nil || !strings.Contains(err.Error(), lockfileRunGitErr) {
-		t.Fatalf("expected gitTrackedChanges unstaged diff failure, got %v", err)
-	}
-
-	writeFakeGitMode(t, repo, "difffail-cached")
-	if _, err := gitTrackedChanges(context.Background(), repo); err == nil || !strings.Contains(err.Error(), lockfileRunGitErr) {
-		t.Fatalf("expected gitTrackedChanges cached diff failure, got %v", err)
-	}
-
-	resolveGitBinaryPathFn = func() (string, error) { return "", context.Canceled }
-	if _, err := gitDiffNameOnly(context.Background(), repo); err == nil {
-		t.Fatalf("expected gitDiffNameOnly to surface git command creation failure")
-	}
-}
-
 func TestGitCommandContextConstructorError(t *testing.T) {
 	originalResolve := resolveGitBinaryPathFn
 	originalExec := execGitCommandContextFn
@@ -100,43 +60,6 @@ func TestGitCommandContextConstructorError(t *testing.T) {
 
 	if _, err := gitCommandContext(context.Background(), t.TempDir(), "status"); err == nil || !strings.Contains(err.Error(), "construct git") {
 		t.Fatalf("expected gitCommandContext to return constructor error, got %v", err)
-	}
-}
-
-func TestGitDiffNameOnlyNeutralizesFilterDriversWithoutAttrSource(t *testing.T) {
-	repo := configureFakeGitRepo(t, "filterdriver")
-
-	if _, err := gitDiffNameOnly(context.Background(), repo); err != nil {
-		t.Fatalf("expected gitDiffNameOnly to construct a portable hardened diff command, got %v", err)
-	}
-}
-
-func TestGitDiffNameOnlyRejectsMalformedCheckAttrOutput(t *testing.T) {
-	cases := []struct {
-		name string
-		mode string
-	}{
-		{name: "truncated output", mode: "checkattrtruncated"},
-		{name: "wrong field count", mode: "checkattrwrongfieldcount"},
-		{name: "wrong attribute", mode: "checkattrwrongattr"},
-		{name: "wrong path order", mode: "checkattrwrongorder"},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			repo := configureFakeGitRepo(t, tc.mode)
-
-			_, err := gitDiffNameOnly(context.Background(), repo)
-			if err == nil {
-				t.Fatal("expected malformed check-attr output to fail closed")
-			}
-			if !strings.Contains(err.Error(), "parse git check-attr --stdin -z filter output") {
-				t.Fatalf("expected parse error from malformed check-attr output, got %v", err)
-			}
-			if strings.Contains(err.Error(), "run git diff") {
-				t.Fatalf("expected malformed check-attr output to abort before git diff, got %v", err)
-			}
-		})
 	}
 }
 
@@ -157,28 +80,6 @@ func TestLockfileDriftFilterAmbiguityErrorNamesAffectedPathsAndDrivers(t *testin
 			t.Fatalf("expected ambiguity error to contain %q, got %v", want, err)
 		}
 	}
-}
-
-func TestGitAttributeCandidatePathsHandlesNilContextAndCommandFailure(t *testing.T) {
-	t.Run("nil context", func(t *testing.T) {
-		repo := configureFakeGitRepo(t, "filterdriver")
-
-		paths, err := gitAttributeCandidatePaths(testNilContext(), repo)
-		if err != nil {
-			t.Fatalf("expected gitAttributeCandidatePaths with nil context to succeed, got %v", err)
-		}
-		if len(paths) != 1 || paths[0] != "package.json" {
-			t.Fatalf("unexpected attribute candidate paths %#v", paths)
-		}
-	})
-
-	t.Run("command failure", func(t *testing.T) {
-		repo := configureFakeGitRepo(t, "lsfilescachedfail")
-
-		if _, err := gitAttributeCandidatePaths(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "ls-files --cached --others --exclude-standard -z") {
-			t.Fatalf("expected cached ls-files failure, got %v", err)
-		}
-	})
 }
 
 func TestCollectLockfileGitContextReturnsEmptyForNonGitWorktree(t *testing.T) {
@@ -261,27 +162,6 @@ func TestCollectLockfileGitContextScopesTrackedAndUntrackedCommandsToCandidatePa
 	}
 }
 
-func TestGitActiveFilterDriversHandlesEmptyPaths(t *testing.T) {
-	drivers, err := gitActiveFilterDrivers(context.Background(), t.TempDir(), nil)
-	if err != nil {
-		t.Fatalf("expected empty path set to skip git check-attr, got %v", err)
-	}
-	if len(drivers) != 0 {
-		t.Fatalf("expected no drivers for empty path set, got %#v", drivers)
-	}
-}
-
-func TestGitActiveFilterDriversDeduplicatesAssignments(t *testing.T) {
-	repo := configureFakeGitRepo(t, "filterdriverdupe")
-	drivers, err := gitActiveFilterDrivers(context.Background(), repo, []string{"package.json", "package-lock.json"})
-	if err != nil {
-		t.Fatalf("expected duplicate filter drivers to parse, got %v", err)
-	}
-	if len(drivers) != 1 || drivers[0] != "foo.bar" {
-		t.Fatalf("expected duplicate filter drivers to deduplicate, got %#v", drivers)
-	}
-}
-
 func TestGitActiveFilterPathDriversAndParser(t *testing.T) {
 	assignments, err := gitActiveFilterPathDrivers(context.Background(), t.TempDir(), nil)
 	if err != nil {
@@ -333,10 +213,10 @@ func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
 		wantSub string
 	}{
 		{
-			name: "tracked HEAD diff failure",
+			name: "changed files tracked HEAD diff failure",
 			mode: "difffail-head",
 			run: func(repo string) error {
-				_, err := gitTrackedChangesForPaths(context.Background(), repo, []string{"package.json"})
+				_, err := gitChangedFilesForPaths(context.Background(), repo, []string{"package.json"})
 				return err
 			},
 			wantSub: lockfileRunGitErr,
@@ -381,6 +261,9 @@ func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
 	original := resolveGitBinaryPathFn
 	resolveGitBinaryPathFn = func() (string, error) { return "", context.Canceled }
 	t.Cleanup(func() { resolveGitBinaryPathFn = original })
+	if _, err := gitTrackedChangesForPaths(context.Background(), t.TempDir(), []string{"package.json"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected scoped tracked command construction failure, got %v", err)
+	}
 	if _, err := gitDiffNameOnlyForPaths(context.Background(), t.TempDir(), []string{"package.json"}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected scoped diff command construction failure, got %v", err)
 	}
@@ -409,20 +292,23 @@ func TestParseNULTerminatedGitFields(t *testing.T) {
 	}
 }
 
-func TestParseGitCheckAttrFilterPathDriversAndDeduplicates(t *testing.T) {
+func TestParseGitCheckAttrFilterPathDrivers(t *testing.T) {
 	output := []byte("package.json\x00filter\x00foo.bar\x00package-lock.json\x00filter\x00unspecified\x00nested/package.json\x00filter\x00foo/bar\x00package.json\x00filter\x00foo.bar\x00")
 	assignments, err := parseGitCheckAttrFilterPathDrivers([]string{"package.json", "package-lock.json", "nested/package.json", "package.json"}, output)
 	if err != nil {
 		t.Fatalf("expected valid check-attr output to parse, got %v", err)
 	}
-	got := uniqueFilterDrivers(assignments)
-	want := []string{"foo.bar", "foo/bar"}
-	if len(got) != len(want) {
-		t.Fatalf("expected %d filter drivers, got %#v", len(want), got)
+	want := []gitFilterPathDriver{
+		{path: "package.json", driver: "foo.bar"},
+		{path: "nested/package.json", driver: "foo/bar"},
+		{path: "package.json", driver: "foo.bar"},
+	}
+	if len(assignments) != len(want) {
+		t.Fatalf("expected %d path-driver assignments, got %#v", len(want), assignments)
 	}
 	for index := range want {
-		if got[index] != want[index] {
-			t.Fatalf("expected filter driver %q at index %d, got %#v", want[index], index, got)
+		if assignments[index] != want[index] {
+			t.Fatalf("expected assignment %#v at index %d, got %#v", want[index], index, assignments)
 		}
 	}
 
@@ -430,18 +316,16 @@ func TestParseGitCheckAttrFilterPathDriversAndDeduplicates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected ignorable filter values to parse, got %v", err)
 	}
-	got = uniqueFilterDrivers(assignments)
-	if len(got) != 0 {
-		t.Fatalf("expected set/unset/blank filter entries to be ignored, got %#v", got)
+	if len(assignments) != 0 {
+		t.Fatalf("expected set/unset/blank filter entries to be ignored, got %#v", assignments)
 	}
 
 	assignments, err = parseGitCheckAttrFilterPathDrivers([]string{"a.json", "package.json"}, []byte("a.json\x00filter\x00\x00package.json\x00filter\x00pwn=drv\x00"))
 	if err != nil {
 		t.Fatalf("expected empty filter value to preserve later triplets, got %v", err)
 	}
-	got = uniqueFilterDrivers(assignments)
-	if len(got) != 1 || got[0] != "pwn=drv" {
-		t.Fatalf("expected empty filter value to preserve later triplets, got %#v", got)
+	if len(assignments) != 1 || assignments[0].path != "package.json" || assignments[0].driver != "pwn=drv" {
+		t.Fatalf("expected empty filter value to preserve later triplets, got %#v", assignments)
 	}
 }
 
@@ -556,10 +440,6 @@ if printf '%s' "$args" | grep -q 'ls-files --cached --others --exclude-standard 
     echo "repo-wide attribute candidate listing should not run" >&2
     exit 1
   fi
-  if [ "$mode" = "lsfilescachedfail" ]; then
-    echo "ls-files cached failed" >&2
-    exit 1
-  fi
   if [ "$mode" = "checkattrfail" ]; then
     printf 'package.json\000'
     exit 0
@@ -621,11 +501,6 @@ if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
   if [ "$mode" = "filterdriver" ]; then
     cat >/dev/null
     printf 'package.json\000filter\000foo.bar\000'
-    exit 0
-  fi
-  if [ "$mode" = "filterdriverdupe" ]; then
-    cat >/dev/null
-    printf 'package.json\000filter\000foo.bar\000package-lock.json\000filter\000foo.bar\000'
     exit 0
   fi
   exit 0
@@ -718,8 +593,4 @@ func useFakeGitCommandContext(t *testing.T) {
 	t.Cleanup(func() {
 		execGitCommandContextFn = original
 	})
-}
-
-func testNilContext() context.Context {
-	return nil
 }

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -559,6 +559,25 @@ func TestParseNULTerminatedGitFields(t *testing.T) {
 	}
 }
 
+func TestParseGitExecutableFilterConfigRecords(t *testing.T) {
+	configured, err := parseGitExecutableFilterConfig([]byte("filter.PWN.clean\n./helper.sh\x00filter.Pwn.Drv+V1.process\nprocess --flag\x00filter.empty.clean\n\x00"))
+	if err != nil {
+		t.Fatalf("parse executable filter config: %v", err)
+	}
+
+	for _, driver := range []string{"pwn", "PWN.DRV+v1"} {
+		if _, ok := configured[gitConfigCaseFold(driver)]; !ok {
+			t.Errorf("expected case-folded driver %q in %#v", driver, configured)
+		}
+	}
+	if _, ok := configured["empty"]; ok {
+		t.Errorf("expected empty filter command to remain inert, got %#v", configured)
+	}
+	if len(configured) != 2 {
+		t.Errorf("expected only executable filter drivers, got %#v", configured)
+	}
+}
+
 func TestParseGitCheckAttrFilterPathDrivers(t *testing.T) {
 	output := []byte("package.json\x00filter\x00foo.bar\x00package-lock.json\x00filter\x00unspecified\x00nested/package.json\x00filter\x00foo/bar\x00package.json\x00filter\x00foo.bar\x00")
 	assignments, err := parseGitCheckAttrFilterPathDrivers([]string{"package.json", "package-lock.json", "nested/package.json", "package.json"}, output)
@@ -783,9 +802,9 @@ if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
   fi
   exit 0
 fi
-if printf '%s' "$args" | grep -q 'config --includes --get'; then
-  if [ "$mode" = "pathscope-filterdriver" ] && printf '%s' "$args" | grep -q 'filter.pwn.clean'; then
-    printf './helper.sh\n'
+if printf '%s' "$args" | grep -q 'config --null --includes --get-regexp'; then
+  if [ "$mode" = "pathscope-filterdriver" ]; then
+    printf 'filter.PWN.clean\n./helper.sh\000'
     exit 0
   fi
   exit 1

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -192,13 +192,13 @@ func TestGitActiveFilterPathDriversAndParser(t *testing.T) {
 	}
 }
 
-func TestConfiguredGitAttributeStateDriverErrors(t *testing.T) {
+func TestConfiguredGitAttributeDriverErrors(t *testing.T) {
 	t.Run("command construction", func(t *testing.T) {
 		original := resolveGitBinaryPathFn
 		resolveGitBinaryPathFn = func() (string, error) { return "", context.Canceled }
 		t.Cleanup(func() { resolveGitBinaryPathFn = original })
 
-		_, err := filterConfiguredGitAttributeStateDrivers(context.Background(), t.TempDir(), []gitFilterPathDriver{{path: "package.json", driver: "set"}})
+		_, err := filterConfiguredGitAttributeDrivers(context.Background(), t.TempDir(), []gitFilterPathDriver{{path: "package.json", driver: "set"}})
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected config command construction error, got %v", err)
 		}
@@ -217,10 +217,55 @@ func TestConfiguredGitAttributeStateDriverErrors(t *testing.T) {
 		})
 
 		_, err := gitFilterDriverHasExecutableConfig(context.Background(), t.TempDir(), "set")
-		if err == nil || !strings.Contains(err.Error(), "run git config --includes --get-regexp") {
+		if err == nil || !strings.Contains(err.Error(), "run git config --includes --get") {
 			t.Fatalf("expected config execution error, got %v", err)
 		}
 	})
+}
+
+func TestConfiguredGitAttributeDriversCacheExactLookups(t *testing.T) {
+	originalResolve := resolveGitBinaryPathFn
+	originalExec := execGitCommandContextFn
+	resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+	lookups := make(map[string]int)
+	execGitCommandContextFn = func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
+		key := args[len(args)-1]
+		lookups[key]++
+		if key == "filter.configured.clean" {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", "printf 'cat\\n'"), nil
+		}
+		return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 1"), nil
+	}
+	t.Cleanup(func() {
+		resolveGitBinaryPathFn = originalResolve
+		execGitCommandContextFn = originalExec
+	})
+
+	active, err := filterConfiguredGitAttributeDrivers(context.Background(), t.TempDir(), []gitFilterPathDriver{
+		{path: "a.json", driver: "configured"},
+		{path: "b.json", driver: "configured"},
+		{path: "c.json", driver: "inert"},
+		{path: "d.json", driver: "inert"},
+	})
+	if err != nil {
+		t.Fatalf("filter configured git attribute drivers: %v", err)
+	}
+	if len(active) != 2 || active[0].path != "a.json" || active[1].path != "b.json" {
+		t.Fatalf("expected configured assignments in input order, got %#v", active)
+	}
+	wantLookups := map[string]int{
+		"filter.configured.clean": 1,
+		"filter.inert.clean":      1,
+		"filter.inert.process":    1,
+	}
+	if len(lookups) != len(wantLookups) {
+		t.Fatalf("expected exact cached config lookups %#v, got %#v", wantLookups, lookups)
+	}
+	for key, want := range wantLookups {
+		if lookups[key] != want {
+			t.Fatalf("expected %q to be queried %d time, got %#v", key, want, lookups)
+		}
+	}
 }
 
 func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
@@ -545,6 +590,13 @@ if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
     exit 0
   fi
   exit 0
+fi
+if printf '%s' "$args" | grep -q 'config --includes --get'; then
+  if [ "$mode" = "pathscope-filterdriver" ] && printf '%s' "$args" | grep -q 'filter.pwn.clean'; then
+    printf './helper.sh\n'
+    exit 0
+  fi
+  exit 1
 fi
 if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
   if [ "$mode" = "pathscope-head" ]; then

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -3,9 +3,11 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -346,6 +348,144 @@ func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
 	if _, err := gitUntrackedFilesForPaths(context.Background(), t.TempDir(), []string{"package.json"}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected scoped untracked command construction failure, got %v", err)
 	}
+}
+
+func TestGitDiffNameOnlyForPathsUsesBoundedLiteralBatches(t *testing.T) {
+	paths := scopedGitBatchRegressionPaths()
+	commands := captureScopedGitPathspecCommands(t, false)
+
+	got, err := gitDiffNameOnlyForPaths(context.Background(), t.TempDir(), paths, "HEAD")
+	if err != nil {
+		t.Fatalf("gitDiffNameOnlyForPaths: %v", err)
+	}
+	assertBoundedScopedGitPathspecCommands(t, *commands)
+	assertOrderedUniqueGitPaths(t, got, paths)
+}
+
+func TestGitUntrackedFilesForPathsUsesBoundedLiteralBatches(t *testing.T) {
+	paths := scopedGitBatchRegressionPaths()
+	commands := captureScopedGitPathspecCommands(t, true)
+
+	got, err := gitUntrackedFilesForPaths(context.Background(), t.TempDir(), paths)
+	if err != nil {
+		t.Fatalf("gitUntrackedFilesForPaths: %v", err)
+	}
+	assertBoundedScopedGitPathspecCommands(t, *commands)
+	assertOrderedUniqueGitPaths(t, got, paths)
+}
+
+func scopedGitBatchRegressionPaths() []string {
+	paths := make([]string, 0, 262)
+	longDir := strings.Repeat("segment/", 32)
+	for index := 259; index >= 0; index-- {
+		paths = append(paths, fmt.Sprintf("pkg-%03d/%spackage.json", index, longDir))
+	}
+	paths = append(paths, paths[50], ":(glob)pkg/[literal] package.json")
+	return paths
+}
+
+func captureScopedGitPathspecCommands(t *testing.T, nulOutput bool) *[][]string {
+	t.Helper()
+
+	originalResolve := resolveGitBinaryPathFn
+	originalExec := execGitCommandContextFn
+	resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+	commands := make([][]string, 0)
+	execGitCommandContextFn = func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
+		paths := literalPathsFromGitCommand(t, args)
+		commands = append(commands, paths)
+		return gitPathOutputCommand(ctx, orderedUniqueGitPaths(paths), nulOutput), nil
+	}
+	t.Cleanup(func() {
+		resolveGitBinaryPathFn = originalResolve
+		execGitCommandContextFn = originalExec
+	})
+	return &commands
+}
+
+func literalPathsFromGitCommand(t *testing.T, args []string) []string {
+	t.Helper()
+
+	separator := -1
+	for index, arg := range args {
+		if arg == "--" {
+			separator = index
+			break
+		}
+	}
+	if separator < 0 {
+		t.Fatalf("expected pathspec separator in git args %#v", args)
+	}
+	paths := make([]string, 0, len(args)-separator-1)
+	for _, pathspec := range args[separator+1:] {
+		path, ok := strings.CutPrefix(pathspec, gitLiteralPathPrefix)
+		if !ok {
+			t.Fatalf("expected literal pathspec, got %q in %#v", pathspec, args)
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func gitPathOutputCommand(ctx context.Context, paths []string, nulOutput bool) *exec.Cmd {
+	format := `%s\n`
+	if nulOutput {
+		format = `%s\000`
+	}
+	args := []string{"-c", `for path do printf "$1" "$path"; done`, "git-output", format}
+	args = append(args, paths...)
+	return exec.CommandContext(ctx, "/bin/sh", args...)
+}
+
+func assertBoundedScopedGitPathspecCommands(t *testing.T, commands [][]string) {
+	t.Helper()
+
+	const (
+		maxPaths = 128
+		maxBytes = 16 * 1024
+	)
+	if len(commands) < 2 {
+		t.Fatalf("expected multiple bounded git commands, got %d", len(commands))
+	}
+	for index, paths := range commands {
+		if len(paths) > maxPaths {
+			t.Errorf("git command %d carried %d pathspecs; max %d", index, len(paths), maxPaths)
+		}
+		bytes := 0
+		for _, path := range paths {
+			bytes += len(gitLiteralPathPrefix) + len(path) + 1
+		}
+		if bytes > maxBytes && len(paths) > 1 {
+			t.Errorf("git command %d carried %d pathspec bytes; max %d", index, bytes, maxBytes)
+		}
+	}
+}
+
+func assertOrderedUniqueGitPaths(t *testing.T, got, input []string) {
+	t.Helper()
+
+	want := orderedUniqueGitPaths(input)
+	if len(got) != len(want) {
+		t.Fatalf("expected %d ordered unique paths, got %d", len(want), len(got))
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("path %d = %q, want %q", index, got[index], want[index])
+		}
+	}
+}
+
+func orderedUniqueGitPaths(paths []string) []string {
+	unique := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		unique[path] = struct{}{}
+	}
+	ordered := make([]string, 0, len(unique))
+	for path := range unique {
+		ordered = append(ordered, path)
+	}
+	sort.Strings(ordered)
+	return ordered
 }
 
 func TestParseNULTerminatedGitOutput(t *testing.T) {

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -619,6 +619,23 @@ func TestParseGitExecutableFilterConfigRecords(t *testing.T) {
 	}
 }
 
+func TestParseGitExecutableFilterConfigPrefersLastValueForEachCommand(t *testing.T) {
+	configured, err := parseGitExecutableFilterConfig([]byte("filter.pwn.clean\n./helper.sh\x00filter.pwn.clean\n\x00filter.pwn.process\nprocess --flag\x00filter.other.process\nprocess --flag\x00filter.other.process\n\x00"))
+	if err != nil {
+		t.Fatalf("parse executable filter config: %v", err)
+	}
+
+	if _, ok := configured["pwn"]; !ok {
+		t.Fatalf("expected later non-empty process command to keep driver executable, got %#v", configured)
+	}
+	if _, ok := configured["other"]; ok {
+		t.Fatalf("expected later empty process override to clear driver executable, got %#v", configured)
+	}
+	if len(configured) != 1 {
+		t.Fatalf("expected only effective executable drivers, got %#v", configured)
+	}
+}
+
 func TestParseGitCheckAttrFilterPathDrivers(t *testing.T) {
 	output := []byte("package.json\x00filter\x00foo.bar\x00package-lock.json\x00eol\x00lf\x00nested/package.json\x00filter\x00foo/bar\x00package.json\x00filter\x00foo.bar\x00")
 	assignments, err := parseGitCheckAttrFilterPathDrivers([]string{"package.json", "package-lock.json", "nested/package.json", "package.json"}, output)

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -215,6 +215,20 @@ func TestCollectLockfileGitContextSkipsIrrelevantPathsAndFailsClosed(t *testing.
 			t.Fatalf("expected relevant filter ambiguity error, got %v", err)
 		}
 	})
+
+	t.Run("malformed check-attr output stays fail closed", func(t *testing.T) {
+		repo := configureFakeGitRepo(t, "checkattrwrongfieldcount")
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+
+		_, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
+		if err == nil || !strings.Contains(err.Error(), "parse git check-attr --stdin -z filter output") {
+			t.Fatalf("expected malformed check-attr failure, got %v", err)
+		}
+		if strings.Contains(err.Error(), "run git diff") {
+			t.Fatalf("expected malformed check-attr output to abort before git diff, got %v", err)
+		}
+	})
 }
 
 func TestCollectLockfileGitContextScopesTrackedAndUntrackedCommandsToCandidatePaths(t *testing.T) {
@@ -572,6 +586,11 @@ if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
   if [ "$mode" = "pathscope-filterdriver" ]; then
     cat >/dev/null
     printf 'package-lock.json\000filter\000unspecified\000package.json\000filter\000pwn\000'
+    exit 0
+  fi
+  if [ "$mode" = "lsfail" ]; then
+    cat >/dev/null
+    printf 'package-lock.json\000filter\000unspecified\000package.json\000filter\000unspecified\000'
     exit 0
   fi
   if [ "$mode" = "checkattrfail" ]; then

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -111,6 +111,35 @@ func TestGitDiffNameOnlyNeutralizesFilterDriversWithoutAttrSource(t *testing.T) 
 	}
 }
 
+func TestGitDiffNameOnlyRejectsMalformedCheckAttrOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		mode string
+	}{
+		{name: "truncated output", mode: "checkattrtruncated"},
+		{name: "wrong field count", mode: "checkattrwrongfieldcount"},
+		{name: "wrong attribute", mode: "checkattrwrongattr"},
+		{name: "wrong path order", mode: "checkattrwrongorder"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := configureFakeGitRepo(t, tc.mode)
+
+			_, err := gitDiffNameOnly(context.Background(), repo)
+			if err == nil {
+				t.Fatal("expected malformed check-attr output to fail closed")
+			}
+			if !strings.Contains(err.Error(), "parse git check-attr --stdin -z filter output") {
+				t.Fatalf("expected parse error from malformed check-attr output, got %v", err)
+			}
+			if strings.Contains(err.Error(), "run git diff") {
+				t.Fatalf("expected malformed check-attr output to abort before git diff, got %v", err)
+			}
+		})
+	}
+}
+
 func TestGitAttributeCandidatePathsHandlesNilContextAndCommandFailure(t *testing.T) {
 	t.Run("nil context", func(t *testing.T) {
 		repo := configureFakeGitRepo(t, "filterdriver")
@@ -165,7 +194,10 @@ func TestParseNULTerminatedGitFields(t *testing.T) {
 
 func TestParseGitCheckAttrFilterDrivers(t *testing.T) {
 	output := []byte("package.json\x00filter\x00foo.bar\x00package-lock.json\x00filter\x00unspecified\x00nested/package.json\x00filter\x00foo/bar\x00package.json\x00filter\x00foo.bar\x00")
-	got := parseGitCheckAttrFilterDrivers(output)
+	got, err := parseGitCheckAttrFilterDrivers([]string{"package.json", "package-lock.json", "nested/package.json", "package.json"}, output)
+	if err != nil {
+		t.Fatalf("expected valid check-attr output to parse, got %v", err)
+	}
 	want := []string{"foo.bar", "foo/bar"}
 	if len(got) != len(want) {
 		t.Fatalf("expected %d filter drivers, got %#v", len(want), got)
@@ -176,14 +208,69 @@ func TestParseGitCheckAttrFilterDrivers(t *testing.T) {
 		}
 	}
 
-	if got := parseGitCheckAttrFilterDrivers([]byte("package.json\x00filter\x00set\x00package-lock.json\x00filter\x00unset\x00nested/package.json\x00filter\x00 \x00")); len(got) != 0 {
+	got, err = parseGitCheckAttrFilterDrivers([]string{"package.json", "package-lock.json", "nested/package.json"}, []byte("package.json\x00filter\x00set\x00package-lock.json\x00filter\x00unset\x00nested/package.json\x00filter\x00 \x00"))
+	if err != nil {
+		t.Fatalf("expected ignorable filter values to parse, got %v", err)
+	}
+	if len(got) != 0 {
 		t.Fatalf("expected set/unset/blank filter entries to be ignored, got %#v", got)
 	}
-	if got := parseGitCheckAttrFilterDrivers([]byte("a.json\x00filter\x00\x00package.json\x00filter\x00pwn=drv\x00")); len(got) != 1 || got[0] != "pwn=drv" {
+
+	got, err = parseGitCheckAttrFilterDrivers([]string{"a.json", "package.json"}, []byte("a.json\x00filter\x00\x00package.json\x00filter\x00pwn=drv\x00"))
+	if err != nil {
+		t.Fatalf("expected empty filter value to preserve later triplets, got %v", err)
+	}
+	if len(got) != 1 || got[0] != "pwn=drv" {
 		t.Fatalf("expected empty filter value to preserve later triplets, got %#v", got)
 	}
-	if got := parseGitCheckAttrFilterDrivers([]byte("package.json\x00filter")); len(got) != 0 {
-		t.Fatalf("expected incomplete check-attr output to be ignored, got %#v", got)
+}
+
+func TestParseGitCheckAttrFilterDriversRejectsMalformedOutput(t *testing.T) {
+	cases := []struct {
+		name       string
+		paths      []string
+		output     []byte
+		errContain string
+	}{
+		{
+			name:       "truncated output",
+			paths:      []string{"package.json"},
+			output:     []byte("package.json\x00filter"),
+			errContain: "truncated output",
+		},
+		{
+			name:       "wrong field count",
+			paths:      []string{"package.json"},
+			output:     []byte("package.json\x00filter\x00foo.bar\x00extra\x00"),
+			errContain: "expected 3 NUL-delimited fields",
+		},
+		{
+			name:       "wrong attribute name",
+			paths:      []string{"package.json"},
+			output:     []byte("package.json\x00eol\x00lf\x00"),
+			errContain: "attribute 0 mismatch",
+		},
+		{
+			name:       "wrong path",
+			paths:      []string{"package.json"},
+			output:     []byte("package-lock.json\x00filter\x00foo.bar\x00"),
+			errContain: "path 0 mismatch",
+		},
+		{
+			name:       "wrong path order",
+			paths:      []string{"package.json", "package-lock.json"},
+			output:     []byte("package-lock.json\x00filter\x00foo.bar\x00package.json\x00filter\x00foo.baz\x00"),
+			errContain: "path 0 mismatch",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseGitCheckAttrFilterDrivers(tc.paths, tc.output)
+			if err == nil || !strings.Contains(err.Error(), tc.errContain) {
+				t.Fatalf("expected error containing %q, got %v", tc.errContain, err)
+			}
+		})
 	}
 }
 
@@ -239,6 +326,14 @@ if printf '%s' "$args" | grep -q 'ls-files --cached --others --exclude-standard 
     printf 'package.json\000'
     exit 0
   fi
+  if [ "$mode" = "checkattrwrongorder" ]; then
+    printf 'package.json\000package-lock.json\000'
+    exit 0
+  fi
+  if [ "$mode" = "checkattrtruncated" ] || [ "$mode" = "checkattrwrongfieldcount" ] || [ "$mode" = "checkattrwrongattr" ]; then
+    printf 'package.json\000'
+    exit 0
+  fi
   if [ "$mode" = "filterdriver" ]; then
     printf 'package.json\000'
     exit 0
@@ -249,6 +344,26 @@ if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
   if [ "$mode" = "checkattrfail" ]; then
     echo "check-attr failed" >&2
     exit 1
+  fi
+  if [ "$mode" = "checkattrtruncated" ]; then
+    cat >/dev/null
+    printf 'package.json\000filter\000foo.bar'
+    exit 0
+  fi
+  if [ "$mode" = "checkattrwrongfieldcount" ]; then
+    cat >/dev/null
+    printf 'package.json\000filter\000foo.bar\000extra\000'
+    exit 0
+  fi
+  if [ "$mode" = "checkattrwrongattr" ]; then
+    cat >/dev/null
+    printf 'package.json\000eol\000lf\000'
+    exit 0
+  fi
+  if [ "$mode" = "checkattrwrongorder" ]; then
+    cat >/dev/null
+    printf 'package-lock.json\000filter\000foo.bar\000package.json\000filter\000foo.baz\000'
+    exit 0
   fi
   if [ "$mode" = "filterdriver" ]; then
     cat >/dev/null
@@ -274,6 +389,10 @@ if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
       fi
     done
     exit 0
+  fi
+  if [ "$mode" = "checkattrtruncated" ] || [ "$mode" = "checkattrwrongfieldcount" ] || [ "$mode" = "checkattrwrongattr" ] || [ "$mode" = "checkattrwrongorder" ]; then
+    echo "git diff should not run after malformed check-attr output" >&2
+    exit 1
   fi
   if printf '%s' "$args" | grep -q -- '--cached'; then
     if [ "$mode" = "difffail-cached" ]; then

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -192,6 +192,37 @@ func TestGitActiveFilterPathDriversAndParser(t *testing.T) {
 	}
 }
 
+func TestConfiguredGitAttributeStateDriverErrors(t *testing.T) {
+	t.Run("command construction", func(t *testing.T) {
+		original := resolveGitBinaryPathFn
+		resolveGitBinaryPathFn = func() (string, error) { return "", context.Canceled }
+		t.Cleanup(func() { resolveGitBinaryPathFn = original })
+
+		_, err := filterConfiguredGitAttributeStateDrivers(context.Background(), t.TempDir(), []gitFilterPathDriver{{path: "package.json", driver: "set"}})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected config command construction error, got %v", err)
+		}
+	})
+
+	t.Run("config execution", func(t *testing.T) {
+		originalResolve := resolveGitBinaryPathFn
+		originalExec := execGitCommandContextFn
+		resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+		execGitCommandContextFn = func(ctx context.Context, _ string, _ ...string) (*exec.Cmd, error) {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 2"), nil
+		}
+		t.Cleanup(func() {
+			resolveGitBinaryPathFn = originalResolve
+			execGitCommandContextFn = originalExec
+		})
+
+		_, err := gitFilterDriverHasExecutableConfig(context.Background(), t.TempDir(), "set")
+		if err == nil || !strings.Contains(err.Error(), "run git config --includes --get-regexp") {
+			t.Fatalf("expected config execution error, got %v", err)
+		}
+	})
+}
+
 func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
 	changed, err := gitChangedFilesForPaths(context.Background(), t.TempDir(), nil)
 	if err != nil || len(changed) != 0 {
@@ -300,6 +331,7 @@ func TestParseGitCheckAttrFilterPathDrivers(t *testing.T) {
 	}
 	want := []gitFilterPathDriver{
 		{path: "package.json", driver: "foo.bar"},
+		{path: "package-lock.json", driver: "unspecified"},
 		{path: "nested/package.json", driver: "foo/bar"},
 		{path: "package.json", driver: "foo.bar"},
 	}
@@ -314,10 +346,19 @@ func TestParseGitCheckAttrFilterPathDrivers(t *testing.T) {
 
 	assignments, err = parseGitCheckAttrFilterPathDrivers([]string{"package.json", "package-lock.json", "nested/package.json"}, []byte("package.json\x00filter\x00set\x00package-lock.json\x00filter\x00unset\x00nested/package.json\x00filter\x00 \x00"))
 	if err != nil {
-		t.Fatalf("expected ignorable filter values to parse, got %v", err)
+		t.Fatalf("expected attribute-state filter values to parse, got %v", err)
 	}
-	if len(assignments) != 0 {
-		t.Fatalf("expected set/unset/blank filter entries to be ignored, got %#v", assignments)
+	want = []gitFilterPathDriver{
+		{path: "package.json", driver: "set"},
+		{path: "package-lock.json", driver: "unset"},
+	}
+	if len(assignments) != len(want) {
+		t.Fatalf("expected set/unset entries to remain available for config disambiguation, got %#v", assignments)
+	}
+	for index := range want {
+		if assignments[index] != want[index] {
+			t.Fatalf("expected assignment %#v at index %d, got %#v", want[index], index, assignments)
+		}
 	}
 
 	assignments, err = parseGitCheckAttrFilterPathDrivers([]string{"a.json", "package.json"}, []byte("a.json\x00filter\x00\x00package.json\x00filter\x00pwn=drv\x00"))

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -529,7 +529,7 @@ if printf '%s' "$args" | grep -q 'rev-parse --verify --quiet HEAD'; then
 fi
 if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
   if [ "$mode" = "pathscope-head" ] || [ "$mode" = "pathscope-unborn" ]; then
-    if ! printf '%s' "$args" | grep -q -- 'ls-files --others --exclude-standard -z -- package-lock.json package.json'; then
+    if ! printf '%s' "$args" | grep -q -- 'ls-files --others --exclude-standard -z -- :(literal)package-lock.json :(literal)package.json'; then
       echo "missing pathspec-scoped untracked args: $args" >&2
       exit 1
     fi
@@ -629,7 +629,7 @@ if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
 fi
 if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
   if [ "$mode" = "pathscope-head" ]; then
-    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv HEAD --name-only -- package-lock.json package.json'; then
+    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv HEAD --name-only -- :(literal)package-lock.json :(literal)package.json'; then
       echo "missing pathspec-scoped head diff args: $args" >&2
       exit 1
     fi
@@ -638,14 +638,14 @@ if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
   fi
   if [ "$mode" = "pathscope-unborn" ]; then
     if printf '%s' "$args" | grep -q -- '--cached'; then
-      if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --cached --name-only -- package-lock.json package.json'; then
+      if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --cached --name-only -- :(literal)package-lock.json :(literal)package.json'; then
         echo "missing pathspec-scoped cached diff args: $args" >&2
         exit 1
       fi
       printf 'package.json\n'
       exit 0
     fi
-    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --name-only -- package-lock.json package.json'; then
+    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --name-only -- :(literal)package-lock.json :(literal)package.json'; then
       echo "missing pathspec-scoped unstaged diff args: $args" >&2
       exit 1
     fi

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -807,7 +807,7 @@ if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
 fi
 if printf '%s' "$args" | grep -q 'config --null --includes --get-regexp'; then
   if [ "$mode" = "pathscope-filterdriver" ]; then
-    printf 'filter.PWN.clean\n./helper.sh\000'
+    printf 'filter.pwn.clean\n./helper.sh\000'
     exit 0
   fi
   exit 1

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -150,6 +150,19 @@ func TestParseNULTerminatedGitOutput(t *testing.T) {
 	}
 }
 
+func TestParseNULTerminatedGitFields(t *testing.T) {
+	got := parseNULTerminatedGitFields([]byte("a\x00\x00b\x00"))
+	want := []string{"a", "", "b"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d nul-delimited fields, got %#v", len(want), got)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("expected field %q at index %d, got %#v", want[index], index, got)
+		}
+	}
+}
+
 func TestParseGitCheckAttrFilterDrivers(t *testing.T) {
 	output := []byte("package.json\x00filter\x00foo.bar\x00package-lock.json\x00filter\x00unspecified\x00nested/package.json\x00filter\x00foo/bar\x00package.json\x00filter\x00foo.bar\x00")
 	got := parseGitCheckAttrFilterDrivers(output)
@@ -165,6 +178,9 @@ func TestParseGitCheckAttrFilterDrivers(t *testing.T) {
 
 	if got := parseGitCheckAttrFilterDrivers([]byte("package.json\x00filter\x00set\x00package-lock.json\x00filter\x00unset\x00nested/package.json\x00filter\x00 \x00")); len(got) != 0 {
 		t.Fatalf("expected set/unset/blank filter entries to be ignored, got %#v", got)
+	}
+	if got := parseGitCheckAttrFilterDrivers([]byte("a.json\x00filter\x00\x00package.json\x00filter\x00pwn=drv\x00")); len(got) != 1 || got[0] != "pwn=drv" {
+		t.Fatalf("expected empty filter value to preserve later triplets, got %#v", got)
 	}
 	if got := parseGitCheckAttrFilterDrivers([]byte("package.json\x00filter")); len(got) != 0 {
 		t.Fatalf("expected incomplete check-attr output to be ignored, got %#v", got)
@@ -247,9 +263,13 @@ if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
       echo "unexpected attr-source flag" >&2
       exit 1
     fi
-    for expected in 'filter.foo.bar.clean=' 'filter.foo.bar.process=' 'filter.foo.bar.required=false'; do
-      if ! printf '%s' "$args" | grep -q "$expected"; then
-        echo "missing filter override: $expected" >&2
+    for expected in \
+      'GIT_CONFIG_KEY_5=filter.foo.bar.clean' \
+      'GIT_CONFIG_KEY_6=filter.foo.bar.process' \
+      'GIT_CONFIG_KEY_7=filter.foo.bar.required' \
+      'GIT_CONFIG_VALUE_7=false'; do
+      if ! env | grep -q "$expected"; then
+        echo "missing filter override env: $expected" >&2
         exit 1
       fi
     done

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -218,25 +218,24 @@ func TestConfiguredGitAttributeDriverErrors(t *testing.T) {
 			execGitCommandContextFn = originalExec
 		})
 
-		_, err := gitFilterDriverHasExecutableConfig(context.Background(), t.TempDir(), "set")
-		if err == nil || !strings.Contains(err.Error(), "run git config --includes --get") {
+		_, err := filterConfiguredGitAttributeDrivers(context.Background(), t.TempDir(), []gitFilterPathDriver{{path: "package.json", driver: "set"}})
+		if err == nil || !strings.Contains(err.Error(), "run git config --null --includes --get-regexp") {
 			t.Fatalf("expected config execution error, got %v", err)
 		}
 	})
 }
 
-func TestConfiguredGitAttributeDriversCacheExactLookups(t *testing.T) {
+func TestConfiguredGitAttributeDriversEnumerateCaseFoldedNullConfigRecords(t *testing.T) {
 	originalResolve := resolveGitBinaryPathFn
 	originalExec := execGitCommandContextFn
 	resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
-	lookups := make(map[string]int)
+	configCalls := 0
 	execGitCommandContextFn = func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
-		key := args[len(args)-1]
-		lookups[key]++
-		if key == "filter.configured.clean" {
-			return exec.CommandContext(ctx, "/bin/sh", "-c", "printf 'cat\\n'"), nil
+		configCalls++
+		if !isExecutableFilterConfigEnumeration(gitSubcommandArgs(args)) {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 1"), nil
 		}
-		return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 1"), nil
+		return shellEscapedOutputCommand(ctx, `filter.PWN.clean\n./helper.sh\000filter.Foo/Bar.process\n./process-helper\000filter.empty.clean\n\000filter.pwned.clean\n./other-helper\000`), nil
 	}
 	t.Cleanup(func() {
 		resolveGitBinaryPathFn = originalResolve
@@ -244,30 +243,73 @@ func TestConfiguredGitAttributeDriversCacheExactLookups(t *testing.T) {
 	})
 
 	active, err := filterConfiguredGitAttributeDrivers(context.Background(), t.TempDir(), []gitFilterPathDriver{
-		{path: "a.json", driver: "configured"},
-		{path: "b.json", driver: "configured"},
-		{path: "c.json", driver: "inert"},
-		{path: "d.json", driver: "inert"},
+		{path: "a.json", driver: "pwn"},
+		{path: "b.json", driver: "Pwn"},
+		{path: "c.json", driver: "foo/bar"},
+		{path: "d.json", driver: "empty"},
+		{path: "e.json", driver: "pwn.*"},
 	})
 	if err != nil {
 		t.Fatalf("filter configured git attribute drivers: %v", err)
 	}
-	if len(active) != 2 || active[0].path != "a.json" || active[1].path != "b.json" {
-		t.Fatalf("expected configured assignments in input order, got %#v", active)
+	if len(active) != 3 || active[0].path != "a.json" || active[1].path != "b.json" || active[2].path != "c.json" {
+		t.Errorf("expected case-folded configured assignments with punctuation in input order, got %#v", active)
 	}
-	wantLookups := map[string]int{
-		"filter.configured.clean": 1,
-		"filter.inert.clean":      1,
-		"filter.inert.process":    1,
+	if configCalls != 1 {
+		t.Errorf("expected one config-only filter command enumeration, got %d config calls", configCalls)
 	}
-	if len(lookups) != len(wantLookups) {
-		t.Fatalf("expected exact cached config lookups %#v, got %#v", wantLookups, lookups)
+}
+
+func TestConfiguredGitAttributeDriversRejectMalformedNullConfigRecords(t *testing.T) {
+	cases := []struct {
+		name       string
+		output     string
+		errContain string
+	}{
+		{name: "truncated record", output: `filter.PWN.clean\n./helper.sh`, errContain: "truncated"},
+		{name: "missing key value separator", output: `filter.PWN.clean\000`, errContain: "key/value separator"},
+		{name: "unexpected key", output: `diff.external\n./helper.sh\000`, errContain: "filter command key"},
 	}
-	for key, want := range wantLookups {
-		if lookups[key] != want {
-			t.Fatalf("expected %q to be queried %d time, got %#v", key, want, lookups)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalResolve := resolveGitBinaryPathFn
+			originalExec := execGitCommandContextFn
+			resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+			execGitCommandContextFn = func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
+				if !isExecutableFilterConfigEnumeration(gitSubcommandArgs(args)) {
+					return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 1"), nil
+				}
+				return shellEscapedOutputCommand(ctx, tc.output), nil
+			}
+			t.Cleanup(func() {
+				resolveGitBinaryPathFn = originalResolve
+				execGitCommandContextFn = originalExec
+			})
+
+			_, err := filterConfiguredGitAttributeDrivers(context.Background(), t.TempDir(), []gitFilterPathDriver{{path: "package.json", driver: "pwn"}})
+			if err == nil || !strings.Contains(err.Error(), tc.errContain) {
+				t.Fatalf("expected malformed config output error containing %q, got %v", tc.errContain, err)
+			}
+		})
+	}
+}
+
+func gitSubcommandArgs(args []string) []string {
+	for index, arg := range args {
+		if arg == "-C" && index+2 < len(args) {
+			return args[index+2:]
 		}
 	}
+	return nil
+}
+
+func isExecutableFilterConfigEnumeration(args []string) bool {
+	return len(args) == 5 && args[0] == "config" && args[1] == "--null" && args[2] == "--includes" && args[3] == "--get-regexp"
+}
+
+func shellEscapedOutputCommand(ctx context.Context, output string) *exec.Cmd {
+	return exec.CommandContext(ctx, "/bin/sh", "-c", `printf '%b' "$1"`, "git-config-output", output)
 }
 
 func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -332,6 +332,10 @@ func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
 	if err != nil || len(untracked) != 0 {
 		t.Fatalf("expected empty scoped untracked set, got %#v err=%v", untracked, err)
 	}
+	visible, err := gitVisibleFilesForPaths(context.Background(), t.TempDir(), nil)
+	if err != nil || len(visible) != 0 {
+		t.Fatalf("expected empty scoped visible set, got %#v err=%v", visible, err)
+	}
 
 	cases := []struct {
 		name    string
@@ -349,8 +353,17 @@ func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
 			wantSub: lockfileRunGitErr,
 		},
 		{
-			name: "changed files untracked classification failure",
+			name: "changed files visible classification failure",
 			mode: "lsfail",
+			run: func(repo string) error {
+				_, err := gitChangedFilesForPaths(context.Background(), repo, []string{"package.json"})
+				return err
+			},
+			wantSub: "ls-files",
+		},
+		{
+			name: "changed files untracked classification failure",
+			mode: "untrackedlsfail",
 			run: func(repo string) error {
 				_, err := gitChangedFilesForPaths(context.Background(), repo, []string{"package.json"})
 				return err
@@ -405,6 +418,9 @@ func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
 	}
 	if _, err := gitUntrackedFilesForPaths(context.Background(), t.TempDir(), []string{"package.json"}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected scoped untracked command construction failure, got %v", err)
+	}
+	if _, err := gitVisibleFilesForPaths(context.Background(), t.TempDir(), []string{"package.json"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected scoped visible command construction failure, got %v", err)
 	}
 }
 
@@ -730,30 +746,22 @@ if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
     fi
     exit 0
   fi
-  if [ "$mode" = "lsfail" ]; then
+  if [ "$mode" = "lsfail" ] || [ "$mode" = "untrackedlsfail" ]; then
     echo "ls-files failed" >&2
     exit 1
   fi
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'ls-files --cached --others --exclude-standard -z'; then
-  if [ "$mode" = "pathscope-head" ] || [ "$mode" = "pathscope-unborn" ] || [ "$mode" = "pathscope-filterdriver" ]; then
-    echo "repo-wide attribute candidate listing should not run" >&2
+  if [ "$mode" = "lsfail" ]; then
+    echo "ls-files failed" >&2
     exit 1
   fi
-  if [ "$mode" = "checkattrfail" ]; then
-    printf 'package.json\000'
+  if printf '%s' "$args" | grep -q -- ':(literal)package-lock.json' && printf '%s' "$args" | grep -q -- ':(literal)package.json'; then
+    printf 'package-lock.json\000package.json\000'
     exit 0
   fi
-  if [ "$mode" = "checkattrwrongorder" ]; then
-    printf 'package.json\000package-lock.json\000'
-    exit 0
-  fi
-  if [ "$mode" = "checkattrtruncated" ] || [ "$mode" = "checkattrwrongfieldcount" ] || [ "$mode" = "checkattrwrongattr" ]; then
-    printf 'package.json\000'
-    exit 0
-  fi
-  if [ "$mode" = "filterdriver" ]; then
+  if printf '%s' "$args" | grep -q -- ':(literal)package.json'; then
     printf 'package.json\000'
     exit 0
   fi

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -564,7 +564,7 @@ func assertScopedGitPathHelperConstructionFailures(t *testing.T) {
 
 func TestGitDiffNameOnlyForPathsUsesBoundedLiteralBatches(t *testing.T) {
 	paths := scopedGitBatchRegressionPaths()
-	commands := captureScopedGitPathspecCommands(t, true)
+	commands := captureScopedGitPathspecCommands(t)
 
 	got, err := gitDiffNameOnlyForPaths(context.Background(), t.TempDir(), paths, "HEAD")
 	if err != nil {
@@ -576,7 +576,7 @@ func TestGitDiffNameOnlyForPathsUsesBoundedLiteralBatches(t *testing.T) {
 
 func TestGitUntrackedFilesForPathsUsesBoundedLiteralBatches(t *testing.T) {
 	paths := scopedGitBatchRegressionPaths()
-	commands := captureScopedGitPathspecCommands(t, true)
+	commands := captureScopedGitPathspecCommands(t)
 
 	got, err := gitUntrackedFilesForPaths(context.Background(), t.TempDir(), paths)
 	if err != nil {
@@ -596,7 +596,7 @@ func scopedGitBatchRegressionPaths() []string {
 	return paths
 }
 
-func captureScopedGitPathspecCommands(t *testing.T, nulOutput bool) *[][]string {
+func captureScopedGitPathspecCommands(t *testing.T) *[][]string {
 	t.Helper()
 
 	originalResolve := resolveGitBinaryPathFn
@@ -606,7 +606,7 @@ func captureScopedGitPathspecCommands(t *testing.T, nulOutput bool) *[][]string 
 	execGitCommandContextFn = func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
 		paths := literalPathsFromGitCommand(t, args)
 		commands = append(commands, paths)
-		return gitPathOutputCommand(ctx, orderedUniqueGitPaths(paths), nulOutput), nil
+		return gitPathOutputCommand(ctx, orderedUniqueGitPaths(paths)), nil
 	}
 	t.Cleanup(func() {
 		resolveGitBinaryPathFn = originalResolve
@@ -639,11 +639,8 @@ func literalPathsFromGitCommand(t *testing.T, args []string) []string {
 	return paths
 }
 
-func gitPathOutputCommand(ctx context.Context, paths []string, nulOutput bool) *exec.Cmd {
-	format := `%s\n`
-	if nulOutput {
-		format = `%s\000`
-	}
+func gitPathOutputCommand(ctx context.Context, paths []string) *exec.Cmd {
+	format := `%s\000`
 	args := []string{"-c", `format="$1"; shift; for path do printf "$format" "$path"; done`, "git-output", format}
 	args = append(args, paths...)
 	return exec.CommandContext(ctx, "/bin/sh", args...)

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/gitexec"
 )
 
 const lockfileRunGitErr = "run git"
@@ -302,10 +304,114 @@ func TestConfiguredGitAttributeDriversRejectMalformedNullConfigRecords(t *testin
 	}
 }
 
+func TestGitPathUsesNamedFilterDriver(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	t.Run("inactive boolean state", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter\n")
+		initGitRepo(t, repo)
+
+		active, err := gitPathUsesNamedFilterDriver(context.Background(), repo, gitFilterPathDriver{path: manifestFileName, driver: "set"})
+		if err != nil {
+			t.Fatalf("gitPathUsesNamedFilterDriver: %v", err)
+		}
+		if active {
+			t.Fatal("expected bare boolean filter state to remain inactive")
+		}
+	})
+
+	t.Run("explicit special-name clean driver", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=set\n")
+		initGitRepo(t, repo)
+
+		active, err := gitPathUsesNamedFilterDriver(context.Background(), repo, gitFilterPathDriver{path: manifestFileName, driver: "set"})
+		if err != nil {
+			t.Fatalf("gitPathUsesNamedFilterDriver: %v", err)
+		}
+		if !active {
+			t.Fatal("expected explicit state-named clean driver to be classified active")
+		}
+	})
+
+	t.Run("explicit special-name process driver from info attributes", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+		initGitRepo(t, repo)
+		writeFile(t, filepath.Join(repo, ".git", "info", "attributes"), manifestFileName+" filter=set\n")
+
+		active, err := gitPathUsesNamedFilterDriver(context.Background(), repo, gitFilterPathDriver{path: manifestFileName, driver: "set"})
+		if err != nil {
+			t.Fatalf("gitPathUsesNamedFilterDriver: %v", err)
+		}
+		if !active {
+			t.Fatal("expected explicit state-named process driver to be classified active")
+		}
+	})
+
+	t.Run("marker probe failure is active but generic probe failure is not", func(t *testing.T) {
+		originalResolve := resolveGitBinaryPathFn
+		originalExec := execGitCommandContextFn
+		resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+		execGitCommandContextFn = func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
+			subcommand := gitSubcommandArgs(args)
+			if len(subcommand) >= 2 && subcommand[0] == "hash-object" && subcommand[1] == "--stdin" {
+				return shellEscapedOutputCommand(ctx, "rawhash\n"), nil
+			}
+			if len(subcommand) >= 1 && subcommand[0] == "hash-object" {
+				return exec.CommandContext(ctx, "/bin/sh", "-c", `printf '%s\n' "$1" >&2; exit 2`, "git-probe", "__LOPPER_LOCKFILE_FILTER_PROBE__"), nil
+			}
+			return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 1"), nil
+		}
+		t.Cleanup(func() {
+			resolveGitBinaryPathFn = originalResolve
+			execGitCommandContextFn = originalExec
+		})
+
+		active, err := gitPathUsesNamedFilterDriver(context.Background(), t.TempDir(), gitFilterPathDriver{path: manifestFileName, driver: "set"})
+		if err != nil {
+			t.Fatalf("expected marked probe failure to classify active, got %v", err)
+		}
+		if !active {
+			t.Fatal("expected marked probe failure to classify active")
+		}
+
+		execGitCommandContextFn = func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
+			subcommand := gitSubcommandArgs(args)
+			if len(subcommand) >= 2 && subcommand[0] == "hash-object" && subcommand[1] == "--stdin" {
+				return shellEscapedOutputCommand(ctx, "rawhash\n"), nil
+			}
+			if len(subcommand) >= 1 && subcommand[0] == "hash-object" {
+				return exec.CommandContext(ctx, "/bin/sh", "-c", `printf '%s\n' "$1" >&2; exit 2`, "git-probe", "generic-probe-failure"), nil
+			}
+			return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 1"), nil
+		}
+
+		active, err = gitPathUsesNamedFilterDriver(context.Background(), t.TempDir(), gitFilterPathDriver{path: manifestFileName, driver: "set"})
+		if err == nil {
+			t.Fatal("expected generic probe failure to return an error")
+		}
+		if active {
+			t.Fatal("expected generic probe failure to remain inactive")
+		}
+	})
+}
+
 func gitSubcommandArgs(args []string) []string {
-	for index, arg := range args {
-		if arg == "-C" && index+2 < len(args) {
-			return args[index+2:]
+	for len(args) > 0 {
+		switch args[0] {
+		case "-C", "-c":
+			if len(args) < 2 {
+				return nil
+			}
+			args = args[2:]
+		default:
+			return args
 		}
 	}
 	return nil

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -195,6 +195,11 @@ func TestGitActiveFilterPathDriversAndParser(t *testing.T) {
 }
 
 func TestConfiguredGitAttributeDriverErrors(t *testing.T) {
+	active, err := filterConfiguredGitAttributeDrivers(context.Background(), t.TempDir(), nil)
+	if err != nil || len(active) != 0 {
+		t.Fatalf("expected empty assignments to skip config enumeration, got active=%#v err=%v", active, err)
+	}
+
 	t.Run("command construction", func(t *testing.T) {
 		original := resolveGitBinaryPathFn
 		resolveGitBinaryPathFn = func() (string, error) { return "", context.Canceled }
@@ -270,6 +275,7 @@ func TestConfiguredGitAttributeDriversRejectMalformedNullConfigRecords(t *testin
 		{name: "truncated record", output: `filter.PWN.clean\n./helper.sh`, errContain: "truncated"},
 		{name: "missing key value separator", output: `filter.PWN.clean\000`, errContain: "key/value separator"},
 		{name: "unexpected key", output: `diff.external\n./helper.sh\000`, errContain: "filter command key"},
+		{name: "unexpected filter command key", output: `filter.pwn.smudge\n./helper.sh\000`, errContain: "filter command key"},
 	}
 
 	for _, tc := range cases {

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -230,6 +230,28 @@ func TestConfiguredGitAttributeDriverErrors(t *testing.T) {
 			t.Fatalf("expected config execution error, got %v", err)
 		}
 	})
+
+	t.Run("state probe construction", func(t *testing.T) {
+		forcedErr := errors.New("construct state filter probe")
+		originalResolve := resolveGitBinaryPathFn
+		originalExec := execGitCommandContextFn
+		resolveGitBinaryPathFn = func() (string, error) { return gitBinaryPath, nil }
+		execGitCommandContextFn = func(ctx context.Context, _ string, args ...string) (*exec.Cmd, error) {
+			if isExecutableFilterConfigEnumeration(gitSubcommandArgs(args)) {
+				return shellEscapedOutputCommand(ctx, `filter.set.clean\n./helper.sh\000`), nil
+			}
+			return nil, forcedErr
+		}
+		t.Cleanup(func() {
+			resolveGitBinaryPathFn = originalResolve
+			execGitCommandContextFn = originalExec
+		})
+
+		_, err := filterConfiguredGitAttributeDrivers(context.Background(), t.TempDir(), []gitFilterPathDriver{{path: manifestFileName, driver: "set"}})
+		if !errors.Is(err, forcedErr) {
+			t.Fatalf("expected state filter probe construction error, got %v", err)
+		}
+	})
 }
 
 func TestConfiguredGitAttributeDriversMatchExactNullConfigRecords(t *testing.T) {
@@ -308,6 +330,21 @@ func TestGitPathUsesNamedFilterDriver(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")
 	}
+
+	t.Run("git command construction failure", func(t *testing.T) {
+		sentinel := errors.New("resolve probe git")
+		originalResolve := resolveGitBinaryPathFn
+		resolveGitBinaryPathFn = func() (string, error) { return "", sentinel }
+		t.Cleanup(func() { resolveGitBinaryPathFn = originalResolve })
+
+		active, err := gitPathUsesNamedFilterDriver(context.Background(), t.TempDir(), gitFilterPathDriver{path: manifestFileName, driver: "set"})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("expected git resolution failure, got %v", err)
+		}
+		if active {
+			t.Fatal("expected failed probe command construction to remain inactive")
+		}
+	})
 
 	t.Run("inactive boolean state", func(t *testing.T) {
 		repo := t.TempDir()

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -60,6 +60,11 @@ func TestLockfileDriftGitErrorBranches(t *testing.T) {
 		t.Fatalf("expected gitChangedFiles to surface ls-files failure, got %v", err)
 	}
 
+	writeFakeGitMode(t, repo, "checkattrfail")
+	if _, err := gitDiffNameOnly(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "check-attr") {
+		t.Fatalf("expected gitDiffNameOnly to surface check-attr failure, got %v", err)
+	}
+
 	writeFakeGitMode(t, repo, "difffail-head")
 	if _, err := gitTrackedChanges(context.Background(), repo); err == nil || !strings.Contains(err.Error(), lockfileRunGitErr) {
 		t.Fatalf("expected gitTrackedChanges HEAD diff failure, got %v", err)
@@ -98,57 +103,75 @@ func TestGitCommandContextConstructorError(t *testing.T) {
 	}
 }
 
-func TestGitDiffNameOnlyRejectsUnsupportedObjectFormat(t *testing.T) {
-	repo := configureFakeGitObjectFormatRepo(t, "objectformat-bad")
+func TestGitDiffNameOnlyNeutralizesFilterDriversWithoutAttrSource(t *testing.T) {
+	repo := configureFakeGitRepo(t, "filterdriver")
 
-	if _, err := gitDiffNameOnly(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "unsupported git object format") {
-		t.Fatalf("expected unsupported git object format error, got %v", err)
+	if _, err := gitDiffNameOnly(context.Background(), repo); err != nil {
+		t.Fatalf("expected gitDiffNameOnly to construct a portable hardened diff command, got %v", err)
 	}
 }
 
-func TestGitObjectFormatErrorBranches(t *testing.T) {
-	t.Run("resolver error", func(t *testing.T) {
-		originalResolve := resolveGitBinaryPathFn
-		originalExec := execGitCommandContextFn
-		resolveGitBinaryPathFn = func() (string, error) { return "", errors.New("missing git") }
-		t.Cleanup(func() {
-			resolveGitBinaryPathFn = originalResolve
-			execGitCommandContextFn = originalExec
-		})
+func TestGitAttributeCandidatePathsHandlesNilContextAndCommandFailure(t *testing.T) {
+	t.Run("nil context", func(t *testing.T) {
+		repo := configureFakeGitRepo(t, "filterdriver")
 
-		var nilCtx context.Context
-		if _, err := gitObjectFormat(nilCtx, t.TempDir()); err == nil || !strings.Contains(err.Error(), "missing git") {
-			t.Fatalf("expected resolver error, got %v", err)
+		paths, err := gitAttributeCandidatePaths(testNilContext(), repo)
+		if err != nil {
+			t.Fatalf("expected gitAttributeCandidatePaths with nil context to succeed, got %v", err)
+		}
+		if len(paths) != 1 || paths[0] != "package.json" {
+			t.Fatalf("unexpected attribute candidate paths %#v", paths)
 		}
 	})
 
-	t.Run("constructor error", func(t *testing.T) {
-		originalResolve := resolveGitBinaryPathFn
-		originalExec := execGitCommandContextFn
-		resolveGitBinaryPathFn = func() (string, error) { return writeFakeGitBinary(t), nil }
-		execGitCommandContextFn = func(context.Context, string, ...string) (*exec.Cmd, error) {
-			return nil, errors.New("construct git")
-		}
-		t.Cleanup(func() {
-			resolveGitBinaryPathFn = originalResolve
-			execGitCommandContextFn = originalExec
-		})
+	t.Run("command failure", func(t *testing.T) {
+		repo := configureFakeGitRepo(t, "lsfilescachedfail")
 
-		if _, err := gitObjectFormat(context.Background(), t.TempDir()); err == nil || !strings.Contains(err.Error(), "construct git") {
-			t.Fatalf("expected constructor error, got %v", err)
-		}
-	})
-
-	t.Run("command output error", func(t *testing.T) {
-		repo := configureFakeGitObjectFormatRepo(t, "objectformatfail")
-
-		if _, err := gitObjectFormat(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "run git rev-parse --show-object-format") {
-			t.Fatalf("expected git object format command failure, got %v", err)
+		if _, err := gitAttributeCandidatePaths(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "ls-files --cached --others --exclude-standard -z") {
+			t.Fatalf("expected cached ls-files failure, got %v", err)
 		}
 	})
 }
 
-func configureFakeGitObjectFormatRepo(t *testing.T, mode string) string {
+func TestGitActiveFilterDriversHandlesEmptyPaths(t *testing.T) {
+	drivers, err := gitActiveFilterDrivers(context.Background(), t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("expected empty path set to skip git check-attr, got %v", err)
+	}
+	if len(drivers) != 0 {
+		t.Fatalf("expected no drivers for empty path set, got %#v", drivers)
+	}
+}
+
+func TestParseNULTerminatedGitOutput(t *testing.T) {
+	got := parseNULTerminatedGitOutput([]byte("a\x00b\x00\x00"))
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("unexpected nul-delimited parse result %#v", got)
+	}
+}
+
+func TestParseGitCheckAttrFilterDrivers(t *testing.T) {
+	output := []byte("package.json\x00filter\x00foo.bar\x00package-lock.json\x00filter\x00unspecified\x00nested/package.json\x00filter\x00foo/bar\x00package.json\x00filter\x00foo.bar\x00")
+	got := parseGitCheckAttrFilterDrivers(output)
+	want := []string{"foo.bar", "foo/bar"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d filter drivers, got %#v", len(want), got)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("expected filter driver %q at index %d, got %#v", want[index], index, got)
+		}
+	}
+
+	if got := parseGitCheckAttrFilterDrivers([]byte("package.json\x00filter\x00set\x00package-lock.json\x00filter\x00unset\x00nested/package.json\x00filter\x00 \x00")); len(got) != 0 {
+		t.Fatalf("expected set/unset/blank filter entries to be ignored, got %#v", got)
+	}
+	if got := parseGitCheckAttrFilterDrivers([]byte("package.json\x00filter")); len(got) != 0 {
+		t.Fatalf("expected incomplete check-attr output to be ignored, got %#v", got)
+	}
+}
+
+func configureFakeGitRepo(t *testing.T, mode string) string {
 	t.Helper()
 
 	original := resolveGitBinaryPathFn
@@ -184,18 +207,6 @@ if printf '%s' "$args" | grep -q 'rev-parse --verify --quiet HEAD'; then
   fi
   exit 0
 fi
-if printf '%s' "$args" | grep -q 'rev-parse --show-object-format'; then
-  if [ "$mode" = "objectformatfail" ]; then
-    echo "show-object-format failed" >&2
-    exit 1
-  fi
-  if [ "$mode" = "objectformat-bad" ]; then
-    echo sha512
-    exit 0
-  fi
-  echo sha1
-  exit 0
-fi
 if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
   if [ "$mode" = "lsfail" ]; then
     echo "ls-files failed" >&2
@@ -203,7 +214,47 @@ if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
   fi
   exit 0
 fi
+if printf '%s' "$args" | grep -q 'ls-files --cached --others --exclude-standard -z'; then
+  if [ "$mode" = "lsfilescachedfail" ]; then
+    echo "ls-files cached failed" >&2
+    exit 1
+  fi
+  if [ "$mode" = "checkattrfail" ]; then
+    printf 'package.json\000'
+    exit 0
+  fi
+  if [ "$mode" = "filterdriver" ]; then
+    printf 'package.json\000'
+    exit 0
+  fi
+  exit 0
+fi
+if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
+  if [ "$mode" = "checkattrfail" ]; then
+    echo "check-attr failed" >&2
+    exit 1
+  fi
+  if [ "$mode" = "filterdriver" ]; then
+    cat >/dev/null
+    printf 'package.json\000filter\000foo.bar\000'
+    exit 0
+  fi
+  exit 0
+fi
 if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
+  if [ "$mode" = "filterdriver" ]; then
+    if printf '%s' "$args" | grep -q -- '--attr-source='; then
+      echo "unexpected attr-source flag" >&2
+      exit 1
+    fi
+    for expected in 'filter.foo.bar.clean=' 'filter.foo.bar.process=' 'filter.foo.bar.required=false'; do
+      if ! printf '%s' "$args" | grep -q "$expected"; then
+        echo "missing filter override: $expected" >&2
+        exit 1
+      fi
+    done
+    exit 0
+  fi
   if printf '%s' "$args" | grep -q -- '--cached'; then
     if [ "$mode" = "difffail-cached" ]; then
       echo "diff failed" >&2
@@ -242,4 +293,8 @@ func useFakeGitCommandContext(t *testing.T) {
 	t.Cleanup(func() {
 		execGitCommandContextFn = original
 	})
+}
+
+func testNilContext() context.Context {
+	return nil
 }

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -409,12 +409,13 @@ func TestParseNULTerminatedGitFields(t *testing.T) {
 	}
 }
 
-func TestParseGitCheckAttrFilterDrivers(t *testing.T) {
+func TestParseGitCheckAttrFilterPathDriversAndDeduplicates(t *testing.T) {
 	output := []byte("package.json\x00filter\x00foo.bar\x00package-lock.json\x00filter\x00unspecified\x00nested/package.json\x00filter\x00foo/bar\x00package.json\x00filter\x00foo.bar\x00")
-	got, err := parseGitCheckAttrFilterDrivers([]string{"package.json", "package-lock.json", "nested/package.json", "package.json"}, output)
+	assignments, err := parseGitCheckAttrFilterPathDrivers([]string{"package.json", "package-lock.json", "nested/package.json", "package.json"}, output)
 	if err != nil {
 		t.Fatalf("expected valid check-attr output to parse, got %v", err)
 	}
+	got := uniqueFilterDrivers(assignments)
 	want := []string{"foo.bar", "foo/bar"}
 	if len(got) != len(want) {
 		t.Fatalf("expected %d filter drivers, got %#v", len(want), got)
@@ -425,24 +426,26 @@ func TestParseGitCheckAttrFilterDrivers(t *testing.T) {
 		}
 	}
 
-	got, err = parseGitCheckAttrFilterDrivers([]string{"package.json", "package-lock.json", "nested/package.json"}, []byte("package.json\x00filter\x00set\x00package-lock.json\x00filter\x00unset\x00nested/package.json\x00filter\x00 \x00"))
+	assignments, err = parseGitCheckAttrFilterPathDrivers([]string{"package.json", "package-lock.json", "nested/package.json"}, []byte("package.json\x00filter\x00set\x00package-lock.json\x00filter\x00unset\x00nested/package.json\x00filter\x00 \x00"))
 	if err != nil {
 		t.Fatalf("expected ignorable filter values to parse, got %v", err)
 	}
+	got = uniqueFilterDrivers(assignments)
 	if len(got) != 0 {
 		t.Fatalf("expected set/unset/blank filter entries to be ignored, got %#v", got)
 	}
 
-	got, err = parseGitCheckAttrFilterDrivers([]string{"a.json", "package.json"}, []byte("a.json\x00filter\x00\x00package.json\x00filter\x00pwn=drv\x00"))
+	assignments, err = parseGitCheckAttrFilterPathDrivers([]string{"a.json", "package.json"}, []byte("a.json\x00filter\x00\x00package.json\x00filter\x00pwn=drv\x00"))
 	if err != nil {
 		t.Fatalf("expected empty filter value to preserve later triplets, got %v", err)
 	}
+	got = uniqueFilterDrivers(assignments)
 	if len(got) != 1 || got[0] != "pwn=drv" {
 		t.Fatalf("expected empty filter value to preserve later triplets, got %#v", got)
 	}
 }
 
-func TestParseGitCheckAttrFilterDriversRejectsMalformedOutput(t *testing.T) {
+func TestParseGitCheckAttrFilterPathDriversRejectsMalformedOutput(t *testing.T) {
 	cases := []struct {
 		name       string
 		paths      []string
@@ -483,7 +486,7 @@ func TestParseGitCheckAttrFilterDriversRejectsMalformedOutput(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := parseGitCheckAttrFilterDrivers(tc.paths, tc.output)
+			_, err := parseGitCheckAttrFilterPathDrivers(tc.paths, tc.output)
 			if err == nil || !strings.Contains(err.Error(), tc.errContain) {
 				t.Fatalf("expected error containing %q, got %v", tc.errContain, err)
 			}

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -300,6 +300,15 @@ func TestScopedGitPathHelpersHandleEmptyPathsAndFailures(t *testing.T) {
 			wantSub: lockfileRunGitErr,
 		},
 		{
+			name: "changed files untracked classification failure",
+			mode: "lsfail",
+			run: func(repo string) error {
+				_, err := gitChangedFilesForPaths(context.Background(), repo, []string{"package.json"})
+				return err
+			},
+			wantSub: "ls-files",
+		},
+		{
 			name: "tracked cached diff failure",
 			mode: "difffail-cached",
 			run: func(repo string) error {
@@ -641,7 +650,7 @@ if printf '%s' "$args" | grep -q 'rev-parse --verify --quiet HEAD'; then
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
-  if [ "$mode" = "pathscope-head" ] || [ "$mode" = "pathscope-unborn" ]; then
+  if [ "$mode" = "pathscope-head" ] || [ "$mode" = "pathscope-unborn" ] || [ "$mode" = "pathscope-filterdriver" ] || [ "$mode" = "checkattrtruncated" ] || [ "$mode" = "checkattrwrongfieldcount" ] || [ "$mode" = "checkattrwrongattr" ] || [ "$mode" = "checkattrwrongorder" ]; then
     if ! printf '%s' "$args" | grep -q -- 'ls-files --others --exclude-standard -z -- :(literal)package-lock.json :(literal)package.json'; then
       echo "missing pathspec-scoped untracked args: $args" >&2
       exit 1
@@ -650,10 +659,6 @@ if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then
       printf 'package-lock.json\000'
     fi
     exit 0
-  fi
-  if [ "$mode" = "pathscope-filterdriver" ] || [ "$mode" = "checkattrtruncated" ] || [ "$mode" = "checkattrwrongfieldcount" ] || [ "$mode" = "checkattrwrongattr" ] || [ "$mode" = "checkattrwrongorder" ]; then
-    echo "scoped untracked listing should not run before filter validation" >&2
-    exit 1
   fi
   if [ "$mode" = "lsfail" ]; then
     echo "ls-files failed" >&2
@@ -685,9 +690,14 @@ if printf '%s' "$args" | grep -q 'ls-files --cached --others --exclude-standard 
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'check-attr --stdin -z filter'; then
-  if [ "$mode" = "pathscope-head" ] || [ "$mode" = "pathscope-unborn" ]; then
+  if [ "$mode" = "pathscope-head" ]; then
     cat >/dev/null
     printf 'package-lock.json\000filter\000unspecified\000package.json\000filter\000unspecified\000'
+    exit 0
+  fi
+  if [ "$mode" = "pathscope-unborn" ]; then
+    cat >/dev/null
+    printf 'package.json\000filter\000unspecified\000'
     exit 0
   fi
   if [ "$mode" = "pathscope-filterdriver" ]; then
@@ -749,18 +759,17 @@ if printf '%s' "$args" | grep -q 'diff --no-ext-diff --no-textconv'; then
   fi
   if [ "$mode" = "pathscope-unborn" ]; then
     if printf '%s' "$args" | grep -q -- '--cached'; then
-      if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --cached --name-only -- :(literal)package-lock.json :(literal)package.json'; then
+      if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --cached --name-only -- :(literal)package.json'; then
         echo "missing pathspec-scoped cached diff args: $args" >&2
         exit 1
       fi
       printf 'package.json\n'
       exit 0
     fi
-    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --name-only -- :(literal)package-lock.json :(literal)package.json'; then
+    if ! printf '%s' "$args" | grep -q -- 'diff --no-ext-diff --no-textconv --name-only -- :(literal)package.json'; then
       echo "missing pathspec-scoped unstaged diff args: $args" >&2
       exit 1
     fi
-    printf 'package-lock.json\n'
     exit 0
   fi
   if [ "$mode" = "pathscope-filterdriver" ]; then

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -432,7 +432,7 @@ func gitPathOutputCommand(ctx context.Context, paths []string, nulOutput bool) *
 	if nulOutput {
 		format = `%s\000`
 	}
-	args := []string{"-c", `for path do printf "$1" "$path"; done`, "git-output", format}
+	args := []string{"-c", `format="$1"; shift; for path do printf "$format" "$path"; done`, "git-output", format}
 	args = append(args, paths...)
 	return exec.CommandContext(ctx, "/bin/sh", args...)
 }

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -181,54 +181,52 @@ func TestGitAttributeCandidatePathsHandlesNilContextAndCommandFailure(t *testing
 	})
 }
 
-func TestCollectLockfileGitContextSkipsIrrelevantPathsAndFailsClosed(t *testing.T) {
-	t.Run("non git worktree", func(t *testing.T) {
-		gitContext, err := collectLockfileGitContext(context.Background(), t.TempDir(), []lockfileRule{lockfileRules[0]})
-		if err != nil {
-			t.Fatalf("collectLockfileGitContext: %v", err)
-		}
-		if gitContext.hasGitContext || len(gitContext.changedFiles) != 0 {
-			t.Fatalf("expected empty git context, got %#v", gitContext)
-		}
-	})
+func TestCollectLockfileGitContextReturnsEmptyForNonGitWorktree(t *testing.T) {
+	gitContext, err := collectLockfileGitContext(context.Background(), t.TempDir(), []lockfileRule{lockfileRules[0]})
+	if err != nil {
+		t.Fatalf("collectLockfileGitContext: %v", err)
+	}
+	if gitContext.hasGitContext || len(gitContext.changedFiles) != 0 {
+		t.Fatalf("expected empty git context, got %#v", gitContext)
+	}
+}
 
-	t.Run("no relevant candidates", func(t *testing.T) {
-		repo := configureFakeGitRepo(t, "filterdriver")
-		writeFile(t, filepath.Join(repo, "README.md"), "hello\n")
+func TestCollectLockfileGitContextIgnoresIrrelevantCandidates(t *testing.T) {
+	repo := configureFakeGitRepo(t, "filterdriver")
+	writeFile(t, filepath.Join(repo, "README.md"), "hello\n")
 
-		gitContext, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
-		if err != nil {
-			t.Fatalf("collectLockfileGitContext: %v", err)
-		}
-		if !gitContext.hasGitContext || len(gitContext.changedFiles) != 0 {
-			t.Fatalf("expected empty candidate-only git context, got %#v", gitContext)
-		}
-	})
+	gitContext, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
+	if err != nil {
+		t.Fatalf("collectLockfileGitContext: %v", err)
+	}
+	if !gitContext.hasGitContext || len(gitContext.changedFiles) != 0 {
+		t.Fatalf("expected empty candidate-only git context, got %#v", gitContext)
+	}
+}
 
-	t.Run("custom filters on relevant candidates fail closed", func(t *testing.T) {
-		repo := configureFakeGitRepo(t, "pathscope-filterdriver")
-		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-		writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+func TestCollectLockfileGitContextFailsClosedForRelevantCustomFilters(t *testing.T) {
+	repo := configureFakeGitRepo(t, "pathscope-filterdriver")
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
 
-		_, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
-		if err == nil || !strings.Contains(err.Error(), "cannot safely evaluate lockfile drift") || !strings.Contains(err.Error(), "package.json (pwn)") {
-			t.Fatalf("expected relevant filter ambiguity error, got %v", err)
-		}
-	})
+	_, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
+	if err == nil || !strings.Contains(err.Error(), "cannot safely evaluate lockfile drift") || !strings.Contains(err.Error(), "package.json (pwn)") {
+		t.Fatalf("expected relevant filter ambiguity error, got %v", err)
+	}
+}
 
-	t.Run("malformed check-attr output stays fail closed", func(t *testing.T) {
-		repo := configureFakeGitRepo(t, "checkattrwrongfieldcount")
-		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-		writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+func TestCollectLockfileGitContextFailsClosedForMalformedCheckAttr(t *testing.T) {
+	repo := configureFakeGitRepo(t, "checkattrwrongfieldcount")
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
 
-		_, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
-		if err == nil || !strings.Contains(err.Error(), "parse git check-attr --stdin -z filter output") {
-			t.Fatalf("expected malformed check-attr failure, got %v", err)
-		}
-		if strings.Contains(err.Error(), "run git diff") {
-			t.Fatalf("expected malformed check-attr output to abort before git diff, got %v", err)
-		}
-	})
+	_, err := collectLockfileGitContext(context.Background(), repo, []lockfileRule{lockfileRules[0]})
+	if err == nil || !strings.Contains(err.Error(), "parse git check-attr --stdin -z filter output") {
+		t.Fatalf("expected malformed check-attr failure, got %v", err)
+	}
+	if strings.Contains(err.Error(), "run git diff") {
+		t.Fatalf("expected malformed check-attr output to abort before git diff, got %v", err)
+	}
 }
 
 func TestCollectLockfileGitContextScopesTrackedAndUntrackedCommandsToCandidatePaths(t *testing.T) {

--- a/internal/app/lockfile_drift_paths_test.go
+++ b/internal/app/lockfile_drift_paths_test.go
@@ -98,6 +98,69 @@ func TestGitCommandContextConstructorError(t *testing.T) {
 	}
 }
 
+func TestGitDiffNameOnlyRejectsUnsupportedObjectFormat(t *testing.T) {
+	repo := configureFakeGitObjectFormatRepo(t, "objectformat-bad")
+
+	if _, err := gitDiffNameOnly(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "unsupported git object format") {
+		t.Fatalf("expected unsupported git object format error, got %v", err)
+	}
+}
+
+func TestGitObjectFormatErrorBranches(t *testing.T) {
+	t.Run("resolver error", func(t *testing.T) {
+		originalResolve := resolveGitBinaryPathFn
+		originalExec := execGitCommandContextFn
+		resolveGitBinaryPathFn = func() (string, error) { return "", errors.New("missing git") }
+		t.Cleanup(func() {
+			resolveGitBinaryPathFn = originalResolve
+			execGitCommandContextFn = originalExec
+		})
+
+		var nilCtx context.Context
+		if _, err := gitObjectFormat(nilCtx, t.TempDir()); err == nil || !strings.Contains(err.Error(), "missing git") {
+			t.Fatalf("expected resolver error, got %v", err)
+		}
+	})
+
+	t.Run("constructor error", func(t *testing.T) {
+		originalResolve := resolveGitBinaryPathFn
+		originalExec := execGitCommandContextFn
+		resolveGitBinaryPathFn = func() (string, error) { return writeFakeGitBinary(t), nil }
+		execGitCommandContextFn = func(context.Context, string, ...string) (*exec.Cmd, error) {
+			return nil, errors.New("construct git")
+		}
+		t.Cleanup(func() {
+			resolveGitBinaryPathFn = originalResolve
+			execGitCommandContextFn = originalExec
+		})
+
+		if _, err := gitObjectFormat(context.Background(), t.TempDir()); err == nil || !strings.Contains(err.Error(), "construct git") {
+			t.Fatalf("expected constructor error, got %v", err)
+		}
+	})
+
+	t.Run("command output error", func(t *testing.T) {
+		repo := configureFakeGitObjectFormatRepo(t, "objectformatfail")
+
+		if _, err := gitObjectFormat(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "run git rev-parse --show-object-format") {
+			t.Fatalf("expected git object format command failure, got %v", err)
+		}
+	})
+}
+
+func configureFakeGitObjectFormatRepo(t *testing.T, mode string) string {
+	t.Helper()
+
+	original := resolveGitBinaryPathFn
+	repo := t.TempDir()
+	fakeGit := writeFakeGitBinary(t)
+	resolveGitBinaryPathFn = func() (string, error) { return fakeGit, nil }
+	t.Cleanup(func() { resolveGitBinaryPathFn = original })
+	useFakeGitCommandContext(t)
+	writeFakeGitMode(t, repo, mode)
+	return repo
+}
+
 func writeFakeGitBinary(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "git")
@@ -119,6 +182,18 @@ if printf '%s' "$args" | grep -q 'rev-parse --verify --quiet HEAD'; then
   if [ "$mode" = "difffail-cached" ] || [ "$mode" = "difffail-unstaged" ]; then
     exit 1
   fi
+  exit 0
+fi
+if printf '%s' "$args" | grep -q 'rev-parse --show-object-format'; then
+  if [ "$mode" = "objectformatfail" ]; then
+    echo "show-object-format failed" >&2
+    exit 1
+  fi
+  if [ "$mode" = "objectformat-bad" ]; then
+    echo sha512
+    exit 0
+  fi
+  echo sha1
   exit 0
 fi
 if printf '%s' "$args" | grep -q 'ls-files --others --exclude-standard'; then

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -84,6 +84,81 @@ func scanLockfileDrift(ctx context.Context, repoPath string, gitContext lockfile
 	return warnings, nil
 }
 
+func collectLockfileManifestChangeCandidatePaths(ctx context.Context, repoPath string, rules []lockfileRule) ([]string, error) {
+	candidates := make([]string, 0, len(rules))
+	seen := make(map[string]struct{}, len(rules))
+	state := lockfileWalkState{
+		repoPath: repoPath,
+		visit: func(snapshot lockfileDirSnapshot) error {
+			paths, err := lockfileManifestChangeCandidatePaths(snapshot, rules)
+			if err != nil {
+				return err
+			}
+			for _, path := range paths {
+				if _, ok := seen[path]; ok {
+					continue
+				}
+				seen[path] = struct{}{}
+				candidates = append(candidates, path)
+			}
+			return nil
+		},
+	}
+	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, walkErr error) error {
+		return processLockfileDir(ctx, path, entry, walkErr, state)
+	})
+	if err != nil && !errors.Is(err, fs.SkipAll) {
+		return nil, err
+	}
+	sort.Strings(candidates)
+	return candidates, nil
+}
+
+func lockfileManifestChangeCandidatePaths(snapshot lockfileDirSnapshot, rules []lockfileRule) ([]string, error) {
+	candidates := make([]string, 0, len(rules))
+	seen := make(map[string]struct{}, len(rules))
+	manifestCache := newLockfileManifestCache(snapshot)
+	for _, rule := range rules {
+		manifests := findRuleManifests(snapshot.files, rule)
+		if len(manifests) == 0 {
+			continue
+		}
+		lockfiles := findRuleLockfiles(snapshot.files, rule.lockfiles)
+		lockfiles, err := findDistributedRuleLockfiles(snapshot, rule, manifests, lockfiles)
+		if err != nil {
+			return nil, err
+		}
+		if len(lockfiles) == 0 {
+			continue
+		}
+		matchesManifest, err := manifestMatchesRuleWithCache(snapshot, rule, manifests[0], manifestCache)
+		if err != nil {
+			return nil, err
+		}
+		if !matchesManifest {
+			continue
+		}
+		for _, manifest := range manifests {
+			path := relativeFilePath(snapshot.repoPath, snapshot.path, manifest)
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			candidates = append(candidates, path)
+		}
+		for _, lockfile := range lockfiles {
+			path := relativeFilePath(snapshot.repoPath, snapshot.path, lockfile.name)
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			candidates = append(candidates, path)
+		}
+	}
+	sort.Strings(candidates)
+	return candidates, nil
+}
+
 func processLockfileDir(ctx context.Context, path string, entry fs.DirEntry, walkErr error, state lockfileWalkState) error {
 	if walkErr != nil {
 		return walkErr

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -64,6 +64,13 @@ type lockfileGitSnapshotBatch struct {
 	seenCandidates     map[string]struct{}
 }
 
+type lockfileFailFastBatchScanner struct {
+	repoPath string
+	rules    []lockfileRule
+	warnings []string
+	batch    lockfileGitSnapshotBatch
+}
+
 func (b *lockfileGitSnapshotBatch) wouldOverflow(candidatePaths []string) bool {
 	if len(b.snapshots) == 0 {
 		return false
@@ -146,83 +153,104 @@ func scanLockfileDriftStopOnFirst(ctx context.Context, repoPath string, rules []
 		return scanLockfileDrift(ctx, repoPath, lockfileGitContext{}, true, rules)
 	}
 
-	batch := lockfileGitSnapshotBatch{}
-	recordFirst := func(snapshot lockfileDirSnapshot, gitContext lockfileGitContext) error {
-		warning, found, err := firstLockfileDriftWarning(snapshot, gitContext, rules)
-		if err != nil {
-			return err
-		}
-		if !found {
-			return nil
-		}
-		warnings = append(warnings, warning)
-		return fs.SkipAll
-	}
-	flush := func() error {
-		snapshots, candidatePaths := batch.take()
-		if len(snapshots) == 0 {
-			return nil
-		}
-		gitContext, err := collectLockfileGitContextForPaths(ctx, repoPath, candidatePaths)
-		if err != nil {
-			return err
-		}
-		for _, snapshot := range snapshots {
-			if err := recordFirst(snapshot, gitContext); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	state := lockfileWalkState{
+	scanner := lockfileFailFastBatchScanner{
 		repoPath: repoPath,
+		rules:    rules,
+		warnings: warnings,
+	}
+	return scanner.scan(ctx)
+}
+
+func (s *lockfileFailFastBatchScanner) scan(ctx context.Context) ([]string, error) {
+	state := lockfileWalkState{
+		repoPath: s.repoPath,
 		visit: func(snapshot lockfileDirSnapshot) error {
-			candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, rules)
-			if err != nil {
-				return err
-			}
-			if len(batch.snapshots) == 0 && len(candidatePaths) == 0 {
-				return recordFirst(snapshot, lockfileGitContext{hasGitContext: true})
-			}
-			if batch.wouldOverflow(candidatePaths) {
-				if err := flush(); err != nil {
-					return err
-				}
-				if len(candidatePaths) == 0 {
-					return recordFirst(snapshot, lockfileGitContext{hasGitContext: true})
-				}
-			}
-			batch.add(snapshot, candidatePaths)
-			return nil
+			return s.visit(ctx, snapshot)
 		},
 	}
-	err = filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			if flushErr := flush(); flushErr != nil {
-				return flushErr
-			}
-			return walkErr
+	walkErr := filepath.WalkDir(s.repoPath, func(path string, entry fs.DirEntry, walkErr error) error {
+		return s.handleWalkEntry(ctx, path, entry, walkErr, state)
+	})
+	return s.result(ctx, walkErr)
+}
+
+func (s *lockfileFailFastBatchScanner) visit(ctx context.Context, snapshot lockfileDirSnapshot) error {
+	candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, s.rules)
+	if err != nil {
+		return err
+	}
+	if len(s.batch.snapshots) == 0 && len(candidatePaths) == 0 {
+		return s.recordFirst(snapshot, lockfileGitContext{hasGitContext: true})
+	}
+	if s.batch.wouldOverflow(candidatePaths) {
+		if err := s.flush(ctx); err != nil {
+			return err
 		}
-		processErr := processLockfileDir(ctx, path, entry, nil, state)
-		if processErr == nil || errors.Is(processErr, fs.SkipDir) || errors.Is(processErr, fs.SkipAll) {
-			return processErr
+		if len(candidatePaths) == 0 {
+			return s.recordFirst(snapshot, lockfileGitContext{hasGitContext: true})
 		}
-		if flushErr := flush(); flushErr != nil {
+	}
+	s.batch.add(snapshot, candidatePaths)
+	return nil
+}
+
+func (s *lockfileFailFastBatchScanner) recordFirst(snapshot lockfileDirSnapshot, gitContext lockfileGitContext) error {
+	warning, found, err := firstLockfileDriftWarning(snapshot, gitContext, s.rules)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+	s.warnings = append(s.warnings, warning)
+	return fs.SkipAll
+}
+
+func (s *lockfileFailFastBatchScanner) flush(ctx context.Context) error {
+	snapshots, candidatePaths := s.batch.take()
+	if len(snapshots) == 0 {
+		return nil
+	}
+	gitContext, err := collectLockfileGitContextForPaths(ctx, s.repoPath, candidatePaths)
+	if err != nil {
+		return err
+	}
+	for _, snapshot := range snapshots {
+		if err := s.recordFirst(snapshot, gitContext); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *lockfileFailFastBatchScanner) handleWalkEntry(ctx context.Context, path string, entry fs.DirEntry, walkErr error, state lockfileWalkState) error {
+	if walkErr != nil {
+		if flushErr := s.flush(ctx); flushErr != nil {
 			return flushErr
 		}
-		return processErr
-	})
-	if err != nil && !errors.Is(err, fs.SkipAll) {
-		return nil, err
+		return walkErr
 	}
-	if flushErr := flush(); flushErr != nil {
+	processErr := processLockfileDir(ctx, path, entry, nil, state)
+	if processErr == nil || errors.Is(processErr, fs.SkipDir) || errors.Is(processErr, fs.SkipAll) {
+		return processErr
+	}
+	if flushErr := s.flush(ctx); flushErr != nil {
+		return flushErr
+	}
+	return processErr
+}
+
+func (s *lockfileFailFastBatchScanner) result(ctx context.Context, walkErr error) ([]string, error) {
+	if walkErr != nil && !errors.Is(walkErr, fs.SkipAll) {
+		return nil, walkErr
+	}
+	if flushErr := s.flush(ctx); flushErr != nil {
 		if errors.Is(flushErr, fs.SkipAll) {
-			return warnings, nil
+			return s.warnings, nil
 		}
 		return nil, flushErr
 	}
-	return warnings, nil
+	return s.warnings, nil
 }
 
 func firstLockfileDriftWarning(snapshot lockfileDirSnapshot, gitContext lockfileGitContext, rules []lockfileRule) (string, bool, error) {

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -175,19 +175,19 @@ func (s *lockfileFailFastBatchScanner) scan(ctx context.Context) ([]string, erro
 }
 
 func (s *lockfileFailFastBatchScanner) visit(ctx context.Context, snapshot lockfileDirSnapshot) error {
+	if err := s.recordFirst(snapshot, lockfileGitContext{}); err != nil {
+		return err
+	}
 	candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, s.rules)
 	if err != nil {
 		return err
 	}
-	if len(s.batch.snapshots) == 0 && len(candidatePaths) == 0 {
-		return s.recordFirst(snapshot, lockfileGitContext{hasGitContext: true})
+	if len(candidatePaths) == 0 {
+		return nil
 	}
 	if s.batch.wouldOverflow(candidatePaths) {
 		if err := s.flush(ctx); err != nil {
 			return err
-		}
-		if len(candidatePaths) == 0 {
-			return s.recordFirst(snapshot, lockfileGitContext{hasGitContext: true})
 		}
 	}
 	s.batch.add(snapshot, candidatePaths)

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -84,6 +84,43 @@ func scanLockfileDrift(ctx context.Context, repoPath string, gitContext lockfile
 	return warnings, nil
 }
 
+func scanLockfileDriftStopOnFirst(ctx context.Context, repoPath string, rules []lockfileRule) ([]string, error) {
+	warnings := make([]string, 0, 1)
+	hasGitContext := isGitWorktree(ctx, repoPath)
+	state := lockfileWalkState{
+		repoPath: repoPath,
+		visit: func(snapshot lockfileDirSnapshot) error {
+			gitContext := lockfileGitContext{}
+			if hasGitContext {
+				candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, rules)
+				if err != nil {
+					return err
+				}
+				gitContext, err = collectLockfileGitContextForPaths(ctx, repoPath, candidatePaths)
+				if err != nil {
+					return err
+				}
+			}
+			findings, err := evaluateLockfileDirWithRules(snapshot, gitContext, rules)
+			if err != nil {
+				return err
+			}
+			if len(findings) == 0 {
+				return nil
+			}
+			warnings = append(warnings, buildLockfileDriftWarning(findings[0]))
+			return fs.SkipAll
+		},
+	}
+	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, walkErr error) error {
+		return processLockfileDir(ctx, path, entry, walkErr, state)
+	})
+	if err != nil && !errors.Is(err, fs.SkipAll) {
+		return nil, err
+	}
+	return warnings, nil
+}
+
 func collectLockfileManifestChangeCandidatePaths(ctx context.Context, repoPath string, rules []lockfileRule) ([]string, error) {
 	candidates := make([]string, 0, len(rules))
 	seen := make(map[string]struct{}, len(rules))

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -55,6 +55,58 @@ type lockfileWalkState struct {
 	visit    func(lockfileDirSnapshot) error
 }
 
+const lockfileGitBatchSnapshots = 128
+
+type lockfileGitSnapshotBatch struct {
+	snapshots          []lockfileDirSnapshot
+	candidatePaths     []string
+	candidatePathBytes int
+	seenCandidates     map[string]struct{}
+}
+
+func (b *lockfileGitSnapshotBatch) wouldOverflow(candidatePaths []string) bool {
+	if len(b.snapshots) == 0 {
+		return false
+	}
+	additionalPaths := 0
+	additionalBytes := 0
+	for _, path := range candidatePaths {
+		if _, seen := b.seenCandidates[path]; seen {
+			continue
+		}
+		additionalPaths++
+		additionalBytes += gitPathspecArgBytes(path)
+	}
+	return len(b.snapshots) >= lockfileGitBatchSnapshots ||
+		len(b.candidatePaths)+additionalPaths > gitPathspecBatchPaths ||
+		b.candidatePathBytes+additionalBytes > gitPathspecBatchBytes
+}
+
+func (b *lockfileGitSnapshotBatch) add(snapshot lockfileDirSnapshot, candidatePaths []string) {
+	b.snapshots = append(b.snapshots, snapshot)
+	if b.seenCandidates == nil {
+		b.seenCandidates = make(map[string]struct{}, len(candidatePaths))
+	}
+	for _, path := range candidatePaths {
+		if _, seen := b.seenCandidates[path]; seen {
+			continue
+		}
+		b.seenCandidates[path] = struct{}{}
+		b.candidatePaths = append(b.candidatePaths, path)
+		b.candidatePathBytes += gitPathspecArgBytes(path)
+	}
+}
+
+func (b *lockfileGitSnapshotBatch) take() ([]lockfileDirSnapshot, []string) {
+	snapshots := b.snapshots
+	candidatePaths := b.candidatePaths
+	b.snapshots = nil
+	b.candidatePaths = nil
+	b.candidatePathBytes = 0
+	clear(b.seenCandidates)
+	return snapshots, candidatePaths
+}
+
 func scanLockfileDrift(ctx context.Context, repoPath string, gitContext lockfileGitContext, stopOnFirst bool, rules []lockfileRule) ([]string, error) {
 	warnings := make([]string, 0, len(rules))
 	state := lockfileWalkState{
@@ -86,39 +138,102 @@ func scanLockfileDrift(ctx context.Context, repoPath string, gitContext lockfile
 
 func scanLockfileDriftStopOnFirst(ctx context.Context, repoPath string, rules []lockfileRule) ([]string, error) {
 	warnings := make([]string, 0, 1)
-	hasGitContext := isGitWorktree(ctx, repoPath)
+	hasGitContext, err := isGitWorktree(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+	if !hasGitContext {
+		return scanLockfileDrift(ctx, repoPath, lockfileGitContext{}, true, rules)
+	}
+
+	batch := lockfileGitSnapshotBatch{}
+	recordFirst := func(snapshot lockfileDirSnapshot, gitContext lockfileGitContext) error {
+		warning, found, err := firstLockfileDriftWarning(snapshot, gitContext, rules)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return nil
+		}
+		warnings = append(warnings, warning)
+		return fs.SkipAll
+	}
+	flush := func() error {
+		snapshots, candidatePaths := batch.take()
+		if len(snapshots) == 0 {
+			return nil
+		}
+		gitContext, err := collectLockfileGitContextForPaths(ctx, repoPath, candidatePaths)
+		if err != nil {
+			return err
+		}
+		for _, snapshot := range snapshots {
+			if err := recordFirst(snapshot, gitContext); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	state := lockfileWalkState{
 		repoPath: repoPath,
 		visit: func(snapshot lockfileDirSnapshot) error {
-			gitContext := lockfileGitContext{}
-			if hasGitContext {
-				candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, rules)
-				if err != nil {
-					return err
-				}
-				gitContext, err = collectLockfileGitContextForPaths(ctx, repoPath, candidatePaths)
-				if err != nil {
-					return err
-				}
-			}
-			findings, err := evaluateLockfileDirWithRules(snapshot, gitContext, rules)
+			candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, rules)
 			if err != nil {
 				return err
 			}
-			if len(findings) == 0 {
-				return nil
+			if len(batch.snapshots) == 0 && len(candidatePaths) == 0 {
+				return recordFirst(snapshot, lockfileGitContext{hasGitContext: true})
 			}
-			warnings = append(warnings, buildLockfileDriftWarning(findings[0]))
-			return fs.SkipAll
+			if batch.wouldOverflow(candidatePaths) {
+				if err := flush(); err != nil {
+					return err
+				}
+				if len(candidatePaths) == 0 {
+					return recordFirst(snapshot, lockfileGitContext{hasGitContext: true})
+				}
+			}
+			batch.add(snapshot, candidatePaths)
+			return nil
 		},
 	}
-	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, walkErr error) error {
-		return processLockfileDir(ctx, path, entry, walkErr, state)
+	err = filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if flushErr := flush(); flushErr != nil {
+				return flushErr
+			}
+			return walkErr
+		}
+		processErr := processLockfileDir(ctx, path, entry, nil, state)
+		if processErr == nil || errors.Is(processErr, fs.SkipDir) || errors.Is(processErr, fs.SkipAll) {
+			return processErr
+		}
+		if flushErr := flush(); flushErr != nil {
+			return flushErr
+		}
+		return processErr
 	})
 	if err != nil && !errors.Is(err, fs.SkipAll) {
 		return nil, err
 	}
+	if flushErr := flush(); flushErr != nil {
+		if errors.Is(flushErr, fs.SkipAll) {
+			return warnings, nil
+		}
+		return nil, flushErr
+	}
 	return warnings, nil
+}
+
+func firstLockfileDriftWarning(snapshot lockfileDirSnapshot, gitContext lockfileGitContext, rules []lockfileRule) (string, bool, error) {
+	findings, err := evaluateLockfileDirWithRules(snapshot, gitContext, rules)
+	if err != nil {
+		return "", false, err
+	}
+	if len(findings) == 0 {
+		return "", false, nil
+	}
+	return buildLockfileDriftWarning(findings[0]), true, nil
 }
 
 func collectLockfileManifestChangeCandidatePaths(ctx context.Context, repoPath string, rules []lockfileRule) ([]string, error) {

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -175,21 +175,24 @@ func (s *lockfileFailFastBatchScanner) scan(ctx context.Context) ([]string, erro
 }
 
 func (s *lockfileFailFastBatchScanner) visit(ctx context.Context, snapshot lockfileDirSnapshot) error {
-	warning, found, err := firstLockfileDriftWarning(snapshot, lockfileGitContext{}, s.rules)
+	warning, findingRuleIndex, found, err := firstLockfileDriftWarningWithRuleIndex(snapshot, lockfileGitContext{}, s.rules)
 	if err != nil {
 		return err
 	}
+	candidateRules := s.rules
 	if found {
+		candidateRules = s.rules[:findingRuleIndex]
+	}
+	candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, candidateRules)
+	if err != nil {
+		return err
+	}
+	if found && len(candidatePaths) == 0 {
 		if err := s.flush(ctx); err != nil {
 			return err
 		}
 		s.warnings = append(s.warnings, warning)
 		return fs.SkipAll
-	}
-
-	candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, s.rules)
-	if err != nil {
-		return err
 	}
 	if len(candidatePaths) == 0 {
 		return nil
@@ -200,6 +203,9 @@ func (s *lockfileFailFastBatchScanner) visit(ctx context.Context, snapshot lockf
 		}
 	}
 	s.batch.add(snapshot, candidatePaths)
+	if found {
+		return s.flush(ctx)
+	}
 	return nil
 }
 
@@ -252,13 +258,12 @@ func (s *lockfileFailFastBatchScanner) recordFirstSnapshotRuleByRule(ctx context
 		if err != nil {
 			return err
 		}
-		if len(candidatePaths) == 0 {
-			continue
-		}
-
-		gitContext, err := collectLockfileGitContextForPaths(ctx, s.repoPath, candidatePaths)
-		if err != nil {
-			return err
+		gitContext := lockfileGitContext{}
+		if len(candidatePaths) > 0 {
+			gitContext, err = collectLockfileGitContextForPaths(ctx, s.repoPath, candidatePaths)
+			if err != nil {
+				return err
+			}
 		}
 
 		finding, found, err := evaluateLockfileRuleWithCache(snapshot, rule, gitContext, manifestCache)
@@ -306,14 +311,30 @@ func (s *lockfileFailFastBatchScanner) result(ctx context.Context, walkErr error
 }
 
 func firstLockfileDriftWarning(snapshot lockfileDirSnapshot, gitContext lockfileGitContext, rules []lockfileRule) (string, bool, error) {
-	findings, err := evaluateLockfileDirWithRules(snapshot, gitContext, rules)
-	if err != nil {
-		return "", false, err
+	warning, _, found, err := firstLockfileDriftWarningWithRuleIndex(snapshot, gitContext, rules)
+	return warning, found, err
+}
+
+func firstLockfileDriftWarningWithRuleIndex(snapshot lockfileDirSnapshot, gitContext lockfileGitContext, rules []lockfileRule) (string, int, bool, error) {
+	manifestCache := newLockfileManifestCache(snapshot)
+	var firstFinding lockfileDriftFinding
+	firstRuleIndex := 0
+	found := false
+	for ruleIndex, rule := range rules {
+		finding, ok, err := evaluateLockfileRuleWithCache(snapshot, rule, gitContext, manifestCache)
+		if err != nil {
+			return "", 0, false, err
+		}
+		if ok && !found {
+			firstFinding = finding
+			firstRuleIndex = ruleIndex
+			found = true
+		}
 	}
-	if len(findings) == 0 {
-		return "", false, nil
+	if !found {
+		return "", 0, false, nil
 	}
-	return buildLockfileDriftWarning(findings[0]), true, nil
+	return buildLockfileDriftWarning(firstFinding), firstRuleIndex, true, nil
 }
 
 func collectLockfileManifestChangeCandidatePaths(ctx context.Context, repoPath string, rules []lockfileRule) ([]string, error) {

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -119,44 +119,59 @@ func lockfileManifestChangeCandidatePaths(snapshot lockfileDirSnapshot, rules []
 	seen := make(map[string]struct{}, len(rules))
 	manifestCache := newLockfileManifestCache(snapshot)
 	for _, rule := range rules {
-		manifests := findRuleManifests(snapshot.files, rule)
-		if len(manifests) == 0 {
-			continue
-		}
-		lockfiles := findRuleLockfiles(snapshot.files, rule.lockfiles)
-		lockfiles, err := findDistributedRuleLockfiles(snapshot, rule, manifests, lockfiles)
+		ruleCandidates, err := lockfileManifestChangeCandidatePathsForRule(snapshot, rule, manifestCache)
 		if err != nil {
 			return nil, err
 		}
-		if len(lockfiles) == 0 {
-			continue
-		}
-		matchesManifest, err := manifestMatchesRuleWithCache(snapshot, rule, manifests[0], manifestCache)
-		if err != nil {
-			return nil, err
-		}
-		if !matchesManifest {
-			continue
-		}
-		for _, manifest := range manifests {
-			path := relativeFilePath(snapshot.repoPath, snapshot.path, manifest)
-			if _, ok := seen[path]; ok {
-				continue
-			}
-			seen[path] = struct{}{}
-			candidates = append(candidates, path)
-		}
-		for _, lockfile := range lockfiles {
-			path := relativeFilePath(snapshot.repoPath, snapshot.path, lockfile.name)
-			if _, ok := seen[path]; ok {
-				continue
-			}
-			seen[path] = struct{}{}
-			candidates = append(candidates, path)
-		}
+		candidates = appendUniqueLockfilePaths(candidates, seen, ruleCandidates)
 	}
 	sort.Strings(candidates)
 	return candidates, nil
+}
+
+func lockfileManifestChangeCandidatePathsForRule(snapshot lockfileDirSnapshot, rule lockfileRule, manifestCache *lockfileManifestCache) ([]string, error) {
+	manifests := findRuleManifests(snapshot.files, rule)
+	if len(manifests) == 0 {
+		return nil, nil
+	}
+	lockfiles := findRuleLockfiles(snapshot.files, rule.lockfiles)
+	lockfiles, err := findDistributedRuleLockfiles(snapshot, rule, manifests, lockfiles)
+	if err != nil {
+		return nil, err
+	}
+	if len(lockfiles) == 0 {
+		return nil, nil
+	}
+	matchesManifest, err := manifestMatchesRuleWithCache(snapshot, rule, manifests[0], manifestCache)
+	if err != nil {
+		return nil, err
+	}
+	if !matchesManifest {
+		return nil, nil
+	}
+	return relativeLockfileCandidatePaths(snapshot, manifests, lockfiles), nil
+}
+
+func relativeLockfileCandidatePaths(snapshot lockfileDirSnapshot, manifests []string, lockfiles []presentLockfile) []string {
+	paths := make([]string, 0, len(manifests)+len(lockfiles))
+	for _, manifest := range manifests {
+		paths = append(paths, relativeFilePath(snapshot.repoPath, snapshot.path, manifest))
+	}
+	for _, lockfile := range lockfiles {
+		paths = append(paths, relativeFilePath(snapshot.repoPath, snapshot.path, lockfile.name))
+	}
+	return paths
+}
+
+func appendUniqueLockfilePaths(candidates []string, seen map[string]struct{}, paths []string) []string {
+	for _, path := range paths {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		candidates = append(candidates, path)
+	}
+	return candidates
 }
 
 func processLockfileDir(ctx context.Context, path string, entry fs.DirEntry, walkErr error, state lockfileWalkState) error {

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -326,13 +326,7 @@ func collectLockfileManifestChangeCandidatePaths(ctx context.Context, repoPath s
 			if err != nil {
 				return err
 			}
-			for _, path := range paths {
-				if _, ok := seen[path]; ok {
-					continue
-				}
-				seen[path] = struct{}{}
-				candidates = append(candidates, path)
-			}
+			candidates = appendUniqueLockfilePaths(candidates, seen, paths)
 			return nil
 		},
 	}

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -222,9 +222,30 @@ func (s *lockfileFailFastBatchScanner) flush(ctx context.Context) error {
 	}
 	gitContext, err := collectLockfileGitContextForPaths(ctx, s.repoPath, candidatePaths)
 	if err != nil {
-		return err
+		var filterErr *lockfileDriftFilterAmbiguityError
+		if !errors.As(err, &filterErr) {
+			return err
+		}
+		return s.flushSnapshotsInOrder(ctx, snapshots)
 	}
 	for _, snapshot := range snapshots {
+		if err := s.recordFirst(snapshot, gitContext); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *lockfileFailFastBatchScanner) flushSnapshotsInOrder(ctx context.Context, snapshots []lockfileDirSnapshot) error {
+	for _, snapshot := range snapshots {
+		candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, s.rules)
+		if err != nil {
+			return err
+		}
+		gitContext, err := collectLockfileGitContextForPaths(ctx, s.repoPath, candidatePaths)
+		if err != nil {
+			return err
+		}
 		if err := s.recordFirst(snapshot, gitContext); err != nil {
 			return err
 		}

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -175,9 +175,18 @@ func (s *lockfileFailFastBatchScanner) scan(ctx context.Context) ([]string, erro
 }
 
 func (s *lockfileFailFastBatchScanner) visit(ctx context.Context, snapshot lockfileDirSnapshot) error {
-	if err := s.recordFirst(snapshot, lockfileGitContext{}); err != nil {
+	warning, found, err := firstLockfileDriftWarning(snapshot, lockfileGitContext{}, s.rules)
+	if err != nil {
 		return err
 	}
+	if found {
+		if err := s.flush(ctx); err != nil {
+			return err
+		}
+		s.warnings = append(s.warnings, warning)
+		return fs.SkipAll
+	}
+
 	candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, s.rules)
 	if err != nil {
 		return err

--- a/internal/app/lockfile_drift_scanner.go
+++ b/internal/app/lockfile_drift_scanner.go
@@ -238,17 +238,39 @@ func (s *lockfileFailFastBatchScanner) flush(ctx context.Context) error {
 
 func (s *lockfileFailFastBatchScanner) flushSnapshotsInOrder(ctx context.Context, snapshots []lockfileDirSnapshot) error {
 	for _, snapshot := range snapshots {
-		candidatePaths, err := lockfileManifestChangeCandidatePaths(snapshot, s.rules)
+		if err := s.recordFirstSnapshotRuleByRule(ctx, snapshot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *lockfileFailFastBatchScanner) recordFirstSnapshotRuleByRule(ctx context.Context, snapshot lockfileDirSnapshot) error {
+	manifestCache := newLockfileManifestCache(snapshot)
+	for _, rule := range s.rules {
+		candidatePaths, err := lockfileManifestChangeCandidatePathsForRule(snapshot, rule, manifestCache)
 		if err != nil {
 			return err
 		}
+		if len(candidatePaths) == 0 {
+			continue
+		}
+
 		gitContext, err := collectLockfileGitContextForPaths(ctx, s.repoPath, candidatePaths)
 		if err != nil {
 			return err
 		}
-		if err := s.recordFirst(snapshot, gitContext); err != nil {
+
+		finding, found, err := evaluateLockfileRuleWithCache(snapshot, rule, gitContext, manifestCache)
+		if err != nil {
 			return err
 		}
+		if !found {
+			continue
+		}
+
+		s.warnings = append(s.warnings, buildLockfileDriftWarning(finding))
+		return fs.SkipAll
 	}
 	return nil
 }

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -581,7 +581,7 @@ func TestDetectLockfileDriftInvalidRepoPath(t *testing.T) {
 func TestDetectLockfileDriftWithFeaturesPropagatesGitContextError(t *testing.T) {
 	repo := t.TempDir()
 	original := collectLockfileGitContextFn
-	collectLockfileGitContextFn = func(context.Context, string) (lockfileGitContext, error) {
+	collectLockfileGitContextFn = func(context.Context, string, []lockfileRule) (lockfileGitContext, error) {
 		return lockfileGitContext{}, errors.New("forced git context failure")
 	}
 	defer func() { collectLockfileGitContextFn = original }()

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -740,9 +740,6 @@ func TestScanLockfileDriftMissingRepoPath(t *testing.T) {
 
 func TestGitHelperErrors(t *testing.T) {
 	repo := t.TempDir()
-	if _, err := gitTrackedChanges(context.Background(), repo); err == nil {
-		t.Fatalf("expected tracked changes command to fail outside git repo")
-	}
 	if _, err := gitUntrackedFiles(context.Background(), repo); err == nil {
 		t.Fatalf("expected untracked files command to fail outside git repo")
 	}
@@ -753,10 +750,6 @@ func TestGitHelperErrors(t *testing.T) {
 
 func TestGitHelperNilContextErrors(t *testing.T) {
 	repo := t.TempDir()
-	//nolint:staticcheck // Deliberate nil context validation coverage.
-	if _, err := gitTrackedChanges(nil, repo); err == nil {
-		t.Fatalf("expected tracked changes command with nil context to fail outside git repo")
-	}
 	//nolint:staticcheck // Deliberate nil context validation coverage.
 	if _, err := gitUntrackedFiles(nil, repo); err == nil {
 		t.Fatalf("expected untracked files command with nil context to fail outside git repo")
@@ -776,9 +769,6 @@ func TestGitHelpersWhenGitUnavailable(t *testing.T) {
 	if isGitWorktree(context.Background(), repo) {
 		t.Fatalf("expected git worktree=false when git is unavailable")
 	}
-	if _, err := gitTrackedChanges(context.Background(), repo); err == nil || !strings.Contains(err.Error(), gitExecutableNotFoundErr) {
-		t.Fatalf("expected tracked changes error for missing git executable, got %v", err)
-	}
 	if _, err := gitUntrackedFiles(context.Background(), repo); err == nil || !strings.Contains(err.Error(), gitExecutableNotFoundErr) {
 		t.Fatalf("expected untracked files error for missing git executable, got %v", err)
 	}
@@ -793,62 +783,9 @@ func TestGitHelpersFallbackExecutableBranch(t *testing.T) {
 	if isGitWorktree(context.Background(), repo) {
 		t.Fatalf("expected non-git temp dir to not be worktree when fallback git is used")
 	}
-	if _, err := gitTrackedChanges(context.Background(), repo); err == nil {
-		t.Fatalf("expected tracked changes command to fail outside git repo with fallback git")
-	}
 	if _, err := gitUntrackedFiles(context.Background(), repo); err == nil {
 		t.Fatalf("expected untracked files command to fail outside git repo with fallback git")
 	}
-}
-
-func TestGitChangedFilesOutsideGitRepo(t *testing.T) {
-	repo := t.TempDir()
-	changed, hasGit, err := gitChangedFiles(context.Background(), repo)
-	if err != nil {
-		t.Fatalf("gitChangedFiles outside git repo: %v", err)
-	}
-	if hasGit {
-		t.Fatalf("expected hasGit=false for non-git repo")
-	}
-	if len(changed) != 0 {
-		t.Fatalf("expected no changed files for non-git repo, got %#v", changed)
-	}
-}
-
-func TestGitChangedFilesInGitRepo(t *testing.T) {
-	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-	initGitRepo(t, repo)
-
-	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdatedV2)
-	writeFile(t, filepath.Join(repo, newUntrackedFileName), "untracked\n")
-
-	changed, hasGit, err := gitChangedFiles(context.Background(), repo)
-	if err != nil {
-		t.Fatalf("gitChangedFiles in git repo: %v", err)
-	}
-	if !hasGit {
-		t.Fatalf("expected hasGit=true for git repo")
-	}
-	assertChangedPathsPresent(t, changed, manifestFileName, newUntrackedFileName)
-}
-
-func TestGitChangedFilesHandlesRepoWithNoHEAD(t *testing.T) {
-	repo := t.TempDir()
-	runGit(t, repo, "init")
-	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-	runGit(t, repo, "add", manifestFileName)
-	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
-	writeFile(t, filepath.Join(repo, newUntrackedFileName), "untracked\n")
-
-	changed, hasGit, err := gitChangedFiles(context.Background(), repo)
-	if err != nil {
-		t.Fatalf("expected gitChangedFiles to succeed when HEAD is missing, got %v", err)
-	}
-	if !hasGit {
-		t.Fatalf("expected hasGit=true when inside git worktree")
-	}
-	assertChangedPathsPresent(t, changed, manifestFileName, newUntrackedFileName)
 }
 
 func TestDetectLockfileDriftNoHeadDoesNotReturnGitError(t *testing.T) {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -991,6 +991,7 @@ func TestGitHelpersWhenGitUnavailable(t *testing.T) {
 	defer func() { resolveGitBinaryPathFn = original }()
 
 	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, ".git", "HEAD"), "ref: refs/heads/main\n")
 	if _, err := isGitWorktree(context.Background(), repo); err == nil || !strings.Contains(err.Error(), gitExecutableNotFoundErr) {
 		t.Fatalf("expected worktree detection error for missing git executable, got %v", err)
 	}

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -566,28 +566,44 @@ func TestDetectLockfileDriftRejectsActiveCustomFiltersWithoutExecutingHelpers(t 
 	}
 }
 
-func TestDetectLockfileDriftRejectsCaseFoldedCustomFiltersBeforeDiff(t *testing.T) {
+func TestDetectLockfileDriftAllowsMismatchedCaseFilterConfig(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")
 	}
 
-	cases := []struct {
-		name             string
-		attributeDriver  string
-		configuredDriver string
-	}{
-		{name: "lowercase attribute", attributeDriver: "pwn", configuredDriver: "PWN"},
-		{name: "mixed-case attribute", attributeDriver: "Pwn", configuredDriver: "pwn"},
+	repo, markerPath, diffCommands := newCaseSensitiveFilterRepo(t, "pwn", "PWN")
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json changed while no matching lockfile changed", "npm install")
+	if *diffCommands == 0 {
+		t.Error("expected mismatched filter config to remain inert and allow git diff")
 	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			runCaseFoldedCustomFilterCase(t, tc.attributeDriver, tc.configuredDriver)
-		})
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected mismatched filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
 	}
 }
 
-func runCaseFoldedCustomFilterCase(t *testing.T, attributeDriver, configuredDriver string) {
+func TestDetectLockfileDriftRejectsExactCaseFilterConfigBeforeDiff(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo, markerPath, diffCommands := newCaseSensitiveFilterRepo(t, "pwn", "pwn")
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	if err == nil || !strings.Contains(err.Error(), "cannot safely evaluate lockfile drift") || !strings.Contains(err.Error(), manifestFileName+" (pwn)") {
+		t.Errorf("expected exact-case filter ambiguity error, got warnings=%#v err=%v", warnings, err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected ambiguity error to suppress drift warnings, got %#v", warnings)
+	}
+	if *diffCommands != 0 {
+		t.Errorf("expected exact-case filter preflight to stop before git diff, got %d diff commands", *diffCommands)
+	}
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected exact-case filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
+	}
+}
+
+func newCaseSensitiveFilterRepo(t *testing.T, attributeDriver, configuredDriver string) (string, string, *int) {
 	t.Helper()
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
@@ -595,13 +611,13 @@ func runCaseFoldedCustomFilterCase(t *testing.T, attributeDriver, configuredDriv
 	writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter="+attributeDriver+"\n")
 	initGitRepo(t, repo)
 
-	markerPath := filepath.Join(t.TempDir(), "case-folded-filter.marker")
+	markerPath := filepath.Join(t.TempDir(), "case-sensitive-filter.marker")
 	helperPath := helperPathInRepo(repo)
 	writeFile(t, helperPath, cleanFilterScript(markerPath))
 	if err := os.Chmod(helperPath, 0o700); err != nil {
 		t.Fatalf("chmod git helper: %v", err)
 	}
-	runGit(t, repo, "config", "filter."+configuredDriver+".clean", "./helper.sh")
+	configureCleanFilter(t, repo, configuredDriver)
 	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
 
 	originalExec := execGitCommandContextFn
@@ -613,20 +629,7 @@ func runCaseFoldedCustomFilterCase(t *testing.T, attributeDriver, configuredDriv
 		return originalExec(ctx, gitPath, args...)
 	}
 	t.Cleanup(func() { execGitCommandContextFn = originalExec })
-
-	warnings, err := detectLockfileDrift(context.Background(), repo, false)
-	if err == nil || !strings.Contains(err.Error(), "cannot safely evaluate lockfile drift") || !strings.Contains(err.Error(), manifestFileName+" ("+attributeDriver+")") {
-		t.Errorf("expected case-folded filter ambiguity error, got warnings=%#v err=%v", warnings, err)
-	}
-	if len(warnings) != 0 {
-		t.Errorf("expected ambiguity error to suppress drift warnings, got %#v", warnings)
-	}
-	if diffCommands != 0 {
-		t.Errorf("expected filter preflight to stop before git diff, got %d diff commands", diffCommands)
-	}
-	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
-		t.Errorf("expected case-folded filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
-	}
+	return repo, markerPath, &diffCommands
 }
 
 func TestDetectLockfileDriftAllowsFilteredUntrackedCandidates(t *testing.T) {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -1015,6 +1015,18 @@ func TestDetectLockfileDriftStopOnFirstPrioritizesEarlierRuleFindingOverLaterSam
 	assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json changed while no matching lockfile changed", "npm install")
 }
 
+func TestDetectLockfileDriftStopOnFirstPrioritizesEarlierRuleFindingOverLaterSameSnapshotImmediateFinding(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\n")
+	initGitRepo(t, repo)
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, true)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json changed while no matching lockfile changed", "npm install")
+}
+
 func TestDetectLockfileDriftStopOnFirstPrioritizesBufferedGitFindingOverLaterImmediateFinding(t *testing.T) {
 	repo := t.TempDir()
 	earlyManifest := filepath.Join(repo, "a-drift", manifestFileName)

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -799,6 +799,21 @@ func TestDetectLockfileDriftStopOnFirstDoesNotPrewalkPastFinding(t *testing.T) {
 	}
 }
 
+func TestDetectLockfileDriftStopOnFirstPrioritizesEarlierBatchFindingOverLaterFilterAmbiguity(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "a-clean", manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, "a-clean", lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, "b-missing", manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, "c-filtered", manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, "c-filtered", lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, ".gitattributes"), "c-filtered/package.json filter=pwn\n")
+	initGitRepo(t, repo)
+	runGit(t, repo, "config", "filter.pwn.clean", "./helper.sh")
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, true)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in b-missing: package.json exists but no matching lockfile", "npm install")
+}
+
 func TestDetectLockfileDriftStopOnFirstFlushesGitBatchBeforeLaterWalkError(t *testing.T) {
 	repo := t.TempDir()
 	earlyManifest := filepath.Join(repo, "a-drift", manifestFileName)

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -395,7 +395,9 @@ type localGitHelperCase struct {
 	helperPath    func(string) string
 	helperScript  func(string) string
 	beforeInit    func(*testing.T, string)
+	beforeDetect  func(*testing.T, string)
 	configureRepo func(*testing.T, string, string)
+	wantErrSubstr string
 }
 
 func helperPathInRepo(repo string) string {
@@ -424,11 +426,12 @@ func configureProcessFilter(t *testing.T, repo, driver string) {
 
 func filterHelperCase(name, markerName, driver string, helperScript func(string) string, beforeInit, repoSetup func(*testing.T, string), configureFilter func(*testing.T, string, string)) localGitHelperCase {
 	return localGitHelperCase{
-		name:         name,
-		markerName:   markerName,
-		helperPath:   helperPathInRepo,
-		helperScript: helperScript,
-		beforeInit:   beforeInit,
+		name:          name,
+		markerName:    markerName,
+		helperPath:    helperPathInRepo,
+		helperScript:  helperScript,
+		beforeInit:    beforeInit,
+		wantErrSubstr: manifestFileName + " (" + driver + ")",
 		configureRepo: func(t *testing.T, repo, helperPath string) {
 			t.Helper()
 			if repoSetup != nil {
@@ -444,27 +447,9 @@ func cleanFilterBeforeInit(t *testing.T, repo string) {
 	writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn\n")
 }
 
-func cleanFilterWithEqualsBeforeInit(t *testing.T, repo string) {
-	t.Helper()
-	writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn=drv\n")
-}
-
-func cleanFilterAfterEmptyAttributeBeforeInit(t *testing.T, repo string) {
-	t.Helper()
-	writeFile(t, filepath.Join(repo, "a.json"), "{}\n")
-	writeFile(t, filepath.Join(repo, ".gitattributes"), "a.json filter=\n"+manifestFileName+" filter=pwn\n")
-}
-
 func processFilterInfoAttributesSetup(t *testing.T, repo string) {
 	t.Helper()
 	writeFile(t, filepath.Join(repo, ".git", "info", "attributes"), manifestFileName+" filter=pwn\n")
-}
-
-func cleanFilterAttributesFileSetup(t *testing.T, repo string) {
-	t.Helper()
-	attributesPath := filepath.Join(t.TempDir(), "global.attributes")
-	writeFile(t, attributesPath, manifestFileName+" filter=pwn\n")
-	runGit(t, repo, "config", "core.attributesFile", attributesPath)
 }
 
 func localGitHelperCases() []localGitHelperCase {
@@ -476,16 +461,17 @@ func localGitHelperCases() []localGitHelperCase {
 			helperScript: func(markerPath string) string {
 				return "#!/bin/sh\necho fsmonitor-ran >> \"" + markerPath + "\"\nprintf 'version 2\\n\\n'\nexit 0\n"
 			},
+			beforeDetect: func(t *testing.T, repo string) {
+				t.Helper()
+				writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+			},
 			configureRepo: func(t *testing.T, repo, helperPath string) {
 				t.Helper()
 				runGit(t, repo, "config", "core.fsmonitor", helperPath)
 			},
 		},
 		filterHelperCase("clean filter", "clean-filter.marker", "pwn", cleanFilterScript, cleanFilterBeforeInit, nil, configureCleanFilter),
-		filterHelperCase("clean filter with equals driver", "clean-filter-equals-driver.marker", "pwn=drv", cleanFilterScript, cleanFilterWithEqualsBeforeInit, nil, configureCleanFilter),
-		filterHelperCase("clean filter after empty attribute value", "clean-filter-after-empty-attr.marker", "pwn", cleanFilterScript, cleanFilterAfterEmptyAttributeBeforeInit, nil, configureCleanFilter),
 		filterHelperCase("process filter from info attributes", "process-filter-info.marker", "pwn", processFilterScript, nil, processFilterInfoAttributesSetup, configureProcessFilter),
-		filterHelperCase("clean filter from core.attributesFile", "clean-filter-attributes-file.marker", "pwn", cleanFilterScript, nil, cleanFilterAttributesFileSetup, configureCleanFilter),
 	}
 }
 
@@ -507,13 +493,26 @@ func runLocalGitHelperCase(t *testing.T, tc localGitHelperCase) {
 		t.Fatalf("chmod git helper: %v", err)
 	}
 	tc.configureRepo(t, repo, helperPath)
-	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+	if tc.beforeDetect != nil {
+		tc.beforeDetect(t, repo)
+	} else {
+		writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+	}
 
 	warnings, err := detectLockfileDrift(context.Background(), repo, false)
-	if err != nil {
-		t.Fatalf(detectLockfileDriftFmt, err)
+	if tc.wantErrSubstr != "" {
+		if err == nil || !strings.Contains(err.Error(), "cannot safely evaluate lockfile drift") || !strings.Contains(err.Error(), tc.wantErrSubstr) {
+			t.Fatalf("expected error containing %q, got %v", tc.wantErrSubstr, err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected ambiguity error to suppress drift warnings, got %#v", warnings)
+		}
+	} else {
+		if err != nil {
+			t.Fatalf(detectLockfileDriftFmt, err)
+		}
+		assertSingleLockfileDriftWarning(t, warnings, nil, "npm in .: package.json changed while no matching lockfile changed", "npm install")
 	}
-	assertSingleLockfileDriftWarning(t, warnings, nil, "npm in .: package.json changed while no matching lockfile changed", "npm install")
 	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected local git helper to never execute, markerPath=%q statErr=%v", markerPath, err)
 	}
@@ -524,9 +523,54 @@ func TestDetectLockfileDriftDoesNotExecuteLocalGitHelpers(t *testing.T) {
 		t.Skip("git binary not available")
 	}
 	for _, tc := range localGitHelperCases() {
+		if tc.wantErrSubstr != "" {
+			continue
+		}
 		t.Run(tc.name, func(t *testing.T) {
 			runLocalGitHelperCase(t, tc)
 		})
+	}
+}
+
+func TestDetectLockfileDriftRejectsActiveCustomFiltersWithoutExecutingHelpers(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+	for _, tc := range localGitHelperCases() {
+		if tc.wantErrSubstr == "" {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			runLocalGitHelperCase(t, tc)
+		})
+	}
+}
+
+func TestDetectLockfileDriftIgnoresUnrelatedFilteredFilesOutsideCandidatePaths(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, "README.md"), "hello\n")
+	writeFile(t, filepath.Join(repo, ".gitattributes"), "README.md filter=pwn\n")
+	initGitRepo(t, repo)
+
+	markerPath := filepath.Join(t.TempDir(), "unrelated-filter.marker")
+	helperPath := helperPathInRepo(repo)
+	writeFile(t, helperPath, cleanFilterScript(markerPath))
+	if err := os.Chmod(helperPath, 0o700); err != nil {
+		t.Fatalf("chmod git helper: %v", err)
+	}
+	configureCleanFilter(t, repo, "pwn")
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json changed while no matching lockfile changed", "npm install")
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected unrelated filtered file helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
 	}
 }
 

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -766,6 +766,39 @@ func TestDetectLockfileDriftStopOnFirst(t *testing.T) {
 	}
 }
 
+func TestDetectLockfileDriftStopOnFirstDoesNotPrewalkPastFinding(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "a-drift", manifestFileName), demoPackageJSON)
+	triggerManifest := filepath.Join(repo, "m-trigger", pyprojectManifestName)
+	writeFile(t, triggerManifest, "[tool.poetry]\nname = \"trigger\"\n")
+	writeFile(t, filepath.Join(repo, "m-trigger", poetryLockName), "# lock\n")
+	laterDir := filepath.Join(repo, "z-later")
+	writeFile(t, filepath.Join(laterDir, "README.md"), "removed during candidate discovery\n")
+	initGitRepo(t, repo)
+
+	originalReadFileUnder := readFileUnderFn
+	readFileUnderFn = func(rootDir, targetPath string) ([]byte, error) {
+		if targetPath == triggerManifest {
+			if err := os.RemoveAll(laterDir); err != nil {
+				return nil, err
+			}
+		}
+		return originalReadFileUnder(rootDir, targetPath)
+	}
+	t.Cleanup(func() { readFileUnderFn = originalReadFileUnder })
+
+	warnings, err := evaluateLockfileDriftPolicy(context.Background(), repo, "fail")
+	if !errors.Is(err, ErrLockfileDrift) {
+		t.Fatalf("expected early lockfile drift error, got warnings=%#v err=%v", warnings, err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "npm in a-drift") {
+		t.Fatalf("expected only the early npm finding, got %#v", warnings)
+	}
+	if _, err := os.Stat(laterDir); err != nil {
+		t.Fatalf("expected fail mode to stop before later candidate discovery: %v", err)
+	}
+}
+
 func TestDetectLockfileDriftContextCancelled(t *testing.T) {
 	repo := t.TempDir()
 	cancelledCtx, cancel := context.WithCancel(context.Background())

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -865,6 +865,24 @@ func TestScopedGitPathHelpersTreatColonMagicTrackedDiffPathsLiterally(t *testing
 	assertSingleLockfileDriftWarning(t, warnings, err, "npm in :(glob)pkg: package.json changed while no matching lockfile changed", "npm install")
 }
 
+func TestDetectLockfileDriftTracksManifestPathContainingNewline(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo := t.TempDir()
+	packageDir := "pkg\nname"
+	manifestPath := filepath.Join(packageDir, manifestFileName)
+	writeFile(t, filepath.Join(repo, manifestPath), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, packageDir, lockfileName), "{}\n")
+	initGitRepo(t, repo)
+
+	writeFile(t, filepath.Join(repo, manifestPath), demoPackageJSONUpdated)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in pkg\nname: package.json changed while no matching lockfile changed", "npm install")
+}
+
 func TestScopedGitPathHelpersTreatColonMagicUntrackedPathsLiterally(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -799,6 +799,44 @@ func TestDetectLockfileDriftStopOnFirstDoesNotPrewalkPastFinding(t *testing.T) {
 	}
 }
 
+func TestDetectLockfileDriftStopOnFirstFlushesGitBatchBeforeLaterWalkError(t *testing.T) {
+	repo := t.TempDir()
+	earlyManifest := filepath.Join(repo, "a-drift", manifestFileName)
+	writeFile(t, earlyManifest, demoPackageJSON)
+	writeFile(t, filepath.Join(repo, "a-drift", lockfileName), "{}\n")
+	triggerManifest := filepath.Join(repo, "m-trigger", pyprojectManifestName)
+	writeFile(t, triggerManifest, "[tool.poetry]\nname = \"trigger\"\n")
+	writeFile(t, filepath.Join(repo, "m-trigger", poetryLockName), "# lock\n")
+	laterDir := filepath.Join(repo, "z-later")
+	writeFile(t, filepath.Join(laterDir, "README.md"), "removed after the earlier candidate is buffered\n")
+	initGitRepo(t, repo)
+	writeFile(t, earlyManifest, demoPackageJSONUpdated)
+
+	originalReadFileUnder := readFileUnderFn
+	triggeredLaterWalkError := false
+	readFileUnderFn = func(rootDir, targetPath string) ([]byte, error) {
+		if targetPath == triggerManifest {
+			triggeredLaterWalkError = true
+			if err := os.RemoveAll(laterDir); err != nil {
+				return nil, err
+			}
+		}
+		return originalReadFileUnder(rootDir, targetPath)
+	}
+	t.Cleanup(func() { readFileUnderFn = originalReadFileUnder })
+
+	warnings, err := evaluateLockfileDriftPolicy(context.Background(), repo, "fail")
+	if !errors.Is(err, ErrLockfileDrift) {
+		t.Fatalf("expected earlier lockfile drift to win over the later walk error, got warnings=%#v err=%v", warnings, err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "npm in a-drift") {
+		t.Fatalf("expected only the earlier npm finding, got %#v", warnings)
+	}
+	if !triggeredLaterWalkError {
+		t.Fatal("expected the bounded candidate batch to encounter the later walk error before flushing")
+	}
+}
+
 func TestDetectLockfileDriftContextCancelled(t *testing.T) {
 	repo := t.TempDir()
 	cancelledCtx, cancel := context.WithCancel(context.Background())

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -1072,6 +1072,7 @@ func TestDetectLockfileDriftPythonMatcherReadError(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\nversion = \"0.1.0\"\n")
 	writeFile(t, filepath.Join(repo, poetryLockName), "metadata = {}\n")
+	initGitRepo(t, repo)
 
 	originalReadFileUnder := readFileUnderFn
 	t.Cleanup(func() {
@@ -1085,12 +1086,14 @@ func TestDetectLockfileDriftPythonMatcherReadError(t *testing.T) {
 		return safeio.ReadFileUnder(rootDir, targetPath)
 	}
 
-	_, err := detectLockfileDrift(context.Background(), repo, false)
-	if err == nil {
-		t.Fatalf("expected read error")
-	}
-	if !strings.Contains(err.Error(), "read pyproject.toml for tool.poetry lockfile drift detection") {
-		t.Fatalf("expected matcher read error context, got %v", err)
+	for _, stopOnFirst := range []bool{false, true} {
+		_, err := detectLockfileDrift(context.Background(), repo, stopOnFirst)
+		if err == nil {
+			t.Fatalf("expected read error with stopOnFirst=%v", stopOnFirst)
+		}
+		if !strings.Contains(err.Error(), "read pyproject.toml for tool.poetry lockfile drift detection") {
+			t.Fatalf("expected matcher read error context with stopOnFirst=%v, got %v", stopOnFirst, err)
+		}
 	}
 }
 

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -424,6 +424,12 @@ func configureCleanFilter(t *testing.T, repo, driver string) {
 	runGit(t, repo, "config", "filter."+driver+".required", "true")
 }
 
+func configureIncludedCleanFilter(t *testing.T, repo, driver string) {
+	t.Helper()
+	writeFile(t, filepath.Join(repo, ".git", "included-filters"), "[filter \""+driver+"\"]\n\tclean = ./helper.sh\n\trequired = true\n")
+	runGit(t, repo, "config", "include.path", "included-filters")
+}
+
 func configureProcessFilter(t *testing.T, repo, driver string) {
 	t.Helper()
 	runGit(t, repo, "config", "filter."+driver+".process", "./helper.sh")
@@ -480,7 +486,7 @@ func localGitHelperCases() []localGitHelperCase {
 				runGit(t, repo, "config", "core.fsmonitor", helperPath)
 			},
 		},
-		filterHelperCase("clean filter", "clean-filter.marker", "pwn", cleanFilterScript, cleanFilterBeforeInit("pwn"), nil, configureCleanFilter),
+		filterHelperCase("clean filter", "clean-filter.marker", "pwn", cleanFilterScript, cleanFilterBeforeInit("pwn"), nil, configureIncludedCleanFilter),
 		filterHelperCase("set-named clean filter", "set-named-clean-filter.marker", "set", cleanFilterScript, cleanFilterBeforeInit("set"), nil, configureCleanFilter),
 		filterHelperCase("unset-named clean filter", "unset-named-clean-filter.marker", "unset", cleanFilterScript, cleanFilterBeforeInit("unset"), nil, configureCleanFilter),
 		filterHelperCase("unspecified-named clean filter", "unspecified-named-clean-filter.marker", "unspecified", cleanFilterScript, cleanFilterBeforeInit("unspecified"), nil, configureCleanFilter),
@@ -579,6 +585,54 @@ func TestDetectLockfileDriftAllowsUnconfiguredStateNamedFilters(t *testing.T) {
 				t.Fatalf(detectLockfileDriftFmt, err)
 			}
 			assertSingleLockfileDriftWarning(t, warnings, nil, "npm in .: package.json changed while no matching lockfile changed", "npm install")
+		})
+	}
+}
+
+func TestDetectLockfileDriftAllowsFiltersWithoutExecutableCommands(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	cases := []struct {
+		name      string
+		driver    string
+		configure func(*testing.T, string)
+	}{
+		{name: "no matching config", driver: "inert"},
+		{
+			name:   "regex metacharacters do not match another driver",
+			driver: "pwn.*",
+			configure: func(t *testing.T, repo string) {
+				t.Helper()
+				runGit(t, repo, "config", "filter.pwned.clean", "./missing-helper.sh")
+			},
+		},
+		{
+			name:   "empty commands",
+			driver: "empty",
+			configure: func(t *testing.T, repo string) {
+				t.Helper()
+				runGit(t, repo, "config", "filter.empty.clean", "")
+				runGit(t, repo, "config", "filter.empty.process", "")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+			writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+			writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter="+tc.driver+"\n")
+			initGitRepo(t, repo)
+			if tc.configure != nil {
+				tc.configure(t, repo)
+			}
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+			warnings, err := detectLockfileDrift(context.Background(), repo, false)
+			assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json changed while no matching lockfile changed", "npm install")
 		})
 	}
 }

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -393,14 +393,77 @@ func TestDetectLockfileDriftDoesNotExecuteLocalGitHelpers(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")
 	}
-	cases := []struct {
+	helperPathInRepo := func(repo string) string { return filepath.Join(repo, "helper.sh") }
+	cleanFilterScript := func(markerPath string) string {
+		return "#!/bin/sh\necho clean-filter-ran >> \"" + markerPath + "\"\ncat\n"
+	}
+	processFilterScript := func(markerPath string) string {
+		return "#!/bin/sh\necho process-filter-ran >> \"" + markerPath + "\"\nprintf 'git-filter-client\\n'\n"
+	}
+	configureCleanFilter := func(t *testing.T, repo, driver string) {
+		t.Helper()
+		runGit(t, repo, "config", "filter."+driver+".clean", "./helper.sh")
+		runGit(t, repo, "config", "filter."+driver+".required", "true")
+	}
+	configureProcessFilter := func(t *testing.T, repo, driver string) {
+		t.Helper()
+		runGit(t, repo, "config", "filter."+driver+".process", "./helper.sh")
+		runGit(t, repo, "config", "filter."+driver+".required", "true")
+	}
+	type helperCase struct {
 		name          string
 		markerName    string
 		helperPath    func(string) string
 		helperScript  func(string) string
 		beforeInit    func(*testing.T, string)
 		configureRepo func(*testing.T, string, string)
-	}{
+	}
+	filterCase := func(name, markerName, driver string, helperScript func(string) string, beforeInit, repoSetup func(*testing.T, string), configureFilter func(*testing.T, string, string)) helperCase {
+		return helperCase{
+			name:         name,
+			markerName:   markerName,
+			helperPath:   helperPathInRepo,
+			helperScript: helperScript,
+			beforeInit:   beforeInit,
+			configureRepo: func(t *testing.T, repo, helperPath string) {
+				t.Helper()
+				if repoSetup != nil {
+					repoSetup(t, repo)
+				}
+				configureFilter(t, repo, driver)
+			},
+		}
+	}
+	cleanFilterBeforeInit := func(t *testing.T, repo string) {
+		t.Helper()
+		writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn\n")
+	}
+	cleanFilterWithEqualsBeforeInit := func(t *testing.T, repo string) {
+		t.Helper()
+		writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn=drv\n")
+	}
+	cleanFilterAfterEmptyAttributeBeforeInit := func(t *testing.T, repo string) {
+		t.Helper()
+		writeFile(t, filepath.Join(repo, "a.json"), "{}\n")
+		writeFile(t, filepath.Join(repo, ".gitattributes"), "a.json filter=\n"+manifestFileName+" filter=pwn\n")
+	}
+	processFilterInfoAttributesSetup := func(t *testing.T, repo string) {
+		t.Helper()
+		writeFile(t, filepath.Join(repo, ".git", "info", "attributes"), manifestFileName+" filter=pwn\n")
+	}
+	cleanFilterAttributesFileSetup := func(t *testing.T, repo string) {
+		t.Helper()
+		attributesPath := filepath.Join(t.TempDir(), "global.attributes")
+		writeFile(t, attributesPath, manifestFileName+" filter=pwn\n")
+		runGit(t, repo, "config", "core.attributesFile", attributesPath)
+	}
+	cleanFilterCase := filterCase("clean filter", "clean-filter.marker", "pwn", cleanFilterScript, cleanFilterBeforeInit, nil, configureCleanFilter)
+	cleanFilterWithEqualsDriverCase := filterCase("clean filter with equals driver", "clean-filter-equals-driver.marker", "pwn=drv", cleanFilterScript, cleanFilterWithEqualsBeforeInit, nil, configureCleanFilter)
+	cleanFilterAfterEmptyAttributeCase := filterCase("clean filter after empty attribute value", "clean-filter-after-empty-attr.marker", "pwn", cleanFilterScript, cleanFilterAfterEmptyAttributeBeforeInit, nil, configureCleanFilter)
+	processFilterFromInfoAttributesCase := filterCase("process filter from info attributes", "process-filter-info.marker", "pwn", processFilterScript, nil, processFilterInfoAttributesSetup, configureProcessFilter)
+	cleanFilterFromAttributesFileCase := filterCase("clean filter from core.attributesFile", "clean-filter-attributes-file.marker", "pwn", cleanFilterScript, nil, cleanFilterAttributesFileSetup, configureCleanFilter)
+
+	cases := []helperCase{
 		{
 			name:       "fsmonitor",
 			markerName: "fsmonitor.marker",
@@ -413,53 +476,11 @@ func TestDetectLockfileDriftDoesNotExecuteLocalGitHelpers(t *testing.T) {
 				runGit(t, repo, "config", "core.fsmonitor", helperPath)
 			},
 		},
-		{
-			name:       "clean filter",
-			markerName: "clean-filter.marker",
-			helperPath: func(repo string) string { return filepath.Join(repo, "helper.sh") },
-			helperScript: func(markerPath string) string {
-				return "#!/bin/sh\necho clean-filter-ran >> \"" + markerPath + "\"\ncat\n"
-			},
-			beforeInit: func(t *testing.T, repo string) {
-				t.Helper()
-				writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn\n")
-			},
-			configureRepo: func(t *testing.T, repo, helperPath string) {
-				t.Helper()
-				runGit(t, repo, "config", "filter.pwn.clean", "./helper.sh")
-				runGit(t, repo, "config", "filter.pwn.required", "true")
-			},
-		},
-		{
-			name:       "process filter from info attributes",
-			markerName: "process-filter-info.marker",
-			helperPath: func(repo string) string { return filepath.Join(repo, "helper.sh") },
-			helperScript: func(markerPath string) string {
-				return "#!/bin/sh\necho process-filter-ran >> \"" + markerPath + "\"\nprintf 'git-filter-client\\n'\n"
-			},
-			configureRepo: func(t *testing.T, repo, helperPath string) {
-				t.Helper()
-				writeFile(t, filepath.Join(repo, ".git", "info", "attributes"), manifestFileName+" filter=pwn\n")
-				runGit(t, repo, "config", "filter.pwn.process", "./helper.sh")
-				runGit(t, repo, "config", "filter.pwn.required", "true")
-			},
-		},
-		{
-			name:       "clean filter from core.attributesFile",
-			markerName: "clean-filter-attributes-file.marker",
-			helperPath: func(repo string) string { return filepath.Join(repo, "helper.sh") },
-			helperScript: func(markerPath string) string {
-				return "#!/bin/sh\necho clean-filter-ran >> \"" + markerPath + "\"\ncat\n"
-			},
-			configureRepo: func(t *testing.T, repo, helperPath string) {
-				t.Helper()
-				attributesPath := filepath.Join(t.TempDir(), "global.attributes")
-				writeFile(t, attributesPath, manifestFileName+" filter=pwn\n")
-				runGit(t, repo, "config", "core.attributesFile", attributesPath)
-				runGit(t, repo, "config", "filter.pwn.clean", "./helper.sh")
-				runGit(t, repo, "config", "filter.pwn.required", "true")
-			},
-		},
+		cleanFilterCase,
+		cleanFilterWithEqualsDriverCase,
+		cleanFilterAfterEmptyAttributeCase,
+		processFilterFromInfoAttributesCase,
+		cleanFilterFromAttributesFileCase,
 	}
 
 	for _, tc := range cases {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -1000,6 +1000,21 @@ func TestDetectLockfileDriftStopOnFirstPrioritizesEarlierGitFindingOverLaterFilt
 	assertSingleLockfileDriftWarning(t, warnings, err, "npm in a-drift: package.json changed while no matching lockfile changed", "npm install")
 }
 
+func TestDetectLockfileDriftStopOnFirstPrioritizesEarlierRuleFindingOverLaterSameSnapshotFilterAmbiguity(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\n")
+	writeFile(t, filepath.Join(repo, "poetry.lock"), "# lock\n")
+	writeFile(t, filepath.Join(repo, ".gitattributes"), pyprojectManifestName+" filter=pwn\n")
+	initGitRepo(t, repo)
+	runGit(t, repo, "config", "filter.pwn.clean", "./helper.sh")
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, true)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json changed while no matching lockfile changed", "npm install")
+}
+
 func TestDetectLockfileDriftStopOnFirstPrioritizesBufferedGitFindingOverLaterImmediateFinding(t *testing.T) {
 	repo := t.TempDir()
 	earlyManifest := filepath.Join(repo, "a-drift", manifestFileName)

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -34,6 +34,12 @@ const (
 	demoPackageJSONUpdated   = "{\n  \"name\": \"demo\",\n  \"version\": \"1.0.1\"\n}\n"
 	demoPackageJSONUpdatedV2 = "{\n  \"name\": \"demo\",\n  \"version\": \"2.0.0\"\n}\n"
 	nestedManifestPath       = "nested/package.json"
+	literalDir               = ":(glob)pkg"
+	ordinaryDir              = "pkg"
+	literalManifest          = literalDir + "/package.json"
+	literalLockfile          = literalDir + "/package-lock.json"
+	ordinaryManifest         = ordinaryDir + "/package.json"
+	ordinaryLockfile         = ordinaryDir + "/package-lock.json"
 	gitBinaryPath            = "/usr/bin/git"
 	gitExecutableNotFoundErr = "git executable not found"
 )
@@ -574,82 +580,75 @@ func TestDetectLockfileDriftIgnoresUnrelatedFilteredFilesOutsideCandidatePaths(t
 	}
 }
 
-func TestScopedGitPathHelpersTreatColonMagicCandidatePathsLiterally(t *testing.T) {
+func TestScopedGitPathHelpersTreatColonMagicTrackedDiffPathsLiterally(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")
 	}
 
-	const (
-		literalDir       = ":(glob)pkg"
-		ordinaryDir      = "pkg"
-		literalManifest  = literalDir + "/package.json"
-		literalLockfile  = literalDir + "/package-lock.json"
-		ordinaryManifest = ordinaryDir + "/package.json"
-		ordinaryLockfile = ordinaryDir + "/package-lock.json"
-	)
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, literalManifest), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, literalLockfile), "{}\n")
+	writeFile(t, filepath.Join(repo, ordinaryManifest), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, ordinaryLockfile), "{}\n")
+	initGitRepo(t, repo)
 
-	t.Run("tracked diff stays exact", func(t *testing.T) {
-		repo := t.TempDir()
-		writeFile(t, filepath.Join(repo, literalManifest), demoPackageJSON)
-		writeFile(t, filepath.Join(repo, literalLockfile), "{}\n")
-		writeFile(t, filepath.Join(repo, ordinaryManifest), demoPackageJSON)
-		writeFile(t, filepath.Join(repo, ordinaryLockfile), "{}\n")
-		initGitRepo(t, repo)
+	writeFile(t, filepath.Join(repo, literalManifest), demoPackageJSONUpdated)
 
-		writeFile(t, filepath.Join(repo, literalManifest), demoPackageJSONUpdated)
+	changed, err := gitChangedFilesForPaths(context.Background(), repo, []string{literalLockfile, literalManifest})
+	if err != nil {
+		t.Fatalf("gitChangedFilesForPaths: %v", err)
+	}
+	if len(changed) != 1 {
+		t.Fatalf("expected only the literal manifest change, got %#v", changed)
+	}
+	assertChangedPathsPresent(t, changed, literalManifest)
+	if _, ok := changed[ordinaryManifest]; ok {
+		t.Fatalf("expected sibling non-literal manifest to remain out of scope, got %#v", changed)
+	}
 
-		changed, err := gitChangedFilesForPaths(context.Background(), repo, []string{literalLockfile, literalManifest})
-		if err != nil {
-			t.Fatalf("gitChangedFilesForPaths: %v", err)
-		}
-		if len(changed) != 1 {
-			t.Fatalf("expected only the literal manifest change, got %#v", changed)
-		}
-		assertChangedPathsPresent(t, changed, literalManifest)
-		if _, ok := changed[ordinaryManifest]; ok {
-			t.Fatalf("expected sibling non-literal manifest to remain out of scope, got %#v", changed)
-		}
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in :(glob)pkg: package.json changed while no matching lockfile changed", "npm install")
+}
 
-		warnings, err := detectLockfileDrift(context.Background(), repo, false)
-		assertSingleLockfileDriftWarning(t, warnings, err, "npm in :(glob)pkg: package.json changed while no matching lockfile changed", "npm install")
-	})
+func TestScopedGitPathHelpersTreatColonMagicUntrackedPathsLiterally(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
 
-	t.Run("untracked listing stays exact", func(t *testing.T) {
-		repo := t.TempDir()
-		writeFile(t, filepath.Join(repo, "README.md"), "tracked\n")
-		initGitRepo(t, repo)
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "README.md"), "tracked\n")
+	initGitRepo(t, repo)
 
-		writeFile(t, filepath.Join(repo, literalManifest), demoPackageJSON)
-		writeFile(t, filepath.Join(repo, literalLockfile), "{}\n")
-		writeFile(t, filepath.Join(repo, ordinaryManifest), demoPackageJSON)
-		writeFile(t, filepath.Join(repo, ordinaryLockfile), "{}\n")
+	writeFile(t, filepath.Join(repo, literalManifest), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, literalLockfile), "{}\n")
+	writeFile(t, filepath.Join(repo, ordinaryManifest), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, ordinaryLockfile), "{}\n")
 
-		untracked, err := gitUntrackedFilesForPaths(context.Background(), repo, []string{literalLockfile, literalManifest})
-		if err != nil {
-			t.Fatalf("gitUntrackedFilesForPaths: %v", err)
-		}
-		if len(untracked) != 2 {
-			t.Fatalf("expected exact literal untracked candidates, got %#v", untracked)
-		}
-		if untracked[0] != literalLockfile || untracked[1] != literalManifest {
-			t.Fatalf("expected literal untracked candidates, got %#v", untracked)
-		}
+	untracked, err := gitUntrackedFilesForPaths(context.Background(), repo, []string{literalLockfile, literalManifest})
+	if err != nil {
+		t.Fatalf("gitUntrackedFilesForPaths: %v", err)
+	}
+	if len(untracked) != 2 {
+		t.Fatalf("expected exact literal untracked candidates, got %#v", untracked)
+	}
+	if untracked[0] != literalLockfile || untracked[1] != literalManifest {
+		t.Fatalf("expected literal untracked candidates, got %#v", untracked)
+	}
 
-		changed, err := gitChangedFilesForPaths(context.Background(), repo, []string{literalLockfile, literalManifest})
-		if err != nil {
-			t.Fatalf("gitChangedFilesForPaths: %v", err)
-		}
-		if len(changed) != 2 {
-			t.Fatalf("expected only literal untracked candidates, got %#v", changed)
-		}
-		assertChangedPathsPresent(t, changed, literalLockfile, literalManifest)
-		if _, ok := changed[ordinaryLockfile]; ok {
-			t.Fatalf("expected sibling non-literal lockfile to remain out of scope, got %#v", changed)
-		}
-		if _, ok := changed[ordinaryManifest]; ok {
-			t.Fatalf("expected sibling non-literal manifest to remain out of scope, got %#v", changed)
-		}
-	})
+	changed, err := gitChangedFilesForPaths(context.Background(), repo, []string{literalLockfile, literalManifest})
+	if err != nil {
+		t.Fatalf("gitChangedFilesForPaths: %v", err)
+	}
+	if len(changed) != 2 {
+		t.Fatalf("expected only literal untracked candidates, got %#v", changed)
+	}
+	assertChangedPathsPresent(t, changed, literalLockfile, literalManifest)
+	if _, ok := changed[ordinaryLockfile]; ok {
+		t.Fatalf("expected sibling non-literal lockfile to remain out of scope, got %#v", changed)
+	}
+	if _, ok := changed[ordinaryManifest]; ok {
+		t.Fatalf("expected sibling non-literal manifest to remain out of scope, got %#v", changed)
+	}
 }
 
 func TestDetectLockfileDriftPreservesTrackedCRLFNormalization(t *testing.T) {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -1027,6 +1027,63 @@ func TestDetectLockfileDriftStopOnFirstPrioritizesEarlierRuleFindingOverLaterSam
 	assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json changed while no matching lockfile changed", "npm install")
 }
 
+func TestDetectLockfileDriftStopOnFirstSurfacesLaterImmediateFindingAfterEarlierCleanCandidate(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\n")
+	initGitRepo(t, repo)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, true)
+	assertSingleLockfileDriftWarning(t, warnings, err, "Poetry in .: pyproject.toml exists but no matching lockfile", "poetry lock")
+}
+
+func TestDetectLockfileDriftStopOnFirstKeepsFirstRuleImmediateFindingOnFastPath(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\n")
+	writeFile(t, filepath.Join(repo, poetryLockName), "# lock\n")
+	writeFile(t, filepath.Join(repo, ".gitattributes"), pyprojectManifestName+" filter=pwn\n")
+	initGitRepo(t, repo)
+	runGit(t, repo, "config", "filter.pwn.clean", "./helper.sh")
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, true)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json exists but no matching lockfile", "npm install")
+}
+
+func TestDetectLockfileDriftStopOnFirstPropagatesEarlierRuleFilterAmbiguityBeforeLaterImmediateFinding(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\n")
+	writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn\n")
+	initGitRepo(t, repo)
+	runGit(t, repo, "config", "filter.pwn.clean", "./helper.sh")
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, true)
+	if err == nil || !strings.Contains(err.Error(), "cannot safely evaluate lockfile drift") || !strings.Contains(err.Error(), manifestFileName+" (pwn)") {
+		t.Fatalf("expected earlier npm filter ambiguity, got warnings=%#v err=%v", warnings, err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected ambiguity to suppress the later immediate warning, got %#v", warnings)
+	}
+}
+
+func TestDetectLockfileDriftStopOnFirstPrioritizesPriorBatchFindingOverMixedSnapshot(t *testing.T) {
+	repo := t.TempDir()
+	earlyManifest := filepath.Join(repo, "a-drift", manifestFileName)
+	writeFile(t, earlyManifest, demoPackageJSON)
+	writeFile(t, filepath.Join(repo, "a-drift", lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, "b-mixed", manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, "b-mixed", lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, "b-mixed", pyprojectManifestName), "[tool.poetry]\nname = \"demo\"\n")
+	initGitRepo(t, repo)
+	writeFile(t, earlyManifest, demoPackageJSONUpdated)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, true)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in a-drift: package.json changed while no matching lockfile changed", "npm install")
+}
+
 func TestDetectLockfileDriftStopOnFirstPrioritizesBufferedGitFindingOverLaterImmediateFinding(t *testing.T) {
 	repo := t.TempDir()
 	earlyManifest := filepath.Join(repo, "a-drift", manifestFileName)

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -664,6 +664,39 @@ func TestDetectLockfileDriftAllowsFilteredUntrackedCandidates(t *testing.T) {
 	}
 }
 
+func TestDetectLockfileDriftIgnoresFilteredIgnoredCandidates(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, ".gitignore"), "package*.json\n")
+	writeFile(t, filepath.Join(repo, ".gitattributes"), "package*.json filter=pwn\n")
+	writeFile(t, filepath.Join(repo, "README.md"), "tracked\n")
+	initGitRepo(t, repo)
+
+	markerPath := filepath.Join(t.TempDir(), "ignored-filter.marker")
+	helperPath := helperPathInRepo(repo)
+	writeFile(t, helperPath, cleanFilterScript(markerPath))
+	if err := os.Chmod(helperPath, 0o700); err != nil {
+		t.Fatalf("chmod git helper: %v", err)
+	}
+	configureCleanFilter(t, repo, "pwn")
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	if err != nil {
+		t.Fatalf(detectLockfileDriftFmt, err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected ignored manifest and lockfile to produce no drift warning, got %#v", warnings)
+	}
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected ignored candidate filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
+	}
+}
+
 func TestDetectLockfileDriftAllowsUnconfiguredStateNamedFilters(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -582,45 +582,50 @@ func TestDetectLockfileDriftRejectsCaseFoldedCustomFiltersBeforeDiff(t *testing.
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			repo := t.TempDir()
-			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-			writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
-			writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter="+tc.attributeDriver+"\n")
-			initGitRepo(t, repo)
-
-			markerPath := filepath.Join(t.TempDir(), "case-folded-filter.marker")
-			helperPath := helperPathInRepo(repo)
-			writeFile(t, helperPath, cleanFilterScript(markerPath))
-			if err := os.Chmod(helperPath, 0o700); err != nil {
-				t.Fatalf("chmod git helper: %v", err)
-			}
-			runGit(t, repo, "config", "filter."+tc.configuredDriver+".clean", "./helper.sh")
-			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
-
-			originalExec := execGitCommandContextFn
-			diffCommands := 0
-			execGitCommandContextFn = func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
-				if lockfileGitCommandGroup(args) == "diff" {
-					diffCommands++
-				}
-				return originalExec(ctx, gitPath, args...)
-			}
-			t.Cleanup(func() { execGitCommandContextFn = originalExec })
-
-			warnings, err := detectLockfileDrift(context.Background(), repo, false)
-			if err == nil || !strings.Contains(err.Error(), "cannot safely evaluate lockfile drift") || !strings.Contains(err.Error(), manifestFileName+" ("+tc.attributeDriver+")") {
-				t.Errorf("expected case-folded filter ambiguity error, got warnings=%#v err=%v", warnings, err)
-			}
-			if len(warnings) != 0 {
-				t.Errorf("expected ambiguity error to suppress drift warnings, got %#v", warnings)
-			}
-			if diffCommands != 0 {
-				t.Errorf("expected filter preflight to stop before git diff, got %d diff commands", diffCommands)
-			}
-			if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
-				t.Errorf("expected case-folded filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
-			}
+			runCaseFoldedCustomFilterCase(t, tc.attributeDriver, tc.configuredDriver)
 		})
+	}
+}
+
+func runCaseFoldedCustomFilterCase(t *testing.T, attributeDriver, configuredDriver string) {
+	t.Helper()
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter="+attributeDriver+"\n")
+	initGitRepo(t, repo)
+
+	markerPath := filepath.Join(t.TempDir(), "case-folded-filter.marker")
+	helperPath := helperPathInRepo(repo)
+	writeFile(t, helperPath, cleanFilterScript(markerPath))
+	if err := os.Chmod(helperPath, 0o700); err != nil {
+		t.Fatalf("chmod git helper: %v", err)
+	}
+	runGit(t, repo, "config", "filter."+configuredDriver+".clean", "./helper.sh")
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+	originalExec := execGitCommandContextFn
+	diffCommands := 0
+	execGitCommandContextFn = func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
+		if lockfileGitCommandGroup(args) == "diff" {
+			diffCommands++
+		}
+		return originalExec(ctx, gitPath, args...)
+	}
+	t.Cleanup(func() { execGitCommandContextFn = originalExec })
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	if err == nil || !strings.Contains(err.Error(), "cannot safely evaluate lockfile drift") || !strings.Contains(err.Error(), manifestFileName+" ("+attributeDriver+")") {
+		t.Errorf("expected case-folded filter ambiguity error, got warnings=%#v err=%v", warnings, err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected ambiguity error to suppress drift warnings, got %#v", warnings)
+	}
+	if diffCommands != 0 {
+		t.Errorf("expected filter preflight to stop before git diff, got %d diff commands", diffCommands)
+	}
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected case-folded filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
 	}
 }
 

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -566,6 +566,64 @@ func TestDetectLockfileDriftRejectsActiveCustomFiltersWithoutExecutingHelpers(t 
 	}
 }
 
+func TestDetectLockfileDriftRejectsCaseFoldedCustomFiltersBeforeDiff(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	cases := []struct {
+		name             string
+		attributeDriver  string
+		configuredDriver string
+	}{
+		{name: "lowercase attribute", attributeDriver: "pwn", configuredDriver: "PWN"},
+		{name: "mixed-case attribute", attributeDriver: "Pwn", configuredDriver: "pwn"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+			writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+			writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter="+tc.attributeDriver+"\n")
+			initGitRepo(t, repo)
+
+			markerPath := filepath.Join(t.TempDir(), "case-folded-filter.marker")
+			helperPath := helperPathInRepo(repo)
+			writeFile(t, helperPath, cleanFilterScript(markerPath))
+			if err := os.Chmod(helperPath, 0o700); err != nil {
+				t.Fatalf("chmod git helper: %v", err)
+			}
+			runGit(t, repo, "config", "filter."+tc.configuredDriver+".clean", "./helper.sh")
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+			originalExec := execGitCommandContextFn
+			diffCommands := 0
+			execGitCommandContextFn = func(ctx context.Context, gitPath string, args ...string) (*exec.Cmd, error) {
+				if lockfileGitCommandGroup(args) == "diff" {
+					diffCommands++
+				}
+				return originalExec(ctx, gitPath, args...)
+			}
+			t.Cleanup(func() { execGitCommandContextFn = originalExec })
+
+			warnings, err := detectLockfileDrift(context.Background(), repo, false)
+			if err == nil || !strings.Contains(err.Error(), "cannot safely evaluate lockfile drift") || !strings.Contains(err.Error(), manifestFileName+" ("+tc.attributeDriver+")") {
+				t.Errorf("expected case-folded filter ambiguity error, got warnings=%#v err=%v", warnings, err)
+			}
+			if len(warnings) != 0 {
+				t.Errorf("expected ambiguity error to suppress drift warnings, got %#v", warnings)
+			}
+			if diffCommands != 0 {
+				t.Errorf("expected filter preflight to stop before git diff, got %d diff commands", diffCommands)
+			}
+			if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+				t.Errorf("expected case-folded filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
+			}
+		})
+	}
+}
+
 func TestDetectLockfileDriftAllowsFilteredUntrackedCandidates(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -389,6 +389,34 @@ func TestSanitizedGitEnvPinsSafePath(t *testing.T) {
 	}
 }
 
+func TestDetectLockfileDriftDoesNotExecuteLocalFsmonitor(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	initGitRepo(t, repo)
+
+	markerPath := filepath.Join(t.TempDir(), "fsmonitor.marker")
+	helperPath := filepath.Join(repo, ".git", "hooks", "pwn-fsmonitor")
+	writeFile(t, helperPath, "#!/bin/sh\necho fsmonitor-ran >> \""+markerPath+"\"\nprintf 'version 2\\n\\n'\nexit 0\n")
+	if err := os.Chmod(helperPath, 0o700); err != nil {
+		t.Fatalf("chmod fsmonitor helper: %v", err)
+	}
+	runGit(t, repo, "config", "core.fsmonitor", helperPath)
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	if err != nil {
+		t.Fatalf(detectLockfileDriftFmt, err)
+	}
+	assertSingleLockfileDriftWarning(t, warnings, nil, "npm in .: package.json changed while no matching lockfile changed", "npm install")
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected local fsmonitor helper to never execute, markerPath=%q statErr=%v", markerPath, err)
+	}
+}
+
 func TestDetectLockfileDriftStopOnFirst(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -389,31 +389,76 @@ func TestSanitizedGitEnvPinsSafePath(t *testing.T) {
 	}
 }
 
-func TestDetectLockfileDriftDoesNotExecuteLocalFsmonitor(t *testing.T) {
+func TestDetectLockfileDriftDoesNotExecuteLocalGitHelpers(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")
 	}
-	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
-	initGitRepo(t, repo)
-
-	markerPath := filepath.Join(t.TempDir(), "fsmonitor.marker")
-	helperPath := filepath.Join(repo, ".git", "hooks", "pwn-fsmonitor")
-	writeFile(t, helperPath, "#!/bin/sh\necho fsmonitor-ran >> \""+markerPath+"\"\nprintf 'version 2\\n\\n'\nexit 0\n")
-	if err := os.Chmod(helperPath, 0o700); err != nil {
-		t.Fatalf("chmod fsmonitor helper: %v", err)
+	cases := []struct {
+		name          string
+		markerName    string
+		helperPath    func(string) string
+		helperScript  func(string) string
+		beforeInit    func(*testing.T, string)
+		configureRepo func(*testing.T, string, string)
+	}{
+		{
+			name:       "fsmonitor",
+			markerName: "fsmonitor.marker",
+			helperPath: func(repo string) string { return filepath.Join(repo, ".git", "hooks", "pwn-fsmonitor") },
+			helperScript: func(markerPath string) string {
+				return "#!/bin/sh\necho fsmonitor-ran >> \"" + markerPath + "\"\nprintf 'version 2\\n\\n'\nexit 0\n"
+			},
+			configureRepo: func(t *testing.T, repo, helperPath string) {
+				t.Helper()
+				runGit(t, repo, "config", "core.fsmonitor", helperPath)
+			},
+		},
+		{
+			name:       "clean filter",
+			markerName: "clean-filter.marker",
+			helperPath: func(repo string) string { return filepath.Join(repo, "helper.sh") },
+			helperScript: func(markerPath string) string {
+				return "#!/bin/sh\necho clean-filter-ran >> \"" + markerPath + "\"\ncat\n"
+			},
+			beforeInit: func(t *testing.T, repo string) {
+				t.Helper()
+				writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn\n")
+			},
+			configureRepo: func(t *testing.T, repo, helperPath string) {
+				t.Helper()
+				runGit(t, repo, "config", "filter.pwn.clean", "./helper.sh")
+			},
+		},
 	}
-	runGit(t, repo, "config", "core.fsmonitor", helperPath)
-	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
 
-	warnings, err := detectLockfileDrift(context.Background(), repo, false)
-	if err != nil {
-		t.Fatalf(detectLockfileDriftFmt, err)
-	}
-	assertSingleLockfileDriftWarning(t, warnings, nil, "npm in .: package.json changed while no matching lockfile changed", "npm install")
-	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected local fsmonitor helper to never execute, markerPath=%q statErr=%v", markerPath, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+			writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+			if tc.beforeInit != nil {
+				tc.beforeInit(t, repo)
+			}
+			initGitRepo(t, repo)
+
+			markerPath := filepath.Join(t.TempDir(), tc.markerName)
+			helperPath := tc.helperPath(repo)
+			writeFile(t, helperPath, tc.helperScript(markerPath))
+			if err := os.Chmod(helperPath, 0o700); err != nil {
+				t.Fatalf("chmod git helper: %v", err)
+			}
+			tc.configureRepo(t, repo, helperPath)
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+			warnings, err := detectLockfileDrift(context.Background(), repo, false)
+			if err != nil {
+				t.Fatalf(detectLockfileDriftFmt, err)
+			}
+			assertSingleLockfileDriftWarning(t, warnings, nil, "npm in .: package.json changed while no matching lockfile changed", "npm install")
+			if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("expected local git helper to never execute, markerPath=%q statErr=%v", markerPath, err)
+			}
+		})
 	}
 }
 
@@ -599,6 +644,34 @@ func TestGitChangedFilesHandlesRepoWithNoHEAD(t *testing.T) {
 		t.Fatalf("expected hasGit=true when inside git worktree")
 	}
 	assertChangedPathsPresent(t, changed, manifestFileName, newUntrackedFileName)
+}
+
+func TestEmptyTreeObjectIDSupportsGitHashFormats(t *testing.T) {
+	t.Run(gitObjectFormatSHA1, func(t *testing.T) {
+		got, err := emptyTreeObjectID(gitObjectFormatSHA1)
+		if err != nil {
+			t.Fatalf("empty tree sha1: %v", err)
+		}
+		if got != "4b825dc642cb6eb9a060e54bf8d69288fbee4904" {
+			t.Fatalf("unexpected sha1 empty tree object id %q", got)
+		}
+	})
+
+	t.Run(gitObjectFormatSHA256, func(t *testing.T) {
+		got, err := emptyTreeObjectID(gitObjectFormatSHA256)
+		if err != nil {
+			t.Fatalf("empty tree sha256: %v", err)
+		}
+		if got != "6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321" {
+			t.Fatalf("unexpected sha256 empty tree object id %q", got)
+		}
+	})
+}
+
+func TestEmptyTreeObjectIDRejectsUnsupportedGitHashFormat(t *testing.T) {
+	if _, err := emptyTreeObjectID("sha512"); err == nil {
+		t.Fatalf("expected unsupported git object format error")
+	}
 }
 
 func TestDetectLockfileDriftNoHeadDoesNotReturnGitError(t *testing.T) {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -448,14 +448,18 @@ func filterHelperCase(name, markerName, driver string, helperScript func(string)
 	}
 }
 
-func cleanFilterBeforeInit(t *testing.T, repo string) {
-	t.Helper()
-	writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn\n")
+func cleanFilterBeforeInit(driver string) func(*testing.T, string) {
+	return func(t *testing.T, repo string) {
+		t.Helper()
+		writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter="+driver+"\n")
+	}
 }
 
-func processFilterInfoAttributesSetup(t *testing.T, repo string) {
-	t.Helper()
-	writeFile(t, filepath.Join(repo, ".git", "info", "attributes"), manifestFileName+" filter=pwn\n")
+func processFilterInfoAttributesSetup(driver string) func(*testing.T, string) {
+	return func(t *testing.T, repo string) {
+		t.Helper()
+		writeFile(t, filepath.Join(repo, ".git", "info", "attributes"), manifestFileName+" filter="+driver+"\n")
+	}
 }
 
 func localGitHelperCases() []localGitHelperCase {
@@ -476,8 +480,12 @@ func localGitHelperCases() []localGitHelperCase {
 				runGit(t, repo, "config", "core.fsmonitor", helperPath)
 			},
 		},
-		filterHelperCase("clean filter", "clean-filter.marker", "pwn", cleanFilterScript, cleanFilterBeforeInit, nil, configureCleanFilter),
-		filterHelperCase("process filter from info attributes", "process-filter-info.marker", "pwn", processFilterScript, nil, processFilterInfoAttributesSetup, configureProcessFilter),
+		filterHelperCase("clean filter", "clean-filter.marker", "pwn", cleanFilterScript, cleanFilterBeforeInit("pwn"), nil, configureCleanFilter),
+		filterHelperCase("set-named clean filter", "set-named-clean-filter.marker", "set", cleanFilterScript, cleanFilterBeforeInit("set"), nil, configureCleanFilter),
+		filterHelperCase("unset-named clean filter", "unset-named-clean-filter.marker", "unset", cleanFilterScript, cleanFilterBeforeInit("unset"), nil, configureCleanFilter),
+		filterHelperCase("unspecified-named clean filter", "unspecified-named-clean-filter.marker", "unspecified", cleanFilterScript, cleanFilterBeforeInit("unspecified"), nil, configureCleanFilter),
+		filterHelperCase("process filter from info attributes", "process-filter-info.marker", "pwn", processFilterScript, nil, processFilterInfoAttributesSetup("pwn"), configureProcessFilter),
+		filterHelperCase("state-named process filter from info attributes", "state-named-process-filter-info.marker", "set", processFilterScript, nil, processFilterInfoAttributesSetup("set"), configureProcessFilter),
 	}
 }
 
@@ -548,6 +556,29 @@ func TestDetectLockfileDriftRejectsActiveCustomFiltersWithoutExecutingHelpers(t 
 		}
 		t.Run(tc.name, func(t *testing.T) {
 			runLocalGitHelperCase(t, tc)
+		})
+	}
+}
+
+func TestDetectLockfileDriftAllowsUnconfiguredStateNamedFilters(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	for _, driver := range []string{"set", "unset", "unspecified"} {
+		t.Run(driver, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+			writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+			writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter="+driver+"\n")
+			initGitRepo(t, repo)
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+			warnings, err := detectLockfileDrift(context.Background(), repo, false)
+			if err != nil {
+				t.Fatalf(detectLockfileDriftFmt, err)
+			}
+			assertSingleLockfileDriftWarning(t, warnings, nil, "npm in .: package.json changed while no matching lockfile changed", "npm install")
 		})
 	}
 }

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -940,6 +940,22 @@ func TestDetectLockfileDriftStopOnFirstPrioritizesEarlierBatchFindingOverLaterFi
 	assertSingleLockfileDriftWarning(t, warnings, err, "npm in b-missing: package.json exists but no matching lockfile", "npm install")
 }
 
+func TestDetectLockfileDriftStopOnFirstPrioritizesEarlierGitFindingOverLaterFilterAmbiguity(t *testing.T) {
+	repo := t.TempDir()
+	earlyManifest := filepath.Join(repo, "a-drift", manifestFileName)
+	writeFile(t, earlyManifest, demoPackageJSON)
+	writeFile(t, filepath.Join(repo, "a-drift", lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, "z-filtered", manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, "z-filtered", lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, ".gitattributes"), "z-filtered/package.json filter=pwn\n")
+	initGitRepo(t, repo)
+	runGit(t, repo, "config", "filter.pwn.clean", "./helper.sh")
+	writeFile(t, earlyManifest, demoPackageJSONUpdated)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, true)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in a-drift: package.json changed while no matching lockfile changed", "npm install")
+}
+
 func TestDetectLockfileDriftStopOnFirstPrioritizesBufferedGitFindingOverLaterImmediateFinding(t *testing.T) {
 	repo := t.TempDir()
 	earlyManifest := filepath.Join(repo, "a-drift", manifestFileName)

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -699,6 +699,22 @@ func TestDetectLockfileDriftAllowsUnconfiguredStateNamedFilters(t *testing.T) {
 	}
 }
 
+func TestDetectLockfileDriftIgnoresUnassignedFilterStateWithMatchingConfig(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	initGitRepo(t, repo)
+	runGit(t, repo, "config", "filter.unspecified.clean", "./unrelated-helper.sh")
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json changed while no matching lockfile changed", "npm install")
+}
+
 func TestDetectLockfileDriftAllowsFiltersWithoutExecutableCommands(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -389,81 +389,86 @@ func TestSanitizedGitEnvPinsSafePath(t *testing.T) {
 	}
 }
 
-func TestDetectLockfileDriftDoesNotExecuteLocalGitHelpers(t *testing.T) {
-	if _, err := gitexec.ResolveBinaryPath(); err != nil {
-		t.Skip("git binary not available")
-	}
-	helperPathInRepo := func(repo string) string { return filepath.Join(repo, "helper.sh") }
-	cleanFilterScript := func(markerPath string) string {
-		return "#!/bin/sh\necho clean-filter-ran >> \"" + markerPath + "\"\ncat\n"
-	}
-	processFilterScript := func(markerPath string) string {
-		return "#!/bin/sh\necho process-filter-ran >> \"" + markerPath + "\"\nprintf 'git-filter-client\\n'\n"
-	}
-	configureCleanFilter := func(t *testing.T, repo, driver string) {
-		t.Helper()
-		runGit(t, repo, "config", "filter."+driver+".clean", "./helper.sh")
-		runGit(t, repo, "config", "filter."+driver+".required", "true")
-	}
-	configureProcessFilter := func(t *testing.T, repo, driver string) {
-		t.Helper()
-		runGit(t, repo, "config", "filter."+driver+".process", "./helper.sh")
-		runGit(t, repo, "config", "filter."+driver+".required", "true")
-	}
-	type helperCase struct {
-		name          string
-		markerName    string
-		helperPath    func(string) string
-		helperScript  func(string) string
-		beforeInit    func(*testing.T, string)
-		configureRepo func(*testing.T, string, string)
-	}
-	filterCase := func(name, markerName, driver string, helperScript func(string) string, beforeInit, repoSetup func(*testing.T, string), configureFilter func(*testing.T, string, string)) helperCase {
-		return helperCase{
-			name:         name,
-			markerName:   markerName,
-			helperPath:   helperPathInRepo,
-			helperScript: helperScript,
-			beforeInit:   beforeInit,
-			configureRepo: func(t *testing.T, repo, helperPath string) {
-				t.Helper()
-				if repoSetup != nil {
-					repoSetup(t, repo)
-				}
-				configureFilter(t, repo, driver)
-			},
-		}
-	}
-	cleanFilterBeforeInit := func(t *testing.T, repo string) {
-		t.Helper()
-		writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn\n")
-	}
-	cleanFilterWithEqualsBeforeInit := func(t *testing.T, repo string) {
-		t.Helper()
-		writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn=drv\n")
-	}
-	cleanFilterAfterEmptyAttributeBeforeInit := func(t *testing.T, repo string) {
-		t.Helper()
-		writeFile(t, filepath.Join(repo, "a.json"), "{}\n")
-		writeFile(t, filepath.Join(repo, ".gitattributes"), "a.json filter=\n"+manifestFileName+" filter=pwn\n")
-	}
-	processFilterInfoAttributesSetup := func(t *testing.T, repo string) {
-		t.Helper()
-		writeFile(t, filepath.Join(repo, ".git", "info", "attributes"), manifestFileName+" filter=pwn\n")
-	}
-	cleanFilterAttributesFileSetup := func(t *testing.T, repo string) {
-		t.Helper()
-		attributesPath := filepath.Join(t.TempDir(), "global.attributes")
-		writeFile(t, attributesPath, manifestFileName+" filter=pwn\n")
-		runGit(t, repo, "config", "core.attributesFile", attributesPath)
-	}
-	cleanFilterCase := filterCase("clean filter", "clean-filter.marker", "pwn", cleanFilterScript, cleanFilterBeforeInit, nil, configureCleanFilter)
-	cleanFilterWithEqualsDriverCase := filterCase("clean filter with equals driver", "clean-filter-equals-driver.marker", "pwn=drv", cleanFilterScript, cleanFilterWithEqualsBeforeInit, nil, configureCleanFilter)
-	cleanFilterAfterEmptyAttributeCase := filterCase("clean filter after empty attribute value", "clean-filter-after-empty-attr.marker", "pwn", cleanFilterScript, cleanFilterAfterEmptyAttributeBeforeInit, nil, configureCleanFilter)
-	processFilterFromInfoAttributesCase := filterCase("process filter from info attributes", "process-filter-info.marker", "pwn", processFilterScript, nil, processFilterInfoAttributesSetup, configureProcessFilter)
-	cleanFilterFromAttributesFileCase := filterCase("clean filter from core.attributesFile", "clean-filter-attributes-file.marker", "pwn", cleanFilterScript, nil, cleanFilterAttributesFileSetup, configureCleanFilter)
+type localGitHelperCase struct {
+	name          string
+	markerName    string
+	helperPath    func(string) string
+	helperScript  func(string) string
+	beforeInit    func(*testing.T, string)
+	configureRepo func(*testing.T, string, string)
+}
 
-	cases := []helperCase{
+func helperPathInRepo(repo string) string {
+	return filepath.Join(repo, "helper.sh")
+}
+
+func cleanFilterScript(markerPath string) string {
+	return "#!/bin/sh\necho clean-filter-ran >> \"" + markerPath + "\"\ncat\n"
+}
+
+func processFilterScript(markerPath string) string {
+	return "#!/bin/sh\necho process-filter-ran >> \"" + markerPath + "\"\nprintf 'git-filter-client\\n'\n"
+}
+
+func configureCleanFilter(t *testing.T, repo, driver string) {
+	t.Helper()
+	runGit(t, repo, "config", "filter."+driver+".clean", "./helper.sh")
+	runGit(t, repo, "config", "filter."+driver+".required", "true")
+}
+
+func configureProcessFilter(t *testing.T, repo, driver string) {
+	t.Helper()
+	runGit(t, repo, "config", "filter."+driver+".process", "./helper.sh")
+	runGit(t, repo, "config", "filter."+driver+".required", "true")
+}
+
+func filterHelperCase(name, markerName, driver string, helperScript func(string) string, beforeInit, repoSetup func(*testing.T, string), configureFilter func(*testing.T, string, string)) localGitHelperCase {
+	return localGitHelperCase{
+		name:         name,
+		markerName:   markerName,
+		helperPath:   helperPathInRepo,
+		helperScript: helperScript,
+		beforeInit:   beforeInit,
+		configureRepo: func(t *testing.T, repo, helperPath string) {
+			t.Helper()
+			if repoSetup != nil {
+				repoSetup(t, repo)
+			}
+			configureFilter(t, repo, driver)
+		},
+	}
+}
+
+func cleanFilterBeforeInit(t *testing.T, repo string) {
+	t.Helper()
+	writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn\n")
+}
+
+func cleanFilterWithEqualsBeforeInit(t *testing.T, repo string) {
+	t.Helper()
+	writeFile(t, filepath.Join(repo, ".gitattributes"), manifestFileName+" filter=pwn=drv\n")
+}
+
+func cleanFilterAfterEmptyAttributeBeforeInit(t *testing.T, repo string) {
+	t.Helper()
+	writeFile(t, filepath.Join(repo, "a.json"), "{}\n")
+	writeFile(t, filepath.Join(repo, ".gitattributes"), "a.json filter=\n"+manifestFileName+" filter=pwn\n")
+}
+
+func processFilterInfoAttributesSetup(t *testing.T, repo string) {
+	t.Helper()
+	writeFile(t, filepath.Join(repo, ".git", "info", "attributes"), manifestFileName+" filter=pwn\n")
+}
+
+func cleanFilterAttributesFileSetup(t *testing.T, repo string) {
+	t.Helper()
+	attributesPath := filepath.Join(t.TempDir(), "global.attributes")
+	writeFile(t, attributesPath, manifestFileName+" filter=pwn\n")
+	runGit(t, repo, "config", "core.attributesFile", attributesPath)
+}
+
+func localGitHelperCases() []localGitHelperCase {
+	return []localGitHelperCase{
 		{
 			name:       "fsmonitor",
 			markerName: "fsmonitor.marker",
@@ -476,40 +481,51 @@ func TestDetectLockfileDriftDoesNotExecuteLocalGitHelpers(t *testing.T) {
 				runGit(t, repo, "config", "core.fsmonitor", helperPath)
 			},
 		},
-		cleanFilterCase,
-		cleanFilterWithEqualsDriverCase,
-		cleanFilterAfterEmptyAttributeCase,
-		processFilterFromInfoAttributesCase,
-		cleanFilterFromAttributesFileCase,
+		filterHelperCase("clean filter", "clean-filter.marker", "pwn", cleanFilterScript, cleanFilterBeforeInit, nil, configureCleanFilter),
+		filterHelperCase("clean filter with equals driver", "clean-filter-equals-driver.marker", "pwn=drv", cleanFilterScript, cleanFilterWithEqualsBeforeInit, nil, configureCleanFilter),
+		filterHelperCase("clean filter after empty attribute value", "clean-filter-after-empty-attr.marker", "pwn", cleanFilterScript, cleanFilterAfterEmptyAttributeBeforeInit, nil, configureCleanFilter),
+		filterHelperCase("process filter from info attributes", "process-filter-info.marker", "pwn", processFilterScript, nil, processFilterInfoAttributesSetup, configureProcessFilter),
+		filterHelperCase("clean filter from core.attributesFile", "clean-filter-attributes-file.marker", "pwn", cleanFilterScript, nil, cleanFilterAttributesFileSetup, configureCleanFilter),
 	}
+}
 
-	for _, tc := range cases {
+func runLocalGitHelperCase(t *testing.T, tc localGitHelperCase) {
+	t.Helper()
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	if tc.beforeInit != nil {
+		tc.beforeInit(t, repo)
+	}
+	initGitRepo(t, repo)
+
+	markerPath := filepath.Join(t.TempDir(), tc.markerName)
+	helperPath := tc.helperPath(repo)
+	writeFile(t, helperPath, tc.helperScript(markerPath))
+	if err := os.Chmod(helperPath, 0o700); err != nil {
+		t.Fatalf("chmod git helper: %v", err)
+	}
+	tc.configureRepo(t, repo, helperPath)
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	if err != nil {
+		t.Fatalf(detectLockfileDriftFmt, err)
+	}
+	assertSingleLockfileDriftWarning(t, warnings, nil, "npm in .: package.json changed while no matching lockfile changed", "npm install")
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected local git helper to never execute, markerPath=%q statErr=%v", markerPath, err)
+	}
+}
+
+func TestDetectLockfileDriftDoesNotExecuteLocalGitHelpers(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+	for _, tc := range localGitHelperCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			repo := t.TempDir()
-			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-			writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
-			if tc.beforeInit != nil {
-				tc.beforeInit(t, repo)
-			}
-			initGitRepo(t, repo)
-
-			markerPath := filepath.Join(t.TempDir(), tc.markerName)
-			helperPath := tc.helperPath(repo)
-			writeFile(t, helperPath, tc.helperScript(markerPath))
-			if err := os.Chmod(helperPath, 0o700); err != nil {
-				t.Fatalf("chmod git helper: %v", err)
-			}
-			tc.configureRepo(t, repo, helperPath)
-			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
-
-			warnings, err := detectLockfileDrift(context.Background(), repo, false)
-			if err != nil {
-				t.Fatalf(detectLockfileDriftFmt, err)
-			}
-			assertSingleLockfileDriftWarning(t, warnings, nil, "npm in .: package.json changed while no matching lockfile changed", "npm install")
-			if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
-				t.Fatalf("expected local git helper to never execute, markerPath=%q statErr=%v", markerPath, err)
-			}
+			runLocalGitHelperCase(t, tc)
 		})
 	}
 }

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -427,6 +427,37 @@ func TestDetectLockfileDriftDoesNotExecuteLocalGitHelpers(t *testing.T) {
 			configureRepo: func(t *testing.T, repo, helperPath string) {
 				t.Helper()
 				runGit(t, repo, "config", "filter.pwn.clean", "./helper.sh")
+				runGit(t, repo, "config", "filter.pwn.required", "true")
+			},
+		},
+		{
+			name:       "process filter from info attributes",
+			markerName: "process-filter-info.marker",
+			helperPath: func(repo string) string { return filepath.Join(repo, "helper.sh") },
+			helperScript: func(markerPath string) string {
+				return "#!/bin/sh\necho process-filter-ran >> \"" + markerPath + "\"\nprintf 'git-filter-client\\n'\n"
+			},
+			configureRepo: func(t *testing.T, repo, helperPath string) {
+				t.Helper()
+				writeFile(t, filepath.Join(repo, ".git", "info", "attributes"), manifestFileName+" filter=pwn\n")
+				runGit(t, repo, "config", "filter.pwn.process", "./helper.sh")
+				runGit(t, repo, "config", "filter.pwn.required", "true")
+			},
+		},
+		{
+			name:       "clean filter from core.attributesFile",
+			markerName: "clean-filter-attributes-file.marker",
+			helperPath: func(repo string) string { return filepath.Join(repo, "helper.sh") },
+			helperScript: func(markerPath string) string {
+				return "#!/bin/sh\necho clean-filter-ran >> \"" + markerPath + "\"\ncat\n"
+			},
+			configureRepo: func(t *testing.T, repo, helperPath string) {
+				t.Helper()
+				attributesPath := filepath.Join(t.TempDir(), "global.attributes")
+				writeFile(t, attributesPath, manifestFileName+" filter=pwn\n")
+				runGit(t, repo, "config", "core.attributesFile", attributesPath)
+				runGit(t, repo, "config", "filter.pwn.clean", "./helper.sh")
+				runGit(t, repo, "config", "filter.pwn.required", "true")
 			},
 		},
 	}
@@ -459,6 +490,22 @@ func TestDetectLockfileDriftDoesNotExecuteLocalGitHelpers(t *testing.T) {
 				t.Fatalf("expected local git helper to never execute, markerPath=%q statErr=%v", markerPath, err)
 			}
 		})
+	}
+}
+
+func TestDetectLockfileDriftPreservesTrackedCRLFNormalization(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, ".gitattributes"), "*.json text eol=crlf\n")
+	writeFile(t, filepath.Join(repo, manifestFileName), "{\r\n  \"name\": \"demo\"\r\n}\r\n")
+	writeFile(t, filepath.Join(repo, lockfileName), "{\r\n  \"lockfileVersion\": 3\r\n}\r\n")
+	initGitRepo(t, repo)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	if err != nil {
+		t.Fatalf(detectLockfileDriftFmt, err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected clean CRLF-normalized repo to produce no lockfile drift warnings, got %#v", warnings)
 	}
 }
 
@@ -644,34 +691,6 @@ func TestGitChangedFilesHandlesRepoWithNoHEAD(t *testing.T) {
 		t.Fatalf("expected hasGit=true when inside git worktree")
 	}
 	assertChangedPathsPresent(t, changed, manifestFileName, newUntrackedFileName)
-}
-
-func TestEmptyTreeObjectIDSupportsGitHashFormats(t *testing.T) {
-	t.Run(gitObjectFormatSHA1, func(t *testing.T) {
-		got, err := emptyTreeObjectID(gitObjectFormatSHA1)
-		if err != nil {
-			t.Fatalf("empty tree sha1: %v", err)
-		}
-		if got != "4b825dc642cb6eb9a060e54bf8d69288fbee4904" {
-			t.Fatalf("unexpected sha1 empty tree object id %q", got)
-		}
-	})
-
-	t.Run(gitObjectFormatSHA256, func(t *testing.T) {
-		got, err := emptyTreeObjectID(gitObjectFormatSHA256)
-		if err != nil {
-			t.Fatalf("empty tree sha256: %v", err)
-		}
-		if got != "6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321" {
-			t.Fatalf("unexpected sha256 empty tree object id %q", got)
-		}
-	})
-}
-
-func TestEmptyTreeObjectIDRejectsUnsupportedGitHashFormat(t *testing.T) {
-	if _, err := emptyTreeObjectID("sha512"); err == nil {
-		t.Fatalf("expected unsupported git object format error")
-	}
 }
 
 func TestDetectLockfileDriftNoHeadDoesNotReturnGitError(t *testing.T) {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -807,8 +807,6 @@ func TestDetectLockfileDriftStopOnFirstFlushesGitBatchBeforeLaterWalkError(t *te
 	triggerManifest := filepath.Join(repo, "m-trigger", pyprojectManifestName)
 	writeFile(t, triggerManifest, "[tool.poetry]\nname = \"trigger\"\n")
 	writeFile(t, filepath.Join(repo, "m-trigger", poetryLockName), "# lock\n")
-	laterDir := filepath.Join(repo, "z-later")
-	writeFile(t, filepath.Join(laterDir, "README.md"), "removed after the earlier candidate is buffered\n")
 	initGitRepo(t, repo)
 	writeFile(t, earlyManifest, demoPackageJSONUpdated)
 
@@ -817,9 +815,14 @@ func TestDetectLockfileDriftStopOnFirstFlushesGitBatchBeforeLaterWalkError(t *te
 	readFileUnderFn = func(rootDir, targetPath string) ([]byte, error) {
 		if targetPath == triggerManifest {
 			triggeredLaterWalkError = true
-			if err := os.RemoveAll(laterDir); err != nil {
+			content, err := originalReadFileUnder(rootDir, targetPath)
+			if err != nil {
 				return nil, err
 			}
+			if err := os.RemoveAll(filepath.Dir(triggerManifest)); err != nil {
+				return nil, err
+			}
+			return content, nil
 		}
 		return originalReadFileUnder(rootDir, targetPath)
 	}
@@ -834,6 +837,49 @@ func TestDetectLockfileDriftStopOnFirstFlushesGitBatchBeforeLaterWalkError(t *te
 	}
 	if !triggeredLaterWalkError {
 		t.Fatal("expected the bounded candidate batch to encounter the later walk error before flushing")
+	}
+}
+
+func TestDetectLockfileDriftStopOnFirstFlushesFinalGitBatch(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+	initGitRepo(t, repo)
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, true)
+	if err != nil {
+		t.Fatalf("detect lockfile drift: %v", err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "package.json changed while no matching lockfile changed") {
+		t.Fatalf("expected final batch manifest drift warning, got %#v", warnings)
+	}
+}
+
+func TestDetectLockfileDriftStopOnFirstPropagatesFinalBatchEvaluationError(t *testing.T) {
+	repo := t.TempDir()
+	manifest := filepath.Join(repo, pyprojectManifestName)
+	writeFile(t, manifest, "[tool.poetry]\nname = \"demo\"\n")
+	writeFile(t, filepath.Join(repo, poetryLockName), "# lock\n")
+	initGitRepo(t, repo)
+
+	originalReadFileUnder := readFileUnderFn
+	forcedErr := errors.New("forced final batch evaluation failure")
+	manifestReads := 0
+	readFileUnderFn = func(rootDir, targetPath string) ([]byte, error) {
+		if targetPath == manifest {
+			manifestReads++
+			if manifestReads == 2 {
+				return nil, forcedErr
+			}
+		}
+		return originalReadFileUnder(rootDir, targetPath)
+	}
+	t.Cleanup(func() { readFileUnderFn = originalReadFileUnder })
+
+	_, err := detectLockfileDrift(context.Background(), repo, true)
+	if !errors.Is(err, forcedErr) {
+		t.Fatalf("expected final batch evaluation error, got %v", err)
 	}
 }
 
@@ -899,7 +945,11 @@ func TestGitHelperErrors(t *testing.T) {
 	if _, err := gitUntrackedFiles(context.Background(), repo); err == nil {
 		t.Fatalf("expected untracked files command to fail outside git repo")
 	}
-	if isGitWorktree(context.Background(), repo) {
+	isWorktree, err := isGitWorktree(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect non-git worktree: %v", err)
+	}
+	if isWorktree {
 		t.Fatalf("expected non-git temp dir to not be worktree")
 	}
 }
@@ -911,7 +961,11 @@ func TestGitHelperNilContextErrors(t *testing.T) {
 		t.Fatalf("expected untracked files command with nil context to fail outside git repo")
 	}
 	//nolint:staticcheck // Deliberate nil context validation coverage.
-	if isGitWorktree(nil, repo) {
+	isWorktree, err := isGitWorktree(nil, repo)
+	if err != nil {
+		t.Fatalf("detect non-git worktree with nil context: %v", err)
+	}
+	if isWorktree {
 		t.Fatalf("expected non-git temp dir to not be worktree with nil context")
 	}
 }
@@ -922,8 +976,8 @@ func TestGitHelpersWhenGitUnavailable(t *testing.T) {
 	defer func() { resolveGitBinaryPathFn = original }()
 
 	repo := t.TempDir()
-	if isGitWorktree(context.Background(), repo) {
-		t.Fatalf("expected git worktree=false when git is unavailable")
+	if _, err := isGitWorktree(context.Background(), repo); err == nil || !strings.Contains(err.Error(), gitExecutableNotFoundErr) {
+		t.Fatalf("expected worktree detection error for missing git executable, got %v", err)
 	}
 	if _, err := gitUntrackedFiles(context.Background(), repo); err == nil || !strings.Contains(err.Error(), gitExecutableNotFoundErr) {
 		t.Fatalf("expected untracked files error for missing git executable, got %v", err)
@@ -936,7 +990,11 @@ func TestGitHelpersFallbackExecutableBranch(t *testing.T) {
 	defer func() { resolveGitBinaryPathFn = original }()
 
 	repo := t.TempDir()
-	if isGitWorktree(context.Background(), repo) {
+	isWorktree, err := isGitWorktree(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect non-git worktree with fallback git: %v", err)
+	}
+	if isWorktree {
 		t.Fatalf("expected non-git temp dir to not be worktree when fallback git is used")
 	}
 	if _, err := gitUntrackedFiles(context.Background(), repo); err == nil {

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -566,6 +566,38 @@ func TestDetectLockfileDriftRejectsActiveCustomFiltersWithoutExecutingHelpers(t 
 	}
 }
 
+func TestDetectLockfileDriftAllowsFilteredUntrackedCandidates(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, ".gitattributes"), "*.json filter=pwn\n")
+	writeFile(t, filepath.Join(repo, "README.md"), "tracked\n")
+	initGitRepo(t, repo)
+
+	markerPath := filepath.Join(t.TempDir(), "untracked-filter.marker")
+	helperPath := helperPathInRepo(repo)
+	writeFile(t, helperPath, cleanFilterScript(markerPath))
+	if err := os.Chmod(helperPath, 0o700); err != nil {
+		t.Fatalf("chmod git helper: %v", err)
+	}
+	configureCleanFilter(t, repo, "pwn")
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+
+	warnings, err := detectLockfileDrift(context.Background(), repo, false)
+	if err != nil {
+		t.Fatalf(detectLockfileDriftFmt, err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected matching untracked manifest and lockfile to produce no drift warning, got %#v", warnings)
+	}
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected untracked candidate filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
+	}
+}
+
 func TestDetectLockfileDriftAllowsUnconfiguredStateNamedFilters(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -633,16 +633,28 @@ func newCaseSensitiveFilterRepo(t *testing.T, attributeDriver, configuredDriver 
 }
 
 func TestDetectLockfileDriftAllowsFilteredUntrackedCandidates(t *testing.T) {
+	runFilteredNonTrackedCandidateCase(t, "")
+}
+
+func TestDetectLockfileDriftIgnoresFilteredIgnoredCandidates(t *testing.T) {
+	runFilteredNonTrackedCandidateCase(t, "package*.json\n")
+}
+
+func runFilteredNonTrackedCandidateCase(t *testing.T, gitignore string) {
+	t.Helper()
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")
 	}
 
 	repo := t.TempDir()
+	if gitignore != "" {
+		writeFile(t, filepath.Join(repo, ".gitignore"), gitignore)
+	}
 	writeFile(t, filepath.Join(repo, ".gitattributes"), "*.json filter=pwn\n")
 	writeFile(t, filepath.Join(repo, "README.md"), "tracked\n")
 	initGitRepo(t, repo)
 
-	markerPath := filepath.Join(t.TempDir(), "untracked-filter.marker")
+	markerPath := filepath.Join(t.TempDir(), "non-tracked-filter.marker")
 	helperPath := helperPathInRepo(repo)
 	writeFile(t, helperPath, cleanFilterScript(markerPath))
 	if err := os.Chmod(helperPath, 0o700); err != nil {
@@ -657,43 +669,10 @@ func TestDetectLockfileDriftAllowsFilteredUntrackedCandidates(t *testing.T) {
 		t.Fatalf(detectLockfileDriftFmt, err)
 	}
 	if len(warnings) != 0 {
-		t.Fatalf("expected matching untracked manifest and lockfile to produce no drift warning, got %#v", warnings)
+		t.Fatalf("expected non-tracked manifest and lockfile to produce no drift warning, got %#v", warnings)
 	}
 	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected untracked candidate filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
-	}
-}
-
-func TestDetectLockfileDriftIgnoresFilteredIgnoredCandidates(t *testing.T) {
-	if _, err := gitexec.ResolveBinaryPath(); err != nil {
-		t.Skip("git binary not available")
-	}
-
-	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, ".gitignore"), "package*.json\n")
-	writeFile(t, filepath.Join(repo, ".gitattributes"), "package*.json filter=pwn\n")
-	writeFile(t, filepath.Join(repo, "README.md"), "tracked\n")
-	initGitRepo(t, repo)
-
-	markerPath := filepath.Join(t.TempDir(), "ignored-filter.marker")
-	helperPath := helperPathInRepo(repo)
-	writeFile(t, helperPath, cleanFilterScript(markerPath))
-	if err := os.Chmod(helperPath, 0o700); err != nil {
-		t.Fatalf("chmod git helper: %v", err)
-	}
-	configureCleanFilter(t, repo, "pwn")
-	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
-	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
-
-	warnings, err := detectLockfileDrift(context.Background(), repo, false)
-	if err != nil {
-		t.Fatalf(detectLockfileDriftFmt, err)
-	}
-	if len(warnings) != 0 {
-		t.Fatalf("expected ignored manifest and lockfile to produce no drift warning, got %#v", warnings)
-	}
-	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected ignored candidate filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
+		t.Fatalf("expected non-tracked candidate filter helper to remain unexecuted, markerPath=%q statErr=%v", markerPath, err)
 	}
 }
 

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -574,6 +574,84 @@ func TestDetectLockfileDriftIgnoresUnrelatedFilteredFilesOutsideCandidatePaths(t
 	}
 }
 
+func TestScopedGitPathHelpersTreatColonMagicCandidatePathsLiterally(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	const (
+		literalDir       = ":(glob)pkg"
+		ordinaryDir      = "pkg"
+		literalManifest  = literalDir + "/package.json"
+		literalLockfile  = literalDir + "/package-lock.json"
+		ordinaryManifest = ordinaryDir + "/package.json"
+		ordinaryLockfile = ordinaryDir + "/package-lock.json"
+	)
+
+	t.Run("tracked diff stays exact", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, literalManifest), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, literalLockfile), "{}\n")
+		writeFile(t, filepath.Join(repo, ordinaryManifest), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, ordinaryLockfile), "{}\n")
+		initGitRepo(t, repo)
+
+		writeFile(t, filepath.Join(repo, literalManifest), demoPackageJSONUpdated)
+
+		changed, err := gitChangedFilesForPaths(context.Background(), repo, []string{literalLockfile, literalManifest})
+		if err != nil {
+			t.Fatalf("gitChangedFilesForPaths: %v", err)
+		}
+		if len(changed) != 1 {
+			t.Fatalf("expected only the literal manifest change, got %#v", changed)
+		}
+		assertChangedPathsPresent(t, changed, literalManifest)
+		if _, ok := changed[ordinaryManifest]; ok {
+			t.Fatalf("expected sibling non-literal manifest to remain out of scope, got %#v", changed)
+		}
+
+		warnings, err := detectLockfileDrift(context.Background(), repo, false)
+		assertSingleLockfileDriftWarning(t, warnings, err, "npm in :(glob)pkg: package.json changed while no matching lockfile changed", "npm install")
+	})
+
+	t.Run("untracked listing stays exact", func(t *testing.T) {
+		repo := t.TempDir()
+		writeFile(t, filepath.Join(repo, "README.md"), "tracked\n")
+		initGitRepo(t, repo)
+
+		writeFile(t, filepath.Join(repo, literalManifest), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, literalLockfile), "{}\n")
+		writeFile(t, filepath.Join(repo, ordinaryManifest), demoPackageJSON)
+		writeFile(t, filepath.Join(repo, ordinaryLockfile), "{}\n")
+
+		untracked, err := gitUntrackedFilesForPaths(context.Background(), repo, []string{literalLockfile, literalManifest})
+		if err != nil {
+			t.Fatalf("gitUntrackedFilesForPaths: %v", err)
+		}
+		if len(untracked) != 2 {
+			t.Fatalf("expected exact literal untracked candidates, got %#v", untracked)
+		}
+		if untracked[0] != literalLockfile || untracked[1] != literalManifest {
+			t.Fatalf("expected literal untracked candidates, got %#v", untracked)
+		}
+
+		changed, err := gitChangedFilesForPaths(context.Background(), repo, []string{literalLockfile, literalManifest})
+		if err != nil {
+			t.Fatalf("gitChangedFilesForPaths: %v", err)
+		}
+		if len(changed) != 2 {
+			t.Fatalf("expected only literal untracked candidates, got %#v", changed)
+		}
+		assertChangedPathsPresent(t, changed, literalLockfile, literalManifest)
+		if _, ok := changed[ordinaryLockfile]; ok {
+			t.Fatalf("expected sibling non-literal lockfile to remain out of scope, got %#v", changed)
+		}
+		if _, ok := changed[ordinaryManifest]; ok {
+			t.Fatalf("expected sibling non-literal manifest to remain out of scope, got %#v", changed)
+		}
+	})
+}
+
 func TestDetectLockfileDriftPreservesTrackedCRLFNormalization(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, ".gitattributes"), "*.json text eol=crlf\n")

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -909,6 +909,31 @@ func TestDetectLockfileDriftStopOnFirstPrioritizesEarlierBatchFindingOverLaterFi
 	assertSingleLockfileDriftWarning(t, warnings, err, "npm in b-missing: package.json exists but no matching lockfile", "npm install")
 }
 
+func TestDetectLockfileDriftStopOnFirstPrioritizesBufferedGitFindingOverLaterImmediateFinding(t *testing.T) {
+	repo := t.TempDir()
+	earlyManifest := filepath.Join(repo, "a-drift", manifestFileName)
+	writeFile(t, earlyManifest, demoPackageJSON)
+	writeFile(t, filepath.Join(repo, "a-drift", lockfileName), "{}\n")
+	writeFile(t, filepath.Join(repo, "b-missing", manifestFileName), demoPackageJSON)
+	initGitRepo(t, repo)
+	writeFile(t, earlyManifest, demoPackageJSONUpdated)
+
+	warnings, err := evaluateLockfileDriftPolicy(context.Background(), repo, "fail")
+	if !errors.Is(err, ErrLockfileDrift) {
+		t.Errorf("expected ErrLockfileDrift, got warnings=%#v err=%v", warnings, err)
+	}
+	if len(warnings) != 1 {
+		t.Errorf("expected exactly one fail-fast warning, got %#v", warnings)
+	}
+	warningText := strings.Join(warnings, "\n")
+	if !strings.Contains(warningText, "npm in a-drift: package.json changed while no matching lockfile changed") {
+		t.Errorf("expected earlier buffered manifest-change warning, got %#v", warnings)
+	}
+	if strings.Contains(warningText, "b-missing") {
+		t.Errorf("expected no later missing-lockfile warning, got %#v", warnings)
+	}
+}
+
 func TestDetectLockfileDriftStopOnFirstFlushesGitBatchBeforeLaterWalkError(t *testing.T) {
 	repo := t.TempDir()
 	earlyManifest := filepath.Join(repo, "a-drift", manifestFileName)

--- a/internal/app/lockfile_drift_test.go
+++ b/internal/app/lockfile_drift_test.go
@@ -715,6 +715,50 @@ func TestDetectLockfileDriftIgnoresUnassignedFilterStateWithMatchingConfig(t *te
 	assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json changed while no matching lockfile changed", "npm install")
 }
 
+func TestDetectLockfileDriftIgnoresBooleanFilterStatesWithMatchingConfig(t *testing.T) {
+	if _, err := gitexec.ResolveBinaryPath(); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	cases := []struct {
+		name          string
+		attributes    string
+		configureRepo func(*testing.T, string)
+	}{
+		{
+			name:       "set state",
+			attributes: manifestFileName + " filter\n",
+			configureRepo: func(t *testing.T, repo string) {
+				t.Helper()
+				runGit(t, repo, "config", "filter.set.clean", "./unrelated-helper.sh")
+			},
+		},
+		{
+			name:       "unset state",
+			attributes: manifestFileName + " -filter\n",
+			configureRepo: func(t *testing.T, repo string) {
+				t.Helper()
+				runGit(t, repo, "config", "filter.unset.clean", "./unrelated-helper.sh")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+			writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+			writeFile(t, filepath.Join(repo, ".gitattributes"), tc.attributes)
+			initGitRepo(t, repo)
+			tc.configureRepo(t, repo)
+			writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSONUpdated)
+
+			warnings, err := detectLockfileDrift(context.Background(), repo, false)
+			assertSingleLockfileDriftWarning(t, warnings, err, "npm in .: package.json changed while no matching lockfile changed", "npm install")
+		})
+	}
+}
+
 func TestDetectLockfileDriftAllowsFiltersWithoutExecutableCommands(t *testing.T) {
 	if _, err := gitexec.ResolveBinaryPath(); err != nil {
 		t.Skip("git binary not available")

--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -28,11 +28,33 @@ var forcedGitConfigOverrides = []gitConfigOverride{
 }
 
 func SafeConfigArgs() []string {
-	args := make([]string, 0, len(forcedGitConfigOverrides)*2)
-	for _, override := range forcedGitConfigOverrides {
-		args = append(args, "-c", fmt.Sprintf("%s=%s", override.key, override.value))
+	return configArgs(forcedGitConfigOverrides)
+}
+
+func FilterDriverConfigArgs(drivers []string) []string {
+	if len(drivers) == 0 {
+		return nil
 	}
-	return args
+
+	overrides := make([]gitConfigOverride, 0, len(drivers)*3)
+	seen := make(map[string]struct{}, len(drivers))
+	for _, driver := range drivers {
+		driver = strings.TrimSpace(driver)
+		if driver == "" {
+			continue
+		}
+		if _, ok := seen[driver]; ok {
+			continue
+		}
+		seen[driver] = struct{}{}
+		cleanKey := fmt.Sprintf("filter.%s.clean", driver)
+		processKey := fmt.Sprintf("filter.%s.process", driver)
+		requiredKey := fmt.Sprintf("filter.%s.required", driver)
+		overrides = append(overrides, gitConfigOverride{key: cleanKey, value: ""})
+		overrides = append(overrides, gitConfigOverride{key: processKey, value: ""})
+		overrides = append(overrides, gitConfigOverride{key: requiredKey, value: "false"})
+	}
+	return configArgs(overrides)
 }
 
 func ResolveBinaryPath() (string, error) {
@@ -116,6 +138,14 @@ func safeGitConfigEnvEntries() []string {
 		entries = append(entries, fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", index, override.key), fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", index, override.value))
 	}
 	return entries
+}
+
+func configArgs(overrides []gitConfigOverride) []string {
+	args := make([]string, 0, len(overrides)*2)
+	for _, override := range overrides {
+		args = append(args, "-c", fmt.Sprintf("%s=%s", override.key, override.value))
+	}
+	return args
 }
 
 func ExecutableAvailable(path string) bool {

--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -27,6 +27,14 @@ var forcedGitConfigOverrides = []gitConfigOverride{
 	{key: "core.pager", value: "cat"},
 }
 
+func SafeConfigArgs() []string {
+	args := make([]string, 0, len(forcedGitConfigOverrides)*2)
+	for _, override := range forcedGitConfigOverrides {
+		args = append(args, "-c", fmt.Sprintf("%s=%s", override.key, override.value))
+	}
+	return args
+}
+
 func ResolveBinaryPath() (string, error) {
 	return resolveBinaryPath(ExecutablePrimary, ExecutableFallback, ExecutableAvailable)
 }

--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -31,32 +31,6 @@ func SafeConfigArgs() []string {
 	return configArgs(forcedGitConfigOverrides)
 }
 
-func FilterDriverConfigArgs(drivers []string) []string {
-	if len(drivers) == 0 {
-		return nil
-	}
-
-	overrides := make([]gitConfigOverride, 0, len(drivers)*3)
-	seen := make(map[string]struct{}, len(drivers))
-	for _, driver := range drivers {
-		driver = strings.TrimSpace(driver)
-		if driver == "" {
-			continue
-		}
-		if _, ok := seen[driver]; ok {
-			continue
-		}
-		seen[driver] = struct{}{}
-		cleanKey := fmt.Sprintf("filter.%s.clean", driver)
-		processKey := fmt.Sprintf("filter.%s.process", driver)
-		requiredKey := fmt.Sprintf("filter.%s.required", driver)
-		overrides = append(overrides, gitConfigOverride{key: cleanKey, value: ""})
-		overrides = append(overrides, gitConfigOverride{key: processKey, value: ""})
-		overrides = append(overrides, gitConfigOverride{key: requiredKey, value: "false"})
-	}
-	return configArgs(overrides)
-}
-
 func ResolveBinaryPath() (string, error) {
 	return resolveBinaryPath(ExecutablePrimary, ExecutableFallback, ExecutableAvailable)
 }
@@ -95,11 +69,18 @@ func CommandContext(ctx context.Context, path string, args ...string) (*exec.Cmd
 }
 
 func SanitizedEnv() []string {
-	return sanitizedEnvEntries(os.Environ())
+	return sanitizedEnvEntries(os.Environ(), nil)
 }
 
-func sanitizedEnvEntries(env []string) []string {
-	filtered := make([]string, 0, len(env)+3+1+len(forcedGitConfigOverrides)*2)
+func SanitizedEnvWithFilterDrivers(drivers []string) []string {
+	return sanitizedEnvEntries(os.Environ(), filterDriverConfigOverrides(drivers))
+}
+
+func sanitizedEnvEntries(env []string, extraOverrides []gitConfigOverride) []string {
+	configOverrides := make([]gitConfigOverride, 0, len(forcedGitConfigOverrides)+len(extraOverrides))
+	configOverrides = append(configOverrides, forcedGitConfigOverrides...)
+	configOverrides = append(configOverrides, extraOverrides...)
+	filtered := make([]string, 0, len(env)+3+1+len(configOverrides)*2)
 	for _, entry := range env {
 		key, _, hasKey := strings.Cut(entry, "=")
 		if !hasKey {
@@ -112,7 +93,7 @@ func sanitizedEnvEntries(env []string) []string {
 		filtered = append(filtered, entry)
 	}
 	filtered = append(filtered, SafeSystemPath, safeGitNoSystemConfig, safeGitGlobalConfig)
-	filtered = append(filtered, safeGitConfigEnvEntries()...)
+	filtered = append(filtered, gitConfigEnvEntries(configOverrides)...)
 	return filtered
 }
 
@@ -132,12 +113,7 @@ func shouldStripGitEnvKey(key string) bool {
 }
 
 func safeGitConfigEnvEntries() []string {
-	entries := make([]string, 0, 1+len(forcedGitConfigOverrides)*2)
-	entries = append(entries, fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(forcedGitConfigOverrides)))
-	for index, override := range forcedGitConfigOverrides {
-		entries = append(entries, fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", index, override.key), fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", index, override.value))
-	}
-	return entries
+	return gitConfigEnvEntries(forcedGitConfigOverrides)
 }
 
 func configArgs(overrides []gitConfigOverride) []string {
@@ -146,6 +122,38 @@ func configArgs(overrides []gitConfigOverride) []string {
 		args = append(args, "-c", fmt.Sprintf("%s=%s", override.key, override.value))
 	}
 	return args
+}
+
+func gitConfigEnvEntries(overrides []gitConfigOverride) []string {
+	entries := make([]string, 0, 1+len(overrides)*2)
+	entries = append(entries, fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(overrides)))
+	for index, override := range overrides {
+		entries = append(entries, fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", index, override.key), fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", index, override.value))
+	}
+	return entries
+}
+
+func filterDriverConfigOverrides(drivers []string) []gitConfigOverride {
+	if len(drivers) == 0 {
+		return nil
+	}
+
+	overrides := make([]gitConfigOverride, 0, len(drivers)*3)
+	seen := make(map[string]struct{}, len(drivers))
+	for _, driver := range drivers {
+		driver = strings.TrimSpace(driver)
+		if driver == "" {
+			continue
+		}
+		if _, ok := seen[driver]; ok {
+			continue
+		}
+		seen[driver] = struct{}{}
+		overrides = append(overrides, gitConfigOverride{key: fmt.Sprintf("filter.%s.clean", driver), value: ""})
+		overrides = append(overrides, gitConfigOverride{key: fmt.Sprintf("filter.%s.process", driver), value: ""})
+		overrides = append(overrides, gitConfigOverride{key: fmt.Sprintf("filter.%s.required", driver), value: "false"})
+	}
+	return overrides
 }
 
 func ExecutableAvailable(path string) bool {

--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -69,18 +69,11 @@ func CommandContext(ctx context.Context, path string, args ...string) (*exec.Cmd
 }
 
 func SanitizedEnv() []string {
-	return sanitizedEnvEntries(os.Environ(), nil)
+	return sanitizedEnvEntries(os.Environ())
 }
 
-func SanitizedEnvWithFilterDrivers(drivers []string) []string {
-	return sanitizedEnvEntries(os.Environ(), filterDriverConfigOverrides(drivers))
-}
-
-func sanitizedEnvEntries(env []string, extraOverrides []gitConfigOverride) []string {
-	configOverrides := make([]gitConfigOverride, 0, len(forcedGitConfigOverrides)+len(extraOverrides))
-	configOverrides = append(configOverrides, forcedGitConfigOverrides...)
-	configOverrides = append(configOverrides, extraOverrides...)
-	filtered := make([]string, 0, len(env)+3+1+len(configOverrides)*2)
+func sanitizedEnvEntries(env []string) []string {
+	filtered := make([]string, 0, len(env)+3+1+len(forcedGitConfigOverrides)*2)
 	for _, entry := range env {
 		key, _, hasKey := strings.Cut(entry, "=")
 		if !hasKey {
@@ -93,7 +86,7 @@ func sanitizedEnvEntries(env []string, extraOverrides []gitConfigOverride) []str
 		filtered = append(filtered, entry)
 	}
 	filtered = append(filtered, SafeSystemPath, safeGitNoSystemConfig, safeGitGlobalConfig)
-	filtered = append(filtered, gitConfigEnvEntries(configOverrides)...)
+	filtered = append(filtered, safeGitConfigEnvEntries()...)
 	return filtered
 }
 
@@ -131,29 +124,6 @@ func gitConfigEnvEntries(overrides []gitConfigOverride) []string {
 		entries = append(entries, fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", index, override.key), fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", index, override.value))
 	}
 	return entries
-}
-
-func filterDriverConfigOverrides(drivers []string) []gitConfigOverride {
-	if len(drivers) == 0 {
-		return nil
-	}
-
-	overrides := make([]gitConfigOverride, 0, len(drivers)*3)
-	seen := make(map[string]struct{}, len(drivers))
-	for _, driver := range drivers {
-		driver = strings.TrimSpace(driver)
-		if driver == "" {
-			continue
-		}
-		if _, ok := seen[driver]; ok {
-			continue
-		}
-		seen[driver] = struct{}{}
-		overrides = append(overrides, gitConfigOverride{key: fmt.Sprintf("filter.%s.clean", driver), value: ""})
-		overrides = append(overrides, gitConfigOverride{key: fmt.Sprintf("filter.%s.process", driver), value: ""})
-		overrides = append(overrides, gitConfigOverride{key: fmt.Sprintf("filter.%s.required", driver), value: "false"})
-	}
-	return overrides
 }
 
 func ExecutableAvailable(path string) bool {

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -22,57 +22,6 @@ func TestSafeConfigArgsForcesNonExecutableGitConfig(t *testing.T) {
 	}
 }
 
-func TestSanitizedEnvWithFilterDriversNeutralizesUniqueDrivers(t *testing.T) {
-	t.Setenv("KEEP_ME", "1")
-
-	env := SanitizedEnvWithFilterDrivers([]string{"foo.bar", "foo/bar", "foo=bar", "", "foo:bar"})
-	for _, expected := range []string{
-		"GIT_CONFIG_COUNT=17",
-		"GIT_CONFIG_KEY_5=filter.foo.bar.clean",
-		"GIT_CONFIG_VALUE_5=",
-		"GIT_CONFIG_KEY_6=filter.foo.bar.process",
-		"GIT_CONFIG_KEY_7=filter.foo.bar.required",
-		"GIT_CONFIG_VALUE_7=false",
-		"GIT_CONFIG_KEY_8=filter.foo/bar.clean",
-		"GIT_CONFIG_KEY_11=filter.foo=bar.clean",
-		"GIT_CONFIG_KEY_12=filter.foo=bar.process",
-		"GIT_CONFIG_KEY_13=filter.foo=bar.required",
-		"GIT_CONFIG_KEY_14=filter.foo:bar.clean",
-		"GIT_CONFIG_KEY_16=filter.foo:bar.required",
-	} {
-		if !containsEnv(env, expected) {
-			t.Fatalf("expected filter driver env override %q in %#v", expected, env)
-		}
-	}
-	if !containsEnv(env, keepMeEnvEntry) {
-		t.Fatalf("expected unrelated env vars to be preserved, got %#v", env)
-	}
-}
-
-func TestFilterDriverConfigOverridesSkipEmptyAndDuplicateDrivers(t *testing.T) {
-	if got := filterDriverConfigOverrides(nil); len(got) != 0 {
-		t.Fatalf("expected nil driver set to produce nil overrides, got %#v", got)
-	}
-
-	overrides := filterDriverConfigOverrides([]string{" pwn ", "", "pwn", "other"})
-	if got, want := len(overrides), 6; got != want {
-		t.Fatalf("expected %d filter overrides, got %#v", want, overrides)
-	}
-	wantKeys := []string{
-		"filter.pwn.clean",
-		"filter.pwn.process",
-		"filter.pwn.required",
-		"filter.other.clean",
-		"filter.other.process",
-		"filter.other.required",
-	}
-	for index, want := range wantKeys {
-		if overrides[index].key != want {
-			t.Fatalf("expected override key %q at index %d, got %#v", want, index, overrides)
-		}
-	}
-}
-
 func TestResolveBinaryPath(t *testing.T) {
 	path, err := ResolveBinaryPath()
 	if err != nil {
@@ -84,29 +33,25 @@ func TestResolveBinaryPath(t *testing.T) {
 }
 
 func TestResolveBinaryPathBranches(t *testing.T) {
-	t.Run("prefers primary", func(t *testing.T) {
-		path, err := resolveBinaryPath("primary", "fallback", func(path string) bool {
-			return path == "primary"
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{name: "prefers primary", want: "primary"},
+		{name: "falls back", want: "fallback"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path, err := resolveBinaryPath("primary", "fallback", func(path string) bool {
+				return path == tc.want
+			})
+			if err != nil {
+				t.Fatalf("resolve %s: %v", tc.want, err)
+			}
+			if path != tc.want {
+				t.Fatalf("expected %s path, got %q", tc.want, path)
+			}
 		})
-		if err != nil {
-			t.Fatalf("resolve primary: %v", err)
-		}
-		if path != "primary" {
-			t.Fatalf("expected primary path, got %q", path)
-		}
-	})
-
-	t.Run("falls back", func(t *testing.T) {
-		path, err := resolveBinaryPath("primary", "fallback", func(path string) bool {
-			return path == "fallback"
-		})
-		if err != nil {
-			t.Fatalf("resolve fallback: %v", err)
-		}
-		if path != "fallback" {
-			t.Fatalf("expected fallback path, got %q", path)
-		}
-	})
+	}
 
 	t.Run("returns error when unavailable", func(t *testing.T) {
 		if _, err := resolveBinaryPath("primary", "fallback", func(string) bool { return false }); err == nil {
@@ -170,7 +115,7 @@ func TestSanitizedEnvEntriesPreservesMalformedEntries(t *testing.T) {
 		"PATH=/tmp/custom-bin",
 		attackerGlobalConfigEnvEntry,
 	}
-	env := sanitizedEnvEntries(input, nil)
+	env := sanitizedEnvEntries(input)
 
 	if !containsEnv(env, "BROKEN") {
 		t.Fatalf("expected malformed env entry to be preserved, got %#v", env)

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -13,6 +13,15 @@ const versionArg = "--version"
 const attackerGlobalConfigEnvEntry = "GIT_CONFIG_GLOBAL=/tmp/attacker-global"
 const keepMeEnvEntry = "KEEP_ME=1"
 
+func TestSafeConfigArgsForcesNonExecutableGitConfig(t *testing.T) {
+	args := SafeConfigArgs()
+	for _, expected := range []string{"core.fsmonitor=false", "diff.external="} {
+		if !containsArgPair(args, "-c", expected) {
+			t.Fatalf("expected safe config arg %q in %#v", expected, args)
+		}
+	}
+}
+
 func TestResolveBinaryPath(t *testing.T) {
 	path, err := ResolveBinaryPath()
 	if err != nil {
@@ -195,4 +204,13 @@ func testKnownGitPaths(t *testing.T, build func(string) (*exec.Cmd, error)) {
 			}
 		})
 	}
+}
+
+func containsArgPair(args []string, key, value string) bool {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == key && args[index+1] == value {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -22,6 +22,28 @@ func TestSafeConfigArgsForcesNonExecutableGitConfig(t *testing.T) {
 	}
 }
 
+func TestFilterDriverConfigArgsNeutralizesUniqueDrivers(t *testing.T) {
+	args := FilterDriverConfigArgs([]string{"foo.bar", "foo/bar", "foo.bar", "", "foo:bar"})
+	for _, expected := range []string{
+		"filter.foo.bar.clean=",
+		"filter.foo.bar.process=",
+		"filter.foo.bar.required=false",
+		"filter.foo/bar.clean=",
+		"filter.foo/bar.process=",
+		"filter.foo/bar.required=false",
+		"filter.foo:bar.clean=",
+		"filter.foo:bar.process=",
+		"filter.foo:bar.required=false",
+	} {
+		if !containsArgPair(args, "-c", expected) {
+			t.Fatalf("expected filter driver override %q in %#v", expected, args)
+		}
+	}
+	if got, want := len(args), 18; got != want {
+		t.Fatalf("expected %d arg entries, got %d (%#v)", want, got, args)
+	}
+}
+
 func TestResolveBinaryPath(t *testing.T) {
 	path, err := ResolveBinaryPath()
 	if err != nil {

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -22,25 +22,54 @@ func TestSafeConfigArgsForcesNonExecutableGitConfig(t *testing.T) {
 	}
 }
 
-func TestFilterDriverConfigArgsNeutralizesUniqueDrivers(t *testing.T) {
-	args := FilterDriverConfigArgs([]string{"foo.bar", "foo/bar", "foo.bar", "", "foo:bar"})
+func TestSanitizedEnvWithFilterDriversNeutralizesUniqueDrivers(t *testing.T) {
+	t.Setenv("KEEP_ME", "1")
+
+	env := SanitizedEnvWithFilterDrivers([]string{"foo.bar", "foo/bar", "foo=bar", "", "foo:bar"})
 	for _, expected := range []string{
-		"filter.foo.bar.clean=",
-		"filter.foo.bar.process=",
-		"filter.foo.bar.required=false",
-		"filter.foo/bar.clean=",
-		"filter.foo/bar.process=",
-		"filter.foo/bar.required=false",
-		"filter.foo:bar.clean=",
-		"filter.foo:bar.process=",
-		"filter.foo:bar.required=false",
+		"GIT_CONFIG_COUNT=17",
+		"GIT_CONFIG_KEY_5=filter.foo.bar.clean",
+		"GIT_CONFIG_VALUE_5=",
+		"GIT_CONFIG_KEY_6=filter.foo.bar.process",
+		"GIT_CONFIG_KEY_7=filter.foo.bar.required",
+		"GIT_CONFIG_VALUE_7=false",
+		"GIT_CONFIG_KEY_8=filter.foo/bar.clean",
+		"GIT_CONFIG_KEY_11=filter.foo=bar.clean",
+		"GIT_CONFIG_KEY_12=filter.foo=bar.process",
+		"GIT_CONFIG_KEY_13=filter.foo=bar.required",
+		"GIT_CONFIG_KEY_14=filter.foo:bar.clean",
+		"GIT_CONFIG_KEY_16=filter.foo:bar.required",
 	} {
-		if !containsArgPair(args, "-c", expected) {
-			t.Fatalf("expected filter driver override %q in %#v", expected, args)
+		if !containsEnv(env, expected) {
+			t.Fatalf("expected filter driver env override %q in %#v", expected, env)
 		}
 	}
-	if got, want := len(args), 18; got != want {
-		t.Fatalf("expected %d arg entries, got %d (%#v)", want, got, args)
+	if !containsEnv(env, keepMeEnvEntry) {
+		t.Fatalf("expected unrelated env vars to be preserved, got %#v", env)
+	}
+}
+
+func TestFilterDriverConfigOverridesSkipEmptyAndDuplicateDrivers(t *testing.T) {
+	if got := filterDriverConfigOverrides(nil); len(got) != 0 {
+		t.Fatalf("expected nil driver set to produce nil overrides, got %#v", got)
+	}
+
+	overrides := filterDriverConfigOverrides([]string{" pwn ", "", "pwn", "other"})
+	if got, want := len(overrides), 6; got != want {
+		t.Fatalf("expected %d filter overrides, got %#v", want, overrides)
+	}
+	wantKeys := []string{
+		"filter.pwn.clean",
+		"filter.pwn.process",
+		"filter.pwn.required",
+		"filter.other.clean",
+		"filter.other.process",
+		"filter.other.required",
+	}
+	for index, want := range wantKeys {
+		if overrides[index].key != want {
+			t.Fatalf("expected override key %q at index %d, got %#v", want, index, overrides)
+		}
 	}
 }
 
@@ -135,12 +164,13 @@ func TestSanitizedEnv(t *testing.T) {
 }
 
 func TestSanitizedEnvEntriesPreservesMalformedEntries(t *testing.T) {
-	env := sanitizedEnvEntries([]string{
+	input := []string{
 		"BROKEN",
 		keepMeEnvEntry,
 		"PATH=/tmp/custom-bin",
 		attackerGlobalConfigEnvEntry,
-	})
+	}
+	env := sanitizedEnvEntries(input, nil)
 
 	if !containsEnv(env, "BROKEN") {
 		t.Fatalf("expected malformed env entry to be preserved, got %#v", env)


### PR DESCRIPTION
## Summary

Harden lockfile drift detection against repository-controlled Git hooks and filters without rejecting inert attribute declarations.

## Changes

- Sanitize lockfile-drift Git invocations so repository-controlled fsmonitor, diff, pager, and filter helpers cannot execute implicitly.
- Scope filter inspection to Git-visible tracked candidate paths, exclude ignored candidates before filter preflight, honor the final value of repeated `clean` and `process` configuration keys, and ignore boolean `set`, `unset`, and `unspecified` attribute states.
- Preserve explicit drivers named `set`, `unset`, or `unspecified` with a causal Git-only probe that never executes repository helpers and returns unrelated probe failures instead of misclassifying them as active filters.
- Transport candidate paths through bounded Git batches, fail closed when Git worktree detection errors, and replay ambiguous batches in filesystem and then rule order so neither a later same-directory filter hazard nor an immediate missing-lock finding can mask an earlier Git-dependent fail-fast finding.
- Parse scoped `git diff --name-only` results with NUL framing so tracked candidate paths containing newlines remain lossless and cannot silently evade drift detection.
- Cover configured, unconfigured, overridden, unassigned, boolean-state, and explicitly state-named filter drivers with real-Git regressions that verify helper commands never run unexpectedly.
- Isolate per-assignment filter classification, reuse the shared candidate-path dedupe helper, and reuse focused probe-test helpers so the security behavior remains explicit while satisfying the new-code complexity and duplication gates.

## Validation

Commands and checks run:

```bash
make ci
```

Additional validation:

- Focused lockfile-drift and Git execution tests cover configured, unconfigured, overridden, unassigned, boolean-state, untracked, and ignored filter declarations, causal probe failures, bounded and NUL-delimited path transport (including embedded newlines), batched fail mode, same-snapshot immediate and Git-dependent rule ordering, ambiguity replay, and walk-error ordering.
- `make ci` passed at the final head with `internal/app` coverage at 98.0%, total coverage at 98.3%, local new-code duplication at 1.07%, and the security, race, memory benchmark, build, and static-analysis gates green.
- The final PR head is required to pass hosted checks, Sonar analysis, and review-thread verification before handoff.

## Risk and compatibility

- Breaking changes: Configured executable Git filters on Git-visible tracked candidate lockfile paths are rejected during drift analysis; ignored candidates remain outside Git drift context.
- Migration required: Disable the filter for analyzed paths or remove its executable configuration.
- Performance impact: Candidate Git context is evaluated in bounded batches instead of unbounded argv expansion or per-directory subprocess fan-out.
- Memory benchmark impact: No intentional regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
