### PR TITLE
fix(release): isolate publication artifact trust boundaries

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf -- dist
-          mkdir -- dist
+          mkdir dist
 
       - name: Build Linux/Windows release artifacts
         env:
@@ -186,7 +186,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf -- dist
-          mkdir -- dist
+          mkdir dist
 
       - name: Build Darwin release artifact
         env:

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Reset Linux/Windows artifact staging
         env:
           PATH: /usr/bin:/bin
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           rm -rf -- dist
@@ -93,7 +93,7 @@ jobs:
         env:
           PATH: /usr/bin:/bin
           RELEASE_TAG: ${{ inputs.tag }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           expected=(
@@ -182,7 +182,7 @@ jobs:
       - name: Reset Darwin arm64 artifact staging
         env:
           PATH: /usr/bin:/bin
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           rm -rf -- dist
@@ -207,7 +207,7 @@ jobs:
         env:
           PATH: /usr/bin:/bin
           RELEASE_TAG: ${{ inputs.tag }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           expected=("dist/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz")

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -66,6 +66,15 @@ jobs:
           make tools-install
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+      - name: Reset Linux/Windows artifact staging
+        env:
+          PATH: /usr/bin:/bin
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          rm -rf -- dist
+          mkdir -- dist
+
       - name: Build Linux/Windows release artifacts
         env:
           TAG: ${{ inputs.tag }}
@@ -80,13 +89,49 @@ jobs:
             RELEASE_BUILD_CHANNEL="$BUILD_CHANNEL" \
             PLATFORMS="linux/amd64 linux/arm64 windows/amd64 windows/arm64"
 
+      - name: Validate Linux/Windows release artifacts
+        env:
+          PATH: /usr/bin:/bin
+          RELEASE_TAG: ${{ inputs.tag }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          expected=(
+            "dist/lopper_${RELEASE_TAG}_linux_amd64.tar.gz"
+            "dist/lopper_${RELEASE_TAG}_linux_arm64.tar.gz"
+            "dist/lopper_${RELEASE_TAG}_windows_amd64.zip"
+            "dist/lopper_${RELEASE_TAG}_windows_arm64.zip"
+          )
+          if find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Linux/Windows artifact staging contains a non-regular entry" >&2
+            exit 1
+          fi
+          file_count="$(find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [ "${file_count}" -ne "${#expected[@]}" ]; then
+            echo "Linux/Windows artifact staging contains an unexpected file count" >&2
+            exit 1
+          fi
+          for artifact in "${expected[@]}"; do
+            if [ ! -f "${artifact}" ] || [ -L "${artifact}" ]; then
+              echo "Expected Linux/Windows artifact ${artifact} is missing or not a regular file" >&2
+              exit 1
+            fi
+            if [ ! -s "${artifact}" ]; then
+              echo "Expected Linux/Windows artifact ${artifact} is empty" >&2
+              exit 1
+            fi
+          done
+
       - name: Upload Linux/Windows artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ inputs.artifact_prefix }}-linux-windows
           path: |
-            dist/*.tar.gz
-            dist/*.zip
+            dist/lopper_${{ inputs.tag }}_linux_amd64.tar.gz
+            dist/lopper_${{ inputs.tag }}_linux_arm64.tar.gz
+            dist/lopper_${{ inputs.tag }}_windows_amd64.zip
+            dist/lopper_${{ inputs.tag }}_windows_arm64.zip
+          if-no-files-found: error
 
   build-darwin:
     runs-on: macos-26
@@ -134,6 +179,15 @@ jobs:
           make tools-install
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+      - name: Reset Darwin arm64 artifact staging
+        env:
+          PATH: /usr/bin:/bin
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          rm -rf -- dist
+          mkdir -- dist
+
       - name: Build Darwin release artifact
         env:
           TAG: ${{ inputs.tag }}
@@ -149,13 +203,40 @@ jobs:
             RELEASE_BUILD_CHANNEL="$BUILD_CHANNEL" \
             PLATFORMS="darwin/${host_goarch}"
 
+      - name: Validate Darwin arm64 release artifact
+        env:
+          PATH: /usr/bin:/bin
+          RELEASE_TAG: ${{ inputs.tag }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          expected=("dist/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz")
+          if find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Darwin arm64 artifact staging contains a non-regular entry" >&2
+            exit 1
+          fi
+          file_count="$(find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [ "${file_count}" -ne "${#expected[@]}" ]; then
+            echo "Darwin arm64 artifact staging contains an unexpected file count" >&2
+            exit 1
+          fi
+          for artifact in "${expected[@]}"; do
+            if [ ! -f "${artifact}" ] || [ -L "${artifact}" ]; then
+              echo "Expected Darwin arm64 artifact ${artifact} is missing or not a regular file" >&2
+              exit 1
+            fi
+            if [ ! -s "${artifact}" ]; then
+              echo "Expected Darwin arm64 artifact ${artifact} is empty" >&2
+              exit 1
+            fi
+          done
+
       - name: Upload Darwin artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ inputs.artifact_prefix }}-darwin
-          path: |
-            dist/*.tar.gz
-            dist/*.zip
+          path: dist/lopper_${{ inputs.tag }}_darwin_arm64.tar.gz
+          if-no-files-found: error
 
   prepare-ghcr:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,9 @@ jobs:
           make sync-version VERSION="$version"
 
       - name: Reset VS Code extension artifact staging
+        env:
+          PATH: /usr/bin:/bin
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           rm -rf -- dist
@@ -250,7 +253,9 @@ jobs:
 
       - name: Validate VS Code extension artifact
         env:
+          PATH: /usr/bin:/bin
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           expected="dist/lopper-vscode-${RELEASE_VERSION}.vsix"
@@ -260,6 +265,10 @@ jobs:
           fi
           if [ ! -f "${expected}" ] || [ -L "${expected}" ]; then
             echo "Expected VS Code artifact ${expected} is missing or not a regular file" >&2
+            exit 1
+          fi
+          if [ ! -s "${expected}" ]; then
+            echo "Expected VS Code artifact ${expected} is empty" >&2
             exit 1
           fi
           if [ "$(find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l)" -ne 1 ]; then
@@ -424,6 +433,9 @@ jobs:
           go run ./tools/featureflag "${args[@]}" > feature-flags.md
 
       - name: Reset release artifact staging
+        env:
+          PATH: /usr/bin:/bin
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           rm -rf -- dist
@@ -436,25 +448,23 @@ jobs:
           merge-multiple: true
           path: dist
 
-      - name: Verify Darwin artifacts are present
-        run: |
-          set -euo pipefail
-          if ! find dist -maxdepth 1 -type f -name '*_darwin_amd64.tar.gz' | grep -q .; then
-            echo "Expected darwin/amd64 artifact is missing from dist/" >&2
-            exit 1
-          fi
-          if ! find dist -maxdepth 1 -type f -name '*_darwin_arm64.tar.gz' | grep -q .; then
-            echo "Expected darwin/arm64 artifact is missing from dist/" >&2
-            exit 1
-          fi
-
       - name: Stage bounded release publication inputs
         env:
+          PATH: /usr/bin:/bin
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
-          expected_vsix="lopper-vscode-${version}.vsix"
+          expected_assets=(
+            "dist/lopper_${RELEASE_TAG}_linux_amd64.tar.gz"
+            "dist/lopper_${RELEASE_TAG}_linux_arm64.tar.gz"
+            "dist/lopper_${RELEASE_TAG}_windows_amd64.zip"
+            "dist/lopper_${RELEASE_TAG}_windows_arm64.zip"
+            "dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz"
+            "dist/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz"
+            "dist/lopper-vscode-${version}.vsix"
+          )
 
           if [ ! -f feature-flags.md ] || [ -L feature-flags.md ]; then
             echo "Feature flag release report must be a regular file" >&2
@@ -464,30 +474,30 @@ jobs:
             echo "Feature flag release report exceeds the 1 MiB publication limit" >&2
             exit 1
           fi
-          if find dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+          if find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
             echo "Release publication inputs must contain only regular files" >&2
             exit 1
           fi
-
-          mapfile -t assets < <(find dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.vsix' \) -print | sort)
-          if [ "${#assets[@]}" -eq 0 ] || [ "${#assets[@]}" -gt 32 ]; then
-            echo "Expected between 1 and 32 release assets, found ${#assets[@]}" >&2
+          file_count="$(find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [ "${file_count}" -ne "${#expected_assets[@]}" ]; then
+            echo "Release publication inputs must contain exactly ${#expected_assets[@]} assets" >&2
             exit 1
           fi
-          if [ "$(find dist -maxdepth 1 -type f | wc -l)" -ne "${#assets[@]}" ]; then
-            echo "Release publication inputs contain an unsupported file type" >&2
-            exit 1
-          fi
-          if [ "$(find dist -maxdepth 1 -type f -name 'lopper-vscode-*.vsix' | wc -l)" -ne 1 ] || [ ! -f "dist/${expected_vsix}" ]; then
-            echo "Expected exactly one VSIX asset named ${expected_vsix}" >&2
-            exit 1
-          fi
-          for asset in "${assets[@]}"; do
+          for asset in "${expected_assets[@]}"; do
+            if [ ! -f "${asset}" ] || [ -L "${asset}" ]; then
+              echo "Expected release asset ${asset} is missing or not a regular file" >&2
+              exit 1
+            fi
+            if [ ! -s "${asset}" ]; then
+              echo "Expected release asset ${asset} is empty" >&2
+              exit 1
+            fi
             if [ "$(stat --format=%s "${asset}")" -gt 1073741824 ]; then
               echo "Release asset ${asset} exceeds the 1 GiB publication limit" >&2
               exit 1
             fi
           done
+          assets=("${expected_assets[@]}")
 
           rm -rf -- publication-inputs
           mkdir -p publication-inputs/dist
@@ -980,11 +990,21 @@ jobs:
       - name: Validate release publication inputs
         working-directory: publication-inputs
         env:
+          PATH: /usr/bin:/bin
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
-          expected_vsix="lopper-vscode-${version}.vsix"
+          expected_assets=(
+            "dist/lopper_${RELEASE_TAG}_linux_amd64.tar.gz"
+            "dist/lopper_${RELEASE_TAG}_linux_arm64.tar.gz"
+            "dist/lopper_${RELEASE_TAG}_windows_amd64.zip"
+            "dist/lopper_${RELEASE_TAG}_windows_arm64.zip"
+            "dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz"
+            "dist/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz"
+            "dist/lopper-vscode-${version}.vsix"
+          )
 
           if find . -mindepth 1 ! -type f ! -type d -print -quit | grep -q .; then
             echo "Release publication inputs contain a non-regular entry" >&2
@@ -992,6 +1012,22 @@ jobs:
           fi
           if [ ! -f SHA256SUMS ] || [ -L SHA256SUMS ]; then
             echo "Release publication checksum manifest is missing or invalid" >&2
+            exit 1
+          fi
+          if find . -mindepth 1 -maxdepth 1 ! -name dist ! -name feature-flags.md ! -name SHA256SUMS -print -quit | grep -q .; then
+            echo "Release publication inputs contain an unexpected top-level path" >&2
+            exit 1
+          fi
+          if [ "$(find . -type f | wc -l | tr -d '[:space:]')" -ne 9 ]; then
+            echo "Release publication inputs contain an unexpected file count" >&2
+            exit 1
+          fi
+          computed_checksums="$(mktemp)"
+          trap 'rm -f "${computed_checksums}"' EXIT
+          mapfile -d '' checksum_files < <(find . -type f ! -name SHA256SUMS -print0 | sort -z)
+          sha256sum "${checksum_files[@]}" > "${computed_checksums}"
+          if ! cmp -s SHA256SUMS "${computed_checksums}"; then
+            echo "Release publication checksum manifest does not cover the exact input set" >&2
             exit 1
           fi
           sha256sum --check --strict SHA256SUMS
@@ -1003,38 +1039,29 @@ jobs:
             echo "Feature flag release report exceeds the 1 MiB publication limit" >&2
             exit 1
           fi
-          if find dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+          if find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
             echo "Release asset directory must contain only regular files" >&2
             exit 1
           fi
-
-          mapfile -t assets < <(find dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.vsix' \) -print | sort)
-          if [ "${#assets[@]}" -eq 0 ] || [ "${#assets[@]}" -gt 32 ]; then
-            echo "Expected between 1 and 32 release assets, found ${#assets[@]}" >&2
+          file_count="$(find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [ "${file_count}" -ne "${#expected_assets[@]}" ]; then
+            echo "Release publication inputs must contain exactly ${#expected_assets[@]} assets" >&2
             exit 1
           fi
-          if [ "$(find dist -maxdepth 1 -type f | wc -l)" -ne "${#assets[@]}" ]; then
-            echo "Release publication inputs contain an unsupported file type" >&2
-            exit 1
-          fi
-          if [ "$(find dist -maxdepth 1 -type f -name 'lopper-vscode-*.vsix' | wc -l)" -ne 1 ] || [ ! -f "dist/${expected_vsix}" ]; then
-            echo "Expected exactly one VSIX asset named ${expected_vsix}" >&2
-            exit 1
-          fi
-          for asset in "${assets[@]}"; do
+          for asset in "${expected_assets[@]}"; do
+            if [ ! -f "${asset}" ] || [ -L "${asset}" ]; then
+              echo "Expected release asset ${asset} is missing or not a regular file" >&2
+              exit 1
+            fi
+            if [ ! -s "${asset}" ]; then
+              echo "Expected release asset ${asset} is empty" >&2
+              exit 1
+            fi
             if [ "$(stat --format=%s "${asset}")" -gt 1073741824 ]; then
               echo "Release asset ${asset} exceeds the 1 GiB publication limit" >&2
               exit 1
             fi
           done
-          if ! find dist -maxdepth 1 -type f -name '*_darwin_amd64.tar.gz' | grep -q .; then
-            echo "Expected darwin/amd64 artifact is missing from release publication inputs" >&2
-            exit 1
-          fi
-          if ! find dist -maxdepth 1 -type f -name '*_darwin_arm64.tar.gz' | grep -q .; then
-            echo "Expected darwin/arm64 artifact is missing from release publication inputs" >&2
-            exit 1
-          fi
 
       - name: Update GitHub Release notes
         env:
@@ -1084,11 +1111,15 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ needs.prepare-release.outputs.tag }}"
-          mapfile -t assets < <(find publication-inputs/dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.vsix' \) | sort)
-          if [ "${#assets[@]}" -eq 0 ]; then
-            echo "No release assets found in publication inputs" >&2
-            exit 1
-          fi
+          assets=(
+            "publication-inputs/dist/lopper_${tag}_linux_amd64.tar.gz"
+            "publication-inputs/dist/lopper_${tag}_linux_arm64.tar.gz"
+            "publication-inputs/dist/lopper_${tag}_windows_amd64.zip"
+            "publication-inputs/dist/lopper_${tag}_windows_arm64.zip"
+            "publication-inputs/dist/lopper_${tag}_darwin_amd64.tar.gz"
+            "publication-inputs/dist/lopper_${tag}_darwin_arm64.tar.gz"
+            "publication-inputs/dist/lopper-vscode-${tag#v}.vsix"
+          )
           gh release upload "$tag" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
 
   finalize-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,25 +328,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Download release artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          pattern: release-*
-          merge-multiple: true
-          path: dist
-
-      - name: Verify Darwin artifacts are present
-        run: |
-          set -euo pipefail
-          if ! find dist -maxdepth 1 -type f -name '*_darwin_amd64.tar.gz' | grep -q .; then
-            echo "Expected darwin/amd64 artifact is missing from dist/" >&2
-            exit 1
-          fi
-          if ! find dist -maxdepth 1 -type f -name '*_darwin_arm64.tar.gz' | grep -q .; then
-            echo "Expected darwin/arm64 artifact is missing from dist/" >&2
-            exit 1
-          fi
-
       - name: Generate feature flag release report
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
@@ -373,6 +354,31 @@ jobs:
             args+=(--previous-catalog "${previous_catalog}")
           fi
           go run ./tools/featureflag "${args[@]}" > feature-flags.md
+
+      - name: Reset release artifact staging
+        run: |
+          set -euo pipefail
+          rm -rf -- dist
+          mkdir -- dist
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist
+
+      - name: Verify Darwin artifacts are present
+        run: |
+          set -euo pipefail
+          if ! find dist -maxdepth 1 -type f -name '*_darwin_amd64.tar.gz' | grep -q .; then
+            echo "Expected darwin/amd64 artifact is missing from dist/" >&2
+            exit 1
+          fi
+          if ! find dist -maxdepth 1 -type f -name '*_darwin_arm64.tar.gz' | grep -q .; then
+            echo "Expected darwin/arm64 artifact is missing from dist/" >&2
+            exit 1
+          fi
 
       - name: Stage bounded release publication inputs
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,6 +248,25 @@ jobs:
           cd extensions/vscode-lopper
           npx @vscode/vsce package --out "../../dist/lopper-vscode-${version}.vsix"
 
+      - name: Validate VS Code extension artifact
+        env:
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          expected="dist/lopper-vscode-${RELEASE_VERSION}.vsix"
+          if find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "VS Code artifact staging contains a non-regular entry" >&2
+            exit 1
+          fi
+          if [ ! -f "${expected}" ] || [ -L "${expected}" ]; then
+            echo "Expected VS Code artifact ${expected} is missing or not a regular file" >&2
+            exit 1
+          fi
+          if [ "$(find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l)" -ne 1 ]; then
+            echo "VS Code artifact staging must contain only ${expected}" >&2
+            exit 1
+          fi
+
       - name: Upload VS Code extension artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,12 +382,9 @@ jobs:
           path: dist/lopper_${{ needs.prepare-release.outputs.tag }}_darwin_amd64.tar.gz
           if-no-files-found: error
 
-  prepare-release-publication:
+  prepare-release-feature-report:
     needs:
       - prepare-release
-      - orchestrate-release
-      - build-vscode-extension
-      - build-darwin-amd64
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
@@ -400,6 +397,17 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.prepare-release.outputs.sha }}
 
+      - name: Verify release source checkout
+        env:
+          EXPECTED_SOURCE_SHA: ${{ needs.prepare-release.outputs.sha }}
+        run: |
+          set -euo pipefail
+          actual_source_sha="$(git rev-parse HEAD)"
+          if [ "${actual_source_sha}" != "${EXPECTED_SOURCE_SHA}" ]; then
+            echo "Checked out release source ${actual_source_sha} does not match ${EXPECTED_SOURCE_SHA}" >&2
+            exit 1
+          fi
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
@@ -410,7 +418,9 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
-          mkdir -p .artifacts
+          report_dir="${RUNNER_TEMP}/release-feature-report"
+          rm -rf -- "${report_dir}"
+          mkdir -- "${report_dir}"
           git fetch --tags --force
           previous_tag=""
           while IFS= read -r candidate; do
@@ -422,7 +432,7 @@ jobs:
 
           args=(report --channel release --release "${RELEASE_TAG}")
           if [ -n "${previous_tag}" ]; then
-            previous_catalog=".artifacts/previous-features.json"
+            previous_catalog="${RUNNER_TEMP}/previous-features.json"
             if git cat-file -e "${previous_tag}:internal/featureflags/features.json" 2>/dev/null; then
               git show "${previous_tag}:internal/featureflags/features.json" > "${previous_catalog}"
             else
@@ -430,32 +440,122 @@ jobs:
             fi
             args+=(--previous-catalog "${previous_catalog}")
           fi
-          go run ./tools/featureflag "${args[@]}" > feature-flags.md
+          go run ./tools/featureflag "${args[@]}" > "${report_dir}/feature-flags.md"
 
-      - name: Reset release artifact staging
+      - name: Validate feature flag release report
         env:
           PATH: /usr/bin:/bin
         shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
-          rm -rf -- dist
-          mkdir -- dist
+          report_dir="${RUNNER_TEMP}/release-feature-report"
+          report="${report_dir}/feature-flags.md"
+          if find -P "${report_dir}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Feature flag release report staging contains a non-regular entry" >&2
+            exit 1
+          fi
+          file_count="$(find -P "${report_dir}" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [ "${file_count}" -ne 1 ]; then
+            echo "Feature flag release report staging must contain exactly one file" >&2
+            exit 1
+          fi
+          if [ ! -f "${report}" ] || [ -L "${report}" ]; then
+            echo "Feature flag release report must be a regular file" >&2
+            exit 1
+          fi
+          if [ ! -s "${report}" ]; then
+            echo "Feature flag release report must not be empty" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s "${report}")" -gt 1048576 ]; then
+            echo "Feature flag release report exceeds the 1 MiB publication limit" >&2
+            exit 1
+          fi
 
-      - name: Download release artifacts
+      - name: Upload feature flag release report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: stable-feature-report
+          path: ${{ runner.temp }}/release-feature-report/feature-flags.md
+          if-no-files-found: error
+
+  prepare-release-publication:
+    needs:
+      - prepare-release
+      - prepare-release-feature-report
+      - orchestrate-release
+      - build-vscode-extension
+      - build-darwin-amd64
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Reset release publication assembly
+        env:
+          PATH: /usr/bin:/bin
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          assembly_root="${RUNNER_TEMP}/release-publication-assembly"
+          rm -rf -- "${assembly_root}"
+          rm -rf -- publication-inputs
+          mkdir -- "${assembly_root}"
+
+      - name: Download feature flag release report
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          pattern: release-*
-          merge-multiple: true
-          path: dist
+          name: stable-feature-report
+          path: ${{ runner.temp }}/release-publication-assembly/feature-report
+
+      - name: Download Linux and Windows release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-linux-windows
+          path: ${{ runner.temp }}/release-publication-assembly/linux-windows
+
+      - name: Download Darwin arm64 release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-darwin
+          path: ${{ runner.temp }}/release-publication-assembly/darwin-arm64
+
+      - name: Download Darwin amd64 release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-darwin-amd64
+          path: ${{ runner.temp }}/release-publication-assembly/darwin-amd64
+
+      - name: Download VS Code extension release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-vscode-extension
+          path: ${{ runner.temp }}/release-publication-assembly/vscode
 
       - name: Stage bounded release publication inputs
         env:
+          ASSEMBLY_ROOT: ${{ runner.temp }}/release-publication-assembly
           PATH: /usr/bin:/bin
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
+          report="${ASSEMBLY_ROOT}/feature-report/feature-flags.md"
+          linux_windows_assets=(
+            "${ASSEMBLY_ROOT}/linux-windows/lopper_${RELEASE_TAG}_linux_amd64.tar.gz"
+            "${ASSEMBLY_ROOT}/linux-windows/lopper_${RELEASE_TAG}_linux_arm64.tar.gz"
+            "${ASSEMBLY_ROOT}/linux-windows/lopper_${RELEASE_TAG}_windows_amd64.zip"
+            "${ASSEMBLY_ROOT}/linux-windows/lopper_${RELEASE_TAG}_windows_arm64.zip"
+          )
+          darwin_arm64_assets=("${ASSEMBLY_ROOT}/darwin-arm64/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz")
+          darwin_amd64_assets=("${ASSEMBLY_ROOT}/darwin-amd64/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz")
+          vsix_assets=("${ASSEMBLY_ROOT}/vscode/lopper-vscode-${version}.vsix")
+          assets=(
+            "${linux_windows_assets[@]}"
+            "${darwin_arm64_assets[@]}"
+            "${darwin_amd64_assets[@]}"
+            "${vsix_assets[@]}"
+          )
           expected_assets=(
             "dist/lopper_${RELEASE_TAG}_linux_amd64.tar.gz"
             "dist/lopper_${RELEASE_TAG}_linux_arm64.tar.gz"
@@ -466,47 +566,76 @@ jobs:
             "dist/lopper-vscode-${version}.vsix"
           )
 
-          if [ ! -f feature-flags.md ] || [ -L feature-flags.md ]; then
-            echo "Feature flag release report must be a regular file" >&2
-            exit 1
-          fi
-          if [ "$(stat --format=%s feature-flags.md)" -gt 1048576 ]; then
-            echo "Feature flag release report exceeds the 1 MiB publication limit" >&2
-            exit 1
-          fi
-          if find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
-            echo "Release publication inputs must contain only regular files" >&2
-            exit 1
-          fi
-          file_count="$(find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
-          if [ "${file_count}" -ne "${#expected_assets[@]}" ]; then
-            echo "Release publication inputs must contain exactly ${#expected_assets[@]} assets" >&2
-            exit 1
-          fi
-          for asset in "${expected_assets[@]}"; do
-            if [ ! -f "${asset}" ] || [ -L "${asset}" ]; then
-              echo "Expected release asset ${asset} is missing or not a regular file" >&2
+          validate_input_root() {
+            local root="$1"
+            local maximum_size="$2"
+            shift 2
+            local expected=("$@")
+            if [ ! -d "${root}" ] || [ -L "${root}" ]; then
+              echo "Release input root ${root} is missing or invalid" >&2
               exit 1
             fi
-            if [ ! -s "${asset}" ]; then
-              echo "Expected release asset ${asset} is empty" >&2
+            if find -P "${root}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+              echo "Release input root ${root} contains a non-regular entry" >&2
               exit 1
             fi
-            if [ "$(stat --format=%s "${asset}")" -gt 1073741824 ]; then
-              echo "Release asset ${asset} exceeds the 1 GiB publication limit" >&2
+            local file_count
+            file_count="$(find -P "${root}" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+            if [ "${file_count}" -ne "${#expected[@]}" ]; then
+              echo "Release input root ${root} contains an unexpected file count" >&2
               exit 1
             fi
-          done
-          assets=("${expected_assets[@]}")
+            local input
+            for input in "${expected[@]}"; do
+              if [ ! -f "${input}" ] || [ -L "${input}" ]; then
+                echo "Expected release input ${input} is missing or not a regular file" >&2
+                exit 1
+              fi
+              if [ ! -s "${input}" ]; then
+                echo "Expected release input ${input} is empty" >&2
+                exit 1
+              fi
+              if [ "$(stat --format=%s "${input}")" -gt "${maximum_size}" ]; then
+                echo "Release input ${input} exceeds its publication limit" >&2
+                exit 1
+              fi
+            done
+          }
+
+          validate_input_root "${ASSEMBLY_ROOT}/feature-report" 1048576 "${report}"
+          validate_input_root "${ASSEMBLY_ROOT}/linux-windows" 1073741824 "${linux_windows_assets[@]}"
+          validate_input_root "${ASSEMBLY_ROOT}/darwin-arm64" 1073741824 "${darwin_arm64_assets[@]}"
+          validate_input_root "${ASSEMBLY_ROOT}/darwin-amd64" 1073741824 "${darwin_amd64_assets[@]}"
+          validate_input_root "${ASSEMBLY_ROOT}/vscode" 1073741824 "${vsix_assets[@]}"
 
           rm -rf -- publication-inputs
           mkdir -p publication-inputs/dist
           cp -- "${assets[@]}" publication-inputs/dist/
-          cp -- feature-flags.md publication-inputs/feature-flags.md
+          cp -- "${report}" publication-inputs/feature-flags.md
+          if find -P publication-inputs -mindepth 1 ! -type f ! -type d -print -quit | grep -q .; then
+            echo "Staged release publication inputs contain a non-regular entry" >&2
+            exit 1
+          fi
+          if [ "$(find -P publication-inputs -type f | wc -l | tr -d '[:space:]')" -ne 8 ]; then
+            echo "Staged release publication inputs must contain seven assets and one report" >&2
+            exit 1
+          fi
+          for asset in "${expected_assets[@]}"; do
+            asset="publication-inputs/${asset}"
+            if [ ! -f "${asset}" ] || [ -L "${asset}" ] || [ ! -s "${asset}" ]; then
+              echo "Staged release asset ${asset} is missing, invalid, or empty" >&2
+              exit 1
+            fi
+          done
+          if [ ! -f publication-inputs/feature-flags.md ] || [ -L publication-inputs/feature-flags.md ] || [ ! -s publication-inputs/feature-flags.md ]; then
+            echo "Staged feature flag release report is missing, invalid, or empty" >&2
+            exit 1
+          fi
           (
             cd publication-inputs
-            mapfile -d '' checksum_files < <(find . -type f -print0 | sort -z)
-            sha256sum "${checksum_files[@]}" > SHA256SUMS
+            manifest_inputs=("feature-flags.md" "${expected_assets[@]}")
+            mapfile -d '' sorted_manifest_inputs < <(printf '%s\0' "${manifest_inputs[@]}" | sort -z)
+            sha256sum "${sorted_manifest_inputs[@]}" > SHA256SUMS
           )
 
       - name: Upload release publication inputs
@@ -1010,8 +1139,12 @@ jobs:
             echo "Release publication inputs contain a non-regular entry" >&2
             exit 1
           fi
-          if [ ! -f SHA256SUMS ] || [ -L SHA256SUMS ]; then
+          if [ ! -f SHA256SUMS ] || [ -L SHA256SUMS ] || [ ! -s SHA256SUMS ]; then
             echo "Release publication checksum manifest is missing or invalid" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s SHA256SUMS)" -gt 65536 ]; then
+            echo "Release publication checksum manifest exceeds the 64 KiB limit" >&2
             exit 1
           fi
           if find . -mindepth 1 -maxdepth 1 ! -name dist ! -name feature-flags.md ! -name SHA256SUMS -print -quit | grep -q .; then
@@ -1022,21 +1155,20 @@ jobs:
             echo "Release publication inputs contain an unexpected file count" >&2
             exit 1
           fi
-          computed_checksums="$(mktemp)"
-          trap 'rm -f "${computed_checksums}"' EXIT
-          mapfile -d '' checksum_files < <(find . -type f ! -name SHA256SUMS -print0 | sort -z)
-          sha256sum "${checksum_files[@]}" > "${computed_checksums}"
-          if ! cmp -s SHA256SUMS "${computed_checksums}"; then
-            echo "Release publication checksum manifest does not cover the exact input set" >&2
-            exit 1
-          fi
-          sha256sum --check --strict SHA256SUMS
           if [ ! -f feature-flags.md ] || [ -L feature-flags.md ]; then
             echo "Feature flag release report must be a regular file" >&2
             exit 1
           fi
+          if [ ! -s feature-flags.md ]; then
+            echo "Feature flag release report must not be empty" >&2
+            exit 1
+          fi
           if [ "$(stat --format=%s feature-flags.md)" -gt 1048576 ]; then
             echo "Feature flag release report exceeds the 1 MiB publication limit" >&2
+            exit 1
+          fi
+          if [ ! -d dist ] || [ -L dist ]; then
+            echo "Release asset directory is missing or invalid" >&2
             exit 1
           fi
           if find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
@@ -1062,6 +1194,17 @@ jobs:
               exit 1
             fi
           done
+
+          computed_checksums="$(mktemp)"
+          trap 'rm -f "${computed_checksums}"' EXIT
+          manifest_inputs=("feature-flags.md" "${expected_assets[@]}")
+          mapfile -d '' sorted_manifest_inputs < <(printf '%s\0' "${manifest_inputs[@]}" | sort -z)
+          sha256sum "${sorted_manifest_inputs[@]}" > "${computed_checksums}"
+          if ! cmp -s SHA256SUMS "${computed_checksums}"; then
+            echo "Release publication checksum manifest does not cover the exact input set" >&2
+            exit 1
+          fi
+          sha256sum --check --strict SHA256SUMS
 
       - name: Update GitHub Release notes
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           PATH: /usr/bin:/bin
           WORKFLOW_REF: ${{ github.workflow_ref }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           expected_workflow_ref="${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/heads/main"
           if [ "${WORKFLOW_REF}" != "${expected_workflow_ref}" ]; then
@@ -236,7 +236,7 @@ jobs:
       - name: Reset VS Code extension artifact staging
         env:
           PATH: /usr/bin:/bin
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           rm -rf -- dist
@@ -255,7 +255,7 @@ jobs:
         env:
           PATH: /usr/bin:/bin
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           expected="dist/lopper-vscode-${RELEASE_VERSION}.vsix"
@@ -328,7 +328,7 @@ jobs:
       - name: Reset Darwin amd64 artifact staging
         env:
           PATH: /usr/bin:/bin
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           rm -rf -- dist
@@ -351,7 +351,7 @@ jobs:
         env:
           PATH: /usr/bin:/bin
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           expected=("dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz")
@@ -445,7 +445,7 @@ jobs:
       - name: Validate feature flag release report
         env:
           PATH: /usr/bin:/bin
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           report_dir="${RUNNER_TEMP}/release-feature-report"
@@ -493,7 +493,7 @@ jobs:
       - name: Reset release publication assembly
         env:
           PATH: /usr/bin:/bin
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           assembly_root="${RUNNER_TEMP}/release-publication-assembly"
@@ -536,7 +536,7 @@ jobs:
           ASSEMBLY_ROOT: ${{ runner.temp }}/release-publication-assembly
           PATH: /usr/bin:/bin
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
@@ -659,7 +659,7 @@ jobs:
         env:
           VSCE_PUBLISH: ${{ secrets.VSCE_PUBLISH }}
           PATH: /usr/bin:/bin
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           if [ -n "${VSCE_PUBLISH:-}" ]; then
             /usr/bin/printf '%s\n' 'configured=true' >> "$GITHUB_OUTPUT"
@@ -817,7 +817,7 @@ jobs:
 
       - name: Validate Marketplace publication inputs
         if: ${{ needs.prepare-marketplace-toolchain.outputs.configured == 'true' }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         env:
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
@@ -1087,7 +1087,7 @@ jobs:
 
       - name: Publish VS Code extension to Marketplace
         if: ${{ needs.prepare-marketplace-toolchain.outputs.configured == 'true' }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         env:
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
           VSCE_PAT: ${{ secrets.VSCE_PUBLISH }}
@@ -1121,7 +1121,7 @@ jobs:
         env:
           PATH: /usr/bin:/bin
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
@@ -1319,7 +1319,7 @@ jobs:
 
       - name: Prepare GitHub Action floating tags
         id: prepare_tags
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
           RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
@@ -1388,7 +1388,7 @@ jobs:
 
       - name: Push GitHub Action floating tags
         if: ${{ steps.prepare_tags.outputs.push == 'true' }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
           RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
@@ -1520,7 +1520,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@fc695c54c2032716dd4cedd007489c8e32fc8a5d
 
       - name: Clone tap repository anonymously
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           git_bin=/usr/bin/git
           mktemp_bin=/usr/bin/mktemp
@@ -1621,7 +1621,7 @@ jobs:
       - name: Regenerate and push formula changes
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           git_bin=/usr/bin/git
           curl_bin=/usr/bin/curl
@@ -1895,7 +1895,7 @@ jobs:
           path: ${{ runner.temp }}/feature-history-input
 
       - name: Prepare trusted feature history commit
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
           RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
@@ -2005,7 +2005,7 @@ jobs:
           fi
 
       - name: Archive prepared trusted feature history worktree
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         env:
           PATH: /usr/bin:/bin
         run: |
@@ -2055,7 +2055,7 @@ jobs:
           path: ${{ runner.temp }}/prepared-feature-release-history-input
 
       - name: Validate prepared trusted feature history worktree
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         env:
           PATH: /usr/bin:/bin
         run: |
@@ -2135,7 +2135,7 @@ jobs:
           fi
 
       - name: Push feature history commit
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         env:
           RELEASE_TAG: ${{ needs.prepare-feature-release-history-push.outputs.release_tag }}
           RELEASE_SHA: ${{ needs.prepare-feature-release-history-push.outputs.release_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf -- dist
-          mkdir -- dist
+          mkdir dist
 
       - name: Package VS Code extension
         env:
@@ -332,7 +332,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf -- dist
-          mkdir -- dist
+          mkdir dist
 
       - name: Build Darwin amd64 release artifact
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1209,9 +1209,10 @@ jobs:
       - name: Update GitHub Release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
-          tag="${{ needs.prepare-release.outputs.tag }}"
+          tag="${RELEASE_TAG}"
           existing_body="$(mktemp)"
           release_notes="$(mktemp)"
 
@@ -1251,9 +1252,10 @@ jobs:
       - name: Upload GitHub Release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
-          tag="${{ needs.prepare-release.outputs.tag }}"
+          tag="${RELEASE_TAG}"
           assets=(
             "publication-inputs/dist/lopper_${tag}_linux_amd64.tar.gz"
             "publication-inputs/dist/lopper_${tag}_linux_arm64.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -948,10 +948,10 @@ jobs:
           (
             cd "${publication_dir}"
             {
-              printf '%s\n' ./feature-flags.md
-              find ./dist -maxdepth 1 -type f -print
+              printf '%s\n' feature-flags.md
+              find dist -maxdepth 1 -type f -print
             } | sort > "${expected_paths}"
-            if grep -Ev '^[0-9a-f]{64}  [.]\/(feature-flags[.]md|dist\/[A-Za-z0-9._+-]+([.]tar[.]gz|[.]zip|[.]vsix))$' SHA256SUMS | grep -q .; then
+            if grep -Ev '^[0-9a-f]{64}  (feature-flags[.]md|dist/[A-Za-z0-9._+-]+([.]tar[.]gz|[.]zip|[.]vsix))$' SHA256SUMS | grep -q .; then
               echo "Marketplace publication checksum manifest contains an unexpected path" >&2
               exit 1
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,14 +225,26 @@ jobs:
       - name: Run VS Code smoke tests
         run: xvfb-run -a make vscode-extension-test
 
+      - name: Sync VS Code extension version
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          make sync-version VERSION="$version"
+
+      - name: Reset VS Code extension artifact staging
+        run: |
+          set -euo pipefail
+          rm -rf -- dist
+          mkdir -- dist
+
       - name: Package VS Code extension
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
-          mkdir -p dist
           version="${RELEASE_TAG#v}"
-          make sync-version VERSION="$version"
           cd extensions/vscode-lopper
           npx @vscode/vsce package --out "../../dist/lopper-vscode-${version}.vsix"
 
@@ -240,7 +252,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-vscode-extension
-          path: dist/*.vsix
+          path: dist/lopper-vscode-${{ needs.prepare-release.outputs.version }}.vsix
+          if-no-files-found: error
 
   build-darwin-amd64:
     needs: prepare-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,6 +316,15 @@ jobs:
           make tools-install
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+      - name: Reset Darwin amd64 artifact staging
+        env:
+          PATH: /usr/bin:/bin
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          rm -rf -- dist
+          mkdir -- dist
+
       - name: Build Darwin amd64 release artifact
         env:
           TAG: ${{ needs.prepare-release.outputs.tag }}
@@ -329,13 +338,40 @@ jobs:
             RELEASE_BUILD_CHANNEL=release \
             PLATFORMS="darwin/amd64"
 
+      - name: Validate Darwin amd64 release artifact
+        env:
+          PATH: /usr/bin:/bin
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          expected=("dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz")
+          if find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Darwin amd64 artifact staging contains a non-regular entry" >&2
+            exit 1
+          fi
+          file_count="$(find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [ "${file_count}" -ne "${#expected[@]}" ]; then
+            echo "Darwin amd64 artifact staging contains an unexpected file count" >&2
+            exit 1
+          fi
+          for artifact in "${expected[@]}"; do
+            if [ ! -f "${artifact}" ] || [ -L "${artifact}" ]; then
+              echo "Expected Darwin amd64 artifact ${artifact} is missing or not a regular file" >&2
+              exit 1
+            fi
+            if [ ! -s "${artifact}" ]; then
+              echo "Expected Darwin amd64 artifact ${artifact} is empty" >&2
+              exit 1
+            fi
+          done
+
       - name: Upload Darwin amd64 artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-darwin-amd64
-          path: |
-            dist/*.tar.gz
-            dist/*.zip
+          path: dist/lopper_${{ needs.prepare-release.outputs.tag }}_darwin_amd64.tar.gz
+          if-no-files-found: error
 
   prepare-release-publication:
     needs:

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -150,64 +150,58 @@ jobs:
           path: dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_darwin_amd64.tar.gz
           if-no-files-found: error
 
-  publish-rolling:
+  prepare-rolling-source-inputs:
     needs:
       - prepare-rolling
-      - orchestrate-rolling
-      - build-darwin-amd64-rolling
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
-    outputs:
-      tag: ${{ needs.prepare-rolling.outputs.tag }}
-    env:
-      ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
-      SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
+      contents: read
     steps:
-      - name: Checkout (for changelog generation)
-        uses: actions/checkout@v7
+      - name: Checkout rolling source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           fetch-depth: 0
-          ref: ${{ env.SOURCE_SHA }}
+          ref: ${{ needs.prepare-rolling.outputs.source_sha }}
+
+      - name: Verify rolling source checkout
+        env:
+          EXPECTED_SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          actual_source_sha="$(git rev-parse HEAD)"
+          if [ "${actual_source_sha}" != "${EXPECTED_SOURCE_SHA}" ]; then
+            echo "Checked out rolling source ${actual_source_sha} does not match ${EXPECTED_SOURCE_SHA}" >&2
+            exit 1
+          fi
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 
-      - name: Download rolling binary artifacts
-        uses: actions/download-artifact@v8
-        with:
-          pattern: rolling-*
-          merge-multiple: true
-          path: dist
-
-      - name: Verify Darwin artifacts are present
-        run: |
-          set -euo pipefail
-          if ! find dist -maxdepth 1 -type f -name '*_darwin_amd64.tar.gz' | grep -q .; then
-            echo "Expected darwin/amd64 artifact is missing from dist/" >&2
-            exit 1
-          fi
-          if ! find dist -maxdepth 1 -type f -name '*_darwin_arm64.tar.gz' | grep -q .; then
-            echo "Expected darwin/arm64 artifact is missing from dist/" >&2
-            exit 1
-          fi
-
       - name: Build rolling source bundle
+        env:
+          ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
+          SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
         run: |
           set -euo pipefail
-          mkdir -p dist
+          source_input_root="${RUNNER_TEMP}/rolling-source-inputs"
+          rm -rf -- "${source_input_root}"
+          mkdir -- "${source_input_root}"
           bundle="lopper_${ROLLING_TAG}_source"
-          archive_path="dist/${bundle}.tar.gz"
+          archive_path="${source_input_root}/lopper_${ROLLING_TAG}_source.tar.gz"
 
-          git archive --format=tar.gz --prefix="${bundle}/" -o "$archive_path" "$SOURCE_SHA"
-          sha256sum "$archive_path" > "${archive_path}.sha256"
+          git archive --format=tar.gz --prefix="${bundle}/" -o "${archive_path}" "${SOURCE_SHA}"
 
       - name: Generate rolling release notes
+        env:
+          ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
+          SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
         run: |
           set -euo pipefail
+          source_input_root="${RUNNER_TEMP}/rolling-source-inputs"
+          feature_report="${RUNNER_TEMP}/rolling-feature-flags.md"
           git fetch --tags --force
           previous_tag=""
           while IFS= read -r candidate; do
@@ -219,8 +213,7 @@ jobs:
 
           args=(report --channel rolling --release "${ROLLING_TAG}")
           if [ -n "${previous_tag}" ]; then
-            mkdir -p .artifacts
-            previous_catalog=".artifacts/previous-features.json"
+            previous_catalog="${RUNNER_TEMP}/previous-rolling-features.json"
             if git cat-file -e "${previous_tag}:internal/featureflags/features.json" 2>/dev/null; then
               git show "${previous_tag}:internal/featureflags/features.json" > "${previous_catalog}"
             else
@@ -228,7 +221,7 @@ jobs:
             fi
             args+=(--previous-catalog "${previous_catalog}")
           fi
-          go run ./tools/featureflag "${args[@]}" > feature-flags.md
+          go run ./tools/featureflag "${args[@]}" > "${feature_report}"
 
           {
             echo "## Rolling build from main"
@@ -240,7 +233,7 @@ jobs:
             echo "- Docker rolling tag: \`ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/lopper:rolling\`"
             echo "- Homebrew rolling formula: \`ben-ranford/tap/lopper-rolling\`"
             echo
-            cat feature-flags.md
+            cat "${feature_report}"
             echo
             if [ -n "${previous_tag}" ]; then
               echo "Changes since \`${previous_tag}\`:"
@@ -251,20 +244,357 @@ jobs:
               echo
               git log --reverse --pretty=format:'- %h %s (%an)' "${SOURCE_SHA}"
             fi
-          } > rolling-changelog.md
+          } > "${source_input_root}/rolling-changelog.md"
+
+      - name: Validate rolling source inputs
+        env:
+          PATH: /usr/bin:/bin
+          ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
+          SOURCE_INPUT_ROOT: ${{ runner.temp }}/rolling-source-inputs
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          archive="${SOURCE_INPUT_ROOT}/lopper_${ROLLING_TAG}_source.tar.gz"
+          changelog="${SOURCE_INPUT_ROOT}/rolling-changelog.md"
+          expected=("${archive}" "${changelog}")
+          if [ ! -d "${SOURCE_INPUT_ROOT}" ] || [ -L "${SOURCE_INPUT_ROOT}" ]; then
+            echo "Rolling source input root is missing or invalid" >&2
+            exit 1
+          fi
+          if find -P "${SOURCE_INPUT_ROOT}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Rolling source input root contains a non-regular entry" >&2
+            exit 1
+          fi
+          file_count="$(find -P "${SOURCE_INPUT_ROOT}" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [ "${file_count}" -ne "${#expected[@]}" ]; then
+            echo "Rolling source input root must contain exactly two files" >&2
+            exit 1
+          fi
+          for input in "${expected[@]}"; do
+            if [ ! -f "${input}" ] || [ -L "${input}" ]; then
+              echo "Expected rolling source input ${input} is missing or invalid" >&2
+              exit 1
+            fi
+            if [ ! -s "${input}" ]; then
+              echo "Expected rolling source input ${input} is empty" >&2
+              exit 1
+            fi
+          done
+          if [ "$(stat --format=%s "${archive}")" -gt 1073741824 ]; then
+            echo "Rolling source archive exceeds the 1 GiB limit" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s "${changelog}")" -gt 1048576 ]; then
+            echo "Rolling changelog exceeds the 1 MiB limit" >&2
+            exit 1
+          fi
+
+      - name: Upload rolling source inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: rolling-source-inputs
+          path: |
+            ${{ runner.temp }}/rolling-source-inputs/lopper_${{ needs.prepare-rolling.outputs.tag }}_source.tar.gz
+            ${{ runner.temp }}/rolling-source-inputs/rolling-changelog.md
+          if-no-files-found: error
+
+  prepare-rolling-publication:
+    needs:
+      - prepare-rolling
+      - prepare-rolling-source-inputs
+      - orchestrate-rolling
+      - build-darwin-amd64-rolling
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Reset rolling publication assembly
+        env:
+          PATH: /usr/bin:/bin
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          assembly_root="${RUNNER_TEMP}/rolling-publication-assembly"
+          rm -rf -- "${assembly_root}"
+          rm -rf -- rolling-publication-inputs
+          mkdir -- "${assembly_root}"
+
+      - name: Download rolling source inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: rolling-source-inputs
+          path: ${{ runner.temp }}/rolling-publication-assembly/source
+
+      - name: Download rolling Linux and Windows artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: rolling-linux-windows
+          path: ${{ runner.temp }}/rolling-publication-assembly/linux-windows
+
+      - name: Download rolling Darwin arm64 artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: rolling-darwin
+          path: ${{ runner.temp }}/rolling-publication-assembly/darwin-arm64
+
+      - name: Download rolling Darwin amd64 artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: rolling-darwin-amd64
+          path: ${{ runner.temp }}/rolling-publication-assembly/darwin-amd64
+
+      - name: Stage bounded rolling publication inputs
+        env:
+          ASSEMBLY_ROOT: ${{ runner.temp }}/rolling-publication-assembly
+          PATH: /usr/bin:/bin
+          ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          source_basename="lopper_${ROLLING_TAG}_source.tar.gz"
+          source_archive="${ASSEMBLY_ROOT}/source/lopper_${ROLLING_TAG}_source.tar.gz"
+          changelog="${ASSEMBLY_ROOT}/source/rolling-changelog.md"
+          linux_windows_assets=(
+            "${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_linux_amd64.tar.gz"
+            "${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_linux_arm64.tar.gz"
+            "${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_windows_amd64.zip"
+            "${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_windows_arm64.zip"
+          )
+          darwin_arm64_assets=("${ASSEMBLY_ROOT}/darwin-arm64/lopper_${ROLLING_TAG}_darwin_arm64.tar.gz")
+          darwin_amd64_assets=("${ASSEMBLY_ROOT}/darwin-amd64/lopper_${ROLLING_TAG}_darwin_amd64.tar.gz")
+          binary_assets=(
+            "${linux_windows_assets[@]}"
+            "${darwin_amd64_assets[@]}"
+            "${darwin_arm64_assets[@]}"
+          )
+          expected_assets=(
+            "dist/lopper_${ROLLING_TAG}_linux_amd64.tar.gz"
+            "dist/lopper_${ROLLING_TAG}_linux_arm64.tar.gz"
+            "dist/lopper_${ROLLING_TAG}_windows_amd64.zip"
+            "dist/lopper_${ROLLING_TAG}_windows_arm64.zip"
+            "dist/lopper_${ROLLING_TAG}_darwin_amd64.tar.gz"
+            "dist/lopper_${ROLLING_TAG}_darwin_arm64.tar.gz"
+            "dist/lopper_${ROLLING_TAG}_source.tar.gz"
+            "dist/lopper_${ROLLING_TAG}_source.tar.gz.sha256"
+          )
+
+          validate_input_root() {
+            local root="$1"
+            local maximum_size="$2"
+            shift 2
+            local expected=("$@")
+            if [ ! -d "${root}" ] || [ -L "${root}" ]; then
+              echo "Rolling input root ${root} is missing or invalid" >&2
+              exit 1
+            fi
+            if find -P "${root}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+              echo "Rolling input root ${root} contains a non-regular entry" >&2
+              exit 1
+            fi
+            local file_count
+            file_count="$(find -P "${root}" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+            if [ "${file_count}" -ne "${#expected[@]}" ]; then
+              echo "Rolling input root ${root} contains an unexpected file count" >&2
+              exit 1
+            fi
+            local input
+            for input in "${expected[@]}"; do
+              if [ ! -f "${input}" ] || [ -L "${input}" ] || [ ! -s "${input}" ]; then
+                echo "Expected rolling input ${input} is missing, invalid, or empty" >&2
+                exit 1
+              fi
+              if [ "$(stat --format=%s "${input}")" -gt "${maximum_size}" ]; then
+                echo "Rolling input ${input} exceeds its publication limit" >&2
+                exit 1
+              fi
+            done
+          }
+
+          validate_input_root "${ASSEMBLY_ROOT}/source" 1073741824 "${source_archive}" "${changelog}"
+          validate_input_root "${ASSEMBLY_ROOT}/linux-windows" 1073741824 "${linux_windows_assets[@]}"
+          validate_input_root "${ASSEMBLY_ROOT}/darwin-arm64" 1073741824 "${darwin_arm64_assets[@]}"
+          validate_input_root "${ASSEMBLY_ROOT}/darwin-amd64" 1073741824 "${darwin_amd64_assets[@]}"
+          if [ "$(stat --format=%s "${changelog}")" -gt 1048576 ]; then
+            echo "Rolling changelog exceeds the 1 MiB limit" >&2
+            exit 1
+          fi
+
+          rm -rf -- rolling-publication-inputs
+          mkdir -p rolling-publication-inputs/dist
+          cp -- "${binary_assets[@]}" rolling-publication-inputs/dist/
+          cp -- "${source_archive}" "rolling-publication-inputs/dist/${source_basename}"
+          cp -- "${changelog}" rolling-publication-inputs/rolling-changelog.md
+          (
+            cd rolling-publication-inputs/dist
+            sha256sum "${source_basename}" > "${source_basename}.sha256"
+            sha256sum --check --strict "${source_basename}.sha256"
+          )
+
+          if find -P rolling-publication-inputs -mindepth 1 ! -type f ! -type d -print -quit | grep -q .; then
+            echo "Staged rolling publication inputs contain a non-regular entry" >&2
+            exit 1
+          fi
+          if [ "$(find -P rolling-publication-inputs -type f | wc -l | tr -d '[:space:]')" -ne 9 ]; then
+            echo "Staged rolling publication inputs must contain eight assets and one changelog" >&2
+            exit 1
+          fi
+          for asset in "${expected_assets[@]}"; do
+            asset="rolling-publication-inputs/${asset}"
+            if [ ! -f "${asset}" ] || [ -L "${asset}" ] || [ ! -s "${asset}" ]; then
+              echo "Staged rolling asset ${asset} is missing, invalid, or empty" >&2
+              exit 1
+            fi
+          done
+          if [ "$(stat --format=%s "rolling-publication-inputs/dist/${source_basename}.sha256")" -gt 4096 ]; then
+            echo "Rolling source checksum sidecar exceeds the 4 KiB limit" >&2
+            exit 1
+          fi
+          if [ ! -f rolling-publication-inputs/rolling-changelog.md ] || [ -L rolling-publication-inputs/rolling-changelog.md ] || [ ! -s rolling-publication-inputs/rolling-changelog.md ]; then
+            echo "Staged rolling changelog is missing, invalid, or empty" >&2
+            exit 1
+          fi
+          (
+            cd rolling-publication-inputs
+            manifest_inputs=("rolling-changelog.md" "${expected_assets[@]}")
+            mapfile -d '' sorted_manifest_inputs < <(printf '%s\0' "${manifest_inputs[@]}" | sort -z)
+            sha256sum "${sorted_manifest_inputs[@]}" > SHA256SUMS
+          )
+          if [ ! -s rolling-publication-inputs/SHA256SUMS ] || [ -L rolling-publication-inputs/SHA256SUMS ] ||
+            [ "$(stat --format=%s rolling-publication-inputs/SHA256SUMS)" -gt 65536 ]; then
+            echo "Rolling publication checksum manifest is missing, invalid, or oversized" >&2
+            exit 1
+          fi
+
+      - name: Upload rolling publication inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: rolling-publication-inputs
+          path: rolling-publication-inputs
+          if-no-files-found: error
+
+  publish-rolling:
+    needs:
+      - prepare-rolling
+      - prepare-rolling-publication
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ needs.prepare-rolling.outputs.tag }}
+    steps:
+      - name: Download rolling publication inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: rolling-publication-inputs
+          path: rolling-publication-inputs
+
+      - name: Validate rolling publication inputs
+        working-directory: rolling-publication-inputs
+        env:
+          PATH: /usr/bin:/bin
+          ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          source_basename="lopper_${ROLLING_TAG}_source.tar.gz"
+          expected_assets=(
+            "dist/lopper_${ROLLING_TAG}_linux_amd64.tar.gz"
+            "dist/lopper_${ROLLING_TAG}_linux_arm64.tar.gz"
+            "dist/lopper_${ROLLING_TAG}_windows_amd64.zip"
+            "dist/lopper_${ROLLING_TAG}_windows_arm64.zip"
+            "dist/lopper_${ROLLING_TAG}_darwin_amd64.tar.gz"
+            "dist/lopper_${ROLLING_TAG}_darwin_arm64.tar.gz"
+            "dist/lopper_${ROLLING_TAG}_source.tar.gz"
+            "dist/lopper_${ROLLING_TAG}_source.tar.gz.sha256"
+          )
+
+          if find . -mindepth 1 ! -type f ! -type d -print -quit | grep -q .; then
+            echo "Rolling publication inputs contain a non-regular entry" >&2
+            exit 1
+          fi
+          if find . -mindepth 1 -maxdepth 1 ! -name dist ! -name rolling-changelog.md ! -name SHA256SUMS -print -quit | grep -q .; then
+            echo "Rolling publication inputs contain an unexpected top-level path" >&2
+            exit 1
+          fi
+          if [ "$(find . -type f | wc -l | tr -d '[:space:]')" -ne 10 ]; then
+            echo "Rolling publication inputs contain an unexpected file count" >&2
+            exit 1
+          fi
+          if [ ! -f SHA256SUMS ] || [ -L SHA256SUMS ] || [ ! -s SHA256SUMS ]; then
+            echo "Rolling publication checksum manifest is missing or invalid" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s SHA256SUMS)" -gt 65536 ]; then
+            echo "Rolling publication checksum manifest exceeds the 64 KiB limit" >&2
+            exit 1
+          fi
+          if [ ! -f rolling-changelog.md ] || [ -L rolling-changelog.md ] || [ ! -s rolling-changelog.md ]; then
+            echo "Rolling changelog is missing, invalid, or empty" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s rolling-changelog.md)" -gt 1048576 ]; then
+            echo "Rolling changelog exceeds the 1 MiB limit" >&2
+            exit 1
+          fi
+          if [ ! -d dist ] || [ -L dist ]; then
+            echo "Rolling asset directory is missing or invalid" >&2
+            exit 1
+          fi
+          if find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Rolling asset directory contains a non-regular entry" >&2
+            exit 1
+          fi
+          if [ "$(find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')" -ne "${#expected_assets[@]}" ]; then
+            echo "Rolling asset directory must contain exactly eight assets" >&2
+            exit 1
+          fi
+          for asset in "${expected_assets[@]}"; do
+            if [ ! -f "${asset}" ] || [ -L "${asset}" ] || [ ! -s "${asset}" ]; then
+              echo "Expected rolling asset ${asset} is missing, invalid, or empty" >&2
+              exit 1
+            fi
+            if [ "$(stat --format=%s "${asset}")" -gt 1073741824 ]; then
+              echo "Rolling asset ${asset} exceeds the 1 GiB limit" >&2
+              exit 1
+            fi
+          done
+          if [ "$(stat --format=%s "dist/${source_basename}.sha256")" -gt 4096 ]; then
+            echo "Rolling source checksum sidecar exceeds the 4 KiB limit" >&2
+            exit 1
+          fi
+
+          (
+            cd dist
+            sha256sum --check --strict "${source_basename}.sha256"
+          )
+          computed_checksums="$(mktemp)"
+          trap 'rm -f "${computed_checksums}"' EXIT
+          manifest_inputs=("rolling-changelog.md" "${expected_assets[@]}")
+          mapfile -d '' sorted_manifest_inputs < <(printf '%s\0' "${manifest_inputs[@]}" | sort -z)
+          sha256sum "${sorted_manifest_inputs[@]}" > "${computed_checksums}"
+          if ! cmp -s SHA256SUMS "${computed_checksums}"; then
+            echo "Rolling publication checksum manifest does not cover the exact input set" >&2
+            exit 1
+          fi
+          sha256sum --check --strict SHA256SUMS
 
       - name: Publish rolling prerelease
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@c12583777ecdfd3be55c69cf75464299dc01057e
         with:
-          tag_name: ${{ env.ROLLING_TAG }}
-          target_commitish: ${{ env.SOURCE_SHA }}
-          name: Rolling ${{ env.ROLLING_TAG }}
-          body_path: rolling-changelog.md
+          tag_name: ${{ needs.prepare-rolling.outputs.tag }}
+          target_commitish: ${{ needs.prepare-rolling.outputs.source_sha }}
+          name: Rolling ${{ needs.prepare-rolling.outputs.tag }}
+          body_path: rolling-publication-inputs/rolling-changelog.md
           prerelease: true
+          fail_on_unmatched_files: true
           files: |
-            dist/*.tar.gz
-            dist/*.zip
-            dist/*.sha256
+            rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_linux_amd64.tar.gz
+            rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_linux_arm64.tar.gz
+            rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_windows_amd64.zip
+            rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_windows_arm64.zip
+            rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_darwin_amd64.tar.gz
+            rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_darwin_arm64.tar.gz
+            rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_source.tar.gz
+            rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_source.tar.gz.sha256
 
   homebrew-tap-token-gate:
     needs:

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Checkout rolling source
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           ref: ${{ env.SOURCE_SHA }}
 
       - name: Compute build metadata
@@ -93,6 +94,15 @@ jobs:
           make tools-install
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+      - name: Reset Darwin amd64 rolling artifact staging
+        env:
+          PATH: /usr/bin:/bin
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          rm -rf -- dist
+          mkdir -- dist
+
       - name: Build Darwin amd64 rolling artifact
         env:
           COMMIT_SHA: ${{ steps.build_meta.outputs.commit }}
@@ -105,13 +115,40 @@ jobs:
             RELEASE_BUILD_CHANNEL=rolling \
             PLATFORMS="darwin/amd64"
 
+      - name: Validate Darwin amd64 rolling artifact
+        env:
+          PATH: /usr/bin:/bin
+          RELEASE_TAG: ${{ needs.prepare-rolling.outputs.tag }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          expected=("dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz")
+          if find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Darwin amd64 rolling artifact staging contains a non-regular entry" >&2
+            exit 1
+          fi
+          file_count="$(find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [ "${file_count}" -ne "${#expected[@]}" ]; then
+            echo "Darwin amd64 rolling artifact staging contains an unexpected file count" >&2
+            exit 1
+          fi
+          for artifact in "${expected[@]}"; do
+            if [ ! -f "${artifact}" ] || [ -L "${artifact}" ]; then
+              echo "Expected Darwin amd64 rolling artifact ${artifact} is missing or not a regular file" >&2
+              exit 1
+            fi
+            if [ ! -s "${artifact}" ]; then
+              echo "Expected Darwin amd64 rolling artifact ${artifact} is empty" >&2
+              exit 1
+            fi
+          done
+
       - name: Upload Darwin amd64 rolling artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: rolling-darwin-amd64
-          path: |
-            dist/*.tar.gz
-            dist/*.zip
+          path: dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_darwin_amd64.tar.gz
+          if-no-files-found: error
 
   publish-rolling:
     needs:

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -60,7 +60,7 @@ jobs:
       SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
     steps:
       - name: Checkout rolling source
-        uses: actions/checkout@v7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           ref: ${{ env.SOURCE_SHA }}
@@ -72,7 +72,7 @@ jobs:
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Reset Darwin amd64 rolling artifact staging
         env:
           PATH: /usr/bin:/bin
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           rm -rf -- dist
@@ -119,7 +119,7 @@ jobs:
         env:
           PATH: /usr/bin:/bin
           RELEASE_TAG: ${{ needs.prepare-rolling.outputs.tag }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           expected=("dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz")
@@ -238,7 +238,7 @@ jobs:
         env:
           NOTES_ROOT: ${{ runner.temp }}/rolling-release-notes
           PATH: /usr/bin:/bin
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           changelog="${NOTES_ROOT}/rolling-changelog.md"
@@ -301,7 +301,7 @@ jobs:
           PATH: /usr/bin:/bin
           ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
           SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           archive_root="${RUNNER_TEMP}/rolling-source-archive"
@@ -316,7 +316,7 @@ jobs:
           ARCHIVE_ROOT: ${{ runner.temp }}/rolling-source-archive
           PATH: /usr/bin:/bin
           ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           archive="${ARCHIVE_ROOT}/lopper_${ROLLING_TAG}_source.tar.gz"
@@ -362,7 +362,7 @@ jobs:
       - name: Reset rolling publication assembly
         env:
           PATH: /usr/bin:/bin
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           assembly_root="${RUNNER_TEMP}/rolling-publication-assembly"
@@ -405,7 +405,7 @@ jobs:
           ASSEMBLY_ROOT: ${{ runner.temp }}/rolling-publication-assembly
           PATH: /usr/bin:/bin
           ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           source_basename="lopper_${ROLLING_TAG}_source.tar.gz"
@@ -551,7 +551,7 @@ jobs:
         env:
           PATH: /usr/bin:/bin
           ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
           source_basename="lopper_${ROLLING_TAG}_source.tar.gz"
@@ -693,7 +693,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@fc695c54c2032716dd4cedd007489c8e32fc8a5d
 
       - name: Clone tap repository anonymously
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           git_bin=/usr/bin/git
           mktemp_bin=/usr/bin/mktemp
@@ -794,7 +794,7 @@ jobs:
       - name: Regenerate and push rolling formula changes
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           git_bin=/usr/bin/git
           curl_bin=/usr/bin/curl

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf -- dist
-          mkdir -- dist
+          mkdir dist
 
       - name: Build Darwin amd64 rolling artifact
         env:

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -150,7 +150,7 @@ jobs:
           path: dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_darwin_amd64.tar.gz
           if-no-files-found: error
 
-  prepare-rolling-source-inputs:
+  prepare-rolling-release-notes:
     needs:
       - prepare-rolling
     runs-on: ubuntu-latest
@@ -180,28 +180,16 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build rolling source bundle
-        env:
-          ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
-          SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
-        run: |
-          set -euo pipefail
-          source_input_root="${RUNNER_TEMP}/rolling-source-inputs"
-          rm -rf -- "${source_input_root}"
-          mkdir -- "${source_input_root}"
-          bundle="lopper_${ROLLING_TAG}_source"
-          archive_path="${source_input_root}/lopper_${ROLLING_TAG}_source.tar.gz"
-
-          git archive --format=tar.gz --prefix="${bundle}/" -o "${archive_path}" "${SOURCE_SHA}"
-
       - name: Generate rolling release notes
         env:
           ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
           SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
         run: |
           set -euo pipefail
-          source_input_root="${RUNNER_TEMP}/rolling-source-inputs"
+          notes_root="${RUNNER_TEMP}/rolling-release-notes"
           feature_report="${RUNNER_TEMP}/rolling-feature-flags.md"
+          rm -rf -- "${notes_root}"
+          mkdir -- "${notes_root}"
           git fetch --tags --force
           previous_tag=""
           while IFS= read -r candidate; do
@@ -244,44 +232,31 @@ jobs:
               echo
               git log --reverse --pretty=format:'- %h %s (%an)' "${SOURCE_SHA}"
             fi
-          } > "${source_input_root}/rolling-changelog.md"
+          } > "${notes_root}/rolling-changelog.md"
 
-      - name: Validate rolling source inputs
+      - name: Validate rolling release notes
         env:
+          NOTES_ROOT: ${{ runner.temp }}/rolling-release-notes
           PATH: /usr/bin:/bin
-          ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
-          SOURCE_INPUT_ROOT: ${{ runner.temp }}/rolling-source-inputs
         shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
         run: |
           set -euo pipefail
-          archive="${SOURCE_INPUT_ROOT}/lopper_${ROLLING_TAG}_source.tar.gz"
-          changelog="${SOURCE_INPUT_ROOT}/rolling-changelog.md"
-          expected=("${archive}" "${changelog}")
-          if [ ! -d "${SOURCE_INPUT_ROOT}" ] || [ -L "${SOURCE_INPUT_ROOT}" ]; then
-            echo "Rolling source input root is missing or invalid" >&2
+          changelog="${NOTES_ROOT}/rolling-changelog.md"
+          if [ ! -d "${NOTES_ROOT}" ] || [ -L "${NOTES_ROOT}" ]; then
+            echo "Rolling release note root is missing or invalid" >&2
             exit 1
           fi
-          if find -P "${SOURCE_INPUT_ROOT}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
-            echo "Rolling source input root contains a non-regular entry" >&2
+          if find -P "${NOTES_ROOT}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Rolling release note root contains a non-regular entry" >&2
             exit 1
           fi
-          file_count="$(find -P "${SOURCE_INPUT_ROOT}" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
-          if [ "${file_count}" -ne "${#expected[@]}" ]; then
-            echo "Rolling source input root must contain exactly two files" >&2
+          file_count="$(find -P "${NOTES_ROOT}" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [ "${file_count}" -ne 1 ]; then
+            echo "Rolling release note root must contain exactly one file" >&2
             exit 1
           fi
-          for input in "${expected[@]}"; do
-            if [ ! -f "${input}" ] || [ -L "${input}" ]; then
-              echo "Expected rolling source input ${input} is missing or invalid" >&2
-              exit 1
-            fi
-            if [ ! -s "${input}" ]; then
-              echo "Expected rolling source input ${input} is empty" >&2
-              exit 1
-            fi
-          done
-          if [ "$(stat --format=%s "${archive}")" -gt 1073741824 ]; then
-            echo "Rolling source archive exceeds the 1 GiB limit" >&2
+          if [ ! -f "${changelog}" ] || [ -L "${changelog}" ] || [ ! -s "${changelog}" ]; then
+            echo "Rolling release notes are missing, invalid, or empty" >&2
             exit 1
           fi
           if [ "$(stat --format=%s "${changelog}")" -gt 1048576 ]; then
@@ -289,19 +264,96 @@ jobs:
             exit 1
           fi
 
-      - name: Upload rolling source inputs
+      - name: Upload rolling release notes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: rolling-source-inputs
-          path: |
-            ${{ runner.temp }}/rolling-source-inputs/lopper_${{ needs.prepare-rolling.outputs.tag }}_source.tar.gz
-            ${{ runner.temp }}/rolling-source-inputs/rolling-changelog.md
+          name: rolling-release-notes
+          path: ${{ runner.temp }}/rolling-release-notes/rolling-changelog.md
+          if-no-files-found: error
+
+  prepare-rolling-source-archive:
+    needs:
+      - prepare-rolling
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout rolling source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ needs.prepare-rolling.outputs.source_sha }}
+
+      - name: Verify rolling source checkout
+        env:
+          EXPECTED_SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          actual_source_sha="$(git rev-parse HEAD)"
+          if [ "${actual_source_sha}" != "${EXPECTED_SOURCE_SHA}" ]; then
+            echo "Checked out rolling source ${actual_source_sha} does not match ${EXPECTED_SOURCE_SHA}" >&2
+            exit 1
+          fi
+
+      - name: Build rolling source archive
+        env:
+          PATH: /usr/bin:/bin
+          ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
+          SOURCE_SHA: ${{ needs.prepare-rolling.outputs.source_sha }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          archive_root="${RUNNER_TEMP}/rolling-source-archive"
+          rm -rf -- "${archive_root}"
+          mkdir -- "${archive_root}"
+          bundle="lopper_${ROLLING_TAG}_source"
+          archive_path="${archive_root}/lopper_${ROLLING_TAG}_source.tar.gz"
+          git archive --format=tar.gz --prefix="${bundle}/" -o "${archive_path}" "${SOURCE_SHA}"
+
+      - name: Validate rolling source archive
+        env:
+          ARCHIVE_ROOT: ${{ runner.temp }}/rolling-source-archive
+          PATH: /usr/bin:/bin
+          ROLLING_TAG: ${{ needs.prepare-rolling.outputs.tag }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+          archive="${ARCHIVE_ROOT}/lopper_${ROLLING_TAG}_source.tar.gz"
+          if [ ! -d "${ARCHIVE_ROOT}" ] || [ -L "${ARCHIVE_ROOT}" ]; then
+            echo "Rolling source archive root is missing or invalid" >&2
+            exit 1
+          fi
+          if find -P "${ARCHIVE_ROOT}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "Rolling source archive root contains a non-regular entry" >&2
+            exit 1
+          fi
+          file_count="$(find -P "${ARCHIVE_ROOT}" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [ "${file_count}" -ne 1 ]; then
+            echo "Rolling source archive root must contain exactly one file" >&2
+            exit 1
+          fi
+          if [ ! -f "${archive}" ] || [ -L "${archive}" ] || [ ! -s "${archive}" ]; then
+            echo "Rolling source archive is missing, invalid, or empty" >&2
+            exit 1
+          fi
+          if [ "$(stat --format=%s "${archive}")" -gt 1073741824 ]; then
+            echo "Rolling source archive exceeds the 1 GiB limit" >&2
+            exit 1
+          fi
+
+      - name: Upload rolling source archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: rolling-source-archive
+          path: ${{ runner.temp }}/rolling-source-archive/lopper_${{ needs.prepare-rolling.outputs.tag }}_source.tar.gz
           if-no-files-found: error
 
   prepare-rolling-publication:
     needs:
       - prepare-rolling
-      - prepare-rolling-source-inputs
+      - prepare-rolling-release-notes
+      - prepare-rolling-source-archive
       - orchestrate-rolling
       - build-darwin-amd64-rolling
     runs-on: ubuntu-latest
@@ -318,11 +370,17 @@ jobs:
           rm -rf -- rolling-publication-inputs
           mkdir -- "${assembly_root}"
 
-      - name: Download rolling source inputs
+      - name: Download rolling source archive
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: rolling-source-inputs
-          path: ${{ runner.temp }}/rolling-publication-assembly/source
+          name: rolling-source-archive
+          path: ${{ runner.temp }}/rolling-publication-assembly/source-archive
+
+      - name: Download rolling release notes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: rolling-release-notes
+          path: ${{ runner.temp }}/rolling-publication-assembly/release-notes
 
       - name: Download rolling Linux and Windows artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -351,8 +409,8 @@ jobs:
         run: |
           set -euo pipefail
           source_basename="lopper_${ROLLING_TAG}_source.tar.gz"
-          source_archive="${ASSEMBLY_ROOT}/source/lopper_${ROLLING_TAG}_source.tar.gz"
-          changelog="${ASSEMBLY_ROOT}/source/rolling-changelog.md"
+          source_archive="${ASSEMBLY_ROOT}/source-archive/lopper_${ROLLING_TAG}_source.tar.gz"
+          changelog="${ASSEMBLY_ROOT}/release-notes/rolling-changelog.md"
           linux_windows_assets=(
             "${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_linux_amd64.tar.gz"
             "${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_linux_arm64.tar.gz"
@@ -409,7 +467,8 @@ jobs:
             done
           }
 
-          validate_input_root "${ASSEMBLY_ROOT}/source" 1073741824 "${source_archive}" "${changelog}"
+          validate_input_root "${ASSEMBLY_ROOT}/source-archive" 1073741824 "${source_archive}"
+          validate_input_root "${ASSEMBLY_ROOT}/release-notes" 1048576 "${changelog}"
           validate_input_root "${ASSEMBLY_ROOT}/linux-windows" 1073741824 "${linux_windows_assets[@]}"
           validate_input_root "${ASSEMBLY_ROOT}/darwin-arm64" 1073741824 "${darwin_arm64_assets[@]}"
           validate_input_root "${ASSEMBLY_ROOT}/darwin-amd64" 1073741824 "${darwin_amd64_assets[@]}"

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -472,9 +472,10 @@ func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 	syncIndex := workflowStepIndexByName(t, workflow.Jobs, jobName, "Sync VS Code extension version")
 	resetIndex := workflowStepIndexByName(t, workflow.Jobs, jobName, "Reset VS Code extension artifact staging")
 	packageIndex := workflowStepIndexByName(t, workflow.Jobs, jobName, "Package VS Code extension")
+	validateIndex := workflowStepIndexByName(t, workflow.Jobs, jobName, "Validate VS Code extension artifact")
 	uploadIndex := workflowStepIndexByName(t, workflow.Jobs, jobName, "Upload VS Code extension artifact")
-	if resetIndex != syncIndex+1 || packageIndex != resetIndex+1 || uploadIndex != packageIndex+1 {
-		t.Fatal("VS Code release packaging must sync, reset, package, and upload in one contiguous sequence")
+	if resetIndex != syncIndex+1 || packageIndex != resetIndex+1 || validateIndex != packageIndex+1 || uploadIndex != validateIndex+1 {
+		t.Fatal("VS Code release packaging must sync, reset, package, validate, and upload in one contiguous sequence")
 	}
 
 	syncStep := build.Steps[syncIndex]
@@ -500,6 +501,17 @@ func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 	if strings.Count(packageStep.Run, "npx ") != 1 {
 		t.Fatal("VS Code extension packaging must run exactly one npx command after resetting artifact staging")
 	}
+
+	validateStep := build.Steps[validateIndex]
+	assertWorkflowStepEnv(t, validateStep, "VS Code extension artifact validation", map[string]string{
+		"RELEASE_VERSION": "${{ needs.prepare-release.outputs.version }}",
+	})
+	assertWorkflowStepRunContainsAll(t, validateStep, "VS Code extension artifact validation", []string{
+		`expected="dist/lopper-vscode-${RELEASE_VERSION}.vsix"`,
+		`find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
+		`[ ! -f "${expected}" ] || [ -L "${expected}" ]`,
+		`find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l`,
+	})
 
 	for _, step := range build.Steps[resetIndex:] {
 		for _, repositoryCommand := range []string{"go run ./", "make ", "npm ", "npx ", "scripts/", "./extensions/"} {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -549,25 +549,70 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
+	reportPreparation := workflowJobByName(t, workflow.Jobs, "prepare-release-feature-report")
+	assertWorkflowJobNeeds(t, reportPreparation, "release feature report preparation", workflowJobNeeds{"prepare-release"})
+	assertWorkflowJobPermissions(t, reportPreparation, "release feature report preparation", map[string]string{"contents": "read"})
+	assertWorkflowJobEnvEmpty(t, reportPreparation, "release feature report preparation")
+	assertWorkflowJobOmitsText(t, reportPreparation, "secrets.", "release feature report preparation must not receive secrets")
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, reportPreparation, "prepare-release-feature-report")
+	assertWorkflowStepOrder(t, reportPreparation, "Checkout release source", "Verify release source checkout", "Setup Go", "Generate feature flag release report", "Validate feature flag release report", "Upload feature flag release report")
+	verifySource := workflowStepByName(t, workflow.Jobs, "prepare-release-feature-report", "Verify release source checkout")
+	assertWorkflowStepEnv(t, verifySource, "release source checkout verification", map[string]string{
+		"EXPECTED_SOURCE_SHA": "${{ needs.prepare-release.outputs.sha }}",
+	})
+	assertWorkflowStepRunContainsAll(t, verifySource, "release source checkout verification", []string{
+		`actual_source_sha="$(git rev-parse HEAD)"`,
+		`[ "${actual_source_sha}" != "${EXPECTED_SOURCE_SHA}" ]`,
+	})
+
+	generateReport := workflowStepByName(t, workflow.Jobs, "prepare-release-feature-report", "Generate feature flag release report")
+	assertWorkflowStepRunContainsAll(t, generateReport, "feature flag release report generation", []string{
+		`report_dir="${RUNNER_TEMP}/release-feature-report"`,
+		`rm -rf -- "${report_dir}"`,
+		`mkdir -- "${report_dir}"`,
+		`go run ./tools/featureflag "${args[@]}" > "${report_dir}/feature-flags.md"`,
+	})
+	validateReport := workflowStepByName(t, workflow.Jobs, "prepare-release-feature-report", "Validate feature flag release report")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "feature report validation shell", got: validateReport.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, validateReport, "feature report validation", map[string]string{"PATH": "/usr/bin:/bin"})
+	assertWorkflowStepRunContainsAll(t, validateReport, "feature report validation", []string{
+		`find -P "${report_dir}" -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
+		`[ ! -f "${report}" ] || [ -L "${report}" ]`,
+		`[ ! -s "${report}" ]`,
+		`find -P "${report_dir}" -mindepth 1 -maxdepth 1 -type f | wc -l`,
+	})
+	reportUpload := workflowStepByName(t, workflow.Jobs, "prepare-release-feature-report", "Upload feature flag release report")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "feature report artifact name", got: reportUpload.With["name"], want: "stable-feature-report"},
+		{label: "feature report artifact path", got: reportUpload.With["path"], want: "${{ runner.temp }}/release-feature-report/feature-flags.md"},
+		{label: "feature report artifact missing-file behavior", got: reportUpload.With["if-no-files-found"], want: "error"},
+	})
+
 	preparation := workflowJobByName(t, workflow.Jobs, "prepare-release-publication")
-	assertWorkflowJobNeeds(t, preparation, "release publication preparation", workflowJobNeeds{"prepare-release", "orchestrate-release", "build-vscode-extension", "build-darwin-amd64"})
-	assertWorkflowJobPermissions(t, preparation, "release publication preparation", map[string]string{"contents": "read"})
+	assertWorkflowJobNeeds(t, preparation, "release publication preparation", workflowJobNeeds{"prepare-release", "prepare-release-feature-report", "orchestrate-release", "build-vscode-extension", "build-darwin-amd64"})
+	assertWorkflowJobHasExplicitEmptyPermissions(t, preparation, "release publication preparation")
+	assertWorkflowJobEnvEmpty(t, preparation, "release publication preparation")
 	assertWorkflowJobOmitsText(t, preparation, "GH_TOKEN", "release publication preparation must not receive GH_TOKEN")
 	assertWorkflowJobOmitsText(t, preparation, "secrets.", "release publication preparation must not receive secrets")
-	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, preparation, "prepare-release-publication")
+	assertWorkflowJobOmitsCheckout(t, preparation, "prepare-release-publication")
+	assertWorkflowJobStepRunsOmitAllFold(t, preparation, "release publication preparation", []string{"go run ./", "make ", "npm ", "npx ", "scripts/"})
 
-	generateIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Generate feature flag release report")
-	resetIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Reset release artifact staging")
-	downloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Download release artifacts")
+	resetIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Reset release publication assembly")
+	reportDownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Download feature flag release report")
+	linuxWindowsDownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Download Linux and Windows release artifacts")
+	darwinArm64DownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Download Darwin arm64 release artifact")
+	darwinAmd64DownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Download Darwin amd64 release artifact")
+	vsixDownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Download VS Code extension release artifact")
 	stageIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Stage bounded release publication inputs")
 	uploadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
-	if generateIndex >= resetIndex {
-		t.Fatal("release-source-controlled report generation must finish before the artifact staging reset")
+	if reportDownloadIndex != resetIndex+1 || linuxWindowsDownloadIndex != reportDownloadIndex+1 ||
+		darwinArm64DownloadIndex != linuxWindowsDownloadIndex+1 || darwinAmd64DownloadIndex != darwinArm64DownloadIndex+1 ||
+		vsixDownloadIndex != darwinAmd64DownloadIndex+1 {
+		t.Fatal("release inputs must be downloaded into fresh roots immediately after resetting publication assembly")
 	}
-	if downloadIndex != resetIndex+1 {
-		t.Fatal("release artifacts must be downloaded immediately after resetting the staging directory")
-	}
-	if stageIndex != downloadIndex+1 || uploadIndex != stageIndex+1 {
+	if stageIndex != vsixDownloadIndex+1 || uploadIndex != stageIndex+1 {
 		t.Fatal("release artifacts must be downloaded, staged, and uploaded in one contiguous sequence")
 	}
 
@@ -577,15 +622,38 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	})
 	assertWorkflowStepEnv(t, resetStep, "release artifact staging reset", map[string]string{"PATH": "/usr/bin:/bin"})
 	assertWorkflowStepRunContainsAll(t, resetStep, "release artifact staging reset", []string{
-		`rm -rf -- dist`,
-		`mkdir -- dist`,
+		`assembly_root="${RUNNER_TEMP}/release-publication-assembly"`,
+		`rm -rf -- "${assembly_root}"`,
+		`rm -rf -- publication-inputs`,
+		`mkdir -- "${assembly_root}"`,
 	})
-	assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- dist`, `mkdir -- dist`, "release artifact staging must remove checkout-provided assets before recreating dist")
-	for _, step := range preparation.Steps[resetIndex:] {
-		for _, repositoryCommand := range []string{"go run ./", "make ", "./extensions/", "scripts/"} {
-			if strings.Contains(step.Run, repositoryCommand) {
-				t.Fatalf("release publication step %q must not execute repository-controlled command %q after resetting artifact staging", step.Name, repositoryCommand)
+	assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- "${assembly_root}"`, `mkdir -- "${assembly_root}"`, "release assembly must remove prior inputs before recreating its runner-temp root")
+	downloadContracts := []struct {
+		index int
+		name  string
+		path  string
+	}{
+		{index: reportDownloadIndex, name: "stable-feature-report", path: "${{ runner.temp }}/release-publication-assembly/feature-report"},
+		{index: linuxWindowsDownloadIndex, name: "release-linux-windows", path: "${{ runner.temp }}/release-publication-assembly/linux-windows"},
+		{index: darwinArm64DownloadIndex, name: "release-darwin", path: "${{ runner.temp }}/release-publication-assembly/darwin-arm64"},
+		{index: darwinAmd64DownloadIndex, name: "release-darwin-amd64", path: "${{ runner.temp }}/release-publication-assembly/darwin-amd64"},
+		{index: vsixDownloadIndex, name: "release-vscode-extension", path: "${{ runner.temp }}/release-publication-assembly/vscode"},
+	}
+	for _, contract := range downloadContracts {
+		download := preparation.Steps[contract.index]
+		assertWorkflowStringValues(t, []workflowStringValue{
+			{label: download.Name + " artifact name", got: download.With["name"], want: contract.name},
+			{label: download.Name + " path", got: download.With["path"], want: contract.path},
+		})
+		for _, forbidden := range []string{"pattern", "merge-multiple"} {
+			if _, ok := download.With[forbidden]; ok {
+				t.Fatalf("%s must not use with.%s", download.Name, forbidden)
 			}
+		}
+	}
+	for _, step := range preparation.Steps {
+		if strings.Contains(step.Run, "${{ needs.") {
+			t.Fatalf("fresh release assembly step %q must bind trusted values through env instead of interpolating expressions into shell source", step.Name)
 		}
 	}
 
@@ -594,10 +662,25 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		{label: "release publication staging shell", got: stageStep.Shell, want: hardenedShell},
 	})
 	assertWorkflowStepEnv(t, stageStep, "release publication staging", map[string]string{
-		"PATH":        "/usr/bin:/bin",
-		"RELEASE_TAG": "${{ needs.prepare-release.outputs.tag }}",
+		"ASSEMBLY_ROOT": "${{ runner.temp }}/release-publication-assembly",
+		"PATH":          "/usr/bin:/bin",
+		"RELEASE_TAG":   "${{ needs.prepare-release.outputs.tag }}",
 	})
 	assertWorkflowStepRunContainsAll(t, stageStep, "release publication staging step", []string{
+		`report="${ASSEMBLY_ROOT}/feature-report/feature-flags.md"`,
+		`linux_windows_assets=(`,
+		`${ASSEMBLY_ROOT}/linux-windows/lopper_${RELEASE_TAG}_linux_amd64.tar.gz`,
+		`${ASSEMBLY_ROOT}/linux-windows/lopper_${RELEASE_TAG}_linux_arm64.tar.gz`,
+		`${ASSEMBLY_ROOT}/linux-windows/lopper_${RELEASE_TAG}_windows_amd64.zip`,
+		`${ASSEMBLY_ROOT}/linux-windows/lopper_${RELEASE_TAG}_windows_arm64.zip`,
+		`darwin_arm64_assets=("${ASSEMBLY_ROOT}/darwin-arm64/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz")`,
+		`darwin_amd64_assets=("${ASSEMBLY_ROOT}/darwin-amd64/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz")`,
+		`vsix_assets=("${ASSEMBLY_ROOT}/vscode/lopper-vscode-${version}.vsix")`,
+		`validate_input_root "${ASSEMBLY_ROOT}/feature-report" 1048576 "${report}"`,
+		`validate_input_root "${ASSEMBLY_ROOT}/linux-windows" 1073741824 "${linux_windows_assets[@]}"`,
+		`validate_input_root "${ASSEMBLY_ROOT}/darwin-arm64" 1073741824 "${darwin_arm64_assets[@]}"`,
+		`validate_input_root "${ASSEMBLY_ROOT}/darwin-amd64" 1073741824 "${darwin_amd64_assets[@]}"`,
+		`validate_input_root "${ASSEMBLY_ROOT}/vscode" 1073741824 "${vsix_assets[@]}"`,
 		`expected_assets=(`,
 		`dist/lopper_${RELEASE_TAG}_linux_amd64.tar.gz`,
 		`dist/lopper_${RELEASE_TAG}_linux_arm64.tar.gz`,
@@ -606,23 +689,24 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz`,
 		`dist/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz`,
 		`dist/lopper-vscode-${version}.vsix`,
-		`find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
 		`[ ! -f "${asset}" ] || [ -L "${asset}" ]`,
 		`[ ! -s "${asset}" ]`,
 		`rm -rf -- publication-inputs`,
 		`mkdir -p publication-inputs/dist`,
-		`publication-inputs/feature-flags.md`,
-		`mapfile -d '' checksum_files`,
-		`sha256sum "${checksum_files[@]}" > SHA256SUMS`,
+		`cp -- "${report}" publication-inputs/feature-flags.md`,
+		`manifest_inputs=("feature-flags.md" "${expected_assets[@]}")`,
+		`printf '%s\0' "${manifest_inputs[@]}" | sort -z`,
+		`sha256sum "${sorted_manifest_inputs[@]}" > SHA256SUMS`,
 	})
 	assertWorkflowStepRunOmitsAll(t, stageStep, "release publication staging step", []string{
 		"Expected between 1 and 32 release assets",
+		"pattern:",
 		`-name '*.tar.gz'`,
 		`-name 'lopper-vscode-*.vsix'`,
 	})
 	assertTextAppearsBefore(t, stageStep.Run, `rm -rf -- publication-inputs`, `mkdir -p publication-inputs/dist`, "release publication staging must remove prior inputs before recreating the directory")
 	assertTextAppearsBefore(t, stageStep.Run, `mkdir -p publication-inputs/dist`, `cp -- "${assets[@]}" publication-inputs/dist/`, "release publication staging must recreate the directory before copying bounded assets")
-	assertTextAppearsBefore(t, stageStep.Run, `mkdir -p publication-inputs/dist`, `cp -- feature-flags.md publication-inputs/feature-flags.md`, "release publication staging must recreate the directory before copying the feature report")
+	assertTextAppearsBefore(t, stageStep.Run, `mkdir -p publication-inputs/dist`, `cp -- "${report}" publication-inputs/feature-flags.md`, "release publication staging must recreate the directory before copying the feature report")
 	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{label: "release publication input artifact name", got: uploadStep.With["name"], want: "publication-inputs"},
@@ -650,9 +734,18 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz`,
 		`dist/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz`,
 		`dist/lopper-vscode-${version}.vsix`,
+		`[ ! -f SHA256SUMS ] || [ -L SHA256SUMS ] || [ ! -s SHA256SUMS ]`,
+		`stat --format=%s SHA256SUMS`,
+		`manifest_inputs=("feature-flags.md" "${expected_assets[@]}")`,
+		`printf '%s\0' "${manifest_inputs[@]}" | sort -z`,
+		`sha256sum "${sorted_manifest_inputs[@]}" > "${computed_checksums}"`,
+		`cmp -s SHA256SUMS "${computed_checksums}"`,
 		`[ ! -f "${asset}" ] || [ -L "${asset}" ]`,
 		`[ ! -s "${asset}" ]`,
 	})
+	assertTextAppearsBefore(t, validateStep.Run, `stat --format=%s "${asset}"`, `sha256sum "${sorted_manifest_inputs[@]}"`, "privileged publication must bound every release asset before hashing it")
+	assertTextAppearsBefore(t, validateStep.Run, `stat --format=%s feature-flags.md`, `sha256sum "${sorted_manifest_inputs[@]}"`, "privileged publication must bound the feature report before hashing it")
+	assertTextAppearsBefore(t, validateStep.Run, `stat --format=%s SHA256SUMS`, `sha256sum "${sorted_manifest_inputs[@]}"`, "privileged publication must bound the checksum manifest before hashing release inputs")
 	assertWorkflowStepRunOmitsAll(t, validateStep, "privileged release publication validation", []string{
 		"Expected between 1 and 32 release assets",
 		`-name '*.tar.gz'`,
@@ -711,9 +804,14 @@ func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
 		"jobs.prepare-marketplace-toolchain.steps.Checkout trusted main Marketplace manifests#1.uses",
 		"jobs.prepare-marketplace-toolchain.steps.Setup Node for Marketplace tooling#1.uses",
 		"jobs.prepare-marketplace-toolchain.steps.Upload Marketplace toolchain#1.uses",
-		"jobs.prepare-release-publication.steps.Checkout release source#1.uses",
-		"jobs.prepare-release-publication.steps.Download release artifacts#1.uses",
-		"jobs.prepare-release-publication.steps.Setup Go#1.uses",
+		"jobs.prepare-release-feature-report.steps.Checkout release source#1.uses",
+		"jobs.prepare-release-feature-report.steps.Setup Go#1.uses",
+		"jobs.prepare-release-feature-report.steps.Upload feature flag release report#1.uses",
+		"jobs.prepare-release-publication.steps.Download Darwin amd64 release artifact#1.uses",
+		"jobs.prepare-release-publication.steps.Download Darwin arm64 release artifact#1.uses",
+		"jobs.prepare-release-publication.steps.Download Linux and Windows release artifacts#1.uses",
+		"jobs.prepare-release-publication.steps.Download VS Code extension release artifact#1.uses",
+		"jobs.prepare-release-publication.steps.Download feature flag release report#1.uses",
 		"jobs.prepare-release-publication.steps.Upload release publication inputs#1.uses",
 		"jobs.prepare-release.steps.Checkout release metadata#1.uses",
 		"jobs.prepare-release.steps.Run release-please#1.uses",
@@ -968,23 +1066,29 @@ func workflowExpressionReferencesCredential(expression string) bool {
 		workflowBareGitHubContextPattern.MatchString(normalized)
 }
 
-func TestReleaseWorkflowPublicationArtifactNameAvoidsReleaseArtifactWildcard(t *testing.T) {
+func TestReleaseWorkflowDownloadsReleaseArtifactsByExactName(t *testing.T) {
 	t.Parallel()
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
-	downloadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Download release artifacts")
-	uploadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
-
-	pattern := downloadStep.With["pattern"]
-	artifactName := uploadStep.With["name"]
-	matched, err := filepath.Match(pattern, artifactName)
-	if err != nil {
-		t.Fatalf("release artifact download pattern %q is invalid: %v", pattern, err)
+	expectedArtifacts := map[string]string{
+		"Download feature flag release report":         "stable-feature-report",
+		"Download Linux and Windows release artifacts": "release-linux-windows",
+		"Download Darwin arm64 release artifact":       "release-darwin",
+		"Download Darwin amd64 release artifact":       "release-darwin-amd64",
+		"Download VS Code extension release artifact":  "release-vscode-extension",
 	}
-	if matched {
-		t.Fatalf("release publication input artifact %q must not match release artifact download pattern %q", artifactName, pattern)
+	for stepName, artifactName := range expectedArtifacts {
+		downloadStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", stepName)
+		if downloadStep.With["name"] != artifactName {
+			t.Fatalf("%s artifact name = %q", stepName, downloadStep.With["name"])
+		}
+		for _, forbidden := range []string{"pattern", "merge-multiple"} {
+			if _, ok := downloadStep.With[forbidden]; ok {
+				t.Fatalf("%s must not use with.%s", stepName, forbidden)
+			}
+		}
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -234,7 +234,7 @@ func TestReleaseWorkflowPinsTrustedMainToWorkflowRevision(t *testing.T) {
 	resolver := preparation.Steps[0]
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{label: "trusted main resolver id", got: resolver.ID, want: "trusted_main"},
-		{label: "trusted main resolver shell", got: resolver.Shell, want: "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"},
+		{label: "trusted main resolver shell", got: resolver.Shell, want: "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}"},
 		{label: "trusted main resolver action", got: resolver.Uses, want: ""},
 		{label: "trusted main resolver condition", got: resolver.If, want: ""},
 		{label: "trusted main resolver working directory", got: resolver.WorkingDirectory, want: ""},
@@ -463,7 +463,7 @@ func TestReleaseWorkflowConfinesMainSyncPATToReleasePleaseAndTrustedFeatureHisto
 
 func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 	t.Parallel()
-	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"
+	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}"
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
@@ -544,7 +544,7 @@ func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 
 func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	t.Parallel()
-	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"
+	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}"
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
@@ -802,7 +802,7 @@ func TestReleaseWorkflowUsesCanonicalPublicationManifestPaths(t *testing.T) {
 
 func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	t.Parallel()
-	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"
+	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}"
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/rolling.yml", &workflow)
@@ -1520,7 +1520,7 @@ func assertMarketplacePreparationGate(t *testing.T, preparation workflowJobConfi
 	if len(gate.Env) != 2 || gate.Env["VSCE_PUBLISH"] != "${{ secrets.VSCE_PUBLISH }}" || gate.Env["PATH"] != "/usr/bin:/bin" {
 		t.Fatalf("Marketplace token detector env = %#v, want only the scoped token and trusted PATH", gate.Env)
 	}
-	wantShell := "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"
+	wantShell := "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}"
 	if gate.Shell != wantShell {
 		t.Fatalf("Marketplace token detector shell = %q, want sanitized shell", gate.Shell)
 	}
@@ -1590,7 +1590,7 @@ func TestReleaseWorkflowPublishesMarketplaceFromValidatedArtifacts(t *testing.T)
 	assertWorkflowStringValues(t, []workflowStringValue{{
 		label: "Marketplace input validation shell",
 		got:   validateStep.Shell,
-		want:  "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}",
+		want:  "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}",
 	}})
 	assertWorkflowStepEnv(t, validateStep, "Marketplace input validation", map[string]string{
 		"RELEASE_VERSION": "${{ needs.prepare-release.outputs.version }}",
@@ -1969,7 +1969,7 @@ func TestReleaseWorkflowPublishesActionFloatingTags(t *testing.T) {
 	prepareStep := workflowStepByName(t, workflow.Jobs, "finalize-release", "Prepare GitHub Action floating tags")
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{label: "action floating tag preparation id", got: prepareStep.ID, want: "prepare_tags"},
-		{label: "action floating tag preparation shell", got: prepareStep.Shell, want: "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"},
+		{label: "action floating tag preparation shell", got: prepareStep.Shell, want: "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}"},
 	})
 	assertWorkflowStepEnv(t, prepareStep, "action floating tag preparation", map[string]string{
 		"RELEASE_TAG": "${{ needs.prepare-release.outputs.tag }}",
@@ -2169,7 +2169,7 @@ func TestReleaseWorkflowHomebrewPublicationUsesFreshCredentialScopedClone(t *tes
 	if len(step.Env) != 1 || step.Env["HOMEBREW_TAP_TOKEN"] != "${{ secrets.HOMEBREW_TAP_TOKEN }}" {
 		t.Fatalf("privileged tap step env = %#v", step.Env)
 	}
-	if step.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
+	if step.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}" {
 		t.Fatalf("privileged tap step shell = %q", step.Shell)
 	}
 	assertWorkflowStepRunContainsAll(t, step, "privileged tap publication step", []string{
@@ -2405,7 +2405,7 @@ func TestReleaseWorkflowPushesFeatureHistoryFromFreshValidatedCommit(t *testing.
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
 	prepareStep := workflowStepByName(t, workflow.Jobs, "prepare-feature-release-history-push", "Prepare trusted feature history commit")
-	if prepareStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
+	if prepareStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}" {
 		t.Fatalf("feature history commit preparation shell = %q", prepareStep.Shell)
 	}
 	if len(prepareStep.Env) != 2 || prepareStep.Env["RELEASE_TAG"] != "${{ needs.prepare-release.outputs.tag }}" || prepareStep.Env["RELEASE_SHA"] != "${{ needs.prepare-release.outputs.sha }}" {
@@ -2716,9 +2716,29 @@ func TestRollingDarwinProducerPinsTrustedActions(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowsUsePortableHardenedBashPath(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		".github/workflows/release-orchestration.yml",
+		".github/workflows/release.yml",
+		".github/workflows/rolling.yml",
+	} {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			workflowText := readConfig(t, path)
+			if strings.Contains(workflowText, "/usr/bin/bash") {
+				t.Fatalf("%s must use the macOS-compatible /bin/bash path for hardened shells", path)
+			}
+		})
+	}
+}
+
 func TestReleaseArchiveProducersUseFreshExactArtifactStaging(t *testing.T) {
 	t.Parallel()
-	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"
+	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}"
 
 	testCases := []struct {
 		name             string
@@ -3818,7 +3838,7 @@ func assertAnonymousValidationCloneStep(t *testing.T, job workflowJobConfig, tc 
 	if cloneStep.Uses != "" {
 		t.Fatalf("%s validation clone step must be a run step, got uses %q", tc.workflowPath, cloneStep.Uses)
 	}
-	if cloneStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
+	if cloneStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}" {
 		t.Fatalf("%s validation clone step shell = %q", tc.workflowPath, cloneStep.Shell)
 	}
 
@@ -3905,7 +3925,7 @@ func assertFreshPrivilegedTapUpdateJob(t *testing.T, jobs map[string]workflowJob
 	if pushStep.Env["HOMEBREW_TAP_TOKEN"] != "${{ secrets.HOMEBREW_TAP_TOKEN }}" {
 		t.Fatalf("%s privileged tap update step HOMEBREW_TAP_TOKEN env = %q", tc.workflowPath, pushStep.Env["HOMEBREW_TAP_TOKEN"])
 	}
-	if pushStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}" {
+	if pushStep.Shell != "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}" {
 		t.Fatalf("%s privileged tap update step shell = %q", tc.workflowPath, pushStep.Shell)
 	}
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -474,6 +474,36 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	assertWorkflowJobOmitsText(t, preparation, "secrets.", "release publication preparation must not receive secrets")
 	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, preparation, "prepare-release-publication")
 
+	generateIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Generate feature flag release report")
+	resetIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Reset release artifact staging")
+	downloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Download release artifacts")
+	verifyIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Verify Darwin artifacts are present")
+	stageIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Stage bounded release publication inputs")
+	uploadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
+	if generateIndex >= resetIndex {
+		t.Fatal("release-source-controlled report generation must finish before the artifact staging reset")
+	}
+	if downloadIndex != resetIndex+1 {
+		t.Fatal("release artifacts must be downloaded immediately after resetting the staging directory")
+	}
+	if downloadIndex >= verifyIndex || verifyIndex >= stageIndex || stageIndex >= uploadIndex {
+		t.Fatal("release artifacts must be downloaded, verified, staged, and uploaded in that order")
+	}
+
+	resetStep := preparation.Steps[resetIndex]
+	assertWorkflowStepRunContainsAll(t, resetStep, "release artifact staging reset", []string{
+		`rm -rf -- dist`,
+		`mkdir -- dist`,
+	})
+	assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- dist`, `mkdir -- dist`, "release artifact staging must remove checkout-provided assets before recreating dist")
+	for _, step := range preparation.Steps[resetIndex:] {
+		for _, repositoryCommand := range []string{"go run ./", "make ", "./extensions/", "scripts/"} {
+			if strings.Contains(step.Run, repositoryCommand) {
+				t.Fatalf("release publication step %q must not execute repository-controlled command %q after resetting artifact staging", step.Name, repositoryCommand)
+			}
+		}
+	}
+
 	stageStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Stage bounded release publication inputs")
 	assertWorkflowStepRunContainsAll(t, stageStep, "release publication staging step", []string{
 		`find dist -maxdepth 1 -type f`,

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -2688,6 +2688,34 @@ func TestDarwinReleaseJobsAssertHostArchitecture(t *testing.T) {
 	}
 }
 
+func TestRollingDarwinProducerPinsTrustedActions(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/rolling.yml", &workflow)
+
+	testCases := []struct {
+		stepName string
+		wantUses string
+	}{
+		{
+			stepName: "Checkout rolling source",
+			wantUses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+		},
+		{
+			stepName: "Setup Go",
+			wantUses: "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c",
+		},
+	}
+
+	for _, tc := range testCases {
+		step := workflowStepByName(t, workflow.Jobs, "build-darwin-amd64-rolling", tc.stepName)
+		if step.Uses != tc.wantUses {
+			t.Errorf("rolling Darwin producer step %q uses %q, want %q", tc.stepName, step.Uses, tc.wantUses)
+		}
+	}
+}
+
 func TestReleaseArchiveProducersUseFreshExactArtifactStaging(t *testing.T) {
 	t.Parallel()
 	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -461,6 +461,65 @@ func TestReleaseWorkflowConfinesMainSyncPATToReleasePleaseAndTrustedFeatureHisto
 	}
 }
 
+func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	const jobName = "build-vscode-extension"
+	build := workflowJobByName(t, workflow.Jobs, jobName)
+	syncIndex := workflowStepIndexByName(t, workflow.Jobs, jobName, "Sync VS Code extension version")
+	resetIndex := workflowStepIndexByName(t, workflow.Jobs, jobName, "Reset VS Code extension artifact staging")
+	packageIndex := workflowStepIndexByName(t, workflow.Jobs, jobName, "Package VS Code extension")
+	uploadIndex := workflowStepIndexByName(t, workflow.Jobs, jobName, "Upload VS Code extension artifact")
+	if resetIndex != syncIndex+1 || packageIndex != resetIndex+1 || uploadIndex != packageIndex+1 {
+		t.Fatal("VS Code release packaging must sync, reset, package, and upload in one contiguous sequence")
+	}
+
+	syncStep := build.Steps[syncIndex]
+	assertWorkflowStepRunContainsAll(t, syncStep, "VS Code extension version sync", []string{
+		`version="${RELEASE_TAG#v}"`,
+		`make sync-version VERSION="$version"`,
+	})
+
+	resetStep := build.Steps[resetIndex]
+	assertWorkflowStepRunContainsAll(t, resetStep, "VS Code extension artifact staging reset", []string{
+		`rm -rf -- dist`,
+		`mkdir -- dist`,
+	})
+	assertWorkflowStepRunOmitsAll(t, resetStep, "VS Code extension artifact staging reset", []string{"mkdir -p"})
+	assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- dist`, `mkdir -- dist`, "VS Code artifact staging must remove checkout-provided files before recreating dist")
+
+	packageStep := build.Steps[packageIndex]
+	const packageCommand = `npx @vscode/vsce package --out "../../dist/lopper-vscode-${version}.vsix"`
+	assertWorkflowStepRunContainsAll(t, packageStep, "VS Code extension package", []string{
+		`version="${RELEASE_TAG#v}"`,
+		packageCommand,
+	})
+	if strings.Count(packageStep.Run, "npx ") != 1 {
+		t.Fatal("VS Code extension packaging must run exactly one npx command after resetting artifact staging")
+	}
+
+	for _, step := range build.Steps[resetIndex:] {
+		for _, repositoryCommand := range []string{"go run ./", "make ", "npm ", "npx ", "scripts/", "./extensions/"} {
+			if step.Name == packageStep.Name && repositoryCommand == "npx " && strings.Contains(step.Run, packageCommand) {
+				continue
+			}
+			if strings.Contains(step.Run, repositoryCommand) {
+				t.Fatalf("VS Code release step %q must not execute repository-controlled command %q after resetting artifact staging", step.Name, repositoryCommand)
+			}
+		}
+	}
+
+	uploadStep := build.Steps[uploadIndex]
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "VS Code release artifact name", got: uploadStep.With["name"], want: "release-vscode-extension"},
+		{label: "VS Code release artifact path", got: uploadStep.With["path"], want: "dist/lopper-vscode-${{ needs.prepare-release.outputs.version }}.vsix"},
+		{label: "VS Code release artifact missing-file behavior", got: uploadStep.With["if-no-files-found"], want: "error"},
+	})
+}
+
 func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -814,72 +814,111 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	}
 	assertWorkflowJobPermissions(t, darwinProducer, "rolling Darwin amd64 producer", map[string]string{"contents": "read"})
 
-	sourcePreparation := workflowJobByName(t, workflow.Jobs, "prepare-rolling-source-inputs")
-	assertWorkflowJobNeeds(t, sourcePreparation, "rolling source input preparation", workflowJobNeeds{"prepare-rolling"})
-	assertWorkflowJobPermissions(t, sourcePreparation, "rolling source input preparation", map[string]string{"contents": "read"})
-	assertWorkflowJobEnvEmpty(t, sourcePreparation, "rolling source input preparation")
-	assertWorkflowJobOmitsText(t, sourcePreparation, "secrets.", "rolling source input preparation must not receive secrets")
-	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, sourcePreparation, "prepare-rolling-source-inputs")
-	assertWorkflowStepOrder(t, sourcePreparation, "Checkout rolling source", "Verify rolling source checkout", "Setup Go", "Build rolling source bundle", "Generate rolling release notes", "Validate rolling source inputs", "Upload rolling source inputs")
-	verifySource := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-inputs", "Verify rolling source checkout")
-	assertWorkflowStepEnv(t, verifySource, "rolling source checkout verification", map[string]string{
+	notesPreparation := workflowJobByName(t, workflow.Jobs, "prepare-rolling-release-notes")
+	assertWorkflowJobNeeds(t, notesPreparation, "rolling release note preparation", workflowJobNeeds{"prepare-rolling"})
+	assertWorkflowJobPermissions(t, notesPreparation, "rolling release note preparation", map[string]string{"contents": "read"})
+	assertWorkflowJobEnvEmpty(t, notesPreparation, "rolling release note preparation")
+	assertWorkflowJobOmitsText(t, notesPreparation, "secrets.", "rolling release note preparation must not receive secrets")
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, notesPreparation, "prepare-rolling-release-notes")
+	assertWorkflowStepOrder(t, notesPreparation, "Checkout rolling source", "Verify rolling source checkout", "Setup Go", "Generate rolling release notes", "Validate rolling release notes", "Upload rolling release notes")
+	generateNotes := workflowStepByName(t, workflow.Jobs, "prepare-rolling-release-notes", "Generate rolling release notes")
+	assertWorkflowStepRunContainsAll(t, generateNotes, "rolling release note generation", []string{
+		`notes_root="${RUNNER_TEMP}/rolling-release-notes"`,
+		`rm -rf -- "${notes_root}"`,
+		`mkdir -- "${notes_root}"`,
+		`go run ./tools/featureflag "${args[@]}" > "${feature_report}"`,
+		`> "${notes_root}/rolling-changelog.md"`,
+	})
+	validateNotes := workflowStepByName(t, workflow.Jobs, "prepare-rolling-release-notes", "Validate rolling release notes")
+	assertWorkflowStringValues(t, []workflowStringValue{{
+		label: "rolling release note validation shell",
+		got:   validateNotes.Shell,
+		want:  hardenedShell,
+	}})
+	assertWorkflowStepEnv(t, validateNotes, "rolling release note validation", map[string]string{
+		"NOTES_ROOT": "${{ runner.temp }}/rolling-release-notes",
+		"PATH":       "/usr/bin:/bin",
+	})
+	assertWorkflowStepRunContainsAll(t, validateNotes, "rolling release note validation", []string{
+		`changelog="${NOTES_ROOT}/rolling-changelog.md"`,
+		`find -P "${NOTES_ROOT}" -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
+		`[ "${file_count}" -ne 1 ]`,
+		`[ ! -f "${changelog}" ] || [ -L "${changelog}" ] || [ ! -s "${changelog}" ]`,
+		`[ "$(stat --format=%s "${changelog}")" -gt 1048576 ]`,
+	})
+	notesUpload := workflowStepByName(t, workflow.Jobs, "prepare-rolling-release-notes", "Upload rolling release notes")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "rolling release note artifact name", got: notesUpload.With["name"], want: "rolling-release-notes"},
+		{label: "rolling release note artifact path", got: notesUpload.With["path"], want: "${{ runner.temp }}/rolling-release-notes/rolling-changelog.md"},
+		{label: "rolling release note missing-file behavior", got: notesUpload.With["if-no-files-found"], want: "error"},
+	})
+
+	archivePreparation := workflowJobByName(t, workflow.Jobs, "prepare-rolling-source-archive")
+	assertWorkflowJobNeeds(t, archivePreparation, "rolling source archive preparation", workflowJobNeeds{"prepare-rolling"})
+	assertWorkflowJobPermissions(t, archivePreparation, "rolling source archive preparation", map[string]string{"contents": "read"})
+	assertWorkflowJobEnvEmpty(t, archivePreparation, "rolling source archive preparation")
+	assertWorkflowJobOmitsText(t, archivePreparation, "secrets.", "rolling source archive preparation must not receive secrets")
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, archivePreparation, "prepare-rolling-source-archive")
+	assertWorkflowJobStepRunsOmitAllFold(t, archivePreparation, "rolling source archive preparation", []string{"go run ./", "make ", "npm ", "npx ", "scripts/", "./extensions/"})
+	assertWorkflowStepOrder(t, archivePreparation, "Checkout rolling source", "Verify rolling source checkout", "Build rolling source archive", "Validate rolling source archive", "Upload rolling source archive")
+	verifySource := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-archive", "Verify rolling source checkout")
+	assertWorkflowStepEnv(t, verifySource, "rolling source archive checkout verification", map[string]string{
 		"EXPECTED_SOURCE_SHA": "${{ needs.prepare-rolling.outputs.source_sha }}",
 	})
-	assertWorkflowStepRunContainsAll(t, verifySource, "rolling source checkout verification", []string{
+	assertWorkflowStepRunContainsAll(t, verifySource, "rolling source archive checkout verification", []string{
 		`actual_source_sha="$(git rev-parse HEAD)"`,
 		`[ "${actual_source_sha}" != "${EXPECTED_SOURCE_SHA}" ]`,
 	})
-	buildSource := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-inputs", "Build rolling source bundle")
-	assertWorkflowStepEnv(t, buildSource, "rolling source bundle", map[string]string{
+	buildSource := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-archive", "Build rolling source archive")
+	assertWorkflowStringValues(t, []workflowStringValue{{
+		label: "rolling source archive build shell",
+		got:   buildSource.Shell,
+		want:  hardenedShell,
+	}})
+	assertWorkflowStepEnv(t, buildSource, "rolling source archive", map[string]string{
+		"PATH":        "/usr/bin:/bin",
 		"ROLLING_TAG": "${{ needs.prepare-rolling.outputs.tag }}",
 		"SOURCE_SHA":  "${{ needs.prepare-rolling.outputs.source_sha }}",
 	})
-	assertWorkflowStepRunContainsAll(t, buildSource, "rolling source bundle", []string{
-		`source_input_root="${RUNNER_TEMP}/rolling-source-inputs"`,
-		`rm -rf -- "${source_input_root}"`,
-		`mkdir -- "${source_input_root}"`,
-		`archive_path="${source_input_root}/lopper_${ROLLING_TAG}_source.tar.gz"`,
+	assertWorkflowStepRunContainsAll(t, buildSource, "rolling source archive", []string{
+		`archive_root="${RUNNER_TEMP}/rolling-source-archive"`,
+		`rm -rf -- "${archive_root}"`,
+		`mkdir -- "${archive_root}"`,
+		`archive_path="${archive_root}/lopper_${ROLLING_TAG}_source.tar.gz"`,
 		`git archive --format=tar.gz --prefix="${bundle}/" -o "${archive_path}" "${SOURCE_SHA}"`,
 	})
-	generateNotes := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-inputs", "Generate rolling release notes")
-	assertWorkflowStepRunContainsAll(t, generateNotes, "rolling release note generation", []string{
-		`go run ./tools/featureflag "${args[@]}" > "${feature_report}"`,
-		`> "${source_input_root}/rolling-changelog.md"`,
-	})
-	validateSource := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-inputs", "Validate rolling source inputs")
+	validateSource := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-archive", "Validate rolling source archive")
 	assertWorkflowStringValues(t, []workflowStringValue{
-		{label: "rolling source input validation shell", got: validateSource.Shell, want: hardenedShell},
+		{label: "rolling source archive validation shell", got: validateSource.Shell, want: hardenedShell},
 	})
-	assertWorkflowStepEnv(t, validateSource, "rolling source input validation", map[string]string{
-		"PATH":              "/usr/bin:/bin",
-		"ROLLING_TAG":       "${{ needs.prepare-rolling.outputs.tag }}",
-		"SOURCE_INPUT_ROOT": "${{ runner.temp }}/rolling-source-inputs",
+	assertWorkflowStepEnv(t, validateSource, "rolling source archive validation", map[string]string{
+		"ARCHIVE_ROOT": "${{ runner.temp }}/rolling-source-archive",
+		"PATH":         "/usr/bin:/bin",
+		"ROLLING_TAG":  "${{ needs.prepare-rolling.outputs.tag }}",
 	})
-	assertWorkflowStepRunContainsAll(t, validateSource, "rolling source input validation", []string{
-		`expected=(`,
-		`${SOURCE_INPUT_ROOT}/lopper_${ROLLING_TAG}_source.tar.gz`,
-		`${SOURCE_INPUT_ROOT}/rolling-changelog.md`,
-		`find -P "${SOURCE_INPUT_ROOT}" -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
-		`[ "${file_count}" -ne "${#expected[@]}" ]`,
-		`[ ! -f "${input}" ] || [ -L "${input}" ]`,
-		`[ ! -s "${input}" ]`,
-		`[ "$(stat --format=%s "${changelog}")" -gt 1048576 ]`,
+	assertWorkflowStepRunContainsAll(t, validateSource, "rolling source archive validation", []string{
+		`archive="${ARCHIVE_ROOT}/lopper_${ROLLING_TAG}_source.tar.gz"`,
+		`find -P "${ARCHIVE_ROOT}" -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
+		`[ "${file_count}" -ne 1 ]`,
+		`[ ! -f "${archive}" ] || [ -L "${archive}" ] || [ ! -s "${archive}" ]`,
+		`[ "$(stat --format=%s "${archive}")" -gt 1073741824 ]`,
 	})
-	sourceUpload := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-inputs", "Upload rolling source inputs")
-	wantSourceUploads := []string{
-		"${{ runner.temp }}/rolling-source-inputs/lopper_${{ needs.prepare-rolling.outputs.tag }}_source.tar.gz",
-		"${{ runner.temp }}/rolling-source-inputs/rolling-changelog.md",
-	}
-	if got := strings.Split(strings.TrimSpace(sourceUpload.With["path"]), "\n"); !slices.Equal(got, wantSourceUploads) {
-		t.Fatalf("rolling source input upload paths = %#v", got)
-	}
+	sourceUpload := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-archive", "Upload rolling source archive")
 	assertWorkflowStringValues(t, []workflowStringValue{
-		{label: "rolling source input artifact name", got: sourceUpload.With["name"], want: "rolling-source-inputs"},
-		{label: "rolling source input missing-file behavior", got: sourceUpload.With["if-no-files-found"], want: "error"},
+		{label: "rolling source archive artifact name", got: sourceUpload.With["name"], want: "rolling-source-archive"},
+		{label: "rolling source archive artifact path", got: sourceUpload.With["path"], want: "${{ runner.temp }}/rolling-source-archive/lopper_${{ needs.prepare-rolling.outputs.tag }}_source.tar.gz"},
+		{label: "rolling source archive missing-file behavior", got: sourceUpload.With["if-no-files-found"], want: "error"},
 	})
+	for _, step := range archivePreparation.Steps[workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-source-archive", "Build rolling source archive")+1:] {
+		for _, repositoryCommand := range []string{"go run ./", "make ", "npm ", "npx ", "scripts/", "./extensions/"} {
+			if strings.Contains(step.Run, repositoryCommand) {
+				t.Fatalf("rolling source archive step %q must not execute repository-controlled command %q after archive creation", step.Name, repositoryCommand)
+			}
+		}
+	}
 
 	preparation := workflowJobByName(t, workflow.Jobs, "prepare-rolling-publication")
-	assertWorkflowJobNeeds(t, preparation, "rolling publication preparation", workflowJobNeeds{"prepare-rolling", "prepare-rolling-source-inputs", "orchestrate-rolling", "build-darwin-amd64-rolling"})
+	assertWorkflowJobNeeds(t, preparation, "rolling publication preparation", workflowJobNeeds{"prepare-rolling", "prepare-rolling-release-notes", "prepare-rolling-source-archive", "orchestrate-rolling", "build-darwin-amd64-rolling"})
 	assertWorkflowJobHasExplicitEmptyPermissions(t, preparation, "rolling publication preparation")
 	assertWorkflowJobEnvEmpty(t, preparation, "rolling publication preparation")
 	assertWorkflowJobOmitsText(t, preparation, "secrets.", "rolling publication preparation must not receive secrets")
@@ -887,13 +926,14 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	assertWorkflowJobStepRunsOmitAllFold(t, preparation, "rolling publication preparation", []string{"go run ./", "make ", "npm ", "npx ", "scripts/", "git "})
 
 	resetIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Reset rolling publication assembly")
-	sourceDownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Download rolling source inputs")
+	sourceDownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Download rolling source archive")
+	notesDownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Download rolling release notes")
 	linuxWindowsDownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Download rolling Linux and Windows artifacts")
 	darwinArm64DownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Download rolling Darwin arm64 artifact")
 	darwinAmd64DownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Download rolling Darwin amd64 artifact")
 	stageIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Stage bounded rolling publication inputs")
 	uploadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Upload rolling publication inputs")
-	if sourceDownloadIndex != resetIndex+1 || linuxWindowsDownloadIndex != sourceDownloadIndex+1 ||
+	if sourceDownloadIndex != resetIndex+1 || notesDownloadIndex != sourceDownloadIndex+1 || linuxWindowsDownloadIndex != notesDownloadIndex+1 ||
 		darwinArm64DownloadIndex != linuxWindowsDownloadIndex+1 || darwinAmd64DownloadIndex != darwinArm64DownloadIndex+1 ||
 		stageIndex != darwinAmd64DownloadIndex+1 || uploadIndex != stageIndex+1 {
 		t.Fatal("rolling publication inputs must reset, download exact producers, stage, and upload contiguously")
@@ -910,7 +950,8 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`mkdir -- "${assembly_root}"`,
 	})
 	downloadContracts := []workflowArtifactDownloadContract{
-		{index: sourceDownloadIndex, name: "rolling-source-inputs", path: "${{ runner.temp }}/rolling-publication-assembly/source"},
+		{index: sourceDownloadIndex, name: "rolling-source-archive", path: "${{ runner.temp }}/rolling-publication-assembly/source-archive"},
+		{index: notesDownloadIndex, name: "rolling-release-notes", path: "${{ runner.temp }}/rolling-publication-assembly/release-notes"},
 		{index: linuxWindowsDownloadIndex, name: "rolling-linux-windows", path: "${{ runner.temp }}/rolling-publication-assembly/linux-windows"},
 		{index: darwinArm64DownloadIndex, name: "rolling-darwin", path: "${{ runner.temp }}/rolling-publication-assembly/darwin-arm64"},
 		{index: darwinAmd64DownloadIndex, name: "rolling-darwin-amd64", path: "${{ runner.temp }}/rolling-publication-assembly/darwin-amd64"},
@@ -931,15 +972,16 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		"ROLLING_TAG":   "${{ needs.prepare-rolling.outputs.tag }}",
 	})
 	assertWorkflowStepRunContainsAll(t, stageStep, "rolling publication staging", []string{
-		`source_archive="${ASSEMBLY_ROOT}/source/lopper_${ROLLING_TAG}_source.tar.gz"`,
-		`changelog="${ASSEMBLY_ROOT}/source/rolling-changelog.md"`,
+		`source_archive="${ASSEMBLY_ROOT}/source-archive/lopper_${ROLLING_TAG}_source.tar.gz"`,
+		`changelog="${ASSEMBLY_ROOT}/release-notes/rolling-changelog.md"`,
 		`${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_linux_amd64.tar.gz`,
 		`${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_linux_arm64.tar.gz`,
 		`${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_windows_amd64.zip`,
 		`${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_windows_arm64.zip`,
 		`${ASSEMBLY_ROOT}/darwin-arm64/lopper_${ROLLING_TAG}_darwin_arm64.tar.gz`,
 		`${ASSEMBLY_ROOT}/darwin-amd64/lopper_${ROLLING_TAG}_darwin_amd64.tar.gz`,
-		`validate_input_root "${ASSEMBLY_ROOT}/source" 1073741824 "${source_archive}" "${changelog}"`,
+		`validate_input_root "${ASSEMBLY_ROOT}/source-archive" 1073741824 "${source_archive}"`,
+		`validate_input_root "${ASSEMBLY_ROOT}/release-notes" 1048576 "${changelog}"`,
 		`validate_input_root "${ASSEMBLY_ROOT}/linux-windows" 1073741824 "${linux_windows_assets[@]}"`,
 		`validate_input_root "${ASSEMBLY_ROOT}/darwin-arm64" 1073741824 "${darwin_arm64_assets[@]}"`,
 		`validate_input_root "${ASSEMBLY_ROOT}/darwin-amd64" 1073741824 "${darwin_amd64_assets[@]}"`,

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -463,6 +463,7 @@ func TestReleaseWorkflowConfinesMainSyncPATToReleasePleaseAndTrustedFeatureHisto
 
 func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 	t.Parallel()
+	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
@@ -485,6 +486,10 @@ func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 	})
 
 	resetStep := build.Steps[resetIndex]
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "VS Code extension artifact staging reset shell", got: resetStep.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, resetStep, "VS Code extension artifact staging reset", map[string]string{"PATH": "/usr/bin:/bin"})
 	assertWorkflowStepRunContainsAll(t, resetStep, "VS Code extension artifact staging reset", []string{
 		`rm -rf -- dist`,
 		`mkdir -- dist`,
@@ -503,13 +508,18 @@ func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 	}
 
 	validateStep := build.Steps[validateIndex]
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "VS Code extension artifact validation shell", got: validateStep.Shell, want: hardenedShell},
+	})
 	assertWorkflowStepEnv(t, validateStep, "VS Code extension artifact validation", map[string]string{
+		"PATH":            "/usr/bin:/bin",
 		"RELEASE_VERSION": "${{ needs.prepare-release.outputs.version }}",
 	})
 	assertWorkflowStepRunContainsAll(t, validateStep, "VS Code extension artifact validation", []string{
 		`expected="dist/lopper-vscode-${RELEASE_VERSION}.vsix"`,
 		`find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
 		`[ ! -f "${expected}" ] || [ -L "${expected}" ]`,
+		`[ ! -s "${expected}" ]`,
 		`find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l`,
 	})
 
@@ -534,6 +544,7 @@ func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 
 func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	t.Parallel()
+	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
@@ -548,7 +559,6 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	generateIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Generate feature flag release report")
 	resetIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Reset release artifact staging")
 	downloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Download release artifacts")
-	verifyIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Verify Darwin artifacts are present")
 	stageIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Stage bounded release publication inputs")
 	uploadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-release-publication", "Upload release publication inputs")
 	if generateIndex >= resetIndex {
@@ -557,11 +567,15 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	if downloadIndex != resetIndex+1 {
 		t.Fatal("release artifacts must be downloaded immediately after resetting the staging directory")
 	}
-	if downloadIndex >= verifyIndex || verifyIndex >= stageIndex || stageIndex >= uploadIndex {
-		t.Fatal("release artifacts must be downloaded, verified, staged, and uploaded in that order")
+	if stageIndex != downloadIndex+1 || uploadIndex != stageIndex+1 {
+		t.Fatal("release artifacts must be downloaded, staged, and uploaded in one contiguous sequence")
 	}
 
 	resetStep := preparation.Steps[resetIndex]
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "release artifact staging reset shell", got: resetStep.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, resetStep, "release artifact staging reset", map[string]string{"PATH": "/usr/bin:/bin"})
 	assertWorkflowStepRunContainsAll(t, resetStep, "release artifact staging reset", []string{
 		`rm -rf -- dist`,
 		`mkdir -- dist`,
@@ -576,14 +590,35 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	}
 
 	stageStep := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Stage bounded release publication inputs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "release publication staging shell", got: stageStep.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, stageStep, "release publication staging", map[string]string{
+		"PATH":        "/usr/bin:/bin",
+		"RELEASE_TAG": "${{ needs.prepare-release.outputs.tag }}",
+	})
 	assertWorkflowStepRunContainsAll(t, stageStep, "release publication staging step", []string{
-		`find dist -maxdepth 1 -type f`,
-		`lopper-vscode-${version}.vsix`,
+		`expected_assets=(`,
+		`dist/lopper_${RELEASE_TAG}_linux_amd64.tar.gz`,
+		`dist/lopper_${RELEASE_TAG}_linux_arm64.tar.gz`,
+		`dist/lopper_${RELEASE_TAG}_windows_amd64.zip`,
+		`dist/lopper_${RELEASE_TAG}_windows_arm64.zip`,
+		`dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz`,
+		`dist/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz`,
+		`dist/lopper-vscode-${version}.vsix`,
+		`find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
+		`[ ! -f "${asset}" ] || [ -L "${asset}" ]`,
+		`[ ! -s "${asset}" ]`,
 		`rm -rf -- publication-inputs`,
 		`mkdir -p publication-inputs/dist`,
 		`publication-inputs/feature-flags.md`,
 		`mapfile -d '' checksum_files`,
 		`sha256sum "${checksum_files[@]}" > SHA256SUMS`,
+	})
+	assertWorkflowStepRunOmitsAll(t, stageStep, "release publication staging step", []string{
+		"Expected between 1 and 32 release assets",
+		`-name '*.tar.gz'`,
+		`-name 'lopper-vscode-*.vsix'`,
 	})
 	assertTextAppearsBefore(t, stageStep.Run, `rm -rf -- publication-inputs`, `mkdir -p publication-inputs/dist`, "release publication staging must remove prior inputs before recreating the directory")
 	assertTextAppearsBefore(t, stageStep.Run, `mkdir -p publication-inputs/dist`, `cp -- "${assets[@]}" publication-inputs/dist/`, "release publication staging must recreate the directory before copying bounded assets")
@@ -598,6 +633,42 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	publication := workflowJobByName(t, workflow.Jobs, "publish")
 	assertWorkflowJobPermissions(t, publication, "fresh release publication", map[string]string{"contents": "write"})
 	assertWorkflowJobEnvEmpty(t, publication, "fresh release publication")
+	validateStep := workflowStepByName(t, workflow.Jobs, "publish", "Validate release publication inputs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "privileged release publication validation shell", got: validateStep.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, validateStep, "privileged release publication validation", map[string]string{
+		"PATH":        "/usr/bin:/bin",
+		"RELEASE_TAG": "${{ needs.prepare-release.outputs.tag }}",
+	})
+	assertWorkflowStepRunContainsAll(t, validateStep, "privileged release publication validation", []string{
+		`expected_assets=(`,
+		`dist/lopper_${RELEASE_TAG}_linux_amd64.tar.gz`,
+		`dist/lopper_${RELEASE_TAG}_linux_arm64.tar.gz`,
+		`dist/lopper_${RELEASE_TAG}_windows_amd64.zip`,
+		`dist/lopper_${RELEASE_TAG}_windows_arm64.zip`,
+		`dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz`,
+		`dist/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz`,
+		`dist/lopper-vscode-${version}.vsix`,
+		`[ ! -f "${asset}" ] || [ -L "${asset}" ]`,
+		`[ ! -s "${asset}" ]`,
+	})
+	assertWorkflowStepRunOmitsAll(t, validateStep, "privileged release publication validation", []string{
+		"Expected between 1 and 32 release assets",
+		`-name '*.tar.gz'`,
+		`-name 'lopper-vscode-*.vsix'`,
+	})
+	uploadAssets := workflowStepByName(t, workflow.Jobs, "publish", "Upload GitHub Release assets")
+	assertWorkflowStepRunContainsAll(t, uploadAssets, "explicit GitHub release asset upload", []string{
+		`publication-inputs/dist/lopper_${tag}_linux_amd64.tar.gz`,
+		`publication-inputs/dist/lopper_${tag}_linux_arm64.tar.gz`,
+		`publication-inputs/dist/lopper_${tag}_windows_amd64.zip`,
+		`publication-inputs/dist/lopper_${tag}_windows_arm64.zip`,
+		`publication-inputs/dist/lopper_${tag}_darwin_amd64.tar.gz`,
+		`publication-inputs/dist/lopper_${tag}_darwin_arm64.tar.gz`,
+		`publication-inputs/dist/lopper-vscode-${tag#v}.vsix`,
+	})
+	assertWorkflowStepRunOmitsAll(t, uploadAssets, "explicit GitHub release asset upload", []string{"find publication-inputs/dist", "*.tar.gz", "*.zip", "*.vsix"})
 	assertReleasePublicationCredentialScope(t, publication)
 	assertReleasePublicationOmitsCheckoutAndCommands(t, publication)
 }

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -2437,6 +2437,22 @@ func TestReleaseArchiveProducersUseFreshExactArtifactStaging(t *testing.T) {
 				"dist/lopper_${{ inputs.tag }}_darwin_arm64.tar.gz",
 			},
 		},
+		{
+			name:             "rolling Darwin amd64",
+			path:             ".github/workflows/rolling.yml",
+			jobName:          "build-darwin-amd64-rolling",
+			resetStepName:    "Reset Darwin amd64 rolling artifact staging",
+			buildStepName:    "Build Darwin amd64 rolling artifact",
+			validateStepName: "Validate Darwin amd64 rolling artifact",
+			uploadStepName:   "Upload Darwin amd64 rolling artifacts",
+			releaseTag:       "${{ needs.prepare-rolling.outputs.tag }}",
+			expectedRuntime: []string{
+				`dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz`,
+			},
+			expectedUploads: []string{
+				"dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_darwin_amd64.tar.gz",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -628,29 +628,14 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`mkdir -- "${assembly_root}"`,
 	})
 	assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- "${assembly_root}"`, `mkdir -- "${assembly_root}"`, "release assembly must remove prior inputs before recreating its runner-temp root")
-	downloadContracts := []struct {
-		index int
-		name  string
-		path  string
-	}{
+	downloadContracts := []workflowArtifactDownloadContract{
 		{index: reportDownloadIndex, name: "stable-feature-report", path: "${{ runner.temp }}/release-publication-assembly/feature-report"},
 		{index: linuxWindowsDownloadIndex, name: "release-linux-windows", path: "${{ runner.temp }}/release-publication-assembly/linux-windows"},
 		{index: darwinArm64DownloadIndex, name: "release-darwin", path: "${{ runner.temp }}/release-publication-assembly/darwin-arm64"},
 		{index: darwinAmd64DownloadIndex, name: "release-darwin-amd64", path: "${{ runner.temp }}/release-publication-assembly/darwin-amd64"},
 		{index: vsixDownloadIndex, name: "release-vscode-extension", path: "${{ runner.temp }}/release-publication-assembly/vscode"},
 	}
-	for _, contract := range downloadContracts {
-		download := preparation.Steps[contract.index]
-		assertWorkflowStringValues(t, []workflowStringValue{
-			{label: download.Name + " artifact name", got: download.With["name"], want: contract.name},
-			{label: download.Name + " path", got: download.With["path"], want: contract.path},
-		})
-		for _, forbidden := range []string{"pattern", "merge-multiple"} {
-			if _, ok := download.With[forbidden]; ok {
-				t.Fatalf("%s must not use with.%s", download.Name, forbidden)
-			}
-		}
-	}
+	assertExactArtifactDownloads(t, preparation.Steps, downloadContracts)
 	for _, step := range preparation.Steps {
 		if strings.Contains(step.Run, "${{ needs.") {
 			t.Fatalf("fresh release assembly step %q must bind trusted values through env instead of interpolating expressions into shell source", step.Name)
@@ -875,28 +860,13 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`rm -rf -- rolling-publication-inputs`,
 		`mkdir -- "${assembly_root}"`,
 	})
-	downloadContracts := []struct {
-		index int
-		name  string
-		path  string
-	}{
+	downloadContracts := []workflowArtifactDownloadContract{
 		{index: sourceDownloadIndex, name: "rolling-source-inputs", path: "${{ runner.temp }}/rolling-publication-assembly/source"},
 		{index: linuxWindowsDownloadIndex, name: "rolling-linux-windows", path: "${{ runner.temp }}/rolling-publication-assembly/linux-windows"},
 		{index: darwinArm64DownloadIndex, name: "rolling-darwin", path: "${{ runner.temp }}/rolling-publication-assembly/darwin-arm64"},
 		{index: darwinAmd64DownloadIndex, name: "rolling-darwin-amd64", path: "${{ runner.temp }}/rolling-publication-assembly/darwin-amd64"},
 	}
-	for _, contract := range downloadContracts {
-		download := preparation.Steps[contract.index]
-		assertWorkflowStringValues(t, []workflowStringValue{
-			{label: download.Name + " artifact name", got: download.With["name"], want: contract.name},
-			{label: download.Name + " path", got: download.With["path"], want: contract.path},
-		})
-		for _, forbidden := range []string{"pattern", "merge-multiple"} {
-			if _, ok := download.With[forbidden]; ok {
-				t.Fatalf("%s must not use with.%s", download.Name, forbidden)
-			}
-		}
-	}
+	assertExactArtifactDownloads(t, preparation.Steps, downloadContracts)
 	for _, step := range preparation.Steps {
 		if strings.Contains(step.Run, "${{ needs.") {
 			t.Fatalf("fresh rolling assembly step %q must bind trusted values through env", step.Name)
@@ -4012,12 +3982,35 @@ type workflowStringValue struct {
 	want  string
 }
 
+type workflowArtifactDownloadContract struct {
+	index int
+	name  string
+	path  string
+}
+
 func assertWorkflowStringValues(t *testing.T, values []workflowStringValue) {
 	t.Helper()
 
 	for _, value := range values {
 		if value.got != value.want {
 			t.Fatalf("%s = %q", value.label, value.got)
+		}
+	}
+}
+
+func assertExactArtifactDownloads(t *testing.T, steps []workflowStepConfig, contracts []workflowArtifactDownloadContract) {
+	t.Helper()
+
+	for _, contract := range contracts {
+		download := steps[contract.index]
+		assertWorkflowStringValues(t, []workflowStringValue{
+			{label: download.Name + " artifact name", got: download.With["name"], want: contract.name},
+			{label: download.Name + " path", got: download.With["path"], want: contract.path},
+		})
+		for _, forbidden := range []string{"pattern", "merge-multiple"} {
+			if _, ok := download.With[forbidden]; ok {
+				t.Fatalf("%s must not use with.%s", download.Name, forbidden)
+			}
 		}
 	}
 }

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -4057,7 +4057,13 @@ func assertReleasePublicationCredentialScope(t *testing.T, publication workflowJ
 	for _, step := range publication.Steps {
 		if _, isAPIStep := apiSteps[step.Name]; isAPIStep {
 			apiSteps[step.Name] = true
-			assertWorkflowStepEnv(t, step, "GitHub API step "+step.Name, map[string]string{"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}"})
+			stepLabel := "GitHub API step " + step.Name
+			assertWorkflowStepEnv(t, step, stepLabel, map[string]string{
+				"GH_TOKEN":    "${{ secrets.GITHUB_TOKEN }}",
+				"RELEASE_TAG": "${{ needs.prepare-release.outputs.tag }}",
+			})
+			assertWorkflowStepRunContainsAll(t, step, stepLabel, []string{`tag="${RELEASE_TAG}"`})
+			assertWorkflowStepRunOmitsAll(t, step, stepLabel, []string{"${{ needs.prepare-release.outputs.tag }}"})
 		} else if _, ok := step.Env["GH_TOKEN"]; ok {
 			t.Fatalf("non-API publication step %q must not receive GH_TOKEN", step.Name)
 		}

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -766,6 +766,266 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	assertReleasePublicationOmitsCheckoutAndCommands(t, publication)
 }
 
+func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
+	t.Parallel()
+	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/rolling.yml", &workflow)
+
+	darwinProducer := workflowJobByName(t, workflow.Jobs, "build-darwin-amd64-rolling")
+	darwinCheckout := workflowStepByName(t, workflow.Jobs, "build-darwin-amd64-rolling", "Checkout rolling source")
+	if darwinCheckout.With["persist-credentials"] != "false" {
+		t.Fatal("rolling Darwin amd64 checkout must disable persisted credentials")
+	}
+	assertWorkflowJobPermissions(t, darwinProducer, "rolling Darwin amd64 producer", map[string]string{"contents": "read"})
+
+	sourcePreparation := workflowJobByName(t, workflow.Jobs, "prepare-rolling-source-inputs")
+	assertWorkflowJobNeeds(t, sourcePreparation, "rolling source input preparation", workflowJobNeeds{"prepare-rolling"})
+	assertWorkflowJobPermissions(t, sourcePreparation, "rolling source input preparation", map[string]string{"contents": "read"})
+	assertWorkflowJobEnvEmpty(t, sourcePreparation, "rolling source input preparation")
+	assertWorkflowJobOmitsText(t, sourcePreparation, "secrets.", "rolling source input preparation must not receive secrets")
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, sourcePreparation, "prepare-rolling-source-inputs")
+	assertWorkflowStepOrder(t, sourcePreparation, "Checkout rolling source", "Verify rolling source checkout", "Setup Go", "Build rolling source bundle", "Generate rolling release notes", "Validate rolling source inputs", "Upload rolling source inputs")
+	verifySource := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-inputs", "Verify rolling source checkout")
+	assertWorkflowStepEnv(t, verifySource, "rolling source checkout verification", map[string]string{
+		"EXPECTED_SOURCE_SHA": "${{ needs.prepare-rolling.outputs.source_sha }}",
+	})
+	assertWorkflowStepRunContainsAll(t, verifySource, "rolling source checkout verification", []string{
+		`actual_source_sha="$(git rev-parse HEAD)"`,
+		`[ "${actual_source_sha}" != "${EXPECTED_SOURCE_SHA}" ]`,
+	})
+	buildSource := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-inputs", "Build rolling source bundle")
+	assertWorkflowStepEnv(t, buildSource, "rolling source bundle", map[string]string{
+		"ROLLING_TAG": "${{ needs.prepare-rolling.outputs.tag }}",
+		"SOURCE_SHA":  "${{ needs.prepare-rolling.outputs.source_sha }}",
+	})
+	assertWorkflowStepRunContainsAll(t, buildSource, "rolling source bundle", []string{
+		`source_input_root="${RUNNER_TEMP}/rolling-source-inputs"`,
+		`rm -rf -- "${source_input_root}"`,
+		`mkdir -- "${source_input_root}"`,
+		`archive_path="${source_input_root}/lopper_${ROLLING_TAG}_source.tar.gz"`,
+		`git archive --format=tar.gz --prefix="${bundle}/" -o "${archive_path}" "${SOURCE_SHA}"`,
+	})
+	generateNotes := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-inputs", "Generate rolling release notes")
+	assertWorkflowStepRunContainsAll(t, generateNotes, "rolling release note generation", []string{
+		`go run ./tools/featureflag "${args[@]}" > "${feature_report}"`,
+		`> "${source_input_root}/rolling-changelog.md"`,
+	})
+	validateSource := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-inputs", "Validate rolling source inputs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "rolling source input validation shell", got: validateSource.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, validateSource, "rolling source input validation", map[string]string{
+		"PATH":              "/usr/bin:/bin",
+		"ROLLING_TAG":       "${{ needs.prepare-rolling.outputs.tag }}",
+		"SOURCE_INPUT_ROOT": "${{ runner.temp }}/rolling-source-inputs",
+	})
+	assertWorkflowStepRunContainsAll(t, validateSource, "rolling source input validation", []string{
+		`expected=(`,
+		`${SOURCE_INPUT_ROOT}/lopper_${ROLLING_TAG}_source.tar.gz`,
+		`${SOURCE_INPUT_ROOT}/rolling-changelog.md`,
+		`find -P "${SOURCE_INPUT_ROOT}" -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
+		`[ "${file_count}" -ne "${#expected[@]}" ]`,
+		`[ ! -f "${input}" ] || [ -L "${input}" ]`,
+		`[ ! -s "${input}" ]`,
+		`[ "$(stat --format=%s "${changelog}")" -gt 1048576 ]`,
+	})
+	sourceUpload := workflowStepByName(t, workflow.Jobs, "prepare-rolling-source-inputs", "Upload rolling source inputs")
+	wantSourceUploads := []string{
+		"${{ runner.temp }}/rolling-source-inputs/lopper_${{ needs.prepare-rolling.outputs.tag }}_source.tar.gz",
+		"${{ runner.temp }}/rolling-source-inputs/rolling-changelog.md",
+	}
+	if got := strings.Split(strings.TrimSpace(sourceUpload.With["path"]), "\n"); !slices.Equal(got, wantSourceUploads) {
+		t.Fatalf("rolling source input upload paths = %#v", got)
+	}
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "rolling source input artifact name", got: sourceUpload.With["name"], want: "rolling-source-inputs"},
+		{label: "rolling source input missing-file behavior", got: sourceUpload.With["if-no-files-found"], want: "error"},
+	})
+
+	preparation := workflowJobByName(t, workflow.Jobs, "prepare-rolling-publication")
+	assertWorkflowJobNeeds(t, preparation, "rolling publication preparation", workflowJobNeeds{"prepare-rolling", "prepare-rolling-source-inputs", "orchestrate-rolling", "build-darwin-amd64-rolling"})
+	assertWorkflowJobHasExplicitEmptyPermissions(t, preparation, "rolling publication preparation")
+	assertWorkflowJobEnvEmpty(t, preparation, "rolling publication preparation")
+	assertWorkflowJobOmitsText(t, preparation, "secrets.", "rolling publication preparation must not receive secrets")
+	assertWorkflowJobOmitsCheckout(t, preparation, "prepare-rolling-publication")
+	assertWorkflowJobStepRunsOmitAllFold(t, preparation, "rolling publication preparation", []string{"go run ./", "make ", "npm ", "npx ", "scripts/", "git "})
+
+	resetIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Reset rolling publication assembly")
+	sourceDownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Download rolling source inputs")
+	linuxWindowsDownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Download rolling Linux and Windows artifacts")
+	darwinArm64DownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Download rolling Darwin arm64 artifact")
+	darwinAmd64DownloadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Download rolling Darwin amd64 artifact")
+	stageIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Stage bounded rolling publication inputs")
+	uploadIndex := workflowStepIndexByName(t, workflow.Jobs, "prepare-rolling-publication", "Upload rolling publication inputs")
+	if sourceDownloadIndex != resetIndex+1 || linuxWindowsDownloadIndex != sourceDownloadIndex+1 ||
+		darwinArm64DownloadIndex != linuxWindowsDownloadIndex+1 || darwinAmd64DownloadIndex != darwinArm64DownloadIndex+1 ||
+		stageIndex != darwinAmd64DownloadIndex+1 || uploadIndex != stageIndex+1 {
+		t.Fatal("rolling publication inputs must reset, download exact producers, stage, and upload contiguously")
+	}
+	resetStep := preparation.Steps[resetIndex]
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "rolling publication assembly reset shell", got: resetStep.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, resetStep, "rolling publication assembly reset", map[string]string{"PATH": "/usr/bin:/bin"})
+	assertWorkflowStepRunContainsAll(t, resetStep, "rolling publication assembly reset", []string{
+		`assembly_root="${RUNNER_TEMP}/rolling-publication-assembly"`,
+		`rm -rf -- "${assembly_root}"`,
+		`rm -rf -- rolling-publication-inputs`,
+		`mkdir -- "${assembly_root}"`,
+	})
+	downloadContracts := []struct {
+		index int
+		name  string
+		path  string
+	}{
+		{index: sourceDownloadIndex, name: "rolling-source-inputs", path: "${{ runner.temp }}/rolling-publication-assembly/source"},
+		{index: linuxWindowsDownloadIndex, name: "rolling-linux-windows", path: "${{ runner.temp }}/rolling-publication-assembly/linux-windows"},
+		{index: darwinArm64DownloadIndex, name: "rolling-darwin", path: "${{ runner.temp }}/rolling-publication-assembly/darwin-arm64"},
+		{index: darwinAmd64DownloadIndex, name: "rolling-darwin-amd64", path: "${{ runner.temp }}/rolling-publication-assembly/darwin-amd64"},
+	}
+	for _, contract := range downloadContracts {
+		download := preparation.Steps[contract.index]
+		assertWorkflowStringValues(t, []workflowStringValue{
+			{label: download.Name + " artifact name", got: download.With["name"], want: contract.name},
+			{label: download.Name + " path", got: download.With["path"], want: contract.path},
+		})
+		for _, forbidden := range []string{"pattern", "merge-multiple"} {
+			if _, ok := download.With[forbidden]; ok {
+				t.Fatalf("%s must not use with.%s", download.Name, forbidden)
+			}
+		}
+	}
+	for _, step := range preparation.Steps {
+		if strings.Contains(step.Run, "${{ needs.") {
+			t.Fatalf("fresh rolling assembly step %q must bind trusted values through env", step.Name)
+		}
+	}
+	stageStep := preparation.Steps[stageIndex]
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "rolling publication staging shell", got: stageStep.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, stageStep, "rolling publication staging", map[string]string{
+		"ASSEMBLY_ROOT": "${{ runner.temp }}/rolling-publication-assembly",
+		"PATH":          "/usr/bin:/bin",
+		"ROLLING_TAG":   "${{ needs.prepare-rolling.outputs.tag }}",
+	})
+	assertWorkflowStepRunContainsAll(t, stageStep, "rolling publication staging", []string{
+		`source_archive="${ASSEMBLY_ROOT}/source/lopper_${ROLLING_TAG}_source.tar.gz"`,
+		`changelog="${ASSEMBLY_ROOT}/source/rolling-changelog.md"`,
+		`${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_linux_amd64.tar.gz`,
+		`${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_linux_arm64.tar.gz`,
+		`${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_windows_amd64.zip`,
+		`${ASSEMBLY_ROOT}/linux-windows/lopper_${ROLLING_TAG}_windows_arm64.zip`,
+		`${ASSEMBLY_ROOT}/darwin-arm64/lopper_${ROLLING_TAG}_darwin_arm64.tar.gz`,
+		`${ASSEMBLY_ROOT}/darwin-amd64/lopper_${ROLLING_TAG}_darwin_amd64.tar.gz`,
+		`validate_input_root "${ASSEMBLY_ROOT}/source" 1073741824 "${source_archive}" "${changelog}"`,
+		`validate_input_root "${ASSEMBLY_ROOT}/linux-windows" 1073741824 "${linux_windows_assets[@]}"`,
+		`validate_input_root "${ASSEMBLY_ROOT}/darwin-arm64" 1073741824 "${darwin_arm64_assets[@]}"`,
+		`validate_input_root "${ASSEMBLY_ROOT}/darwin-amd64" 1073741824 "${darwin_amd64_assets[@]}"`,
+		`[ "$(stat --format=%s "${changelog}")" -gt 1048576 ]`,
+		`cp -- "${binary_assets[@]}" rolling-publication-inputs/dist/`,
+		`cp -- "${source_archive}" "rolling-publication-inputs/dist/${source_basename}"`,
+		`cp -- "${changelog}" rolling-publication-inputs/rolling-changelog.md`,
+		`sha256sum "${source_basename}" > "${source_basename}.sha256"`,
+		`expected_assets=(`,
+		`dist/lopper_${ROLLING_TAG}_linux_amd64.tar.gz`,
+		`dist/lopper_${ROLLING_TAG}_linux_arm64.tar.gz`,
+		`dist/lopper_${ROLLING_TAG}_windows_amd64.zip`,
+		`dist/lopper_${ROLLING_TAG}_windows_arm64.zip`,
+		`dist/lopper_${ROLLING_TAG}_darwin_amd64.tar.gz`,
+		`dist/lopper_${ROLLING_TAG}_darwin_arm64.tar.gz`,
+		`dist/lopper_${ROLLING_TAG}_source.tar.gz`,
+		`dist/lopper_${ROLLING_TAG}_source.tar.gz.sha256`,
+		`stat --format=%s "rolling-publication-inputs/dist/${source_basename}.sha256"`,
+		`manifest_inputs=("rolling-changelog.md" "${expected_assets[@]}")`,
+		`sha256sum "${sorted_manifest_inputs[@]}" > SHA256SUMS`,
+	})
+	assertWorkflowStepRunOmitsAll(t, stageStep, "rolling publication staging", []string{"*.tar.gz", "*.zip", "find dist", "pattern:"})
+	uploadInputs := preparation.Steps[uploadIndex]
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "rolling publication input artifact name", got: uploadInputs.With["name"], want: "rolling-publication-inputs"},
+		{label: "rolling publication input artifact path", got: uploadInputs.With["path"], want: "rolling-publication-inputs"},
+		{label: "rolling publication input missing-file behavior", got: uploadInputs.With["if-no-files-found"], want: "error"},
+	})
+
+	publication := workflowJobByName(t, workflow.Jobs, "publish-rolling")
+	assertWorkflowJobNeeds(t, publication, "rolling publication", workflowJobNeeds{"prepare-rolling", "prepare-rolling-publication"})
+	assertWorkflowJobPermissions(t, publication, "rolling publication", map[string]string{"contents": "write"})
+	assertWorkflowJobEnvEmpty(t, publication, "rolling publication")
+	assertWorkflowStringValues(t, []workflowStringValue{{
+		label: "rolling publication tag output",
+		got:   publication.Outputs["tag"],
+		want:  "${{ needs.prepare-rolling.outputs.tag }}",
+	}})
+	assertWorkflowJobOmitsCheckout(t, publication, "publish-rolling")
+	assertWorkflowJobStepRunsOmitAllFold(t, publication, "rolling publication", []string{"go run ./", "make ", "npm ", "npx ", "scripts/", "git "})
+	assertWorkflowStepOrder(t, publication, "Download rolling publication inputs", "Validate rolling publication inputs", "Publish rolling prerelease")
+	downloadInputs := workflowStepByName(t, workflow.Jobs, "publish-rolling", "Download rolling publication inputs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "privileged rolling publication download name", got: downloadInputs.With["name"], want: "rolling-publication-inputs"},
+		{label: "privileged rolling publication download path", got: downloadInputs.With["path"], want: "rolling-publication-inputs"},
+	})
+	validateInputs := workflowStepByName(t, workflow.Jobs, "publish-rolling", "Validate rolling publication inputs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "privileged rolling publication validation shell", got: validateInputs.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, validateInputs, "privileged rolling publication validation", map[string]string{
+		"PATH":        "/usr/bin:/bin",
+		"ROLLING_TAG": "${{ needs.prepare-rolling.outputs.tag }}",
+	})
+	assertWorkflowStepRunContainsAll(t, validateInputs, "privileged rolling publication validation", []string{
+		`expected_assets=(`,
+		`dist/lopper_${ROLLING_TAG}_linux_amd64.tar.gz`,
+		`dist/lopper_${ROLLING_TAG}_linux_arm64.tar.gz`,
+		`dist/lopper_${ROLLING_TAG}_windows_amd64.zip`,
+		`dist/lopper_${ROLLING_TAG}_windows_arm64.zip`,
+		`dist/lopper_${ROLLING_TAG}_darwin_amd64.tar.gz`,
+		`dist/lopper_${ROLLING_TAG}_darwin_arm64.tar.gz`,
+		`dist/lopper_${ROLLING_TAG}_source.tar.gz`,
+		`dist/lopper_${ROLLING_TAG}_source.tar.gz.sha256`,
+		`[ "$(find . -type f | wc -l | tr -d '[:space:]')" -ne 10 ]`,
+		`[ ! -f SHA256SUMS ] || [ -L SHA256SUMS ] || [ ! -s SHA256SUMS ]`,
+		`stat --format=%s SHA256SUMS`,
+		`[ ! -f rolling-changelog.md ] || [ -L rolling-changelog.md ] || [ ! -s rolling-changelog.md ]`,
+		`[ "$(stat --format=%s rolling-changelog.md)" -gt 1048576 ]`,
+		`[ ! -f "${asset}" ] || [ -L "${asset}" ] || [ ! -s "${asset}" ]`,
+		`stat --format=%s "dist/${source_basename}.sha256"`,
+		`sha256sum --check --strict "${source_basename}.sha256"`,
+		`manifest_inputs=("rolling-changelog.md" "${expected_assets[@]}")`,
+		`sha256sum "${sorted_manifest_inputs[@]}" > "${computed_checksums}"`,
+		`cmp -s SHA256SUMS "${computed_checksums}"`,
+		`sha256sum --check --strict SHA256SUMS`,
+	})
+	assertTextAppearsBefore(t, validateInputs.Run, `stat --format=%s "${asset}"`, `sha256sum --check --strict "${source_basename}.sha256"`, "rolling publisher must bound every asset before verifying checksums")
+	assertTextAppearsBefore(t, validateInputs.Run, `stat --format=%s rolling-changelog.md`, `sha256sum "${sorted_manifest_inputs[@]}"`, "rolling publisher must bound the changelog before hashing inputs")
+	publishStep := workflowStepByName(t, workflow.Jobs, "publish-rolling", "Publish rolling prerelease")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "rolling release action", got: publishStep.Uses, want: "softprops/action-gh-release@c12583777ecdfd3be55c69cf75464299dc01057e"},
+		{label: "rolling release tag", got: publishStep.With["tag_name"], want: "${{ needs.prepare-rolling.outputs.tag }}"},
+		{label: "rolling release target", got: publishStep.With["target_commitish"], want: "${{ needs.prepare-rolling.outputs.source_sha }}"},
+		{label: "rolling release body", got: publishStep.With["body_path"], want: "rolling-publication-inputs/rolling-changelog.md"},
+		{label: "rolling unmatched-file behavior", got: publishStep.With["fail_on_unmatched_files"], want: "true"},
+	})
+	wantPublishedAssets := []string{
+		"rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_linux_amd64.tar.gz",
+		"rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_linux_arm64.tar.gz",
+		"rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_windows_amd64.zip",
+		"rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_windows_arm64.zip",
+		"rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_darwin_amd64.tar.gz",
+		"rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_darwin_arm64.tar.gz",
+		"rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_source.tar.gz",
+		"rolling-publication-inputs/dist/lopper_${{ needs.prepare-rolling.outputs.tag }}_source.tar.gz.sha256",
+	}
+	if got := strings.Split(strings.TrimSpace(publishStep.With["files"]), "\n"); !slices.Equal(got, wantPublishedAssets) {
+		t.Fatalf("rolling published assets = %#v", got)
+	}
+	if strings.Contains(publishStep.With["files"], "*") {
+		t.Fatal("rolling publication must not upload asset globs")
+	}
+}
+
 func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -492,10 +492,10 @@ func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 	assertWorkflowStepEnv(t, resetStep, "VS Code extension artifact staging reset", map[string]string{"PATH": "/usr/bin:/bin"})
 	assertWorkflowStepRunContainsAll(t, resetStep, "VS Code extension artifact staging reset", []string{
 		`rm -rf -- dist`,
-		`mkdir -- dist`,
+		`mkdir dist`,
 	})
 	assertWorkflowStepRunOmitsAll(t, resetStep, "VS Code extension artifact staging reset", []string{"mkdir -p"})
-	assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- dist`, `mkdir -- dist`, "VS Code artifact staging must remove checkout-provided files before recreating dist")
+	assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- dist`, `mkdir dist`, "VS Code artifact staging must remove checkout-provided files before recreating dist")
 
 	packageStep := build.Steps[packageIndex]
 	const packageCommand = `npx @vscode/vsce package --out "../../dist/lopper-vscode-${version}.vsix"`
@@ -2716,21 +2716,31 @@ func TestRollingDarwinProducerPinsTrustedActions(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowsUsePortableHardenedBashPath(t *testing.T) {
+func TestReleaseWorkflowsUsePortableCommands(t *testing.T) {
 	t.Parallel()
 
-	for _, path := range []string{
+	testCases := []struct {
+		name      string
+		forbidden string
+	}{
+		{name: "hardened bash path", forbidden: "/usr/bin/bash"},
+		{name: "release staging mkdir", forbidden: "mkdir -- dist"},
+	}
+	paths := []string{
 		".github/workflows/release-orchestration.yml",
 		".github/workflows/release.yml",
 		".github/workflows/rolling.yml",
-	} {
-		path := path
-		t.Run(path, func(t *testing.T) {
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			workflowText := readConfig(t, path)
-			if strings.Contains(workflowText, "/usr/bin/bash") {
-				t.Fatalf("%s must use the macOS-compatible /bin/bash path for hardened shells", path)
+			for _, path := range paths {
+				workflowText := readConfig(t, path)
+				if strings.Contains(workflowText, tc.forbidden) {
+					t.Errorf("%s contains non-portable command fragment %q", path, tc.forbidden)
+				}
 			}
 		})
 	}
@@ -2845,8 +2855,8 @@ func TestReleaseArchiveProducersUseFreshExactArtifactStaging(t *testing.T) {
 				{label: tc.resetStepName + " shell", got: resetStep.Shell, want: hardenedShell},
 			})
 			assertWorkflowStepEnv(t, resetStep, tc.resetStepName, map[string]string{"PATH": "/usr/bin:/bin"})
-			assertWorkflowStepRunContainsAll(t, resetStep, tc.resetStepName, []string{`rm -rf -- dist`, `mkdir -- dist`})
-			assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- dist`, `mkdir -- dist`, "archive staging must remove checkout-provided files before recreating dist")
+			assertWorkflowStepRunContainsAll(t, resetStep, tc.resetStepName, []string{`rm -rf -- dist`, `mkdir dist`})
+			assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- dist`, `mkdir dist`, "archive staging must remove checkout-provided files before recreating dist")
 
 			validateStep := job.Steps[validateIndex]
 			assertWorkflowStringValues(t, []workflowStringValue{

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -2192,6 +2192,134 @@ func TestDarwinReleaseJobsAssertHostArchitecture(t *testing.T) {
 	}
 }
 
+func TestReleaseArchiveProducersUseFreshExactArtifactStaging(t *testing.T) {
+	t.Parallel()
+	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"
+
+	testCases := []struct {
+		name             string
+		path             string
+		jobName          string
+		resetStepName    string
+		buildStepName    string
+		validateStepName string
+		uploadStepName   string
+		releaseTag       string
+		expectedRuntime  []string
+		expectedUploads  []string
+	}{
+		{
+			name:             "stable Darwin amd64",
+			path:             ".github/workflows/release.yml",
+			jobName:          "build-darwin-amd64",
+			resetStepName:    "Reset Darwin amd64 artifact staging",
+			buildStepName:    "Build Darwin amd64 release artifact",
+			validateStepName: "Validate Darwin amd64 release artifact",
+			uploadStepName:   "Upload Darwin amd64 artifacts",
+			releaseTag:       "${{ needs.prepare-release.outputs.tag }}",
+			expectedRuntime: []string{
+				`dist/lopper_${RELEASE_TAG}_darwin_amd64.tar.gz`,
+			},
+			expectedUploads: []string{
+				"dist/lopper_${{ needs.prepare-release.outputs.tag }}_darwin_amd64.tar.gz",
+			},
+		},
+		{
+			name:             "orchestrated Linux and Windows",
+			path:             ".github/workflows/release-orchestration.yml",
+			jobName:          "build-linux-windows",
+			resetStepName:    "Reset Linux/Windows artifact staging",
+			buildStepName:    "Build Linux/Windows release artifacts",
+			validateStepName: "Validate Linux/Windows release artifacts",
+			uploadStepName:   "Upload Linux/Windows artifacts",
+			releaseTag:       "${{ inputs.tag }}",
+			expectedRuntime: []string{
+				`dist/lopper_${RELEASE_TAG}_linux_amd64.tar.gz`,
+				`dist/lopper_${RELEASE_TAG}_linux_arm64.tar.gz`,
+				`dist/lopper_${RELEASE_TAG}_windows_amd64.zip`,
+				`dist/lopper_${RELEASE_TAG}_windows_arm64.zip`,
+			},
+			expectedUploads: []string{
+				"dist/lopper_${{ inputs.tag }}_linux_amd64.tar.gz",
+				"dist/lopper_${{ inputs.tag }}_linux_arm64.tar.gz",
+				"dist/lopper_${{ inputs.tag }}_windows_amd64.zip",
+				"dist/lopper_${{ inputs.tag }}_windows_arm64.zip",
+			},
+		},
+		{
+			name:             "orchestrated Darwin arm64",
+			path:             ".github/workflows/release-orchestration.yml",
+			jobName:          "build-darwin",
+			resetStepName:    "Reset Darwin arm64 artifact staging",
+			buildStepName:    "Build Darwin release artifact",
+			validateStepName: "Validate Darwin arm64 release artifact",
+			uploadStepName:   "Upload Darwin artifacts",
+			releaseTag:       "${{ inputs.tag }}",
+			expectedRuntime: []string{
+				`dist/lopper_${RELEASE_TAG}_darwin_arm64.tar.gz`,
+			},
+			expectedUploads: []string{
+				"dist/lopper_${{ inputs.tag }}_darwin_arm64.tar.gz",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var workflow workflowConfig
+			readYAMLConfig(t, tc.path, &workflow)
+			job := workflowJobByName(t, workflow.Jobs, tc.jobName)
+			resetIndex := workflowStepIndexByName(t, workflow.Jobs, tc.jobName, tc.resetStepName)
+			buildIndex := workflowStepIndexByName(t, workflow.Jobs, tc.jobName, tc.buildStepName)
+			validateIndex := workflowStepIndexByName(t, workflow.Jobs, tc.jobName, tc.validateStepName)
+			uploadIndex := workflowStepIndexByName(t, workflow.Jobs, tc.jobName, tc.uploadStepName)
+			if buildIndex != resetIndex+1 || validateIndex != buildIndex+1 || uploadIndex != validateIndex+1 {
+				t.Fatal("archive release producer must reset, build, validate, and upload in one contiguous sequence")
+			}
+
+			resetStep := job.Steps[resetIndex]
+			assertWorkflowStringValues(t, []workflowStringValue{
+				{label: tc.resetStepName + " shell", got: resetStep.Shell, want: hardenedShell},
+			})
+			assertWorkflowStepEnv(t, resetStep, tc.resetStepName, map[string]string{"PATH": "/usr/bin:/bin"})
+			assertWorkflowStepRunContainsAll(t, resetStep, tc.resetStepName, []string{`rm -rf -- dist`, `mkdir -- dist`})
+			assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- dist`, `mkdir -- dist`, "archive staging must remove checkout-provided files before recreating dist")
+
+			validateStep := job.Steps[validateIndex]
+			assertWorkflowStringValues(t, []workflowStringValue{
+				{label: tc.validateStepName + " shell", got: validateStep.Shell, want: hardenedShell},
+			})
+			assertWorkflowStepEnv(t, validateStep, tc.validateStepName, map[string]string{
+				"PATH":        "/usr/bin:/bin",
+				"RELEASE_TAG": tc.releaseTag,
+			})
+			validationContract := []string{
+				`find -P dist -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
+				`find -P dist -mindepth 1 -maxdepth 1 -type f | wc -l`,
+				`[ ! -f "${artifact}" ] || [ -L "${artifact}" ]`,
+				`[ ! -s "${artifact}" ]`,
+			}
+			validationContract = append(validationContract, tc.expectedRuntime...)
+			assertWorkflowStepRunContainsAll(t, validateStep, tc.validateStepName, validationContract)
+
+			uploadStep := job.Steps[uploadIndex]
+			gotUploads := strings.Split(strings.TrimSpace(uploadStep.With["path"]), "\n")
+			if !slices.Equal(gotUploads, tc.expectedUploads) {
+				t.Fatalf("%s upload paths = %#v, want %#v", tc.uploadStepName, gotUploads, tc.expectedUploads)
+			}
+			if strings.Contains(uploadStep.With["path"], "*") {
+				t.Fatalf("%s must not upload archive globs", tc.uploadStepName)
+			}
+			if uploadStep.With["if-no-files-found"] != "error" {
+				t.Fatalf("%s must fail when an expected artifact is missing", tc.uploadStepName)
+			}
+		})
+	}
+}
+
 func TestMakefileReleasePackagesRuntimeHooks(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -751,6 +751,55 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	assertReleasePublicationOmitsCheckoutAndCommands(t, publication)
 }
 
+func TestReleaseWorkflowUsesCanonicalPublicationManifestPaths(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+
+	assembler := workflowStepByName(t, workflow.Jobs, "prepare-release-publication", "Stage bounded release publication inputs")
+	publisher := workflowStepByName(t, workflow.Jobs, "publish", "Validate release publication inputs")
+	marketplace := workflowStepByName(t, workflow.Jobs, "publish-marketplace", "Validate Marketplace publication inputs")
+
+	const canonicalInputs = `manifest_inputs=("feature-flags.md" "${expected_assets[@]}")`
+	for name, step := range map[string]workflowStepConfig{
+		"assembler": assembler,
+		"publisher": publisher,
+	} {
+		if !strings.Contains(step.Run, canonicalInputs) {
+			t.Fatalf("%s must hash canonical publication paths without a leading ./", name)
+		}
+	}
+
+	assertWorkflowStepRunContainsAll(t, marketplace, "Marketplace canonical publication manifest paths", []string{
+		`printf '%s\n' feature-flags.md`,
+		`find dist -maxdepth 1 -type f -print`,
+	})
+	assertWorkflowStepRunOmitsAll(t, marketplace, "Marketplace canonical publication manifest paths", []string{
+		`printf '%s\n' ./feature-flags.md`,
+		`find ./dist -maxdepth 1 -type f -print`,
+		`[.]\/`,
+	})
+
+	manifestPatternMatch := regexp.MustCompile(`grep -Ev '([^']+)' SHA256SUMS`).FindStringSubmatch(marketplace.Run)
+	if len(manifestPatternMatch) != 2 {
+		t.Fatal("Marketplace validation must expose one checksum-manifest path pattern")
+	}
+	manifestPattern, err := regexp.Compile(manifestPatternMatch[1])
+	if err != nil {
+		t.Fatalf("compile Marketplace checksum-manifest path pattern: %v", err)
+	}
+	for _, line := range []string{
+		strings.Repeat("a", 64) + "  feature-flags.md",
+		strings.Repeat("b", 64) + "  dist/lopper_v1.2.3_linux_amd64.tar.gz",
+		strings.Repeat("c", 64) + "  dist/lopper-vscode-1.2.3.vsix",
+	} {
+		if !manifestPattern.MatchString(line) {
+			t.Fatalf("Marketplace checksum-manifest path pattern rejects canonical producer line %q", line)
+		}
+	}
+}
+
 func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	t.Parallel()
 	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /usr/bin/bash --noprofile --norc -euo pipefail {0}"


### PR DESCRIPTION
## Summary

Close the release artifact provenance gap found during the final Aardvark review wave. Stable and rolling assets are assembled only from exact, validated producer artifacts, and write-capable publisher jobs never execute repository-controlled code.

## Changes

- Reset producer staging before builds and validate exact regular, non-empty native and VSIX outputs.
- Generate source-derived metadata in read-only jobs, assemble publication inputs in fresh permissionless jobs, and publish from fresh write-only jobs without checkout.
- Isolate rolling release-note execution from a separate source-archive job that never executes repository-controlled code.
- Validate exact stable and rolling asset inventories, size bounds, checksum sidecars, and aggregate manifests before publication.
- Use one canonical stable checksum path convention across the assembler, GitHub publisher, and Marketplace publisher.
- Pin the rolling Darwin producer's checkout and Go setup actions to repository-standard immutable SHAs.
- Use the portable macOS Bash path and staging-directory syntax identified by Codex review.
- Add regression coverage for producer order, privilege boundaries, artifact inventories, manifest consumers, SHA/tag binding, immutable actions, portable Darwin commands, and repository-command exclusion.

## Validation

Commands and checks run on exact head `ced883cf4ebccde2058a836bc98b620627e4814b`:

```bash
make ci
go test ./scripts -count=1
actionlint
make dup-check
git diff --check origin/main...HEAD
```

- Hosted checks: 9 successful, 2 expected skips, 0 pending or failing, including the macOS smoke job.
- SonarCloud quality gate: `OK`, 0 unresolved issues, 0.0% new-code duplication.
- Local duplication gate: 1.63%, below the 3% limit.
- Independent code-reviewer: `APPROVE`, zero actionable findings.
- Independent architect: `CLEAR`, with Apple Bash 3.2 compatibility smoke-tested.
- Final cleanup pass: `PASS`/no-op; no mutable release action references, debug residue, or fallback paths.
- Final fetch confirmed `origin/main` remained `8cc89bb8c67f5c11f70c29b55a35f862bd5c2d13`; the latest rebase was a no-op.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Application runtime is unchanged; release workflows add bounded artifact-isolation jobs and downloads.
- Memory benchmark impact: None; the memory benchmark gate passes.
- Residual risk: Checksums prove transport and inventory integrity, not reproducible semantic provenance; this is nonblocking under the repository's merged-source trust model.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
