### PR TITLE
fix(pr-metadata): require trusted release-please identity

### DIFF
--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -55,4 +55,8 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: go run ./tools/prcheck --check-repo-policy --title "$PR_TITLE" --head-ref "$PR_HEAD_REF" --body-file "$PR_BODY_FILE"
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY_OWNER_LOGIN: ${{ github.event.repository.owner.login }}
+          REPOSITORY_FULL_NAME: ${{ github.repository }}
+        run: go run ./tools/prcheck --check-repo-policy --title "$PR_TITLE" --head-ref "$PR_HEAD_REF" --author-login "$PR_AUTHOR_LOGIN" --repo-owner-login "$REPOSITORY_OWNER_LOGIN" --head-repo-full-name "$PR_HEAD_REPO_FULL_NAME" --repo-full-name "$REPOSITORY_FULL_NAME" --body-file "$PR_BODY_FILE"

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -55,8 +55,6 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
           PR_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
-          REPOSITORY_OWNER_LOGIN: ${{ github.event.repository.owner.login }}
           REPOSITORY_FULL_NAME: ${{ github.repository }}
-        run: go run ./tools/prcheck --check-repo-policy --title "$PR_TITLE" --head-ref "$PR_HEAD_REF" --author-login "$PR_AUTHOR_LOGIN" --repo-owner-login "$REPOSITORY_OWNER_LOGIN" --head-repo-full-name "$PR_HEAD_REPO_FULL_NAME" --repo-full-name "$REPOSITORY_FULL_NAME" --body-file "$PR_BODY_FILE"
+        run: go run ./tools/prcheck --check-repo-policy --title "$PR_TITLE" --head-ref "$PR_HEAD_REF" --head-repo-full-name "$PR_HEAD_REPO_FULL_NAME" --repo-full-name "$REPOSITORY_FULL_NAME" --body-file "$PR_BODY_FILE"

--- a/tools/prcheck/main.go
+++ b/tools/prcheck/main.go
@@ -51,8 +51,6 @@ type repoMergePolicy struct {
 }
 
 type releasePleaseIdentity struct {
-	authorLogin            string
-	repositoryOwnerLogin   string
 	headRepositoryFullName string
 	repositoryFullName     string
 }
@@ -66,8 +64,6 @@ func run(args []string, getenv func(string) string, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	title := fs.String("title", strings.TrimSpace(getenv("PR_TITLE")), "pull request title")
 	headRef := fs.String("head-ref", strings.TrimSpace(getenv("PR_HEAD_REF")), "pull request head ref")
-	authorLogin := fs.String("author-login", strings.TrimSpace(getenv("PR_AUTHOR_LOGIN")), "pull request author login")
-	repositoryOwnerLogin := fs.String("repo-owner-login", strings.TrimSpace(getenv("REPOSITORY_OWNER_LOGIN")), "repository owner login")
 	headRepositoryFullName := fs.String("head-repo-full-name", strings.TrimSpace(getenv("PR_HEAD_REPO_FULL_NAME")), "pull request head repository full name")
 	repositoryFullName := fs.String("repo-full-name", strings.TrimSpace(getenv("REPOSITORY_FULL_NAME")), "repository full name")
 	bodyFile := fs.String("body-file", "", "path to a file containing the pull request body")
@@ -90,8 +86,6 @@ func run(args []string, getenv func(string) string, stderr io.Writer) int {
 	}
 
 	releaseIdentity := releasePleaseIdentity{
-		authorLogin:            *authorLogin,
-		repositoryOwnerLogin:   *repositoryOwnerLogin,
 		headRepositoryFullName: *headRepositoryFullName,
 		repositoryFullName:     *repositoryFullName,
 	}
@@ -202,15 +196,10 @@ func requiredItemFailures(content string, items []string, valid func(string, str
 }
 
 func isTrustedReleasePleasePR(headRef, title string, identity releasePleaseIdentity) bool {
-	if !strings.HasPrefix(strings.TrimSpace(headRef), "release-please--branches--") {
+	if strings.TrimSpace(headRef) != "release-please--branches--main" {
 		return false
 	}
 	if !releasePleaseTitlePattern.MatchString(strings.TrimSpace(title)) {
-		return false
-	}
-	authorLogin := strings.TrimSpace(identity.authorLogin)
-	repositoryOwnerLogin := strings.TrimSpace(identity.repositoryOwnerLogin)
-	if authorLogin == "" || authorLogin != repositoryOwnerLogin {
 		return false
 	}
 	headRepositoryFullName := strings.TrimSpace(identity.headRepositoryFullName)

--- a/tools/prcheck/main.go
+++ b/tools/prcheck/main.go
@@ -11,6 +11,7 @@ import (
 )
 
 var titlePattern = regexp.MustCompile(`^(feat|fix|perf|docs|refactor|revert|test|ci|build|chore)(\([a-z0-9][a-z0-9._/-]*\))?!?: [^\s].+$`)
+var releasePleaseTitlePattern = regexp.MustCompile(`^chore\(main\): release [0-9]+\.[0-9]+\.[0-9]+$`)
 
 var placeholderTexts = []string{
 	"Describe the problem and the intent of this change. Use `N/A` only when the section truly does not apply.",
@@ -49,6 +50,13 @@ type repoMergePolicy struct {
 	squashMergeCommitTitle string
 }
 
+type releasePleaseIdentity struct {
+	authorLogin            string
+	repositoryOwnerLogin   string
+	headRepositoryFullName string
+	repositoryFullName     string
+}
+
 func main() {
 	os.Exit(run(os.Args[1:], os.Getenv, os.Stderr))
 }
@@ -58,6 +66,10 @@ func run(args []string, getenv func(string) string, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	title := fs.String("title", strings.TrimSpace(getenv("PR_TITLE")), "pull request title")
 	headRef := fs.String("head-ref", strings.TrimSpace(getenv("PR_HEAD_REF")), "pull request head ref")
+	authorLogin := fs.String("author-login", strings.TrimSpace(getenv("PR_AUTHOR_LOGIN")), "pull request author login")
+	repositoryOwnerLogin := fs.String("repo-owner-login", strings.TrimSpace(getenv("REPOSITORY_OWNER_LOGIN")), "repository owner login")
+	headRepositoryFullName := fs.String("head-repo-full-name", strings.TrimSpace(getenv("PR_HEAD_REPO_FULL_NAME")), "pull request head repository full name")
+	repositoryFullName := fs.String("repo-full-name", strings.TrimSpace(getenv("REPOSITORY_FULL_NAME")), "repository full name")
 	bodyFile := fs.String("body-file", "", "path to a file containing the pull request body")
 	checkRepoPolicy := fs.Bool("check-repo-policy", false, "validate repository merge policy")
 	allowMergeCommit := fs.String("allow-merge-commit", strings.TrimSpace(getenv("REPO_ALLOW_MERGE_COMMIT")), "whether the repository allows merge commits")
@@ -77,7 +89,14 @@ func run(args []string, getenv func(string) string, stderr io.Writer) int {
 		body = string(data)
 	}
 
-	if err := validate(*title, *headRef, body); err != nil {
+	releaseIdentity := releasePleaseIdentity{
+		authorLogin:            *authorLogin,
+		repositoryOwnerLogin:   *repositoryOwnerLogin,
+		headRepositoryFullName: *headRepositoryFullName,
+		repositoryFullName:     *repositoryFullName,
+	}
+
+	if err := validate(*title, *headRef, body, releaseIdentity); err != nil {
 		return writeRunError(stderr, "%v\n", err)
 	}
 	if *checkRepoPolicy {
@@ -105,14 +124,14 @@ func writeErrorMessage(stderr io.Writer, format string, args ...any) {
 	}
 }
 
-func validate(title, headRef, body string) error {
+func validate(title, headRef, body string, releaseIdentity releasePleaseIdentity) error {
 	var failures []string
 	title = strings.TrimSpace(title)
 	if !titlePattern.MatchString(title) {
 		failures = append(failures, "PR title must be a Conventional Commit title using one of feat, fix, perf, docs, refactor, revert, test, ci, build, or chore; use fix(scope): ... for bug fixes instead of bug: ...")
 	}
 
-	if isReleasePleasePR(headRef, title) {
+	if isTrustedReleasePleasePR(headRef, title, releaseIdentity) {
 		if len(failures) > 0 {
 			return errors.New(strings.Join(failures, "\n"))
 		}
@@ -182,9 +201,21 @@ func requiredItemFailures(content string, items []string, valid func(string, str
 	return failures
 }
 
-func isReleasePleasePR(headRef, title string) bool {
-	return strings.HasPrefix(strings.TrimSpace(headRef), "release-please--branches--") &&
-		regexp.MustCompile(`^chore\(main\): release [0-9]+\.[0-9]+\.[0-9]+$`).MatchString(strings.TrimSpace(title))
+func isTrustedReleasePleasePR(headRef, title string, identity releasePleaseIdentity) bool {
+	if !strings.HasPrefix(strings.TrimSpace(headRef), "release-please--branches--") {
+		return false
+	}
+	if !releasePleaseTitlePattern.MatchString(strings.TrimSpace(title)) {
+		return false
+	}
+	authorLogin := strings.TrimSpace(identity.authorLogin)
+	repositoryOwnerLogin := strings.TrimSpace(identity.repositoryOwnerLogin)
+	if authorLogin == "" || authorLogin != repositoryOwnerLogin {
+		return false
+	}
+	headRepositoryFullName := strings.TrimSpace(identity.headRepositoryFullName)
+	repositoryFullName := strings.TrimSpace(identity.repositoryFullName)
+	return headRepositoryFullName != "" && headRepositoryFullName == repositoryFullName
 }
 
 func parseSections(body string) map[string]string {

--- a/tools/prcheck/main_test.go
+++ b/tools/prcheck/main_test.go
@@ -11,9 +11,13 @@ import (
 func TestRunAcceptsEnvBody(t *testing.T) {
 	var stderr bytes.Buffer
 	env := mapEnv(map[string]string{
-		"PR_TITLE":    "fix(release): validate PR metadata",
-		"PR_HEAD_REF": "bug/issue-000-pr-title-template-gate",
-		"PR_BODY":     validBody(),
+		"PR_TITLE":               "fix(release): validate PR metadata",
+		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
+		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
+		"PR_AUTHOR_LOGIN":        "ben-ranford",
+		"PR_BODY":                validBody(),
+		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
+		"REPOSITORY_OWNER_LOGIN": "ben-ranford",
 	})
 	code := run(nil, env, &stderr)
 	if code != 0 {
@@ -37,9 +41,13 @@ func TestRunAcceptsBodyFile(t *testing.T) {
 func TestRunAcceptsValidRepoPolicy(t *testing.T) {
 	var stderr bytes.Buffer
 	base := map[string]string{
-		"PR_TITLE":    "fix(release): validate PR metadata",
-		"PR_HEAD_REF": "bug/issue-000-pr-title-template-gate",
-		"PR_BODY":     validBody(),
+		"PR_TITLE":               "fix(release): validate PR metadata",
+		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
+		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
+		"PR_AUTHOR_LOGIN":        "ben-ranford",
+		"PR_BODY":                validBody(),
+		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
+		"REPOSITORY_OWNER_LOGIN": "ben-ranford",
 	}
 	values := mergeMaps(base, validRepoPolicyEnv())
 	env := mapEnv(values)
@@ -52,9 +60,13 @@ func TestRunAcceptsValidRepoPolicy(t *testing.T) {
 func TestRunRejectsInvalidRepoPolicy(t *testing.T) {
 	var stderr bytes.Buffer
 	base := map[string]string{
-		"PR_TITLE":    "fix(release): validate PR metadata",
-		"PR_HEAD_REF": "bug/issue-000-pr-title-template-gate",
-		"PR_BODY":     validBody(),
+		"PR_TITLE":               "fix(release): validate PR metadata",
+		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
+		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
+		"PR_AUTHOR_LOGIN":        "ben-ranford",
+		"PR_BODY":                validBody(),
+		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
+		"REPOSITORY_OWNER_LOGIN": "ben-ranford",
 	}
 	policy := map[string]string{
 		"REPO_ALLOW_MERGE_COMMIT":        "true",
@@ -76,9 +88,13 @@ func TestRunRejectsInvalidRepoPolicy(t *testing.T) {
 func TestRunRejectsMissingRepoPolicyValue(t *testing.T) {
 	var stderr bytes.Buffer
 	base := map[string]string{
-		"PR_TITLE":    "fix(release): validate PR metadata",
-		"PR_HEAD_REF": "bug/issue-000-pr-title-template-gate",
-		"PR_BODY":     validBody(),
+		"PR_TITLE":               "fix(release): validate PR metadata",
+		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
+		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
+		"PR_AUTHOR_LOGIN":        "ben-ranford",
+		"PR_BODY":                validBody(),
+		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
+		"REPOSITORY_OWNER_LOGIN": "ben-ranford",
 	}
 	policy := map[string]string{
 		"REPO_ALLOW_MERGE_COMMIT": "false",
@@ -97,9 +113,13 @@ func TestRunRejectsMissingRepoPolicyValue(t *testing.T) {
 
 func TestRunHandlesRepoPolicyValidationErrorWriteFailure(t *testing.T) {
 	base := map[string]string{
-		"PR_TITLE":    "fix(release): validate PR metadata",
-		"PR_HEAD_REF": "bug/issue-000-pr-title-template-gate",
-		"PR_BODY":     validBody(),
+		"PR_TITLE":               "fix(release): validate PR metadata",
+		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
+		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
+		"PR_AUTHOR_LOGIN":        "ben-ranford",
+		"PR_BODY":                validBody(),
+		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
+		"REPOSITORY_OWNER_LOGIN": "ben-ranford",
 	}
 	policy := map[string]string{
 		"REPO_ALLOW_MERGE_COMMIT":        "false",
@@ -161,13 +181,13 @@ func TestRunHandlesValidationErrorWriteFailure(t *testing.T) {
 
 func TestValidateAcceptsCompletedTemplate(t *testing.T) {
 	body := validBody()
-	if err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body); err != nil {
+	if err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{}); err != nil {
 		t.Fatalf("validate returned error: %v", err)
 	}
 }
 
 func TestValidateRejectsBugTitle(t *testing.T) {
-	err := validate("bug: patch adapter parser", "bug/issue-123-parser", validBody())
+	err := validate("bug: patch adapter parser", "bug/issue-123-parser", validBody(), releasePleaseIdentity{})
 	if err == nil {
 		t.Fatal("validate succeeded for unsupported bug title")
 	}
@@ -177,52 +197,57 @@ func TestValidateRejectsBugTitle(t *testing.T) {
 }
 
 func TestValidateRejectsNonConventionalTitle(t *testing.T) {
-	err := validate("patch adapter parser", "bug/issue-123-parser", validBody())
+	err := validate("patch adapter parser", "bug/issue-123-parser", validBody(), releasePleaseIdentity{})
 	if err == nil {
 		t.Fatal("validate succeeded for non-conventional title")
 	}
 }
 
 func TestValidateRequiresTemplateSections(t *testing.T) {
-	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", strings.Replace(validBody(), "## Validation", "## Verification", 1))
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", strings.Replace(validBody(), "## Validation", "## Verification", 1), releasePleaseIdentity{})
 	expectValidationError(t, err, `missing required template section "Validation"`)
 }
 
 func TestValidateRejectsPlaceholderOnlySection(t *testing.T) {
 	body := strings.Replace(validBody(), "Stops release-please from missing patch fixes.", "Describe the problem and the intent of this change.", 1)
-	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{})
 	expectValidationError(t, err, `section "Summary" must be completed`)
 }
 
 func TestValidateRequiresRiskFields(t *testing.T) {
 	body := strings.Replace(validBody(), "- Performance impact: None\n", "", 1)
-	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{})
 	expectValidationError(t, err, `field "Performance impact"`)
 }
 
 func TestValidateRequiresCheckedChecklist(t *testing.T) {
 	body := strings.Replace(validBody(), "- [x] Ready for review", "- [ ] Ready for review", 1)
-	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{})
 	expectValidationError(t, err, `Checklist item "Ready for review"`)
 }
 
 func TestValidateRejectsBlankSectionWithCommentOnly(t *testing.T) {
 	body := strings.Replace(validBody(), "Stops release-please from missing patch fixes.", "<!-- TODO -->", 1)
-	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body)
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{})
 	if err == nil {
 		t.Fatal("validate succeeded with comment-only Summary")
 	}
 }
 
 func TestValidateExemptsGeneratedReleasePleaseBody(t *testing.T) {
-	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser")
+	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", trustedReleasePleaseIdentity())
 	if err != nil {
 		t.Fatalf("validate returned error: %v", err)
 	}
 }
 
+func TestValidateRejectsSpoofedReleasePleaseIdentity(t *testing.T) {
+	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", spoofedReleasePleaseIdentity())
+	expectValidationError(t, err, `missing required template section "Summary"`)
+}
+
 func TestValidateReleasePleaseExemptionStillRequiresReleaseTitle(t *testing.T) {
-	err := validate("release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser")
+	err := validate("release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", trustedReleasePleaseIdentity())
 	if err == nil {
 		t.Fatal("validate succeeded for generated release PR with non-conventional title")
 	}
@@ -288,6 +313,24 @@ func validRepoPolicyEnv() map[string]string {
 		"REPO_ALLOW_REBASE_MERGE":        "false",
 		"REPO_ALLOW_SQUASH_MERGE":        "true",
 		"REPO_SQUASH_MERGE_COMMIT_TITLE": "PR_TITLE",
+	}
+}
+
+func trustedReleasePleaseIdentity() releasePleaseIdentity {
+	return releasePleaseIdentity{
+		authorLogin:            "ben-ranford",
+		repositoryOwnerLogin:   "ben-ranford",
+		headRepositoryFullName: "ben-ranford/lopper",
+		repositoryFullName:     "ben-ranford/lopper",
+	}
+}
+
+func spoofedReleasePleaseIdentity() releasePleaseIdentity {
+	return releasePleaseIdentity{
+		authorLogin:            "attacker",
+		repositoryOwnerLogin:   "ben-ranford",
+		headRepositoryFullName: "attacker/lopper",
+		repositoryFullName:     "ben-ranford/lopper",
 	}
 }
 

--- a/tools/prcheck/main_test.go
+++ b/tools/prcheck/main_test.go
@@ -14,10 +14,8 @@ func TestRunAcceptsEnvBody(t *testing.T) {
 		"PR_TITLE":               "fix(release): validate PR metadata",
 		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
 		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
-		"PR_AUTHOR_LOGIN":        "ben-ranford",
 		"PR_BODY":                validBody(),
 		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
-		"REPOSITORY_OWNER_LOGIN": "ben-ranford",
 	})
 	code := run(nil, env, &stderr)
 	if code != 0 {
@@ -44,10 +42,8 @@ func TestRunAcceptsValidRepoPolicy(t *testing.T) {
 		"PR_TITLE":               "fix(release): validate PR metadata",
 		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
 		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
-		"PR_AUTHOR_LOGIN":        "ben-ranford",
 		"PR_BODY":                validBody(),
 		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
-		"REPOSITORY_OWNER_LOGIN": "ben-ranford",
 	}
 	values := mergeMaps(base, validRepoPolicyEnv())
 	env := mapEnv(values)
@@ -63,10 +59,8 @@ func TestRunRejectsInvalidRepoPolicy(t *testing.T) {
 		"PR_TITLE":               "fix(release): validate PR metadata",
 		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
 		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
-		"PR_AUTHOR_LOGIN":        "ben-ranford",
 		"PR_BODY":                validBody(),
 		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
-		"REPOSITORY_OWNER_LOGIN": "ben-ranford",
 	}
 	policy := map[string]string{
 		"REPO_ALLOW_MERGE_COMMIT":        "true",
@@ -91,10 +85,8 @@ func TestRunRejectsMissingRepoPolicyValue(t *testing.T) {
 		"PR_TITLE":               "fix(release): validate PR metadata",
 		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
 		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
-		"PR_AUTHOR_LOGIN":        "ben-ranford",
 		"PR_BODY":                validBody(),
 		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
-		"REPOSITORY_OWNER_LOGIN": "ben-ranford",
 	}
 	policy := map[string]string{
 		"REPO_ALLOW_MERGE_COMMIT": "false",
@@ -116,10 +108,8 @@ func TestRunHandlesRepoPolicyValidationErrorWriteFailure(t *testing.T) {
 		"PR_TITLE":               "fix(release): validate PR metadata",
 		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
 		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
-		"PR_AUTHOR_LOGIN":        "ben-ranford",
 		"PR_BODY":                validBody(),
 		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
-		"REPOSITORY_OWNER_LOGIN": "ben-ranford",
 	}
 	policy := map[string]string{
 		"REPO_ALLOW_MERGE_COMMIT":        "false",
@@ -246,6 +236,19 @@ func TestValidateRejectsSpoofedReleasePleaseIdentity(t *testing.T) {
 	expectValidationError(t, err, `missing required template section "Summary"`)
 }
 
+func TestValidateRejectsReleasePleasePrefixSpoof(t *testing.T) {
+	err := validate("chore(main): release 1.5.1", "release-please--branches--main-attacker", "## Changelog\n\n* fix: parser", trustedReleasePleaseIdentity())
+	expectValidationError(t, err, `missing required template section "Summary"`)
+}
+
+func TestValidateAcceptsRepositoryOwnedReleasePRFromNonOwnerToken(t *testing.T) {
+	identity := trustedReleasePleaseIdentity()
+	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", identity)
+	if err != nil {
+		t.Fatalf("validate returned error: %v", err)
+	}
+}
+
 func TestValidateReleasePleaseExemptionStillRequiresReleaseTitle(t *testing.T) {
 	err := validate("release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", trustedReleasePleaseIdentity())
 	if err == nil {
@@ -318,8 +321,6 @@ func validRepoPolicyEnv() map[string]string {
 
 func trustedReleasePleaseIdentity() releasePleaseIdentity {
 	return releasePleaseIdentity{
-		authorLogin:            "ben-ranford",
-		repositoryOwnerLogin:   "ben-ranford",
 		headRepositoryFullName: "ben-ranford/lopper",
 		repositoryFullName:     "ben-ranford/lopper",
 	}
@@ -327,8 +328,6 @@ func trustedReleasePleaseIdentity() releasePleaseIdentity {
 
 func spoofedReleasePleaseIdentity() releasePleaseIdentity {
 	return releasePleaseIdentity{
-		authorLogin:            "attacker",
-		repositoryOwnerLogin:   "ben-ranford",
 		headRepositoryFullName: "attacker/lopper",
 		repositoryFullName:     "ben-ranford/lopper",
 	}


### PR DESCRIPTION
## Summary

The PR metadata gate was trusting attacker-controlled release-like branch names and titles, which let a forked PR skip the required template and metadata checks by imitating a release-please PR. This change binds that exemption to trusted repository identity from the pull request event while preserving genuine generated release PR behavior.

Closes #1223.

## Changes

- Passes trusted pull request identity fields from `.github/workflows/pr-metadata.yml` into `tools/prcheck`.
- Requires the release-please exemption to match the release branch/title pattern, the repository-owned head repository, and the repository owner's pull request identity.
- Adds a focused regression test proving an attacker-controlled branch name and title do not receive the exemption, while the genuine generated release PR case still passes.

## Validation

Commands and checks run:

```bash
go test ./tools/prcheck
make actionlint
make ci
```

Additional manual validation:

- Read issue `#1223` and inspected recent release PR metadata to confirm genuine release PRs use the repository-owned `release-please--branches--main` branch with repository owner identity.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
