### PR TITLE
fix(ci): pin Sonar review action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
           SONAR_HOST_URL: https://sonarcloud.io
         if: ${{ github.event_name == 'pull_request' && !env.ACT && env.SONAR_TOKEN != '' }}
         continue-on-error: true
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const marker = '<!-- lopper-sonar-review -->';

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -1,0 +1,30 @@
+package scripts
+
+import "testing"
+
+func TestCIWorkflowPinsPrivilegedSonarReviewCommentStep(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/ci.yml", &workflow)
+
+	verify := workflowJobByName(t, workflow.Jobs, "verify")
+	assertWorkflowJobPermissions(t, verify, "ci verify", map[string]string{
+		"contents":      "read",
+		"issues":        "write",
+		"pull-requests": "write",
+	})
+
+	assertWorkflowEnvKeyOnlyOnStep(t, workflow.Jobs, "SONAR_TOKEN", "verify", "Post SonarQube review comments (PR)")
+
+	sonar := workflowStepByName(t, workflow.Jobs, "verify", "Post SonarQube review comments (PR)")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "Sonar review comment action", got: sonar.Uses, want: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3"},
+		{label: "Sonar review comment condition", got: sonar.If, want: "${{ github.event_name == 'pull_request' && !env.ACT && env.SONAR_TOKEN != '' }}"},
+	})
+	assertWorkflowStepEnv(t, sonar, "Sonar review comment step", map[string]string{
+		"SONAR_HOST_URL":    "https://sonarcloud.io",
+		"SONAR_PROJECT_KEY": "ben-ranford_lopper",
+		"SONAR_TOKEN":       "${{ secrets.SONAR_TOKEN }}",
+	})
+}


### PR DESCRIPTION
## Summary

This PR fixes the privileged Sonar review comment step in `.github/workflows/ci.yml`. That step runs with `SONAR_TOKEN` in scope on pull request CI, so leaving `actions/github-script@v9` as a mutable tag meant compromised or retargeted upstream action code could execute with that token and the job's existing GitHub permissions.

Root cause: the Sonar-specific `github-script` invocation was not pinned to the immutable commit behind `v9`, even though this repo already uses full-SHA action pins for other credentialed workflow paths.

Closes #1263.

## Changes

- Pin `Post SonarQube review comments (PR)` from `actions/github-script@v9` to `actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3`.
- Add `scripts/ci_workflow_test.go` to assert `SONAR_TOKEN` stays scoped only to that step, the step keeps existing permissions, and the action ref stays SHA-pinned.

## Validation

Commands and checks run:

```bash
go test ./scripts -run TestCIWorkflowPinsPrivilegedSonarReviewCommentStep -count=1
make ci
```

Additional manual validation:

- N/A

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None; `make ci` memory delta passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

