### PR TITLE
fix(release): keep prior feature catalogs workspace-relative

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,7 @@ jobs:
           set -euo pipefail
           version="${RELEASE_TAG#v}"
           cd extensions/vscode-lopper
-          npx @vscode/vsce package --out "../../dist/lopper-vscode-${version}.vsix"
+          ./node_modules/.bin/vsce package --out "../../dist/lopper-vscode-${version}.vsix"
 
       - name: Validate VS Code extension artifact
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1554,6 +1554,7 @@ jobs:
 
           source_url="https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz"
           curl --fail --show-error --silent --location \
+            --proto '=https' --proto-redir '=https' \
             --retry 5 --retry-all-errors --retry-delay 2 \
             --connect-timeout 20 --max-time 180 \
             "$source_url" -o /tmp/lopper-source.tar.gz
@@ -1682,6 +1683,7 @@ jobs:
 
           source_url="https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz"
           "${curl_bin}" --fail --show-error --silent --location \
+            --proto '=https' --proto-redir '=https' \
             --retry 5 --retry-all-errors --retry-delay 2 \
             --connect-timeout 20 --max-time 180 \
             "${source_url}" -o "${source_archive}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,9 +430,11 @@ jobs:
             fi
           done < <(git tag --list 'v[0-9]*' --sort=-v:refname)
 
+          rm -rf -- .artifacts
+          mkdir -- .artifacts
           args=(report --channel release --release "${RELEASE_TAG}")
           if [ -n "${previous_tag}" ]; then
-            previous_catalog="${RUNNER_TEMP}/previous-features.json"
+            previous_catalog=".artifacts/previous-features.json"
             if git cat-file -e "${previous_tag}:internal/featureflags/features.json" 2>/dev/null; then
               git show "${previous_tag}:internal/featureflags/features.json" > "${previous_catalog}"
             else

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -199,9 +199,11 @@ jobs:
             fi
           done < <(git tag --list 'rolling-*' --sort=-creatordate)
 
+          rm -rf -- .artifacts
+          mkdir -- .artifacts
           args=(report --channel rolling --release "${ROLLING_TAG}")
           if [ -n "${previous_tag}" ]; then
-            previous_catalog="${RUNNER_TEMP}/previous-rolling-features.json"
+            previous_catalog=".artifacts/previous-rolling-features.json"
             if git cat-file -e "${previous_tag}:internal/featureflags/features.json" 2>/dev/null; then
               git show "${previous_tag}:internal/featureflags/features.json" > "${previous_catalog}"
             else

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -727,6 +727,7 @@ jobs:
 
           source_url="https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz"
           curl --fail --show-error --silent --location \
+            --proto '=https' --proto-redir '=https' \
             --retry 5 --retry-all-errors --retry-delay 2 \
             --connect-timeout 20 --max-time 180 \
             "$source_url" -o /tmp/lopper-rolling-source.tar.gz
@@ -855,6 +856,7 @@ jobs:
 
           source_url="https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz"
           "${curl_bin}" --fail --show-error --silent --location \
+            --proto '=https' --proto-redir '=https' \
             --retry 5 --retry-all-errors --retry-delay 2 \
             --connect-timeout 20 --max-time 180 \
             "${source_url}" -o "${source_archive}"

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -498,14 +498,12 @@ func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 	assertTextAppearsBefore(t, resetStep.Run, `rm -rf -- dist`, `mkdir dist`, "VS Code artifact staging must remove checkout-provided files before recreating dist")
 
 	packageStep := build.Steps[packageIndex]
-	const packageCommand = `npx @vscode/vsce package --out "../../dist/lopper-vscode-${version}.vsix"`
+	const packageCommand = `./node_modules/.bin/vsce package --out "../../dist/lopper-vscode-${version}.vsix"`
 	assertWorkflowStepRunContainsAll(t, packageStep, "VS Code extension package", []string{
 		`version="${RELEASE_TAG#v}"`,
 		packageCommand,
 	})
-	if strings.Count(packageStep.Run, "npx ") != 1 {
-		t.Fatal("VS Code extension packaging must run exactly one npx command after resetting artifact staging")
-	}
+	assertWorkflowStepRunOmitsAll(t, packageStep, "VS Code extension package", []string{"npx ", "@vscode/vsce package"})
 
 	validateStep := build.Steps[validateIndex]
 	assertWorkflowStringValues(t, []workflowStringValue{
@@ -525,9 +523,6 @@ func TestReleaseWorkflowBuildsVSIXFromFreshArtifactStaging(t *testing.T) {
 
 	for _, step := range build.Steps[resetIndex:] {
 		for _, repositoryCommand := range []string{"go run ./", "make ", "npm ", "npx ", "scripts/", "./extensions/"} {
-			if step.Name == packageStep.Name && repositoryCommand == "npx " && strings.Contains(step.Run, packageCommand) {
-				continue
-			}
 			if strings.Contains(step.Run, repositoryCommand) {
 				t.Fatalf("VS Code release step %q must not execute repository-controlled command %q after resetting artifact staging", step.Name, repositoryCommand)
 			}

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3926,6 +3926,8 @@ func assertValidationRegenerationStep(t *testing.T, jobs map[string]workflowJobC
 	validationRegenerate := workflowStepByName(t, jobs, tc.validationJobName, tc.regenerateStepName)
 	for _, want := range []string{
 		tc.sourceURLLine,
+		`--proto '=https'`,
+		`--proto-redir '=https'`,
 		`version "${FORMULA_VERSION}"`,
 		`cat > ` + tc.formulaPath + ` <<RUBY`,
 	} {
@@ -3987,6 +3989,8 @@ func assertPrivilegedStepContainsRequiredHardening(t *testing.T, pushStep workfl
 		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
 		`git_safe clone --origin origin --branch main --single-branch https://github.com/ben-ranford/homebrew-tap.git "${tap_repo}"`,
 		tc.sourceURLLine,
+		`--proto '=https'`,
+		`--proto-redir '=https'`,
 		`version "${FORMULA_VERSION}"`,
 		`cat > "${tap_repo}/` + tc.formulaPath + `" <<RUBY`,
 		`git_safe -C "${tap_repo}" add ` + tc.formulaPath,

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -573,6 +573,7 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`rm -rf -- .artifacts`,
 		`mkdir -- .artifacts`,
 		`previous_catalog=".artifacts/previous-features.json"`,
+		`args+=(--previous-catalog "${previous_catalog}")`,
 		`go run ./tools/featureflag "${args[@]}" > "${report_dir}/feature-flags.md"`,
 	})
 	assertWorkflowStepRunOmitsAll(t, generateReport, "feature flag release report generation", []string{
@@ -580,7 +581,8 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	})
 	assertTextAppearsBefore(t, generateReport.Run, `rm -rf -- .artifacts`, `mkdir -- .artifacts`, "release feature report generation must reset its workspace-confined catalog staging directory")
 	assertTextAppearsBefore(t, generateReport.Run, `mkdir -- .artifacts`, `previous_catalog=".artifacts/previous-features.json"`, "release feature report generation must recreate catalog staging before selecting the relative path")
-	assertTextAppearsBefore(t, generateReport.Run, `previous_catalog=".artifacts/previous-features.json"`, `go run ./tools/featureflag`, "release feature report generation must stage the workspace-confined catalog before running the report")
+	assertTextAppearsBefore(t, generateReport.Run, `previous_catalog=".artifacts/previous-features.json"`, `args+=(--previous-catalog "${previous_catalog}")`, "release feature report generation must select the workspace-confined catalog before passing it to the report")
+	assertTextAppearsBefore(t, generateReport.Run, `args+=(--previous-catalog "${previous_catalog}")`, `go run ./tools/featureflag`, "release feature report generation must pass the staged catalog to the report")
 	validateReport := workflowStepByName(t, workflow.Jobs, "prepare-release-feature-report", "Validate feature flag release report")
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{label: "feature report validation shell", got: validateReport.Shell, want: hardenedShell},
@@ -838,6 +840,7 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`rm -rf -- .artifacts`,
 		`mkdir -- .artifacts`,
 		`previous_catalog=".artifacts/previous-rolling-features.json"`,
+		`args+=(--previous-catalog "${previous_catalog}")`,
 		`go run ./tools/featureflag "${args[@]}" > "${feature_report}"`,
 		`> "${notes_root}/rolling-changelog.md"`,
 	})
@@ -846,7 +849,8 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	})
 	assertTextAppearsBefore(t, generateNotes.Run, `rm -rf -- .artifacts`, `mkdir -- .artifacts`, "rolling release note generation must reset its workspace-confined catalog staging directory")
 	assertTextAppearsBefore(t, generateNotes.Run, `mkdir -- .artifacts`, `previous_catalog=".artifacts/previous-rolling-features.json"`, "rolling release note generation must recreate catalog staging before selecting the relative path")
-	assertTextAppearsBefore(t, generateNotes.Run, `previous_catalog=".artifacts/previous-rolling-features.json"`, `go run ./tools/featureflag`, "rolling release note generation must stage the workspace-confined catalog before running the report")
+	assertTextAppearsBefore(t, generateNotes.Run, `previous_catalog=".artifacts/previous-rolling-features.json"`, `args+=(--previous-catalog "${previous_catalog}")`, "rolling release note generation must select the workspace-confined catalog before passing it to the report")
+	assertTextAppearsBefore(t, generateNotes.Run, `args+=(--previous-catalog "${previous_catalog}")`, `go run ./tools/featureflag`, "rolling release note generation must pass the staged catalog to the report")
 	validateNotes := workflowStepByName(t, workflow.Jobs, "prepare-rolling-release-notes", "Validate rolling release notes")
 	assertWorkflowStringValues(t, []workflowStringValue{{
 		label: "rolling release note validation shell",

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -570,8 +570,17 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`report_dir="${RUNNER_TEMP}/release-feature-report"`,
 		`rm -rf -- "${report_dir}"`,
 		`mkdir -- "${report_dir}"`,
+		`rm -rf -- .artifacts`,
+		`mkdir -- .artifacts`,
+		`previous_catalog=".artifacts/previous-features.json"`,
 		`go run ./tools/featureflag "${args[@]}" > "${report_dir}/feature-flags.md"`,
 	})
+	assertWorkflowStepRunOmitsAll(t, generateReport, "feature flag release report generation", []string{
+		`previous_catalog="${RUNNER_TEMP}/previous-features.json"`,
+	})
+	assertTextAppearsBefore(t, generateReport.Run, `rm -rf -- .artifacts`, `mkdir -- .artifacts`, "release feature report generation must reset its workspace-confined catalog staging directory")
+	assertTextAppearsBefore(t, generateReport.Run, `mkdir -- .artifacts`, `previous_catalog=".artifacts/previous-features.json"`, "release feature report generation must recreate catalog staging before selecting the relative path")
+	assertTextAppearsBefore(t, generateReport.Run, `previous_catalog=".artifacts/previous-features.json"`, `go run ./tools/featureflag`, "release feature report generation must stage the workspace-confined catalog before running the report")
 	validateReport := workflowStepByName(t, workflow.Jobs, "prepare-release-feature-report", "Validate feature flag release report")
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{label: "feature report validation shell", got: validateReport.Shell, want: hardenedShell},
@@ -826,9 +835,18 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 		`notes_root="${RUNNER_TEMP}/rolling-release-notes"`,
 		`rm -rf -- "${notes_root}"`,
 		`mkdir -- "${notes_root}"`,
+		`rm -rf -- .artifacts`,
+		`mkdir -- .artifacts`,
+		`previous_catalog=".artifacts/previous-rolling-features.json"`,
 		`go run ./tools/featureflag "${args[@]}" > "${feature_report}"`,
 		`> "${notes_root}/rolling-changelog.md"`,
 	})
+	assertWorkflowStepRunOmitsAll(t, generateNotes, "rolling release note generation", []string{
+		`previous_catalog="${RUNNER_TEMP}/previous-rolling-features.json"`,
+	})
+	assertTextAppearsBefore(t, generateNotes.Run, `rm -rf -- .artifacts`, `mkdir -- .artifacts`, "rolling release note generation must reset its workspace-confined catalog staging directory")
+	assertTextAppearsBefore(t, generateNotes.Run, `mkdir -- .artifacts`, `previous_catalog=".artifacts/previous-rolling-features.json"`, "rolling release note generation must recreate catalog staging before selecting the relative path")
+	assertTextAppearsBefore(t, generateNotes.Run, `previous_catalog=".artifacts/previous-rolling-features.json"`, `go run ./tools/featureflag`, "rolling release note generation must stage the workspace-confined catalog before running the report")
 	validateNotes := workflowStepByName(t, workflow.Jobs, "prepare-rolling-release-notes", "Validate rolling release notes")
 	assertWorkflowStringValues(t, []workflowStringValue{{
 		label: "rolling release note validation shell",


### PR DESCRIPTION
## Summary

Repair the rolling release failure triggered after PR #1211 merged. The release-note producer passed an absolute runner-temp catalog path to a deliberately workspace-confined reader, so the path was prefixed with the checkout root and the job could not find the previous feature catalog. The stable release report contained the same latent defect.

## Changes

- Reset and recreate the ignored `.artifacts` staging directory before writing previous feature catalogs.
- Pass repository-relative catalog paths to the stable and rolling feature-report commands, preserving the existing safe I/O confinement boundary.
- Regression-lock reset, recreation, relative assignment, argument append, invocation order, and the absence of the broken absolute path in both workflows.
- Package the VS Code extension with the lockfile-installed `vsce` binary instead of an on-demand `npx` install.
- Restrict stable and rolling Homebrew source downloads and redirects to HTTPS in validation and privileged publication jobs.

## Validation

Commands and checks run on exact head `44a413ed1acb0a68be2759e23ba81ffed997017a`:

```bash
make ci
go test ./scripts -count=1
go test ./tools/featureflag -count=1
go test ./scripts -run 'Test(ReleaseWorkflowPublishesFromFreshValidatedInputs|RollingWorkflowPublishesFromFreshValidatedInputs)$' -count=1
go test ./scripts -run 'Test(HomebrewTapWorkflowsUseFreshPrivilegedTapUpdateJobs|HomebrewTapWorkflowsUseImmutablePreparedSourceBindings)$' -count=1
actionlint
git diff --check origin/main...HEAD
```

- The new regression assertions failed against the prior workflow configuration and pass after the fix.
- A real `featureflag report --previous-catalog .artifacts/previous-rolling-features.json` invocation against an existing rolling tag produced a non-empty report.
- All four incremental commits passed the repository pre-commit `make ci` gate with 98.3% coverage, 0 gosec issues, 0 known vulnerabilities, and passing race, leak, memory, and build gates.
- Independent code-reviewer: `APPROVE`, zero findings at the exact local head.
- Independent architecture precheck: pass; the workspace confinement and release privilege boundaries remain intact.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None; only release workflow path staging changes.
- Memory benchmark impact: None; the memory benchmark gate passes.
- Residual risk: The live rolling workflow must still prove the corrected path on GitHub after merge.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
