### PR TITLE
fix(report): preserve highest OSV duplicate severity

### DIFF
--- a/internal/report/vulnerability.go
+++ b/internal/report/vulnerability.go
@@ -315,6 +315,7 @@ func normalizeAdvisories(advisories []VulnerabilityAdvisory) []VulnerabilityAdvi
 		}
 		key := strings.ToLower(advisory.ID) + "\x00" + CanonicalPackageNameForEcosystem(advisory.Ecosystem, advisory.Package) + "\x00" + advisory.Ecosystem
 		if index, ok := indexByKey[key]; ok {
+			normalized[index].Severity = mergeAdvisorySeverity(normalized[index].Severity, advisory.Severity)
 			normalized[index].FixedVersion = mergeAdvisoryFixedVersion(normalized[index].FixedVersion, advisory.FixedVersion)
 			normalized[index].Aliases = sortedUniqueStrings(append(normalized[index].Aliases, advisory.Aliases...))
 			normalized[index].AffectedVersions = sortedUniqueStrings(append(normalized[index].AffectedVersions, advisory.AffectedVersions...))
@@ -340,6 +341,13 @@ func mergeAdvisoryFixedVersion(existing, incoming string) string {
 		return existing
 	}
 	return ""
+}
+
+func mergeAdvisorySeverity(existing, incoming string) string {
+	if severityRank(incoming) > severityRank(existing) {
+		return normalizeSeverity(incoming)
+	}
+	return normalizeSeverity(existing)
 }
 
 func advisoryMatchesDependency(advisory VulnerabilityAdvisory, dep DependencyReport) bool {

--- a/internal/report/vulnerability_test.go
+++ b/internal/report/vulnerability_test.go
@@ -273,140 +273,100 @@ func TestNormalizeAdvisoriesMergesDuplicateFixedVersionsConservatively(t *testin
 }
 
 func TestAnnotateVulnerabilitiesMergesDuplicateOSVSeverityConservatively(t *testing.T) {
-	dependency := DependencyReport{
-		Language:          "js-ts",
-		Name:              "example-lib",
-		UsedExportsCount:  1,
-		TotalExportsCount: 1,
-		UsedImports: []ImportUse{
-			{
-				Name:   "default",
-				Module: "example-lib",
-				Locations: []Location{
-					{File: "src/app.ts", Line: 7, Column: 1},
-				},
-			},
-		},
-	}
-	duplicateRanges := []VulnerabilityVersionRange{
-		{
-			Type: "SEMVER",
-			Events: []VulnerabilityVersionEvent{
-				{Introduced: "0"},
-				{Fixed: "1.2.3"},
-			},
-		},
-	}
 	tests := []struct {
 		name       string
 		advisories []VulnerabilityAdvisory
 	}{
 		{
-			name: "low then critical",
-			advisories: []VulnerabilityAdvisory{
-				{
-					ID:               "OSV-dup",
-					Package:          "example-lib",
-					Ecosystem:        "npm",
-					Severity:         "low",
-					FixedVersion:     "1.2.3",
-					Aliases:          []string{"CVE-2026-0001"},
-					AffectedVersions: []string{"1.0.0"},
-					VersionRanges:    duplicateRanges,
-				},
-				{
-					ID:               "OSV-dup",
-					Package:          "example-lib",
-					Ecosystem:        "npm",
-					Severity:         "critical",
-					FixedVersion:     "1.2.3",
-					Aliases:          []string{"GHSA-dup"},
-					AffectedVersions: []string{"1.1.0"},
-					VersionRanges:    duplicateRanges,
-				},
-			},
+			name:       "low then critical",
+			advisories: duplicateOSVAdvisaries("low", "critical"),
 		},
 		{
-			name: "critical then low",
-			advisories: []VulnerabilityAdvisory{
-				{
-					ID:               "OSV-dup",
-					Package:          "example-lib",
-					Ecosystem:        "npm",
-					Severity:         "critical",
-					FixedVersion:     "1.2.3",
-					Aliases:          []string{"GHSA-dup"},
-					AffectedVersions: []string{"1.1.0"},
-					VersionRanges:    duplicateRanges,
-				},
-				{
-					ID:               "OSV-dup",
-					Package:          "example-lib",
-					Ecosystem:        "npm",
-					Severity:         "low",
-					FixedVersion:     "1.2.3",
-					Aliases:          []string{"CVE-2026-0001"},
-					AffectedVersions: []string{"1.0.0"},
-					VersionRanges:    duplicateRanges,
-				},
-			},
+			name:       "critical then low",
+			advisories: duplicateOSVAdvisaries("critical", "low"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			reportData := Report{
-				Dependencies: []DependencyReport{
-					dependency,
-				},
-			}
-			reportData.Dependencies[0].Identity = &DependencyIdentity{
-				Name:      "example-lib",
-				Ecosystem: "npm",
-				Version:   "1.1.0",
-			}
-
-			normalized := normalizeAdvisories(tc.advisories)
-			if len(normalized) != 1 {
-				t.Fatalf("expected one normalized advisory, got %#v", normalized)
-			}
-
-			got := normalized[0]
-			if got.Severity != "critical" {
-				t.Fatalf("expected merged severity to remain critical, got %#v", got)
-			}
-			if got.FixedVersion != "1.2.3" {
-				t.Fatalf("expected duplicate fixed version to be preserved, got %#v", got)
-			}
-			if !slices.Equal(got.Aliases, []string{"CVE-2026-0001", "GHSA-dup"}) {
-				t.Fatalf("expected merged aliases, got %#v", got.Aliases)
-			}
-			if !slices.Equal(got.AffectedVersions, []string{"1.0.0", "1.1.0"}) {
-				t.Fatalf("expected merged affected versions, got %#v", got.AffectedVersions)
-			}
-			if len(got.VersionRanges) != 1 || got.VersionRanges[0].Type != duplicateRanges[0].Type || !slices.Equal(got.VersionRanges[0].Events, duplicateRanges[0].Events) {
-				t.Fatalf("expected merged version ranges, got %#v", got.VersionRanges)
-			}
-
-			AnnotateVulnerabilities(&reportData, tc.advisories)
-			if len(reportData.Dependencies[0].Vulnerabilities) != 1 {
-				t.Fatalf("expected one merged finding, got %#v", reportData.Dependencies[0].Vulnerabilities)
-			}
-
-			finding := reportData.Dependencies[0].Vulnerabilities[0]
-			if finding.Severity != "critical" || finding.Priority != VulnerabilityPriorityCritical || finding.PriorityScore != 90 {
-				t.Fatalf("expected critical merged finding, got %#v", finding)
-			}
-			if !VulnerabilityPriorityMeetsThreshold(finding.Priority, VulnerabilityPriorityCritical) {
-				t.Fatalf("expected merged finding to meet critical threshold, got %#v", finding)
-			}
-			if !slices.Contains(finding.Evidence, "aliases: CVE-2026-0001, GHSA-dup") {
-				t.Fatalf("expected merged alias evidence, got %#v", finding.Evidence)
-			}
-			if !slices.Contains(finding.Evidence, "fixed_version: 1.2.3") {
-				t.Fatalf("expected fixed version evidence, got %#v", finding.Evidence)
-			}
+			assertDuplicateOSVSeverityMerge(t, tc.advisories)
 		})
+	}
+}
+
+func duplicateOSVAdvisaries(firstSeverity, secondSeverity string) []VulnerabilityAdvisory {
+	low := VulnerabilityAdvisory{
+		ID:               "OSV-dup",
+		Package:          "example-lib",
+		Ecosystem:        "npm",
+		Severity:         "low",
+		FixedVersion:     "1.2.3",
+		Aliases:          []string{"CVE-2026-0001"},
+		AffectedVersions: []string{"1.0.0"},
+		VersionRanges: []VulnerabilityVersionRange{{
+			Type: "SEMVER",
+			Events: []VulnerabilityVersionEvent{
+				{Introduced: "0"},
+				{Fixed: "1.2.3"},
+			},
+		}},
+	}
+	critical := low
+	critical.Severity = "critical"
+	critical.Aliases = []string{"GHSA-dup"}
+	critical.AffectedVersions = []string{"1.1.0"}
+	if firstSeverity == "critical" {
+		return []VulnerabilityAdvisory{critical, low}
+	}
+	return []VulnerabilityAdvisory{low, critical}
+}
+
+func assertDuplicateOSVSeverityMerge(t *testing.T, advisories []VulnerabilityAdvisory) {
+	t.Helper()
+	normalized := normalizeAdvisories(advisories)
+	if len(normalized) != 1 {
+		t.Fatalf("expected one normalized advisory, got %#v", normalized)
+	}
+
+	got := normalized[0]
+	if got.Severity != "critical" || got.FixedVersion != "1.2.3" {
+		t.Fatalf("expected merged critical severity and fixed version, got %#v", got)
+	}
+	if !slices.Equal(got.Aliases, []string{"CVE-2026-0001", "GHSA-dup"}) {
+		t.Fatalf("expected merged aliases, got %#v", got.Aliases)
+	}
+	if !slices.Equal(got.AffectedVersions, []string{"1.0.0", "1.1.0"}) {
+		t.Fatalf("expected merged affected versions, got %#v", got.AffectedVersions)
+	}
+	if len(got.VersionRanges) != 1 || got.VersionRanges[0].Type != "SEMVER" || len(got.VersionRanges[0].Events) != 2 {
+		t.Fatalf("expected merged version ranges, got %#v", got.VersionRanges)
+	}
+
+	reportData := Report{Dependencies: []DependencyReport{{
+		Language:          "js-ts",
+		Name:              "example-lib",
+		UsedExportsCount:  1,
+		TotalExportsCount: 1,
+		UsedImports: []ImportUse{{
+			Name: "default", Module: "example-lib",
+			Locations: []Location{{File: "src/app.ts", Line: 7, Column: 1}},
+		}},
+		Identity: &DependencyIdentity{Name: "example-lib", Ecosystem: "npm", Version: "1.1.0"},
+	}}}
+	AnnotateVulnerabilities(&reportData, advisories)
+	if len(reportData.Dependencies[0].Vulnerabilities) != 1 {
+		t.Fatalf("expected one merged finding, got %#v", reportData.Dependencies[0].Vulnerabilities)
+	}
+
+	finding := reportData.Dependencies[0].Vulnerabilities[0]
+	if finding.Severity != "critical" || finding.Priority != VulnerabilityPriorityCritical || finding.PriorityScore != 90 {
+		t.Fatalf("expected critical merged finding, got %#v", finding)
+	}
+	if !VulnerabilityPriorityMeetsThreshold(finding.Priority, VulnerabilityPriorityCritical) {
+		t.Fatalf("expected merged finding to meet critical threshold, got %#v", finding)
+	}
+	if !slices.Contains(finding.Evidence, "aliases: CVE-2026-0001, GHSA-dup") || !slices.Contains(finding.Evidence, "fixed_version: 1.2.3") {
+		t.Fatalf("expected merged finding evidence, got %#v", finding.Evidence)
 	}
 }
 

--- a/internal/report/vulnerability_test.go
+++ b/internal/report/vulnerability_test.go
@@ -279,11 +279,11 @@ func TestAnnotateVulnerabilitiesMergesDuplicateOSVSeverityConservatively(t *test
 	}{
 		{
 			name:       "low then critical",
-			advisories: duplicateOSVAdvisaries("low", "critical"),
+			advisories: duplicateOSVAdvisaries("low"),
 		},
 		{
 			name:       "critical then low",
-			advisories: duplicateOSVAdvisaries("critical", "low"),
+			advisories: duplicateOSVAdvisaries("critical"),
 		},
 	}
 
@@ -294,7 +294,7 @@ func TestAnnotateVulnerabilitiesMergesDuplicateOSVSeverityConservatively(t *test
 	}
 }
 
-func duplicateOSVAdvisaries(firstSeverity, secondSeverity string) []VulnerabilityAdvisory {
+func duplicateOSVAdvisaries(firstSeverity string) []VulnerabilityAdvisory {
 	low := VulnerabilityAdvisory{
 		ID:               "OSV-dup",
 		Package:          "example-lib",

--- a/internal/report/vulnerability_test.go
+++ b/internal/report/vulnerability_test.go
@@ -272,6 +272,144 @@ func TestNormalizeAdvisoriesMergesDuplicateFixedVersionsConservatively(t *testin
 	}
 }
 
+func TestAnnotateVulnerabilitiesMergesDuplicateOSVSeverityConservatively(t *testing.T) {
+	dependency := DependencyReport{
+		Language:          "js-ts",
+		Name:              "example-lib",
+		UsedExportsCount:  1,
+		TotalExportsCount: 1,
+		UsedImports: []ImportUse{
+			{
+				Name:   "default",
+				Module: "example-lib",
+				Locations: []Location{
+					{File: "src/app.ts", Line: 7, Column: 1},
+				},
+			},
+		},
+	}
+	duplicateRanges := []VulnerabilityVersionRange{
+		{
+			Type: "SEMVER",
+			Events: []VulnerabilityVersionEvent{
+				{Introduced: "0"},
+				{Fixed: "1.2.3"},
+			},
+		},
+	}
+	tests := []struct {
+		name       string
+		advisories []VulnerabilityAdvisory
+	}{
+		{
+			name: "low then critical",
+			advisories: []VulnerabilityAdvisory{
+				{
+					ID:               "OSV-dup",
+					Package:          "example-lib",
+					Ecosystem:        "npm",
+					Severity:         "low",
+					FixedVersion:     "1.2.3",
+					Aliases:          []string{"CVE-2026-0001"},
+					AffectedVersions: []string{"1.0.0"},
+					VersionRanges:    duplicateRanges,
+				},
+				{
+					ID:               "OSV-dup",
+					Package:          "example-lib",
+					Ecosystem:        "npm",
+					Severity:         "critical",
+					FixedVersion:     "1.2.3",
+					Aliases:          []string{"GHSA-dup"},
+					AffectedVersions: []string{"1.1.0"},
+					VersionRanges:    duplicateRanges,
+				},
+			},
+		},
+		{
+			name: "critical then low",
+			advisories: []VulnerabilityAdvisory{
+				{
+					ID:               "OSV-dup",
+					Package:          "example-lib",
+					Ecosystem:        "npm",
+					Severity:         "critical",
+					FixedVersion:     "1.2.3",
+					Aliases:          []string{"GHSA-dup"},
+					AffectedVersions: []string{"1.1.0"},
+					VersionRanges:    duplicateRanges,
+				},
+				{
+					ID:               "OSV-dup",
+					Package:          "example-lib",
+					Ecosystem:        "npm",
+					Severity:         "low",
+					FixedVersion:     "1.2.3",
+					Aliases:          []string{"CVE-2026-0001"},
+					AffectedVersions: []string{"1.0.0"},
+					VersionRanges:    duplicateRanges,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reportData := Report{
+				Dependencies: []DependencyReport{
+					dependency,
+				},
+			}
+			reportData.Dependencies[0].Identity = &DependencyIdentity{
+				Name:      "example-lib",
+				Ecosystem: "npm",
+				Version:   "1.1.0",
+			}
+
+			normalized := normalizeAdvisories(tc.advisories)
+			if len(normalized) != 1 {
+				t.Fatalf("expected one normalized advisory, got %#v", normalized)
+			}
+
+			got := normalized[0]
+			if got.Severity != "critical" {
+				t.Fatalf("expected merged severity to remain critical, got %#v", got)
+			}
+			if got.FixedVersion != "1.2.3" {
+				t.Fatalf("expected duplicate fixed version to be preserved, got %#v", got)
+			}
+			if !slices.Equal(got.Aliases, []string{"CVE-2026-0001", "GHSA-dup"}) {
+				t.Fatalf("expected merged aliases, got %#v", got.Aliases)
+			}
+			if !slices.Equal(got.AffectedVersions, []string{"1.0.0", "1.1.0"}) {
+				t.Fatalf("expected merged affected versions, got %#v", got.AffectedVersions)
+			}
+			if len(got.VersionRanges) != 1 || got.VersionRanges[0].Type != duplicateRanges[0].Type || !slices.Equal(got.VersionRanges[0].Events, duplicateRanges[0].Events) {
+				t.Fatalf("expected merged version ranges, got %#v", got.VersionRanges)
+			}
+
+			AnnotateVulnerabilities(&reportData, tc.advisories)
+			if len(reportData.Dependencies[0].Vulnerabilities) != 1 {
+				t.Fatalf("expected one merged finding, got %#v", reportData.Dependencies[0].Vulnerabilities)
+			}
+
+			finding := reportData.Dependencies[0].Vulnerabilities[0]
+			if finding.Severity != "critical" || finding.Priority != VulnerabilityPriorityCritical || finding.PriorityScore != 90 {
+				t.Fatalf("expected critical merged finding, got %#v", finding)
+			}
+			if !VulnerabilityPriorityMeetsThreshold(finding.Priority, VulnerabilityPriorityCritical) {
+				t.Fatalf("expected merged finding to meet critical threshold, got %#v", finding)
+			}
+			if !slices.Contains(finding.Evidence, "aliases: CVE-2026-0001, GHSA-dup") {
+				t.Fatalf("expected merged alias evidence, got %#v", finding.Evidence)
+			}
+			if !slices.Contains(finding.Evidence, "fixed_version: 1.2.3") {
+				t.Fatalf("expected fixed version evidence, got %#v", finding.Evidence)
+			}
+		})
+	}
+}
+
 func TestAnnotateVulnerabilitiesKeepsAmbiguousOSVOpenAboveEarlyFixedVersion(t *testing.T) {
 	reportData := Report{
 		Dependencies: []DependencyReport{


### PR DESCRIPTION
## Summary

Duplicate OSV affected blocks for the same advisory/package could preserve the first record’s severity, allowing a low-severity record to downgrade a later critical record and bypass a critical vulnerability threshold.

## Changes

- Merge duplicate advisories using the highest normalized severity regardless of input order.
- Add low→critical and critical→low regression fixtures.
- Verify aliases, affected versions, fixed version, version ranges, critical priority, and threshold behavior remain correct.

Closes #1316

## Validation

Commands and checks run:

```bash
go test ./internal/report -count=1
go test ./internal/app -run 'TestExecuteAnalyseReachableVulnerabilityThresholdUses(OSVCVSSVector|AffectedOSVSeverity)$' -count=1
go test ./... -count=1
make ci
```

Additional manual validation:

- SonarCloud quality gate passed with zero new issues, zero accepted issues, zero hotspots, and zero duplicated new-code lines.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Negligible; duplicate normalization now compares severity rank.
- Memory benchmark impact: No regression; repository memory gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review