### PR TITLE
refactor(baseline): share typed snapshot envelope and validation

### DIFF
--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -22,11 +22,12 @@ type Snapshot[T any] struct {
 
 type SnapshotDecodeOptions[T any] struct {
 	DecodeLegacy      func([]byte) (T, error)
-	Normalize         func(T) T
+	Repair            func(T) T
 	UnsupportedSchema func(string) error
 }
 
 type SnapshotStore[T any] struct {
+	Repair            func(T) T
 	Normalize         func(T) T
 	UnsupportedSchema func(string) error
 	ValidateKey       func(string, string) error
@@ -80,8 +81,8 @@ func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, st
 			return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)
 		}
 		v := snapshot.Report
-		if options.Normalize != nil {
-			v = options.Normalize(v)
+		if options.Repair != nil {
+			v = options.Repair(v)
 		}
 		return v, strings.TrimSpace(snapshot.Key), nil
 	}
@@ -91,8 +92,8 @@ func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, st
 		var zero T
 		return zero, "", err
 	}
-	if options.Normalize != nil {
-		v = options.Normalize(v)
+	if options.Repair != nil {
+		v = options.Repair(v)
 	}
 	return v, "", nil
 }
@@ -153,7 +154,7 @@ func ValidateSnapshotKey(requestedKey, storedKey string, mismatchErr error) erro
 
 func snapshotDecodeOptions[T any](store SnapshotStore[T]) SnapshotDecodeOptions[T] {
 	return SnapshotDecodeOptions[T]{
-		Normalize:         store.Normalize,
+		Repair:            store.Repair,
 		UnsupportedSchema: store.UnsupportedSchema,
 	}
 }

--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -26,6 +26,13 @@ type SnapshotDecodeOptions[T any] struct {
 	UnsupportedSchema func(string) error
 }
 
+type SnapshotStore[T any] struct {
+	Normalize         func(T) T
+	UnsupportedSchema func(string) error
+	ValidateKey       func(string, string) error
+	ExistsErr         error
+}
+
 func NewSnapshot[T any](key string, report T, now time.Time, normalize func(T) T) Snapshot[T] {
 	if normalize != nil {
 		report = normalize(report)
@@ -90,6 +97,29 @@ func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, st
 	return v, "", nil
 }
 
+func LoadConfiguredSnapshot[T any](path string, store SnapshotStore[T]) (T, string, error) {
+	return LoadSnapshotFile(path, snapshotDecodeOptions(store))
+}
+
+func DecodeConfiguredSnapshot[T any](data []byte, store SnapshotStore[T]) (T, string, error) {
+	return DecodeSnapshot(data, snapshotDecodeOptions(store))
+}
+
+func LoadConfiguredStoreSnapshot[T any](dir, key string, maxBytes int64, store SnapshotStore[T]) (T, string, string, error) {
+	decode := func(data []byte) (T, string, error) {
+		return DecodeConfiguredSnapshot(data, store)
+	}
+	return LoadStoreSnapshot(dir, key, maxBytes, decode, store.ValidateKey)
+}
+
+func SaveConfiguredSnapshot[T any](dir, key string, now time.Time, report T, store SnapshotStore[T]) (string, error) {
+	return SaveSnapshot(dir, key, now, report, store.ExistsErr, store.Normalize)
+}
+
+func NewConfiguredSnapshot[T any](key string, report T, now time.Time, store SnapshotStore[T]) Snapshot[T] {
+	return NewSnapshot(key, report, now, store.Normalize)
+}
+
 func LoadStoreSnapshot[T any](dir, key string, maxBytes int64, decode func([]byte) (T, string, error), validateKey func(string, string) error) (T, string, string, error) {
 	trimmedKey := strings.TrimSpace(key)
 	path := ResolveSnapshotPath(dir, trimmedKey)
@@ -119,6 +149,13 @@ func ValidateSnapshotKey(requestedKey, storedKey string, mismatchErr error) erro
 		return nil
 	}
 	return fmt.Errorf("%w: requested %q, stored %q", mismatchErr, requestedKey, storedKey)
+}
+
+func snapshotDecodeOptions[T any](store SnapshotStore[T]) SnapshotDecodeOptions[T] {
+	return SnapshotDecodeOptions[T]{
+		Normalize:         store.Normalize,
+		UnsupportedSchema: store.UnsupportedSchema,
+	}
 }
 
 func decodeLegacySnapshot[T any](data []byte, decodeLegacy func([]byte) (T, error)) (T, error) {

--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -41,6 +42,17 @@ func SaveSnapshot[T any](dir, key string, now time.Time, report T, existsErr err
 	return SaveJSON(dir, key, existsErr, func(trimmedKey string) Snapshot[T] {
 		return NewSnapshot(trimmedKey, report, now, normalize)
 	})
+}
+
+func SortedCopyByStrings[T any](items []T, primaryKey func(T) string, secondaryKey func(T) string) []T {
+	copied := append([]T(nil), items...)
+	slices.SortFunc(copied, func(left, right T) int {
+		if diff := strings.Compare(primaryKey(left), primaryKey(right)); diff != 0 {
+			return diff
+		}
+		return strings.Compare(secondaryKey(left), secondaryKey(right))
+	})
+	return copied
 }
 
 func LoadSnapshotFile[T any](path string, options SnapshotDecodeOptions[T]) (T, string, error) {

--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -74,7 +74,7 @@ func LoadSnapshotFile[T any](path string, options SnapshotDecodeOptions[T]) (T, 
 func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, string, error) {
 	var snapshot Snapshot[T]
 	if err := json.Unmarshal(data, &snapshot); err == nil && strings.TrimSpace(snapshot.BaselineSchemaVersion) != "" {
-		version := strings.TrimSpace(snapshot.BaselineSchemaVersion)
+		version := snapshot.BaselineSchemaVersion
 		if version != SnapshotSchemaVersion {
 			var zero T
 			return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)

--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -1,0 +1,125 @@
+package baseline
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+const SnapshotSchemaVersion = "1.0.0"
+
+type Snapshot[T any] struct {
+	BaselineSchemaVersion string    `json:"baselineSchemaVersion"`
+	Key                   string    `json:"key"`
+	SavedAt               time.Time `json:"savedAt"`
+	Report                T         `json:"report"`
+}
+
+type SnapshotDecodeOptions[T any] struct {
+	DecodeLegacy      func([]byte) (T, error)
+	Normalize         func(T) T
+	UnsupportedSchema func(string) error
+}
+
+func NewSnapshot[T any](key string, report T, now time.Time, normalize func(T) T) Snapshot[T] {
+	if normalize != nil {
+		report = normalize(report)
+	}
+	return Snapshot[T]{
+		BaselineSchemaVersion: SnapshotSchemaVersion,
+		Key:                   strings.TrimSpace(key),
+		SavedAt:               now.UTC(),
+		Report:                report,
+	}
+}
+
+func SaveSnapshot[T any](dir, key string, now time.Time, report T, existsErr error, normalize func(T) T) (string, error) {
+	return SaveJSON(dir, key, existsErr, func(trimmedKey string) Snapshot[T] {
+		return NewSnapshot(trimmedKey, report, now, normalize)
+	})
+}
+
+func LoadSnapshotFile[T any](path string, options SnapshotDecodeOptions[T]) (T, string, error) {
+	data, err := safeio.ReadFile(path)
+	if err != nil {
+		var zero T
+		return zero, "", err
+	}
+	return DecodeSnapshot(data, options)
+}
+
+func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, string, error) {
+	var snapshot Snapshot[T]
+	if err := json.Unmarshal(data, &snapshot); err == nil && strings.TrimSpace(snapshot.BaselineSchemaVersion) != "" {
+		version := strings.TrimSpace(snapshot.BaselineSchemaVersion)
+		if version != SnapshotSchemaVersion {
+			var zero T
+			return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)
+		}
+		v := snapshot.Report
+		if options.Normalize != nil {
+			v = options.Normalize(v)
+		}
+		return v, strings.TrimSpace(snapshot.Key), nil
+	}
+
+	v, err := decodeLegacySnapshot(data, options.DecodeLegacy)
+	if err != nil {
+		var zero T
+		return zero, "", err
+	}
+	if options.Normalize != nil {
+		v = options.Normalize(v)
+	}
+	return v, "", nil
+}
+
+func LoadStoreSnapshot[T any](dir, key string, maxBytes int64, decode func([]byte) (T, string, error), validateKey func(string, string) error) (T, string, string, error) {
+	trimmedKey := strings.TrimSpace(key)
+	path := ResolveSnapshotPath(dir, trimmedKey)
+	data, err := ReadStoreEntry(dir, filepath.Base(path), maxBytes)
+	if err != nil {
+		var zero T
+		return zero, "", path, err
+	}
+	v, loadedKey, err := decode(data)
+	if err != nil {
+		var zero T
+		return zero, "", path, err
+	}
+	if validateKey != nil {
+		if err := validateKey(trimmedKey, loadedKey); err != nil {
+			var zero T
+			return zero, loadedKey, path, err
+		}
+	}
+	return v, loadedKey, path, nil
+}
+
+func ValidateSnapshotKey(requestedKey, storedKey string, mismatchErr error) error {
+	requestedKey = strings.TrimSpace(requestedKey)
+	storedKey = strings.TrimSpace(storedKey)
+	if requestedKey == storedKey && requestedKey != "" {
+		return nil
+	}
+	return fmt.Errorf("%w: requested %q, stored %q", mismatchErr, requestedKey, storedKey)
+}
+
+func decodeLegacySnapshot[T any](data []byte, decodeLegacy func([]byte) (T, error)) (T, error) {
+	if decodeLegacy != nil {
+		return decodeLegacy(data)
+	}
+	var v T
+	return v, json.Unmarshal(data, &v)
+}
+
+func snapshotSchemaError(version string, unsupportedSchema func(string) error) error {
+	if unsupportedSchema != nil {
+		return unsupportedSchema(version)
+	}
+	return fmt.Errorf("unsupported baseline schema version: %s", version)
+}

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -146,16 +146,39 @@ func TestDecodeSnapshotSupportsEnvelopeAndLegacyFallback(t *testing.T) {
 	}
 }
 
+type snapshotDecodeCompatibilityCase struct {
+	name      string
+	data      string
+	wantKey   string
+	wantValue string
+	wantErr   string
+}
+
+func assertSnapshotDecodeCompatibility(t *testing.T, tc snapshotDecodeCompatibilityCase) {
+	t.Helper()
+
+	got, key, err := DecodeSnapshot([]byte(tc.data), normalizedSnapshotDecodeOptions())
+	if tc.wantErr != "" {
+		if err == nil || err.Error() != tc.wantErr {
+			t.Fatalf("DecodeSnapshot() error = %v, want %q", err, tc.wantErr)
+		}
+		if got != (testSnapshotReport{}) || key != "" {
+			t.Fatalf("DecodeSnapshot() error result = %#v, %q, want zero values", got, key)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("DecodeSnapshot() error = %v", err)
+	}
+	if got.Value != tc.wantValue || key != tc.wantKey {
+		t.Fatalf("DecodeSnapshot() = %#v, %q, want value=%q key=%q", got, key, tc.wantValue, tc.wantKey)
+	}
+}
+
 func TestDecodeSnapshotSchemaVersionCompatibility(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name      string
-		data      string
-		wantKey   string
-		wantValue string
-		wantErr   string
-	}{
+	tests := []snapshotDecodeCompatibilityCase{
 		{
 			name:      "exact version accepted",
 			data:      `{"baselineSchemaVersion":"1.0.0","key":" label:test ","savedAt":"2026-07-12T00:00:00Z","report":{"value":"snapshot"}}`,
@@ -178,23 +201,7 @@ func TestDecodeSnapshotSchemaVersionCompatibility(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			got, key, err := DecodeSnapshot([]byte(tc.data), normalizedSnapshotDecodeOptions())
-			if tc.wantErr != "" {
-				if err == nil || err.Error() != tc.wantErr {
-					t.Fatalf("DecodeSnapshot() error = %v, want %q", err, tc.wantErr)
-				}
-				if got != (testSnapshotReport{}) || key != "" {
-					t.Fatalf("DecodeSnapshot() error result = %#v, %q, want zero values", got, key)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("DecodeSnapshot() error = %v", err)
-			}
-			if got.Value != tc.wantValue || key != tc.wantKey {
-				t.Fatalf("DecodeSnapshot() = %#v, %q, want value=%q key=%q", got, key, tc.wantValue, tc.wantKey)
-			}
+			assertSnapshotDecodeCompatibility(t, tc)
 		})
 	}
 }

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -1,0 +1,255 @@
+package baseline
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testSnapshotReport struct {
+	Value string `json:"value"`
+}
+
+func TestSaveSnapshotWritesEnvelopeWithUTCTimestamp(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 12, 8, 30, 0, 0, time.FixedZone("AEST", 10*60*60))
+	path, err := SaveSnapshot(t.TempDir(), " label:weekly ", now, testSnapshotReport{Value: "ok"}, nil, func(report testSnapshotReport) testSnapshotReport {
+		report.Value = strings.ToUpper(report.Value)
+		return report
+	})
+	if err != nil {
+		t.Fatalf("SaveSnapshot() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+
+	var snapshot Snapshot[testSnapshotReport]
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+	if snapshot.BaselineSchemaVersion != SnapshotSchemaVersion {
+		t.Fatalf("schema version = %q, want %q", snapshot.BaselineSchemaVersion, SnapshotSchemaVersion)
+	}
+	if snapshot.Key != "label:weekly" {
+		t.Fatalf("key = %q, want %q", snapshot.Key, "label:weekly")
+	}
+	if snapshot.SavedAt.Location() != time.UTC || !snapshot.SavedAt.Equal(now.UTC()) {
+		t.Fatalf("savedAt = %s, want %s", snapshot.SavedAt, now.UTC())
+	}
+	if snapshot.Report.Value != "OK" {
+		t.Fatalf("report = %#v, want normalized value", snapshot.Report)
+	}
+}
+
+func TestDecodeSnapshotSupportsEnvelopeAndLegacyFallback(t *testing.T) {
+	t.Parallel()
+
+	snapshotData := []byte(`{"baselineSchemaVersion":"1.0.0","key":" label:test ","savedAt":"2026-07-12T00:00:00Z","report":{"value":"snapshot"}}`)
+	reportData, key, err := DecodeSnapshot(snapshotData, SnapshotDecodeOptions[testSnapshotReport]{
+		DecodeLegacy: func(data []byte) (testSnapshotReport, error) {
+			var report testSnapshotReport
+			return report, json.Unmarshal(data, &report)
+		},
+		Normalize: func(report testSnapshotReport) testSnapshotReport {
+			report.Value = strings.ToUpper(report.Value)
+			return report
+		},
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot(snapshot) error = %v", err)
+	}
+	if key != "label:test" || reportData.Value != "SNAPSHOT" {
+		t.Fatalf("unexpected snapshot decode result: key=%q report=%#v", key, reportData)
+	}
+
+	legacyData := []byte(`{"value":"legacy"}`)
+	legacyReport, legacyKey, err := DecodeSnapshot(legacyData, SnapshotDecodeOptions[testSnapshotReport]{
+		DecodeLegacy: func(data []byte) (testSnapshotReport, error) {
+			var report testSnapshotReport
+			return report, json.Unmarshal(data, &report)
+		},
+		Normalize: func(report testSnapshotReport) testSnapshotReport {
+			report.Value = strings.ToUpper(report.Value)
+			return report
+		},
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot(legacy) error = %v", err)
+	}
+	if legacyKey != "" || legacyReport.Value != "LEGACY" {
+		t.Fatalf("unexpected legacy decode result: key=%q report=%#v", legacyKey, legacyReport)
+	}
+}
+
+func TestDecodeSnapshotRejectsUnsupportedSchemaWithCustomError(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := DecodeSnapshot([]byte(`{"baselineSchemaVersion":"9.9.9","key":"label:bad","report":{"value":"x"}}`), SnapshotDecodeOptions[testSnapshotReport]{
+		DecodeLegacy: func(data []byte) (testSnapshotReport, error) {
+			var report testSnapshotReport
+			return report, json.Unmarshal(data, &report)
+		},
+		UnsupportedSchema: func(version string) error {
+			return fmt.Errorf("unsupported custom baseline schema version: %s", version)
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported custom baseline schema version: 9.9.9") {
+		t.Fatalf("expected custom unsupported schema error, got %v", err)
+	}
+}
+
+func TestLoadSnapshotFileLoadsEnvelopeAndReturnsReadError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2026, time.July, 12, 0, 0, 0, 0, time.UTC)
+	path, err := SaveSnapshot(dir, "label:weekly", now, testSnapshotReport{Value: "ok"}, nil, nil)
+	if err != nil {
+		t.Fatalf("SaveSnapshot() error = %v", err)
+	}
+
+	got, key, err := LoadSnapshotFile(path, SnapshotDecodeOptions[testSnapshotReport]{})
+	if err != nil {
+		t.Fatalf("LoadSnapshotFile() error = %v", err)
+	}
+	if got.Value != "ok" || key != "label:weekly" {
+		t.Fatalf("LoadSnapshotFile() = %#v, %q, want value and key", got, key)
+	}
+
+	got, key, err = LoadSnapshotFile(path+".missing", SnapshotDecodeOptions[testSnapshotReport]{})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("LoadSnapshotFile() missing error = %v, want os.ErrNotExist", err)
+	}
+	if got != (testSnapshotReport{}) || key != "" {
+		t.Fatalf("LoadSnapshotFile() missing = %#v, %q, want zero values", got, key)
+	}
+}
+
+func TestDecodeSnapshotUsesDefaultLegacyAndSchemaErrors(t *testing.T) {
+	t.Parallel()
+
+	got, key, err := DecodeSnapshot([]byte(`{"value":"legacy"}`), SnapshotDecodeOptions[testSnapshotReport]{})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot() legacy error = %v", err)
+	}
+	if got.Value != "legacy" || key != "" {
+		t.Fatalf("DecodeSnapshot() legacy = %#v, %q, want legacy value and empty key", got, key)
+	}
+
+	_, _, err = DecodeSnapshot([]byte(`{`), SnapshotDecodeOptions[testSnapshotReport]{})
+	if err == nil {
+		t.Fatal("DecodeSnapshot() malformed legacy input returned nil error")
+	}
+
+	_, _, err = DecodeSnapshot([]byte(`{"baselineSchemaVersion":"9.9.9"}`), SnapshotDecodeOptions[testSnapshotReport]{})
+	if err == nil || err.Error() != "unsupported baseline schema version: 9.9.9" {
+		t.Fatalf("DecodeSnapshot() unsupported schema error = %v", err)
+	}
+}
+
+func TestLoadStoreSnapshotReadsResolvedPathAndValidatesKey(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2026, time.July, 12, 0, 0, 0, 0, time.UTC)
+	path, err := SaveSnapshot(dir, "label:weekly", now, testSnapshotReport{Value: "ok"}, nil, nil)
+	if err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	decode := func(data []byte) (testSnapshotReport, string, error) {
+		return DecodeSnapshot(data, SnapshotDecodeOptions[testSnapshotReport]{
+			DecodeLegacy: func(data []byte) (testSnapshotReport, error) {
+				var report testSnapshotReport
+				return report, json.Unmarshal(data, &report)
+			},
+		})
+	}
+	validate := func(requestedKey, storedKey string) error {
+		return ValidateSnapshotKey(requestedKey, storedKey, errors.New("snapshot key mismatch"))
+	}
+	reportData, key, resolvedPath, err := LoadStoreSnapshot(dir, " label:weekly ", MaxSnapshotBytes, decode, validate)
+	if err != nil {
+		t.Fatalf("LoadStoreSnapshot() error = %v", err)
+	}
+	if resolvedPath != path || key != "label:weekly" || reportData.Value != "ok" {
+		t.Fatalf("unexpected keyed load result: path=%q key=%q report=%#v", resolvedPath, key, reportData)
+	}
+}
+
+func TestLoadStoreSnapshotReturnsReadDecodeAndValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2026, time.July, 12, 0, 0, 0, 0, time.UTC)
+	savedPath, err := SaveSnapshot(dir, "label:weekly", now, testSnapshotReport{Value: "ok"}, nil, nil)
+	if err != nil {
+		t.Fatalf("SaveSnapshot() error = %v", err)
+	}
+
+	decodeCalled := false
+	unexpectedDecode := func([]byte) (testSnapshotReport, string, error) {
+		decodeCalled = true
+		return testSnapshotReport{}, "", nil
+	}
+	got, key, path, err := LoadStoreSnapshot(dir, "label:missing", MaxSnapshotBytes, unexpectedDecode, nil)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("LoadStoreSnapshot() read error = %v, want os.ErrNotExist", err)
+	}
+	if decodeCalled || got != (testSnapshotReport{}) || key != "" || path != ResolveSnapshotPath(dir, "label:missing") {
+		t.Fatalf("LoadStoreSnapshot() read failure = %#v, %q, %q, decodeCalled=%t", got, key, path, decodeCalled)
+	}
+
+	decodeErr := errors.New("decode snapshot")
+	failDecode := func([]byte) (testSnapshotReport, string, error) {
+		return testSnapshotReport{}, "", decodeErr
+	}
+	got, key, path, err = LoadStoreSnapshot(dir, "label:weekly", MaxSnapshotBytes, failDecode, nil)
+	if !errors.Is(err, decodeErr) {
+		t.Fatalf("LoadStoreSnapshot() decode error = %v, want %v", err, decodeErr)
+	}
+	if got != (testSnapshotReport{}) || key != "" || path != savedPath {
+		t.Fatalf("LoadStoreSnapshot() decode failure = %#v, %q, %q", got, key, path)
+	}
+
+	decode := func([]byte) (testSnapshotReport, string, error) {
+		return testSnapshotReport{Value: "decoded"}, "label:stored", nil
+	}
+	got, key, path, err = LoadStoreSnapshot(dir, "label:weekly", MaxSnapshotBytes, decode, nil)
+	if err != nil || got.Value != "decoded" || key != "label:stored" || path != savedPath {
+		t.Fatalf("LoadStoreSnapshot() without validation = %#v, %q, %q, %v", got, key, path, err)
+	}
+
+	validateErr := errors.New("validate snapshot key")
+	rejectKey := func(string, string) error {
+		return validateErr
+	}
+	got, key, path, err = LoadStoreSnapshot(dir, "label:weekly", MaxSnapshotBytes, decode, rejectKey)
+	if !errors.Is(err, validateErr) {
+		t.Fatalf("LoadStoreSnapshot() validation error = %v, want %v", err, validateErr)
+	}
+	if got != (testSnapshotReport{}) || key != "label:stored" || path != savedPath {
+		t.Fatalf("LoadStoreSnapshot() validation failure = %#v, %q, %q", got, key, path)
+	}
+}
+
+func TestValidateSnapshotKeyWrapsCustomMismatchError(t *testing.T) {
+	t.Parallel()
+
+	errMarker := errors.New("snapshot key mismatch")
+	err := ValidateSnapshotKey(" label:a ", "label:b", errMarker)
+	if !errors.Is(err, errMarker) {
+		t.Fatalf("expected wrapped mismatch error, got %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), `requested "label:a", stored "label:b"`) {
+		t.Fatalf("expected detailed mismatch error, got %v", err)
+	}
+}

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,19 @@ import (
 
 type testSnapshotReport struct {
 	Value string `json:"value"`
+}
+
+type testSortedSnapshotItem struct {
+	Group string
+	Name  string
+}
+
+func sortedSnapshotGroup(item testSortedSnapshotItem) string {
+	return item.Group
+}
+
+func sortedSnapshotName(item testSortedSnapshotItem) string {
+	return item.Name
 }
 
 func decodeTestSnapshotReport(data []byte) (testSnapshotReport, error) {
@@ -239,5 +253,89 @@ func TestValidateSnapshotKeyWrapsCustomMismatchError(t *testing.T) {
 	}
 	if err == nil || !strings.Contains(err.Error(), `requested "label:a", stored "label:b"`) {
 		t.Fatalf("expected detailed mismatch error, got %v", err)
+	}
+}
+
+func TestSortedCopyByStringsReturnsEmptyResultWhenInputIsNil(t *testing.T) {
+	t.Parallel()
+
+	got := SortedCopyByStrings[testSortedSnapshotItem](nil, sortedSnapshotGroup, sortedSnapshotName)
+
+	if len(got) != 0 {
+		t.Fatalf("SortedCopyByStrings(nil) length = %d, want 0", len(got))
+	}
+}
+
+func TestSortedCopyByStringsReturnsEmptyResultWhenInputIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := SortedCopyByStrings([]testSortedSnapshotItem{}, sortedSnapshotGroup, sortedSnapshotName)
+
+	if len(got) != 0 {
+		t.Fatalf("SortedCopyByStrings(empty) length = %d, want 0", len(got))
+	}
+}
+
+func TestSortedCopyByStringsOrdersItemsByPrimaryKey(t *testing.T) {
+	t.Parallel()
+
+	items := []testSortedSnapshotItem{
+		{Group: "charlie", Name: "three"},
+		{Group: "alpha", Name: "one"},
+		{Group: "bravo", Name: "two"},
+	}
+
+	got := SortedCopyByStrings(items, sortedSnapshotGroup, sortedSnapshotName)
+
+	want := []testSortedSnapshotItem{
+		{Group: "alpha", Name: "one"},
+		{Group: "bravo", Name: "two"},
+		{Group: "charlie", Name: "three"},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("SortedCopyByStrings() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSortedCopyByStringsUsesSecondaryKeyToBreakPrimaryTies(t *testing.T) {
+	t.Parallel()
+
+	items := []testSortedSnapshotItem{
+		{Group: "alpha", Name: "gamma"},
+		{Group: "alpha", Name: "beta"},
+		{Group: "alpha", Name: "alpha"},
+	}
+
+	got := SortedCopyByStrings(items, sortedSnapshotGroup, sortedSnapshotName)
+
+	want := []testSortedSnapshotItem{
+		{Group: "alpha", Name: "alpha"},
+		{Group: "alpha", Name: "beta"},
+		{Group: "alpha", Name: "gamma"},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("SortedCopyByStrings() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSortedCopyByStringsDoesNotMutateInputSlice(t *testing.T) {
+	t.Parallel()
+
+	items := []testSortedSnapshotItem{
+		{Group: "bravo", Name: "two"},
+		{Group: "alpha", Name: "one"},
+	}
+	original := append([]testSortedSnapshotItem(nil), items...)
+
+	got := SortedCopyByStrings(items, sortedSnapshotGroup, sortedSnapshotName)
+
+	if !slices.Equal(items, original) {
+		t.Fatalf("input mutated: got %#v, want %#v", items, original)
+	}
+	if len(got) != len(items) {
+		t.Fatalf("sorted copy length = %d, want %d", len(got), len(items))
+	}
+	if len(got) > 0 && &got[0] == &items[0] {
+		t.Fatal("SortedCopyByStrings() reused input backing array")
 	}
 }

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -88,7 +88,7 @@ func normalizeTestSnapshotReport(report testSnapshotReport) testSnapshotReport {
 func normalizedSnapshotDecodeOptions() SnapshotDecodeOptions[testSnapshotReport] {
 	return SnapshotDecodeOptions[testSnapshotReport]{
 		DecodeLegacy: decodeTestSnapshotReport,
-		Normalize:    normalizeTestSnapshotReport,
+		Repair:       normalizeTestSnapshotReport,
 	}
 }
 
@@ -366,7 +366,12 @@ func TestValidateSnapshotKeyWrapsCustomMismatchError(t *testing.T) {
 func TestConfiguredSnapshotHelpersRoundTrip(t *testing.T) {
 	t.Parallel()
 
+	repair := func(report testSnapshotReport) testSnapshotReport {
+		report.Value = "repaired:" + report.Value
+		return report
+	}
 	store := SnapshotStore[testSnapshotReport]{
+		Repair:            repair,
 		Normalize:         normalizeTestSnapshotReport,
 		UnsupportedSchema: func(version string) error { return fmt.Errorf("unsupported configured schema version: %s", version) },
 		ValidateKey: func(requestedKey, storedKey string) error {
@@ -391,7 +396,7 @@ func TestConfiguredSnapshotHelpersRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfiguredSnapshot() error = %v", err)
 	}
-	if key != "label:configured" || got.Value != "OK" {
+	if key != "label:configured" || got.Value != "repaired:OK" {
 		t.Fatalf("LoadConfiguredSnapshot() = key=%q report=%#v", key, got)
 	}
 
@@ -404,7 +409,7 @@ func TestConfiguredSnapshotHelpersRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecodeConfiguredSnapshot() error = %v", err)
 	}
-	if decodedKey != "label:configured" || decoded.Value != "OK" {
+	if decodedKey != "label:configured" || decoded.Value != "repaired:OK" {
 		t.Fatalf("DecodeConfiguredSnapshot() = key=%q report=%#v", decodedKey, decoded)
 	}
 
@@ -412,7 +417,7 @@ func TestConfiguredSnapshotHelpersRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfiguredStoreSnapshot() error = %v", err)
 	}
-	if resolvedPath != path || loadedKey != "label:configured" || loaded.Value != "OK" {
+	if resolvedPath != path || loadedKey != "label:configured" || loaded.Value != "repaired:OK" {
 		t.Fatalf("LoadConfiguredStoreSnapshot() = path=%q key=%q report=%#v", resolvedPath, loadedKey, loaded)
 	}
 }

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -20,12 +20,59 @@ type testSortedSnapshotItem struct {
 	Name  string
 }
 
+var (
+	testSortedSnapshotItemsUnorderedByPrimary = []testSortedSnapshotItem{
+		{Group: "charlie", Name: "three"},
+		{Group: "alpha", Name: "one"},
+		{Group: "bravo", Name: "two"},
+	}
+	testSortedSnapshotItemsOrderedByPrimary = []testSortedSnapshotItem{
+		{Group: "alpha", Name: "one"},
+		{Group: "bravo", Name: "two"},
+		{Group: "charlie", Name: "three"},
+	}
+	testSortedSnapshotItemsTiedOnPrimary = []testSortedSnapshotItem{
+		{Group: "alpha", Name: "gamma"},
+		{Group: "alpha", Name: "beta"},
+		{Group: "alpha", Name: "alpha"},
+	}
+	testSortedSnapshotItemsOrderedBySecondary = []testSortedSnapshotItem{
+		{Group: "alpha", Name: "alpha"},
+		{Group: "alpha", Name: "beta"},
+		{Group: "alpha", Name: "gamma"},
+	}
+)
+
 func sortedSnapshotGroup(item testSortedSnapshotItem) string {
 	return item.Group
 }
 
 func sortedSnapshotName(item testSortedSnapshotItem) string {
 	return item.Name
+}
+
+func assertSortedCopyByStringsReturnsEmptyResult(t *testing.T, name string, items []testSortedSnapshotItem) {
+	t.Helper()
+
+	t.Run(name, func(t *testing.T) {
+		t.Parallel()
+
+		got := SortedCopyByStrings(items, sortedSnapshotGroup, sortedSnapshotName)
+
+		if len(got) != 0 {
+			t.Fatalf("SortedCopyByStrings(%s) length = %d, want 0", name, len(got))
+		}
+	})
+}
+
+func assertSortedCopyByStringsOrder(t *testing.T, items, want []testSortedSnapshotItem) {
+	t.Helper()
+
+	got := SortedCopyByStrings(items, sortedSnapshotGroup, sortedSnapshotName)
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("SortedCopyByStrings() = %#v, want %#v", got, want)
+	}
 }
 
 func decodeTestSnapshotReport(data []byte) (testSnapshotReport, error) {
@@ -259,62 +306,41 @@ func TestValidateSnapshotKeyWrapsCustomMismatchError(t *testing.T) {
 func TestSortedCopyByStringsReturnsEmptyResultWhenInputIsNil(t *testing.T) {
 	t.Parallel()
 
-	got := SortedCopyByStrings[testSortedSnapshotItem](nil, sortedSnapshotGroup, sortedSnapshotName)
-
-	if len(got) != 0 {
-		t.Fatalf("SortedCopyByStrings(nil) length = %d, want 0", len(got))
-	}
+	assertSortedCopyByStringsReturnsEmptyResult(t, "nil", nil)
 }
 
 func TestSortedCopyByStringsReturnsEmptyResultWhenInputIsEmpty(t *testing.T) {
 	t.Parallel()
 
-	got := SortedCopyByStrings([]testSortedSnapshotItem{}, sortedSnapshotGroup, sortedSnapshotName)
-
-	if len(got) != 0 {
-		t.Fatalf("SortedCopyByStrings(empty) length = %d, want 0", len(got))
-	}
+	assertSortedCopyByStringsReturnsEmptyResult(t, "empty", []testSortedSnapshotItem{})
 }
 
-func TestSortedCopyByStringsOrdersItemsByPrimaryKey(t *testing.T) {
+func TestSortedCopyByStringsOrdersItemsByConfiguredKeys(t *testing.T) {
 	t.Parallel()
 
-	items := []testSortedSnapshotItem{
-		{Group: "charlie", Name: "three"},
-		{Group: "alpha", Name: "one"},
-		{Group: "bravo", Name: "two"},
+	cases := []struct {
+		name  string
+		items []testSortedSnapshotItem
+		want  []testSortedSnapshotItem
+	}{
+		{
+			name:  "orders items by primary key",
+			items: testSortedSnapshotItemsUnorderedByPrimary,
+			want:  testSortedSnapshotItemsOrderedByPrimary,
+		},
+		{
+			name:  "uses secondary key to break primary ties",
+			items: testSortedSnapshotItemsTiedOnPrimary,
+			want:  testSortedSnapshotItemsOrderedBySecondary,
+		},
 	}
 
-	got := SortedCopyByStrings(items, sortedSnapshotGroup, sortedSnapshotName)
-
-	want := []testSortedSnapshotItem{
-		{Group: "alpha", Name: "one"},
-		{Group: "bravo", Name: "two"},
-		{Group: "charlie", Name: "three"},
-	}
-	if !slices.Equal(got, want) {
-		t.Fatalf("SortedCopyByStrings() = %#v, want %#v", got, want)
-	}
-}
-
-func TestSortedCopyByStringsUsesSecondaryKeyToBreakPrimaryTies(t *testing.T) {
-	t.Parallel()
-
-	items := []testSortedSnapshotItem{
-		{Group: "alpha", Name: "gamma"},
-		{Group: "alpha", Name: "beta"},
-		{Group: "alpha", Name: "alpha"},
-	}
-
-	got := SortedCopyByStrings(items, sortedSnapshotGroup, sortedSnapshotName)
-
-	want := []testSortedSnapshotItem{
-		{Group: "alpha", Name: "alpha"},
-		{Group: "alpha", Name: "beta"},
-		{Group: "alpha", Name: "gamma"},
-	}
-	if !slices.Equal(got, want) {
-		t.Fatalf("SortedCopyByStrings() = %#v, want %#v", got, want)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assertSortedCopyByStringsOrder(t, tc.items, tc.want)
+		})
 	}
 }
 

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -14,14 +14,28 @@ type testSnapshotReport struct {
 	Value string `json:"value"`
 }
 
+func decodeTestSnapshotReport(data []byte) (testSnapshotReport, error) {
+	var report testSnapshotReport
+	return report, json.Unmarshal(data, &report)
+}
+
+func normalizeTestSnapshotReport(report testSnapshotReport) testSnapshotReport {
+	report.Value = strings.ToUpper(report.Value)
+	return report
+}
+
+func normalizedSnapshotDecodeOptions() SnapshotDecodeOptions[testSnapshotReport] {
+	return SnapshotDecodeOptions[testSnapshotReport]{
+		DecodeLegacy: decodeTestSnapshotReport,
+		Normalize:    normalizeTestSnapshotReport,
+	}
+}
+
 func TestSaveSnapshotWritesEnvelopeWithUTCTimestamp(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.July, 12, 8, 30, 0, 0, time.FixedZone("AEST", 10*60*60))
-	path, err := SaveSnapshot(t.TempDir(), " label:weekly ", now, testSnapshotReport{Value: "ok"}, nil, func(report testSnapshotReport) testSnapshotReport {
-		report.Value = strings.ToUpper(report.Value)
-		return report
-	})
+	path, err := SaveSnapshot(t.TempDir(), " label:weekly ", now, testSnapshotReport{Value: "ok"}, nil, normalizeTestSnapshotReport)
 	if err != nil {
 		t.Fatalf("SaveSnapshot() error = %v", err)
 	}
@@ -53,16 +67,7 @@ func TestDecodeSnapshotSupportsEnvelopeAndLegacyFallback(t *testing.T) {
 	t.Parallel()
 
 	snapshotData := []byte(`{"baselineSchemaVersion":"1.0.0","key":" label:test ","savedAt":"2026-07-12T00:00:00Z","report":{"value":"snapshot"}}`)
-	reportData, key, err := DecodeSnapshot(snapshotData, SnapshotDecodeOptions[testSnapshotReport]{
-		DecodeLegacy: func(data []byte) (testSnapshotReport, error) {
-			var report testSnapshotReport
-			return report, json.Unmarshal(data, &report)
-		},
-		Normalize: func(report testSnapshotReport) testSnapshotReport {
-			report.Value = strings.ToUpper(report.Value)
-			return report
-		},
-	})
+	reportData, key, err := DecodeSnapshot(snapshotData, normalizedSnapshotDecodeOptions())
 	if err != nil {
 		t.Fatalf("DecodeSnapshot(snapshot) error = %v", err)
 	}
@@ -71,16 +76,7 @@ func TestDecodeSnapshotSupportsEnvelopeAndLegacyFallback(t *testing.T) {
 	}
 
 	legacyData := []byte(`{"value":"legacy"}`)
-	legacyReport, legacyKey, err := DecodeSnapshot(legacyData, SnapshotDecodeOptions[testSnapshotReport]{
-		DecodeLegacy: func(data []byte) (testSnapshotReport, error) {
-			var report testSnapshotReport
-			return report, json.Unmarshal(data, &report)
-		},
-		Normalize: func(report testSnapshotReport) testSnapshotReport {
-			report.Value = strings.ToUpper(report.Value)
-			return report
-		},
-	})
+	legacyReport, legacyKey, err := DecodeSnapshot(legacyData, normalizedSnapshotDecodeOptions())
 	if err != nil {
 		t.Fatalf("DecodeSnapshot(legacy) error = %v", err)
 	}
@@ -93,10 +89,7 @@ func TestDecodeSnapshotRejectsUnsupportedSchemaWithCustomError(t *testing.T) {
 	t.Parallel()
 
 	_, _, err := DecodeSnapshot([]byte(`{"baselineSchemaVersion":"9.9.9","key":"label:bad","report":{"value":"x"}}`), SnapshotDecodeOptions[testSnapshotReport]{
-		DecodeLegacy: func(data []byte) (testSnapshotReport, error) {
-			var report testSnapshotReport
-			return report, json.Unmarshal(data, &report)
-		},
+		DecodeLegacy: decodeTestSnapshotReport,
 		UnsupportedSchema: func(version string) error {
 			return fmt.Errorf("unsupported custom baseline schema version: %s", version)
 		},
@@ -166,12 +159,7 @@ func TestLoadStoreSnapshotReadsResolvedPathAndValidatesKey(t *testing.T) {
 	}
 
 	decode := func(data []byte) (testSnapshotReport, string, error) {
-		return DecodeSnapshot(data, SnapshotDecodeOptions[testSnapshotReport]{
-			DecodeLegacy: func(data []byte) (testSnapshotReport, error) {
-				var report testSnapshotReport
-				return report, json.Unmarshal(data, &report)
-			},
-		})
+		return DecodeSnapshot(data, SnapshotDecodeOptions[testSnapshotReport]{DecodeLegacy: decodeTestSnapshotReport})
 	}
 	validate := func(requestedKey, storedKey string) error {
 		return ValidateSnapshotKey(requestedKey, storedKey, errors.New("snapshot key mismatch"))

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -146,6 +146,59 @@ func TestDecodeSnapshotSupportsEnvelopeAndLegacyFallback(t *testing.T) {
 	}
 }
 
+func TestDecodeSnapshotSchemaVersionCompatibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		data      string
+		wantKey   string
+		wantValue string
+		wantErr   string
+	}{
+		{
+			name:      "exact version accepted",
+			data:      `{"baselineSchemaVersion":"1.0.0","key":" label:test ","savedAt":"2026-07-12T00:00:00Z","report":{"value":"snapshot"}}`,
+			wantKey:   "label:test",
+			wantValue: "SNAPSHOT",
+		},
+		{
+			name:    "padded version rejected with raw value",
+			data:    `{"baselineSchemaVersion":" 1.0.0 ","key":"label:test","savedAt":"2026-07-12T00:00:00Z","report":{"value":"snapshot"}}`,
+			wantErr: "unsupported baseline schema version:  1.0.0 ",
+		},
+		{
+			name:      "whitespace version falls back to missing behavior",
+			data:      `{"baselineSchemaVersion":"   ","value":"legacy"}`,
+			wantValue: "LEGACY",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, key, err := DecodeSnapshot([]byte(tc.data), normalizedSnapshotDecodeOptions())
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("DecodeSnapshot() error = %v, want %q", err, tc.wantErr)
+				}
+				if got != (testSnapshotReport{}) || key != "" {
+					t.Fatalf("DecodeSnapshot() error result = %#v, %q, want zero values", got, key)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DecodeSnapshot() error = %v", err)
+			}
+			if got.Value != tc.wantValue || key != tc.wantKey {
+				t.Fatalf("DecodeSnapshot() = %#v, %q, want value=%q key=%q", got, key, tc.wantValue, tc.wantKey)
+			}
+		})
+	}
+}
+
 func TestDecodeSnapshotRejectsUnsupportedSchemaWithCustomError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -303,6 +303,101 @@ func TestValidateSnapshotKeyWrapsCustomMismatchError(t *testing.T) {
 	}
 }
 
+func TestConfiguredSnapshotHelpersRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := SnapshotStore[testSnapshotReport]{
+		Normalize:         normalizeTestSnapshotReport,
+		UnsupportedSchema: func(version string) error { return fmt.Errorf("unsupported configured schema version: %s", version) },
+		ValidateKey: func(requestedKey, storedKey string) error {
+			return ValidateSnapshotKey(requestedKey, storedKey, errors.New("configured key mismatch"))
+		},
+		ExistsErr: errors.New("configured snapshot already exists"),
+	}
+	dir := t.TempDir()
+	now := time.Date(2026, time.July, 12, 11, 15, 0, 0, time.FixedZone("AEST", 10*60*60))
+
+	wantSnapshot := NewConfiguredSnapshot(" label:configured ", testSnapshotReport{Value: "ok"}, now, store)
+	if wantSnapshot.Key != "label:configured" || wantSnapshot.Report.Value != "OK" || !wantSnapshot.SavedAt.Equal(now.UTC()) {
+		t.Fatalf("NewConfiguredSnapshot() = %#v", wantSnapshot)
+	}
+
+	path, err := SaveConfiguredSnapshot(dir, " label:configured ", now, testSnapshotReport{Value: "ok"}, store)
+	if err != nil {
+		t.Fatalf("SaveConfiguredSnapshot() error = %v", err)
+	}
+
+	got, key, err := LoadConfiguredSnapshot(path, store)
+	if err != nil {
+		t.Fatalf("LoadConfiguredSnapshot() error = %v", err)
+	}
+	if key != "label:configured" || got.Value != "OK" {
+		t.Fatalf("LoadConfiguredSnapshot() = key=%q report=%#v", key, got)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read configured snapshot: %v", err)
+	}
+
+	decoded, decodedKey, err := DecodeConfiguredSnapshot(data, store)
+	if err != nil {
+		t.Fatalf("DecodeConfiguredSnapshot() error = %v", err)
+	}
+	if decodedKey != "label:configured" || decoded.Value != "OK" {
+		t.Fatalf("DecodeConfiguredSnapshot() = key=%q report=%#v", decodedKey, decoded)
+	}
+
+	loaded, loadedKey, resolvedPath, err := LoadConfiguredStoreSnapshot(dir, " label:configured ", MaxSnapshotBytes, store)
+	if err != nil {
+		t.Fatalf("LoadConfiguredStoreSnapshot() error = %v", err)
+	}
+	if resolvedPath != path || loadedKey != "label:configured" || loaded.Value != "OK" {
+		t.Fatalf("LoadConfiguredStoreSnapshot() = path=%q key=%q report=%#v", resolvedPath, loadedKey, loaded)
+	}
+}
+
+func TestConfiguredSnapshotHelpersReturnCustomErrors(t *testing.T) {
+	t.Parallel()
+
+	unsupportedMarker := errors.New("unsupported configured schema")
+	validateMarker := errors.New("configured key mismatch")
+	existsMarker := errors.New("configured snapshot already exists")
+	store := SnapshotStore[testSnapshotReport]{
+		Normalize: normalizeTestSnapshotReport,
+		UnsupportedSchema: func(version string) error {
+			return fmt.Errorf("%w: %s", unsupportedMarker, version)
+		},
+		ValidateKey: func(string, string) error {
+			return validateMarker
+		},
+		ExistsErr: existsMarker,
+	}
+	dir := t.TempDir()
+	now := time.Date(2026, time.July, 12, 0, 0, 0, 0, time.UTC)
+
+	path, err := SaveConfiguredSnapshot(dir, "label:configured", now, testSnapshotReport{Value: "ok"}, store)
+	if err != nil {
+		t.Fatalf("SaveConfiguredSnapshot() initial save error = %v", err)
+	}
+
+	if _, err := SaveConfiguredSnapshot(dir, "label:configured", now, testSnapshotReport{Value: "again"}, store); !errors.Is(err, existsMarker) {
+		t.Fatalf("SaveConfiguredSnapshot() duplicate error = %v, want %v", err, existsMarker)
+	}
+
+	if _, _, err := DecodeConfiguredSnapshot([]byte(`{"baselineSchemaVersion":"9.9.9","key":"label:bad","report":{"value":"x"}}`), store); !errors.Is(err, unsupportedMarker) {
+		t.Fatalf("DecodeConfiguredSnapshot() unsupported schema error = %v, want %v", err, unsupportedMarker)
+	}
+
+	_, loadedKey, resolvedPath, err := LoadConfiguredStoreSnapshot(dir, "label:configured", MaxSnapshotBytes, store)
+	if !errors.Is(err, validateMarker) {
+		t.Fatalf("LoadConfiguredStoreSnapshot() validation error = %v, want %v", err, validateMarker)
+	}
+	if loadedKey != "label:configured" || resolvedPath != path {
+		t.Fatalf("LoadConfiguredStoreSnapshot() validation result = key=%q path=%q", loadedKey, resolvedPath)
+	}
+}
+
 func TestSortedCopyByStringsReturnsEmptyResultWhenInputIsNil(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dashboard/baseline.go
+++ b/internal/dashboard/baseline.go
@@ -19,6 +19,7 @@ var ErrBaselineKeyMismatch = errors.New("dashboard baseline snapshot key does no
 type BaselineSnapshot = baselineutil.Snapshot[Report]
 
 var baselineSnapshots = baselineutil.SnapshotStore[Report]{
+	Repair:            repairSnapshotReport,
 	Normalize:         normalizeSnapshotReport,
 	UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
 	ValidateKey:       validateBaselineSnapshotKey,
@@ -252,8 +253,13 @@ func normalizeSnapshotReport(rep Report) Report {
 	normalized := rep
 	normalized.Repos = baselineutil.SortedCopyByStrings(rep.Repos, func(repo RepoResult) string { return repo.Name }, func(repo RepoResult) string { return repo.Path })
 	normalized.RemediationItems = dedupeAndSortRemediationItems(rep.RemediationItems)
-	if normalized.Summary == (Summary{}) {
-		normalized.Summary = computeSummary(normalized)
+	return repairSnapshotReport(normalized)
+}
+
+func repairSnapshotReport(rep Report) Report {
+	repaired := rep
+	if repaired.Summary == (Summary{}) {
+		repaired.Summary = computeSummary(repaired)
 	}
-	return normalized
+	return repaired
 }

--- a/internal/dashboard/baseline.go
+++ b/internal/dashboard/baseline.go
@@ -18,6 +18,13 @@ var ErrBaselineKeyMismatch = errors.New("dashboard baseline snapshot key does no
 
 type BaselineSnapshot = baselineutil.Snapshot[Report]
 
+var baselineSnapshots = baselineutil.SnapshotStore[Report]{
+	Normalize:         normalizeSnapshotReport,
+	UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
+	ValidateKey:       validateBaselineSnapshotKey,
+	ExistsErr:         ErrBaselineAlreadyExists,
+}
+
 func Load(path string) (Report, error) {
 	rep, _, err := LoadWithKey(path)
 	if err != nil {
@@ -27,25 +34,15 @@ func Load(path string) (Report, error) {
 }
 
 func LoadWithKey(path string) (Report, string, error) {
-	return baselineutil.LoadSnapshotFile(path, baselineutil.SnapshotDecodeOptions[Report]{
-		Normalize:         normalizeSnapshotReport,
-		UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
-	})
-}
-
-func decodeBaselineSnapshot(data []byte) (Report, string, error) {
-	return baselineutil.DecodeSnapshot(data, baselineutil.SnapshotDecodeOptions[Report]{
-		Normalize:         normalizeSnapshotReport,
-		UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
-	})
+	return baselineutil.LoadConfiguredSnapshot(path, baselineSnapshots)
 }
 
 func LoadSnapshot(dir, key string) (Report, string, string, error) {
-	return baselineutil.LoadStoreSnapshot(dir, key, baselineutil.MaxSnapshotBytes, decodeBaselineSnapshot, validateBaselineSnapshotKey)
+	return baselineutil.LoadConfiguredStoreSnapshot(dir, key, baselineutil.MaxSnapshotBytes, baselineSnapshots)
 }
 
 func SaveSnapshot(dir string, key string, rep Report, now time.Time) (string, error) {
-	return baselineutil.SaveSnapshot(dir, key, now, rep, ErrBaselineAlreadyExists, normalizeSnapshotReport)
+	return baselineutil.SaveConfiguredSnapshot(dir, key, now, rep, baselineSnapshots)
 }
 
 func BaselineSnapshotPath(dir, key string) string {

--- a/internal/dashboard/baseline.go
+++ b/internal/dashboard/baseline.go
@@ -1,30 +1,22 @@
 package dashboard
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
 	baselineutil "github.com/ben-ranford/lopper/internal/baseline"
-	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
-const BaselineSnapshotSchemaVersion = "1.0.0"
+const BaselineSnapshotSchemaVersion = baselineutil.SnapshotSchemaVersion
 
 var ErrBaselineAlreadyExists = errors.New("dashboard baseline snapshot already exists")
 
 var ErrBaselineKeyMismatch = errors.New("dashboard baseline snapshot key does not match requested key")
 
-type BaselineSnapshot struct {
-	BaselineSchemaVersion string    `json:"baselineSchemaVersion"`
-	Key                   string    `json:"key"`
-	SavedAt               time.Time `json:"savedAt"`
-	Report                Report    `json:"report"`
-}
+type BaselineSnapshot = baselineutil.Snapshot[Report]
 
 func Load(path string) (Report, error) {
 	rep, _, err := LoadWithKey(path)
@@ -35,56 +27,25 @@ func Load(path string) (Report, error) {
 }
 
 func LoadWithKey(path string) (Report, string, error) {
-	data, err := safeio.ReadFile(path)
-	if err != nil {
-		return Report{}, "", err
-	}
-	return decodeBaselineSnapshot(data)
+	return baselineutil.LoadSnapshotFile(path, baselineutil.SnapshotDecodeOptions[Report]{
+		Normalize:         normalizeSnapshotReport,
+		UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
+	})
 }
 
 func decodeBaselineSnapshot(data []byte) (Report, string, error) {
-	var snapshot BaselineSnapshot
-	if err := json.Unmarshal(data, &snapshot); err == nil && strings.TrimSpace(snapshot.BaselineSchemaVersion) != "" {
-		if snapshot.BaselineSchemaVersion != BaselineSnapshotSchemaVersion {
-			return Report{}, "", fmt.Errorf("unsupported dashboard baseline schema version: %s", snapshot.BaselineSchemaVersion)
-		}
-		if snapshot.Report.Summary == (Summary{}) {
-			snapshot.Report.Summary = computeSummary(snapshot.Report)
-		}
-		return snapshot.Report, strings.TrimSpace(snapshot.Key), nil
-	}
-
-	var rep Report
-	if err := json.Unmarshal(data, &rep); err != nil {
-		return Report{}, "", err
-	}
-	if rep.Summary == (Summary{}) {
-		rep.Summary = computeSummary(rep)
-	}
-	return rep, "", nil
+	return baselineutil.DecodeSnapshot(data, baselineutil.SnapshotDecodeOptions[Report]{
+		Normalize:         normalizeSnapshotReport,
+		UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
+	})
 }
 
 func LoadSnapshot(dir, key string) (Report, string, string, error) {
-	trimmedKey := strings.TrimSpace(key)
-	path := ResolveBaselineSnapshotPath(dir, trimmedKey)
-	data, err := baselineutil.ReadStoreEntry(dir, filepath.Base(path), baselineutil.MaxSnapshotBytes)
-	if err != nil {
-		return Report{}, "", path, err
-	}
-	rep, loadedKey, err := decodeBaselineSnapshot(data)
-	if err != nil {
-		return Report{}, "", path, err
-	}
-	if loadedKey != trimmedKey || trimmedKey == "" {
-		return Report{}, loadedKey, path, fmt.Errorf("%w: requested %q, stored %q", ErrBaselineKeyMismatch, trimmedKey, loadedKey)
-	}
-	return rep, loadedKey, path, nil
+	return baselineutil.LoadStoreSnapshot(dir, key, baselineutil.MaxSnapshotBytes, decodeBaselineSnapshot, validateBaselineSnapshotKey)
 }
 
 func SaveSnapshot(dir string, key string, rep Report, now time.Time) (string, error) {
-	return baselineutil.SaveJSON(dir, key, ErrBaselineAlreadyExists, func(trimmedKey string) BaselineSnapshot {
-		return newBaselineSnapshot(trimmedKey, rep, now)
-	})
+	return baselineutil.SaveSnapshot(dir, key, now, rep, ErrBaselineAlreadyExists, normalizeSnapshotReport)
 }
 
 func BaselineSnapshotPath(dir, key string) string {
@@ -282,13 +243,12 @@ func countRepoField(repos []RepoResult, selector func(RepoResult) bool) int {
 	return total
 }
 
-func newBaselineSnapshot(key string, rep Report, now time.Time) BaselineSnapshot {
-	return BaselineSnapshot{
-		BaselineSchemaVersion: BaselineSnapshotSchemaVersion,
-		Key:                   key,
-		SavedAt:               now.UTC(),
-		Report:                normalizeSnapshotReport(rep),
-	}
+func validateBaselineSnapshotKey(requestedKey, storedKey string) error {
+	return baselineutil.ValidateSnapshotKey(requestedKey, storedKey, ErrBaselineKeyMismatch)
+}
+
+func unsupportedBaselineSnapshotSchemaError(version string) error {
+	return fmt.Errorf("unsupported dashboard baseline schema version: %s", version)
 }
 
 func normalizeSnapshotReport(rep Report) Report {

--- a/internal/dashboard/baseline.go
+++ b/internal/dashboard/baseline.go
@@ -253,14 +253,8 @@ func unsupportedBaselineSnapshotSchemaError(version string) error {
 
 func normalizeSnapshotReport(rep Report) Report {
 	normalized := rep
-	normalized.Repos = append([]RepoResult(nil), rep.Repos...)
+	normalized.Repos = baselineutil.SortedCopyByStrings(rep.Repos, func(repo RepoResult) string { return repo.Name }, func(repo RepoResult) string { return repo.Path })
 	normalized.RemediationItems = dedupeAndSortRemediationItems(rep.RemediationItems)
-	sort.Slice(normalized.Repos, func(i, j int) bool {
-		if normalized.Repos[i].Name != normalized.Repos[j].Name {
-			return normalized.Repos[i].Name < normalized.Repos[j].Name
-		}
-		return normalized.Repos[i].Path < normalized.Repos[j].Path
-	})
 	if normalized.Summary == (Summary{}) {
 		normalized.Summary = computeSummary(normalized)
 	}

--- a/internal/dashboard/baseline_loading_comparison_test.go
+++ b/internal/dashboard/baseline_loading_comparison_test.go
@@ -1,9 +1,11 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -69,6 +71,72 @@ func TestDashboardBaselineLoadLegacyRemoteFieldsEmpty(t *testing.T) {
 	if legacy.Repos[0].RepoURL != "" || legacy.Repos[0].Revision != nil || legacy.Repos[0].ResolvedCommit != "" {
 		t.Fatalf("expected legacy baseline remote metadata fields to remain empty, got %#v", legacy.Repos[0])
 	}
+}
+
+func assertDashboardLoadPreservesReport(t *testing.T, payload any, want Report, wantKey string) {
+	t.Helper()
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal dashboard baseline: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write dashboard baseline: %v", err)
+	}
+	got, key, err := LoadWithKey(path)
+	if err != nil {
+		t.Fatalf("LoadWithKey() error = %v", err)
+	}
+	if key != wantKey {
+		t.Fatalf("LoadWithKey() key = %q, want %q", key, wantKey)
+	}
+	if !got.GeneratedAt.Equal(want.GeneratedAt) || !reflect.DeepEqual(got.Repos, want.Repos) {
+		t.Fatalf("LoadWithKey() repos = %#v, want %#v", got.Repos, want.Repos)
+	}
+	if got.Summary != want.Summary {
+		t.Fatalf("LoadWithKey() summary = %#v, want %#v", got.Summary, want.Summary)
+	}
+	if !reflect.DeepEqual(got.RemediationItems, want.RemediationItems) {
+		t.Fatalf("LoadWithKey() remediation items = %#v, want %#v", got.RemediationItems, want.RemediationItems)
+	}
+	if !reflect.DeepEqual(got.SourceWarnings, want.SourceWarnings) {
+		t.Fatalf("LoadWithKey() warnings = %#v, want %#v", got.SourceWarnings, want.SourceWarnings)
+	}
+}
+
+func TestDashboardLoadWithKeyPreservesReportData(t *testing.T) {
+	t.Parallel()
+
+	want := Report{
+		GeneratedAt: time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC),
+		Repos: []RepoResult{
+			{Name: "zeta", Path: "./zeta", DependencyCount: 2},
+			{Name: "alpha", Path: "./alpha", DependencyCount: 1},
+		},
+		Summary: Summary{TotalRepos: 99, TotalDeps: 77},
+		RemediationItems: []RemediationItem{
+			{ID: " duplicate ", Repo: " zeta ", Category: " risk ", Priority: " LOW ", Evidence: []string{" first ", "first"}},
+			{ID: "duplicate", Repo: "alpha", Category: "risk", Priority: " High ", Evidence: []string{"second"}},
+		},
+		SourceWarnings: []string{" first ", "first"},
+	}
+
+	t.Run("envelope", func(t *testing.T) {
+		t.Parallel()
+		snapshot := BaselineSnapshot{
+			BaselineSchemaVersion: BaselineSnapshotSchemaVersion,
+			Key:                   " label:preserved ",
+			SavedAt:               time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC),
+			Report:                want,
+		}
+		assertDashboardLoadPreservesReport(t, snapshot, want, "label:preserved")
+	})
+
+	t.Run("legacy", func(t *testing.T) {
+		t.Parallel()
+		assertDashboardLoadPreservesReport(t, want, want, "")
+	})
 }
 
 func TestDashboardLoadWithKeyPreservesOversizedExplicitBaselineCompatibility(t *testing.T) {
@@ -251,7 +319,7 @@ func TestDashboardBaselineComparisonBranches(t *testing.T) {
 	}
 }
 
-func TestDashboardBaselineSnapshotSortsSameNameByPath(t *testing.T) {
+func TestDashboardSaveSnapshotCanonicalizesReport(t *testing.T) {
 	t.Parallel()
 
 	reportData := Report{
@@ -259,17 +327,42 @@ func TestDashboardBaselineSnapshotSortsSameNameByPath(t *testing.T) {
 			{Name: "api", Path: "./z"},
 			{Name: "api", Path: "./a"},
 		},
+		RemediationItems: []RemediationItem{
+			{ID: " duplicate ", Repo: " api ", Category: " risk ", Priority: " low ", Evidence: []string{" first ", "shared"}},
+			{ID: "alpha", Repo: " web ", Category: " risk ", Priority: " CRITICAL "},
+			{ID: "duplicate", Repo: "api", Category: "risk", Priority: " HIGH ", Evidence: []string{"shared", "second"}},
+		},
 	}
 	path, err := SaveSnapshot(t.TempDir(), "label:sorted", reportData, time.Date(2026, time.March, 11, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("SaveSnapshot() error = %v", err)
 	}
-	loaded, _, err := LoadWithKey(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("LoadWithKey() error = %v", err)
+		t.Fatalf("read dashboard snapshot: %v", err)
 	}
-	if len(loaded.Repos) != 2 || loaded.Repos[0].Path != "./a" || loaded.Repos[1].Path != "./z" {
-		t.Fatalf("expected repos sorted by name then path, got %#v", loaded.Repos)
+	var snapshot BaselineSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		t.Fatalf("unmarshal dashboard snapshot: %v", err)
+	}
+	if len(snapshot.Report.Repos) != 2 || snapshot.Report.Repos[0].Path != "./a" || snapshot.Report.Repos[1].Path != "./z" {
+		t.Fatalf("expected repos sorted by name then path, got %#v", snapshot.Report.Repos)
+	}
+	if snapshot.Report.Summary.TotalRepos != 2 {
+		t.Fatalf("saved summary = %#v, want computed repo count", snapshot.Report.Summary)
+	}
+	if len(snapshot.Report.RemediationItems) != 2 {
+		t.Fatalf("saved remediation items = %#v, want deduplicated items", snapshot.Report.RemediationItems)
+	}
+	if snapshot.Report.RemediationItems[0].ID != "alpha" || snapshot.Report.RemediationItems[0].Priority != "critical" {
+		t.Fatalf("first saved remediation item = %#v, want canonical critical item", snapshot.Report.RemediationItems[0])
+	}
+	duplicate := snapshot.Report.RemediationItems[1]
+	if duplicate.ID != "duplicate" || duplicate.Repo != "api" || duplicate.Category != "risk" || duplicate.Priority != "high" {
+		t.Fatalf("second saved remediation item = %#v, want normalized duplicate", duplicate)
+	}
+	if !reflect.DeepEqual(duplicate.Evidence, []string{"first", "shared", "second"}) {
+		t.Fatalf("saved duplicate evidence = %#v, want compact merged evidence", duplicate.Evidence)
 	}
 }
 

--- a/internal/dashboard/baseline_loading_comparison_test.go
+++ b/internal/dashboard/baseline_loading_comparison_test.go
@@ -99,62 +99,66 @@ func TestDashboardBaselineLoadRejectsUnsupportedSchema(t *testing.T) {
 	}
 }
 
+type dashboardSchemaCompatibilityCase struct {
+	content   string
+	wantKey   string
+	wantRepos int
+	wantErr   string
+}
+
+func assertDashboardSchemaCompatibility(t *testing.T, tc dashboardSchemaCompatibilityCase) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "snapshot.json")
+	if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+		t.Fatalf("write dashboard snapshot: %v", err)
+	}
+
+	rep, key, err := LoadWithKey(path)
+	if tc.wantErr != "" {
+		if err == nil || err.Error() != tc.wantErr {
+			t.Fatalf("LoadWithKey() error = %v, want %q", err, tc.wantErr)
+		}
+		if len(rep.Repos) != 0 || rep.GeneratedAt != (time.Time{}) || key != "" {
+			t.Fatalf("LoadWithKey() error result = %#v, %q, want zero values", rep, key)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("LoadWithKey() error = %v", err)
+	}
+	if len(rep.Repos) != tc.wantRepos || key != tc.wantKey {
+		t.Fatalf("LoadWithKey() = repos=%d key=%q, want repos=%d key=%q", len(rep.Repos), key, tc.wantRepos, tc.wantKey)
+	}
+}
+
 func TestDashboardBaselineLoadSchemaVersionCompatibility(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name      string
-		content   string
-		wantKey   string
-		wantRepos int
-		wantErr   string
-	}{
-		{
-			name:      "exact version accepted",
+	t.Run("exact version accepted", func(t *testing.T) {
+		t.Parallel()
+		assertDashboardSchemaCompatibility(t, dashboardSchemaCompatibilityCase{
 			content:   `{"baselineSchemaVersion":"1.0.0","key":" label:exact ","savedAt":"2026-03-11T00:00:00Z","report":{"generated_at":"2026-03-10T00:00:00Z","repos":[{"name":"api","path":"./api","dependency_count":2}]}}`,
 			wantKey:   "label:exact",
 			wantRepos: 1,
-		},
-		{
-			name:    "padded version rejected with raw unsupported value",
+		})
+	})
+
+	t.Run("padded version rejected with raw unsupported value", func(t *testing.T) {
+		t.Parallel()
+		assertDashboardSchemaCompatibility(t, dashboardSchemaCompatibilityCase{
 			content: `{"baselineSchemaVersion":" 1.0.0 ","key":"label:padded","savedAt":"2026-03-11T00:00:00Z","report":{"generated_at":"2026-03-10T00:00:00Z","repos":[]}}`,
 			wantErr: "unsupported dashboard baseline schema version:  1.0.0 ",
-		},
-		{
-			name:      "whitespace version matches missing legacy behavior",
+		})
+	})
+
+	t.Run("whitespace version matches missing legacy behavior", func(t *testing.T) {
+		t.Parallel()
+		assertDashboardSchemaCompatibility(t, dashboardSchemaCompatibilityCase{
 			content:   `{"baselineSchemaVersion":"   ","generated_at":"2026-03-12T00:00:00Z","repos":[{"name":"api","path":"./api","dependency_count":3}]}`,
 			wantRepos: 1,
-		},
-	}
-
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			path := filepath.Join(t.TempDir(), "snapshot.json")
-			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
-				t.Fatalf("write dashboard snapshot: %v", err)
-			}
-
-			rep, key, err := LoadWithKey(path)
-			if tc.wantErr != "" {
-				if err == nil || err.Error() != tc.wantErr {
-					t.Fatalf("LoadWithKey() error = %v, want %q", err, tc.wantErr)
-				}
-				if len(rep.Repos) != 0 || rep.GeneratedAt != (time.Time{}) || key != "" {
-					t.Fatalf("LoadWithKey() error result = %#v, %q, want zero values", rep, key)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("LoadWithKey() error = %v", err)
-			}
-			if len(rep.Repos) != tc.wantRepos || key != tc.wantKey {
-				t.Fatalf("LoadWithKey() = repos=%d key=%q, want repos=%d key=%q", len(rep.Repos), key, tc.wantRepos, tc.wantKey)
-			}
 		})
-	}
+	})
 }
 
 func TestDashboardBaselineLoadReportsReadErrors(t *testing.T) {

--- a/internal/dashboard/baseline_loading_comparison_test.go
+++ b/internal/dashboard/baseline_loading_comparison_test.go
@@ -99,6 +99,64 @@ func TestDashboardBaselineLoadRejectsUnsupportedSchema(t *testing.T) {
 	}
 }
 
+func TestDashboardBaselineLoadSchemaVersionCompatibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		content   string
+		wantKey   string
+		wantRepos int
+		wantErr   string
+	}{
+		{
+			name:      "exact version accepted",
+			content:   `{"baselineSchemaVersion":"1.0.0","key":" label:exact ","savedAt":"2026-03-11T00:00:00Z","report":{"generated_at":"2026-03-10T00:00:00Z","repos":[{"name":"api","path":"./api","dependency_count":2}]}}`,
+			wantKey:   "label:exact",
+			wantRepos: 1,
+		},
+		{
+			name:    "padded version rejected with raw unsupported value",
+			content: `{"baselineSchemaVersion":" 1.0.0 ","key":"label:padded","savedAt":"2026-03-11T00:00:00Z","report":{"generated_at":"2026-03-10T00:00:00Z","repos":[]}}`,
+			wantErr: "unsupported dashboard baseline schema version:  1.0.0 ",
+		},
+		{
+			name:      "whitespace version matches missing legacy behavior",
+			content:   `{"baselineSchemaVersion":"   ","generated_at":"2026-03-12T00:00:00Z","repos":[{"name":"api","path":"./api","dependency_count":3}]}`,
+			wantRepos: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "snapshot.json")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("write dashboard snapshot: %v", err)
+			}
+
+			rep, key, err := LoadWithKey(path)
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("LoadWithKey() error = %v, want %q", err, tc.wantErr)
+				}
+				if len(rep.Repos) != 0 || rep.GeneratedAt != (time.Time{}) || key != "" {
+					t.Fatalf("LoadWithKey() error result = %#v, %q, want zero values", rep, key)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadWithKey() error = %v", err)
+			}
+			if len(rep.Repos) != tc.wantRepos || key != tc.wantKey {
+				t.Fatalf("LoadWithKey() = repos=%d key=%q, want repos=%d key=%q", len(rep.Repos), key, tc.wantRepos, tc.wantKey)
+			}
+		})
+	}
+}
+
 func TestDashboardBaselineLoadReportsReadErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/report/baseline_snapshot.go
+++ b/internal/report/baseline_snapshot.go
@@ -17,6 +17,13 @@ var ErrBaselineKeyMismatch = errors.New("baseline snapshot key does not match re
 
 type BaselineSnapshot = baselineutil.Snapshot[Report]
 
+var baselineSnapshots = baselineutil.SnapshotStore[Report]{
+	Normalize:         normalizeSnapshotReport,
+	UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
+	ValidateKey:       ValidateBaselineSnapshotKey,
+	ExistsErr:         ErrBaselineAlreadyExists,
+}
+
 func Load(path string) (Report, error) {
 	rep, _, err := LoadWithKey(path)
 	if err != nil {
@@ -26,21 +33,11 @@ func Load(path string) (Report, error) {
 }
 
 func LoadWithKey(path string) (Report, string, error) {
-	return baselineutil.LoadSnapshotFile(path, baselineutil.SnapshotDecodeOptions[Report]{
-		Normalize:         normalizeSnapshotReport,
-		UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
-	})
-}
-
-func decodeBaselineSnapshot(data []byte) (Report, string, error) {
-	return baselineutil.DecodeSnapshot(data, baselineutil.SnapshotDecodeOptions[Report]{
-		Normalize:         normalizeSnapshotReport,
-		UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
-	})
+	return baselineutil.LoadConfiguredSnapshot(path, baselineSnapshots)
 }
 
 func LoadSnapshot(dir, key string) (Report, string, string, error) {
-	return baselineutil.LoadStoreSnapshot(dir, key, baselineutil.MaxSnapshotBytes, decodeBaselineSnapshot, ValidateBaselineSnapshotKey)
+	return baselineutil.LoadConfiguredStoreSnapshot(dir, key, baselineutil.MaxSnapshotBytes, baselineSnapshots)
 }
 
 func ValidateBaselineSnapshotKey(requestedKey, storedKey string) error {
@@ -48,7 +45,7 @@ func ValidateBaselineSnapshotKey(requestedKey, storedKey string) error {
 }
 
 func SaveSnapshot(dir string, key string, rep Report, now time.Time) (string, error) {
-	return baselineutil.SaveSnapshot(dir, key, now, rep, ErrBaselineAlreadyExists, normalizeSnapshotReport)
+	return baselineutil.SaveConfiguredSnapshot(dir, key, now, rep, baselineSnapshots)
 }
 
 func BaselineSnapshotPath(dir, key string) string {
@@ -60,7 +57,7 @@ func ResolveBaselineSnapshotPath(dir, key string) string {
 }
 
 func newBaselineSnapshot(key string, rep Report, now time.Time) BaselineSnapshot {
-	return baselineutil.NewSnapshot(key, rep, now, normalizeSnapshotReport)
+	return baselineutil.NewConfiguredSnapshot(key, rep, now, baselineSnapshots)
 }
 
 func normalizeSnapshotReport(rep Report) Report {

--- a/internal/report/baseline_snapshot.go
+++ b/internal/report/baseline_snapshot.go
@@ -18,6 +18,7 @@ var ErrBaselineKeyMismatch = errors.New("baseline snapshot key does not match re
 type BaselineSnapshot = baselineutil.Snapshot[Report]
 
 var baselineSnapshots = baselineutil.SnapshotStore[Report]{
+	Repair:            repairSnapshotReport,
 	Normalize:         normalizeSnapshotReport,
 	UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
 	ValidateKey:       ValidateBaselineSnapshotKey,
@@ -63,16 +64,22 @@ func newBaselineSnapshot(key string, rep Report, now time.Time) BaselineSnapshot
 func normalizeSnapshotReport(rep Report) Report {
 	normalized := rep
 	normalized.Dependencies = baselineutil.SortedCopyByStrings(rep.Dependencies, func(dependency DependencyReport) string { return dependency.Language }, func(dependency DependencyReport) string { return dependency.Name })
-	if normalized.Summary == nil {
-		normalized.Summary = ComputeSummary(normalized.Dependencies)
-	}
-	if len(normalized.LanguageBreakdown) == 0 {
-		normalized.LanguageBreakdown = ComputeLanguageBreakdown(normalized.Dependencies)
-	}
+	normalized = repairSnapshotReport(normalized)
 	if strings.TrimSpace(normalized.SchemaVersion) == "" {
 		normalized.SchemaVersion = SchemaVersion
 	}
 	return normalized
+}
+
+func repairSnapshotReport(rep Report) Report {
+	repaired := rep
+	if repaired.Summary == nil {
+		repaired.Summary = ComputeSummary(repaired.Dependencies)
+	}
+	if len(repaired.LanguageBreakdown) == 0 {
+		repaired.LanguageBreakdown = ComputeLanguageBreakdown(repaired.Dependencies)
+	}
+	return repaired
 }
 
 func unsupportedBaselineSnapshotSchemaError(version string) error {

--- a/internal/report/baseline_snapshot.go
+++ b/internal/report/baseline_snapshot.go
@@ -3,7 +3,6 @@ package report
 import (
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -66,13 +65,7 @@ func newBaselineSnapshot(key string, rep Report, now time.Time) BaselineSnapshot
 
 func normalizeSnapshotReport(rep Report) Report {
 	normalized := rep
-	normalized.Dependencies = append([]DependencyReport(nil), rep.Dependencies...)
-	sort.Slice(normalized.Dependencies, func(i, j int) bool {
-		if normalized.Dependencies[i].Language != normalized.Dependencies[j].Language {
-			return normalized.Dependencies[i].Language < normalized.Dependencies[j].Language
-		}
-		return normalized.Dependencies[i].Name < normalized.Dependencies[j].Name
-	})
+	normalized.Dependencies = baselineutil.SortedCopyByStrings(rep.Dependencies, func(dependency DependencyReport) string { return dependency.Language }, func(dependency DependencyReport) string { return dependency.Name })
 	if normalized.Summary == nil {
 		normalized.Summary = ComputeSummary(normalized.Dependencies)
 	}

--- a/internal/report/baseline_snapshot.go
+++ b/internal/report/baseline_snapshot.go
@@ -1,30 +1,22 @@
 package report
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
 	baselineutil "github.com/ben-ranford/lopper/internal/baseline"
-	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
-const BaselineSnapshotSchemaVersion = "1.0.0"
+const BaselineSnapshotSchemaVersion = baselineutil.SnapshotSchemaVersion
 
 var ErrBaselineAlreadyExists = errors.New("baseline snapshot already exists")
 
 var ErrBaselineKeyMismatch = errors.New("baseline snapshot key does not match requested key")
 
-type BaselineSnapshot struct {
-	BaselineSchemaVersion string    `json:"baselineSchemaVersion"`
-	Key                   string    `json:"key"`
-	SavedAt               time.Time `json:"savedAt"`
-	Report                Report    `json:"report"`
-}
+type BaselineSnapshot = baselineutil.Snapshot[Report]
 
 func Load(path string) (Report, error) {
 	rep, _, err := LoadWithKey(path)
@@ -35,71 +27,29 @@ func Load(path string) (Report, error) {
 }
 
 func LoadWithKey(path string) (Report, string, error) {
-	data, err := safeio.ReadFile(path)
-	if err != nil {
-		return Report{}, "", err
-	}
-	return decodeBaselineSnapshot(data)
+	return baselineutil.LoadSnapshotFile(path, baselineutil.SnapshotDecodeOptions[Report]{
+		Normalize:         normalizeSnapshotReport,
+		UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
+	})
 }
 
 func decodeBaselineSnapshot(data []byte) (Report, string, error) {
-	var snapshot BaselineSnapshot
-	if err := json.Unmarshal(data, &snapshot); err == nil && strings.TrimSpace(snapshot.BaselineSchemaVersion) != "" {
-		if snapshot.BaselineSchemaVersion != BaselineSnapshotSchemaVersion {
-			return Report{}, "", fmt.Errorf("unsupported baseline schema version: %s", snapshot.BaselineSchemaVersion)
-		}
-		if snapshot.Report.Summary == nil {
-			snapshot.Report.Summary = ComputeSummary(snapshot.Report.Dependencies)
-		}
-		if len(snapshot.Report.LanguageBreakdown) == 0 {
-			snapshot.Report.LanguageBreakdown = ComputeLanguageBreakdown(snapshot.Report.Dependencies)
-		}
-		return snapshot.Report, strings.TrimSpace(snapshot.Key), nil
-	}
-
-	var rep Report
-	if err := json.Unmarshal(data, &rep); err != nil {
-		return Report{}, "", err
-	}
-	if rep.Summary == nil {
-		rep.Summary = ComputeSummary(rep.Dependencies)
-	}
-	if len(rep.LanguageBreakdown) == 0 {
-		rep.LanguageBreakdown = ComputeLanguageBreakdown(rep.Dependencies)
-	}
-	return rep, "", nil
+	return baselineutil.DecodeSnapshot(data, baselineutil.SnapshotDecodeOptions[Report]{
+		Normalize:         normalizeSnapshotReport,
+		UnsupportedSchema: unsupportedBaselineSnapshotSchemaError,
+	})
 }
 
 func LoadSnapshot(dir, key string) (Report, string, string, error) {
-	trimmedKey := strings.TrimSpace(key)
-	path := ResolveBaselineSnapshotPath(dir, trimmedKey)
-	data, err := baselineutil.ReadStoreEntry(dir, filepath.Base(path), baselineutil.MaxSnapshotBytes)
-	if err != nil {
-		return Report{}, "", path, err
-	}
-	rep, loadedKey, err := decodeBaselineSnapshot(data)
-	if err != nil {
-		return Report{}, "", path, err
-	}
-	if err := ValidateBaselineSnapshotKey(trimmedKey, loadedKey); err != nil {
-		return Report{}, loadedKey, path, err
-	}
-	return rep, loadedKey, path, nil
+	return baselineutil.LoadStoreSnapshot(dir, key, baselineutil.MaxSnapshotBytes, decodeBaselineSnapshot, ValidateBaselineSnapshotKey)
 }
 
 func ValidateBaselineSnapshotKey(requestedKey, storedKey string) error {
-	requestedKey = strings.TrimSpace(requestedKey)
-	storedKey = strings.TrimSpace(storedKey)
-	if requestedKey == storedKey && requestedKey != "" {
-		return nil
-	}
-	return fmt.Errorf("%w: requested %q, stored %q", ErrBaselineKeyMismatch, requestedKey, storedKey)
+	return baselineutil.ValidateSnapshotKey(requestedKey, storedKey, ErrBaselineKeyMismatch)
 }
 
 func SaveSnapshot(dir string, key string, rep Report, now time.Time) (string, error) {
-	return baselineutil.SaveJSON(dir, key, ErrBaselineAlreadyExists, func(trimmedKey string) BaselineSnapshot {
-		return newBaselineSnapshot(trimmedKey, rep, now)
-	})
+	return baselineutil.SaveSnapshot(dir, key, now, rep, ErrBaselineAlreadyExists, normalizeSnapshotReport)
 }
 
 func BaselineSnapshotPath(dir, key string) string {
@@ -111,12 +61,7 @@ func ResolveBaselineSnapshotPath(dir, key string) string {
 }
 
 func newBaselineSnapshot(key string, rep Report, now time.Time) BaselineSnapshot {
-	return BaselineSnapshot{
-		BaselineSchemaVersion: BaselineSnapshotSchemaVersion,
-		Key:                   key,
-		SavedAt:               now.UTC(),
-		Report:                normalizeSnapshotReport(rep),
-	}
+	return baselineutil.NewSnapshot(key, rep, now, normalizeSnapshotReport)
 }
 
 func normalizeSnapshotReport(rep Report) Report {
@@ -138,4 +83,8 @@ func normalizeSnapshotReport(rep Report) Report {
 		normalized.SchemaVersion = SchemaVersion
 	}
 	return normalized
+}
+
+func unsupportedBaselineSnapshotSchemaError(version string) error {
+	return fmt.Errorf("unsupported baseline schema version: %s", version)
 }

--- a/internal/report/baseline_snapshot_test.go
+++ b/internal/report/baseline_snapshot_test.go
@@ -152,16 +152,44 @@ func TestLoadWithKeyUnsupportedSnapshotSchema(t *testing.T) {
 	}
 }
 
+type loadWithKeyCompatibilityCase struct {
+	name     string
+	content  string
+	wantKey  string
+	wantRepo string
+	wantErr  string
+}
+
+func assertLoadWithKeyCompatibility(t *testing.T, tc loadWithKeyCompatibilityCase) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "snapshot.json")
+	if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	rep, key, err := LoadWithKey(path)
+	if tc.wantErr != "" {
+		if err == nil || err.Error() != tc.wantErr {
+			t.Fatalf("LoadWithKey() error = %v, want %q", err, tc.wantErr)
+		}
+		if rep.RepoPath != "" || rep.SchemaVersion != "" || len(rep.Dependencies) != 0 || key != "" {
+			t.Fatalf("LoadWithKey() error result = %#v, %q, want zero values", rep, key)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("LoadWithKey() error = %v", err)
+	}
+	if rep.RepoPath != tc.wantRepo || key != tc.wantKey {
+		t.Fatalf("LoadWithKey() = repo=%q key=%q, want repo=%q key=%q", rep.RepoPath, key, tc.wantRepo, tc.wantKey)
+	}
+}
+
 func TestLoadWithKeySnapshotSchemaVersionCompatibility(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name     string
-		content  string
-		wantKey  string
-		wantRepo string
-		wantErr  string
-	}{
+	tests := []loadWithKeyCompatibilityCase{
 		{
 			name:     "exact version accepted",
 			content:  `{"baselineSchemaVersion":"1.0.0","key":" label:exact ","savedAt":"2026-01-01T00:00:00Z","report":{"schemaVersion":"0.1.0","generatedAt":"2026-01-01T00:00:00Z","repoPath":".","dependencies":[]}}` + "\n",
@@ -184,28 +212,7 @@ func TestLoadWithKeySnapshotSchemaVersionCompatibility(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			path := filepath.Join(t.TempDir(), "snapshot.json")
-			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
-				t.Fatalf("write snapshot: %v", err)
-			}
-
-			rep, key, err := LoadWithKey(path)
-			if tc.wantErr != "" {
-				if err == nil || err.Error() != tc.wantErr {
-					t.Fatalf("LoadWithKey() error = %v, want %q", err, tc.wantErr)
-				}
-				if rep.RepoPath != "" || rep.SchemaVersion != "" || len(rep.Dependencies) != 0 || key != "" {
-					t.Fatalf("LoadWithKey() error result = %#v, %q, want zero values", rep, key)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("LoadWithKey() error = %v", err)
-			}
-			if rep.RepoPath != tc.wantRepo || key != tc.wantKey {
-				t.Fatalf("LoadWithKey() = repo=%q key=%q, want repo=%q key=%q", rep.RepoPath, key, tc.wantRepo, tc.wantKey)
-			}
+			assertLoadWithKeyCompatibility(t, tc)
 		})
 	}
 }

--- a/internal/report/baseline_snapshot_test.go
+++ b/internal/report/baseline_snapshot_test.go
@@ -152,6 +152,64 @@ func TestLoadWithKeyUnsupportedSnapshotSchema(t *testing.T) {
 	}
 }
 
+func TestLoadWithKeySnapshotSchemaVersionCompatibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		wantKey  string
+		wantRepo string
+		wantErr  string
+	}{
+		{
+			name:     "exact version accepted",
+			content:  `{"baselineSchemaVersion":"1.0.0","key":" label:exact ","savedAt":"2026-01-01T00:00:00Z","report":{"schemaVersion":"0.1.0","generatedAt":"2026-01-01T00:00:00Z","repoPath":".","dependencies":[]}}` + "\n",
+			wantKey:  "label:exact",
+			wantRepo: ".",
+		},
+		{
+			name:    "padded version rejected with raw unsupported value",
+			content: `{"baselineSchemaVersion":" 1.0.0 ","key":"label:padded","savedAt":"2026-01-01T00:00:00Z","report":{"schemaVersion":"0.1.0","generatedAt":"2026-01-01T00:00:00Z","repoPath":".","dependencies":[]}}` + "\n",
+			wantErr: "unsupported baseline schema version:  1.0.0 ",
+		},
+		{
+			name:     "whitespace version matches missing legacy behavior",
+			content:  `{"baselineSchemaVersion":"   ","schemaVersion":"0.1.0","generatedAt":"2026-01-01T00:00:00Z","repoPath":"legacy","dependencies":[]}` + "\n",
+			wantRepo: "legacy",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "snapshot.json")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("write snapshot: %v", err)
+			}
+
+			rep, key, err := LoadWithKey(path)
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("LoadWithKey() error = %v, want %q", err, tc.wantErr)
+				}
+				if rep.RepoPath != "" || rep.SchemaVersion != "" || len(rep.Dependencies) != 0 || key != "" {
+					t.Fatalf("LoadWithKey() error result = %#v, %q, want zero values", rep, key)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadWithKey() error = %v", err)
+			}
+			if rep.RepoPath != tc.wantRepo || key != tc.wantKey {
+				t.Fatalf("LoadWithKey() = repo=%q key=%q, want repo=%q key=%q", rep.RepoPath, key, tc.wantRepo, tc.wantKey)
+			}
+		})
+	}
+}
+
 func TestSaveSnapshotValidationErrors(t *testing.T) {
 	now := time.Date(2026, time.February, 22, 10, 0, 0, 0, time.UTC)
 	if _, err := SaveSnapshot("", testLabelX, Report{}, now); err == nil || !strings.Contains(err.Error(), "baseline store directory is required") {

--- a/internal/report/baseline_snapshot_test.go
+++ b/internal/report/baseline_snapshot_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"encoding/json"
 	"math"
 	"os"
 	"path/filepath"
@@ -291,31 +292,44 @@ func TestSaveSnapshotRejectsSymlinkedStoreDir(t *testing.T) {
 	}
 }
 
-func TestSaveSnapshotSortsDependenciesDeterministically(t *testing.T) {
+func TestSaveSnapshotCanonicalizesReport(t *testing.T) {
 	now := time.Date(2026, time.February, 22, 10, 0, 0, 0, time.UTC)
 	reportData := Report{
 		Dependencies: []DependencyReport{
-			{Name: "zeta", Language: "python"},
-			{Name: "alpha", Language: "go"},
-			{Name: "beta", Language: "go"},
+			{Name: "zeta", Language: "python", TotalExportsCount: 1},
+			{Name: "alpha", Language: "go", TotalExportsCount: 1},
+			{Name: "beta", Language: "go", TotalExportsCount: 1},
 		},
 	}
 	path, err := SaveSnapshot(t.TempDir(), "label:sorted", reportData, now)
 	if err != nil {
 		t.Fatalf("save snapshot: %v", err)
 	}
-	rep, _, err := LoadWithKey(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("load snapshot: %v", err)
+		t.Fatalf("read snapshot: %v", err)
+	}
+	var snapshot BaselineSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
 	}
 	gotOrder := []string{
-		rep.Dependencies[0].Language + "/" + rep.Dependencies[0].Name,
-		rep.Dependencies[1].Language + "/" + rep.Dependencies[1].Name,
-		rep.Dependencies[2].Language + "/" + rep.Dependencies[2].Name,
+		snapshot.Report.Dependencies[0].Language + "/" + snapshot.Report.Dependencies[0].Name,
+		snapshot.Report.Dependencies[1].Language + "/" + snapshot.Report.Dependencies[1].Name,
+		snapshot.Report.Dependencies[2].Language + "/" + snapshot.Report.Dependencies[2].Name,
 	}
 	wantOrder := []string{"go/alpha", "go/beta", "python/zeta"}
 	if !slices.Equal(gotOrder, wantOrder) {
 		t.Fatalf("unexpected dependency order: got=%v want=%v", gotOrder, wantOrder)
+	}
+	if snapshot.Report.SchemaVersion != SchemaVersion {
+		t.Fatalf("saved schema version = %q, want %q", snapshot.Report.SchemaVersion, SchemaVersion)
+	}
+	if snapshot.Report.Summary == nil || snapshot.Report.Summary.DependencyCount != 3 {
+		t.Fatalf("saved summary = %#v, want computed dependency count", snapshot.Report.Summary)
+	}
+	if len(snapshot.Report.LanguageBreakdown) != 2 || snapshot.Report.LanguageBreakdown[0].Language != "go" || snapshot.Report.LanguageBreakdown[1].Language != "python" {
+		t.Fatalf("saved language breakdown = %#v, want canonical languages", snapshot.Report.LanguageBreakdown)
 	}
 }
 
@@ -339,5 +353,74 @@ func TestLoadWithKeySnapshotComputesMissingFields(t *testing.T) {
 	}
 	if len(rep.LanguageBreakdown) != 1 || rep.LanguageBreakdown[0].Language != "js-ts" {
 		t.Fatalf("expected computed language breakdown, got %#v", rep.LanguageBreakdown)
+	}
+}
+
+func assertLoadWithKeyPreservesReportData(t *testing.T, content, wantKey string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write baseline: %v", err)
+	}
+	rep, key, err := LoadWithKey(path)
+	if err != nil {
+		t.Fatalf("LoadWithKey() error = %v", err)
+	}
+	if key != wantKey {
+		t.Fatalf("LoadWithKey() key = %q, want %q", key, wantKey)
+	}
+	if len(rep.Dependencies) != 3 {
+		t.Fatalf("LoadWithKey() dependencies = %#v, want three supplied values", rep.Dependencies)
+	}
+	gotDependencies := []string{
+		rep.Dependencies[0].Language + "/" + rep.Dependencies[0].Name,
+		rep.Dependencies[1].Language + "/" + rep.Dependencies[1].Name,
+		rep.Dependencies[2].Language + "/" + rep.Dependencies[2].Name,
+	}
+	wantDependencies := []string{"python/zeta", "go/alpha", "go/alpha"}
+	if !slices.Equal(gotDependencies, wantDependencies) {
+		t.Fatalf("LoadWithKey() dependencies = %v, want %v", gotDependencies, wantDependencies)
+	}
+	if rep.SchemaVersion != "" {
+		t.Fatalf("LoadWithKey() schema version = %q, want preserved empty value", rep.SchemaVersion)
+	}
+	if rep.Summary == nil || rep.Summary.DependencyCount != 99 {
+		t.Fatalf("LoadWithKey() summary = %#v, want supplied summary", rep.Summary)
+	}
+	if len(rep.LanguageBreakdown) != 1 || rep.LanguageBreakdown[0].Language != "preserved" || rep.LanguageBreakdown[0].DependencyCount != 77 {
+		t.Fatalf("LoadWithKey() language breakdown = %#v, want supplied value", rep.LanguageBreakdown)
+	}
+	if !slices.Equal(rep.Warnings, []string{" first ", "first"}) {
+		t.Fatalf("LoadWithKey() warnings = %q, want supplied values", rep.Warnings)
+	}
+}
+
+func TestLoadWithKeyPreservesReportData(t *testing.T) {
+	t.Parallel()
+
+	const reportJSON = `{"generatedAt":"2026-01-01T00:00:00Z","repoPath":"preserved","dependencies":[{"language":"python","name":"zeta"},{"language":"go","name":"alpha"},{"language":"go","name":"alpha"}],"summary":{"dependencyCount":99},"languageBreakdown":[{"language":"preserved","dependencyCount":77}],"warnings":[" first ","first"]}`
+	tests := []struct {
+		name    string
+		content string
+		wantKey string
+	}{
+		{
+			name:    "envelope",
+			content: `{"baselineSchemaVersion":"1.0.0","key":" label:preserved ","savedAt":"2026-01-02T00:00:00Z","report":` + reportJSON + `}`,
+			wantKey: "label:preserved",
+		},
+		{
+			name:    "legacy",
+			content: reportJSON,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assertLoadWithKeyPreservesReportData(t, tc.content, tc.wantKey)
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Centralize report and dashboard baseline snapshots behind one typed envelope and validation path while preserving their existing normalization and compatibility behavior.

Closes #1347

## Changes

- Add a generic snapshot envelope with shared schema-version and cache-key validation.
- Route report and dashboard snapshot persistence through the shared baseline package.
- Preserve legacy snapshot fallback, consumer-specific normalization, and deterministic ordering.
- Add direct shared-contract coverage for success and failure paths.

## Validation

Commands and checks run:

```bash
make ci
go test ./internal/baseline ./internal/report ./internal/dashboard
git diff --check origin/main...HEAD
```

The pre-commit hook passed the complete repository CI gate. After rebasing onto the latest `origin/main`, the affected package tests and diff check passed again.

## Risk and compatibility

- Breaking changes: none; legacy snapshots remain readable.
- Migration required: none.
- Performance impact: no material change; shared logic replaces duplicate implementations.
- Memory benchmark impact: repository memory benchmark gate passed with no regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
