### PR TITLE
ci(queue): add queue-me merge controller

### DIFF
--- a/.github/workflows/queue-me.yml
+++ b/.github/workflows/queue-me.yml
@@ -14,6 +14,8 @@ on:
       - ready_for_review
       - converted_to_draft
       - closed
+      - edited
+      - auto_merge_enabled
 
 concurrency:
   group: queue-me-${{ github.repository }}
@@ -100,6 +102,7 @@ jobs:
         env:
           QUEUE_CONTROLLER_PATH: ${{ runner.temp }}/queue_me_controller.js
           QUEUE_LABEL: queue-me
+          QUEUE_APP_SLUG: ${{ steps.queue_token.outputs.app-slug }}
         with:
           github-token: ${{ steps.queue_token.outputs.token }}
           script: |

--- a/.github/workflows/queue-me.yml
+++ b/.github/workflows/queue-me.yml
@@ -39,12 +39,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout trusted queue controller
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: ${{ github.workflow_sha }}
-          persist-credentials: false
-
       - name: Check queue app configuration
         id: queue_config
         shell: bash
@@ -73,14 +67,40 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
 
+      - name: Materialize trusted queue controller
+        if: steps.queue_config.outputs.configured == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          QUEUE_CONTROLLER_PATH: ${{ runner.temp }}/queue_me_controller.js
+          TRUSTED_CONTROLLER_REF: ${{ github.workflow_sha }}
+        with:
+          github-token: ${{ steps.queue_token.outputs.token }}
+          script: |
+            const fs = require('node:fs');
+            const { data } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'scripts/queue_me_controller.js',
+              ref: process.env.TRUSTED_CONTROLLER_REF,
+            });
+            if (Array.isArray(data) || data.type !== 'file' || data.encoding !== 'base64') {
+              throw new Error('Trusted queue controller is not a base64-encoded repository file.');
+            }
+            const source = Buffer.from(data.content.replaceAll('\n', ''), 'base64').toString('utf8');
+            fs.writeFileSync(process.env.QUEUE_CONTROLLER_PATH, source, {
+              encoding: 'utf8',
+              flag: 'wx',
+              mode: 0o600,
+            });
+
       - name: Advance queue
         if: steps.queue_config.outputs.configured == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
+          QUEUE_CONTROLLER_PATH: ${{ runner.temp }}/queue_me_controller.js
           QUEUE_LABEL: queue-me
         with:
           github-token: ${{ steps.queue_token.outputs.token }}
           script: |
-            const controllerPath = `${process.env.GITHUB_WORKSPACE}/scripts/queue_me_controller.js`;
-            const runController = require(controllerPath);
+            const runController = require(process.env.QUEUE_CONTROLLER_PATH);
             await runController({ github, context, core });

--- a/.github/workflows/queue-me.yml
+++ b/.github/workflows/queue-me.yml
@@ -66,6 +66,7 @@ jobs:
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Materialize trusted queue controller
         if: steps.queue_config.outputs.configured == 'true'

--- a/.github/workflows/queue-me.yml
+++ b/.github/workflows/queue-me.yml
@@ -1,0 +1,86 @@
+name: queue me
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - closed
+
+concurrency:
+  group: queue-me-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  advance:
+    name: advance queue-me
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request_target' &&
+        (
+          (github.event.action == 'labeled' && github.event.label.name == 'queue-me') ||
+          (github.event.action == 'unlabeled' && github.event.label.name == 'queue-me') ||
+          contains(github.event.pull_request.labels.*.name, 'queue-me')
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout trusted queue controller
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Check queue app configuration
+        id: queue_config
+        shell: bash
+        env:
+          QUEUE_APP_CLIENT_ID: ${{ vars.QUEUE_APP_CLIENT_ID }}
+          QUEUE_APP_PRIVATE_KEY: ${{ secrets.QUEUE_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${QUEUE_APP_CLIENT_ID}" && -n "${QUEUE_APP_PRIVATE_KEY}" ]]; then
+            echo "configured=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "configured=false" >> "${GITHUB_OUTPUT}"
+            echo "::notice::queue-me is inactive until QUEUE_APP_CLIENT_ID and QUEUE_APP_PRIVATE_KEY are configured."
+          fi
+
+      - name: Create queue app token
+        if: steps.queue_config.outputs.configured == 'true'
+        id: queue_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ vars.QUEUE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.QUEUE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Advance queue
+        if: steps.queue_config.outputs.configured == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          QUEUE_LABEL: queue-me
+        with:
+          github-token: ${{ steps.queue_token.outputs.token }}
+          script: |
+            const controllerPath = `${process.env.GITHUB_WORKSPACE}/scripts/queue_me_controller.js`;
+            const runController = require(controllerPath);
+            await runController({ github, context, core });

--- a/.github/workflows/queue-me.yml
+++ b/.github/workflows/queue-me.yml
@@ -28,7 +28,10 @@ jobs:
   advance:
     name: advance queue-me
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/main'
+      ) ||
       github.event_name == 'push' ||
       (
         github.event_name == 'pull_request_target' &&

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -39,11 +39,12 @@ The workflow uses `pull_request_target`, but it never checks out a repository tr
 
 Configure the controller once:
 
-1. Enable **Allow auto-merge** under **Settings > General > Pull Requests**. The controller relies on repository auto-merge while required checks are pending.
-2. Create and install a GitHub App on this repository with repository permissions `Contents: Read and write`, `Issues: Read and write`, `Pull requests: Read and write`, and `Workflows: Read and write`. The Workflows permission lets queued maintenance pull requests update files under `.github/workflows`.
-3. Add the App's client ID as repository variable `QUEUE_APP_CLIENT_ID`.
-4. Add its private key as repository secret `QUEUE_APP_PRIVATE_KEY`.
-5. Run the `queue me` workflow manually once. This creates the `queue-me` label when it is missing and reports an empty queue successfully.
+1. Enable **Allow squash merging** under **Settings > General > Pull Requests**. The controller always uses squash merges.
+2. Enable **Allow auto-merge** in the same settings section. The controller relies on repository auto-merge while required checks are pending.
+3. Create and install a GitHub App on this repository with repository permissions `Contents: Read and write`, `Issues: Read and write`, `Pull requests: Read and write`, and `Workflows: Read and write`. The Workflows permission lets queued maintenance pull requests update files under `.github/workflows`.
+4. Add the App's client ID as repository variable `QUEUE_APP_CLIENT_ID`.
+5. Add its private key as repository secret `QUEUE_APP_PRIVATE_KEY`.
+6. Run the `queue me` workflow manually once. This creates the `queue-me` label when it is missing and reports an empty queue successfully.
 
 If the App configuration is absent, the workflow exits successfully with a notice and performs no writes. Rebase conflicts, draft queue leaders, and all fork branches pause the queue and update one sticky status comment on the blocking pull request. Fork pull requests must be rebased manually because the repository-scoped App token cannot write to a contributor's fork. The controller never requests reviews; ordinary review and stale-approval policy remains owned by the repository ruleset.
 

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -35,7 +35,7 @@ Stable release automation:
 
 `.github/workflows/queue-me.yml` provides a repository-hosted queue for the default branch without requiring GitHub's organization-only merge queue feature. Apply the `queue-me` label to any open, non-draft pull request targeting `main`. The controller processes labeled pull requests in ascending PR-number order, rebases only the current queue leader, and enables squash auto-merge so the existing ruleset remains authoritative for checks, Sonar, metadata, and resolved conversations. A merge or any other push to `main` causes the next leader to be rebased against the new exact base. Removing `queue-me` disables that pull request's auto-merge and advances the remaining queue.
 
-The workflow uses `pull_request_target`, but it checks out only the trusted `github.workflow_sha`; it never checks out or executes pull-request code. API writes use a repository-scoped GitHub App installation token so the rebase-generated `synchronize` event can start normal CI without the recursive-workflow restrictions of `GITHUB_TOKEN`.
+The workflow uses `pull_request_target`, but it never checks out a repository tree. It downloads only `scripts/queue_me_controller.js` from the exact trusted `github.workflow_sha` through GitHub's Contents API, writes that blob to runner temporary storage, and executes it. API writes use a repository-scoped GitHub App installation token so the rebase-generated `synchronize` event can start normal CI without the recursive-workflow restrictions of `GITHUB_TOKEN`.
 
 Configure the controller once:
 

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -39,10 +39,11 @@ The workflow uses `pull_request_target`, but it never checks out a repository tr
 
 Configure the controller once:
 
-1. Create and install a GitHub App on this repository with repository permissions `Contents: Read and write`, `Issues: Read and write`, and `Pull requests: Read and write`.
-2. Add the App's client ID as repository variable `QUEUE_APP_CLIENT_ID`.
-3. Add its private key as repository secret `QUEUE_APP_PRIVATE_KEY`.
-4. Run the `queue me` workflow manually once. This creates the `queue-me` label when it is missing and reports an empty queue successfully.
+1. Enable **Allow auto-merge** under **Settings > General > Pull Requests**. The controller relies on repository auto-merge while required checks are pending.
+2. Create and install a GitHub App on this repository with repository permissions `Contents: Read and write`, `Issues: Read and write`, `Pull requests: Read and write`, and `Workflows: Read and write`. The Workflows permission lets queued maintenance pull requests update files under `.github/workflows`.
+3. Add the App's client ID as repository variable `QUEUE_APP_CLIENT_ID`.
+4. Add its private key as repository secret `QUEUE_APP_PRIVATE_KEY`.
+5. Run the `queue me` workflow manually once. This creates the `queue-me` label when it is missing and reports an empty queue successfully.
 
 If the App configuration is absent, the workflow exits successfully with a notice and performs no writes. Rebase conflicts, draft queue leaders, and fork branches without maintainer-edit permission pause the queue and update one sticky status comment on the blocking pull request. The controller never requests reviews; ordinary review and stale-approval policy remains owned by the repository ruleset.
 

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -3,6 +3,7 @@
 This repository includes these GitHub Actions workflows:
 
 - `.github/workflows/ci.yml`: runs checks on pull requests
+- `.github/workflows/queue-me.yml`: serializes pull requests carrying the `queue-me` label, rebases the oldest numbered pull request onto current `main`, and arms squash auto-merge
 - `.github/workflows/release.yml`: release-please-backed stable release workflow. On pushes to `main`, it creates or updates a release PR from Conventional Commits; when that release PR is merged, it creates a draft semver GitHub release, publishes assets, publishes images, optionally publishes the VS Code extension, publishes the draft release, updates the GitHub Action floating tags, and then updates the Homebrew tap with:
   - Linux/Windows artifacts from Ubuntu (cross-compiled with `zig`)
   - Darwin artifact from macOS (native arch)
@@ -29,6 +30,23 @@ Stable release automation:
 - Release commits should use Conventional Commit prefixes: `fix:` for patch releases, `feat:` for minor releases, and any type with a breaking-change marker (for example `feat!:` or `fix!:`) or a `BREAKING CHANGE:` footer for major releases.
 - Stable releases also publish the first-party action version refs. The release tag, such as `v1.7.0`, is the exact action ref; the workflow force-updates `v1` and `v1.7` to the same release commit for standard GitHub Actions major/minor pinning.
 - Set repository secret `RELEASE_PLEASE_TOKEN` to a PAT with contents and pull request write access so release-please-created PRs can trigger normal CI. If it is not configured, the workflow falls back to `MAIN_SYNC_PAT` and then `GITHUB_TOKEN`.
+
+## Pull request auto-merge queue
+
+`.github/workflows/queue-me.yml` provides a repository-hosted queue for the default branch without requiring GitHub's organization-only merge queue feature. Apply the `queue-me` label to any open, non-draft pull request targeting `main`. The controller processes labeled pull requests in ascending PR-number order, rebases only the current queue leader, and enables squash auto-merge so the existing ruleset remains authoritative for checks, Sonar, metadata, and resolved conversations. A merge or any other push to `main` causes the next leader to be rebased against the new exact base. Removing `queue-me` disables that pull request's auto-merge and advances the remaining queue.
+
+The workflow uses `pull_request_target`, but it checks out only the trusted `github.workflow_sha`; it never checks out or executes pull-request code. API writes use a repository-scoped GitHub App installation token so the rebase-generated `synchronize` event can start normal CI without the recursive-workflow restrictions of `GITHUB_TOKEN`.
+
+Configure the controller once:
+
+1. Create and install a GitHub App on this repository with repository permissions `Contents: Read and write`, `Issues: Read and write`, and `Pull requests: Read and write`.
+2. Add the App's client ID as repository variable `QUEUE_APP_CLIENT_ID`.
+3. Add its private key as repository secret `QUEUE_APP_PRIVATE_KEY`.
+4. Run the `queue me` workflow manually once. This creates the `queue-me` label when it is missing and reports an empty queue successfully.
+
+If the App configuration is absent, the workflow exits successfully with a notice and performs no writes. Rebase conflicts, draft queue leaders, and fork branches without maintainer-edit permission pause the queue and update one sticky status comment on the blocking pull request. The controller never requests reviews; ordinary review and stale-approval policy remains owned by the repository ruleset.
+
+Validate the no-credential path locally with `act workflow_dispatch -W .github/workflows/queue-me.yml --job advance --strict`; it must report the inactive-controller notice, skip token creation and API writes, and complete successfully.
 
 ## Example pipeline
 

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -45,7 +45,7 @@ Configure the controller once:
 4. Add its private key as repository secret `QUEUE_APP_PRIVATE_KEY`.
 5. Run the `queue me` workflow manually once. This creates the `queue-me` label when it is missing and reports an empty queue successfully.
 
-If the App configuration is absent, the workflow exits successfully with a notice and performs no writes. Rebase conflicts, draft queue leaders, and fork branches without maintainer-edit permission pause the queue and update one sticky status comment on the blocking pull request. The controller never requests reviews; ordinary review and stale-approval policy remains owned by the repository ruleset.
+If the App configuration is absent, the workflow exits successfully with a notice and performs no writes. Rebase conflicts, draft queue leaders, and all fork branches pause the queue and update one sticky status comment on the blocking pull request. Fork pull requests must be rebased manually because the repository-scoped App token cannot write to a contributor's fork. The controller never requests reviews; ordinary review and stale-approval policy remains owned by the repository ruleset.
 
 Validate the no-credential path locally with `act workflow_dispatch -W .github/workflows/queue-me.yml --job advance --strict`; it must report the inactive-controller notice, skip token creation and API writes, and complete successfully.
 

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -46,7 +46,7 @@ Configure the controller once:
 5. Add its private key as repository secret `QUEUE_APP_PRIVATE_KEY`.
 6. Run the `queue me` workflow manually once. This creates the `queue-me` label when it is missing and reports an empty queue successfully.
 
-If the App configuration is absent, the workflow exits successfully with a notice and performs no writes. Rebase conflicts, draft queue leaders, and all fork branches pause the queue and update one sticky status comment on the blocking pull request. Fork pull requests must be rebased manually because the repository-scoped App token cannot write to a contributor's fork. The controller never requests reviews; ordinary review and stale-approval policy remains owned by the repository ruleset.
+If the App configuration is absent, the workflow exits successfully with a notice and performs no writes. Rebase conflicts, draft queue leaders, and stale fork branches pause the queue and update one sticky status comment on the blocking pull request. Fork pull requests must be rebased manually when stale because the repository-scoped App token cannot write to a contributor's fork; once current with the default branch, they can advance through normal squash auto-merge. The controller never requests reviews; ordinary review and stale-approval policy remains owned by the repository ruleset.
 
 Validate the no-credential path locally with `act workflow_dispatch -W .github/workflows/queue-me.yml --job advance --strict`; it must report the inactive-controller notice, skip token creation and API writes, and complete successfully.
 

--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -117,7 +117,12 @@ async function disableAutoMerge(github, owner, repo, number) {
   );
 }
 
-async function rebaseOntoDefault(github, pull, defaultBranchSHA) {
+async function rebaseOntoDefault(
+  github,
+  pull,
+  defaultBranchSHA,
+  { canUpdateBranch = true } = {},
+) {
   const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
     owner: pull.base.repo.owner.login,
     repo: pull.base.repo.name,
@@ -125,6 +130,9 @@ async function rebaseOntoDefault(github, pull, defaultBranchSHA) {
   });
   if (isBranchCurrent(comparison.status)) {
     return { headSHA: pull.head.sha, rebased: false };
+  }
+  if (!canUpdateBranch) {
+    return { headSHA: pull.head.sha, rebased: false, needsManualRebase: true };
   }
   const result = await github.graphql(
     `mutation RebaseQueuedPull($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) {
@@ -343,17 +351,6 @@ async function runController({
     );
     return;
   }
-  if (leader.head.repo?.full_name !== repository.full_name) {
-    await syncStatusComment(
-      github,
-      owner,
-      repo,
-      leader.number,
-      `## Queue status\n\nQueue paused: the repository-scoped queue App cannot update fork branches. Rebase this pull request onto \`${defaultBranch}\` manually, then remove and reapply \`${queueLabel}\`.`,
-    );
-    return;
-  }
-
   const { data: branch } = await github.rest.repos.getBranch({
     owner,
     repo,
@@ -361,7 +358,9 @@ async function runController({
   });
   let update;
   try {
-    update = await rebaseOntoDefault(github, leader, branch.commit.sha);
+    update = await rebaseOntoDefault(github, leader, branch.commit.sha, {
+      canUpdateBranch: leader.head.repo?.full_name === repository.full_name,
+    });
   } catch (error) {
     await syncStatusComment(
       github,
@@ -371,6 +370,16 @@ async function runController({
       `## Queue status\n\nQueue paused: GitHub could not rebase this pull request onto \`${defaultBranch}\`. Resolve the conflict and push the branch to retry.\n\n\`${safeError(error)}\``,
     );
     throw error;
+  }
+  if (update.needsManualRebase) {
+    await syncStatusComment(
+      github,
+      owner,
+      repo,
+      leader.number,
+      `## Queue status\n\nQueue paused: this fork branch does not contain current \`${defaultBranch}\`, and the repository-scoped queue App cannot update it. Rebase the fork branch manually; the queue will retry after the push.`,
+    );
+    return;
   }
 
   try {

--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -331,12 +331,17 @@ async function runController({
   for (const follower of queued.slice(1)) {
     await disableAutoMerge(github, owner, repo, follower.number);
   }
-  if (eventPull && eventPull.number !== leader.number && context.payload.action === 'labeled') {
+  const eventQueueEntry = eventPull && queued.find((pull) => pull.number === eventPull.number);
+  if (
+    eventQueueEntry &&
+    eventQueueEntry.number !== leader.number &&
+    context.payload.action === 'labeled'
+  ) {
     await syncStatusComment(
       github,
       owner,
       repo,
-      eventPull.number,
+      eventQueueEntry.number,
       `## Queue status\n\nQueued behind #${leader.number}. Pull requests advance in ascending number order.`,
     );
   }

--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -254,11 +254,7 @@ async function reconcileEventPull({
     );
     return;
   }
-  if (
-    context.payload.action !== 'edited' ||
-    !hasLabel(eventPull, queueLabel) ||
-    eventPull.base?.ref === defaultBranch
-  ) {
+  if (!hasLabel(eventPull, queueLabel) || eventPull.base?.ref === defaultBranch) {
     return;
   }
   await disableAutoMerge(github, owner, repo, eventPull.number);

--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -1,0 +1,359 @@
+'use strict';
+
+const COMMENT_MARKER = '<!-- queue-me-controller -->';
+const DEFAULT_QUEUE_LABEL = 'queue-me';
+
+function labelName(label) {
+  return typeof label === 'string' ? label : label?.name;
+}
+
+function hasLabel(pull, queueLabel) {
+  return (pull.labels || []).some((label) => labelName(label) === queueLabel);
+}
+
+function sortQueuedPulls(pulls) {
+  return [...pulls].sort((left, right) => left.number - right.number);
+}
+
+function isBranchCurrent(comparisonStatus) {
+  return comparisonStatus === 'ahead' || comparisonStatus === 'identical';
+}
+
+function shortSHA(sha) {
+  return typeof sha === 'string' ? sha.slice(0, 10) : 'unknown';
+}
+
+function safeError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replaceAll('`', "'").slice(0, 1200);
+}
+
+async function ensureQueueLabel(github, owner, repo, queueLabel) {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name: queueLabel });
+  } catch (error) {
+    if (error?.status !== 404) {
+      throw error;
+    }
+    await github.rest.issues.createLabel({
+      owner,
+      repo,
+      name: queueLabel,
+      color: '1D76DB',
+      description: 'Rebase and squash-merge automatically in deterministic PR order',
+    });
+  }
+}
+
+async function pullState(github, owner, repo, number) {
+  const result = await github.graphql(
+    `query QueuePullState($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          id
+          number
+          headRefOid
+          isDraft
+          mergeable
+          mergeStateStatus
+          autoMergeRequest {
+            enabledAt
+            mergeMethod
+          }
+        }
+      }
+    }`,
+    { owner, repo, number },
+  );
+  return result.repository.pullRequest;
+}
+
+async function syncStatusComment(github, owner, repo, number, body) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: number,
+    per_page: 100,
+  });
+  const existing = comments.find(
+    (comment) =>
+      comment.user?.type === 'Bot' &&
+      typeof comment.body === 'string' &&
+      comment.body.includes(COMMENT_MARKER),
+  );
+  const nextBody = `${COMMENT_MARKER}\n${body}`;
+  if (existing?.body === nextBody) {
+    return;
+  }
+  if (existing) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body: nextBody,
+    });
+    return;
+  }
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: number,
+    body: nextBody,
+  });
+}
+
+async function disableAutoMerge(github, owner, repo, number) {
+  const state = await pullState(github, owner, repo, number);
+  if (!state?.autoMergeRequest) {
+    return;
+  }
+  await github.graphql(
+    `mutation DisableQueueAutoMerge($pullRequestId: ID!) {
+      disablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {
+        pullRequest { number }
+      }
+    }`,
+    { pullRequestId: state.id },
+  );
+}
+
+async function rebaseOntoDefault(github, pull, defaultBranchSHA) {
+  const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+    owner: pull.base.repo.owner.login,
+    repo: pull.base.repo.name,
+    basehead: `${defaultBranchSHA}...${pull.head.sha}`,
+  });
+  if (isBranchCurrent(comparison.status)) {
+    return { headSHA: pull.head.sha, rebased: false };
+  }
+  const result = await github.graphql(
+    `mutation RebaseQueuedPull($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) {
+      updatePullRequestBranch(input: {
+        pullRequestId: $pullRequestId
+        expectedHeadOid: $expectedHeadOid
+        updateMethod: REBASE
+      }) {
+        pullRequest {
+          headRefOid
+          number
+        }
+      }
+    }`,
+    {
+      pullRequestId: pull.node_id,
+      expectedHeadOid: pull.head.sha,
+    },
+  );
+  return {
+    headSHA: result.updatePullRequestBranch.pullRequest.headRefOid,
+    rebased: true,
+  };
+}
+
+async function mergeNow(github, pullRequestId, expectedHeadOid) {
+  return github.graphql(
+    `mutation MergeQueuedPull($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) {
+      mergePullRequest(input: {
+        pullRequestId: $pullRequestId
+        expectedHeadOid: $expectedHeadOid
+        mergeMethod: SQUASH
+      }) {
+        pullRequest { number merged mergedAt }
+      }
+    }`,
+    { pullRequestId, expectedHeadOid },
+  );
+}
+
+async function armAutoMerge(github, pullRequestId) {
+  return github.graphql(
+    `mutation ArmQueueAutoMerge($pullRequestId: ID!) {
+      enablePullRequestAutoMerge(input: {
+        pullRequestId: $pullRequestId
+        mergeMethod: SQUASH
+      }) {
+        pullRequest {
+          number
+          autoMergeRequest { enabledAt mergeMethod }
+        }
+      }
+    }`,
+    { pullRequestId },
+  );
+}
+
+async function armOrMerge(github, state) {
+  if (state.autoMergeRequest) {
+    return 'armed';
+  }
+  if (state.mergeable === 'MERGEABLE' && state.mergeStateStatus === 'CLEAN') {
+    await mergeNow(github, state.id, state.headRefOid);
+    return 'merged';
+  }
+  try {
+    await armAutoMerge(github, state.id);
+    return 'armed';
+  } catch (error) {
+    const refreshed = await pullStateByID(github, state.id);
+    if (refreshed.mergeable === 'MERGEABLE' && refreshed.mergeStateStatus === 'CLEAN') {
+      await mergeNow(github, refreshed.id, refreshed.headRefOid);
+      return 'merged';
+    }
+    throw error;
+  }
+}
+
+async function pullStateByID(github, pullRequestId) {
+  const result = await github.graphql(
+    `query QueuePullStateByID($pullRequestId: ID!) {
+      node(id: $pullRequestId) {
+        ... on PullRequest {
+          id
+          number
+          headRefOid
+          mergeable
+          mergeStateStatus
+          autoMergeRequest { enabledAt mergeMethod }
+        }
+      }
+    }`,
+    { pullRequestId },
+  );
+  return result.node;
+}
+
+async function runController({ github, context, core }) {
+  const queueLabel = process.env.QUEUE_LABEL || DEFAULT_QUEUE_LABEL;
+  const { owner, repo } = context.repo;
+  await ensureQueueLabel(github, owner, repo, queueLabel);
+
+  const eventPull = context.payload.pull_request;
+  if (
+    context.eventName === 'pull_request_target' &&
+    context.payload.action === 'unlabeled' &&
+    context.payload.label?.name === queueLabel &&
+    eventPull
+  ) {
+    await disableAutoMerge(github, owner, repo, eventPull.number);
+    await syncStatusComment(
+      github,
+      owner,
+      repo,
+      eventPull.number,
+      `## Queue status\n\nRemoved from \`${queueLabel}\`; automatic merge is disabled.`,
+    );
+  }
+
+  const { data: repository } = await github.rest.repos.get({ owner, repo });
+  const defaultBranch = repository.default_branch;
+  const pulls = await github.paginate(github.rest.pulls.list, {
+    owner,
+    repo,
+    state: 'open',
+    base: defaultBranch,
+    sort: 'created',
+    direction: 'asc',
+    per_page: 100,
+  });
+  const queued = sortQueuedPulls(pulls.filter((pull) => hasLabel(pull, queueLabel)));
+  if (queued.length === 0) {
+    core.notice(`No open ${defaultBranch} pull requests carry the ${queueLabel} label.`);
+    return;
+  }
+
+  const leader = queued[0];
+  for (const follower of queued.slice(1)) {
+    await disableAutoMerge(github, owner, repo, follower.number);
+  }
+  if (eventPull && eventPull.number !== leader.number && context.payload.action === 'labeled') {
+    await syncStatusComment(
+      github,
+      owner,
+      repo,
+      eventPull.number,
+      `## Queue status\n\nQueued behind #${leader.number}. Pull requests advance in ascending number order.`,
+    );
+  }
+  await disableAutoMerge(github, owner, repo, leader.number);
+  if (leader.draft) {
+    await syncStatusComment(
+      github,
+      owner,
+      repo,
+      leader.number,
+      `## Queue status\n\nQueue paused: the oldest queued pull request is still a draft.`,
+    );
+    return;
+  }
+  if (leader.head.repo?.full_name !== repository.full_name && !leader.maintainer_can_modify) {
+    await syncStatusComment(
+      github,
+      owner,
+      repo,
+      leader.number,
+      `## Queue status\n\nQueue paused: maintainers cannot rebase this fork branch. Enable maintainer edits or rebase it manually.`,
+    );
+    return;
+  }
+
+  const { data: branch } = await github.rest.repos.getBranch({
+    owner,
+    repo,
+    branch: defaultBranch,
+  });
+  let update;
+  try {
+    update = await rebaseOntoDefault(github, leader, branch.commit.sha);
+  } catch (error) {
+    await syncStatusComment(
+      github,
+      owner,
+      repo,
+      leader.number,
+      `## Queue status\n\nQueue paused: GitHub could not rebase this pull request onto \`${defaultBranch}\`. Resolve the conflict and push the branch to retry.\n\n\`${safeError(error)}\``,
+    );
+    throw error;
+  }
+
+  try {
+    const state = await pullState(github, owner, repo, leader.number);
+    if (state.headRefOid !== update.headSHA) {
+      throw new Error(
+        `Pull request head moved from ${shortSHA(update.headSHA)} to ${shortSHA(state.headRefOid)} while advancing the queue.`,
+      );
+    }
+    const result = await armOrMerge(github, state);
+    const rebaseSummary = update.rebased
+      ? `Rebased \`${shortSHA(leader.head.sha)}\` to \`${shortSHA(update.headSHA)}\` on current \`${defaultBranch}\`.`
+      : `Head \`${shortSHA(update.headSHA)}\` already contains current \`${defaultBranch}\`.`;
+    const mergeSummary = result === 'merged'
+      ? 'All repository requirements were satisfied, so GitHub squash-merged it.'
+      : 'Squash auto-merge is armed and will wait for the repository ruleset.';
+    await syncStatusComment(
+      github,
+      owner,
+      repo,
+      leader.number,
+      `## Queue status\n\n${rebaseSummary}\n\n${mergeSummary}`,
+    );
+  } catch (error) {
+    await syncStatusComment(
+      github,
+      owner,
+      repo,
+      leader.number,
+      `## Queue status\n\nQueue paused while enabling or completing squash auto-merge.\n\n\`${safeError(error)}\``,
+    );
+    throw error;
+  }
+}
+
+module.exports = runController;
+module.exports.testables = {
+  hasLabel,
+  isBranchCurrent,
+  labelName,
+  safeError,
+  shortSHA,
+  sortQueuedPulls,
+};

--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -228,11 +228,18 @@ async function pullStateByID(github, pullRequestId) {
   return result.node;
 }
 
-async function runController({ github, context, core }) {
+async function runController({
+  github,
+  context,
+  core,
+  queueAppSlug = process.env.QUEUE_APP_SLUG,
+}) {
   const queueLabel = process.env.QUEUE_LABEL || DEFAULT_QUEUE_LABEL;
   const { owner, repo } = context.repo;
   await ensureQueueLabel(github, owner, repo, queueLabel);
 
+  const { data: repository } = await github.rest.repos.get({ owner, repo });
+  const defaultBranch = repository.default_branch;
   const eventPull = context.payload.pull_request;
   if (
     context.eventName === 'pull_request_target' &&
@@ -250,8 +257,23 @@ async function runController({ github, context, core }) {
     );
   }
 
-  const { data: repository } = await github.rest.repos.get({ owner, repo });
-  const defaultBranch = repository.default_branch;
+  if (
+    context.eventName === 'pull_request_target' &&
+    context.payload.action === 'edited' &&
+    eventPull &&
+    hasLabel(eventPull, queueLabel) &&
+    eventPull.base?.ref !== defaultBranch
+  ) {
+    await disableAutoMerge(github, owner, repo, eventPull.number);
+    await syncStatusComment(
+      github,
+      owner,
+      repo,
+      eventPull.number,
+      `## Queue status\n\nQueue paused: the base changed to \`${eventPull.base?.ref || 'unknown'}\`. Automatic merge is disabled because \`${queueLabel}\` pull requests must target \`${defaultBranch}\`.`,
+    );
+  }
+
   const pulls = await github.paginate(github.rest.pulls.list, {
     owner,
     repo,
@@ -268,6 +290,16 @@ async function runController({ github, context, core }) {
   }
 
   const leader = queued[0];
+  if (
+    context.eventName === 'pull_request_target' &&
+    context.payload.action === 'auto_merge_enabled' &&
+    eventPull?.number === leader.number &&
+    queueAppSlug &&
+    context.payload.sender?.login === `${queueAppSlug}[bot]`
+  ) {
+    core.notice(`Ignoring the queue App's auto-merge event for leader #${leader.number}.`);
+    return;
+  }
   for (const follower of queued.slice(1)) {
     await disableAutoMerge(github, owner, repo, follower.number);
   }
@@ -291,13 +323,13 @@ async function runController({ github, context, core }) {
     );
     return;
   }
-  if (leader.head.repo?.full_name !== repository.full_name && !leader.maintainer_can_modify) {
+  if (leader.head.repo?.full_name !== repository.full_name) {
     await syncStatusComment(
       github,
       owner,
       repo,
       leader.number,
-      `## Queue status\n\nQueue paused: maintainers cannot rebase this fork branch. Enable maintainer edits or rebase it manually.`,
+      `## Queue status\n\nQueue paused: the repository-scoped queue App cannot update fork branches. Rebase this pull request onto \`${defaultBranch}\` manually, then remove and reapply \`${queueLabel}\`.`,
     );
     return;
   }

--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -165,11 +165,12 @@ async function mergeNow(github, pullRequestId, expectedHeadOid) {
   );
 }
 
-async function armAutoMerge(github, pullRequestId) {
+async function armAutoMerge(github, pullRequestId, expectedHeadOid) {
   return github.graphql(
-    `mutation ArmQueueAutoMerge($pullRequestId: ID!) {
+    `mutation ArmQueueAutoMerge($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) {
       enablePullRequestAutoMerge(input: {
         pullRequestId: $pullRequestId
+        expectedHeadOid: $expectedHeadOid
         mergeMethod: SQUASH
       }) {
         pullRequest {
@@ -178,7 +179,7 @@ async function armAutoMerge(github, pullRequestId) {
         }
       }
     }`,
-    { pullRequestId },
+    { pullRequestId, expectedHeadOid },
   );
 }
 
@@ -191,12 +192,17 @@ async function armOrMerge(github, state) {
     return 'merged';
   }
   try {
-    await armAutoMerge(github, state.id);
+    await armAutoMerge(github, state.id, state.headRefOid);
     return 'armed';
   } catch (error) {
     const refreshed = await pullStateByID(github, state.id);
+    if (refreshed.headRefOid !== state.headRefOid) {
+      throw new Error(
+        `Pull request head moved from ${shortSHA(state.headRefOid)} to ${shortSHA(refreshed.headRefOid)} while arming auto-merge.`,
+      );
+    }
     if (refreshed.mergeable === 'MERGEABLE' && refreshed.mergeStateStatus === 'CLEAN') {
-      await mergeNow(github, refreshed.id, refreshed.headRefOid);
+      await mergeNow(github, refreshed.id, state.headRefOid);
       return 'merged';
     }
     throw error;
@@ -320,6 +326,16 @@ async function runController({ github, context, core }) {
     if (state.headRefOid !== update.headSHA) {
       throw new Error(
         `Pull request head moved from ${shortSHA(update.headSHA)} to ${shortSHA(state.headRefOid)} while advancing the queue.`,
+      );
+    }
+    const { data: latestBranch } = await github.rest.repos.getBranch({
+      owner,
+      repo,
+      branch: defaultBranch,
+    });
+    if (latestBranch.commit.sha !== branch.commit.sha) {
+      throw new Error(
+        `Default branch ${defaultBranch} moved from ${shortSHA(branch.commit.sha)} to ${shortSHA(latestBranch.commit.sha)} while advancing the queue.`,
       );
     }
     const result = await armOrMerge(github, state);

--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -25,7 +25,7 @@ function shortSHA(sha) {
 
 function safeError(error) {
   const message = error instanceof Error ? error.message : String(error);
-  return message.replaceAll('`', "'").slice(0, 1200);
+  return message.replace(/[\r\n]+/g, ' ').replaceAll('`', "'").slice(0, 1200);
 }
 
 async function ensureQueueLabel(github, owner, repo, queueLabel) {

--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -228,6 +228,59 @@ async function pullStateByID(github, pullRequestId) {
   return result.node;
 }
 
+async function reconcileEventPull({
+  github,
+  context,
+  owner,
+  repo,
+  queueLabel,
+  defaultBranch,
+  eventPull,
+}) {
+  if (!eventPull || context.eventName !== 'pull_request_target') {
+    return;
+  }
+  if (
+    context.payload.action === 'unlabeled' &&
+    context.payload.label?.name === queueLabel
+  ) {
+    await disableAutoMerge(github, owner, repo, eventPull.number);
+    await syncStatusComment(
+      github,
+      owner,
+      repo,
+      eventPull.number,
+      `## Queue status\n\nRemoved from \`${queueLabel}\`; automatic merge is disabled.`,
+    );
+    return;
+  }
+  if (
+    context.payload.action !== 'edited' ||
+    !hasLabel(eventPull, queueLabel) ||
+    eventPull.base?.ref === defaultBranch
+  ) {
+    return;
+  }
+  await disableAutoMerge(github, owner, repo, eventPull.number);
+  await syncStatusComment(
+    github,
+    owner,
+    repo,
+    eventPull.number,
+    `## Queue status\n\nQueue paused: the base changed to \`${eventPull.base?.ref || 'unknown'}\`. Automatic merge is disabled because \`${queueLabel}\` pull requests must target \`${defaultBranch}\`.`,
+  );
+}
+
+function isQueueAppLeaderAutoMergeEvent({ context, eventPull, leader, queueAppSlug }) {
+  return (
+    context.eventName === 'pull_request_target' &&
+    context.payload.action === 'auto_merge_enabled' &&
+    eventPull?.number === leader.number &&
+    queueAppSlug &&
+    context.payload.sender?.login === `${queueAppSlug}[bot]`
+  );
+}
+
 async function runController({
   github,
   context,
@@ -241,38 +294,15 @@ async function runController({
   const { data: repository } = await github.rest.repos.get({ owner, repo });
   const defaultBranch = repository.default_branch;
   const eventPull = context.payload.pull_request;
-  if (
-    context.eventName === 'pull_request_target' &&
-    context.payload.action === 'unlabeled' &&
-    context.payload.label?.name === queueLabel &&
-    eventPull
-  ) {
-    await disableAutoMerge(github, owner, repo, eventPull.number);
-    await syncStatusComment(
-      github,
-      owner,
-      repo,
-      eventPull.number,
-      `## Queue status\n\nRemoved from \`${queueLabel}\`; automatic merge is disabled.`,
-    );
-  }
-
-  if (
-    context.eventName === 'pull_request_target' &&
-    context.payload.action === 'edited' &&
-    eventPull &&
-    hasLabel(eventPull, queueLabel) &&
-    eventPull.base?.ref !== defaultBranch
-  ) {
-    await disableAutoMerge(github, owner, repo, eventPull.number);
-    await syncStatusComment(
-      github,
-      owner,
-      repo,
-      eventPull.number,
-      `## Queue status\n\nQueue paused: the base changed to \`${eventPull.base?.ref || 'unknown'}\`. Automatic merge is disabled because \`${queueLabel}\` pull requests must target \`${defaultBranch}\`.`,
-    );
-  }
+  await reconcileEventPull({
+    github,
+    context,
+    owner,
+    repo,
+    queueLabel,
+    defaultBranch,
+    eventPull,
+  });
 
   const pulls = await github.paginate(github.rest.pulls.list, {
     owner,
@@ -290,13 +320,7 @@ async function runController({
   }
 
   const leader = queued[0];
-  if (
-    context.eventName === 'pull_request_target' &&
-    context.payload.action === 'auto_merge_enabled' &&
-    eventPull?.number === leader.number &&
-    queueAppSlug &&
-    context.payload.sender?.login === `${queueAppSlug}[bot]`
-  ) {
+  if (isQueueAppLeaderAutoMergeEvent({ context, eventPull, leader, queueAppSlug })) {
     core.notice(`Ignoring the queue App's auto-merge event for leader #${leader.number}.`);
     return;
   }

--- a/scripts/queue_me_controller.test.js
+++ b/scripts/queue_me_controller.test.js
@@ -405,6 +405,31 @@ test('non-default-base queue events disable auto-merge', async (t) => {
   }
 });
 
+test('a non-default-base pause comment is not replaced by a queue position', async () => {
+  const leader = makePull(10);
+  const releasePull = makePull(20);
+  releasePull.base.ref = 'release';
+  const harness = makeHarness({
+    pulls: [leader],
+    eventPull: releasePull,
+    action: 'labeled',
+    initialStates: {
+      20: { autoMergeRequest: { enabledAt: 'manual', mergeMethod: 'SQUASH' } },
+    },
+  });
+
+  await runController(harness.args);
+
+  const eventComments = harness.calls.comments.filter(
+    (comment) => comment.number === 20 || comment.number === undefined,
+  );
+  assert.deepEqual(harness.calls.disabled, [20]);
+  assert.equal(eventComments.length, 1);
+  assert.match(eventComments[0].body, /base changed to `release`/);
+  assert.doesNotMatch(eventComments[0].body, /Queued behind/);
+  assert.deepEqual(harness.calls.armed, [10]);
+});
+
 test('manually enabling auto-merge on a follower restores queue ordering', async () => {
   const leader = makePull(10);
   const follower = makePull(20);

--- a/scripts/queue_me_controller.test.js
+++ b/scripts/queue_me_controller.test.js
@@ -367,6 +367,29 @@ test('changing a queued pull request away from main disables auto-merge', async 
   assert.equal(harness.calls.notices.length, 1);
 });
 
+test('non-default-base queue events disable auto-merge', async (t) => {
+  for (const action of ['labeled', 'auto_merge_enabled']) {
+    await t.test(action, async () => {
+      const pull = makePull(10);
+      pull.base.ref = 'release';
+      const harness = makeHarness({
+        eventPull: pull,
+        action,
+        initialStates: {
+          10: { autoMergeRequest: { enabledAt: 'before', mergeMethod: 'SQUASH' } },
+        },
+      });
+
+      await runController(harness.args);
+
+      assert.deepEqual(harness.calls.disabled, [10]);
+      assert.deepEqual(harness.calls.armed, []);
+      assert.match(harness.calls.comments[0].body, /base changed to `release`/);
+      assert.equal(harness.calls.notices.length, 1);
+    });
+  }
+});
+
 test('manually enabling auto-merge on a follower restores queue ordering', async () => {
   const leader = makePull(10);
   const follower = makePull(20);

--- a/scripts/queue_me_controller.test.js
+++ b/scripts/queue_me_controller.test.js
@@ -184,8 +184,8 @@ test('isBranchCurrent accepts only ancestor-preserving compare states', () => {
 test('status helpers bound untrusted API text', () => {
   assert.equal(testables.shortSHA('1234567890abcdef'), '1234567890');
   assert.equal(testables.shortSHA(undefined), 'unknown');
-  const sanitized = testables.safeError(new Error('bad `branch`'));
-  assert.equal(sanitized, "bad 'branch'");
+  const sanitized = testables.safeError(new Error('bad `branch`\r\ntry again'));
+  assert.equal(sanitized, "bad 'branch' try again");
   assert.equal(testables.safeError('x'.repeat(1300)).length, 1200);
 });
 

--- a/scripts/queue_me_controller.test.js
+++ b/scripts/queue_me_controller.test.js
@@ -51,6 +51,8 @@ function makeHarness(options = {}) {
   const comments = new Map();
   const calls = {
     armed: [],
+    armExpectedHeads: [],
+    branchReads: [],
     comments: [],
     createdLabels: [],
     disabled: [],
@@ -88,7 +90,12 @@ function makeHarness(options = {}) {
       },
       repos: {
         get: async () => ({ data: repository }),
-        getBranch: async () => ({ data: { commit: { sha: 'base-sha' } } }),
+        getBranch: async () => {
+          const branchSHAs = options.branchSHAs || ['base-sha'];
+          const sha = branchSHAs[Math.min(calls.branchReads.length, branchSHAs.length - 1)];
+          calls.branchReads.push(sha);
+          return { data: { commit: { sha } } };
+        },
         compareCommitsWithBasehead: async () => ({
           data: { status: options.comparisonStatus || 'ahead' },
         }),
@@ -102,11 +109,12 @@ function makeHarness(options = {}) {
     },
     graphql: async (query, variables) => {
       if (query.includes('QueuePullState($owner')) {
-        return { repository: { pullRequest: states.get(variables.number) } };
+        return { repository: { pullRequest: { ...states.get(variables.number) } } };
       }
       if (query.includes('QueuePullStateByID')) {
+        const state = [...states.values()].find((value) => value.id === variables.pullRequestId);
         return {
-          node: [...states.values()].find((state) => state.id === variables.pullRequestId),
+          node: { ...state },
         };
       }
       if (query.includes('DisableQueueAutoMerge')) {
@@ -126,6 +134,13 @@ function makeHarness(options = {}) {
       }
       if (query.includes('ArmQueueAutoMerge')) {
         const state = [...states.values()].find((value) => value.id === variables.pullRequestId);
+        calls.armExpectedHeads.push(variables.expectedHeadOid);
+        if (options.armErrorHead) {
+          state.headRefOid = options.armErrorHead;
+        }
+        if (options.armError) {
+          throw options.armError;
+        }
         state.autoMergeRequest = { enabledAt: 'now', mergeMethod: 'SQUASH' };
         calls.armed.push(state.number);
         return { enablePullRequestAutoMerge: { pullRequest: state } };
@@ -214,6 +229,7 @@ test('controller disables followers and arms only the oldest numbered pull reque
 
   assert.deepEqual(harness.calls.disabled, [20]);
   assert.deepEqual(harness.calls.armed, [10]);
+  assert.deepEqual(harness.calls.armExpectedHeads, ['head-10']);
   assert.deepEqual(harness.calls.merged, []);
   assert.match(
     harness.calls.comments.find((comment) => comment.number === 20).body,
@@ -299,4 +315,33 @@ test('a rebase conflict pauses the queue with a bounded status message', async (
   assert.deepEqual(harness.calls.armed, []);
   assert.match(harness.calls.comments[0].body, /could not rebase/);
   assert.match(harness.calls.comments[0].body, /conflict in 'workflow'/);
+});
+
+test('controller pauses when the default branch moves before auto-merge is armed', async () => {
+  const harness = makeHarness({
+    pulls: [makePull(10)],
+    branchSHAs: ['base-sha', 'new-base-sha'],
+  });
+
+  await assert.rejects(runController(harness.args), /Default branch main moved/);
+
+  assert.deepEqual(harness.calls.branchReads, ['base-sha', 'new-base-sha']);
+  assert.deepEqual(harness.calls.armed, []);
+  assert.deepEqual(harness.calls.merged, []);
+  assert.match(harness.calls.comments[0].body, /Default branch main moved/);
+});
+
+test('controller never merges an unverified head after auto-merge arming races a push', async () => {
+  const harness = makeHarness({
+    pulls: [makePull(10)],
+    armError: new Error('expected head mismatch'),
+    armErrorHead: 'pushed-head',
+  });
+
+  await assert.rejects(runController(harness.args), /Pull request head moved/);
+
+  assert.deepEqual(harness.calls.armExpectedHeads, ['head-10']);
+  assert.deepEqual(harness.calls.armed, []);
+  assert.deepEqual(harness.calls.merged, []);
+  assert.match(harness.calls.comments[0].body, /Pull request head moved/);
 });

--- a/scripts/queue_me_controller.test.js
+++ b/scripts/queue_me_controller.test.js
@@ -14,6 +14,7 @@ function makePull(number, overrides = {}) {
     draft: false,
     maintainer_can_modify: true,
     base: {
+      ref: 'main',
       repo: {
         name: 'lopper',
         owner: { login: 'octo' },
@@ -159,6 +160,7 @@ function makeHarness(options = {}) {
         action: options.action || 'labeled',
         label: { name: 'queue-me' },
         pull_request: eventPull,
+        sender: options.sender || { login: 'octocat', type: 'User' },
       }
     : {};
   return {
@@ -172,6 +174,7 @@ function makeHarness(options = {}) {
       core: {
         notice: (message) => calls.notices.push(message),
       },
+      queueAppSlug: options.queueAppSlug,
     },
     calls,
   };
@@ -278,16 +281,15 @@ test('removing queue-me disables auto-merge and leaves an empty queue green', as
   assert.equal(harness.calls.notices.length, 1);
 });
 
-test('drafts and unmodifiable forks pause before rebase or auto-merge', async (t) => {
+test('drafts and fork branches pause before rebase or auto-merge', async (t) => {
   const cases = [
     { name: 'draft', pull: makePull(10, { draft: true }), message: /still a draft/ },
     {
       name: 'fork',
       pull: makePull(10, {
         head: { sha: 'fork-head', repo: { full_name: 'contributor/lopper' } },
-        maintainer_can_modify: false,
       }),
-      message: /maintainers cannot rebase this fork branch/,
+      message: /queue App cannot update fork branches/,
     },
   ];
 
@@ -344,4 +346,61 @@ test('controller never merges an unverified head after auto-merge arming races a
   assert.deepEqual(harness.calls.armed, []);
   assert.deepEqual(harness.calls.merged, []);
   assert.match(harness.calls.comments[0].body, /Pull request head moved/);
+});
+
+test('changing a queued pull request away from main disables auto-merge', async () => {
+  const pull = makePull(10);
+  pull.base.ref = 'release';
+  const harness = makeHarness({
+    eventPull: pull,
+    action: 'edited',
+    initialStates: {
+      10: { autoMergeRequest: { enabledAt: 'before', mergeMethod: 'SQUASH' } },
+    },
+  });
+
+  await runController(harness.args);
+
+  assert.deepEqual(harness.calls.disabled, [10]);
+  assert.deepEqual(harness.calls.armed, []);
+  assert.match(harness.calls.comments[0].body, /base changed to `release`/);
+  assert.equal(harness.calls.notices.length, 1);
+});
+
+test('manually enabling auto-merge on a follower restores queue ordering', async () => {
+  const leader = makePull(10);
+  const follower = makePull(20);
+  const harness = makeHarness({
+    pulls: [leader, follower],
+    eventPull: follower,
+    action: 'auto_merge_enabled',
+    initialStates: {
+      20: { autoMergeRequest: { enabledAt: 'manual', mergeMethod: 'SQUASH' } },
+    },
+  });
+
+  await runController(harness.args);
+
+  assert.deepEqual(harness.calls.disabled, [20]);
+  assert.deepEqual(harness.calls.armed, [10]);
+});
+
+test("the queue App's leader auto-merge event does not trigger a disable-enable loop", async () => {
+  const leader = makePull(10);
+  const harness = makeHarness({
+    pulls: [leader],
+    eventPull: leader,
+    action: 'auto_merge_enabled',
+    queueAppSlug: 'queue-app',
+    sender: { login: 'queue-app[bot]', type: 'Bot' },
+    initialStates: {
+      10: { autoMergeRequest: { enabledAt: 'controller', mergeMethod: 'SQUASH' } },
+    },
+  });
+
+  await runController(harness.args);
+
+  assert.deepEqual(harness.calls.disabled, []);
+  assert.deepEqual(harness.calls.armed, []);
+  assert.match(harness.calls.notices[0], /Ignoring the queue App's auto-merge event/);
 });

--- a/scripts/queue_me_controller.test.js
+++ b/scripts/queue_me_controller.test.js
@@ -1,0 +1,302 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const runController = require('./queue_me_controller.js');
+const { testables } = runController;
+
+function makePull(number, overrides = {}) {
+  return {
+    number,
+    node_id: `PR_${number}`,
+    labels: [{ name: 'queue-me' }],
+    draft: false,
+    maintainer_can_modify: true,
+    base: {
+      repo: {
+        name: 'lopper',
+        owner: { login: 'octo' },
+      },
+    },
+    head: {
+      sha: `head-${number}`,
+      repo: { full_name: 'octo/lopper' },
+    },
+    ...overrides,
+  };
+}
+
+function makeHarness(options = {}) {
+  const pulls = options.pulls || [];
+  const eventPull = options.eventPull;
+  const allPulls = eventPull && !pulls.some((pull) => pull.number === eventPull.number)
+    ? [...pulls, eventPull]
+    : pulls;
+  const states = new Map(
+    allPulls.map((pull) => [
+      pull.number,
+      {
+        id: pull.node_id,
+        number: pull.number,
+        headRefOid: pull.head.sha,
+        isDraft: pull.draft,
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'BLOCKED',
+        autoMergeRequest: null,
+        ...(options.initialStates?.[pull.number] || {}),
+      },
+    ]),
+  );
+  const comments = new Map();
+  const calls = {
+    armed: [],
+    comments: [],
+    createdLabels: [],
+    disabled: [],
+    merged: [],
+    notices: [],
+    rebased: [],
+  };
+  const repository = { default_branch: 'main', full_name: 'octo/lopper' };
+
+  const github = {
+    rest: {
+      issues: {
+        getLabel: async () => {
+          if (options.labelMissing) {
+            const error = new Error('label missing');
+            error.status = 404;
+            throw error;
+          }
+        },
+        createLabel: async (input) => {
+          calls.createdLabels.push(input.name);
+        },
+        listComments: async () => {},
+        createComment: async (input) => {
+          const comment = { id: calls.comments.length + 1, body: input.body, user: { type: 'Bot' } };
+          comments.set(input.issue_number, [comment]);
+          calls.comments.push({ number: input.issue_number, body: input.body });
+        },
+        updateComment: async (input) => {
+          calls.comments.push({ number: undefined, body: input.body });
+        },
+      },
+      pulls: {
+        list: async () => {},
+      },
+      repos: {
+        get: async () => ({ data: repository }),
+        getBranch: async () => ({ data: { commit: { sha: 'base-sha' } } }),
+        compareCommitsWithBasehead: async () => ({
+          data: { status: options.comparisonStatus || 'ahead' },
+        }),
+      },
+    },
+    paginate: async (_method, input) => {
+      if (input.issue_number) {
+        return comments.get(input.issue_number) || [];
+      }
+      return pulls;
+    },
+    graphql: async (query, variables) => {
+      if (query.includes('QueuePullState($owner')) {
+        return { repository: { pullRequest: states.get(variables.number) } };
+      }
+      if (query.includes('QueuePullStateByID')) {
+        return {
+          node: [...states.values()].find((state) => state.id === variables.pullRequestId),
+        };
+      }
+      if (query.includes('DisableQueueAutoMerge')) {
+        const state = [...states.values()].find((value) => value.id === variables.pullRequestId);
+        state.autoMergeRequest = null;
+        calls.disabled.push(state.number);
+        return { disablePullRequestAutoMerge: { pullRequest: { number: state.number } } };
+      }
+      if (query.includes('RebaseQueuedPull')) {
+        if (options.rebaseError) {
+          throw options.rebaseError;
+        }
+        const state = [...states.values()].find((value) => value.id === variables.pullRequestId);
+        state.headRefOid = options.rebasedHead || `rebased-${state.number}`;
+        calls.rebased.push(state.number);
+        return { updatePullRequestBranch: { pullRequest: state } };
+      }
+      if (query.includes('ArmQueueAutoMerge')) {
+        const state = [...states.values()].find((value) => value.id === variables.pullRequestId);
+        state.autoMergeRequest = { enabledAt: 'now', mergeMethod: 'SQUASH' };
+        calls.armed.push(state.number);
+        return { enablePullRequestAutoMerge: { pullRequest: state } };
+      }
+      if (query.includes('MergeQueuedPull')) {
+        const state = [...states.values()].find((value) => value.id === variables.pullRequestId);
+        calls.merged.push(state.number);
+        return { mergePullRequest: { pullRequest: { number: state.number, merged: true } } };
+      }
+      throw new Error(`unexpected GraphQL operation: ${query}`);
+    },
+  };
+
+  const payload = eventPull
+    ? {
+        action: options.action || 'labeled',
+        label: { name: 'queue-me' },
+        pull_request: eventPull,
+      }
+    : {};
+  return {
+    args: {
+      github,
+      context: {
+        repo: { owner: 'octo', repo: 'lopper' },
+        eventName: eventPull ? 'pull_request_target' : 'workflow_dispatch',
+        payload,
+      },
+      core: {
+        notice: (message) => calls.notices.push(message),
+      },
+    },
+    calls,
+  };
+}
+
+test('sortQueuedPulls uses deterministic ascending PR numbers', () => {
+  const sorted = testables.sortQueuedPulls([{ number: 42 }, { number: 7 }, { number: 19 }]);
+  assert.deepEqual(sorted.map((pull) => pull.number), [7, 19, 42]);
+});
+
+test('hasLabel accepts REST label objects and string labels', () => {
+  assert.equal(testables.hasLabel({ labels: [{ name: 'queue-me' }] }, 'queue-me'), true);
+  assert.equal(testables.hasLabel({ labels: ['queue-me'] }, 'queue-me'), true);
+  assert.equal(testables.hasLabel({ labels: [{ name: 'other' }] }, 'queue-me'), false);
+  assert.equal(testables.hasLabel({}, 'queue-me'), false);
+});
+
+test('isBranchCurrent accepts only ancestor-preserving compare states', () => {
+  assert.equal(testables.isBranchCurrent('ahead'), true);
+  assert.equal(testables.isBranchCurrent('identical'), true);
+  assert.equal(testables.isBranchCurrent('behind'), false);
+  assert.equal(testables.isBranchCurrent('diverged'), false);
+});
+
+test('status helpers bound untrusted API text', () => {
+  assert.equal(testables.shortSHA('1234567890abcdef'), '1234567890');
+  assert.equal(testables.shortSHA(undefined), 'unknown');
+  const sanitized = testables.safeError(new Error('bad `branch`'));
+  assert.equal(sanitized, "bad 'branch'");
+  assert.equal(testables.safeError('x'.repeat(1300)).length, 1200);
+});
+
+test('controller creates the queue label and exits cleanly for an empty queue', async () => {
+  const harness = makeHarness({ labelMissing: true });
+
+  await runController(harness.args);
+
+  assert.deepEqual(harness.calls.createdLabels, ['queue-me']);
+  assert.equal(harness.calls.notices.length, 1);
+  assert.match(harness.calls.notices[0], /No open main pull requests/);
+});
+
+test('controller disables followers and arms only the oldest numbered pull request', async () => {
+  const leader = makePull(10);
+  const follower = makePull(20);
+  const harness = makeHarness({
+    pulls: [follower, leader],
+    eventPull: follower,
+    initialStates: {
+      20: { autoMergeRequest: { enabledAt: 'before', mergeMethod: 'SQUASH' } },
+    },
+  });
+
+  await runController(harness.args);
+
+  assert.deepEqual(harness.calls.disabled, [20]);
+  assert.deepEqual(harness.calls.armed, [10]);
+  assert.deepEqual(harness.calls.merged, []);
+  assert.match(
+    harness.calls.comments.find((comment) => comment.number === 20).body,
+    /Queued behind #10/,
+  );
+  assert.match(
+    harness.calls.comments.find((comment) => comment.number === 10).body,
+    /Squash auto-merge is armed/,
+  );
+});
+
+test('controller rebases a stale leader and merges it when repository rules are satisfied', async () => {
+  const leader = makePull(10);
+  const harness = makeHarness({
+    pulls: [leader],
+    comparisonStatus: 'behind',
+    initialStates: {
+      10: { mergeStateStatus: 'CLEAN' },
+    },
+  });
+
+  await runController(harness.args);
+
+  assert.deepEqual(harness.calls.rebased, [10]);
+  assert.deepEqual(harness.calls.merged, [10]);
+  assert.deepEqual(harness.calls.armed, []);
+  assert.match(harness.calls.comments[0].body, /Rebased/);
+  assert.match(harness.calls.comments[0].body, /GitHub squash-merged it/);
+});
+
+test('removing queue-me disables auto-merge and leaves an empty queue green', async () => {
+  const pull = makePull(10, { labels: [] });
+  const harness = makeHarness({
+    eventPull: pull,
+    action: 'unlabeled',
+    initialStates: {
+      10: { autoMergeRequest: { enabledAt: 'before', mergeMethod: 'SQUASH' } },
+    },
+  });
+
+  await runController(harness.args);
+
+  assert.deepEqual(harness.calls.disabled, [10]);
+  assert.deepEqual(harness.calls.armed, []);
+  assert.match(harness.calls.comments[0].body, /automatic merge is disabled/);
+  assert.equal(harness.calls.notices.length, 1);
+});
+
+test('drafts and unmodifiable forks pause before rebase or auto-merge', async (t) => {
+  const cases = [
+    { name: 'draft', pull: makePull(10, { draft: true }), message: /still a draft/ },
+    {
+      name: 'fork',
+      pull: makePull(10, {
+        head: { sha: 'fork-head', repo: { full_name: 'contributor/lopper' } },
+        maintainer_can_modify: false,
+      }),
+      message: /maintainers cannot rebase this fork branch/,
+    },
+  ];
+
+  for (const scenario of cases) {
+    await t.test(scenario.name, async () => {
+      const harness = makeHarness({ pulls: [scenario.pull] });
+      await runController(harness.args);
+      assert.deepEqual(harness.calls.rebased, []);
+      assert.deepEqual(harness.calls.armed, []);
+      assert.match(harness.calls.comments[0].body, scenario.message);
+    });
+  }
+});
+
+test('a rebase conflict pauses the queue with a bounded status message', async () => {
+  const leader = makePull(10);
+  const harness = makeHarness({
+    pulls: [leader],
+    comparisonStatus: 'behind',
+    rebaseError: new Error('conflict in `workflow`'),
+  });
+
+  await assert.rejects(runController(harness.args), /conflict/);
+
+  assert.deepEqual(harness.calls.armed, []);
+  assert.match(harness.calls.comments[0].body, /could not rebase/);
+  assert.match(harness.calls.comments[0].body, /conflict in 'workflow'/);
+});

--- a/scripts/queue_me_controller.test.js
+++ b/scripts/queue_me_controller.test.js
@@ -281,27 +281,42 @@ test('removing queue-me disables auto-merge and leaves an empty queue green', as
   assert.equal(harness.calls.notices.length, 1);
 });
 
-test('drafts and fork branches pause before rebase or auto-merge', async (t) => {
+test('drafts and stale fork branches pause before rebase or auto-merge', async (t) => {
   const cases = [
     { name: 'draft', pull: makePull(10, { draft: true }), message: /still a draft/ },
     {
-      name: 'fork',
+      name: 'stale fork',
       pull: makePull(10, {
         head: { sha: 'fork-head', repo: { full_name: 'contributor/lopper' } },
       }),
-      message: /queue App cannot update fork branches/,
+      options: { comparisonStatus: 'behind' },
+      message: /queue App cannot update it/,
     },
   ];
 
   for (const scenario of cases) {
     await t.test(scenario.name, async () => {
-      const harness = makeHarness({ pulls: [scenario.pull] });
+      const harness = makeHarness({ pulls: [scenario.pull], ...scenario.options });
       await runController(harness.args);
       assert.deepEqual(harness.calls.rebased, []);
       assert.deepEqual(harness.calls.armed, []);
       assert.match(harness.calls.comments[0].body, scenario.message);
     });
   }
+});
+
+test('a current fork branch can arm auto-merge without a branch update', async () => {
+  const fork = makePull(10, {
+    head: { sha: 'fork-head', repo: { full_name: 'contributor/lopper' } },
+  });
+  const harness = makeHarness({ pulls: [fork], comparisonStatus: 'ahead' });
+
+  await runController(harness.args);
+
+  assert.deepEqual(harness.calls.rebased, []);
+  assert.deepEqual(harness.calls.armed, [10]);
+  assert.deepEqual(harness.calls.armExpectedHeads, ['fork-head']);
+  assert.match(harness.calls.comments[0].body, /Squash auto-merge is armed/);
 });
 
 test('a rebase conflict pauses the queue with a bounded status message', async () => {

--- a/scripts/queue_me_workflow_test.go
+++ b/scripts/queue_me_workflow_test.go
@@ -28,6 +28,8 @@ func TestQueueMeWorkflowContract(t *testing.T) {
 		"- edited",
 		"- auto_merge_enabled",
 		"cancel-in-progress: false",
+		"github.event_name == 'workflow_dispatch' &&",
+		"github.ref == 'refs/heads/main'",
 		"permissions:\n  contents: read",
 		"actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
 		"client-id: ${{ vars.QUEUE_APP_CLIENT_ID }}",

--- a/scripts/queue_me_workflow_test.go
+++ b/scripts/queue_me_workflow_test.go
@@ -96,7 +96,7 @@ func TestQueueMeControllerNodeSuite(t *testing.T) {
 		t.Fatal("node is required to test the queue-me controller")
 	}
 	command := exec.Command(node, "--test", "queue_me_controller.test.js")
-	command.Dir = "."
+	command.Dir = repoPath(t, "scripts")
 	output, err := command.CombinedOutput()
 	if err != nil {
 		t.Fatalf("queue-me node tests failed: %v\n%s", err, output)

--- a/scripts/queue_me_workflow_test.go
+++ b/scripts/queue_me_workflow_test.go
@@ -1,0 +1,101 @@
+package scripts
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestQueueMeWorkflowContract(t *testing.T) {
+	workflowText := readConfig(t, ".github/workflows/queue-me.yml")
+	var workflow map[string]any
+	if err := yaml.Unmarshal([]byte(workflowText), &workflow); err != nil {
+		t.Fatalf("parse queue-me workflow: %v", err)
+	}
+
+	required := []string{
+		"pull_request_target:",
+		"workflow_dispatch:",
+		"push:",
+		"- main",
+		"- labeled",
+		"- unlabeled",
+		"- synchronize",
+		"- converted_to_draft",
+		"- closed",
+		"cancel-in-progress: false",
+		"permissions:\n  contents: read",
+		"actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+		"ref: ${{ github.workflow_sha }}",
+		"persist-credentials: false",
+		"actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
+		"client-id: ${{ vars.QUEUE_APP_CLIENT_ID }}",
+		"private-key: ${{ secrets.QUEUE_APP_PRIVATE_KEY }}",
+		"permission-contents: write",
+		"permission-issues: write",
+		"permission-pull-requests: write",
+		"actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+		"QUEUE_LABEL: queue-me",
+		"scripts/queue_me_controller.js",
+	}
+	for _, fragment := range required {
+		if !strings.Contains(workflowText, fragment) {
+			t.Fatalf("queue-me workflow missing %q", fragment)
+		}
+	}
+	for _, forbidden := range []string{
+		"actions/checkout@v",
+		"actions/github-script@v",
+		"pull_request:\n",
+		"persist-credentials: true",
+	} {
+		if strings.Contains(workflowText, forbidden) {
+			t.Fatalf("queue-me workflow contains unsafe fragment %q", forbidden)
+		}
+	}
+}
+
+func TestQueueMeControllerContract(t *testing.T) {
+	controller := readConfig(t, "scripts/queue_me_controller.js")
+	for _, fragment := range []string{
+		"compareCommitsWithBasehead",
+		"updatePullRequestBranch",
+		"expectedHeadOid",
+		"updateMethod: REBASE",
+		"enablePullRequestAutoMerge",
+		"disablePullRequestAutoMerge",
+		"mergePullRequest",
+		"mergeMethod: SQUASH",
+		"maintainer_can_modify",
+		"left.number - right.number",
+		"COMMENT_MARKER",
+	} {
+		if !strings.Contains(controller, fragment) {
+			t.Fatalf("queue-me controller missing %q", fragment)
+		}
+	}
+	for _, forbidden := range []string{
+		"requestReviews",
+		"force-push",
+		"process.env.QUEUE_APP_PRIVATE_KEY",
+	} {
+		if strings.Contains(controller, forbidden) {
+			t.Fatalf("queue-me controller contains forbidden fragment %q", forbidden)
+		}
+	}
+}
+
+func TestQueueMeControllerNodeSuite(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Fatal("node is required to test the queue-me controller")
+	}
+	command := exec.Command(node, "--test", "queue_me_controller.test.js")
+	command.Dir = "."
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("queue-me node tests failed: %v\n%s", err, output)
+	}
+}

--- a/scripts/queue_me_workflow_test.go
+++ b/scripts/queue_me_workflow_test.go
@@ -33,6 +33,7 @@ func TestQueueMeWorkflowContract(t *testing.T) {
 		"permission-contents: write",
 		"permission-issues: write",
 		"permission-pull-requests: write",
+		"permission-workflows: write",
 		"actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
 		"QUEUE_CONTROLLER_PATH: ${{ runner.temp }}/queue_me_controller.js",
 		"TRUSTED_CONTROLLER_REF: ${{ github.workflow_sha }}",

--- a/scripts/queue_me_workflow_test.go
+++ b/scripts/queue_me_workflow_test.go
@@ -27,9 +27,6 @@ func TestQueueMeWorkflowContract(t *testing.T) {
 		"- closed",
 		"cancel-in-progress: false",
 		"permissions:\n  contents: read",
-		"actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
-		"ref: ${{ github.workflow_sha }}",
-		"persist-credentials: false",
 		"actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
 		"client-id: ${{ vars.QUEUE_APP_CLIENT_ID }}",
 		"private-key: ${{ secrets.QUEUE_APP_PRIVATE_KEY }}",
@@ -37,8 +34,14 @@ func TestQueueMeWorkflowContract(t *testing.T) {
 		"permission-issues: write",
 		"permission-pull-requests: write",
 		"actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+		"QUEUE_CONTROLLER_PATH: ${{ runner.temp }}/queue_me_controller.js",
+		"TRUSTED_CONTROLLER_REF: ${{ github.workflow_sha }}",
+		"github.rest.repos.getContent",
+		"path: 'scripts/queue_me_controller.js'",
+		"ref: process.env.TRUSTED_CONTROLLER_REF",
+		"flag: 'wx'",
 		"QUEUE_LABEL: queue-me",
-		"scripts/queue_me_controller.js",
+		"require(process.env.QUEUE_CONTROLLER_PATH)",
 	}
 	for _, fragment := range required {
 		if !strings.Contains(workflowText, fragment) {
@@ -46,10 +49,10 @@ func TestQueueMeWorkflowContract(t *testing.T) {
 		}
 	}
 	for _, forbidden := range []string{
-		"actions/checkout@v",
+		"actions/checkout@",
 		"actions/github-script@v",
+		"github.event.pull_request.head",
 		"pull_request:\n",
-		"persist-credentials: true",
 	} {
 		if strings.Contains(workflowText, forbidden) {
 			t.Fatalf("queue-me workflow contains unsafe fragment %q", forbidden)

--- a/scripts/queue_me_workflow_test.go
+++ b/scripts/queue_me_workflow_test.go
@@ -25,6 +25,8 @@ func TestQueueMeWorkflowContract(t *testing.T) {
 		"- synchronize",
 		"- converted_to_draft",
 		"- closed",
+		"- edited",
+		"- auto_merge_enabled",
 		"cancel-in-progress: false",
 		"permissions:\n  contents: read",
 		"actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
@@ -42,6 +44,7 @@ func TestQueueMeWorkflowContract(t *testing.T) {
 		"ref: process.env.TRUSTED_CONTROLLER_REF",
 		"flag: 'wx'",
 		"QUEUE_LABEL: queue-me",
+		"QUEUE_APP_SLUG: ${{ steps.queue_token.outputs.app-slug }}",
 		"require(process.env.QUEUE_CONTROLLER_PATH)",
 	}
 	for _, fragment := range required {
@@ -72,7 +75,6 @@ func TestQueueMeControllerContract(t *testing.T) {
 		"disablePullRequestAutoMerge",
 		"mergePullRequest",
 		"mergeMethod: SQUASH",
-		"maintainer_can_modify",
 		"left.number - right.number",
 		"COMMENT_MARKER",
 	} {


### PR DESCRIPTION
## Summary

Add a repository-hosted pull request queue for this personal-owner repository, where GitHub's native merge queue is unavailable. Applying the general `queue-me` label now selects pull requests for deterministic rebase-and-squash processing while the existing ruleset remains authoritative.

## Changes

- add a serialized `pull_request_target` controller that materializes only the controller blob from the exact trusted workflow SHA
- issue a repository-scoped GitHub App token for branch updates, comments, label creation, and merges
- process queued pull requests by ascending PR number, rebasing only the leader onto the exact current default branch
- disable auto-merge for followers and arm squash auto-merge only after the leader head is verified
- pause safely on drafts, conflicts, and unmodifiable forks, with one sticky queue-status comment
- add controller-path tests, workflow security-contract tests, setup documentation, and local `act` guidance

## Validation

Commands and checks run:

```bash
make ci
node --experimental-test-coverage --test scripts/queue_me_controller.test.js
act workflow_dispatch -W .github/workflows/queue-me.yml --job advance --strict --dryrun
act workflow_dispatch -W .github/workflows/queue-me.yml --job advance --strict --pull=false --rm --container-architecture linux/amd64
```

Additional manual validation:

- confirmed the no-credential `act` run emits the inactive-controller notice, skips token creation and API writes, and succeeds
- confirmed controller-path coverage is 84.96% lines, 88.41% branches, and 90.00% functions
- confirmed the complete repository gate passes with 98.2% Go coverage and no lint, security, vulnerability, race, or benchmark failures

## Risk and compatibility

- Breaking changes: none
- Migration required: none; activation requires the documented GitHub App variable and secret
- Performance impact: bounded GitHub API calls serialized by repository-wide workflow concurrency
- Memory benchmark impact: none; the memory benchmark gate passes without regression

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
