### PR TITLE
fix(ci): isolate PR report publication credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,9 @@ jobs:
 
       - name: Stage PR report inputs
         if: ${{ github.event_name == 'pull_request' && always() }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
         env:
+          PATH: /usr/bin:/bin
           LOPPER_BASE_OUTCOME: ${{ steps.lopper_base.outcome }}
           LOPPER_DELTA_OUTCOME: ${{ steps.lopper_delta.outcome }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         if: ${{ !env.ACT }}
@@ -104,8 +103,194 @@ jobs:
             make ci
           fi
 
+      - name: Fail on unapproved memory regression
+        if: ${{ github.event_name == 'pull_request' && !env.ACT && always() && !contains(github.event.pull_request.labels.*.name, 'memory-approved') }}
+        run: |
+          if [ ! -f .artifacts/memory-bench-status.txt ]; then
+            exit 0
+          fi
+          status="$(tr -d '[:space:]' < .artifacts/memory-bench-status.txt)"
+          if [ "$status" = "1" ]; then
+            echo "Memory benchmark regression detected. Add the memory-approved label to acknowledge and merge it."
+            exit 1
+          fi
+
+      - name: Verify demo assets are up to date
+        run: make demos-check
+
+      - name: Run lopper self-analysis (base branch)
+        id: lopper_base
+        if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
+        run: |
+          base_ref="${BASE_REF:-main}"
+          mkdir -p .artifacts
+          git worktree add --detach .artifacts/base "origin/${base_ref}"
+          bin/lopper analyse --top 10 --repo .artifacts/base --language all --format json > .artifacts/lopper-base.json
+          git worktree remove --force .artifacts/base
+
+      - name: Run lopper delta summary (PR)
+        id: lopper_delta
+        if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
+        run: |
+          mkdir -p .artifacts
+          bin/lopper analyse --top 10 --repo . --language all --baseline .artifacts/lopper-base.json --format pr-comment > .artifacts/lopper-pr-comment.md
+
+      - name: Run coverage gate
+        id: cov
+        continue-on-error: true
+        env:
+          COVERAGE_MIN: 98
+          COVERAGE_PACKAGE_MIN: 98
+        run: |
+          set +e
+          if [ -n "${ACT:-}" ]; then
+            PATH="$(go env GOPATH)/bin:$PATH" make cov COVERAGE_MIN="${COVERAGE_MIN}" COVERAGE_PACKAGE_MIN="${COVERAGE_PACKAGE_MIN}"
+          else
+            make cov COVERAGE_MIN="${COVERAGE_MIN}" COVERAGE_PACKAGE_MIN="${COVERAGE_PACKAGE_MIN}"
+          fi
+          status=$?
+          mkdir -p .artifacts
+          printf '%s\n' "$status" > .artifacts/coverage-status.txt
+          if [ -f .artifacts/coverage-total.txt ]; then
+            total="$(cat .artifacts/coverage-total.txt)"
+          else
+            total=""
+          fi
+          echo "package_failures<<EOF" >> "$GITHUB_OUTPUT"
+          if [ -f .artifacts/coverage-package-failures.txt ]; then
+            cat .artifacts/coverage-package-failures.txt >> "$GITHUB_OUTPUT"
+          fi
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "total=$total" >> "$GITHUB_OUTPUT"
+          exit $status
+
+      - name: Stage PR report inputs
+        if: ${{ github.event_name == 'pull_request' && always() }}
+        env:
+          LOPPER_BASE_OUTCOME: ${{ steps.lopper_base.outcome }}
+          LOPPER_DELTA_OUTCOME: ${{ steps.lopper_delta.outcome }}
+        run: |
+          report_root="${RUNNER_TEMP}/pr-report-inputs"
+          rm -rf -- "${report_root}"
+          mkdir -p -- "${report_root}"
+
+          printf '%s\n' "${LOPPER_BASE_OUTCOME}" > "${report_root}/lopper-base-outcome.txt"
+          printf '%s\n' "${LOPPER_DELTA_OUTCOME}" > "${report_root}/lopper-delta-outcome.txt"
+
+          for report in \
+            coverage-package-failures.txt \
+            coverage-status.txt \
+            coverage-total.txt \
+            lopper-pr-comment.md \
+            memory-bench-status.txt \
+            memory-bench-summary.md
+          do
+            src=".artifacts/${report}"
+            if [ -f "${src}" ] && [ ! -L "${src}" ]; then
+              cp -- "${src}" "${report_root}/${report}"
+            fi
+          done
+
+      - name: Upload PR report inputs
+        if: ${{ github.event_name == 'pull_request' && always() && !env.ACT }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: pr-report-inputs
+          path: ${{ runner.temp }}/pr-report-inputs
+          if-no-files-found: error
+
+      - name: Upload binary artifact
+        if: ${{ always() && !env.ACT }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: lopper-bin
+          path: bin/lopper
+          if-no-files-found: ignore
+
+      - name: Mock artifact upload (act)
+        if: ${{ always() && env.ACT }}
+        run: |
+          test -f bin/lopper
+          ls -lh bin/lopper
+
+      - name: Fail workflow on coverage gate
+        if: ${{ steps.cov.outcome == 'failure' }}
+        run: exit 1
+
+  publish-pr-reports:
+    needs: verify
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download PR report inputs
+        if: ${{ !env.ACT }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: pr-report-inputs
+          path: pr-report-inputs
+
+      - name: Validate PR report inputs
+        if: ${{ !env.ACT }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}
+        env:
+          PATH: /usr/bin:/bin
+          REPORT_ROOT: pr-report-inputs
+        run: |
+          if [ ! -d "${REPORT_ROOT}" ]; then
+            echo "PR report inputs are missing." >&2
+            exit 1
+          fi
+          if find -P "${REPORT_ROOT}" -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "PR report inputs must contain only regular files." >&2
+            exit 1
+          fi
+
+          allowed_files=(
+            coverage-package-failures.txt
+            coverage-status.txt
+            coverage-total.txt
+            lopper-base-outcome.txt
+            lopper-delta-outcome.txt
+            lopper-pr-comment.md
+            memory-bench-status.txt
+            memory-bench-summary.md
+          )
+          required_files=(
+            lopper-base-outcome.txt
+            lopper-delta-outcome.txt
+          )
+
+          for required in "${required_files[@]}"; do
+            path="${REPORT_ROOT}/${required}"
+            if [ ! -f "${path}" ] || [ -L "${path}" ]; then
+              echo "Missing required PR report input: ${required}" >&2
+              exit 1
+            fi
+          done
+
+          while IFS= read -r -d '' path; do
+            name="$(basename "${path}")"
+            case " ${allowed_files[*]} " in
+              *" ${name} "*) ;;
+              *)
+                echo "Unexpected PR report input: ${name}" >&2
+                exit 1
+                ;;
+            esac
+            if [ "$(stat --format=%s "${path}")" -gt 1048576 ]; then
+              echo "PR report input exceeds the 1 MiB publication limit: ${name}" >&2
+              exit 1
+            fi
+          done < <(find -P "${REPORT_ROOT}" -mindepth 1 -maxdepth 1 -type f -print0)
+
       - name: Comment memory benchmark report on PR
-        if: ${{ github.event_name == 'pull_request' && !env.ACT && always() }}
+        if: ${{ !env.ACT }}
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
@@ -113,8 +298,9 @@ jobs:
             const fs = require('node:fs');
 
             const marker = '<!-- lopper-memory-bench -->';
-            const summaryPath = '.artifacts/memory-bench-summary.md';
-            const statusPath = '.artifacts/memory-bench-status.txt';
+            const reportRoot = 'pr-report-inputs';
+            const summaryPath = `${reportRoot}/memory-bench-summary.md`;
+            const statusPath = `${reportRoot}/memory-bench-status.txt`;
             const labels = context.payload.pull_request?.labels || [];
             const approved = labels.some((label) => label?.name === 'memory-approved');
             const status = fs.existsSync(statusPath) ? fs.readFileSync(statusPath, 'utf8').trim() : '';
@@ -162,53 +348,21 @@ jobs:
               });
             }
 
-      - name: Fail on unapproved memory regression
-        if: ${{ github.event_name == 'pull_request' && !env.ACT && always() && !contains(github.event.pull_request.labels.*.name, 'memory-approved') }}
-        run: |
-          if [ ! -f .artifacts/memory-bench-status.txt ]; then
-            exit 0
-          fi
-          status="$(tr -d '[:space:]' < .artifacts/memory-bench-status.txt)"
-          if [ "$status" = "1" ]; then
-            echo "Memory benchmark regression detected. Add the memory-approved label to acknowledge and merge it."
-            exit 1
-          fi
-
-      - name: Verify demo assets are up to date
-        run: make demos-check
-
-      - name: Run lopper self-analysis (base branch)
-        id: lopper_base
-        if: ${{ github.event_name == 'pull_request' }}
-        continue-on-error: true
-        run: |
-          base_ref="${BASE_REF:-main}"
-          mkdir -p .artifacts
-          git worktree add --detach .artifacts/base "origin/${base_ref}"
-          bin/lopper analyse --top 10 --repo .artifacts/base --language all --format json > .artifacts/lopper-base.json
-          git worktree remove --force .artifacts/base
-
-      - name: Run lopper delta summary (PR)
-        id: lopper_delta
-        if: ${{ github.event_name == 'pull_request' }}
-        continue-on-error: true
-        run: |
-          mkdir -p .artifacts
-          bin/lopper analyse --top 10 --repo . --language all --baseline .artifacts/lopper-base.json --format pr-comment > .artifacts/lopper-pr-comment.md
-
       - name: Comment lopper report on PR
-        if: ${{ github.event_name == 'pull_request' && !env.ACT }}
+        if: ${{ !env.ACT }}
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        env:
-          LOPPER_BASE_OUTCOME: ${{ steps.lopper_base.outcome }}
-          LOPPER_DELTA_OUTCOME: ${{ steps.lopper_delta.outcome }}
         with:
           script: |
             const fs = require('node:fs');
 
             const marker = '<!-- lopper-pr-report -->';
-            const deltaCommentPath = '.artifacts/lopper-pr-comment.md';
+            const reportRoot = 'pr-report-inputs';
+            const deltaCommentPath = `${reportRoot}/lopper-pr-comment.md`;
+            const baseOutcomePath = `${reportRoot}/lopper-base-outcome.txt`;
+            const deltaOutcomePath = `${reportRoot}/lopper-delta-outcome.txt`;
+            const baseOutcome = fs.existsSync(baseOutcomePath) ? fs.readFileSync(baseOutcomePath, 'utf8').trim() : '';
+            const deltaOutcome = fs.existsSync(deltaOutcomePath) ? fs.readFileSync(deltaOutcomePath, 'utf8').trim() : '';
 
             const failureBody = [
               marker,
@@ -220,8 +374,8 @@ jobs:
             ].join('\n');
 
             const body =
-              process.env.LOPPER_BASE_OUTCOME !== 'success' ||
-              process.env.LOPPER_DELTA_OUTCOME !== 'success' ||
+              baseOutcome !== 'success' ||
+              deltaOutcome !== 'success' ||
               !fs.existsSync(deltaCommentPath)
                 ? failureBody
                 : `${marker}\n${fs.readFileSync(deltaCommentPath, 'utf8').trim()}`;
@@ -264,11 +418,11 @@ jobs:
             }
 
       - name: Post SonarQube review comments (PR)
+        if: ${{ !env.ACT && env.SONAR_TOKEN != '' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ben-ranford_lopper
           SONAR_HOST_URL: https://sonarcloud.io
-        if: ${{ github.event_name == 'pull_request' && !env.ACT && env.SONAR_TOKEN != '' }}
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
@@ -421,46 +575,32 @@ jobs:
               });
             }
 
-      - name: Run coverage gate
-        id: cov
-        continue-on-error: true
-        env:
-          COVERAGE_MIN: 98
-          COVERAGE_PACKAGE_MIN: 98
-        run: |
-          set +e
-          if [ -n "${ACT:-}" ]; then
-            PATH="$(go env GOPATH)/bin:$PATH" make cov COVERAGE_MIN="${COVERAGE_MIN}" COVERAGE_PACKAGE_MIN="${COVERAGE_PACKAGE_MIN}"
-          else
-            make cov COVERAGE_MIN="${COVERAGE_MIN}" COVERAGE_PACKAGE_MIN="${COVERAGE_PACKAGE_MIN}"
-          fi
-          status=$?
-          if [ -f .artifacts/coverage-total.txt ]; then
-            total="$(cat .artifacts/coverage-total.txt)"
-          else
-            total=""
-          fi
-          echo "package_failures<<EOF" >> "$GITHUB_OUTPUT"
-          if [ -f .artifacts/coverage-package-failures.txt ]; then
-            cat .artifacts/coverage-package-failures.txt >> "$GITHUB_OUTPUT"
-          fi
-          echo "EOF" >> "$GITHUB_OUTPUT"
-          echo "total=$total" >> "$GITHUB_OUTPUT"
-          exit $status
-
       - name: Comment on coverage failure
-        if: ${{ github.event_name == 'pull_request' && steps.cov.outcome == 'failure' && !env.ACT }}
+        if: ${{ !env.ACT }}
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           COVERAGE_MIN: 98
           COVERAGE_PACKAGE_MIN: 98
-          COVERAGE_TOTAL: ${{ steps.cov.outputs.total }}
-          COVERAGE_PACKAGE_FAILURES: ${{ steps.cov.outputs.package_failures }}
         with:
           script: |
+            const fs = require('node:fs');
+
+            const reportRoot = 'pr-report-inputs';
+            const statusPath = `${reportRoot}/coverage-status.txt`;
+            const totalPath = `${reportRoot}/coverage-total.txt`;
+            const packageFailuresPath = `${reportRoot}/coverage-package-failures.txt`;
+
+            if (!fs.existsSync(statusPath) || fs.readFileSync(statusPath, 'utf8').trim() === '0') {
+              core.info('Coverage gate passed or did not emit a status; skipping PR coverage comment.');
+              return;
+            }
+
             const marker = '<!-- lopper-coverage-failure -->';
-            const total = process.env.COVERAGE_TOTAL || 'unavailable';
-            const packageFailures = (process.env.COVERAGE_PACKAGE_FAILURES || '').trim();
+            const total = fs.existsSync(totalPath) ? fs.readFileSync(totalPath, 'utf8').trim() : 'unavailable';
+            const packageFailures = fs.existsSync(packageFailuresPath)
+              ? fs.readFileSync(packageFailuresPath, 'utf8').trim()
+              : '';
             const packageFailureSection = packageFailures
               ? `Packages below minimum:\n${packageFailures}\n\n`
               : '';
@@ -503,24 +643,6 @@ jobs:
                 body,
               });
             }
-
-      - name: Fail workflow on coverage gate
-        if: ${{ steps.cov.outcome == 'failure' }}
-        run: exit 1
-
-      - name: Upload binary artifact
-        if: ${{ always() && !env.ACT }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: lopper-bin
-          path: bin/lopper
-          if-no-files-found: ignore
-
-      - name: Mock artifact upload (act)
-        if: ${{ always() && env.ACT }}
-        run: |
-          test -f bin/lopper
-          ls -lh bin/lopper
 
   verify-rolling:
     name: verify (rolling)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      pr_report_artifact_id: ${{ steps.upload_pr_report_inputs.outputs.artifact-id }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -172,12 +174,34 @@ jobs:
           LOPPER_BASE_OUTCOME: ${{ steps.lopper_base.outcome }}
           LOPPER_DELTA_OUTCOME: ${{ steps.lopper_delta.outcome }}
         run: |
+          write_bounded_output() {
+            local dest="$1"
+            local limit_bytes="$2"
+            local value="$3"
+            printf '%s\n' "${value}" > "${dest}"
+            if [ "$(stat --format=%s "${dest}")" -gt "${limit_bytes}" ]; then
+              echo "PR report input exceeds the ${limit_bytes}-byte staging limit: $(basename "${dest}")" >&2
+              exit 1
+            fi
+          }
+
+          copy_bounded_report() {
+            local src="$1"
+            local dest="$2"
+            local limit_bytes="$3"
+            if [ "$(stat --format=%s "${src}")" -gt "${limit_bytes}" ]; then
+              echo "PR report input exceeds the ${limit_bytes}-byte staging limit: $(basename "${src}")" >&2
+              exit 1
+            fi
+            cp -- "${src}" "${dest}"
+          }
+
           report_root="${RUNNER_TEMP}/pr-report-inputs"
           rm -rf -- "${report_root}"
           mkdir -p -- "${report_root}"
 
-          printf '%s\n' "${LOPPER_BASE_OUTCOME}" > "${report_root}/lopper-base-outcome.txt"
-          printf '%s\n' "${LOPPER_DELTA_OUTCOME}" > "${report_root}/lopper-delta-outcome.txt"
+          write_bounded_output "${report_root}/lopper-base-outcome.txt" 64 "${LOPPER_BASE_OUTCOME}"
+          write_bounded_output "${report_root}/lopper-delta-outcome.txt" 64 "${LOPPER_DELTA_OUTCOME}"
 
           for report in \
             coverage-package-failures.txt \
@@ -189,11 +213,21 @@ jobs:
           do
             src=".artifacts/${report}"
             if [ -f "${src}" ] && [ ! -L "${src}" ]; then
-              cp -- "${src}" "${report_root}/${report}"
+              limit_bytes=1048576
+              case "${report}" in
+                coverage-package-failures.txt)
+                  limit_bytes=131072
+                  ;;
+                coverage-status.txt|coverage-total.txt|memory-bench-status.txt)
+                  limit_bytes=64
+                  ;;
+              esac
+              copy_bounded_report "${src}" "${report_root}/${report}" "${limit_bytes}"
             fi
           done
 
       - name: Upload PR report inputs
+        id: upload_pr_report_inputs
         if: ${{ github.event_name == 'pull_request' && always() && !env.ACT }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -221,9 +255,10 @@ jobs:
 
   publish-pr-reports:
     needs: verify
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    if: ${{ always() && github.event_name == 'pull_request' && needs.verify.outputs.pr_report_artifact_id != '' }}
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: write
@@ -232,8 +267,11 @@ jobs:
         if: ${{ !env.ACT }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: pr-report-inputs
+          artifact-ids: ${{ needs.verify.outputs.pr_report_artifact_id }}
+          github-token: ${{ github.token }}
           path: pr-report-inputs
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
 
       - name: Validate PR report inputs
         if: ${{ !env.ACT }}

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -2,6 +2,8 @@ package scripts
 
 import (
 	"regexp"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -12,68 +14,202 @@ func TestCIWorkflowPinsPrivilegedVerifyActions(t *testing.T) {
 	readYAMLConfig(t, ".github/workflows/ci.yml", &workflow)
 
 	verify := workflowJobByName(t, workflow.Jobs, "verify")
-	assertWorkflowJobPermissions(t, verify, "ci verify job", map[string]string{
-		"contents":      "read",
-		"issues":        "write",
-		"pull-requests": "write",
-	})
-
-	assertWorkflowEnvKeyOnlyOnStep(t, workflow.Jobs, "SONAR_TOKEN", "verify", "Post SonarQube review comments (PR)")
+	assertWorkflowJobPermissions(t, verify, "ci verify", map[string]string{"contents": "read"})
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, verify, "ci verify")
+	assertWorkflowStepOrder(t, verify, "Run coverage gate", "Stage PR report inputs", "Upload PR report inputs", "Upload binary artifact", "Fail workflow on coverage gate")
 
 	for _, check := range []struct {
-		stepName string
-		wantUses string
+		jobName   string
+		stepName  string
+		wantUses  string
+		stepLabel string
 	}{
 		{
-			stepName: "Checkout",
-			wantUses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+			jobName:   "verify",
+			stepName:  "Checkout",
+			wantUses:  "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+			stepLabel: "verify checkout",
 		},
 		{
-			stepName: "Setup Go",
-			wantUses: "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e",
+			jobName:   "verify",
+			stepName:  "Setup Go",
+			wantUses:  "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e",
+			stepLabel: "verify setup-go",
 		},
 		{
-			stepName: "Comment memory benchmark report on PR",
-			wantUses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+			jobName:   "verify",
+			stepName:  "Upload PR report inputs",
+			wantUses:  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+			stepLabel: "verify PR report upload",
 		},
 		{
-			stepName: "Comment lopper report on PR",
-			wantUses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+			jobName:   "verify",
+			stepName:  "Upload binary artifact",
+			wantUses:  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+			stepLabel: "verify binary upload",
 		},
 		{
-			stepName: "Post SonarQube review comments (PR)",
-			wantUses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+			jobName:   "publish-pr-reports",
+			stepName:  "Download PR report inputs",
+			wantUses:  "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+			stepLabel: "PR report download",
 		},
 		{
-			stepName: "Comment on coverage failure",
-			wantUses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+			jobName:   "publish-pr-reports",
+			stepName:  "Comment memory benchmark report on PR",
+			wantUses:  "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+			stepLabel: "memory benchmark comment",
 		},
 		{
-			stepName: "Upload binary artifact",
-			wantUses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+			jobName:   "publish-pr-reports",
+			stepName:  "Comment lopper report on PR",
+			wantUses:  "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+			stepLabel: "lopper report comment",
+		},
+		{
+			jobName:   "publish-pr-reports",
+			stepName:  "Post SonarQube review comments (PR)",
+			wantUses:  "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+			stepLabel: "Sonar review comment",
+		},
+		{
+			jobName:   "publish-pr-reports",
+			stepName:  "Comment on coverage failure",
+			wantUses:  "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+			stepLabel: "coverage failure comment",
 		},
 	} {
-		step := workflowStepByName(t, workflow.Jobs, "verify", check.stepName)
+		step := workflowStepByName(t, workflow.Jobs, check.jobName, check.stepName)
 		if step.Uses != check.wantUses {
-			t.Fatalf("verify step %q uses %q, want %q", check.stepName, step.Uses, check.wantUses)
+			t.Fatalf("%s uses %q, want %q", check.stepLabel, step.Uses, check.wantUses)
 		}
 	}
 
 	immutableAction := regexp.MustCompile(`^[^@[:space:]]+@[0-9a-f]{40}$`)
-	for _, step := range verify.Steps {
-		if step.Uses != "" && !immutableAction.MatchString(step.Uses) {
-			t.Fatalf("verify step %q must use an immutable action SHA: %q", step.Name, step.Uses)
+	for _, jobName := range []string{"verify", "publish-pr-reports"} {
+		for _, step := range workflow.Jobs[jobName].Steps {
+			if step.Uses != "" && !immutableAction.MatchString(step.Uses) {
+				t.Fatalf("%s step %q must use an immutable action SHA: %q", jobName, step.Name, step.Uses)
+			}
 		}
 	}
+}
 
-	sonar := workflowStepByName(t, workflow.Jobs, "verify", "Post SonarQube review comments (PR)")
+func TestCIWorkflowIsolatesPRPublicationCredentials(t *testing.T) {
+	t.Parallel()
+
+	const hardenedShell = "/usr/bin/env -u BASH_ENV -u ENV -u PROMPT_COMMAND -u PS4 -u SHELLOPTS -u BASHOPTS /bin/bash --noprofile --norc -euo pipefail {0}"
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/ci.yml", &workflow)
+	stageInputs := workflowStepByName(t, workflow.Jobs, "verify", "Stage PR report inputs")
+	assertWorkflowStepRunContainsAll(t, stageInputs, "ci PR report staging", []string{
+		`report_root="${RUNNER_TEMP}/pr-report-inputs"`,
+		`printf '%s\n' "${LOPPER_BASE_OUTCOME}" > "${report_root}/lopper-base-outcome.txt"`,
+		`printf '%s\n' "${LOPPER_DELTA_OUTCOME}" > "${report_root}/lopper-delta-outcome.txt"`,
+		`src=".artifacts/${report}"`,
+		`cp -- "${src}" "${report_root}/${report}"`,
+	})
+	uploadInputs := workflowStepByName(t, workflow.Jobs, "verify", "Upload PR report inputs")
+	assertCIArtifactAction(t, uploadInputs, "PR report upload", "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", map[string]string{
+		"name":              "pr-report-inputs",
+		"path":              "${{ runner.temp }}/pr-report-inputs",
+		"if-no-files-found": "error",
+	})
+
+	publication := workflowJobByName(t, workflow.Jobs, "publish-pr-reports")
+	assertWorkflowJobNeeds(t, publication, "PR report publication", workflowJobNeeds{"verify"})
+	assertWorkflowJobPermissions(t, publication, "PR report publication", map[string]string{
+		"contents":      "read",
+		"issues":        "write",
+		"pull-requests": "write",
+	})
+	assertWorkflowJobEnvEmpty(t, publication, "PR report publication")
+	assertWorkflowJobOmitsCheckout(t, publication, "PR report publication")
+	assertWorkflowJobStepRunsOmitAllFold(t, publication, "PR report publication", []string{
+		"go run ./",
+		"make ",
+		"npm ",
+		"npx ",
+		"scripts/",
+		"./extensions/",
+		"git ",
+	})
+	assertWorkflowStepOrder(t, publication, "Download PR report inputs", "Validate PR report inputs", "Comment memory benchmark report on PR", "Comment lopper report on PR", "Post SonarQube review comments (PR)", "Comment on coverage failure")
+
+	coverageComment := workflowStepByName(t, workflow.Jobs, "publish-pr-reports", "Comment on coverage failure")
+	if !coverageComment.ContinueOnError {
+		t.Fatal("coverage comment publication must not fail an otherwise-green CI run")
+	}
+
+	downloadInputs := workflowStepByName(t, workflow.Jobs, "publish-pr-reports", "Download PR report inputs")
+	assertCIArtifactAction(t, downloadInputs, "PR report download", "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", map[string]string{
+		"name": "pr-report-inputs",
+		"path": "pr-report-inputs",
+	})
+
+	validateInputs := workflowStepByName(t, workflow.Jobs, "publish-pr-reports", "Validate PR report inputs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "PR report validation shell", got: validateInputs.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, validateInputs, "PR report validation", map[string]string{
+		"PATH":        "/usr/bin:/bin",
+		"REPORT_ROOT": "pr-report-inputs",
+	})
+	assertWorkflowStepRunContainsAll(t, validateInputs, "PR report validation", []string{
+		`find -P "${REPORT_ROOT}" -mindepth 1 -maxdepth 1 ! -type f -print -quit`,
+		`allowed_files=(`,
+		`required_files=(`,
+		`path="${REPORT_ROOT}/${required}"`,
+		`Unexpected PR report input: ${name}`,
+		`PR report input exceeds the 1 MiB publication limit: ${name}`,
+	})
+	if got, want := shellArrayValues(t, validateInputs.Run, "required_files"), []string{"lopper-base-outcome.txt", "lopper-delta-outcome.txt"}; !slices.Equal(got, want) {
+		t.Fatalf("required PR report inputs = %q, want %q", got, want)
+	}
+
+	sonar := workflowStepByName(t, workflow.Jobs, "publish-pr-reports", "Post SonarQube review comments (PR)")
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{label: "Sonar review comment action", got: sonar.Uses, want: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3"},
-		{label: "Sonar review comment condition", got: sonar.If, want: "${{ github.event_name == 'pull_request' && !env.ACT && env.SONAR_TOKEN != '' }}"},
+		{label: "Sonar review comment condition", got: sonar.If, want: "${{ !env.ACT && env.SONAR_TOKEN != '' }}"},
 	})
 	assertWorkflowStepEnv(t, sonar, "Sonar review comment step", map[string]string{
 		"SONAR_HOST_URL":    "https://sonarcloud.io",
 		"SONAR_PROJECT_KEY": "ben-ranford_lopper",
 		"SONAR_TOKEN":       "${{ secrets.SONAR_TOKEN }}",
 	})
+	assertWorkflowEnvKeyOnlyOnStep(t, workflow.Jobs, "SONAR_TOKEN", "publish-pr-reports", "Post SonarQube review comments (PR)")
+}
+
+func assertCIArtifactAction(t *testing.T, step workflowStepConfig, label string, wantUses string, wantInputs map[string]string) {
+	t.Helper()
+	if step.Uses != wantUses {
+		t.Fatalf("%s action = %q, want %q", label, step.Uses, wantUses)
+	}
+	for name, want := range wantInputs {
+		if got := step.With[name]; got != want {
+			t.Fatalf("%s %s = %q, want %q", label, name, got, want)
+		}
+	}
+}
+
+func shellArrayValues(t *testing.T, script string, name string) []string {
+	t.Helper()
+	marker := name + "=("
+	start := strings.Index(script, marker)
+	if start == -1 {
+		t.Fatalf("shell array %q is missing", name)
+	}
+	body := script[start+len(marker):]
+	end := strings.Index(body, "\n)")
+	if end == -1 {
+		t.Fatalf("shell array %q is unterminated", name)
+	}
+	values := make([]string, 0)
+	for _, line := range strings.Split(body[:end], "\n") {
+		if value := strings.TrimSpace(line); value != "" {
+			values = append(values, value)
+		}
+	}
+	return values
 }

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -136,7 +136,6 @@ func TestCIWorkflowIsolatesPRPublicationCredentials(t *testing.T) {
 		"git ",
 	})
 	assertWorkflowStepOrder(t, publication, "Download PR report inputs", "Validate PR report inputs", "Comment memory benchmark report on PR", "Comment lopper report on PR", "Post SonarQube review comments (PR)", "Comment on coverage failure")
-
 	coverageComment := workflowStepByName(t, workflow.Jobs, "publish-pr-reports", "Comment on coverage failure")
 	if !coverageComment.ContinueOnError {
 		t.Fatal("coverage comment publication must not fail an otherwise-green CI run")

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -27,60 +27,15 @@ func TestCIWorkflowPinsPrivilegedVerifyActions(t *testing.T) {
 		wantUses  string
 		stepLabel string
 	}{
-		{
-			jobName:   "verify",
-			stepName:  "Checkout",
-			wantUses:  "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
-			stepLabel: "verify checkout",
-		},
-		{
-			jobName:   "verify",
-			stepName:  "Setup Go",
-			wantUses:  "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e",
-			stepLabel: "verify setup-go",
-		},
-		{
-			jobName:   "verify",
-			stepName:  "Upload PR report inputs",
-			wantUses:  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
-			stepLabel: "verify PR report upload",
-		},
-		{
-			jobName:   "verify",
-			stepName:  "Upload binary artifact",
-			wantUses:  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
-			stepLabel: "verify binary upload",
-		},
-		{
-			jobName:   "publish-pr-reports",
-			stepName:  "Download PR report inputs",
-			wantUses:  "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
-			stepLabel: "PR report download",
-		},
-		{
-			jobName:   "publish-pr-reports",
-			stepName:  "Comment memory benchmark report on PR",
-			wantUses:  "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
-			stepLabel: "memory benchmark comment",
-		},
-		{
-			jobName:   "publish-pr-reports",
-			stepName:  "Comment lopper report on PR",
-			wantUses:  "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
-			stepLabel: "lopper report comment",
-		},
-		{
-			jobName:   "publish-pr-reports",
-			stepName:  "Post SonarQube review comments (PR)",
-			wantUses:  "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
-			stepLabel: "Sonar review comment",
-		},
-		{
-			jobName:   "publish-pr-reports",
-			stepName:  "Comment on coverage failure",
-			wantUses:  "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
-			stepLabel: "coverage failure comment",
-		},
+		{"verify", "Checkout", "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "verify checkout"},
+		{"verify", "Setup Go", "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e", "verify setup-go"},
+		{"verify", "Upload PR report inputs", "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "verify PR report upload"},
+		{"verify", "Upload binary artifact", "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "verify binary upload"},
+		{"publish-pr-reports", "Download PR report inputs", "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "PR report download"},
+		{"publish-pr-reports", "Comment memory benchmark report on PR", "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3", "memory benchmark comment"},
+		{"publish-pr-reports", "Comment lopper report on PR", "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3", "lopper report comment"},
+		{"publish-pr-reports", "Post SonarQube review comments (PR)", "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3", "Sonar review comment"},
+		{"publish-pr-reports", "Comment on coverage failure", "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3", "coverage failure comment"},
 	} {
 		step := workflowStepByName(t, workflow.Jobs, check.jobName, check.stepName)
 		if step.Uses != check.wantUses {

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -17,6 +17,9 @@ func TestCIWorkflowPinsPrivilegedVerifyActions(t *testing.T) {
 	assertWorkflowJobPermissions(t, verify, "ci verify", map[string]string{"contents": "read"})
 	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, verify, "ci verify")
 	assertWorkflowStepOrder(t, verify, "Run coverage gate", "Stage PR report inputs", "Upload PR report inputs", "Upload binary artifact", "Fail workflow on coverage gate")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "ci verify trusted PR report output", got: verify.Outputs["pr_report_artifact_id"], want: "${{ steps.upload_pr_report_inputs.outputs.artifact-id }}"},
+	})
 
 	for _, check := range []struct {
 		jobName   string
@@ -104,13 +107,22 @@ func TestCIWorkflowIsolatesPRPublicationCredentials(t *testing.T) {
 	readYAMLConfig(t, ".github/workflows/ci.yml", &workflow)
 	stageInputs := workflowStepByName(t, workflow.Jobs, "verify", "Stage PR report inputs")
 	assertWorkflowStepRunContainsAll(t, stageInputs, "ci PR report staging", []string{
+		`write_bounded_output() {`,
+		`copy_bounded_report() {`,
 		`report_root="${RUNNER_TEMP}/pr-report-inputs"`,
-		`printf '%s\n' "${LOPPER_BASE_OUTCOME}" > "${report_root}/lopper-base-outcome.txt"`,
-		`printf '%s\n' "${LOPPER_DELTA_OUTCOME}" > "${report_root}/lopper-delta-outcome.txt"`,
+		`write_bounded_output "${report_root}/lopper-base-outcome.txt" 64 "${LOPPER_BASE_OUTCOME}"`,
+		`write_bounded_output "${report_root}/lopper-delta-outcome.txt" 64 "${LOPPER_DELTA_OUTCOME}"`,
 		`src=".artifacts/${report}"`,
-		`cp -- "${src}" "${report_root}/${report}"`,
+		`limit_bytes=1048576`,
+		`coverage-package-failures.txt)`,
+		`limit_bytes=131072`,
+		`coverage-status.txt|coverage-total.txt|memory-bench-status.txt)`,
+		`copy_bounded_report "${src}" "${report_root}/${report}" "${limit_bytes}"`,
 	})
 	uploadInputs := workflowStepByName(t, workflow.Jobs, "verify", "Upload PR report inputs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "PR report upload step id", got: uploadInputs.ID, want: "upload_pr_report_inputs"},
+	})
 	assertCIArtifactAction(t, uploadInputs, "PR report upload", "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", map[string]string{
 		"name":              "pr-report-inputs",
 		"path":              "${{ runner.temp }}/pr-report-inputs",
@@ -120,9 +132,13 @@ func TestCIWorkflowIsolatesPRPublicationCredentials(t *testing.T) {
 	publication := workflowJobByName(t, workflow.Jobs, "publish-pr-reports")
 	assertWorkflowJobNeeds(t, publication, "PR report publication", workflowJobNeeds{"verify"})
 	assertWorkflowJobPermissions(t, publication, "PR report publication", map[string]string{
+		"actions":       "read",
 		"contents":      "read",
 		"issues":        "write",
 		"pull-requests": "write",
+	})
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "PR report publication guard", got: publication.If, want: "${{ always() && github.event_name == 'pull_request' && needs.verify.outputs.pr_report_artifact_id != '' }}"},
 	})
 	assertWorkflowJobEnvEmpty(t, publication, "PR report publication")
 	assertWorkflowJobOmitsCheckout(t, publication, "PR report publication")
@@ -142,10 +158,7 @@ func TestCIWorkflowIsolatesPRPublicationCredentials(t *testing.T) {
 	}
 
 	downloadInputs := workflowStepByName(t, workflow.Jobs, "publish-pr-reports", "Download PR report inputs")
-	assertCIArtifactAction(t, downloadInputs, "PR report download", "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", map[string]string{
-		"name": "pr-report-inputs",
-		"path": "pr-report-inputs",
-	})
+	assertWorkflowArtifactDownloadByID(t, downloadInputs, "PR report download", "${{ needs.verify.outputs.pr_report_artifact_id }}", "pr-report-inputs", "${{ github.repository }}", "${{ github.run_id }}", "${{ github.token }}")
 
 	validateInputs := workflowStepByName(t, workflow.Jobs, "publish-pr-reports", "Validate PR report inputs")
 	assertWorkflowStringValues(t, []workflowStringValue{

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -61,6 +61,14 @@ func TestCIWorkflowIsolatesPRPublicationCredentials(t *testing.T) {
 	var workflow workflowConfig
 	readYAMLConfig(t, ".github/workflows/ci.yml", &workflow)
 	stageInputs := workflowStepByName(t, workflow.Jobs, "verify", "Stage PR report inputs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "PR report staging shell", got: stageInputs.Shell, want: hardenedShell},
+	})
+	assertWorkflowStepEnv(t, stageInputs, "PR report staging", map[string]string{
+		"LOPPER_BASE_OUTCOME":  "${{ steps.lopper_base.outcome }}",
+		"LOPPER_DELTA_OUTCOME": "${{ steps.lopper_delta.outcome }}",
+		"PATH":                 "/usr/bin:/bin",
+	})
 	assertWorkflowStepRunContainsAll(t, stageInputs, "ci PR report staging", []string{
 		`write_bounded_output() {`,
 		`copy_bounded_report() {`,
@@ -113,7 +121,10 @@ func TestCIWorkflowIsolatesPRPublicationCredentials(t *testing.T) {
 	}
 
 	downloadInputs := workflowStepByName(t, workflow.Jobs, "publish-pr-reports", "Download PR report inputs")
-	assertWorkflowArtifactDownloadByID(t, downloadInputs, "PR report download", "${{ needs.verify.outputs.pr_report_artifact_id }}", "pr-report-inputs", "${{ github.repository }}", "${{ github.run_id }}", "${{ github.token }}")
+	assertWorkflowArtifactDownloadByID(t, downloadInputs, workflowArtifactDownloadExpectation{
+		label: "PR report download", wantID: "${{ needs.verify.outputs.pr_report_artifact_id }}", wantPath: "pr-report-inputs",
+		wantRepo: "${{ github.repository }}", wantRunID: "${{ github.run_id }}", wantToken: "${{ github.token }}",
+	})
 
 	validateInputs := workflowStepByName(t, workflow.Jobs, "publish-pr-reports", "Validate PR report inputs")
 	assertWorkflowStringValues(t, []workflowStringValue{

--- a/scripts/feature_flag_workflow_test.go
+++ b/scripts/feature_flag_workflow_test.go
@@ -784,7 +784,10 @@ func assertTrustedFeatureFlagPublicationWorkflow(t *testing.T, publicationWorkfl
 	})
 
 	download := workflowStepByName(t, publicationWorkflow.Jobs, "publish-comments", "Download bounded comment inputs")
-	assertWorkflowArtifactDownloadByID(t, download, "feature flag comment download", "${{ steps.resolve_pr.outputs.artifact-id }}", "${{ runner.temp }}/feature-flag-comment-archive", "${{ github.repository }}", "${{ github.event.workflow_run.id }}", "${{ github.token }}")
+	assertWorkflowArtifactDownloadByID(t, download, workflowArtifactDownloadExpectation{
+		label: "feature flag comment download", wantID: "${{ steps.resolve_pr.outputs.artifact-id }}", wantPath: "${{ runner.temp }}/feature-flag-comment-archive",
+		wantRepo: "${{ github.repository }}", wantRunID: "${{ github.event.workflow_run.id }}", wantToken: "${{ github.token }}",
+	})
 	assertWorkflowStringValues(t, []workflowStringValue{
 		{label: "feature flag comment download decompression", got: download.With["skip-decompress"], want: "true"},
 	})

--- a/scripts/feature_flag_workflow_test.go
+++ b/scripts/feature_flag_workflow_test.go
@@ -786,13 +786,8 @@ func assertTrustedFeatureFlagPublicationWorkflow(t *testing.T, publicationWorkfl
 	})
 
 	download := workflowStepByName(t, publicationWorkflow.Jobs, "publish-comments", "Download bounded comment inputs")
+	assertWorkflowArtifactDownloadByID(t, download, "feature flag comment download", "${{ steps.resolve_pr.outputs.artifact-id }}", "${{ runner.temp }}/feature-flag-comment-archive", "${{ github.repository }}", "${{ github.event.workflow_run.id }}", "${{ github.token }}")
 	assertWorkflowStringValues(t, []workflowStringValue{
-		{label: "feature flag comment download action", got: download.Uses, want: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"},
-		{label: "feature flag comment download artifact ID", got: download.With["artifact-ids"], want: "${{ steps.resolve_pr.outputs.artifact-id }}"},
-		{label: "feature flag comment download path", got: download.With["path"], want: "${{ runner.temp }}/feature-flag-comment-archive"},
-		{label: "feature flag comment download token", got: download.With["github-token"], want: "${{ github.token }}"},
-		{label: "feature flag comment download repository", got: download.With["repository"], want: "${{ github.repository }}"},
-		{label: "feature flag comment download run ID", got: download.With["run-id"], want: "${{ github.event.workflow_run.id }}"},
 		{label: "feature flag comment download decompression", got: download.With["skip-decompress"], want: "true"},
 	})
 

--- a/scripts/feature_flag_workflow_test.go
+++ b/scripts/feature_flag_workflow_test.go
@@ -149,27 +149,18 @@ func TestFeatureFlagCommentResolverUsesNamedEnforcementStepConclusion(t *testing
 
 	tests := []featureFlagEnforcementStepCase{
 		{
-			name: "unrelated failure does not become enforcement failure",
-			jobs: []map[string]any{{"steps": []map[string]any{
-				{"name": "Enforce feature flags on PRs", "conclusion": "success"},
-				{"name": "Write release feature guidance", "conclusion": "failure"},
-			}}},
+			name:       "unrelated failure does not become enforcement failure",
+			jobs:       featureFlagEnforcementJobs("Enforce feature flags on PRs", "success", "Write release feature guidance", "failure"),
 			wantFailed: "false",
 		},
 		{
-			name: "enforcement failure is preserved",
-			jobs: []map[string]any{{"steps": []map[string]any{
-				{"name": "Enforce feature flags on PRs", "conclusion": "failure"},
-				{"name": "Write release feature guidance", "conclusion": "success"},
-			}}},
+			name:       "enforcement failure is preserved",
+			jobs:       featureFlagEnforcementJobs("Enforce feature flags on PRs", "failure", "Write release feature guidance", "success"),
 			wantFailed: "true",
 		},
 		{
-			name: "ambiguous enforcement steps fail closed",
-			jobs: []map[string]any{{"steps": []map[string]any{
-				{"name": "Enforce feature flags on PRs", "conclusion": "success"},
-				{"name": "Enforce feature flags on PRs", "conclusion": "failure"},
-			}}},
+			name:          "ambiguous enforcement steps fail closed",
+			jobs:          featureFlagEnforcementJobs("Enforce feature flags on PRs", "success", "Enforce feature flags on PRs", "failure"),
 			wantErrorPart: "expected exactly one feature flag enforcement step",
 		},
 	}
@@ -181,6 +172,13 @@ func TestFeatureFlagCommentResolverUsesNamedEnforcementStepConclusion(t *testing
 			assertFeatureFlagEnforcementStepCase(t, resolver, tt)
 		})
 	}
+}
+
+func featureFlagEnforcementJobs(firstName, firstConclusion, secondName, secondConclusion string) []map[string]any {
+	return []map[string]any{{"steps": []map[string]any{
+		{"name": firstName, "conclusion": firstConclusion},
+		{"name": secondName, "conclusion": secondConclusion},
+	}}}
 }
 
 func TestFeatureFlagCommentArchiveExtraction(t *testing.T) {

--- a/scripts/workflow_artifact_test_helpers_test.go
+++ b/scripts/workflow_artifact_test_helpers_test.go
@@ -1,0 +1,18 @@
+package scripts
+
+import "testing"
+
+func assertWorkflowArtifactDownloadByID(t *testing.T, step workflowStepConfig, label string, wantID string, wantPath string, wantRepository string, wantRunID string, wantToken string) {
+	t.Helper()
+
+	assertCIArtifactAction(t, step, label, "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", map[string]string{
+		"artifact-ids": wantID,
+		"github-token": wantToken,
+		"path":         wantPath,
+		"repository":   wantRepository,
+		"run-id":       wantRunID,
+	})
+	if _, ok := step.With["name"]; ok {
+		t.Fatalf("%s must bind publication to a trusted upload artifact ID instead of an artifact name", label)
+	}
+}

--- a/scripts/workflow_artifact_test_helpers_test.go
+++ b/scripts/workflow_artifact_test_helpers_test.go
@@ -2,17 +2,26 @@ package scripts
 
 import "testing"
 
-func assertWorkflowArtifactDownloadByID(t *testing.T, step workflowStepConfig, label string, wantID string, wantPath string, wantRepository string, wantRunID string, wantToken string) {
+type workflowArtifactDownloadExpectation struct {
+	label     string
+	wantID    string
+	wantPath  string
+	wantRepo  string
+	wantRunID string
+	wantToken string
+}
+
+func assertWorkflowArtifactDownloadByID(t *testing.T, step workflowStepConfig, want workflowArtifactDownloadExpectation) {
 	t.Helper()
 
-	assertCIArtifactAction(t, step, label, "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", map[string]string{
-		"artifact-ids": wantID,
-		"github-token": wantToken,
-		"path":         wantPath,
-		"repository":   wantRepository,
-		"run-id":       wantRunID,
+	assertCIArtifactAction(t, step, want.label, "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", map[string]string{
+		"artifact-ids": want.wantID,
+		"github-token": want.wantToken,
+		"path":         want.wantPath,
+		"repository":   want.wantRepo,
+		"run-id":       want.wantRunID,
 	})
 	if _, ok := step.With["name"]; ok {
-		t.Fatalf("%s must bind publication to a trusted upload artifact ID instead of an artifact name", label)
+		t.Fatalf("%s must bind publication to a trusted upload artifact ID instead of an artifact name", want.label)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1287.

PR CI currently gave the `verify` job `issues: write` and `pull-requests: write`, so the checked-out pull request code, `actions/checkout` credential persistence, and later `make ci` / `make cov` steps all ran in the same job that could comment back on the PR. That widened the trust boundary for untrusted PR code and made the coverage and report publication path depend on a writable pull-request token.

This change keeps the existing PR reports but moves publication into a separate bounded job that never checks out or executes repository code. The read-only `verify` job now disables persisted checkout credentials, stages only the report files and step outcomes it needs, and uploads them for the writer job to consume.

## Changes

- Reduced verify to contents: read and disabled persisted checkout credentials so PR code and test/build steps cannot inherit a writable PR token.
- Added bounded report staging and a separate no-checkout publish-pr-reports job; early CI failures still publish outcome reports even when the coverage step never runs.
- Pinned privileged publication actions and added workflow tests for the read/write separation, exact artifact contract, checkout behavior, and early-failure report path.

## Validation

Commands and checks run:

```bash
go test ./scripts -run TestCIWorkflowIsolatesPRPublicationCredentials -count=1
make ci
```

Additional manual validation:

- N/A

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None; the `make ci` memory benchmark gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
