### PR TITLE
fix(ci): pin privileged PR workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,7 +510,7 @@ jobs:
 
       - name: Upload binary artifact
         if: ${{ always() && !env.ACT }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: lopper-bin
           path: bin/lopper

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 
       - name: Setup Go
         if: ${{ !env.ACT }}
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           go-version-file: go.mod
 
@@ -107,7 +107,7 @@ jobs:
       - name: Comment memory benchmark report on PR
         if: ${{ github.event_name == 'pull_request' && !env.ACT && always() }}
         continue-on-error: true
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const fs = require('node:fs');
@@ -199,7 +199,7 @@ jobs:
       - name: Comment lopper report on PR
         if: ${{ github.event_name == 'pull_request' && !env.ACT }}
         continue-on-error: true
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           LOPPER_BASE_OUTCOME: ${{ steps.lopper_base.outcome }}
           LOPPER_DELTA_OUTCOME: ${{ steps.lopper_delta.outcome }}
@@ -450,7 +450,7 @@ jobs:
 
       - name: Comment on coverage failure
         if: ${{ github.event_name == 'pull_request' && steps.cov.outcome == 'failure' && !env.ACT }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           COVERAGE_MIN: 98
           COVERAGE_PACKAGE_MIN: 98

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -1,21 +1,62 @@
 package scripts
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestCIWorkflowPinsPrivilegedSonarReviewCommentStep(t *testing.T) {
+func TestCIWorkflowPinsPrivilegedVerifyActions(t *testing.T) {
 	t.Parallel()
 
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/ci.yml", &workflow)
 
 	verify := workflowJobByName(t, workflow.Jobs, "verify")
-	assertWorkflowJobPermissions(t, verify, "ci verify", map[string]string{
+	assertWorkflowJobPermissions(t, verify, "ci verify job", map[string]string{
 		"contents":      "read",
 		"issues":        "write",
 		"pull-requests": "write",
 	})
 
 	assertWorkflowEnvKeyOnlyOnStep(t, workflow.Jobs, "SONAR_TOKEN", "verify", "Post SonarQube review comments (PR)")
+
+	for _, check := range []struct {
+		stepName string
+		wantUses string
+	}{
+		{
+			stepName: "Checkout",
+			wantUses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+		},
+		{
+			stepName: "Setup Go",
+			wantUses: "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e",
+		},
+		{
+			stepName: "Comment memory benchmark report on PR",
+			wantUses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+		},
+		{
+			stepName: "Comment lopper report on PR",
+			wantUses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+		},
+		{
+			stepName: "Post SonarQube review comments (PR)",
+			wantUses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+		},
+		{
+			stepName: "Comment on coverage failure",
+			wantUses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+		},
+	} {
+		step := workflowStepByName(t, workflow.Jobs, "verify", check.stepName)
+		if step.Uses != check.wantUses {
+			t.Fatalf("verify step %q uses %q, want %q", check.stepName, step.Uses, check.wantUses)
+		}
+		if strings.Contains(step.Uses, "@v") {
+			t.Fatalf("verify step %q must not use a mutable major tag: %q", check.stepName, step.Uses)
+		}
+	}
 
 	sonar := workflowStepByName(t, workflow.Jobs, "verify", "Post SonarQube review comments (PR)")
 	assertWorkflowStringValues(t, []workflowStringValue{

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -1,7 +1,7 @@
 package scripts
 
 import (
-	"strings"
+	"regexp"
 	"testing"
 )
 
@@ -48,13 +48,21 @@ func TestCIWorkflowPinsPrivilegedVerifyActions(t *testing.T) {
 			stepName: "Comment on coverage failure",
 			wantUses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
 		},
+		{
+			stepName: "Upload binary artifact",
+			wantUses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+		},
 	} {
 		step := workflowStepByName(t, workflow.Jobs, "verify", check.stepName)
 		if step.Uses != check.wantUses {
 			t.Fatalf("verify step %q uses %q, want %q", check.stepName, step.Uses, check.wantUses)
 		}
-		if strings.Contains(step.Uses, "@v") {
-			t.Fatalf("verify step %q must not use a mutable major tag: %q", check.stepName, step.Uses)
+	}
+
+	immutableAction := regexp.MustCompile(`^[^@[:space:]]+@[0-9a-f]{40}$`)
+	for _, step := range verify.Steps {
+		if step.Uses != "" && !immutableAction.MatchString(step.Uses) {
+			t.Fatalf("verify step %q must use an immutable action SHA: %q", step.Name, step.Uses)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Closes #1265.

The `verify` job in `.github/workflows/ci.yml` still referenced mutable major tags for `actions/checkout`, `actions/setup-go`, and `actions/github-script` while running on pull requests with `issues: write` and `pull-requests: write`. The Sonar review comment step also exposes `SONAR_TOKEN`, so a retargeted action tag could execute privileged code in CI and exfiltrate credentials or mutate PR state.

## Changes

- Pinned every third-party action in the privileged verify job to immutable full commit SHAs, including checkout, Go setup, artifact upload, and each GitHub Script comment step.
- Added scripts/ci_workflow_test.go coverage that rejects any non-SHA action in the writer job, preserves the expected trusted action identities, and verifies SONAR_TOKEN is scoped only to the Sonar step.
- Kept the change scoped to issue #1265 without changing the broader writable-token model tracked separately.

## Validation

Commands and checks run:

```bash
go test ./scripts -run TestCIWorkflowPinsPrivilegedVerifyActions -count=1
go test ./scripts -count=1
make ci
```

Additional manual validation:

- None.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: `make ci` memory benchmark gate passed with no regressions.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
