### PR TITLE
fix(release): close late publication review findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,6 +415,7 @@ jobs:
             fi
           done
 
+          rm -rf -- publication-inputs
           mkdir -p publication-inputs/dist
           cp -- "${assets[@]}" publication-inputs/dist/
           cp -- feature-flags.md publication-inputs/feature-flags.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -436,15 +436,15 @@ func TestReleaseWorkflowManualReleaseRequiresExistingReleaseAfterExplicit404(t *
 	}
 }
 
-func TestReleaseWorkflowConfinesMainSyncPATToTrustedFeatureHistoryPush(t *testing.T) {
+func TestReleaseWorkflowConfinesMainSyncPATToReleasePleaseAndTrustedFeatureHistoryPush(t *testing.T) {
 	t.Parallel()
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
 	releasePlease := workflowStepByName(t, workflow.Jobs, "prepare-release", "Run release-please")
-	if got := releasePlease.With["token"]; got != "${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}" {
-		t.Fatalf("release-please token = %q, want RELEASE_PLEASE_TOKEN fallback to GITHUB_TOKEN", got)
+	if got := releasePlease.With["token"]; got != "${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}" {
+		t.Fatalf("release-please token = %q, want RELEASE_PLEASE_TOKEN fallback to MAIN_SYNC_PAT then GITHUB_TOKEN", got)
 	}
 
 	manual := workflowStepByName(t, workflow.Jobs, "prepare-release", "Prepare manual release")
@@ -453,8 +453,8 @@ func TestReleaseWorkflowConfinesMainSyncPATToTrustedFeatureHistoryPush(t *testin
 	}
 
 	workflowText := readConfig(t, ".github/workflows/release.yml")
-	if got := strings.Count(workflowText, "secrets.MAIN_SYNC_PAT"); got != 1 {
-		t.Fatalf("release workflow MAIN_SYNC_PAT references = %d, want only trusted feature history push fallback", got)
+	if got := strings.Count(workflowText, "secrets.MAIN_SYNC_PAT"); got != 2 {
+		t.Fatalf("release workflow MAIN_SYNC_PAT references = %d, want release-please and trusted feature history push fallbacks only", got)
 	}
 	if !strings.Contains(workflowText, "PUSH_TOKEN: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}") {
 		t.Fatal("trusted feature history push must retain MAIN_SYNC_PAT fallback to GITHUB_TOKEN")
@@ -508,7 +508,7 @@ func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
 	want := []string{
-		"jobs.prepare-release.steps.Run release-please#1.with.token=${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}",
+		"jobs.prepare-release.steps.Run release-please#1.with.token=${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}",
 		"jobs.prepare-release.steps.Checkout release metadata#1.with.token=${{ secrets.GITHUB_TOKEN }}",
 		"jobs.prepare-release.steps.Prepare manual release#1.env.GH_TOKEN=${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}",
 		"jobs.prepare-marketplace-toolchain.steps.Detect Marketplace token#1.env.VSCE_PUBLISH=${{ secrets.VSCE_PUBLISH }}",

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -478,10 +478,15 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	assertWorkflowStepRunContainsAll(t, stageStep, "release publication staging step", []string{
 		`find dist -maxdepth 1 -type f`,
 		`lopper-vscode-${version}.vsix`,
+		`rm -rf -- publication-inputs`,
+		`mkdir -p publication-inputs/dist`,
 		`publication-inputs/feature-flags.md`,
 		`mapfile -d '' checksum_files`,
 		`sha256sum "${checksum_files[@]}" > SHA256SUMS`,
 	})
+	assertTextAppearsBefore(t, stageStep.Run, `rm -rf -- publication-inputs`, `mkdir -p publication-inputs/dist`, "release publication staging must remove prior inputs before recreating the directory")
+	assertTextAppearsBefore(t, stageStep.Run, `mkdir -p publication-inputs/dist`, `cp -- "${assets[@]}" publication-inputs/dist/`, "release publication staging must recreate the directory before copying bounded assets")
+	assertTextAppearsBefore(t, stageStep.Run, `mkdir -p publication-inputs/dist`, `cp -- feature-flags.md publication-inputs/feature-flags.md`, "release publication staging must recreate the directory before copying the feature report")
 	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{label: "release publication input artifact name", got: uploadStep.With["name"], want: "publication-inputs"},


### PR DESCRIPTION
## Summary

Close two late Codex findings that arrived after the Aardvark release hardening pull requests had merged: rebuild publication staging from a clean directory and preserve the documented release-please personal access token fallback.

## Changes

- Remove and recreate `publication-inputs` before copying the already validated release assets and generating checksums.
- Lock the removal, recreation, and bounded-copy ordering with workflow regression assertions.
- Restore the release-please token order to `RELEASE_PLEASE_TOKEN`, then `MAIN_SYNC_PAT`, then `GITHUB_TOKEN`.
- Keep `MAIN_SYNC_PAT` excluded from the manual release shell path and constrained to the pinned release-please action plus the existing trusted feature-history push.
- Update the exact credential-binding audit to reject any additional secret exposure.

## Validation

- Focused release workflow Go tests passed after each corrective commit.
- `actionlint .github/workflows/release.yml` passed after each corrective commit.
- Full `make ci` passed in both commit hooks, including lint, security, tests, race, memory benchmarks, build, and 98.2% total coverage.
- `git diff --check` passed.

## Risk and compatibility

- Breaking changes: none.
- Migration required: none; repositories using the documented `MAIN_SYNC_PAT` fallback retain their existing behavior.
- Performance impact: negligible cleanup of one small staging directory during stable release preparation.
- Memory benchmark impact: none; the memory regression gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
