### PR TITLE
fix(release): inline trusted GHCR tag sanitization

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -600,12 +600,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: ${{ inputs.source_sha || github.sha }}
-          persist-credentials: false
-
       - name: Compute image name
         id: image
         run: |
@@ -613,13 +607,39 @@ jobs:
           echo "name=ghcr.io/${owner}/lopper" >> "$GITHUB_OUTPUT"
 
       - name: Compute manifest image tags
+        id: image_tags
         shell: bash
         env:
           IMAGE_TAGS: ${{ inputs.image_tags }}
           IMAGE_NAME: ${{ steps.image.outputs.name }}
         run: |
           set -euo pipefail
-          bash scripts/release-image-tags.sh > image-tags.txt
+          valid_image_tag_pattern='^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'
+          declare -a sanitized_tags=()
+          while IFS= read -r raw_tag || [[ -n "$raw_tag" ]]; do
+            tag="${raw_tag%$'\r'}"
+            tag="${tag#"${tag%%[![:space:]]*}"}"
+            tag="${tag%"${tag##*[![:space:]]}"}"
+            if [[ -z "$tag" ]]; then
+              continue
+            fi
+            if [[ ! "$tag" =~ $valid_image_tag_pattern ]]; then
+              printf '::error::Malformed image tag rejected. Tags must match %s.\n' "$valid_image_tag_pattern" >&2
+              printf 'Rejected image tag: %q\n' "$tag" >&2
+              exit 1
+            fi
+            sanitized_tags+=("$tag")
+          done <<< "$IMAGE_TAGS"
+          if [[ "${#sanitized_tags[@]}" -eq 0 ]]; then
+            printf '::error::No valid image tags were provided.\n' >&2
+            exit 1
+          fi
+
+          image_tags_file="$(mktemp)"
+          for tag in "${sanitized_tags[@]}"; do
+            printf '%s:%s\n' "$IMAGE_NAME" "$tag" >> "$image_tags_file"
+          done
+          echo "file=$image_tags_file" >> "$GITHUB_OUTPUT"
 
       - name: Prepare manifest publication payload
         shell: bash
@@ -627,11 +647,12 @@ jobs:
           SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
           IMAGE_NAME: ${{ steps.image.outputs.name }}
           RELEASE_TAG: ${{ inputs.tag }}
+          IMAGE_TAGS_FILE: ${{ steps.image_tags.outputs.file }}
         run: |
           set -euo pipefail
           payload_root="${RUNNER_TEMP}/ghcr-manifest-publication"
           mkdir -p "${payload_root}"
-          install -m 0600 image-tags.txt "${payload_root}/image-tags.txt"
+          install -m 0600 "${IMAGE_TAGS_FILE}" "${payload_root}/image-tags.txt"
           jq -n \
             --arg source_sha "${SOURCE_SHA}" \
             --arg image_name "${IMAGE_NAME}" \

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -2073,10 +2073,25 @@ func assertTrustedGHCRManifestPublisher(t *testing.T, workflow workflowConfig) {
 	prepareManifest := workflowJobByName(t, workflow.Jobs, "prepare-ghcr-manifest")
 	assertWorkflowJobPermissions(t, prepareManifest, "prepare-ghcr-manifest", map[string]string{"contents": "read"})
 	assertGHCRJobDoesNotReference(t, prepareManifest, "secrets.GITHUB_TOKEN", "prepare-ghcr-manifest")
-	manifestCheckout := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Checkout")
-	if manifestCheckout.With["persist-credentials"] != "false" {
-		t.Fatalf("prepare-ghcr-manifest checkout persist-credentials = %q, want false", manifestCheckout.With["persist-credentials"])
+	for _, step := range prepareManifest.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") || strings.HasPrefix(step.Uses, "./") {
+			t.Fatalf("prepare-ghcr-manifest must not make repository code available; step %q uses %q", step.Name, step.Uses)
+		}
+		if strings.Contains(step.Run, "scripts/") {
+			t.Fatalf("prepare-ghcr-manifest must not execute repository scripts; step %q run = %q", step.Name, step.Run)
+		}
 	}
+	manifestTags := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Compute manifest image tags")
+	if manifestTags.ID != "image_tags" {
+		t.Fatalf("manifest image tag step ID = %q, want stable file output source", manifestTags.ID)
+	}
+	manifestPayload := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Prepare manifest publication payload")
+	if got := manifestPayload.Env["IMAGE_TAGS_FILE"]; got != "${{ steps.image_tags.outputs.file }}" {
+		t.Fatalf("manifest payload IMAGE_TAGS_FILE = %q, want trusted image tag output", got)
+	}
+	assertWorkflowStepRunContainsAll(t, manifestPayload, "manifest payload tag binding", []string{
+		`install -m 0600 "${IMAGE_TAGS_FILE}" "${payload_root}/image-tags.txt"`,
+	})
 	manifestUpload := workflowStepByName(t, workflow.Jobs, "prepare-ghcr-manifest", "Upload manifest publication payload")
 	if manifestUpload.With["name"] != "ghcr-manifest-publication-payload" {
 		t.Fatalf("manifest artifact name = %q", manifestUpload.With["name"])
@@ -2394,7 +2409,7 @@ func assertArchImageTagStep(t *testing.T, step workflowStepConfig, stepName stri
 		t.Fatalf("%s IMAGE_ARCH_SUFFIX env = %q, want %q", stepName, step.Env["IMAGE_ARCH_SUFFIX"], suffix)
 	}
 	if !strings.Contains(step.Run, "bash scripts/release-image-tags.sh > image-tags.txt") {
-		t.Fatalf("%s must generate tags through scripts/release-image-tags.sh", stepName)
+		t.Fatalf("%s must generate tokenless build tags through scripts/release-image-tags.sh", stepName)
 	}
 	if strings.Contains(step.Run, "while IFS= read -r tag") {
 		t.Fatalf("%s must not use the stale unsanitized tag loop", stepName)
@@ -2404,8 +2419,22 @@ func assertArchImageTagStep(t *testing.T, step workflowStepConfig, stepName stri
 func assertManifestImageTagStep(t *testing.T, manifestStep workflowStepConfig) {
 	t.Helper()
 
-	if !strings.Contains(manifestStep.Run, "bash scripts/release-image-tags.sh > image-tags.txt") {
-		t.Fatal("manifest preparation step must sanitize image tags before publication")
+	for _, want := range []string{
+		"valid_image_tag_pattern='^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'",
+		"declare -a sanitized_tags=()",
+		`while IFS= read -r raw_tag || [[ -n "$raw_tag" ]]`,
+		`if [[ ! "$tag" =~ $valid_image_tag_pattern ]]`,
+		`sanitized_tags+=("$tag")`,
+		`for tag in "${sanitized_tags[@]}"; do`,
+		`printf '%s:%s\n' "$IMAGE_NAME" "$tag"`,
+		`echo "file=$image_tags_file" >> "$GITHUB_OUTPUT"`,
+	} {
+		if !strings.Contains(manifestStep.Run, want) {
+			t.Fatalf("manifest preparation must contain trusted inline tag sanitizer snippet %q", want)
+		}
+	}
+	if strings.Contains(manifestStep.Run, "scripts/release-image-tags.sh") {
+		t.Fatal("manifest preparation must not execute repository-controlled tag sanitizer scripts")
 	}
 	if strings.Contains(manifestStep.Run, "docker ") {
 		t.Fatal("manifest preparation step must not publish Docker manifests")


### PR DESCRIPTION
## Summary

Keep GHCR manifest publication independent of release-source code by deriving its destination tags with a trusted inline sanitizer before any registry credentials are available.

## Changes

- Remove the release-source checkout from the tokenless `prepare-ghcr-manifest` job so repository-controlled scripts and local actions are unavailable in that lane.
- Trim and validate the complete `image_tags` input against the OCI tag grammar before emitting any manifest destination, then write the trusted tag set to an isolated temporary file.
- Pass the trusted file path through an explicit step output and bind the integrity-protected manifest publication payload to that output.
- Preserve main's stronger fresh-publisher boundaries, exact artifact validation, and digest-pinned amd64/arm64 manifest inputs.
- Update release workflow contract tests for the checkout-free preparation job, inline sanitizer, and trusted file-output dataflow.

## Validation

- `go test ./scripts -run 'TestReleaseOrchestration' -count=1`
- Focused GHCR preparation, integrity, exact-tag, and digest-pinning workflow contract tests
- `make ci` (formatting, lint, actionlint, duplication, security, vulnerability, unit, leak, race, memory benchmark, build, and 98.2% coverage gates)

## Risk and compatibility

- Breaking changes: none for valid release tags; malformed or empty tag sets continue to fail closed before publication.
- Migration required: none.
- Performance impact: negligible; manifest preparation performs the same bounded tag normalization without a repository checkout.
- Memory benchmark impact: none; the memory regression gate passed with no regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
