### PR TITLE
fix(release): gate rolling ghcr publication

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -357,7 +357,10 @@ jobs:
           path: ${{ runner.temp }}/ghcr-${{ matrix.architecture }}-publication
 
   publish-ghcr-images:
-    needs: prepare-ghcr
+    needs:
+      - build-linux-windows
+      - build-darwin
+      - prepare-ghcr
     outputs:
       amd64_digest: ${{ steps.publish_amd64.outputs.digest }}
       arm64_digest: ${{ steps.publish_arm64.outputs.digest }}

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -36,6 +36,7 @@ jobs:
   orchestrate-rolling:
     needs:
       - prepare-rolling
+      - build-darwin-amd64-rolling
     permissions:
       contents: read
       packages: write

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3190,6 +3190,12 @@ func TestReleaseOrchestrationGatesGHCRPublicationOnValidatedArtifactProducers(t 
 
 	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
 	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"build-linux-windows", "build-darwin", "prepare-ghcr"})
+
+	var rollingWorkflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/rolling.yml", &rollingWorkflow)
+
+	orchestrateRolling := workflowJobByName(t, rollingWorkflow.Jobs, "orchestrate-rolling")
+	assertWorkflowJobNeeds(t, orchestrateRolling, "orchestrate-rolling", workflowJobNeeds{"prepare-rolling", "build-darwin-amd64-rolling"})
 }
 
 func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3176,10 +3176,20 @@ func TestReleaseOrchestrationUsesStaticGHCRPreparationMatrix(t *testing.T) {
 		t.Fatalf("prepare-ghcr build tags = %q, want image_tags output", build.With["tags"])
 	}
 	publishImages := workflow.Jobs["publish-ghcr-images"]
-	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"prepare-ghcr"})
+	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"build-linux-windows", "build-darwin", "prepare-ghcr"})
 	if publishImages.If != "" {
 		t.Fatalf("publish-ghcr-images if = %q, want no override of failed-needs handling", publishImages.If)
 	}
+}
+
+func TestReleaseOrchestrationGatesGHCRPublicationOnValidatedArtifactProducers(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
+
+	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
+	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"build-linux-windows", "build-darwin", "prepare-ghcr"})
 }
 
 func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
@@ -3253,7 +3263,7 @@ func assertTrustedGHCRImagePublisher(t *testing.T, workflow workflowConfig, arch
 	t.Helper()
 
 	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
-	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"prepare-ghcr"})
+	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"build-linux-windows", "build-darwin", "prepare-ghcr"})
 	assertWorkflowJobPermissions(t, publishImages, "publish-ghcr-images", map[string]string{"packages": "write"})
 	assertFreshGHCRPublisher(t, publishImages, "Log in to GHCR")
 	validation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Validate OCI publication payloads")


### PR DESCRIPTION
## Summary

Closes #1247.

Rolling GHCR publication could begin before all validated artifact producers for the exact source had succeeded. The reusable workflow did not wait on its Linux/Windows or Darwin arm64 builders, and rolling's separate Intel-Darwin producer was a caller-level sibling that could still fail after images had already been pushed.

## Changes

- Gate `publish-ghcr-images` on the reusable workflow's Linux/Windows, Darwin arm64, and GHCR preparation jobs.
- Gate the rolling reusable-workflow call on the caller-level Intel-Darwin producer, creating a complete transitive publication barrier.
- Add a cross-workflow regression test that asserts both sides of the dependency graph.

## Validation

Commands and checks run:

```bash
go test ./scripts -run TestReleaseOrchestrationGatesGHCRPublicationOnValidatedArtifactProducers -count=1
go test ./scripts
make actionlint
make ci
```

Additional manual validation:

- Confirmed the dependency chain is Intel Darwin -> reusable orchestration -> internal validated producers -> GHCR image publication -> manifest publication.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Rolling orchestration waits for Intel-Darwin validation before starting; publication can no longer outrun that required producer.
- Memory benchmark impact: None; `make ci` memory benchmark gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
