### PR TITLE
refactor(rust): remove unreachable decoder branches

### DIFF
--- a/internal/lang/rust/scan_imports.go
+++ b/internal/lang/rust/scan_imports.go
@@ -381,18 +381,12 @@ func consumeRustIdentifier(value []byte) (string, int, bool) {
 		return "", 0, false
 	}
 	first, width := utf8.DecodeRune(value)
-	if first == utf8.RuneError && width == 0 {
-		return "", 0, false
-	}
 	if !isRustIdentifierStartRune(first) {
 		return "", 0, false
 	}
 	index := width
 	for index < len(value) {
 		r, w := utf8.DecodeRune(value[index:])
-		if r == utf8.RuneError && w == 0 {
-			break
-		}
 		if !isRustIdentifierContinueRune(r) {
 			break
 		}

--- a/internal/lang/rust/scan_use.go
+++ b/internal/lang/rust/scan_use.go
@@ -95,9 +95,6 @@ func countRustDeclarationTokens(clause string, wanted map[string]struct{}) map[s
 func nextRustIdentifierToken(content string, searchStart int) (string, int, bool) {
 	for searchStart < len(content) {
 		r, width := utf8.DecodeRuneInString(content[searchStart:])
-		if r == utf8.RuneError && width == 0 {
-			return "", searchStart, false
-		}
 		if !isRustIdentifierStartRune(r) {
 			searchStart += width
 			continue
@@ -107,9 +104,6 @@ func nextRustIdentifierToken(content string, searchStart int) (string, int, bool
 		searchStart += width
 		for searchStart < len(content) {
 			next, nextWidth := utf8.DecodeRuneInString(content[searchStart:])
-			if next == utf8.RuneError && nextWidth == 0 {
-				break
-			}
 			if !isRustIdentifierContinueRune(next) {
 				break
 			}


### PR DESCRIPTION
## Summary

Apply the one material simplification found by the mandatory 48-file Aardvark cleanup pass: remove impossible UTF-8 decoder branches from the Rust import scanners while preserving malformed-input and Unicode behavior.

## Changes

- Remove four `width == 0` branches that cannot execute because each decoder call is guarded by a non-empty byte or string slice.
- Keep identifier parsing, malformed-byte handling, Unicode recognition, token boundaries, and public behavior unchanged.
- Retain the existing malformed-input and Unicode regression suite as the behavior lock.

## Validation

- `go test -count=1 ./internal/lang/rust`
- `go test -race -count=1 ./internal/lang/rust`
- `go vet ./internal/lang/rust`
- `gofmt -d internal/lang/rust/scan_imports.go internal/lang/rust/scan_use.go`
- Full `make ci` in the commit hook: formatting, module verification, lint, actionlint, security scans, vulnerability scan, unit and leak tests, race tests, memory benchmarks, build, and coverage all passed.
- Total coverage: 98.3%; memory benchmark gate: passed; new-code duplication: 0.00%.

## Risk and compatibility

- Breaking changes: none.
- Migration required: none.
- Performance impact: negligible reduction in unreachable conditional checks.
- Memory benchmark impact: none; the memory regression gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
