### PR TITLE
fix(dashboard): secure output writes

### DIFF
--- a/internal/app/analyse_pipeline.go
+++ b/internal/app/analyse_pipeline.go
@@ -27,7 +27,7 @@ func (a *App) executeAnalyse(ctx context.Context, req Request) (string, error) {
 	decorateAnalyseReport(&reportData, prepared)
 	reportData, err = a.runAnalysePostStages(ctx, req.RepoPath, req.Analyse, reportData)
 
-	return a.completeAnalyseExecution(ctx, req.Analyse, reportData, err)
+	return a.completeAnalyseExecution(ctx, req.RepoPath, req.Analyse, reportData, err)
 }
 
 func (a *App) invokeAnalyse(ctx context.Context, prepared preparedAnalyseExecution) (report.Report, error) {
@@ -83,7 +83,7 @@ func analyseValidationStage(validate func(report.Report) error) analyseReportSta
 	}
 }
 
-func (a *App) completeAnalyseExecution(ctx context.Context, req AnalyseRequest, reportData report.Report, runErr error) (string, error) {
+func (a *App) completeAnalyseExecution(ctx context.Context, repoPath string, req AnalyseRequest, reportData report.Report, runErr error) (string, error) {
 	a.appendNotificationWarnings(ctx, req.Notifications, &reportData, buildNotificationOutcome(reportData, runErr))
 	if err := validateAnalyseFeatures(req); err != nil {
 		if runErr != nil {
@@ -99,7 +99,7 @@ func (a *App) completeAnalyseExecution(ctx context.Context, req AnalyseRequest, 
 		return "", err
 	}
 
-	output, err := persistCommandOutput(formatted, req.OutputPath, "analyse report")
+	output, err := persistCommandOutput(formatted, req.OutputPath, "analyse report", repoPath)
 	if err != nil {
 		return "", err
 	}

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -122,6 +122,48 @@ func TestExecuteAnalyseOutputFile(t *testing.T) {
 	}
 }
 
+func TestExecuteAnalyseRejectsAbsoluteOutputUnderRequestedRepoSymlinkOutsideWorkingDirectory(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir outside nested: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(repo, "reports")); err != nil {
+		t.Fatalf("create repo reports symlink: %v", err)
+	}
+	cwd := t.TempDir()
+	chdirCanonicalWorkspace(t, cwd)
+
+	analyzer := &fakeAnalyzer{
+		report: report.Report{
+			RepoPath: repo,
+			Dependencies: []report.DependencyReport{
+				{Name: "lodash", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50},
+			},
+		},
+	}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+	outputPath := filepath.Join(repo, "reports", "nested", "analyse.json")
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.TopN = 1
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.OutputPath = outputPath
+
+	_, err := application.Execute(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
+		t.Fatalf("expected repo-root symlink rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "nested", "analyse.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside analyse output to remain absent, got err=%v", statErr)
+	}
+}
+
 func TestExecuteAnalyseForwardsRustRecommendationThreshold(t *testing.T) {
 	analyzer := &fakeAnalyzer{
 		report: report.Report{
@@ -409,7 +451,7 @@ func TestCompleteAnalyseExecutionPrefersRunErrorOverFeatureValidationError(t *te
 	runErr := errors.New("post-stage failed")
 	req := AnalyseRequest{Format: report.FormatCycloneDX}
 
-	_, err := application.completeAnalyseExecution(context.Background(), req, report.Report{}, runErr)
+	_, err := application.completeAnalyseExecution(context.Background(), "", req, report.Report{}, runErr)
 	if !errors.Is(err, runErr) {
 		t.Fatalf("expected run error to win, got %v", err)
 	}
@@ -419,7 +461,7 @@ func TestCompleteAnalyseExecutionReturnsFeatureValidationErrorWithoutRunError(t 
 	application := &App{Formatter: report.NewFormatter()}
 	req := AnalyseRequest{Format: report.FormatCycloneDX}
 
-	_, err := application.completeAnalyseExecution(context.Background(), req, report.Report{}, nil)
+	_, err := application.completeAnalyseExecution(context.Background(), "", req, report.Report{}, nil)
 	if err == nil || !strings.Contains(err.Error(), "requires --enable-feature") {
 		t.Fatalf("expected feature validation error, got %v", err)
 	}
@@ -430,7 +472,7 @@ func TestCompleteAnalyseExecutionPrefersRunErrorOverFormatError(t *testing.T) {
 	runErr := errors.New("post-stage failed")
 	req := AnalyseRequest{Format: report.Format("weird")}
 
-	_, err := application.completeAnalyseExecution(context.Background(), req, report.Report{}, runErr)
+	_, err := application.completeAnalyseExecution(context.Background(), "", req, report.Report{}, runErr)
 	if !errors.Is(err, runErr) {
 		t.Fatalf("expected run error to win, got %v", err)
 	}
@@ -440,7 +482,7 @@ func TestCompleteAnalyseExecutionReturnsFormatErrorWithoutRunError(t *testing.T)
 	application := &App{Formatter: report.NewFormatter()}
 	req := AnalyseRequest{Format: report.Format("weird")}
 
-	_, err := application.completeAnalyseExecution(context.Background(), req, report.Report{}, nil)
+	_, err := application.completeAnalyseExecution(context.Background(), "", req, report.Report{}, nil)
 	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "unknown format") {
 		t.Fatalf("expected format error, got %v", err)
 	}
@@ -458,7 +500,7 @@ func TestCompleteAnalyseExecutionReturnsPersistError(t *testing.T) {
 		OutputPath: filepath.Join(workspace, "reports", "analyse.json"),
 	}
 
-	_, err := application.completeAnalyseExecution(context.Background(), req, report.Report{}, nil)
+	_, err := application.completeAnalyseExecution(context.Background(), workspace, req, report.Report{}, nil)
 	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
 		t.Fatalf("expected persist error, got %v", err)
 	}

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -403,3 +403,63 @@ func TestExecuteAnalyseBootstrapBaselineStoreOnFirstSave(t *testing.T) {
 		t.Fatalf("expected initial baseline snapshot to be written: %v", err)
 	}
 }
+
+func TestCompleteAnalyseExecutionPrefersRunErrorOverFeatureValidationError(t *testing.T) {
+	application := &App{Formatter: report.NewFormatter()}
+	runErr := errors.New("post-stage failed")
+	req := AnalyseRequest{Format: report.FormatCycloneDX}
+
+	_, err := application.completeAnalyseExecution(context.Background(), req, report.Report{}, runErr)
+	if !errors.Is(err, runErr) {
+		t.Fatalf("expected run error to win, got %v", err)
+	}
+}
+
+func TestCompleteAnalyseExecutionReturnsFeatureValidationErrorWithoutRunError(t *testing.T) {
+	application := &App{Formatter: report.NewFormatter()}
+	req := AnalyseRequest{Format: report.FormatCycloneDX}
+
+	_, err := application.completeAnalyseExecution(context.Background(), req, report.Report{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "requires --enable-feature") {
+		t.Fatalf("expected feature validation error, got %v", err)
+	}
+}
+
+func TestCompleteAnalyseExecutionPrefersRunErrorOverFormatError(t *testing.T) {
+	application := &App{Formatter: report.NewFormatter()}
+	runErr := errors.New("post-stage failed")
+	req := AnalyseRequest{Format: report.Format("weird")}
+
+	_, err := application.completeAnalyseExecution(context.Background(), req, report.Report{}, runErr)
+	if !errors.Is(err, runErr) {
+		t.Fatalf("expected run error to win, got %v", err)
+	}
+}
+
+func TestCompleteAnalyseExecutionReturnsFormatErrorWithoutRunError(t *testing.T) {
+	application := &App{Formatter: report.NewFormatter()}
+	req := AnalyseRequest{Format: report.Format("weird")}
+
+	_, err := application.completeAnalyseExecution(context.Background(), req, report.Report{}, nil)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "unknown format") {
+		t.Fatalf("expected format error, got %v", err)
+	}
+}
+
+func TestCompleteAnalyseExecutionReturnsPersistError(t *testing.T) {
+	application := &App{Formatter: report.NewFormatter()}
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create reports symlink: %v", err)
+	}
+	req := AnalyseRequest{
+		Format:     report.FormatJSON,
+		OutputPath: filepath.Join(workspace, "reports", "analyse.json"),
+	}
+
+	_, err := application.completeAnalyseExecution(context.Background(), req, report.Report{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
+		t.Fatalf("expected persist error, got %v", err)
+	}
+}

--- a/internal/app/app_test_helpers_test.go
+++ b/internal/app/app_test_helpers_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -104,6 +106,37 @@ func assertForwardedAnalyseRequest(t *testing.T, got analysis.Request) {
 
 func testTime() time.Time {
 	return time.Date(2026, time.February, 22, 15, 0, 0, 0, time.UTC)
+}
+
+func chdirCanonicalWorkspace(t *testing.T, workspace string) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("chdir workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatalf("canonicalize workspace: %v", err)
+	}
+	return canonicalWorkspace
+}
+
+func writeBlockedFile(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
 }
 
 func mustEnabledPreviewFeatureSet(t *testing.T) featureflags.Set {

--- a/internal/app/coverage_thresholds_test.go
+++ b/internal/app/coverage_thresholds_test.go
@@ -98,7 +98,7 @@ func TestAnalyseFormatterKeepsOriginalErrorWhenFallbackFormattingFails(t *testin
 
 	application := &App{Formatter: report.NewFormatter()}
 	originalErr := errors.New("original failure")
-	formatted, err := application.completeAnalyseExecution(context.Background(), AnalyseRequest{Format: report.Format("bogus")}, report.Report{}, originalErr)
+	formatted, err := application.completeAnalyseExecution(context.Background(), "", AnalyseRequest{Format: report.Format("bogus")}, report.Report{}, originalErr)
 	if formatted != "" {
 		t.Fatalf("expected empty formatted output on formatter failure, got %q", formatted)
 	}
@@ -110,7 +110,7 @@ func TestAnalyseFormatterKeepsOriginalErrorWhenFallbackFormattingFails(t *testin
 func TestAnalyseFormatterReturnsFormatterErrorWithoutOriginalError(t *testing.T) {
 	application := &App{Formatter: report.NewFormatter()}
 
-	formatted, err := application.completeAnalyseExecution(context.Background(), AnalyseRequest{Format: report.Format("bogus")}, report.Report{}, nil)
+	formatted, err := application.completeAnalyseExecution(context.Background(), "", AnalyseRequest{Format: report.Format("bogus")}, report.Report{}, nil)
 	if formatted != "" {
 		t.Fatalf("expected empty formatted output on formatter failure, got %q", formatted)
 	}

--- a/internal/app/dashboard.go
+++ b/internal/app/dashboard.go
@@ -42,7 +42,7 @@ func (a *App) executeDashboard(ctx context.Context, req Request) (string, error)
 	if err != nil {
 		return "", err
 	}
-	return persistDashboardOutput(formatted, resolved.outputPath)
+	return persistDashboardOutput(formatted, resolved.outputPath, dashboardOutputTrustedRoots(executionPlan)...)
 }
 
 func (a *App) applyDashboardBaselineIfNeeded(reportData dashboard.Report, repoPath string, resolved resolvedDashboardRequest, includeRemediationQueue bool) (dashboard.Report, error) {
@@ -89,4 +89,21 @@ func resolveDashboardBaselinePaths(repoPath string, resolved resolvedDashboardRe
 func appendDashboardBaselineSaveWarning(reportData dashboard.Report, savedPath string) dashboard.Report {
 	reportData.SourceWarnings = append(reportData.SourceWarnings, "saved immutable dashboard baseline snapshot: "+savedPath)
 	return reportData
+}
+
+func dashboardOutputTrustedRoots(plan dashboardExecutionPlan) []string {
+	roots := make([]string, 0, len(plan.initialResults))
+	seen := make(map[string]struct{}, len(plan.initialResults))
+	for _, result := range plan.initialResults {
+		path := strings.TrimSpace(result.Input.Path)
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		roots = append(roots, path)
+	}
+	return roots
 }

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/safeio"
@@ -33,17 +34,14 @@ func persistCommandOutput(formatted, outputPath, label string) (string, error) {
 }
 
 func commandOutputRoot(outputPath string) (string, error) {
-	if filepath.IsAbs(outputPath) {
-		return absoluteCommandOutputRoot(outputPath)
-	}
-	workspaceRoot, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("resolve output workspace: %w", err)
-	}
-	return workspaceRoot, nil
+	return rootedCommandOutputRoot(outputPath)
 }
 
 func absoluteCommandOutputRoot(outputPath string) (string, error) {
+	return rootedCommandOutputRoot(outputPath)
+}
+
+func rootedCommandOutputRoot(outputPath string) (string, error) {
 	outputAbs, err := filepath.Abs(outputPath)
 	if err != nil {
 		return "", fmt.Errorf("resolve output path: %w", err)
@@ -78,6 +76,12 @@ func resolveExistingOutputRoot(outputAbs, outputPath string) (string, error) {
 }
 
 func inspectOutputRootPath(current, outputPath string) (string, bool, error) {
+	if isKnownSystemAliasRoot(current) {
+		if _, err := os.Stat(current); err == nil {
+			return current, true, nil
+		}
+	}
+
 	info, err := os.Lstat(current)
 	switch {
 	case err == nil:
@@ -151,11 +155,35 @@ func resolveAliasedWorkspaceRoot(outputAbs, workspaceRoot string) (string, error
 }
 
 func pathWithinRoot(rootAbs, targetAbs string) (bool, error) {
+	if pathsUseDifferentWindowsVolumes(rootAbs, targetAbs) {
+		return false, nil
+	}
 	rel, err := filepath.Rel(rootAbs, targetAbs)
 	if err != nil {
 		return false, fmt.Errorf("compute output path: %w", err)
 	}
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))), nil
+}
+
+func isKnownSystemAliasRoot(path string) bool {
+	return runtime.GOOS == "darwin" && (path == "/tmp" || path == "/var")
+}
+
+func pathsUseDifferentWindowsVolumes(rootAbs, targetAbs string) bool {
+	rootVolume := pathVolumeName(rootAbs)
+	targetVolume := pathVolumeName(targetAbs)
+	return rootVolume != "" && targetVolume != "" && rootVolume != targetVolume
+}
+
+func pathVolumeName(path string) string {
+	volume := filepath.VolumeName(path)
+	if volume == "" && len(path) >= 2 && path[1] == ':' {
+		drive := path[0]
+		if ('a' <= drive && drive <= 'z') || ('A' <= drive && drive <= 'Z') {
+			volume = path[:2]
+		}
+	}
+	return strings.ToLower(volume)
 }
 
 func ensureCommandOutputParent(rootDir, outputPath string) error {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -109,9 +109,45 @@ func trustedCommandOutputRoot(outputAbs string) (string, error) {
 		return "", err
 	}
 	if !withinWorkspace {
-		return "", nil
+		resolvedWorkspaceRoot, err := filepath.EvalSymlinks(workspaceRoot)
+		if err != nil {
+			return "", fmt.Errorf("resolve output workspace symlinks: %w", err)
+		}
+		aliasedWorkspaceRoot, err := resolveAliasedWorkspaceRoot(outputAbs, resolvedWorkspaceRoot)
+		if err != nil {
+			return "", err
+		}
+		if aliasedWorkspaceRoot == "" {
+			return "", nil
+		}
+		return aliasedWorkspaceRoot, nil
 	}
 	return workspaceRoot, nil
+}
+
+func resolveAliasedWorkspaceRoot(outputAbs, workspaceRoot string) (string, error) {
+	current := filepath.Dir(filepath.Clean(outputAbs))
+	for {
+		_, err := os.Lstat(current)
+		switch {
+		case err == nil:
+			resolvedCurrent, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", err
+			}
+			if resolvedCurrent == workspaceRoot {
+				return current, nil
+			}
+		case !os.IsNotExist(err):
+			return "", err
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", nil
+		}
+		current = parent
+	}
 }
 
 func pathWithinRoot(rootAbs, targetAbs string) (bool, error) {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/safeio"
@@ -37,6 +36,9 @@ func persistCommandOutput(formatted, outputPath, label string, trustedRoots ...s
 }
 
 func commandOutputRoot(outputPath string, trustedRoots ...string) (string, error) {
+	if err := rejectAmbiguousParentTraversal(outputPath); err != nil {
+		return "", err
+	}
 	outputAbs, err := filepath.Abs(outputPath)
 	if err != nil {
 		return "", fmt.Errorf("resolve output path: %w", err)
@@ -102,10 +104,8 @@ func resolveExistingOutputRoot(outputAbs, outputPath string) (string, error) {
 }
 
 func inspectOutputRootPath(current, outputPath string) (string, bool, error) {
-	if isKnownSystemAliasRoot(current) {
-		if _, err := os.Stat(current); err == nil {
-			return current, true, nil
-		}
+	if isRootLevelSystemAlias(current) {
+		return current, true, nil
 	}
 
 	info, err := os.Lstat(current)
@@ -148,10 +148,8 @@ func rejectLexicalOutputRootSymlinks(existingRoot string) error {
 }
 
 func rejectLexicalOutputRootPath(path string) error {
-	if isKnownSystemAliasRoot(path) {
-		if _, err := os.Stat(path); err == nil {
-			return nil
-		}
+	if isRootLevelSystemAlias(path) {
+		return nil
 	}
 
 	info, err := os.Lstat(path)
@@ -234,12 +232,18 @@ func trustedCommandOutputRootForRoot(outputAbs, root string) (string, error) {
 }
 
 func validateTrustedCommandOutputRoot(rootAbs string) error {
-	info, err := os.Stat(rootAbs)
+	info, err := os.Lstat(rootAbs)
 	if err != nil {
 		return fmt.Errorf("resolve trusted output workspace: %w", err)
 	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("trusted output workspace is a symlink: %s", rootAbs)
+	}
 	if !info.IsDir() {
 		return fmt.Errorf("trusted output workspace is not a directory: %s", rootAbs)
+	}
+	if err := rejectLexicalOutputRootSymlinks(rootAbs); err != nil {
+		return fmt.Errorf("validate trusted output workspace: %w", err)
 	}
 	return nil
 }
@@ -285,8 +289,21 @@ func pathWithinRoot(rootAbs, targetAbs string) (bool, error) {
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))), nil
 }
 
-func isKnownSystemAliasRoot(path string) bool {
-	return runtime.GOOS == "darwin" && (path == "/tmp" || path == "/var")
+func isRootLevelSystemAlias(path string) bool {
+	cleanPath := filepath.Clean(path)
+	if !filepath.IsAbs(cleanPath) {
+		return false
+	}
+	parent := filepath.Dir(cleanPath)
+	if parent == cleanPath || filepath.Dir(parent) != parent {
+		return false
+	}
+	linkInfo, err := os.Lstat(cleanPath)
+	if err != nil || linkInfo.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	targetInfo, err := os.Stat(cleanPath)
+	return err == nil && targetInfo.IsDir()
 }
 
 func pathsUseDifferentWindowsVolumes(rootAbs, targetAbs string) bool {
@@ -323,6 +340,28 @@ func hasDirectoryStyleOutputPath(path string) bool {
 	}
 	base := path[last:]
 	return base == "." || base == ".."
+}
+
+func rejectAmbiguousParentTraversal(path string) error {
+	seenPathComponent := false
+	componentStart := 0
+	for i := 0; i <= len(path); i++ {
+		if i < len(path) && !os.IsPathSeparator(path[i]) {
+			continue
+		}
+		component := path[componentStart:i]
+		componentStart = i + 1
+		switch component {
+		case "", ".":
+		case "..":
+			if seenPathComponent {
+				return fmt.Errorf("output path contains parent traversal after path component: %s", path)
+			}
+		default:
+			seenPathComponent = true
+		}
+	}
+	return nil
 }
 
 func ensureCommandOutputParent(rootDir, outputPath string) error {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -89,8 +89,14 @@ func resolveExistingOutputRoot(outputAbs, outputPath string) (string, error) {
 	current := filepath.Dir(outputAbs)
 	for {
 		next, done, err := inspectOutputRootPath(current, outputPath)
-		if done || err != nil {
-			return next, err
+		if err != nil {
+			return "", err
+		}
+		if done {
+			if err := rejectLexicalOutputRootSymlinks(next); err != nil {
+				return "", err
+			}
+			return next, nil
 		}
 		current = next
 	}
@@ -122,6 +128,41 @@ func inspectOutputRootPath(current, outputPath string) (string, bool, error) {
 		return "", true, fmt.Errorf("resolve output root for %s: no existing parent directory", outputPath)
 	}
 	return parent, false, nil
+}
+
+func rejectLexicalOutputRootSymlinks(existingRoot string) error {
+	ancestors := []string{filepath.Clean(existingRoot)}
+	for {
+		parent := filepath.Dir(ancestors[len(ancestors)-1])
+		if parent == ancestors[len(ancestors)-1] {
+			break
+		}
+		ancestors = append(ancestors, parent)
+	}
+
+	for i := len(ancestors) - 1; i >= 0; i-- {
+		if err := rejectLexicalOutputRootPath(ancestors[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectLexicalOutputRootPath(path string) error {
+	if isKnownSystemAliasRoot(path) {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		}
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("output root contains symlink: %s", path)
+	}
+	return nil
 }
 
 func trustedCommandOutputRoot(outputAbs string) (string, error) {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -217,17 +217,20 @@ func trustedCommandOutputRootForRoot(outputAbs, root string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	resolvedRoot, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		if withinWorkspace {
+			return "", fmt.Errorf("resolve trusted output workspace: %w", err)
+		}
+		return "", nil
+	}
 	if withinWorkspace {
-		if err := validateTrustedCommandOutputRoot(rootAbs); err != nil {
+		if err := validateTrustedCommandOutputRoot(resolvedRoot); err != nil {
 			return "", err
 		}
 		return rootAbs, nil
 	}
 
-	resolvedRoot, err := filepath.EvalSymlinks(rootAbs)
-	if err != nil {
-		return "", nil
-	}
 	return resolveAliasedWorkspaceRoot(outputAbs, resolvedRoot)
 }
 

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -37,14 +37,6 @@ func persistCommandOutput(formatted, outputPath, label string, trustedRoots ...s
 }
 
 func commandOutputRoot(outputPath string, trustedRoots ...string) (string, error) {
-	return rootedCommandOutputRoot(outputPath, trustedRoots...)
-}
-
-func absoluteCommandOutputRoot(outputPath string) (string, error) {
-	return rootedCommandOutputRoot(outputPath)
-}
-
-func rootedCommandOutputRoot(outputPath string, trustedRoots ...string) (string, error) {
 	outputAbs, err := filepath.Abs(outputPath)
 	if err != nil {
 		return "", fmt.Errorf("resolve output path: %w", err)

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,10 +31,42 @@ func persistCommandOutput(formatted, outputPath, label string, trustedRoots ...s
 	if err := ensureCommandOutputParent(outputRoot, trimmedOutputPath); err != nil {
 		return "", err
 	}
+	if err := ensureExistingCommandOutputWritable(outputRoot, trimmedOutputPath); err != nil {
+		return "", err
+	}
 	if err := safeio.WriteFileUnder(outputRoot, trimmedOutputPath, []byte(formatted), 0o600); err != nil {
 		return "", err
 	}
 	return label + " written to " + trimmedOutputPath, nil
+}
+
+func ensureExistingCommandOutputWritable(rootDir, outputPath string) (returnErr error) {
+	outputAbs, err := filepath.Abs(outputPath)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(rootDir, outputAbs)
+	if err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, root.Close())
+	}()
+
+	info, err := root.Lstat(rel)
+	if err != nil || !info.Mode().IsRegular() {
+		return nil
+	}
+
+	file, err := root.OpenFile(rel, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	return file.Close()
 }
 
 func commandOutputRoot(outputPath string, trustedRoots ...string) (string, error) {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -53,34 +53,50 @@ func absoluteCommandOutputRoot(outputPath string) (string, error) {
 		return "", err
 	}
 
+	existingRoot, err := resolveExistingOutputRoot(outputAbs, outputPath)
+	if err != nil {
+		return "", err
+	}
+	if workspaceRoot == "" {
+		return existingRoot, nil
+	}
+	if err := rejectSymlinkedOutputRoot(workspaceRoot, filepath.Dir(outputAbs)); err != nil {
+		return "", err
+	}
+	return workspaceRoot, nil
+}
+
+func resolveExistingOutputRoot(outputAbs, outputPath string) (string, error) {
 	current := filepath.Dir(outputAbs)
 	for {
-		info, err := os.Lstat(current)
-		if err == nil {
-			if info.Mode()&os.ModeSymlink != 0 {
-				return "", fmt.Errorf("output root contains symlink: %s", current)
-			}
-			if !info.IsDir() {
-				return "", fmt.Errorf("output root is not a directory: %s", current)
-			}
-			if workspaceRoot != "" {
-				if err := rejectSymlinkedOutputRoot(workspaceRoot, filepath.Dir(outputAbs)); err != nil {
-					return "", err
-				}
-				return workspaceRoot, nil
-			}
-			return current, nil
+		next, done, err := inspectOutputRootPath(current, outputPath)
+		if done || err != nil {
+			return next, err
 		}
-		if !os.IsNotExist(err) {
-			return "", err
-		}
-
-		parent := filepath.Dir(current)
-		if parent == current {
-			return "", fmt.Errorf("resolve output root for %s: no existing parent directory", outputPath)
-		}
-		current = parent
+		current = next
 	}
+}
+
+func inspectOutputRootPath(current, outputPath string) (string, bool, error) {
+	info, err := os.Lstat(current)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", true, fmt.Errorf("output root contains symlink: %s", current)
+		}
+		if !info.IsDir() {
+			return "", true, fmt.Errorf("output root is not a directory: %s", current)
+		}
+		return current, true, nil
+	case !os.IsNotExist(err):
+		return "", true, err
+	}
+
+	parent := filepath.Dir(current)
+	if parent == current {
+		return "", true, fmt.Errorf("resolve output root for %s: no existing parent directory", outputPath)
+	}
+	return parent, false, nil
 }
 
 func trustedCommandOutputRoot(outputAbs string) (string, error) {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,20 +11,27 @@ import (
 )
 
 var (
-	mkdirAllCommandOutputParentFn = os.MkdirAll
-	writeCommandOutputFileFn      = func(rootDir, outputPath string, data []byte, perm, _ os.FileMode) error {
-		if err := ensureCommandOutputParent(rootDir, outputPath); err != nil {
-			return err
-		}
-		return safeio.WriteFileUnder(rootDir, outputPath, data, perm)
+	openCommandOutputWriteRootFn = safeio.OpenWriteRoot
+	writeCommandOutputFileFn     = func(root *safeio.WriteRoot, targetPath string, data []byte, perm, parentPerm os.FileMode) error {
+		return root.WriteFileCreatingParents(targetPath, data, perm, parentPerm)
 	}
 )
+
+type commandOutputRootBoundary struct {
+	path     string
+	resolved string
+}
+
+type commandOutputDestination struct {
+	root       *safeio.WriteRoot
+	targetPath string
+}
 
 func persistDashboardOutput(formatted, outputPath string, trustedRoots ...string) (string, error) {
 	return persistCommandOutput(formatted, outputPath, "dashboard report", trustedRoots...)
 }
 
-func persistCommandOutput(formatted, outputPath, label string, trustedRoots ...string) (string, error) {
+func persistCommandOutput(formatted, outputPath, label string, trustedRoots ...string) (result string, returnErr error) {
 	trimmedOutputPath := strings.TrimSpace(outputPath)
 	if trimmedOutputPath == "" || trimmedOutputPath == "-" {
 		return formatted, nil
@@ -32,79 +40,118 @@ func persistCommandOutput(formatted, outputPath, label string, trustedRoots ...s
 		return "", fmt.Errorf("output path must name a file: %s", trimmedOutputPath)
 	}
 
-	outputRoot, err := commandOutputRoot(trimmedOutputPath, trustedRoots...)
+	destination, err := openCommandOutputDestination(trimmedOutputPath, trustedRoots...)
 	if err != nil {
 		return "", err
 	}
-	if err := writeCommandOutputFileFn(outputRoot, trimmedOutputPath, []byte(formatted), 0o600, 0o750); err != nil {
+	defer func() {
+		if closeErr := destination.root.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+	if err := writeCommandOutputFileFn(destination.root, destination.targetPath, []byte(formatted), 0o600, 0o750); err != nil {
 		return "", err
 	}
 	return label + " written to " + trimmedOutputPath, nil
 }
 
 func commandOutputRoot(outputPath string, trustedRoots ...string) (string, error) {
+	root, _, err := commandOutputRootBoundaryForPath(outputPath, trustedRoots...)
+	return root.path, err
+}
+
+func openCommandOutputDestination(outputPath string, trustedRoots ...string) (commandOutputDestination, error) {
+	root, outputAbs, err := commandOutputRootBoundaryForPath(outputPath, trustedRoots...)
+	if err != nil {
+		return commandOutputDestination{}, err
+	}
+	targetPath, err := filepath.Rel(root.path, outputAbs)
+	if err != nil {
+		return commandOutputDestination{}, fmt.Errorf("compute output path: %w", err)
+	}
+	if targetPath == ".." || strings.HasPrefix(targetPath, ".."+string(os.PathSeparator)) {
+		return commandOutputDestination{}, fmt.Errorf("output path escapes workspace: %s", outputPath)
+	}
+	writeRoot, err := openCommandOutputWriteRootFn(root.resolved)
+	if err != nil {
+		return commandOutputDestination{}, err
+	}
+	return commandOutputDestination{root: writeRoot, targetPath: targetPath}, nil
+}
+
+func commandOutputRootBoundaryForPath(outputPath string, trustedRoots ...string) (commandOutputRootBoundary, string, error) {
 	if err := rejectAmbiguousParentTraversal(outputPath); err != nil {
-		return "", err
+		return commandOutputRootBoundary{}, "", err
 	}
 	outputAbs, err := filepath.Abs(outputPath)
 	if err != nil {
-		return "", fmt.Errorf("resolve output path: %w", err)
+		return commandOutputRootBoundary{}, "", fmt.Errorf("resolve output path: %w", err)
 	}
 
-	trustedRoot, err := resolvedCommandOutputRoot(outputAbs, func() (string, error) {
-		return trustedCommandOutputRootForRoots(outputAbs, trustedRoots...)
+	trustedRoot, err := resolvedCommandOutputRoot(outputAbs, func() (commandOutputRootBoundary, error) {
+		return trustedCommandOutputRootBoundaryForRoots(outputAbs, trustedRoots...)
 	})
-	if trustedRoot != "" || err != nil {
-		return trustedRoot, err
+	if trustedRoot.path != "" || err != nil {
+		return trustedRoot, outputAbs, err
 	}
 
-	workspaceRoot, workspaceErr := resolvedCommandOutputRoot(outputAbs, func() (string, error) {
-		return trustedCommandOutputRoot(outputAbs)
+	workspaceRoot, workspaceErr := resolvedCommandOutputRoot(outputAbs, func() (commandOutputRootBoundary, error) {
+		return trustedCommandOutputRootBoundary(outputAbs)
 	})
-	if workspaceRoot != "" {
-		return workspaceRoot, nil
+	if workspaceRoot.path != "" {
+		return workspaceRoot, outputAbs, nil
 	}
 
-	return fallbackCommandOutputRoot(outputAbs, outputPath, workspaceErr)
+	fallbackRoot, err := fallbackCommandOutputRootBoundary(outputAbs, outputPath, workspaceErr)
+	return fallbackRoot, outputAbs, err
 }
 
-func resolvedCommandOutputRoot(outputAbs string, resolve func() (string, error)) (string, error) {
+func resolvedCommandOutputRoot(outputAbs string, resolve func() (commandOutputRootBoundary, error)) (commandOutputRootBoundary, error) {
 	root, err := resolve()
-	if err != nil || root == "" {
+	if err != nil || root.path == "" {
 		return root, err
 	}
-	if err := rejectSymlinkedOutputRoot(root, filepath.Dir(outputAbs)); err != nil {
-		return "", err
+	if err := rejectSymlinkedOutputRoot(root.path, filepath.Dir(outputAbs)); err != nil {
+		return commandOutputRootBoundary{}, err
 	}
 	return root, nil
 }
 
 func fallbackCommandOutputRoot(outputAbs, outputPath string, workspaceErr error) (string, error) {
+	root, err := fallbackCommandOutputRootBoundary(outputAbs, outputPath, workspaceErr)
+	return root.path, err
+}
+
+func fallbackCommandOutputRootBoundary(outputAbs, outputPath string, workspaceErr error) (commandOutputRootBoundary, error) {
 	existingRoot, err := resolveExistingOutputRoot(outputAbs, outputPath)
 	if err != nil {
-		return "", err
+		return commandOutputRootBoundary{}, err
 	}
 	if workspaceErr != nil && filepath.IsAbs(outputPath) {
 		return existingRoot, nil
 	}
 	if workspaceErr != nil {
-		return "", workspaceErr
+		return commandOutputRootBoundary{}, workspaceErr
 	}
 	return existingRoot, nil
 }
 
-func resolveExistingOutputRoot(outputAbs, outputPath string) (string, error) {
+func resolveExistingOutputRoot(outputAbs, outputPath string) (commandOutputRootBoundary, error) {
 	current := filepath.Dir(outputAbs)
 	for {
 		next, done, err := inspectOutputRootPath(current, outputPath)
 		if err != nil {
-			return "", err
+			return commandOutputRootBoundary{}, err
 		}
 		if done {
-			if err := rejectLexicalOutputRootSymlinks(next); err != nil {
-				return "", err
+			resolved, err := filepath.EvalSymlinks(next)
+			if err != nil {
+				return commandOutputRootBoundary{}, err
 			}
-			return next, nil
+			if err := rejectLexicalOutputRootSymlinks(next); err != nil {
+				return commandOutputRootBoundary{}, err
+			}
+			return commandOutputRootBoundary{path: next, resolved: resolved}, nil
 		}
 		current = next
 	}
@@ -170,75 +217,83 @@ func rejectLexicalOutputRootPath(path string) error {
 }
 
 func trustedCommandOutputRoot(outputAbs string) (string, error) {
+	root, err := trustedCommandOutputRootBoundary(outputAbs)
+	return root.path, err
+}
+
+func trustedCommandOutputRootBoundary(outputAbs string) (commandOutputRootBoundary, error) {
 	workspaceRoot, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("resolve output workspace: %w", err)
+		return commandOutputRootBoundary{}, fmt.Errorf("resolve output workspace: %w", err)
 	}
 	withinWorkspace, err := pathWithinRoot(workspaceRoot, outputAbs)
 	if err != nil {
-		return "", err
+		return commandOutputRootBoundary{}, err
 	}
-	if !withinWorkspace {
-		resolvedWorkspaceRoot, err := filepath.EvalSymlinks(workspaceRoot)
-		if err != nil {
-			return "", fmt.Errorf("resolve output workspace symlinks: %w", err)
-		}
-		aliasedWorkspaceRoot, err := resolveAliasedWorkspaceRoot(outputAbs, resolvedWorkspaceRoot)
-		if err != nil {
-			return "", err
-		}
-		if aliasedWorkspaceRoot == "" {
-			return "", nil
-		}
-		return aliasedWorkspaceRoot, nil
+	resolvedWorkspaceRoot, err := filepath.EvalSymlinks(workspaceRoot)
+	if err != nil {
+		return commandOutputRootBoundary{}, fmt.Errorf("resolve output workspace symlinks: %w", err)
 	}
-	return workspaceRoot, nil
+	if withinWorkspace {
+		return commandOutputRootBoundary{path: workspaceRoot, resolved: resolvedWorkspaceRoot}, nil
+	}
+	return resolveAliasedWorkspaceRootBoundary(outputAbs, resolvedWorkspaceRoot)
 }
 
 func trustedCommandOutputRootForRoots(outputAbs string, roots ...string) (string, error) {
+	root, err := trustedCommandOutputRootBoundaryForRoots(outputAbs, roots...)
+	return root.path, err
+}
+
+func trustedCommandOutputRootBoundaryForRoots(outputAbs string, roots ...string) (commandOutputRootBoundary, error) {
 	for _, root := range roots {
-		trustedRoot, err := trustedCommandOutputRootForRoot(outputAbs, root)
+		trustedRoot, err := trustedCommandOutputRootBoundaryForRoot(outputAbs, root)
 		if err != nil {
-			return "", err
+			return commandOutputRootBoundary{}, err
 		}
-		if trustedRoot != "" {
+		if trustedRoot.path != "" {
 			return trustedRoot, nil
 		}
 	}
-	return "", nil
+	return commandOutputRootBoundary{}, nil
 }
 
 func trustedCommandOutputRootForRoot(outputAbs, root string) (string, error) {
+	trustedRoot, err := trustedCommandOutputRootBoundaryForRoot(outputAbs, root)
+	return trustedRoot.path, err
+}
+
+func trustedCommandOutputRootBoundaryForRoot(outputAbs, root string) (commandOutputRootBoundary, error) {
 	trimmedRoot := strings.TrimSpace(root)
 	if trimmedRoot == "" {
-		return "", nil
+		return commandOutputRootBoundary{}, nil
 	}
 	rootAbs, err := filepath.Abs(trimmedRoot)
 	if err != nil {
 		if filepath.IsAbs(outputAbs) && !filepath.IsAbs(trimmedRoot) {
-			return "", nil
+			return commandOutputRootBoundary{}, nil
 		}
-		return "", fmt.Errorf("resolve trusted output workspace: %w", err)
+		return commandOutputRootBoundary{}, fmt.Errorf("resolve trusted output workspace: %w", err)
 	}
 	withinWorkspace, err := pathWithinRoot(rootAbs, outputAbs)
 	if err != nil {
-		return "", err
+		return commandOutputRootBoundary{}, err
 	}
 	resolvedRoot, err := filepath.EvalSymlinks(rootAbs)
 	if err != nil {
 		if withinWorkspace {
-			return "", fmt.Errorf("resolve trusted output workspace: %w", err)
+			return commandOutputRootBoundary{}, fmt.Errorf("resolve trusted output workspace: %w", err)
 		}
-		return "", nil
+		return commandOutputRootBoundary{}, nil
 	}
 	if withinWorkspace {
 		if err := validateTrustedCommandOutputRoot(resolvedRoot); err != nil {
-			return "", err
+			return commandOutputRootBoundary{}, err
 		}
-		return rootAbs, nil
+		return commandOutputRootBoundary{path: rootAbs, resolved: resolvedRoot}, nil
 	}
 
-	return resolveAliasedWorkspaceRoot(outputAbs, resolvedRoot)
+	return resolveAliasedWorkspaceRootBoundary(outputAbs, resolvedRoot)
 }
 
 func validateTrustedCommandOutputRoot(rootAbs string) error {
@@ -259,25 +314,30 @@ func validateTrustedCommandOutputRoot(rootAbs string) error {
 }
 
 func resolveAliasedWorkspaceRoot(outputAbs, workspaceRoot string) (string, error) {
+	root, err := resolveAliasedWorkspaceRootBoundary(outputAbs, workspaceRoot)
+	return root.path, err
+}
+
+func resolveAliasedWorkspaceRootBoundary(outputAbs, workspaceRoot string) (commandOutputRootBoundary, error) {
 	current := filepath.Dir(filepath.Clean(outputAbs))
-	var aliasRoot string
+	var aliasRoot commandOutputRootBoundary
 	for {
 		_, err := os.Lstat(current)
 		switch {
 		case err == nil:
 			resolvedCurrent, err := filepath.EvalSymlinks(current)
 			if err != nil {
-				return "", err
+				return commandOutputRootBoundary{}, err
 			}
 			withinWorkspace, err := pathWithinRoot(workspaceRoot, resolvedCurrent)
 			if err != nil {
-				return "", err
+				return commandOutputRootBoundary{}, err
 			}
 			if withinWorkspace {
-				aliasRoot = current
+				aliasRoot = commandOutputRootBoundary{path: current, resolved: resolvedCurrent}
 			}
 		case !os.IsNotExist(err):
-			return "", err
+			return commandOutputRootBoundary{}, err
 		}
 
 		parent := filepath.Dir(current)
@@ -372,37 +432,6 @@ func rejectAmbiguousParentTraversal(path string) error {
 		}
 	}
 	return nil
-}
-
-func ensureCommandOutputParent(rootDir, outputPath string) error {
-	rootAbs, err := filepath.Abs(rootDir)
-	if err != nil {
-		return fmt.Errorf("resolve output root: %w", err)
-	}
-	outputAbs, err := filepath.Abs(outputPath)
-	if err != nil {
-		return fmt.Errorf("resolve output path: %w", err)
-	}
-	rel, err := filepath.Rel(rootAbs, outputAbs)
-	if err != nil {
-		return fmt.Errorf("compute output path: %w", err)
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return fmt.Errorf("output path escapes workspace: %s", outputPath)
-	}
-
-	parent := filepath.Dir(outputAbs)
-	if err := rejectSymlinkedOutputParent(rootAbs, parent); err != nil {
-		return err
-	}
-	if err := mkdirAllCommandOutputParentFn(parent, 0o750); err != nil {
-		return err
-	}
-	return rejectSymlinkedOutputParent(rootAbs, parent)
-}
-
-func rejectSymlinkedOutputParent(rootAbs, parentAbs string) error {
-	return rejectSymlinkedPath(rootAbs, parentAbs, "output parent escapes workspace: %s", "output parent contains symlink: %s")
 }
 
 func rejectSymlinkedOutputRoot(rootAbs, parentAbs string) error {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -1,9 +1,12 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 func persistDashboardOutput(formatted, outputPath string) (string, error) {
@@ -16,11 +19,86 @@ func persistCommandOutput(formatted, outputPath, label string) (string, error) {
 		return formatted, nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(trimmedOutputPath), 0o750); err != nil {
+	outputRoot, err := commandOutputRoot(trimmedOutputPath)
+	if err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(trimmedOutputPath, []byte(formatted), 0o600); err != nil {
+	if err := ensureCommandOutputParent(outputRoot, trimmedOutputPath); err != nil {
+		return "", err
+	}
+	if err := safeio.WriteFileUnder(outputRoot, trimmedOutputPath, []byte(formatted), 0o600); err != nil {
 		return "", err
 	}
 	return label + " written to " + trimmedOutputPath, nil
+}
+
+func commandOutputRoot(outputPath string) (string, error) {
+	if filepath.IsAbs(outputPath) {
+		volume := filepath.VolumeName(outputPath)
+		return volume + string(os.PathSeparator), nil
+	}
+	workspaceRoot, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve output workspace: %w", err)
+	}
+	return workspaceRoot, nil
+}
+
+func ensureCommandOutputParent(rootDir, outputPath string) error {
+	rootAbs, err := filepath.Abs(rootDir)
+	if err != nil {
+		return fmt.Errorf("resolve output root: %w", err)
+	}
+	outputAbs, err := filepath.Abs(outputPath)
+	if err != nil {
+		return fmt.Errorf("resolve output path: %w", err)
+	}
+	rel, err := filepath.Rel(rootAbs, outputAbs)
+	if err != nil {
+		return fmt.Errorf("compute output path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("output path escapes workspace: %s", outputPath)
+	}
+
+	parent := filepath.Dir(outputAbs)
+	if err := rejectSymlinkedOutputParent(rootAbs, parent); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(parent, 0o750); err != nil {
+		return err
+	}
+	return rejectSymlinkedOutputParent(rootAbs, parent)
+}
+
+func rejectSymlinkedOutputParent(rootAbs, parentAbs string) error {
+	rel, err := filepath.Rel(rootAbs, parentAbs)
+	if err != nil {
+		return fmt.Errorf("compute output parent: %w", err)
+	}
+	if rel == "." {
+		return nil
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("output parent escapes workspace: %s", parentAbs)
+	}
+
+	current := rootAbs
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("output parent contains symlink: %s", current)
+		}
+	}
+	return nil
 }

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -48,6 +48,10 @@ func absoluteCommandOutputRoot(outputPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve output path: %w", err)
 	}
+	workspaceRoot, err := trustedCommandOutputRoot(outputAbs)
+	if err != nil {
+		return "", err
+	}
 
 	current := filepath.Dir(outputAbs)
 	for {
@@ -58,6 +62,12 @@ func absoluteCommandOutputRoot(outputPath string) (string, error) {
 			}
 			if !info.IsDir() {
 				return "", fmt.Errorf("output root is not a directory: %s", current)
+			}
+			if workspaceRoot != "" {
+				if err := rejectSymlinkedOutputRoot(workspaceRoot, filepath.Dir(outputAbs)); err != nil {
+					return "", err
+				}
+				return workspaceRoot, nil
 			}
 			return current, nil
 		}
@@ -71,6 +81,29 @@ func absoluteCommandOutputRoot(outputPath string) (string, error) {
 		}
 		current = parent
 	}
+}
+
+func trustedCommandOutputRoot(outputAbs string) (string, error) {
+	workspaceRoot, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve output workspace: %w", err)
+	}
+	withinWorkspace, err := pathWithinRoot(workspaceRoot, outputAbs)
+	if err != nil {
+		return "", err
+	}
+	if !withinWorkspace {
+		return "", nil
+	}
+	return workspaceRoot, nil
+}
+
+func pathWithinRoot(rootAbs, targetAbs string) (bool, error) {
+	rel, err := filepath.Rel(rootAbs, targetAbs)
+	if err != nil {
+		return false, fmt.Errorf("compute output path: %w", err)
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))), nil
 }
 
 func ensureCommandOutputParent(rootDir, outputPath string) error {
@@ -101,6 +134,14 @@ func ensureCommandOutputParent(rootDir, outputPath string) error {
 }
 
 func rejectSymlinkedOutputParent(rootAbs, parentAbs string) error {
+	return rejectSymlinkedPath(rootAbs, parentAbs, "output parent escapes workspace: %s", "output parent contains symlink: %s")
+}
+
+func rejectSymlinkedOutputRoot(rootAbs, parentAbs string) error {
+	return rejectSymlinkedPath(rootAbs, parentAbs, "output root escapes workspace: %s", "output root contains symlink: %s")
+}
+
+func rejectSymlinkedPath(rootAbs, parentAbs, escapeFormat, symlinkFormat string) error {
 	rel, err := filepath.Rel(rootAbs, parentAbs)
 	if err != nil {
 		return fmt.Errorf("compute output parent: %w", err)
@@ -109,7 +150,7 @@ func rejectSymlinkedOutputParent(rootAbs, parentAbs string) error {
 		return nil
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return fmt.Errorf("output parent escapes workspace: %s", parentAbs)
+		return fmt.Errorf(escapeFormat, parentAbs)
 	}
 
 	current := rootAbs
@@ -126,7 +167,7 @@ func rejectSymlinkedOutputParent(rootAbs, parentAbs string) error {
 			return err
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("output parent contains symlink: %s", current)
+			return fmt.Errorf(symlinkFormat, current)
 		}
 	}
 	return nil

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -15,6 +15,7 @@ var (
 	writeCommandOutputFileFn     = func(root *safeio.WriteRoot, targetPath string, data []byte, perm, parentPerm os.FileMode) error {
 		return root.WriteFileCreatingParents(targetPath, data, perm, parentPerm)
 	}
+	commandOutputBoundaryAcceptedFn = func() error { return nil }
 )
 
 type commandOutputRootBoundary struct {
@@ -71,6 +72,9 @@ func openCommandOutputDestination(outputPath string, trustedRoots ...string) (co
 	}
 	if targetPath == ".." || strings.HasPrefix(targetPath, ".."+string(os.PathSeparator)) {
 		return commandOutputDestination{}, fmt.Errorf("output path escapes workspace: %s", outputPath)
+	}
+	if err := commandOutputBoundaryAcceptedFn(); err != nil {
+		return commandOutputDestination{}, err
 	}
 	writeRoot, err := openCommandOutputWriteRootFn(root.resolved)
 	if err != nil {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -83,7 +83,7 @@ func commandOutputRootBoundaryForPath(outputPath string, trustedRoots ...string)
 	if err := rejectAmbiguousParentTraversal(outputPath); err != nil {
 		return commandOutputRootBoundary{}, "", err
 	}
-	outputAbs, err := filepath.Abs(outputPath)
+	outputAbs, err := absoluteCommandOutputPath(outputPath)
 	if err != nil {
 		return commandOutputRootBoundary{}, "", fmt.Errorf("resolve output path: %w", err)
 	}
@@ -104,6 +104,21 @@ func commandOutputRootBoundaryForPath(outputPath string, trustedRoots ...string)
 
 	fallbackRoot, err := fallbackCommandOutputRootBoundary(outputAbs, outputPath, workspaceErr)
 	return fallbackRoot, outputAbs, err
+}
+
+func absoluteCommandOutputPath(outputPath string) (string, error) {
+	if filepath.IsAbs(outputPath) {
+		return filepath.Clean(outputPath), nil
+	}
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	physicalWorkingDirectory, err := filepath.EvalSymlinks(workingDirectory)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(physicalWorkingDirectory, outputPath), nil
 }
 
 func resolvedCommandOutputRoot(outputAbs string, resolve func() (commandOutputRootBoundary, error)) (commandOutputRootBoundary, error) {
@@ -287,13 +302,35 @@ func trustedCommandOutputRootBoundaryForRoot(outputAbs, root string) (commandOut
 		return commandOutputRootBoundary{}, nil
 	}
 	if withinWorkspace {
-		if err := validateTrustedCommandOutputRoot(resolvedRoot); err != nil {
+		if err := validateTrustedCommandOutputRootBoundary(rootAbs, resolvedRoot); err != nil {
 			return commandOutputRootBoundary{}, err
 		}
 		return commandOutputRootBoundary{path: rootAbs, resolved: resolvedRoot}, nil
 	}
 
-	return resolveAliasedWorkspaceRootBoundary(outputAbs, resolvedRoot)
+	aliasedRoot, err := resolveAliasedWorkspaceRootBoundary(outputAbs, resolvedRoot)
+	if err != nil || aliasedRoot.path == "" {
+		return aliasedRoot, err
+	}
+	if err := validateTrustedCommandOutputRootBoundary(rootAbs, resolvedRoot); err != nil {
+		return commandOutputRootBoundary{}, err
+	}
+	return aliasedRoot, nil
+}
+
+func validateTrustedCommandOutputRootBoundary(rootAbs, resolvedRoot string) error {
+	if err := validateTrustedCommandOutputRoot(resolvedRoot); err != nil {
+		return err
+	}
+	info, err := os.Lstat(rootAbs)
+	if err != nil {
+		return fmt.Errorf("resolve trusted output workspace: %w", err)
+	}
+	lexicalRoot := rootAbs
+	if info.Mode()&os.ModeSymlink != 0 {
+		lexicalRoot = filepath.Dir(rootAbs)
+	}
+	return validateTrustedCommandOutputRoot(lexicalRoot)
 }
 
 func validateTrustedCommandOutputRoot(rootAbs string) error {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -19,7 +19,7 @@ func persistCommandOutput(formatted, outputPath, label string, trustedRoots ...s
 	if trimmedOutputPath == "" || trimmedOutputPath == "-" {
 		return formatted, nil
 	}
-	if hasTrailingOutputPathSeparator(trimmedOutputPath) {
+	if hasDirectoryStyleOutputPath(trimmedOutputPath) {
 		return "", fmt.Errorf("output path must name a file: %s", trimmedOutputPath)
 	}
 
@@ -316,6 +316,21 @@ func pathVolumeName(path string) string {
 
 func hasTrailingOutputPathSeparator(path string) bool {
 	return path != "" && os.IsPathSeparator(path[len(path)-1])
+}
+
+func hasDirectoryStyleOutputPath(path string) bool {
+	if hasTrailingOutputPathSeparator(path) {
+		return true
+	}
+	last := 0
+	for i := len(path) - 1; i >= 0; i-- {
+		if os.IsPathSeparator(path[i]) {
+			last = i + 1
+			break
+		}
+	}
+	base := path[last:]
+	return base == "." || base == ".."
 }
 
 func ensureCommandOutputParent(rootDir, outputPath string) error {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -131,6 +131,7 @@ func trustedCommandOutputRoot(outputAbs string) (string, error) {
 
 func resolveAliasedWorkspaceRoot(outputAbs, workspaceRoot string) (string, error) {
 	current := filepath.Dir(filepath.Clean(outputAbs))
+	var aliasRoot string
 	for {
 		_, err := os.Lstat(current)
 		switch {
@@ -139,8 +140,12 @@ func resolveAliasedWorkspaceRoot(outputAbs, workspaceRoot string) (string, error
 			if err != nil {
 				return "", err
 			}
-			if resolvedCurrent == workspaceRoot {
-				return current, nil
+			withinWorkspace, err := pathWithinRoot(workspaceRoot, resolvedCurrent)
+			if err != nil {
+				return "", err
+			}
+			if withinWorkspace {
+				aliasRoot = current
 			}
 		case !os.IsNotExist(err):
 			return "", err
@@ -148,7 +153,7 @@ func resolveAliasedWorkspaceRoot(outputAbs, workspaceRoot string) (string, error
 
 		parent := filepath.Dir(current)
 		if parent == current {
-			return "", nil
+			return aliasRoot, nil
 		}
 		current = parent
 	}

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -10,11 +10,11 @@ import (
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
-func persistDashboardOutput(formatted, outputPath string) (string, error) {
-	return persistCommandOutput(formatted, outputPath, "dashboard report")
+func persistDashboardOutput(formatted, outputPath string, trustedRoots ...string) (string, error) {
+	return persistCommandOutput(formatted, outputPath, "dashboard report", trustedRoots...)
 }
 
-func persistCommandOutput(formatted, outputPath, label string) (string, error) {
+func persistCommandOutput(formatted, outputPath, label string, trustedRoots ...string) (string, error) {
 	trimmedOutputPath := strings.TrimSpace(outputPath)
 	if trimmedOutputPath == "" || trimmedOutputPath == "-" {
 		return formatted, nil
@@ -23,7 +23,7 @@ func persistCommandOutput(formatted, outputPath, label string) (string, error) {
 		return "", fmt.Errorf("output path must name a file: %s", trimmedOutputPath)
 	}
 
-	outputRoot, err := commandOutputRoot(trimmedOutputPath)
+	outputRoot, err := commandOutputRoot(trimmedOutputPath, trustedRoots...)
 	if err != nil {
 		return "", err
 	}
@@ -36,35 +36,47 @@ func persistCommandOutput(formatted, outputPath, label string) (string, error) {
 	return label + " written to " + trimmedOutputPath, nil
 }
 
-func commandOutputRoot(outputPath string) (string, error) {
-	return rootedCommandOutputRoot(outputPath)
+func commandOutputRoot(outputPath string, trustedRoots ...string) (string, error) {
+	return rootedCommandOutputRoot(outputPath, trustedRoots...)
 }
 
 func absoluteCommandOutputRoot(outputPath string) (string, error) {
 	return rootedCommandOutputRoot(outputPath)
 }
 
-func rootedCommandOutputRoot(outputPath string) (string, error) {
+func rootedCommandOutputRoot(outputPath string, trustedRoots ...string) (string, error) {
 	outputAbs, err := filepath.Abs(outputPath)
 	if err != nil {
 		return "", fmt.Errorf("resolve output path: %w", err)
 	}
-	workspaceRoot, err := trustedCommandOutputRoot(outputAbs)
+
+	trustedRoot, err := trustedCommandOutputRootForRoots(outputAbs, trustedRoots...)
 	if err != nil {
 		return "", err
+	}
+	if trustedRoot != "" {
+		if err := rejectSymlinkedOutputRoot(trustedRoot, filepath.Dir(outputAbs)); err != nil {
+			return "", err
+		}
+		return trustedRoot, nil
+	}
+
+	workspaceRoot, workspaceErr := trustedCommandOutputRoot(outputAbs)
+	if workspaceErr != nil {
+		return "", workspaceErr
+	}
+	if workspaceRoot != "" {
+		if err := rejectSymlinkedOutputRoot(workspaceRoot, filepath.Dir(outputAbs)); err != nil {
+			return "", err
+		}
+		return workspaceRoot, nil
 	}
 
 	existingRoot, err := resolveExistingOutputRoot(outputAbs, outputPath)
 	if err != nil {
 		return "", err
 	}
-	if workspaceRoot == "" {
-		return existingRoot, nil
-	}
-	if err := rejectSymlinkedOutputRoot(workspaceRoot, filepath.Dir(outputAbs)); err != nil {
-		return "", err
-	}
-	return workspaceRoot, nil
+	return existingRoot, nil
 }
 
 func resolveExistingOutputRoot(outputAbs, outputPath string) (string, error) {
@@ -130,6 +142,46 @@ func trustedCommandOutputRoot(outputAbs string) (string, error) {
 		return aliasedWorkspaceRoot, nil
 	}
 	return workspaceRoot, nil
+}
+
+func trustedCommandOutputRootForRoots(outputAbs string, roots ...string) (string, error) {
+	for _, root := range roots {
+		trustedRoot, err := trustedCommandOutputRootForRoot(outputAbs, root)
+		if err != nil {
+			return "", err
+		}
+		if trustedRoot != "" {
+			return trustedRoot, nil
+		}
+	}
+	return "", nil
+}
+
+func trustedCommandOutputRootForRoot(outputAbs, root string) (string, error) {
+	trimmedRoot := strings.TrimSpace(root)
+	if trimmedRoot == "" {
+		return "", nil
+	}
+	rootAbs, err := filepath.Abs(trimmedRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve trusted output workspace: %w", err)
+	}
+	withinWorkspace, err := pathWithinRoot(rootAbs, outputAbs)
+	if err != nil {
+		return "", err
+	}
+	if withinWorkspace {
+		return rootAbs, nil
+	}
+
+	resolvedRoot, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("resolve trusted output workspace symlinks: %w", err)
+	}
+	return resolveAliasedWorkspaceRoot(outputAbs, resolvedRoot)
 }
 
 func resolveAliasedWorkspaceRoot(outputAbs, workspaceRoot string) (string, error) {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -218,17 +218,28 @@ func trustedCommandOutputRootForRoot(outputAbs, root string) (string, error) {
 		return "", err
 	}
 	if withinWorkspace {
+		if err := validateTrustedCommandOutputRoot(rootAbs); err != nil {
+			return "", err
+		}
 		return rootAbs, nil
 	}
 
 	resolvedRoot, err := filepath.EvalSymlinks(rootAbs)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", fmt.Errorf("resolve trusted output workspace symlinks: %w", err)
+		return "", nil
 	}
 	return resolveAliasedWorkspaceRoot(outputAbs, resolvedRoot)
+}
+
+func validateTrustedCommandOutputRoot(rootAbs string) error {
+	info, err := os.Stat(rootAbs)
+	if err != nil {
+		return fmt.Errorf("resolve trusted output workspace: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("trusted output workspace is not a directory: %s", rootAbs)
+	}
+	return nil
 }
 
 func resolveAliasedWorkspaceRoot(outputAbs, workspaceRoot string) (string, error) {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -34,14 +34,43 @@ func persistCommandOutput(formatted, outputPath, label string) (string, error) {
 
 func commandOutputRoot(outputPath string) (string, error) {
 	if filepath.IsAbs(outputPath) {
-		volume := filepath.VolumeName(outputPath)
-		return volume + string(os.PathSeparator), nil
+		return absoluteCommandOutputRoot(outputPath)
 	}
 	workspaceRoot, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("resolve output workspace: %w", err)
 	}
 	return workspaceRoot, nil
+}
+
+func absoluteCommandOutputRoot(outputPath string) (string, error) {
+	outputAbs, err := filepath.Abs(outputPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve output path: %w", err)
+	}
+
+	current := filepath.Dir(outputAbs)
+	for {
+		info, err := os.Lstat(current)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return "", fmt.Errorf("output root contains symlink: %s", current)
+			}
+			if !info.IsDir() {
+				return "", fmt.Errorf("output root is not a directory: %s", current)
+			}
+			return current, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("resolve output root for %s: no existing parent directory", outputPath)
+		}
+		current = parent
+	}
 }
 
 func ensureCommandOutputParent(rootDir, outputPath string) error {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -19,6 +19,9 @@ func persistCommandOutput(formatted, outputPath, label string) (string, error) {
 	if trimmedOutputPath == "" || trimmedOutputPath == "-" {
 		return formatted, nil
 	}
+	if hasTrailingOutputPathSeparator(trimmedOutputPath) {
+		return "", fmt.Errorf("output path must name a file: %s", trimmedOutputPath)
+	}
 
 	outputRoot, err := commandOutputRoot(trimmedOutputPath)
 	if err != nil {
@@ -189,6 +192,10 @@ func pathVolumeName(path string) string {
 		}
 	}
 	return strings.ToLower(volume)
+}
+
+func hasTrailingOutputPathSeparator(path string) bool {
+	return path != "" && os.IsPathSeparator(path[len(path)-1])
 }
 
 func ensureCommandOutputParent(rootDir, outputPath string) error {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,42 +30,10 @@ func persistCommandOutput(formatted, outputPath, label string, trustedRoots ...s
 	if err := ensureCommandOutputParent(outputRoot, trimmedOutputPath); err != nil {
 		return "", err
 	}
-	if err := ensureExistingCommandOutputWritable(outputRoot, trimmedOutputPath); err != nil {
-		return "", err
-	}
 	if err := safeio.WriteFileUnder(outputRoot, trimmedOutputPath, []byte(formatted), 0o600); err != nil {
 		return "", err
 	}
 	return label + " written to " + trimmedOutputPath, nil
-}
-
-func ensureExistingCommandOutputWritable(rootDir, outputPath string) (returnErr error) {
-	outputAbs, err := filepath.Abs(outputPath)
-	if err != nil {
-		return err
-	}
-	rel, err := filepath.Rel(rootDir, outputAbs)
-	if err != nil {
-		return err
-	}
-	root, err := os.OpenRoot(rootDir)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		returnErr = errors.Join(returnErr, root.Close())
-	}()
-
-	info, err := root.Lstat(rel)
-	if err != nil || !info.Mode().IsRegular() {
-		return nil
-	}
-
-	file, err := root.OpenFile(rel, os.O_WRONLY, 0)
-	if err != nil {
-		return err
-	}
-	return file.Close()
 }
 
 func commandOutputRoot(outputPath string, trustedRoots ...string) (string, error) {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -62,10 +62,7 @@ func rootedCommandOutputRoot(outputPath string, trustedRoots ...string) (string,
 	}
 
 	workspaceRoot, workspaceErr := trustedCommandOutputRoot(outputAbs)
-	if workspaceErr != nil {
-		return "", workspaceErr
-	}
-	if workspaceRoot != "" {
+	if workspaceErr == nil && workspaceRoot != "" {
 		if err := rejectSymlinkedOutputRoot(workspaceRoot, filepath.Dir(outputAbs)); err != nil {
 			return "", err
 		}
@@ -74,7 +71,16 @@ func rootedCommandOutputRoot(outputPath string, trustedRoots ...string) (string,
 
 	existingRoot, err := resolveExistingOutputRoot(outputAbs, outputPath)
 	if err != nil {
+		if workspaceErr != nil && filepath.IsAbs(outputPath) {
+			return "", err
+		}
 		return "", err
+	}
+	if workspaceErr != nil && filepath.IsAbs(outputPath) {
+		return existingRoot, nil
+	}
+	if workspaceErr != nil {
+		return "", workspaceErr
 	}
 	return existingRoot, nil
 }

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -9,6 +9,16 @@ import (
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
+var (
+	mkdirAllCommandOutputParentFn = os.MkdirAll
+	writeCommandOutputFileFn      = func(rootDir, outputPath string, data []byte, perm, _ os.FileMode) error {
+		if err := ensureCommandOutputParent(rootDir, outputPath); err != nil {
+			return err
+		}
+		return safeio.WriteFileUnder(rootDir, outputPath, data, perm)
+	}
+)
+
 func persistDashboardOutput(formatted, outputPath string, trustedRoots ...string) (string, error) {
 	return persistCommandOutput(formatted, outputPath, "dashboard report", trustedRoots...)
 }
@@ -26,10 +36,7 @@ func persistCommandOutput(formatted, outputPath, label string, trustedRoots ...s
 	if err != nil {
 		return "", err
 	}
-	if err := ensureCommandOutputParent(outputRoot, trimmedOutputPath); err != nil {
-		return "", err
-	}
-	if err := safeio.WriteFileUnder(outputRoot, trimmedOutputPath, []byte(formatted), 0o600); err != nil {
+	if err := writeCommandOutputFileFn(outputRoot, trimmedOutputPath, []byte(formatted), 0o600, 0o750); err != nil {
 		return "", err
 	}
 	return label + " written to " + trimmedOutputPath, nil
@@ -388,7 +395,7 @@ func ensureCommandOutputParent(rootDir, outputPath string) error {
 	if err := rejectSymlinkedOutputParent(rootAbs, parent); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(parent, 0o750); err != nil {
+	if err := mkdirAllCommandOutputParentFn(parent, 0o750); err != nil {
 		return err
 	}
 	return rejectSymlinkedOutputParent(rootAbs, parent)

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -50,30 +50,37 @@ func rootedCommandOutputRoot(outputPath string, trustedRoots ...string) (string,
 		return "", fmt.Errorf("resolve output path: %w", err)
 	}
 
-	trustedRoot, err := trustedCommandOutputRootForRoots(outputAbs, trustedRoots...)
-	if err != nil {
-		return "", err
-	}
-	if trustedRoot != "" {
-		if err := rejectSymlinkedOutputRoot(trustedRoot, filepath.Dir(outputAbs)); err != nil {
-			return "", err
-		}
-		return trustedRoot, nil
+	trustedRoot, err := resolvedCommandOutputRoot(outputAbs, func() (string, error) {
+		return trustedCommandOutputRootForRoots(outputAbs, trustedRoots...)
+	})
+	if trustedRoot != "" || err != nil {
+		return trustedRoot, err
 	}
 
-	workspaceRoot, workspaceErr := trustedCommandOutputRoot(outputAbs)
-	if workspaceErr == nil && workspaceRoot != "" {
-		if err := rejectSymlinkedOutputRoot(workspaceRoot, filepath.Dir(outputAbs)); err != nil {
-			return "", err
-		}
+	workspaceRoot, workspaceErr := resolvedCommandOutputRoot(outputAbs, func() (string, error) {
+		return trustedCommandOutputRoot(outputAbs)
+	})
+	if workspaceRoot != "" {
 		return workspaceRoot, nil
 	}
 
+	return fallbackCommandOutputRoot(outputAbs, outputPath, workspaceErr)
+}
+
+func resolvedCommandOutputRoot(outputAbs string, resolve func() (string, error)) (string, error) {
+	root, err := resolve()
+	if err != nil || root == "" {
+		return root, err
+	}
+	if err := rejectSymlinkedOutputRoot(root, filepath.Dir(outputAbs)); err != nil {
+		return "", err
+	}
+	return root, nil
+}
+
+func fallbackCommandOutputRoot(outputAbs, outputPath string, workspaceErr error) (string, error) {
 	existingRoot, err := resolveExistingOutputRoot(outputAbs, outputPath)
 	if err != nil {
-		if workspaceErr != nil && filepath.IsAbs(outputPath) {
-			return "", err
-		}
 		return "", err
 	}
 	if workspaceErr != nil && filepath.IsAbs(outputPath) {

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -218,6 +218,9 @@ func trustedCommandOutputRootForRoot(outputAbs, root string) (string, error) {
 	}
 	rootAbs, err := filepath.Abs(trimmedRoot)
 	if err != nil {
+		if filepath.IsAbs(outputAbs) && !filepath.IsAbs(trimmedRoot) {
+			return "", nil
+		}
 		return "", fmt.Errorf("resolve trusted output workspace: %w", err)
 	}
 	withinWorkspace, err := pathWithinRoot(rootAbs, outputAbs)

--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	openCommandOutputWriteRootFn = safeio.OpenWriteRoot
+	openCommandOutputWriteRootFn = safeio.OpenCanonicalWriteRoot
 	writeCommandOutputFileFn     = func(root *safeio.WriteRoot, targetPath string, data []byte, perm, parentPerm os.FileMode) error {
 		return root.WriteFileCreatingParents(targetPath, data, perm, parentPerm)
 	}
@@ -73,11 +73,14 @@ func openCommandOutputDestination(outputPath string, trustedRoots ...string) (co
 	if targetPath == ".." || strings.HasPrefix(targetPath, ".."+string(os.PathSeparator)) {
 		return commandOutputDestination{}, fmt.Errorf("output path escapes workspace: %s", outputPath)
 	}
-	if err := commandOutputBoundaryAcceptedFn(); err != nil {
-		return commandOutputDestination{}, err
-	}
 	writeRoot, err := openCommandOutputWriteRootFn(root.resolved)
 	if err != nil {
+		return commandOutputDestination{}, err
+	}
+	if err := commandOutputBoundaryAcceptedFn(); err != nil {
+		if closeErr := writeRoot.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
 		return commandOutputDestination{}, err
 	}
 	return commandOutputDestination{root: writeRoot, targetPath: targetPath}, nil

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -163,6 +163,53 @@ func TestCommandOutputRootAbsolutePathUsesExistingParentOutsideWorkspace(t *test
 	}
 }
 
+func TestPersistCommandOutputRejectsAbsolutePathWithLexicalAncestorSymlink(t *testing.T) {
+	workspace := t.TempDir()
+	chdirCanonicalWorkspace(t, workspace)
+
+	base := filepath.Join(t.TempDir(), "base")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatalf("mkdir base: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir outside nested: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(base, "link")); err != nil {
+		t.Fatalf("create escaping symlink: %v", err)
+	}
+
+	outputPath := filepath.Join(base, "link", "nested", "output.json")
+	_, err := persistCommandOutput("{}", outputPath, "dashboard report")
+	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
+		t.Fatalf("expected lexical ancestor symlink rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "nested", "output.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside output to remain absent, got err=%v", statErr)
+	}
+}
+
+func TestRejectLexicalOutputRootSymlinksAllowsRegularExistingPath(t *testing.T) {
+	existingRoot := filepath.Join(t.TempDir(), "base", "nested")
+	if err := os.MkdirAll(existingRoot, 0o755); err != nil {
+		t.Fatalf("mkdir existing root: %v", err)
+	}
+
+	if err := rejectLexicalOutputRootSymlinks(existingRoot); err != nil {
+		t.Fatalf("reject lexical output root symlinks: %v", err)
+	}
+}
+
+func TestRejectLexicalOutputRootSymlinksAllowsKnownDarwinAliasRoot(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("known system alias roots only apply on darwin")
+	}
+
+	if err := rejectLexicalOutputRootSymlinks("/tmp"); err != nil {
+		t.Fatalf("reject lexical output root symlinks: %v", err)
+	}
+}
+
 func TestCommandOutputRootAllowsRelativeParentOutsideWorkspace(t *testing.T) {
 	workspaceParent := t.TempDir()
 	workspace := filepath.Join(workspaceParent, "workspace")

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -676,6 +676,82 @@ func TestPersistCommandOutputPinsCanonicalRootBeforeAcceptedBoundaryRetarget(t *
 	}
 }
 
+func TestOpenCommandOutputDestinationClosesRootOnBoundaryError(t *testing.T) {
+	workspace := t.TempDir()
+	outputPath := filepath.Join(workspace, "report.json")
+	boundaryErr := errors.New("boundary failure")
+	originalOpen := openCommandOutputWriteRootFn
+	originalAccepted := commandOutputBoundaryAcceptedFn
+	openCommandOutputWriteRootFn = func(rootPath string) (*safeio.WriteRoot, error) {
+		root, err := safeio.OpenWriteRoot(rootPath)
+		if err != nil {
+			return nil, err
+		}
+		if err := root.Close(); err != nil {
+			return nil, err
+		}
+		return root, nil
+	}
+	commandOutputBoundaryAcceptedFn = func() error { return boundaryErr }
+	t.Cleanup(func() {
+		openCommandOutputWriteRootFn = originalOpen
+		commandOutputBoundaryAcceptedFn = originalAccepted
+	})
+
+	destination, err := openCommandOutputDestination(outputPath, workspace)
+	if destination.root != nil {
+		if closeErr := destination.root.Close(); closeErr != nil {
+			t.Fatalf("close unexpected destination root: %v", closeErr)
+		}
+		t.Fatal("expected destination root to remain nil")
+	}
+	if !errors.Is(err, boundaryErr) {
+		t.Fatalf("expected boundary error, got %v", err)
+	}
+}
+
+func TestTrustedCommandOutputRootIgnoresRelativeRootWhenCWDUnavailable(t *testing.T) {
+	withRemovedWorkingDirectory(t, func() {
+		root, err := trustedCommandOutputRootBoundaryForRoot(filepath.Join(string(os.PathSeparator), "output.json"), "relative-root")
+		if err != nil {
+			t.Fatalf("expected unavailable relative root to be ignored, got %v", err)
+		}
+		if root.path != "" || root.resolved != "" {
+			t.Fatalf("expected empty trusted root, got %+v", root)
+		}
+	})
+}
+
+func TestTrustedCommandOutputRootReturnsErrorForRelativePathsWhenCWDUnavailable(t *testing.T) {
+	withRemovedWorkingDirectory(t, func() {
+		root, err := trustedCommandOutputRootBoundaryForRoot("relative-output.json", "relative-root")
+		if root.path != "" || root.resolved != "" {
+			t.Fatalf("expected empty trusted root, got %+v", root)
+		}
+		if err == nil {
+			t.Fatal("expected trusted root resolution error")
+		}
+	})
+}
+
+func TestRejectSymlinkedPathPropagatesLookupError(t *testing.T) {
+	root := t.TempDir()
+	nonDirectory := filepath.Join(root, "file")
+	if err := os.WriteFile(nonDirectory, []byte("file"), 0o600); err != nil {
+		t.Fatalf("write non-directory path: %v", err)
+	}
+	target := filepath.Join(nonDirectory, "child", "output.json")
+
+	err := rejectSymlinkedPath(root, target, "escape: %s", "symlink: %s")
+	if err == nil {
+		t.Fatal("expected lookup error below non-directory path")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected path lookup error, got %v", err)
+	}
+}
+
 func TestPersistCommandOutputAllowsRelativeOutputFromSymlinkedWorkspace(t *testing.T) {
 	workspace, workspaceAlias := createWorkspaceAlias(t)
 	originalWD, err := os.Getwd()

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -83,7 +83,7 @@ func TestRootedCommandOutputRootAllowsAbsolutePathWhenWorkspaceLookupFails(t *te
 }
 
 func TestRootedCommandOutputRootPropagatesTrustedRootLookupError(t *testing.T) {
-	assertTrustedRootLookupError(t, "trusted root lookup failure", func(outputPath string, trustedRoot string) error {
+	assertTrustedRootLookupError(t, "trusted root lookup failure", func(outputPath, trustedRoot string) error {
 		_, err := rootedCommandOutputRoot(outputPath, trustedRoot)
 		return err
 	})
@@ -407,7 +407,7 @@ func TestTrustedCommandOutputRootForRootUsesResolvedRootForRealPath(t *testing.T
 }
 
 func TestTrustedCommandOutputRootForRootsPropagatesRootError(t *testing.T) {
-	assertTrustedRootLookupError(t, "trusted root resolution error", func(outputPath string, trustedRoot string) error {
+	assertTrustedRootLookupError(t, "trusted root resolution error", func(outputPath, trustedRoot string) error {
 		_, err := trustedCommandOutputRootForRoots(outputPath, trustedRoot)
 		return err
 	})

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -68,12 +68,16 @@ func TestRootedCommandOutputRootPropagatesOutputPathResolutionError(t *testing.T
 	})
 }
 
-func TestRootedCommandOutputRootPropagatesWorkspaceLookupErrorForAbsolutePath(t *testing.T) {
+func TestRootedCommandOutputRootAllowsAbsolutePathWhenWorkspaceLookupFails(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
 	withUnreadableWorkingDirectory(t, func() {
-		_, err := rootedCommandOutputRoot(outputPath)
-		if err == nil || !strings.Contains(err.Error(), "resolve output workspace") {
-			t.Fatalf("expected workspace lookup failure, got %v", err)
+		root, err := rootedCommandOutputRoot(outputPath)
+		if err != nil {
+			t.Fatalf("rooted command output root: %v", err)
+		}
+		wantRoot := filepath.Dir(filepath.Dir(outputPath))
+		if root != wantRoot {
+			t.Fatalf("expected fallback output root %q, got %q", wantRoot, root)
 		}
 	})
 }
@@ -99,6 +103,28 @@ func TestPersistDashboardOutputUsesDashboardLabel(t *testing.T) {
 	}
 	if status != "dashboard report written to report.json" {
 		t.Fatalf("unexpected status: %q", status)
+	}
+}
+
+func TestPersistCommandOutputAllowsAbsoluteExternalPathWhenWorkingDirectoryRemoved(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
+
+	withRemovedWorkingDirectory(t, func() {
+		status, err := persistCommandOutput("{}", outputPath, "dashboard report")
+		if err != nil {
+			t.Fatalf("persist command output: %v", err)
+		}
+		if status != "dashboard report written to "+outputPath {
+			t.Fatalf("unexpected status: %q", status)
+		}
+	})
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(data) != "{}" {
+		t.Fatalf("unexpected output content: %q", string(data))
 	}
 }
 
@@ -749,6 +775,32 @@ func withUnreadableWorkingDirectory(t *testing.T, fn func()) {
 	if err := os.Chmod(workspace, 0); err != nil {
 		t.Fatalf("chmod unreadable workspace: %v", err)
 	}
+
+	fn()
+}
+
+func withRemovedWorkingDirectory(t *testing.T, fn func()) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("removed working directory semantics are not stable on windows")
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	workspace := t.TempDir()
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("chdir removed workspace: %v", err)
+	}
+	if err := os.RemoveAll(workspace); err != nil {
+		t.Fatalf("remove workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
 
 	fn()
 }

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -566,13 +566,21 @@ func TestPersistCommandOutputRejectsTrustedRootWithSymlinkAncestor(t *testing.T)
 		t.Fatalf("create trusted root ancestor symlink: %v", err)
 	}
 
-	outputPath := filepath.Join(trustedRoot, "report.json")
-	_, err := persistCommandOutput("after", outputPath, "dashboard report", trustedRoot)
-	if err == nil || !strings.Contains(err.Error(), "trusted output workspace") {
-		t.Fatalf("expected trusted root ancestor symlink rejection, got %v", err)
+	for name, outputPath := range map[string]string{
+		"lexical output":   filepath.Join(trustedRoot, "report-lexical.json"),
+		"canonical output": filepath.Join(outsideRoot, "report-canonical.json"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := persistCommandOutput("after", outputPath, "dashboard report", trustedRoot)
+			if err == nil || !strings.Contains(err.Error(), "trusted output workspace") {
+				t.Fatalf("expected trusted root ancestor symlink rejection, got %v", err)
+			}
+		})
 	}
-	if _, statErr := os.Stat(filepath.Join(outsideRoot, "report.json")); !os.IsNotExist(statErr) {
-		t.Fatalf("expected outside output to remain absent, got err=%v", statErr)
+	for _, name := range []string{"report-lexical.json", "report-canonical.json"} {
+		if _, statErr := os.Stat(filepath.Join(outsideRoot, name)); !os.IsNotExist(statErr) {
+			t.Fatalf("expected outside output %q to remain absent, got err=%v", name, statErr)
+		}
 	}
 }
 
@@ -1043,6 +1051,16 @@ func TestValidateTrustedCommandOutputRootRejectsSymlinkAncestor(t *testing.T) {
 	err := validateTrustedCommandOutputRoot(filepath.Join(parentAlias, "repo"))
 	if err == nil || !strings.Contains(err.Error(), "validate trusted output workspace") {
 		t.Fatalf("expected trusted root ancestor symlink rejection, got %v", err)
+	}
+}
+
+func TestValidateTrustedCommandOutputRootBoundaryPropagatesLexicalLookupError(t *testing.T) {
+	resolvedRoot := t.TempDir()
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+
+	err := validateTrustedCommandOutputRootBoundary(missingRoot, resolvedRoot)
+	if err == nil || !strings.Contains(err.Error(), "resolve trusted output workspace") {
+		t.Fatalf("expected lexical trusted root lookup error, got %v", err)
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -530,6 +530,76 @@ func TestPersistCommandOutputAllowsTrustedRootAlias(t *testing.T) {
 	}
 }
 
+func TestPersistCommandOutputPinsTrustedRootAliasBeforeWrite(t *testing.T) {
+	workspace, trustedRootAlias := createWorkspaceAlias(t)
+	outside := t.TempDir()
+	outsideTarget := filepath.Join(outside, "reports", "report.json")
+	if err := os.MkdirAll(filepath.Dir(outsideTarget), 0o755); err != nil {
+		t.Fatalf("mkdir outside reports: %v", err)
+	}
+	if err := os.WriteFile(outsideTarget, []byte("outside-before"), 0o600); err != nil {
+		t.Fatalf("seed outside target: %v", err)
+	}
+
+	originalWrite := writeCommandOutputFileFn
+	writeCommandOutputFileFn = func(rootDir, outputPath string, data []byte, perm, parentPerm os.FileMode) error {
+		if err := os.Remove(trustedRootAlias); err != nil {
+			return err
+		}
+		if err := os.Symlink(outside, trustedRootAlias); err != nil {
+			return err
+		}
+		return originalWrite(rootDir, outputPath, data, perm, parentPerm)
+	}
+	t.Cleanup(func() {
+		writeCommandOutputFileFn = originalWrite
+	})
+
+	outputPath := filepath.Join(trustedRootAlias, "reports", "report.json")
+	status, err := persistCommandOutput("workspace-after", outputPath, "dashboard report", trustedRootAlias)
+	if err != nil {
+		t.Fatalf("persist command output through retargeted alias: %v", err)
+	}
+	if status != "dashboard report written to "+outputPath {
+		t.Fatalf("unexpected status: %q", status)
+	}
+	if got := readTextFile(t, filepath.Join(workspace, "reports", "report.json")); got != "workspace-after" {
+		t.Fatalf("unexpected workspace output: %q", got)
+	}
+	if got := readTextFile(t, outsideTarget); got != "outside-before" {
+		t.Fatalf("unexpected outside output: %q", got)
+	}
+}
+
+func TestPersistCommandOutputAllowsRelativeOutputFromSymlinkedWorkspace(t *testing.T) {
+	workspace, workspaceAlias := createWorkspaceAlias(t)
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	t.Setenv("PWD", workspaceAlias)
+	if err := os.Chdir(workspaceAlias); err != nil {
+		t.Fatalf("chdir workspace alias: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	outputPath := filepath.Join("reports", "report.json")
+	status, err := persistCommandOutput("{}", outputPath, "dashboard report", ".")
+	if err != nil {
+		t.Fatalf("persist relative command output from workspace alias: %v", err)
+	}
+	if status != "dashboard report written to "+outputPath {
+		t.Fatalf("unexpected status: %q", status)
+	}
+	if got := readTextFile(t, filepath.Join(workspace, outputPath)); got != "{}" {
+		t.Fatalf("unexpected aliased output: %q", got)
+	}
+}
+
 func TestPersistCommandOutputRejectsSymlinkEscapeUnderTrustedRootAlias(t *testing.T) {
 	workspace, trustedRootAlias := createWorkspaceAlias(t)
 	outside := t.TempDir()
@@ -832,6 +902,38 @@ func TestEnsureCommandOutputParentRejectsSymlinkedParent(t *testing.T) {
 	err := ensureCommandOutputParent(root, filepath.Join(root, "reports", "report.json"))
 	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
 		t.Fatalf("expected symlinked parent rejection, got %v", err)
+	}
+}
+
+func TestEnsureCommandOutputParentDoesNotCreateOutsideAfterMissingParentSwap(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	outsideSentinel := filepath.Join(outside, "sentinel.txt")
+	if err := os.WriteFile(outsideSentinel, []byte("outside-before"), 0o600); err != nil {
+		t.Fatalf("seed outside sentinel: %v", err)
+	}
+
+	originalMkdirAll := mkdirAllCommandOutputParentFn
+	mkdirAllCommandOutputParentFn = func(path string, perm os.FileMode) error {
+		if err := os.Symlink(outside, filepath.Join(root, "reports")); err != nil {
+			return err
+		}
+		return originalMkdirAll(path, perm)
+	}
+	t.Cleanup(func() {
+		mkdirAllCommandOutputParentFn = originalMkdirAll
+	})
+
+	outputPath := filepath.Join(root, "reports", "nested", "report.json")
+	err := ensureCommandOutputParent(root, outputPath)
+	if err == nil {
+		t.Fatal("expected swapped parent symlink to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "nested")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside nested directory to remain absent, got err=%v", statErr)
+	}
+	if got := readTextFile(t, outsideSentinel); got != "outside-before" {
+		t.Fatalf("unexpected outside sentinel: %q", got)
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -1,0 +1,149 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommandOutputRootRelativePathUsesWorkspace(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+
+	workspace := t.TempDir()
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("chdir workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	root, err := commandOutputRoot("reports/output.json")
+	if err != nil {
+		t.Fatalf("command output root: %v", err)
+	}
+	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatalf("canonicalize workspace: %v", err)
+	}
+	if root != canonicalWorkspace {
+		t.Fatalf("expected workspace root %q, got %q", canonicalWorkspace, root)
+	}
+}
+
+func TestAbsoluteCommandOutputRootRejectsSymlinkBoundary(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create reports symlink: %v", err)
+	}
+
+	_, err := absoluteCommandOutputRoot(filepath.Join(workspace, "reports", "output.json"))
+	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
+		t.Fatalf("expected symlink boundary rejection, got %v", err)
+	}
+}
+
+func TestAbsoluteCommandOutputRootRejectsFileBoundary(t *testing.T) {
+	workspace := t.TempDir()
+	blocker := filepath.Join(workspace, "reports")
+	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	_, err := absoluteCommandOutputRoot(filepath.Join(blocker, "output.json"))
+	if err == nil || !strings.Contains(err.Error(), "output root is not a directory") {
+		t.Fatalf("expected file boundary rejection, got %v", err)
+	}
+}
+
+func TestAbsoluteCommandOutputRootPropagatesLookupError(t *testing.T) {
+	workspace := t.TempDir()
+	locked := filepath.Join(workspace, "locked")
+	if err := os.MkdirAll(locked, 0o700); err != nil {
+		t.Fatalf("mkdir locked: %v", err)
+	}
+	if err := os.Chmod(locked, 0); err != nil {
+		t.Fatalf("chmod locked: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(locked, 0o700); err != nil {
+			t.Errorf("restore locked perms: %v", err)
+		}
+	})
+
+	_, err := absoluteCommandOutputRoot(filepath.Join(locked, "missing", "output.json"))
+	if err == nil {
+		t.Fatal("expected lookup error for inaccessible parent")
+	}
+}
+
+func TestEnsureCommandOutputParentRejectsEscapingPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	outputPath := filepath.Join(root, "..", "outside", "report.json")
+	err := ensureCommandOutputParent(root, outputPath)
+	if err == nil || !strings.Contains(err.Error(), "output path escapes workspace") {
+		t.Fatalf("expected escaping output path rejection, got %v", err)
+	}
+}
+
+func TestEnsureCommandOutputParentPropagatesMkdirAllError(t *testing.T) {
+	root := t.TempDir()
+	blocker := filepath.Join(root, "blocked")
+	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	err := ensureCommandOutputParent(root, filepath.Join(blocker, "report.json"))
+	if err == nil {
+		t.Fatal("expected mkdir failure under regular file")
+	}
+}
+
+func TestRejectSymlinkedOutputParentAllowsRootParent(t *testing.T) {
+	root := t.TempDir()
+	if err := rejectSymlinkedOutputParent(root, root); err != nil {
+		t.Fatalf("expected root parent to be allowed, got %v", err)
+	}
+}
+
+func TestRejectSymlinkedOutputParentRejectsEscapingParent(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	err := rejectSymlinkedOutputParent(root, filepath.Dir(root))
+	if err == nil || !strings.Contains(err.Error(), "output parent escapes workspace") {
+		t.Fatalf("expected escaping parent rejection, got %v", err)
+	}
+}
+
+func TestRejectSymlinkedOutputParentAllowsMissingTail(t *testing.T) {
+	root := t.TempDir()
+	if err := rejectSymlinkedOutputParent(root, filepath.Join(root, "missing", "nested")); err != nil {
+		t.Fatalf("expected missing tail to be allowed, got %v", err)
+	}
+}
+
+func TestRejectSymlinkedOutputParentPropagatesLookupError(t *testing.T) {
+	root := t.TempDir()
+	blocker := filepath.Join(root, "blocked")
+	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	err := rejectSymlinkedOutputParent(root, filepath.Join(blocker, "nested"))
+	if err == nil {
+		t.Fatal("expected lookup error under regular file")
+	}
+}

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -344,6 +344,33 @@ func TestTrustedCommandOutputRootForRootsReturnsEmptyWhenRootsDoNotMatch(t *test
 	}
 }
 
+func TestTrustedCommandOutputRootForRootsSkipsInvalidNonMatchingRoot(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	writeBlockedFile(t, blocker)
+	validRoot := t.TempDir()
+	outputPath := filepath.Join(validRoot, "reports", "output.json")
+
+	root, err := trustedCommandOutputRootForRoots(outputPath, filepath.Join(blocker, "repo"), validRoot)
+	if err != nil {
+		t.Fatalf("trusted command output root for roots: %v", err)
+	}
+	if root != validRoot {
+		t.Fatalf("expected later valid trusted root %q, got %q", validRoot, root)
+	}
+}
+
+func TestTrustedCommandOutputRootForRootsFailsClosedForInvalidMatchingRoot(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	writeBlockedFile(t, blocker)
+	invalidRoot := filepath.Join(blocker, "repo")
+	outputPath := filepath.Join(invalidRoot, "reports", "output.json")
+
+	_, err := trustedCommandOutputRootForRoots(outputPath, invalidRoot, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "resolve trusted output workspace") {
+		t.Fatalf("expected invalid matching trusted root to fail closed, got %v", err)
+	}
+}
+
 func TestTrustedCommandOutputRootForRootIgnoresMissingRootOutsideOutputPath(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
 	root, err := trustedCommandOutputRootForRoot(outputPath, filepath.Join(t.TempDir(), "missing", "repo"))
@@ -892,9 +919,10 @@ func assertTrustedRootLookupError(t *testing.T, label string, lookup func(output
 	root := t.TempDir()
 	blocker := filepath.Join(root, "blocked")
 	writeBlockedFile(t, blocker)
+	trustedRoot := filepath.Join(blocker, "repo")
 
-	err := lookup(filepath.Join(t.TempDir(), "reports", "output.json"), filepath.Join(blocker, "repo"))
-	if err == nil || !strings.Contains(err.Error(), "resolve trusted output workspace symlinks") {
+	err := lookup(filepath.Join(trustedRoot, "reports", "output.json"), trustedRoot)
+	if err == nil || !strings.Contains(err.Error(), "resolve trusted output workspace") {
 		t.Fatalf("expected %s, got %v", label, err)
 	}
 }

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -21,6 +22,44 @@ func TestCommandOutputRootRelativePathUsesWorkspace(t *testing.T) {
 	}
 }
 
+func TestPersistCommandOutputBypassesFileWritesForEmptyAndDash(t *testing.T) {
+	for _, outputPath := range []string{"   ", " - "} {
+		status, err := persistCommandOutput("formatted output", outputPath, "dashboard report")
+		if err != nil {
+			t.Fatalf("persist command output %q: %v", outputPath, err)
+		}
+		if status != "formatted output" {
+			t.Fatalf("expected passthrough output for %q, got %q", outputPath, status)
+		}
+	}
+}
+
+func TestPersistDashboardOutputUsesDashboardLabel(t *testing.T) {
+	workspace := t.TempDir()
+	chdirCanonicalWorkspace(t, workspace)
+
+	status, err := persistDashboardOutput("{}", "report.json")
+	if err != nil {
+		t.Fatalf("persist dashboard output: %v", err)
+	}
+	if status != "dashboard report written to report.json" {
+		t.Fatalf("unexpected status: %q", status)
+	}
+}
+
+func TestPersistCommandOutputPropagatesDirectoryTargetError(t *testing.T) {
+	workspace := t.TempDir()
+	chdirCanonicalWorkspace(t, workspace)
+	if err := os.MkdirAll(filepath.Join(workspace, "reports"), 0o755); err != nil {
+		t.Fatalf("mkdir reports: %v", err)
+	}
+
+	_, err := persistCommandOutput("{}", "reports", "dashboard report")
+	if err == nil {
+		t.Fatal("expected directory target error")
+	}
+}
+
 func TestCommandOutputRootAbsolutePathUsesExistingParentOutsideWorkspace(t *testing.T) {
 	outputRoot := filepath.Join(t.TempDir(), "reports")
 	if err := os.MkdirAll(outputRoot, 0o755); err != nil {
@@ -33,6 +72,51 @@ func TestCommandOutputRootAbsolutePathUsesExistingParentOutsideWorkspace(t *test
 	}
 	if root != outputRoot {
 		t.Fatalf("expected absolute output root %q, got %q", outputRoot, root)
+	}
+}
+
+func TestCommandOutputRootAllowsRelativeParentOutsideWorkspace(t *testing.T) {
+	workspaceParent := t.TempDir()
+	workspace := filepath.Join(workspaceParent, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	chdirCanonicalWorkspace(t, workspace)
+
+	outputPath := filepath.Join("..", "reports", "output.json")
+	status, err := persistCommandOutput("{}", outputPath, "dashboard report")
+	if err != nil {
+		t.Fatalf("persist command output: %v", err)
+	}
+	if status != "dashboard report written to "+outputPath {
+		t.Fatalf("unexpected status: %q", status)
+	}
+
+	outputAbs := filepath.Join(workspaceParent, "reports", "output.json")
+	data, err := os.ReadFile(outputAbs)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(data) != "{}" {
+		t.Fatalf("unexpected output content: %q", string(data))
+	}
+}
+
+func TestCommandOutputRootAllowsKnownDarwinSystemAliasRoots(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("known system alias roots only apply on darwin")
+	}
+
+	workspace := t.TempDir()
+	chdirCanonicalWorkspace(t, workspace)
+
+	outputPath := filepath.Join("/tmp", "lopper-command-output-root", t.Name(), "report.json")
+	root, err := commandOutputRoot(outputPath)
+	if err != nil {
+		t.Fatalf("command output root: %v", err)
+	}
+	if root != "/tmp" {
+		t.Fatalf("expected /tmp root, got %q", root)
 	}
 }
 
@@ -160,6 +244,19 @@ func TestTrustedCommandOutputRootReturnsEmptyOutsideWorkspace(t *testing.T) {
 	}
 }
 
+func TestTrustedCommandOutputRootReturnsWorkspaceForWorkspaceRootPath(t *testing.T) {
+	workspace := t.TempDir()
+	canonicalWorkspace := chdirCanonicalWorkspace(t, workspace)
+
+	root, err := trustedCommandOutputRoot(canonicalWorkspace)
+	if err != nil {
+		t.Fatalf("trusted command output root: %v", err)
+	}
+	if root != canonicalWorkspace {
+		t.Fatalf("expected trusted workspace root %q, got %q", canonicalWorkspace, root)
+	}
+}
+
 func TestAbsoluteCommandOutputRootRejectsFileBoundary(t *testing.T) {
 	workspace := t.TempDir()
 	blocker := filepath.Join(workspace, "reports")
@@ -210,6 +307,19 @@ func TestEnsureCommandOutputParentCreatesNestedDirectories(t *testing.T) {
 		t.Fatalf("stat output parent: %v", err)
 	} else if !info.IsDir() {
 		t.Fatalf("expected output parent directory, got mode %v", info.Mode())
+	}
+}
+
+func TestEnsureCommandOutputParentRejectsSymlinkedParent(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "reports")); err != nil {
+		t.Fatalf("create reports symlink: %v", err)
+	}
+
+	err := ensureCommandOutputParent(root, filepath.Join(root, "reports", "report.json"))
+	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
+		t.Fatalf("expected symlinked parent rejection, got %v", err)
 	}
 }
 
@@ -280,6 +390,53 @@ func TestPathWithinRoot(t *testing.T) {
 	}
 }
 
+func TestPathWithinRootAllowsRootPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	within, err := pathWithinRoot(root, root)
+	if err != nil {
+		t.Fatalf("pathWithinRoot root path: %v", err)
+	}
+	if !within {
+		t.Fatal("expected root path to remain within root")
+	}
+}
+
+func TestPathWithinRootTreatsDifferentWindowsVolumesAsOutside(t *testing.T) {
+	within, err := pathWithinRoot(`C:\repo`, `D:\reports\output.json`)
+	if err != nil {
+		t.Fatalf("pathWithinRoot different volumes: %v", err)
+	}
+	if within {
+		t.Fatal("expected different-volume path to be treated as outside root")
+	}
+}
+
+func TestPathVolumeNameFallsBackToWindowsDrivePrefix(t *testing.T) {
+	if got := pathVolumeName(`D:\reports\output.json`); got != "d:" {
+		t.Fatalf("expected windows drive prefix, got %q", got)
+	}
+	if got := pathVolumeName("/tmp/report.json"); got != "" {
+		t.Fatalf("expected no volume for posix path, got %q", got)
+	}
+}
+
+func TestIsKnownSystemAliasRoot(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		for _, path := range []string{"/tmp", "/var"} {
+			if !isKnownSystemAliasRoot(path) {
+				t.Fatalf("expected %q to be treated as a known system alias root", path)
+			}
+		}
+	}
+	if isKnownSystemAliasRoot("reports") {
+		t.Fatal("expected relative path to be rejected as a known system alias root")
+	}
+}
+
 func TestResolveAliasedWorkspaceRootPropagatesBrokenAliasError(t *testing.T) {
 	workspace := t.TempDir()
 	brokenAlias := filepath.Join(t.TempDir(), "repo")
@@ -300,4 +457,18 @@ func blockedPathFixture(t *testing.T) (string, string) {
 	blocker := filepath.Join(root, "blocked")
 	writeBlockedFile(t, blocker)
 	return root, blocker
+}
+
+func TestRejectSymlinkedOutputParentRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "reports")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("create reports symlink: %v", err)
+	}
+
+	err := rejectSymlinkedOutputParent(root, filepath.Join(link, "nested"))
+	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
 }

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -434,6 +434,18 @@ func TestTrustedCommandOutputRootForRootIgnoresRelativeRootWhenLookupFailsForAbs
 	})
 }
 
+func TestTrustedCommandOutputRootForRootRejectsFileRoot(t *testing.T) {
+	rootFile := filepath.Join(t.TempDir(), "repo")
+	if err := os.WriteFile(rootFile, []byte("not-a-dir"), 0o600); err != nil {
+		t.Fatalf("write root file: %v", err)
+	}
+
+	_, err := trustedCommandOutputRootForRoot(filepath.Join(rootFile, "reports", "output.json"), rootFile)
+	if err == nil || !strings.Contains(err.Error(), "trusted output workspace is not a directory") {
+		t.Fatalf("expected file-root rejection, got %v", err)
+	}
+}
+
 func TestTrustedCommandOutputRootForRootUsesAliasPath(t *testing.T) {
 	_, workspaceAlias := createWorkspaceAlias(t)
 
@@ -802,6 +814,28 @@ func TestPathVolumeNameFallsBackToWindowsDrivePrefix(t *testing.T) {
 	}
 	if got := pathVolumeName("/tmp/report.json"); got != "" {
 		t.Fatalf("expected no volume for posix path, got %q", got)
+	}
+}
+
+func TestFallbackCommandOutputRootPropagatesRelativeWorkspaceError(t *testing.T) {
+	outputAbs := filepath.Join(t.TempDir(), "reports", "output.json")
+	workspaceErr := errors.New("workspace lookup failed")
+
+	_, err := fallbackCommandOutputRoot(outputAbs, filepath.Join("reports", "output.json"), workspaceErr)
+	if !errors.Is(err, workspaceErr) {
+		t.Fatalf("expected workspace lookup error, got %v", err)
+	}
+}
+
+func TestValidateTrustedCommandOutputRootRejectsFile(t *testing.T) {
+	rootFile := filepath.Join(t.TempDir(), "repo")
+	if err := os.WriteFile(rootFile, []byte("not-a-dir"), 0o600); err != nil {
+		t.Fatalf("write root file: %v", err)
+	}
+
+	err := validateTrustedCommandOutputRoot(rootFile)
+	if err == nil || !strings.Contains(err.Error(), "trusted output workspace is not a directory") {
+		t.Fatalf("expected trusted root file rejection, got %v", err)
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 func TestCommandOutputRootRelativePathUsesWorkspace(t *testing.T) {
@@ -159,6 +161,24 @@ func TestPersistCommandOutputPropagatesParentCreationError(t *testing.T) {
 	_, err := persistCommandOutput("{}", filepath.Join("reports", "output.json"), "dashboard report")
 	if err == nil {
 		t.Fatal("expected parent creation error")
+	}
+}
+
+func TestOpenCommandOutputDestinationPropagatesOpenRootError(t *testing.T) {
+	workspace := t.TempDir()
+	chdirCanonicalWorkspace(t, workspace)
+	expectedErr := errors.New("open pinned root failure")
+	originalOpen := openCommandOutputWriteRootFn
+	openCommandOutputWriteRootFn = func(string) (*safeio.WriteRoot, error) {
+		return nil, expectedErr
+	}
+	t.Cleanup(func() {
+		openCommandOutputWriteRootFn = originalOpen
+	})
+
+	_, err := openCommandOutputDestination("report.json")
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected pinned root open error, got %v", err)
 	}
 }
 
@@ -542,14 +562,14 @@ func TestPersistCommandOutputPinsTrustedRootAliasBeforeWrite(t *testing.T) {
 	}
 
 	originalWrite := writeCommandOutputFileFn
-	writeCommandOutputFileFn = func(rootDir, outputPath string, data []byte, perm, parentPerm os.FileMode) error {
+	writeCommandOutputFileFn = func(root *safeio.WriteRoot, outputPath string, data []byte, perm, parentPerm os.FileMode) error {
 		if err := os.Remove(trustedRootAlias); err != nil {
 			return err
 		}
 		if err := os.Symlink(outside, trustedRootAlias); err != nil {
 			return err
 		}
-		return originalWrite(rootDir, outputPath, data, perm, parentPerm)
+		return originalWrite(root, outputPath, data, perm, parentPerm)
 	}
 	t.Cleanup(func() {
 		writeCommandOutputFileFn = originalWrite
@@ -846,141 +866,6 @@ func TestInspectOutputRootPathPropagatesLookupError(t *testing.T) {
 	}
 }
 
-func TestEnsureCommandOutputParentRejectsEscapingPath(t *testing.T) {
-	root := filepath.Join(t.TempDir(), "root")
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Fatalf("mkdir root: %v", err)
-	}
-
-	outputPath := filepath.Join(root, "..", "outside", "report.json")
-	err := ensureCommandOutputParent(root, outputPath)
-	if err == nil || !strings.Contains(err.Error(), "output path escapes workspace") {
-		t.Fatalf("expected escaping output path rejection, got %v", err)
-	}
-}
-
-func TestEnsureCommandOutputParentPropagatesRootResolutionError(t *testing.T) {
-	withUnreadableWorkingDirectory(t, func() {
-		err := ensureCommandOutputParent("reports", "report.json")
-		if err == nil || !strings.Contains(err.Error(), "resolve output root") {
-			t.Fatalf("expected output root resolution failure, got %v", err)
-		}
-	})
-}
-
-func TestEnsureCommandOutputParentPropagatesOutputResolutionError(t *testing.T) {
-	root := t.TempDir()
-	withUnreadableWorkingDirectory(t, func() {
-		err := ensureCommandOutputParent(root, "report.json")
-		if err == nil || !strings.Contains(err.Error(), "resolve output path") {
-			t.Fatalf("expected output path resolution failure, got %v", err)
-		}
-	})
-}
-
-func TestEnsureCommandOutputParentCreatesNestedDirectories(t *testing.T) {
-	root := t.TempDir()
-	outputPath := filepath.Join(root, "reports", "nested", "report.json")
-
-	if err := ensureCommandOutputParent(root, outputPath); err != nil {
-		t.Fatalf("ensure command output parent: %v", err)
-	}
-	if info, err := os.Stat(filepath.Dir(outputPath)); err != nil {
-		t.Fatalf("stat output parent: %v", err)
-	} else if !info.IsDir() {
-		t.Fatalf("expected output parent directory, got mode %v", info.Mode())
-	}
-}
-
-func TestEnsureCommandOutputParentRejectsSymlinkedParent(t *testing.T) {
-	root := t.TempDir()
-	outside := t.TempDir()
-	if err := os.Symlink(outside, filepath.Join(root, "reports")); err != nil {
-		t.Fatalf("create reports symlink: %v", err)
-	}
-
-	err := ensureCommandOutputParent(root, filepath.Join(root, "reports", "report.json"))
-	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
-		t.Fatalf("expected symlinked parent rejection, got %v", err)
-	}
-}
-
-func TestEnsureCommandOutputParentDoesNotCreateOutsideAfterMissingParentSwap(t *testing.T) {
-	root := t.TempDir()
-	outside := t.TempDir()
-	outsideSentinel := filepath.Join(outside, "sentinel.txt")
-	if err := os.WriteFile(outsideSentinel, []byte("outside-before"), 0o600); err != nil {
-		t.Fatalf("seed outside sentinel: %v", err)
-	}
-
-	originalMkdirAll := mkdirAllCommandOutputParentFn
-	mkdirAllCommandOutputParentFn = func(path string, perm os.FileMode) error {
-		if err := os.Symlink(outside, filepath.Join(root, "reports")); err != nil {
-			return err
-		}
-		return originalMkdirAll(path, perm)
-	}
-	t.Cleanup(func() {
-		mkdirAllCommandOutputParentFn = originalMkdirAll
-	})
-
-	outputPath := filepath.Join(root, "reports", "nested", "report.json")
-	err := ensureCommandOutputParent(root, outputPath)
-	if err == nil {
-		t.Fatal("expected swapped parent symlink to be rejected")
-	}
-	if _, statErr := os.Stat(filepath.Join(outside, "nested")); !os.IsNotExist(statErr) {
-		t.Fatalf("expected outside nested directory to remain absent, got err=%v", statErr)
-	}
-	if got := readTextFile(t, outsideSentinel); got != "outside-before" {
-		t.Fatalf("unexpected outside sentinel: %q", got)
-	}
-}
-
-func TestEnsureCommandOutputParentPropagatesMkdirAllError(t *testing.T) {
-	root, blocker := blockedPathFixture(t)
-
-	err := ensureCommandOutputParent(root, filepath.Join(blocker, "report.json"))
-	if err == nil {
-		t.Fatal("expected mkdir failure under regular file")
-	}
-}
-
-func TestRejectSymlinkedOutputParentAllowsRootParent(t *testing.T) {
-	root := t.TempDir()
-	if err := rejectSymlinkedOutputParent(root, root); err != nil {
-		t.Fatalf("expected root parent to be allowed, got %v", err)
-	}
-}
-
-func TestRejectSymlinkedOutputParentRejectsEscapingParent(t *testing.T) {
-	root := filepath.Join(t.TempDir(), "root")
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Fatalf("mkdir root: %v", err)
-	}
-
-	err := rejectSymlinkedOutputParent(root, filepath.Dir(root))
-	if err == nil || !strings.Contains(err.Error(), "output parent escapes workspace") {
-		t.Fatalf("expected escaping parent rejection, got %v", err)
-	}
-}
-
-func TestRejectSymlinkedOutputParentAllowsMissingTail(t *testing.T) {
-	root := t.TempDir()
-	if err := rejectSymlinkedOutputParent(root, filepath.Join(root, "missing", "nested")); err != nil {
-		t.Fatalf("expected missing tail to be allowed, got %v", err)
-	}
-}
-
-func TestRejectSymlinkedOutputParentPropagatesLookupError(t *testing.T) {
-	root, blocker := blockedPathFixture(t)
-
-	err := rejectSymlinkedOutputParent(root, filepath.Join(blocker, "nested"))
-	if err == nil {
-		t.Fatal("expected lookup error under regular file")
-	}
-}
-
 func TestPathWithinRoot(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "root")
 	if err := os.MkdirAll(root, 0o755); err != nil {
@@ -1057,6 +942,37 @@ func TestValidateTrustedCommandOutputRootRejectsFile(t *testing.T) {
 	err := validateTrustedCommandOutputRoot(rootFile)
 	if err == nil || !strings.Contains(err.Error(), "trusted output workspace is not a directory") {
 		t.Fatalf("expected trusted root file rejection, got %v", err)
+	}
+}
+
+func TestValidateTrustedCommandOutputRootRejectsMissingAndSymlinkRoots(t *testing.T) {
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+	if err := validateTrustedCommandOutputRoot(missingRoot); err == nil || !strings.Contains(err.Error(), "resolve trusted output workspace") {
+		t.Fatalf("expected missing trusted root rejection, got %v", err)
+	}
+
+	rootAlias := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(t.TempDir(), rootAlias); err != nil {
+		t.Fatalf("create trusted root alias: %v", err)
+	}
+	if err := validateTrustedCommandOutputRoot(rootAlias); err == nil || !strings.Contains(err.Error(), "trusted output workspace is a symlink") {
+		t.Fatalf("expected symlink trusted root rejection, got %v", err)
+	}
+}
+
+func TestValidateTrustedCommandOutputRootRejectsSymlinkAncestor(t *testing.T) {
+	canonicalParent := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(canonicalParent, "repo"), 0o755); err != nil {
+		t.Fatalf("mkdir canonical repo: %v", err)
+	}
+	parentAlias := filepath.Join(t.TempDir(), "parent-alias")
+	if err := os.Symlink(canonicalParent, parentAlias); err != nil {
+		t.Fatalf("create parent alias: %v", err)
+	}
+
+	err := validateTrustedCommandOutputRoot(filepath.Join(parentAlias, "repo"))
+	if err == nil || !strings.Contains(err.Error(), "validate trusted output workspace") {
+		t.Fatalf("expected trusted root ancestor symlink rejection, got %v", err)
 	}
 }
 
@@ -1139,15 +1055,6 @@ func TestResolveAliasedWorkspaceRootReturnsTopmostWorkspaceAlias(t *testing.T) {
 	if root != reportsAlias {
 		t.Fatalf("expected topmost workspace alias %q, got %q", reportsAlias, root)
 	}
-}
-
-func blockedPathFixture(t *testing.T) (string, string) {
-	t.Helper()
-
-	root := t.TempDir()
-	blocker := filepath.Join(root, "blocked")
-	writeBlockedFile(t, blocker)
-	return root, blocker
 }
 
 func withUnreadableWorkingDirectory(t *testing.T, fn func()) {
@@ -1276,19 +1183,5 @@ func TestRestoreWorkingDirectoryPermissionsIgnoresRemovedDirectory(t *testing.T)
 
 	if err := restoreWorkingDirectoryPermissions(workspace); err != nil {
 		t.Fatalf("restore working directory permissions: %v", err)
-	}
-}
-
-func TestRejectSymlinkedOutputParentRejectsSymlink(t *testing.T) {
-	root := t.TempDir()
-	outside := t.TempDir()
-	link := filepath.Join(root, "reports")
-	if err := os.Symlink(outside, link); err != nil {
-		t.Fatalf("create reports symlink: %v", err)
-	}
-
-	err := rejectSymlinkedOutputParent(root, filepath.Join(link, "nested"))
-	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
-		t.Fatalf("expected symlink rejection, got %v", err)
 	}
 }

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -214,6 +214,15 @@ func TestRejectLexicalOutputRootSymlinksAllowsRegularExistingPath(t *testing.T) 
 	}
 }
 
+func TestRejectLexicalOutputRootPathRejectsDisappearedPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "disappeared")
+
+	err := rejectLexicalOutputRootPath(missing)
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected missing output root error, got %v", err)
+	}
+}
+
 func TestRejectLexicalOutputRootSymlinksAllowsKnownDarwinAliasRoot(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("known system alias roots only apply on darwin")
@@ -685,6 +694,16 @@ func TestEnsureCommandOutputParentPropagatesRootResolutionError(t *testing.T) {
 		err := ensureCommandOutputParent("reports", "report.json")
 		if err == nil || !strings.Contains(err.Error(), "resolve output root") {
 			t.Fatalf("expected output root resolution failure, got %v", err)
+		}
+	})
+}
+
+func TestEnsureCommandOutputParentPropagatesOutputResolutionError(t *testing.T) {
+	root := t.TempDir()
+	withUnreadableWorkingDirectory(t, func() {
+		err := ensureCommandOutputParent(root, "report.json")
+		if err == nil || !strings.Contains(err.Error(), "resolve output path") {
+			t.Fatalf("expected output path resolution failure, got %v", err)
 		}
 	})
 }

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -97,11 +97,7 @@ func TestEnsureCommandOutputParentRejectsEscapingPath(t *testing.T) {
 }
 
 func TestEnsureCommandOutputParentPropagatesMkdirAllError(t *testing.T) {
-	root := t.TempDir()
-	blocker := filepath.Join(root, "blocked")
-	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
-		t.Fatalf("write blocker: %v", err)
-	}
+	root, blocker := blockedPathFixture(t)
 
 	err := ensureCommandOutputParent(root, filepath.Join(blocker, "report.json"))
 	if err == nil {
@@ -136,14 +132,21 @@ func TestRejectSymlinkedOutputParentAllowsMissingTail(t *testing.T) {
 }
 
 func TestRejectSymlinkedOutputParentPropagatesLookupError(t *testing.T) {
-	root := t.TempDir()
-	blocker := filepath.Join(root, "blocked")
-	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
-		t.Fatalf("write blocker: %v", err)
-	}
+	root, blocker := blockedPathFixture(t)
 
 	err := rejectSymlinkedOutputParent(root, filepath.Join(blocker, "nested"))
 	if err == nil {
 		t.Fatal("expected lookup error under regular file")
 	}
+}
+
+func blockedPathFixture(t *testing.T) (string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	blocker := filepath.Join(root, "blocked")
+	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	return root, blocker
 }

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -68,6 +68,27 @@ func TestRootedCommandOutputRootPropagatesOutputPathResolutionError(t *testing.T
 	})
 }
 
+func TestRootedCommandOutputRootPropagatesWorkspaceLookupErrorForAbsolutePath(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
+	withUnreadableWorkingDirectory(t, func() {
+		_, err := rootedCommandOutputRoot(outputPath)
+		if err == nil || !strings.Contains(err.Error(), "resolve output workspace") {
+			t.Fatalf("expected workspace lookup failure, got %v", err)
+		}
+	})
+}
+
+func TestRootedCommandOutputRootPropagatesTrustedRootLookupError(t *testing.T) {
+	root := t.TempDir()
+	blocker := filepath.Join(root, "blocked")
+	writeBlockedFile(t, blocker)
+
+	_, err := rootedCommandOutputRoot(filepath.Join(t.TempDir(), "reports", "output.json"), filepath.Join(blocker, "repo"))
+	if err == nil || !strings.Contains(err.Error(), "resolve trusted output workspace symlinks") {
+		t.Fatalf("expected trusted root lookup failure, got %v", err)
+	}
+}
+
 func TestPersistDashboardOutputUsesDashboardLabel(t *testing.T) {
 	workspace := t.TempDir()
 	chdirCanonicalWorkspace(t, workspace)
@@ -218,6 +239,92 @@ func TestTrustedCommandOutputRootUsesWorkspaceAlias(t *testing.T) {
 	}
 	if root != workspaceAlias {
 		t.Fatalf("expected workspace alias root %q, got %q", workspaceAlias, root)
+	}
+}
+
+func TestTrustedCommandOutputRootForRootsUsesFirstMatchingRoot(t *testing.T) {
+	workspace := t.TempDir()
+	outputPath := filepath.Join(workspace, "reports", "output.json")
+	root, err := trustedCommandOutputRootForRoots(outputPath, "", filepath.Join(t.TempDir(), "other"), workspace)
+	if err != nil {
+		t.Fatalf("trusted command output root for roots: %v", err)
+	}
+	if root != workspace {
+		t.Fatalf("expected matching trusted root %q, got %q", workspace, root)
+	}
+}
+
+func TestTrustedCommandOutputRootForRootsReturnsEmptyWhenRootsDoNotMatch(t *testing.T) {
+	root, err := trustedCommandOutputRootForRoots(filepath.Join(t.TempDir(), "reports", "output.json"), filepath.Join(t.TempDir(), "repo"))
+	if err != nil {
+		t.Fatalf("trusted command output root for roots: %v", err)
+	}
+	if root != "" {
+		t.Fatalf("expected no trusted root, got %q", root)
+	}
+}
+
+func TestTrustedCommandOutputRootForRootIgnoresMissingRootOutsideOutputPath(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
+	root, err := trustedCommandOutputRootForRoot(outputPath, filepath.Join(t.TempDir(), "missing", "repo"))
+	if err != nil {
+		t.Fatalf("trusted command output root for missing root: %v", err)
+	}
+	if root != "" {
+		t.Fatalf("expected no trusted root for missing path, got %q", root)
+	}
+}
+
+func TestTrustedCommandOutputRootForRootUsesAliasPath(t *testing.T) {
+	workspace := t.TempDir()
+	workspaceAlias := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(workspace, workspaceAlias); err != nil {
+		t.Fatalf("create workspace alias: %v", err)
+	}
+
+	root, err := trustedCommandOutputRootForRoot(filepath.Join(workspaceAlias, "reports", "output.json"), workspaceAlias)
+	if err != nil {
+		t.Fatalf("trusted command output root for alias: %v", err)
+	}
+	if root != workspaceAlias {
+		t.Fatalf("expected alias trusted root %q, got %q", workspaceAlias, root)
+	}
+}
+
+func TestTrustedCommandOutputRootForRootsPropagatesRootError(t *testing.T) {
+	root := t.TempDir()
+	blocker := filepath.Join(root, "blocked")
+	writeBlockedFile(t, blocker)
+
+	_, err := trustedCommandOutputRootForRoots(filepath.Join(t.TempDir(), "reports", "output.json"), filepath.Join(blocker, "repo"))
+	if err == nil || !strings.Contains(err.Error(), "resolve trusted output workspace symlinks") {
+		t.Fatalf("expected trusted root resolution error, got %v", err)
+	}
+}
+
+func TestPersistCommandOutputAllowsNewDirectoriesThroughWorkspaceAlias(t *testing.T) {
+	workspace := t.TempDir()
+	workspaceAlias := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(workspace, workspaceAlias); err != nil {
+		t.Fatalf("create workspace alias: %v", err)
+	}
+	chdirCanonicalWorkspace(t, workspace)
+
+	outputPath := filepath.Join(workspaceAlias, "new", "report.json")
+	status, err := persistCommandOutput("{}", outputPath, "dashboard report")
+	if err != nil {
+		t.Fatalf("persist command output: %v", err)
+	}
+	if status != "dashboard report written to "+outputPath {
+		t.Fatalf("unexpected status: %q", status)
+	}
+
+	data, err := os.ReadFile(filepath.Join(workspace, "new", "report.json"))
+	if err != nil {
+		t.Fatalf("read aliased output: %v", err)
+	}
+	if string(data) != "{}" {
+		t.Fatalf("unexpected aliased output content: %q", string(data))
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -59,21 +59,21 @@ func TestPersistCommandOutputRejectsTrailingSeparator(t *testing.T) {
 	}
 }
 
-func TestRootedCommandOutputRootPropagatesOutputPathResolutionError(t *testing.T) {
+func TestCommandOutputRootPropagatesOutputPathResolutionError(t *testing.T) {
 	withUnreadableWorkingDirectory(t, func() {
-		_, err := rootedCommandOutputRoot("report.json")
+		_, err := commandOutputRoot("report.json")
 		if err == nil || !strings.Contains(err.Error(), "resolve output path") {
 			t.Fatalf("expected output path resolution failure, got %v", err)
 		}
 	})
 }
 
-func TestRootedCommandOutputRootAllowsAbsolutePathWhenWorkspaceLookupFails(t *testing.T) {
+func TestCommandOutputRootAllowsAbsolutePathWhenWorkspaceLookupFails(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
 	withUnreadableWorkingDirectory(t, func() {
-		root, err := rootedCommandOutputRoot(outputPath)
+		root, err := commandOutputRoot(outputPath)
 		if err != nil {
-			t.Fatalf("rooted command output root: %v", err)
+			t.Fatalf("command output root: %v", err)
 		}
 		wantRoot := filepath.Dir(filepath.Dir(outputPath))
 		if root != wantRoot {
@@ -82,12 +82,12 @@ func TestRootedCommandOutputRootAllowsAbsolutePathWhenWorkspaceLookupFails(t *te
 	})
 }
 
-func TestRootedCommandOutputRootAllowsAbsolutePathWhenRelativeTrustedRootLookupFails(t *testing.T) {
+func TestCommandOutputRootAllowsAbsolutePathWhenRelativeTrustedRootLookupFails(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
 	withRemovedWorkingDirectory(t, func() {
-		root, err := rootedCommandOutputRoot(outputPath, ".")
+		root, err := commandOutputRoot(outputPath, ".")
 		if err != nil {
-			t.Fatalf("rooted command output root: %v", err)
+			t.Fatalf("command output root: %v", err)
 		}
 		wantRoot := filepath.Dir(filepath.Dir(outputPath))
 		if root != wantRoot {
@@ -96,19 +96,19 @@ func TestRootedCommandOutputRootAllowsAbsolutePathWhenRelativeTrustedRootLookupF
 	})
 }
 
-func TestRootedCommandOutputRootPropagatesTrustedRootLookupError(t *testing.T) {
+func TestCommandOutputRootPropagatesTrustedRootLookupError(t *testing.T) {
 	assertTrustedRootLookupError(t, "trusted root lookup failure", func(outputPath, trustedRoot string) error {
-		_, err := rootedCommandOutputRoot(outputPath, trustedRoot)
+		_, err := commandOutputRoot(outputPath, trustedRoot)
 		return err
 	})
 }
 
-func TestRootedCommandOutputRootUsesTrustedRoot(t *testing.T) {
+func TestCommandOutputRootUsesTrustedRoot(t *testing.T) {
 	trustedRoot := t.TempDir()
 
-	root, err := rootedCommandOutputRoot(filepath.Join(trustedRoot, "reports", "output.json"), trustedRoot)
+	root, err := commandOutputRoot(filepath.Join(trustedRoot, "reports", "output.json"), trustedRoot)
 	if err != nil {
-		t.Fatalf("rooted command output root: %v", err)
+		t.Fatalf("command output root: %v", err)
 	}
 	if root != trustedRoot {
 		t.Fatalf("expected trusted root %q, got %q", trustedRoot, root)
@@ -294,20 +294,20 @@ func TestCommandOutputRootAllowsKnownDarwinSystemAliasRoots(t *testing.T) {
 	}
 }
 
-func TestAbsoluteCommandOutputRootRejectsSymlinkBoundary(t *testing.T) {
+func TestCommandOutputRootRejectsSymlinkBoundary(t *testing.T) {
 	workspace := t.TempDir()
 	outside := t.TempDir()
 	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
 		t.Fatalf("create reports symlink: %v", err)
 	}
 
-	_, err := absoluteCommandOutputRoot(filepath.Join(workspace, "reports", "output.json"))
+	_, err := commandOutputRoot(filepath.Join(workspace, "reports", "output.json"))
 	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
 		t.Fatalf("expected symlink boundary rejection, got %v", err)
 	}
 }
 
-func TestAbsoluteCommandOutputRootRejectsSymlinkBoundaryWhenTargetNestedExists(t *testing.T) {
+func TestCommandOutputRootRejectsSymlinkBoundaryWhenTargetNestedExists(t *testing.T) {
 	workspace := t.TempDir()
 	outside := filepath.Join(t.TempDir(), "outside")
 	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
@@ -318,13 +318,13 @@ func TestAbsoluteCommandOutputRootRejectsSymlinkBoundaryWhenTargetNestedExists(t
 	}
 	canonicalWorkspace := chdirCanonicalWorkspace(t, workspace)
 
-	_, err := absoluteCommandOutputRoot(filepath.Join(canonicalWorkspace, "reports", "nested", "output.json"))
+	_, err := commandOutputRoot(filepath.Join(canonicalWorkspace, "reports", "nested", "output.json"))
 	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
 		t.Fatalf("expected nested symlink boundary rejection, got %v", err)
 	}
 }
 
-func TestAbsoluteCommandOutputRootUsesWorkspaceBoundary(t *testing.T) {
+func TestCommandOutputRootUsesWorkspaceBoundary(t *testing.T) {
 	workspace := t.TempDir()
 	canonicalWorkspace := chdirCanonicalWorkspace(t, workspace)
 	outputPath := filepath.Join(canonicalWorkspace, "reports", "existing", "output.json")
@@ -332,9 +332,9 @@ func TestAbsoluteCommandOutputRootUsesWorkspaceBoundary(t *testing.T) {
 		t.Fatalf("mkdir output parent: %v", err)
 	}
 
-	root, err := absoluteCommandOutputRoot(outputPath)
+	root, err := commandOutputRoot(outputPath)
 	if err != nil {
-		t.Fatalf("absolute command output root: %v", err)
+		t.Fatalf("command output root: %v", err)
 	}
 	if root != canonicalWorkspace {
 		t.Fatalf("expected workspace root %q, got %q", canonicalWorkspace, root)
@@ -602,18 +602,18 @@ func TestTrustedCommandOutputRootPropagatesWorkspaceLookupError(t *testing.T) {
 	})
 }
 
-func TestAbsoluteCommandOutputRootRejectsFileBoundary(t *testing.T) {
+func TestCommandOutputRootRejectsFileBoundary(t *testing.T) {
 	workspace := t.TempDir()
 	blocker := filepath.Join(workspace, "reports")
 	writeBlockedFile(t, blocker)
 
-	_, err := absoluteCommandOutputRoot(filepath.Join(blocker, "output.json"))
+	_, err := commandOutputRoot(filepath.Join(blocker, "output.json"))
 	if err == nil || !strings.Contains(err.Error(), "output root is not a directory") {
 		t.Fatalf("expected file boundary rejection, got %v", err)
 	}
 }
 
-func TestAbsoluteCommandOutputRootRejectsSymlinkBoundaryViaWorkspaceSubdirectoryAlias(t *testing.T) {
+func TestCommandOutputRootRejectsSymlinkBoundaryViaWorkspaceSubdirectoryAlias(t *testing.T) {
 	workspace := t.TempDir()
 	outside := filepath.Join(t.TempDir(), "outside")
 	if err := os.MkdirAll(filepath.Join(workspace, "reports"), 0o755); err != nil {
@@ -631,18 +631,18 @@ func TestAbsoluteCommandOutputRootRejectsSymlinkBoundaryViaWorkspaceSubdirectory
 	}
 	chdirCanonicalWorkspace(t, workspace)
 
-	_, err := absoluteCommandOutputRoot(filepath.Join(reportsAlias, "link", "nested", "output.json"))
+	_, err := commandOutputRoot(filepath.Join(reportsAlias, "link", "nested", "output.json"))
 	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
 		t.Fatalf("expected symlink boundary rejection via subdirectory alias, got %v", err)
 	}
 }
 
-func TestAbsoluteCommandOutputRootPropagatesLookupError(t *testing.T) {
+func TestCommandOutputRootPropagatesLookupError(t *testing.T) {
 	workspace := t.TempDir()
 	locked := filepath.Join(workspace, "locked")
 	writeBlockedFile(t, locked)
 
-	_, err := absoluteCommandOutputRoot(filepath.Join(locked, "missing", "output.json"))
+	_, err := commandOutputRoot(filepath.Join(locked, "missing", "output.json"))
 	if err == nil {
 		t.Fatal("expected lookup error for inaccessible parent")
 	}

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -36,6 +36,21 @@ func TestCommandOutputRootRelativePathUsesWorkspace(t *testing.T) {
 	}
 }
 
+func TestCommandOutputRootAbsolutePathUsesExistingParentOutsideWorkspace(t *testing.T) {
+	outputRoot := filepath.Join(t.TempDir(), "reports")
+	if err := os.MkdirAll(outputRoot, 0o755); err != nil {
+		t.Fatalf("mkdir output root: %v", err)
+	}
+
+	root, err := commandOutputRoot(filepath.Join(outputRoot, "output.json"))
+	if err != nil {
+		t.Fatalf("command output root: %v", err)
+	}
+	if root != outputRoot {
+		t.Fatalf("expected absolute output root %q, got %q", outputRoot, root)
+	}
+}
+
 func TestAbsoluteCommandOutputRootRejectsSymlinkBoundary(t *testing.T) {
 	workspace := t.TempDir()
 	outside := t.TempDir()
@@ -46,6 +61,70 @@ func TestAbsoluteCommandOutputRootRejectsSymlinkBoundary(t *testing.T) {
 	_, err := absoluteCommandOutputRoot(filepath.Join(workspace, "reports", "output.json"))
 	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
 		t.Fatalf("expected symlink boundary rejection, got %v", err)
+	}
+}
+
+func TestAbsoluteCommandOutputRootRejectsSymlinkBoundaryWhenTargetNestedExists(t *testing.T) {
+	workspace := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir outside nested: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create reports symlink: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("chdir workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatalf("canonicalize workspace: %v", err)
+	}
+
+	_, err = absoluteCommandOutputRoot(filepath.Join(canonicalWorkspace, "reports", "nested", "output.json"))
+	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
+		t.Fatalf("expected nested symlink boundary rejection, got %v", err)
+	}
+}
+
+func TestAbsoluteCommandOutputRootUsesWorkspaceBoundary(t *testing.T) {
+	workspace := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("chdir workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatalf("canonicalize workspace: %v", err)
+	}
+	outputPath := filepath.Join(canonicalWorkspace, "reports", "existing", "output.json")
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		t.Fatalf("mkdir output parent: %v", err)
+	}
+
+	root, err := absoluteCommandOutputRoot(outputPath)
+	if err != nil {
+		t.Fatalf("absolute command output root: %v", err)
+	}
+	if root != canonicalWorkspace {
+		t.Fatalf("expected workspace root %q, got %q", canonicalWorkspace, root)
 	}
 }
 
@@ -96,6 +175,20 @@ func TestEnsureCommandOutputParentRejectsEscapingPath(t *testing.T) {
 	}
 }
 
+func TestEnsureCommandOutputParentCreatesNestedDirectories(t *testing.T) {
+	root := t.TempDir()
+	outputPath := filepath.Join(root, "reports", "nested", "report.json")
+
+	if err := ensureCommandOutputParent(root, outputPath); err != nil {
+		t.Fatalf("ensure command output parent: %v", err)
+	}
+	if info, err := os.Stat(filepath.Dir(outputPath)); err != nil {
+		t.Fatalf("stat output parent: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("expected output parent directory, got mode %v", info.Mode())
+	}
+}
+
 func TestEnsureCommandOutputParentPropagatesMkdirAllError(t *testing.T) {
 	root, blocker := blockedPathFixture(t)
 
@@ -137,6 +230,29 @@ func TestRejectSymlinkedOutputParentPropagatesLookupError(t *testing.T) {
 	err := rejectSymlinkedOutputParent(root, filepath.Join(blocker, "nested"))
 	if err == nil {
 		t.Fatal("expected lookup error under regular file")
+	}
+}
+
+func TestPathWithinRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	within, err := pathWithinRoot(root, filepath.Join(root, "nested", "report.json"))
+	if err != nil {
+		t.Fatalf("pathWithinRoot within root: %v", err)
+	}
+	if !within {
+		t.Fatal("expected nested path to remain within root")
+	}
+
+	within, err = pathWithinRoot(root, filepath.Join(filepath.Dir(root), "outside", "report.json"))
+	if err != nil {
+		t.Fatalf("pathWithinRoot outside root: %v", err)
+	}
+	if within {
+		t.Fatal("expected sibling path to escape root")
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -251,6 +251,31 @@ func TestCommandOutputRootAllowsRelativeParentOutsideWorkspace(t *testing.T) {
 	}
 }
 
+func TestPersistCommandOutputRejectsRelativeParentSymlinkEscape(t *testing.T) {
+	workspaceParent := t.TempDir()
+	workspace := filepath.Join(workspaceParent, "workspace")
+	if err := os.MkdirAll(filepath.Join(workspace, "app"), 0o755); err != nil {
+		t.Fatalf("mkdir workspace app: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir outside nested: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create reports symlink: %v", err)
+	}
+	chdirCanonicalWorkspace(t, filepath.Join(workspace, "app"))
+
+	outputPath := filepath.Join("..", "reports", "nested", "output.json")
+	_, err := persistCommandOutput("{}", outputPath, "dashboard report")
+	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
+		t.Fatalf("expected parent-relative symlink rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "nested", "output.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside output to remain absent, got err=%v", statErr)
+	}
+}
+
 func TestCommandOutputRootAllowsKnownDarwinSystemAliasRoots(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("known system alias roots only apply on darwin")
@@ -892,6 +917,14 @@ func withUnreadableWorkingDirectory(t *testing.T, fn func()) {
 	})
 	if err := os.Chmod(workspace, 0); err != nil {
 		t.Fatalf("chmod unreadable workspace: %v", err)
+	}
+	if _, err := os.Getwd(); err == nil {
+		if err := os.Chmod(workspace, 0o755); err != nil {
+			t.Fatalf("restore workspace permissions for removal: %v", err)
+		}
+		if err := os.RemoveAll(workspace); err != nil {
+			t.Fatalf("remove unreadable workspace fallback: %v", err)
+		}
 	}
 
 	fn()

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -43,10 +43,10 @@ func TestPersistCommandOutputRejectsTrailingSeparator(t *testing.T) {
 		t.Fatalf("write existing file: %v", err)
 	}
 
-	for _, outputPath := range []string{"reports/", "existing-file/"} {
+	for _, outputPath := range []string{"reports/", "existing-file/", "reports/.", "existing-file/."} {
 		_, err := persistCommandOutput("{}", outputPath, "dashboard report")
 		if err == nil || !strings.Contains(err.Error(), "output path must name a file") {
-			t.Fatalf("expected trailing-separator rejection for %q, got %v", outputPath, err)
+			t.Fatalf("expected directory-style output rejection for %q, got %v", outputPath, err)
 		}
 	}
 
@@ -780,11 +780,17 @@ func TestPathVolumeNameFallsBackToWindowsDrivePrefix(t *testing.T) {
 	}
 }
 
-func TestHasTrailingOutputPathSeparator(t *testing.T) {
+func TestHasDirectoryStyleOutputPath(t *testing.T) {
 	if !hasTrailingOutputPathSeparator("reports/") {
 		t.Fatal("expected trailing slash to be treated as a path separator")
 	}
-	if hasTrailingOutputPathSeparator("report.json") {
+	if !hasDirectoryStyleOutputPath("reports/.") {
+		t.Fatal("expected trailing dot path element to be rejected")
+	}
+	if !hasDirectoryStyleOutputPath("reports/..") {
+		t.Fatal("expected trailing dotdot path element to be rejected")
+	}
+	if hasDirectoryStyleOutputPath(filepath.Join("reports", "out.json")) {
 		t.Fatal("expected ordinary file path to remain valid")
 	}
 }

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -83,6 +83,83 @@ func TestAbsoluteCommandOutputRootUsesWorkspaceBoundary(t *testing.T) {
 	}
 }
 
+func TestTrustedCommandOutputRootUsesWorkspaceAlias(t *testing.T) {
+	workspace := t.TempDir()
+	workspaceAlias := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(workspace, workspaceAlias); err != nil {
+		t.Fatalf("create workspace alias: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, "reports"), 0o755); err != nil {
+		t.Fatalf("mkdir reports: %v", err)
+	}
+	chdirCanonicalWorkspace(t, workspace)
+
+	root, err := trustedCommandOutputRoot(filepath.Join(workspaceAlias, "reports", "output.json"))
+	if err != nil {
+		t.Fatalf("trusted command output root: %v", err)
+	}
+	if root != workspaceAlias {
+		t.Fatalf("expected workspace alias root %q, got %q", workspaceAlias, root)
+	}
+}
+
+func TestTrustedCommandOutputRootUsesResolvedWorkspaceForRealPathWhenCwdIsAlias(t *testing.T) {
+	workspace := t.TempDir()
+	workspaceAlias := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(workspace, workspaceAlias); err != nil {
+		t.Fatalf("create workspace alias: %v", err)
+	}
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(workspaceAlias); err != nil {
+		t.Fatalf("chdir workspace alias: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	t.Setenv("PWD", workspaceAlias)
+
+	root, err := trustedCommandOutputRoot(filepath.Join(workspace, "reports", "output.json"))
+	if err != nil {
+		t.Fatalf("trusted command output root: %v", err)
+	}
+	if root != workspace {
+		t.Fatalf("expected resolved workspace root %q, got %q", workspace, root)
+	}
+}
+
+func TestTrustedCommandOutputRootPropagatesBrokenWorkspaceAliasError(t *testing.T) {
+	workspace := t.TempDir()
+	chdirCanonicalWorkspace(t, workspace)
+
+	brokenAlias := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(filepath.Join(t.TempDir(), "missing"), brokenAlias); err != nil {
+		t.Fatalf("create broken alias: %v", err)
+	}
+
+	_, err := trustedCommandOutputRoot(filepath.Join(brokenAlias, "reports", "output.json"))
+	if err == nil {
+		t.Fatal("expected broken workspace alias lookup to fail")
+	}
+}
+
+func TestTrustedCommandOutputRootReturnsEmptyOutsideWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	chdirCanonicalWorkspace(t, workspace)
+
+	root, err := trustedCommandOutputRoot(filepath.Join(t.TempDir(), "reports", "output.json"))
+	if err != nil {
+		t.Fatalf("trusted command output root: %v", err)
+	}
+	if root != "" {
+		t.Fatalf("expected no trusted workspace root, got %q", root)
+	}
+}
+
 func TestAbsoluteCommandOutputRootRejectsFileBoundary(t *testing.T) {
 	workspace := t.TempDir()
 	blocker := filepath.Join(workspace, "reports")
@@ -200,6 +277,19 @@ func TestPathWithinRoot(t *testing.T) {
 	}
 	if within {
 		t.Fatal("expected sibling path to escape root")
+	}
+}
+
+func TestResolveAliasedWorkspaceRootPropagatesBrokenAliasError(t *testing.T) {
+	workspace := t.TempDir()
+	brokenAlias := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(filepath.Join(t.TempDir(), "missing"), brokenAlias); err != nil {
+		t.Fatalf("create broken alias: %v", err)
+	}
+
+	_, err := resolveAliasedWorkspaceRoot(filepath.Join(brokenAlias, "reports", "output.json"), workspace)
+	if err == nil {
+		t.Fatal("expected broken alias resolution to fail")
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -59,6 +59,15 @@ func TestPersistCommandOutputRejectsTrailingSeparator(t *testing.T) {
 	}
 }
 
+func TestRootedCommandOutputRootPropagatesOutputPathResolutionError(t *testing.T) {
+	withUnreadableWorkingDirectory(t, func() {
+		_, err := rootedCommandOutputRoot("report.json")
+		if err == nil || !strings.Contains(err.Error(), "resolve output path") {
+			t.Fatalf("expected output path resolution failure, got %v", err)
+		}
+	})
+}
+
 func TestPersistDashboardOutputUsesDashboardLabel(t *testing.T) {
 	workspace := t.TempDir()
 	chdirCanonicalWorkspace(t, workspace)
@@ -302,6 +311,15 @@ func TestTrustedCommandOutputRootReturnsWorkspaceForWorkspaceRootPath(t *testing
 	}
 }
 
+func TestTrustedCommandOutputRootPropagatesWorkspaceLookupError(t *testing.T) {
+	withUnreadableWorkingDirectory(t, func() {
+		_, err := trustedCommandOutputRoot(filepath.Join(t.TempDir(), "reports", "output.json"))
+		if err == nil || !strings.Contains(err.Error(), "resolve output workspace") {
+			t.Fatalf("expected workspace lookup failure, got %v", err)
+		}
+	})
+}
+
 func TestAbsoluteCommandOutputRootRejectsFileBoundary(t *testing.T) {
 	workspace := t.TempDir()
 	blocker := filepath.Join(workspace, "reports")
@@ -352,6 +370,21 @@ func TestAbsoluteCommandOutputRootPropagatesLookupError(t *testing.T) {
 	}
 }
 
+func TestInspectOutputRootPathPropagatesLookupError(t *testing.T) {
+	workspace := t.TempDir()
+	locked := filepath.Join(workspace, "locked")
+	writeBlockedFile(t, locked)
+
+	_, _, err := inspectOutputRootPath(filepath.Join(locked, "missing"), "output.json")
+	if err == nil {
+		t.Fatal("expected lookup error for child under file")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) || pathErr.Op != "lstat" || pathErr.Path != filepath.Join(locked, "missing") {
+		t.Fatalf("expected propagated lstat path error for child under file, got %v", err)
+	}
+}
+
 func TestEnsureCommandOutputParentRejectsEscapingPath(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "root")
 	if err := os.MkdirAll(root, 0o755); err != nil {
@@ -363,6 +396,15 @@ func TestEnsureCommandOutputParentRejectsEscapingPath(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "output path escapes workspace") {
 		t.Fatalf("expected escaping output path rejection, got %v", err)
 	}
+}
+
+func TestEnsureCommandOutputParentPropagatesRootResolutionError(t *testing.T) {
+	withUnreadableWorkingDirectory(t, func() {
+		err := ensureCommandOutputParent("reports", "report.json")
+		if err == nil || !strings.Contains(err.Error(), "resolve output root") {
+			t.Fatalf("expected output root resolution failure, got %v", err)
+		}
+	})
 }
 
 func TestEnsureCommandOutputParentCreatesNestedDirectories(t *testing.T) {
@@ -528,6 +570,21 @@ func TestResolveAliasedWorkspaceRootPropagatesBrokenAliasError(t *testing.T) {
 	}
 }
 
+func TestResolveAliasedWorkspaceRootPropagatesLookupError(t *testing.T) {
+	workspace := t.TempDir()
+	locked := filepath.Join(t.TempDir(), "locked")
+	writeBlockedFile(t, locked)
+
+	_, err := resolveAliasedWorkspaceRoot(filepath.Join(locked, "reports", "output.json"), workspace)
+	if err == nil {
+		t.Fatal("expected lookup error for child under file")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) || pathErr.Op != "lstat" || pathErr.Path != filepath.Join(locked, "reports") {
+		t.Fatalf("expected propagated lstat path error for child under file, got %v", err)
+	}
+}
+
 func TestResolveAliasedWorkspaceRootReturnsTopmostWorkspaceAlias(t *testing.T) {
 	workspace := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(workspace, "reports", "existing"), 0o755); err != nil {
@@ -558,6 +615,35 @@ func blockedPathFixture(t *testing.T) (string, string) {
 	blocker := filepath.Join(root, "blocked")
 	writeBlockedFile(t, blocker)
 	return root, blocker
+}
+
+func withUnreadableWorkingDirectory(t *testing.T, fn func()) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("working directory permission errors are not stable on windows")
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	workspace := t.TempDir()
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("chdir unreadable workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+		if err := os.Chmod(workspace, 0o755); err != nil {
+			t.Errorf("restore workspace permissions: %v", err)
+		}
+	})
+	if err := os.Chmod(workspace, 0); err != nil {
+		t.Fatalf("chmod unreadable workspace: %v", err)
+	}
+
+	fn()
 }
 
 func TestRejectSymlinkedOutputParentRejectsSymlink(t *testing.T) {

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -510,50 +510,60 @@ func TestTrustedCommandOutputRootForRootRejectsFileRoot(t *testing.T) {
 	}
 }
 
-func TestPersistCommandOutputRejectsSymlinkedTrustedRoot(t *testing.T) {
-	outside := t.TempDir()
-	trustedRoot := filepath.Join(t.TempDir(), "repo")
-	if err := os.Symlink(outside, trustedRoot); err != nil {
-		t.Fatalf("create trusted root symlink: %v", err)
-	}
+func TestPersistCommandOutputAllowsTrustedRootAlias(t *testing.T) {
+	workspace, trustedRootAlias := createWorkspaceAlias(t)
+	outputPath := filepath.Join(trustedRootAlias, "reports", "report.json")
 
-	outputPath := filepath.Join(trustedRoot, "report.json")
-	_, err := persistCommandOutput("{}", outputPath, "dashboard report", trustedRoot)
-	if err == nil || !strings.Contains(err.Error(), "trusted output workspace is a symlink") {
-		t.Fatalf("expected symlinked trusted root rejection, got %v", err)
+	status, err := persistCommandOutput("{}", outputPath, "dashboard report", trustedRootAlias)
+	if err != nil {
+		t.Fatalf("persist command output through trusted root alias: %v", err)
 	}
-	if _, statErr := os.Stat(filepath.Join(outside, "report.json")); !os.IsNotExist(statErr) {
-		t.Fatalf("expected outside output to remain absent, got err=%v", statErr)
+	if status != "dashboard report written to "+outputPath {
+		t.Fatalf("unexpected status: %q", status)
+	}
+	data, err := os.ReadFile(filepath.Join(workspace, "reports", "report.json"))
+	if err != nil {
+		t.Fatalf("read output through trusted root alias: %v", err)
+	}
+	if string(data) != "{}" {
+		t.Fatalf("unexpected output content: %q", string(data))
 	}
 }
 
-func TestPersistCommandOutputRejectsTrustedRootWithSymlinkedAncestor(t *testing.T) {
+func TestPersistCommandOutputRejectsSymlinkEscapeUnderTrustedRootAlias(t *testing.T) {
+	workspace, trustedRootAlias := createWorkspaceAlias(t)
 	outside := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(outside, "repo"), 0o755); err != nil {
-		t.Fatalf("mkdir outside repo: %v", err)
+	outsideTarget := filepath.Join(outside, "report.json")
+	if err := os.WriteFile(outsideTarget, []byte("before"), 0o600); err != nil {
+		t.Fatalf("seed outside target: %v", err)
 	}
-	alias := filepath.Join(t.TempDir(), "alias")
-	if err := os.Symlink(outside, alias); err != nil {
-		t.Fatalf("create trusted root ancestor symlink: %v", err)
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create escaping output symlink: %v", err)
 	}
-	trustedRoot := filepath.Join(alias, "repo")
 
-	outputPath := filepath.Join(trustedRoot, "report.json")
-	_, err := persistCommandOutput("{}", outputPath, "dashboard report", trustedRoot)
+	outputPath := filepath.Join(trustedRootAlias, "reports", "report.json")
+	_, err := persistCommandOutput("after", outputPath, "dashboard report", trustedRootAlias)
 	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
-		t.Fatalf("expected trusted root ancestor symlink rejection, got %v", err)
+		t.Fatalf("expected symlink escape rejection under trusted root alias, got %v", err)
 	}
-	if _, statErr := os.Stat(filepath.Join(outside, "repo", "report.json")); !os.IsNotExist(statErr) {
-		t.Fatalf("expected outside output to remain absent, got err=%v", statErr)
+	data, readErr := os.ReadFile(outsideTarget)
+	if readErr != nil {
+		t.Fatalf("read outside target: %v", readErr)
+	}
+	if string(data) != "before" {
+		t.Fatalf("expected outside target to remain unchanged, got %q", string(data))
 	}
 }
 
-func TestTrustedCommandOutputRootForRootRejectsAliasPath(t *testing.T) {
+func TestTrustedCommandOutputRootForRootUsesAliasPath(t *testing.T) {
 	_, workspaceAlias := createWorkspaceAlias(t)
 
-	_, err := trustedCommandOutputRootForRoot(filepath.Join(workspaceAlias, "reports", "output.json"), workspaceAlias)
-	if err == nil || !strings.Contains(err.Error(), "trusted output workspace is a symlink") {
-		t.Fatalf("expected alias trusted root rejection, got %v", err)
+	root, err := trustedCommandOutputRootForRoot(filepath.Join(workspaceAlias, "reports", "output.json"), workspaceAlias)
+	if err != nil {
+		t.Fatalf("trusted command output root for alias: %v", err)
+	}
+	if root != workspaceAlias {
+		t.Fatalf("expected alias trusted root %q, got %q", workspaceAlias, root)
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -83,14 +83,10 @@ func TestRootedCommandOutputRootAllowsAbsolutePathWhenWorkspaceLookupFails(t *te
 }
 
 func TestRootedCommandOutputRootPropagatesTrustedRootLookupError(t *testing.T) {
-	root := t.TempDir()
-	blocker := filepath.Join(root, "blocked")
-	writeBlockedFile(t, blocker)
-
-	_, err := rootedCommandOutputRoot(filepath.Join(t.TempDir(), "reports", "output.json"), filepath.Join(blocker, "repo"))
-	if err == nil || !strings.Contains(err.Error(), "resolve trusted output workspace symlinks") {
-		t.Fatalf("expected trusted root lookup failure, got %v", err)
-	}
+	assertTrustedRootLookupError(t, "trusted root lookup failure", func(outputPath string, trustedRoot string) error {
+		_, err := rootedCommandOutputRoot(outputPath, trustedRoot)
+		return err
+	})
 }
 
 func TestPersistDashboardOutputUsesDashboardLabel(t *testing.T) {
@@ -107,25 +103,11 @@ func TestPersistDashboardOutputUsesDashboardLabel(t *testing.T) {
 }
 
 func TestPersistCommandOutputAllowsAbsoluteExternalPathWhenWorkingDirectoryRemoved(t *testing.T) {
-	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
+	assertPersistCommandOutputWritesAbsolutePath(t, withRemovedWorkingDirectory)
+}
 
-	withRemovedWorkingDirectory(t, func() {
-		status, err := persistCommandOutput("{}", outputPath, "dashboard report")
-		if err != nil {
-			t.Fatalf("persist command output: %v", err)
-		}
-		if status != "dashboard report written to "+outputPath {
-			t.Fatalf("unexpected status: %q", status)
-		}
-	})
-
-	data, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatalf("read output: %v", err)
-	}
-	if string(data) != "{}" {
-		t.Fatalf("unexpected output content: %q", string(data))
-	}
+func TestPersistCommandOutputAllowsAbsoluteExternalPathWhenWorkingDirectoryUnreadable(t *testing.T) {
+	assertPersistCommandOutputWritesAbsolutePath(t, withUnreadableWorkingDirectory)
 }
 
 func TestPersistCommandOutputPropagatesDirectoryTargetError(t *testing.T) {
@@ -302,11 +284,7 @@ func TestTrustedCommandOutputRootForRootIgnoresMissingRootOutsideOutputPath(t *t
 }
 
 func TestTrustedCommandOutputRootForRootUsesAliasPath(t *testing.T) {
-	workspace := t.TempDir()
-	workspaceAlias := filepath.Join(t.TempDir(), "repo")
-	if err := os.Symlink(workspace, workspaceAlias); err != nil {
-		t.Fatalf("create workspace alias: %v", err)
-	}
+	_, workspaceAlias := createWorkspaceAlias(t)
 
 	root, err := trustedCommandOutputRootForRoot(filepath.Join(workspaceAlias, "reports", "output.json"), workspaceAlias)
 	if err != nil {
@@ -317,15 +295,23 @@ func TestTrustedCommandOutputRootForRootUsesAliasPath(t *testing.T) {
 	}
 }
 
-func TestTrustedCommandOutputRootForRootsPropagatesRootError(t *testing.T) {
-	root := t.TempDir()
-	blocker := filepath.Join(root, "blocked")
-	writeBlockedFile(t, blocker)
+func TestTrustedCommandOutputRootForRootUsesResolvedRootForRealPath(t *testing.T) {
+	workspace, workspaceAlias := createWorkspaceAlias(t)
 
-	_, err := trustedCommandOutputRootForRoots(filepath.Join(t.TempDir(), "reports", "output.json"), filepath.Join(blocker, "repo"))
-	if err == nil || !strings.Contains(err.Error(), "resolve trusted output workspace symlinks") {
-		t.Fatalf("expected trusted root resolution error, got %v", err)
+	root, err := trustedCommandOutputRootForRoot(filepath.Join(workspace, "reports", "output.json"), workspaceAlias)
+	if err != nil {
+		t.Fatalf("trusted command output root for real path: %v", err)
 	}
+	if root != workspace {
+		t.Fatalf("expected resolved trusted root %q, got %q", workspace, root)
+	}
+}
+
+func TestTrustedCommandOutputRootForRootsPropagatesRootError(t *testing.T) {
+	assertTrustedRootLookupError(t, "trusted root resolution error", func(outputPath string, trustedRoot string) error {
+		_, err := trustedCommandOutputRootForRoots(outputPath, trustedRoot)
+		return err
+	})
 }
 
 func TestPersistCommandOutputAllowsNewDirectoriesThroughWorkspaceAlias(t *testing.T) {
@@ -803,6 +789,53 @@ func withRemovedWorkingDirectory(t *testing.T, fn func()) {
 	})
 
 	fn()
+}
+
+func assertPersistCommandOutputWritesAbsolutePath(t *testing.T, withWorkspaceFailure func(*testing.T, func())) {
+	t.Helper()
+
+	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
+	withWorkspaceFailure(t, func() {
+		status, err := persistCommandOutput("{}", outputPath, "dashboard report")
+		if err != nil {
+			t.Fatalf("persist command output: %v", err)
+		}
+		if status != "dashboard report written to "+outputPath {
+			t.Fatalf("unexpected status: %q", status)
+		}
+	})
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(data) != "{}" {
+		t.Fatalf("unexpected output content: %q", string(data))
+	}
+}
+
+func assertTrustedRootLookupError(t *testing.T, label string, lookup func(outputPath string, trustedRoot string) error) {
+	t.Helper()
+
+	root := t.TempDir()
+	blocker := filepath.Join(root, "blocked")
+	writeBlockedFile(t, blocker)
+
+	err := lookup(filepath.Join(t.TempDir(), "reports", "output.json"), filepath.Join(blocker, "repo"))
+	if err == nil || !strings.Contains(err.Error(), "resolve trusted output workspace symlinks") {
+		t.Fatalf("expected %s, got %v", label, err)
+	}
+}
+
+func createWorkspaceAlias(t *testing.T) (string, string) {
+	t.Helper()
+
+	workspace := t.TempDir()
+	workspaceAlias := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(workspace, workspaceAlias); err != nil {
+		t.Fatalf("create workspace alias: %v", err)
+	}
+	return workspace, workspaceAlias
 }
 
 func TestRejectSymlinkedOutputParentRejectsSymlink(t *testing.T) {

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -550,6 +550,32 @@ func TestPersistCommandOutputAllowsTrustedRootAlias(t *testing.T) {
 	}
 }
 
+func TestPersistCommandOutputRejectsTrustedRootWithSymlinkAncestor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink ancestor semantics are covered on Unix")
+	}
+
+	rootParent := t.TempDir()
+	outside := t.TempDir()
+	trustedRoot := filepath.Join(rootParent, "reports", "nested")
+	outsideRoot := filepath.Join(outside, "nested")
+	if err := os.MkdirAll(outsideRoot, 0o755); err != nil {
+		t.Fatalf("mkdir outside root: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(rootParent, "reports")); err != nil {
+		t.Fatalf("create trusted root ancestor symlink: %v", err)
+	}
+
+	outputPath := filepath.Join(trustedRoot, "report.json")
+	_, err := persistCommandOutput("after", outputPath, "dashboard report", trustedRoot)
+	if err == nil || !strings.Contains(err.Error(), "trusted output workspace") {
+		t.Fatalf("expected trusted root ancestor symlink rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outsideRoot, "report.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside output to remain absent, got err=%v", statErr)
+	}
+}
+
 func TestPersistCommandOutputPinsTrustedRootAliasBeforeWrite(t *testing.T) {
 	workspace, trustedRootAlias := createWorkspaceAlias(t)
 	outside := t.TempDir()
@@ -617,6 +643,50 @@ func TestPersistCommandOutputAllowsRelativeOutputFromSymlinkedWorkspace(t *testi
 	}
 	if got := readTextFile(t, filepath.Join(workspace, outputPath)); got != "{}" {
 		t.Fatalf("unexpected aliased output: %q", got)
+	}
+}
+
+func TestPersistCommandOutputResolvesParentRelativeOutputFromPhysicalWorkspace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("logical PWD symlink semantics are covered on Unix")
+	}
+
+	physicalParent := t.TempDir()
+	workspace := filepath.Join(physicalParent, "app")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir physical workspace: %v", err)
+	}
+	workspaceAlias := filepath.Join(t.TempDir(), "workspace-alias")
+	if err := os.Symlink(workspace, workspaceAlias); err != nil {
+		t.Fatalf("create workspace alias: %v", err)
+	}
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(workspaceAlias); err != nil {
+		t.Fatalf("chdir workspace alias: %v", err)
+	}
+	t.Setenv("PWD", workspaceAlias)
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	outputPath := filepath.Join("..", "report.json")
+	status, err := persistCommandOutput("{}", outputPath, "dashboard report", ".")
+	if err != nil {
+		t.Fatalf("persist parent-relative output from workspace alias: %v", err)
+	}
+	if status != "dashboard report written to "+outputPath {
+		t.Fatalf("unexpected status: %q", status)
+	}
+	if got := readTextFile(t, filepath.Join(physicalParent, "report.json")); got != "{}" {
+		t.Fatalf("unexpected physical parent output: %q", got)
+	}
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(workspaceAlias), "report.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected logical alias parent output to remain absent, got err=%v", statErr)
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -187,6 +187,26 @@ func TestTrustedCommandOutputRootUsesWorkspaceAlias(t *testing.T) {
 	}
 }
 
+func TestTrustedCommandOutputRootUsesWorkspaceSubdirectoryAlias(t *testing.T) {
+	workspace := t.TempDir()
+	workspaceAlias := filepath.Join(t.TempDir(), "reports-alias")
+	if err := os.MkdirAll(filepath.Join(workspace, "reports"), 0o755); err != nil {
+		t.Fatalf("mkdir reports: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(workspace, "reports"), workspaceAlias); err != nil {
+		t.Fatalf("create reports alias: %v", err)
+	}
+	chdirCanonicalWorkspace(t, workspace)
+
+	root, err := trustedCommandOutputRoot(filepath.Join(workspaceAlias, "nested", "output.json"))
+	if err != nil {
+		t.Fatalf("trusted command output root: %v", err)
+	}
+	if root != workspaceAlias {
+		t.Fatalf("expected workspace subdirectory alias root %q, got %q", workspaceAlias, root)
+	}
+}
+
 func TestTrustedCommandOutputRootUsesResolvedWorkspaceForRealPathWhenCwdIsAlias(t *testing.T) {
 	workspace := t.TempDir()
 	workspaceAlias := filepath.Join(t.TempDir(), "repo")
@@ -265,6 +285,30 @@ func TestAbsoluteCommandOutputRootRejectsFileBoundary(t *testing.T) {
 	_, err := absoluteCommandOutputRoot(filepath.Join(blocker, "output.json"))
 	if err == nil || !strings.Contains(err.Error(), "output root is not a directory") {
 		t.Fatalf("expected file boundary rejection, got %v", err)
+	}
+}
+
+func TestAbsoluteCommandOutputRootRejectsSymlinkBoundaryViaWorkspaceSubdirectoryAlias(t *testing.T) {
+	workspace := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(filepath.Join(workspace, "reports"), 0o755); err != nil {
+		t.Fatalf("mkdir reports: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir outside nested: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports", "link")); err != nil {
+		t.Fatalf("create reports link symlink: %v", err)
+	}
+	reportsAlias := filepath.Join(t.TempDir(), "reports-alias")
+	if err := os.Symlink(filepath.Join(workspace, "reports"), reportsAlias); err != nil {
+		t.Fatalf("create reports alias: %v", err)
+	}
+	chdirCanonicalWorkspace(t, workspace)
+
+	_, err := absoluteCommandOutputRoot(filepath.Join(reportsAlias, "link", "nested", "output.json"))
+	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
+		t.Fatalf("expected symlink boundary rejection via subdirectory alias, got %v", err)
 	}
 }
 
@@ -447,6 +491,29 @@ func TestResolveAliasedWorkspaceRootPropagatesBrokenAliasError(t *testing.T) {
 	_, err := resolveAliasedWorkspaceRoot(filepath.Join(brokenAlias, "reports", "output.json"), workspace)
 	if err == nil {
 		t.Fatal("expected broken alias resolution to fail")
+	}
+}
+
+func TestResolveAliasedWorkspaceRootReturnsTopmostWorkspaceAlias(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, "reports", "existing"), 0o755); err != nil {
+		t.Fatalf("mkdir reports existing: %v", err)
+	}
+	resolvedWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatalf("resolve workspace symlinks: %v", err)
+	}
+	reportsAlias := filepath.Join(t.TempDir(), "reports-alias")
+	if err := os.Symlink(filepath.Join(workspace, "reports"), reportsAlias); err != nil {
+		t.Fatalf("create reports alias: %v", err)
+	}
+
+	root, err := resolveAliasedWorkspaceRoot(filepath.Join(reportsAlias, "existing", "output.json"), resolvedWorkspace)
+	if err != nil {
+		t.Fatalf("resolve aliased workspace root: %v", err)
+	}
+	if root != reportsAlias {
+		t.Fatalf("expected topmost workspace alias %q, got %q", reportsAlias, root)
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -9,28 +9,12 @@ import (
 )
 
 func TestCommandOutputRootRelativePathUsesWorkspace(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get cwd: %v", err)
-	}
-
 	workspace := t.TempDir()
-	if err := os.Chdir(workspace); err != nil {
-		t.Fatalf("chdir workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Errorf("restore cwd: %v", err)
-		}
-	})
+	canonicalWorkspace := chdirCanonicalWorkspace(t, workspace)
 
 	root, err := commandOutputRoot("reports/output.json")
 	if err != nil {
 		t.Fatalf("command output root: %v", err)
-	}
-	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
-	if err != nil {
-		t.Fatalf("canonicalize workspace: %v", err)
 	}
 	if root != canonicalWorkspace {
 		t.Fatalf("expected workspace root %q, got %q", canonicalWorkspace, root)
@@ -74,24 +58,9 @@ func TestAbsoluteCommandOutputRootRejectsSymlinkBoundaryWhenTargetNestedExists(t
 	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
 		t.Fatalf("create reports symlink: %v", err)
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get cwd: %v", err)
-	}
-	if err := os.Chdir(workspace); err != nil {
-		t.Fatalf("chdir workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Errorf("restore cwd: %v", err)
-		}
-	})
-	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
-	if err != nil {
-		t.Fatalf("canonicalize workspace: %v", err)
-	}
+	canonicalWorkspace := chdirCanonicalWorkspace(t, workspace)
 
-	_, err = absoluteCommandOutputRoot(filepath.Join(canonicalWorkspace, "reports", "nested", "output.json"))
+	_, err := absoluteCommandOutputRoot(filepath.Join(canonicalWorkspace, "reports", "nested", "output.json"))
 	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
 		t.Fatalf("expected nested symlink boundary rejection, got %v", err)
 	}
@@ -99,22 +68,7 @@ func TestAbsoluteCommandOutputRootRejectsSymlinkBoundaryWhenTargetNestedExists(t
 
 func TestAbsoluteCommandOutputRootUsesWorkspaceBoundary(t *testing.T) {
 	workspace := t.TempDir()
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get cwd: %v", err)
-	}
-	if err := os.Chdir(workspace); err != nil {
-		t.Fatalf("chdir workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Errorf("restore cwd: %v", err)
-		}
-	})
-	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
-	if err != nil {
-		t.Fatalf("canonicalize workspace: %v", err)
-	}
+	canonicalWorkspace := chdirCanonicalWorkspace(t, workspace)
 	outputPath := filepath.Join(canonicalWorkspace, "reports", "existing", "output.json")
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
 		t.Fatalf("mkdir output parent: %v", err)
@@ -132,9 +86,7 @@ func TestAbsoluteCommandOutputRootUsesWorkspaceBoundary(t *testing.T) {
 func TestAbsoluteCommandOutputRootRejectsFileBoundary(t *testing.T) {
 	workspace := t.TempDir()
 	blocker := filepath.Join(workspace, "reports")
-	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
-		t.Fatalf("write blocker: %v", err)
-	}
+	writeBlockedFile(t, blocker)
 
 	_, err := absoluteCommandOutputRoot(filepath.Join(blocker, "output.json"))
 	if err == nil || !strings.Contains(err.Error(), "output root is not a directory") {
@@ -145,9 +97,7 @@ func TestAbsoluteCommandOutputRootRejectsFileBoundary(t *testing.T) {
 func TestAbsoluteCommandOutputRootPropagatesLookupError(t *testing.T) {
 	workspace := t.TempDir()
 	locked := filepath.Join(workspace, "locked")
-	if err := os.WriteFile(locked, []byte("blocked"), 0o600); err != nil {
-		t.Fatalf("write locked: %v", err)
-	}
+	writeBlockedFile(t, locked)
 
 	_, err := absoluteCommandOutputRoot(filepath.Join(locked, "missing", "output.json"))
 	if err == nil {
@@ -258,8 +208,6 @@ func blockedPathFixture(t *testing.T) (string, string) {
 
 	root := t.TempDir()
 	blocker := filepath.Join(root, "blocked")
-	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
-		t.Fatalf("write blocker: %v", err)
-	}
+	writeBlockedFile(t, blocker)
 	return root, blocker
 }

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -285,6 +285,30 @@ func TestPersistCommandOutputRejectsRelativeParentSymlinkEscape(t *testing.T) {
 	}
 }
 
+func TestPersistCommandOutputRejectsParentTraversalAfterSymlink(t *testing.T) {
+	workspace := t.TempDir()
+	externalRoot := t.TempDir()
+	outside := filepath.Join(externalRoot, "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create reports symlink: %v", err)
+	}
+	chdirCanonicalWorkspace(t, workspace)
+
+	outputPath := strings.Join([]string{"reports", "..", "report.json"}, string(os.PathSeparator))
+	_, err := persistCommandOutput("after", outputPath, "dashboard report")
+	if err == nil || !strings.Contains(err.Error(), "parent traversal after path component") {
+		t.Fatalf("expected ambiguous parent traversal rejection, got %v", err)
+	}
+	for _, path := range []string{filepath.Join(workspace, "report.json"), filepath.Join(externalRoot, "report.json")} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("expected %q to remain absent, got err=%v", path, statErr)
+		}
+	}
+}
+
 func TestCommandOutputRootAllowsKnownDarwinSystemAliasRoots(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("known system alias roots only apply on darwin")
@@ -300,6 +324,37 @@ func TestCommandOutputRootAllowsKnownDarwinSystemAliasRoots(t *testing.T) {
 	}
 	if root != "/tmp" {
 		t.Fatalf("expected /tmp root, got %q", root)
+	}
+}
+
+func TestCommandOutputRootAllowsRootLevelSystemAlias(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("root-level directory symlink discovery is not stable on windows")
+	}
+
+	var aliasRoot string
+	for _, candidate := range []string{"/etc", "/home", "/bin", "/sbin", "/lib", "/lib64"} {
+		linkInfo, err := os.Lstat(candidate)
+		if err != nil || linkInfo.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		targetInfo, err := os.Stat(candidate)
+		if err == nil && targetInfo.IsDir() {
+			aliasRoot = candidate
+			break
+		}
+	}
+	if aliasRoot == "" {
+		t.Skip("no root-level system directory alias is available")
+	}
+
+	outputPath := filepath.Join(aliasRoot, "lopper-system-alias-test-missing", "report.json")
+	root, err := commandOutputRoot(outputPath)
+	if err != nil {
+		t.Fatalf("command output root: %v", err)
+	}
+	if root != aliasRoot {
+		t.Fatalf("expected system alias root %q, got %q", aliasRoot, root)
 	}
 }
 
@@ -455,15 +510,50 @@ func TestTrustedCommandOutputRootForRootRejectsFileRoot(t *testing.T) {
 	}
 }
 
-func TestTrustedCommandOutputRootForRootUsesAliasPath(t *testing.T) {
+func TestPersistCommandOutputRejectsSymlinkedTrustedRoot(t *testing.T) {
+	outside := t.TempDir()
+	trustedRoot := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(outside, trustedRoot); err != nil {
+		t.Fatalf("create trusted root symlink: %v", err)
+	}
+
+	outputPath := filepath.Join(trustedRoot, "report.json")
+	_, err := persistCommandOutput("{}", outputPath, "dashboard report", trustedRoot)
+	if err == nil || !strings.Contains(err.Error(), "trusted output workspace is a symlink") {
+		t.Fatalf("expected symlinked trusted root rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "report.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside output to remain absent, got err=%v", statErr)
+	}
+}
+
+func TestPersistCommandOutputRejectsTrustedRootWithSymlinkedAncestor(t *testing.T) {
+	outside := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(outside, "repo"), 0o755); err != nil {
+		t.Fatalf("mkdir outside repo: %v", err)
+	}
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(outside, alias); err != nil {
+		t.Fatalf("create trusted root ancestor symlink: %v", err)
+	}
+	trustedRoot := filepath.Join(alias, "repo")
+
+	outputPath := filepath.Join(trustedRoot, "report.json")
+	_, err := persistCommandOutput("{}", outputPath, "dashboard report", trustedRoot)
+	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
+		t.Fatalf("expected trusted root ancestor symlink rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "repo", "report.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside output to remain absent, got err=%v", statErr)
+	}
+}
+
+func TestTrustedCommandOutputRootForRootRejectsAliasPath(t *testing.T) {
 	_, workspaceAlias := createWorkspaceAlias(t)
 
-	root, err := trustedCommandOutputRootForRoot(filepath.Join(workspaceAlias, "reports", "output.json"), workspaceAlias)
-	if err != nil {
-		t.Fatalf("trusted command output root for alias: %v", err)
-	}
-	if root != workspaceAlias {
-		t.Fatalf("expected alias trusted root %q, got %q", workspaceAlias, root)
+	_, err := trustedCommandOutputRootForRoot(filepath.Join(workspaceAlias, "reports", "output.json"), workspaceAlias)
+	if err == nil || !strings.Contains(err.Error(), "trusted output workspace is a symlink") {
+		t.Fatalf("expected alias trusted root rejection, got %v", err)
 	}
 }
 
@@ -873,16 +963,18 @@ func TestHasDirectoryStyleOutputPath(t *testing.T) {
 	}
 }
 
-func TestIsKnownSystemAliasRoot(t *testing.T) {
+func TestIsRootLevelSystemAlias(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		for _, path := range []string{"/tmp", "/var"} {
-			if !isKnownSystemAliasRoot(path) {
-				t.Fatalf("expected %q to be treated as a known system alias root", path)
+			if !isRootLevelSystemAlias(path) {
+				t.Fatalf("expected %q to be treated as a root-level system alias", path)
 			}
 		}
 	}
-	if isKnownSystemAliasRoot("reports") {
-		t.Fatal("expected relative path to be rejected as a known system alias root")
+	for _, path := range []string{"reports", filepath.Join(t.TempDir(), "reports")} {
+		if isRootLevelSystemAlias(path) {
+			t.Fatalf("expected %q not to be treated as a root-level system alias", path)
+		}
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -945,7 +945,7 @@ func withUnreadableWorkingDirectory(t *testing.T, fn func()) {
 		if err := os.Chdir(originalWD); err != nil {
 			t.Errorf("restore cwd: %v", err)
 		}
-		if err := os.Chmod(workspace, 0o755); err != nil {
+		if err := restoreWorkingDirectoryPermissions(workspace); err != nil {
 			t.Errorf("restore workspace permissions: %v", err)
 		}
 	})
@@ -962,6 +962,13 @@ func withUnreadableWorkingDirectory(t *testing.T, fn func()) {
 	}
 
 	fn()
+}
+
+func restoreWorkingDirectoryPermissions(workspace string) error {
+	if err := os.Chmod(workspace, 0o755); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func withRemovedWorkingDirectory(t *testing.T, fn func()) {
@@ -1036,6 +1043,17 @@ func createWorkspaceAlias(t *testing.T) (string, string) {
 		t.Fatalf("create workspace alias: %v", err)
 	}
 	return workspace, workspaceAlias
+}
+
+func TestRestoreWorkingDirectoryPermissionsIgnoresRemovedDirectory(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.RemoveAll(workspace); err != nil {
+		t.Fatalf("remove workspace: %v", err)
+	}
+
+	if err := restoreWorkingDirectoryPermissions(workspace); err != nil {
+		t.Fatalf("restore working directory permissions: %v", err)
+	}
 }
 
 func TestRejectSymlinkedOutputParentRejectsSymlink(t *testing.T) {

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -89,6 +89,18 @@ func TestRootedCommandOutputRootPropagatesTrustedRootLookupError(t *testing.T) {
 	})
 }
 
+func TestRootedCommandOutputRootUsesTrustedRoot(t *testing.T) {
+	trustedRoot := t.TempDir()
+
+	root, err := rootedCommandOutputRoot(filepath.Join(trustedRoot, "reports", "output.json"), trustedRoot)
+	if err != nil {
+		t.Fatalf("rooted command output root: %v", err)
+	}
+	if root != trustedRoot {
+		t.Fatalf("expected trusted root %q, got %q", trustedRoot, root)
+	}
+}
+
 func TestPersistDashboardOutputUsesDashboardLabel(t *testing.T) {
 	workspace := t.TempDir()
 	chdirCanonicalWorkspace(t, workspace)
@@ -120,6 +132,19 @@ func TestPersistCommandOutputPropagatesDirectoryTargetError(t *testing.T) {
 	_, err := persistCommandOutput("{}", "reports", "dashboard report")
 	if err == nil {
 		t.Fatal("expected directory target error")
+	}
+}
+
+func TestPersistCommandOutputPropagatesParentCreationError(t *testing.T) {
+	workspace := t.TempDir()
+	chdirCanonicalWorkspace(t, workspace)
+	if err := os.WriteFile(filepath.Join(workspace, "reports"), []byte("block"), 0o600); err != nil {
+		t.Fatalf("write blocking file: %v", err)
+	}
+
+	_, err := persistCommandOutput("{}", filepath.Join("reports", "output.json"), "dashboard report")
+	if err == nil {
+		t.Fatal("expected parent creation error")
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,21 +145,17 @@ func TestAbsoluteCommandOutputRootRejectsFileBoundary(t *testing.T) {
 func TestAbsoluteCommandOutputRootPropagatesLookupError(t *testing.T) {
 	workspace := t.TempDir()
 	locked := filepath.Join(workspace, "locked")
-	if err := os.MkdirAll(locked, 0o700); err != nil {
-		t.Fatalf("mkdir locked: %v", err)
+	if err := os.WriteFile(locked, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write locked: %v", err)
 	}
-	if err := os.Chmod(locked, 0); err != nil {
-		t.Fatalf("chmod locked: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chmod(locked, 0o700); err != nil {
-			t.Errorf("restore locked perms: %v", err)
-		}
-	})
 
 	_, err := absoluteCommandOutputRoot(filepath.Join(locked, "missing", "output.json"))
 	if err == nil {
 		t.Fatal("expected lookup error for inaccessible parent")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) || pathErr.Op != "lstat" || pathErr.Path != filepath.Join(locked, "missing") {
+		t.Fatalf("expected propagated lstat path error for child under file, got %v", err)
 	}
 }
 

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -82,6 +82,20 @@ func TestRootedCommandOutputRootAllowsAbsolutePathWhenWorkspaceLookupFails(t *te
 	})
 }
 
+func TestRootedCommandOutputRootAllowsAbsolutePathWhenRelativeTrustedRootLookupFails(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
+	withRemovedWorkingDirectory(t, func() {
+		root, err := rootedCommandOutputRoot(outputPath, ".")
+		if err != nil {
+			t.Fatalf("rooted command output root: %v", err)
+		}
+		wantRoot := filepath.Dir(filepath.Dir(outputPath))
+		if root != wantRoot {
+			t.Fatalf("expected fallback output root %q, got %q", wantRoot, root)
+		}
+	})
+}
+
 func TestRootedCommandOutputRootPropagatesTrustedRootLookupError(t *testing.T) {
 	assertTrustedRootLookupError(t, "trusted root lookup failure", func(outputPath, trustedRoot string) error {
 		_, err := rootedCommandOutputRoot(outputPath, trustedRoot)
@@ -380,6 +394,19 @@ func TestTrustedCommandOutputRootForRootIgnoresMissingRootOutsideOutputPath(t *t
 	if root != "" {
 		t.Fatalf("expected no trusted root for missing path, got %q", root)
 	}
+}
+
+func TestTrustedCommandOutputRootForRootIgnoresRelativeRootWhenLookupFailsForAbsoluteOutput(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "reports", "output.json")
+	withRemovedWorkingDirectory(t, func() {
+		root, err := trustedCommandOutputRootForRoot(outputPath, ".")
+		if err != nil {
+			t.Fatalf("trusted command output root for relative root: %v", err)
+		}
+		if root != "" {
+			t.Fatalf("expected no trusted root when relative lookup fails, got %q", root)
+		}
+	})
 }
 
 func TestTrustedCommandOutputRootForRootUsesAliasPath(t *testing.T) {

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -625,6 +625,57 @@ func TestPersistCommandOutputPinsTrustedRootAliasBeforeWrite(t *testing.T) {
 	}
 }
 
+func TestPersistCommandOutputPinsCanonicalRootBeforeAcceptedBoundaryRetarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics are covered on Unix")
+	}
+
+	rootParent := t.TempDir()
+	workspace := filepath.Join(rootParent, "workspace")
+	relocatedWorkspace := filepath.Join(rootParent, "workspace-relocated")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	workspaceAlias := filepath.Join(t.TempDir(), "workspace-alias")
+	if err := os.Symlink(workspace, workspaceAlias); err != nil {
+		t.Fatalf("create workspace alias: %v", err)
+	}
+	outside := t.TempDir()
+	outsideTarget := filepath.Join(outside, "reports", "report.json")
+	if err := os.MkdirAll(filepath.Dir(outsideTarget), 0o755); err != nil {
+		t.Fatalf("mkdir outside reports: %v", err)
+	}
+	if err := os.WriteFile(outsideTarget, []byte("outside-before"), 0o600); err != nil {
+		t.Fatalf("seed outside target: %v", err)
+	}
+
+	originalAccepted := commandOutputBoundaryAcceptedFn
+	commandOutputBoundaryAcceptedFn = func() error {
+		if err := os.Rename(workspace, relocatedWorkspace); err != nil {
+			return err
+		}
+		return os.Symlink(outside, workspace)
+	}
+	t.Cleanup(func() {
+		commandOutputBoundaryAcceptedFn = originalAccepted
+	})
+
+	outputPath := filepath.Join(workspaceAlias, "reports", "report.json")
+	status, err := persistCommandOutput("workspace-after", outputPath, "dashboard report", workspaceAlias)
+	if err != nil {
+		t.Fatalf("persist through retargeted canonical root: %v", err)
+	}
+	if status != "dashboard report written to "+outputPath {
+		t.Fatalf("unexpected status: %q", status)
+	}
+	if got := readTextFile(t, filepath.Join(relocatedWorkspace, "reports", "report.json")); got != "workspace-after" {
+		t.Fatalf("unexpected pinned workspace output: %q", got)
+	}
+	if got := readTextFile(t, outsideTarget); got != "outside-before" {
+		t.Fatalf("unexpected outside output: %q", got)
+	}
+}
+
 func TestPersistCommandOutputAllowsRelativeOutputFromSymlinkedWorkspace(t *testing.T) {
 	workspace, workspaceAlias := createWorkspaceAlias(t)
 	originalWD, err := os.Getwd()

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -34,6 +34,31 @@ func TestPersistCommandOutputBypassesFileWritesForEmptyAndDash(t *testing.T) {
 	}
 }
 
+func TestPersistCommandOutputRejectsTrailingSeparator(t *testing.T) {
+	workspace := t.TempDir()
+	chdirCanonicalWorkspace(t, workspace)
+
+	existingFile := filepath.Join(workspace, "existing-file")
+	if err := os.WriteFile(existingFile, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	for _, outputPath := range []string{"reports/", "existing-file/"} {
+		_, err := persistCommandOutput("{}", outputPath, "dashboard report")
+		if err == nil || !strings.Contains(err.Error(), "output path must name a file") {
+			t.Fatalf("expected trailing-separator rejection for %q, got %v", outputPath, err)
+		}
+	}
+
+	data, err := os.ReadFile(existingFile)
+	if err != nil {
+		t.Fatalf("read existing file: %v", err)
+	}
+	if string(data) != "keep" {
+		t.Fatalf("expected existing file to remain unchanged, got %q", string(data))
+	}
+}
+
 func TestPersistDashboardOutputUsesDashboardLabel(t *testing.T) {
 	workspace := t.TempDir()
 	chdirCanonicalWorkspace(t, workspace)
@@ -465,6 +490,15 @@ func TestPathVolumeNameFallsBackToWindowsDrivePrefix(t *testing.T) {
 	}
 	if got := pathVolumeName("/tmp/report.json"); got != "" {
 		t.Fatalf("expected no volume for posix path, got %q", got)
+	}
+}
+
+func TestHasTrailingOutputPathSeparator(t *testing.T) {
+	if !hasTrailingOutputPathSeparator("reports/") {
+		t.Fatal("expected trailing slash to be treated as a path separator")
+	}
+	if hasTrailingOutputPathSeparator("report.json") {
+		t.Fatal("expected ordinary file path to remain valid")
 	}
 }
 

--- a/internal/app/dashboard_remote_test.go
+++ b/internal/app/dashboard_remote_test.go
@@ -803,6 +803,9 @@ func TestDashboardCheckoutHelpers(t *testing.T) {
 	if !pathWithinDir(root, root) {
 		t.Fatalf("expected cache root to be within itself")
 	}
+	if pathWithinDir("relative", filepath.Join(root, "child")) {
+		t.Fatalf("expected mixed relative and absolute paths to be rejected")
+	}
 	if _, err := dashboardCheckoutPath("relative", spec, dashboard.RepoRevision{}); err == nil || !strings.Contains(err.Error(), "absolute") {
 		t.Fatalf("expected relative checkout root error, got %v", err)
 	}

--- a/internal/app/dashboard_remote_test.go
+++ b/internal/app/dashboard_remote_test.go
@@ -788,24 +788,12 @@ func TestDashboardCheckoutHelpers(t *testing.T) {
 	if branchCheckout == first || tagCheckout == first || branchCheckout == tagCheckout {
 		t.Fatalf("expected distinct checkout paths for unpinned, branch, and tag pins: %q %q %q", first, branchCheckout, tagCheckout)
 	}
-	if sanitized := sanitizeDashboardCheckoutName(" ../repo name:with/slash "); sanitized != "repo-name-with-slash" {
-		t.Fatalf("unexpected sanitized checkout name: %q", sanitized)
-	}
-	if sanitized := sanitizeDashboardCheckoutName("!!!"); sanitized != "repo" {
-		t.Fatalf("expected empty sanitized name fallback, got %q", sanitized)
-	}
-	if pathWithinDir(root, filepath.Dir(root)) {
-		t.Fatalf("expected parent directory to be outside cache root")
-	}
-	if !pathWithinDir(root, filepath.Join(root, "child")) {
-		t.Fatalf("expected child directory to be within cache root")
-	}
-	if !pathWithinDir(root, root) {
-		t.Fatalf("expected cache root to be within itself")
-	}
-	if pathWithinDir("relative", filepath.Join(root, "child")) {
-		t.Fatalf("expected mixed relative and absolute paths to be rejected")
-	}
+	assertDashboardCheckoutName(t, " ../repo name:with/slash ", "repo-name-with-slash")
+	assertDashboardCheckoutName(t, "!!!", "repo")
+	assertPathWithinDir(t, root, filepath.Dir(root), false, "expected parent directory to be outside cache root")
+	assertPathWithinDir(t, root, filepath.Join(root, "child"), true, "expected child directory to be within cache root")
+	assertPathWithinDir(t, root, root, true, "expected cache root to be within itself")
+	assertPathWithinDir(t, "relative", filepath.Join(root, "child"), false, "expected mixed relative and absolute paths to be rejected")
 	if _, err := dashboardCheckoutPath("relative", spec, dashboard.RepoRevision{}); err == nil || !strings.Contains(err.Error(), "absolute") {
 		t.Fatalf("expected relative checkout root error, got %v", err)
 	}
@@ -816,6 +804,20 @@ func TestDashboardCheckoutHelpers(t *testing.T) {
 	}
 	if args := gitArgsForURL(testHTTPSRepoURL, "status"); len(args) != 1 || args[0] != "status" {
 		t.Fatalf("expected passthrough https git args, got %#v", args)
+	}
+}
+
+func assertDashboardCheckoutName(t *testing.T, input, want string) {
+	t.Helper()
+	if got := sanitizeDashboardCheckoutName(input); got != want {
+		t.Fatalf("sanitizeDashboardCheckoutName(%q) = %q, want %q", input, got, want)
+	}
+}
+
+func assertPathWithinDir(t *testing.T, root, candidate string, want bool, message string) {
+	t.Helper()
+	if got := pathWithinDir(root, candidate); got != want {
+		t.Fatalf("%s: pathWithinDir(%q, %q) = %t", message, root, candidate, got)
 	}
 }
 

--- a/internal/app/dashboard_remote_test.go
+++ b/internal/app/dashboard_remote_test.go
@@ -509,6 +509,23 @@ func TestDashboardRepoMaterializerRefreshesUsableCheckout(t *testing.T) {
 	assertCommandContains(t, commands, "clean -fdx")
 }
 
+func TestDashboardRepoMaterializerRefreshCheckoutUsesPinnedRevision(t *testing.T) {
+	spec := mustParseDashboardRepoURL(t, testHTTPSRepoURL)
+
+	var commands []string
+	withDashboardGitRemoteOriginAndCommit(t, testHTTPSRepoURL, testResolvedCommit, &commands)
+
+	materializer := &dashboardRepoMaterializer{cacheRoot: t.TempDir(), gitPath: "/usr/bin/git"}
+	got, err := materializer.refreshCheckout(context.Background(), t.TempDir(), spec, dashboard.RepoRevision{Branch: "release/main"})
+	if err != nil {
+		t.Fatalf("refresh checkout with pinned revision: %v", err)
+	}
+	if got != testResolvedCommit {
+		t.Fatalf("expected resolved commit %s, got %s", testResolvedCommit, got)
+	}
+	assertCommandContains(t, commands, "fetch --prune --no-tags --depth=1 origin refs/heads/release/main")
+}
+
 func TestDashboardRepoMaterializerRefreshFailure(t *testing.T) {
 	cacheRoot := t.TempDir()
 	spec := mustParseDashboardRepoURL(t, testHTTPSRepoURL)

--- a/internal/app/dashboard_request_output_test.go
+++ b/internal/app/dashboard_request_output_test.go
@@ -206,3 +206,28 @@ func TestPersistDashboardOutputRejectsAbsoluteSymlinkedNestedParent(t *testing.T
 		t.Fatalf("expected outside nested report to remain absent, got err=%v", statErr)
 	}
 }
+
+func TestPersistDashboardOutputRejectsAbsoluteSymlinkedNestedParentViaWorkspaceAlias(t *testing.T) {
+	workspace := t.TempDir()
+	workspaceAlias := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(workspace, workspaceAlias); err != nil {
+		t.Fatalf("create workspace alias: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "out")
+	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir outside nested: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create reports symlink: %v", err)
+	}
+	chdirCanonicalWorkspace(t, workspace)
+
+	outputPath := filepath.Join(workspaceAlias, "reports", "nested", "org-report.json")
+	_, err := persistDashboardOutput(`{"report":true}`, outputPath)
+	if err == nil {
+		t.Fatal("expected absolute nested symlinked parent via workspace alias to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "nested", "org-report.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside nested report to remain absent, got err=%v", statErr)
+	}
+}

--- a/internal/app/dashboard_request_output_test.go
+++ b/internal/app/dashboard_request_output_test.go
@@ -117,7 +117,31 @@ func TestExecuteDashboardOutputPathErrors(t *testing.T) {
 	})
 }
 
-func TestPersistDashboardOutputDoesNotFollowSymlinkTarget(t *testing.T) {
+func TestPersistDashboardOutputPreservesExistingFileMode(t *testing.T) {
+	workspace := t.TempDir()
+	outputPath := filepath.Join(workspace, "org-report.html")
+	if err := os.WriteFile(outputPath, []byte("before"), 0o644); err != nil {
+		t.Fatalf("seed report file: %v", err)
+	}
+	if err := os.Chmod(outputPath, 0o644); err != nil {
+		t.Fatalf("chmod report file: %v", err)
+	}
+
+	chdirCanonicalWorkspace(t, workspace)
+
+	if _, err := persistDashboardOutput("<html>report</html>", "org-report.html"); err != nil {
+		t.Fatalf("persist dashboard output: %v", err)
+	}
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		t.Fatalf("stat dashboard output: %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("expected existing dashboard output mode 0644 to be preserved, got %#o", info.Mode().Perm())
+	}
+}
+
+func TestPersistDashboardOutputRejectsSymlinkTarget(t *testing.T) {
 	workspace := t.TempDir()
 	outside := filepath.Join(t.TempDir(), "outside.txt")
 	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
@@ -130,8 +154,8 @@ func TestPersistDashboardOutputDoesNotFollowSymlinkTarget(t *testing.T) {
 
 	chdirCanonicalWorkspace(t, workspace)
 
-	if _, err := persistDashboardOutput("<html>report</html>", "org-report.html"); err != nil {
-		t.Fatalf("persist dashboard output: %v", err)
+	if _, err := persistDashboardOutput("<html>report</html>", "org-report.html"); err == nil {
+		t.Fatal("expected symlink target to be rejected")
 	}
 	data, err := os.ReadFile(outside)
 	if err != nil {
@@ -140,12 +164,12 @@ func TestPersistDashboardOutputDoesNotFollowSymlinkTarget(t *testing.T) {
 	if string(data) != "secret" {
 		t.Fatalf("expected symlink target to remain unchanged, got %q", string(data))
 	}
-	written, err := os.ReadFile(outputPath)
+	info, err := os.Lstat(outputPath)
 	if err != nil {
-		t.Fatalf("read dashboard output: %v", err)
+		t.Fatalf("lstat dashboard output: %v", err)
 	}
-	if string(written) != "<html>report</html>" {
-		t.Fatalf("expected report at output path, got %q", string(written))
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected dashboard output path to remain a symlink, got mode %v", info.Mode())
 	}
 }
 

--- a/internal/app/dashboard_request_output_test.go
+++ b/internal/app/dashboard_request_output_test.go
@@ -98,3 +98,75 @@ func TestExecuteDashboardOutputPathErrors(t *testing.T) {
 		}
 	})
 }
+
+func TestPersistDashboardOutputDoesNotFollowSymlinkTarget(t *testing.T) {
+	workspace := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed outside file: %v", err)
+	}
+	outputPath := filepath.Join(workspace, "org-report.html")
+	if err := os.Symlink(outside, outputPath); err != nil {
+		t.Fatalf("create output symlink: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("chdir workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	if _, err := persistDashboardOutput("<html>report</html>", "org-report.html"); err != nil {
+		t.Fatalf("persist dashboard output: %v", err)
+	}
+	data, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatalf("read outside file: %v", err)
+	}
+	if string(data) != "secret" {
+		t.Fatalf("expected symlink target to remain unchanged, got %q", string(data))
+	}
+	written, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read dashboard output: %v", err)
+	}
+	if string(written) != "<html>report</html>" {
+		t.Fatalf("expected report at output path, got %q", string(written))
+	}
+}
+
+func TestPersistDashboardOutputRejectsSymlinkedParent(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create parent symlink: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("chdir workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	_, err = persistDashboardOutput(`{"report":true}`, filepath.Join("reports", "org-report.json"))
+	if err == nil {
+		t.Fatal("expected symlinked parent to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "org-report.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside report to remain absent, got err=%v", statErr)
+	}
+}

--- a/internal/app/dashboard_request_output_test.go
+++ b/internal/app/dashboard_request_output_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/dashboard"
@@ -49,6 +50,25 @@ func TestDashboardRequestAdditionalBranches(t *testing.T) {
 	absoluteBaselineStore := filepath.Join(t.TempDir(), "baselines")
 	if got := resolveDashboardConfigPath(configDir, absoluteBaselineStore); got != absoluteBaselineStore {
 		t.Fatalf("expected absolute dashboard config path to pass through, got %q", got)
+	}
+}
+
+func TestDashboardOutputTrustedRootsDedupesAndSkipsBlankPaths(t *testing.T) {
+	plan := dashboardExecutionPlan{
+		initialResults: []dashboard.RepoAnalysis{
+			{Input: dashboard.RepoInput{Path: "  "}},
+			{Input: dashboard.RepoInput{Path: "/repo/a"}},
+			{Input: dashboard.RepoInput{Path: "/repo/a"}},
+			{Input: dashboard.RepoInput{Path: "/repo/b"}},
+		},
+	}
+
+	roots := dashboardOutputTrustedRoots(plan)
+	if len(roots) != 2 {
+		t.Fatalf("expected two unique trusted roots, got %#v", roots)
+	}
+	if roots[0] != "/repo/a" || roots[1] != "/repo/b" {
+		t.Fatalf("unexpected trusted roots: %#v", roots)
 	}
 }
 
@@ -229,5 +249,42 @@ func TestPersistDashboardOutputRejectsAbsoluteSymlinkedNestedParentViaWorkspaceA
 	}
 	if _, statErr := os.Stat(filepath.Join(outside, "nested", "org-report.json")); !os.IsNotExist(statErr) {
 		t.Fatalf("expected outside nested report to remain absent, got err=%v", statErr)
+	}
+}
+
+func TestExecuteDashboardRejectsAbsoluteOutputUnderRequestedRepoSymlinkOutsideWorkingDirectory(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir outside nested: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(repo, "reports")); err != nil {
+		t.Fatalf("create reports symlink: %v", err)
+	}
+	chdirCanonicalWorkspace(t, t.TempDir())
+
+	analyzer := &mapAnalyzer{
+		reports: map[string]report.Report{
+			repo: {Dependencies: []report.DependencyReport{{Name: "dep"}}},
+		},
+		errs: map[string]error{},
+	}
+	application := &App{Analyzer: analyzer}
+
+	req := DefaultRequest()
+	req.Mode = ModeDashboard
+	req.Dashboard.Format = "json"
+	req.Dashboard.Repos = []DashboardRepo{{Name: "repo", Path: repo}}
+	req.Dashboard.OutputPath = filepath.Join(repo, "reports", "nested", "org-report.json")
+
+	_, err := application.Execute(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "output root contains symlink") {
+		t.Fatalf("expected dashboard repo-root symlink rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "nested", "org-report.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside dashboard output to remain absent, got err=%v", statErr)
 	}
 }

--- a/internal/app/dashboard_request_output_test.go
+++ b/internal/app/dashboard_request_output_test.go
@@ -209,3 +209,39 @@ func TestPersistDashboardOutputRejectsAbsoluteSymlinkedParent(t *testing.T) {
 		t.Fatalf("expected outside report to remain absent, got err=%v", statErr)
 	}
 }
+
+func TestPersistDashboardOutputRejectsAbsoluteSymlinkedNestedParent(t *testing.T) {
+	workspace := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir outside nested: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create parent symlink: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("chdir workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatalf("canonicalize workspace: %v", err)
+	}
+	outputPath := filepath.Join(canonicalWorkspace, "reports", "nested", "org-report.json")
+
+	_, err = persistDashboardOutput(`{"report":true}`, outputPath)
+	if err == nil {
+		t.Fatal("expected absolute nested symlinked parent to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "nested", "org-report.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside nested report to remain absent, got err=%v", statErr)
+	}
+}

--- a/internal/app/dashboard_request_output_test.go
+++ b/internal/app/dashboard_request_output_test.go
@@ -141,6 +141,46 @@ func TestPersistDashboardOutputPreservesExistingFileMode(t *testing.T) {
 	}
 }
 
+func TestPersistDashboardOutputRejectsReadOnlyExistingFile(t *testing.T) {
+	workspace := t.TempDir()
+	outputPath := filepath.Join(workspace, "org-report.html")
+	if err := os.WriteFile(outputPath, []byte("before"), 0o600); err != nil {
+		t.Fatalf("seed report file: %v", err)
+	}
+	if err := os.Chmod(outputPath, 0o400); err != nil {
+		t.Fatalf("chmod report file read-only: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(outputPath, 0o600); err != nil && !os.IsNotExist(err) {
+			t.Errorf("restore report file permissions: %v", err)
+		}
+	})
+
+	probe, probeErr := os.OpenFile(outputPath, os.O_WRONLY, 0)
+	if probeErr == nil {
+		if err := probe.Close(); err != nil {
+			t.Fatalf("close writability probe: %v", err)
+		}
+		t.Skip("effective privileges bypass read-only file permissions")
+	}
+	if !os.IsPermission(probeErr) {
+		t.Skipf("read-only file semantics are not testable: %v", probeErr)
+	}
+
+	chdirCanonicalWorkspace(t, workspace)
+
+	if _, err := persistDashboardOutput("<html>after</html>", "org-report.html"); err == nil {
+		t.Fatal("expected read-only dashboard output to be rejected")
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read dashboard output: %v", err)
+	}
+	if string(data) != "before" {
+		t.Fatalf("expected read-only dashboard output to remain unchanged, got %q", string(data))
+	}
+}
+
 func TestPersistDashboardOutputRejectsSymlinkTarget(t *testing.T) {
 	workspace := t.TempDir()
 	outside := filepath.Join(t.TempDir(), "outside.txt")

--- a/internal/app/dashboard_request_output_test.go
+++ b/internal/app/dashboard_request_output_test.go
@@ -170,3 +170,42 @@ func TestPersistDashboardOutputRejectsSymlinkedParent(t *testing.T) {
 		t.Fatalf("expected outside report to remain absent, got err=%v", statErr)
 	}
 }
+
+func TestPersistDashboardOutputAllowsAbsolutePathUnderSystemSymlinkPrefix(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "reports", "org-report.json")
+
+	if _, err := persistDashboardOutput(`{"report":true}`, outputPath); err != nil {
+		t.Fatalf("persist dashboard output: %v", err)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read dashboard output: %v", err)
+	}
+	if string(data) != `{"report":true}` {
+		t.Fatalf("expected dashboard report content, got %q", string(data))
+	}
+	root, err := commandOutputRoot(outputPath)
+	if err != nil {
+		t.Fatalf("resolve command output root: %v", err)
+	}
+	if root == string(os.PathSeparator) {
+		t.Fatalf("expected absolute output root to stop at existing parent directory, got %q", root)
+	}
+}
+
+func TestPersistDashboardOutputRejectsAbsoluteSymlinkedParent(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	outputPath := filepath.Join(workspace, "reports", "org-report.json")
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create parent symlink: %v", err)
+	}
+
+	_, err := persistDashboardOutput(`{"report":true}`, outputPath)
+	if err == nil {
+		t.Fatal("expected absolute symlinked parent to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "org-report.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside report to remain absent, got err=%v", statErr)
+	}
+}

--- a/internal/app/dashboard_request_output_test.go
+++ b/internal/app/dashboard_request_output_test.go
@@ -117,30 +117,6 @@ func TestExecuteDashboardOutputPathErrors(t *testing.T) {
 	})
 }
 
-func TestPersistDashboardOutputPreservesExistingFileMode(t *testing.T) {
-	workspace := t.TempDir()
-	outputPath := filepath.Join(workspace, "org-report.html")
-	if err := os.WriteFile(outputPath, []byte("before"), 0o644); err != nil {
-		t.Fatalf("seed report file: %v", err)
-	}
-	if err := os.Chmod(outputPath, 0o644); err != nil {
-		t.Fatalf("chmod report file: %v", err)
-	}
-
-	chdirCanonicalWorkspace(t, workspace)
-
-	if _, err := persistDashboardOutput("<html>report</html>", "org-report.html"); err != nil {
-		t.Fatalf("persist dashboard output: %v", err)
-	}
-	info, err := os.Stat(outputPath)
-	if err != nil {
-		t.Fatalf("stat dashboard output: %v", err)
-	}
-	if info.Mode().Perm() != 0o644 {
-		t.Fatalf("expected existing dashboard output mode 0644 to be preserved, got %#o", info.Mode().Perm())
-	}
-}
-
 func TestPersistDashboardOutputRejectsReadOnlyExistingFile(t *testing.T) {
 	workspace := t.TempDir()
 	outputPath := filepath.Join(workspace, "org-report.html")
@@ -181,56 +157,6 @@ func TestPersistDashboardOutputRejectsReadOnlyExistingFile(t *testing.T) {
 	}
 }
 
-func TestPersistDashboardOutputRejectsSymlinkTarget(t *testing.T) {
-	workspace := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "outside.txt")
-	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
-		t.Fatalf("seed outside file: %v", err)
-	}
-	outputPath := filepath.Join(workspace, "org-report.html")
-	if err := os.Symlink(outside, outputPath); err != nil {
-		t.Fatalf("create output symlink: %v", err)
-	}
-
-	chdirCanonicalWorkspace(t, workspace)
-
-	if _, err := persistDashboardOutput("<html>report</html>", "org-report.html"); err == nil {
-		t.Fatal("expected symlink target to be rejected")
-	}
-	data, err := os.ReadFile(outside)
-	if err != nil {
-		t.Fatalf("read outside file: %v", err)
-	}
-	if string(data) != "secret" {
-		t.Fatalf("expected symlink target to remain unchanged, got %q", string(data))
-	}
-	info, err := os.Lstat(outputPath)
-	if err != nil {
-		t.Fatalf("lstat dashboard output: %v", err)
-	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		t.Fatalf("expected dashboard output path to remain a symlink, got mode %v", info.Mode())
-	}
-}
-
-func TestPersistDashboardOutputRejectsSymlinkedParent(t *testing.T) {
-	workspace := t.TempDir()
-	outside := t.TempDir()
-	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
-		t.Fatalf("create parent symlink: %v", err)
-	}
-
-	chdirCanonicalWorkspace(t, workspace)
-
-	_, err := persistDashboardOutput(`{"report":true}`, filepath.Join("reports", "org-report.json"))
-	if err == nil {
-		t.Fatal("expected symlinked parent to be rejected")
-	}
-	if _, statErr := os.Stat(filepath.Join(outside, "org-report.json")); !os.IsNotExist(statErr) {
-		t.Fatalf("expected outside report to remain absent, got err=%v", statErr)
-	}
-}
-
 func TestPersistDashboardOutputAllowsAbsolutePathUnderSystemSymlinkPrefix(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "reports", "org-report.json")
 
@@ -250,69 +176,6 @@ func TestPersistDashboardOutputAllowsAbsolutePathUnderSystemSymlinkPrefix(t *tes
 	}
 	if root == string(os.PathSeparator) {
 		t.Fatalf("expected absolute output root to stop at existing parent directory, got %q", root)
-	}
-}
-
-func TestPersistDashboardOutputRejectsAbsoluteSymlinkedParent(t *testing.T) {
-	workspace := t.TempDir()
-	outside := t.TempDir()
-	outputPath := filepath.Join(workspace, "reports", "org-report.json")
-	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
-		t.Fatalf("create parent symlink: %v", err)
-	}
-
-	_, err := persistDashboardOutput(`{"report":true}`, outputPath)
-	if err == nil {
-		t.Fatal("expected absolute symlinked parent to be rejected")
-	}
-	if _, statErr := os.Stat(filepath.Join(outside, "org-report.json")); !os.IsNotExist(statErr) {
-		t.Fatalf("expected outside report to remain absent, got err=%v", statErr)
-	}
-}
-
-func TestPersistDashboardOutputRejectsAbsoluteSymlinkedNestedParent(t *testing.T) {
-	workspace := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "outside")
-	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
-		t.Fatalf("mkdir outside nested: %v", err)
-	}
-	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
-		t.Fatalf("create parent symlink: %v", err)
-	}
-	canonicalWorkspace := chdirCanonicalWorkspace(t, workspace)
-	outputPath := filepath.Join(canonicalWorkspace, "reports", "nested", "org-report.json")
-
-	_, err := persistDashboardOutput(`{"report":true}`, outputPath)
-	if err == nil {
-		t.Fatal("expected absolute nested symlinked parent to be rejected")
-	}
-	if _, statErr := os.Stat(filepath.Join(outside, "nested", "org-report.json")); !os.IsNotExist(statErr) {
-		t.Fatalf("expected outside nested report to remain absent, got err=%v", statErr)
-	}
-}
-
-func TestPersistDashboardOutputRejectsAbsoluteSymlinkedNestedParentViaWorkspaceAlias(t *testing.T) {
-	workspace := t.TempDir()
-	workspaceAlias := filepath.Join(t.TempDir(), "repo")
-	if err := os.Symlink(workspace, workspaceAlias); err != nil {
-		t.Fatalf("create workspace alias: %v", err)
-	}
-	outside := filepath.Join(t.TempDir(), "out")
-	if err := os.MkdirAll(filepath.Join(outside, "nested"), 0o755); err != nil {
-		t.Fatalf("mkdir outside nested: %v", err)
-	}
-	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
-		t.Fatalf("create reports symlink: %v", err)
-	}
-	chdirCanonicalWorkspace(t, workspace)
-
-	outputPath := filepath.Join(workspaceAlias, "reports", "nested", "org-report.json")
-	_, err := persistDashboardOutput(`{"report":true}`, outputPath)
-	if err == nil {
-		t.Fatal("expected absolute nested symlinked parent via workspace alias to be rejected")
-	}
-	if _, statErr := os.Stat(filepath.Join(outside, "nested", "org-report.json")); !os.IsNotExist(statErr) {
-		t.Fatalf("expected outside nested report to remain absent, got err=%v", statErr)
 	}
 }
 

--- a/internal/app/dashboard_request_output_test.go
+++ b/internal/app/dashboard_request_output_test.go
@@ -66,9 +66,7 @@ func TestExecuteDashboardOutputPathErrors(t *testing.T) {
 	t.Run("mkdir output directory failure", func(t *testing.T) {
 		root := t.TempDir()
 		blocker := filepath.Join(root, "blocked")
-		if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
-			t.Fatalf("write blocker: %v", err)
-		}
+		writeBlockedFile(t, blocker)
 
 		req := DefaultRequest()
 		req.Mode = ModeDashboard
@@ -110,18 +108,7 @@ func TestPersistDashboardOutputDoesNotFollowSymlinkTarget(t *testing.T) {
 		t.Fatalf("create output symlink: %v", err)
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get cwd: %v", err)
-	}
-	if err := os.Chdir(workspace); err != nil {
-		t.Fatalf("chdir workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Errorf("restore cwd: %v", err)
-		}
-	})
+	chdirCanonicalWorkspace(t, workspace)
 
 	if _, err := persistDashboardOutput("<html>report</html>", "org-report.html"); err != nil {
 		t.Fatalf("persist dashboard output: %v", err)
@@ -149,20 +136,9 @@ func TestPersistDashboardOutputRejectsSymlinkedParent(t *testing.T) {
 		t.Fatalf("create parent symlink: %v", err)
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get cwd: %v", err)
-	}
-	if err := os.Chdir(workspace); err != nil {
-		t.Fatalf("chdir workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Errorf("restore cwd: %v", err)
-		}
-	})
+	chdirCanonicalWorkspace(t, workspace)
 
-	_, err = persistDashboardOutput(`{"report":true}`, filepath.Join("reports", "org-report.json"))
+	_, err := persistDashboardOutput(`{"report":true}`, filepath.Join("reports", "org-report.json"))
 	if err == nil {
 		t.Fatal("expected symlinked parent to be rejected")
 	}
@@ -219,25 +195,10 @@ func TestPersistDashboardOutputRejectsAbsoluteSymlinkedNestedParent(t *testing.T
 	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
 		t.Fatalf("create parent symlink: %v", err)
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get cwd: %v", err)
-	}
-	if err := os.Chdir(workspace); err != nil {
-		t.Fatalf("chdir workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Errorf("restore cwd: %v", err)
-		}
-	})
-	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
-	if err != nil {
-		t.Fatalf("canonicalize workspace: %v", err)
-	}
+	canonicalWorkspace := chdirCanonicalWorkspace(t, workspace)
 	outputPath := filepath.Join(canonicalWorkspace, "reports", "nested", "org-report.json")
 
-	_, err = persistDashboardOutput(`{"report":true}`, outputPath)
+	_, err := persistDashboardOutput(`{"report":true}`, outputPath)
 	if err == nil {
 		t.Fatal("expected absolute nested symlinked parent to be rejected")
 	}

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -172,6 +172,22 @@ func TestExecuteFeaturesDefaultReleaseAndStdoutOutputPath(t *testing.T) {
 	}
 }
 
+func TestExecuteFeaturesDefaultsBlankChannel(t *testing.T) {
+	application := &App{Features: mustFeatureRegistry(t)}
+	req := DefaultRequest()
+	req.Mode = ModeFeatures
+	req.Features.Format = "json"
+	req.Features.Channel = "   "
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute features with blank channel: %v", err)
+	}
+	if !strings.Contains(output, `"code": "LOP-FEAT-0002"`) {
+		t.Fatalf("expected feature manifest output, got %q", output)
+	}
+}
+
 func TestExecuteFeaturesTableAndInvalidFormat(t *testing.T) {
 	application := &App{Features: mustFeatureRegistry(t)}
 	req := DefaultRequest()

--- a/internal/app/profile_test.go
+++ b/internal/app/profile_test.go
@@ -112,9 +112,7 @@ func TestExecuteProfileErrorPaths(t *testing.T) {
 	}
 
 	blocker := filepath.Join(t.TempDir(), "blocker")
-	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
-		t.Fatalf("write blocker: %v", err)
-	}
+	writeBlockedFile(t, blocker)
 	req.Profile.Name = "strict"
 	req.Profile.OutputPath = filepath.Join(blocker, ".lopper.yml")
 	if _, err := application.Execute(context.Background(), req); err == nil {
@@ -131,9 +129,7 @@ func TestExecuteProfileErrorPaths(t *testing.T) {
 
 func TestPersistProfileConfigPropagatesStatError(t *testing.T) {
 	blocker := filepath.Join(t.TempDir(), "blocked")
-	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
-		t.Fatalf("write blocker: %v", err)
-	}
+	writeBlockedFile(t, blocker)
 
 	_, err := persistProfileConfig("thresholds: {}", filepath.Join(blocker, "profile.yaml"), false)
 	if err == nil {
@@ -147,9 +143,7 @@ func TestPersistProfileConfigPropagatesStatError(t *testing.T) {
 
 func TestPersistProfileConfigPropagatesMkdirAllError(t *testing.T) {
 	blocker := filepath.Join(t.TempDir(), "blocked")
-	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
-		t.Fatalf("write blocker: %v", err)
-	}
+	writeBlockedFile(t, blocker)
 
 	if _, err := persistProfileConfig("thresholds: {}", filepath.Join(blocker, "profile.yaml"), true); err == nil {
 		t.Fatal("expected mkdir error under regular file")

--- a/internal/app/profile_test.go
+++ b/internal/app/profile_test.go
@@ -129,6 +129,33 @@ func TestExecuteProfileErrorPaths(t *testing.T) {
 	}
 }
 
+func TestPersistProfileConfigPropagatesStatError(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	_, err := persistProfileConfig("thresholds: {}", filepath.Join(blocker, "profile.yaml"), false)
+	if err == nil {
+		t.Fatal("expected stat error under regular file")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) || pathErr.Op != "stat" || pathErr.Path != filepath.Join(blocker, "profile.yaml") {
+		t.Fatalf("expected propagated stat path error, got %v", err)
+	}
+}
+
+func TestPersistProfileConfigPropagatesMkdirAllError(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	if _, err := persistProfileConfig("thresholds: {}", filepath.Join(blocker, "profile.yaml"), true); err == nil {
+		t.Fatal("expected mkdir error under regular file")
+	}
+}
+
 func mustProfileFeatureSet(t *testing.T) featureflags.Set {
 	t.Helper()
 	registry, err := featureflags.NewRegistry([]featureflags.Flag{{

--- a/internal/app/tui_actions_test.go
+++ b/internal/app/tui_actions_test.go
@@ -31,6 +31,13 @@ func TestTUIActionRunnerUsesAnalysePipelineForCodemodApply(t *testing.T) {
 	}
 }
 
+func TestTUIActionRunnerNilAppReturnsNil(t *testing.T) {
+	var application *App
+	if runner := application.tuiActionRunner(); runner != nil {
+		t.Fatalf("expected nil runner, got %#v", runner)
+	}
+}
+
 func TestTUIActionRunnerSavesBaselineWithLabel(t *testing.T) {
 	analyzer := &fakeAnalyzer{
 		report: report.Report{
@@ -60,5 +67,35 @@ func TestTUIActionRunnerSavesBaselineWithLabel(t *testing.T) {
 	}
 	if analyzer.lastReq.TopN != 5 || analyzer.lastReq.Language != "all" {
 		t.Fatalf("expected TUI baseline save to forward summary options, got %#v", analyzer.lastReq)
+	}
+}
+
+func TestTUIActionRunnerSavesBaselineWithKey(t *testing.T) {
+	analyzer := &fakeAnalyzer{
+		report: report.Report{
+			SchemaVersion: report.SchemaVersion,
+			Dependencies:  []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+		},
+	}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+	runner := application.tuiActionRunner()
+
+	store := t.TempDir()
+	_, savedPath, err := runner.SaveBaseline(context.Background(), ui.BaselineSaveRequest{
+		RepoPath:          ".",
+		TopN:              3,
+		Language:          "go",
+		BaselineStorePath: store,
+		BaselineLabel:     "   ",
+		BaselineKey:       "commit:abc123",
+	})
+	if err != nil {
+		t.Fatalf("save baseline action: %v", err)
+	}
+	if savedPath != report.BaselineSnapshotPath(store, "commit:abc123") {
+		t.Fatalf("expected key-based snapshot path, got %q", savedPath)
+	}
+	if analyzer.lastReq.TopN != 3 || analyzer.lastReq.Language != "go" {
+		t.Fatalf("expected TUI baseline save with key to forward summary options, got %#v", analyzer.lastReq)
 	}
 }

--- a/internal/app/tui_actions_test.go
+++ b/internal/app/tui_actions_test.go
@@ -39,14 +39,7 @@ func TestTUIActionRunnerNilAppReturnsNil(t *testing.T) {
 }
 
 func TestTUIActionRunnerSavesBaselineWithLabel(t *testing.T) {
-	analyzer := &fakeAnalyzer{
-		report: report.Report{
-			SchemaVersion: report.SchemaVersion,
-			Dependencies:  []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
-		},
-	}
-	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
-	runner := application.tuiActionRunner()
+	analyzer, runner := baselineTUIActionRunner()
 
 	store := t.TempDir()
 	_, savedPath, err := runner.SaveBaseline(context.Background(), ui.BaselineSaveRequest{
@@ -71,15 +64,7 @@ func TestTUIActionRunnerSavesBaselineWithLabel(t *testing.T) {
 }
 
 func TestTUIActionRunnerSavesBaselineWithKey(t *testing.T) {
-	analyzer := &fakeAnalyzer{
-		report: report.Report{
-			SchemaVersion: report.SchemaVersion,
-			Dependencies:  []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
-		},
-	}
-	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
-	runner := application.tuiActionRunner()
-
+	analyzer, runner := baselineTUIActionRunner()
 	store := t.TempDir()
 	_, savedPath, err := runner.SaveBaseline(context.Background(), ui.BaselineSaveRequest{
 		RepoPath:          ".",
@@ -98,4 +83,15 @@ func TestTUIActionRunnerSavesBaselineWithKey(t *testing.T) {
 	if analyzer.lastReq.TopN != 3 || analyzer.lastReq.Language != "go" {
 		t.Fatalf("expected TUI baseline save with key to forward summary options, got %#v", analyzer.lastReq)
 	}
+}
+
+func baselineTUIActionRunner() (*fakeAnalyzer, ui.ActionRunner) {
+	analyzer := &fakeAnalyzer{
+		report: report.Report{
+			SchemaVersion: report.SchemaVersion,
+			Dependencies:  []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+		},
+	}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+	return analyzer, application.tuiActionRunner()
 }

--- a/internal/safeio/filesystem.go
+++ b/internal/safeio/filesystem.go
@@ -18,6 +18,8 @@ type FileSystem interface {
 type Root interface {
 	Open(name string) (File, error)
 	OpenFile(name string, flag int, perm os.FileMode) (File, error)
+	Lstat(name string) (fs.FileInfo, error)
+	MkdirAll(name string, perm os.FileMode) error
 	Rename(oldName, newName string) error
 	Remove(name string) error
 	Close() error
@@ -62,6 +64,14 @@ func (r *osRoot) Open(name string) (File, error) {
 
 func (r *osRoot) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
 	return r.root.OpenFile(name, flag, perm)
+}
+
+func (r *osRoot) Lstat(name string) (fs.FileInfo, error) {
+	return r.root.Lstat(name)
+}
+
+func (r *osRoot) MkdirAll(name string, perm os.FileMode) error {
+	return r.root.MkdirAll(name, perm)
 }
 
 func (r *osRoot) Rename(oldName, newName string) error {

--- a/internal/safeio/filesystem.go
+++ b/internal/safeio/filesystem.go
@@ -1,10 +1,13 @@
 package safeio
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // FileSystem captures the filesystem operations safeio needs.
@@ -12,14 +15,16 @@ type FileSystem interface {
 	Abs(path string) (string, error)
 	Rel(basepath, targpath string) (string, error)
 	OpenRoot(name string) (Root, error)
+	OpenRootNoFollow(name string) (Root, error)
 }
 
 // Root is a filesystem root used for path-confined operations.
 type Root interface {
 	Open(name string) (File, error)
 	OpenFile(name string, flag int, perm os.FileMode) (File, error)
+	OpenRoot(name string) (Root, error)
 	Lstat(name string) (fs.FileInfo, error)
-	MkdirAll(name string, perm os.FileMode) error
+	Mkdir(name string, perm os.FileMode) error
 	Rename(oldName, newName string) error
 	Remove(name string) error
 	Close() error
@@ -54,6 +59,71 @@ func (*osFileSystem) OpenRoot(name string) (Root, error) {
 	return &osRoot{root: root}, nil
 }
 
+func (f *osFileSystem) OpenRootNoFollow(name string) (Root, error) {
+	volumeRoot := filepath.VolumeName(name) + string(os.PathSeparator)
+	rel, err := filepath.Rel(volumeRoot, name)
+	if err != nil {
+		return nil, err
+	}
+	root, err := f.OpenRoot(volumeRoot)
+	if err != nil {
+		return nil, err
+	}
+	if rel == "." {
+		return root, nil
+	}
+
+	currentPath := volumeRoot
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		currentPath = filepath.Join(currentPath, part)
+		next, err := openRootChildNoFollow(root, part, currentPath)
+		if err != nil {
+			return nil, closeRootWithError(root, err)
+		}
+		if err := root.Close(); err != nil {
+			return nil, closeRootWithError(next, err)
+		}
+		root = next
+	}
+	return root, nil
+}
+
+func openRootChildNoFollow(root Root, name, path string) (Root, error) {
+	info, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("root contains symlink: %s", path)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("root is not a directory: %s", path)
+	}
+
+	next, err := root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := next.Lstat(".")
+	if err != nil {
+		return nil, closeRootWithError(next, err)
+	}
+	if !os.SameFile(info, openedInfo) {
+		return nil, closeRootWithError(next, fmt.Errorf("root changed while opening: %s", path))
+	}
+	return next, nil
+}
+
+func closeRootWithError(root Root, err error) error {
+	if closeErr := root.Close(); closeErr != nil {
+		return errors.Join(err, closeErr)
+	}
+	return err
+}
+
 type osRoot struct {
 	root *os.Root
 }
@@ -66,12 +136,20 @@ func (r *osRoot) OpenFile(name string, flag int, perm os.FileMode) (File, error)
 	return r.root.OpenFile(name, flag, perm)
 }
 
+func (r *osRoot) OpenRoot(name string) (Root, error) {
+	root, err := r.root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	return &osRoot{root: root}, nil
+}
+
 func (r *osRoot) Lstat(name string) (fs.FileInfo, error) {
 	return r.root.Lstat(name)
 }
 
-func (r *osRoot) MkdirAll(name string, perm os.FileMode) error {
-	return r.root.MkdirAll(name, perm)
+func (r *osRoot) Mkdir(name string, perm os.FileMode) error {
+	return r.root.Mkdir(name, perm)
 }
 
 func (r *osRoot) Rename(oldName, newName string) error {

--- a/internal/safeio/path.go
+++ b/internal/safeio/path.go
@@ -12,6 +12,7 @@ import (
 type rootedTarget struct {
 	rootAbs string
 	rel     string
+	abs     string
 }
 
 type rootedTargetPolicy int
@@ -45,7 +46,7 @@ func resolveRootedTarget(rootDir, targetPath string, policy rootedTargetPolicy) 
 		return rootedTarget{}, err
 	}
 
-	return rootedTarget{rootAbs: rootAbs, rel: rel}, nil
+	return rootedTarget{rootAbs: rootAbs, rel: rel, abs: targetAbs}, nil
 }
 
 func resolveExactFileTarget(targetPath string) (exactFileTarget, error) {

--- a/internal/safeio/test_helpers_test.go
+++ b/internal/safeio/test_helpers_test.go
@@ -80,11 +80,23 @@ func openTestRoot(t *testing.T, rootDir string) Root {
 	return root
 }
 
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(data) != want {
+		t.Fatalf("unexpected content for %s: %q", path, string(data))
+	}
+}
+
 type fakeFileSystem struct {
-	base     FileSystem
-	abs      func(path string) (string, error)
-	rel      func(basepath, targpath string) (string, error)
-	openRoot func(name string) (Root, error)
+	base             FileSystem
+	abs              func(path string) (string, error)
+	rel              func(basepath, targpath string) (string, error)
+	openRoot         func(name string) (Root, error)
+	openRootNoFollow func(name string) (Root, error)
 }
 
 func (f *fakeFileSystem) fallback() FileSystem {
@@ -115,12 +127,23 @@ func (f *fakeFileSystem) OpenRoot(name string) (Root, error) {
 	return f.fallback().OpenRoot(name)
 }
 
+func (f *fakeFileSystem) OpenRootNoFollow(name string) (Root, error) {
+	if f.openRootNoFollow != nil {
+		return f.openRootNoFollow(name)
+	}
+	if f.openRoot != nil {
+		return f.openRoot(name)
+	}
+	return f.fallback().OpenRootNoFollow(name)
+}
+
 type fakeRoot struct {
 	Root
 	open     func(name string) (File, error)
 	openFile func(name string, flag int, perm os.FileMode) (File, error)
+	openRoot func(name string) (Root, error)
 	lstat    func(name string) (fs.FileInfo, error)
-	mkdirAll func(name string, perm os.FileMode) error
+	mkdir    func(name string, perm os.FileMode) error
 	rename   func(oldName, newName string) error
 	remove   func(name string) error
 	close    func() error
@@ -140,6 +163,13 @@ func (r *fakeRoot) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 	return r.Root.OpenFile(name, flag, perm)
 }
 
+func (r *fakeRoot) OpenRoot(name string) (Root, error) {
+	if r.openRoot != nil {
+		return r.openRoot(name)
+	}
+	return r.Root.OpenRoot(name)
+}
+
 func (r *fakeRoot) Lstat(name string) (fs.FileInfo, error) {
 	if r.lstat != nil {
 		return r.lstat(name)
@@ -147,11 +177,11 @@ func (r *fakeRoot) Lstat(name string) (fs.FileInfo, error) {
 	return r.Root.Lstat(name)
 }
 
-func (r *fakeRoot) MkdirAll(name string, perm os.FileMode) error {
-	if r.mkdirAll != nil {
-		return r.mkdirAll(name, perm)
+func (r *fakeRoot) Mkdir(name string, perm os.FileMode) error {
+	if r.mkdir != nil {
+		return r.mkdir(name, perm)
 	}
-	return r.Root.MkdirAll(name, perm)
+	return r.Root.Mkdir(name, perm)
 }
 
 func (r *fakeRoot) Rename(oldName, newName string) error {

--- a/internal/safeio/test_helpers_test.go
+++ b/internal/safeio/test_helpers_test.go
@@ -119,6 +119,8 @@ type fakeRoot struct {
 	Root
 	open     func(name string) (File, error)
 	openFile func(name string, flag int, perm os.FileMode) (File, error)
+	lstat    func(name string) (fs.FileInfo, error)
+	mkdirAll func(name string, perm os.FileMode) error
 	rename   func(oldName, newName string) error
 	remove   func(name string) error
 	close    func() error
@@ -136,6 +138,20 @@ func (r *fakeRoot) OpenFile(name string, flag int, perm os.FileMode) (File, erro
 		return r.openFile(name, flag, perm)
 	}
 	return r.Root.OpenFile(name, flag, perm)
+}
+
+func (r *fakeRoot) Lstat(name string) (fs.FileInfo, error) {
+	if r.lstat != nil {
+		return r.lstat(name)
+	}
+	return r.Root.Lstat(name)
+}
+
+func (r *fakeRoot) MkdirAll(name string, perm os.FileMode) error {
+	if r.mkdirAll != nil {
+		return r.mkdirAll(name, perm)
+	}
+	return r.Root.MkdirAll(name, perm)
 }
 
 func (r *fakeRoot) Rename(oldName, newName string) error {

--- a/internal/safeio/test_helpers_test.go
+++ b/internal/safeio/test_helpers_test.go
@@ -91,6 +91,15 @@ func assertFileContent(t *testing.T, path, want string) {
 	}
 }
 
+func statTestPath(t *testing.T, path string) fs.FileInfo {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info
+}
+
 type fakeFileSystem struct {
 	base             FileSystem
 	abs              func(path string) (string, error)

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,6 +23,20 @@ func OpenWriteRoot(rootDir string) (*WriteRoot, error) {
 		return nil, err
 	}
 	return openWriteRoot(rootAbs)
+}
+
+// OpenCanonicalWriteRoot pins a canonical root without following symlinks in
+// any component of rootDir.
+func OpenCanonicalWriteRoot(rootDir string) (*WriteRoot, error) {
+	rootAbs, err := resolveAbsolutePath("root", rootDir)
+	if err != nil {
+		return nil, err
+	}
+	root, err := fileSystem.OpenRootNoFollow(rootAbs)
+	if err != nil {
+		return nil, fmt.Errorf("open canonical root: %w", err)
+	}
+	return &WriteRoot{root: root, rootAbs: rootAbs}, nil
 }
 
 func openWriteRoot(rootAbs string) (*WriteRoot, error) {
@@ -44,13 +59,7 @@ func (r *WriteRoot) WriteFileCreatingParents(targetPath string, data []byte, per
 	if err != nil {
 		return err
 	}
-	if err := r.ensureParentDirectories(target, parentPerm); err != nil {
-		return err
-	}
-	if err := writeFileParentReadyFn(); err != nil {
-		return err
-	}
-	return r.writeFile(target, data, perm)
+	return r.writeFileAtTarget(target, data, perm, true, parentPerm)
 }
 
 func (r *WriteRoot) resolveTarget(targetPath string) (rootedTarget, error) {
@@ -64,36 +73,98 @@ func (r *WriteRoot) resolveTarget(targetPath string) (rootedTarget, error) {
 	return rootedTarget{rootAbs: r.rootAbs, rel: rel, abs: filepath.Join(r.rootAbs, rel)}, nil
 }
 
-func (r *WriteRoot) ensureParentDirectories(target rootedTarget, perm os.FileMode) error {
-	parentRel := filepath.Dir(target.rel)
-	if parentRel == "." {
-		return nil
-	}
-	if err := rejectRootedParentSymlinks(r.root, r.rootAbs, parentRel); err != nil {
+func (r *WriteRoot) writeFileAtTarget(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode) (returnErr error) {
+	parent, closeParent, err := r.openTargetParent(target, createParents, parentPerm)
+	if err != nil {
 		return err
 	}
-	if err := r.root.MkdirAll(parentRel, perm); err != nil {
+	if closeParent {
+		defer func() {
+			if closeErr := parent.Close(); closeErr != nil {
+				returnErr = errors.Join(returnErr, closeErr)
+			}
+		}()
+	}
+	if err := writeFileParentReadyFn(); err != nil {
 		return err
 	}
-	return rejectRootedParentSymlinks(r.root, r.rootAbs, parentRel)
+	parentTarget := target
+	parentTarget.rel = filepath.Base(target.rel)
+	return writeFileAtRoot(parent, parentTarget, data, perm)
 }
 
-func rejectRootedParentSymlinks(root Root, rootAbs, parentRel string) error {
-	current := ""
-	for _, part := range strings.Split(parentRel, string(os.PathSeparator)) {
-		current = filepath.Join(current, part)
-		info, err := root.Lstat(current)
-		if os.IsNotExist(err) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("output parent contains symlink: %s", filepath.Join(rootAbs, current))
-		}
+func (r *WriteRoot) openTargetParent(target rootedTarget, create bool, perm os.FileMode) (Root, bool, error) {
+	parentRel := filepath.Dir(target.rel)
+	if parentRel == "." {
+		return r.root, false, nil
 	}
-	return nil
+
+	current := r.root
+	currentOwned := false
+	currentAbs := r.rootAbs
+	for _, part := range strings.Split(parentRel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		partAbs := filepath.Join(currentAbs, part)
+		next, err := openTargetParentChild(current, part, partAbs, create, perm)
+		if err != nil {
+			return nil, false, closeOwnedRootWithError(current, currentOwned, err)
+		}
+		if currentOwned {
+			if err := current.Close(); err != nil {
+				return nil, false, closeRootWithError(next, err)
+			}
+		}
+		current = next
+		currentOwned = true
+		currentAbs = partAbs
+	}
+	return current, currentOwned, nil
+}
+
+func openTargetParentChild(root Root, name, path string, create bool, perm os.FileMode) (Root, error) {
+	info, err := lstatOrCreateDirectory(root, name, create, perm)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("output parent contains symlink: %s", path)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("output parent is not a directory: %s", path)
+	}
+
+	next, err := root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := next.Lstat(".")
+	if err != nil {
+		return nil, closeRootWithError(next, err)
+	}
+	if !os.SameFile(info, openedInfo) {
+		return nil, closeRootWithError(next, fmt.Errorf("output parent changed while opening: %s", path))
+	}
+	return next, nil
+}
+
+func lstatOrCreateDirectory(root Root, name string, create bool, perm os.FileMode) (fs.FileInfo, error) {
+	info, err := root.Lstat(name)
+	if !os.IsNotExist(err) || !create {
+		return info, err
+	}
+	if mkdirErr := root.Mkdir(name, perm); mkdirErr != nil && !errors.Is(mkdirErr, fs.ErrExist) {
+		return nil, mkdirErr
+	}
+	return root.Lstat(name)
+}
+
+func closeOwnedRootWithError(root Root, owned bool, err error) error {
+	if !owned {
+		return err
+	}
+	return closeRootWithError(root, err)
 }
 
 const atomicTempPrefix = ".safeio-atomic-"
@@ -121,16 +192,16 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 			returnErr = errors.Join(returnErr, closeErr)
 		}
 	}()
-	return root.writeFile(target, data, perm)
+	return root.writeFileAtTarget(target, data, perm, false, 0)
 }
 
-func (r *WriteRoot) writeFile(target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {
-	writePerm, existingRegular, err := resolvedWriteFilePerm(r.root, target, perm)
+func writeFileAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {
+	writePerm, existingRegular, err := resolvedWriteFilePerm(root, target, perm)
 	if err != nil {
 		return err
 	}
 	if existingRegular {
-		file, err := r.root.OpenFile(target.rel, os.O_WRONLY, 0)
+		file, err := root.OpenFile(target.rel, os.O_WRONLY, 0)
 		if err != nil {
 			return err
 		}
@@ -139,7 +210,7 @@ func (r *WriteRoot) writeFile(target rootedTarget, data []byte, perm os.FileMode
 		}
 	}
 
-	session, err := newAtomicWriteSession(r.root, target.rel, writePerm)
+	session, err := newAtomicWriteSession(root, target.rel, writePerm)
 	if err != nil {
 		return err
 	}

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -21,6 +21,10 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 	if err != nil {
 		return err
 	}
+	writePerm, err := resolvedWriteFilePerm(target, perm)
+	if err != nil {
+		return err
+	}
 
 	root, err := fileSystem.OpenRoot(target.rootAbs)
 	if err != nil {
@@ -32,7 +36,7 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 		}
 	}()
 
-	session, err := newAtomicWriteSession(root, target.rel, perm)
+	session, err := newAtomicWriteSession(root, target.rel, writePerm)
 	if err != nil {
 		return err
 	}
@@ -43,7 +47,25 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 		}
 	}()
 
-	return session.writeAndCommit(data, perm)
+	return session.writeAndCommit(data, writePerm)
+}
+
+func resolvedWriteFilePerm(target rootedTarget, requestedPerm os.FileMode) (os.FileMode, error) {
+	info, err := os.Lstat(target.abs)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return 0, fmt.Errorf("target path is a symlink: %s", target.abs)
+		}
+		if !info.Mode().IsRegular() {
+			return 0, fmt.Errorf("target path is not a regular file: %s", target.abs)
+		}
+		return info.Mode().Perm(), nil
+	case os.IsNotExist(err):
+		return requestedPerm, nil
+	default:
+		return 0, err
+	}
 }
 
 func cleanupAtomicTempFile(root Root, tempRel string, tempFile File) error {

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -16,6 +16,8 @@ var (
 )
 
 // WriteFileUnder atomically writes targetPath only if it resolves under rootDir.
+// Existing regular targets must be writable and retain their permission bits.
+// Ownership follows atomic replacement semantics; writes never fall back to in-place mutation.
 func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (returnErr error) {
 	target, err := resolveRootedTarget(rootDir, targetPath, rejectRootTarget)
 	if err != nil {

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -47,6 +47,9 @@ func (r *WriteRoot) WriteFileCreatingParents(targetPath string, data []byte, per
 	if err := r.ensureParentDirectories(target, parentPerm); err != nil {
 		return err
 	}
+	if err := writeFileParentReadyFn(); err != nil {
+		return err
+	}
 	return r.writeFile(target, data, perm)
 }
 
@@ -96,8 +99,9 @@ func rejectRootedParentSymlinks(root Root, rootAbs, parentRel string) error {
 const atomicTempPrefix = ".safeio-atomic-"
 
 var (
-	randomTempNameFn = randomTempName
-	randReadFn       = rand.Read
+	randomTempNameFn       = randomTempName
+	randReadFn             = rand.Read
+	writeFileParentReadyFn = func() error { return nil }
 )
 
 // WriteFileUnder atomically writes targetPath only if it resolves under rootDir.

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -6,7 +6,92 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+// WriteRoot pins a filesystem root for path-confined atomic writes.
+type WriteRoot struct {
+	root    Root
+	rootAbs string
+}
+
+// OpenWriteRoot opens rootDir once for subsequent root-relative writes.
+func OpenWriteRoot(rootDir string) (*WriteRoot, error) {
+	rootAbs, err := resolveAbsolutePath("root", rootDir)
+	if err != nil {
+		return nil, err
+	}
+	return openWriteRoot(rootAbs)
+}
+
+func openWriteRoot(rootAbs string) (*WriteRoot, error) {
+	root, err := fileSystem.OpenRoot(rootAbs)
+	if err != nil {
+		return nil, fmt.Errorf("open root: %w", err)
+	}
+	return &WriteRoot{root: root, rootAbs: rootAbs}, nil
+}
+
+// Close releases the pinned filesystem root.
+func (r *WriteRoot) Close() error {
+	return r.root.Close()
+}
+
+// WriteFileCreatingParents atomically writes a root-relative file, creating
+// missing parent directories inside the pinned root.
+func (r *WriteRoot) WriteFileCreatingParents(targetPath string, data []byte, perm, parentPerm os.FileMode) error {
+	target, err := r.resolveTarget(targetPath)
+	if err != nil {
+		return err
+	}
+	if err := r.ensureParentDirectories(target, parentPerm); err != nil {
+		return err
+	}
+	return r.writeFile(target, data, perm)
+}
+
+func (r *WriteRoot) resolveTarget(targetPath string) (rootedTarget, error) {
+	if filepath.IsAbs(targetPath) {
+		return rootedTarget{}, fmt.Errorf("target path must be relative to root: %s", targetPath)
+	}
+	rel, err := normalizeRootedTarget(targetPath, filepath.Clean(targetPath), rejectRootTarget)
+	if err != nil {
+		return rootedTarget{}, err
+	}
+	return rootedTarget{rootAbs: r.rootAbs, rel: rel, abs: filepath.Join(r.rootAbs, rel)}, nil
+}
+
+func (r *WriteRoot) ensureParentDirectories(target rootedTarget, perm os.FileMode) error {
+	parentRel := filepath.Dir(target.rel)
+	if parentRel == "." {
+		return nil
+	}
+	if err := rejectRootedParentSymlinks(r.root, r.rootAbs, parentRel); err != nil {
+		return err
+	}
+	if err := r.root.MkdirAll(parentRel, perm); err != nil {
+		return err
+	}
+	return rejectRootedParentSymlinks(r.root, r.rootAbs, parentRel)
+}
+
+func rejectRootedParentSymlinks(root Root, rootAbs, parentRel string) error {
+	current := ""
+	for _, part := range strings.Split(parentRel, string(os.PathSeparator)) {
+		current = filepath.Join(current, part)
+		info, err := root.Lstat(current)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("output parent contains symlink: %s", filepath.Join(rootAbs, current))
+		}
+	}
+	return nil
+}
 
 const atomicTempPrefix = ".safeio-atomic-"
 
@@ -23,22 +108,25 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 	if err != nil {
 		return err
 	}
-	writePerm, existingRegular, err := resolvedWriteFilePerm(target, perm)
+	root, err := openWriteRoot(target.rootAbs)
 	if err != nil {
 		return err
-	}
-
-	root, err := fileSystem.OpenRoot(target.rootAbs)
-	if err != nil {
-		return fmt.Errorf("open root: %w", err)
 	}
 	defer func() {
 		if closeErr := root.Close(); closeErr != nil {
 			returnErr = errors.Join(returnErr, closeErr)
 		}
 	}()
+	return root.writeFile(target, data, perm)
+}
+
+func (r *WriteRoot) writeFile(target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {
+	writePerm, existingRegular, err := resolvedWriteFilePerm(r.root, target, perm)
+	if err != nil {
+		return err
+	}
 	if existingRegular {
-		file, err := root.OpenFile(target.rel, os.O_WRONLY, 0)
+		file, err := r.root.OpenFile(target.rel, os.O_WRONLY, 0)
 		if err != nil {
 			return err
 		}
@@ -47,7 +135,7 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 		}
 	}
 
-	session, err := newAtomicWriteSession(root, target.rel, writePerm)
+	session, err := newAtomicWriteSession(r.root, target.rel, writePerm)
 	if err != nil {
 		return err
 	}
@@ -61,8 +149,8 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 	return session.writeAndCommit(data, writePerm)
 }
 
-func resolvedWriteFilePerm(target rootedTarget, requestedPerm os.FileMode) (os.FileMode, bool, error) {
-	info, err := os.Lstat(target.abs)
+func resolvedWriteFilePerm(root Root, target rootedTarget, requestedPerm os.FileMode) (os.FileMode, bool, error) {
+	info, err := root.Lstat(target.rel)
 	switch {
 	case err == nil:
 		if info.Mode()&os.ModeSymlink != 0 {

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -21,7 +21,7 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 	if err != nil {
 		return err
 	}
-	writePerm, err := resolvedWriteFilePerm(target, perm)
+	writePerm, existingRegular, err := resolvedWriteFilePerm(target, perm)
 	if err != nil {
 		return err
 	}
@@ -35,6 +35,15 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 			returnErr = errors.Join(returnErr, closeErr)
 		}
 	}()
+	if existingRegular {
+		file, err := root.OpenFile(target.rel, os.O_WRONLY, 0)
+		if err != nil {
+			return err
+		}
+		if err := file.Close(); err != nil {
+			return err
+		}
+	}
 
 	session, err := newAtomicWriteSession(root, target.rel, writePerm)
 	if err != nil {
@@ -50,21 +59,21 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 	return session.writeAndCommit(data, writePerm)
 }
 
-func resolvedWriteFilePerm(target rootedTarget, requestedPerm os.FileMode) (os.FileMode, error) {
+func resolvedWriteFilePerm(target rootedTarget, requestedPerm os.FileMode) (os.FileMode, bool, error) {
 	info, err := os.Lstat(target.abs)
 	switch {
 	case err == nil:
 		if info.Mode()&os.ModeSymlink != 0 {
-			return 0, fmt.Errorf("target path is a symlink: %s", target.abs)
+			return 0, false, fmt.Errorf("target path is a symlink: %s", target.abs)
 		}
 		if !info.Mode().IsRegular() {
-			return 0, fmt.Errorf("target path is not a regular file: %s", target.abs)
+			return 0, false, fmt.Errorf("target path is not a regular file: %s", target.abs)
 		}
-		return info.Mode().Perm(), nil
+		return info.Mode().Perm(), true, nil
 	case os.IsNotExist(err):
-		return requestedPerm, nil
+		return requestedPerm, false, nil
 	default:
-		return 0, err
+		return 0, false, err
 	}
 }
 

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -44,6 +44,36 @@ func TestWriteFileUnderWritesFileInsideRoot(t *testing.T) {
 	}
 }
 
+func TestWriteFileUnderPreservesExistingRegularFileMode(t *testing.T) {
+	rootDir := t.TempDir()
+	targetPath := filepath.Join(rootDir, writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("before"), 0o644); err != nil {
+		t.Fatalf("seed target file: %v", err)
+	}
+	if err := os.Chmod(targetPath, 0o644); err != nil {
+		t.Fatalf("chmod target file: %v", err)
+	}
+
+	if err := WriteFileUnder(rootDir, targetPath, []byte("after"), 0o600); err != nil {
+		t.Fatalf("WriteFileUnder returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read replaced file: %v", err)
+	}
+	if string(data) != "after" {
+		t.Fatalf("unexpected content: got %q", string(data))
+	}
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatalf("stat replaced file: %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("expected existing file mode 0644 to be preserved, got %#o", info.Mode().Perm())
+	}
+}
+
 func TestWriteFileUnderRejectsPathTraversalOutsideRoot(t *testing.T) {
 	parentDir := t.TempDir()
 	rootDir := filepath.Join(parentDir, "root")
@@ -96,7 +126,7 @@ func TestWriteFileUnderRejectsNonDirectoryRoot(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when root is not a directory")
 	}
-	if !strings.Contains(err.Error(), "open root") {
+	if !strings.Contains(err.Error(), "open root") && !strings.Contains(err.Error(), "not a directory") {
 		t.Fatalf(unexpectedErrFmt, err)
 	}
 }
@@ -154,6 +184,37 @@ func TestWriteFileUnderRejectsExistingDirectoryTarget(t *testing.T) {
 	err := WriteFileUnder(rootDir, targetPath, []byte("hello"), 0o600)
 	if err == nil {
 		t.Fatal("expected directory target error")
+	}
+}
+
+func TestWriteFileUnderRejectsSymlinkTarget(t *testing.T) {
+	rootDir := t.TempDir()
+	outsidePath := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed outside file: %v", err)
+	}
+	targetPath := filepath.Join(rootDir, writeTestFileName)
+	if err := os.Symlink(outsidePath, targetPath); err != nil {
+		t.Fatalf("create target symlink: %v", err)
+	}
+
+	err := WriteFileUnder(rootDir, targetPath, []byte("hello"), 0o600)
+	if err == nil {
+		t.Fatal("expected symlink target error")
+	}
+	data, readErr := os.ReadFile(outsidePath)
+	if readErr != nil {
+		t.Fatalf("read outside file: %v", readErr)
+	}
+	if string(data) != "secret" {
+		t.Fatalf("expected outside file to remain unchanged, got %q", string(data))
+	}
+	info, statErr := os.Lstat(targetPath)
+	if statErr != nil {
+		t.Fatalf("lstat target symlink: %v", statErr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected target path to remain a symlink, got mode %v", info.Mode())
 	}
 }
 

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -18,6 +18,47 @@ const (
 	closeTempFileErrFmt = "close temp file: %v"
 )
 
+func openTestWriteRoot(t *testing.T, rootDir string, open func(string) (*WriteRoot, error)) *WriteRoot {
+	t.Helper()
+	root, err := open(rootDir)
+	if err != nil {
+		t.Fatalf("open test write root: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close test write root: %v", closeErr)
+		}
+	})
+	return root
+}
+
+func changedDirectoryTestRoot(t *testing.T) (*fakeRoot, *bool) {
+	t.Helper()
+	expectedInfo := statTestPath(t, t.TempDir())
+	changedInfo := statTestPath(t, t.TempDir())
+	childClosed := false
+	child := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return changedInfo, nil },
+		close: func() error {
+			childClosed = true
+			return nil
+		},
+	}
+	root := &fakeRoot{
+		lstat:    func(string) (fs.FileInfo, error) { return expectedInfo, nil },
+		openRoot: func(string) (Root, error) { return child, nil },
+	}
+	return root, &childClosed
+}
+
+func assertWriteRootRejectsParent(t *testing.T, root *WriteRoot, wantError, failureMessage string) {
+	t.Helper()
+	err := root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
+	if err == nil || !strings.Contains(err.Error(), wantError) {
+		t.Fatalf("%s, got %v", failureMessage, err)
+	}
+}
+
 func TestWriteFileUnderWritesFileInsideRoot(t *testing.T) {
 	rootDir := t.TempDir()
 	targetPath := filepath.Join(rootDir, "nested", writeTestFileName)
@@ -211,15 +252,7 @@ func TestWriteFileUnderReturnsErrorForMissingParentDir(t *testing.T) {
 
 func TestWriteRootCreatesMissingParentsAndWritesAtomically(t *testing.T) {
 	rootDir := t.TempDir()
-	root, err := OpenWriteRoot(rootDir)
-	if err != nil {
-		t.Fatalf("OpenWriteRoot returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
-			t.Errorf("close write root: %v", closeErr)
-		}
-	})
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
 
 	targetPath := filepath.Join("reports", "nested", writeTestFileName)
 	if err := root.WriteFileCreatingParents(targetPath, []byte("hello"), 0o640, 0o750); err != nil {
@@ -278,15 +311,7 @@ func TestOpenCanonicalWriteRootWritesInsideCanonicalRoot(t *testing.T) {
 		t.Fatalf("resolve canonical root: %v", err)
 	}
 
-	root, err := OpenCanonicalWriteRoot(canonicalRoot)
-	if err != nil {
-		t.Fatalf("OpenCanonicalWriteRoot returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
-			t.Errorf("close canonical write root: %v", closeErr)
-		}
-	})
+	root := openTestWriteRoot(t, canonicalRoot, OpenCanonicalWriteRoot)
 
 	targetPath := filepath.Join("reports", "nested", writeTestFileName)
 	if err := root.WriteFileCreatingParents(targetPath, []byte("canonical"), 0o640, 0o750); err != nil {
@@ -438,20 +463,7 @@ func TestOpenRootChildNoFollowJoinsChildLookupAndCloseErrors(t *testing.T) {
 }
 
 func TestOpenRootChildNoFollowRejectsChangedDirectory(t *testing.T) {
-	expectedInfo := statTestPath(t, t.TempDir())
-	changedInfo := statTestPath(t, t.TempDir())
-	childClosed := false
-	child := &fakeRoot{
-		lstat: func(string) (fs.FileInfo, error) { return changedInfo, nil },
-		close: func() error {
-			childClosed = true
-			return nil
-		},
-	}
-	root := &fakeRoot{
-		lstat:    func(string) (fs.FileInfo, error) { return expectedInfo, nil },
-		openRoot: func(string) (Root, error) { return child, nil },
-	}
+	root, childClosed := changedDirectoryTestRoot(t)
 
 	opened, err := openRootChildNoFollow(root, "child", "/root/child")
 	if opened != nil {
@@ -460,7 +472,7 @@ func TestOpenRootChildNoFollowRejectsChangedDirectory(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "root changed while opening") {
 		t.Fatalf("expected changed-directory error, got %v", err)
 	}
-	if !childClosed {
+	if !*childClosed {
 		t.Fatal("expected changed child root to be closed")
 	}
 }
@@ -538,20 +550,8 @@ func TestWriteRootRejectsSymlinkedParent(t *testing.T) {
 	if err := os.Symlink(outside, filepath.Join(rootDir, "reports")); err != nil {
 		t.Fatalf("create reports symlink: %v", err)
 	}
-	root, err := OpenWriteRoot(rootDir)
-	if err != nil {
-		t.Fatalf("OpenWriteRoot returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
-			t.Errorf("close write root: %v", closeErr)
-		}
-	})
-
-	err = root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
-	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
-		t.Fatalf("expected symlinked parent rejection, got %v", err)
-	}
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+	assertWriteRootRejectsParent(t, root, "output parent contains symlink", "expected symlinked parent rejection")
 	data, readErr := os.ReadFile(outsideTarget)
 	if readErr != nil {
 		t.Fatalf("read outside target: %v", readErr)
@@ -566,20 +566,8 @@ func TestWriteRootRejectsNonDirectoryParent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(rootDir, "reports"), []byte("not a directory"), 0o600); err != nil {
 		t.Fatalf("write non-directory parent: %v", err)
 	}
-	root, err := OpenWriteRoot(rootDir)
-	if err != nil {
-		t.Fatalf("OpenWriteRoot returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
-			t.Errorf("close write root: %v", closeErr)
-		}
-	})
-
-	err = root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
-	if err == nil || !strings.Contains(err.Error(), "output parent is not a directory") {
-		t.Fatalf("expected non-directory parent rejection, got %v", err)
-	}
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+	assertWriteRootRejectsParent(t, root, "output parent is not a directory", "expected non-directory parent rejection")
 }
 
 func TestOpenTargetParentChildPropagatesOpenError(t *testing.T) {
@@ -630,20 +618,7 @@ func TestOpenTargetParentChildClosesChildOnLookupError(t *testing.T) {
 }
 
 func TestOpenTargetParentChildRejectsChangedDirectory(t *testing.T) {
-	expectedInfo := statTestPath(t, t.TempDir())
-	changedInfo := statTestPath(t, t.TempDir())
-	childClosed := false
-	child := &fakeRoot{
-		lstat: func(string) (fs.FileInfo, error) { return changedInfo, nil },
-		close: func() error {
-			childClosed = true
-			return nil
-		},
-	}
-	root := &fakeRoot{
-		lstat:    func(string) (fs.FileInfo, error) { return expectedInfo, nil },
-		openRoot: func(string) (Root, error) { return child, nil },
-	}
+	root, childClosed := changedDirectoryTestRoot(t)
 
 	opened, err := openTargetParentChild(root, "parent", "/root/parent", false, 0)
 	if opened != nil {
@@ -652,7 +627,7 @@ func TestOpenTargetParentChildRejectsChangedDirectory(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "output parent changed while opening") {
 		t.Fatalf("expected changed parent error, got %v", err)
 	}
-	if !childClosed {
+	if !*childClosed {
 		t.Fatal("expected changed parent root to be closed")
 	}
 }

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -396,6 +397,71 @@ func TestWriteRootDoesNotCreateOutsideAfterMissingParentSwap(t *testing.T) {
 	}
 	if string(data) != "outside-before" {
 		t.Fatalf("unexpected outside sentinel: %q", string(data))
+	}
+}
+
+func TestWriteRootPinsParentBeforeInRootSymlinkRetarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics are covered on Unix")
+	}
+
+	rootDir := t.TempDir()
+	originalParent := filepath.Join(rootDir, "reports")
+	relocatedParent := filepath.Join(rootDir, "reports-relocated")
+	redirectedParent := filepath.Join(rootDir, "redirected")
+	if err := os.MkdirAll(originalParent, 0o755); err != nil {
+		t.Fatalf("mkdir original parent: %v", err)
+	}
+	if err := os.MkdirAll(redirectedParent, 0o755); err != nil {
+		t.Fatalf("mkdir redirected parent: %v", err)
+	}
+	originalTarget := filepath.Join(originalParent, writeTestFileName)
+	redirectedTarget := filepath.Join(redirectedParent, writeTestFileName)
+	if err := os.WriteFile(originalTarget, []byte("original-before"), 0o600); err != nil {
+		t.Fatalf("seed original target: %v", err)
+	}
+	if err := os.WriteFile(redirectedTarget, []byte("redirected-before"), 0o600); err != nil {
+		t.Fatalf("seed redirected target: %v", err)
+	}
+
+	originalReady := writeFileParentReadyFn
+	writeFileParentReadyFn = func() error {
+		if err := os.Rename(originalParent, relocatedParent); err != nil {
+			return err
+		}
+		return os.Symlink(filepath.Base(redirectedParent), originalParent)
+	}
+	t.Cleanup(func() {
+		writeFileParentReadyFn = originalReady
+	})
+
+	root, err := OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("OpenWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+
+	err = root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
+	if err != nil {
+		t.Fatalf("WriteFileCreatingParents returned error: %v", err)
+	}
+	originalData, err := os.ReadFile(filepath.Join(relocatedParent, writeTestFileName))
+	if err != nil {
+		t.Fatalf("read pinned parent target: %v", err)
+	}
+	if string(originalData) != "after" {
+		t.Fatalf("unexpected pinned parent content: %q", string(originalData))
+	}
+	redirectedData, err := os.ReadFile(redirectedTarget)
+	if err != nil {
+		t.Fatalf("read redirected target: %v", err)
+	}
+	if string(redirectedData) != "redirected-before" {
+		t.Fatalf("unexpected redirected content: %q", string(redirectedData))
 	}
 }
 

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -208,6 +208,197 @@ func TestWriteFileUnderReturnsErrorForMissingParentDir(t *testing.T) {
 	}
 }
 
+func TestWriteRootCreatesMissingParentsAndWritesAtomically(t *testing.T) {
+	rootDir := t.TempDir()
+	root, err := OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("OpenWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+
+	targetPath := filepath.Join("reports", "nested", writeTestFileName)
+	if err := root.WriteFileCreatingParents(targetPath, []byte("hello"), 0o640, 0o750); err != nil {
+		t.Fatalf("WriteFileCreatingParents returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(rootDir, targetPath))
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("unexpected content: %q", string(data))
+	}
+	info, err := os.Stat(filepath.Join(rootDir, targetPath))
+	if err != nil {
+		t.Fatalf("stat written file: %v", err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("unexpected file mode: %#o", info.Mode().Perm())
+	}
+
+	if err := root.WriteFileCreatingParents("root-file.txt", []byte("root"), 0o600, 0o750); err != nil {
+		t.Fatalf("write root-level file: %v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(rootDir, "root-file.txt")); err != nil {
+		t.Fatalf("read root-level file: %v", err)
+	} else if string(data) != "root" {
+		t.Fatalf("unexpected root-level content: %q", string(data))
+	}
+}
+
+func TestOpenWriteRootPropagatesRootResolutionError(t *testing.T) {
+	expectedErr := errors.New("root abs failure")
+	withFileSystem(t, &fakeFileSystem{abs: func(string) (string, error) {
+		return "", expectedErr
+	}})
+
+	root, err := OpenWriteRoot(".")
+	if root != nil {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close unexpected root: %v", closeErr)
+		}
+	}
+	if !errors.Is(err, expectedErr) || !strings.Contains(err.Error(), "resolve root path") {
+		t.Fatalf("expected root path resolution error, got %v", err)
+	}
+}
+
+func TestWriteRootPropagatesParentLookupError(t *testing.T) {
+	expectedErr := errors.New("parent lookup failure")
+	withFileSystem(t, &fakeFileSystem{openRoot: func(string) (Root, error) {
+		return &fakeRoot{
+			lstat: func(string) (fs.FileInfo, error) {
+				return nil, expectedErr
+			},
+			close: func() error {
+				return nil
+			},
+		}, nil
+	}})
+
+	root, err := OpenWriteRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+
+	err = root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("hello"), 0o600, 0o750)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected parent lookup error, got %v", err)
+	}
+}
+
+func TestWriteRootRejectsNonRelativeTargets(t *testing.T) {
+	rootDir := t.TempDir()
+	root, err := OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("OpenWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+
+	for _, targetPath := range []string{rootDir, "..", filepath.Join("..", writeTestFileName), "."} {
+		err := root.WriteFileCreatingParents(targetPath, []byte("hello"), 0o600, 0o750)
+		if err == nil {
+			t.Fatalf("expected target %q to be rejected", targetPath)
+		}
+	}
+}
+
+func TestWriteRootRejectsSymlinkedParent(t *testing.T) {
+	rootDir := t.TempDir()
+	outside := t.TempDir()
+	outsideTarget := filepath.Join(outside, writeTestFileName)
+	if err := os.WriteFile(outsideTarget, []byte("outside-before"), 0o600); err != nil {
+		t.Fatalf("seed outside target: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(rootDir, "reports")); err != nil {
+		t.Fatalf("create reports symlink: %v", err)
+	}
+	root, err := OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("OpenWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+
+	err = root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
+	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
+		t.Fatalf("expected symlinked parent rejection, got %v", err)
+	}
+	data, readErr := os.ReadFile(outsideTarget)
+	if readErr != nil {
+		t.Fatalf("read outside target: %v", readErr)
+	}
+	if string(data) != "outside-before" {
+		t.Fatalf("unexpected outside content: %q", string(data))
+	}
+}
+
+func TestWriteRootDoesNotCreateOutsideAfterMissingParentSwap(t *testing.T) {
+	rootDir := t.TempDir()
+	outside := t.TempDir()
+	outsideSentinel := filepath.Join(outside, "sentinel.txt")
+	if err := os.WriteFile(outsideSentinel, []byte("outside-before"), 0o600); err != nil {
+		t.Fatalf("seed outside sentinel: %v", err)
+	}
+
+	withFileSystem(t, &fakeFileSystem{openRoot: func(name string) (Root, error) {
+		root, err := (&osFileSystem{}).OpenRoot(name)
+		if err != nil {
+			return nil, err
+		}
+		return &fakeRoot{
+			Root: root,
+			mkdirAll: func(path string, perm os.FileMode) error {
+				if err := os.Symlink(outside, filepath.Join(rootDir, "reports")); err != nil {
+					return err
+				}
+				return root.MkdirAll(path, perm)
+			},
+		}, nil
+	}})
+
+	root, err := OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("OpenWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+
+	err = root.WriteFileCreatingParents(filepath.Join("reports", "nested", writeTestFileName), []byte("after"), 0o600, 0o750)
+	if err == nil {
+		t.Fatal("expected swapped parent symlink to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "nested")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside nested directory to remain absent, got err=%v", statErr)
+	}
+	data, readErr := os.ReadFile(outsideSentinel)
+	if readErr != nil {
+		t.Fatalf("read outside sentinel: %v", readErr)
+	}
+	if string(data) != "outside-before" {
+		t.Fatalf("unexpected outside sentinel: %q", string(data))
+	}
+}
+
 func TestWriteFileUnderRejectsRootPathTarget(t *testing.T) {
 	rootDir := t.TempDir()
 	err := WriteFileUnder(rootDir, rootDir, []byte("hello"), 0o600)
@@ -439,6 +630,9 @@ func withAtomicWriteFileSystem(t *testing.T, tempFile File, remove func(string) 
 	}
 	withFileSystem(t, &fakeFileSystem{openRoot: func(string) (Root, error) {
 		return &fakeRoot{
+			lstat: func(string) (fs.FileInfo, error) {
+				return nil, os.ErrNotExist
+			},
 			openFile: func(string, int, os.FileMode) (File, error) {
 				return tempFile, nil
 			},

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -74,6 +74,48 @@ func TestWriteFileUnderPreservesExistingRegularFileMode(t *testing.T) {
 	}
 }
 
+func TestWriteFileUnderRejectsReadOnlyExistingRegularFile(t *testing.T) {
+	rootDir := t.TempDir()
+	targetPath := filepath.Join(rootDir, writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("before"), 0o600); err != nil {
+		t.Fatalf("seed target file: %v", err)
+	}
+	if err := os.Chmod(targetPath, 0o400); err != nil {
+		t.Fatalf("chmod target file read-only: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(targetPath, 0o600); err != nil && !os.IsNotExist(err) {
+			t.Errorf("restore target file permissions: %v", err)
+		}
+	})
+
+	probe, probeErr := os.OpenFile(targetPath, os.O_WRONLY, 0)
+	if probeErr == nil {
+		if err := probe.Close(); err != nil {
+			t.Fatalf("close writability probe: %v", err)
+		}
+		t.Skip("effective privileges bypass read-only file permissions")
+	}
+	if !os.IsPermission(probeErr) {
+		t.Skipf("read-only file semantics are not testable: %v", probeErr)
+	}
+
+	err := WriteFileUnder(rootDir, targetPath, []byte("after"), 0o600)
+	if err == nil {
+		t.Fatal("expected read-only existing file to be rejected")
+	}
+	if !os.IsPermission(err) {
+		t.Fatalf("expected permission error, got %v", err)
+	}
+	data, readErr := os.ReadFile(targetPath)
+	if readErr != nil {
+		t.Fatalf("read target file: %v", readErr)
+	}
+	if string(data) != "before" {
+		t.Fatalf("expected read-only target to remain unchanged, got %q", string(data))
+	}
+}
+
 func TestWriteFileUnderRejectsPathTraversalOutsideRoot(t *testing.T) {
 	parentDir := t.TempDir()
 	rootDir := filepath.Join(parentDir, "root")

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -268,6 +268,217 @@ func TestOpenWriteRootPropagatesRootResolutionError(t *testing.T) {
 	}
 }
 
+func TestOpenCanonicalWriteRootWritesInsideCanonicalRoot(t *testing.T) {
+	rootDir := filepath.Join(t.TempDir(), "canonical", "root")
+	if err := os.MkdirAll(rootDir, 0o755); err != nil {
+		t.Fatalf("mkdir canonical root: %v", err)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(rootDir)
+	if err != nil {
+		t.Fatalf("resolve canonical root: %v", err)
+	}
+
+	root, err := OpenCanonicalWriteRoot(canonicalRoot)
+	if err != nil {
+		t.Fatalf("OpenCanonicalWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close canonical write root: %v", closeErr)
+		}
+	})
+
+	targetPath := filepath.Join("reports", "nested", writeTestFileName)
+	if err := root.WriteFileCreatingParents(targetPath, []byte("canonical"), 0o640, 0o750); err != nil {
+		t.Fatalf("write through canonical root: %v", err)
+	}
+	assertFileContent(t, filepath.Join(canonicalRoot, targetPath), "canonical")
+}
+
+func TestOpenCanonicalWriteRootPropagatesResolutionError(t *testing.T) {
+	expectedErr := errors.New("canonical abs failure")
+	withFileSystem(t, &fakeFileSystem{abs: func(string) (string, error) {
+		return "", expectedErr
+	}})
+
+	root, err := OpenCanonicalWriteRoot(".")
+	if root != nil {
+		t.Fatal("expected canonical write root to remain nil")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected canonical resolution error, got %v", err)
+	}
+}
+
+func TestOpenCanonicalWriteRootWrapsOpenError(t *testing.T) {
+	expectedErr := errors.New("canonical open failure")
+	withFileSystem(t, &fakeFileSystem{openRootNoFollow: func(string) (Root, error) {
+		return nil, expectedErr
+	}})
+
+	root, err := OpenCanonicalWriteRoot(t.TempDir())
+	if root != nil {
+		t.Fatal("expected canonical write root to remain nil")
+	}
+	if !errors.Is(err, expectedErr) || !strings.Contains(err.Error(), "open canonical root") {
+		t.Fatalf("expected wrapped canonical open error, got %v", err)
+	}
+}
+
+func TestOpenRootNoFollowOpensVolumeRoot(t *testing.T) {
+	volumeRoot := filepath.VolumeName(t.TempDir()) + string(os.PathSeparator)
+	root, err := (&osFileSystem{}).OpenRootNoFollow(volumeRoot)
+	if err != nil {
+		t.Fatalf("OpenRootNoFollow returned error: %v", err)
+	}
+	if err := root.Close(); err != nil {
+		t.Fatalf("close volume root: %v", err)
+	}
+}
+
+func TestOpenRootNoFollowRejectsInvalidComponents(t *testing.T) {
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve test parent: %v", err)
+	}
+	filePath := filepath.Join(parent, "file")
+	if err := os.WriteFile(filePath, []byte("file"), 0o600); err != nil {
+		t.Fatalf("write non-directory component: %v", err)
+	}
+	symlinkPath := filepath.Join(parent, "link")
+	if err := os.Symlink(parent, symlinkPath); err != nil {
+		t.Fatalf("create root symlink: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "missing", path: filepath.Join(parent, "missing"), want: "no such file"},
+		{name: "file", path: filePath, want: "root is not a directory"},
+		{name: "symlink", path: symlinkPath, want: "root contains symlink"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root, err := (&osFileSystem{}).OpenRootNoFollow(tc.path)
+			if root != nil {
+				if closeErr := root.Close(); closeErr != nil {
+					t.Fatalf("close unexpected root: %v", closeErr)
+				}
+				t.Fatal("expected rejected root to remain nil")
+			}
+			if err == nil || !strings.Contains(strings.ToLower(err.Error()), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestOpenRootChildNoFollowPropagatesLookupError(t *testing.T) {
+	expectedErr := errors.New("child lookup failure")
+	root := &fakeRoot{lstat: func(string) (fs.FileInfo, error) {
+		return nil, expectedErr
+	}}
+
+	child, err := openRootChildNoFollow(root, "child", "/root/child")
+	if child != nil {
+		t.Fatal("expected child root to remain nil")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected child lookup error, got %v", err)
+	}
+}
+
+func TestOpenRootChildNoFollowPropagatesOpenError(t *testing.T) {
+	dirInfo := statTestPath(t, t.TempDir())
+	expectedErr := errors.New("child open failure")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) {
+			return nil, expectedErr
+		},
+	}
+
+	child, err := openRootChildNoFollow(root, "child", "/root/child")
+	if child != nil {
+		t.Fatal("expected child root to remain nil")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected child open error, got %v", err)
+	}
+}
+
+func TestOpenRootChildNoFollowJoinsChildLookupAndCloseErrors(t *testing.T) {
+	dirInfo := statTestPath(t, t.TempDir())
+	lookupErr := errors.New("opened child lookup failure")
+	closeErr := errors.New("opened child close failure")
+	childClosed := false
+	child := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, lookupErr },
+		close: func() error {
+			childClosed = true
+			return closeErr
+		},
+	}
+	root := &fakeRoot{
+		lstat:    func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) { return child, nil },
+	}
+
+	opened, err := openRootChildNoFollow(root, "child", "/root/child")
+	if opened != nil {
+		t.Fatal("expected rejected child root to remain nil")
+	}
+	if !errors.Is(err, lookupErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined lookup and close errors, got %v", err)
+	}
+	if !childClosed {
+		t.Fatal("expected rejected child root to be closed")
+	}
+}
+
+func TestOpenRootChildNoFollowRejectsChangedDirectory(t *testing.T) {
+	expectedInfo := statTestPath(t, t.TempDir())
+	changedInfo := statTestPath(t, t.TempDir())
+	childClosed := false
+	child := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return changedInfo, nil },
+		close: func() error {
+			childClosed = true
+			return nil
+		},
+	}
+	root := &fakeRoot{
+		lstat:    func(string) (fs.FileInfo, error) { return expectedInfo, nil },
+		openRoot: func(string) (Root, error) { return child, nil },
+	}
+
+	opened, err := openRootChildNoFollow(root, "child", "/root/child")
+	if opened != nil {
+		t.Fatal("expected changed child root to remain nil")
+	}
+	if err == nil || !strings.Contains(err.Error(), "root changed while opening") {
+		t.Fatalf("expected changed-directory error, got %v", err)
+	}
+	if !childClosed {
+		t.Fatal("expected changed child root to be closed")
+	}
+}
+
+func TestOSRootOpenRootReturnsMissingDirectoryError(t *testing.T) {
+	root := openTestRoot(t, t.TempDir())
+	child, err := root.OpenRoot("missing")
+	if child != nil {
+		if closeErr := child.Close(); closeErr != nil {
+			t.Fatalf("close unexpected child root: %v", closeErr)
+		}
+		t.Fatal("expected missing child root to remain nil")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing child root error, got %v", err)
+	}
+}
+
 func TestWriteRootPropagatesParentLookupError(t *testing.T) {
 	expectedErr := errors.New("parent lookup failure")
 	withFileSystem(t, &fakeFileSystem{openRoot: func(string) (Root, error) {
@@ -347,6 +558,283 @@ func TestWriteRootRejectsSymlinkedParent(t *testing.T) {
 	}
 	if string(data) != "outside-before" {
 		t.Fatalf("unexpected outside content: %q", string(data))
+	}
+}
+
+func TestWriteRootRejectsNonDirectoryParent(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootDir, "reports"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write non-directory parent: %v", err)
+	}
+	root, err := OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("OpenWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+
+	err = root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
+	if err == nil || !strings.Contains(err.Error(), "output parent is not a directory") {
+		t.Fatalf("expected non-directory parent rejection, got %v", err)
+	}
+}
+
+func TestOpenTargetParentChildPropagatesOpenError(t *testing.T) {
+	dirInfo := statTestPath(t, t.TempDir())
+	expectedErr := errors.New("parent open failure")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) {
+			return nil, expectedErr
+		},
+	}
+
+	child, err := openTargetParentChild(root, "parent", "/root/parent", false, 0)
+	if child != nil {
+		t.Fatal("expected parent root to remain nil")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected parent open error, got %v", err)
+	}
+}
+
+func TestOpenTargetParentChildClosesChildOnLookupError(t *testing.T) {
+	dirInfo := statTestPath(t, t.TempDir())
+	expectedErr := errors.New("opened parent lookup failure")
+	childClosed := false
+	child := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, expectedErr },
+		close: func() error {
+			childClosed = true
+			return nil
+		},
+	}
+	root := &fakeRoot{
+		lstat:    func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) { return child, nil },
+	}
+
+	opened, err := openTargetParentChild(root, "parent", "/root/parent", false, 0)
+	if opened != nil {
+		t.Fatal("expected rejected parent root to remain nil")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected opened parent lookup error, got %v", err)
+	}
+	if !childClosed {
+		t.Fatal("expected rejected parent root to be closed")
+	}
+}
+
+func TestOpenTargetParentChildRejectsChangedDirectory(t *testing.T) {
+	expectedInfo := statTestPath(t, t.TempDir())
+	changedInfo := statTestPath(t, t.TempDir())
+	childClosed := false
+	child := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return changedInfo, nil },
+		close: func() error {
+			childClosed = true
+			return nil
+		},
+	}
+	root := &fakeRoot{
+		lstat:    func(string) (fs.FileInfo, error) { return expectedInfo, nil },
+		openRoot: func(string) (Root, error) { return child, nil },
+	}
+
+	opened, err := openTargetParentChild(root, "parent", "/root/parent", false, 0)
+	if opened != nil {
+		t.Fatal("expected changed parent root to remain nil")
+	}
+	if err == nil || !strings.Contains(err.Error(), "output parent changed while opening") {
+		t.Fatalf("expected changed parent error, got %v", err)
+	}
+	if !childClosed {
+		t.Fatal("expected changed parent root to be closed")
+	}
+}
+
+func TestLstatOrCreateDirectoryPropagatesMkdirError(t *testing.T) {
+	expectedErr := errors.New("mkdir parent failure")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		mkdir: func(string, os.FileMode) error {
+			return expectedErr
+		},
+	}
+
+	info, err := lstatOrCreateDirectory(root, "parent", true, 0o750)
+	if info != nil {
+		t.Fatal("expected directory info to remain nil")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected mkdir error, got %v", err)
+	}
+}
+
+func TestOpenTargetParentClosesOwnedParentAfterDescendantError(t *testing.T) {
+	dirInfo := statTestPath(t, t.TempDir())
+	expectedErr := errors.New("descendant lookup failure")
+	ownedClosed := false
+	owned := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "." {
+				return dirInfo, nil
+			}
+			return nil, expectedErr
+		},
+		close: func() error {
+			ownedClosed = true
+			return nil
+		},
+	}
+	root := &fakeRoot{
+		lstat:    func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) { return owned, nil },
+	}
+	writeRoot := &WriteRoot{root: root, rootAbs: "/root"}
+	target := rootedTarget{rootAbs: "/root", rel: filepath.Join("first", "second", writeTestFileName)}
+
+	parent, closeParent, err := writeRoot.openTargetParent(target, false, 0)
+	if parent != nil || closeParent {
+		t.Fatal("expected descendant failure to return no parent root")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected descendant lookup error, got %v", err)
+	}
+	if !ownedClosed {
+		t.Fatal("expected owned parent root to be closed")
+	}
+}
+
+func TestOpenTargetParentClosesNextWhenOwnedParentCloseFails(t *testing.T) {
+	firstInfo := statTestPath(t, t.TempDir())
+	secondInfo := statTestPath(t, t.TempDir())
+	closeErr := errors.New("owned parent close failure")
+	nextCloseErr := errors.New("next parent close failure")
+	nextClosed := false
+	next := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return secondInfo, nil },
+		close: func() error {
+			nextClosed = true
+			return nextCloseErr
+		},
+	}
+	owned := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "." {
+				return firstInfo, nil
+			}
+			return secondInfo, nil
+		},
+		openRoot: func(string) (Root, error) { return next, nil },
+		close:    func() error { return closeErr },
+	}
+	root := &fakeRoot{
+		lstat:    func(string) (fs.FileInfo, error) { return firstInfo, nil },
+		openRoot: func(string) (Root, error) { return owned, nil },
+	}
+	writeRoot := &WriteRoot{root: root, rootAbs: "/root"}
+	target := rootedTarget{rootAbs: "/root", rel: filepath.Join("first", "second", writeTestFileName)}
+
+	parent, closeParent, err := writeRoot.openTargetParent(target, false, 0)
+	if parent != nil || closeParent {
+		t.Fatal("expected close failure to return no parent root")
+	}
+	if !errors.Is(err, closeErr) || !errors.Is(err, nextCloseErr) {
+		t.Fatalf("expected joined parent close errors, got %v", err)
+	}
+	if !nextClosed {
+		t.Fatal("expected next parent root to be closed")
+	}
+}
+
+func TestWriteFileAtTargetJoinsReadyAndParentCloseErrors(t *testing.T) {
+	dirInfo := statTestPath(t, t.TempDir())
+	readyErr := errors.New("parent ready failure")
+	closeErr := errors.New("parent close failure")
+	parentClosed := false
+	parent := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		close: func() error {
+			parentClosed = true
+			return closeErr
+		},
+	}
+	root := &fakeRoot{
+		lstat:    func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) { return parent, nil },
+	}
+	writeRoot := &WriteRoot{root: root, rootAbs: "/root"}
+	target := rootedTarget{rootAbs: "/root", rel: filepath.Join("parent", writeTestFileName)}
+	originalReady := writeFileParentReadyFn
+	writeFileParentReadyFn = func() error { return readyErr }
+	t.Cleanup(func() {
+		writeFileParentReadyFn = originalReady
+	})
+
+	err := writeRoot.writeFileAtTarget(target, []byte("data"), 0o600, false, 0)
+	if !errors.Is(err, readyErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined ready and close errors, got %v", err)
+	}
+	if !parentClosed {
+		t.Fatal("expected pinned parent root to be closed")
+	}
+}
+
+func TestWriteFileAtRootReturnsExistingTargetCloseError(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("before"), 0o600); err != nil {
+		t.Fatalf("seed existing target: %v", err)
+	}
+	fileInfo := statTestPath(t, targetPath)
+	expectedErr := errors.New("existing target close failure")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return fileInfo, nil },
+		openFile: func(string, int, os.FileMode) (File, error) {
+			return &fakeFile{close: func() error { return expectedErr }}, nil
+		},
+	}
+	target := rootedTarget{rel: writeTestFileName, abs: targetPath}
+
+	err := writeFileAtRoot(root, target, []byte("after"), 0o600)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected existing target close error, got %v", err)
+	}
+}
+
+func TestWriteFileAtRootReturnsAtomicSessionCreationError(t *testing.T) {
+	expectedErr := errors.New("atomic temp creation failure")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		openFile: func(string, int, os.FileMode) (File, error) {
+			return nil, expectedErr
+		},
+	}
+	target := rootedTarget{rel: writeTestFileName, abs: filepath.Join(t.TempDir(), writeTestFileName)}
+
+	err := writeFileAtRoot(root, target, []byte("data"), 0o600)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected atomic session creation error, got %v", err)
+	}
+}
+
+func TestResolvedWriteFilePermPropagatesLookupError(t *testing.T) {
+	expectedErr := errors.New("target lookup failure")
+	root := &fakeRoot{lstat: func(string) (fs.FileInfo, error) {
+		return nil, expectedErr
+	}}
+	target := rootedTarget{rel: writeTestFileName, abs: filepath.Join(t.TempDir(), writeTestFileName)}
+
+	perm, existing, err := resolvedWriteFilePerm(root, target, 0o600)
+	if perm != 0 || existing {
+		t.Fatalf("expected empty permission result, got perm=%#o existing=%t", perm, existing)
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected target lookup error, got %v", err)
 	}
 }
 

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -365,11 +365,11 @@ func TestWriteRootDoesNotCreateOutsideAfterMissingParentSwap(t *testing.T) {
 		}
 		return &fakeRoot{
 			Root: root,
-			mkdirAll: func(path string, perm os.FileMode) error {
+			mkdir: func(path string, perm os.FileMode) error {
 				if err := os.Symlink(outside, filepath.Join(rootDir, "reports")); err != nil {
 					return err
 				}
-				return root.MkdirAll(path, perm)
+				return root.Mkdir(path, perm)
 			},
 		}, nil
 	}})
@@ -449,20 +449,8 @@ func TestWriteRootPinsParentBeforeInRootSymlinkRetarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteFileCreatingParents returned error: %v", err)
 	}
-	originalData, err := os.ReadFile(filepath.Join(relocatedParent, writeTestFileName))
-	if err != nil {
-		t.Fatalf("read pinned parent target: %v", err)
-	}
-	if string(originalData) != "after" {
-		t.Fatalf("unexpected pinned parent content: %q", string(originalData))
-	}
-	redirectedData, err := os.ReadFile(redirectedTarget)
-	if err != nil {
-		t.Fatalf("read redirected target: %v", err)
-	}
-	if string(redirectedData) != "redirected-before" {
-		t.Fatalf("unexpected redirected content: %q", string(redirectedData))
-	}
+	assertFileContent(t, filepath.Join(relocatedParent, writeTestFileName), "after")
+	assertFileContent(t, redirectedTarget, "redirected-before")
 }
 
 func TestWriteFileUnderRejectsRootPathTarget(t *testing.T) {


### PR DESCRIPTION
## Summary

Secure dashboard output writes under a trusted root by pinning the write root once, creating parents safely inside that root, and preserving valid workspace alias paths while rejecting symlink escapes.

## Changes

- Route dashboard output persistence through a pinned `safeio.WriteRoot` so root-relative atomic writes stay confined to the resolved trusted workspace.
- Create missing parent directories inside the pinned root, then re-check parent segments so symlink swaps and nested symlink escapes fail closed.
- Preserve normal relative and parent-relative output semantics from a symlinked working directory while allowing a direct trusted-root alias and rejecting nested lexical symlink ancestors.
- Expand regression coverage for trusted-root aliases, safe parent creation, directory and symlink rejection, and TOCTOU-style parent-swap races.

## Validation

Commands and checks run:

```bash
make ci
```

Additional validation:

- Focused dashboard-materialization and safe-I/O tests cover trusted-root alias compatibility, physical working-directory semantics, rooted parent creation, and swapped-parent symlink race rejection.
- The final PR head is required to pass hosted checks, Sonar analysis, and review-thread verification before handoff.

## Risk and compatibility

- Breaking changes: Unsafe output targets that escape through symlinked parents or resolve outside the trusted root are rejected.
- Migration required: Keep dashboard output paths beneath the trusted workspace or approved trusted root without nested symlink hops.
- Performance impact: Bounded root-resolution and parent-segment checks are added before writes.
- Memory benchmark impact: No intentional regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
