### PR TITLE
fix(runtime): bound runtime trace loading

### DIFF
--- a/internal/analysis/pipeline_test.go
+++ b/internal/analysis/pipeline_test.go
@@ -1,12 +1,14 @@
 package analysis
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/safeio"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
@@ -200,6 +202,17 @@ func TestAnnotateRuntimeTraceInvalidFileFails(t *testing.T) {
 	}
 }
 
+func TestAnnotateRuntimeTraceOversizedFileFails(t *testing.T) {
+	tracePath := filepath.Join(t.TempDir(), "trace.ndjson")
+	if err := os.WriteFile(tracePath, []byte(oversizedRuntimeTraceContentForAnalysisTest()), 0o600); err != nil {
+		t.Fatalf("write oversized trace: %v", err)
+	}
+
+	if _, err := annotateRuntimeTraceIfPresent(tracePath, "js-ts", report.Report{}, false); !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected oversized runtime trace to fail with ErrFileTooLarge, got %v", err)
+	}
+}
+
 func TestAnnotateRuntimeTraceSkipsUnsupportedLanguageBeforeReadingTrace(t *testing.T) {
 	tracePath := filepath.Join(t.TempDir(), "trace.ndjson")
 	if err := os.WriteFile(tracePath, []byte("{not-json}\n"), 0o600); err != nil {
@@ -213,4 +226,11 @@ func TestAnnotateRuntimeTraceSkipsUnsupportedLanguageBeforeReadingTrace(t *testi
 	if len(annotated.Warnings) != 0 {
 		t.Fatalf("expected no warnings when unsupported trace is skipped, got %#v", annotated.Warnings)
 	}
+}
+
+func oversizedRuntimeTraceContentForAnalysisTest() string {
+	const maxRuntimeTraceBytes = 8 * 1024 * 1024
+	line := "{\"module\":\"lodash/map\"}\n"
+	repeat := maxRuntimeTraceBytes/len(line) + 1
+	return strings.Repeat(line, repeat)
 }

--- a/internal/runtime/trace_load.go
+++ b/internal/runtime/trace_load.go
@@ -2,25 +2,36 @@ package runtime
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
-func Load(path string) (Trace, error) {
-	content, err := safeio.ReadFile(path)
+const maxRuntimeTraceBytes int64 = 8 * 1024 * 1024
+
+func Load(path string) (_ Trace, err error) {
+	file, err := safeio.OpenFile(path)
 	if err != nil {
 		return Trace{}, err
 	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
 
 	trace := newTrace()
-	scanner := bufio.NewScanner(bytes.NewReader(content))
+	scanner := bufio.NewScanner(newRuntimeTraceByteLimitReader(file, maxRuntimeTraceBytes))
 	line := 0
 	for scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return Trace{}, err
+		}
 		line++
 		text := strings.TrimSpace(scanner.Text())
 		if text == "" {
@@ -44,6 +55,41 @@ func Load(path string) (Trace, error) {
 	}
 
 	return trace, nil
+}
+
+type runtimeTraceByteLimitReader struct {
+	reader    io.Reader
+	remaining int64
+}
+
+func newRuntimeTraceByteLimitReader(reader io.Reader, maxBytes int64) io.Reader {
+	return &runtimeTraceByteLimitReader{reader: reader, remaining: maxBytes}
+}
+
+func (r *runtimeTraceByteLimitReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	limit := r.remaining + 1
+	if limit <= 0 {
+		limit = 1
+	}
+	if int64(len(p)) > limit {
+		p = p[:limit]
+	}
+
+	n, err := r.reader.Read(p)
+	if int64(n) <= r.remaining {
+		r.remaining -= int64(n)
+		return n, err
+	}
+
+	allowed := int(r.remaining)
+	if allowed < 0 {
+		allowed = 0
+	}
+	r.remaining = 0
+	return allowed, safeio.ErrFileTooLarge
 }
 
 func newTrace() Trace {

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 func TestLoadTrace(t *testing.T) {
@@ -102,6 +104,13 @@ func TestLoadTraceParseErrorIncludesLineNumber(t *testing.T) {
 	}
 }
 
+func TestLoadTraceOversizedFile(t *testing.T) {
+	_, err := loadTraceFromContent(t, oversizedRuntimeTraceContent())
+	if !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected oversized trace to fail with ErrFileTooLarge, got %v", err)
+	}
+}
+
 func TestLoadTraceSkipsBlankLines(t *testing.T) {
 	trace, err := loadTraceFromContent(t, "\n   \n{\"module\":\""+lodashMapModule+"\"}\n")
 	if err != nil {
@@ -130,4 +139,10 @@ func TestLoadTraceSkipsEventsWithoutDependencies(t *testing.T) {
 	if len(trace.DependencyLoads) != 0 || len(trace.DependencyModules) != 0 || len(trace.DependencySymbols) != 0 {
 		t.Fatalf("expected dependency-free events to be ignored, got %#v", trace)
 	}
+}
+
+func oversizedRuntimeTraceContent() string {
+	line := "{\"module\":\"" + leftPadModule + "\"}\n"
+	repeat := int(maxRuntimeTraceBytes/int64(len(line))) + 1
+	return strings.Repeat(line, repeat)
 }

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -142,7 +142,9 @@ func TestLoadTraceSkipsEventsWithoutDependencies(t *testing.T) {
 }
 
 func oversizedRuntimeTraceContent() string {
+	const maxRuntimeTraceBytesForTest = 8 * 1024 * 1024
+
 	line := "{\"module\":\"" + leftPadModule + "\"}\n"
-	repeat := int(maxRuntimeTraceBytes/int64(len(line))) + 1
+	repeat := maxRuntimeTraceBytesForTest/len(line) + 1
 	return strings.Repeat(line, repeat)
 }


### PR DESCRIPTION
## Summary

Restore streaming runtime-trace loading and impose a hard whole-trace byte limit so repository-controlled traces cannot be materialized without bound.

Closes #1267

## Changes

- Stream trace records from the confined file handle instead of reading the complete file into memory.
- Reject traces larger than 8 MiB with `safeio.ErrFileTooLarge`.
- Preserve line-oriented parsing and existing error propagation through analysis.
- Add runtime and analysis-layer oversized-trace regressions.

## Validation

Commands and checks run:

```bash
make ci
```

The pre-commit hook reran the complete CI gate successfully, including lint, security, vulnerability, leak, race, memory, build, and coverage checks.

Regression-Test: ./internal/runtime::TestLoadTraceOversizedFile
Regression-Test: ./internal/analysis::TestAnnotateRuntimeTraceOversizedFileFails

## Risk and compatibility

- Breaking changes: traces larger than 8 MiB are now rejected explicitly.
- Migration required: none for normal traces.
- Performance impact: trace parsing remains incremental and avoids whole-file allocation.
- Memory benchmark impact: repository memory benchmark gate passed with no regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
