### PR TITLE
fix(ci): revalidate queue base before merge

### DIFF
--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -407,12 +407,6 @@ async function runController({
   }
 
   try {
-    const state = await pullState(github, owner, repo, leader.number);
-    if (state.headRefOid !== update.headSHA) {
-      throw new Error(
-        `Pull request head moved from ${shortSHA(update.headSHA)} to ${shortSHA(state.headRefOid)} while advancing the queue.`,
-      );
-    }
     const { data: latestBranch } = await github.rest.repos.getBranch({
       owner,
       repo,
@@ -421,6 +415,12 @@ async function runController({
     if (latestBranch.commit.sha !== branch.commit.sha) {
       throw new Error(
         `Default branch ${defaultBranch} moved from ${shortSHA(branch.commit.sha)} to ${shortSHA(latestBranch.commit.sha)} while advancing the queue.`,
+      );
+    }
+    const state = await pullState(github, owner, repo, leader.number);
+    if (state.headRefOid !== update.headSHA) {
+      throw new Error(
+        `Pull request head moved from ${shortSHA(update.headSHA)} to ${shortSHA(state.headRefOid)} while advancing the queue.`,
       );
     }
     const result = await armOrMerge(github, state, {

--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -52,6 +52,8 @@ async function pullState(github, owner, repo, number) {
         pullRequest(number: $number) {
           id
           number
+          baseRefName
+          baseRefOid
           headRefOid
           isDraft
           mergeable
@@ -66,6 +68,19 @@ async function pullState(github, owner, repo, number) {
     { owner, repo, number },
   );
   return result.repository.pullRequest;
+}
+
+function assertExpectedBaseState(state, expectedBaseRefName, expectedBaseRefOid) {
+  if (state.baseRefName !== expectedBaseRefName) {
+    throw new Error(
+      `Pull request base changed from ${expectedBaseRefName} to ${state.baseRefName || 'unknown'} while advancing the queue.`,
+    );
+  }
+  if (state.baseRefOid !== expectedBaseRefOid) {
+    throw new Error(
+      `Pull request base ${expectedBaseRefName} moved from ${shortSHA(expectedBaseRefOid)} to ${shortSHA(state.baseRefOid)} while advancing the queue.`,
+    );
+  }
 }
 
 async function syncStatusComment(github, owner, repo, number, body) {
@@ -191,7 +206,8 @@ async function armAutoMerge(github, pullRequestId, expectedHeadOid) {
   );
 }
 
-async function armOrMerge(github, state) {
+async function armOrMerge(github, state, { expectedBaseRefName, expectedBaseRefOid }) {
+  assertExpectedBaseState(state, expectedBaseRefName, expectedBaseRefOid);
   if (state.autoMergeRequest) {
     return 'armed';
   }
@@ -209,6 +225,7 @@ async function armOrMerge(github, state) {
         `Pull request head moved from ${shortSHA(state.headRefOid)} to ${shortSHA(refreshed.headRefOid)} while arming auto-merge.`,
       );
     }
+    assertExpectedBaseState(refreshed, expectedBaseRefName, expectedBaseRefOid);
     if (refreshed.mergeable === 'MERGEABLE' && refreshed.mergeStateStatus === 'CLEAN') {
       await mergeNow(github, refreshed.id, state.headRefOid);
       return 'merged';
@@ -224,6 +241,8 @@ async function pullStateByID(github, pullRequestId) {
         ... on PullRequest {
           id
           number
+          baseRefName
+          baseRefOid
           headRefOid
           mergeable
           mergeStateStatus
@@ -404,7 +423,10 @@ async function runController({
         `Default branch ${defaultBranch} moved from ${shortSHA(branch.commit.sha)} to ${shortSHA(latestBranch.commit.sha)} while advancing the queue.`,
       );
     }
-    const result = await armOrMerge(github, state);
+    const result = await armOrMerge(github, state, {
+      expectedBaseRefName: defaultBranch,
+      expectedBaseRefOid: branch.commit.sha,
+    });
     const rebaseSummary = update.rebased
       ? `Rebased \`${shortSHA(leader.head.sha)}\` to \`${shortSHA(update.headSHA)}\` on current \`${defaultBranch}\`.`
       : `Head \`${shortSHA(update.headSHA)}\` already contains current \`${defaultBranch}\`.`;

--- a/scripts/queue_me_controller.test.js
+++ b/scripts/queue_me_controller.test.js
@@ -112,7 +112,11 @@ function makeHarness(options = {}) {
     },
     graphql: async (query, variables) => {
       if (query.includes('QueuePullState($owner')) {
-        return { repository: { pullRequest: { ...states.get(variables.number) } } };
+        const state = states.get(variables.number);
+        if (calls.branchReads.length >= 2 && options.stateAfterFinalBranchRead?.[variables.number]) {
+          Object.assign(state, options.stateAfterFinalBranchRead[variables.number]);
+        }
+        return { repository: { pullRequest: { ...state } } };
       }
       if (query.includes('QueuePullStateByID')) {
         const state = [...states.values()].find((value) => value.id === variables.pullRequestId);
@@ -371,7 +375,7 @@ test('controller revalidates baseRefName and baseRefOid immediately before auto-
       name: 'retargeted base pauses before auto-merge',
       harness: makeHarness({
         pulls: [makePull(10)],
-        initialStates: {
+        stateAfterFinalBranchRead: {
           10: { baseRefName: 'release' },
         },
       }),
@@ -381,7 +385,7 @@ test('controller revalidates baseRefName and baseRefOid immediately before auto-
       name: 'base tip drift pauses before merge',
       harness: makeHarness({
         pulls: [makePull(10)],
-        initialStates: {
+        stateAfterFinalBranchRead: {
           10: { baseRefOid: '1234567890abcdef', mergeStateStatus: 'CLEAN' },
         },
       }),

--- a/scripts/queue_me_controller.test.js
+++ b/scripts/queue_me_controller.test.js
@@ -31,6 +31,7 @@ function makePull(number, overrides = {}) {
 function makeHarness(options = {}) {
   const pulls = options.pulls || [];
   const eventPull = options.eventPull;
+  const branchSHAs = options.branchSHAs || ['base-sha'];
   const allPulls = eventPull && !pulls.some((pull) => pull.number === eventPull.number)
     ? [...pulls, eventPull]
     : pulls;
@@ -40,6 +41,8 @@ function makeHarness(options = {}) {
       {
         id: pull.node_id,
         number: pull.number,
+        baseRefName: pull.base.ref,
+        baseRefOid: branchSHAs[0],
         headRefOid: pull.head.sha,
         isDraft: pull.draft,
         mergeable: 'MERGEABLE',
@@ -92,7 +95,6 @@ function makeHarness(options = {}) {
       repos: {
         get: async () => ({ data: repository }),
         getBranch: async () => {
-          const branchSHAs = options.branchSHAs || ['base-sha'];
           const sha = branchSHAs[Math.min(calls.branchReads.length, branchSHAs.length - 1)];
           calls.branchReads.push(sha);
           return { data: { commit: { sha } } };
@@ -361,6 +363,41 @@ test('controller never merges an unverified head after auto-merge arming races a
   assert.deepEqual(harness.calls.armed, []);
   assert.deepEqual(harness.calls.merged, []);
   assert.match(harness.calls.comments[0].body, /Pull request head moved/);
+});
+
+test('controller revalidates baseRefName and baseRefOid immediately before auto-merge or merge', async (t) => {
+  const cases = [
+    {
+      name: 'retargeted base pauses before auto-merge',
+      harness: makeHarness({
+        pulls: [makePull(10)],
+        initialStates: {
+          10: { baseRefName: 'release' },
+        },
+      }),
+      message: /Pull request base changed from main to release/,
+    },
+    {
+      name: 'base tip drift pauses before merge',
+      harness: makeHarness({
+        pulls: [makePull(10)],
+        initialStates: {
+          10: { baseRefOid: '1234567890abcdef', mergeStateStatus: 'CLEAN' },
+        },
+      }),
+      message: /Pull request base main moved from base-sha to 1234567890/,
+    },
+  ];
+
+  for (const scenario of cases) {
+    await t.test(scenario.name, async () => {
+      await assert.rejects(runController(scenario.harness.args), scenario.message);
+
+      assert.deepEqual(scenario.harness.calls.armed, []);
+      assert.deepEqual(scenario.harness.calls.merged, []);
+      assert.match(scenario.harness.calls.comments[0].body, scenario.message);
+    });
+  }
 });
 
 test('changing a queued pull request away from main disables auto-merge', async () => {


### PR DESCRIPTION
## Summary

Closes #1213.

The queue controller selected queue leaders from a REST snapshot and verified only the head SHA before the final auto-merge or merge step. If a queued pull request was retargeted or the base branch tip drifted after that snapshot, the controller could still arm or complete the merge against stale base state.

## Changes

- added `baseRefName` and `baseRefOid` to the final GraphQL pull request state reads used during queue advancement
- rejected queue advancement when either the expected base branch name or the expected base branch tip no longer matches immediately before auto-merge or merge
- added a focused regression that proves both retargeted-base and base-tip-drift races pause safely without arming or merging

## Validation

Commands and checks run:

```bash
node --test scripts/queue_me_controller.test.js
make ci
```

Additional manual validation:

- verified the new regression halts before `enablePullRequestAutoMerge` and before `mergePullRequest` when the fresh GraphQL base state no longer matches the queue snapshot

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None beyond two extra GraphQL fields on existing queue state reads.
- Memory benchmark impact: `make ci` memory delta passed; benchmark deltas stayed within gate thresholds.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review