### PR TITLE
test(ci): ratchet high-risk regression coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,20 @@ bench-gate:
 	fi; \
 	exit "$$status"
 
+.PHONY: benchdelta-cov
+benchdelta-cov:
+	@mkdir -p .artifacts
+	@GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) ./tools/benchdelta -covermode=atomic -coverprofile=".artifacts/benchdelta-coverage.out"
+	@GOFLAGS=-buildvcs=false $(GO_CMD) run ./tools/coveragegate \
+		-coverprofile=".artifacts/benchdelta-coverage.out" \
+		-min=97.0 \
+		-package-min=97.0 \
+		-total-out=".artifacts/benchdelta-coverage-total.txt" \
+		-packages-out=".artifacts/benchdelta-coverage-packages.txt" \
+		-package-failures-out=".artifacts/benchdelta-coverage-package-failures.txt"
+
+ci: benchdelta-cov
+
 cov:
 	@mkdir -p $$(dirname "$(COVERAGE_FILE)")
 	@pkgs=$$(GOFLAGS=-buildvcs=false $(GO_CMD) list ./... | grep -Ev '/internal/testutil$$|/internal/testsupport$$|/tools/benchdelta$$'); \

--- a/internal/lang/php/adapter_helpers_extra_test.go
+++ b/internal/lang/php/adapter_helpers_extra_test.go
@@ -600,10 +600,10 @@ func TestScanRepoSkipsNestedComposerPackagesAndTracksDynamicUsage(t *testing.T) 
 	if len(scan.Files) != 1 || scan.Files[0].Path != filepath.Join("src", "root.php") {
 		t.Fatalf("expected only root PHP file to be scanned, got %#v", scan.Files)
 	}
-	if got := scan.DynamicUsageByDependency[helpersVendorLibDependency]; got != 1 {
+	if scan.DynamicUsageByDependency[helpersVendorLibDependency] != 1 {
 		t.Fatalf("expected dynamic usage count for %q, got %#v", helpersVendorLibDependency, scan.DynamicUsageByDependency)
 	}
-	if got := scan.GroupedImportsByDependency[helpersVendorLibDependency]; got != 1 {
+	if scan.GroupedImportsByDependency[helpersVendorLibDependency] != 1 {
 		t.Fatalf("expected grouped import count for %q, got %#v", helpersVendorLibDependency, scan.GroupedImportsByDependency)
 	}
 	if !containsWarning(scan.Warnings, "skipped 1 nested composer package directory") {

--- a/internal/lang/php/adapter_helpers_extra_test.go
+++ b/internal/lang/php/adapter_helpers_extra_test.go
@@ -577,6 +577,43 @@ func TestScanRepoNoDeclaredDependencyWarningAndUnresolvedWarning(t *testing.T) {
 	}
 }
 
+func TestScanRepoSkipsNestedComposerPackagesAndTracksDynamicUsage(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, helpersComposerJSON), fmt.Sprintf(`{"require":{%q:"^1.0"}}`, helpersVendorLibDependency))
+	writeFile(t, filepath.Join(repo, "src", "root.php"), helpersPHPHeader+
+		"use Vendor\\Lib\\{Client};\n"+
+		"class_exists(Client::class);\n"+
+		"$client = new Client();\n")
+	writeFile(t, filepath.Join(repo, "packages", "nested", helpersComposerJSON), fmt.Sprintf(`{"require":{%q:"^1.0"}}`, helpersVendorPkgDependency))
+	writeFile(t, filepath.Join(repo, "packages", "nested", "src", "nested.php"), helpersPHPHeader+
+		"use Vendor\\Pkg\\Nested;\n"+
+		"$nested = new Nested();\n")
+
+	scan, err := scanRepo(context.Background(), repo, composerData{
+		DeclaredDependencies: map[string]struct{}{helpersVendorLibDependency: {}},
+		NamespaceToDep:       map[string]string{"Vendor\\Lib": helpersVendorLibDependency, "Vendor\\Pkg": helpersVendorPkgDependency},
+		LocalNamespaces:      map[string]struct{}{},
+	})
+	if err != nil {
+		t.Fatalf(helpersScanRepoErr, err)
+	}
+	if len(scan.Files) != 1 || scan.Files[0].Path != filepath.Join("src", "root.php") {
+		t.Fatalf("expected only root PHP file to be scanned, got %#v", scan.Files)
+	}
+	if got := scan.DynamicUsageByDependency[helpersVendorLibDependency]; got != 1 {
+		t.Fatalf("expected dynamic usage count for %q, got %#v", helpersVendorLibDependency, scan.DynamicUsageByDependency)
+	}
+	if got := scan.GroupedImportsByDependency[helpersVendorLibDependency]; got != 1 {
+		t.Fatalf("expected grouped import count for %q, got %#v", helpersVendorLibDependency, scan.GroupedImportsByDependency)
+	}
+	if !containsWarning(scan.Warnings, "skipped 1 nested composer package directory") {
+		t.Fatalf("expected nested package skip warning, got %#v", scan.Warnings)
+	}
+	if !containsWarning(scan.Warnings, "dynamic loading/reflection patterns detected") {
+		t.Fatalf("expected dynamic usage warning, got %#v", scan.Warnings)
+	}
+}
+
 func TestReadComposerManifestAndLockMappingsErrorFromFileRoot(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "root-file")
 	writeFile(t, root, "x")

--- a/internal/report/format_csv.go
+++ b/internal/report/format_csv.go
@@ -76,29 +76,35 @@ func formatCSV(reportData Report) (string, error) {
 	var buffer bytes.Buffer
 	writer := csv.NewWriter(&buffer)
 
+	if err := writeCSVRows(writer.Write, reportData); err != nil {
+		return "", err
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return "", err
+	}
+	return buffer.String(), nil
+}
+
+func writeCSVRows(writeRow func([]string) error, reportData Report) error {
 	includeIdentity := hasCSVIdentity(reportData.Dependencies)
 	header := append([]string{}, analyseCSVHeader...)
 	if includeIdentity {
 		header = append(header, analyseCSVIdentityHeader...)
 	}
-	if err := writer.Write(header); err != nil {
-		return "", err
+	if err := writeRow(header); err != nil {
+		return err
 	}
 	for _, dep := range sortedDependenciesForCSV(reportData.Dependencies) {
 		row := formatDependencyCSVRow(reportData, dep)
 		if includeIdentity {
 			row = append(row, formatDependencyIdentityCSVRow(dep.Identity)...)
 		}
-		if err := writer.Write(csvsanitize.EscapeLeadingFormulaRow(row)); err != nil {
-			return "", err
+		if err := writeRow(csvsanitize.EscapeLeadingFormulaRow(row)); err != nil {
+			return err
 		}
 	}
-
-	writer.Flush()
-	if err := writer.Error(); err != nil {
-		return "", err
-	}
-	return buffer.String(), nil
+	return nil
 }
 
 func hasCSVIdentity(dependencies []DependencyReport) bool {

--- a/internal/report/format_csv_test.go
+++ b/internal/report/format_csv_test.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"encoding/csv"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -246,6 +247,32 @@ func TestFormatCSVIncludesIdentityColumnsWhenPresent(t *testing.T) {
 		"identity_evidence":       "go.mod|go.sum",
 		"identity_conflicts":      "v1.2.2 from vendored metadata",
 	})
+}
+
+type failCSVRowWriter struct {
+	call   int
+	failOn int
+}
+
+func (f *failCSVRowWriter) Write(_ []string) error {
+	f.call++
+	if f.call == f.failOn {
+		return errors.New("csv write failed")
+	}
+	return nil
+}
+
+func TestWriteCSVRowsPropagatesHeaderAndRowErrors(t *testing.T) {
+	reportData := Report{
+		Dependencies: []DependencyReport{{Language: "go", Name: "alpha"}},
+	}
+
+	if err := writeCSVRows((&failCSVRowWriter{failOn: 1}).Write, reportData); err == nil || !strings.Contains(err.Error(), "csv write failed") {
+		t.Fatalf("expected header write error, got %v", err)
+	}
+	if err := writeCSVRows((&failCSVRowWriter{failOn: 2}).Write, reportData); err == nil || !strings.Contains(err.Error(), "csv write failed") {
+		t.Fatalf("expected row write error, got %v", err)
+	}
 }
 
 func TestFormatCSVOmitsExceptionSuppressedVulnerabilities(t *testing.T) {

--- a/internal/runtime/capture_process_unix.go
+++ b/internal/runtime/capture_process_unix.go
@@ -12,6 +12,12 @@ import (
 
 const runtimeCommandWaitDelay = 100 * time.Millisecond
 
+var runtimeProcessSignal = func(process *os.Process, signal syscall.Signal) error {
+	return process.Signal(signal)
+}
+
+var runtimeKillProcessGroup = syscall.Kill
+
 func configureRuntimeCommand(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.WaitDelay = runtimeCommandWaitDelay
@@ -19,13 +25,13 @@ func configureRuntimeCommand(cmd *exec.Cmd) {
 		if cmd.Process == nil {
 			return os.ErrProcessDone
 		}
-		if err := cmd.Process.Signal(syscall.Signal(0)); err != nil {
+		if err := runtimeProcessSignal(cmd.Process, syscall.Signal(0)); err != nil {
 			if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
 				return os.ErrProcessDone
 			}
 			return err
 		}
-		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		if err := runtimeKillProcessGroup(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
 			if errors.Is(err, syscall.ESRCH) {
 				return os.ErrProcessDone
 			}

--- a/internal/runtime/capture_process_unix_test.go
+++ b/internal/runtime/capture_process_unix_test.go
@@ -12,6 +12,53 @@ import (
 	"testing"
 )
 
+func TestConfigureRuntimeCommandCancelPropagatesSignalErrors(t *testing.T) {
+	originalSignal := runtimeProcessSignal
+	originalKill := runtimeKillProcessGroup
+	t.Cleanup(func() {
+		runtimeProcessSignal = originalSignal
+		runtimeKillProcessGroup = originalKill
+	})
+
+	expected := syscall.EPERM
+	runtimeProcessSignal = func(*os.Process, syscall.Signal) error {
+		return expected
+	}
+
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	cmd.Process = &os.Process{Pid: 42}
+	configureRuntimeCommand(cmd)
+
+	if err := cmd.Cancel(); !errors.Is(err, expected) {
+		t.Fatalf("expected signal error %v, got %v", expected, err)
+	}
+}
+
+func TestConfigureRuntimeCommandCancelPropagatesKillErrors(t *testing.T) {
+	originalSignal := runtimeProcessSignal
+	originalKill := runtimeKillProcessGroup
+	t.Cleanup(func() {
+		runtimeProcessSignal = originalSignal
+		runtimeKillProcessGroup = originalKill
+	})
+
+	expected := syscall.EPERM
+	runtimeProcessSignal = func(*os.Process, syscall.Signal) error {
+		return nil
+	}
+	runtimeKillProcessGroup = func(int, syscall.Signal) error {
+		return expected
+	}
+
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	cmd.Process = &os.Process{Pid: 42}
+	configureRuntimeCommand(cmd)
+
+	if err := cmd.Cancel(); !errors.Is(err, expected) {
+		t.Fatalf("expected kill error %v, got %v", expected, err)
+	}
+}
+
 func TestConfigureRuntimeCommand(t *testing.T) {
 	cmd := exec.Command("/bin/sh", "-c", "exit 0")
 	configureRuntimeCommand(cmd)

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3040,6 +3040,44 @@ func TestMakefileReleasePackagesRuntimeHooks(t *testing.T) {
 	}
 }
 
+func TestMakefileBenchdeltaCoverageRatchet(t *testing.T) {
+	t.Parallel()
+
+	makefile := readConfig(t, "Makefile")
+	targetPattern := regexp.MustCompile(`(?m)^benchdelta-cov:\n(?:\t.*\n)+`)
+	target := targetPattern.FindString(makefile)
+	if target == "" {
+		t.Fatal("Makefile must define the benchdelta-cov target")
+	}
+
+	for _, want := range []string{
+		`./tools/benchdelta -covermode=atomic -coverprofile=".artifacts/benchdelta-coverage.out"`,
+		`$(GO_CMD) run ./tools/coveragegate`,
+		`-min=97.0`,
+		`-package-min=97.0`,
+		`-total-out=".artifacts/benchdelta-coverage-total.txt"`,
+		`-packages-out=".artifacts/benchdelta-coverage-packages.txt"`,
+		`-package-failures-out=".artifacts/benchdelta-coverage-package-failures.txt"`,
+	} {
+		if !strings.Contains(target, want) {
+			t.Fatalf("benchdelta-cov target must contain %q", want)
+		}
+	}
+
+	ciPattern := regexp.MustCompile(`(?m)^ci:.*\bbenchdelta-cov\b`)
+	if !ciPattern.MatchString(makefile) {
+		t.Fatal("ci target must depend on benchdelta-cov")
+	}
+	for _, want := range []string{
+		`COVERAGE_MIN ?= 98`,
+		`COVERAGE_PACKAGE_MIN ?= $(COVERAGE_MIN)`,
+	} {
+		if !strings.Contains(makefile, want) {
+			t.Fatalf("global coverage gate must retain %q", want)
+		}
+	}
+}
+
 func TestReleaseImageTagScriptSanitizesAndValidatesTags(t *testing.T) {
 	t.Parallel()
 

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -128,17 +128,7 @@ func TestMainExitCodesAndErrorPaths(t *testing.T) {
 		return
 	}
 
-	dir := t.TempDir()
-	basePath := filepath.Join(dir, "base.txt")
-	headPath := filepath.Join(dir, "head.txt")
-	writeBenchmarkFixture(t, basePath, []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-	})
-	writeBenchmarkFixture(t, headPath, []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-	})
+	dir, basePath, headPath := writeMatchingBenchmarkFixtures(t)
 
 	tests := []struct {
 		name       string
@@ -179,26 +169,9 @@ func TestMainExitCodesAndErrorPaths(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := exec.Command(os.Args[0], "-test.run=TestMainExitCodesAndErrorPaths", "--")
-			cmd.Args = append(cmd.Args, tc.args...)
-			cmd.Env = append(os.Environ(), "GO_WANT_BENCHDELTA_HELPER=1")
-			output, err := cmd.CombinedOutput()
-			if tc.wantCode == 0 {
-				if err != nil {
-					t.Fatalf("expected success, got %v\n%s", err, output)
-				}
-			} else {
-				var exitErr *exec.ExitError
-				if !errors.As(err, &exitErr) {
-					t.Fatalf("expected exit error for code %d, got %v\n%s", tc.wantCode, err, output)
-				}
-				if exitErr.ExitCode() != tc.wantCode {
-					t.Fatalf("exit code = %d, want %d\n%s", exitErr.ExitCode(), tc.wantCode, output)
-				}
-			}
-			if !strings.Contains(string(output), tc.wantOutput) {
-				t.Fatalf("expected output to contain %q, got %q", tc.wantOutput, string(output))
-			}
+			output, exitCode := runBenchdeltaHelper(t, "TestMainExitCodesAndErrorPaths", tc.args...)
+			assertBenchdeltaHelperExit(t, output, exitCode, tc.wantCode)
+			assertBenchdeltaHelperOutput(t, output, tc.wantOutput)
 		})
 	}
 }
@@ -208,36 +181,16 @@ func TestMainSummaryWriteErrorExit(t *testing.T) {
 		return
 	}
 
-	dir := t.TempDir()
-	basePath := filepath.Join(dir, "base.txt")
-	headPath := filepath.Join(dir, "head.txt")
-	writeBenchmarkFixture(t, basePath, []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-	})
-	writeBenchmarkFixture(t, headPath, []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-	})
+	dir, basePath, headPath := writeMatchingBenchmarkFixtures(t)
 
 	blocker := filepath.Join(dir, "blocker")
 	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
 		t.Fatalf("write blocker: %v", err)
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestMainSummaryWriteErrorExit", "--", "-base", basePath, "-head", headPath, "-summary-out", filepath.Join(blocker, "summary.md"))
-	cmd.Env = append(os.Environ(), "GO_WANT_BENCHDELTA_HELPER=1")
-	output, err := cmd.CombinedOutput()
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected summary write exit error, got %v\n%s", err, output)
-	}
-	if exitErr.ExitCode() != 2 {
-		t.Fatalf("exit code = %d, want 2\n%s", exitErr.ExitCode(), output)
-	}
-	if !strings.Contains(string(output), "write summary") {
-		t.Fatalf("expected summary write error, got %q", string(output))
-	}
+	output, exitCode := runBenchdeltaHelper(t, "TestMainSummaryWriteErrorExit", "-base", basePath, "-head", headPath, "-summary-out", filepath.Join(blocker, "summary.md"))
+	assertBenchdeltaHelperExit(t, output, exitCode, 2)
+	assertBenchdeltaHelperOutput(t, output, "write summary")
 }
 
 func runBenchdeltaMainIfRequested(t *testing.T) bool {
@@ -263,5 +216,52 @@ func writeBenchmarkFixture(t *testing.T, path string, lines []string) {
 	content := append([]string{"goos: darwin"}, lines...)
 	if err := os.WriteFile(path, []byte(strings.Join(content, "\n")+"\n"), 0o644); err != nil {
 		t.Fatalf("write benchmark fixture: %v", err)
+	}
+}
+
+func writeMatchingBenchmarkFixtures(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.txt")
+	headPath := filepath.Join(dir, "head.txt")
+	lines := []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+	}
+	writeBenchmarkFixture(t, basePath, lines)
+	writeBenchmarkFixture(t, headPath, lines)
+	return dir, basePath, headPath
+}
+
+func runBenchdeltaHelper(t *testing.T, testName string, args ...string) ([]byte, int) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run="+testName, "--")
+	cmd.Args = append(cmd.Args, args...)
+	cmd.Env = append(os.Environ(), "GO_WANT_BENCHDELTA_HELPER=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return output, 0
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected subprocess exit error or success, got %v\n%s", err, output)
+	}
+	return output, exitErr.ExitCode()
+}
+
+func assertBenchdeltaHelperExit(t *testing.T, output []byte, gotCode, wantCode int) {
+	t.Helper()
+	if gotCode != wantCode {
+		t.Fatalf("exit code = %d, want %d\n%s", gotCode, wantCode, output)
+	}
+}
+
+func assertBenchdeltaHelperOutput(t *testing.T, output []byte, want string) {
+	t.Helper()
+	if !strings.Contains(string(output), want) {
+		t.Fatalf("expected output to contain %q, got %q", want, string(output))
 	}
 }

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -239,7 +239,14 @@ func runBenchdeltaHelper(t *testing.T, testName string, args ...string) ([]byte,
 
 	cmd := exec.Command(os.Args[0], "-test.run="+testName, "--")
 	cmd.Args = append(cmd.Args, args...)
-	cmd.Env = append(os.Environ(), "GO_WANT_BENCHDELTA_HELPER=1")
+	cmd.Env = make([]string, 0, len(os.Environ())+1)
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "GO_WANT_BENCHDELTA_HELPER=") {
+			continue
+		}
+		cmd.Env = append(cmd.Env, entry)
+	}
+	cmd.Env = append(cmd.Env, "GO_WANT_BENCHDELTA_HELPER=1")
 	output, err := cmd.CombinedOutput()
 	if err == nil {
 		return output, 0

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -76,5 +79,189 @@ func TestPercentDelta(t *testing.T) {
 	}
 	if got, failed := percentDelta(100, 105, 10); got != "+5.0%" || failed {
 		t.Fatalf("expected +5.0%% without failure, got %q failed=%t", got, failed)
+	}
+}
+
+func TestBenchmarkParsingAndFormattingBranches(t *testing.T) {
+	name, sample, ok := parseBenchmarkLine("", "BenchmarkFresh-8 1000 25000 ns/op 128 B/op 3 allocs/op")
+	if !ok || name != "unknown-package/BenchmarkFresh" {
+		t.Fatalf("expected unknown-package fallback benchmark, got name=%q ok=%v", name, ok)
+	}
+	if len(sample.bytesPerOp) != 1 || len(sample.allocsPerOp) != 1 {
+		t.Fatalf("expected bytes and allocs samples, got %#v", sample)
+	}
+
+	for _, line := range []string{
+		"BenchmarkShort",
+		"BenchmarkNoMetrics-8 1000 25000 ns/op",
+		"BenchmarkBadValue-8 1000 nope B/op",
+	} {
+		if _, _, ok := parseBenchmarkLine("pkg", line); ok {
+			t.Fatalf("expected parseBenchmarkLine(%q) to be ignored", line)
+		}
+	}
+
+	if got := normalizeBenchmarkName("BenchmarkDash-foo"); got != "BenchmarkDash-foo" {
+		t.Fatalf("expected non-numeric suffix to remain, got %q", got)
+	}
+	if got := normalizeBenchmarkName("BenchmarkNoDash"); got != "BenchmarkNoDash" {
+		t.Fatalf("expected dashless name to remain, got %q", got)
+	}
+	if got := average(nil); got != 0 {
+		t.Fatalf("expected zero average for empty slice, got %.1f", got)
+	}
+	if got := average([]float64{2, 4, 6}); got != 4 {
+		t.Fatalf("expected average 4, got %.1f", got)
+	}
+
+	summary, hasRegression := compareBenchmarks(benchmarkData{}, benchmarkData{}, deltaThresholds{bytesPct: 15, allocsPct: 10})
+	if hasRegression {
+		t.Fatalf("expected empty comparison to pass, got summary %q", summary)
+	}
+	if !strings.Contains(summary, "No overlapping benchmark names were found") || !strings.Contains(summary, "Result: memory benchmark gate passed.") {
+		t.Fatalf("expected empty comparison summary, got %q", summary)
+	}
+}
+
+func TestMainExitCodesAndErrorPaths(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.txt")
+	headPath := filepath.Join(dir, "head.txt")
+	writeBenchmarkFixture(t, basePath, []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+	})
+	writeBenchmarkFixture(t, headPath, []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+	})
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantCode   int
+		wantOutput string
+	}{
+		{
+			name:       "success",
+			args:       []string{"-base", basePath, "-head", headPath},
+			wantCode:   0,
+			wantOutput: "Result: memory benchmark gate passed.",
+		},
+		{
+			name:       "regression",
+			args:       []string{"-base", basePath, "-head", filepath.Join(dir, "regressed.txt")},
+			wantCode:   1,
+			wantOutput: "Result: memory benchmark regression detected.",
+		},
+		{
+			name:       "missing args",
+			args:       nil,
+			wantCode:   2,
+			wantOutput: "both -base and -head are required",
+		},
+		{
+			name:       "missing base file",
+			args:       []string{"-base", filepath.Join(dir, "missing.txt"), "-head", headPath},
+			wantCode:   2,
+			wantOutput: "parse base benchmarks",
+		},
+	}
+
+	writeBenchmarkFixture(t, filepath.Join(dir, "regressed.txt"), []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkFormat-8 1000 100 ns/op 130 B/op 2 allocs/op",
+	})
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=TestMainExitCodesAndErrorPaths", "--")
+			cmd.Args = append(cmd.Args, tc.args...)
+			cmd.Env = append(os.Environ(), "GO_WANT_BENCHDELTA_HELPER=1")
+			output, err := cmd.CombinedOutput()
+			if tc.wantCode == 0 {
+				if err != nil {
+					t.Fatalf("expected success, got %v\n%s", err, output)
+				}
+			} else {
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) {
+					t.Fatalf("expected exit error for code %d, got %v\n%s", tc.wantCode, err, output)
+				}
+				if exitErr.ExitCode() != tc.wantCode {
+					t.Fatalf("exit code = %d, want %d\n%s", exitErr.ExitCode(), tc.wantCode, output)
+				}
+			}
+			if !strings.Contains(string(output), tc.wantOutput) {
+				t.Fatalf("expected output to contain %q, got %q", tc.wantOutput, string(output))
+			}
+		})
+	}
+}
+
+func TestMainSummaryWriteErrorExit(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.txt")
+	headPath := filepath.Join(dir, "head.txt")
+	writeBenchmarkFixture(t, basePath, []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+	})
+	writeBenchmarkFixture(t, headPath, []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+	})
+
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainSummaryWriteErrorExit", "--", "-base", basePath, "-head", headPath, "-summary-out", filepath.Join(blocker, "summary.md"))
+	cmd.Env = append(os.Environ(), "GO_WANT_BENCHDELTA_HELPER=1")
+	output, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected summary write exit error, got %v\n%s", err, output)
+	}
+	if exitErr.ExitCode() != 2 {
+		t.Fatalf("exit code = %d, want 2\n%s", exitErr.ExitCode(), output)
+	}
+	if !strings.Contains(string(output), "write summary") {
+		t.Fatalf("expected summary write error, got %q", string(output))
+	}
+}
+
+func runBenchdeltaMainIfRequested(t *testing.T) bool {
+	t.Helper()
+	if os.Getenv("GO_WANT_BENCHDELTA_HELPER") != "1" {
+		return false
+	}
+
+	argsIndex := slices.Index(os.Args, "--")
+	if argsIndex < 0 {
+		t.Fatal("missing helper args separator")
+	}
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	cmdArgs := os.Args[argsIndex+1:]
+	os.Args = append([]string{oldArgs[0]}, cmdArgs...)
+	main()
+	return true
+}
+
+func writeBenchmarkFixture(t *testing.T, path string, lines []string) {
+	t.Helper()
+	content := append([]string{"goos: darwin"}, lines...)
+	if err := os.WriteFile(path, []byte(strings.Join(content, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write benchmark fixture: %v", err)
 	}
 }

--- a/tools/featureflag/main_test.go
+++ b/tools/featureflag/main_test.go
@@ -1703,6 +1703,41 @@ func TestMainUsesExitFuncOnError(t *testing.T) {
 	}
 }
 
+func TestMainUsesExitFuncOnUnknownCommand(t *testing.T) {
+	oldExit := exitFunc
+	oldArgs := os.Args
+	oldStderr := os.Stderr
+	defer func() {
+		exitFunc = oldExit
+		os.Args = oldArgs
+		os.Stderr = oldStderr
+	}()
+
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	os.Stderr = errW
+	code := 0
+	exitFunc = func(c int) { code = c }
+	os.Args = []string{"featureflag", "definitely-missing"}
+
+	main()
+	if err := errW.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(errR); err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "unknown featureflag command") {
+		t.Fatalf("expected unknown-command error on stderr, got %q", buf.String())
+	}
+}
+
 func testRegistry(t *testing.T) *featureflags.Registry {
 	t.Helper()
 	registry, err := featureflags.NewRegistry([]featureflags.Flag{


### PR DESCRIPTION
## Summary

Add deterministic regression coverage for previously excluded or high-risk paths and enforce a focused coverage floor for benchdelta.

Closes #1311

## Changes

- Add focused tests for PHP helpers, CSV write failures, Unix process cancellation, feature fallback, release workflow configuration, and benchdelta.
- Harden CSV error propagation and Unix cancellation behavior covered by those tests.
- Add a 97.0 percent benchdelta coverage ratchet while retaining the existing global and package coverage gates.

## Validation

- `make ci`
- Benchdelta coverage is 97.2 percent and repository coverage is 98.3 percent.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Pull-request CI performs one additional focused coverage run.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
