### PR TITLE
fix(release): run source CI before publish

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -21,9 +21,135 @@ on:
         type: string
 
 jobs:
-  # Release promotion assumes the selected source commit has already passed
-  # the checks required to merge into main.
+  verify-source-ci:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+    steps:
+      - name: Verify required CI for source SHA
+        env:
+          PATH: /usr/bin:/bin
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+          PROTECTED_BRANCH: main
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          set -euo pipefail
+
+          source_sha="${SOURCE_SHA}"
+          if [[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Release source SHA must be a lowercase full 40-character commit SHA; got ${source_sha}." >&2
+            exit 1
+          fi
+
+          api_url="${GITHUB_API_URL:-https://api.github.com}"
+          auth_args=()
+          if [ -n "${GH_TOKEN:-}" ]; then
+            auth_args=(-H "Authorization: Bearer ${GH_TOKEN}")
+          fi
+
+          rules_file="$(mktemp)"
+          check_runs_file="$(mktemp)"
+          statuses_file="$(mktemp)"
+          required_file="$(mktemp)"
+          trap 'rm -f "${rules_file}" "${check_runs_file}" "${statuses_file}" "${required_file}"' EXIT
+
+          rules_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/rules/branches/${PROTECTED_BRANCH}"
+          check_runs_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/commits/${source_sha}/check-runs?per_page=100"
+          statuses_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/commits/${source_sha}/status"
+
+          curl -fsSL -H "Accept: application/vnd.github+json" "${auth_args[@]}" "${rules_endpoint}" > "${rules_file}"
+          jq -c '
+            [
+              .[]
+              | select(.type == "required_status_checks")
+              | .parameters.required_status_checks[]?
+              | {context, integration_id}
+            ]
+            | unique_by(.context + ":" + (.integration_id | tostring))
+          ' "${rules_file}" > "${required_file}"
+          if [ "$(jq 'length' "${required_file}")" -lt 1 ]; then
+            echo "::error::No required status checks are configured for ${PROTECTED_BRANCH}; refusing release promotion without exact CI validation." >&2
+            exit 1
+          fi
+
+          curl -fsSL -H "Accept: application/vnd.github+json" "${auth_args[@]}" "${check_runs_endpoint}" > "${check_runs_file}"
+          curl -fsSL -H "Accept: application/vnd.github+json" "${auth_args[@]}" "${statuses_endpoint}" > "${statuses_file}"
+
+          while IFS=$'\t' read -r context integration_id; do
+            [ -n "${context}" ] || continue
+
+            check_result="$(
+              jq -r \
+                --arg context "${context}" \
+                --arg integration_id "${integration_id}" \
+                --arg source_sha "${source_sha}" '
+                  [
+                    .check_runs[]
+                    | select(.name == $context)
+                    | select(.head_sha == $source_sha)
+                    | select(
+                        ($integration_id == "null")
+                        or ((.app.id // -1 | tostring) == $integration_id)
+                      )
+                  ]
+                  | if length == 0 then
+                      empty
+                    else
+                      max_by(.id)
+                      | "check-run\t\(.status // "")\t\(.conclusion // "")\t\(.html_url // "")"
+                    end
+                ' "${check_runs_file}"
+            )"
+            if [ -n "${check_result}" ]; then
+              IFS=$'\t' read -r check_kind check_status check_conclusion check_url <<< "${check_result}"
+              if [ "${check_status}" != "completed" ]; then
+                echo "::error::Required check ${context} for ${source_sha} is ${check_status:-unknown}; exact source SHA CI must complete successfully before release." >&2
+                exit 1
+              fi
+              if [ "${check_conclusion}" != "success" ]; then
+                echo "::error::Required check ${context} for ${source_sha} concluded ${check_conclusion:-unknown}; exact source SHA CI must pass before release. ${check_url}" >&2
+                exit 1
+              fi
+              continue
+            fi
+
+            status_result="$(
+              jq -r \
+                --arg context "${context}" \
+                --arg integration_id "${integration_id}" '
+                  [
+                    .statuses[]
+                    | select(.context == $context)
+                    | select(
+                        ($integration_id == "null")
+                        or ((.creator.id // -1 | tostring) == $integration_id)
+                      )
+                  ]
+                  | if length == 0 then
+                      empty
+                    else
+                      .[0]
+                      | "status\t\(.state // "")\t\(.target_url // "")"
+                    end
+                ' "${statuses_file}"
+            )"
+            if [ -z "${status_result}" ]; then
+              echo "::error::Required check ${context} is absent for exact source SHA ${source_sha}; refusing release promotion." >&2
+              exit 1
+            fi
+
+            IFS=$'\t' read -r status_kind status_state status_url <<< "${status_result}"
+            if [ "${status_state}" != "success" ]; then
+              echo "::error::Required status ${context} for ${source_sha} is ${status_state:-unknown}; exact source SHA CI must pass before release. ${status_url}" >&2
+              exit 1
+            fi
+          done < <(jq -r '.[] | [.context, (.integration_id | tostring)] | @tsv' "${required_file}")
+
   build-linux-windows:
+    needs:
+      - verify-source-ci
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,6 +260,8 @@ jobs:
           if-no-files-found: error
 
   build-darwin:
+    needs:
+      - verify-source-ci
     runs-on: macos-26
     permissions:
       contents: read
@@ -239,6 +367,8 @@ jobs:
           if-no-files-found: error
 
   prepare-ghcr:
+    needs:
+      - verify-source-ci
     strategy:
       fail-fast: false
       matrix:
@@ -680,6 +810,8 @@ jobs:
           sbom: true
 
   prepare-ghcr-manifest:
+    needs:
+      - verify-source-ci
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-          fetch-depth: 0
+          fetch-depth: 2
           ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Verify exact release source

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -41,7 +41,8 @@ jobs:
         run: |
           source_sha="${SOURCE_SHA}"
           if [[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::Release source SHA must be a lowercase full 40-character commit SHA; got ${source_sha}." >&2
+            echo "::error::Release source SHA must be a lowercase full 40-character commit SHA." >&2
+            printf 'Rejected release source SHA: %q\n' "${source_sha}" >&2
             exit 1
           fi
 

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -10,10 +10,6 @@ on:
         required: false
         type: string
         default: ''
-      memory_approved:
-        required: false
-        type: boolean
-        default: false
       artifact_prefix:
         required: true
         type: string
@@ -25,75 +21,7 @@ on:
         type: string
 
 jobs:
-  verify-source-ci:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout exact release source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-          fetch-depth: 2
-          ref: ${{ inputs.source_sha || github.sha }}
-
-      - name: Verify exact release source
-        env:
-          PATH: /usr/bin:/bin
-          SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
-        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
-        run: |
-          source_sha="${SOURCE_SHA}"
-          if [[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::Release source SHA must be a lowercase full 40-character commit SHA." >&2
-            printf 'Rejected release source SHA: %q\n' "${source_sha}" >&2
-            exit 1
-          fi
-
-          checked_out_sha="$(git rev-parse HEAD)"
-          if [ "${checked_out_sha}" != "${source_sha}" ]; then
-            echo "::error::Release source checkout resolved to ${checked_out_sha}, expected ${source_sha}." >&2
-            exit 1
-          fi
-
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
-        with:
-          go-version-file: go.mod
-
-      - name: Install shellcheck
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
-
-      - name: Resolve gosec version
-        id: gosec_version
-        run: echo "value=$(make --silent print-gosec-version)" >> "$GITHUB_OUTPUT"
-
-      - name: Install Go tooling
-        env:
-          GOSEC_VERSION: ${{ steps.gosec_version.outputs.value }}
-        run: |
-          make tools-install
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-
-      - name: Run exact source CI gate
-        env:
-          BUILD_CHANNEL: ${{ inputs.build_channel }}
-          MEMORY_BENCH_ENFORCE: ${{ inputs.memory_approved && '0' || '1' }}
-          SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
-        run: |
-          parent_sha="$(git rev-parse "${SOURCE_SHA}^")"
-          export MEMORY_BENCH_BASE="${parent_sha}"
-          export DUPLICATION_BASE="${parent_sha}"
-          export SUPPRESSION_BASE="${parent_sha}"
-          make ci BUILD_CHANNEL="${BUILD_CHANNEL}"
-
-      - name: Verify demo assets
-        run: make demos-check
   build-linux-windows:
-    needs:
-      - verify-source-ci
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -204,8 +132,6 @@ jobs:
           if-no-files-found: error
 
   build-darwin:
-    needs:
-      - verify-source-ci
     runs-on: macos-26
     permissions:
       contents: read
@@ -311,8 +237,6 @@ jobs:
           if-no-files-found: error
 
   prepare-ghcr:
-    needs:
-      - verify-source-ci
     strategy:
       fail-fast: false
       matrix:
@@ -754,8 +678,6 @@ jobs:
           sbom: true
 
   prepare-ghcr-manifest:
-    needs:
-      - verify-source-ci
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: ''
+      memory_approved:
+        required: false
+        type: boolean
+        default: false
       artifact_prefix:
         required: true
         type: string
@@ -76,11 +80,11 @@ jobs:
       - name: Run exact source CI gate
         env:
           BUILD_CHANNEL: ${{ inputs.build_channel }}
+          MEMORY_BENCH_ENFORCE: ${{ inputs.memory_approved && '0' || '1' }}
           SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
         run: |
           parent_sha="$(git rev-parse "${SOURCE_SHA}^")"
           export MEMORY_BENCH_BASE="${parent_sha}"
-          export MEMORY_BENCH_ENFORCE=0
           export DUPLICATION_BASE="${parent_sha}"
           export SUPPRESSION_BASE="${parent_sha}"
           make ci BUILD_CHANNEL="${BUILD_CHANNEL}"

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -75,10 +75,15 @@ jobs:
 
       - name: Run exact source CI gate
         env:
+          BUILD_CHANNEL: ${{ inputs.build_channel }}
           SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
         run: |
           parent_sha="$(git rev-parse "${SOURCE_SHA}^")"
-          MEMORY_BENCH_BASE="${parent_sha}" make ci
+          export MEMORY_BENCH_BASE="${parent_sha}"
+          export MEMORY_BENCH_ENFORCE=0
+          export DUPLICATION_BASE="${parent_sha}"
+          export SUPPRESSION_BASE="${parent_sha}"
+          make ci BUILD_CHANNEL="${BUILD_CHANNEL}"
 
       - name: Verify demo assets
         run: make demos-check

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -24,129 +24,63 @@ jobs:
   verify-source-ci:
     runs-on: ubuntu-latest
     permissions:
-      checks: read
       contents: read
     steps:
-      - name: Verify required CI for source SHA
+      - name: Checkout exact release source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ inputs.source_sha || github.sha }}
+
+      - name: Verify exact release source
         env:
           PATH: /usr/bin:/bin
-          GH_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
-          PROTECTED_BRANCH: main
         shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         run: |
-          set -euo pipefail
-
           source_sha="${SOURCE_SHA}"
           if [[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::Release source SHA must be a lowercase full 40-character commit SHA; got ${source_sha}." >&2
             exit 1
           fi
 
-          api_url="${GITHUB_API_URL:-https://api.github.com}"
-          auth_args=()
-          if [ -n "${GH_TOKEN:-}" ]; then
-            auth_args=(-H "Authorization: Bearer ${GH_TOKEN}")
-          fi
-
-          rules_file="$(mktemp)"
-          check_runs_file="$(mktemp)"
-          statuses_file="$(mktemp)"
-          required_file="$(mktemp)"
-          trap 'rm -f "${rules_file}" "${check_runs_file}" "${statuses_file}" "${required_file}"' EXIT
-
-          rules_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/rules/branches/${PROTECTED_BRANCH}"
-          check_runs_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/commits/${source_sha}/check-runs?per_page=100"
-          statuses_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/commits/${source_sha}/status"
-
-          curl -fsSL -H "Accept: application/vnd.github+json" "${auth_args[@]}" "${rules_endpoint}" > "${rules_file}"
-          jq -c '
-            [
-              .[]
-              | select(.type == "required_status_checks")
-              | .parameters.required_status_checks[]?
-              | {context, integration_id}
-            ]
-            | unique_by(.context + ":" + (.integration_id | tostring))
-          ' "${rules_file}" > "${required_file}"
-          if [ "$(jq 'length' "${required_file}")" -lt 1 ]; then
-            echo "::error::No required status checks are configured for ${PROTECTED_BRANCH}; refusing release promotion without exact CI validation." >&2
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [ "${checked_out_sha}" != "${source_sha}" ]; then
+            echo "::error::Release source checkout resolved to ${checked_out_sha}, expected ${source_sha}." >&2
             exit 1
           fi
 
-          curl -fsSL -H "Accept: application/vnd.github+json" "${auth_args[@]}" "${check_runs_endpoint}" > "${check_runs_file}"
-          curl -fsSL -H "Accept: application/vnd.github+json" "${auth_args[@]}" "${statuses_endpoint}" > "${statuses_file}"
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: go.mod
 
-          while IFS=$'\t' read -r context integration_id; do
-            [ -n "${context}" ] || continue
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
 
-            check_result="$(
-              jq -r \
-                --arg context "${context}" \
-                --arg integration_id "${integration_id}" \
-                --arg source_sha "${source_sha}" '
-                  [
-                    .check_runs[]
-                    | select(.name == $context)
-                    | select(.head_sha == $source_sha)
-                    | select(
-                        ($integration_id == "null")
-                        or ((.app.id // -1 | tostring) == $integration_id)
-                      )
-                  ]
-                  | if length == 0 then
-                      empty
-                    else
-                      max_by(.id)
-                      | "check-run\t\(.status // "")\t\(.conclusion // "")\t\(.html_url // "")"
-                    end
-                ' "${check_runs_file}"
-            )"
-            if [ -n "${check_result}" ]; then
-              IFS=$'\t' read -r check_kind check_status check_conclusion check_url <<< "${check_result}"
-              if [ "${check_status}" != "completed" ]; then
-                echo "::error::Required check ${context} for ${source_sha} is ${check_status:-unknown}; exact source SHA CI must complete successfully before release." >&2
-                exit 1
-              fi
-              if [ "${check_conclusion}" != "success" ]; then
-                echo "::error::Required check ${context} for ${source_sha} concluded ${check_conclusion:-unknown}; exact source SHA CI must pass before release. ${check_url}" >&2
-                exit 1
-              fi
-              continue
-            fi
+      - name: Resolve gosec version
+        id: gosec_version
+        run: echo "value=$(make --silent print-gosec-version)" >> "$GITHUB_OUTPUT"
 
-            status_result="$(
-              jq -r \
-                --arg context "${context}" \
-                --arg integration_id "${integration_id}" '
-                  [
-                    .statuses[]
-                    | select(.context == $context)
-                    | select(
-                        ($integration_id == "null")
-                        or ((.creator.id // -1 | tostring) == $integration_id)
-                      )
-                  ]
-                  | if length == 0 then
-                      empty
-                    else
-                      .[0]
-                      | "status\t\(.state // "")\t\(.target_url // "")"
-                    end
-                ' "${statuses_file}"
-            )"
-            if [ -z "${status_result}" ]; then
-              echo "::error::Required check ${context} is absent for exact source SHA ${source_sha}; refusing release promotion." >&2
-              exit 1
-            fi
+      - name: Install Go tooling
+        env:
+          GOSEC_VERSION: ${{ steps.gosec_version.outputs.value }}
+        run: |
+          make tools-install
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
-            IFS=$'\t' read -r status_kind status_state status_url <<< "${status_result}"
-            if [ "${status_state}" != "success" ]; then
-              echo "::error::Required status ${context} for ${source_sha} is ${status_state:-unknown}; exact source SHA CI must pass before release. ${status_url}" >&2
-              exit 1
-            fi
-          done < <(jq -r '.[] | [.context, (.integration_id | tostring)] | @tsv' "${required_file}")
+      - name: Run exact source CI gate
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+        run: |
+          parent_sha="$(git rev-parse "${SOURCE_SHA}^")"
+          MEMORY_BENCH_BASE="${parent_sha}" make ci
 
+      - name: Verify demo assets
+        run: make demos-check
   build-linux-windows:
     needs:
       - verify-source-ci

--- a/.github/workflows/release-source-ci.yml
+++ b/.github/workflows/release-source-ci.yml
@@ -1,0 +1,83 @@
+name: release-source-ci
+
+on:
+  workflow_call:
+    inputs:
+      source_sha:
+        required: true
+        type: string
+      build_channel:
+        required: true
+        type: string
+      memory_approved:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  verify-source-ci:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact release source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 2
+          ref: ${{ inputs.source_sha }}
+
+      - name: Verify exact release source
+        env:
+          PATH: /usr/bin:/bin
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
+        run: |
+          source_sha="${SOURCE_SHA}"
+          if [[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Release source SHA must be a lowercase full 40-character commit SHA." >&2
+            printf 'Rejected release source SHA: %q\n' "${source_sha}" >&2
+            exit 1
+          fi
+
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [ "${checked_out_sha}" != "${source_sha}" ]; then
+            echo "::error::Release source checkout resolved to ${checked_out_sha}, expected ${source_sha}." >&2
+            exit 1
+          fi
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: go.mod
+
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Resolve gosec version
+        id: gosec_version
+        run: echo "value=$(make --silent print-gosec-version)" >> "$GITHUB_OUTPUT"
+
+      - name: Install Go tooling
+        env:
+          GOSEC_VERSION: ${{ steps.gosec_version.outputs.value }}
+        run: |
+          make tools-install
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Run exact source CI gate
+        env:
+          BUILD_CHANNEL: ${{ inputs.build_channel }}
+          MEMORY_BENCH_ENFORCE: ${{ inputs.memory_approved && '0' || '1' }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          parent_sha="$(git rev-parse "${SOURCE_SHA}^")"
+          export MEMORY_BENCH_BASE="${parent_sha}"
+          export DUPLICATION_BASE="${parent_sha}"
+          export SUPPRESSION_BASE="${parent_sha}"
+          make ci BUILD_CHANNEL="${BUILD_CHANNEL}"
+
+      - name: Verify demo assets
+        run: make demos-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
       source_sha: ${{ needs.prepare-release.outputs.sha }}
       artifact_prefix: release
       build_channel: release
+      memory_approved: false
       image_tags: |
         ${{ needs.prepare-release.outputs.tag }}
         latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,9 @@ jobs:
         latest
 
   build-vscode-extension:
-    needs: prepare-release
+    needs:
+      - prepare-release
+      - orchestrate-release
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
@@ -285,7 +287,9 @@ jobs:
           if-no-files-found: error
 
   build-darwin-amd64:
-    needs: prepare-release
+    needs:
+      - prepare-release
+      - orchestrate-release
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: macos-26-intel
     permissions:
@@ -386,6 +390,7 @@ jobs:
   prepare-release-feature-report:
     needs:
       - prepare-release
+      - orchestrate-release
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,8 +171,21 @@ jobs:
             echo "sha=${resolved_sha}"
           } >> "$GITHUB_OUTPUT"
 
-  orchestrate-release:
+  verify-release-source-ci:
     needs: prepare-release
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/release-source-ci.yml
+    with:
+      source_sha: ${{ needs.prepare-release.outputs.sha }}
+      build_channel: release
+      memory_approved: false
+
+  orchestrate-release:
+    needs:
+      - prepare-release
+      - verify-release-source-ci
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     permissions:
       contents: read
@@ -183,7 +196,6 @@ jobs:
       source_sha: ${{ needs.prepare-release.outputs.sha }}
       artifact_prefix: release
       build_channel: release
-      memory_approved: false
       image_tags: |
         ${{ needs.prepare-release.outputs.tag }}
         latest
@@ -191,7 +203,7 @@ jobs:
   build-vscode-extension:
     needs:
       - prepare-release
-      - orchestrate-release
+      - verify-release-source-ci
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
@@ -289,7 +301,7 @@ jobs:
   build-darwin-amd64:
     needs:
       - prepare-release
-      - orchestrate-release
+      - verify-release-source-ci
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: macos-26-intel
     permissions:
@@ -390,7 +402,7 @@ jobs:
   prepare-release-feature-report:
     needs:
       - prepare-release
-      - orchestrate-release
+      - verify-release-source-ci
     if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -54,6 +54,7 @@ jobs:
   build-darwin-amd64-rolling:
     needs:
       - prepare-rolling
+      - orchestrate-rolling
     runs-on: macos-26-intel
     permissions:
       contents: read
@@ -155,6 +156,7 @@ jobs:
   prepare-rolling-release-notes:
     needs:
       - prepare-rolling
+      - orchestrate-rolling
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -278,6 +280,7 @@ jobs:
   prepare-rolling-source-archive:
     needs:
       - prepare-rolling
+      - orchestrate-rolling
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -33,10 +33,21 @@ jobs:
             echo "source_sha=${source_sha}"
           } >> "$GITHUB_OUTPUT"
 
+  verify-rolling-source-ci:
+    needs:
+      - prepare-rolling
+    permissions:
+      contents: read
+    uses: ./.github/workflows/release-source-ci.yml
+    with:
+      source_sha: ${{ needs.prepare-rolling.outputs.source_sha }}
+      build_channel: rolling
+      memory_approved: ${{ contains(github.event.pull_request.labels.*.name, 'memory-approved') }}
+
   orchestrate-rolling:
     needs:
       - prepare-rolling
-      - build-darwin-amd64-rolling
+      - verify-rolling-source-ci
     permissions:
       contents: read
       packages: write
@@ -46,7 +57,6 @@ jobs:
       source_sha: ${{ needs.prepare-rolling.outputs.source_sha }}
       artifact_prefix: rolling
       build_channel: rolling
-      memory_approved: ${{ contains(github.event.pull_request.labels.*.name, 'memory-approved') }}
       image_tags: |
         ${{ needs.prepare-rolling.outputs.tag }}
         rolling
@@ -54,7 +64,7 @@ jobs:
   build-darwin-amd64-rolling:
     needs:
       - prepare-rolling
-      - orchestrate-rolling
+      - verify-rolling-source-ci
     runs-on: macos-26-intel
     permissions:
       contents: read
@@ -156,7 +166,7 @@ jobs:
   prepare-rolling-release-notes:
     needs:
       - prepare-rolling
-      - orchestrate-rolling
+      - verify-rolling-source-ci
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -280,7 +290,7 @@ jobs:
   prepare-rolling-source-archive:
     needs:
       - prepare-rolling
-      - orchestrate-rolling
+      - verify-rolling-source-ci
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -46,6 +46,7 @@ jobs:
       source_sha: ${{ needs.prepare-rolling.outputs.source_sha }}
       artifact_prefix: rolling
       build_channel: rolling
+      memory_approved: ${{ contains(github.event.pull_request.labels.*.name, 'memory-approved') }}
       image_tags: |
         ${{ needs.prepare-rolling.outputs.tag }}
         rolling

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -9,6 +9,7 @@ This repository includes these GitHub Actions workflows:
   - Darwin artifact from macOS (native arch)
   - GHCR multi-arch image (`linux/amd64`, `linux/arm64`) tagged with the release tag and `latest`
 - `.github/workflows/release-orchestration.yml`: reusable workflow invoked by `release.yml` and `rolling.yml` to build release artifacts and publish GHCR images
+- `.github/workflows/release-source-ci.yml`: read-only reusable workflow that validates the exact promoted source before stable or rolling artifact production starts
 - `.github/workflows/rolling.yml`: on merge to `main`, publishes a rolling prerelease with Linux/Windows/Darwin build artifacts plus source bundle assets, updates GHCR `rolling`, and updates Homebrew tap formula `lopper-rolling`
 - `.github/workflows/docker-ghcr.yml`: manual-only fallback to build/push the GHCR image on demand
 - `.github/workflows/memory-profiles.yml`: scheduled/manual alloc-space profiling for the watched hotspot packages (`dotnet`, `rust`, `analysis`, `golang`) with uploaded artifacts and a workflow summary

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -119,6 +119,7 @@ func (n *workflowJobNeeds) UnmarshalYAML(node *yaml.Node) error {
 }
 
 type workflowStepConfig struct {
+	ContinueOnError  bool              `yaml:"continue-on-error"`
 	Name             string            `yaml:"name"`
 	ID               string            `yaml:"id"`
 	If               string            `yaml:"if"`
@@ -130,13 +131,22 @@ type workflowStepConfig struct {
 	With             map[string]string `yaml:"with"`
 }
 
+type releasePleaseChangelogSection struct {
+	Type    string `json:"type"`
+	Section string `json:"section"`
+	Hidden  bool   `json:"hidden"`
+}
+
 func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	t.Parallel()
 
 	var config struct {
-		Packages map[string]struct {
-			ChangelogPath string `json:"changelog-path"`
-			ExtraFiles    []struct {
+		Versioning string `json:"versioning"`
+		Packages   map[string]struct {
+			Versioning        string                          `json:"versioning"`
+			ChangelogPath     string                          `json:"changelog-path"`
+			ChangelogSections []releasePleaseChangelogSection `json:"changelog-sections"`
+			ExtraFiles        []struct {
 				Path string `json:"path"`
 			} `json:"extra-files"`
 		} `json:"packages"`
@@ -153,6 +163,11 @@ func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	if rootPackage.ChangelogPath == "extensions/vscode-lopper/CHANGELOG.md" {
 		t.Fatal("root release notes must not be written to the VS Code extension changelog")
 	}
+	if config.Versioning != "" || rootPackage.Versioning != "" {
+		t.Fatal("release-please must keep default versioning so preview commits bump patch and feat graduations bump minor")
+	}
+
+	assertPreviewChangelogSection(t, rootPackage.ChangelogSections)
 
 	extraFiles := map[string]bool{}
 	for _, extraFile := range rootPackage.ExtraFiles {
@@ -168,6 +183,21 @@ func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	}
 }
 
+func assertPreviewChangelogSection(t *testing.T, sections []releasePleaseChangelogSection) {
+	t.Helper()
+
+	for _, section := range sections {
+		if section.Type != "preview" {
+			continue
+		}
+		if section.Section != "Preview Features" || section.Hidden {
+			t.Fatalf("preview changelog section = %#v, want visible Preview Features", section)
+		}
+		return
+	}
+	t.Fatal("release-please config must expose preview commits in release notes")
+}
+
 func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	t.Parallel()
 
@@ -178,8 +208,8 @@ func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	if !ok {
 		t.Fatal("graduate-feature workflow must define the milestone input")
 	}
-	if milestone.Default != "v1.7.0" {
-		t.Fatalf("graduate-feature milestone default = %q, want v1.7.0", milestone.Default)
+	if milestone.Default != "v1.9.0" {
+		t.Fatalf("graduate-feature milestone default = %q, want v1.9.0", milestone.Default)
 	}
 
 	workflowText := readConfig(t, ".github/workflows/graduate-feature.yml")
@@ -188,6 +218,70 @@ func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	}
 	if strings.Contains(workflowText, "--label target-series:") {
 		t.Fatal("graduate-feature workflow must not hardcode a target-series label")
+	}
+	for _, want := range []string{
+		`git commit -m "feat(flags): graduate ${FEATURE} to stable"`,
+		`--title "feat(flags): graduate ${FEATURE} to stable"`,
+	} {
+		if !strings.Contains(workflowText, want) {
+			t.Fatalf("graduate-feature workflow must preserve the minor-bump title %q", want)
+		}
+	}
+}
+
+func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/feature-flag-enforcement.yml", &workflow)
+	checkout := workflowStepByName(t, workflow.Jobs, "enforce", "Checkout")
+	if checkout.With["fetch-depth"] != "0" {
+		t.Fatal("feature flag enforcement checkout must fetch complete base history for stale PRs")
+	}
+	if checkout.With["persist-credentials"] != "false" {
+		t.Fatal("feature flag enforcement checkout must not persist credentials")
+	}
+	classify := workflowStepByName(t, workflow.Jobs, "enforce", "Classify PR")
+	if !strings.Contains(classify.Run, `grep -Eq '^(feat|preview)`) {
+		t.Fatal("feature flag enforcement must classify preview titles as feature PRs")
+	}
+	if !strings.Contains(classify.Run, `echo "preview_pr=true"`) {
+		t.Fatal("feature flag enforcement must expose preview PR classification")
+	}
+	for _, want := range []string{
+		`sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'`,
+		`printf '%s\n' "${pr_title}"`,
+	} {
+		if !strings.Contains(classify.Run, want) {
+			t.Fatalf("feature flag enforcement must classify the trimmed PR title using %q", want)
+		}
+	}
+
+	rejectOverrides := workflowStepByName(t, workflow.Jobs, "enforce", "Reject release overrides on preview PRs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "preview override condition", got: rejectOverrides.If, want: "${{ steps.classify_pr.outputs.preview_pr == 'true' }}"},
+		{label: "preview PR body", got: rejectOverrides.Env["PR_BODY"], want: "${{ github.event.pull_request.body }}"},
+	})
+	assertWorkflowStepRunContainsAll(t, rejectOverrides, "preview release override guard", []string{
+		`release_directive_pattern='^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)'`,
+		`non_preview_entry_pattern='^(feat|feature|fix|bug|perf|docs|refactor|revert)`,
+		`printf '%s\n' "${PR_BODY}"`,
+		`grep -Eiq "${release_directive_pattern}" "${pr_body}"`,
+		`grep -Eiq "${non_preview_entry_pattern}" "${pr_body}"`,
+		`grep -Eiq "${release_directive_pattern}" "${commit_messages}"`,
+		`grep -Eiq "${non_preview_entry_pattern}" "${commit_messages}"`,
+		`merge_base="$(git merge-base "origin/${base_ref}" HEAD)"`,
+		`git log --format=%B "${merge_base}..HEAD"`,
+		`(BREAKING[ -]CHANGE|Release-As)`,
+		`(feat|feature|fix|bug|perf|docs|refactor|revert)`,
+		`?!:[[:space:]]+[^[:space:]]`,
+		`[^[:space:]]'`,
+	})
+	if got := strings.Count(rejectOverrides.Run, "exit 1"); got != 3 {
+		t.Fatalf("preview release override guard failure exits = %d, want 3", got)
+	}
+	if strings.Contains(rejectOverrides.Run, "commit_subjects") {
+		t.Fatal("preview release override guard must scan full commit messages instead of subjects only")
 	}
 }
 
@@ -3097,10 +3191,26 @@ func TestReleaseOrchestrationUsesStaticGHCRPreparationMatrix(t *testing.T) {
 		t.Fatalf("prepare-ghcr build tags = %q, want image_tags output", build.With["tags"])
 	}
 	publishImages := workflow.Jobs["publish-ghcr-images"]
-	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"prepare-ghcr"})
+	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"build-linux-windows", "build-darwin", "prepare-ghcr"})
 	if publishImages.If != "" {
 		t.Fatalf("publish-ghcr-images if = %q, want no override of failed-needs handling", publishImages.If)
 	}
+}
+
+func TestReleaseOrchestrationGatesGHCRPublicationOnValidatedArtifactProducers(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
+
+	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
+	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"build-linux-windows", "build-darwin", "prepare-ghcr"})
+
+	var rollingWorkflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/rolling.yml", &rollingWorkflow)
+
+	orchestrateRolling := workflowJobByName(t, rollingWorkflow.Jobs, "orchestrate-rolling")
+	assertWorkflowJobNeeds(t, orchestrateRolling, "orchestrate-rolling", workflowJobNeeds{"prepare-rolling", "verify-rolling-source-ci"})
 }
 
 func TestReleaseSourceCIRunsExactSourceGate(t *testing.T) {
@@ -3341,7 +3451,7 @@ func assertTrustedGHCRImagePublisher(t *testing.T, workflow workflowConfig, arch
 	t.Helper()
 
 	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
-	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"prepare-ghcr"})
+	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"build-linux-windows", "build-darwin", "prepare-ghcr"})
 	assertWorkflowJobPermissions(t, publishImages, "publish-ghcr-images", map[string]string{"packages": "write"})
 	assertFreshGHCRPublisher(t, publishImages, "Log in to GHCR")
 	validation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Validate OCI publication payloads")

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3132,11 +3132,16 @@ func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) 
 
 	ciGate := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Run exact source CI gate")
 	assertWorkflowStepEnv(t, ciGate, "exact source CI gate", map[string]string{
-		"SOURCE_SHA": "${{ inputs.source_sha || github.sha }}",
+		"BUILD_CHANNEL": "${{ inputs.build_channel }}",
+		"SOURCE_SHA":    "${{ inputs.source_sha || github.sha }}",
 	})
 	assertWorkflowStepRunContainsAll(t, ciGate, "exact source CI gate", []string{
 		`parent_sha="$(git rev-parse "${SOURCE_SHA}^")"`,
-		`MEMORY_BENCH_BASE="${parent_sha}" make ci`,
+		`export MEMORY_BENCH_BASE="${parent_sha}"`,
+		`export MEMORY_BENCH_ENFORCE=0`,
+		`export DUPLICATION_BASE="${parent_sha}"`,
+		`export SUPPRESSION_BASE="${parent_sha}"`,
+		`make ci BUILD_CHANNEL="${BUILD_CHANNEL}"`,
 	})
 
 	for _, jobName := range []string{

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -558,7 +558,7 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
 	reportPreparation := workflowJobByName(t, workflow.Jobs, "prepare-release-feature-report")
-	assertWorkflowJobNeeds(t, reportPreparation, "release feature report preparation", workflowJobNeeds{"prepare-release", "orchestrate-release"})
+	assertWorkflowJobNeeds(t, reportPreparation, "release feature report preparation", workflowJobNeeds{"prepare-release", "verify-release-source-ci"})
 	assertWorkflowJobPermissions(t, reportPreparation, "release feature report preparation", map[string]string{"contents": "read"})
 	assertWorkflowJobEnvEmpty(t, reportPreparation, "release feature report preparation")
 	assertWorkflowJobOmitsText(t, reportPreparation, "secrets.", "release feature report preparation must not receive secrets")
@@ -834,7 +834,7 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	assertWorkflowJobPermissions(t, darwinProducer, "rolling Darwin amd64 producer", map[string]string{"contents": "read"})
 
 	notesPreparation := workflowJobByName(t, workflow.Jobs, "prepare-rolling-release-notes")
-	assertWorkflowJobNeeds(t, notesPreparation, "rolling release note preparation", workflowJobNeeds{"prepare-rolling", "orchestrate-rolling"})
+	assertWorkflowJobNeeds(t, notesPreparation, "rolling release note preparation", workflowJobNeeds{"prepare-rolling", "verify-rolling-source-ci"})
 	assertWorkflowJobPermissions(t, notesPreparation, "rolling release note preparation", map[string]string{"contents": "read"})
 	assertWorkflowJobEnvEmpty(t, notesPreparation, "rolling release note preparation")
 	assertWorkflowJobOmitsText(t, notesPreparation, "secrets.", "rolling release note preparation must not receive secrets")
@@ -884,7 +884,7 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	})
 
 	archivePreparation := workflowJobByName(t, workflow.Jobs, "prepare-rolling-source-archive")
-	assertWorkflowJobNeeds(t, archivePreparation, "rolling source archive preparation", workflowJobNeeds{"prepare-rolling", "orchestrate-rolling"})
+	assertWorkflowJobNeeds(t, archivePreparation, "rolling source archive preparation", workflowJobNeeds{"prepare-rolling", "verify-rolling-source-ci"})
 	assertWorkflowJobPermissions(t, archivePreparation, "rolling source archive preparation", map[string]string{"contents": "read"})
 	assertWorkflowJobEnvEmpty(t, archivePreparation, "rolling source archive preparation")
 	assertWorkflowJobOmitsText(t, archivePreparation, "secrets.", "rolling source archive preparation must not receive secrets")
@@ -1146,6 +1146,7 @@ func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
 		"jobs.build-vscode-extension.steps.Setup Node#1.uses",
 		"jobs.build-vscode-extension.steps.Upload VS Code extension artifact#1.uses",
 		"jobs.orchestrate-release.uses",
+		"jobs.verify-release-source-ci.uses",
 		"jobs.prepare-feature-release-history-push.steps.Download feature history patch#1.uses",
 		"jobs.prepare-feature-release-history-push.steps.Upload prepared trusted feature history worktree#1.uses",
 		"jobs.prepare-feature-release-history.steps.Checkout trusted main tooling#1.uses",
@@ -2758,6 +2759,7 @@ func TestReleaseWorkflowsUsePortableCommands(t *testing.T) {
 	}
 	paths := []string{
 		".github/workflows/release-orchestration.yml",
+		".github/workflows/release-source-ci.yml",
 		".github/workflows/release.yml",
 		".github/workflows/rolling.yml",
 	}
@@ -3101,11 +3103,18 @@ func TestReleaseOrchestrationUsesStaticGHCRPreparationMatrix(t *testing.T) {
 	}
 }
 
-func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) {
+func TestReleaseSourceCIRunsExactSourceGate(t *testing.T) {
 	t.Parallel()
 
 	var workflow workflowConfig
-	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
+	readYAMLConfig(t, ".github/workflows/release-source-ci.yml", &workflow)
+	source, ok := workflow.On.WorkflowCall.Inputs["source_sha"]
+	if !ok {
+		t.Fatal("release source CI must define a source_sha input")
+	}
+	if !source.Required || source.Type != "string" || source.Default != nil {
+		t.Fatalf("source_sha input = %#v, want required string without a default", source)
+	}
 
 	verification := workflowJobByName(t, workflow.Jobs, "verify-source-ci")
 	assertWorkflowJobPermissions(t, verification, "source CI verification", map[string]string{"contents": "read"})
@@ -3116,7 +3125,7 @@ func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) 
 	checkout := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Checkout exact release source")
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{label: "source CI checkout action", got: checkout.Uses, want: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"},
-		{label: "source CI checkout ref", got: checkout.With["ref"], want: "${{ inputs.source_sha || github.sha }}"},
+		{label: "source CI checkout ref", got: checkout.With["ref"], want: "${{ inputs.source_sha }}"},
 		{label: "source CI checkout persist-credentials", got: checkout.With["persist-credentials"], want: "false"},
 		{label: "source CI checkout fetch-depth", got: checkout.With["fetch-depth"], want: "2"},
 	})
@@ -3124,7 +3133,7 @@ func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) 
 	verifySource := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Verify exact release source")
 	assertWorkflowStepEnv(t, verifySource, "source CI verification", map[string]string{
 		"PATH":       "/usr/bin:/bin",
-		"SOURCE_SHA": "${{ inputs.source_sha || github.sha }}",
+		"SOURCE_SHA": "${{ inputs.source_sha }}",
 	})
 	assertWorkflowStepRunContainsAll(t, verifySource, "source CI verification", []string{
 		`[[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]`,
@@ -3147,7 +3156,7 @@ func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) 
 	assertWorkflowStepEnv(t, ciGate, "exact source CI gate", map[string]string{
 		"BUILD_CHANNEL":        "${{ inputs.build_channel }}",
 		"MEMORY_BENCH_ENFORCE": "${{ inputs.memory_approved && '0' || '1' }}",
-		"SOURCE_SHA":           "${{ inputs.source_sha || github.sha }}",
+		"SOURCE_SHA":           "${{ inputs.source_sha }}",
 	})
 	assertWorkflowStepRunContainsAll(t, ciGate, "exact source CI gate", []string{
 		`parent_sha="$(git rev-parse "${SOURCE_SHA}^")"`,
@@ -3156,26 +3165,16 @@ func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) 
 		`export SUPPRESSION_BASE="${parent_sha}"`,
 		`make ci BUILD_CHANNEL="${BUILD_CHANNEL}"`,
 	})
-
-	for _, jobName := range []string{
-		"build-linux-windows",
-		"build-darwin",
-		"prepare-ghcr",
-		"prepare-ghcr-manifest",
-	} {
-		job := workflowJobByName(t, workflow.Jobs, jobName)
-		assertWorkflowJobNeeds(t, job, jobName, workflowJobNeeds{"verify-source-ci"})
-	}
 }
 
 func TestReleaseCallersPassMemoryApprovalToSourceCI(t *testing.T) {
 	t.Parallel()
 
 	var reusable workflowConfig
-	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &reusable)
+	readYAMLConfig(t, ".github/workflows/release-source-ci.yml", &reusable)
 	approval, ok := reusable.On.WorkflowCall.Inputs["memory_approved"]
 	if !ok {
-		t.Fatal("release orchestration must define a memory_approved input")
+		t.Fatal("release source CI must define a memory_approved input")
 	}
 	if approval.Required || approval.Type != "boolean" || approval.Default != false {
 		t.Fatalf("memory_approved input = %#v, want optional boolean defaulting to false", approval)
@@ -3185,7 +3184,7 @@ func TestReleaseCallersPassMemoryApprovalToSourceCI(t *testing.T) {
 	readYAMLConfig(t, ".github/workflows/rolling.yml", &rolling)
 	assertWorkflowStringValues(t, []workflowStringValue{{
 		label: "rolling memory approval",
-		got:   rolling.Jobs["orchestrate-rolling"].With["memory_approved"],
+		got:   rolling.Jobs["verify-rolling-source-ci"].With["memory_approved"],
 		want:  "${{ contains(github.event.pull_request.labels.*.name, 'memory-approved') }}",
 	}})
 
@@ -3193,7 +3192,7 @@ func TestReleaseCallersPassMemoryApprovalToSourceCI(t *testing.T) {
 	readYAMLConfig(t, ".github/workflows/release.yml", &release)
 	assertWorkflowStringValues(t, []workflowStringValue{{
 		label: "release memory approval",
-		got:   release.Jobs["orchestrate-release"].With["memory_approved"],
+		got:   release.Jobs["verify-release-source-ci"].With["memory_approved"],
 		want:  "false",
 	}})
 }
@@ -3201,31 +3200,42 @@ func TestReleaseCallersPassMemoryApprovalToSourceCI(t *testing.T) {
 func TestReleaseCallersWaitForExactSourceCIBeforeProducingArtifacts(t *testing.T) {
 	t.Parallel()
 
-	type producerContract struct {
-		name  string
-		needs workflowJobNeeds
-	}
 	testCases := []struct {
-		path         string
-		orchestrator string
-		producers    []producerContract
+		path          string
+		preparation   string
+		gate          string
+		orchestrator  string
+		sourceSHA     string
+		buildChannel  string
+		producerNeeds workflowJobNeeds
+		producers     []string
 	}{
 		{
-			path:         ".github/workflows/release.yml",
-			orchestrator: "orchestrate-release",
-			producers: []producerContract{
-				{name: "build-vscode-extension", needs: workflowJobNeeds{"prepare-release", "orchestrate-release"}},
-				{name: "build-darwin-amd64", needs: workflowJobNeeds{"prepare-release", "orchestrate-release"}},
-				{name: "prepare-release-feature-report", needs: workflowJobNeeds{"prepare-release", "orchestrate-release"}},
+			path:          ".github/workflows/release.yml",
+			preparation:   "prepare-release",
+			gate:          "verify-release-source-ci",
+			orchestrator:  "orchestrate-release",
+			sourceSHA:     "${{ needs.prepare-release.outputs.sha }}",
+			buildChannel:  "release",
+			producerNeeds: workflowJobNeeds{"prepare-release", "verify-release-source-ci"},
+			producers: []string{
+				"build-vscode-extension",
+				"build-darwin-amd64",
+				"prepare-release-feature-report",
 			},
 		},
 		{
-			path:         ".github/workflows/rolling.yml",
-			orchestrator: "orchestrate-rolling",
-			producers: []producerContract{
-				{name: "build-darwin-amd64-rolling", needs: workflowJobNeeds{"prepare-rolling", "orchestrate-rolling"}},
-				{name: "prepare-rolling-release-notes", needs: workflowJobNeeds{"prepare-rolling", "orchestrate-rolling"}},
-				{name: "prepare-rolling-source-archive", needs: workflowJobNeeds{"prepare-rolling", "orchestrate-rolling"}},
+			path:          ".github/workflows/rolling.yml",
+			preparation:   "prepare-rolling",
+			gate:          "verify-rolling-source-ci",
+			orchestrator:  "orchestrate-rolling",
+			sourceSHA:     "${{ needs.prepare-rolling.outputs.source_sha }}",
+			buildChannel:  "rolling",
+			producerNeeds: workflowJobNeeds{"prepare-rolling", "verify-rolling-source-ci"},
+			producers: []string{
+				"build-darwin-amd64-rolling",
+				"prepare-rolling-release-notes",
+				"prepare-rolling-source-archive",
 			},
 		},
 	}
@@ -3238,13 +3248,23 @@ func TestReleaseCallersWaitForExactSourceCIBeforeProducingArtifacts(t *testing.T
 			var workflow workflowConfig
 			readYAMLConfig(t, testCase.path, &workflow)
 
+			gate := workflowJobByName(t, workflow.Jobs, testCase.gate)
+			assertWorkflowJobNeeds(t, gate, testCase.gate, workflowJobNeeds{testCase.preparation})
+			assertWorkflowJobPermissions(t, gate, testCase.gate, map[string]string{"contents": "read"})
+			assertWorkflowStringValues(t, []workflowStringValue{
+				{label: testCase.gate + " reusable workflow", got: gate.Uses, want: "./.github/workflows/release-source-ci.yml"},
+				{label: testCase.gate + " source SHA", got: gate.With["source_sha"], want: testCase.sourceSHA},
+				{label: testCase.gate + " build channel", got: gate.With["build_channel"], want: testCase.buildChannel},
+			})
+
 			orchestrator := workflowJobByName(t, workflow.Jobs, testCase.orchestrator)
+			assertWorkflowJobNeeds(t, orchestrator, testCase.orchestrator, workflowJobNeeds{testCase.preparation, testCase.gate})
 			if orchestrator.Uses != "./.github/workflows/release-orchestration.yml" {
 				t.Fatalf("%s uses = %q", testCase.orchestrator, orchestrator.Uses)
 			}
 			for _, producer := range testCase.producers {
-				job := workflowJobByName(t, workflow.Jobs, producer.name)
-				assertWorkflowJobNeeds(t, job, producer.name, producer.needs)
+				job := workflowJobByName(t, workflow.Jobs, producer)
+				assertWorkflowJobNeeds(t, job, producer, testCase.producerNeeds)
 			}
 		})
 	}

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3197,6 +3197,53 @@ func TestReleaseOrchestrationGatesGHCRPublicationOnValidatedArtifactProducers(t 
 	orchestrateRolling := workflowJobByName(t, rollingWorkflow.Jobs, "orchestrate-rolling")
 	assertWorkflowJobNeeds(t, orchestrateRolling, "orchestrate-rolling", workflowJobNeeds{"prepare-rolling", "build-darwin-amd64-rolling"})
 }
+func TestReleaseOrchestrationVerifiesRequiredSourceChecksBeforeReleaseBuilds(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
+
+	verification := workflowJobByName(t, workflow.Jobs, "verify-source-ci")
+	assertWorkflowJobPermissions(t, verification, "source CI verification", map[string]string{
+		"checks":   "read",
+		"contents": "read",
+	})
+	assertWorkflowJobOmitsCheckout(t, verification, "source CI verification")
+
+	step := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Verify required CI for source SHA")
+	assertWorkflowStepEnv(t, step, "source CI verification", map[string]string{
+		"PATH":             "/usr/bin:/bin",
+		"GH_TOKEN":         "${{ github.token }}",
+		"SOURCE_SHA":       "${{ inputs.source_sha || github.sha }}",
+		"PROTECTED_BRANCH": "main",
+	})
+	assertWorkflowStepRunContainsAll(t, step, "source CI verification", []string{
+		`rules_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/rules/branches/${PROTECTED_BRANCH}"`,
+		`check_runs_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/commits/${source_sha}/check-runs?per_page=100"`,
+		`statuses_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/commits/${source_sha}/status"`,
+		`select(.type == "required_status_checks")`,
+		`required_status_checks[]?`,
+		`unique_by(.context + ":" + (.integration_id | tostring))`,
+		`No required status checks are configured for ${PROTECTED_BRANCH}; refusing release promotion without exact CI validation.`,
+		`select(.head_sha == $source_sha)`,
+		`Required check ${context} is absent for exact source SHA ${source_sha}; refusing release promotion.`,
+		`Required check ${context} for ${source_sha} concluded ${check_conclusion:-unknown}; exact source SHA CI must pass before release.`,
+		`Required status ${context} for ${source_sha} is ${status_state:-unknown}; exact source SHA CI must pass before release.`,
+	})
+	if strings.Contains(step.Run, "scripts/") {
+		t.Fatal("source CI verification must use the GitHub API directly, not repository scripts")
+	}
+
+	for _, jobName := range []string{
+		"build-linux-windows",
+		"build-darwin",
+		"prepare-ghcr",
+		"prepare-ghcr-manifest",
+	} {
+		job := workflowJobByName(t, workflow.Jobs, jobName)
+		assertWorkflowJobNeeds(t, job, jobName, workflowJobNeeds{"verify-source-ci"})
+	}
+}
 
 func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {
 	t.Parallel()

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3105,7 +3105,7 @@ func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) 
 		{label: "source CI checkout action", got: checkout.Uses, want: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"},
 		{label: "source CI checkout ref", got: checkout.With["ref"], want: "${{ inputs.source_sha || github.sha }}"},
 		{label: "source CI checkout persist-credentials", got: checkout.With["persist-credentials"], want: "false"},
-		{label: "source CI checkout fetch-depth", got: checkout.With["fetch-depth"], want: "0"},
+		{label: "source CI checkout fetch-depth", got: checkout.With["fetch-depth"], want: "2"},
 	})
 
 	verifySource := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Verify exact release source")

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3115,8 +3115,13 @@ func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) 
 	})
 	assertWorkflowStepRunContainsAll(t, verifySource, "source CI verification", []string{
 		`[[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]`,
+		`echo "::error::Release source SHA must be a lowercase full 40-character commit SHA." >&2`,
+		`printf 'Rejected release source SHA: %q\n' "${source_sha}" >&2`,
 		`checked_out_sha="$(git rev-parse HEAD)"`,
 		`[ "${checked_out_sha}" != "${source_sha}" ]`,
+	})
+	assertWorkflowStepRunOmitsAll(t, verifySource, "source CI verification", []string{
+		`::error::Release source SHA must be a lowercase full 40-character commit SHA; got ${source_sha}.`,
 	})
 
 	setupGo := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Setup Go")

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -558,7 +558,7 @@ func TestReleaseWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
 
 	reportPreparation := workflowJobByName(t, workflow.Jobs, "prepare-release-feature-report")
-	assertWorkflowJobNeeds(t, reportPreparation, "release feature report preparation", workflowJobNeeds{"prepare-release"})
+	assertWorkflowJobNeeds(t, reportPreparation, "release feature report preparation", workflowJobNeeds{"prepare-release", "orchestrate-release"})
 	assertWorkflowJobPermissions(t, reportPreparation, "release feature report preparation", map[string]string{"contents": "read"})
 	assertWorkflowJobEnvEmpty(t, reportPreparation, "release feature report preparation")
 	assertWorkflowJobOmitsText(t, reportPreparation, "secrets.", "release feature report preparation must not receive secrets")
@@ -834,7 +834,7 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	assertWorkflowJobPermissions(t, darwinProducer, "rolling Darwin amd64 producer", map[string]string{"contents": "read"})
 
 	notesPreparation := workflowJobByName(t, workflow.Jobs, "prepare-rolling-release-notes")
-	assertWorkflowJobNeeds(t, notesPreparation, "rolling release note preparation", workflowJobNeeds{"prepare-rolling"})
+	assertWorkflowJobNeeds(t, notesPreparation, "rolling release note preparation", workflowJobNeeds{"prepare-rolling", "orchestrate-rolling"})
 	assertWorkflowJobPermissions(t, notesPreparation, "rolling release note preparation", map[string]string{"contents": "read"})
 	assertWorkflowJobEnvEmpty(t, notesPreparation, "rolling release note preparation")
 	assertWorkflowJobOmitsText(t, notesPreparation, "secrets.", "rolling release note preparation must not receive secrets")
@@ -884,7 +884,7 @@ func TestRollingWorkflowPublishesFromFreshValidatedInputs(t *testing.T) {
 	})
 
 	archivePreparation := workflowJobByName(t, workflow.Jobs, "prepare-rolling-source-archive")
-	assertWorkflowJobNeeds(t, archivePreparation, "rolling source archive preparation", workflowJobNeeds{"prepare-rolling"})
+	assertWorkflowJobNeeds(t, archivePreparation, "rolling source archive preparation", workflowJobNeeds{"prepare-rolling", "orchestrate-rolling"})
 	assertWorkflowJobPermissions(t, archivePreparation, "rolling source archive preparation", map[string]string{"contents": "read"})
 	assertWorkflowJobEnvEmpty(t, archivePreparation, "rolling source archive preparation")
 	assertWorkflowJobOmitsText(t, archivePreparation, "secrets.", "rolling source archive preparation must not receive secrets")
@@ -3196,6 +3196,58 @@ func TestReleaseCallersPassMemoryApprovalToSourceCI(t *testing.T) {
 		got:   release.Jobs["orchestrate-release"].With["memory_approved"],
 		want:  "false",
 	}})
+}
+
+func TestReleaseCallersWaitForExactSourceCIBeforeProducingArtifacts(t *testing.T) {
+	t.Parallel()
+
+	type producerContract struct {
+		name  string
+		needs workflowJobNeeds
+	}
+	testCases := []struct {
+		path         string
+		orchestrator string
+		producers    []producerContract
+	}{
+		{
+			path:         ".github/workflows/release.yml",
+			orchestrator: "orchestrate-release",
+			producers: []producerContract{
+				{name: "build-vscode-extension", needs: workflowJobNeeds{"prepare-release", "orchestrate-release"}},
+				{name: "build-darwin-amd64", needs: workflowJobNeeds{"prepare-release", "orchestrate-release"}},
+				{name: "prepare-release-feature-report", needs: workflowJobNeeds{"prepare-release", "orchestrate-release"}},
+			},
+		},
+		{
+			path:         ".github/workflows/rolling.yml",
+			orchestrator: "orchestrate-rolling",
+			producers: []producerContract{
+				{name: "build-darwin-amd64-rolling", needs: workflowJobNeeds{"prepare-rolling", "orchestrate-rolling"}},
+				{name: "prepare-rolling-release-notes", needs: workflowJobNeeds{"prepare-rolling", "orchestrate-rolling"}},
+				{name: "prepare-rolling-source-archive", needs: workflowJobNeeds{"prepare-rolling", "orchestrate-rolling"}},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.path, func(t *testing.T) {
+			t.Parallel()
+
+			var workflow workflowConfig
+			readYAMLConfig(t, testCase.path, &workflow)
+
+			orchestrator := workflowJobByName(t, workflow.Jobs, testCase.orchestrator)
+			if orchestrator.Uses != "./.github/workflows/release-orchestration.yml" {
+				t.Fatalf("%s uses = %q", testCase.orchestrator, orchestrator.Uses)
+			}
+			for _, producer := range testCase.producers {
+				job := workflowJobByName(t, workflow.Jobs, producer.name)
+				assertWorkflowJobNeeds(t, job, producer.name, producer.needs)
+			}
+		})
+	}
 }
 
 func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -49,7 +49,18 @@ type workflowDispatchConfig struct {
 	Inputs map[string]workflowInput `yaml:"inputs"`
 }
 
+type workflowCallConfig struct {
+	Inputs map[string]workflowCallInput `yaml:"inputs"`
+}
+
+type workflowCallInput struct {
+	Default  any    `yaml:"default"`
+	Required bool   `yaml:"required"`
+	Type     string `yaml:"type"`
+}
+
 type workflowOnConfig struct {
+	WorkflowCall     workflowCallConfig     `yaml:"workflow_call"`
 	WorkflowDispatch workflowDispatchConfig `yaml:"workflow_dispatch"`
 }
 
@@ -68,6 +79,8 @@ type workflowJobConfig struct {
 	RunsOn          string               `yaml:"runs-on"`
 	Steps           []workflowStepConfig `yaml:"steps"`
 	Strategy        workflowStrategy     `yaml:"strategy"`
+	Uses            string               `yaml:"uses"`
+	With            map[string]string    `yaml:"with"`
 }
 
 type workflowStrategy struct {
@@ -3132,13 +3145,13 @@ func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) 
 
 	ciGate := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Run exact source CI gate")
 	assertWorkflowStepEnv(t, ciGate, "exact source CI gate", map[string]string{
-		"BUILD_CHANNEL": "${{ inputs.build_channel }}",
-		"SOURCE_SHA":    "${{ inputs.source_sha || github.sha }}",
+		"BUILD_CHANNEL":        "${{ inputs.build_channel }}",
+		"MEMORY_BENCH_ENFORCE": "${{ inputs.memory_approved && '0' || '1' }}",
+		"SOURCE_SHA":           "${{ inputs.source_sha || github.sha }}",
 	})
 	assertWorkflowStepRunContainsAll(t, ciGate, "exact source CI gate", []string{
 		`parent_sha="$(git rev-parse "${SOURCE_SHA}^")"`,
 		`export MEMORY_BENCH_BASE="${parent_sha}"`,
-		`export MEMORY_BENCH_ENFORCE=0`,
 		`export DUPLICATION_BASE="${parent_sha}"`,
 		`export SUPPRESSION_BASE="${parent_sha}"`,
 		`make ci BUILD_CHANNEL="${BUILD_CHANNEL}"`,
@@ -3153,6 +3166,36 @@ func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) 
 		job := workflowJobByName(t, workflow.Jobs, jobName)
 		assertWorkflowJobNeeds(t, job, jobName, workflowJobNeeds{"verify-source-ci"})
 	}
+}
+
+func TestReleaseCallersPassMemoryApprovalToSourceCI(t *testing.T) {
+	t.Parallel()
+
+	var reusable workflowConfig
+	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &reusable)
+	approval, ok := reusable.On.WorkflowCall.Inputs["memory_approved"]
+	if !ok {
+		t.Fatal("release orchestration must define a memory_approved input")
+	}
+	if approval.Required || approval.Type != "boolean" || approval.Default != false {
+		t.Fatalf("memory_approved input = %#v, want optional boolean defaulting to false", approval)
+	}
+
+	var rolling workflowConfig
+	readYAMLConfig(t, ".github/workflows/rolling.yml", &rolling)
+	assertWorkflowStringValues(t, []workflowStringValue{{
+		label: "rolling memory approval",
+		got:   rolling.Jobs["orchestrate-rolling"].With["memory_approved"],
+		want:  "${{ contains(github.event.pull_request.labels.*.name, 'memory-approved') }}",
+	}})
+
+	var release workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &release)
+	assertWorkflowStringValues(t, []workflowStringValue{{
+		label: "release memory approval",
+		got:   release.Jobs["orchestrate-release"].With["memory_approved"],
+		want:  "false",
+	}})
 }
 
 func TestReleaseOrchestrationUsesFreshTrustedGHCRPublicationJobs(t *testing.T) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -106,7 +106,6 @@ func (n *workflowJobNeeds) UnmarshalYAML(node *yaml.Node) error {
 }
 
 type workflowStepConfig struct {
-	ContinueOnError  bool              `yaml:"continue-on-error"`
 	Name             string            `yaml:"name"`
 	ID               string            `yaml:"id"`
 	If               string            `yaml:"if"`
@@ -118,22 +117,13 @@ type workflowStepConfig struct {
 	With             map[string]string `yaml:"with"`
 }
 
-type releasePleaseChangelogSection struct {
-	Type    string `json:"type"`
-	Section string `json:"section"`
-	Hidden  bool   `json:"hidden"`
-}
-
 func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	t.Parallel()
 
 	var config struct {
-		Versioning string `json:"versioning"`
-		Packages   map[string]struct {
-			Versioning        string                          `json:"versioning"`
-			ChangelogPath     string                          `json:"changelog-path"`
-			ChangelogSections []releasePleaseChangelogSection `json:"changelog-sections"`
-			ExtraFiles        []struct {
+		Packages map[string]struct {
+			ChangelogPath string `json:"changelog-path"`
+			ExtraFiles    []struct {
 				Path string `json:"path"`
 			} `json:"extra-files"`
 		} `json:"packages"`
@@ -150,11 +140,6 @@ func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	if rootPackage.ChangelogPath == "extensions/vscode-lopper/CHANGELOG.md" {
 		t.Fatal("root release notes must not be written to the VS Code extension changelog")
 	}
-	if config.Versioning != "" || rootPackage.Versioning != "" {
-		t.Fatal("release-please must keep default versioning so preview commits bump patch and feat graduations bump minor")
-	}
-
-	assertPreviewChangelogSection(t, rootPackage.ChangelogSections)
 
 	extraFiles := map[string]bool{}
 	for _, extraFile := range rootPackage.ExtraFiles {
@@ -170,21 +155,6 @@ func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	}
 }
 
-func assertPreviewChangelogSection(t *testing.T, sections []releasePleaseChangelogSection) {
-	t.Helper()
-
-	for _, section := range sections {
-		if section.Type != "preview" {
-			continue
-		}
-		if section.Section != "Preview Features" || section.Hidden {
-			t.Fatalf("preview changelog section = %#v, want visible Preview Features", section)
-		}
-		return
-	}
-	t.Fatal("release-please config must expose preview commits in release notes")
-}
-
 func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	t.Parallel()
 
@@ -195,8 +165,8 @@ func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	if !ok {
 		t.Fatal("graduate-feature workflow must define the milestone input")
 	}
-	if milestone.Default != "v1.9.0" {
-		t.Fatalf("graduate-feature milestone default = %q, want v1.9.0", milestone.Default)
+	if milestone.Default != "v1.7.0" {
+		t.Fatalf("graduate-feature milestone default = %q, want v1.7.0", milestone.Default)
 	}
 
 	workflowText := readConfig(t, ".github/workflows/graduate-feature.yml")
@@ -205,70 +175,6 @@ func TestGraduateFeatureWorkflowTargetsCurrentSeries(t *testing.T) {
 	}
 	if strings.Contains(workflowText, "--label target-series:") {
 		t.Fatal("graduate-feature workflow must not hardcode a target-series label")
-	}
-	for _, want := range []string{
-		`git commit -m "feat(flags): graduate ${FEATURE} to stable"`,
-		`--title "feat(flags): graduate ${FEATURE} to stable"`,
-	} {
-		if !strings.Contains(workflowText, want) {
-			t.Fatalf("graduate-feature workflow must preserve the minor-bump title %q", want)
-		}
-	}
-}
-
-func TestFeatureFlagEnforcementClassifiesPreviewPRs(t *testing.T) {
-	t.Parallel()
-
-	var workflow workflowConfig
-	readYAMLConfig(t, ".github/workflows/feature-flag-enforcement.yml", &workflow)
-	checkout := workflowStepByName(t, workflow.Jobs, "enforce", "Checkout")
-	if checkout.With["fetch-depth"] != "0" {
-		t.Fatal("feature flag enforcement checkout must fetch complete base history for stale PRs")
-	}
-	if checkout.With["persist-credentials"] != "false" {
-		t.Fatal("feature flag enforcement checkout must not persist credentials")
-	}
-	classify := workflowStepByName(t, workflow.Jobs, "enforce", "Classify PR")
-	if !strings.Contains(classify.Run, `grep -Eq '^(feat|preview)`) {
-		t.Fatal("feature flag enforcement must classify preview titles as feature PRs")
-	}
-	if !strings.Contains(classify.Run, `echo "preview_pr=true"`) {
-		t.Fatal("feature flag enforcement must expose preview PR classification")
-	}
-	for _, want := range []string{
-		`sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'`,
-		`printf '%s\n' "${pr_title}"`,
-	} {
-		if !strings.Contains(classify.Run, want) {
-			t.Fatalf("feature flag enforcement must classify the trimmed PR title using %q", want)
-		}
-	}
-
-	rejectOverrides := workflowStepByName(t, workflow.Jobs, "enforce", "Reject release overrides on preview PRs")
-	assertWorkflowStringValues(t, []workflowStringValue{
-		{label: "preview override condition", got: rejectOverrides.If, want: "${{ steps.classify_pr.outputs.preview_pr == 'true' }}"},
-		{label: "preview PR body", got: rejectOverrides.Env["PR_BODY"], want: "${{ github.event.pull_request.body }}"},
-	})
-	assertWorkflowStepRunContainsAll(t, rejectOverrides, "preview release override guard", []string{
-		`release_directive_pattern='^(BREAKING[ -]CHANGE|Release-As):|(BEGIN|END)_(COMMIT_OVERRIDE|NESTED_COMMIT)'`,
-		`non_preview_entry_pattern='^(feat|feature|fix|bug|perf|docs|refactor|revert)`,
-		`printf '%s\n' "${PR_BODY}"`,
-		`grep -Eiq "${release_directive_pattern}" "${pr_body}"`,
-		`grep -Eiq "${non_preview_entry_pattern}" "${pr_body}"`,
-		`grep -Eiq "${release_directive_pattern}" "${commit_messages}"`,
-		`grep -Eiq "${non_preview_entry_pattern}" "${commit_messages}"`,
-		`merge_base="$(git merge-base "origin/${base_ref}" HEAD)"`,
-		`git log --format=%B "${merge_base}..HEAD"`,
-		`(BREAKING[ -]CHANGE|Release-As)`,
-		`(feat|feature|fix|bug|perf|docs|refactor|revert)`,
-		`?!:[[:space:]]+[^[:space:]]`,
-		`[^[:space:]]'`,
-	})
-	if got := strings.Count(rejectOverrides.Run, "exit 1"); got != 3 {
-		t.Fatalf("preview release override guard failure exits = %d, want 3", got)
-	}
-	if strings.Contains(rejectOverrides.Run, "commit_subjects") {
-		t.Fatal("preview release override guard must scan full commit messages instead of subjects only")
 	}
 }
 
@@ -3176,63 +3082,57 @@ func TestReleaseOrchestrationUsesStaticGHCRPreparationMatrix(t *testing.T) {
 		t.Fatalf("prepare-ghcr build tags = %q, want image_tags output", build.With["tags"])
 	}
 	publishImages := workflow.Jobs["publish-ghcr-images"]
-	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"build-linux-windows", "build-darwin", "prepare-ghcr"})
+	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"prepare-ghcr"})
 	if publishImages.If != "" {
 		t.Fatalf("publish-ghcr-images if = %q, want no override of failed-needs handling", publishImages.If)
 	}
 }
 
-func TestReleaseOrchestrationGatesGHCRPublicationOnValidatedArtifactProducers(t *testing.T) {
-	t.Parallel()
-
-	var workflow workflowConfig
-	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
-
-	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
-	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"build-linux-windows", "build-darwin", "prepare-ghcr"})
-
-	var rollingWorkflow workflowConfig
-	readYAMLConfig(t, ".github/workflows/rolling.yml", &rollingWorkflow)
-
-	orchestrateRolling := workflowJobByName(t, rollingWorkflow.Jobs, "orchestrate-rolling")
-	assertWorkflowJobNeeds(t, orchestrateRolling, "orchestrate-rolling", workflowJobNeeds{"prepare-rolling", "build-darwin-amd64-rolling"})
-}
-func TestReleaseOrchestrationVerifiesRequiredSourceChecksBeforeReleaseBuilds(t *testing.T) {
+func TestReleaseOrchestrationRunsExactSourceCIBeforeReleaseBuilds(t *testing.T) {
 	t.Parallel()
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/release-orchestration.yml", &workflow)
 
 	verification := workflowJobByName(t, workflow.Jobs, "verify-source-ci")
-	assertWorkflowJobPermissions(t, verification, "source CI verification", map[string]string{
-		"checks":   "read",
-		"contents": "read",
-	})
-	assertWorkflowJobOmitsCheckout(t, verification, "source CI verification")
+	assertWorkflowJobPermissions(t, verification, "source CI verification", map[string]string{"contents": "read"})
+	assertWorkflowJobOmitsText(t, verification, "secrets.", "source CI verification must not receive secrets")
+	assertWorkflowJobStepRunsOmitAllFold(t, verification, "source CI verification", []string{"gh api", "curl "})
+	assertWorkflowStepOrder(t, verification, "Checkout exact release source", "Verify exact release source", "Setup Go", "Install shellcheck", "Resolve gosec version", "Install Go tooling", "Run exact source CI gate", "Verify demo assets")
 
-	step := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Verify required CI for source SHA")
-	assertWorkflowStepEnv(t, step, "source CI verification", map[string]string{
-		"PATH":             "/usr/bin:/bin",
-		"GH_TOKEN":         "${{ github.token }}",
-		"SOURCE_SHA":       "${{ inputs.source_sha || github.sha }}",
-		"PROTECTED_BRANCH": "main",
+	checkout := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Checkout exact release source")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "source CI checkout action", got: checkout.Uses, want: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"},
+		{label: "source CI checkout ref", got: checkout.With["ref"], want: "${{ inputs.source_sha || github.sha }}"},
+		{label: "source CI checkout persist-credentials", got: checkout.With["persist-credentials"], want: "false"},
+		{label: "source CI checkout fetch-depth", got: checkout.With["fetch-depth"], want: "0"},
 	})
-	assertWorkflowStepRunContainsAll(t, step, "source CI verification", []string{
-		`rules_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/rules/branches/${PROTECTED_BRANCH}"`,
-		`check_runs_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/commits/${source_sha}/check-runs?per_page=100"`,
-		`statuses_endpoint="${api_url}/repos/${GITHUB_REPOSITORY}/commits/${source_sha}/status"`,
-		`select(.type == "required_status_checks")`,
-		`required_status_checks[]?`,
-		`unique_by(.context + ":" + (.integration_id | tostring))`,
-		`No required status checks are configured for ${PROTECTED_BRANCH}; refusing release promotion without exact CI validation.`,
-		`select(.head_sha == $source_sha)`,
-		`Required check ${context} is absent for exact source SHA ${source_sha}; refusing release promotion.`,
-		`Required check ${context} for ${source_sha} concluded ${check_conclusion:-unknown}; exact source SHA CI must pass before release.`,
-		`Required status ${context} for ${source_sha} is ${status_state:-unknown}; exact source SHA CI must pass before release.`,
+
+	verifySource := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Verify exact release source")
+	assertWorkflowStepEnv(t, verifySource, "source CI verification", map[string]string{
+		"PATH":       "/usr/bin:/bin",
+		"SOURCE_SHA": "${{ inputs.source_sha || github.sha }}",
 	})
-	if strings.Contains(step.Run, "scripts/") {
-		t.Fatal("source CI verification must use the GitHub API directly, not repository scripts")
-	}
+	assertWorkflowStepRunContainsAll(t, verifySource, "source CI verification", []string{
+		`[[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]`,
+		`checked_out_sha="$(git rev-parse HEAD)"`,
+		`[ "${checked_out_sha}" != "${source_sha}" ]`,
+	})
+
+	setupGo := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Setup Go")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "source CI setup-go action", got: setupGo.Uses, want: "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c"},
+		{label: "source CI Go version source", got: setupGo.With["go-version-file"], want: "go.mod"},
+	})
+
+	ciGate := workflowStepByName(t, workflow.Jobs, "verify-source-ci", "Run exact source CI gate")
+	assertWorkflowStepEnv(t, ciGate, "exact source CI gate", map[string]string{
+		"SOURCE_SHA": "${{ inputs.source_sha || github.sha }}",
+	})
+	assertWorkflowStepRunContainsAll(t, ciGate, "exact source CI gate", []string{
+		`parent_sha="$(git rev-parse "${SOURCE_SHA}^")"`,
+		`MEMORY_BENCH_BASE="${parent_sha}" make ci`,
+	})
 
 	for _, jobName := range []string{
 		"build-linux-windows",
@@ -3316,7 +3216,7 @@ func assertTrustedGHCRImagePublisher(t *testing.T, workflow workflowConfig, arch
 	t.Helper()
 
 	publishImages := workflowJobByName(t, workflow.Jobs, "publish-ghcr-images")
-	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"build-linux-windows", "build-darwin", "prepare-ghcr"})
+	assertWorkflowJobNeeds(t, publishImages, "publish-ghcr-images", workflowJobNeeds{"prepare-ghcr"})
 	assertWorkflowJobPermissions(t, publishImages, "publish-ghcr-images", map[string]string{"packages": "write"})
 	assertFreshGHCRPublisher(t, publishImages, "Log in to GHCR")
 	validation := workflowStepByName(t, workflow.Jobs, "publish-ghcr-images", "Validate OCI publication payloads")


### PR DESCRIPTION
## Summary

Closes #1236.

Release promotion previously trusted the selected source SHA and started build/publication work without proving that exact post-merge source passed the repository CI gate. Checking PR-required status contexts on a squash SHA is not valid because those attestations belong to the PR head, so this change performs the verification directly in an isolated read-only job.

## Changes

- Add a dedicated reusable source-CI workflow that requires the exact promoted SHA, checks out and verifies that commit with persisted credentials disabled, and runs without secrets or write permissions.
- Run the repository's full `make ci` gate plus demo-asset verification against that immutable source, with diff-based checks anchored to its parent and the caller's release build channel.
- Preserve approved rolling memory-regression handling through a trusted boolean derived from the merged PR's `memory-approved` label; stable releases remain strict by default.
- Make stable and rolling orchestration plus every source-derived caller artifact producer depend directly on the source-CI gate, preserving post-gate fan-out while keeping publication behind the complete artifact set.
- Add focused workflow-contract coverage for source binding, permissions, caller DAG ordering, memory approval, pinned actions, and CI configuration, and document the reusable gate.

## Validation

Commands and checks run:

```bash
go test ./scripts -run 'TestRelease(SourceCIRunsExactSourceGate|CallersPassMemoryApprovalToSourceCI|CallersWaitForExactSourceCIBeforeProducingArtifacts|WorkflowPublishesFromFreshValidatedInputs)$|TestRollingWorkflowPublishesFromFreshValidatedInputs$' -count=1
go test ./scripts -count=1
make actionlint
make ci
```

Additional manual validation:

- Verified the source-CI workflow has exactly one `make ci` invocation and both caller DAGs bind their orchestrator and source-derived artifact producers to the same required source SHA gate.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Adds one serialized read-only CI gate before stable or rolling build fan-out.
- Memory benchmark impact: The gate compares against the promoted commit's parent; rolling releases retain an approved-regression exception only when the merged PR carries `memory-approved`.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
