### PR TITLE
fix: validate manual release source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,6 @@ on:
         description: Release tag or version to publish, such as v1.6.0 or 1.6.0
         required: true
         type: string
-      source_sha:
-        description: Release source ref or SHA; defaults to the selected workflow ref when omitted
-        required: false
-        type: string
 
 concurrency:
   # Serialize release runs so newer commits queue behind in-flight releases.
@@ -62,13 +58,12 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Checkout manual release source
+      - name: Checkout release metadata
         if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: ${{ inputs.source_sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare manual release
@@ -90,7 +85,6 @@ jobs:
             tag="v${tag}"
           fi
 
-          resolved_sha="$(git rev-parse HEAD)"
           encoded_tag="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$tag")"
           release_lookup_error="$(mktemp)"
           set +e
@@ -145,18 +139,11 @@ jobs:
               echo "::error::Existing release ${tag} target commit could not be verified." >&2
               exit 1
             fi
-            if [ "${existing_commit}" != "${resolved_sha}" ]; then
-              echo "::error::Existing release ${tag} points to ${existing_commit}, but this run resolved ${resolved_sha}." >&2
-              exit 1
-            fi
+            resolved_sha="${existing_commit}"
           elif grep -q "HTTP 404" "${release_lookup_error}"; then
             rm -f "${release_lookup_error}"
-            gh release create "${tag}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --target "${resolved_sha}" \
-              --draft \
-              --title "Release ${tag}" \
-              --notes ""
+            echo "::error::Manual release promotion can only retry an existing GitHub release for ${tag}." >&2
+            exit 1
           else
             cat "${release_lookup_error}" >&2
             rm -f "${release_lookup_error}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,10 @@ jobs:
           if [[ "${tag}" != v* ]]; then
             tag="v${tag}"
           fi
+          if ! git check-ref-format --normalize "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "::error::tag input must be a valid Git tag name." >&2
+            exit 1
+          fi
 
           encoded_tag="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$tag")"
           release_lookup_error="$(mktemp)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,69 +90,79 @@ jobs:
           fi
 
           encoded_tag="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$tag")"
+          release_metadata_file="$(mktemp)"
           release_lookup_error="$(mktemp)"
+          trap 'rm -f "${release_metadata_file}" "${release_lookup_error}"' EXIT
           set +e
-          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" >/dev/null 2>"${release_lookup_error}"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" >"${release_metadata_file}" 2>"${release_lookup_error}"
           release_lookup_status=$?
           set -e
-          if [ "${release_lookup_status}" -eq 0 ]; then
-            rm -f "${release_lookup_error}"
-            echo "Reusing existing GitHub release ${tag}."
-            release_ref_json="$(mktemp)"
-            if ! gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${encoded_tag}" >"${release_ref_json}" 2>/dev/null; then
-              echo "::error::Existing release ${tag} tag ref could not be verified." >&2
-              rm -f "${release_ref_json}"
-              exit 1
-            fi
-
-            existing_ref_type="$(jq -r '.object.type // empty' "${release_ref_json}")"
-            existing_ref_sha="$(jq -r '.object.sha // empty' "${release_ref_json}")"
-            existing_commit=""
-
-            case "${existing_ref_type}" in
-              commit)
-                existing_commit="${existing_ref_sha}"
-                ;;
-              tag)
-                annotated_tag_json="$(mktemp)"
-                if ! gh api "repos/${GITHUB_REPOSITORY}/git/tags/${existing_ref_sha}" >"${annotated_tag_json}" 2>/dev/null; then
-                  echo "::error::Existing release ${tag} annotated tag target could not be verified." >&2
-                  rm -f "${annotated_tag_json}" "${release_ref_json}"
-                  exit 1
-                fi
-
-                annotated_target_type="$(jq -r '.object.type // empty' "${annotated_tag_json}")"
-                if [ "${annotated_target_type}" != "commit" ]; then
-                  echo "::error::Existing release ${tag} tag target type ${annotated_target_type} is not a commit." >&2
-                  rm -f "${annotated_tag_json}" "${release_ref_json}"
-                  exit 1
-                fi
-
-                existing_commit="$(jq -r '.object.sha // empty' "${annotated_tag_json}")"
-                rm -f "${annotated_tag_json}"
-                ;;
-              *)
-                echo "::error::Existing release ${tag} tag ref type ${existing_ref_type} is not supported." >&2
-                rm -f "${release_ref_json}"
+          if [ "${release_lookup_status}" -ne 0 ]; then
+            if grep -q "HTTP 404" "${release_lookup_error}"; then
+              if ! gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases" \
+                | jq -c --arg tag "$tag" '.[].[] | select(.tag_name == $tag)' \
+                | head -n1 >"${release_metadata_file}"; then
+                echo "::error::Failed to search draft GitHub releases for ${tag}." >&2
                 exit 1
-                ;;
-            esac
-
-            rm -f "${release_ref_json}"
-            if [ -z "${existing_commit}" ]; then
-              echo "::error::Existing release ${tag} target commit could not be verified." >&2
-              exit 1
+              fi
+            else
+              cat "${release_lookup_error}" >&2
+              echo "::error::Failed to look up GitHub release ${tag}." >&2
+              exit "${release_lookup_status}"
             fi
-            resolved_sha="${existing_commit}"
-          elif grep -q "HTTP 404" "${release_lookup_error}"; then
-            rm -f "${release_lookup_error}"
+          fi
+          if ! [ -s "${release_metadata_file}" ]; then
             echo "::error::Manual release promotion can only retry an existing GitHub release for ${tag}." >&2
             exit 1
-          else
-            cat "${release_lookup_error}" >&2
-            rm -f "${release_lookup_error}"
-            exit "${release_lookup_status}"
           fi
+
+          echo "Reusing existing GitHub release ${tag}."
+          release_ref_json="$(mktemp)"
+          if ! gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${encoded_tag}" >"${release_ref_json}" 2>/dev/null; then
+            echo "::error::Existing release ${tag} tag ref could not be verified." >&2
+            rm -f "${release_ref_json}"
+            exit 1
+          fi
+
+          existing_ref_type="$(jq -r '.object.type // empty' "${release_ref_json}")"
+          existing_ref_sha="$(jq -r '.object.sha // empty' "${release_ref_json}")"
+          existing_commit=""
+
+          case "${existing_ref_type}" in
+            commit)
+              existing_commit="${existing_ref_sha}"
+              ;;
+            tag)
+              annotated_tag_json="$(mktemp)"
+              if ! gh api "repos/${GITHUB_REPOSITORY}/git/tags/${existing_ref_sha}" >"${annotated_tag_json}" 2>/dev/null; then
+                echo "::error::Existing release ${tag} annotated tag target could not be verified." >&2
+                rm -f "${annotated_tag_json}" "${release_ref_json}"
+                exit 1
+              fi
+
+              annotated_target_type="$(jq -r '.object.type // empty' "${annotated_tag_json}")"
+              if [ "${annotated_target_type}" != "commit" ]; then
+                echo "::error::Existing release ${tag} tag target type ${annotated_target_type} is not a commit." >&2
+                rm -f "${annotated_tag_json}" "${release_ref_json}"
+                exit 1
+              fi
+
+              existing_commit="$(jq -r '.object.sha // empty' "${annotated_tag_json}")"
+              rm -f "${annotated_tag_json}"
+              ;;
+            *)
+              echo "::error::Existing release ${tag} tag ref type ${existing_ref_type} is not supported." >&2
+              rm -f "${release_ref_json}"
+              exit 1
+              ;;
+          esac
+
+          rm -f "${release_ref_json}"
+          if [ -z "${existing_commit}" ]; then
+            echo "::error::Existing release ${tag} target commit could not be verified." >&2
+            exit 1
+          fi
+          resolved_sha="${existing_commit}"
 
           {
             echo "release_created=true"

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -24,7 +24,7 @@ Stable release automation:
 - Release versioning and changelog generation are configured in `release-please-config.json` and tracked in `.release-please-manifest.json`.
 - The Go project release notes are generated into the root `CHANGELOG.md`; the VS Code extension keeps its own `extensions/vscode-lopper/CHANGELOG.md`.
 - The current stable version is also synced into `extensions/vscode-lopper/package.json` and `extensions/vscode-lopper/package-lock.json` by the release-please PR.
-- Manual `workflow_dispatch` runs accept only a release tag/version, normalize it to the semver tag, validate the tag ref, fetch `refs/tags/<tag>`, and derive the release source SHA from that tag.
+- Manual `workflow_dispatch` runs accept only a release tag/version, normalize it to the semver tag, validate the tag ref, resolve `refs/tags/<tag>` through the GitHub API, and derive the release source SHA from that immutable tag commit.
 - Manual retries only rebuild an existing GitHub release for the selected tag. The workflow reuses the existing published or draft release metadata and fails instead of creating a missing release.
 - Release commits should use Conventional Commit prefixes: `fix:` for patch releases, `feat:` for minor releases, and any type with a breaking-change marker (for example `feat!:` or `fix!:`) or a `BREAKING CHANGE:` footer for major releases.
 - Stable releases also publish the first-party action version refs. The release tag, such as `v1.7.0`, is the exact action ref; the workflow force-updates `v1` and `v1.7` to the same release commit for standard GitHub Actions major/minor pinning.

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -24,7 +24,8 @@ Stable release automation:
 - Release versioning and changelog generation are configured in `release-please-config.json` and tracked in `.release-please-manifest.json`.
 - The Go project release notes are generated into the root `CHANGELOG.md`; the VS Code extension keeps its own `extensions/vscode-lopper/CHANGELOG.md`.
 - The current stable version is also synced into `extensions/vscode-lopper/package.json` and `extensions/vscode-lopper/package-lock.json` by the release-please PR.
-- Manual `workflow_dispatch` runs accept a release tag/version plus an optional `source_sha`, resolve the selected source ref, and create or reuse the draft GitHub release when the tag is not already present.
+- Manual `workflow_dispatch` runs accept only a release tag/version, normalize it to the semver tag, validate the tag ref, fetch `refs/tags/<tag>`, and derive the release source SHA from that tag.
+- Manual retries only rebuild an existing GitHub release for the selected tag. The workflow reuses the existing published or draft release metadata and fails instead of creating a missing release.
 - Release commits should use Conventional Commit prefixes: `fix:` for patch releases, `feat:` for minor releases, and any type with a breaking-change marker (for example `feat!:` or `fix!:`) or a `BREAKING CHANGE:` footer for major releases.
 - Stable releases also publish the first-party action version refs. The release tag, such as `v1.7.0`, is the exact action ref; the workflow force-updates `v1` and `v1.7` to the same release commit for standard GitHub Actions major/minor pinning.
 - Set repository secret `RELEASE_PLEASE_TOKEN` to a PAT with contents and pull request write access so release-please-created PRs can trigger normal CI. If it is not configured, the workflow falls back to `MAIN_SYNC_PAT` and then `GITHUB_TOKEN`.

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -332,6 +332,26 @@ func TestReleaseWorkflowManualDispatchFallsBackToDraftReleaseLookup(t *testing.T
 	}
 }
 
+func TestReleaseWorkflowMetadataCheckoutDoesNotPersistWriteToken(t *testing.T) {
+	t.Parallel()
+
+	var workflow struct {
+		Jobs map[string]workflowJobConfig `yaml:"jobs"`
+	}
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	step := workflowStepByName(t, workflow.Jobs, "prepare-release", "Checkout release metadata")
+	if !strings.HasPrefix(step.Uses, "actions/checkout@") {
+		t.Fatalf("release metadata checkout uses %q, want actions/checkout", step.Uses)
+	}
+	if step.With["token"] != "${{ secrets.GITHUB_TOKEN }}" {
+		t.Fatalf("release metadata checkout token = %q, want GITHUB_TOKEN only", step.With["token"])
+	}
+	if step.With["persist-credentials"] != "false" {
+		t.Fatal("release metadata checkout must set persist-credentials: false so its write token is not stored in local git config")
+	}
+}
+
 func TestReleaseWorkflowManualDispatchStrictlyValidatesExistingReleaseCommit(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -322,6 +322,21 @@ func TestReleaseWorkflowManualDispatchValidatesTagBeforeLookup(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowManualDispatchFallsBackToDraftReleaseLookup(t *testing.T) {
+	t.Parallel()
+
+	workflowText := readConfig(t, ".github/workflows/release.yml")
+	if !strings.Contains(workflowText, `gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases"`) {
+		t.Fatal("manual release flow must fall back to listing releases when the tag lookup misses a draft release")
+	}
+	if !strings.Contains(workflowText, `jq -c --arg tag "$tag" '.[].[] | select(.tag_name == $tag)'`) {
+		t.Fatal("manual release flow must filter the release list by the requested tag")
+	}
+	if strings.Contains(workflowText, `head -n1 >"${release_metadata_file}" || true`) {
+		t.Fatal("manual release draft lookup must not mask API or JSON failures")
+	}
+}
+
 func TestReleaseWorkflowManualDispatchStrictlyValidatesExistingReleaseCommit(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -1662,6 +1662,28 @@ func TestReleaseWorkflowManualReleaseVerifiesExistingTagsViaGitHubAPI(t *testing
 	if strings.Contains(step.Run, `release_json`) {
 		t.Fatal("manual release existing-release probe must not persist an unused response body")
 	}
+
+	finalizeJob := workflowJobRequired(t, workflow.Jobs, "finalize-release")
+	if !slices.Equal(finalizeJob.Needs, workflowNeeds{"prepare-release", "publish", "publish-vscode-marketplace"}) {
+		t.Fatalf("finalize-release needs = %#v, want prepare-release + publish + publish-vscode-marketplace", finalizeJob.Needs)
+	}
+	if len(finalizeJob.Permissions) != 1 || finalizeJob.Permissions["contents"] != "write" {
+		t.Fatalf("finalize-release permissions = %#v, want only contents: write", finalizeJob.Permissions)
+	}
+	if _, ok := workflowStepByNameIfPresent(workflow.Jobs, "publish", "Publish GitHub Release"); ok {
+		t.Fatal("publish job must not make the GitHub Release public directly")
+	}
+	if _, ok := workflowStepByNameIfPresent(workflow.Jobs, "publish", "Update GitHub Action floating tags"); ok {
+		t.Fatal("publish job must not move floating action tags directly")
+	}
+	finalizeRelease := workflowStepByName(t, workflow.Jobs, "finalize-release", "Publish GitHub Release")
+	if finalizeRelease.Env["GH_TOKEN"] != "${{ secrets.GITHUB_TOKEN }}" {
+		t.Fatalf("finalize release GH_TOKEN env = %q", finalizeRelease.Env["GH_TOKEN"])
+	}
+	floatingTags := workflowStepByName(t, workflow.Jobs, "finalize-release", "Update GitHub Action floating tags")
+	if floatingTags.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" {
+		t.Fatalf("finalize floating tag RELEASE_TAG env = %q", floatingTags.Env["RELEASE_TAG"])
+	}
 }
 
 func TestRenovateDoesNotAutomergeMajorUpdates(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -301,6 +301,27 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowManualDispatchValidatesTagBeforeLookup(t *testing.T) {
+	t.Parallel()
+
+	workflowText := readConfig(t, ".github/workflows/release.yml")
+	validation := `git check-ref-format --normalize "refs/tags/${tag}" >/dev/null 2>&1`
+	lookup := `encoded_tag="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$tag")"`
+
+	validationIndex := strings.Index(workflowText, validation)
+	if validationIndex == -1 {
+		t.Fatal("manual release flow must validate the user-supplied tag before using it as a ref")
+	}
+
+	lookupIndex := strings.Index(workflowText, lookup)
+	if lookupIndex == -1 {
+		t.Fatal("manual release flow must encode the validated release tag")
+	}
+	if validationIndex > lookupIndex {
+		t.Fatal("manual release flow must validate the user-supplied tag before looking it up")
+	}
+}
+
 func TestReleaseWorkflowManualDispatchStrictlyValidatesExistingReleaseCommit(t *testing.T) {
 	t.Parallel()
 
@@ -318,9 +339,9 @@ func TestReleaseWorkflowManualDispatchStrictlyValidatesExistingReleaseCommit(t *
 		`case "${existing_ref_type}" in`,
 		`if ! gh api "repos/${GITHUB_REPOSITORY}/git/tags/${existing_ref_sha}" >"${annotated_tag_json}" 2>/dev/null; then`,
 		`if [ -z "${existing_commit}" ]; then`,
-		`if [ "${existing_commit}" != "${resolved_sha}" ]; then`,
+		`resolved_sha="${existing_commit}"`,
 	})
-	for _, forbidden := range []string{"target_commitish", `git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"`, `[ -n "${existing_commit}" ] &&`} {
+	for _, forbidden := range []string{"target_commitish", `git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"`, `resolved_sha="$(git rev-parse HEAD)"`, `[ -n "${existing_commit}" ] &&`} {
 		if strings.Contains(manualStep.Run, forbidden) {
 			t.Fatalf("manual release flow must not contain stale validation path %q", forbidden)
 		}

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -328,7 +328,7 @@ func TestReleaseWorkflowManualDispatchFallsBackToDraftReleaseLookup(t *testing.T
 		t.Fatal("manual release flow must filter the release list by the requested tag")
 	}
 	if strings.Contains(workflowText, `head -n1 >"${release_metadata_file}" || true`) {
-		t.Fatal("manual release draft lookup must not mask API or JSON failures")
+		t.Fatal("manual release draft lookup must not mask API or JSON failures as a missing release")
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -238,7 +238,7 @@ func TestReleaseWorkflowPinsTrustedMainToWorkflowRevision(t *testing.T) {
 	assertTextAppearsBefore(t, resolver.Run, `if [ "${WORKFLOW_REF}" != "${expected_workflow_ref}" ]; then`, `/usr/bin/printf 'trusted_main_sha=%s\n' "${WORKFLOW_SHA}" >> "$GITHUB_OUTPUT"`, "trusted main workflow ref must be validated before output")
 	assertTextAppearsBefore(t, resolver.Run, `if [[ ! "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then`, `/usr/bin/printf 'trusted_main_sha=%s\n' "${WORKFLOW_SHA}" >> "$GITHUB_OUTPUT"`, "trusted main workflow SHA must be validated before output")
 	assertWorkflowStepRunOmitsAll(t, resolver, "trusted main workflow resolver", []string{"git ", "gh ", "curl ", "wget ", "secrets.", "token"})
-	assertWorkflowStepOrder(t, preparation, "Resolve trusted main workflow revision", "Run release-please", "Checkout manual release source", "Prepare manual release")
+	assertWorkflowStepOrder(t, preparation, "Resolve trusted main workflow revision", "Run release-please", "Checkout release metadata", "Prepare manual release")
 
 	wantTrustedMain := "${{ needs.prepare-release.outputs.trusted_main_sha }}"
 	marketplaceCheckout := workflowStepByName(t, workflow.Jobs, "prepare-marketplace-toolchain", "Checkout trusted main Marketplace manifests")
@@ -276,11 +276,11 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	if !strings.Contains(workflowText, "Manual release promotion can only retry an existing GitHub release for ${tag}.") {
 		t.Fatal("manual release flow must require an existing GitHub release to retry")
 	}
-	if !strings.Contains(workflowText, `resolved_sha="$(git rev-list -n 1 "refs/tags/${tag}")"`) {
-		t.Fatal("manual release flow must resolve the source SHA from the requested release tag")
+	if !strings.Contains(workflowText, `resolved_sha="${existing_commit}"`) {
+		t.Fatal("manual release flow must use the API-verified release tag commit as its source SHA")
 	}
-	if !strings.Contains(workflowText, "GitHub release ${tag} targets ${release_target_sha}, but tag ${tag} points to ${resolved_sha}.") {
-		t.Fatal("manual release flow must fail when release metadata disagrees with the tag target")
+	if strings.Contains(workflowText, `resolved_sha="$(git rev-list -n 1 "refs/tags/${tag}")"`) {
+		t.Fatal("manual release flow must not resolve its source through an unauthenticated tag fetch")
 	}
 	if !strings.Contains(workflowText, "needs.prepare-release.outputs.sha") {
 		t.Fatal("downstream release jobs must use the resolved prepare-release SHA")
@@ -363,7 +363,7 @@ func TestReleaseWorkflowManualDispatchStrictlyValidatesExistingReleaseCommit(t *
 	manualStep := workflowStepByName(t, workflow.Jobs, "prepare-release", "Prepare manual release")
 	assertWorkflowStepRunContainsAll(t, manualStep, "manual release preparation step", []string{
 		`release_lookup_error="$(mktemp)"`,
-		`elif grep -q "HTTP 404" "${release_lookup_error}"; then`,
+		`if grep -q "HTTP 404" "${release_lookup_error}"; then`,
 		`if ! gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${encoded_tag}" >"${release_ref_json}" 2>/dev/null; then`,
 		`existing_ref_type="$(jq -r '.object.type // empty' "${release_ref_json}")"`,
 		`case "${existing_ref_type}" in`,
@@ -378,7 +378,7 @@ func TestReleaseWorkflowManualDispatchStrictlyValidatesExistingReleaseCommit(t *
 	}
 }
 
-func TestReleaseWorkflowManualReleaseCreatesOnlyAfterExplicit404(t *testing.T) {
+func TestReleaseWorkflowManualReleaseRequiresExistingReleaseAfterExplicit404(t *testing.T) {
 	t.Parallel()
 
 	var workflow struct {
@@ -388,21 +388,28 @@ func TestReleaseWorkflowManualReleaseCreatesOnlyAfterExplicit404(t *testing.T) {
 
 	manualStep := workflowStepByName(t, workflow.Jobs, "prepare-release", "Prepare manual release")
 	assertWorkflowStepRunContainsAll(t, manualStep, "manual release lookup failure contract", []string{
+		`release_metadata_file="$(mktemp)"`,
 		`release_lookup_error="$(mktemp)"`,
-		`gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" >/dev/null 2>"${release_lookup_error}"`,
+		`gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" >"${release_metadata_file}" 2>"${release_lookup_error}"`,
 		`release_lookup_status=$?`,
-		`elif grep -q "HTTP 404" "${release_lookup_error}"; then`,
+		`if grep -q "HTTP 404" "${release_lookup_error}"; then`,
+		`gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases"`,
+		`if ! [ -s "${release_metadata_file}" ]; then`,
+		`Manual release promotion can only retry an existing GitHub release for ${tag}.`,
 		`cat "${release_lookup_error}" >&2`,
 		`exit "${release_lookup_status}"`,
-		`gh release create "${tag}"`,
 	})
+	if strings.Contains(manualStep.Run, `gh release create "${tag}"`) {
+		t.Fatal("manual release retries must not create missing releases")
+	}
 
-	lookupIndex := strings.Index(manualStep.Run, `gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" >/dev/null 2>"${release_lookup_error}"`)
+	lookupIndex := strings.Index(manualStep.Run, `gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" >"${release_metadata_file}" 2>"${release_lookup_error}"`)
 	statusIndex := strings.Index(manualStep.Run, `release_lookup_status=$?`)
-	notFoundIndex := strings.Index(manualStep.Run, `elif grep -q "HTTP 404" "${release_lookup_error}"; then`)
-	createIndex := strings.Index(manualStep.Run, `gh release create "${tag}"`)
-	if lookupIndex < 0 || statusIndex < lookupIndex || notFoundIndex < statusIndex || createIndex < notFoundIndex {
-		t.Fatal("manual release creation must follow the captured lookup status and explicit HTTP 404 evidence")
+	notFoundIndex := strings.Index(manualStep.Run, `if grep -q "HTTP 404" "${release_lookup_error}"; then`)
+	draftLookupIndex := strings.Index(manualStep.Run, `gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases"`)
+	requireExistingIndex := strings.Index(manualStep.Run, `if ! [ -s "${release_metadata_file}" ]; then`)
+	if lookupIndex < 0 || statusIndex < lookupIndex || notFoundIndex < statusIndex || draftLookupIndex < notFoundIndex || requireExistingIndex < draftLookupIndex {
+		t.Fatal("manual release retry validation must follow the captured lookup status and explicit HTTP 404 evidence")
 	}
 }
 
@@ -1627,7 +1634,7 @@ func TestReleaseWorkflowManualCheckoutUsesReadOnlyToken(t *testing.T) {
 	}
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	step := workflowStepByName(t, workflow.Jobs, "prepare-release", "Checkout manual release source")
+	step := workflowStepByName(t, workflow.Jobs, "prepare-release", "Checkout release metadata")
 	if got := workflowStepWithString(t, step, "token"); got != "${{ secrets.GITHUB_TOKEN }}" {
 		t.Fatalf("manual release checkout token = %q, want GITHUB_TOKEN-only checkout", got)
 	}
@@ -1651,7 +1658,7 @@ func TestReleaseWorkflowManualReleaseVerifiesExistingTagsViaGitHubAPI(t *testing
 		`case "${existing_ref_type}" in`,
 		`if ! gh api "repos/${GITHUB_REPOSITORY}/git/tags/${existing_ref_sha}" >"${annotated_tag_json}" 2>/dev/null; then`,
 		`echo "::error::Existing release ${tag} target commit could not be verified." >&2`,
-		`if [ "${existing_commit}" != "${resolved_sha}" ]; then`,
+		`resolved_sha="${existing_commit}"`,
 	})
 	if strings.Contains(step.Run, `git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"`) {
 		t.Fatal("manual release existing-tag verification must not rely on an unauthenticated tag fetch")
@@ -1661,28 +1668,6 @@ func TestReleaseWorkflowManualReleaseVerifiesExistingTagsViaGitHubAPI(t *testing
 	}
 	if strings.Contains(step.Run, `release_json`) {
 		t.Fatal("manual release existing-release probe must not persist an unused response body")
-	}
-
-	finalizeJob := workflowJobRequired(t, workflow.Jobs, "finalize-release")
-	if !slices.Equal(finalizeJob.Needs, workflowNeeds{"prepare-release", "publish", "publish-vscode-marketplace"}) {
-		t.Fatalf("finalize-release needs = %#v, want prepare-release + publish + publish-vscode-marketplace", finalizeJob.Needs)
-	}
-	if len(finalizeJob.Permissions) != 1 || finalizeJob.Permissions["contents"] != "write" {
-		t.Fatalf("finalize-release permissions = %#v, want only contents: write", finalizeJob.Permissions)
-	}
-	if _, ok := workflowStepByNameIfPresent(workflow.Jobs, "publish", "Publish GitHub Release"); ok {
-		t.Fatal("publish job must not make the GitHub Release public directly")
-	}
-	if _, ok := workflowStepByNameIfPresent(workflow.Jobs, "publish", "Update GitHub Action floating tags"); ok {
-		t.Fatal("publish job must not move floating action tags directly")
-	}
-	finalizeRelease := workflowStepByName(t, workflow.Jobs, "finalize-release", "Publish GitHub Release")
-	if finalizeRelease.Env["GH_TOKEN"] != "${{ secrets.GITHUB_TOKEN }}" {
-		t.Fatalf("finalize release GH_TOKEN env = %q", finalizeRelease.Env["GH_TOKEN"])
-	}
-	floatingTags := workflowStepByName(t, workflow.Jobs, "finalize-release", "Update GitHub Action floating tags")
-	if floatingTags.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" {
-		t.Fatalf("finalize floating tag RELEASE_TAG env = %q", floatingTags.Env["RELEASE_TAG"])
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -262,30 +262,25 @@ func TestReleaseWorkflowManualDispatchUsesResolvedSourceRef(t *testing.T) {
 	if !tag.Required {
 		t.Fatal("manual release dispatch must require a release tag or version")
 	}
-	if strings.Contains(strings.ToLower(tag.Description), "existing release tag") {
-		t.Fatal("manual release dispatch should not require a pre-existing release tag")
-	}
-
-	sourceSHA, ok := workflow.On.WorkflowDispatch.Inputs["source_sha"]
-	if !ok {
-		t.Fatal("release workflow must define the source_sha input")
-	}
-	if strings.Contains(strings.ToLower(sourceSHA.Description), "defaults to tag") {
-		t.Fatal("manual release source should not fall back to the tag name")
+	if _, ok := workflow.On.WorkflowDispatch.Inputs["source_sha"]; ok {
+		t.Fatal("release workflow must not expose a source_sha manual dispatch input")
 	}
 
 	workflowText := readConfig(t, ".github/workflows/release.yml")
 	if strings.Contains(workflowText, "inputs.source_sha || inputs.tag") {
 		t.Fatal("manual release jobs must not fall back to tag names for source checkout")
 	}
-	if !strings.Contains(workflowText, "gh release create \"${tag}\"") {
-		t.Fatal("manual release flow must create a draft GitHub release when one is missing")
+	if strings.Contains(workflowText, "gh release create \"${tag}\"") {
+		t.Fatal("manual release flow must not create a new GitHub release during a retry")
 	}
-	if !strings.Contains(workflowText, "--target \"${resolved_sha}\"") {
-		t.Fatal("manual release flow must target the resolved source SHA")
+	if !strings.Contains(workflowText, "Manual release promotion can only retry an existing GitHub release for ${tag}.") {
+		t.Fatal("manual release flow must require an existing GitHub release to retry")
 	}
-	if !strings.Contains(workflowText, "Existing release ${tag} points to ${existing_commit}, but this run resolved ${resolved_sha}.") {
-		t.Fatal("manual release flow must fail when an existing release tag points to a different commit")
+	if !strings.Contains(workflowText, `resolved_sha="$(git rev-list -n 1 "refs/tags/${tag}")"`) {
+		t.Fatal("manual release flow must resolve the source SHA from the requested release tag")
+	}
+	if !strings.Contains(workflowText, "GitHub release ${tag} targets ${release_target_sha}, but tag ${tag} points to ${resolved_sha}.") {
+		t.Fatal("manual release flow must fail when release metadata disagrees with the tag target")
 	}
 	if !strings.Contains(workflowText, "needs.prepare-release.outputs.sha") {
 		t.Fatal("downstream release jobs must use the resolved prepare-release SHA")


### PR DESCRIPTION
## Summary

Harden manual stable-release retries so they can rebuild only an existing GitHub release from the immutable commit addressed by its validated tag.

## Changes

- Remove the manual `source_sha` override and use a read-only, non-persisting metadata checkout instead of checking out a user-selected source.
- Normalize and validate the requested tag before using it in GitHub API calls.
- Reuse only an existing published or draft GitHub release; fail closed when no release exists or a lookup fails.
- Resolve lightweight and annotated tag targets through the GitHub Git-data API, and pass that verified commit to downstream release jobs without trusting `target_commitish` or the checked-out HEAD.
- Update release workflow contract tests and `docs/ci-usage.md` for the tag-only retry model.

## Validation

- `go test ./scripts -run 'TestReleaseWorkflow' -count=1`
- `go test ./scripts ./tools/featureflag -run 'Test.*(release|Release|workflow|Workflow|homebrew|Homebrew|marketplace|Marketplace|credential|Credential|token|Token|artifact|Artifact|manual|Manual)' -count=1`
- `make ci` (including formatting, lint, actionlint, duplication, security, vulnerability, unit, leak, race, memory benchmark, build, and 98.2% coverage gates)

## Risk and compatibility

- Breaking changes: manual release dispatch no longer accepts an arbitrary `source_sha` and cannot create a missing release.
- Migration required: create the release through the normal trusted release path, then use its tag to retry publication.
- Security: release source identity comes from the Git tag API; release metadata such as `target_commitish` is never trusted as the build source.
- Performance impact: none; the change affects release-control flow only.
- Memory benchmark impact: none; the memory regression gate passed with no regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
