### PR TITLE
ci: enforce parser fuzz regression corpora

### DIFF
--- a/.github/workflows/parser-fuzz.yml
+++ b/.github/workflows/parser-fuzz.yml
@@ -27,3 +27,11 @@ jobs:
           go test ./internal/lang/golang -run '^$' -fuzz '^FuzzParseModFile$' -fuzztime=20s -parallel=1
           go test ./internal/lang/cpp -run '^$' -fuzz '^FuzzParseIncludes$' -fuzztime=20s -parallel=1
           go test ./internal/lang/swift -run '^$' -fuzz '^FuzzParseCarthageDependencies$' -fuzztime=20s -parallel=1
+
+      - name: Upload discovered parser fuzz regressions
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: parser-fuzz-regressions
+          path: internal/lang/*/testdata/fuzz/**
+          if-no-files-found: warn

--- a/.github/workflows/parser-fuzz.yml
+++ b/.github/workflows/parser-fuzz.yml
@@ -1,0 +1,29 @@
+name: parser-fuzz
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4 * * 3'
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Run bounded parser fuzzing
+        run: |
+          go test ./internal/lang/golang -run '^$' -fuzz '^FuzzParseModFile$' -fuzztime=20s -parallel=1
+          go test ./internal/lang/cpp -run '^$' -fuzz '^FuzzParseIncludes$' -fuzztime=20s -parallel=1
+          go test ./internal/lang/swift -run '^$' -fuzz '^FuzzParseCarthageDependencies$' -fuzztime=20s -parallel=1

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,12 @@ vuln-check:
 test:
 	$(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) ./...
 
+.PHONY: fuzz-corpus-check
+fuzz-corpus-check:
+	$(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) ./scripts -run '^(TestParserFuzzCorpusContract|TestParserFuzzWorkflowContract)$$'
+
+ci: fuzz-corpus-check
+
 cyclonedx-schema-check:
 	$(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) ./internal/report -run '^TestCycloneDXSchema'
 

--- a/internal/lang/cpp/fuzz_test.go
+++ b/internal/lang/cpp/fuzz_test.go
@@ -1,31 +1,48 @@
 package cpp
 
 import (
+	"path/filepath"
 	"slices"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 func FuzzParseIncludes(f *testing.F) {
 	f.Fuzz(func(t *testing.T, content []byte) {
-		includesA := parseIncludes(content)
-		includesB := parseIncludes(content)
-
-		if !slices.Equal(includesA, includesB) {
-			t.Fatalf("parseIncludes is not deterministic: %#v != %#v", includesA, includesB)
-		}
-
-		lastLine := 0
-		for _, include := range includesA {
-			if include.Line <= 0 {
-				t.Fatalf("parseIncludes returned an invalid line number: %#v", include)
-			}
-			if include.Column <= 0 {
-				t.Fatalf("parseIncludes returned an invalid column number: %#v", include)
-			}
-			if include.Line < lastLine {
-				t.Fatalf("parseIncludes returned out-of-order includes: %#v", includesA)
-			}
-			lastLine = include.Line
-		}
+		assertParseIncludesProperties(t, content)
 	})
+}
+
+func TestParseIncludesCommittedFuzzCorpus(t *testing.T) {
+	for _, seed := range testutil.LoadByteFuzzCorpus(t, filepath.Join("testdata", "fuzz", "FuzzParseIncludes")) {
+		t.Run(seed.Name, func(t *testing.T) {
+			assertParseIncludesProperties(t, seed.Data)
+		})
+	}
+}
+
+func assertParseIncludesProperties(t *testing.T, content []byte) {
+	t.Helper()
+
+	includesA := parseIncludes(content)
+	includesB := parseIncludes(content)
+
+	if !slices.Equal(includesA, includesB) {
+		t.Fatalf("parseIncludes is not deterministic: %#v != %#v", includesA, includesB)
+	}
+
+	lastLine := 0
+	for _, include := range includesA {
+		if include.Line <= 0 {
+			t.Fatalf("parseIncludes returned an invalid line number: %#v", include)
+		}
+		if include.Column <= 0 {
+			t.Fatalf("parseIncludes returned an invalid column number: %#v", include)
+		}
+		if include.Line < lastLine {
+			t.Fatalf("parseIncludes returned out-of-order includes: %#v", includesA)
+		}
+		lastLine = include.Line
+	}
 }

--- a/internal/lang/cpp/fuzz_test.go
+++ b/internal/lang/cpp/fuzz_test.go
@@ -1,0 +1,31 @@
+package cpp
+
+import (
+	"slices"
+	"testing"
+)
+
+func FuzzParseIncludes(f *testing.F) {
+	f.Fuzz(func(t *testing.T, content []byte) {
+		includesA := parseIncludes(content)
+		includesB := parseIncludes(content)
+
+		if !slices.Equal(includesA, includesB) {
+			t.Fatalf("parseIncludes is not deterministic: %#v != %#v", includesA, includesB)
+		}
+
+		lastLine := 0
+		for _, include := range includesA {
+			if include.Line <= 0 {
+				t.Fatalf("parseIncludes returned an invalid line number: %#v", include)
+			}
+			if include.Column <= 0 {
+				t.Fatalf("parseIncludes returned an invalid column number: %#v", include)
+			}
+			if include.Line < lastLine {
+				t.Fatalf("parseIncludes returned out-of-order includes: %#v", includesA)
+			}
+			lastLine = include.Line
+		}
+	})
+}

--- a/internal/lang/cpp/testdata/fuzz/FuzzParseIncludes/mixed_include_directives
+++ b/internal/lang/cpp/testdata/fuzz/FuzzParseIncludes/mixed_include_directives
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("#include <fmt/core.h>\n#include \"local/header.hpp\"\n#include_next <fmt/core.h>\n#include SOME_MACRO_HEADER\n#include <broken\n")

--- a/internal/lang/cpp/testdata/fuzz/FuzzParseIncludes/whitespace_and_missing_header
+++ b/internal/lang/cpp/testdata/fuzz/FuzzParseIncludes/whitespace_and_missing_header
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("  # include <vector>\n\t#include \"project/header.hpp\"\n#include <>\n")

--- a/internal/lang/golang/fuzz_test.go
+++ b/internal/lang/golang/fuzz_test.go
@@ -2,8 +2,11 @@ package golang
 
 import (
 	"maps"
+	"path/filepath"
 	"slices"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 func FuzzParseModFile(f *testing.F) {
@@ -11,31 +14,61 @@ func FuzzParseModFile(f *testing.F) {
 		modulePathA, dependenciesA, replacementsA := parseGoMod(content)
 		modulePathB, dependenciesB, replacementsB := parseGoMod(content)
 
-		if modulePathA != modulePathB {
-			t.Fatalf("parseGoMod module path is not deterministic: %q != %q", modulePathA, modulePathB)
-		}
-		if !slices.Equal(dependenciesA, dependenciesB) {
-			t.Fatalf("parseGoMod dependencies are not deterministic: %#v != %#v", dependenciesA, dependenciesB)
-		}
-		if !maps.Equal(replacementsA, replacementsB) {
-			t.Fatalf("parseGoMod replacements are not deterministic: %#v != %#v", replacementsA, replacementsB)
-		}
-
-		if !slices.IsSorted(dependenciesA) {
-			t.Fatalf("parseGoMod returned unsorted dependencies: %#v", dependenciesA)
-		}
-		for i, dependency := range dependenciesA {
-			if dependency == "" {
-				t.Fatalf("parseGoMod returned an empty dependency in %#v", dependenciesA)
-			}
-			if i > 0 && dependenciesA[i-1] == dependency {
-				t.Fatalf("parseGoMod returned duplicate dependencies: %#v", dependenciesA)
-			}
-		}
-		for replacement, original := range replacementsA {
-			if replacement == "" || original == "" {
-				t.Fatalf("parseGoMod returned an empty replacement mapping: %#v", replacementsA)
-			}
-		}
+		assertDeterministicGoModParse(t, modulePathA, dependenciesA, replacementsA, modulePathB, dependenciesB, replacementsB)
+		assertSortedUniqueGoModDependencies(t, dependenciesA)
+		assertNonEmptyGoModReplacements(t, replacementsA)
 	})
+}
+
+func TestParseModFileCommittedFuzzCorpus(t *testing.T) {
+	for _, seed := range testutil.LoadByteFuzzCorpus(t, filepath.Join("testdata", "fuzz", "FuzzParseModFile")) {
+		t.Run(seed.Name, func(t *testing.T) {
+			modulePathA, dependenciesA, replacementsA := parseGoMod(seed.Data)
+			modulePathB, dependenciesB, replacementsB := parseGoMod(seed.Data)
+
+			assertDeterministicGoModParse(t, modulePathA, dependenciesA, replacementsA, modulePathB, dependenciesB, replacementsB)
+			assertSortedUniqueGoModDependencies(t, dependenciesA)
+			assertNonEmptyGoModReplacements(t, replacementsA)
+		})
+	}
+}
+
+func assertDeterministicGoModParse(t *testing.T, modulePathA string, dependenciesA []string, replacementsA map[string]string, modulePathB string, dependenciesB []string, replacementsB map[string]string) {
+	t.Helper()
+
+	if modulePathA != modulePathB {
+		t.Fatalf("parseGoMod module path is not deterministic: %q != %q", modulePathA, modulePathB)
+	}
+	if !slices.Equal(dependenciesA, dependenciesB) {
+		t.Fatalf("parseGoMod dependencies are not deterministic: %#v != %#v", dependenciesA, dependenciesB)
+	}
+	if !maps.Equal(replacementsA, replacementsB) {
+		t.Fatalf("parseGoMod replacements are not deterministic: %#v != %#v", replacementsA, replacementsB)
+	}
+}
+
+func assertSortedUniqueGoModDependencies(t *testing.T, dependencies []string) {
+	t.Helper()
+
+	if !slices.IsSorted(dependencies) {
+		t.Fatalf("parseGoMod returned unsorted dependencies: %#v", dependencies)
+	}
+	for i, dependency := range dependencies {
+		if dependency == "" {
+			t.Fatalf("parseGoMod returned an empty dependency in %#v", dependencies)
+		}
+		if i > 0 && dependencies[i-1] == dependency {
+			t.Fatalf("parseGoMod returned duplicate dependencies: %#v", dependencies)
+		}
+	}
+}
+
+func assertNonEmptyGoModReplacements(t *testing.T, replacements map[string]string) {
+	t.Helper()
+
+	for replacement, original := range replacements {
+		if replacement == "" || original == "" {
+			t.Fatalf("parseGoMod returned an empty replacement mapping: %#v", replacements)
+		}
+	}
 }

--- a/internal/lang/golang/fuzz_test.go
+++ b/internal/lang/golang/fuzz_test.go
@@ -1,0 +1,41 @@
+package golang
+
+import (
+	"maps"
+	"slices"
+	"testing"
+)
+
+func FuzzParseModFile(f *testing.F) {
+	f.Fuzz(func(t *testing.T, content []byte) {
+		modulePathA, dependenciesA, replacementsA := parseGoMod(content)
+		modulePathB, dependenciesB, replacementsB := parseGoMod(content)
+
+		if modulePathA != modulePathB {
+			t.Fatalf("parseGoMod module path is not deterministic: %q != %q", modulePathA, modulePathB)
+		}
+		if !slices.Equal(dependenciesA, dependenciesB) {
+			t.Fatalf("parseGoMod dependencies are not deterministic: %#v != %#v", dependenciesA, dependenciesB)
+		}
+		if !maps.Equal(replacementsA, replacementsB) {
+			t.Fatalf("parseGoMod replacements are not deterministic: %#v != %#v", replacementsA, replacementsB)
+		}
+
+		if !slices.IsSorted(dependenciesA) {
+			t.Fatalf("parseGoMod returned unsorted dependencies: %#v", dependenciesA)
+		}
+		for i, dependency := range dependenciesA {
+			if dependency == "" {
+				t.Fatalf("parseGoMod returned an empty dependency in %#v", dependenciesA)
+			}
+			if i > 0 && dependenciesA[i-1] == dependency {
+				t.Fatalf("parseGoMod returned duplicate dependencies: %#v", dependenciesA)
+			}
+		}
+		for replacement, original := range replacementsA {
+			if replacement == "" || original == "" {
+				t.Fatalf("parseGoMod returned an empty replacement mapping: %#v", replacementsA)
+			}
+		}
+	})
+}

--- a/internal/lang/golang/testdata/fuzz/FuzzParseModFile/commented_inline_block
+++ b/internal/lang/golang/testdata/fuzz/FuzzParseModFile/commented_inline_block
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("module example.com/root\nrequire ( github.com/acme/dep v1.2.3 ) // keep comment\n")

--- a/internal/lang/golang/testdata/fuzz/FuzzParseModFile/inline_require_block
+++ b/internal/lang/golang/testdata/fuzz/FuzzParseModFile/inline_require_block
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("module example.com/root\nrequire ( github.com/acme/dep v1.2.3 )\nrequire github.com/acme/other v1.4.0\nreplace example.com/old => github.com/fork/old v1.2.4\n")

--- a/internal/lang/golang/testdata/fuzz/FuzzParseModFile/malformed_require_block
+++ b/internal/lang/golang/testdata/fuzz/FuzzParseModFile/malformed_require_block
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("module example.com/root\nrequire (\n")

--- a/internal/lang/swift/fuzz_test.go
+++ b/internal/lang/swift/fuzz_test.go
@@ -1,27 +1,44 @@
 package swift
 
 import (
+	"path/filepath"
 	"slices"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 func FuzzParseCarthageDependencies(f *testing.F) {
 	f.Fuzz(func(t *testing.T, content []byte) {
-		manifestA := parseCarthageManifestDependencies(content)
-		manifestB := parseCarthageManifestDependencies(content)
-		if !slices.Equal(manifestA, manifestB) {
-			t.Fatalf("parseCarthageManifestDependencies is not deterministic: %#v != %#v", manifestA, manifestB)
-		}
-
-		resolvedA := parseCarthageResolvedDependencies(content)
-		resolvedB := parseCarthageResolvedDependencies(content)
-		if !slices.Equal(resolvedA, resolvedB) {
-			t.Fatalf("parseCarthageResolvedDependencies is not deterministic: %#v != %#v", resolvedA, resolvedB)
-		}
-
-		assertSortedUniqueCarthageDependencies(t, manifestA)
-		assertSortedUniqueCarthageDependencies(t, resolvedA)
+		assertParseCarthageDependenciesProperties(t, content)
 	})
+}
+
+func TestParseCarthageDependenciesCommittedFuzzCorpus(t *testing.T) {
+	for _, seed := range testutil.LoadByteFuzzCorpus(t, filepath.Join("testdata", "fuzz", "FuzzParseCarthageDependencies")) {
+		t.Run(seed.Name, func(t *testing.T) {
+			assertParseCarthageDependenciesProperties(t, seed.Data)
+		})
+	}
+}
+
+func assertParseCarthageDependenciesProperties(t *testing.T, content []byte) {
+	t.Helper()
+
+	manifestA := parseCarthageManifestDependencies(content)
+	manifestB := parseCarthageManifestDependencies(content)
+	if !slices.Equal(manifestA, manifestB) {
+		t.Fatalf("parseCarthageManifestDependencies is not deterministic: %#v != %#v", manifestA, manifestB)
+	}
+
+	resolvedA := parseCarthageResolvedDependencies(content)
+	resolvedB := parseCarthageResolvedDependencies(content)
+	if !slices.Equal(resolvedA, resolvedB) {
+		t.Fatalf("parseCarthageResolvedDependencies is not deterministic: %#v != %#v", resolvedA, resolvedB)
+	}
+
+	assertSortedUniqueCarthageDependencies(t, manifestA)
+	assertSortedUniqueCarthageDependencies(t, resolvedA)
 }
 
 func assertSortedUniqueCarthageDependencies(t *testing.T, entries []carthageDependency) {

--- a/internal/lang/swift/fuzz_test.go
+++ b/internal/lang/swift/fuzz_test.go
@@ -1,0 +1,40 @@
+package swift
+
+import (
+	"slices"
+	"testing"
+)
+
+func FuzzParseCarthageDependencies(f *testing.F) {
+	f.Fuzz(func(t *testing.T, content []byte) {
+		manifestA := parseCarthageManifestDependencies(content)
+		manifestB := parseCarthageManifestDependencies(content)
+		if !slices.Equal(manifestA, manifestB) {
+			t.Fatalf("parseCarthageManifestDependencies is not deterministic: %#v != %#v", manifestA, manifestB)
+		}
+
+		resolvedA := parseCarthageResolvedDependencies(content)
+		resolvedB := parseCarthageResolvedDependencies(content)
+		if !slices.Equal(resolvedA, resolvedB) {
+			t.Fatalf("parseCarthageResolvedDependencies is not deterministic: %#v != %#v", resolvedA, resolvedB)
+		}
+
+		assertSortedUniqueCarthageDependencies(t, manifestA)
+		assertSortedUniqueCarthageDependencies(t, resolvedA)
+	})
+}
+
+func assertSortedUniqueCarthageDependencies(t *testing.T, entries []carthageDependency) {
+	t.Helper()
+
+	lastDependency := ""
+	for _, entry := range entries {
+		if entry.Dependency == "" {
+			t.Fatalf("Carthage parser returned an empty dependency: %#v", entries)
+		}
+		if lastDependency != "" && lastDependency >= entry.Dependency {
+			t.Fatalf("Carthage parser returned unsorted or duplicate dependencies: %#v", entries)
+		}
+		lastDependency = entry.Dependency
+	}
+}

--- a/internal/lang/swift/testdata/fuzz/FuzzParseCarthageDependencies/hash_fragment_binary
+++ b/internal/lang/swift/testdata/fuzz/FuzzParseCarthageDependencies/hash_fragment_binary
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("binary \"https://example.com/FancyKit.json#sha256=abc123\" \"1.2.3\" # trailing comment\n")

--- a/internal/lang/swift/testdata/fuzz/FuzzParseCarthageDependencies/manifest_with_comments
+++ b/internal/lang/swift/testdata/fuzz/FuzzParseCarthageDependencies/manifest_with_comments
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("github \"owner/repo\" \"1.0.0\" # trailing comment\nbinary \"https://example.com/FancyKit.json#sha=abc\\\"def\" \"1.2.3\" # trailing\n")

--- a/internal/testutil/fuzz_corpus.go
+++ b/internal/testutil/fuzz_corpus.go
@@ -1,0 +1,97 @@
+package testutil
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type ByteFuzzSeed struct {
+	Name string
+	Data []byte
+}
+
+func LoadByteFuzzCorpus(tb testing.TB, dir string) []ByteFuzzSeed {
+	tb.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		tb.Fatalf("read fuzz corpus %s: %v", dir, err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		tb.Fatalf("open fuzz corpus root %s: %v", dir, err)
+	}
+	defer func() {
+		if err := root.Close(); err != nil {
+			tb.Fatalf("close fuzz corpus root %s: %v", dir, err)
+		}
+	}()
+
+	seeds := make([]ByteFuzzSeed, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			tb.Fatalf("fuzz corpus %s contains nested directory %s", dir, entry.Name())
+		}
+
+		body := readRootedFuzzSeed(tb, root, dir, entry.Name())
+		path := filepath.Join(dir, entry.Name())
+		seeds = append(seeds, ByteFuzzSeed{
+			Name: entry.Name(),
+			Data: parseByteFuzzSeed(tb, path, body),
+		})
+	}
+
+	slices.SortFunc(seeds, func(a, b ByteFuzzSeed) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return seeds
+}
+
+func readRootedFuzzSeed(tb testing.TB, root *os.Root, dir string, name string) string {
+	tb.Helper()
+
+	file, err := root.Open(name)
+	if err != nil {
+		tb.Fatalf("open fuzz seed %s: %v", filepath.Join(dir, name), err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			tb.Fatalf("close fuzz seed %s: %v", filepath.Join(dir, name), err)
+		}
+	}()
+
+	body, err := io.ReadAll(file)
+	if err != nil {
+		tb.Fatalf("read fuzz seed %s: %v", filepath.Join(dir, name), err)
+	}
+	return string(body)
+}
+
+func parseByteFuzzSeed(tb testing.TB, path string, raw string) []byte {
+	tb.Helper()
+
+	header, body, ok := strings.Cut(raw, "\n")
+	if !ok {
+		tb.Fatalf("fuzz seed %s is missing a payload line", path)
+	}
+	if header != "go test fuzz v1" {
+		tb.Fatalf("fuzz seed %s has unexpected header %q", path, header)
+	}
+
+	payload := strings.TrimSpace(body)
+	if !strings.HasPrefix(payload, "[]byte(") || !strings.HasSuffix(payload, ")") {
+		tb.Fatalf("fuzz seed %s must wrap a []byte literal, got %q", path, payload)
+	}
+
+	literal := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(payload, "[]byte("), ")"))
+	value, err := strconv.Unquote(literal)
+	if err != nil {
+		tb.Fatalf("unquote fuzz seed %s: %v", path, err)
+	}
+	return []byte(value)
+}

--- a/internal/testutil/fuzz_corpus_test.go
+++ b/internal/testutil/fuzz_corpus_test.go
@@ -1,0 +1,23 @@
+package testutil
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadByteFuzzCorpus(t *testing.T) {
+	dir := t.TempDir()
+	MustWriteFile(t, filepath.Join(dir, "b"), "go test fuzz v1\n[]byte(`second\\nseed`)\n")
+	MustWriteFile(t, filepath.Join(dir, "a"), "go test fuzz v1\n[]byte(\"first seed\")\n")
+
+	seeds := LoadByteFuzzCorpus(t, dir)
+	if len(seeds) != 2 {
+		t.Fatalf("expected two seeds, got %#v", seeds)
+	}
+	if seeds[0].Name != "a" || string(seeds[0].Data) != "first seed" {
+		t.Fatalf("unexpected first seed %#v", seeds[0])
+	}
+	if seeds[1].Name != "b" || string(seeds[1].Data) != "second\\nseed" {
+		t.Fatalf("unexpected second seed %#v", seeds[1])
+	}
+}

--- a/scripts/fuzz_corpus_contract_test.go
+++ b/scripts/fuzz_corpus_contract_test.go
@@ -1,0 +1,66 @@
+package scripts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fuzzCorpusManifest struct {
+	Targets []fuzzCorpusTarget `json:"targets"`
+}
+
+type fuzzCorpusTarget struct {
+	Name         string `json:"name"`
+	Source       string `json:"source"`
+	Corpus       string `json:"corpus"`
+	MinSeedFiles int    `json:"min_seed_files"`
+}
+
+func TestParserFuzzCorpusContract(t *testing.T) {
+	var manifest fuzzCorpusManifest
+	readJSONConfig(t, "testdata/fuzz/manifest.json", &manifest)
+	if len(manifest.Targets) == 0 {
+		t.Fatal("fuzz corpus manifest must list at least one target")
+	}
+
+	for _, target := range manifest.Targets {
+		if target.Name == "" || target.Source == "" || target.Corpus == "" {
+			t.Fatalf("fuzz corpus manifest contains an incomplete target: %#v", target)
+		}
+		if target.MinSeedFiles <= 0 {
+			t.Fatalf("fuzz corpus manifest target must require at least one seed: %#v", target)
+		}
+
+		sourceText := readConfig(t, target.Source)
+		wantSignature := "func " + target.Name + "("
+		if !strings.Contains(sourceText, wantSignature) {
+			t.Fatalf("%s must declare %s", target.Source, wantSignature)
+		}
+
+		corpusDir := repoPath(t, target.Corpus)
+		entries, err := os.ReadDir(corpusDir)
+		if err != nil {
+			t.Fatalf("read corpus directory %s: %v", target.Corpus, err)
+		}
+
+		seedCount := 0
+		for _, entry := range entries {
+			if entry.IsDir() {
+				t.Fatalf("corpus directory %s must not contain nested directories: %s", target.Corpus, entry.Name())
+			}
+			seedCount++
+
+			seedPath := filepath.Join(target.Corpus, entry.Name())
+			seedText := readConfig(t, seedPath)
+			if !strings.HasPrefix(seedText, "go test fuzz v1\n") {
+				t.Fatalf("corpus seed %s must use the go fuzz corpus format", seedPath)
+			}
+		}
+
+		if seedCount < target.MinSeedFiles {
+			t.Fatalf("corpus directory %s contains %d seeds, want at least %d", target.Corpus, seedCount, target.MinSeedFiles)
+		}
+	}
+}

--- a/scripts/fuzz_corpus_contract_test.go
+++ b/scripts/fuzz_corpus_contract_test.go
@@ -26,41 +26,68 @@ func TestParserFuzzCorpusContract(t *testing.T) {
 	}
 
 	for _, target := range manifest.Targets {
-		if target.Name == "" || target.Source == "" || target.Corpus == "" {
-			t.Fatalf("fuzz corpus manifest contains an incomplete target: %#v", target)
-		}
-		if target.MinSeedFiles <= 0 {
-			t.Fatalf("fuzz corpus manifest target must require at least one seed: %#v", target)
-		}
+		assertValidFuzzCorpusTarget(t, target)
+		assertFuzzTargetSignature(t, target)
+		assertCorpusSeedContract(t, target)
+	}
+}
 
-		sourceText := readConfig(t, target.Source)
-		wantSignature := "func " + target.Name + "("
-		if !strings.Contains(sourceText, wantSignature) {
-			t.Fatalf("%s must declare %s", target.Source, wantSignature)
+func assertValidFuzzCorpusTarget(t *testing.T, target fuzzCorpusTarget) {
+	t.Helper()
+
+	if target.Name == "" || target.Source == "" || target.Corpus == "" {
+		t.Fatalf("fuzz corpus manifest contains an incomplete target: %#v", target)
+	}
+	if target.MinSeedFiles <= 0 {
+		t.Fatalf("fuzz corpus manifest target must require at least one seed: %#v", target)
+	}
+}
+
+func assertFuzzTargetSignature(t *testing.T, target fuzzCorpusTarget) {
+	t.Helper()
+
+	sourceText := readConfig(t, target.Source)
+	wantSignature := "func " + target.Name + "("
+	if !strings.Contains(sourceText, wantSignature) {
+		t.Fatalf("%s must declare %s", target.Source, wantSignature)
+	}
+}
+
+func assertCorpusSeedContract(t *testing.T, target fuzzCorpusTarget) {
+	t.Helper()
+
+	entries := readCorpusEntries(t, target.Corpus)
+	seedCount := countValidCorpusSeeds(t, target.Corpus, entries)
+	if seedCount < target.MinSeedFiles {
+		t.Fatalf("corpus directory %s contains %d seeds, want at least %d", target.Corpus, seedCount, target.MinSeedFiles)
+	}
+}
+
+func readCorpusEntries(t *testing.T, corpus string) []os.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(repoPath(t, corpus))
+	if err != nil {
+		t.Fatalf("read corpus directory %s: %v", corpus, err)
+	}
+	return entries
+}
+
+func countValidCorpusSeeds(t *testing.T, corpus string, entries []os.DirEntry) int {
+	t.Helper()
+
+	seedCount := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			t.Fatalf("corpus directory %s must not contain nested directories: %s", corpus, entry.Name())
 		}
+		seedCount++
 
-		corpusDir := repoPath(t, target.Corpus)
-		entries, err := os.ReadDir(corpusDir)
-		if err != nil {
-			t.Fatalf("read corpus directory %s: %v", target.Corpus, err)
-		}
-
-		seedCount := 0
-		for _, entry := range entries {
-			if entry.IsDir() {
-				t.Fatalf("corpus directory %s must not contain nested directories: %s", target.Corpus, entry.Name())
-			}
-			seedCount++
-
-			seedPath := filepath.Join(target.Corpus, entry.Name())
-			seedText := readConfig(t, seedPath)
-			if !strings.HasPrefix(seedText, "go test fuzz v1\n") {
-				t.Fatalf("corpus seed %s must use the go fuzz corpus format", seedPath)
-			}
-		}
-
-		if seedCount < target.MinSeedFiles {
-			t.Fatalf("corpus directory %s contains %d seeds, want at least %d", target.Corpus, seedCount, target.MinSeedFiles)
+		seedPath := filepath.Join(corpus, entry.Name())
+		seedText := readConfig(t, seedPath)
+		if !strings.HasPrefix(seedText, "go test fuzz v1\n") {
+			t.Fatalf("corpus seed %s must use the go fuzz corpus format", seedPath)
 		}
 	}
+	return seedCount
 }

--- a/scripts/parser_fuzz_workflow_test.go
+++ b/scripts/parser_fuzz_workflow_test.go
@@ -13,7 +13,15 @@ func TestParserFuzzWorkflowContract(t *testing.T) {
 	job := workflowJobByName(t, workflow.Jobs, "discover")
 	assertWorkflowJobPermissions(t, job, "parser fuzz discovery", map[string]string{"contents": "read"})
 	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, job, "parser fuzz discovery")
-	assertWorkflowStepOrder(t, job, "Checkout", "Setup Go", "Run bounded parser fuzzing")
+	assertWorkflowStepOrder(t, job, "Checkout", "Setup Go", "Run bounded parser fuzzing", "Upload discovered parser fuzz regressions")
+
+	upload := workflowStepByName(t, workflow.Jobs, "discover", "Upload discovered parser fuzz regressions")
+	if upload.Uses != "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" {
+		t.Fatalf("parser fuzz upload action = %q, want immutable upload-artifact action", upload.Uses)
+	}
+	if upload.If != "${{ failure() }}" {
+		t.Fatalf("parser fuzz upload condition = %q, want failure-only upload", upload.If)
+	}
 
 	workflowText := readConfig(t, ".github/workflows/parser-fuzz.yml")
 	for _, fragment := range []string{
@@ -26,6 +34,9 @@ func TestParserFuzzWorkflowContract(t *testing.T) {
 		"go test ./internal/lang/golang -run '^$' -fuzz '^FuzzParseModFile$' -fuzztime=20s -parallel=1",
 		"go test ./internal/lang/cpp -run '^$' -fuzz '^FuzzParseIncludes$' -fuzztime=20s -parallel=1",
 		"go test ./internal/lang/swift -run '^$' -fuzz '^FuzzParseCarthageDependencies$' -fuzztime=20s -parallel=1",
+		"name: parser-fuzz-regressions",
+		"path: internal/lang/*/testdata/fuzz/**",
+		"if-no-files-found: warn",
 	} {
 		if !strings.Contains(workflowText, fragment) {
 			t.Fatalf("parser fuzz workflow missing %q", fragment)

--- a/scripts/parser_fuzz_workflow_test.go
+++ b/scripts/parser_fuzz_workflow_test.go
@@ -1,0 +1,36 @@
+package scripts
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParserFuzzWorkflowContract(t *testing.T) {
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/parser-fuzz.yml", &workflow)
+
+	job := workflowJobByName(t, workflow.Jobs, "discover")
+	assertWorkflowJobPermissions(t, job, "parser fuzz discovery", map[string]string{"contents": "read"})
+	assertWorkflowJobCheckoutsDisablePersistedCredentials(t, job, "parser fuzz discovery")
+	assertWorkflowStepOrder(t, job, "Checkout", "Setup Go", "Run bounded parser fuzzing")
+
+	workflowText := readConfig(t, ".github/workflows/parser-fuzz.yml")
+	for _, fragment := range []string{
+		"workflow_dispatch:",
+		"schedule:",
+		"cron: '17 4 * * 3'",
+		"timeout-minutes: 15",
+		"actions/checkout@v7",
+		"actions/setup-go@v7",
+		"go test ./internal/lang/golang -run '^$' -fuzz '^FuzzParseModFile$' -fuzztime=20s -parallel=1",
+		"go test ./internal/lang/cpp -run '^$' -fuzz '^FuzzParseIncludes$' -fuzztime=20s -parallel=1",
+		"go test ./internal/lang/swift -run '^$' -fuzz '^FuzzParseCarthageDependencies$' -fuzztime=20s -parallel=1",
+	} {
+		if !strings.Contains(workflowText, fragment) {
+			t.Fatalf("parser fuzz workflow missing %q", fragment)
+		}
+	}
+
+	assertWorkflowJobOmitsText(t, job, "secrets.", "parser fuzz discovery must be secretless")
+	assertWorkflowJobOmitsText(t, job, "github.token", "parser fuzz discovery must not use github.token")
+}

--- a/scripts/parser_fuzz_workflow_test.go
+++ b/scripts/parser_fuzz_workflow_test.go
@@ -1,6 +1,7 @@
 package scripts
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -32,5 +33,8 @@ func TestParserFuzzWorkflowContract(t *testing.T) {
 	}
 
 	assertWorkflowJobOmitsText(t, job, "secrets.", "parser fuzz discovery must be secretless")
+	if regexp.MustCompile(`\bsecrets\s*\[`).MatchString(workflowText) {
+		t.Fatal("parser fuzz discovery must be secretless")
+	}
 	assertWorkflowJobOmitsText(t, job, "github.token", "parser fuzz discovery must not use github.token")
 }

--- a/testdata/fuzz/manifest.json
+++ b/testdata/fuzz/manifest.json
@@ -1,0 +1,22 @@
+{
+  "targets": [
+    {
+      "name": "FuzzParseModFile",
+      "source": "internal/lang/golang/fuzz_test.go",
+      "corpus": "internal/lang/golang/testdata/fuzz/FuzzParseModFile",
+      "min_seed_files": 3
+    },
+    {
+      "name": "FuzzParseIncludes",
+      "source": "internal/lang/cpp/fuzz_test.go",
+      "corpus": "internal/lang/cpp/testdata/fuzz/FuzzParseIncludes",
+      "min_seed_files": 2
+    },
+    {
+      "name": "FuzzParseCarthageDependencies",
+      "source": "internal/lang/swift/fuzz_test.go",
+      "corpus": "internal/lang/swift/testdata/fuzz/FuzzParseCarthageDependencies",
+      "min_seed_files": 2
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Turn parser fuzz discoveries into deterministic regression inputs while keeping bounded fuzz exploration on a scheduled and manual workflow.

Closes #1315

## Changes

- Add Go, C++, and Swift fuzz targets with committed seed corpora.
- Enforce a manifest-backed corpus contract in pull-request CI.
- Add a secretless, bounded scheduled and manual fuzz-discovery workflow.

## Validation

- `make ci`
- Corpus contract, workflow contract, and deterministic seed executions pass.
- The final #1311 and #1315 heads produce a conflict-free merge tree.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Pull-request CI runs committed parser seeds; bounded discovery runs separately on schedule or manual dispatch.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
