### PR TITLE
fix(ci): bind regression proof to exact package

### DIFF
--- a/internal/prmetadata/regression.go
+++ b/internal/prmetadata/regression.go
@@ -138,6 +138,9 @@ func parseRegressionDeclaration(value string) (RegressionDeclaration, error) {
 	}
 
 	packagePath := match[1]
+	if strings.Contains(packagePath, "...") {
+		return RegressionDeclaration{}, fmt.Errorf("regression-test package path must name exactly one package")
+	}
 	cleaned := path.Clean(strings.TrimPrefix(packagePath, "./"))
 	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 		return RegressionDeclaration{}, fmt.Errorf("regression-test package path must stay under the repository root")

--- a/internal/prmetadata/regression_test.go
+++ b/internal/prmetadata/regression_test.go
@@ -38,6 +38,8 @@ func TestParseRegressionProofRejectsInvalidMetadata(t *testing.T) {
 	}{
 		{name: "malformed declaration", body: "Regression-Test: ./pkg::testLower", wantErr: "invalid Regression-Test declaration"},
 		{name: "traversal", body: "Regression-Test: ./pkg/../evil::TestTraversal", wantErr: "canonical"},
+		{name: "all packages pattern", body: "Regression-Test: ./...::TestOne", wantErr: "exactly one package"},
+		{name: "nested packages pattern", body: "Regression-Test: ./internal/...::TestOne", wantErr: "exactly one package"},
 		{name: "injection characters", body: "Regression-Test: ./pkg;rm-rf::TestInjection", wantErr: "invalid Regression-Test declaration"},
 		{name: "duplicate declaration", body: "Regression-Test: ./pkg::TestOne\nRegression-Test: ./pkg::TestOne", wantErr: "duplicate regression-test declaration"},
 		{name: "repeated exemption", body: "Regression-Test-Exemption: first reason\nRegression-Test-Exemption: second reason", wantErr: "at most once"},
@@ -73,6 +75,7 @@ func TestParseRegressionDeclarationDirectBranches(t *testing.T) {
 		{name: "root path", value: `./::TestOne`, wantErr: "invalid Regression-Test declaration"},
 		{name: "parent traversal", value: `./..::TestOne`, wantErr: "stay under the repository root"},
 		{name: "non canonical", value: `./pkg/../nested::TestOne`, wantErr: "canonical"},
+		{name: "package pattern", value: `./internal/...::TestOne`, wantErr: "exactly one package"},
 		{name: "valid", value: `./pkg/nested::TestOne`},
 	}
 

--- a/tools/regressionproof/main.go
+++ b/tools/regressionproof/main.go
@@ -39,8 +39,9 @@ const (
 )
 
 type goTestEvent struct {
-	Action string `json:"Action"`
-	Test   string `json:"Test"`
+	Action  string `json:"Action"`
+	Package string `json:"Package"`
+	Test    string `json:"Test"`
 }
 
 type confinedWriteRoot interface {
@@ -209,13 +210,24 @@ func (r *runner) prove(ctx context.Context, repoRoot, baseSHA string, declaratio
 	}
 
 	for _, declaration := range declarations {
+		basePackage, err := r.resolvePackage(ctx, worktreeRoot, declaration.PackagePath)
+		if err != nil {
+			return finish(err)
+		}
 		if err := r.compilePackage(ctx, worktreeRoot, declaration.PackagePath); err != nil {
 			return finish(fmt.Errorf("base regression test package %s must compile before proof: %w", declaration.PackagePath, err))
 		}
-		if err := r.expectFailure(ctx, worktreeRoot, declaration); err != nil {
+		if err := r.expectFailure(ctx, worktreeRoot, basePackage, declaration); err != nil {
 			return finish(err)
 		}
-		if err := r.expectPass(ctx, repoRoot, declaration); err != nil {
+		headPackage, err := r.resolvePackage(ctx, repoRoot, declaration.PackagePath)
+		if err != nil {
+			return finish(err)
+		}
+		if headPackage != basePackage {
+			return finish(fmt.Errorf("regression-test package identity changed between base and head: %s != %s", basePackage, headPackage))
+		}
+		if err := r.expectPass(ctx, repoRoot, headPackage, declaration); err != nil {
 			return finish(err)
 		}
 		if _, writeErr := fmt.Fprintf(stdout, "Regression proof verified: %s::%s\n", declaration.PackagePath, declaration.TestName); writeErr != nil {
@@ -333,6 +345,25 @@ func copyProofFiles(headRoot, baseRoot string, files []string) (returnErr error)
 	return nil
 }
 
+func (r *runner) resolvePackage(ctx context.Context, repoRoot, packagePath string) (string, error) {
+	args := []string{"list", buildVCSFlag, "-f", "{{.ImportPath}}", packagePath}
+	output, err := r.execCommand(ctx, "go", args, repoRoot, os.Environ())
+	if err != nil {
+		return "", fmt.Errorf("resolve regression-test package %s: %w", packagePath, err)
+	}
+
+	var packages []string
+	for _, line := range strings.Split(string(output), "\n") {
+		if importPath := strings.TrimSpace(line); importPath != "" {
+			packages = append(packages, importPath)
+		}
+	}
+	if len(packages) != 1 {
+		return "", fmt.Errorf("regression-test package path %s must resolve to exactly one package; got %d", packagePath, len(packages))
+	}
+	return packages[0], nil
+}
+
 func (r *runner) compilePackage(ctx context.Context, repoRoot, packagePath string) (returnErr error) {
 	testBinaryDir, err := os.MkdirTemp("", "lopper-regressionproof-test-*")
 	if err != nil {
@@ -349,8 +380,8 @@ func (r *runner) compilePackage(ctx context.Context, repoRoot, packagePath strin
 	return err
 }
 
-func (r *runner) expectFailure(ctx context.Context, repoRoot string, declaration prmetadata.RegressionDeclaration) error {
-	action, err := r.runDeclaredTest(ctx, repoRoot, declaration)
+func (r *runner) expectFailure(ctx context.Context, repoRoot, expectedPackage string, declaration prmetadata.RegressionDeclaration) error {
+	action, err := r.runDeclaredTest(ctx, repoRoot, expectedPackage, declaration)
 	if err != nil {
 		return fmt.Errorf("run base regression test %s::%s: %w", declaration.PackagePath, declaration.TestName, err)
 	}
@@ -365,8 +396,8 @@ func (r *runner) expectFailure(ctx context.Context, repoRoot string, declaration
 	return fmt.Errorf("base regression test finished without a recognized outcome: %s::%s", declaration.PackagePath, declaration.TestName)
 }
 
-func (r *runner) expectPass(ctx context.Context, repoRoot string, declaration prmetadata.RegressionDeclaration) error {
-	action, err := r.runDeclaredTest(ctx, repoRoot, declaration)
+func (r *runner) expectPass(ctx context.Context, repoRoot, expectedPackage string, declaration prmetadata.RegressionDeclaration) error {
+	action, err := r.runDeclaredTest(ctx, repoRoot, expectedPackage, declaration)
 	if err != nil {
 		return fmt.Errorf("pull request regression test must pass on head for %s::%s: %w", declaration.PackagePath, declaration.TestName, err)
 	}
@@ -379,9 +410,9 @@ func (r *runner) expectPass(ctx context.Context, repoRoot string, declaration pr
 	return nil
 }
 
-func (r *runner) runDeclaredTest(ctx context.Context, repoRoot string, declaration prmetadata.RegressionDeclaration) (testAction, error) {
+func (r *runner) runDeclaredTest(ctx context.Context, repoRoot, expectedPackage string, declaration prmetadata.RegressionDeclaration) (testAction, error) {
 	output, err := r.execCommand(ctx, "go", []string{"test", buildVCSFlag, "-count=1", "-json", "-run", "^" + declaration.TestName + "$", declaration.PackagePath}, repoRoot, os.Environ())
-	action, parseErr := parseDeclaredTestAction(output, declaration.TestName)
+	action, parseErr := parseDeclaredTestAction(output, expectedPackage, declaration.TestName)
 	if parseErr != nil {
 		if err != nil {
 			return "", errors.Join(err, parseErr)
@@ -395,7 +426,7 @@ func (r *runner) runDeclaredTest(ctx context.Context, repoRoot string, declarati
 	return action, nil
 }
 
-func parseDeclaredTestAction(output []byte, testName string) (testAction, error) {
+func parseDeclaredTestAction(output []byte, expectedPackage, testName string) (testAction, error) {
 	var sawJSON bool
 	for _, line := range strings.Split(string(output), "\n") {
 		line = strings.TrimSpace(line)
@@ -407,7 +438,7 @@ func parseDeclaredTestAction(output []byte, testName string) (testAction, error)
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			return "", fmt.Errorf("parse go test json for %s: %w", testName, err)
 		}
-		if event.Test != testName {
+		if event.Package != expectedPackage || event.Test != testName {
 			continue
 		}
 		switch event.Action {

--- a/tools/regressionproof/main_test.go
+++ b/tools/regressionproof/main_test.go
@@ -308,6 +308,7 @@ func TestRunnerRunRequiresReasonAndMaintainerLabelForExemption(t *testing.T) {
 func TestParseDeclaredTestAction(t *testing.T) {
 	t.Parallel()
 
+	const expectedPackage = "example.com/pkg"
 	tests := []struct {
 		name    string
 		output  string
@@ -318,25 +319,37 @@ func TestParseDeclaredTestAction(t *testing.T) {
 		{
 			name:   "pass",
 			test:   "TestThing",
-			output: "{\"Action\":\"run\",\"Test\":\"TestThing\"}\n{\"Action\":\"pass\",\"Test\":\"TestThing\"}\n",
+			output: "{\"Action\":\"run\",\"Package\":\"example.com/pkg\",\"Test\":\"TestThing\"}\n{\"Action\":\"pass\",\"Package\":\"example.com/pkg\",\"Test\":\"TestThing\"}\n",
 			want:   testActionPass,
 		},
 		{
 			name:   "fail",
 			test:   "TestThing",
-			output: "{\"Action\":\"fail\",\"Test\":\"TestThing\"}\n",
+			output: "{\"Action\":\"fail\",\"Package\":\"example.com/pkg\",\"Test\":\"TestThing\"}\n",
 			want:   testActionFail,
 		},
 		{
 			name:   "skip",
 			test:   "TestThing",
-			output: "{\"Action\":\"skip\",\"Test\":\"TestThing\"}\n",
+			output: "{\"Action\":\"skip\",\"Package\":\"example.com/pkg\",\"Test\":\"TestThing\"}\n",
 			want:   testActionSkip,
 		},
 		{
 			name:    "missing outcome",
 			test:    "TestThing",
-			output:  "{\"Action\":\"pass\",\"Test\":\"OtherTest\"}\n",
+			output:  "{\"Action\":\"pass\",\"Package\":\"example.com/pkg\",\"Test\":\"OtherTest\"}\n",
+			wantErr: "did not report an outcome",
+		},
+		{
+			name:    "mismatched package pass",
+			test:    "TestThing",
+			output:  "{\"Action\":\"pass\",\"Package\":\"example.com/other\",\"Test\":\"TestThing\"}\n",
+			wantErr: "did not report an outcome",
+		},
+		{
+			name:    "mismatched package fail",
+			test:    "TestThing",
+			output:  "{\"Action\":\"fail\",\"Package\":\"example.com/other\",\"Test\":\"TestThing\"}\n",
 			wantErr: "did not report an outcome",
 		},
 		{
@@ -355,7 +368,7 @@ func TestParseDeclaredTestAction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseDeclaredTestAction([]byte(tt.output), tt.test)
+			got, err := parseDeclaredTestAction([]byte(tt.output), expectedPackage, tt.test)
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("parseDeclaredTestAction error = %v, want %q", err, tt.wantErr)
@@ -674,37 +687,38 @@ func testCopyProofFiles(t *testing.T) {
 
 func testExpectHelpers(t *testing.T) {
 	t.Helper()
+	const expectedPackage = "example.com/pkg"
 	r := &runner{stderr: &bytes.Buffer{}, execCommand: func(context.Context, string, []string, string, []string) ([]byte, error) {
 		return nil, errors.New("boom")
 	}}
-	if err := r.expectFailure(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil {
+	if err := r.expectFailure(context.Background(), ".", expectedPackage, prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil {
 		t.Fatal("expectFailure succeeded for non-exit error")
 	}
-	if err := r.expectPass(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil {
+	if err := r.expectPass(context.Background(), ".", expectedPackage, prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil {
 		t.Fatal("expectPass succeeded for failing command")
 	}
 
 	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
-		return []byte("{\"Action\":\"fail\",\"Test\":\"TestThing\"}\n"), &exec.ExitError{}
+		return []byte("{\"Action\":\"fail\",\"Package\":\"example.com/pkg\",\"Test\":\"TestThing\"}\n"), &exec.ExitError{}
 	}
-	if err := r.expectFailure(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err != nil {
+	if err := r.expectFailure(context.Background(), ".", expectedPackage, prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err != nil {
 		t.Fatalf("expectFailure returned error for exit failure: %v", err)
 	}
 
 	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
-		return []byte("{\"Action\":\"skip\",\"Test\":\"TestThing\"}\n"), nil
+		return []byte("{\"Action\":\"skip\",\"Package\":\"example.com/pkg\",\"Test\":\"TestThing\"}\n"), nil
 	}
-	if err := r.expectFailure(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil || !strings.Contains(err.Error(), "must fail instead of skip") {
+	if err := r.expectFailure(context.Background(), ".", expectedPackage, prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil || !strings.Contains(err.Error(), "must fail instead of skip") {
 		t.Fatalf("expectFailure error = %v, want skipped-test rejection", err)
 	}
-	if err := r.expectPass(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil || !strings.Contains(err.Error(), "must pass instead of skip") {
+	if err := r.expectPass(context.Background(), ".", expectedPackage, prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil || !strings.Contains(err.Error(), "must pass instead of skip") {
 		t.Fatalf("expectPass error = %v, want skipped-test rejection", err)
 	}
 
 	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
-		return []byte("{\"Action\":\"run\",\"Test\":\"TestThing\"}\n"), nil
+		return []byte("{\"Action\":\"run\",\"Package\":\"example.com/pkg\",\"Test\":\"TestThing\"}\n"), nil
 	}
-	if err := r.expectFailure(context.Background(), ".", prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil || !strings.Contains(err.Error(), "did not report an outcome") {
+	if err := r.expectFailure(context.Background(), ".", expectedPackage, prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}); err == nil || !strings.Contains(err.Error(), "did not report an outcome") {
 		t.Fatalf("expectFailure error = %v, want unrecognized outcome rejection", err)
 	}
 }
@@ -713,22 +727,58 @@ func TestRunDeclaredTestBranches(t *testing.T) {
 	t.Parallel()
 
 	declaration := prmetadata.RegressionDeclaration{PackagePath: "./pkg", TestName: "TestThing"}
+	const expectedPackage = "example.com/pkg"
 	r := &runner{stderr: &bytes.Buffer{}}
 
 	parseFailure := errors.New("transport failed")
 	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
 		return []byte("plain text\n"), parseFailure
 	}
-	if _, err := r.runDeclaredTest(context.Background(), ".", declaration); !errors.Is(err, parseFailure) || !strings.Contains(err.Error(), "did not emit JSON output") {
+	if _, err := r.runDeclaredTest(context.Background(), ".", expectedPackage, declaration); !errors.Is(err, parseFailure) || !strings.Contains(err.Error(), "did not emit JSON output") {
 		t.Fatalf("runDeclaredTest error = %v, want joined transport and parse errors", err)
 	}
 
 	commandFailure := errors.New("exec failed")
 	r.execCommand = func(context.Context, string, []string, string, []string) ([]byte, error) {
-		return []byte("{\"Action\":\"pass\",\"Test\":\"TestThing\"}\n"), commandFailure
+		return []byte("{\"Action\":\"pass\",\"Package\":\"example.com/pkg\",\"Test\":\"TestThing\"}\n"), commandFailure
 	}
-	if _, err := r.runDeclaredTest(context.Background(), ".", declaration); !errors.Is(err, commandFailure) {
+	if _, err := r.runDeclaredTest(context.Background(), ".", expectedPackage, declaration); !errors.Is(err, commandFailure) {
 		t.Fatalf("runDeclaredTest error = %v, want command failure", err)
+	}
+}
+
+func TestResolvePackageRequiresExactlyOnePackage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		output  string
+		err     error
+		want    string
+		wantErr string
+	}{
+		{name: "single package", output: "example.com/pkg\n", want: "example.com/pkg"},
+		{name: "no package", wantErr: "got 0"},
+		{name: "multiple packages", output: "example.com/one\nexample.com/two\n", wantErr: "got 2"},
+		{name: "go list failure", err: errors.New("list failed"), wantErr: "resolve regression-test package"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &runner{execCommand: func(context.Context, string, []string, string, []string) ([]byte, error) {
+				return []byte(tt.output), tt.err
+			}}
+			got, err := r.resolvePackage(context.Background(), ".", "./pkg")
+			if tt.wantErr == "" {
+				if err != nil || got != tt.want {
+					t.Fatalf("resolvePackage = %q, %v; want %q", got, err, tt.want)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("resolvePackage error = %v, want %q", err, tt.wantErr)
+			}
+		})
 	}
 }
 
@@ -994,6 +1044,99 @@ func TestRegressionProof(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "must pass on head") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProveReportsPackageResolutionFailure(t *testing.T) {
+	repo := newRegressionProofRepo(t, regressionProofScenario{
+		baseFiles: map[string]string{
+			"go.mod": "module example.com/regressionproof\n\ngo 1.23\n",
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return false }
+`,
+		},
+		headFiles: map[string]string{
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return true }
+`,
+			"buggy/buggy_test.go": `package buggy
+
+import "testing"
+
+func TestRegressionProof(t *testing.T) {
+	if !Fixed() {
+		t.Fatal("expected true")
+	}
+}
+`,
+		},
+	})
+
+	declaration := prmetadata.RegressionDeclaration{PackagePath: "./buggy", TestName: "TestRegressionProof"}
+	commandRunner := (&execRunner{}).Run
+	tests := []struct {
+		name       string
+		failOnHead bool
+	}{
+		{name: "base package"},
+		{name: "head package", failOnHead: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listFailure := errors.New("list failed")
+			r := &runner{stderr: &bytes.Buffer{}, execCommand: func(ctx context.Context, name string, args []string, dir string, env []string) ([]byte, error) {
+				isGoList := name == "go" && len(args) > 0 && args[0] == "list"
+				isHead := dir == repo.path
+				if isGoList && isHead == tt.failOnHead {
+					return nil, listFailure
+				}
+				return commandRunner(ctx, name, args, dir, env)
+			}}
+
+			err := r.prove(context.Background(), repo.path, repo.baseSHA, []prmetadata.RegressionDeclaration{declaration}, &bytes.Buffer{})
+			if !errors.Is(err, listFailure) {
+				t.Fatalf("prove error = %v, want package resolution failure", err)
+			}
+		})
+	}
+}
+
+func TestProveRejectsPackageIdentityChangeBetweenRevisions(t *testing.T) {
+	repo := newRegressionProofRepo(t, regressionProofScenario{
+		baseFiles: map[string]string{
+			"go.mod": "module example.com/old\n\ngo 1.23\n",
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return false }
+`,
+		},
+		headFiles: map[string]string{
+			"go.mod": "module example.com/new\n\ngo 1.23\n",
+			"buggy/buggy.go": `package buggy
+
+func Fixed() bool { return true }
+`,
+			"buggy/buggy_test.go": `package buggy
+
+import "testing"
+
+func TestRegressionProof(t *testing.T) {
+	if !Fixed() {
+		t.Fatal("expected true")
+	}
+}
+`,
+		},
+	})
+
+	r := &runner{stderr: &bytes.Buffer{}, execCommand: (&execRunner{}).Run}
+	declaration := prmetadata.RegressionDeclaration{PackagePath: "./buggy", TestName: "TestRegressionProof"}
+	err := r.prove(context.Background(), repo.path, repo.baseSHA, []prmetadata.RegressionDeclaration{declaration}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "package identity changed between base and head: example.com/old/buggy != example.com/new/buggy") {
+		t.Fatalf("prove error = %v, want package identity mismatch", err)
 	}
 }
 


### PR DESCRIPTION
Closes #1398

## Summary

Bind fail-before/pass-after regression proof to one exact Go package so same-named tests in other packages cannot satisfy the gate.

## Changes

- reject recursive package patterns in Regression-Test declarations
- require go list to resolve exactly one package on base and head
- bind go test JSON outcomes to both package import path and test name
- cover wildcard, zero/multiple-package, and mismatched-package pass/fail cases

## Validation

Commands and checks run:

```bash
make ci
```

Additional manual validation:

- focused internal/prmetadata and tools/regressionproof tests
- total coverage 98.3%; per-package floor 98%

Regression-Test: ./internal/prmetadata::TestParseRegressionProofRejectsInvalidMetadata

## Risk and compatibility

- Breaking changes: recursive Regression-Test package patterns are intentionally rejected
- Migration required: bug-fix PRs must name one exact package
- Performance impact: one bounded go list call per declaration on base and head
- Memory benchmark impact: none; memory delta gate passed

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review