### PR TITLE
fix(report): sanitize PR comment markdown

### DIFF
--- a/internal/report/format_pr_comment.go
+++ b/internal/report/format_pr_comment.go
@@ -7,6 +7,15 @@ import (
 	"strings"
 )
 
+var prCommentMarkdownPairs = []string{
+	"\r\n", "\\n", "\r", "\\n", "\n", "\\n", "\t", "\\t",
+	"&", "&amp;", "<", "&lt;", ">", "&gt;",
+	"\\", "\\\\", "|", "\\|", "`", "'",
+	"[", "\\[", "]", "\\]", "(", "\\(", ")", "\\)", "!", "\\!",
+}
+
+var prCommentMarkdownReplacer = strings.NewReplacer(prCommentMarkdownPairs...)
+
 func formatPRComment(report Report) string {
 	comparison := report.BaselineComparison
 	if comparison == nil {
@@ -41,7 +50,7 @@ func formatPRComment(report Report) string {
 		buffer.WriteString("| # | Dependency | Language | SPDX |\n")
 		buffer.WriteString("| --- | --- | --- | --- |\n")
 		for i, denied := range comparison.NewDeniedLicenses {
-			fmt.Fprintf(&buffer, "| %d | `%s` | %s | %s |\n", i+1, escapeMarkdownTable(denied.Name), escapeMarkdownTable(denied.Language), escapeMarkdownTable(denied.SPDX))
+			fmt.Fprintf(&buffer, "| %d | %s | %s | %s |\n", i+1, markdownCodeCell(denied.Name), markdownCodeCell(denied.Language), markdownCodeCell(denied.SPDX))
 		}
 	}
 
@@ -52,12 +61,12 @@ func formatPRComment(report Report) string {
 		for i, finding := range topVulnerabilityDeltas(comparison.NewReachableVulnerabilities, 10) {
 			row := []string{
 				fmt.Sprintf("%d", i+1),
-				"`" + escapeMarkdownTable(finding.Name) + "`",
-				escapeMarkdownTable(finding.AdvisoryID),
-				escapeMarkdownTable(finding.Severity),
-				escapeMarkdownTable(fmt.Sprintf("%s (%.1f)", finding.Priority, finding.PriorityScore)),
-				escapeMarkdownTable(emptyDash(finding.FixedVersion)),
-				escapeMarkdownTable(finding.Source),
+				markdownCodeCell(finding.Name),
+				markdownCodeCell(finding.AdvisoryID),
+				markdownCodeCell(finding.Severity),
+				markdownCodeCell(fmt.Sprintf("%s (%.1f)", finding.Priority, finding.PriorityScore)),
+				markdownCodeCell(emptyDash(finding.FixedVersion)),
+				markdownCodeCell(finding.Source),
 			}
 			buffer.WriteString("| " + strings.Join(row, " | ") + " |\n")
 		}
@@ -79,8 +88,8 @@ func formatPRComment(report Report) string {
 		row := []string{
 			fmt.Sprintf("%d", i+1),
 			string(delta.Kind),
-			"`" + escapeMarkdownTable(delta.Name) + "`",
-			escapeMarkdownTable(delta.Language),
+			markdownCodeCell(delta.Name),
+			markdownCodeCell(delta.Language),
 			signedPct(delta.UsedPercentDelta),
 			signedInt(delta.UsedExportsCountDelta),
 			signedInt(delta.TotalExportsCountDelta),
@@ -112,9 +121,9 @@ func appendRuntimePRCommentSection(buffer *strings.Builder, title string, deltas
 	for i, delta := range top {
 		row := []string{
 			fmt.Sprintf("%d", i+1),
-			"`" + escapeMarkdownTable(delta.Name) + "`",
-			escapeMarkdownTable(delta.Language),
-			escapeMarkdownTable(formatRuntimeDelta(delta.RuntimeDelta)),
+			markdownCodeCell(delta.Name),
+			markdownCodeCell(delta.Language),
+			markdownCodeCell(formatRuntimeDelta(delta.RuntimeDelta)),
 		}
 		buffer.WriteString("| " + strings.Join(row, " | ") + " |\n")
 	}
@@ -202,5 +211,9 @@ func signedBytes(value int64) string {
 }
 
 func escapeMarkdownTable(value string) string {
-	return strings.NewReplacer("|", "\\|", "`", "'", "\n", "\\n", "\r", "\\r").Replace(value)
+	return sanitizeTerminalString(prCommentMarkdownReplacer.Replace(value))
+}
+
+func markdownCodeCell(value string) string {
+	return "`" + escapeMarkdownTable(value) + "`"
 }

--- a/internal/report/format_pr_comment.go
+++ b/internal/report/format_pr_comment.go
@@ -7,14 +7,20 @@ import (
 	"strings"
 )
 
-var prCommentMarkdownPairs = []string{
+var prCommentTablePairs = []string{
 	"\r\n", "\\n", "\r", "\\n", "\n", "\\n", "\t", "\\t",
 	"&", "&amp;", "<", "&lt;", ">", "&gt;",
 	"\\", "\\\\", "|", "\\|", "`", "'",
-	"[", "\\[", "]", "\\]", "(", "\\(", ")", "\\)", "!", "\\!",
+	"[", "\\[", "]", "\\]",
 }
 
-var prCommentMarkdownReplacer = strings.NewReplacer(prCommentMarkdownPairs...)
+var prCommentCodePairs = []string{
+	"\r\n", "\\n", "\r", "\\n", "\n", "\\n", "\t", "\\t",
+	"\\", "\\\\", "|", "\\|", "`", "'",
+}
+
+var prCommentTableReplacer = strings.NewReplacer(prCommentTablePairs...)
+var prCommentCodeReplacer = strings.NewReplacer(prCommentCodePairs...)
 
 func formatPRComment(report Report) string {
 	comparison := report.BaselineComparison
@@ -50,7 +56,7 @@ func formatPRComment(report Report) string {
 		buffer.WriteString("| # | Dependency | Language | SPDX |\n")
 		buffer.WriteString("| --- | --- | --- | --- |\n")
 		for i, denied := range comparison.NewDeniedLicenses {
-			fmt.Fprintf(&buffer, "| %d | %s | %s | %s |\n", i+1, markdownCodeCell(denied.Name), markdownCodeCell(denied.Language), markdownCodeCell(denied.SPDX))
+			fmt.Fprintf(&buffer, "| %d | %s | %s | %s |\n", i+1, markdownCodeCell(denied.Name), escapeMarkdownTable(denied.Language), escapeMarkdownTable(denied.SPDX))
 		}
 	}
 
@@ -62,11 +68,11 @@ func formatPRComment(report Report) string {
 			row := []string{
 				fmt.Sprintf("%d", i+1),
 				markdownCodeCell(finding.Name),
-				markdownCodeCell(finding.AdvisoryID),
-				markdownCodeCell(finding.Severity),
-				markdownCodeCell(fmt.Sprintf("%s (%.1f)", finding.Priority, finding.PriorityScore)),
-				markdownCodeCell(emptyDash(finding.FixedVersion)),
-				markdownCodeCell(finding.Source),
+				escapeMarkdownTable(finding.AdvisoryID),
+				escapeMarkdownTable(finding.Severity),
+				escapeMarkdownTable(fmt.Sprintf("%s (%.1f)", finding.Priority, finding.PriorityScore)),
+				escapeMarkdownTable(emptyDash(finding.FixedVersion)),
+				escapeMarkdownTable(finding.Source),
 			}
 			buffer.WriteString("| " + strings.Join(row, " | ") + " |\n")
 		}
@@ -89,7 +95,7 @@ func formatPRComment(report Report) string {
 			fmt.Sprintf("%d", i+1),
 			string(delta.Kind),
 			markdownCodeCell(delta.Name),
-			markdownCodeCell(delta.Language),
+			escapeMarkdownTable(delta.Language),
 			signedPct(delta.UsedPercentDelta),
 			signedInt(delta.UsedExportsCountDelta),
 			signedInt(delta.TotalExportsCountDelta),
@@ -122,8 +128,8 @@ func appendRuntimePRCommentSection(buffer *strings.Builder, title string, deltas
 		row := []string{
 			fmt.Sprintf("%d", i+1),
 			markdownCodeCell(delta.Name),
-			markdownCodeCell(delta.Language),
-			markdownCodeCell(formatRuntimeDelta(delta.RuntimeDelta)),
+			escapeMarkdownTable(delta.Language),
+			escapeMarkdownTable(formatRuntimeDelta(delta.RuntimeDelta)),
 		}
 		buffer.WriteString("| " + strings.Join(row, " | ") + " |\n")
 	}
@@ -211,9 +217,15 @@ func signedBytes(value int64) string {
 }
 
 func escapeMarkdownTable(value string) string {
-	return sanitizeTerminalString(prCommentMarkdownReplacer.Replace(value))
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return sanitizeTerminalString(prCommentTableReplacer.Replace(value))
 }
 
 func markdownCodeCell(value string) string {
-	return "`" + escapeMarkdownTable(value) + "`"
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return "`" + sanitizeTerminalString(prCommentCodeReplacer.Replace(value)) + "`"
 }

--- a/internal/report/format_test.go
+++ b/internal/report/format_test.go
@@ -285,7 +285,7 @@ func TestFormatPRCommentZeroDeltasAreUnsigned(t *testing.T) {
 		t.Fatalf("format pr-comment with zero deltas: %v", err)
 	}
 
-	assertOutputContains(t, output, "| Dependency count | 0 |", "| Used percent | 0.0% |", "| Waste percent | 0.0% |", "| Estimated unused bytes | 0 B |", "| Known licenses | 0 |", "| Unknown licenses | 0 |", "| Denied licenses | 0 |", "| 1 | changed | `same` | `js-ts` | 0.0% | 0 | 0 | 0 B |")
+	assertOutputContains(t, output, "| Dependency count | 0 |", "| Used percent | 0.0% |", "| Waste percent | 0.0% |", "| Estimated unused bytes | 0 B |", "| Known licenses | 0 |", "| Unknown licenses | 0 |", "| Denied licenses | 0 |", "| 1 | changed | `same` | js-ts | 0.0% | 0 | 0 | 0 B |")
 	if strings.Contains(output, "+0") {
 		t.Fatalf("expected zero deltas to render without a leading plus, got %q", output)
 	}
@@ -335,14 +335,14 @@ func TestFormatPRCommentSanitizesDependencyAndLanguageMarkdown(t *testing.T) {
 	}
 
 	expectedContains := []string{
-		"`safe'name\\nwith\\|new-line\\t&lt;img src=x&gt;\\x1b\\[31m\\[link\\]\\(https://example.com\\)`",
-		"`js-ts\\n&lt;script&gt;alert\\(1\\)&lt;/script&gt;\\t\\!\\[img\\]\\(https://example.com/img.png\\)`",
-		"| 1 | added | `safe'name\\nwith\\|new-line\\t&lt;img src=x&gt;\\x1b\\[31m\\[link\\]\\(https://example.com\\)` | `js-ts\\n&lt;script&gt;alert\\(1\\)&lt;/script&gt;\\t\\!\\[img\\]\\(https://example.com/img.png\\)` |",
-		"| 1 | `deny\\|dep` | `lang\\x07` | `GPL-3.0\\n\\!\\[badge\\]\\(https://example.com/badge.svg\\)` |",
-		"| 1 | `runtime&lt;dep&gt;` | `lang\\[rt\\]` | `runtime-only regression` |",
+		"`safe'name\\nwith\\|new-line\\t<img src=x>\\x1b[31m[link](https://example.com)`",
+		"js-ts\\n&lt;script&gt;alert(1)&lt;/script&gt;\\t!\\[img\\](https://example.com/img.png)",
+		"| 1 | added | `safe'name\\nwith\\|new-line\\t<img src=x>\\x1b[31m[link](https://example.com)` | js-ts\\n&lt;script&gt;alert(1)&lt;/script&gt;\\t!\\[img\\](https://example.com/img.png) |",
+		"| 1 | `deny\\|dep` | lang\\x07 | GPL-3.0\\n!\\[badge\\](https://example.com/badge.svg) |",
+		"| 1 | `runtime<dep>` | lang\\[rt\\] | runtime-only regression |",
 	}
 	assertOutputContains(t, output, expectedContains...)
-	assertOutputNotContains(t, output, "<img src=x>", "<script>", "[link](https://example.com)", "![img](https://example.com/img.png)", "\x1b[31m")
+	assertOutputNotContains(t, output, "<script>", "![img](https://example.com/img.png)", "\x1b[31m", "safe'name\nwith")
 }
 
 func TestFormatPRCommentSanitizesAdvisoryMarkdownFields(t *testing.T) {
@@ -369,10 +369,27 @@ func TestFormatPRCommentSanitizesAdvisoryMarkdownFields(t *testing.T) {
 	}
 
 	expectedContains := []string{
-		"| 1 | `example.com/lib` | `GHSA-1234\\n\\[click\\]\\(https://example.com\\)` | `high&lt;script&gt;alert\\(1\\)&lt;/script&gt;` | `critical \\(9.7\\)` | `1.2.3\\t\\!\\[badge\\]\\(https://example.com/badge.svg\\)` | `repo&lt;details&gt;boom&lt;/details&gt;\\x1f` |",
+		"| 1 | `example.com/lib` | GHSA-1234\\n\\[click\\](https://example.com) | high&lt;script&gt;alert(1)&lt;/script&gt; | critical (9.7) | 1.2.3\\t!\\[badge\\](https://example.com/badge.svg) | repo&lt;details&gt;boom&lt;/details&gt;\\x1f |",
 	}
 	assertOutputContains(t, output, expectedContains...)
 	assertOutputNotContains(t, output, "[click](https://example.com)", "![badge](https://example.com/badge.svg)", "<script>", "<details>", "\x1f")
+}
+
+func TestMarkdownCellsPreserveReadableContentAndRenderEmptyValues(t *testing.T) {
+	t.Parallel()
+
+	if got := markdownCodeCell(""); got != "-" {
+		t.Fatalf("empty Markdown code cell = %q, want dash", got)
+	}
+	if got := escapeMarkdownTable(" \t "); got != "-" {
+		t.Fatalf("blank Markdown table cell = %q, want dash", got)
+	}
+	if got := markdownCodeCell("lang[rt] <script> (9.7)"); got != "`lang[rt] <script> (9.7)`" {
+		t.Fatalf("readable Markdown code cell = %q", got)
+	}
+	if got := escapeMarkdownTable("critical (9.7)"); got != "critical (9.7)" {
+		t.Fatalf("readable Markdown table cell = %q", got)
+	}
 }
 
 func TestFormatPRCommentNoBaseline(t *testing.T) {

--- a/internal/report/format_test.go
+++ b/internal/report/format_test.go
@@ -21,6 +21,15 @@ func assertOutputContains(t *testing.T, output string, values ...string) {
 	}
 }
 
+func assertOutputNotContains(t *testing.T, output string, values ...string) {
+	t.Helper()
+	for _, value := range values {
+		if strings.Contains(output, value) {
+			t.Fatalf("expected output not to contain %q", value)
+		}
+	}
+}
+
 func sampleEffectivePolicy(source string, failOnIncrease, lowConfidence, minUsage int, usageWeight, impactWeight, confidenceWeight float64) *EffectivePolicy {
 	return &EffectivePolicy{
 		Sources: []string{source},
@@ -276,13 +285,13 @@ func TestFormatPRCommentZeroDeltasAreUnsigned(t *testing.T) {
 		t.Fatalf("format pr-comment with zero deltas: %v", err)
 	}
 
-	assertOutputContains(t, output, "| Dependency count | 0 |", "| Used percent | 0.0% |", "| Waste percent | 0.0% |", "| Estimated unused bytes | 0 B |", "| Known licenses | 0 |", "| Unknown licenses | 0 |", "| Denied licenses | 0 |", "| 1 | changed | `same` | js-ts | 0.0% | 0 | 0 | 0 B |")
+	assertOutputContains(t, output, "| Dependency count | 0 |", "| Used percent | 0.0% |", "| Waste percent | 0.0% |", "| Estimated unused bytes | 0 B |", "| Known licenses | 0 |", "| Unknown licenses | 0 |", "| Denied licenses | 0 |", "| 1 | changed | `same` | `js-ts` | 0.0% | 0 | 0 | 0 B |")
 	if strings.Contains(output, "+0") {
 		t.Fatalf("expected zero deltas to render without a leading plus, got %q", output)
 	}
 }
 
-func TestFormatPRCommentEscapesDependencyNameNewlines(t *testing.T) {
+func TestFormatPRCommentSanitizesDependencyAndLanguageMarkdown(t *testing.T) {
 	reportData := Report{
 		BaselineComparison: &BaselineComparison{
 			SummaryDelta: SummaryDelta{
@@ -292,23 +301,78 @@ func TestFormatPRCommentEscapesDependencyNameNewlines(t *testing.T) {
 			Dependencies: []DependencyDelta{
 				{
 					Kind:                  DependencyDeltaAdded,
-					Name:                  "safe`name\nwith`new-line",
-					Language:              "js-ts",
+					Name:                  "safe`name\nwith|new-line\t<img src=x>\x1b[31m[link](https://example.com)",
+					Language:              "js-ts\r\n<script>alert(1)</script>\t![img](https://example.com/img.png)",
 					UsedPercentDelta:      0.1,
 					UsedExportsCountDelta: 0,
+				},
+			},
+			NewDeniedLicenses: []DeniedLicenseDelta{
+				{
+					Name:     "deny|dep",
+					Language: "lang\x07",
+					SPDX:     "GPL-3.0\n![badge](https://example.com/badge.svg)",
+				},
+			},
+			RuntimeRegressions: []DependencyDelta{
+				{
+					Kind:     DependencyDeltaChanged,
+					Name:     "runtime<dep>",
+					Language: "lang[rt]",
+					RuntimeDelta: &RuntimeDelta{
+						Comparable:            true,
+						BaselinePresent:       true,
+						CurrentPresent:        true,
+						RuntimeOnlyRegression: true,
+					},
 				},
 			},
 		},
 	}
 	output, err := NewFormatter().Format(reportData, FormatPRComment)
 	if err != nil {
-		t.Fatalf("format pr-comment escapes newlines: %v", err)
+		t.Fatalf("format pr-comment sanitizes dependency and language markdown: %v", err)
 	}
 
-	assertOutputContains(t, output, "`safe'name\\nwith'new-line`")
-	if strings.Contains(output, "`safe'name\nwith'new-line`") {
-		t.Fatalf("expected dependency name newline to be escaped as literal")
+	expectedContains := []string{
+		"`safe'name\\nwith\\|new-line\\t&lt;img src=x&gt;\\x1b\\[31m\\[link\\]\\(https://example.com\\)`",
+		"`js-ts\\n&lt;script&gt;alert\\(1\\)&lt;/script&gt;\\t\\!\\[img\\]\\(https://example.com/img.png\\)`",
+		"| 1 | added | `safe'name\\nwith\\|new-line\\t&lt;img src=x&gt;\\x1b\\[31m\\[link\\]\\(https://example.com\\)` | `js-ts\\n&lt;script&gt;alert\\(1\\)&lt;/script&gt;\\t\\!\\[img\\]\\(https://example.com/img.png\\)` |",
+		"| 1 | `deny\\|dep` | `lang\\x07` | `GPL-3.0\\n\\!\\[badge\\]\\(https://example.com/badge.svg\\)` |",
+		"| 1 | `runtime&lt;dep&gt;` | `lang\\[rt\\]` | `runtime-only regression` |",
 	}
+	assertOutputContains(t, output, expectedContains...)
+	assertOutputNotContains(t, output, "<img src=x>", "<script>", "[link](https://example.com)", "![img](https://example.com/img.png)", "\x1b[31m")
+}
+
+func TestFormatPRCommentSanitizesAdvisoryMarkdownFields(t *testing.T) {
+	reportData := Report{
+		BaselineComparison: &BaselineComparison{
+			SummaryDelta: SummaryDelta{},
+			NewReachableVulnerabilities: []VulnerabilityDelta{
+				{
+					Language:      "go|lang",
+					Name:          "example.com/lib",
+					AdvisoryID:    "GHSA-1234\n[click](https://example.com)",
+					Severity:      "high<script>alert(1)</script>",
+					FixedVersion:  "1.2.3\t![badge](https://example.com/badge.svg)",
+					Source:        "repo<details>boom</details>\x1f",
+					Priority:      "critical",
+					PriorityScore: 9.7,
+				},
+			},
+		},
+	}
+	output, err := NewFormatter().Format(reportData, FormatPRComment)
+	if err != nil {
+		t.Fatalf("format pr-comment sanitizes advisory fields: %v", err)
+	}
+
+	expectedContains := []string{
+		"| 1 | `example.com/lib` | `GHSA-1234\\n\\[click\\]\\(https://example.com\\)` | `high&lt;script&gt;alert\\(1\\)&lt;/script&gt;` | `critical \\(9.7\\)` | `1.2.3\\t\\!\\[badge\\]\\(https://example.com/badge.svg\\)` | `repo&lt;details&gt;boom&lt;/details&gt;\\x1f` |",
+	}
+	assertOutputContains(t, output, expectedContains...)
+	assertOutputNotContains(t, output, "[click](https://example.com)", "![badge](https://example.com/badge.svg)", "<script>", "<details>", "\x1f")
 }
 
 func TestFormatPRCommentNoBaseline(t *testing.T) {

--- a/internal/report/vulnerability_format_test.go
+++ b/internal/report/vulnerability_format_test.go
@@ -10,7 +10,7 @@ func TestVulnerabilityFindingsRenderAcrossFormats(t *testing.T) {
 
 	assertFormattedOutputContains(t, reportData, FormatTable, "Vulnerabilities", "GHSA-critical critical/critical 91.2 reachable fixed 2.0.0", "new reachable vulnerability")
 	assertFormattedOutputContains(t, reportData, FormatCSV, "vulnerability_findings", "GHSA-critical:dep-a:critical:critical:91.2:reachable:fixed=2.0.0:source=local:test", "critical", ",1,")
-	assertFormattedOutputContains(t, reportData, FormatPRComment, "Reachable vulnerabilities", "Newly reachable vulnerabilities", "| 1 | `dep-a` | `GHSA-critical` | `critical` | `critical \\(91.2\\)` | `2.0.0` | `local:test` |")
+	assertFormattedOutputContains(t, reportData, FormatPRComment, "Reachable vulnerabilities", "Newly reachable vulnerabilities", "| 1 | `dep-a` | GHSA-critical | critical | critical (91.2) | 2.0.0 | local:test |")
 	assertFormattedOutputContains(t, reportData, FormatCycloneDX, "lopper:summary", "lopper:baseline:new-reachable-vulnerabilities", "GHSA-critical")
 }
 

--- a/internal/report/vulnerability_format_test.go
+++ b/internal/report/vulnerability_format_test.go
@@ -10,7 +10,7 @@ func TestVulnerabilityFindingsRenderAcrossFormats(t *testing.T) {
 
 	assertFormattedOutputContains(t, reportData, FormatTable, "Vulnerabilities", "GHSA-critical critical/critical 91.2 reachable fixed 2.0.0", "new reachable vulnerability")
 	assertFormattedOutputContains(t, reportData, FormatCSV, "vulnerability_findings", "GHSA-critical:dep-a:critical:critical:91.2:reachable:fixed=2.0.0:source=local:test", "critical", ",1,")
-	assertFormattedOutputContains(t, reportData, FormatPRComment, "Reachable vulnerabilities", "Newly reachable vulnerabilities", "| 1 | `dep-a` | GHSA-critical | critical | critical (91.2) | 2.0.0 | local:test |")
+	assertFormattedOutputContains(t, reportData, FormatPRComment, "Reachable vulnerabilities", "Newly reachable vulnerabilities", "| 1 | `dep-a` | `GHSA-critical` | `critical` | `critical \\(91.2\\)` | `2.0.0` | `local:test` |")
 	assertFormattedOutputContains(t, reportData, FormatCycloneDX, "lopper:summary", "lopper:baseline:new-reachable-vulnerabilities", "GHSA-critical")
 }
 


### PR DESCRIPTION
## Summary

Closes #1286.

The PR-comment formatter was only escaping pipes, backticks, and line breaks in a narrow way, even though dependency names, languages, denied-license fields, and advisory metadata can be sourced from repository-controlled content or baseline/advisory input. That left GitHub PR comments vulnerable to Markdown table breaks, line breaks, raw HTML, link/image syntax, and control-character rendering in the `pr-comment` report.

The root cause was that `internal/report/format_pr_comment.go` treated most repository-controlled cells as plain Markdown table text and did not apply the same control-character hardening used elsewhere in the report surface.

## Changes

- Added context-specific sanitizers: plain table cells escape Markdown, HTML, and control syntax without harming readability, while dependency-name code spans use the smaller escaping set appropriate to inline code.
- Preserved the established report presentation: only dependency names use inline code; language, license, advisory, severity, priority, fixed-version, source, and runtime fields remain readable plain table text. Empty or whitespace-only values render as a dash.
- Added adversarial regression coverage for table, line, HTML, link/image, and control-character injection across dependency, language, license, and advisory fields.

## Validation

Commands and checks run:

```bash
go test ./internal/report -run 'TestFormatPRComment'
go test ./internal/report
make ci
```

Additional manual validation:

- Verified the new regression assertions cover table, line, HTML, link/image, and control-character injection cases while preserving deterministic readable output.

## Risk and compatibility

- Breaking changes: None expected; the change is limited to `pr-comment` Markdown rendering.
- Migration required: None.
- Performance impact: None expected.
- Memory benchmark impact: None; the memory benchmark gate passed with no regressions.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
