### PR TITLE
chore(release): add preview patch versioning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- PR title must use Conventional Commits, for example `fix(scope): concise summary`. Squash merges publish that title to `main`, so do not rewrite it into a non-conventional subject. -->
+<!-- PR title must use Conventional Commits, for example `fix(scope): concise summary`. Use `preview(scope): summary` for default-off feature work and `feat(flags): graduate ...` only when graduating it. Squash merges publish that title to `main`, so do not rewrite it into a non-conventional subject. -->
 
 ## Summary
 

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -87,7 +87,7 @@ jobs:
             exit 1
           fi
           git log --format=%B "origin/${base_ref}..HEAD" > "${commit_messages}"
-          if grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|^[[:space:]]*(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)[[:space:]]*$' "${commit_messages}"; then
+          if grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${commit_messages}"; then
             echo "::error::Preview commits must not contain breaking-change or release-please version override directives." >&2
             exit 1
           fi

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -78,16 +78,22 @@ jobs:
           set -euo pipefail
           base_ref="${PR_BASE_REF:-main}"
           commit_messages="$(mktemp "${RUNNER_TEMP}/preview-commit-messages.XXXXXX")"
+          commit_subjects="$(mktemp "${RUNNER_TEMP}/preview-commit-subjects.XXXXXX")"
           pr_body="$(mktemp "${RUNNER_TEMP}/preview-pr-body.XXXXXX")"
-          trap 'rm -f "${commit_messages}" "${pr_body}"' EXIT
+          trap 'rm -f "${commit_messages}" "${commit_subjects}" "${pr_body}"' EXIT
           printf '%s\n' "${PR_BODY}" > "${pr_body}"
           if grep -Eiq '^[[:space:]]*(BEGIN|END)_COMMIT_OVERRIDE[[:space:]]*$' "${pr_body}"; then
             echo "::error::Preview PR descriptions must not contain release-please commit override blocks." >&2
             exit 1
           fi
           git log --format=%B "origin/${base_ref}..HEAD" > "${commit_messages}"
-          if grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|^(BEGIN|END)_COMMIT_OVERRIDE[[:space:]]*$' "${commit_messages}"; then
+          if grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|^[[:space:]]*(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)[[:space:]]*$' "${commit_messages}"; then
             echo "::error::Preview commits must not contain breaking-change or release-please version override directives." >&2
+            exit 1
+          fi
+          git log --format=%s "origin/${base_ref}..HEAD" > "${commit_subjects}"
+          if grep -Eiq '^(feat|fix|bug|perf|docs|refactor|revert)(\([^)]+\))?:[[:space:]]+[^[:space:]]|^[[:alnum:]_-]+(\([^)]+\))?!:[[:space:]]+[^[:space:]]' "${commit_subjects}"; then
+            echo "::error::Preview branch commits must not add non-preview release entries or breaking subjects to the squash body." >&2
             exit 1
           fi
 

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -79,9 +79,8 @@ jobs:
           set -euo pipefail
           base_ref="${PR_BASE_REF:-main}"
           commit_messages="$(mktemp "${RUNNER_TEMP}/preview-commit-messages.XXXXXX")"
-          commit_subjects="$(mktemp "${RUNNER_TEMP}/preview-commit-subjects.XXXXXX")"
           pr_body="$(mktemp "${RUNNER_TEMP}/preview-pr-body.XXXXXX")"
-          trap 'rm -f "${commit_messages}" "${commit_subjects}" "${pr_body}"' EXIT
+          trap 'rm -f "${commit_messages}" "${pr_body}"' EXIT
           printf '%s\n' "${PR_BODY}" > "${pr_body}"
           if grep -Eiq '(BEGIN|END)_COMMIT_OVERRIDE' "${pr_body}"; then
             echo "::error::Preview PR descriptions must not contain release-please commit override blocks." >&2
@@ -92,8 +91,7 @@ jobs:
             echo "::error::Preview commits must not contain breaking-change or release-please version override directives." >&2
             exit 1
           fi
-          git log --format=%s "origin/${base_ref}..HEAD" > "${commit_subjects}"
-          if grep -Eiq '^(feat|fix|bug|perf|docs|refactor|revert)(\([^)]+\))?:[[:space:]]+[^[:space:]]|^[[:alnum:]_-]+(\([^)]+\))?!:[[:space:]]+[^[:space:]]' "${commit_subjects}"; then
+          if grep -Eiq '^(feat|fix|bug|perf|docs|refactor|revert)(\([^)]+\))?:[[:space:]]+[^[:space:]]|^[[:alnum:]_-]+(\([^)]+\))?!:[[:space:]]+[^[:space:]]' "${commit_messages}"; then
             echo "::error::Preview branch commits must not add non-preview release entries or breaking subjects to the squash body." >&2
             exit 1
           fi

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -53,12 +53,13 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-          if printf '%s\n' "${PR_TITLE}" | grep -Eq '^(feat|preview)(\([^)]+\))?(!)?:[[:space:]]+[^[:space:]]'; then
+          pr_title="$(printf '%s\n' "${PR_TITLE}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+          if printf '%s\n' "${pr_title}" | grep -Eq '^(feat|preview)(\([^)]+\))?(!)?:[[:space:]]+[^[:space:]]'; then
             echo "feature_pr=true" >> "$GITHUB_OUTPUT"
           else
             echo "feature_pr=false" >> "$GITHUB_OUTPUT"
           fi
-          if printf '%s\n' "${PR_TITLE}" | grep -Eq '^preview(\([^)]+\))?(!)?:[[:space:]]+[^[:space:]]'; then
+          if printf '%s\n' "${pr_title}" | grep -Eq '^preview(\([^)]+\))?(!)?:[[:space:]]+[^[:space:]]'; then
             echo "preview_pr=true" >> "$GITHUB_OUTPUT"
           else
             echo "preview_pr=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -82,8 +82,8 @@ jobs:
           pr_body="$(mktemp "${RUNNER_TEMP}/preview-pr-body.XXXXXX")"
           trap 'rm -f "${commit_messages}" "${pr_body}"' EXIT
           printf '%s\n' "${PR_BODY}" > "${pr_body}"
-          if grep -Eiq '(BEGIN|END)_COMMIT_OVERRIDE' "${pr_body}"; then
-            echo "::error::Preview PR descriptions must not contain release-please commit override blocks." >&2
+          if grep -Eiq '(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${pr_body}"; then
+            echo "::error::Preview PR descriptions must not contain release-please override or nested commit blocks." >&2
             exit 1
           fi
           merge_base="$(git merge-base "origin/${base_ref}" HEAD)"

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -81,18 +81,20 @@ jobs:
           commit_messages="$(mktemp "${RUNNER_TEMP}/preview-commit-messages.XXXXXX")"
           pr_body="$(mktemp "${RUNNER_TEMP}/preview-pr-body.XXXXXX")"
           trap 'rm -f "${commit_messages}" "${pr_body}"' EXIT
+          release_directive_pattern='^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)'
+          non_preview_entry_pattern='^(feat|feature|fix|bug|perf|docs|refactor|revert)(\([^)]+\))?:[[:space:]]+[^[:space:]]|^[[:alnum:]_-]+(\([^)]+\))?!:[[:space:]]+[^[:space:]]'
           printf '%s\n' "${PR_BODY}" > "${pr_body}"
-          if grep -Eiq '(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${pr_body}"; then
-            echo "::error::Preview PR descriptions must not contain release-please override or nested commit blocks." >&2
+          if grep -Eiq "${release_directive_pattern}" "${pr_body}" || grep -Eiq "${non_preview_entry_pattern}" "${pr_body}"; then
+            echo "::error::Preview PR descriptions must not contain release footers, non-preview entries, or release-please override blocks." >&2
             exit 1
           fi
           merge_base="$(git merge-base "origin/${base_ref}" HEAD)"
           git log --format=%B "${merge_base}..HEAD" > "${commit_messages}"
-          if grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${commit_messages}"; then
+          if grep -Eiq "${release_directive_pattern}" "${commit_messages}"; then
             echo "::error::Preview commits must not contain breaking-change or release-please version override directives." >&2
             exit 1
           fi
-          if grep -Eiq '^(feat|feature|fix|bug|perf|docs|refactor|revert)(\([^)]+\))?:[[:space:]]+[^[:space:]]|^[[:alnum:]_-]+(\([^)]+\))?!:[[:space:]]+[^[:space:]]' "${commit_messages}"; then
+          if grep -Eiq "${non_preview_entry_pattern}" "${commit_messages}"; then
             echo "::error::Preview branch commits must not add non-preview release entries or breaking subjects to the squash body." >&2
             exit 1
           fi

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -83,7 +83,7 @@ jobs:
           pr_body="$(mktemp "${RUNNER_TEMP}/preview-pr-body.XXXXXX")"
           trap 'rm -f "${commit_messages}" "${commit_subjects}" "${pr_body}"' EXIT
           printf '%s\n' "${PR_BODY}" > "${pr_body}"
-          if grep -Eiq '^[[:space:]]*(BEGIN|END)_COMMIT_OVERRIDE[[:space:]]*$' "${pr_body}"; then
+          if grep -Eiq '(BEGIN|END)_COMMIT_OVERRIDE' "${pr_body}"; then
             echo "::error::Preview PR descriptions must not contain release-please commit override blocks." >&2
             exit 1
           fi

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -73,11 +73,18 @@ jobs:
         if: ${{ steps.classify_pr.outputs.preview_pr == 'true' }}
         env:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
           base_ref="${PR_BASE_REF:-main}"
           commit_messages="$(mktemp "${RUNNER_TEMP}/preview-commit-messages.XXXXXX")"
-          trap 'rm -f "${commit_messages}"' EXIT
+          pr_body="$(mktemp "${RUNNER_TEMP}/preview-pr-body.XXXXXX")"
+          trap 'rm -f "${commit_messages}" "${pr_body}"' EXIT
+          printf '%s\n' "${PR_BODY}" > "${pr_body}"
+          if grep -Eiq '^[[:space:]]*(BEGIN|END)_COMMIT_OVERRIDE[[:space:]]*$' "${pr_body}"; then
+            echo "::error::Preview PR descriptions must not contain release-please commit override blocks." >&2
+            exit 1
+          fi
           git log --format=%B "origin/${base_ref}..HEAD" > "${commit_messages}"
           if grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|^(BEGIN|END)_COMMIT_OVERRIDE[[:space:]]*$' "${commit_messages}"; then
             echo "::error::Preview commits must not contain breaking-change or release-please version override directives." >&2

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -32,7 +32,7 @@ jobs:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           base_ref="${PR_BASE_REF:-main}"
-          git fetch --no-tags --depth=1 origin "${base_ref}"
+          git fetch --no-tags origin "+refs/heads/${base_ref}:refs/remotes/origin/${base_ref}"
 
       - name: Capture base feature catalog
         env:
@@ -86,7 +86,8 @@ jobs:
             echo "::error::Preview PR descriptions must not contain release-please commit override blocks." >&2
             exit 1
           fi
-          git log --format=%B "origin/${base_ref}..HEAD" > "${commit_messages}"
+          merge_base="$(git merge-base "origin/${base_ref}" HEAD)"
+          git log --format=%B "${merge_base}..HEAD" > "${commit_messages}"
           if grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${commit_messages}"; then
             echo "::error::Preview commits must not contain breaking-change or release-please version override directives." >&2
             exit 1

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -53,15 +53,35 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-          if printf '%s\n' "${PR_TITLE}" | grep -Eq '^feat(\([^)]+\))?(!)?:[[:space:]]+[^[:space:]]'; then
+          if printf '%s\n' "${PR_TITLE}" | grep -Eq '^(feat|preview)(\([^)]+\))?(!)?:[[:space:]]+[^[:space:]]'; then
             echo "feature_pr=true" >> "$GITHUB_OUTPUT"
           else
             echo "feature_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+          if printf '%s\n' "${PR_TITLE}" | grep -Eq '^preview(\([^)]+\))?(!)?:[[:space:]]+[^[:space:]]'; then
+            echo "preview_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "preview_pr=false" >> "$GITHUB_OUTPUT"
           fi
           if [[ "${PR_HEAD_REF}" == release-please--branches--* ]]; then
             echo "release_pr=true" >> "$GITHUB_OUTPUT"
           else
             echo "release_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Reject release overrides on preview PRs
+        if: ${{ steps.classify_pr.outputs.preview_pr == 'true' }}
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          base_ref="${PR_BASE_REF:-main}"
+          commit_messages="$(mktemp "${RUNNER_TEMP}/preview-commit-messages.XXXXXX")"
+          trap 'rm -f "${commit_messages}"' EXIT
+          git log --format=%B "origin/${base_ref}..HEAD" > "${commit_messages}"
+          if grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|^(BEGIN|END)_COMMIT_OVERRIDE[[:space:]]*$' "${commit_messages}"; then
+            echo "::error::Preview commits must not contain breaking-change or release-please version override directives." >&2
+            exit 1
           fi
 
       - name: Enforce feature flags on PRs

--- a/.github/workflows/feature-flag-enforcement.yml
+++ b/.github/workflows/feature-flag-enforcement.yml
@@ -91,7 +91,7 @@ jobs:
             echo "::error::Preview commits must not contain breaking-change or release-please version override directives." >&2
             exit 1
           fi
-          if grep -Eiq '^(feat|fix|bug|perf|docs|refactor|revert)(\([^)]+\))?:[[:space:]]+[^[:space:]]|^[[:alnum:]_-]+(\([^)]+\))?!:[[:space:]]+[^[:space:]]' "${commit_messages}"; then
+          if grep -Eiq '^(feat|feature|fix|bug|perf|docs|refactor|revert)(\([^)]+\))?:[[:space:]]+[^[:space:]]|^[[:alnum:]_-]+(\([^)]+\))?!:[[:space:]]+[^[:space:]]' "${commit_messages}"; then
             echo "::error::Preview branch commits must not add non-preview release entries or breaking subjects to the squash body." >&2
             exit 1
           fi

--- a/.github/workflows/graduate-feature.yml
+++ b/.github/workflows/graduate-feature.yml
@@ -28,7 +28,7 @@ on:
       milestone:
         description: Milestone to assign to the graduation PR
         required: false
-        default: "v1.7.0"
+        default: "v1.9.0"
         type: string
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ Use these commit types for changes that should appear in release notes:
 - `feat(flags): graduate ...` for feature graduation and the resulting minor release.
 - `type(scope)!: summary` or a `BREAKING CHANGE:` footer for major releases.
 
-Do not use breaking-change markers, `Release-As` footers, or commit override directives on `preview` commits. Preview work stays default-off and patch-versioned until a separate graduation PR uses `feat`.
+Do not use breaking-change markers, `Release-As` footers, commit override directives, or nested commit blocks on `preview` PRs. Because squash bodies include branch commit messages, branch commit subjects must also avoid the non-preview release-note types `feat`, `fix`, `bug`, `perf`, `docs`, `refactor`, and `revert`; use `preview`, `test`, `build`, `ci`, or `chore` as appropriate. Preview work stays default-off and patch-versioned until a separate graduation PR uses `feat(flags)`.
 
 Use non-release types such as `test`, `ci`, `build`, or `chore` when the change should not by itself create a release PR.
 Good scopes include `release`, `ci`, `vscode`, `js`, `jvm`, `go`, `report`, `ui`, `runtime`, and `homebrew`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,8 @@ Contributor rules:
 - The stable release workflow stamps `firstStableRelease` after a flag ships in a semver release so later release PRs only surface first-release preview flags.
 - Graduation requires a separate PR that changes the registry lifecycle to `stable` and states the rollout evidence.
 - Use `make feature-flag-graduate FEATURE=...` locally, or run `graduate-feature.yml`, to prepare a graduation PR.
-- PRs that use the `feat` Conventional Commit type must add at least one new feature flag entry, and new entries must stay `preview`.
+- New preview implementations use `preview(scope): summary`, add at least one new feature flag entry, and keep every new entry `preview`.
+- Graduation PRs use `feat(flags): graduate ...` and change at least one existing flag from `preview` to `stable`.
 - PRs that add, lock, or graduate a feature flag must run `go run ./tools/featureflag validate`.
 
 Reviewers should ask for a flag when the change changes default user behavior but lacks enough evidence for immediate stable rollout.
@@ -104,8 +105,11 @@ Use these commit types for changes that should appear in release notes:
 - `docs(scope): summary` for documentation-only patch releases.
 - `refactor(scope): summary` for refactoring patch releases.
 - `perf(scope): summary` for performance patch releases.
-- `feat(scope): summary` for minor releases.
+- `preview(scope): summary` for opt-in feature work that stays on the current patch release line.
+- `feat(flags): graduate ...` for feature graduation and the resulting minor release.
 - `type(scope)!: summary` or a `BREAKING CHANGE:` footer for major releases.
+
+Do not use breaking-change markers, `Release-As` footers, or commit override directives on `preview` commits. Preview work stays default-off and patch-versioned until a separate graduation PR uses `feat`.
 
 Use non-release types such as `test`, `ci`, `build`, or `chore` when the change should not by itself create a release PR.
 Good scopes include `release`, `ci`, `vscode`, `js`, `jvm`, `go`, `report`, `ui`, `runtime`, and `homebrew`.

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -29,7 +29,7 @@ Stable release automation:
 - Manual retries only rebuild an existing GitHub release for the selected tag. The workflow reuses the existing published or draft release metadata and fails instead of creating a missing release.
 - Release commits should use Conventional Commit prefixes: `fix:` for patch fixes, `preview:` for opt-in feature work that remains on the current patch line, `feat:` for graduated features and minor releases, and any non-preview type with a breaking-change marker (for example `feat!:` or `fix!:`) or a `BREAKING CHANGE:` footer for major releases.
 - Release Please includes `preview:` commits under **Preview Features**. Its default versioning treats that custom type as patch, while the separate `feat(flags): graduate ...` PR requests the minor bump.
-- CI rejects breaking-change markers and Release Please override directives in preview PR commit messages so a preview squash commit cannot escape the patch line.
+- CI rejects breaking-change markers, Release Please override/nested-commit directives, and non-preview release-note subjects in preview PR commit messages and descriptions so a preview squash commit cannot escape the patch line.
 - Stable releases also publish the first-party action version refs. The release tag, such as `v1.7.0`, is the exact action ref; the workflow force-updates `v1` and `v1.7` to the same release commit for standard GitHub Actions major/minor pinning.
 - Set repository secret `RELEASE_PLEASE_TOKEN` to a PAT with contents and pull request write access so release-please-created PRs can trigger normal CI. If it is not configured, the workflow falls back to `MAIN_SYNC_PAT` and then `GITHUB_TOKEN`.
 

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -27,7 +27,9 @@ Stable release automation:
 - The current stable version is also synced into `extensions/vscode-lopper/package.json` and `extensions/vscode-lopper/package-lock.json` by the release-please PR.
 - Manual `workflow_dispatch` runs accept only a release tag/version, normalize it to the semver tag, validate the tag ref, resolve `refs/tags/<tag>` through the GitHub API, and derive the release source SHA from that immutable tag commit.
 - Manual retries only rebuild an existing GitHub release for the selected tag. The workflow reuses the existing published or draft release metadata and fails instead of creating a missing release.
-- Release commits should use Conventional Commit prefixes: `fix:` for patch releases, `feat:` for minor releases, and any type with a breaking-change marker (for example `feat!:` or `fix!:`) or a `BREAKING CHANGE:` footer for major releases.
+- Release commits should use Conventional Commit prefixes: `fix:` for patch fixes, `preview:` for opt-in feature work that remains on the current patch line, `feat:` for graduated features and minor releases, and any non-preview type with a breaking-change marker (for example `feat!:` or `fix!:`) or a `BREAKING CHANGE:` footer for major releases.
+- Release Please includes `preview:` commits under **Preview Features**. Its default versioning treats that custom type as patch, while the separate `feat(flags): graduate ...` PR requests the minor bump.
+- CI rejects breaking-change markers and Release Please override directives in preview PR commit messages so a preview squash commit cannot escape the patch line.
 - Stable releases also publish the first-party action version refs. The release tag, such as `v1.7.0`, is the exact action ref; the workflow force-updates `v1` and `v1.7` to the same release commit for standard GitHub Actions major/minor pinning.
 - Set repository secret `RELEASE_PLEASE_TOKEN` to a PAT with contents and pull request write access so release-please-created PRs can trigger normal CI. If it is not configured, the workflow falls back to `MAIN_SYNC_PAT` and then `GITHUB_TOKEN`.
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -56,7 +56,8 @@ Validate the registry and release locks before opening a PR:
 go run ./tools/featureflag validate
 ```
 
-PRs titled with the `feat` Conventional Commit type must add at least one new feature flag entry, and CI rejects any newly added flag whose lifecycle is not `preview`.
+PRs that introduce opt-in behavior use `preview(scope): summary`, must add at least one new feature flag entry, and keep every new flag in the `preview` lifecycle.
+Graduation PRs use `feat(flags): graduate ...` and promote an existing flag from `preview` to `stable`; this explicit title transition is what permits the next minor release.
 The PR enforcement workflow keeps a sticky report on feature PRs and on any PR that violates the preview-lifecycle rule.
 
 ## User Activation

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,10 @@
           "section": "Features"
         },
         {
+          "type": "preview",
+          "section": "Preview Features"
+        },
+        {
           "type": "fix",
           "section": "Bug Fixes"
         },

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -235,9 +235,12 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 	})
 	assertWorkflowStepRunContainsAll(t, rejectOverrides, "preview release override guard", []string{
 		`printf '%s\n' "${PR_BODY}"`,
-		`(BEGIN|END)_COMMIT_OVERRIDE`,
+		`(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)`,
 		`git log --format=%B "origin/${base_ref}..HEAD"`,
+		`git log --format=%s "origin/${base_ref}..HEAD"`,
 		`(BREAKING[ -]CHANGE|Release-As)`,
+		`(feat|fix|bug|perf|docs|refactor|revert)`,
+		`?!:[[:space:]]+[^[:space:]]`,
 	})
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -244,7 +244,7 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 	assertWorkflowStepRunContainsAll(t, rejectOverrides, "preview release override guard", []string{
 		`printf '%s\n' "${PR_BODY}"`,
 		`grep -Eiq '(BEGIN|END)_COMMIT_OVERRIDE' "${pr_body}"`,
-		`(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)`,
+		`grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${commit_messages}"`,
 		`git log --format=%B "origin/${base_ref}..HEAD"`,
 		`(BREAKING[ -]CHANGE|Release-As)`,
 		`(feat|fix|bug|perf|docs|refactor|revert)`,

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -227,6 +227,14 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 	if !strings.Contains(classify.Run, `echo "preview_pr=true"`) {
 		t.Fatal("feature flag enforcement must expose preview PR classification")
 	}
+	for _, want := range []string{
+		`sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'`,
+		`printf '%s\n' "${pr_title}"`,
+	} {
+		if !strings.Contains(classify.Run, want) {
+			t.Fatalf("feature flag enforcement must classify the trimmed PR title using %q", want)
+		}
+	}
 
 	rejectOverrides := workflowStepByName(t, workflow.Jobs, "enforce", "Reject release overrides on preview PRs")
 	assertWorkflowStringValues(t, []workflowStringValue{

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -250,7 +250,7 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 	})
 	assertWorkflowStepRunContainsAll(t, rejectOverrides, "preview release override guard", []string{
 		`printf '%s\n' "${PR_BODY}"`,
-		`grep -Eiq '(BEGIN|END)_COMMIT_OVERRIDE' "${pr_body}"`,
+		`grep -Eiq '(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${pr_body}"`,
 		`grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${commit_messages}"`,
 		`merge_base="$(git merge-base "origin/${base_ref}" HEAD)"`,
 		`git log --format=%B "${merge_base}..HEAD"`,

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -121,9 +121,16 @@ func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	t.Parallel()
 
 	var config struct {
-		Packages map[string]struct {
-			ChangelogPath string `json:"changelog-path"`
-			ExtraFiles    []struct {
+		Versioning string `json:"versioning"`
+		Packages   map[string]struct {
+			Versioning        string `json:"versioning"`
+			ChangelogPath     string `json:"changelog-path"`
+			ChangelogSections []struct {
+				Type    string `json:"type"`
+				Section string `json:"section"`
+				Hidden  bool   `json:"hidden"`
+			} `json:"changelog-sections"`
+			ExtraFiles []struct {
 				Path string `json:"path"`
 			} `json:"extra-files"`
 		} `json:"packages"`
@@ -139,6 +146,23 @@ func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	}
 	if rootPackage.ChangelogPath == "extensions/vscode-lopper/CHANGELOG.md" {
 		t.Fatal("root release notes must not be written to the VS Code extension changelog")
+	}
+	if config.Versioning != "" || rootPackage.Versioning != "" {
+		t.Fatal("release-please must keep default versioning so preview commits bump patch and feat graduations bump minor")
+	}
+
+	previewSectionFound := false
+	for _, section := range rootPackage.ChangelogSections {
+		if section.Type != "preview" {
+			continue
+		}
+		previewSectionFound = true
+		if section.Section != "Preview Features" || section.Hidden {
+			t.Fatalf("preview changelog section = %#v, want visible Preview Features", section)
+		}
+	}
+	if !previewSectionFound {
+		t.Fatal("release-please config must expose preview commits in release notes")
 	}
 
 	extraFiles := map[string]bool{}
@@ -165,8 +189,8 @@ func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	if !ok {
 		t.Fatal("graduate-feature workflow must define the milestone input")
 	}
-	if milestone.Default != "v1.7.0" {
-		t.Fatalf("graduate-feature milestone default = %q, want v1.7.0", milestone.Default)
+	if milestone.Default != "v1.9.0" {
+		t.Fatalf("graduate-feature milestone default = %q, want v1.9.0", milestone.Default)
 	}
 
 	workflowText := readConfig(t, ".github/workflows/graduate-feature.yml")
@@ -176,6 +200,38 @@ func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	if strings.Contains(workflowText, "--label target-series:") {
 		t.Fatal("graduate-feature workflow must not hardcode a target-series label")
 	}
+	for _, want := range []string{
+		`git commit -m "feat(flags): graduate ${FEATURE} to stable"`,
+		`--title "feat(flags): graduate ${FEATURE} to stable"`,
+	} {
+		if !strings.Contains(workflowText, want) {
+			t.Fatalf("graduate-feature workflow must preserve the minor-bump title %q", want)
+		}
+	}
+}
+
+func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/feature-flag-enforcement.yml", &workflow)
+	classify := workflowStepByName(t, workflow.Jobs, "enforce", "Classify PR")
+	if !strings.Contains(classify.Run, `grep -Eq '^(feat|preview)`) {
+		t.Fatal("feature flag enforcement must classify preview titles as feature PRs")
+	}
+	if !strings.Contains(classify.Run, `echo "preview_pr=true"`) {
+		t.Fatal("feature flag enforcement must expose preview PR classification")
+	}
+
+	rejectOverrides := workflowStepByName(t, workflow.Jobs, "enforce", "Reject release overrides on preview PRs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "preview override condition", got: rejectOverrides.If, want: "${{ steps.classify_pr.outputs.preview_pr == 'true' }}"},
+	})
+	assertWorkflowStepRunContainsAll(t, rejectOverrides, "preview release override guard", []string{
+		`git log --format=%B "origin/${base_ref}..HEAD"`,
+		`(BREAKING[ -]CHANGE|Release-As)`,
+		`(BEGIN|END)_COMMIT_OVERRIDE`,
+	})
 }
 
 func TestGraduateFeatureWorkflowCreatesTemplateCompatiblePRBody(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -117,20 +117,22 @@ type workflowStepConfig struct {
 	With             map[string]string `yaml:"with"`
 }
 
+type releasePleaseChangelogSection struct {
+	Type    string `json:"type"`
+	Section string `json:"section"`
+	Hidden  bool   `json:"hidden"`
+}
+
 func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	t.Parallel()
 
 	var config struct {
 		Versioning string `json:"versioning"`
 		Packages   map[string]struct {
-			Versioning        string `json:"versioning"`
-			ChangelogPath     string `json:"changelog-path"`
-			ChangelogSections []struct {
-				Type    string `json:"type"`
-				Section string `json:"section"`
-				Hidden  bool   `json:"hidden"`
-			} `json:"changelog-sections"`
-			ExtraFiles []struct {
+			Versioning        string                          `json:"versioning"`
+			ChangelogPath     string                          `json:"changelog-path"`
+			ChangelogSections []releasePleaseChangelogSection `json:"changelog-sections"`
+			ExtraFiles        []struct {
 				Path string `json:"path"`
 			} `json:"extra-files"`
 		} `json:"packages"`
@@ -151,19 +153,7 @@ func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 		t.Fatal("release-please must keep default versioning so preview commits bump patch and feat graduations bump minor")
 	}
 
-	previewSectionFound := false
-	for _, section := range rootPackage.ChangelogSections {
-		if section.Type != "preview" {
-			continue
-		}
-		previewSectionFound = true
-		if section.Section != "Preview Features" || section.Hidden {
-			t.Fatalf("preview changelog section = %#v, want visible Preview Features", section)
-		}
-	}
-	if !previewSectionFound {
-		t.Fatal("release-please config must expose preview commits in release notes")
-	}
+	assertPreviewChangelogSection(t, rootPackage.ChangelogSections)
 
 	extraFiles := map[string]bool{}
 	for _, extraFile := range rootPackage.ExtraFiles {
@@ -177,6 +167,21 @@ func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 			t.Fatalf("release-please config should keep syncing %s", path)
 		}
 	}
+}
+
+func assertPreviewChangelogSection(t *testing.T, sections []releasePleaseChangelogSection) {
+	t.Helper()
+
+	for _, section := range sections {
+		if section.Type != "preview" {
+			continue
+		}
+		if section.Section != "Preview Features" || section.Hidden {
+			t.Fatalf("preview changelog section = %#v, want visible Preview Features", section)
+		}
+		return
+	}
+	t.Fatal("release-please config must expose preview commits in release notes")
 }
 
 func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -243,6 +243,7 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 	})
 	assertWorkflowStepRunContainsAll(t, rejectOverrides, "preview release override guard", []string{
 		`printf '%s\n' "${PR_BODY}"`,
+		`grep -Eiq '(BEGIN|END)_COMMIT_OVERRIDE' "${pr_body}"`,
 		`(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)`,
 		`git log --format=%B "origin/${base_ref}..HEAD"`,
 		`git log --format=%s "origin/${base_ref}..HEAD"`,

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -220,6 +220,13 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/feature-flag-enforcement.yml", &workflow)
+	fetchBase := workflowStepByName(t, workflow.Jobs, "enforce", "Fetch PR base")
+	if strings.Contains(fetchBase.Run, "--depth") {
+		t.Fatal("feature flag enforcement must fetch complete base history for stale PRs")
+	}
+	if !strings.Contains(fetchBase.Run, `+refs/heads/${base_ref}:refs/remotes/origin/${base_ref}`) {
+		t.Fatal("feature flag enforcement must update the base remote-tracking ref")
+	}
 	classify := workflowStepByName(t, workflow.Jobs, "enforce", "Classify PR")
 	if !strings.Contains(classify.Run, `grep -Eq '^(feat|preview)`) {
 		t.Fatal("feature flag enforcement must classify preview titles as feature PRs")
@@ -245,7 +252,8 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 		`printf '%s\n' "${PR_BODY}"`,
 		`grep -Eiq '(BEGIN|END)_COMMIT_OVERRIDE' "${pr_body}"`,
 		`grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${commit_messages}"`,
-		`git log --format=%B "origin/${base_ref}..HEAD"`,
+		`merge_base="$(git merge-base "origin/${base_ref}" HEAD)"`,
+		`git log --format=%B "${merge_base}..HEAD"`,
 		`(BREAKING[ -]CHANGE|Release-As)`,
 		`(feat|feature|fix|bug|perf|docs|refactor|revert)`,
 		`?!:[[:space:]]+[^[:space:]]`,

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -247,7 +247,7 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 		`grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${commit_messages}"`,
 		`git log --format=%B "origin/${base_ref}..HEAD"`,
 		`(BREAKING[ -]CHANGE|Release-As)`,
-		`(feat|fix|bug|perf|docs|refactor|revert)`,
+		`(feat|feature|fix|bug|perf|docs|refactor|revert)`,
 		`?!:[[:space:]]+[^[:space:]]`,
 		`[^[:space:]]' "${commit_messages}"`,
 	})

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -249,15 +249,19 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 		{label: "preview PR body", got: rejectOverrides.Env["PR_BODY"], want: "${{ github.event.pull_request.body }}"},
 	})
 	assertWorkflowStepRunContainsAll(t, rejectOverrides, "preview release override guard", []string{
+		`release_directive_pattern='^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)'`,
+		`non_preview_entry_pattern='^(feat|feature|fix|bug|perf|docs|refactor|revert)`,
 		`printf '%s\n' "${PR_BODY}"`,
-		`grep -Eiq '(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${pr_body}"`,
-		`grep -Eiq '^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)' "${commit_messages}"`,
+		`grep -Eiq "${release_directive_pattern}" "${pr_body}"`,
+		`grep -Eiq "${non_preview_entry_pattern}" "${pr_body}"`,
+		`grep -Eiq "${release_directive_pattern}" "${commit_messages}"`,
+		`grep -Eiq "${non_preview_entry_pattern}" "${commit_messages}"`,
 		`merge_base="$(git merge-base "origin/${base_ref}" HEAD)"`,
 		`git log --format=%B "${merge_base}..HEAD"`,
 		`(BREAKING[ -]CHANGE|Release-As)`,
 		`(feat|feature|fix|bug|perf|docs|refactor|revert)`,
 		`?!:[[:space:]]+[^[:space:]]`,
-		`[^[:space:]]' "${commit_messages}"`,
+		`[^[:space:]]'`,
 	})
 	if strings.Contains(rejectOverrides.Run, "commit_subjects") {
 		t.Fatal("preview release override guard must scan full commit messages instead of subjects only")

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -263,6 +263,9 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 		`?!:[[:space:]]+[^[:space:]]`,
 		`[^[:space:]]'`,
 	})
+	if got := strings.Count(rejectOverrides.Run, "exit 1"); got != 3 {
+		t.Fatalf("preview release override guard failure exits = %d, want 3", got)
+	}
 	if strings.Contains(rejectOverrides.Run, "commit_subjects") {
 		t.Fatal("preview release override guard must scan full commit messages instead of subjects only")
 	}

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -246,11 +246,14 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 		`grep -Eiq '(BEGIN|END)_COMMIT_OVERRIDE' "${pr_body}"`,
 		`(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)`,
 		`git log --format=%B "origin/${base_ref}..HEAD"`,
-		`git log --format=%s "origin/${base_ref}..HEAD"`,
 		`(BREAKING[ -]CHANGE|Release-As)`,
 		`(feat|fix|bug|perf|docs|refactor|revert)`,
 		`?!:[[:space:]]+[^[:space:]]`,
+		`[^[:space:]]' "${commit_messages}"`,
 	})
+	if strings.Contains(rejectOverrides.Run, "commit_subjects") {
+		t.Fatal("preview release override guard must scan full commit messages instead of subjects only")
+	}
 }
 
 func TestGraduateFeatureWorkflowCreatesTemplateCompatiblePRBody(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -231,11 +231,13 @@ func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
 	rejectOverrides := workflowStepByName(t, workflow.Jobs, "enforce", "Reject release overrides on preview PRs")
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{label: "preview override condition", got: rejectOverrides.If, want: "${{ steps.classify_pr.outputs.preview_pr == 'true' }}"},
+		{label: "preview PR body", got: rejectOverrides.Env["PR_BODY"], want: "${{ github.event.pull_request.body }}"},
 	})
 	assertWorkflowStepRunContainsAll(t, rejectOverrides, "preview release override guard", []string{
+		`printf '%s\n' "${PR_BODY}"`,
+		`(BEGIN|END)_COMMIT_OVERRIDE`,
 		`git log --format=%B "origin/${base_ref}..HEAD"`,
 		`(BREAKING[ -]CHANGE|Release-As)`,
-		`(BEGIN|END)_COMMIT_OVERRIDE`,
 	})
 }
 

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -1027,7 +1027,7 @@ func TestFormatReportStableDefaultsRequiresComparison(t *testing.T) {
 	}
 }
 
-func TestRunPREnforceFeaturePRRequiresNewFlag(t *testing.T) {
+func TestRunPREnforcePreviewPRRequiresNewFlag(t *testing.T) {
 	root := t.TempDir()
 	writeFeatureCatalog(t, root, `[
   {
@@ -1049,9 +1049,9 @@ func TestRunPREnforceFeaturePRRequiresNewFlag(t *testing.T) {
 	t.Chdir(root)
 
 	output, err := captureStdout(t, func() error {
-		return run([]string{"pr-enforce", "--pr-title", "feat(runtime): add new feature", "--previous-catalog", previousCatalog})
+		return run([]string{"pr-enforce", "--pr-title", "preview(runtime): add new feature", "--previous-catalog", previousCatalog})
 	})
-	if err == nil || !strings.Contains(err.Error(), "must add at least one new feature flag or graduate an existing preview flag") {
+	if err == nil || !strings.Contains(err.Error(), "Preview PRs must add at least one new feature flag") {
 		t.Fatalf("expected missing feature flag enforcement error, got %v", err)
 	}
 	if !strings.Contains(output, "Check: failed") || !strings.Contains(output, "New feature flags in this PR") {
@@ -1086,7 +1086,7 @@ func TestRunPREnforceFeaturePRAllowsGraduationOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected graduation-only feature PR to pass, got %v", err)
 	}
-	for _, want := range []string{"Check: passed", "Graduated feature flags in this PR", "`LOP-FEAT-0001` `graduated-flag` (`preview` -> `stable`)", "Passed. This feature PR graduates existing preview feature flags to stable."} {
+	for _, want := range []string{"Check: passed", "Graduated feature flags in this PR", "`LOP-FEAT-0001` `graduated-flag` (`preview` -> `stable`)", "Passed. This feature graduation PR promotes existing preview feature flags to stable."} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected report to contain %q, got %s", want, output)
 		}
@@ -1362,12 +1362,12 @@ func TestRunPREnforceReportsAddedPreviewFlag(t *testing.T) {
 	t.Chdir(root)
 
 	output, err := captureStdout(t, func() error {
-		return run([]string{"pr-enforce", "--pr-title", "feat(vscode): add preview workflow", "--previous-catalog", previousCatalog})
+		return run([]string{"pr-enforce", "--pr-title", "preview(vscode): add preview workflow", "--previous-catalog", previousCatalog})
 	})
 	if err != nil {
 		t.Fatalf("expected preview feature flag enforcement success, got %v", err)
 	}
-	for _, want := range []string{"Check: passed", "`LOP-FEAT-0002` `new-flag` (`preview`)", "Passed. This feature PR adds at least one new preview feature flag."} {
+	for _, want := range []string{"Check: passed", "`LOP-FEAT-0002` `new-flag` (`preview`)", "Passed. This preview PR adds at least one new preview feature flag."} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected report to contain %q, got %s", want, output)
 		}
@@ -1544,6 +1544,8 @@ func TestIsFeaturePRTitle(t *testing.T) {
 		{title: "feat: add preview workflow", want: true},
 		{title: "feat(ci): add preview workflow", want: true},
 		{title: "feat(ci)!: add preview workflow", want: true},
+		{title: "preview: add preview workflow", want: true},
+		{title: "preview(ci): add preview workflow", want: true},
 		{title: "fix(ci): repair workflow", want: false},
 		{title: "refactor(ci): split workflow", want: false},
 		{title: "", want: false},
@@ -1551,6 +1553,41 @@ func TestIsFeaturePRTitle(t *testing.T) {
 		if got := isFeaturePRTitle(tc.title); got != tc.want {
 			t.Fatalf("isFeaturePRTitle(%q) = %v, want %v", tc.title, got, tc.want)
 		}
+	}
+}
+
+func TestEvaluatePREnforcementRequiresLifecycleTitle(t *testing.T) {
+	previewFlag := featureflags.Flag{Code: "LOP-FEAT-0001", Name: "preview-flag", Lifecycle: featureflags.LifecyclePreview}
+	stableFlag := previewFlag
+	stableFlag.Lifecycle = featureflags.LifecycleStable
+
+	for _, tc := range []struct {
+		name     string
+		title    string
+		current  []featureflags.Flag
+		previous []featureflags.Flag
+		want     string
+	}{
+		{
+			name:    "preview implementation uses feat",
+			title:   "feat(runtime): add preview capture",
+			current: []featureflags.Flag{previewFlag},
+			want:    "must use a `preview(scope): ...` PR title",
+		},
+		{
+			name:     "graduation uses preview",
+			title:    "preview(flags): graduate capture",
+			current:  []featureflags.Flag{stableFlag},
+			previous: []featureflags.Flag{previewFlag},
+			want:     "Feature graduations must use a `feat(flags): ...` PR title",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := evaluatePREnforcement(tc.title, tc.current, tc.previous, nil)
+			if err := result.err(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected lifecycle title error containing %q, got %v", tc.want, err)
+			}
+		})
 	}
 }
 

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -1515,21 +1515,7 @@ func TestRunReleasePRCommentRejectsInjectedErrors(t *testing.T) {
 	}
 }
 
-func TestFormatPREnforcementReportNonFeatureBranches(t *testing.T) {
-	previewFlag := featureflags.Flag{
-		Code:        "LOP-FEAT-0002",
-		Name:        "new-flag",
-		Description: "New behavior",
-		Lifecycle:   featureflags.LifecyclePreview,
-	}
-	addedPreview := formatPREnforcementReport(prEnforcementResult{
-		RequireFlag: false,
-		AddedFlags:  []featureflags.Flag{previewFlag},
-	})
-	if !strings.Contains(addedPreview, "Passed. Added feature flags all start as `preview`.") {
-		t.Fatalf("expected non-feature added preview success message, got %s", addedPreview)
-	}
-
+func TestFormatPREnforcementReportWithoutFlagChanges(t *testing.T) {
 	noRequirement := formatPREnforcementReport(prEnforcementResult{})
 	if !strings.Contains(noRequirement, "Passed. No new feature flag was required for this PR.") {
 		t.Fatalf("expected no-requirement success message, got %s", noRequirement)
@@ -1577,6 +1563,33 @@ func TestEvaluatePREnforcementRequiresLifecycleTitle(t *testing.T) {
 		{
 			name:     "graduation uses preview",
 			title:    "preview(flags): graduate capture",
+			current:  []featureflags.Flag{stableFlag},
+			previous: []featureflags.Flag{previewFlag},
+			want:     "Feature graduations must use a `feat(flags): ...` PR title",
+		},
+		{
+			name:    "new flag uses non-feature title",
+			title:   "chore(flags): add preview capture",
+			current: []featureflags.Flag{previewFlag},
+			want:    "must use a `preview(scope): ...` PR title",
+		},
+		{
+			name:     "graduation uses non-feature title",
+			title:    "fix(flags): stabilize capture",
+			current:  []featureflags.Flag{stableFlag},
+			previous: []featureflags.Flag{previewFlag},
+			want:     "Feature graduations must use a `feat(flags): ...` PR title",
+		},
+		{
+			name:     "graduation uses wrong feature scope",
+			title:    "feat(runtime): stabilize capture",
+			current:  []featureflags.Flag{stableFlag},
+			previous: []featureflags.Flag{previewFlag},
+			want:     "Feature graduations must use a `feat(flags): ...` PR title",
+		},
+		{
+			name:     "graduation uses breaking feature title",
+			title:    "feat(flags)!: stabilize capture",
 			current:  []featureflags.Flag{stableFlag},
 			previous: []featureflags.Flag{previewFlag},
 			want:     "Feature graduations must use a `feat(flags): ...` PR title",

--- a/tools/featureflag/pr_enforce.go
+++ b/tools/featureflag/pr_enforce.go
@@ -15,10 +15,11 @@ import (
 	"github.com/ben-ranford/lopper/internal/featureflags"
 )
 
-var featurePRTitlePattern = regexp.MustCompile(`(?i)^feat(?:\([^)]*\))?(?:!)?:\s+\S`)
+var featurePRTitlePattern = regexp.MustCompile(`(?i)^(feat|preview)(?:\([^)]*\))?(?:!)?:\s+\S`)
 
 type prEnforcementResult struct {
 	RequireFlag       bool
+	FeaturePRType     string
 	AddedFlags        []featureflags.Flag
 	GraduatedFlags    []featureflags.Flag
 	InvalidAddedFlags []featureflags.Flag
@@ -64,8 +65,10 @@ func runPREnforce(args []string) error {
 }
 
 func evaluatePREnforcement(prTitle string, current, previous []featureflags.Flag, catalogViolations []string) prEnforcementResult {
+	prType := featurePRType(prTitle)
 	result := prEnforcementResult{
-		RequireFlag:       isFeaturePRTitle(prTitle),
+		RequireFlag:       prType != "",
+		FeaturePRType:     prType,
 		CatalogViolations: catalogViolations,
 	}
 	if len(catalogViolations) > 0 {
@@ -178,7 +181,15 @@ func formatDuplicateRefs(refs []string) string {
 }
 
 func isFeaturePRTitle(title string) bool {
-	return featurePRTitlePattern.MatchString(strings.TrimSpace(title))
+	return featurePRType(title) != ""
+}
+
+func featurePRType(title string) string {
+	matches := featurePRTitlePattern.FindStringSubmatch(strings.TrimSpace(title))
+	if len(matches) < 2 {
+		return ""
+	}
+	return strings.ToLower(matches[1])
 }
 
 func newlyAddedFlags(current, previous []featureflags.Flag) []featureflags.Flag {
@@ -227,12 +238,12 @@ func formatPREnforcementReport(result prEnforcementResult) string {
 	b.WriteString("<!-- lopper-feature-flag-enforcement -->\n")
 	b.WriteString("## Feature flag enforcement\n\n")
 	if result.RequireFlag {
-		b.WriteString("- Feature PR: yes (`feat` PR title)\n")
+		fmt.Fprintf(&b, "- Feature PR: yes (`%s` PR title)\n", result.FeaturePRType)
 	} else {
 		b.WriteString("- Feature PR: no\n")
 	}
 	fmt.Fprintf(&b, "- Check: %s\n", status)
-	b.WriteString("- Rule: feature PRs must add a feature flag or graduate an existing preview flag, new flags must start as `preview`, and feature flag ids and names must be unique.\n\n")
+	b.WriteString("- Rule: `preview` PRs add new preview flags, `feat` PRs graduate existing preview flags, new flags must start as `preview`, and feature flag ids and names must be unique.\n\n")
 
 	writePREnforcementFlagSection(&b, "New feature flags in this PR", result.AddedFlags, writeAddedFlag)
 	writePREnforcementFlagSection(&b, "Graduated feature flags in this PR", result.GraduatedFlags, writeGraduatedFlag)
@@ -282,10 +293,10 @@ func writeFlagDescription(b *strings.Builder, description string) {
 
 func previewEnforcementSuccessMessage(result prEnforcementResult) string {
 	switch {
-	case result.RequireFlag && len(result.AddedFlags) > 0:
-		return "Passed. This feature PR adds at least one new preview feature flag.\n"
-	case result.RequireFlag && len(result.GraduatedFlags) > 0:
-		return "Passed. This feature PR graduates existing preview feature flags to stable.\n"
+	case result.FeaturePRType == "preview" && len(result.AddedFlags) > 0:
+		return "Passed. This preview PR adds at least one new preview feature flag.\n"
+	case result.FeaturePRType == "feat" && len(result.GraduatedFlags) > 0:
+		return "Passed. This feature graduation PR promotes existing preview feature flags to stable.\n"
 	case len(result.AddedFlags) > 0:
 		return "Passed. Added feature flags all start as `preview`.\n"
 	default:
@@ -299,9 +310,7 @@ func (r *prEnforcementResult) violations() []string {
 	if len(violations) > 0 {
 		return violations
 	}
-	if r.RequireFlag && len(r.AddedFlags) == 0 && len(r.GraduatedFlags) == 0 {
-		violations = append(violations, "Feature PRs must add at least one new feature flag or graduate an existing preview flag in `internal/featureflags/features.json`.")
-	}
+	violations = append(violations, r.featurePRTypeViolations()...)
 	if len(r.InvalidAddedFlags) > 0 {
 		parts := make([]string, 0, len(r.InvalidAddedFlags))
 		for _, flag := range r.InvalidAddedFlags {
@@ -310,6 +319,34 @@ func (r *prEnforcementResult) violations() []string {
 		violations = append(violations, "New feature flags must start as `preview`: "+strings.Join(parts, ", ")+".")
 	}
 	return violations
+}
+
+func (r *prEnforcementResult) featurePRTypeViolations() []string {
+	switch r.FeaturePRType {
+	case "preview":
+		var violations []string
+		if len(r.AddedFlags) == 0 {
+			violations = append(violations, "Preview PRs must add at least one new feature flag in `internal/featureflags/features.json`.")
+		}
+		if len(r.GraduatedFlags) > 0 {
+			violations = append(violations, "Feature graduations must use a `feat(flags): ...` PR title so release-please performs the minor version bump.")
+		}
+		return violations
+	case "feat":
+		var violations []string
+		if len(r.AddedFlags) > 0 {
+			violations = append(violations, "New preview feature flags must use a `preview(scope): ...` PR title so release-please keeps the current minor release line.")
+		}
+		if len(r.GraduatedFlags) == 0 {
+			violations = append(violations, "Feature PRs must graduate at least one existing preview flag in `internal/featureflags/features.json`.")
+		}
+		return violations
+	default:
+		if r.RequireFlag && len(r.AddedFlags) == 0 && len(r.GraduatedFlags) == 0 {
+			return []string{"Feature PRs must add at least one new feature flag or graduate an existing preview flag in `internal/featureflags/features.json`."}
+		}
+		return nil
+	}
 }
 
 func (r *prEnforcementResult) err() error {

--- a/tools/featureflag/pr_enforce.go
+++ b/tools/featureflag/pr_enforce.go
@@ -15,11 +15,13 @@ import (
 	"github.com/ben-ranford/lopper/internal/featureflags"
 )
 
-var featurePRTitlePattern = regexp.MustCompile(`(?i)^(feat|preview)(?:\([^)]*\))?(?:!)?:\s+\S`)
+var featurePRTitlePattern = regexp.MustCompile(`(?i)^(feat|preview)(?:\(([^)]*)\))?(!)?:\s+\S`)
 
 type prEnforcementResult struct {
 	RequireFlag       bool
 	FeaturePRType     string
+	FeaturePRScope    string
+	FeaturePRBreaking bool
 	AddedFlags        []featureflags.Flag
 	GraduatedFlags    []featureflags.Flag
 	InvalidAddedFlags []featureflags.Flag
@@ -65,10 +67,12 @@ func runPREnforce(args []string) error {
 }
 
 func evaluatePREnforcement(prTitle string, current, previous []featureflags.Flag, catalogViolations []string) prEnforcementResult {
-	prType := featurePRType(prTitle)
+	prType, prScope, prBreaking := featurePRMetadata(prTitle)
 	result := prEnforcementResult{
 		RequireFlag:       prType != "",
 		FeaturePRType:     prType,
+		FeaturePRScope:    prScope,
+		FeaturePRBreaking: prBreaking,
 		CatalogViolations: catalogViolations,
 	}
 	if len(catalogViolations) > 0 {
@@ -185,11 +189,16 @@ func isFeaturePRTitle(title string) bool {
 }
 
 func featurePRType(title string) string {
+	prType, _, _ := featurePRMetadata(title)
+	return prType
+}
+
+func featurePRMetadata(title string) (string, string, bool) {
 	matches := featurePRTitlePattern.FindStringSubmatch(strings.TrimSpace(title))
-	if len(matches) < 2 {
-		return ""
+	if len(matches) < 4 {
+		return "", "", false
 	}
-	return strings.ToLower(matches[1])
+	return strings.ToLower(matches[1]), strings.ToLower(matches[2]), matches[3] == "!"
 }
 
 func newlyAddedFlags(current, previous []featureflags.Flag) []featureflags.Flag {
@@ -297,8 +306,6 @@ func previewEnforcementSuccessMessage(result prEnforcementResult) string {
 		return "Passed. This preview PR adds at least one new preview feature flag.\n"
 	case result.FeaturePRType == "feat" && len(result.GraduatedFlags) > 0:
 		return "Passed. This feature graduation PR promotes existing preview feature flags to stable.\n"
-	case len(result.AddedFlags) > 0:
-		return "Passed. Added feature flags all start as `preview`.\n"
 	default:
 		return "Passed. No new feature flag was required for this PR.\n"
 	}
@@ -322,30 +329,28 @@ func (r *prEnforcementResult) violations() []string {
 }
 
 func (r *prEnforcementResult) featurePRTypeViolations() []string {
+	violations := make([]string, 0, 2)
+	if len(r.AddedFlags) > 0 && r.FeaturePRType != "preview" {
+		violations = append(violations, "New preview feature flags must use a `preview(scope): ...` PR title so release-please keeps the current minor release line.")
+	}
+	validGraduationTitle := r.FeaturePRType == "feat" && r.FeaturePRScope == "flags" && !r.FeaturePRBreaking
+	if len(r.GraduatedFlags) > 0 && !validGraduationTitle {
+		violations = append(violations, "Feature graduations must use a `feat(flags): ...` PR title so release-please performs the minor version bump.")
+	}
+
 	switch r.FeaturePRType {
 	case "preview":
-		var violations []string
 		if len(r.AddedFlags) == 0 {
 			violations = append(violations, "Preview PRs must add at least one new feature flag in `internal/featureflags/features.json`.")
 		}
-		if len(r.GraduatedFlags) > 0 {
-			violations = append(violations, "Feature graduations must use a `feat(flags): ...` PR title so release-please performs the minor version bump.")
-		}
 		return violations
 	case "feat":
-		var violations []string
-		if len(r.AddedFlags) > 0 {
-			violations = append(violations, "New preview feature flags must use a `preview(scope): ...` PR title so release-please keeps the current minor release line.")
-		}
 		if len(r.GraduatedFlags) == 0 {
 			violations = append(violations, "Feature PRs must graduate at least one existing preview flag in `internal/featureflags/features.json`.")
 		}
 		return violations
 	default:
-		if r.RequireFlag && len(r.AddedFlags) == 0 && len(r.GraduatedFlags) == 0 {
-			return []string{"Feature PRs must add at least one new feature flag or graduate an existing preview flag in `internal/featureflags/features.json`."}
-		}
-		return nil
+		return violations
 	}
 }
 

--- a/tools/prcheck/main.go
+++ b/tools/prcheck/main.go
@@ -10,7 +10,8 @@ import (
 	"strings"
 )
 
-var titlePattern = regexp.MustCompile(`^(feat|fix|perf|docs|refactor|revert|test|ci|build|chore)(\([a-z0-9][a-z0-9._/-]*\))?!?: [^\s].+$`)
+var titlePattern = regexp.MustCompile(`^(feat|preview|fix|perf|docs|refactor|revert|test|ci|build|chore)(\([a-z0-9][a-z0-9._/-]*\))?!?: [^\s].+$`)
+var breakingPreviewTitlePattern = regexp.MustCompile(`^preview(?:\([a-z0-9][a-z0-9._/-]*\))?!:`)
 var releasePleaseTitlePattern = regexp.MustCompile(`^chore\(main\): release [0-9]+\.[0-9]+\.[0-9]+$`)
 
 var placeholderTexts = []string{
@@ -122,7 +123,10 @@ func validate(title, headRef, body string, releaseIdentity releasePleaseIdentity
 	var failures []string
 	title = strings.TrimSpace(title)
 	if !titlePattern.MatchString(title) {
-		failures = append(failures, "PR title must be a Conventional Commit title using one of feat, fix, perf, docs, refactor, revert, test, ci, build, or chore; use fix(scope): ... for bug fixes instead of bug: ...")
+		failures = append(failures, "PR title must be a Conventional Commit title using one of feat, preview, fix, perf, docs, refactor, revert, test, ci, build, or chore; use fix(scope): ... for bug fixes instead of bug: ...")
+	}
+	if breakingPreviewTitlePattern.MatchString(title) {
+		failures = append(failures, "Preview PR titles must not use a breaking-change marker; graduate the feature with feat(flags): ... before requesting a larger version bump")
 	}
 
 	if isTrustedReleasePleasePR(headRef, title, releaseIdentity) {

--- a/tools/prcheck/main_test.go
+++ b/tools/prcheck/main_test.go
@@ -176,6 +176,17 @@ func TestValidateAcceptsCompletedTemplate(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsPreviewTitle(t *testing.T) {
+	if err := validate("preview(runtime): add opt-in capture", "feat/preview-runtime-capture", validBody(), releasePleaseIdentity{}); err != nil {
+		t.Fatalf("validate returned error: %v", err)
+	}
+}
+
+func TestValidateRejectsBreakingPreviewTitle(t *testing.T) {
+	err := validate("preview(runtime)!: replace capture format", "feat/preview-runtime-capture", validBody(), releasePleaseIdentity{})
+	expectValidationError(t, err, "Preview PR titles must not use a breaking-change marker")
+}
+
 func TestValidateRejectsBugTitle(t *testing.T) {
 	err := validate("bug: patch adapter parser", "bug/issue-123-parser", validBody(), releasePleaseIdentity{})
 	if err == nil {


### PR DESCRIPTION
## Summary

Keeps default-off feature work on the current patch release line until an explicit feature graduation requests the next minor release.

## Changes

- Adds a visible `preview` Release Please changelog type that uses default patch versioning.
- Enforces `preview(scope): ...` for new preview flags and `feat(flags): ...` for graduation.
- Rejects breaking and Release Please override directives on preview PR commits.
- Updates the graduation workflow default to `v1.9.0` and documents the release contract.

## Validation

Commands and checks run:

```bash
go test ./tools/prcheck ./tools/featureflag
go test ./scripts -run 'TestReleasePleaseWritesRootChangelog|TestGraduateFeatureWorkflowTargetsCurrentSeries|TestFeatureFlagEnforcementClassifiesPreviewPRs'
make ci
```

Additional manual validation:

- Verified the pinned action resolves `release-please@17.6.0`.
- Ran the pinned versioning/changelog implementation against this config: `preview` produced `1.8.3` with visible Preview Features notes, while `feat` graduation produced `1.9.0`.

## Risk and compatibility

- Breaking changes: None.
- Migration required: Preview implementation PRs must use the new `preview` title type; graduation remains `feat(flags)`.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review