### PR TITLE
fix(ci): render sanitized feature flag markdown

### DIFF
--- a/.github/workflows/feature-flag-comment-publish.yml
+++ b/.github/workflows/feature-flag-comment-publish.yml
@@ -330,6 +330,20 @@ jobs:
               raise SystemExit("rendered comment directory already exists")
           rendered_dir.mkdir(mode=0o700)
 
+          def strip_trusted_preamble(text, marker, title):
+              lines = text.split("\n")
+              if not lines or lines[0] != marker:
+                  return text
+
+              lines = lines[1:]
+              while lines and not lines[0]:
+                  lines = lines[1:]
+              if lines and lines[0] == f"## {title}":
+                  lines = lines[1:]
+                  while lines and not lines[0]:
+                      lines = lines[1:]
+              return "\n".join(lines)
+
           def render(source_name, destination_name, marker, title):
               source = comment_dir / source_name
               if not source.exists():
@@ -347,22 +361,24 @@ jobs:
                   for character in text
                   if character in "\n\t" or not unicodedata.category(character).startswith("C")
               )
+              text = strip_trusted_preamble(text, marker, title)
               text = text.replace("@", "@\u200b")
-              inert = html.escape(text, quote=True)
-              if not inert:
-                  inert = "[empty after sanitization]"
+              sanitized = html.escape(text, quote=True)
+              sanitized = sanitized.replace("[", "&#91;")
+              sanitized = sanitized.replace("://", ":\u200b//")
+              sanitized = sanitized.replace("www.", "www.\u200b")
+              if not sanitized:
+                  sanitized = "[empty after sanitization]"
               if truncated:
-                  inert += "\n\n[output truncated at 8192 bytes]"
+                  sanitized += "\n\n[output truncated at 8192 bytes]"
 
               body = "\n".join([
                   marker,
                   f"## {title}",
                   "",
-                  "_The diagnostic below is inert, untrusted pull-request output._",
+                  "_Untrusted pull-request output is sanitized before Markdown rendering._",
                   "",
-                  "<pre>",
-                  inert,
-                  "</pre>",
+                  sanitized,
                   "",
               ])
               destination = rendered_dir / destination_name

--- a/scripts/feature_flag_workflow_test.go
+++ b/scripts/feature_flag_workflow_test.go
@@ -239,7 +239,7 @@ func TestFeatureFlagCommentArchiveExtraction(t *testing.T) {
 	}
 }
 
-func TestFeatureFlagTrustedCommentRenderingNeutralizesUntrustedMarkdown(t *testing.T) {
+func TestFeatureFlagTrustedCommentRenderingRendersSanitizedMarkdown(t *testing.T) {
 	t.Parallel()
 
 	var workflow workflowConfig
@@ -277,8 +277,11 @@ func writeUntrustedCommentSources(t *testing.T, commentDir string, tests []trust
 		t.Fatalf("create comment source directory: %v", err)
 	}
 	for _, tt := range tests {
-		malicious := tt.marker + "\r\n</pre><script>alert(1)</script>\n" +
-			"[link](https://example.invalid) ![image](https://example.invalid/x) @org/team\x00\u202e\n" +
+		malicious := tt.marker + "\r\n## " + tt.title + "\r\n\r\n" +
+			"### Stable by default\r\n\r\n- `LOP-FEAT-TEST` `test-flag`\r\n" +
+			"</pre><script>alert(1)</script>\n" +
+			"[link](https://example.invalid) ![image](https://example.invalid/x) " +
+			"@org/team www.example.invalid\x00\u202e\n" +
 			strings.Repeat("'", 9_000)
 		if err := os.WriteFile(filepath.Join(commentDir, tt.source), []byte(malicious), 0o600); err != nil {
 			t.Fatalf("write untrusted %s: %v", tt.source, err)
@@ -309,7 +312,7 @@ func assertTrustedCommentBody(t *testing.T, renderedDir string, tt trustedCommen
 	}
 	body := string(bodyBytes)
 	assertTrustedCommentIdentity(t, body, tt)
-	assertTrustedCommentEscaping(t, body, tt.source)
+	assertTrustedCommentSanitization(t, body, tt.source)
 	if len(bodyBytes) > 60_000 {
 		t.Fatalf("rendered %s body is oversized: %d bytes", tt.source, len(bodyBytes))
 	}
@@ -324,24 +327,41 @@ func assertTrustedCommentIdentity(t *testing.T, body string, tt trustedCommentRe
 	if strings.Count(body, tt.marker) != 1 {
 		t.Fatalf("rendered %s contains an untrusted marker", tt.source)
 	}
+	for _, want := range []string{"### Stable by default", "- `LOP-FEAT-TEST` `test-flag`"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("rendered %s is missing rendered Markdown %q", tt.source, want)
+		}
+	}
 }
 
-func assertTrustedCommentEscaping(t *testing.T, body, source string) {
+func assertTrustedCommentSanitization(t *testing.T, body, source string) {
 	t.Helper()
 
 	for _, want := range []string{
-		"<pre>",
-		"</pre>",
-		"&lt;!--",
+		"_Untrusted pull-request output is sanitized before Markdown rendering._",
 		"&lt;/pre&gt;&lt;script&gt;alert(1)&lt;/script&gt;",
+		"&#91;link](https:\u200b//example.invalid)",
+		"!&#91;image](https:\u200b//example.invalid/x)",
 		"@\u200borg/team",
+		"www.\u200bexample.invalid",
 		"[output truncated at 8192 bytes]",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("rendered %s is missing %q", source, want)
 		}
 	}
-	for _, forbidden := range []string{"</pre><script>", "<script>", "@org/team", "\x00", "\u202e"} {
+	for _, forbidden := range []string{
+		"<pre>",
+		"</pre>",
+		"<script>",
+		"[link](",
+		"![image](",
+		"://",
+		"www.example.invalid",
+		"@org/team",
+		"\x00",
+		"\u202e",
+	} {
 		if strings.Contains(body, forbidden) {
 			t.Fatalf("rendered %s contains active untrusted content %q", source, forbidden)
 		}
@@ -842,10 +862,12 @@ func assertTrustedFeatureFlagPublicationWorkflow(t *testing.T, publicationWorkfl
 		`max_source_bytes = 8_192`,
 		`raw = handle.read(max_source_bytes + 1)`,
 		`unicodedata.category(character).startswith("C")`,
+		`text = strip_trusted_preamble(text, marker, title)`,
 		`text = text.replace("@", "@\u200b")`,
-		`inert = html.escape(text, quote=True)`,
-		`"<pre>"`,
-		`"</pre>"`,
+		`sanitized = html.escape(text, quote=True)`,
+		`sanitized = sanitized.replace("[", "&#91;")`,
+		`sanitized = sanitized.replace("://", ":\u200b//")`,
+		`sanitized = sanitized.replace("www.", "www.\u200b")`,
 		`destination.open("x", encoding="utf-8", newline="\n")`,
 	})
 


### PR DESCRIPTION
## Summary

Fix the release feature-flag diagnostic so its sanitized headings, lists, and inline code render as Markdown instead of appearing as literal text in one escaped preformatted block. The security boundary remains intact: raw HTML, mentions, links, images, autolinks, and control characters stay inert.

Related to #1309.

## Changes

- Strip the expected generated marker and title before adding the publisher-owned marker and heading.
- Render sanitized structural Markdown outside a `<pre>` block.
- Continue escaping HTML and control characters, suppressing mentions, and neutralizing Markdown links, images, and literal autolinks.
- Extend the workflow contract test with rendered-layout and hostile-input assertions.

## Validation

Commands and checks run:

```bash
go test ./scripts -run 'TestFeatureFlag' -count=1
actionlint .github/workflows/feature-flag-comment-publish.yml
git diff --check
make ci
```

Additional manual validation:

- Confirmed two full `make ci` runs passed lint, workflow validation, security and vulnerability scans, normal/leak/race tests, memory delta, build, and the repository coverage gates.

Regression-Test: ./scripts::TestFeatureFlagTrustedCommentRenderingRendersSanitizedMarkdown

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: None
- Memory benchmark impact: None

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
