### PR TITLE
fix(ci): refresh stale queue follower status

### DIFF
--- a/scripts/queue_me_controller.js
+++ b/scripts/queue_me_controller.js
@@ -83,7 +83,14 @@ function assertExpectedBaseState(state, expectedBaseRefName, expectedBaseRefOid)
   }
 }
 
-async function syncStatusComment(github, owner, repo, number, body) {
+async function syncStatusComment(
+  github,
+  owner,
+  repo,
+  number,
+  body,
+  { createIfMissing = true } = {},
+) {
   const comments = await github.paginate(github.rest.issues.listComments, {
     owner,
     repo,
@@ -107,6 +114,9 @@ async function syncStatusComment(github, owner, repo, number, body) {
       comment_id: existing.id,
       body: nextBody,
     });
+    return;
+  }
+  if (!createIfMissing) {
     return;
   }
   await github.rest.issues.createComment({
@@ -347,21 +357,19 @@ async function runController({
     core.notice(`Ignoring the queue App's auto-merge event for leader #${leader.number}.`);
     return;
   }
+  const eventQueueEntry = eventPull && queued.find((pull) => pull.number === eventPull.number);
   for (const follower of queued.slice(1)) {
     await disableAutoMerge(github, owner, repo, follower.number);
-  }
-  const eventQueueEntry = eventPull && queued.find((pull) => pull.number === eventPull.number);
-  if (
-    eventQueueEntry &&
-    eventQueueEntry.number !== leader.number &&
-    context.payload.action === 'labeled'
-  ) {
     await syncStatusComment(
       github,
       owner,
       repo,
-      eventQueueEntry.number,
+      follower.number,
       `## Queue status\n\nQueued behind #${leader.number}. Pull requests advance in ascending number order.`,
+      {
+        createIfMissing:
+          eventQueueEntry?.number === follower.number && context.payload.action === 'labeled',
+      },
     );
   }
   await disableAutoMerge(github, owner, repo, leader.number);

--- a/scripts/queue_me_controller.test.js
+++ b/scripts/queue_me_controller.test.js
@@ -86,7 +86,15 @@ function makeHarness(options = {}) {
           calls.comments.push({ number: input.issue_number, body: input.body });
         },
         updateComment: async (input) => {
-          calls.comments.push({ number: undefined, body: input.body });
+          for (const [number, issueComments] of comments) {
+            const existing = issueComments.find((comment) => comment.id === input.comment_id);
+            if (existing) {
+              existing.body = input.body;
+              calls.comments.push({ number, body: input.body });
+              return;
+            }
+          }
+          throw new Error(`unknown comment ${input.comment_id}`);
         },
       },
       pulls: {
@@ -183,7 +191,15 @@ function makeHarness(options = {}) {
       queueAppSlug: options.queueAppSlug,
     },
     calls,
+    pulls,
   };
+}
+
+function commentsFor(harness, number) {
+  return harness.calls.comments
+    .filter((comment) => comment.number === number)
+    .map((comment) => comment.body)
+    .at(-1) || '';
 }
 
 test('sortQueuedPulls uses deterministic ascending PR numbers', () => {
@@ -248,6 +264,29 @@ test('controller disables followers and arms only the oldest numbered pull reque
     harness.calls.comments.find((comment) => comment.number === 10).body,
     /Squash auto-merge is armed/,
   );
+});
+
+test('queue refresh updates a stale follower position after the leader advances', async () => {
+  const formerLeader = makePull(3);
+  const currentLeader = makePull(5);
+  const follower = makePull(8);
+  const harness = makeHarness({
+    pulls: [formerLeader, currentLeader, follower],
+    eventPull: follower,
+  });
+
+  await runController(harness.args);
+  assert.match(commentsFor(harness, 8), /Queued behind #3/);
+  assert.equal(commentsFor(harness, 5), '');
+
+  harness.pulls.splice(0, harness.pulls.length, currentLeader, follower);
+  harness.args.context.eventName = 'push';
+  harness.args.context.payload = {};
+
+  await runController(harness.args);
+
+  assert.match(commentsFor(harness, 8), /Queued behind #5/);
+  assert.doesNotMatch(commentsFor(harness, 8), /Queued behind #3/);
 });
 
 test('controller rebases a stale leader and merges it when repository rules are satisfied', async () => {


### PR DESCRIPTION
## Summary

The queue controller now refreshes stale follower-position comments whenever the queue advances.

## Changes

- Reconcile existing queue follower status comments on every queue refresh.
- Preserve comment creation for newly labeled followers only.
- Add regression coverage for a follower retaining a merged leader.

## Validation

Commands and checks run:

```bash
node --test scripts/queue_me_controller.test.js
go test ./scripts
make ci
```

`make ci` passed lint, actionlint, security, vulnerability, all Go tests, goleak, race, memory, build, and 98.3% coverage.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: One existing-comment lookup per queued follower during queue reconciliation.
- Memory benchmark impact: None; `make ci` memory delta passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review