### PR TITLE
fix(ci): scope release publish secrets

### DIFF
--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -495,18 +495,22 @@ func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
 		"jobs.push-feature-release-history.steps.Push feature history commit#1.env.PUSH_TOKEN=${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}",
 	}
 	slices.Sort(want)
-	got := workflowCredentialBindings(t, workflowYAMLMappingValue(&workflow, "jobs"))
+	got := workflowCredentialBindings(t, &workflow)
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("release publication secret bindings = %#v, want %#v", got, want)
 	}
 }
 
-func TestWorkflowCredentialBindingsAuditRawJobFieldsAndDuplicateSteps(t *testing.T) {
+func TestWorkflowCredentialBindingsAuditRawWorkflowFieldsAliasesAndDuplicateSteps(t *testing.T) {
 	t.Parallel()
 
-	const config = `jobs:
+	const config = `env:
+  GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+jobs:
   publisher:
+    env:
+      ANCHORED_TOKEN: &anchored-token ${{ secrets.ALIAS_TOKEN }}
     container:
       credentials:
         password: ${{ secrets['CONTAINER_TOKEN'] }}
@@ -517,41 +521,50 @@ func TestWorkflowCredentialBindingsAuditRawJobFieldsAndDuplicateSteps(t *testing
       - name: Publish
         env:
           TOKEN: ${{ secrets.SECOND_TOKEN }}
+      - name: Publish all
+        env:
+          ALL_SECRETS: ${{ toJson(secrets) }}
+          ANCHORED_TOKEN: *anchored-token
   future-publisher:
     services:
       registry:
         credentials:
           password: ${{ secrets.SERVICE_TOKEN }}
+  inherited-publisher:
+    uses: ./.github/workflows/publish.yml
+    secrets: inherit
 `
 	var workflow yaml.Node
 	if err := yaml.Unmarshal([]byte(config), &workflow); err != nil {
 		t.Fatalf("parse workflow fixture: %v", err)
 	}
 	want := []string{
+		"env.GH_TOKEN=${{ secrets.WORKFLOW_TOKEN }}",
 		"jobs.future-publisher.services.registry.credentials.password=${{ secrets.SERVICE_TOKEN }}",
+		"jobs.inherited-publisher.secrets=inherit",
 		"jobs.publisher.container.credentials.password=${{ secrets['CONTAINER_TOKEN'] }}",
+		"jobs.publisher.env.ANCHORED_TOKEN=${{ secrets.ALIAS_TOKEN }}",
 		"jobs.publisher.steps.Publish#1.env.TOKEN=${{ github[\"token\"] }}",
 		"jobs.publisher.steps.Publish#2.env.TOKEN=${{ secrets.SECOND_TOKEN }}",
+		"jobs.publisher.steps.Publish all#1.env.ALL_SECRETS=${{ toJson(secrets) }}",
+		"jobs.publisher.steps.Publish all#1.env.ANCHORED_TOKEN=${{ secrets.ALIAS_TOKEN }}",
 	}
 	slices.Sort(want)
 
-	got := workflowCredentialBindings(t, workflowYAMLMappingValue(&workflow, "jobs"))
+	got := workflowCredentialBindings(t, &workflow)
 	if !slices.Equal(got, want) {
 		t.Fatalf("raw workflow credential bindings = %#v, want %#v", got, want)
 	}
 }
 
-func workflowCredentialBindings(t *testing.T, jobs *yaml.Node) []string {
+func workflowCredentialBindings(t *testing.T, workflow *yaml.Node) []string {
 	t.Helper()
 
-	if jobs == nil || jobs.Kind != yaml.MappingNode {
-		t.Fatal("workflow must define a jobs mapping")
+	if workflow == nil || workflow.Kind != yaml.DocumentNode || len(workflow.Content) != 1 {
+		t.Fatal("workflow must define one YAML document")
 	}
 	bindings := make([]string, 0)
-	for index := 0; index < len(jobs.Content); index += 2 {
-		jobName := jobs.Content[index].Value
-		collectWorkflowCredentialBindings(jobs.Content[index+1], "jobs."+jobName, &bindings)
-	}
+	collectWorkflowCredentialBindings(workflow.Content[0], "", &bindings)
 	slices.Sort(bindings)
 	return bindings
 }
@@ -559,24 +572,36 @@ func workflowCredentialBindings(t *testing.T, jobs *yaml.Node) []string {
 func collectWorkflowCredentialBindings(node *yaml.Node, path string, bindings *[]string) {
 	switch node.Kind {
 	case yaml.ScalarNode:
-		if workflowValueReferencesCredential(node.Value) {
+		if workflowValueReferencesCredential(path, node.Value) {
 			*bindings = append(*bindings, path+"="+node.Value)
+		}
+	case yaml.AliasNode:
+		if node.Alias != nil {
+			collectWorkflowCredentialBindings(node.Alias, path, bindings)
 		}
 	case yaml.MappingNode:
 		for index := 0; index < len(node.Content); index += 2 {
 			key := node.Content[index].Value
 			value := node.Content[index+1]
+			childPath := workflowCredentialChildPath(path, key)
 			if key == "steps" && value.Kind == yaml.SequenceNode {
-				collectWorkflowCredentialStepBindings(value, path+".steps", bindings)
+				collectWorkflowCredentialStepBindings(value, childPath, bindings)
 				continue
 			}
-			collectWorkflowCredentialBindings(value, path+"."+key, bindings)
+			collectWorkflowCredentialBindings(value, childPath, bindings)
 		}
 	case yaml.SequenceNode:
 		for index, child := range node.Content {
 			collectWorkflowCredentialBindings(child, path+"["+strconv.Itoa(index)+"]", bindings)
 		}
 	}
+}
+
+func workflowCredentialChildPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
 }
 
 func collectWorkflowCredentialStepBindings(steps *yaml.Node, path string, bindings *[]string) {
@@ -614,13 +639,37 @@ func workflowYAMLMappingValue(node *yaml.Node, key string) *yaml.Node {
 	return nil
 }
 
-func workflowValueReferencesCredential(value string) bool {
+func workflowValueReferencesCredential(path, value string) bool {
 	normalized := strings.Join(strings.Fields(strings.ToLower(value)), "")
 	normalized = strings.ReplaceAll(normalized, `"`, `'`)
-	return strings.Contains(normalized, "secrets.") ||
-		strings.Contains(normalized, "secrets['") ||
+	return workflowContainsContext(normalized, "secrets") ||
 		strings.Contains(normalized, "github.token") ||
-		strings.Contains(normalized, "github['token']")
+		strings.Contains(normalized, "github['token']") ||
+		(strings.HasSuffix(strings.ToLower(path), ".secrets") && normalized == "inherit")
+}
+
+func workflowContainsContext(value, context string) bool {
+	for start := 0; start < len(value); {
+		offset := strings.Index(value[start:], context)
+		if offset < 0 {
+			return false
+		}
+		index := start + offset
+		end := index + len(context)
+		beforeBoundary := index == 0 || !workflowIdentifierByte(value[index-1])
+		afterBoundary := end == len(value) || !workflowIdentifierByte(value[end])
+		if beforeBoundary && afterBoundary {
+			return true
+		}
+		start = index + 1
+	}
+	return false
+}
+
+func workflowIdentifierByte(character byte) bool {
+	return character >= 'a' && character <= 'z' ||
+		character >= '0' && character <= '9' ||
+		character == '_'
 }
 
 func TestReleaseWorkflowPublicationArtifactNameAvoidsReleaseArtifactWildcard(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -473,6 +473,73 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	assertReleasePublicationOmitsCheckoutAndCommands(t, publication)
 }
 
+func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	want := map[string]string{
+		"prepare-marketplace-toolchain/Detect Marketplace token/env.VSCE_PUBLISH":        "${{ secrets.VSCE_PUBLISH }}",
+		"publish-marketplace/Publish VS Code extension to Marketplace/env.VSCE_PAT":      "${{ secrets.VSCE_PUBLISH }}",
+		"publish/Update GitHub Release notes/env.GH_TOKEN":                               "${{ secrets.GITHUB_TOKEN }}",
+		"publish/Upload GitHub Release assets/env.GH_TOKEN":                              "${{ secrets.GITHUB_TOKEN }}",
+		"finalize-release/Publish GitHub Release/env.GH_TOKEN":                           "${{ secrets.GITHUB_TOKEN }}",
+		"finalize-release/Push GitHub Action floating tags/env.PUSH_TOKEN":               "${{ secrets.GITHUB_TOKEN }}",
+		"homebrew-tap-token-gate/Detect tap token/env.HOMEBREW_TAP_TOKEN":                "${{ secrets.HOMEBREW_TAP_TOKEN }}",
+		"update-homebrew-tap/Regenerate and push formula changes/env.HOMEBREW_TAP_TOKEN": "${{ secrets.HOMEBREW_TAP_TOKEN }}",
+		"push-feature-release-history/Push feature history commit/env.PUSH_TOKEN":        "${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}",
+	}
+	publicationJobs := []string{
+		"prepare-release-publication",
+		"prepare-marketplace-toolchain",
+		"publish-marketplace",
+		"publish",
+		"finalize-release",
+		"homebrew-tap-token-gate",
+		"validate-homebrew-tap",
+		"update-homebrew-tap",
+		"prepare-feature-release-history",
+		"prepare-feature-release-history-push",
+		"push-feature-release-history",
+	}
+	hasCredentialReference := func(value string) bool {
+		return strings.Contains(value, "secrets.") || strings.Contains(value, "github.token")
+	}
+
+	got := make(map[string]string, len(want))
+	for _, jobName := range publicationJobs {
+		job := workflowJobByName(t, workflow.Jobs, jobName)
+		jobValues := append([]string{job.If, job.RunsOn}, mapValues(job.Env)...)
+		jobValues = append(jobValues, mapValues(job.Outputs)...)
+		for _, value := range jobValues {
+			if hasCredentialReference(value) {
+				t.Fatalf("release publication credential must not be scoped to job %q", jobName)
+			}
+		}
+		for _, step := range job.Steps {
+			unscopedValues := []string{step.If, step.Run, step.Shell, step.Uses, step.WorkingDirectory}
+			unscopedValues = append(unscopedValues, mapValues(step.With)...)
+			for _, value := range unscopedValues {
+				if hasCredentialReference(value) {
+					t.Fatalf("release publication credential must reach %s step %q only through step env", jobName, step.Name)
+				}
+			}
+			for key, value := range step.Env {
+				if !hasCredentialReference(value) {
+					continue
+				}
+				binding := jobName + "/" + step.Name + "/env." + key
+				got[binding] = value
+			}
+		}
+	}
+
+	if !maps.Equal(got, want) {
+		t.Fatalf("release publication secret bindings = %#v, want %#v", got, want)
+	}
+}
+
 func TestReleaseWorkflowPublicationArtifactNameAvoidsReleaseArtifactWildcard(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -503,41 +503,59 @@ func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
 		"prepare-feature-release-history-push",
 		"push-feature-release-history",
 	}
-	hasCredentialReference := func(value string) bool {
-		return strings.Contains(value, "secrets.") || strings.Contains(value, "github.token")
-	}
-
-	got := make(map[string]string, len(want))
-	for _, jobName := range publicationJobs {
-		job := workflowJobByName(t, workflow.Jobs, jobName)
-		jobValues := append([]string{job.If, job.RunsOn}, mapValues(job.Env)...)
-		jobValues = append(jobValues, mapValues(job.Outputs)...)
-		for _, value := range jobValues {
-			if hasCredentialReference(value) {
-				t.Fatalf("release publication credential must not be scoped to job %q", jobName)
-			}
-		}
-		for _, step := range job.Steps {
-			unscopedValues := []string{step.If, step.Run, step.Shell, step.Uses, step.WorkingDirectory}
-			unscopedValues = append(unscopedValues, mapValues(step.With)...)
-			for _, value := range unscopedValues {
-				if hasCredentialReference(value) {
-					t.Fatalf("release publication credential must reach %s step %q only through step env", jobName, step.Name)
-				}
-			}
-			for key, value := range step.Env {
-				if !hasCredentialReference(value) {
-					continue
-				}
-				binding := jobName + "/" + step.Name + "/env." + key
-				got[binding] = value
-			}
-		}
-	}
+	got := releasePublicationCredentialBindings(t, workflow.Jobs, publicationJobs)
 
 	if !maps.Equal(got, want) {
 		t.Fatalf("release publication secret bindings = %#v, want %#v", got, want)
 	}
+}
+
+func releasePublicationCredentialBindings(t *testing.T, jobs map[string]workflowJobConfig, jobNames []string) map[string]string {
+	t.Helper()
+
+	bindings := make(map[string]string)
+	for _, jobName := range jobNames {
+		collectReleasePublicationJobCredentialBindings(t, jobName, workflowJobByName(t, jobs, jobName), bindings)
+	}
+	return bindings
+}
+
+func collectReleasePublicationJobCredentialBindings(t *testing.T, jobName string, job workflowJobConfig, bindings map[string]string) {
+	t.Helper()
+
+	jobValues := append([]string{job.If, job.RunsOn}, mapValues(job.Env)...)
+	jobValues = append(jobValues, mapValues(job.Outputs)...)
+	assertWorkflowValuesOmitCredentialReferences(t, jobValues, "release publication job "+jobName)
+	for _, step := range job.Steps {
+		collectReleasePublicationStepCredentialBindings(t, jobName, step, bindings)
+	}
+}
+
+func collectReleasePublicationStepCredentialBindings(t *testing.T, jobName string, step workflowStepConfig, bindings map[string]string) {
+	t.Helper()
+
+	unscopedValues := []string{step.If, step.Run, step.Shell, step.Uses, step.WorkingDirectory}
+	unscopedValues = append(unscopedValues, mapValues(step.With)...)
+	assertWorkflowValuesOmitCredentialReferences(t, unscopedValues, jobName+" step "+step.Name)
+	for key, value := range step.Env {
+		if workflowValueReferencesCredential(value) {
+			bindings[jobName+"/"+step.Name+"/env."+key] = value
+		}
+	}
+}
+
+func assertWorkflowValuesOmitCredentialReferences(t *testing.T, values []string, label string) {
+	t.Helper()
+
+	for _, value := range values {
+		if workflowValueReferencesCredential(value) {
+			t.Fatalf("%s must not reference a release publication credential", label)
+		}
+	}
+}
+
+func workflowValueReferencesCredential(value string) bool {
+	return strings.Contains(value, "secrets.") || strings.Contains(value, "github.token")
 }
 
 func TestReleaseWorkflowPublicationArtifactNameAvoidsReleaseArtifactWildcard(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"slices"
 	"strconv"
@@ -15,6 +16,11 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	workflowSecretsContextPattern    = regexp.MustCompile(`(?:^|[^a-z0-9_])secrets(?:$|[^a-z0-9_])`)
+	workflowBareGitHubContextPattern = regexp.MustCompile(`(?:^|[^a-z0-9_])github(?:$|[^a-z0-9_.\[])`)
 )
 
 type workflowInput struct {
@@ -525,6 +531,10 @@ jobs:
         env:
           ALL_SECRETS: ${{ toJson(secrets) }}
           ANCHORED_TOKEN: *anchored-token
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          EVENT_NAME: ${{ github.event_name }}
+      - name: Explain configuration
+        run: echo "no secrets configured"
   future-publisher:
     services:
       registry:
@@ -548,6 +558,7 @@ jobs:
 		"jobs.publisher.steps.Publish#2.env.TOKEN=${{ secrets.SECOND_TOKEN }}",
 		"jobs.publisher.steps.Publish all#1.env.ALL_SECRETS=${{ toJson(secrets) }}",
 		"jobs.publisher.steps.Publish all#1.env.ANCHORED_TOKEN=${{ secrets.ALIAS_TOKEN }}",
+		"jobs.publisher.steps.Publish all#1.env.GITHUB_CONTEXT=${{ toJson(github) }}",
 	}
 	slices.Sort(want)
 
@@ -564,37 +575,47 @@ func workflowCredentialBindings(t *testing.T, workflow *yaml.Node) []string {
 		t.Fatal("workflow must define one YAML document")
 	}
 	bindings := make([]string, 0)
-	collectWorkflowCredentialBindings(workflow.Content[0], "", &bindings)
+	collectWorkflowCredentialBindings(t, workflow.Content[0], "", &bindings, make(map[*yaml.Node]bool))
 	slices.Sort(bindings)
 	return bindings
 }
 
-func collectWorkflowCredentialBindings(node *yaml.Node, path string, bindings *[]string) {
+func collectWorkflowCredentialBindings(t *testing.T, node *yaml.Node, path string, bindings *[]string, resolvingAliases map[*yaml.Node]bool) {
 	switch node.Kind {
 	case yaml.ScalarNode:
 		if workflowValueReferencesCredential(path, node.Value) {
 			*bindings = append(*bindings, path+"="+node.Value)
 		}
 	case yaml.AliasNode:
-		if node.Alias != nil {
-			collectWorkflowCredentialBindings(node.Alias, path, bindings)
-		}
+		collectWorkflowCredentialAliasBindings(t, node, path, bindings, resolvingAliases)
 	case yaml.MappingNode:
 		for index := 0; index < len(node.Content); index += 2 {
 			key := node.Content[index].Value
 			value := node.Content[index+1]
 			childPath := workflowCredentialChildPath(path, key)
 			if key == "steps" && value.Kind == yaml.SequenceNode {
-				collectWorkflowCredentialStepBindings(value, childPath, bindings)
+				collectWorkflowCredentialStepBindings(t, value, childPath, bindings, resolvingAliases)
 				continue
 			}
-			collectWorkflowCredentialBindings(value, childPath, bindings)
+			collectWorkflowCredentialBindings(t, value, childPath, bindings, resolvingAliases)
 		}
 	case yaml.SequenceNode:
 		for index, child := range node.Content {
-			collectWorkflowCredentialBindings(child, path+"["+strconv.Itoa(index)+"]", bindings)
+			collectWorkflowCredentialBindings(t, child, path+"["+strconv.Itoa(index)+"]", bindings, resolvingAliases)
 		}
 	}
+}
+
+func collectWorkflowCredentialAliasBindings(t *testing.T, alias *yaml.Node, path string, bindings *[]string, resolvingAliases map[*yaml.Node]bool) {
+	if alias.Alias == nil {
+		return
+	}
+	if resolvingAliases[alias.Alias] {
+		t.Fatalf("workflow credential alias cycle at %s", path)
+	}
+	resolvingAliases[alias.Alias] = true
+	collectWorkflowCredentialBindings(t, alias.Alias, path, bindings, resolvingAliases)
+	delete(resolvingAliases, alias.Alias)
 }
 
 func workflowCredentialChildPath(path, key string) string {
@@ -604,7 +625,7 @@ func workflowCredentialChildPath(path, key string) string {
 	return path + "." + key
 }
 
-func collectWorkflowCredentialStepBindings(steps *yaml.Node, path string, bindings *[]string) {
+func collectWorkflowCredentialStepBindings(t *testing.T, steps *yaml.Node, path string, bindings *[]string, resolvingAliases map[*yaml.Node]bool) {
 	stepNameOccurrences := make(map[string]int)
 	for _, step := range steps.Content {
 		nameNode := workflowYAMLMappingValue(step, "name")
@@ -614,7 +635,7 @@ func collectWorkflowCredentialStepBindings(steps *yaml.Node, path string, bindin
 		}
 		stepNameOccurrences[stepName]++
 		stepPath := path + "." + stepName + "#" + strconv.Itoa(stepNameOccurrences[stepName])
-		collectWorkflowCredentialBindings(step, stepPath, bindings)
+		collectWorkflowCredentialBindings(t, step, stepPath, bindings, resolvingAliases)
 	}
 }
 
@@ -640,36 +661,33 @@ func workflowYAMLMappingValue(node *yaml.Node, key string) *yaml.Node {
 }
 
 func workflowValueReferencesCredential(path, value string) bool {
-	normalized := strings.Join(strings.Fields(strings.ToLower(value)), "")
-	normalized = strings.ReplaceAll(normalized, `"`, `'`)
-	return workflowContainsContext(normalized, "secrets") ||
-		strings.Contains(normalized, "github.token") ||
-		strings.Contains(normalized, "github['token']") ||
-		(strings.HasSuffix(strings.ToLower(path), ".secrets") && normalized == "inherit")
-}
-
-func workflowContainsContext(value, context string) bool {
-	for start := 0; start < len(value); {
-		offset := strings.Index(value[start:], context)
-		if offset < 0 {
+	if strings.HasSuffix(strings.ToLower(path), ".secrets") && strings.EqualFold(strings.TrimSpace(value), "inherit") {
+		return true
+	}
+	for remainder := value; ; {
+		start := strings.Index(remainder, "${{")
+		if start < 0 {
 			return false
 		}
-		index := start + offset
-		end := index + len(context)
-		beforeBoundary := index == 0 || !workflowIdentifierByte(value[index-1])
-		afterBoundary := end == len(value) || !workflowIdentifierByte(value[end])
-		if beforeBoundary && afterBoundary {
+		remainder = remainder[start+3:]
+		end := strings.Index(remainder, "}}")
+		if end < 0 {
+			return false
+		}
+		if workflowExpressionReferencesCredential(remainder[:end]) {
 			return true
 		}
-		start = index + 1
+		remainder = remainder[end+2:]
 	}
-	return false
 }
 
-func workflowIdentifierByte(character byte) bool {
-	return character >= 'a' && character <= 'z' ||
-		character >= '0' && character <= '9' ||
-		character == '_'
+func workflowExpressionReferencesCredential(expression string) bool {
+	normalized := strings.Join(strings.Fields(strings.ToLower(expression)), "")
+	normalized = strings.ReplaceAll(normalized, `"`, `'`)
+	return workflowSecretsContextPattern.MatchString(normalized) ||
+		strings.Contains(normalized, "github.token") ||
+		strings.Contains(normalized, "github['token']") ||
+		workflowBareGitHubContextPattern.MatchString(normalized)
 }
 
 func TestReleaseWorkflowPublicationArtifactNameAvoidsReleaseArtifactWildcard(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -19,8 +19,24 @@ import (
 )
 
 var (
-	workflowSecretsContextPattern    = regexp.MustCompile(`(?:^|[^a-z0-9_])secrets(?:$|[^a-z0-9_])`)
-	workflowBareGitHubContextPattern = regexp.MustCompile(`(?:^|[^a-z0-9_])github(?:$|[^a-z0-9_.\[])`)
+	workflowSecretsContextPattern          = regexp.MustCompile(`(?:^|[^a-z0-9_])secrets(?:$|[^a-z0-9_])`)
+	workflowGitHubCredentialContextPattern = regexp.MustCompile(`(?:^|[^a-z0-9_])github(?:\.token|\['token'\]|\.\*|\['\*'\])(?:$|[^a-z0-9_])`)
+	workflowBareGitHubContextPattern       = regexp.MustCompile(`(?:^|[^a-z0-9_])github(?:$|[^a-z0-9_.\[])`)
+)
+
+const workflowImplicitGitHubToken = "<implicit github.token>"
+
+type workflowCredentialRole uint8
+
+const (
+	workflowCredentialGenericRole workflowCredentialRole = iota
+	workflowCredentialRootRole
+	workflowCredentialJobsRole
+	workflowCredentialJobRole
+	workflowCredentialStepsRole
+	workflowCredentialStepRole
+	workflowCredentialExpressionRole
+	workflowCredentialInheritedSecretsRole
 )
 
 type workflowInput struct {
@@ -500,6 +516,40 @@ func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
 		"jobs.update-homebrew-tap.steps.Regenerate and push formula changes#1.env.HOMEBREW_TAP_TOKEN=${{ secrets.HOMEBREW_TAP_TOKEN }}",
 		"jobs.push-feature-release-history.steps.Push feature history commit#1.env.PUSH_TOKEN=${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}",
 	}
+	wantImplicitGitHubTokenPaths := []string{
+		"jobs.build-darwin-amd64.steps.Checkout release source#1.uses",
+		"jobs.build-darwin-amd64.steps.Setup Go#1.uses",
+		"jobs.build-darwin-amd64.steps.Upload Darwin amd64 artifacts#1.uses",
+		"jobs.build-vscode-extension.steps.Checkout release source#1.uses",
+		"jobs.build-vscode-extension.steps.Setup Go#1.uses",
+		"jobs.build-vscode-extension.steps.Setup Node#1.uses",
+		"jobs.build-vscode-extension.steps.Upload VS Code extension artifact#1.uses",
+		"jobs.orchestrate-release.uses",
+		"jobs.prepare-feature-release-history-push.steps.Download feature history patch#1.uses",
+		"jobs.prepare-feature-release-history-push.steps.Upload prepared trusted feature history worktree#1.uses",
+		"jobs.prepare-feature-release-history.steps.Checkout trusted main tooling#1.uses",
+		"jobs.prepare-feature-release-history.steps.Checkout validated release data#1.uses",
+		"jobs.prepare-feature-release-history.steps.Setup Go#1.uses",
+		"jobs.prepare-feature-release-history.steps.Upload feature history patch#1.uses",
+		"jobs.prepare-marketplace-toolchain.steps.Checkout trusted main Marketplace manifests#1.uses",
+		"jobs.prepare-marketplace-toolchain.steps.Setup Node for Marketplace tooling#1.uses",
+		"jobs.prepare-marketplace-toolchain.steps.Upload Marketplace toolchain#1.uses",
+		"jobs.prepare-release-publication.steps.Checkout release source#1.uses",
+		"jobs.prepare-release-publication.steps.Download release artifacts#1.uses",
+		"jobs.prepare-release-publication.steps.Setup Go#1.uses",
+		"jobs.prepare-release-publication.steps.Upload release publication inputs#1.uses",
+		"jobs.prepare-release.steps.Checkout release metadata#1.uses",
+		"jobs.prepare-release.steps.Run release-please#1.uses",
+		"jobs.publish-marketplace.steps.Download Marketplace toolchain#1.uses",
+		"jobs.publish-marketplace.steps.Download release publication inputs#1.uses",
+		"jobs.publish-marketplace.steps.Setup Node for Marketplace tooling#1.uses",
+		"jobs.publish.steps.Download release publication inputs#1.uses",
+		"jobs.push-feature-release-history.steps.Download prepared trusted feature history worktree#1.uses",
+		"jobs.validate-homebrew-tap.steps.Set up Homebrew#1.uses",
+	}
+	for _, path := range wantImplicitGitHubTokenPaths {
+		want = append(want, path+"="+workflowImplicitGitHubToken)
+	}
 	slices.Sort(want)
 	got := workflowCredentialBindings(t, &workflow)
 
@@ -532,10 +582,17 @@ jobs:
           ALL_SECRETS: ${{ toJson(secrets) }}
           ANCHORED_TOKEN: *anchored-token
           GITHUB_CONTEXT: ${{ toJson(github) }}
+          GITHUB_WILDCARD_CONTEXT: ${{ toJson(github.*) }}
           EVENT_NAME: ${{ github.event_name }}
       - name: Explain configuration
         run: echo "no secrets configured"
+      - name: Checkout implicitly
+        uses: actions/checkout@v4
+        with:
+          if: secrets.NOT_AN_EXPRESSION
+          uses: documentation-only-input
   future-publisher:
+    if: github.token != '' && secrets.IF_TOKEN != ''
     services:
       registry:
         credentials:
@@ -551,7 +608,9 @@ jobs:
 	want := []string{
 		"env.GH_TOKEN=${{ secrets.WORKFLOW_TOKEN }}",
 		"jobs.future-publisher.services.registry.credentials.password=${{ secrets.SERVICE_TOKEN }}",
+		"jobs.future-publisher.if=github.token != '' && secrets.IF_TOKEN != ''",
 		"jobs.inherited-publisher.secrets=inherit",
+		"jobs.inherited-publisher.uses=" + workflowImplicitGitHubToken,
 		"jobs.publisher.container.credentials.password=${{ secrets['CONTAINER_TOKEN'] }}",
 		"jobs.publisher.env.ANCHORED_TOKEN=${{ secrets.ALIAS_TOKEN }}",
 		"jobs.publisher.steps.Publish#1.env.TOKEN=${{ github[\"token\"] }}",
@@ -559,6 +618,8 @@ jobs:
 		"jobs.publisher.steps.Publish all#1.env.ALL_SECRETS=${{ toJson(secrets) }}",
 		"jobs.publisher.steps.Publish all#1.env.ANCHORED_TOKEN=${{ secrets.ALIAS_TOKEN }}",
 		"jobs.publisher.steps.Publish all#1.env.GITHUB_CONTEXT=${{ toJson(github) }}",
+		"jobs.publisher.steps.Publish all#1.env.GITHUB_WILDCARD_CONTEXT=${{ toJson(github.*) }}",
+		"jobs.publisher.steps.Checkout implicitly#1.uses=" + workflowImplicitGitHubToken,
 	}
 	slices.Sort(want)
 
@@ -575,38 +636,46 @@ func workflowCredentialBindings(t *testing.T, workflow *yaml.Node) []string {
 		t.Fatal("workflow must define one YAML document")
 	}
 	bindings := make([]string, 0)
-	collectWorkflowCredentialBindings(t, workflow.Content[0], "", &bindings, make(map[*yaml.Node]bool))
+	collectWorkflowCredentialBindings(t, workflow.Content[0], "", &bindings, make(map[*yaml.Node]bool), workflowCredentialRootRole)
 	slices.Sort(bindings)
 	return bindings
 }
 
-func collectWorkflowCredentialBindings(t *testing.T, node *yaml.Node, path string, bindings *[]string, resolvingAliases map[*yaml.Node]bool) {
+func collectWorkflowCredentialBindings(t *testing.T, node *yaml.Node, path string, bindings *[]string, resolvingAliases map[*yaml.Node]bool, role workflowCredentialRole) {
 	switch node.Kind {
 	case yaml.ScalarNode:
-		if workflowValueReferencesCredential(path, node.Value) {
-			*bindings = append(*bindings, path+"="+node.Value)
-		}
+		collectWorkflowCredentialScalarBindings(node, path, bindings, role)
 	case yaml.AliasNode:
-		collectWorkflowCredentialAliasBindings(t, node, path, bindings, resolvingAliases)
+		collectWorkflowCredentialAliasBindings(t, node, path, bindings, resolvingAliases, role)
 	case yaml.MappingNode:
 		for index := 0; index < len(node.Content); index += 2 {
 			key := node.Content[index].Value
 			value := node.Content[index+1]
 			childPath := workflowCredentialChildPath(path, key)
-			if key == "steps" && value.Kind == yaml.SequenceNode {
-				collectWorkflowCredentialStepBindings(t, value, childPath, bindings, resolvingAliases)
-				continue
+			if workflowRoleReceivesImplicitGitHubToken(role, key) {
+				*bindings = append(*bindings, childPath+"="+workflowImplicitGitHubToken)
 			}
-			collectWorkflowCredentialBindings(t, value, childPath, bindings, resolvingAliases)
+			childRole := workflowCredentialChildRole(role, key)
+			collectWorkflowCredentialBindings(t, value, childPath, bindings, resolvingAliases, childRole)
 		}
 	case yaml.SequenceNode:
+		if role == workflowCredentialStepsRole {
+			collectWorkflowCredentialStepBindings(t, node, path, bindings, resolvingAliases)
+			return
+		}
 		for index, child := range node.Content {
-			collectWorkflowCredentialBindings(t, child, path+"["+strconv.Itoa(index)+"]", bindings, resolvingAliases)
+			collectWorkflowCredentialBindings(t, child, path+"["+strconv.Itoa(index)+"]", bindings, resolvingAliases, workflowCredentialGenericRole)
 		}
 	}
 }
 
-func collectWorkflowCredentialAliasBindings(t *testing.T, alias *yaml.Node, path string, bindings *[]string, resolvingAliases map[*yaml.Node]bool) {
+func collectWorkflowCredentialScalarBindings(node *yaml.Node, path string, bindings *[]string, role workflowCredentialRole) {
+	if workflowValueReferencesCredential(role, node.Value) {
+		*bindings = append(*bindings, path+"="+node.Value)
+	}
+}
+
+func collectWorkflowCredentialAliasBindings(t *testing.T, alias *yaml.Node, path string, bindings *[]string, resolvingAliases map[*yaml.Node]bool, role workflowCredentialRole) {
 	if alias.Alias == nil {
 		return
 	}
@@ -614,8 +683,38 @@ func collectWorkflowCredentialAliasBindings(t *testing.T, alias *yaml.Node, path
 		t.Fatalf("workflow credential alias cycle at %s", path)
 	}
 	resolvingAliases[alias.Alias] = true
-	collectWorkflowCredentialBindings(t, alias.Alias, path, bindings, resolvingAliases)
+	collectWorkflowCredentialBindings(t, alias.Alias, path, bindings, resolvingAliases, role)
 	delete(resolvingAliases, alias.Alias)
+}
+
+func workflowCredentialChildRole(parent workflowCredentialRole, key string) workflowCredentialRole {
+	switch parent {
+	case workflowCredentialRootRole:
+		if key == "jobs" {
+			return workflowCredentialJobsRole
+		}
+	case workflowCredentialJobsRole:
+		return workflowCredentialJobRole
+	case workflowCredentialJobRole:
+		if key == "steps" {
+			return workflowCredentialStepsRole
+		}
+		if key == "if" {
+			return workflowCredentialExpressionRole
+		}
+		if key == "secrets" {
+			return workflowCredentialInheritedSecretsRole
+		}
+	case workflowCredentialStepRole:
+		if key == "if" {
+			return workflowCredentialExpressionRole
+		}
+	}
+	return workflowCredentialGenericRole
+}
+
+func workflowRoleReceivesImplicitGitHubToken(role workflowCredentialRole, key string) bool {
+	return key == "uses" && (role == workflowCredentialJobRole || role == workflowCredentialStepRole)
 }
 
 func workflowCredentialChildPath(path, key string) string {
@@ -635,7 +734,7 @@ func collectWorkflowCredentialStepBindings(t *testing.T, steps *yaml.Node, path 
 		}
 		stepNameOccurrences[stepName]++
 		stepPath := path + "." + stepName + "#" + strconv.Itoa(stepNameOccurrences[stepName])
-		collectWorkflowCredentialBindings(t, step, stepPath, bindings, resolvingAliases)
+		collectWorkflowCredentialBindings(t, step, stepPath, bindings, resolvingAliases, workflowCredentialStepRole)
 	}
 }
 
@@ -660,8 +759,11 @@ func workflowYAMLMappingValue(node *yaml.Node, key string) *yaml.Node {
 	return nil
 }
 
-func workflowValueReferencesCredential(path, value string) bool {
-	if strings.HasSuffix(strings.ToLower(path), ".secrets") && strings.EqualFold(strings.TrimSpace(value), "inherit") {
+func workflowValueReferencesCredential(role workflowCredentialRole, value string) bool {
+	if role == workflowCredentialInheritedSecretsRole && strings.EqualFold(strings.TrimSpace(value), "inherit") {
+		return true
+	}
+	if role == workflowCredentialExpressionRole && workflowExpressionReferencesCredential(value) {
 		return true
 	}
 	for remainder := value; ; {
@@ -685,8 +787,7 @@ func workflowExpressionReferencesCredential(expression string) bool {
 	normalized := strings.Join(strings.Fields(strings.ToLower(expression)), "")
 	normalized = strings.ReplaceAll(normalized, `"`, `'`)
 	return workflowSecretsContextPattern.MatchString(normalized) ||
-		strings.Contains(normalized, "github.token") ||
-		strings.Contains(normalized, "github['token']") ||
+		workflowGitHubCredentialContextPattern.MatchString(normalized) ||
 		workflowBareGitHubContextPattern.MatchString(normalized)
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -476,86 +477,150 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
 	t.Parallel()
 
-	var workflow workflowConfig
+	var workflow yaml.Node
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	want := map[string]string{
-		"prepare-marketplace-toolchain/Detect Marketplace token/env.VSCE_PUBLISH":        "${{ secrets.VSCE_PUBLISH }}",
-		"publish-marketplace/Publish VS Code extension to Marketplace/env.VSCE_PAT":      "${{ secrets.VSCE_PUBLISH }}",
-		"publish/Update GitHub Release notes/env.GH_TOKEN":                               "${{ secrets.GITHUB_TOKEN }}",
-		"publish/Upload GitHub Release assets/env.GH_TOKEN":                              "${{ secrets.GITHUB_TOKEN }}",
-		"finalize-release/Publish GitHub Release/env.GH_TOKEN":                           "${{ secrets.GITHUB_TOKEN }}",
-		"finalize-release/Push GitHub Action floating tags/env.PUSH_TOKEN":               "${{ secrets.GITHUB_TOKEN }}",
-		"homebrew-tap-token-gate/Detect tap token/env.HOMEBREW_TAP_TOKEN":                "${{ secrets.HOMEBREW_TAP_TOKEN }}",
-		"update-homebrew-tap/Regenerate and push formula changes/env.HOMEBREW_TAP_TOKEN": "${{ secrets.HOMEBREW_TAP_TOKEN }}",
-		"push-feature-release-history/Push feature history commit/env.PUSH_TOKEN":        "${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}",
+	want := []string{
+		"jobs.prepare-release.steps.Run release-please#1.with.token=${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}",
+		"jobs.prepare-release.steps.Checkout release metadata#1.with.token=${{ secrets.GITHUB_TOKEN }}",
+		"jobs.prepare-release.steps.Prepare manual release#1.env.GH_TOKEN=${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}",
+		"jobs.prepare-marketplace-toolchain.steps.Detect Marketplace token#1.env.VSCE_PUBLISH=${{ secrets.VSCE_PUBLISH }}",
+		"jobs.publish-marketplace.steps.Publish VS Code extension to Marketplace#1.env.VSCE_PAT=${{ secrets.VSCE_PUBLISH }}",
+		"jobs.publish.steps.Update GitHub Release notes#1.env.GH_TOKEN=${{ secrets.GITHUB_TOKEN }}",
+		"jobs.publish.steps.Upload GitHub Release assets#1.env.GH_TOKEN=${{ secrets.GITHUB_TOKEN }}",
+		"jobs.finalize-release.steps.Publish GitHub Release#1.env.GH_TOKEN=${{ secrets.GITHUB_TOKEN }}",
+		"jobs.finalize-release.steps.Push GitHub Action floating tags#1.env.PUSH_TOKEN=${{ secrets.GITHUB_TOKEN }}",
+		"jobs.homebrew-tap-token-gate.steps.Detect tap token#1.env.HOMEBREW_TAP_TOKEN=${{ secrets.HOMEBREW_TAP_TOKEN }}",
+		"jobs.update-homebrew-tap.steps.Regenerate and push formula changes#1.env.HOMEBREW_TAP_TOKEN=${{ secrets.HOMEBREW_TAP_TOKEN }}",
+		"jobs.push-feature-release-history.steps.Push feature history commit#1.env.PUSH_TOKEN=${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}",
 	}
-	publicationJobs := []string{
-		"prepare-release-publication",
-		"prepare-marketplace-toolchain",
-		"publish-marketplace",
-		"publish",
-		"finalize-release",
-		"homebrew-tap-token-gate",
-		"validate-homebrew-tap",
-		"update-homebrew-tap",
-		"prepare-feature-release-history",
-		"prepare-feature-release-history-push",
-		"push-feature-release-history",
-	}
-	got := releasePublicationCredentialBindings(t, workflow.Jobs, publicationJobs)
+	slices.Sort(want)
+	got := workflowCredentialBindings(t, workflowYAMLMappingValue(&workflow, "jobs"))
 
-	if !maps.Equal(got, want) {
+	if !slices.Equal(got, want) {
 		t.Fatalf("release publication secret bindings = %#v, want %#v", got, want)
 	}
 }
 
-func releasePublicationCredentialBindings(t *testing.T, jobs map[string]workflowJobConfig, jobNames []string) map[string]string {
+func TestWorkflowCredentialBindingsAuditRawJobFieldsAndDuplicateSteps(t *testing.T) {
+	t.Parallel()
+
+	const config = `jobs:
+  publisher:
+    container:
+      credentials:
+        password: ${{ secrets['CONTAINER_TOKEN'] }}
+    steps:
+      - name: Publish
+        env:
+          TOKEN: ${{ github["token"] }}
+      - name: Publish
+        env:
+          TOKEN: ${{ secrets.SECOND_TOKEN }}
+  future-publisher:
+    services:
+      registry:
+        credentials:
+          password: ${{ secrets.SERVICE_TOKEN }}
+`
+	var workflow yaml.Node
+	if err := yaml.Unmarshal([]byte(config), &workflow); err != nil {
+		t.Fatalf("parse workflow fixture: %v", err)
+	}
+	want := []string{
+		"jobs.future-publisher.services.registry.credentials.password=${{ secrets.SERVICE_TOKEN }}",
+		"jobs.publisher.container.credentials.password=${{ secrets['CONTAINER_TOKEN'] }}",
+		"jobs.publisher.steps.Publish#1.env.TOKEN=${{ github[\"token\"] }}",
+		"jobs.publisher.steps.Publish#2.env.TOKEN=${{ secrets.SECOND_TOKEN }}",
+	}
+	slices.Sort(want)
+
+	got := workflowCredentialBindings(t, workflowYAMLMappingValue(&workflow, "jobs"))
+	if !slices.Equal(got, want) {
+		t.Fatalf("raw workflow credential bindings = %#v, want %#v", got, want)
+	}
+}
+
+func workflowCredentialBindings(t *testing.T, jobs *yaml.Node) []string {
 	t.Helper()
 
-	bindings := make(map[string]string)
-	for _, jobName := range jobNames {
-		collectReleasePublicationJobCredentialBindings(t, jobName, workflowJobByName(t, jobs, jobName), bindings)
+	if jobs == nil || jobs.Kind != yaml.MappingNode {
+		t.Fatal("workflow must define a jobs mapping")
 	}
+	bindings := make([]string, 0)
+	for index := 0; index < len(jobs.Content); index += 2 {
+		jobName := jobs.Content[index].Value
+		collectWorkflowCredentialBindings(jobs.Content[index+1], "jobs."+jobName, &bindings)
+	}
+	slices.Sort(bindings)
 	return bindings
 }
 
-func collectReleasePublicationJobCredentialBindings(t *testing.T, jobName string, job workflowJobConfig, bindings map[string]string) {
-	t.Helper()
-
-	jobValues := append([]string{job.If, job.RunsOn}, mapValues(job.Env)...)
-	jobValues = append(jobValues, mapValues(job.Outputs)...)
-	assertWorkflowValuesOmitCredentialReferences(t, jobValues, "release publication job "+jobName)
-	for _, step := range job.Steps {
-		collectReleasePublicationStepCredentialBindings(t, jobName, step, bindings)
-	}
-}
-
-func collectReleasePublicationStepCredentialBindings(t *testing.T, jobName string, step workflowStepConfig, bindings map[string]string) {
-	t.Helper()
-
-	unscopedValues := []string{step.If, step.Run, step.Shell, step.Uses, step.WorkingDirectory}
-	unscopedValues = append(unscopedValues, mapValues(step.With)...)
-	assertWorkflowValuesOmitCredentialReferences(t, unscopedValues, jobName+" step "+step.Name)
-	for key, value := range step.Env {
-		if workflowValueReferencesCredential(value) {
-			bindings[jobName+"/"+step.Name+"/env."+key] = value
+func collectWorkflowCredentialBindings(node *yaml.Node, path string, bindings *[]string) {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if workflowValueReferencesCredential(node.Value) {
+			*bindings = append(*bindings, path+"="+node.Value)
+		}
+	case yaml.MappingNode:
+		for index := 0; index < len(node.Content); index += 2 {
+			key := node.Content[index].Value
+			value := node.Content[index+1]
+			if key == "steps" && value.Kind == yaml.SequenceNode {
+				collectWorkflowCredentialStepBindings(value, path+".steps", bindings)
+				continue
+			}
+			collectWorkflowCredentialBindings(value, path+"."+key, bindings)
+		}
+	case yaml.SequenceNode:
+		for index, child := range node.Content {
+			collectWorkflowCredentialBindings(child, path+"["+strconv.Itoa(index)+"]", bindings)
 		}
 	}
 }
 
-func assertWorkflowValuesOmitCredentialReferences(t *testing.T, values []string, label string) {
-	t.Helper()
+func collectWorkflowCredentialStepBindings(steps *yaml.Node, path string, bindings *[]string) {
+	stepNameOccurrences := make(map[string]int)
+	for _, step := range steps.Content {
+		nameNode := workflowYAMLMappingValue(step, "name")
+		stepName := "<unnamed>"
+		if nameNode != nil && nameNode.Value != "" {
+			stepName = nameNode.Value
+		}
+		stepNameOccurrences[stepName]++
+		stepPath := path + "." + stepName + "#" + strconv.Itoa(stepNameOccurrences[stepName])
+		collectWorkflowCredentialBindings(step, stepPath, bindings)
+	}
+}
 
-	for _, value := range values {
-		if workflowValueReferencesCredential(value) {
-			t.Fatalf("%s must not reference a release publication credential", label)
+func workflowYAMLMappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yaml.DocumentNode {
+		if len(node.Content) == 0 {
+			return nil
+		}
+		node = node.Content[0]
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for index := 0; index < len(node.Content); index += 2 {
+		if node.Content[index].Value == key {
+			return node.Content[index+1]
 		}
 	}
+	return nil
 }
 
 func workflowValueReferencesCredential(value string) bool {
-	return strings.Contains(value, "secrets.") || strings.Contains(value, "github.token")
+	normalized := strings.Join(strings.Fields(strings.ToLower(value)), "")
+	normalized = strings.ReplaceAll(normalized, `"`, `'`)
+	return strings.Contains(normalized, "secrets.") ||
+		strings.Contains(normalized, "secrets['") ||
+		strings.Contains(normalized, "github.token") ||
+		strings.Contains(normalized, "github['token']")
 }
 
 func TestReleaseWorkflowPublicationArtifactNameAvoidsReleaseArtifactWildcard(t *testing.T) {


### PR DESCRIPTION
## Summary

Lock the release workflow's existing publish-secret boundaries with an exact raw-workflow regression contract after rebasing the PR onto the complete Aardvark release-security chain.

## Changes

- Rebase onto current `main` through #1204 and remove the 52 historical commits whose runtime behavior is already present in stronger merged release boundaries.
- Inventory every credential reference across the complete release workflow YAML document, including workflow-level fields and job fields not modeled by the typed workflow test fixture.
- Require the inventory to match the named step, field, environment key, and approved credential expression for GitHub Release, Marketplace, floating-tag, Homebrew tap, feature-history, and release-preparation boundaries.
- Detect dot, bracket, bare, wildcard, and pass-through credential contexts inside GitHub Actions expressions, including `secrets: inherit`, `${{ toJson(secrets) }}`, `github.*`, and whole-`github` context exposure.
- Model unwrapped job/step `if:` expressions and the implicit `github.token` available to every action step and reusable-workflow `uses:` boundary; all 29 current `uses:` sites are explicitly allowlisted.
- Track workflow traversal roles so nested action inputs named `if` or `uses` do not create false bindings, while YAML aliases retain job/step semantics and fail fast with the binding path on cycles.
- Ignore non-expression prose and non-credential GitHub properties, and preserve duplicate step-name ordinals so unrelated workflow text cannot overwrite or create bindings.
- Split traversal and validation into bounded helpers after direct Sonar analysis identified excessive cognitive complexity in the initial aggregate test.
- Preserve the current workflow behavior without reintroducing the PR's superseded release implementation.

## Validation

- `go test ./scripts -run 'Test(ReleaseWorkflowScopesPublicationSecretsToNamedSteps|WorkflowCredentialBindingsAuditRawWorkflowFieldsAliasesAndDuplicateSteps|ReleaseWorkflowPublishesFromFreshValidatedInputs)' -count=1`
- `golangci-lint run ./scripts`
- `make ci` via each incremental commit hook: formatting, module verification, feature flags, lint, actionlint, duplication, inline suppressions, gosec, vulnerability scan, unit tests, leak checks, race tests, memory benchmarks, build, and coverage all passed.
- Total coverage: 98.2%; memory benchmark gate: passed; new-code duplication: 0.00%.

## Risk and compatibility

- Breaking changes: none; this is a workflow contract test only.
- Migration required: none.
- Performance impact: none in release automation; the added assertions run only in tests.
- Memory benchmark impact: none; the memory regression gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
