### PR TITLE
ci: prove bug-fix regression tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,8 @@ Additional manual validation:
 
 - 
 
+<!-- For fix(...) PRs, add one or more exact lines like `Regression-Test: ./package::TestName`. If no deterministic regression proof is possible, add exactly one line `Regression-Test-Exemption: <reason>` and ask a maintainer to apply the `regression-exempt` label; both the non-empty reason and maintainer-controlled label are required. -->
+
 ## Risk and compatibility
 
 - Breaking changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,14 @@ name: ci
 
 on:
   pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
 
 jobs:
   extension-changes:
@@ -80,14 +88,31 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           base_ref="${PR_BASE_REF:-main}"
+          printf 'BASE_SHA=%s\n' "${PR_BASE_SHA}" >> "$GITHUB_ENV"
           printf 'BASE_REF=%s\n' "${base_ref}" >> "$GITHUB_ENV"
+
+      - name: Write PR body for regression proof
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const bodyPath = path.join(process.env.RUNNER_TEMP, 'pr-regression-body.md');
+            fs.writeFileSync(bodyPath, context.payload.pull_request?.body || '', 'utf8');
+            core.exportVariable('PR_BODY_FILE', bodyPath);
 
       - name: Fetch PR base
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           base_ref="${BASE_REF:-main}"
+          base_sha="${BASE_SHA:-}"
+          if [ -n "${base_sha}" ]; then
+            git fetch --no-tags --depth=1 origin "${base_sha}"
+          fi
           git fetch --no-tags --depth=1 origin "${base_ref}"
 
       - name: Run CI target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,15 @@ jobs:
             make ci
           fi
 
+      - name: Prove regression tests for fix PRs
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_REGRESSION_EXEMPT_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'regression-exempt') }}
+        run: |
+          go run ./tools/regressionproof --repo . --body-file "$PR_BODY_FILE" --title "$PR_TITLE" --base-sha "$PR_BASE_SHA" --regression-exempt-label "$PR_REGRESSION_EXEMPT_LABEL"
+
       - name: Fail on unapproved memory regression
         if: ${{ github.event_name == 'pull_request' && !env.ACT && always() && !contains(github.event.pull_request.labels.*.name, 'memory-approved') }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           fi
 
       - name: Prove regression tests for fix PRs
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'renovate[bot]' }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -8,6 +8,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
+      - unlabeled
 
 jobs:
   validate:
@@ -56,5 +58,6 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_REGRESSION_EXEMPT_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'regression-exempt') }}
           REPOSITORY_FULL_NAME: ${{ github.repository }}
-        run: go run ./tools/prcheck --check-repo-policy --title "$PR_TITLE" --head-ref "$PR_HEAD_REF" --head-repo-full-name "$PR_HEAD_REPO_FULL_NAME" --repo-full-name "$REPOSITORY_FULL_NAME" --body-file "$PR_BODY_FILE"
+        run: go run ./tools/prcheck --check-repo-policy --title "$PR_TITLE" --head-ref "$PR_HEAD_REF" --head-repo-full-name "$PR_HEAD_REPO_FULL_NAME" --repo-full-name "$REPOSITORY_FULL_NAME" --body-file "$PR_BODY_FILE" --regression-exempt-label "$PR_REGRESSION_EXEMPT_LABEL"

--- a/internal/prmetadata/regression.go
+++ b/internal/prmetadata/regression.go
@@ -1,0 +1,137 @@
+package prmetadata
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+)
+
+var (
+	fixTitlePattern             = regexp.MustCompile(`^fix(?:\([a-z0-9][a-z0-9._/-]*\))?!?:`)
+	regressionDeclarationLineRE = regexp.MustCompile(`^Regression-Test:\s*(.+?)\s*$`)
+	regressionDeclarationRE     = regexp.MustCompile(`^(\./[A-Za-z0-9._/-]+)::(Test[A-Za-z0-9_]+)$`)
+	regressionExemptionLineRE   = regexp.MustCompile(`^Regression-Test-Exemption:\s*(.+?)\s*$`)
+)
+
+type RegressionDeclaration struct {
+	PackagePath string
+	TestName    string
+}
+
+type RegressionMetadata struct {
+	Declarations    []RegressionDeclaration
+	ExemptionReason string
+}
+
+func IsFixTitle(title string) bool {
+	return fixTitlePattern.MatchString(strings.TrimSpace(title))
+}
+
+// ParseRegressionExemptionLabel accepts only the exact boolean values emitted by GitHub expressions.
+func ParseRegressionExemptionLabel(value string) (bool, error) {
+	switch value {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("regression exemption label value must be exactly true or false")
+	}
+}
+
+func ParseRegressionProof(body string) (RegressionMetadata, error) {
+	var metadata RegressionMetadata
+	seen := make(map[RegressionDeclaration]struct{})
+
+	for _, rawLine := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+
+		if match := regressionDeclarationLineRE.FindStringSubmatch(line); len(match) == 2 {
+			declaration, err := parseRegressionDeclaration(match[1])
+			if err != nil {
+				return RegressionMetadata{}, err
+			}
+			if _, ok := seen[declaration]; ok {
+				return RegressionMetadata{}, fmt.Errorf("duplicate regression-test declaration %q", declaration.PackagePath+"::"+declaration.TestName)
+			}
+			seen[declaration] = struct{}{}
+			metadata.Declarations = append(metadata.Declarations, declaration)
+			continue
+		}
+		if strings.HasPrefix(line, "Regression-Test:") {
+			return RegressionMetadata{}, fmt.Errorf("invalid Regression-Test declaration %q", line)
+		}
+
+		if match := regressionExemptionLineRE.FindStringSubmatch(line); len(match) == 2 {
+			if metadata.ExemptionReason != "" {
+				return RegressionMetadata{}, fmt.Errorf("regression-test-exemption must be declared at most once")
+			}
+			metadata.ExemptionReason = strings.TrimSpace(match[1])
+			continue
+		}
+		if strings.HasPrefix(line, "Regression-Test-Exemption:") {
+			return RegressionMetadata{}, fmt.Errorf("regression-test-exemption must include a non-empty reason")
+		}
+	}
+
+	if metadata.ExemptionReason != "" && len(metadata.Declarations) > 0 {
+		return RegressionMetadata{}, fmt.Errorf("regression-test declarations cannot be combined with regression-test-exemption")
+	}
+
+	return metadata, nil
+}
+
+func ValidateRegressionRequirements(title, body string, hasExemptionLabel bool) error {
+	metadata, err := ParseRegressionProof(body)
+	if err != nil {
+		return err
+	}
+
+	isFix := IsFixTitle(title)
+	if !isFix {
+		if len(metadata.Declarations) > 0 || metadata.ExemptionReason != "" {
+			return fmt.Errorf("regression-test metadata is only allowed on conventional fix(...) pull requests")
+		}
+		return nil
+	}
+
+	if metadata.ExemptionReason != "" {
+		if !hasExemptionLabel {
+			return fmt.Errorf("regression-test exemption requires the maintainer-controlled regression-exempt label")
+		}
+		return nil
+	}
+	if len(metadata.Declarations) == 0 {
+		if hasExemptionLabel {
+			return fmt.Errorf("the regression-exempt label requires a non-empty Regression-Test-Exemption reason")
+		}
+		return fmt.Errorf("fix(...) pull requests must declare at least one Regression-Test or one Regression-Test-Exemption")
+	}
+	return nil
+}
+
+func parseRegressionDeclaration(value string) (RegressionDeclaration, error) {
+	match := regressionDeclarationRE.FindStringSubmatch(strings.TrimSpace(value))
+	if len(match) != 3 {
+		return RegressionDeclaration{}, fmt.Errorf("invalid Regression-Test declaration %q", value)
+	}
+
+	packagePath := match[1]
+	cleaned := path.Clean(strings.TrimPrefix(packagePath, "./"))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return RegressionDeclaration{}, fmt.Errorf("regression-test package path must stay under the repository root")
+	}
+	canonical := "./" + cleaned
+	if canonical != packagePath {
+		return RegressionDeclaration{}, fmt.Errorf("regression-test package path must be canonical: %q", packagePath)
+	}
+
+	return RegressionDeclaration{
+		PackagePath: canonical,
+		TestName:    match[2],
+	}, nil
+}

--- a/internal/prmetadata/regression.go
+++ b/internal/prmetadata/regression.go
@@ -24,6 +24,14 @@ type RegressionMetadata struct {
 	ExemptionReason string
 }
 
+type regressionProofLineKind uint8
+
+const (
+	regressionProofLineIgnored regressionProofLineKind = iota
+	regressionProofLineDeclaration
+	regressionProofLineExemption
+)
+
 func IsFixTitle(title string) bool {
 	return fixTitlePattern.MatchString(strings.TrimSpace(title))
 }
@@ -50,31 +58,22 @@ func ParseRegressionProof(body string) (RegressionMetadata, error) {
 			continue
 		}
 
-		if match := regressionDeclarationLineRE.FindStringSubmatch(line); len(match) == 2 {
-			declaration, err := parseRegressionDeclaration(match[1])
-			if err != nil {
-				return RegressionMetadata{}, err
-			}
+		kind, declaration, exemptionReason, err := parseRegressionProofLine(line)
+		if err != nil {
+			return RegressionMetadata{}, err
+		}
+		switch kind {
+		case regressionProofLineDeclaration:
 			if _, ok := seen[declaration]; ok {
 				return RegressionMetadata{}, fmt.Errorf("duplicate regression-test declaration %q", declaration.PackagePath+"::"+declaration.TestName)
 			}
 			seen[declaration] = struct{}{}
 			metadata.Declarations = append(metadata.Declarations, declaration)
-			continue
-		}
-		if strings.HasPrefix(line, "Regression-Test:") {
-			return RegressionMetadata{}, fmt.Errorf("invalid Regression-Test declaration %q", line)
-		}
-
-		if match := regressionExemptionLineRE.FindStringSubmatch(line); len(match) == 2 {
+		case regressionProofLineExemption:
 			if metadata.ExemptionReason != "" {
 				return RegressionMetadata{}, fmt.Errorf("regression-test-exemption must be declared at most once")
 			}
-			metadata.ExemptionReason = strings.TrimSpace(match[1])
-			continue
-		}
-		if strings.HasPrefix(line, "Regression-Test-Exemption:") {
-			return RegressionMetadata{}, fmt.Errorf("regression-test-exemption must include a non-empty reason")
+			metadata.ExemptionReason = exemptionReason
 		}
 	}
 
@@ -83,6 +82,24 @@ func ParseRegressionProof(body string) (RegressionMetadata, error) {
 	}
 
 	return metadata, nil
+}
+
+func parseRegressionProofLine(line string) (regressionProofLineKind, RegressionDeclaration, string, error) {
+	if match := regressionDeclarationLineRE.FindStringSubmatch(line); len(match) == 2 {
+		declaration, err := parseRegressionDeclaration(match[1])
+		return regressionProofLineDeclaration, declaration, "", err
+	}
+	if strings.HasPrefix(line, "Regression-Test:") {
+		return regressionProofLineIgnored, RegressionDeclaration{}, "", fmt.Errorf("invalid Regression-Test declaration %q", line)
+	}
+
+	if match := regressionExemptionLineRE.FindStringSubmatch(line); len(match) == 2 {
+		return regressionProofLineExemption, RegressionDeclaration{}, strings.TrimSpace(match[1]), nil
+	}
+	if strings.HasPrefix(line, "Regression-Test-Exemption:") {
+		return regressionProofLineIgnored, RegressionDeclaration{}, "", fmt.Errorf("regression-test-exemption must include a non-empty reason")
+	}
+	return regressionProofLineIgnored, RegressionDeclaration{}, "", nil
 }
 
 func ValidateRegressionRequirements(title, body string, hasExemptionLabel bool) error {

--- a/internal/prmetadata/regression_test.go
+++ b/internal/prmetadata/regression_test.go
@@ -48,11 +48,16 @@ func TestParseRegressionProofRejectsInvalidMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ParseRegressionProof(tt.body)
-			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-				t.Fatalf("ParseRegressionProof error = %v, want %q", err, tt.wantErr)
-			}
+			assertRegressionProofError(t, tt.body, tt.wantErr)
 		})
+	}
+}
+
+func assertRegressionProofError(t *testing.T, body, wantErr string) {
+	t.Helper()
+	_, err := ParseRegressionProof(body)
+	if err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("ParseRegressionProof error = %v, want %q", err, wantErr)
 	}
 }
 

--- a/internal/prmetadata/regression_test.go
+++ b/internal/prmetadata/regression_test.go
@@ -1,0 +1,216 @@
+package prmetadata
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRegressionMetadataAcceptsMultipleDeclarations(t *testing.T) {
+	t.Parallel()
+
+	lines := []string{
+		"## Validation",
+		"",
+		"Regression-Test: ./pkg/alpha::TestOne",
+		"Regression-Test: ./pkg/beta::TestTwo",
+	}
+	body := strings.Join(lines, "\n")
+
+	metadata, err := ParseRegressionProof(body)
+	if err != nil {
+		t.Fatalf("ParseRegressionProof returned error: %v", err)
+	}
+	if metadata.ExemptionReason != "" {
+		t.Fatalf("ExemptionReason = %q, want empty", metadata.ExemptionReason)
+	}
+	if len(metadata.Declarations) != 2 {
+		t.Fatalf("len(Declarations) = %d, want 2", len(metadata.Declarations))
+	}
+}
+
+func TestParseRegressionProofRejectsInvalidMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{name: "malformed declaration", body: "Regression-Test: ./pkg::testLower", wantErr: "invalid Regression-Test declaration"},
+		{name: "traversal", body: "Regression-Test: ./pkg/../evil::TestTraversal", wantErr: "canonical"},
+		{name: "injection characters", body: "Regression-Test: ./pkg;rm-rf::TestInjection", wantErr: "invalid Regression-Test declaration"},
+		{name: "duplicate declaration", body: "Regression-Test: ./pkg::TestOne\nRegression-Test: ./pkg::TestOne", wantErr: "duplicate regression-test declaration"},
+		{name: "repeated exemption", body: "Regression-Test-Exemption: first reason\nRegression-Test-Exemption: second reason", wantErr: "at most once"},
+		{name: "blank exemption", body: "Regression-Test-Exemption:   ", wantErr: "non-empty reason"},
+		{name: "declaration and exemption", body: "Regression-Test: ./pkg::TestOne\nRegression-Test-Exemption: not needed", wantErr: "cannot be combined"},
+		{name: "backslash path", body: `Regression-Test: .\pkg::TestOne`, wantErr: "invalid Regression-Test declaration"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseRegressionProof(tt.body)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ParseRegressionProof error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseRegressionDeclarationDirectBranches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{name: "backslash", value: `.\\pkg::TestOne`, wantErr: "invalid Regression-Test declaration"},
+		{name: "root path", value: `./::TestOne`, wantErr: "invalid Regression-Test declaration"},
+		{name: "parent traversal", value: `./..::TestOne`, wantErr: "stay under the repository root"},
+		{name: "non canonical", value: `./pkg/../nested::TestOne`, wantErr: "canonical"},
+		{name: "valid", value: `./pkg/nested::TestOne`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			declaration, err := parseRegressionDeclaration(tt.value)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("parseRegressionDeclaration returned error: %v", err)
+				}
+				if declaration.PackagePath != "./pkg/nested" || declaration.TestName != "TestOne" {
+					t.Fatalf("declaration = %#v", declaration)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("parseRegressionDeclaration error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseRegressionExemptionLabelIsStrict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		value   string
+		want    bool
+		wantErr bool
+	}{
+		{value: "true", want: true},
+		{value: "false"},
+		{value: "TRUE", wantErr: true},
+		{value: "1", wantErr: true},
+		{value: " true ", wantErr: true},
+		{value: "$(touch injected)", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		got, err := ParseRegressionExemptionLabel(tt.value)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("ParseRegressionExemptionLabel(%q) succeeded", tt.value)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("ParseRegressionExemptionLabel(%q) returned error: %v", tt.value, err)
+		}
+		if got != tt.want {
+			t.Fatalf("ParseRegressionExemptionLabel(%q) = %t, want %t", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestValidateRegressionRequirementsRejectsFixWithoutProof(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateRegressionRequirements("fix(ci): tighten validation", "## Validation\n\nNo regression proof\n", false)
+	if err == nil {
+		t.Fatal("ValidateRegressionRequirements succeeded without fix proof metadata")
+	}
+	if !strings.Contains(err.Error(), "must declare at least one Regression-Test") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRegressionRequirementsRequiresReasonAndMaintainerLabel(t *testing.T) {
+	t.Parallel()
+
+	title := "fix(ci): tighten validation"
+	reason := "Regression-Test-Exemption: external dependency outage has no deterministic local reproducer"
+
+	tests := []struct {
+		name     string
+		body     string
+		hasLabel bool
+		wantErr  string
+	}{
+		{name: "reason only", body: reason, wantErr: "maintainer-controlled regression-exempt label"},
+		{name: "label only", body: "## Validation\n\nNo regression proof\n", hasLabel: true, wantErr: "requires a non-empty Regression-Test-Exemption reason"},
+		{name: "reason and label", body: reason, hasLabel: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRegressionRequirements(title, tt.body, tt.hasLabel)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateRegressionRequirements returned error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateRegressionRequirements error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRegressionRequirementsAcceptsFixDeclaration(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateRegressionRequirements("fix(ci): tighten validation", "Regression-Test: ./pkg::TestThing", false)
+	if err != nil {
+		t.Fatalf("ValidateRegressionRequirements returned error: %v", err)
+	}
+}
+
+func TestValidateRegressionRequirementsAcceptsNonFixWithoutMetadata(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateRegressionRequirements("feat(ci): add gate", "## Validation\n\nNo regression metadata\n", false)
+	if err != nil {
+		t.Fatalf("ValidateRegressionRequirements returned error: %v", err)
+	}
+}
+
+func TestValidateRegressionRequirementsRejectsMetadataOnNonFixPR(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{
+		"Regression-Test: ./pkg::TestThing",
+		"Regression-Test-Exemption: no deterministic reproducer",
+	} {
+		err := ValidateRegressionRequirements("feat(ci): add gate", body, true)
+		if err == nil {
+			t.Fatalf("ValidateRegressionRequirements succeeded for non-fix metadata %q", body)
+		}
+		if !strings.Contains(err.Error(), "only allowed on conventional fix") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func TestValidateRegressionRequirementsReturnsParseError(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateRegressionRequirements("fix(ci): add gate", "Regression-Test: invalid", false)
+	if err == nil {
+		t.Fatal("ValidateRegressionRequirements succeeded for malformed metadata")
+	}
+	if !strings.Contains(err.Error(), "invalid Regression-Test declaration") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -15,6 +15,13 @@ type pullRequestTriggerWorkflow struct {
 	} `yaml:"on"`
 }
 
+type workflowActionCheck struct {
+	jobName   string
+	stepName  string
+	wantUses  string
+	stepLabel string
+}
+
 func TestCIWorkflowPinsPrivilegedVerifyActions(t *testing.T) {
 	t.Parallel()
 
@@ -29,12 +36,7 @@ func TestCIWorkflowPinsPrivilegedVerifyActions(t *testing.T) {
 		{label: "ci verify trusted PR report output", got: verify.Outputs["pr_report_artifact_id"], want: "${{ steps.upload_pr_report_inputs.outputs.artifact-id }}"},
 	})
 
-	for _, check := range []struct {
-		jobName   string
-		stepName  string
-		wantUses  string
-		stepLabel string
-	}{
+	for _, check := range []workflowActionCheck{
 		{"verify", "Checkout", "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "verify checkout"},
 		{"verify", "Setup Go", "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e", "verify setup-go"},
 		{"verify", "Upload PR report inputs", "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "verify PR report upload"},

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -242,7 +242,7 @@ func TestCIWorkflowRunsRegressionProofGateInVerifyJob(t *testing.T) {
 
 	proof := workflowStepByName(t, workflow.Jobs, "verify", "Prove regression tests for fix PRs")
 	assertWorkflowStringValues(t, []workflowStringValue{
-		{label: "regression proof condition", got: proof.If, want: "${{ github.event_name == 'pull_request' }}"},
+		{label: "regression proof condition", got: proof.If, want: "${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'renovate[bot]' }}"},
 		{label: "regression proof title env", got: proof.Env["PR_TITLE"], want: "${{ github.event.pull_request.title }}"},
 		{label: "regression proof base env", got: proof.Env["PR_BASE_SHA"], want: "${{ github.event.pull_request.base.sha }}"},
 		{label: "regression proof exemption label env", got: proof.Env["PR_REGRESSION_EXEMPT_LABEL"], want: "${{ contains(github.event.pull_request.labels.*.name, 'regression-exempt') }}"},

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+type pullRequestTriggerWorkflow struct {
+	On struct {
+		PullRequest struct {
+			Types []string `yaml:"types"`
+		} `yaml:"pull_request"`
+	} `yaml:"on"`
+}
+
 func TestCIWorkflowPinsPrivilegedVerifyActions(t *testing.T) {
 	t.Parallel()
 
@@ -190,4 +198,88 @@ func shellArrayValues(t *testing.T, script string, name string) []string {
 		}
 	}
 	return values
+}
+
+func TestCIWorkflowRunsRegressionProofGateInVerifyJob(t *testing.T) {
+	t.Parallel()
+	assertPullRequestTriggerTypes(t, ".github/workflows/ci.yml")
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/ci.yml", &workflow)
+
+	verify := workflowJobByName(t, workflow.Jobs, "verify")
+	expectedOrder := []string{
+		"Resolve PR base ref",
+		"Write PR body for regression proof",
+		"Fetch PR base",
+		"Run CI target",
+		"Prove regression tests for fix PRs",
+	}
+	assertWorkflowStepOrder(t, verify, expectedOrder...)
+
+	resolveBase := workflowStepByName(t, workflow.Jobs, "verify", "Resolve PR base ref")
+	assertWorkflowStepRunContainsAll(t, resolveBase, "resolve PR base ref", []string{
+		`printf 'BASE_REF=%s\n' "${base_ref}" >> "$GITHUB_ENV"`,
+		`printf 'BASE_SHA=%s\n' "${PR_BASE_SHA}" >> "$GITHUB_ENV"`,
+	})
+
+	writeBody := workflowStepByName(t, workflow.Jobs, "verify", "Write PR body for regression proof")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "regression body writer action", got: writeBody.Uses, want: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3"},
+		{label: "regression body writer condition", got: writeBody.If, want: "${{ github.event_name == 'pull_request' }}"},
+	})
+	assertWorkflowStepRunContainsAll(t, workflowStepConfig{Run: writeBody.With["script"]}, "regression body writer", []string{
+		`const bodyPath = path.join(process.env.RUNNER_TEMP, 'pr-regression-body.md');`,
+		`core.exportVariable('PR_BODY_FILE', bodyPath);`,
+	})
+
+	fetchBase := workflowStepByName(t, workflow.Jobs, "verify", "Fetch PR base")
+	assertWorkflowStepRunContainsAll(t, fetchBase, "fetch PR base", []string{
+		`base_sha="${BASE_SHA:-}"`,
+		`git fetch --no-tags --depth=1 origin "${base_sha}"`,
+		`git fetch --no-tags --depth=1 origin "${base_ref}"`,
+	})
+
+	proof := workflowStepByName(t, workflow.Jobs, "verify", "Prove regression tests for fix PRs")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "regression proof condition", got: proof.If, want: "${{ github.event_name == 'pull_request' }}"},
+		{label: "regression proof title env", got: proof.Env["PR_TITLE"], want: "${{ github.event.pull_request.title }}"},
+		{label: "regression proof base env", got: proof.Env["PR_BASE_SHA"], want: "${{ github.event.pull_request.base.sha }}"},
+		{label: "regression proof exemption label env", got: proof.Env["PR_REGRESSION_EXEMPT_LABEL"], want: "${{ contains(github.event.pull_request.labels.*.name, 'regression-exempt') }}"},
+	})
+	assertWorkflowStepRunContainsAll(t, proof, "regression proof step", []string{
+		`go run ./tools/regressionproof --repo . --body-file "$PR_BODY_FILE" --title "$PR_TITLE" --base-sha "$PR_BASE_SHA" --regression-exempt-label "$PR_REGRESSION_EXEMPT_LABEL"`,
+	})
+}
+
+func TestPRMetadataWorkflowPassesMaintainerExemptionLabel(t *testing.T) {
+	t.Parallel()
+	assertPullRequestTriggerTypes(t, ".github/workflows/pr-metadata.yml")
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/pr-metadata.yml", &workflow)
+	validation := workflowStepByName(t, workflow.Jobs, "validate", "Validate PR title and template")
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "PR metadata exemption label env", got: validation.Env["PR_REGRESSION_EXEMPT_LABEL"], want: "${{ contains(github.event.pull_request.labels.*.name, 'regression-exempt') }}"},
+	})
+	assertWorkflowStepRunContainsAll(t, validation, "PR metadata validation", []string{
+		`--regression-exempt-label "$PR_REGRESSION_EXEMPT_LABEL"`,
+	})
+}
+
+func assertPullRequestTriggerTypes(t *testing.T, workflowPath string) {
+	t.Helper()
+
+	var workflow pullRequestTriggerWorkflow
+	readYAMLConfig(t, workflowPath, &workflow)
+	want := []string{"opened", "edited", "synchronize", "reopened", "ready_for_review", "labeled", "unlabeled"}
+	got := workflow.On.PullRequest.Types
+	if len(got) != len(want) {
+		t.Fatalf("%s pull_request types = %v, want %v", workflowPath, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s pull_request types = %v, want %v", workflowPath, got, want)
+		}
+	}
 }

--- a/tools/prcheck/main.go
+++ b/tools/prcheck/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/prmetadata"
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 var titlePattern = regexp.MustCompile(`^(feat|preview|fix|perf|docs|refactor|revert|test|ci|build|chore)(\([a-z0-9][a-z0-9._/-]*\))?!?: [^\s].+$`)
@@ -90,7 +91,7 @@ func run(args []string, getenv func(string) string, stderr io.Writer) int {
 
 	body := strings.TrimSpace(getenv("PR_BODY"))
 	if *bodyFile != "" {
-		data, err := os.ReadFile(*bodyFile)
+		data, err := safeio.ReadFileLimit(*bodyFile, 1<<20)
 		if err != nil {
 			return writeError(stderr, "read PR body: %v\n", err)
 		}

--- a/tools/prcheck/main.go
+++ b/tools/prcheck/main.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/ben-ranford/lopper/internal/prmetadata"
 )
 
 var titlePattern = regexp.MustCompile(`^(feat|preview|fix|perf|docs|refactor|revert|test|ci|build|chore)(\([a-z0-9][a-z0-9._/-]*\))?!?: [^\s].+$`)
@@ -63,11 +65,16 @@ func main() {
 func run(args []string, getenv func(string) string, stderr io.Writer) int {
 	fs := flag.NewFlagSet("prcheck", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	exemptionLabelDefault := getenv("PR_REGRESSION_EXEMPT_LABEL")
+	if exemptionLabelDefault == "" {
+		exemptionLabelDefault = "false"
+	}
 	title := fs.String("title", strings.TrimSpace(getenv("PR_TITLE")), "pull request title")
 	headRef := fs.String("head-ref", strings.TrimSpace(getenv("PR_HEAD_REF")), "pull request head ref")
 	headRepositoryFullName := fs.String("head-repo-full-name", strings.TrimSpace(getenv("PR_HEAD_REPO_FULL_NAME")), "pull request head repository full name")
 	repositoryFullName := fs.String("repo-full-name", strings.TrimSpace(getenv("REPOSITORY_FULL_NAME")), "repository full name")
 	bodyFile := fs.String("body-file", "", "path to a file containing the pull request body")
+	exemptionLabel := fs.String("regression-exempt-label", exemptionLabelDefault, "whether the pull request has the maintainer-controlled regression-exempt label")
 	checkRepoPolicy := fs.Bool("check-repo-policy", false, "validate repository merge policy")
 	allowMergeCommit := fs.String("allow-merge-commit", strings.TrimSpace(getenv("REPO_ALLOW_MERGE_COMMIT")), "whether the repository allows merge commits")
 	allowRebaseMerge := fs.String("allow-rebase-merge", strings.TrimSpace(getenv("REPO_ALLOW_REBASE_MERGE")), "whether the repository allows rebase merges")
@@ -76,12 +83,16 @@ func run(args []string, getenv func(string) string, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	hasExemptionLabel, err := prmetadata.ParseRegressionExemptionLabel(*exemptionLabel)
+	if err != nil {
+		return writeError(stderr, "%v\n", err)
+	}
 
 	body := strings.TrimSpace(getenv("PR_BODY"))
 	if *bodyFile != "" {
 		data, err := os.ReadFile(*bodyFile)
 		if err != nil {
-			return writeRunError(stderr, "read PR body: %v\n", err)
+			return writeError(stderr, "read PR body: %v\n", err)
 		}
 		body = string(data)
 	}
@@ -91,8 +102,8 @@ func run(args []string, getenv func(string) string, stderr io.Writer) int {
 		repositoryFullName:     *repositoryFullName,
 	}
 
-	if err := validate(*title, *headRef, body, releaseIdentity); err != nil {
-		return writeRunError(stderr, "%v\n", err)
+	if err := validate(*title, *headRef, body, releaseIdentity, hasExemptionLabel); err != nil {
+		return writeError(stderr, "%v\n", err)
 	}
 	if *checkRepoPolicy {
 		policy := repoMergePolicy{
@@ -102,24 +113,20 @@ func run(args []string, getenv func(string) string, stderr io.Writer) int {
 			squashMergeCommitTitle: *squashMergeCommitTitle,
 		}
 		if err := validateRepoMergePolicy(policy); err != nil {
-			return writeRunError(stderr, "%v\n", err)
+			return writeError(stderr, "%v\n", err)
 		}
 	}
 	return 0
 }
 
-func writeRunError(stderr io.Writer, format string, args ...any) int {
-	writeErrorMessage(stderr, format, args...)
+func writeError(stderr io.Writer, format string, args ...any) int {
+	if _, err := fmt.Fprintf(stderr, format, args...); err != nil {
+		return 1
+	}
 	return 1
 }
 
-func writeErrorMessage(stderr io.Writer, format string, args ...any) {
-	if _, err := fmt.Fprintf(stderr, format, args...); err != nil {
-		return
-	}
-}
-
-func validate(title, headRef, body string, releaseIdentity releasePleaseIdentity) error {
+func validate(title, headRef, body string, releaseIdentity releasePleaseIdentity, hasExemptionLabel bool) error {
 	var failures []string
 	title = strings.TrimSpace(title)
 	if !titlePattern.MatchString(title) {
@@ -141,6 +148,9 @@ func validate(title, headRef, body string, releaseIdentity releasePleaseIdentity
 	failures = append(failures, incompleteSectionFailures(sections)...)
 	failures = append(failures, riskFieldFailures(sections)...)
 	failures = append(failures, checklistFailures(sections)...)
+	if err := prmetadata.ValidateRegressionRequirements(title, body, hasExemptionLabel); err != nil {
+		failures = append(failures, err.Error())
+	}
 
 	if len(failures) > 0 {
 		return errors.New(strings.Join(failures, "\n"))

--- a/tools/prcheck/main_test.go
+++ b/tools/prcheck/main_test.go
@@ -36,6 +36,33 @@ func TestRunAcceptsBodyFile(t *testing.T) {
 	}
 }
 
+func TestRunRequiresMaintainerLabelForRegressionExemption(t *testing.T) {
+	const declaration = "Regression-Test: ./tools/prcheck::TestValidateAcceptsCompletedTemplate"
+	const exemption = "Regression-Test-Exemption: no deterministic local reproducer"
+	body := strings.Replace(validBody(), declaration, exemption, 1)
+	values := map[string]string{
+		"PR_TITLE":               "fix(release): validate PR metadata",
+		"PR_HEAD_REF":            "bug/issue-000-pr-title-template-gate",
+		"PR_HEAD_REPO_FULL_NAME": "ben-ranford/lopper",
+		"PR_BODY":                body,
+		"REPOSITORY_FULL_NAME":   "ben-ranford/lopper",
+	}
+
+	var stderr bytes.Buffer
+	if code := run(nil, mapEnv(values), &stderr); code != 1 {
+		t.Fatalf("reason-only run exited with %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "maintainer-controlled regression-exempt label") {
+		t.Fatalf("reason-only stderr = %q", stderr.String())
+	}
+
+	stderr.Reset()
+	values["PR_REGRESSION_EXEMPT_LABEL"] = "true"
+	if code := run(nil, mapEnv(values), &stderr); code != 0 {
+		t.Fatalf("reason-and-label run exited with %d, stderr: %s", code, stderr.String())
+	}
+}
+
 func TestRunAcceptsValidRepoPolicy(t *testing.T) {
 	var stderr bytes.Buffer
 	base := map[string]string{
@@ -171,24 +198,25 @@ func TestRunHandlesValidationErrorWriteFailure(t *testing.T) {
 
 func TestValidateAcceptsCompletedTemplate(t *testing.T) {
 	body := validBody()
-	if err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{}); err != nil {
+	if err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{}, false); err != nil {
 		t.Fatalf("validate returned error: %v", err)
 	}
 }
 
 func TestValidateAcceptsPreviewTitle(t *testing.T) {
-	if err := validate("preview(runtime): add opt-in capture", "feat/preview-runtime-capture", validBody(), releasePleaseIdentity{}); err != nil {
+	body := strings.Replace(validBody(), "\nRegression-Test: ./tools/prcheck::TestValidateAcceptsCompletedTemplate\n", "\n", 1)
+	if err := validate("preview(runtime): add opt-in capture", "feat/preview-runtime-capture", body, releasePleaseIdentity{}, false); err != nil {
 		t.Fatalf("validate returned error: %v", err)
 	}
 }
 
 func TestValidateRejectsBreakingPreviewTitle(t *testing.T) {
-	err := validate("preview(runtime)!: replace capture format", "feat/preview-runtime-capture", validBody(), releasePleaseIdentity{})
+	err := validate("preview(runtime)!: replace capture format", "feat/preview-runtime-capture", validBody(), releasePleaseIdentity{}, false)
 	expectValidationError(t, err, "Preview PR titles must not use a breaking-change marker")
 }
 
 func TestValidateRejectsBugTitle(t *testing.T) {
-	err := validate("bug: patch adapter parser", "bug/issue-123-parser", validBody(), releasePleaseIdentity{})
+	err := validate("bug: patch adapter parser", "bug/issue-123-parser", validBody(), releasePleaseIdentity{}, false)
 	if err == nil {
 		t.Fatal("validate succeeded for unsupported bug title")
 	}
@@ -198,70 +226,70 @@ func TestValidateRejectsBugTitle(t *testing.T) {
 }
 
 func TestValidateRejectsNonConventionalTitle(t *testing.T) {
-	err := validate("patch adapter parser", "bug/issue-123-parser", validBody(), releasePleaseIdentity{})
+	err := validate("patch adapter parser", "bug/issue-123-parser", validBody(), releasePleaseIdentity{}, false)
 	if err == nil {
 		t.Fatal("validate succeeded for non-conventional title")
 	}
 }
 
 func TestValidateRequiresTemplateSections(t *testing.T) {
-	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", strings.Replace(validBody(), "## Validation", "## Verification", 1), releasePleaseIdentity{})
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", strings.Replace(validBody(), "## Validation", "## Verification", 1), releasePleaseIdentity{}, false)
 	expectValidationError(t, err, `missing required template section "Validation"`)
 }
 
 func TestValidateRejectsPlaceholderOnlySection(t *testing.T) {
 	body := strings.Replace(validBody(), "Stops release-please from missing patch fixes.", "Describe the problem and the intent of this change.", 1)
-	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{})
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{}, false)
 	expectValidationError(t, err, `section "Summary" must be completed`)
 }
 
 func TestValidateRequiresRiskFields(t *testing.T) {
 	body := strings.Replace(validBody(), "- Performance impact: None\n", "", 1)
-	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{})
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{}, false)
 	expectValidationError(t, err, `field "Performance impact"`)
 }
 
 func TestValidateRequiresCheckedChecklist(t *testing.T) {
 	body := strings.Replace(validBody(), "- [x] Ready for review", "- [ ] Ready for review", 1)
-	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{})
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{}, false)
 	expectValidationError(t, err, `Checklist item "Ready for review"`)
 }
 
 func TestValidateRejectsBlankSectionWithCommentOnly(t *testing.T) {
 	body := strings.Replace(validBody(), "Stops release-please from missing patch fixes.", "<!-- TODO -->", 1)
-	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{})
+	err := validate("fix(release): validate PR metadata", "bug/issue-000-pr-title-template-gate", body, releasePleaseIdentity{}, false)
 	if err == nil {
 		t.Fatal("validate succeeded with comment-only Summary")
 	}
 }
 
 func TestValidateExemptsGeneratedReleasePleaseBody(t *testing.T) {
-	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", trustedReleasePleaseIdentity())
+	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", trustedReleasePleaseIdentity(), false)
 	if err != nil {
 		t.Fatalf("validate returned error: %v", err)
 	}
 }
 
 func TestValidateRejectsSpoofedReleasePleaseIdentity(t *testing.T) {
-	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", spoofedReleasePleaseIdentity())
+	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", spoofedReleasePleaseIdentity(), false)
 	expectValidationError(t, err, `missing required template section "Summary"`)
 }
 
 func TestValidateRejectsReleasePleasePrefixSpoof(t *testing.T) {
-	err := validate("chore(main): release 1.5.1", "release-please--branches--main-attacker", "## Changelog\n\n* fix: parser", trustedReleasePleaseIdentity())
+	err := validate("chore(main): release 1.5.1", "release-please--branches--main-attacker", "## Changelog\n\n* fix: parser", trustedReleasePleaseIdentity(), false)
 	expectValidationError(t, err, `missing required template section "Summary"`)
 }
 
 func TestValidateAcceptsRepositoryOwnedReleasePRFromNonOwnerToken(t *testing.T) {
 	identity := trustedReleasePleaseIdentity()
-	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", identity)
+	err := validate("chore(main): release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", identity, false)
 	if err != nil {
 		t.Fatalf("validate returned error: %v", err)
 	}
 }
 
 func TestValidateReleasePleaseExemptionStillRequiresReleaseTitle(t *testing.T) {
-	err := validate("release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", trustedReleasePleaseIdentity())
+	err := validate("release 1.5.1", "release-please--branches--main", "## Changelog\n\n* fix: parser", trustedReleasePleaseIdentity(), false)
 	if err == nil {
 		t.Fatal("validate succeeded for generated release PR with non-conventional title")
 	}
@@ -287,6 +315,8 @@ go test ./tools/prcheck
 Additional manual validation:
 
 - Reviewed release-please title requirements.
+
+Regression-Test: ./tools/prcheck::TestValidateAcceptsCompletedTemplate
 
 ## Risk and compatibility
 

--- a/tools/prcheck/main_test.go
+++ b/tools/prcheck/main_test.go
@@ -36,6 +36,18 @@ func TestRunAcceptsBodyFile(t *testing.T) {
 	}
 }
 
+func TestRunRejectsOversizedBodyFile(t *testing.T) {
+	bodyFile := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(bodyFile, []byte(strings.Repeat("x", 1<<20+1)), 0o600); err != nil {
+		t.Fatalf("write oversized body file: %v", err)
+	}
+	var stderr bytes.Buffer
+	code := run([]string{"--title", "fix(release): validate PR metadata", "--head-ref", "bug/issue-000-pr-title-template-gate", "--body-file", bodyFile}, mapEnv(nil), &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "read PR body") {
+		t.Fatalf("run exited with %d, stderr: %s", code, stderr.String())
+	}
+}
+
 func TestRunRequiresMaintainerLabelForRegressionExemption(t *testing.T) {
 	const declaration = "Regression-Test: ./tools/prcheck::TestValidateAcceptsCompletedTemplate"
 	const exemption = "Regression-Test-Exemption: no deterministic local reproducer"

--- a/tools/regressionproof/main.go
+++ b/tools/regressionproof/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -26,6 +27,21 @@ var (
 	statFile             = os.Stat
 	absPath              = filepath.Abs
 )
+
+const buildVCSFlag = "-buildvcs=false"
+
+type testAction string
+
+const (
+	testActionPass testAction = "pass"
+	testActionFail testAction = "fail"
+	testActionSkip testAction = "skip"
+)
+
+type goTestEvent struct {
+	Action string `json:"Action"`
+	Test   string `json:"Test"`
+}
 
 type confinedWriteRoot interface {
 	WriteFileCreatingParents(targetPath string, data []byte, perm, parentPerm os.FileMode) error
@@ -231,13 +247,13 @@ func selectProofFiles(changedFiles []string, declarations []prmetadata.Regressio
 	for _, declaration := range declarations {
 		packageDir := strings.TrimPrefix(declaration.PackagePath, "./")
 		for _, changed := range changedFiles {
-			if isPackageTestFile(packageDir, changed) || isPackageTestdataFile(packageDir, changed) {
+			if isProofSupportFile(packageDir, changed) {
 				selected[changed] = struct{}{}
 			}
 		}
 	}
 	if len(selected) == 0 {
-		return nil, errors.New("regression proof requires at least one changed *_test.go file or package testdata fixture in the declared package")
+		return nil, errors.New("regression proof requires at least one changed *_test.go file, package testdata fixture, or shared testdata fixture")
 	}
 
 	files := make([]string, 0, len(selected))
@@ -248,6 +264,10 @@ func selectProofFiles(changedFiles []string, declarations []prmetadata.Regressio
 	return files, nil
 }
 
+func isProofSupportFile(packageDir, changed string) bool {
+	return isPackageTestFile(packageDir, changed) || isPackageTestdataFile(packageDir, changed) || isSharedTestdataFile(changed)
+}
+
 func isPackageTestFile(packageDir, changed string) bool {
 	return filepath.ToSlash(filepath.Dir(changed)) == packageDir && strings.HasSuffix(changed, "_test.go")
 }
@@ -255,6 +275,10 @@ func isPackageTestFile(packageDir, changed string) bool {
 func isPackageTestdataFile(packageDir, changed string) bool {
 	prefix := packageDir + "/testdata/"
 	return strings.HasPrefix(changed, prefix)
+}
+
+func isSharedTestdataFile(changed string) bool {
+	return strings.HasPrefix(changed, "testdata/")
 }
 
 func (r *runner) createBaseWorktree(ctx context.Context, repoRoot, mergeBase string) (string, func() error, error) {
@@ -310,27 +334,84 @@ func copyProofFiles(headRoot, baseRoot string, files []string) (returnErr error)
 }
 
 func (r *runner) compilePackage(ctx context.Context, repoRoot, packagePath string) error {
-	_, err := r.execCommand(ctx, "go", []string{"test", "-buildvcs=false", "-run", "^$", packagePath}, repoRoot, os.Environ())
+	_, err := r.execCommand(ctx, "go", []string{"test", buildVCSFlag, "-run", "^$", packagePath}, repoRoot, os.Environ())
 	return err
 }
 
 func (r *runner) expectFailure(ctx context.Context, repoRoot string, declaration prmetadata.RegressionDeclaration) error {
-	_, err := r.execCommand(ctx, "go", []string{"test", "-buildvcs=false", "-count=1", "-run", "^" + declaration.TestName + "$", declaration.PackagePath}, repoRoot, os.Environ())
-	if err == nil {
+	action, err := r.runDeclaredTest(ctx, repoRoot, declaration)
+	if err != nil {
+		return fmt.Errorf("run base regression test %s::%s: %w", declaration.PackagePath, declaration.TestName, err)
+	}
+	switch action {
+	case testActionFail:
+		return nil
+	case testActionSkip:
+		return fmt.Errorf("base regression test must fail instead of skip: %s::%s", declaration.PackagePath, declaration.TestName)
+	case testActionPass:
 		return fmt.Errorf("base regression test unexpectedly passed: %s::%s", declaration.PackagePath, declaration.TestName)
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return nil
-	}
-	return fmt.Errorf("run base regression test %s::%s: %w", declaration.PackagePath, declaration.TestName, err)
+	return fmt.Errorf("base regression test finished without a recognized outcome: %s::%s", declaration.PackagePath, declaration.TestName)
 }
 
 func (r *runner) expectPass(ctx context.Context, repoRoot string, declaration prmetadata.RegressionDeclaration) error {
-	if _, err := r.execCommand(ctx, "go", []string{"test", "-buildvcs=false", "-count=1", "-run", "^" + declaration.TestName + "$", declaration.PackagePath}, repoRoot, os.Environ()); err != nil {
+	action, err := r.runDeclaredTest(ctx, repoRoot, declaration)
+	if err != nil {
 		return fmt.Errorf("pull request regression test must pass on head for %s::%s: %w", declaration.PackagePath, declaration.TestName, err)
 	}
+	if action == testActionSkip {
+		return fmt.Errorf("pull request regression test must pass instead of skip on head for %s::%s", declaration.PackagePath, declaration.TestName)
+	}
+	if action != testActionPass {
+		return fmt.Errorf("pull request regression test must pass on head for %s::%s", declaration.PackagePath, declaration.TestName)
+	}
 	return nil
+}
+
+func (r *runner) runDeclaredTest(ctx context.Context, repoRoot string, declaration prmetadata.RegressionDeclaration) (testAction, error) {
+	output, err := r.execCommand(ctx, "go", []string{"test", buildVCSFlag, "-count=1", "-json", "-run", "^" + declaration.TestName + "$", declaration.PackagePath}, repoRoot, os.Environ())
+	action, parseErr := parseDeclaredTestAction(output, declaration.TestName)
+	if parseErr != nil {
+		if err != nil {
+			return "", errors.Join(err, parseErr)
+		}
+		return "", parseErr
+	}
+	var exitErr *exec.ExitError
+	if err != nil && !errors.As(err, &exitErr) {
+		return "", err
+	}
+	return action, nil
+}
+
+func parseDeclaredTestAction(output []byte, testName string) (testAction, error) {
+	var sawJSON bool
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		sawJSON = true
+		var event goTestEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			return "", fmt.Errorf("parse go test json for %s: %w", testName, err)
+		}
+		if event.Test != testName {
+			continue
+		}
+		switch event.Action {
+		case string(testActionPass):
+			return testActionPass, nil
+		case string(testActionFail):
+			return testActionFail, nil
+		case string(testActionSkip):
+			return testActionSkip, nil
+		}
+	}
+	if sawJSON {
+		return "", fmt.Errorf("go test did not report an outcome for %s", testName)
+	}
+	return "", fmt.Errorf("go test did not emit JSON output for %s", testName)
 }
 
 func (r *runner) gitOutput(ctx context.Context, repoRoot string, args ...string) (string, error) {

--- a/tools/regressionproof/main.go
+++ b/tools/regressionproof/main.go
@@ -1,0 +1,356 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/gitexec"
+	"github.com/ben-ranford/lopper/internal/prmetadata"
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+var (
+	resolveGitBinaryPath = gitexec.ResolveBinaryPath
+	removeAll            = os.RemoveAll
+	mkdirTemp            = os.MkdirTemp
+	readFileUnder        = safeio.ReadFileUnder
+	statFile             = os.Stat
+	absPath              = filepath.Abs
+)
+
+type confinedWriteRoot interface {
+	WriteFileCreatingParents(targetPath string, data []byte, perm, parentPerm os.FileMode) error
+	Close() error
+}
+
+var openWriteRoot = func(rootDir string) (confinedWriteRoot, error) {
+	return safeio.OpenWriteRoot(rootDir)
+}
+
+type execRunner struct{}
+
+func (*execRunner) Run(ctx context.Context, name string, args []string, dir string, env []string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	if len(env) > 0 {
+		cmd.Env = env
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	output := append(stdout.Bytes(), stderr.Bytes()...)
+	if err != nil {
+		return output, &commandError{name: name, args: args, output: output, err: err}
+	}
+	return output, nil
+}
+
+type commandError struct {
+	name   string
+	args   []string
+	output []byte
+	err    error
+}
+
+func (e *commandError) Error() string {
+	output := strings.TrimSpace(string(e.output))
+	if output == "" {
+		return fmt.Sprintf("%s %s: %v", e.name, strings.Join(e.args, " "), e.err)
+	}
+	return fmt.Sprintf("%s %s: %v: %s", e.name, strings.Join(e.args, " "), e.err, output)
+}
+
+func (e *commandError) Unwrap() error {
+	return e.err
+}
+
+type runner struct {
+	stderr      io.Writer
+	execCommand func(context.Context, string, []string, string, []string) ([]byte, error)
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Getenv, os.Stdout, os.Stderr))
+}
+
+func run(args []string, getenv func(string) string, stdout, stderr io.Writer) int {
+	execRunner := &execRunner{}
+	r := &runner{stderr: stderr, execCommand: execRunner.Run}
+	return r.run(args, getenv, stdout)
+}
+
+func (r *runner) run(args []string, getenv func(string) string, stdout io.Writer) int {
+	fs := flag.NewFlagSet("regressionproof", flag.ContinueOnError)
+	fs.SetOutput(r.stderr)
+	exemptionLabelDefault := getenv("PR_REGRESSION_EXEMPT_LABEL")
+	if exemptionLabelDefault == "" {
+		exemptionLabelDefault = "false"
+	}
+	title := fs.String("title", strings.TrimSpace(getenv("PR_TITLE")), "pull request title")
+	repoRoot := fs.String("repo", ".", "repository root")
+	baseSHA := fs.String("base-sha", strings.TrimSpace(getenv("PR_BASE_SHA")), "pull request base SHA")
+	bodyFile := fs.String("body-file", strings.TrimSpace(getenv("PR_BODY_FILE")), "path to a file containing the pull request body")
+	exemptionLabel := fs.String("regression-exempt-label", exemptionLabelDefault, "whether the pull request has the maintainer-controlled regression-exempt label")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	hasExemptionLabel, err := prmetadata.ParseRegressionExemptionLabel(*exemptionLabel)
+	if err != nil {
+		return writeError(r.stderr, "%v\n", err)
+	}
+
+	body, err := readBody(*bodyFile, getenv)
+	if err != nil {
+		return writeError(r.stderr, "read PR body: %v\n", err)
+	}
+
+	metadata, err := prmetadata.ParseRegressionProof(body)
+	if err != nil {
+		return writeError(r.stderr, "%v\n", err)
+	}
+	if err := prmetadata.ValidateRegressionRequirements(*title, body, hasExemptionLabel); err != nil {
+		return writeError(r.stderr, "%v\n", err)
+	}
+	if !prmetadata.IsFixTitle(*title) {
+		if _, writeErr := fmt.Fprintln(stdout, "Regression proof skipped: non-fix PR."); writeErr != nil {
+			return writeError(r.stderr, "write regression proof status: %v\n", writeErr)
+		}
+		return 0
+	}
+	if metadata.ExemptionReason != "" {
+		if _, writeErr := fmt.Fprintf(stdout, "Regression proof exempted by regression-exempt label: %s\n", metadata.ExemptionReason); writeErr != nil {
+			return writeError(r.stderr, "write regression proof status: %v\n", writeErr)
+		}
+		return 0
+	}
+	if strings.TrimSpace(*baseSHA) == "" {
+		err := errors.New("base SHA is required for regression proof")
+		return writeError(r.stderr, "%v\n", err)
+	}
+
+	repoAbs, err := absPath(*repoRoot)
+	if err != nil {
+		return writeError(r.stderr, "resolve repo root: %v\n", err)
+	}
+	ctx := context.Background()
+	if err := r.prove(ctx, repoAbs, strings.TrimSpace(*baseSHA), metadata.Declarations, stdout); err != nil {
+		return writeError(r.stderr, "%v\n", err)
+	}
+	return 0
+}
+
+func readBody(bodyFile string, getenv func(string) string) (string, error) {
+	if strings.TrimSpace(bodyFile) != "" {
+		data, err := safeio.ReadFileLimit(bodyFile, 1<<20)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	}
+	return getenv("PR_BODY"), nil
+}
+
+func (r *runner) prove(ctx context.Context, repoRoot, baseSHA string, declarations []prmetadata.RegressionDeclaration, stdout io.Writer) error {
+	mergeBase, err := r.gitOutput(ctx, repoRoot, "merge-base", baseSHA, "HEAD")
+	if err != nil {
+		return fmt.Errorf("resolve merge base: %w", err)
+	}
+	mergeBase = strings.TrimSpace(mergeBase)
+	if mergeBase == "" {
+		return errors.New("resolve merge base: git returned an empty commit")
+	}
+
+	changedFiles, err := r.changedFiles(ctx, repoRoot, mergeBase)
+	if err != nil {
+		return err
+	}
+	selectedFiles, err := selectProofFiles(changedFiles, declarations)
+	if err != nil {
+		return err
+	}
+
+	worktreeRoot, cleanup, err := r.createBaseWorktree(ctx, repoRoot, mergeBase)
+	if err != nil {
+		return err
+	}
+	finish := func(baseErr error) error {
+		return errors.Join(baseErr, cleanup())
+	}
+
+	if err := copyProofFiles(repoRoot, worktreeRoot, selectedFiles); err != nil {
+		return finish(err)
+	}
+
+	for _, declaration := range declarations {
+		if err := r.compilePackage(ctx, worktreeRoot, declaration.PackagePath); err != nil {
+			return finish(fmt.Errorf("base regression test package %s must compile before proof: %w", declaration.PackagePath, err))
+		}
+		if err := r.expectFailure(ctx, worktreeRoot, declaration); err != nil {
+			return finish(err)
+		}
+		if err := r.expectPass(ctx, repoRoot, declaration); err != nil {
+			return finish(err)
+		}
+		if _, writeErr := fmt.Fprintf(stdout, "Regression proof verified: %s::%s\n", declaration.PackagePath, declaration.TestName); writeErr != nil {
+			return finish(writeErr)
+		}
+	}
+
+	return finish(nil)
+}
+
+func (r *runner) changedFiles(ctx context.Context, repoRoot, mergeBase string) ([]string, error) {
+	output, err := r.gitOutput(ctx, repoRoot, "diff", "--name-only", "--diff-filter=ACMR", mergeBase+"..HEAD", "--")
+	if err != nil {
+		return nil, fmt.Errorf("list changed files: %w", err)
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		files = append(files, filepath.ToSlash(line))
+	}
+	return files, nil
+}
+
+func selectProofFiles(changedFiles []string, declarations []prmetadata.RegressionDeclaration) ([]string, error) {
+	selected := make(map[string]struct{})
+	for _, declaration := range declarations {
+		packageDir := strings.TrimPrefix(declaration.PackagePath, "./")
+		for _, changed := range changedFiles {
+			if isPackageTestFile(packageDir, changed) || isPackageTestdataFile(packageDir, changed) {
+				selected[changed] = struct{}{}
+			}
+		}
+	}
+	if len(selected) == 0 {
+		return nil, errors.New("regression proof requires at least one changed *_test.go file or package testdata fixture in the declared package")
+	}
+
+	files := make([]string, 0, len(selected))
+	for file := range selected {
+		files = append(files, file)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func isPackageTestFile(packageDir, changed string) bool {
+	return filepath.ToSlash(filepath.Dir(changed)) == packageDir && strings.HasSuffix(changed, "_test.go")
+}
+
+func isPackageTestdataFile(packageDir, changed string) bool {
+	prefix := packageDir + "/testdata/"
+	return strings.HasPrefix(changed, prefix)
+}
+
+func (r *runner) createBaseWorktree(ctx context.Context, repoRoot, mergeBase string) (string, func() error, error) {
+	worktreeParent, err := mkdirTemp("", "lopper-regression-proof-")
+	if err != nil {
+		return "", nil, fmt.Errorf("create worktree parent: %w", err)
+	}
+	worktreePath := filepath.Join(worktreeParent, "base")
+	if _, err := r.runGit(ctx, repoRoot, "worktree", "add", "--detach", worktreePath, mergeBase); err != nil {
+		if removeErr := removeAll(worktreeParent); removeErr != nil {
+			err = errors.Join(err, fmt.Errorf("remove failed worktree parent: %w", removeErr))
+		}
+		return "", nil, fmt.Errorf("create base worktree: %w", err)
+	}
+
+	cleanup := func() error {
+		_, removeWorktreeErr := r.runGit(context.Background(), repoRoot, "worktree", "remove", "--force", worktreePath)
+		removeParentErr := removeAll(worktreeParent)
+		return errors.Join(removeWorktreeErr, removeParentErr)
+	}
+	return worktreePath, cleanup, nil
+}
+
+func copyProofFiles(headRoot, baseRoot string, files []string) (returnErr error) {
+	writeRoot, err := openWriteRoot(baseRoot)
+	if err != nil {
+		return fmt.Errorf("open base worktree root: %w", err)
+	}
+	defer func() {
+		if closeErr := writeRoot.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, fmt.Errorf("close base worktree root: %w", closeErr))
+		}
+	}()
+
+	for _, rel := range files {
+		sourcePath := filepath.Join(headRoot, filepath.FromSlash(rel))
+		data, err := readFileUnder(headRoot, sourcePath)
+		if err != nil {
+			return fmt.Errorf("read changed proof file %s: %w", rel, err)
+		}
+		info, err := statFile(sourcePath)
+		if err != nil {
+			return fmt.Errorf("stat changed proof file %s: %w", rel, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("changed proof file %s must be a regular file", rel)
+		}
+		if err := writeRoot.WriteFileCreatingParents(filepath.FromSlash(rel), data, info.Mode().Perm(), 0o755); err != nil {
+			return fmt.Errorf("copy changed proof file %s into base worktree: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+func (r *runner) compilePackage(ctx context.Context, repoRoot, packagePath string) error {
+	_, err := r.execCommand(ctx, "go", []string{"test", "-buildvcs=false", "-run", "^$", packagePath}, repoRoot, os.Environ())
+	return err
+}
+
+func (r *runner) expectFailure(ctx context.Context, repoRoot string, declaration prmetadata.RegressionDeclaration) error {
+	_, err := r.execCommand(ctx, "go", []string{"test", "-buildvcs=false", "-count=1", "-run", "^" + declaration.TestName + "$", declaration.PackagePath}, repoRoot, os.Environ())
+	if err == nil {
+		return fmt.Errorf("base regression test unexpectedly passed: %s::%s", declaration.PackagePath, declaration.TestName)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return nil
+	}
+	return fmt.Errorf("run base regression test %s::%s: %w", declaration.PackagePath, declaration.TestName, err)
+}
+
+func (r *runner) expectPass(ctx context.Context, repoRoot string, declaration prmetadata.RegressionDeclaration) error {
+	if _, err := r.execCommand(ctx, "go", []string{"test", "-buildvcs=false", "-count=1", "-run", "^" + declaration.TestName + "$", declaration.PackagePath}, repoRoot, os.Environ()); err != nil {
+		return fmt.Errorf("pull request regression test must pass on head for %s::%s: %w", declaration.PackagePath, declaration.TestName, err)
+	}
+	return nil
+}
+
+func (r *runner) gitOutput(ctx context.Context, repoRoot string, args ...string) (string, error) {
+	output, err := r.runGit(ctx, repoRoot, args...)
+	return string(output), err
+}
+
+func (r *runner) runGit(ctx context.Context, repoRoot string, args ...string) ([]byte, error) {
+	gitPath, err := resolveGitBinaryPath()
+	if err != nil {
+		return nil, err
+	}
+	fullArgs := append([]string{"-C", repoRoot}, gitexec.SafeConfigArgs()...)
+	fullArgs = append(fullArgs, args...)
+	return r.execCommand(ctx, gitPath, fullArgs, repoRoot, gitexec.SanitizedEnv())
+}
+
+func writeError(stderr io.Writer, format string, args ...any) int {
+	if _, err := fmt.Fprintf(stderr, format, args...); err != nil {
+		return 1
+	}
+	return 1
+}

--- a/tools/regressionproof/main.go
+++ b/tools/regressionproof/main.go
@@ -424,7 +424,7 @@ func (r *runner) runGit(ctx context.Context, repoRoot string, args ...string) ([
 	if err != nil {
 		return nil, err
 	}
-	fullArgs := append([]string{"-C", repoRoot}, gitexec.SafeConfigArgs()...)
+	fullArgs := append(gitexec.SafeConfigArgs(), "-C", repoRoot)
 	fullArgs = append(fullArgs, args...)
 	return r.execCommand(ctx, gitPath, fullArgs, repoRoot, gitexec.SanitizedEnv())
 }

--- a/tools/regressionproof/main_test.go
+++ b/tools/regressionproof/main_test.go
@@ -1,0 +1,1033 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/gitexec"
+	"github.com/ben-ranford/lopper/internal/prmetadata"
+)
+
+func TestRunRejectsInvalidRegressionProofs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		scenario regressionProofScenario
+		wantErr  string
+	}{
+		{
+			name: "missing changed regression files",
+			scenario: regressionProofScenario{
+				baseFiles: map[string]string{
+					"go.mod":         "module example.com/regressionproof\n\ngo 1.23\n",
+					"buggy/buggy.go": "package buggy\n\nfunc Fixed() bool { return false }\n",
+				},
+				headFiles: map[string]string{
+					"buggy/buggy.go": "package buggy\n\nfunc Fixed() bool { return true }\n",
+				},
+			},
+			wantErr: "requires at least one changed *_test.go file",
+		},
+		{
+			name: "base unexpectedly passes",
+			scenario: regressionProofScenario{
+				baseFiles: map[string]string{
+					"go.mod": "module example.com/regressionproof\n\ngo 1.23\n",
+					"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return true }
+`,
+				},
+				headFiles: map[string]string{
+					"buggy/buggy_test.go": `package buggy
+
+import "testing"
+
+func TestRegressionProof(t *testing.T) {
+	if !Fixed() {
+		t.Fatal("expected true")
+	}
+}
+`,
+				},
+			},
+			wantErr: "unexpectedly passed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newRegressionProofRepo(t, tt.scenario)
+			code, stderr := runRegressionProof(t, repo, regressionProofInvocation{title: "fix(buggy): add proof gate", body: regressionProofBody()})
+			if code != 1 {
+				t.Fatalf("run exited with %d, want 1 (stderr: %s)", code, stderr)
+			}
+			if !strings.Contains(stderr, tt.wantErr) {
+				t.Fatalf("stderr = %q, want %q", stderr, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunFailsWhenBaseDoesNotCompile(t *testing.T) {
+	t.Parallel()
+
+	repo := newRegressionProofRepo(t, regressionProofScenario{
+		baseFiles: map[string]string{
+			"go.mod": "module example.com/regressionproof\n\ngo 1.23\n",
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return false }
+`,
+		},
+		headFiles: map[string]string{
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return true }
+
+func NewBehavior() bool { return true }
+`,
+			"buggy/buggy_test.go": `package buggy
+
+import "testing"
+
+func TestRegressionProof(t *testing.T) {
+	if !NewBehavior() {
+		t.Fatal("expected new behavior")
+	}
+}
+`,
+		},
+	})
+
+	code, stderr := runRegressionProof(t, repo, regressionProofInvocation{title: "fix(buggy): add proof gate", body: regressionProofBody()})
+	if code != 1 {
+		t.Fatalf("run exited with %d, want 1 (stderr: %s)", code, stderr)
+	}
+	if !strings.Contains(stderr, "must compile before proof") {
+		t.Fatalf("stderr = %q, want compile failure", stderr)
+	}
+}
+
+func TestRunAcceptsValidRegressionProof(t *testing.T) {
+	t.Parallel()
+
+	repo := newRegressionProofRepo(t, regressionProofScenario{
+		baseFiles: map[string]string{
+			"go.mod": "module example.com/regressionproof\n\ngo 1.23\n",
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return false }
+`,
+		},
+		headFiles: map[string]string{
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return true }
+`,
+			"buggy/buggy_test.go": `package buggy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRegressionProof(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "expected.txt"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	want := strings.TrimSpace(string(data)) == "true"
+	if got := Fixed(); got != want {
+		t.Fatalf("Fixed() = %v, want %v", got, want)
+	}
+}
+`,
+			"buggy/testdata/expected.txt": "true\n",
+		},
+	})
+
+	code, stderr := runRegressionProof(t, repo, regressionProofInvocation{title: "fix(buggy): add proof gate", body: regressionProofBody()})
+	if code != 0 {
+		t.Fatalf("run exited with %d, want 0 (stderr: %s)", code, stderr)
+	}
+}
+
+func TestCommandErrorFormattingAndUnwrap(t *testing.T) {
+	t.Parallel()
+
+	errWithOutput := &commandError{name: "go", args: []string{"test"}, output: []byte("boom\n"), err: errors.New("exit")}
+	if got := errWithOutput.Error(); !strings.Contains(got, "boom") {
+		t.Fatalf("Error() = %q, want embedded output", got)
+	}
+	if !errors.Is(errWithOutput, errWithOutput.err) {
+		t.Fatal("commandError must unwrap to the underlying error")
+	}
+
+	errWithoutOutput := &commandError{name: "go", args: []string{"test"}, err: errors.New("exit")}
+	if got := errWithoutOutput.Error(); strings.Contains(got, "boom") {
+		t.Fatalf("Error() = %q, want no stale output", got)
+	}
+}
+
+func TestReadBodyUsesEnvAndRejectsOversizedFile(t *testing.T) {
+	t.Parallel()
+
+	body, err := readBody("", regressionProofEnv(map[string]string{"PR_BODY": "from env"}))
+	if err != nil || body != "from env" {
+		t.Fatalf("readBody env = %q, %v", body, err)
+	}
+
+	path := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", 1<<20+1)), 0o600); err != nil {
+		t.Fatalf("write oversized body: %v", err)
+	}
+	if _, err := readBody(path, func(string) string { return "" }); err == nil {
+		t.Fatal("readBody succeeded for oversized body file")
+	}
+}
+
+func TestRunnerRunHandlesInvalidFlagsAndMissingBody(t *testing.T) {
+	t.Parallel()
+
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: (&execRunner{}).Run}
+	if code := r.run([]string{"--bad-flag"}, func(string) string { return "" }, &bytes.Buffer{}); code != 2 {
+		t.Fatalf("run returned %d, want 2", code)
+	}
+	if code := r.run([]string{"--body-file", filepath.Join(t.TempDir(), "missing.md")}, func(string) string { return "" }, &bytes.Buffer{}); code != 1 {
+		t.Fatalf("run returned %d, want 1 for missing body file", code)
+	}
+	var stderr bytes.Buffer
+	r.stderr = &stderr
+	if code := r.run([]string{"--regression-exempt-label", "$(touch injected)"}, func(string) string { return "" }, &bytes.Buffer{}); code != 1 {
+		t.Fatalf("run returned %d, want 1 for malformed exemption label boolean", code)
+	}
+	if !strings.Contains(stderr.String(), "must be exactly true or false") {
+		t.Fatalf("stderr = %q, want strict boolean validation failure", stderr.String())
+	}
+}
+
+func TestRunnerRunRequiresReasonAndMaintainerLabelForExemption(t *testing.T) {
+	t.Parallel()
+
+	reason := "Regression-Test-Exemption: no deterministic reproducer"
+	tests := []struct {
+		name       string
+		title      string
+		body       string
+		labelValue string
+		wantCode   int
+		wantText   string
+	}{
+		{name: "reason only", title: "fix(ci): add gate", body: reason, labelValue: "false", wantCode: 1, wantText: "maintainer-controlled regression-exempt label"},
+		{name: "label only", title: "fix(ci): add gate", body: "## Validation\n\nNo regression metadata\n", labelValue: "true", wantCode: 1, wantText: "requires a non-empty Regression-Test-Exemption reason"},
+		{name: "reason and label", title: "fix(ci): add gate", body: reason, labelValue: "true", wantCode: 0, wantText: "Regression proof exempted"},
+		{name: "non-fix metadata", title: "feat(ci): add gate", body: reason, labelValue: "true", wantCode: 1, wantText: "only allowed on conventional fix"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			r := &runner{stderr: &stderr, execCommand: (&execRunner{}).Run}
+			env := regressionProofEnv(map[string]string{
+				"PR_TITLE":                   tt.title,
+				"PR_BODY":                    tt.body,
+				"PR_REGRESSION_EXEMPT_LABEL": tt.labelValue,
+			})
+			code := r.run(nil, env, &stdout)
+			if code != tt.wantCode {
+				t.Fatalf("run returned %d, want %d (stderr: %s)", code, tt.wantCode, stderr.String())
+			}
+			output := stdout.String() + stderr.String()
+			if !strings.Contains(output, tt.wantText) {
+				t.Fatalf("output = %q, want %q", output, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestRunnerRunSkipsNonFixAndRejectsMissingBase(t *testing.T) {
+	t.Parallel()
+
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: (&execRunner{}).Run}
+	stdout := &bytes.Buffer{}
+	nonFixEnv := regressionProofEnv(map[string]string{
+		"PR_TITLE": "feat(ci): add gate",
+		"PR_BODY":  "## Validation\n\nNo regression metadata\n",
+	})
+	code := r.run(nil, nonFixEnv, stdout)
+	if code != 0 || !strings.Contains(stdout.String(), "skipped") {
+		t.Fatalf("non-fix run = %d, stdout = %q", code, stdout.String())
+	}
+
+	missingBaseEnv := regressionProofEnv(map[string]string{
+		"PR_TITLE": "fix(ci): add gate",
+		"PR_BODY":  "Regression-Test: ./pkg::TestThing",
+	})
+	code = r.run(nil, missingBaseEnv, &bytes.Buffer{})
+	if code != 1 {
+		t.Fatalf("run returned %d, want 1 for missing base SHA", code)
+	}
+}
+
+func TestRunnerRunRejectsMalformedMetadataAndWriterFailures(t *testing.T) {
+	t.Parallel()
+
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: (&execRunner{}).Run}
+	malformedEnv := regressionProofEnv(map[string]string{
+		"PR_TITLE": "fix(ci): add gate",
+		"PR_BODY":  "Regression-Test: invalid",
+	})
+	code := r.run(nil, malformedEnv, &bytes.Buffer{})
+	if code != 1 {
+		t.Fatalf("run returned %d, want 1 for malformed metadata", code)
+	}
+
+	nonFixStatusEnv := regressionProofEnv(map[string]string{
+		"PR_TITLE": "feat(ci): add gate",
+		"PR_BODY":  "## Validation\n\nNo regression metadata\n",
+	})
+	code = r.run(nil, nonFixStatusEnv, &errWriter{})
+	if code != 1 {
+		t.Fatalf("run returned %d, want 1 for stdout write failure", code)
+	}
+
+	exemptionStatusEnv := regressionProofEnv(map[string]string{
+		"PR_TITLE":                   "fix(ci): add gate",
+		"PR_BODY":                    "Regression-Test-Exemption: no deterministic reproducer",
+		"PR_REGRESSION_EXEMPT_LABEL": "true",
+	})
+	code = r.run(nil, exemptionStatusEnv, &errWriter{})
+	if code != 1 {
+		t.Fatalf("run returned %d, want 1 for exemption write failure", code)
+	}
+
+	stderrWriteEnv := regressionProofEnv(map[string]string{
+		"PR_TITLE":    "fix(ci): add gate",
+		"PR_BODY":     "Regression-Test: ./pkg::TestThing",
+		"PR_BASE_SHA": "base",
+	})
+	code = r.run(nil, stderrWriteEnv, &errWriter{})
+	if code != 1 {
+		t.Fatalf("run returned %d, want 1 for stderr write failure", code)
+	}
+
+	validationEnv := regressionProofEnv(map[string]string{
+		"PR_TITLE": "feat(ci): add gate",
+		"PR_BODY":  "Regression-Test: ./pkg::TestThing",
+	})
+	code = r.run(nil, validationEnv, &bytes.Buffer{})
+	if code != 1 {
+		t.Fatalf("run returned %d, want 1 for validation rejection", code)
+	}
+}
+
+func TestRunnerRunProofAndAbsFailures(t *testing.T) {
+	originalAbsPath := absPath
+	defer func() { absPath = originalAbsPath }()
+
+	r := &runner{
+		stderr: &bytes.Buffer{},
+		execCommand: func(context.Context, string, []string, string, []string) ([]byte, error) {
+			return nil, errors.New("proof failed")
+		},
+	}
+	proofFailureEnv := regressionProofEnv(map[string]string{
+		"PR_TITLE":    "fix(ci): add gate",
+		"PR_BODY":     "Regression-Test: ./pkg::TestThing",
+		"PR_BASE_SHA": "base",
+	})
+	code := r.run(nil, proofFailureEnv, &bytes.Buffer{})
+	if code != 1 {
+		t.Fatalf("run returned %d, want 1 for proof failure", code)
+	}
+
+	absPath = func(string) (string, error) {
+		return "", errors.New("abs failed")
+	}
+	r = &runner{stderr: &bytes.Buffer{}, execCommand: (&execRunner{}).Run}
+	absFailureEnv := regressionProofEnv(map[string]string{
+		"PR_TITLE":    "fix(ci): add gate",
+		"PR_BODY":     "Regression-Test: ./pkg::TestThing",
+		"PR_BASE_SHA": "base",
+	})
+	code = r.run(nil, absFailureEnv, &bytes.Buffer{})
+	if code != 1 {
+		t.Fatalf("run returned %d, want 1 for abs failure", code)
+	}
+}
+
+func TestChangedFilesAndRunGitErrorPaths(t *testing.T) {
+	originalResolve := resolveGitBinaryPath
+	resolveGitBinaryPath = func() (string, error) { return "", errors.New("no git") }
+	defer func() { resolveGitBinaryPath = originalResolve }()
+
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: func(context.Context, string, []string, string, []string) ([]byte, error) {
+		return nil, nil
+	}}
+	if _, err := r.runGit(context.Background(), ".", "status"); err == nil {
+		t.Fatal("runGit succeeded without a git binary")
+	}
+
+	resolveGitBinaryPath = originalResolve
+	gitPath, err := gitexec.ResolveBinaryPath()
+	if err != nil {
+		t.Fatalf("ResolveBinaryPath: %v", err)
+	}
+	r.execCommand = func(_ context.Context, name string, args []string, dir string, env []string) ([]byte, error) {
+		if name != gitPath {
+			t.Fatalf("name = %q, want git path %q", name, gitPath)
+		}
+		if len(env) == 0 || dir != "." {
+			t.Fatalf("unexpected runGit call: dir=%q env=%d", dir, len(env))
+		}
+		return []byte("pkg/a_test.go\npkg/testdata/case.txt\n\n"), nil
+	}
+	files, err := r.changedFiles(context.Background(), ".", "base")
+	if err != nil {
+		t.Fatalf("changedFiles returned error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("changedFiles = %#v, want 2 files", files)
+	}
+
+	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
+		return nil, errors.New("diff failed")
+	}
+	if _, err := r.changedFiles(context.Background(), ".", "base"); err == nil {
+		t.Fatal("changedFiles succeeded when git diff failed")
+	}
+
+	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
+		return []byte("\n \n"), nil
+	}
+	files, err = r.changedFiles(context.Background(), ".", "base")
+	if err != nil {
+		t.Fatalf("changedFiles returned error for empty diff: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("changedFiles = %#v, want no files", files)
+	}
+}
+
+func TestCreateBaseWorktreeFailureAndCleanup(t *testing.T) {
+	originalResolve := resolveGitBinaryPath
+	originalRemoveAll := removeAll
+	originalMkdirTemp := mkdirTemp
+	defer func() {
+		resolveGitBinaryPath = originalResolve
+		removeAll = originalRemoveAll
+		mkdirTemp = originalMkdirTemp
+	}()
+
+	mkdirTemp = func(string, string) (string, error) {
+		return "", errors.New("mkdir failed")
+	}
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: func(context.Context, string, []string, string, []string) ([]byte, error) {
+		return nil, nil
+	}}
+	if _, _, err := r.createBaseWorktree(context.Background(), ".", "base"); err == nil {
+		t.Fatal("createBaseWorktree succeeded despite tempdir failure")
+	}
+
+	mkdirTemp = originalMkdirTemp
+
+	gitPath, err := gitexec.ResolveBinaryPath()
+	if err != nil {
+		t.Fatalf("ResolveBinaryPath: %v", err)
+	}
+	resolveGitBinaryPath = func() (string, error) { return gitPath, nil }
+
+	var removed []string
+	removeAll = func(path string) error {
+		removed = append(removed, path)
+		return nil
+	}
+
+	r = &runner{stderr: &bytes.Buffer{}, execCommand: func(_ context.Context, _ string, args []string, _ string, _ []string) ([]byte, error) {
+		if strings.Contains(strings.Join(args, " "), "worktree add") {
+			return nil, errors.New("add failed")
+		}
+		return nil, nil
+	}}
+	if _, _, err := r.createBaseWorktree(context.Background(), ".", "base"); err == nil {
+		t.Fatal("createBaseWorktree succeeded on add failure")
+	}
+	if len(removed) != 1 {
+		t.Fatalf("removeAll calls = %d, want 1", len(removed))
+	}
+
+	removeAll = func(path string) error {
+		removed = append(removed, path)
+		return errors.New("cleanup add failed")
+	}
+	if _, _, err := r.createBaseWorktree(context.Background(), ".", "base"); err == nil {
+		t.Fatal("createBaseWorktree succeeded on add failure with cleanup error")
+	}
+
+	removeAll = func(path string) error {
+		removed = append(removed, path)
+		return errors.New("cleanup failed")
+	}
+	r.execCommand = func(_ context.Context, _ string, _ []string, _ string, _ []string) ([]byte, error) {
+		return nil, nil
+	}
+	worktreePath, cleanup, err := r.createBaseWorktree(context.Background(), ".", "base")
+	if err != nil {
+		t.Fatalf("createBaseWorktree returned error: %v", err)
+	}
+	if !strings.HasSuffix(worktreePath, "base") {
+		t.Fatalf("worktreePath = %q", worktreePath)
+	}
+	if err := cleanup(); err == nil {
+		t.Fatal("cleanup succeeded despite removeAll failure")
+	}
+
+	removeAll = func(string) error { return nil }
+	r.execCommand = func(_ context.Context, _ string, args []string, _ string, _ []string) ([]byte, error) {
+		if strings.Contains(strings.Join(args, " "), "worktree remove") {
+			return nil, errors.New("remove worktree failed")
+		}
+		return nil, nil
+	}
+	_, cleanup, err = r.createBaseWorktree(context.Background(), ".", "base")
+	if err != nil {
+		t.Fatalf("createBaseWorktree returned error: %v", err)
+	}
+	if err := cleanup(); err == nil {
+		t.Fatal("cleanup succeeded despite worktree remove failure")
+	}
+}
+
+func TestCopyProofFilesAndExpectHelpers(t *testing.T) {
+	t.Parallel()
+
+	headRoot := t.TempDir()
+	baseRoot := t.TempDir()
+	sourcePath := filepath.Join(headRoot, "pkg", "case_test.go")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("package pkg\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := copyProofFiles(headRoot, baseRoot, []string{"pkg/case_test.go"}); err != nil {
+		t.Fatalf("copyProofFiles returned error: %v", err)
+	}
+	targetData, err := os.ReadFile(filepath.Join(baseRoot, "pkg", "case_test.go"))
+	if err != nil || string(targetData) != "package pkg\n" {
+		t.Fatalf("copied file = %q, %v", string(targetData), err)
+	}
+
+	dirHead := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dirHead, "pkg", "dir_test.go"), 0o755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+	if err := copyProofFiles(dirHead, t.TempDir(), []string{"pkg/dir_test.go"}); err == nil {
+		t.Fatal("copyProofFiles succeeded for non-regular source")
+	}
+
+	baseFile := filepath.Join(t.TempDir(), "base-file")
+	if err := os.WriteFile(baseFile, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write base file: %v", err)
+	}
+	if err := copyProofFiles(headRoot, baseFile, []string{"pkg/case_test.go"}); err == nil {
+		t.Fatal("copyProofFiles succeeded for non-directory base root")
+	}
+	if err := copyProofFiles(headRoot, baseRoot, []string{"pkg/missing_test.go"}); err == nil {
+		t.Fatal("copyProofFiles succeeded for missing source file")
+	}
+	if err := copyProofFiles(headRoot, filepath.Join(baseRoot, "missing", "child"), []string{"pkg/case_test.go"}); err == nil {
+		t.Fatal("copyProofFiles succeeded for missing base root")
+	}
+
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: func(context.Context, string, []string, string, []string) ([]byte, error) {
+		return nil, errors.New("boom")
+	}}
+	if err := r.expectFailure(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil {
+		t.Fatal("expectFailure succeeded for non-exit error")
+	}
+	if err := r.expectPass(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil {
+		t.Fatal("expectPass succeeded for failing command")
+	}
+
+	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
+		return nil, &exec.ExitError{}
+	}
+	if err := r.expectFailure(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err != nil {
+		t.Fatalf("expectFailure returned error for exit failure: %v", err)
+	}
+}
+
+func TestCopyProofFilesInjectedFailures(t *testing.T) {
+	originalOpenWriteRoot := openWriteRoot
+	originalReadFileUnder := readFileUnder
+	originalStatFile := statFile
+	defer func() {
+		openWriteRoot = originalOpenWriteRoot
+		readFileUnder = originalReadFileUnder
+		statFile = originalStatFile
+	}()
+
+	headRoot := t.TempDir()
+	sourcePath := filepath.Join(headRoot, "pkg", "case_test.go")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("package pkg\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	openWriteRoot = func(string) (confinedWriteRoot, error) {
+		return nil, errors.New("open failed")
+	}
+	if err := copyProofFiles(headRoot, t.TempDir(), []string{"pkg/case_test.go"}); err == nil {
+		t.Fatal("copyProofFiles succeeded despite openWriteRoot failure")
+	}
+
+	writeRoot := &stubWriteRoot{}
+	openWriteRoot = func(string) (confinedWriteRoot, error) {
+		return writeRoot, nil
+	}
+	assertClosedOnce := func(label string) {
+		t.Helper()
+		if writeRoot.closeCalls != 1 {
+			t.Fatalf("%s close calls = %d, want 1", label, writeRoot.closeCalls)
+		}
+		writeRoot.closeCalls = 0
+	}
+
+	readFailure := errors.New("read failed")
+	closeFailure := errors.New("close failed")
+	writeRoot.closeErr = closeFailure
+	readFileUnder = func(string, string) ([]byte, error) {
+		return nil, readFailure
+	}
+	err := copyProofFiles(headRoot, t.TempDir(), []string{"pkg/case_test.go"})
+	if !errors.Is(err, readFailure) || !errors.Is(err, closeFailure) {
+		t.Fatalf("copyProofFiles error = %v, want joined read and close failures", err)
+	}
+	assertClosedOnce("read failure")
+
+	writeRoot.closeErr = nil
+	readFileUnder = func(string, string) ([]byte, error) {
+		return []byte("package pkg\n"), nil
+	}
+	statFailure := errors.New("stat failed")
+	statFile = func(string) (fs.FileInfo, error) {
+		return nil, statFailure
+	}
+	if err := copyProofFiles(headRoot, t.TempDir(), []string{"pkg/case_test.go"}); !errors.Is(err, statFailure) {
+		t.Fatalf("copyProofFiles error = %v, want stat failure", err)
+	}
+	assertClosedOnce("stat failure")
+
+	statFile = func(string) (fs.FileInfo, error) {
+		return &stubFileInfo{mode: 0o644}, nil
+	}
+	writeFailure := errors.New("write failed")
+	writeRoot.writeErr = writeFailure
+	if err := copyProofFiles(headRoot, t.TempDir(), []string{"pkg/case_test.go"}); !errors.Is(err, writeFailure) {
+		t.Fatalf("copyProofFiles error = %v, want write failure", err)
+	}
+	assertClosedOnce("write failure")
+
+	writeRoot.writeErr = nil
+	statFile = func(string) (fs.FileInfo, error) {
+		return &stubFileInfo{mode: os.ModeDir | 0o755}, nil
+	}
+	if err := copyProofFiles(headRoot, t.TempDir(), []string{"pkg/case_test.go"}); err == nil {
+		t.Fatal("copyProofFiles succeeded despite non-regular source")
+	}
+	assertClosedOnce("non-regular source")
+
+	statFile = func(string) (fs.FileInfo, error) {
+		return &stubFileInfo{mode: 0o644}, nil
+	}
+	writeRoot.closeErr = closeFailure
+	if err := copyProofFiles(headRoot, t.TempDir(), []string{"pkg/case_test.go"}); !errors.Is(err, closeFailure) {
+		t.Fatalf("copyProofFiles error = %v, want close failure", err)
+	}
+	assertClosedOnce("close failure")
+}
+
+func TestProveErrorBranchesAndWriteError(t *testing.T) {
+	gitPath, err := gitexec.ResolveBinaryPath()
+	if err != nil {
+		t.Fatalf("ResolveBinaryPath: %v", err)
+	}
+	originalResolve := resolveGitBinaryPath
+	originalOpenWriteRoot := openWriteRoot
+	resolveGitBinaryPath = func() (string, error) { return gitPath, nil }
+	defer func() {
+		resolveGitBinaryPath = originalResolve
+		openWriteRoot = originalOpenWriteRoot
+	}()
+
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: func(_ context.Context, _ string, args []string, _ string, _ []string) ([]byte, error) {
+		if strings.Contains(strings.Join(args, " "), "merge-base") {
+			return []byte(""), nil
+		}
+		return nil, nil
+	}}
+	if err := r.prove(context.Background(), ".", "base", []prmetadata.RegressionDeclaration{{PackagePath: "./pkg", TestName: "TestThing"}}, &bytes.Buffer{}); err == nil {
+		t.Fatal("prove succeeded with empty merge-base output")
+	}
+
+	r.execCommand = func(_ context.Context, _ string, args []string, _ string, _ []string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "merge-base"):
+			return []byte("deadbeef\n"), nil
+		case strings.Contains(joined, "diff"):
+			return nil, errors.New("diff failed")
+		default:
+			return nil, nil
+		}
+	}
+	if err := r.prove(context.Background(), ".", "base", []prmetadata.RegressionDeclaration{{PackagePath: "./pkg", TestName: "TestThing"}}, &bytes.Buffer{}); err == nil {
+		t.Fatal("prove succeeded despite changedFiles failure")
+	}
+
+	r.execCommand = func(_ context.Context, _ string, args []string, _ string, _ []string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "merge-base"):
+			return []byte("deadbeef\n"), nil
+		case strings.Contains(joined, "diff"):
+			return []byte("pkg/case_test.go\n"), nil
+		case strings.Contains(joined, "worktree add"):
+			return nil, errors.New("add failed")
+		default:
+			return nil, nil
+		}
+	}
+	if err := r.prove(context.Background(), ".", "base", []prmetadata.RegressionDeclaration{{PackagePath: "./pkg", TestName: "TestThing"}}, &bytes.Buffer{}); err == nil {
+		t.Fatal("prove succeeded despite worktree creation failure")
+	}
+
+	r.execCommand = func(_ context.Context, _ string, args []string, _ string, _ []string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "merge-base"):
+			return []byte("deadbeef\n"), nil
+		case strings.Contains(joined, "diff"):
+			return []byte("pkg/case_test.go\n"), nil
+		case strings.Contains(joined, "worktree add"):
+			return nil, nil
+		case strings.Contains(joined, "worktree remove"):
+			return nil, errors.New("cleanup failed")
+		case strings.Contains(joined, "go test"):
+			return nil, &exec.ExitError{}
+		default:
+			return nil, errors.New("unexpected args")
+		}
+	}
+	headRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(headRoot, "pkg"), 0o755); err != nil {
+		t.Fatalf("mkdir head pkg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(headRoot, "pkg", "case_test.go"), []byte("package pkg\n"), 0o644); err != nil {
+		t.Fatalf("write head file: %v", err)
+	}
+	if err := r.prove(context.Background(), headRoot, "base", []prmetadata.RegressionDeclaration{{PackagePath: "./pkg", TestName: "TestThing"}}, &bytes.Buffer{}); err == nil {
+		t.Fatal("prove succeeded despite cleanup failure")
+	}
+
+	openWriteRoot = func(string) (confinedWriteRoot, error) {
+		return nil, errors.New("open failed")
+	}
+	r.execCommand = func(_ context.Context, _ string, args []string, _ string, _ []string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "merge-base"):
+			return []byte("deadbeef\n"), nil
+		case strings.Contains(joined, "diff"):
+			return []byte("pkg/case_test.go\n"), nil
+		case strings.Contains(joined, "worktree add"), strings.Contains(joined, "worktree remove"):
+			return nil, nil
+		default:
+			return nil, errors.New("unexpected args")
+		}
+	}
+	if err := r.prove(context.Background(), headRoot, "base", []prmetadata.RegressionDeclaration{{PackagePath: "./pkg", TestName: "TestThing"}}, &bytes.Buffer{}); err == nil {
+		t.Fatal("prove succeeded despite copy failure")
+	}
+	openWriteRoot = originalOpenWriteRoot
+
+	r.execCommand = func(_ context.Context, _ string, args []string, _ string, _ []string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "merge-base"):
+			return []byte("deadbeef\n"), nil
+		case strings.Contains(joined, "diff"):
+			return []byte("pkg/case_test.go\n"), nil
+		case strings.Contains(joined, "worktree add"), strings.Contains(joined, "worktree remove"):
+			return nil, nil
+		case strings.Contains(joined, " -run ^$ "):
+			return nil, errors.New("compile failed")
+		default:
+			return nil, &exec.ExitError{}
+		}
+	}
+	if err := r.prove(context.Background(), headRoot, "base", []prmetadata.RegressionDeclaration{{PackagePath: "./pkg", TestName: "TestThing"}}, &bytes.Buffer{}); err == nil {
+		t.Fatal("prove succeeded despite compile failure")
+	}
+
+	if got := writeError(&errWriter{}, "ignored"); got != 1 {
+		t.Fatalf("writeError = %d, want 1", got)
+	}
+}
+
+func TestProveFailsWhenHeadTestStillFails(t *testing.T) {
+	repo := newRegressionProofRepo(t, regressionProofScenario{
+		baseFiles: map[string]string{
+			"go.mod": "module example.com/regressionproof\n\ngo 1.23\n",
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return false }
+`,
+		},
+		headFiles: map[string]string{
+			"buggy/buggy_test.go": `package buggy
+
+import "testing"
+
+func TestRegressionProof(t *testing.T) {
+	if !Fixed() {
+		t.Fatal("expected true")
+	}
+}
+`,
+		},
+	})
+
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: (&execRunner{}).Run}
+	declaration := prmetadata.RegressionDeclaration{PackagePath: "./buggy", TestName: "TestRegressionProof"}
+	err := r.prove(context.Background(), repo.path, repo.baseSHA, []prmetadata.RegressionDeclaration{declaration}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("prove succeeded despite failing head test")
+	}
+	if !strings.Contains(err.Error(), "must pass on head") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProveFailsWhenStatusWriteFails(t *testing.T) {
+	repo := newRegressionProofRepo(t, regressionProofScenario{
+		baseFiles: map[string]string{
+			"go.mod": "module example.com/regressionproof\n\ngo 1.23\n",
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return false }
+`,
+		},
+		headFiles: map[string]string{
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return true }
+`,
+			"buggy/buggy_test.go": `package buggy
+
+import "testing"
+
+func TestRegressionProof(t *testing.T) {
+	if !Fixed() {
+		t.Fatal("expected true")
+	}
+}
+`,
+		},
+	})
+
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: (&execRunner{}).Run}
+	declaration := prmetadata.RegressionDeclaration{PackagePath: "./buggy", TestName: "TestRegressionProof"}
+	if err := r.prove(context.Background(), repo.path, repo.baseSHA, []prmetadata.RegressionDeclaration{declaration}, &errWriter{}); err == nil {
+		t.Fatal("prove succeeded despite status write failure")
+	}
+}
+
+func TestMain(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("LOPPER_REGRESSIONPROOF_HELPER_MAIN") == "1" {
+		os.Args = []string{"regressionproof"}
+		main()
+		return
+	}
+
+	bodyFile := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(bodyFile, []byte("## Validation\n"), 0o600); err != nil {
+		t.Fatalf("write body file: %v", err)
+	}
+
+	command := exec.Command(os.Args[0], "-test.run=^TestMain$")
+	helperVars := []string{
+		"LOPPER_REGRESSIONPROOF_HELPER_MAIN=1",
+		"PR_TITLE=feat(ci): add gate",
+		"PR_BODY_FILE=" + bodyFile,
+	}
+	helperEnv := append(os.Environ(), helperVars...)
+	command.Env = helperEnv
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper main failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "Regression proof skipped: non-fix PR.") {
+		t.Fatalf("helper output = %q", string(output))
+	}
+}
+
+type regressionProofInvocation struct {
+	title string
+	body  string
+}
+
+func runRegressionProof(t *testing.T, repo regressionProofRepo, invocation regressionProofInvocation) (int, string) {
+	t.Helper()
+
+	bodyFile := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(bodyFile, []byte(invocation.body), 0o600); err != nil {
+		t.Fatalf("write body file: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	env := map[string]string{
+		"PR_TITLE":    invocation.title,
+		"PR_BASE_SHA": repo.baseSHA,
+	}
+	code := run([]string{"--repo", repo.path, "--body-file", bodyFile}, regressionProofEnv(env), &stdout, &stderr)
+	return code, stderr.String()
+}
+
+func regressionProofEnv(values map[string]string) func(string) string {
+	return func(key string) string {
+		return values[key]
+	}
+}
+
+func regressionProofBody() string {
+	lines := []string{
+		"## Validation",
+		"",
+		"Regression-Test: ./buggy::TestRegressionProof",
+	}
+	return strings.Join(lines, "\n")
+}
+
+type regressionProofScenario struct {
+	baseFiles map[string]string
+	headFiles map[string]string
+}
+
+type regressionProofRepo struct {
+	path    string
+	baseSHA string
+}
+
+func newRegressionProofRepo(t *testing.T, scenario regressionProofScenario) regressionProofRepo {
+	t.Helper()
+
+	repoPath := t.TempDir()
+	runRepoCommand(t, repoPath, "git", "init")
+	runRepoCommand(t, repoPath, "git", "config", "user.name", "Test User")
+	runRepoCommand(t, repoPath, "git", "config", "user.email", "test@example.com")
+
+	writeFiles(t, repoPath, scenario.baseFiles)
+	runRepoCommand(t, repoPath, "git", "add", ".")
+	runRepoCommand(t, repoPath, "git", "commit", "-m", "base")
+	baseSHA := strings.TrimSpace(runRepoCommand(t, repoPath, "git", "rev-parse", "HEAD"))
+
+	writeFiles(t, repoPath, scenario.headFiles)
+	runRepoCommand(t, repoPath, "git", "add", ".")
+	runRepoCommand(t, repoPath, "git", "commit", "-m", "head")
+
+	return regressionProofRepo{path: repoPath, baseSHA: baseSHA}
+}
+
+func writeFiles(t *testing.T, repoPath string, files map[string]string) {
+	t.Helper()
+
+	for rel, content := range files {
+		path := filepath.Join(repoPath, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+}
+
+func runRepoCommand(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+
+	switch name {
+	case "git":
+		gitPath, err := gitexec.ResolveBinaryPath()
+		if err != nil {
+			t.Fatalf("resolve git: %v", err)
+		}
+		commandArgs := append([]string{"-C", dir}, args...)
+		command := exec.Command(gitPath, commandArgs...)
+		command.Env = gitexec.SanitizedEnv()
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, output)
+		}
+		return string(output)
+	default:
+		command := exec.Command(name, args...)
+		command.Dir = dir
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, output)
+		}
+		return string(output)
+	}
+}
+
+type errWriter struct{}
+
+func (*errWriter) Write([]byte) (int, error) {
+	return 0, os.ErrClosed
+}
+
+type stubWriteRoot struct {
+	writeErr   error
+	closeErr   error
+	closeCalls int
+}
+
+func (s *stubWriteRoot) WriteFileCreatingParents(string, []byte, os.FileMode, os.FileMode) error {
+	return s.writeErr
+}
+
+func (s *stubWriteRoot) Close() error {
+	s.closeCalls++
+	return s.closeErr
+}
+
+type stubFileInfo struct {
+	mode os.FileMode
+}
+
+func (s *stubFileInfo) Name() string       { return "stub" }
+func (s *stubFileInfo) Size() int64        { return 0 }
+func (s *stubFileInfo) Mode() os.FileMode  { return s.mode }
+func (s *stubFileInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (s *stubFileInfo) IsDir() bool        { return s.mode.IsDir() }
+func (s *stubFileInfo) Sys() any           { return nil }

--- a/tools/regressionproof/main_test.go
+++ b/tools/regressionproof/main_test.go
@@ -35,7 +35,7 @@ func TestRunRejectsInvalidRegressionProofs(t *testing.T) {
 					"buggy/buggy.go": "package buggy\n\nfunc Fixed() bool { return true }\n",
 				},
 			},
-			wantErr: "requires at least one changed *_test.go file",
+			wantErr: "requires at least one changed *_test.go file, package testdata fixture, or shared testdata fixture",
 		},
 		{
 			name: "base unexpectedly passes",
@@ -164,6 +164,53 @@ func TestRegressionProof(t *testing.T) {
 	}
 }
 
+func TestRunAcceptsSharedTopLevelFixtureProof(t *testing.T) {
+	t.Parallel()
+
+	repo := newRegressionProofRepo(t, regressionProofScenario{
+		baseFiles: map[string]string{
+			"go.mod": "module example.com/regressionproof\n\ngo 1.23\n",
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return false }
+`,
+			"testdata/shared/expected.txt": "false\n",
+		},
+		headFiles: map[string]string{
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return true }
+`,
+			"buggy/buggy_test.go": `package buggy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRegressionProof(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "testdata", "shared", "expected.txt"))
+	if err != nil {
+		t.Fatalf("read shared fixture: %v", err)
+	}
+	want := strings.TrimSpace(string(data)) == "true"
+	if got := Fixed(); got != want {
+		t.Fatalf("Fixed() = %v, want %v", got, want)
+	}
+}
+`,
+			"testdata/shared/expected.txt": "true\n",
+		},
+	})
+
+	code, stderr := runRegressionProof(t, repo, regressionProofInvocation{title: "fix(buggy): prove shared fixture", body: regressionProofBody()})
+	if code != 0 {
+		t.Fatalf("run exited with %d, want 0 (stderr: %s)", code, stderr)
+	}
+}
+
 func TestCommandErrorFormattingAndUnwrap(t *testing.T) {
 	t.Parallel()
 
@@ -253,6 +300,73 @@ func TestRunnerRunRequiresReasonAndMaintainerLabelForExemption(t *testing.T) {
 			output := stdout.String() + stderr.String()
 			if !strings.Contains(output, tt.wantText) {
 				t.Fatalf("output = %q, want %q", output, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestParseDeclaredTestAction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		output  string
+		test    string
+		want    testAction
+		wantErr string
+	}{
+		{
+			name:   "pass",
+			test:   "TestThing",
+			output: "{\"Action\":\"run\",\"Test\":\"TestThing\"}\n{\"Action\":\"pass\",\"Test\":\"TestThing\"}\n",
+			want:   testActionPass,
+		},
+		{
+			name:   "fail",
+			test:   "TestThing",
+			output: "{\"Action\":\"fail\",\"Test\":\"TestThing\"}\n",
+			want:   testActionFail,
+		},
+		{
+			name:   "skip",
+			test:   "TestThing",
+			output: "{\"Action\":\"skip\",\"Test\":\"TestThing\"}\n",
+			want:   testActionSkip,
+		},
+		{
+			name:    "missing outcome",
+			test:    "TestThing",
+			output:  "{\"Action\":\"pass\",\"Test\":\"OtherTest\"}\n",
+			wantErr: "did not report an outcome",
+		},
+		{
+			name:    "non json output",
+			test:    "TestThing",
+			output:  "plain text failure\n",
+			wantErr: "did not emit JSON output",
+		},
+		{
+			name:    "invalid json",
+			test:    "TestThing",
+			output:  "{broken\n",
+			wantErr: "parse go test json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDeclaredTestAction([]byte(tt.output), tt.test)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("parseDeclaredTestAction error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDeclaredTestAction returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseDeclaredTestAction = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -564,10 +678,50 @@ func TestCopyProofFilesAndExpectHelpers(t *testing.T) {
 	}
 
 	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
-		return nil, &exec.ExitError{}
+		return []byte("{\"Action\":\"fail\",\"Test\":\"TestThing\"}\n"), &exec.ExitError{}
 	}
 	if err := r.expectFailure(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err != nil {
 		t.Fatalf("expectFailure returned error for exit failure: %v", err)
+	}
+
+	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
+		return []byte("{\"Action\":\"skip\",\"Test\":\"TestThing\"}\n"), nil
+	}
+	if err := r.expectFailure(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil || !strings.Contains(err.Error(), "must fail instead of skip") {
+		t.Fatalf("expectFailure error = %v, want skipped-test rejection", err)
+	}
+	if err := r.expectPass(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil || !strings.Contains(err.Error(), "must pass instead of skip") {
+		t.Fatalf("expectPass error = %v, want skipped-test rejection", err)
+	}
+
+	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
+		return []byte("{\"Action\":\"run\",\"Test\":\"TestThing\"}\n"), nil
+	}
+	if err := r.expectFailure(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil || !strings.Contains(err.Error(), "did not report an outcome") {
+		t.Fatalf("expectFailure error = %v, want unrecognized outcome rejection", err)
+	}
+}
+
+func TestRunDeclaredTestBranches(t *testing.T) {
+	t.Parallel()
+
+	declaration := prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}
+	r := &runner{stderr: &bytes.Buffer{}}
+
+	parseFailure := errors.New("transport failed")
+	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
+		return []byte("plain text\n"), parseFailure
+	}
+	if _, err := r.runDeclaredTest(context.Background(), ".", declaration); !errors.Is(err, parseFailure) || !strings.Contains(err.Error(), "did not emit JSON output") {
+		t.Fatalf("runDeclaredTest error = %v, want joined transport and parse errors", err)
+	}
+
+	commandFailure := errors.New("exec failed")
+	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
+		return []byte("{\"Action\":\"pass\",\"Test\":\"TestThing\"}\n"), commandFailure
+	}
+	if _, err := r.runDeclaredTest(context.Background(), ".", declaration); !errors.Is(err, commandFailure) {
+		t.Fatalf("runDeclaredTest error = %v, want command failure", err)
 	}
 }
 
@@ -821,6 +975,45 @@ func TestRegressionProof(t *testing.T) {
 		t.Fatal("prove succeeded despite failing head test")
 	}
 	if !strings.Contains(err.Error(), "must pass on head") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProveFailsWhenHeadTestSkips(t *testing.T) {
+	repo := newRegressionProofRepo(t, regressionProofScenario{
+		baseFiles: map[string]string{
+			"go.mod": "module example.com/regressionproof\n\ngo 1.23\n",
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return false }
+`,
+		},
+		headFiles: map[string]string{
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return true }
+`,
+			"buggy/buggy_test.go": `package buggy
+
+import "testing"
+
+func TestRegressionProof(t *testing.T) {
+	if !Fixed() {
+		t.Fatal("expected true")
+	}
+	t.Skip("platform-specific")
+}
+`,
+		},
+	})
+
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: (&execRunner{}).Run}
+	declaration := prmetadata.RegressionDeclaration{PackagePath: "./buggy", TestName: "TestRegressionProof"}
+	err := r.prove(context.Background(), repo.path, repo.baseSHA, []prmetadata.RegressionDeclaration{declaration}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("prove succeeded despite skipped head test")
+	}
+	if !strings.Contains(err.Error(), "must pass instead of skip on head") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/tools/regressionproof/main_test.go
+++ b/tools/regressionproof/main_test.go
@@ -627,7 +627,11 @@ func TestCreateBaseWorktreeFailureAndCleanup(t *testing.T) {
 
 func TestCopyProofFilesAndExpectHelpers(t *testing.T) {
 	t.Parallel()
+	testCopyProofFiles(t)
+	testExpectHelpers(t)
+}
 
+func testCopyProofFiles(t *testing.T) {
 	headRoot := t.TempDir()
 	baseRoot := t.TempDir()
 	sourcePath := filepath.Join(headRoot, "pkg", "case_test.go")
@@ -666,7 +670,10 @@ func TestCopyProofFilesAndExpectHelpers(t *testing.T) {
 	if err := copyProofFiles(headRoot, filepath.Join(baseRoot, "missing", "child"), []string{"pkg/case_test.go"}); err == nil {
 		t.Fatal("copyProofFiles succeeded for missing base root")
 	}
+}
 
+func testExpectHelpers(t *testing.T) {
+	t.Helper()
 	r := &runner{stderr: &bytes.Buffer{}, execCommand: func(context.Context, string, []string, string, []string) ([]byte, error) {
 		return nil, errors.New("boom")
 	}}


### PR DESCRIPTION
## Summary

Require bug-fix pull requests to provide executable evidence that their named regression test fails on the base revision and passes on the proposed revision.

Closes #1314

## Changes

- Validate exact Regression-Test metadata and a maintainer-controlled exemption path.
- Run declared tests in an isolated base worktree with changed tests and testdata copied safely.
- Add workflow, policy, documentation, and adversarial unit coverage for the proof path.

## Validation

- `make ci`
- Regression-proof, metadata, workflow, and command-safety test suites pass.

## Risk and compatibility

- Breaking changes: None for the shipped CLI; fix pull requests gain a required CI policy.
- Migration required: None.
- Performance impact: Fix pull requests run each declared test once on base and once on head.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
