### PR TITLE
fix(vscode): reject untrusted workspace symlink binaries

### DIFF
--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -408,6 +408,10 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
   }
 
   private async isWorkspaceLocalBinary(binaryPath: string, workspaceRoots: readonly string[]): Promise<boolean> {
+    if (workspaceRoots.some((workspaceRoot) => isPathInsideWorkspace(binaryPath, workspaceRoot))) {
+      return true;
+    }
+
     try {
       const [canonicalBinaryPath, ...canonicalWorkspaceRoots] = await Promise.all([
         this.canonicalizePath(binaryPath),

--- a/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
@@ -593,6 +593,75 @@ suite("managed binary installer", () => {
     }
   });
 
+  test("rejects configured symlinks located under the workspace in untrusted workspaces", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-workspace-link-"));
+    const outsideRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-outside-target-"));
+    const outsideBinary = path.join(outsideRoot, platformBinaryName());
+    const workspaceLink = path.join(workspaceRoot, platformBinaryName());
+
+    try {
+      await writeExecutable(outsideBinary);
+      await symlink(outsideBinary, workspaceLink);
+      const lifecycle = createPathFallbackLifecycle();
+
+      await assert.rejects(
+        lifecycle.resolveBinaryPath({
+          workspaceRoot,
+          workspaceTrusted: false,
+          autoDownloadBinary: false,
+          configuredBinaryPath: workspaceLink,
+        }),
+        (error: unknown) =>
+          error instanceof BinaryResolutionError
+          && error.message.includes("workspace-local binary in an untrusted workspace"),
+      );
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("skips PATH symlinks located under the workspace in untrusted workspaces", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-path-link-workspace-"));
+    const outsideRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-path-link-target-"));
+    const fallbackRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-path-link-fallback-"));
+    const workspacePathRoot = path.join(workspaceRoot, "path-bin");
+    const workspaceLink = path.join(workspacePathRoot, platformBinaryName());
+    const outsideBinary = path.join(outsideRoot, platformBinaryName());
+    const fallbackBinary = path.join(fallbackRoot, platformBinaryName());
+    const previousPath = process.env.PATH;
+
+    try {
+      await mkdir(workspacePathRoot, { recursive: true });
+      await writeExecutable(outsideBinary);
+      await writeExecutable(fallbackBinary);
+      await symlink(outsideBinary, workspaceLink);
+      process.env.PATH = joinPathEntries([workspacePathRoot, fallbackRoot, previousPath]);
+      const lifecycle = createPathFallbackLifecycle();
+
+      const resolvedPath = await lifecycle.resolveBinaryPath({
+        workspaceRoot,
+        workspaceTrusted: false,
+        autoDownloadBinary: false,
+      });
+
+      assert.equal(resolvedPath, fallbackBinary);
+    } finally {
+      restoreEnv("PATH", previousPath);
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+      await rm(fallbackRoot, { recursive: true, force: true });
+    }
+  });
+
   test("skips PATH candidates when canonicalization fails in untrusted workspaces", async () => {
     const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-workspace-"));
     const blockedRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-path-blocked-"));


### PR DESCRIPTION
## Summary

Preserve the VS Code extension's untrusted-workspace boundary by treating binaries that physically live under a workspace root as workspace-local even when their symlink targets point outside the workspace.

## Changes

- Update `isWorkspaceLocalBinary` in `extensions/vscode-lopper/src/managedBinary.ts` to check the literal candidate path against the workspace root before canonicalizing it with `realpath`.
- Keep canonical-target checks for other paths while ensuring workspace-local symlinks cannot bypass the extension's trust model.
- Add regression tests for configured workspace symlinks and PATH entries that resolve to external binaries through workspace-local symlinks.

## Validation

Commands and checks run:

```bash
npm run compile
npx mocha out/test/suite/managedBinary.test.js
npm run test:e2e
```

Additional manual validation:

- `npm run compile` in `extensions/vscode-lopper` succeeded.
- `npx mocha out/test/suite/managedBinary.test.js` passed with 27 tests passing.
- `npm run test:e2e` passed with 105 tests using VS Code 1.90.0.

## Risk and compatibility

- Breaking changes: In untrusted workspaces, workspace-local symlink binaries are now rejected even if their targets are outside the workspace.
- Migration required: Point the extension at a binary outside the workspace root or trust the workspace before using a workspace-local symlink.
- Performance impact: None expected.
- Memory benchmark impact: Not measured.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
