### PR TITLE
test(ci): add hermetic CLI end-to-end gate

### DIFF
--- a/cmd/lopper/analyse_binary_e2e_test.go
+++ b/cmd/lopper/analyse_binary_e2e_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+const (
+	binaryBuildTimeout = 2 * time.Minute
+	binaryRunTimeout   = 30 * time.Second
+)
+
+func TestAnalyseBinaryHermeticE2E(t *testing.T) {
+	moduleRoot := mustModuleRoot(t)
+	fixtureRepo := filepath.Join(moduleRoot, "testdata", "js", "esm")
+	workspaceRoot := t.TempDir()
+	repoPath := filepath.Join(workspaceRoot, "repo")
+	copyDir(t, fixtureRepo, repoPath)
+
+	binDir := filepath.Join(workspaceRoot, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	binaryPath := filepath.Join(binDir, "lopper")
+	buildBinary(t, moduleRoot, binaryPath)
+
+	homePath := filepath.Join(workspaceRoot, "home")
+	xdgConfigPath := filepath.Join(workspaceRoot, "xdg-config")
+	xdgCachePath := filepath.Join(workspaceRoot, "xdg-cache")
+	for _, dir := range []string{homePath, xdgConfigPath, xdgCachePath} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), binaryRunTimeout)
+	defer cancel()
+
+	args := []string{
+		"analyse", "lodash",
+		"--repo", repoPath,
+		"--format", "json",
+		"--cache=false",
+	}
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	cmd.Dir = workspaceRoot
+	cmd.Env = []string{
+		"HOME=" + homePath,
+		"PATH=" + os.Getenv("PATH"),
+		"TMPDIR=" + workspaceRoot,
+		"TMP=" + workspaceRoot,
+		"TEMP=" + workspaceRoot,
+		"TZ=UTC",
+		"LANG=C",
+		"LC_ALL=C",
+		"TERM=dumb",
+		"NO_COLOR=1",
+		"CLICOLOR=0",
+		"CLICOLOR_FORCE=0",
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=" + filepath.Join(homePath, ".gitconfig"),
+		"GIT_TERMINAL_PROMPT=0",
+		"XDG_CONFIG_HOME=" + xdgConfigPath,
+		"XDG_CACHE_HOME=" + xdgCachePath,
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("lopper analyse timed out after %s", binaryRunTimeout)
+	}
+	if err != nil {
+		t.Fatalf("lopper analyse failed: %v stderr=%q", err, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr output, got %q", stderr.String())
+	}
+
+	got := decodeJSON(t, stdout.Bytes())
+	assertGeneratedAtUTC(t, got)
+	normalizeReport(t, got)
+
+	goldenPath := filepath.Join(moduleRoot, "testdata", "cli", "analyse_binary_e2e.golden.json")
+	goldenReport, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden report: %v", err)
+	}
+	want := decodeJSON(t, goldenReport)
+	if !reflect.DeepEqual(got, want) {
+		gotJSON, err := json.MarshalIndent(got, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal actual report: %v", err)
+		}
+		t.Fatalf("unexpected report output\nwant:\n%s\n\ngot:\n%s", string(goldenReport), string(gotJSON))
+	}
+}
+
+func buildBinary(t *testing.T, moduleRoot string, binaryPath string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), binaryBuildTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-buildvcs=false", "-o", binaryPath, "./cmd/lopper")
+	cmd.Dir = moduleRoot
+	cmd.Env = append(os.Environ(), "GOFLAGS=-buildvcs=false")
+
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("go build timed out after %s", binaryBuildTimeout)
+	}
+	if err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, string(output))
+	}
+}
+
+func mustModuleRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve module root: %v", err)
+	}
+	return root
+}
+
+func copyDir(t *testing.T, src string, dst string) {
+	t.Helper()
+	if err := filepath.WalkDir(src, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		targetPath := filepath.Join(dst, relPath)
+		if entry.IsDir() {
+			return os.MkdirAll(targetPath, 0o755)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(targetPath, content, 0o644)
+	}); err != nil {
+		t.Fatalf("copy fixture repo: %v", err)
+	}
+}
+
+func decodeJSON(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decode json: %v\n%s", err, string(data))
+	}
+	return payload
+}
+
+func assertGeneratedAtUTC(t *testing.T, payload map[string]any) {
+	t.Helper()
+	value, ok := payload["generatedAt"].(string)
+	if !ok || value == "" {
+		t.Fatalf("expected generatedAt string, got %#v", payload["generatedAt"])
+	}
+	timestamp, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatalf("parse generatedAt %q: %v", value, err)
+	}
+	if timestamp.Location() != time.UTC {
+		t.Fatalf("expected generatedAt in UTC, got %q", value)
+	}
+}
+
+func normalizeReport(t *testing.T, payload map[string]any) {
+	t.Helper()
+	payload["generatedAt"] = "<generatedAt>"
+	payload["repoPath"] = "<repo>"
+
+	cacheValue, ok := payload["cache"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected cache object, got %#v", payload["cache"])
+	}
+	cacheValue["path"] = "<repo>/.lopper-cache"
+}

--- a/cmd/lopper/analyse_binary_e2e_test.go
+++ b/cmd/lopper/analyse_binary_e2e_test.go
@@ -11,6 +11,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/ben-ranford/lopper/internal/version"
 )
 
 const (
@@ -54,7 +56,6 @@ func TestAnalyseBinaryHermeticE2E(t *testing.T) {
 	cmd.Dir = workspaceRoot
 	cmd.Env = []string{
 		"HOME=" + homePath,
-		"PATH=" + os.Getenv("PATH"),
 		"TMPDIR=" + workspaceRoot,
 		"TMP=" + workspaceRoot,
 		"TEMP=" + workspaceRoot,
@@ -92,7 +93,7 @@ func TestAnalyseBinaryHermeticE2E(t *testing.T) {
 	assertGeneratedAtUTC(t, got)
 	normalizeReport(t, got)
 
-	goldenPath := filepath.Join(moduleRoot, "testdata", "cli", "analyse_binary_e2e.golden.json")
+	goldenPath := filepath.Join(moduleRoot, "testdata", "cli", expectedGoldenReportName())
 	goldenReport, err := os.ReadFile(goldenPath)
 	if err != nil {
 		t.Fatalf("read golden report: %v", err)
@@ -113,9 +114,18 @@ func buildBinary(t *testing.T, moduleRoot string, binaryPath string) {
 	ctx, cancel := context.WithTimeout(context.Background(), binaryBuildTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-buildvcs=false", "-o", binaryPath, "./cmd/lopper")
+	args := []string{
+		"build",
+		"-trimpath",
+		"-buildvcs=false",
+		"-ldflags",
+		"-X github.com/ben-ranford/lopper/internal/version.buildChannel=" + version.Current().BuildChannel,
+		"-o",
+		binaryPath,
+		"./cmd/lopper",
+	}
+	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = moduleRoot
-	cmd.Env = append(os.Environ(), "GOFLAGS=-buildvcs=false")
 
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
@@ -193,4 +203,11 @@ func normalizeReport(t *testing.T, payload map[string]any) {
 		t.Fatalf("expected cache object, got %#v", payload["cache"])
 	}
 	cacheValue["path"] = "<repo>/.lopper-cache"
+}
+
+func expectedGoldenReportName() string {
+	if version.Current().BuildChannel == "rolling" {
+		return "analyse_binary_e2e.rolling.golden.json"
+	}
+	return "analyse_binary_e2e.golden.json"
 }

--- a/testdata/cli/analyse_binary_e2e.golden.json
+++ b/testdata/cli/analyse_binary_e2e.golden.json
@@ -1,0 +1,242 @@
+{
+  "schemaVersion": "0.2.0",
+  "generatedAt": "<generatedAt>",
+  "repoPath": "<repo>",
+  "scope": {
+    "mode": "package",
+    "packages": [
+      "."
+    ]
+  },
+  "dependencies": [
+    {
+      "language": "js-ts",
+      "name": "lodash",
+      "usedExportsCount": 1,
+      "totalExportsCount": 1,
+      "usedPercent": 100,
+      "estimatedUnusedBytes": 0,
+      "topUsedSymbols": [
+        {
+          "name": "map",
+          "count": 1
+        }
+      ],
+      "usedImports": [
+        {
+          "name": "map",
+          "module": "lodash",
+          "locations": [
+            {
+              "file": "index.js",
+              "line": 1,
+              "column": 10
+            }
+          ]
+        }
+      ],
+      "reachabilityConfidence": {
+        "model": "reachability-v2",
+        "score": 93,
+        "summary": "no runtime trace; export inventory; precise imports",
+        "rationaleCodes": [
+          "runtime-evidence-absent",
+          "export-inventory-known",
+          "precise-static-imports",
+          "usage-uncertainty-clear",
+          "dependency-entrypoints-static",
+          "no-risk-cues"
+        ],
+        "signals": [
+          {
+            "code": "runtime-evidence-absent",
+            "score": 65,
+            "weight": 0.2,
+            "contribution": 13,
+            "rationale": "no runtime trace evidence was available for this dependency"
+          },
+          {
+            "code": "export-inventory-known",
+            "score": 100,
+            "weight": 0.3,
+            "contribution": 30,
+            "rationale": "export inventory is available for deterministic symbol coverage"
+          },
+          {
+            "code": "precise-static-imports",
+            "score": 100,
+            "weight": 0.2,
+            "contribution": 20,
+            "rationale": "explicit static imports provide precise symbol attribution"
+          },
+          {
+            "code": "usage-uncertainty-clear",
+            "score": 100,
+            "weight": 0.15,
+            "contribution": 15,
+            "rationale": "no unresolved dynamic import or require usage was observed"
+          },
+          {
+            "code": "dependency-entrypoints-static",
+            "score": 100,
+            "weight": 0.1,
+            "contribution": 10,
+            "rationale": "dependency entrypoints appear statically declared"
+          },
+          {
+            "code": "no-risk-cues",
+            "score": 100,
+            "weight": 0.05,
+            "contribution": 5,
+            "rationale": "no additional dependency risk cues reduced reachability confidence"
+          }
+        ]
+      },
+      "removalCandidate": {
+        "score": 18.6,
+        "usage": 0,
+        "impact": 0,
+        "confidence": 93,
+        "weights": {
+          "usage": 0.5,
+          "impact": 0.3,
+          "confidence": 0.2
+        },
+        "rationale": [
+          "no runtime trace evidence was available for this dependency",
+          "export inventory is available for deterministic symbol coverage",
+          "explicit static imports provide precise symbol attribution"
+        ]
+      },
+      "license": {
+        "source": "unknown",
+        "confidence": "low",
+        "unknown": true
+      },
+      "provenance": {
+        "source": "local-manifest",
+        "confidence": "medium",
+        "signals": [
+          "manifest:package.json",
+          "name:lodash"
+        ]
+      }
+    }
+  ],
+  "usageUncertainty": {
+    "confirmedImportUses": 1,
+    "uncertainImportUses": 0
+  },
+  "summary": {
+    "dependencyCount": 1,
+    "usedExportsCount": 1,
+    "totalExportsCount": 1,
+    "usedPercent": 100,
+    "knownLicenseCount": 0,
+    "unknownLicenseCount": 1,
+    "deniedLicenseCount": 0,
+    "reachability": {
+      "model": "reachability-v2",
+      "averageScore": 93,
+      "lowestScore": 93,
+      "highestScore": 93
+    }
+  },
+  "languageBreakdown": [
+    {
+      "language": "js-ts",
+      "dependencyCount": 1,
+      "usedExportsCount": 1,
+      "totalExportsCount": 1,
+      "usedPercent": 100
+    }
+  ],
+  "cache": {
+    "enabled": false,
+    "path": "<repo>/.lopper-cache",
+    "hits": 0,
+    "misses": 0,
+    "writes": 0
+  },
+  "effectiveThresholds": {
+    "failOnIncreasePercent": -1,
+    "lowConfidenceWarningPercent": 40,
+    "minUsagePercentForRecommendations": 40,
+    "maxUncertainImportCount": -1,
+    "reachableVulnerabilityPriority": "off"
+  },
+  "effectivePolicy": {
+    "sources": [
+      "defaults"
+    ],
+    "mergeTrace": [
+      {
+        "field": "thresholds.fail_on_increase_percent",
+        "source": "defaults"
+      },
+      {
+        "field": "thresholds.low_confidence_warning_percent",
+        "source": "defaults"
+      },
+      {
+        "field": "thresholds.min_usage_percent_for_recommendations",
+        "source": "defaults"
+      },
+      {
+        "field": "thresholds.max_uncertain_import_count",
+        "source": "defaults"
+      },
+      {
+        "field": "thresholds.reachable_vulnerability_priority",
+        "source": "defaults"
+      },
+      {
+        "field": "thresholds.lockfile_drift_policy",
+        "source": "defaults"
+      },
+      {
+        "field": "removal_candidate_weights.usage",
+        "source": "defaults"
+      },
+      {
+        "field": "removal_candidate_weights.impact",
+        "source": "defaults"
+      },
+      {
+        "field": "removal_candidate_weights.confidence",
+        "source": "defaults"
+      },
+      {
+        "field": "license.deny",
+        "source": "defaults"
+      },
+      {
+        "field": "license.fail_on_deny",
+        "source": "defaults"
+      },
+      {
+        "field": "license.include_registry_provenance",
+        "source": "defaults"
+      }
+    ],
+    "thresholds": {
+      "failOnIncreasePercent": -1,
+      "lowConfidenceWarningPercent": 40,
+      "minUsagePercentForRecommendations": 40,
+      "maxUncertainImportCount": -1,
+      "reachableVulnerabilityPriority": "off"
+    },
+    "removalCandidateWeights": {
+      "usage": 0.5,
+      "impact": 0.3,
+      "confidence": 0.2
+    },
+    "license": {
+      "failOnDenied": false,
+      "includeRegistryProvenance": false
+    },
+    "vulnerabilities": {
+      "reachablePriorityThreshold": "off"
+    }
+  }
+}

--- a/testdata/cli/analyse_binary_e2e.rolling.golden.json
+++ b/testdata/cli/analyse_binary_e2e.rolling.golden.json
@@ -1,0 +1,253 @@
+{
+  "schemaVersion": "0.2.0",
+  "generatedAt": "<generatedAt>",
+  "repoPath": "<repo>",
+  "scope": {
+    "mode": "package",
+    "packages": [
+      "."
+    ]
+  },
+  "dependencies": [
+    {
+      "language": "js-ts",
+      "name": "lodash",
+      "identity": {
+        "ecosystem": "npm",
+        "name": "lodash",
+        "versionStatus": "unknown",
+        "purlStatus": "unavailable",
+        "source": "node_modules/lodash/package.json",
+        "confidence": "high",
+        "evidence": [
+          "node_modules/lodash/package.json"
+        ]
+      },
+      "usedExportsCount": 1,
+      "totalExportsCount": 1,
+      "usedPercent": 100,
+      "estimatedUnusedBytes": 0,
+      "topUsedSymbols": [
+        {
+          "name": "map",
+          "count": 1
+        }
+      ],
+      "usedImports": [
+        {
+          "name": "map",
+          "module": "lodash",
+          "locations": [
+            {
+              "file": "index.js",
+              "line": 1,
+              "column": 10
+            }
+          ]
+        }
+      ],
+      "reachabilityConfidence": {
+        "model": "reachability-v2",
+        "score": 93,
+        "summary": "no runtime trace; export inventory; precise imports",
+        "rationaleCodes": [
+          "runtime-evidence-absent",
+          "export-inventory-known",
+          "precise-static-imports",
+          "usage-uncertainty-clear",
+          "dependency-entrypoints-static",
+          "no-risk-cues"
+        ],
+        "signals": [
+          {
+            "code": "runtime-evidence-absent",
+            "score": 65,
+            "weight": 0.2,
+            "contribution": 13,
+            "rationale": "no runtime trace evidence was available for this dependency"
+          },
+          {
+            "code": "export-inventory-known",
+            "score": 100,
+            "weight": 0.3,
+            "contribution": 30,
+            "rationale": "export inventory is available for deterministic symbol coverage"
+          },
+          {
+            "code": "precise-static-imports",
+            "score": 100,
+            "weight": 0.2,
+            "contribution": 20,
+            "rationale": "explicit static imports provide precise symbol attribution"
+          },
+          {
+            "code": "usage-uncertainty-clear",
+            "score": 100,
+            "weight": 0.15,
+            "contribution": 15,
+            "rationale": "no unresolved dynamic import or require usage was observed"
+          },
+          {
+            "code": "dependency-entrypoints-static",
+            "score": 100,
+            "weight": 0.1,
+            "contribution": 10,
+            "rationale": "dependency entrypoints appear statically declared"
+          },
+          {
+            "code": "no-risk-cues",
+            "score": 100,
+            "weight": 0.05,
+            "contribution": 5,
+            "rationale": "no additional dependency risk cues reduced reachability confidence"
+          }
+        ]
+      },
+      "removalCandidate": {
+        "score": 18.6,
+        "usage": 0,
+        "impact": 0,
+        "confidence": 93,
+        "weights": {
+          "usage": 0.5,
+          "impact": 0.3,
+          "confidence": 0.2
+        },
+        "rationale": [
+          "no runtime trace evidence was available for this dependency",
+          "export inventory is available for deterministic symbol coverage",
+          "explicit static imports provide precise symbol attribution"
+        ]
+      },
+      "license": {
+        "source": "unknown",
+        "confidence": "low",
+        "unknown": true
+      },
+      "provenance": {
+        "source": "local-manifest",
+        "confidence": "medium",
+        "signals": [
+          "manifest:package.json",
+          "name:lodash"
+        ]
+      }
+    }
+  ],
+  "usageUncertainty": {
+    "confirmedImportUses": 1,
+    "uncertainImportUses": 0
+  },
+  "summary": {
+    "dependencyCount": 1,
+    "usedExportsCount": 1,
+    "totalExportsCount": 1,
+    "usedPercent": 100,
+    "knownLicenseCount": 0,
+    "unknownLicenseCount": 1,
+    "deniedLicenseCount": 0,
+    "reachability": {
+      "model": "reachability-v2",
+      "averageScore": 93,
+      "lowestScore": 93,
+      "highestScore": 93
+    }
+  },
+  "languageBreakdown": [
+    {
+      "language": "js-ts",
+      "dependencyCount": 1,
+      "usedExportsCount": 1,
+      "totalExportsCount": 1,
+      "usedPercent": 100
+    }
+  ],
+  "cache": {
+    "enabled": false,
+    "path": "<repo>/.lopper-cache",
+    "hits": 0,
+    "misses": 0,
+    "writes": 0
+  },
+  "effectiveThresholds": {
+    "failOnIncreasePercent": -1,
+    "lowConfidenceWarningPercent": 40,
+    "minUsagePercentForRecommendations": 40,
+    "maxUncertainImportCount": -1,
+    "reachableVulnerabilityPriority": "off"
+  },
+  "effectivePolicy": {
+    "sources": [
+      "defaults"
+    ],
+    "mergeTrace": [
+      {
+        "field": "thresholds.fail_on_increase_percent",
+        "source": "defaults"
+      },
+      {
+        "field": "thresholds.low_confidence_warning_percent",
+        "source": "defaults"
+      },
+      {
+        "field": "thresholds.min_usage_percent_for_recommendations",
+        "source": "defaults"
+      },
+      {
+        "field": "thresholds.max_uncertain_import_count",
+        "source": "defaults"
+      },
+      {
+        "field": "thresholds.reachable_vulnerability_priority",
+        "source": "defaults"
+      },
+      {
+        "field": "thresholds.lockfile_drift_policy",
+        "source": "defaults"
+      },
+      {
+        "field": "removal_candidate_weights.usage",
+        "source": "defaults"
+      },
+      {
+        "field": "removal_candidate_weights.impact",
+        "source": "defaults"
+      },
+      {
+        "field": "removal_candidate_weights.confidence",
+        "source": "defaults"
+      },
+      {
+        "field": "license.deny",
+        "source": "defaults"
+      },
+      {
+        "field": "license.fail_on_deny",
+        "source": "defaults"
+      },
+      {
+        "field": "license.include_registry_provenance",
+        "source": "defaults"
+      }
+    ],
+    "thresholds": {
+      "failOnIncreasePercent": -1,
+      "lowConfidenceWarningPercent": 40,
+      "minUsagePercentForRecommendations": 40,
+      "maxUncertainImportCount": -1,
+      "reachableVulnerabilityPriority": "off"
+    },
+    "removalCandidateWeights": {
+      "usage": 0.5,
+      "impact": 0.3,
+      "confidence": 0.2
+    },
+    "license": {
+      "failOnDenied": false,
+      "includeRegistryProvenance": false
+    },
+    "vulnerabilities": {
+      "reachablePriorityThreshold": "off"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add a deterministic pull-request test that builds and exercises the real lopper CLI in a fully isolated environment.

Closes #1312

## Changes

- Build the production binary and analyze a fixed local JavaScript fixture.
- Isolate home, cache, temporary, locale, color, and Git prompt state.
- Normalize volatile fields and compare the complete JSON result with a committed golden file.

## Validation

- `make ci`
- The hermetic binary end-to-end test passes without enabling a network-capable path.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Pull-request CI performs one additional local binary build and analysis.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
