### PR TITLE
fix(runtime): redact runtime path context to repo-relative values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ vuln-check:
 	$(GO_CMD) run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
 test:
-	node --test scripts/runtime/context-helper_test.mjs scripts/runtime/hooks_test.mjs
+	node --test scripts/runtime/context-helper_test.mjs scripts/runtime/hooks_test.mjs scripts/runtime/test-link-helpers_test.mjs
 	PYTHONDONTWRITEBYTECODE=1 python3 scripts/runtime/sitecustomize_test.py
 	@pkgs=$$(GOFLAGS=-buildvcs=false $(GO_CMD) list ./... | grep -Ev '/internal/app$$'); \
 		$(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) $$pkgs

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,8 @@ vuln-check:
 	$(GO_CMD) run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
 test:
+	node --test scripts/runtime/context-helper_test.mjs scripts/runtime/hooks_test.mjs
+	PYTHONDONTWRITEBYTECODE=1 python3 scripts/runtime/sitecustomize_test.py
 	@pkgs=$$(GOFLAGS=-buildvcs=false $(GO_CMD) list ./... | grep -Ev '/internal/app$$'); \
 		$(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) $$pkgs
 	@$(MAKE) test-lockfiledrift-head

--- a/README.md
+++ b/README.md
@@ -341,12 +341,14 @@ Capture a runtime trace:
 
 ```bash
 export LOPPER_RUNTIME_TRACE=.artifacts/lopper-runtime.ndjson
+export LOPPER_RUNTIME_REPO_ROOT="$(pwd)"
 export LOPPER_ROOT=/path/to/lopper
 export NODE_OPTIONS="--require ${LOPPER_ROOT}/scripts/runtime/require-hook.cjs --loader ${LOPPER_ROOT}/scripts/runtime/loader.mjs"
 npm test
 ```
 
 Use the hook files from the lopper checkout or install tree. Relative hook paths resolve from the repo running `npm test`, not from lopper itself.
+Manual hook setup must also export `LOPPER_RUNTIME_REPO_ROOT` to the intended capture root. Without it, JS/TS hooks fail closed and redact repo-local path context instead of guessing from the current working directory, which avoids ambiguous nested-workspace traces.
 
 Or let Lopper run the test command and capture the trace automatically:
 

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -125,7 +125,7 @@ func finalizeReport(req Request, repoPath string, identityRepoPath string, analy
 	var err error
 	pythonRuntimeTraceEnabled := req.Features.Enabled(pythonRuntimeTraceFeature) ||
 		(req.PythonRuntimeTraceCaptured && req.Features.Enabled(pythonRuntimeCaptureFeature))
-	reportData, err = annotateRuntimeTraceIfPresent(req.RuntimeTracePath, req.Language, reportData, pythonRuntimeTraceEnabled)
+	reportData, err = annotateRuntimeTraceIfPresent(req.RuntimeTracePath, repoPath, req.Language, reportData, pythonRuntimeTraceEnabled)
 	if err != nil {
 		return report.Report{}, err
 	}
@@ -328,7 +328,7 @@ func remapAnalyzedRoots(roots []string, fromRepoPath, toRepoPath string) []strin
 	return uniqueSorted(remapped)
 }
 
-func annotateRuntimeTraceIfPresent(runtimeTracePath string, languageID string, reportData report.Report, pythonRuntimeTraceEnabled bool) (report.Report, error) {
+func annotateRuntimeTraceIfPresent(runtimeTracePath string, repoPath string, languageID string, reportData report.Report, pythonRuntimeTraceEnabled bool) (report.Report, error) {
 	if runtimeTracePath == "" {
 		return reportData, nil
 	}
@@ -336,7 +336,7 @@ func annotateRuntimeTraceIfPresent(runtimeTracePath string, languageID string, r
 	if len(supportedLanguages) == 0 {
 		return reportData, nil
 	}
-	traceData, err := runtime.Load(runtimeTracePath)
+	traceData, err := runtime.LoadForRepo(runtimeTracePath, repoPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			reportData.Warnings = append(reportData.Warnings, "runtime trace file not found; continuing with static analysis")

--- a/internal/analysis/pipeline_test.go
+++ b/internal/analysis/pipeline_test.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -255,6 +256,83 @@ func TestAnnotateRuntimeTraceRedactsEmbeddedRelativeTraversal(t *testing.T) {
 	if len(usage.Entrypoints) != 1 || usage.Entrypoints[0].Module != "src/main.js" {
 		t.Fatalf("expected repo-relative entrypoint to be preserved, got %#v", usage.Entrypoints)
 	}
+}
+
+func TestAnnotateRuntimeTraceRedactsNonHostAbsoluteContext(t *testing.T) {
+	repo := t.TempDir()
+	tracePath := filepath.Join(t.TempDir(), "trace.ndjson")
+	mainPath := filepath.Join(repo, "src", "main.js")
+	spacePath := filepath.Join(repo, "src", "hello world.js")
+	if err := os.MkdirAll(filepath.Dir(mainPath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	for _, path := range []string{mainPath, spacePath} {
+		if err := os.WriteFile(path, []byte("console.log('x')\n"), 0o600); err != nil {
+			t.Fatalf("write repo file: %v", err)
+		}
+	}
+	mainURL := fileURLForAnalysisTest(mainPath, "")
+	localhostSpaceURL := fileURLForAnalysisTest(spacePath, "localhost")
+	repoURL := fileURLForAnalysisTest(repo, "")
+	content := `{"module":"lodash/map","parent":"C:\\Users\\alice\\project\\main.js","entrypoint":"` + mainURL + `"}` + "\n" +
+		`{"module":"lodash/map","parent":"` + localhostSpaceURL + `","entrypoint":"\\\\server\\share\\project\\main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"src/main.js","entrypoint":"//server/share/project/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"src/main.js","entrypoint":"\\/server/share/project/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"src/main.js","entrypoint":"/\\server/share/project/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"file://localhost/C:/Users/alice/project/main.js","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"src/main.js","entrypoint":"file://server/share/project/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"` + strings.TrimSuffix(repoURL, "/") + `/src/bad%ZZ.js","entrypoint":"file://localhost/%43%3A%2FUsers/alice/project/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"` + strings.TrimSuffix(repoURL, "/") + `/src%2F..%2F..%2FUsers/alice/main.js","entrypoint":"file://localhost/%2F%2Fserver/share/project/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"x:private-token","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"a:foo/bar.js","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"C:Users/alice/private.js","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"data:text/plain,secret","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"mailto:test@example.com","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"https:foo","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"https:/foo","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"lodash/map","parent":"node:internal/modules/cjs/loader","entrypoint":"lodash/map"}` + "\n"
+	if err := os.WriteFile(tracePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write trace: %v", err)
+	}
+
+	annotated, err := annotateRuntimeTraceIfPresent(tracePath, repo, "js-ts", report.Report{}, false)
+	if err != nil {
+		t.Fatalf("annotate runtime trace: %v", err)
+	}
+	if len(annotated.Dependencies) != 1 || annotated.Dependencies[0].RuntimeUsage == nil {
+		t.Fatalf("expected runtime-only dependency row, got %#v", annotated.Dependencies)
+	}
+	usage := annotated.Dependencies[0].RuntimeUsage
+	if !runtimeUsageHasExactModules(usage.ParentModules, "node:internal/modules/cjs/loader", "src/hello world.js", "src/main.js") {
+		t.Fatalf("expected only local parent contexts, got %#v", usage.ParentModules)
+	}
+	if !runtimeUsageHasExactModules(usage.Entrypoints, "lodash/map", "src/main.js") {
+		t.Fatalf("expected only local entrypoint contexts, got %#v", usage.Entrypoints)
+	}
+}
+
+func fileURLForAnalysisTest(pathValue, host string) string {
+	pathValue = filepath.ToSlash(pathValue)
+	if !strings.HasPrefix(pathValue, "/") {
+		pathValue = "/" + pathValue
+	}
+	return (&url.URL{Scheme: "file", Host: host, Path: pathValue}).String()
+}
+
+func runtimeUsageHasExactModules(got []report.RuntimeModuleUsage, want ...string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	modules := make(map[string]struct{}, len(got))
+	for _, item := range got {
+		modules[item.Module] = struct{}{}
+	}
+	for _, module := range want {
+		if _, ok := modules[module]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func oversizedRuntimeTraceContentForAnalysisTest() string {

--- a/internal/analysis/pipeline_test.go
+++ b/internal/analysis/pipeline_test.go
@@ -314,6 +314,41 @@ func TestAnnotateRuntimeTraceRedactsNonHostAbsoluteContext(t *testing.T) {
 	}
 }
 
+func TestAnnotateRuntimeTraceSkipsUnsafeNodeModulesHybridResolvedPaths(t *testing.T) {
+	repo := t.TempDir()
+	tracePath := filepath.Join(t.TempDir(), "trace.ndjson")
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "src", "main.js"), []byte("console.log('x')\n"), 0o600); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+	content :=
+		`{"resolved":"node_modules/fixture-dep/index.js","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"resolved":"node_modules/fixture-dep/C:/Users/alice/private.mjs","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"resolved":"node_modules/fixture-dep/https:/secret.mjs","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"resolved":"node_modules/fixture-dep/.env/private.mjs","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"resolved":"node_modules/fixture-dep/~/.ssh/id_rsa","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n"
+	if err := os.WriteFile(tracePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write trace: %v", err)
+	}
+
+	annotated, err := annotateRuntimeTraceIfPresent(tracePath, repo, "js-ts", report.Report{}, false)
+	if err != nil {
+		t.Fatalf("annotate runtime trace: %v", err)
+	}
+	if len(annotated.Dependencies) != 1 || annotated.Dependencies[0].RuntimeUsage == nil {
+		t.Fatalf("expected runtime-only dependency row, got %#v", annotated.Dependencies)
+	}
+	usage := annotated.Dependencies[0].RuntimeUsage
+	if !runtimeUsageHasExactModules(usage.Modules, "fixture-dep/index.js") {
+		t.Fatalf("expected only safe runtime module in report usage, got %#v", usage.Modules)
+	}
+	if len(usage.TopSymbols) != 1 || usage.TopSymbols[0].Module != "fixture-dep/index.js" || usage.TopSymbols[0].Symbol != "index" {
+		t.Fatalf("expected only safe runtime symbol in report usage, got %#v", usage.TopSymbols)
+	}
+}
+
 type analysisRuntimeTraceFixtureRow struct {
 	parent     string
 	entrypoint string

--- a/internal/analysis/pipeline_test.go
+++ b/internal/analysis/pipeline_test.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"encoding/json"
 	"errors"
 	"net/url"
 	"os"
@@ -274,23 +275,25 @@ func TestAnnotateRuntimeTraceRedactsNonHostAbsoluteContext(t *testing.T) {
 	mainURL := fileURLForAnalysisTest(mainPath, "")
 	localhostSpaceURL := fileURLForAnalysisTest(spacePath, "localhost")
 	repoURL := fileURLForAnalysisTest(repo, "")
-	content := `{"module":"lodash/map","parent":"C:\\Users\\alice\\project\\main.js","entrypoint":"` + mainURL + `"}` + "\n" +
-		`{"module":"lodash/map","parent":"` + localhostSpaceURL + `","entrypoint":"\\\\server\\share\\project\\main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"src/main.js","entrypoint":"//server/share/project/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"src/main.js","entrypoint":"\\/server/share/project/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"src/main.js","entrypoint":"/\\server/share/project/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"file://localhost/C:/Users/alice/project/main.js","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"src/main.js","entrypoint":"file://server/share/project/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"` + strings.TrimSuffix(repoURL, "/") + `/src/bad%ZZ.js","entrypoint":"file://localhost/%43%3A%2FUsers/alice/project/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"` + strings.TrimSuffix(repoURL, "/") + `/src%2F..%2F..%2FUsers/alice/main.js","entrypoint":"file://localhost/%2F%2Fserver/share/project/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"x:private-token","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"a:foo/bar.js","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"C:Users/alice/private.js","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"data:text/plain,secret","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"mailto:test@example.com","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"https:foo","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"https:/foo","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"lodash/map","parent":"node:internal/modules/cjs/loader","entrypoint":"lodash/map"}` + "\n"
+	content := analysisRuntimeTraceFixtureContent(t, []analysisRuntimeTraceFixtureRow{
+		{parent: "C:\\Users\\alice\\project\\main.js", entrypoint: mainURL},
+		{parent: localhostSpaceURL, entrypoint: `\\server\share\project\main.js`},
+		{parent: "src/main.js", entrypoint: "//server/share/project/main.js"},
+		{parent: "src/main.js", entrypoint: `\/server/share/project/main.js`},
+		{parent: "src/main.js", entrypoint: `/\server/share/project/main.js`},
+		{parent: "file://localhost/C:/Users/alice/project/main.js", entrypoint: "src/main.js"},
+		{parent: "src/main.js", entrypoint: "file://server/share/project/main.js"},
+		{parent: strings.TrimSuffix(repoURL, "/") + "/src/bad%ZZ.js", entrypoint: "file://localhost/%43%3A%2FUsers/alice/project/main.js"},
+		{parent: strings.TrimSuffix(repoURL, "/") + "/src%2F..%2F..%2FUsers/alice/main.js", entrypoint: "file://localhost/%2F%2Fserver/share/project/main.js"},
+		{parent: "x:private-token", entrypoint: "src/main.js"},
+		{parent: "a:foo/bar.js", entrypoint: "src/main.js"},
+		{parent: "C:Users/alice/private.js", entrypoint: "src/main.js"},
+		{parent: "data:text/plain,secret", entrypoint: "src/main.js"},
+		{parent: "mailto:test@example.com", entrypoint: "src/main.js"},
+		{parent: "https:foo", entrypoint: "src/main.js"},
+		{parent: "https:/foo", entrypoint: "src/main.js"},
+		{parent: "node:internal/modules/cjs/loader", entrypoint: "lodash/map"},
+	})
 	if err := os.WriteFile(tracePath, []byte(content), 0o600); err != nil {
 		t.Fatalf("write trace: %v", err)
 	}
@@ -311,12 +314,41 @@ func TestAnnotateRuntimeTraceRedactsNonHostAbsoluteContext(t *testing.T) {
 	}
 }
 
-func fileURLForAnalysisTest(pathValue, host string) string {
-	pathValue = filepath.ToSlash(pathValue)
-	if !strings.HasPrefix(pathValue, "/") {
-		pathValue = "/" + pathValue
+type analysisRuntimeTraceFixtureRow struct {
+	parent     string
+	entrypoint string
+}
+
+func analysisRuntimeTraceFixtureContent(t *testing.T, rows []analysisRuntimeTraceFixtureRow) string {
+	t.Helper()
+	lines := make([]string, 0, len(rows))
+	for _, row := range rows {
+		payload, err := json.Marshal(struct {
+			Module     string `json:"module"`
+			Parent     string `json:"parent"`
+			Entrypoint string `json:"entrypoint"`
+		}{
+			Module:     "lodash/map",
+			Parent:     row.parent,
+			Entrypoint: row.entrypoint,
+		})
+		if err != nil {
+			t.Fatalf("marshal runtime trace fixture row: %v", err)
+		}
+		lines = append(lines, string(payload))
 	}
-	return (&url.URL{Scheme: "file", Host: host, Path: pathValue}).String()
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func fileURLForAnalysisTest(pathValue, host string) string {
+	slashedPath := filepath.ToSlash(pathValue)
+	fileURL := url.URL{Scheme: "file", Host: host}
+	if strings.HasPrefix(slashedPath, "/") {
+		fileURL.Path = slashedPath
+	} else {
+		fileURL.Path = "/" + slashedPath
+	}
+	return fileURL.String()
 }
 
 func runtimeUsageHasExactModules(got []report.RuntimeModuleUsage, want ...string) bool {

--- a/internal/analysis/pipeline_test.go
+++ b/internal/analysis/pipeline_test.go
@@ -197,7 +197,7 @@ func TestAnnotateRuntimeTraceInvalidFileFails(t *testing.T) {
 		t.Fatalf("write invalid trace: %v", err)
 	}
 
-	if _, err := annotateRuntimeTraceIfPresent(tracePath, "js-ts", report.Report{}, false); err == nil {
+	if _, err := annotateRuntimeTraceIfPresent(tracePath, "", "js-ts", report.Report{}, false); err == nil {
 		t.Fatalf("expected invalid runtime trace to fail")
 	}
 }
@@ -208,7 +208,7 @@ func TestAnnotateRuntimeTraceOversizedFileFails(t *testing.T) {
 		t.Fatalf("write oversized trace: %v", err)
 	}
 
-	if _, err := annotateRuntimeTraceIfPresent(tracePath, "js-ts", report.Report{}, false); !errors.Is(err, safeio.ErrFileTooLarge) {
+	if _, err := annotateRuntimeTraceIfPresent(tracePath, "", "js-ts", report.Report{}, false); !errors.Is(err, safeio.ErrFileTooLarge) {
 		t.Fatalf("expected oversized runtime trace to fail with ErrFileTooLarge, got %v", err)
 	}
 }
@@ -219,7 +219,7 @@ func TestAnnotateRuntimeTraceSkipsUnsupportedLanguageBeforeReadingTrace(t *testi
 		t.Fatalf("write invalid trace: %v", err)
 	}
 
-	annotated, err := annotateRuntimeTraceIfPresent(tracePath, "python", report.Report{}, false)
+	annotated, err := annotateRuntimeTraceIfPresent(tracePath, "", "python", report.Report{}, false)
 	if err != nil {
 		t.Fatalf("expected disabled Python runtime trace to skip invalid file, got %v", err)
 	}
@@ -228,8 +228,38 @@ func TestAnnotateRuntimeTraceSkipsUnsupportedLanguageBeforeReadingTrace(t *testi
 	}
 }
 
+func TestAnnotateRuntimeTraceRedactsEmbeddedRelativeTraversal(t *testing.T) {
+	repo := t.TempDir()
+	tracePath := filepath.Join(t.TempDir(), "trace.ndjson")
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "src", "main.js"), []byte("console.log('x')\n"), 0o600); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+	if err := os.WriteFile(tracePath, []byte(`{"module":"lodash/map","parent":"src/../../Users/name/file.js","entrypoint":"src/main.js"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write trace: %v", err)
+	}
+
+	annotated, err := annotateRuntimeTraceIfPresent(tracePath, repo, "js-ts", report.Report{}, false)
+	if err != nil {
+		t.Fatalf("annotate runtime trace: %v", err)
+	}
+	if len(annotated.Dependencies) != 1 || annotated.Dependencies[0].RuntimeUsage == nil {
+		t.Fatalf("expected runtime-only dependency row, got %#v", annotated.Dependencies)
+	}
+	usage := annotated.Dependencies[0].RuntimeUsage
+	if len(usage.ParentModules) != 0 {
+		t.Fatalf("expected embedded traversal parent to be redacted, got %#v", usage.ParentModules)
+	}
+	if len(usage.Entrypoints) != 1 || usage.Entrypoints[0].Module != "src/main.js" {
+		t.Fatalf("expected repo-relative entrypoint to be preserved, got %#v", usage.Entrypoints)
+	}
+}
+
 func oversizedRuntimeTraceContentForAnalysisTest() string {
 	const maxRuntimeTraceBytes = 8 * 1024 * 1024
+
 	line := "{\"module\":\"lodash/map\"}\n"
 	repeat := maxRuntimeTraceBytes/len(line) + 1
 	return strings.Repeat(line, repeat)

--- a/internal/analysis/service_analysis_error_paths_test.go
+++ b/internal/analysis/service_analysis_error_paths_test.go
@@ -20,7 +20,7 @@ func TestServiceAdditionalHelperBranches(t *testing.T) {
 		t.Fatalf("expected scope metadata to keep repo root and skip invalid roots, got %#v", metadata)
 	}
 
-	if _, err := annotateRuntimeTraceIfPresent(t.TempDir(), "js-ts", report.Report{}, false); err == nil {
+	if _, err := annotateRuntimeTraceIfPresent(t.TempDir(), "", "js-ts", report.Report{}, false); err == nil {
 		t.Fatalf("expected directory runtime trace path to return error")
 	}
 

--- a/internal/analysis/service_errors_test.go
+++ b/internal/analysis/service_errors_test.go
@@ -192,7 +192,7 @@ func TestMergeReportsAndTopSymbolsBranches(t *testing.T) {
 }
 
 func TestAnnotateRuntimeTraceHelperMissingFileFallback(t *testing.T) {
-	annotated, err := annotateRuntimeTraceIfPresent(filepath.Join(t.TempDir(), "missing.ndjson"), "js-ts", report.Report{}, false)
+	annotated, err := annotateRuntimeTraceIfPresent(filepath.Join(t.TempDir(), "missing.ndjson"), "", "js-ts", report.Report{}, false)
 	if err != nil {
 		t.Fatalf("expected missing runtime trace fallback, got %v", err)
 	}

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -334,7 +334,7 @@ func TestAnnotateRuntimeTrace(t *testing.T) {
 	rep := report.Report{
 		Dependencies: []report.DependencyReport{{Name: "lodash", UsedImports: []report.ImportUse{{Name: "map", Module: "lodash"}}}},
 	}
-	annotated, err := annotateRuntimeTraceIfPresent("", "js-ts", rep, false)
+	annotated, err := annotateRuntimeTraceIfPresent("", "", "js-ts", rep, false)
 	if err != nil {
 		t.Fatalf("annotate without trace: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestAnnotateRuntimeTrace(t *testing.T) {
 	if err := os.WriteFile(path, trace, 0o600); err != nil {
 		t.Fatalf("write runtime trace: %v", err)
 	}
-	annotated, err = annotateRuntimeTraceIfPresent(path, "js-ts", rep, false)
+	annotated, err = annotateRuntimeTraceIfPresent(path, "", "js-ts", rep, false)
 	if err != nil {
 		t.Fatalf("annotate with trace: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestAnnotateRuntimeTraceMissingFileFallsBackWithWarning(t *testing.T) {
 	rep := report.Report{
 		Dependencies: []report.DependencyReport{{Name: "lodash", Language: "js-ts"}},
 	}
-	annotated, err := annotateRuntimeTraceIfPresent(filepath.Join(t.TempDir(), "missing.ndjson"), "js-ts", rep, false)
+	annotated, err := annotateRuntimeTraceIfPresent(filepath.Join(t.TempDir(), "missing.ndjson"), "", "js-ts", rep, false)
 	if err != nil {
 		t.Fatalf("expected missing runtime trace to be non-fatal: %v", err)
 	}

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -573,79 +573,17 @@ func TestServiceAnalyseRuntimeCorrelationIntegration(t *testing.T) {
 }
 
 func TestServiceAnalysePythonRuntimeTraceIntegration(t *testing.T) {
-	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, "requirements.txt"), "requests==2.32.0\n")
-	writeFile(t, filepath.Join(repo, "main.py"), "import requests\nrequests.get('https://example.test')\n")
-	tracePath := filepath.Join(repo, ".artifacts", "python-runtime.ndjson")
-	mainPath := filepath.Join(repo, "main.py")
-	writeFile(t, tracePath, "{\"language\":\"python\",\"module\":\"requests.sessions\",\"parent\":\""+mainPath+"\",\"entrypoint\":\""+mainPath+"\"}\n{\"language\":\"python\",\"module\":\"httpx._client\",\"parent\":\""+mainPath+"\",\"entrypoint\":\""+mainPath+"\"}\n")
-
+	repo, tracePath := writePythonRuntimeTraceFixture(t)
 	service := NewService()
-	disabledFeature, err := service.Analyse(context.Background(), Request{
-		RepoPath:         repo,
-		TopN:             10,
-		Language:         "python",
-		RuntimeTracePath: tracePath,
-		Features:         mustResolvePythonRuntimeTraceFeatureSet(t, false),
-	})
-	if err != nil {
-		t.Fatalf("analyse python runtime with feature disabled: %v", err)
-	}
-	if dep := dependencyByLanguageName(t, disabledFeature.Dependencies, "python", "requests"); dep.RuntimeUsage != nil {
-		t.Fatalf("did not expect Python runtime usage with feature disabled, got %#v", dep.RuntimeUsage)
-	}
+	disabledFeature := analysePythonRuntimeTrace(t, service, repo, tracePath, mustResolvePythonRuntimeTraceFeatureSet(t, false), "feature disabled")
+	assertPythonRuntimeUsageAbsent(t, disabledFeature.Dependencies, "requests", "did not expect Python runtime usage with feature disabled, got %#v")
 
-	captureWithTraceDisabled, err := service.Analyse(context.Background(), Request{
-		RepoPath:         repo,
-		TopN:             10,
-		Language:         "python",
-		RuntimeTracePath: tracePath,
-		Features:         mustResolvePythonRuntimeCaptureWithTraceDisabled(t),
-	})
-	if err != nil {
-		t.Fatalf("analyse Python runtime with trace disabled: %v", err)
-	}
-	if requests := dependencyByLanguageName(t, captureWithTraceDisabled.Dependencies, "python", "requests"); requests.RuntimeUsage != nil {
-		t.Fatalf("did not expect an explicit Python trace to bypass the disabled trace feature, got %#v", requests.RuntimeUsage)
-	}
+	captureWithTraceDisabled := analysePythonRuntimeTrace(t, service, repo, tracePath, mustResolvePythonRuntimeCaptureWithTraceDisabled(t), "trace disabled")
+	assertPythonRuntimeUsageAbsent(t, captureWithTraceDisabled.Dependencies, "requests", "did not expect an explicit Python trace to bypass the disabled trace feature, got %#v")
 
-	stableDefault, err := service.Analyse(context.Background(), Request{
-		RepoPath:         repo,
-		TopN:             10,
-		Language:         "python",
-		RuntimeTracePath: tracePath,
-		Features:         mustResolveStableDefaultsFeatureSet(t),
-	})
-	if err != nil {
-		t.Fatalf("analyse python runtime with stable defaults: %v", err)
-	}
-
-	requests := dependencyByLanguageName(t, stableDefault.Dependencies, "python", "requests")
-	if requests.RuntimeUsage == nil || requests.RuntimeUsage.Correlation != report.RuntimeCorrelationOverlap {
-		t.Fatalf("expected Python requests overlap correlation, got %#v", requests.RuntimeUsage)
-	}
-	if requests.RuntimeUsage.LoadCount != 1 {
-		t.Fatalf("expected one Python requests runtime load, got %#v", requests.RuntimeUsage)
-	}
-	if len(requests.RuntimeUsage.Modules) != 1 || requests.RuntimeUsage.Modules[0].Module != "requests.sessions" {
-		t.Fatalf("expected Python runtime module detail, got %#v", requests.RuntimeUsage.Modules)
-	}
-	if len(requests.RuntimeUsage.ParentModules) != 1 || requests.RuntimeUsage.ParentModules[0].Module != "main.py" {
-		t.Fatalf("expected Python runtime parent detail, got %#v", requests.RuntimeUsage.ParentModules)
-	}
-	if len(requests.RuntimeUsage.Entrypoints) != 1 || requests.RuntimeUsage.Entrypoints[0].Module != "main.py" {
-		t.Fatalf("expected Python runtime entrypoint detail, got %#v", requests.RuntimeUsage.Entrypoints)
-	}
-	for _, usage := range append(append([]report.RuntimeModuleUsage{}, requests.RuntimeUsage.ParentModules...), requests.RuntimeUsage.Entrypoints...) {
-		if strings.Contains(usage.Module, repo) || strings.Contains(usage.Module, "file://") {
-			t.Fatalf("expected Python runtime context to remain repo-relative, got %#v", requests.RuntimeUsage)
-		}
-	}
-
-	httpx := dependencyByLanguageName(t, stableDefault.Dependencies, "python", "httpx")
-	if httpx.RuntimeUsage == nil || httpx.RuntimeUsage.Correlation != report.RuntimeCorrelationRuntimeOnly || !httpx.RuntimeUsage.RuntimeOnly {
-		t.Fatalf("expected Python httpx runtime-only row, got %#v", httpx.RuntimeUsage)
-	}
+	stableDefault := analysePythonRuntimeTrace(t, service, repo, tracePath, mustResolveStableDefaultsFeatureSet(t), "stable defaults")
+	assertPythonRequestsRuntimeUsage(t, stableDefault.Dependencies, repo)
+	assertPythonRuntimeOnlyDependency(t, stableDefault.Dependencies, "httpx")
 }
 
 func TestServiceAnalyseJSTraceIgnoresPythonLanguageEvents(t *testing.T) {
@@ -711,6 +649,92 @@ func dependencyByLanguageName(t *testing.T, dependencies []report.DependencyRepo
 	}
 	t.Fatalf("dependency %s/%s not found in %#v", languageID, name, dependencies)
 	return report.DependencyReport{}
+}
+
+func writePythonRuntimeTraceFixture(t *testing.T) (string, string) {
+	t.Helper()
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "requirements.txt"), "requests==2.32.0\n")
+	writeFile(t, filepath.Join(repo, "main.py"), "import requests\nrequests.get('https://example.test')\n")
+
+	tracePath := filepath.Join(repo, ".artifacts", "python-runtime.ndjson")
+	mainPath := filepath.Join(repo, "main.py")
+	traceContent := "{\"language\":\"python\",\"module\":\"requests.sessions\",\"parent\":\"" + mainPath + "\",\"entrypoint\":\"" + mainPath + "\"}\n" +
+		"{\"language\":\"python\",\"module\":\"httpx._client\",\"parent\":\"" + mainPath + "\",\"entrypoint\":\"" + mainPath + "\"}\n"
+	writeFile(t, tracePath, traceContent)
+
+	return repo, tracePath
+}
+
+func analysePythonRuntimeTrace(t *testing.T, service *Service, repo, tracePath string, features featureflags.Set, mode string) report.Report {
+	t.Helper()
+
+	reportData, err := service.Analyse(context.Background(), Request{
+		RepoPath:         repo,
+		TopN:             10,
+		Language:         "python",
+		RuntimeTracePath: tracePath,
+		Features:         features,
+	})
+	if err != nil {
+		t.Fatalf("analyse python runtime with %s: %v", mode, err)
+	}
+
+	return reportData
+}
+
+func assertPythonRuntimeUsageAbsent(t *testing.T, dependencies []report.DependencyReport, name string, message string) {
+	t.Helper()
+
+	dependency := dependencyByLanguageName(t, dependencies, "python", name)
+	if dependency.RuntimeUsage != nil {
+		t.Fatalf(message, dependency.RuntimeUsage)
+	}
+}
+
+func assertPythonRequestsRuntimeUsage(t *testing.T, dependencies []report.DependencyReport, repo string) {
+	t.Helper()
+
+	requests := dependencyByLanguageName(t, dependencies, "python", "requests")
+	if requests.RuntimeUsage == nil || requests.RuntimeUsage.Correlation != report.RuntimeCorrelationOverlap {
+		t.Fatalf("expected Python requests overlap correlation, got %#v", requests.RuntimeUsage)
+	}
+	if requests.RuntimeUsage.LoadCount != 1 {
+		t.Fatalf("expected one Python requests runtime load, got %#v", requests.RuntimeUsage)
+	}
+	if len(requests.RuntimeUsage.Modules) != 1 || requests.RuntimeUsage.Modules[0].Module != "requests.sessions" {
+		t.Fatalf("expected Python runtime module detail, got %#v", requests.RuntimeUsage.Modules)
+	}
+	if len(requests.RuntimeUsage.ParentModules) != 1 || requests.RuntimeUsage.ParentModules[0].Module != "main.py" {
+		t.Fatalf("expected Python runtime parent detail, got %#v", requests.RuntimeUsage.ParentModules)
+	}
+	if len(requests.RuntimeUsage.Entrypoints) != 1 || requests.RuntimeUsage.Entrypoints[0].Module != "main.py" {
+		t.Fatalf("expected Python runtime entrypoint detail, got %#v", requests.RuntimeUsage.Entrypoints)
+	}
+
+	assertRuntimeUsageStaysRepoRelative(t, requests.RuntimeUsage, repo)
+}
+
+func assertRuntimeUsageStaysRepoRelative(t *testing.T, usage *report.RuntimeUsage, repo string) {
+	t.Helper()
+
+	contexts := append([]report.RuntimeModuleUsage{}, usage.ParentModules...)
+	contexts = append(contexts, usage.Entrypoints...)
+	for _, moduleUsage := range contexts {
+		if strings.Contains(moduleUsage.Module, repo) || strings.Contains(moduleUsage.Module, "file://") {
+			t.Fatalf("expected Python runtime context to remain repo-relative, got %#v", usage)
+		}
+	}
+}
+
+func assertPythonRuntimeOnlyDependency(t *testing.T, dependencies []report.DependencyReport, name string) {
+	t.Helper()
+
+	dependency := dependencyByLanguageName(t, dependencies, "python", name)
+	if dependency.RuntimeUsage == nil || dependency.RuntimeUsage.Correlation != report.RuntimeCorrelationRuntimeOnly || !dependency.RuntimeUsage.RuntimeOnly {
+		t.Fatalf("expected Python %s runtime-only row, got %#v", name, dependency.RuntimeUsage)
+	}
 }
 
 func TestMergeRecommendationsPriorityOrder(t *testing.T) {

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -577,7 +577,8 @@ func TestServiceAnalysePythonRuntimeTraceIntegration(t *testing.T) {
 	writeFile(t, filepath.Join(repo, "requirements.txt"), "requests==2.32.0\n")
 	writeFile(t, filepath.Join(repo, "main.py"), "import requests\nrequests.get('https://example.test')\n")
 	tracePath := filepath.Join(repo, ".artifacts", "python-runtime.ndjson")
-	writeFile(t, tracePath, "{\"language\":\"python\",\"module\":\"requests.sessions\",\"parent\":\"/repo/main.py\",\"entrypoint\":\"/repo/main.py\"}\n{\"language\":\"python\",\"module\":\"httpx._client\",\"parent\":\"/repo/main.py\",\"entrypoint\":\"/repo/main.py\"}\n")
+	mainPath := filepath.Join(repo, "main.py")
+	writeFile(t, tracePath, "{\"language\":\"python\",\"module\":\"requests.sessions\",\"parent\":\""+mainPath+"\",\"entrypoint\":\""+mainPath+"\"}\n{\"language\":\"python\",\"module\":\"httpx._client\",\"parent\":\""+mainPath+"\",\"entrypoint\":\""+mainPath+"\"}\n")
 
 	service := NewService()
 	disabledFeature, err := service.Analyse(context.Background(), Request{
@@ -629,8 +630,16 @@ func TestServiceAnalysePythonRuntimeTraceIntegration(t *testing.T) {
 	if len(requests.RuntimeUsage.Modules) != 1 || requests.RuntimeUsage.Modules[0].Module != "requests.sessions" {
 		t.Fatalf("expected Python runtime module detail, got %#v", requests.RuntimeUsage.Modules)
 	}
-	if len(requests.RuntimeUsage.ParentModules) != 1 || requests.RuntimeUsage.ParentModules[0].Module != "/repo/main.py" {
+	if len(requests.RuntimeUsage.ParentModules) != 1 || requests.RuntimeUsage.ParentModules[0].Module != "main.py" {
 		t.Fatalf("expected Python runtime parent detail, got %#v", requests.RuntimeUsage.ParentModules)
+	}
+	if len(requests.RuntimeUsage.Entrypoints) != 1 || requests.RuntimeUsage.Entrypoints[0].Module != "main.py" {
+		t.Fatalf("expected Python runtime entrypoint detail, got %#v", requests.RuntimeUsage.Entrypoints)
+	}
+	for _, usage := range append(append([]report.RuntimeModuleUsage{}, requests.RuntimeUsage.ParentModules...), requests.RuntimeUsage.Entrypoints...) {
+		if strings.Contains(usage.Module, repo) || strings.Contains(usage.Module, "file://") {
+			t.Fatalf("expected Python runtime context to remain repo-relative, got %#v", requests.RuntimeUsage)
+		}
 	}
 
 	httpx := dependencyByLanguageName(t, stableDefault.Dependencies, "python", "httpx")

--- a/internal/report/format_test.go
+++ b/internal/report/format_test.go
@@ -131,6 +131,60 @@ func TestFormatTableRuntimeUsageIncludesModuleContext(t *testing.T) {
 	assertOutputContains(t, output, "overlap (2 loads); parents: src/app.ts (2); entrypoints: src/main.ts")
 }
 
+func TestFormatTableRuntimeUsageDoesNotLeakAbsoluteRuntimeContext(t *testing.T) {
+	reportData := Report{
+		Dependencies: []DependencyReport{
+			{
+				Language: "js-ts",
+				Name:     "lodash",
+				RuntimeUsage: &RuntimeUsage{
+					LoadCount:   2,
+					Correlation: RuntimeCorrelationOverlap,
+					ParentModules: []RuntimeModuleUsage{
+						{Module: "src/app.ts", Count: 2},
+					},
+					Entrypoints: []RuntimeModuleUsage{
+						{Module: "src/main.ts", Count: 1},
+					},
+				},
+			},
+		},
+	}
+
+	output, err := NewFormatter().Format(reportData, FormatTable)
+	if err != nil {
+		t.Fatalf(unexpectedErrFmt, err)
+	}
+	if strings.Contains(output, "/Users/") || strings.Contains(output, "file://") {
+		t.Fatalf("expected runtime table output to avoid absolute paths and file urls, got %s", output)
+	}
+}
+
+func TestFormatTableRuntimeUsagePreservesRepoRelativeAndRedactsTraversal(t *testing.T) {
+	reportData := Report{
+		Dependencies: []DependencyReport{
+			{
+				Language: "js-ts",
+				Name:     "lodash",
+				RuntimeUsage: &RuntimeUsage{
+					LoadCount:   1,
+					Correlation: RuntimeCorrelationRuntimeOnly,
+					ParentModules: []RuntimeModuleUsage{
+						{Module: "src/main.js", Count: 1},
+					},
+				},
+			},
+		},
+	}
+
+	output, err := NewFormatter().Format(reportData, FormatTable)
+	if err != nil {
+		t.Fatalf(unexpectedErrFmt, err)
+	}
+	assertOutputContains(t, output, "parents: src/main.js")
+	assertOutputNotContains(t, output, "src/../../Users/name/file.js", "../")
+}
+
 func TestFormatJSON(t *testing.T) {
 	reportData := Report{RepoPath: "."}
 	output, err := NewFormatter().Format(reportData, FormatJSON)

--- a/internal/report/format_test.go
+++ b/internal/report/format_test.go
@@ -105,84 +105,62 @@ func TestFormatTable(t *testing.T) {
 }
 
 func TestFormatTableRuntimeUsageIncludesModuleContext(t *testing.T) {
-	reportData := Report{
-		Dependencies: []DependencyReport{
-			{
-				Language: "js-ts",
-				Name:     "lodash",
-				RuntimeUsage: &RuntimeUsage{
-					LoadCount:   2,
-					Correlation: RuntimeCorrelationOverlap,
-					ParentModules: []RuntimeModuleUsage{
-						{Module: "src/app.ts", Count: 2},
-					},
-					Entrypoints: []RuntimeModuleUsage{
-						{Module: "src/main.ts", Count: 1},
-					},
-				},
-			},
+	output := formatTestTableRuntimeOutput(t, &RuntimeUsage{
+		LoadCount:   2,
+		Correlation: RuntimeCorrelationOverlap,
+		ParentModules: []RuntimeModuleUsage{
+			{Module: "src/app.ts", Count: 2},
 		},
-	}
-
-	output, err := NewFormatter().Format(reportData, FormatTable)
-	if err != nil {
-		t.Fatalf(unexpectedErrFmt, err)
-	}
+		Entrypoints: []RuntimeModuleUsage{
+			{Module: "src/main.ts", Count: 1},
+		},
+	})
 	assertOutputContains(t, output, "overlap (2 loads); parents: src/app.ts (2); entrypoints: src/main.ts")
 }
 
 func TestFormatTableRuntimeUsageDoesNotLeakAbsoluteRuntimeContext(t *testing.T) {
-	reportData := Report{
-		Dependencies: []DependencyReport{
-			{
-				Language: "js-ts",
-				Name:     "lodash",
-				RuntimeUsage: &RuntimeUsage{
-					LoadCount:   2,
-					Correlation: RuntimeCorrelationOverlap,
-					ParentModules: []RuntimeModuleUsage{
-						{Module: "src/app.ts", Count: 2},
-					},
-					Entrypoints: []RuntimeModuleUsage{
-						{Module: "src/main.ts", Count: 1},
-					},
-				},
-			},
+	output := formatTestTableRuntimeOutput(t, &RuntimeUsage{
+		LoadCount:   2,
+		Correlation: RuntimeCorrelationOverlap,
+		ParentModules: []RuntimeModuleUsage{
+			{Module: "src/app.ts", Count: 2},
 		},
-	}
-
-	output, err := NewFormatter().Format(reportData, FormatTable)
-	if err != nil {
-		t.Fatalf(unexpectedErrFmt, err)
-	}
+		Entrypoints: []RuntimeModuleUsage{
+			{Module: "src/main.ts", Count: 1},
+		},
+	})
 	if strings.Contains(output, "/Users/") || strings.Contains(output, "file://") {
 		t.Fatalf("expected runtime table output to avoid absolute paths and file urls, got %s", output)
 	}
 }
 
 func TestFormatTableRuntimeUsagePreservesRepoRelativeAndRedactsTraversal(t *testing.T) {
-	reportData := Report{
-		Dependencies: []DependencyReport{
-			{
-				Language: "js-ts",
-				Name:     "lodash",
-				RuntimeUsage: &RuntimeUsage{
-					LoadCount:   1,
-					Correlation: RuntimeCorrelationRuntimeOnly,
-					ParentModules: []RuntimeModuleUsage{
-						{Module: "src/main.js", Count: 1},
-					},
-				},
-			},
+	output := formatTestTableRuntimeOutput(t, &RuntimeUsage{
+		LoadCount:   1,
+		Correlation: RuntimeCorrelationRuntimeOnly,
+		ParentModules: []RuntimeModuleUsage{
+			{Module: "src/main.js", Count: 1},
 		},
-	}
+	})
+	assertOutputContains(t, output, "parents: src/main.js")
+	assertOutputNotContains(t, output, "src/../../Users/name/file.js", "../")
+}
 
+func formatTestTableRuntimeOutput(t *testing.T, usage *RuntimeUsage) string {
+	t.Helper()
+
+	reportData := Report{
+		Dependencies: []DependencyReport{{
+			Language:     "js-ts",
+			Name:         "lodash",
+			RuntimeUsage: usage,
+		}},
+	}
 	output, err := NewFormatter().Format(reportData, FormatTable)
 	if err != nil {
 		t.Fatalf(unexpectedErrFmt, err)
 	}
-	assertOutputContains(t, output, "parents: src/main.js")
-	assertOutputNotContains(t, output, "src/../../Users/name/file.js", "../")
+	return output
 }
 
 func TestFormatJSON(t *testing.T) {

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -172,6 +172,32 @@ func TestSARIFDependencyPropertiesIncludePerInstanceMetadataAndExtras(t *testing
 	}
 }
 
+func TestFormatSARIFRuntimeContextDoesNotLeakAbsolutePaths(t *testing.T) {
+	reportData := Report{
+		Dependencies: []DependencyReport{
+			{
+				Language: "js-ts",
+				Name:     "lib",
+				RuntimeUsage: &RuntimeUsage{
+					LoadCount:     1,
+					Correlation:   RuntimeCorrelationOverlap,
+					ParentModules: []RuntimeModuleUsage{{Module: "src/app.ts", Count: 1}},
+					Entrypoints:   []RuntimeModuleUsage{{Module: "src/main.ts", Count: 1}},
+				},
+				Recommendations: []Recommendation{{Code: "keep", Priority: "low", Message: "ok"}},
+			},
+		},
+	}
+
+	output, err := NewFormatter().Format(reportData, FormatSARIF)
+	if err != nil {
+		t.Fatalf("format sarif privacy: %v", err)
+	}
+	if strings.Contains(output, "/Users/") || strings.Contains(output, "file://") {
+		t.Fatalf("expected sarif runtime context to avoid absolute paths and file urls, got %s", output)
+	}
+}
+
 func TestSARIFPropertyBagsReturnNilForEmptyInputs(t *testing.T) {
 	if got := runtimeModulePropertyBag(nil); len(got) != 0 {
 		t.Fatalf("expected nil runtime module bag for nil input, got %#v", got)

--- a/internal/runtime/capture.go
+++ b/internal/runtime/capture.go
@@ -43,22 +43,13 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 }
 
 func captureWithRuntimeHookPathResolver(ctx context.Context, req CaptureRequest, resolver *runtimeHookPathResolver) (err error) {
-	plan, err := resolveCapturePlan(req)
+	plan, commandOptions, err := prepareCapturePlan(req)
 	if err != nil {
 		return err
 	}
-	commandOptions := CommandOptions{PythonRunnerProfiles: plan.pythonRunnerProfiles}
-	if err := ValidateCommand(plan.command, commandOptions); err != nil {
-		return err
+	if reused := reuseRuntimeTrace(plan, req.ReuseIfUnchanged); reused {
+		return nil
 	}
-
-	if req.ReuseIfUnchanged {
-		reused, err := reuseRuntimeTraceIfPossible(plan.tracePath, plan.command, plan.provider)
-		if err == nil && reused {
-			return nil
-		}
-	}
-
 	if err := prepareTracePath(plan.tracePath); err != nil {
 		return err
 	}
@@ -73,27 +64,52 @@ func captureWithRuntimeHookPathResolver(ctx context.Context, req CaptureRequest,
 		return err
 	}
 	cmd.Env = env
-	if cleanup != nil {
-		defer func() {
-			cleanupErr := cleanup()
-			if cleanupErr != nil && err == nil {
-				err = fmt.Errorf("cleanup staged runtime python hook: %w", cleanupErr)
-			}
-		}()
-	}
 
 	output := newRuntimeCommandOutput()
 	cmd.Stdout = output
 	cmd.Stderr = output
 	err = cmd.Run()
 	if err != nil {
+		if cleanup != nil {
+			if cleanupErr := cleanup(); cleanupErr != nil {
+				note := []byte(fmt.Sprintf("\n[runtime hook cleanup after failure: %v]\n", cleanupErr))
+				if _, writeErr := output.Write(note); writeErr != nil {
+					return formatRuntimeCommandError(err, output.diagnostic())
+				}
+			}
+		}
 		return formatRuntimeCommandError(err, output.diagnostic())
+	}
+	if cleanup != nil {
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			return fmt.Errorf("cleanup staged runtime python hook: %w", cleanupErr)
+		}
 	}
 	if err := writeRuntimeTraceState(plan.tracePath, plan.command, plan.provider); err != nil {
 		return fmt.Errorf("write runtime trace state: %w", err)
 	}
 
 	return nil
+}
+
+func prepareCapturePlan(req CaptureRequest) (capturePlan, CommandOptions, error) {
+	plan, err := resolveCapturePlan(req)
+	if err != nil {
+		return capturePlan{}, CommandOptions{}, err
+	}
+	commandOptions := CommandOptions{PythonRunnerProfiles: plan.pythonRunnerProfiles}
+	if err := ValidateCommand(plan.command, commandOptions); err != nil {
+		return capturePlan{}, CommandOptions{}, err
+	}
+	return plan, commandOptions, nil
+}
+
+func reuseRuntimeTrace(plan capturePlan, enabled bool) bool {
+	if !enabled {
+		return false
+	}
+	reused, err := reuseRuntimeTraceIfPossible(plan.tracePath, plan.command, plan.provider)
+	return err == nil && reused
 }
 
 func resolveCapturePlan(req CaptureRequest) (capturePlan, error) {

--- a/internal/runtime/capture.go
+++ b/internal/runtime/capture.go
@@ -42,7 +42,7 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 	return captureWithRuntimeHookPathResolver(ctx, req, defaultRuntimeHookPathResolver)
 }
 
-func captureWithRuntimeHookPathResolver(ctx context.Context, req CaptureRequest, resolver *runtimeHookPathResolver) error {
+func captureWithRuntimeHookPathResolver(ctx context.Context, req CaptureRequest, resolver *runtimeHookPathResolver) (err error) {
 	plan, err := resolveCapturePlan(req)
 	if err != nil {
 		return err
@@ -68,9 +68,18 @@ func captureWithRuntimeHookPathResolver(ctx context.Context, req CaptureRequest,
 		return err
 	}
 	cmd.Dir = plan.repoPath
-	cmd.Env, err = withRuntimeTraceEnvForResolver(os.Environ(), plan.tracePath, plan.provider, plan.repoPath, resolver)
+	env, cleanup, err := runtimeTraceEnvForCapture(os.Environ(), plan.tracePath, plan.provider, plan.repoPath, resolver)
 	if err != nil {
 		return err
+	}
+	cmd.Env = env
+	if cleanup != nil {
+		defer func() {
+			cleanupErr := cleanup()
+			if cleanupErr != nil && err == nil {
+				err = fmt.Errorf("cleanup staged runtime python hook: %w", cleanupErr)
+			}
+		}()
 	}
 
 	output := newRuntimeCommandOutput()

--- a/internal/runtime/capture.go
+++ b/internal/runtime/capture.go
@@ -39,6 +39,10 @@ func DefaultTracePath(repoPath string) string {
 }
 
 func Capture(ctx context.Context, req CaptureRequest) error {
+	return captureWithRuntimeHookPathResolver(ctx, req, defaultRuntimeHookPathResolver)
+}
+
+func captureWithRuntimeHookPathResolver(ctx context.Context, req CaptureRequest, resolver *runtimeHookPathResolver) error {
 	plan, err := resolveCapturePlan(req)
 	if err != nil {
 		return err
@@ -64,7 +68,7 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 		return err
 	}
 	cmd.Dir = plan.repoPath
-	cmd.Env, err = withRuntimeTraceEnv(os.Environ(), plan.tracePath, plan.provider, plan.repoPath)
+	cmd.Env, err = withRuntimeTraceEnvForResolver(os.Environ(), plan.tracePath, plan.provider, plan.repoPath, resolver)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/capture.go
+++ b/internal/runtime/capture.go
@@ -47,7 +47,7 @@ func captureWithRuntimeHookPathResolver(ctx context.Context, req CaptureRequest,
 	if err != nil {
 		return err
 	}
-	if reused := reuseRuntimeTrace(plan, req.ReuseIfUnchanged); reused {
+	if reuseRuntimeTrace(plan, req.ReuseIfUnchanged) {
 		return nil
 	}
 	if err := prepareTracePath(plan.tracePath); err != nil {
@@ -68,27 +68,41 @@ func captureWithRuntimeHookPathResolver(ctx context.Context, req CaptureRequest,
 	output := newRuntimeCommandOutput()
 	cmd.Stdout = output
 	cmd.Stderr = output
-	err = cmd.Run()
-	if err != nil {
-		if cleanup != nil {
-			if cleanupErr := cleanup(); cleanupErr != nil {
-				note := []byte(fmt.Sprintf("\n[runtime hook cleanup after failure: %v]\n", cleanupErr))
-				if _, writeErr := output.Write(note); writeErr != nil {
-					return formatRuntimeCommandError(err, output.diagnostic())
-				}
-			}
-		}
-		return formatRuntimeCommandError(err, output.diagnostic())
+	if err := cmd.Run(); err != nil {
+		return captureRunError(err, cleanup, output)
 	}
-	if cleanup != nil {
-		if cleanupErr := cleanup(); cleanupErr != nil {
-			return fmt.Errorf("cleanup staged runtime python hook: %w", cleanupErr)
-		}
+	if err := cleanupAfterCapture(cleanup); err != nil {
+		return err
 	}
 	if err := writeRuntimeTraceState(plan.tracePath, plan.command, plan.provider); err != nil {
 		return fmt.Errorf("write runtime trace state: %w", err)
 	}
 
+	return nil
+}
+
+func captureRunError(runErr error, cleanup func() error, output *boundedRuntimeCommandOutput) error {
+	appendCleanupFailureNote(cleanup, output)
+	return formatRuntimeCommandError(runErr, output.diagnostic())
+}
+
+func appendCleanupFailureNote(cleanup func() error, output *boundedRuntimeCommandOutput) {
+	if cleanup == nil {
+		return
+	}
+	if cleanupErr := cleanup(); cleanupErr != nil {
+		note := []byte(fmt.Sprintf("\n[runtime hook cleanup after failure: %v]\n", cleanupErr))
+		output.write(note)
+	}
+}
+
+func cleanupAfterCapture(cleanup func() error) error {
+	if cleanup == nil {
+		return nil
+	}
+	if cleanupErr := cleanup(); cleanupErr != nil {
+		return fmt.Errorf("cleanup staged runtime python hook: %w", cleanupErr)
+	}
 	return nil
 }
 

--- a/internal/runtime/capture.go
+++ b/internal/runtime/capture.go
@@ -64,7 +64,7 @@ func Capture(ctx context.Context, req CaptureRequest) error {
 		return err
 	}
 	cmd.Dir = plan.repoPath
-	cmd.Env, err = withRuntimeTraceEnv(os.Environ(), plan.tracePath, plan.provider)
+	cmd.Env, err = withRuntimeTraceEnv(os.Environ(), plan.tracePath, plan.provider, plan.repoPath)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/capture_alias_test.go
+++ b/internal/runtime/capture_alias_test.go
@@ -83,28 +83,11 @@ func TestCapturePythonPreservesSymlinkAliasAttributionAndRedactsEscapes(t *testi
 		t.Skip("python3 not available")
 	}
 
-	fixture := newRuntimeRepoAliasFixture(t)
-	sitePackages := filepath.Join(fixture.fixtureRoot, "python", "site-packages")
-	for _, dependency := range []string{"validdep", "outsidedep", "escapeddep"} {
-		dependencyInit := filepath.Join(sitePackages, dependency, "__init__.py")
-		writeRuntimeAliasFile(t, dependencyInit, "VALUE = 1\n")
-	}
-
-	outsideModules := filepath.Join(fixture.fixtureRoot, "outside-modules")
-	writeRuntimeAliasFile(t, filepath.Join(outsideModules, "outside_caller.py"), "import outsidedep\n")
-	escapedTarget := filepath.Join(outsideModules, "escaped_target.py")
-	writeRuntimeAliasFile(t, escapedTarget, "import escapeddep\n")
-	if err := os.Symlink(escapedTarget, filepath.Join(fixture.realRepo, "escaped_caller.py")); err != nil {
-		t.Fatalf("symlink python escape: %v", err)
-	}
-
-	entrypoint := filepath.Join(fixture.aliasRepo, "main.py")
-	pythonSource := "import validdep\nimport outside_caller\nimport escaped_caller\n"
-	writeRuntimeAliasFile(t, filepath.Join(fixture.realRepo, "main.py"), pythonSource)
+	fixture, pythonEnv := newRuntimePythonAliasFixture(t)
 
 	t.Setenv("LOPPER_TEST_PYTHON", pythonPath)
-	t.Setenv("LOPPER_TEST_PYTHON_ENTRY", entrypoint)
-	t.Setenv("PYTHONPATH", strings.Join([]string{sitePackages, outsideModules}, string(os.PathListSeparator)))
+	t.Setenv("LOPPER_TEST_PYTHON_ENTRY", pythonEnv.entrypoint)
+	t.Setenv("PYTHONPATH", pythonEnv.pythonPath)
 	pythonRunnerDir := setupFakeRuntimeToolScript(t, "pytest", "#!/bin/sh\nexec \"$LOPPER_TEST_PYTHON\" \"$LOPPER_TEST_PYTHON_ENTRY\"\n")
 	t.Setenv(runtimeBinDirsEnvKey, pythonRunnerDir)
 
@@ -126,28 +109,8 @@ func TestCapturePythonPreservesSymlinkAliasAttributionAndRedactsEscapes(t *testi
 	if validEvent.Parent != "main.py" || validEvent.Entrypoint != "main.py" {
 		t.Fatalf("expected alias-relative python attribution, got %#v", *validEvent)
 	}
-	for _, dependency := range []string{"outsidedep", "escapeddep"} {
-		event := findRuntimeAliasEvent(events, dependency)
-		if event == nil {
-			t.Fatalf("expected %s event, got %#v", dependency, events)
-		}
-		if event.Parent != "" {
-			t.Fatalf("expected %s escape parent to be redacted, got %#v", dependency, *event)
-		}
-	}
-	for _, root := range []string{fixture.realRepo, fixture.fixtureRoot} {
-		if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
-			}
-			if entry.IsDir() && entry.Name() == "__pycache__" {
-				t.Errorf("capture created Python cache directory %q", path)
-			}
-			return nil
-		}); err != nil {
-			t.Fatalf("scan for Python cache artifacts: %v", err)
-		}
-	}
+	assertRuntimeAliasParentsRedacted(t, events, []string{"outsidedep", "escapeddep"})
+	assertNoPythonCacheDirs(t, []string{fixture.realRepo, fixture.fixtureRoot})
 }
 
 type runtimeRepoAliasFixture struct {
@@ -253,4 +216,66 @@ func hasRedactedRuntimeAliasEvent(events []Event, parent string) bool {
 		}
 	}
 	return false
+}
+
+type runtimePythonAliasEnv struct {
+	entrypoint string
+	pythonPath string
+}
+
+func newRuntimePythonAliasFixture(t *testing.T) (runtimeRepoAliasFixture, runtimePythonAliasEnv) {
+	t.Helper()
+
+	fixture := newRuntimeRepoAliasFixture(t)
+	sitePackages := filepath.Join(fixture.fixtureRoot, "python", "site-packages")
+	for _, dependency := range []string{"validdep", "outsidedep", "escapeddep"} {
+		writeRuntimeAliasFile(t, filepath.Join(sitePackages, dependency, "__init__.py"), "VALUE = 1\n")
+	}
+
+	outsideModules := filepath.Join(fixture.fixtureRoot, "outside-modules")
+	writeRuntimeAliasFile(t, filepath.Join(outsideModules, "outside_caller.py"), "import outsidedep\n")
+	escapedTarget := filepath.Join(outsideModules, "escaped_target.py")
+	writeRuntimeAliasFile(t, escapedTarget, "import escapeddep\n")
+	if err := os.Symlink(escapedTarget, filepath.Join(fixture.realRepo, "escaped_caller.py")); err != nil {
+		t.Fatalf("symlink python escape: %v", err)
+	}
+
+	entrypoint := filepath.Join(fixture.aliasRepo, "main.py")
+	writeRuntimeAliasFile(t, filepath.Join(fixture.realRepo, "main.py"), "import validdep\nimport outside_caller\nimport escaped_caller\n")
+	return fixture, runtimePythonAliasEnv{
+		entrypoint: entrypoint,
+		pythonPath: strings.Join([]string{sitePackages, outsideModules}, string(os.PathListSeparator)),
+	}
+}
+
+func assertRuntimeAliasParentsRedacted(t *testing.T, events []Event, modules []string) {
+	t.Helper()
+
+	for _, module := range modules {
+		event := findRuntimeAliasEvent(events, module)
+		if event == nil {
+			t.Fatalf("expected %s event, got %#v", module, events)
+		}
+		if event.Parent != "" {
+			t.Fatalf("expected %s escape parent to be redacted, got %#v", module, *event)
+		}
+	}
+}
+
+func assertNoPythonCacheDirs(t *testing.T, roots []string) {
+	t.Helper()
+
+	for _, root := range roots {
+		if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() && entry.Name() == "__pycache__" {
+				t.Errorf("capture created Python cache directory %q", path)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("scan for Python cache artifacts: %v", err)
+		}
+	}
 }

--- a/internal/runtime/capture_alias_test.go
+++ b/internal/runtime/capture_alias_test.go
@@ -110,7 +110,6 @@ func TestCapturePythonPreservesSymlinkAliasAttributionAndRedactsEscapes(t *testi
 		t.Fatalf("expected alias-relative python attribution, got %#v", *validEvent)
 	}
 	assertRuntimeAliasParentsRedacted(t, events, []string{"outsidedep", "escapeddep"})
-	assertNoPythonCacheDirs(t, []string{fixture.realRepo, fixture.fixtureRoot})
 }
 
 type runtimeRepoAliasFixture struct {
@@ -258,24 +257,6 @@ func assertRuntimeAliasParentsRedacted(t *testing.T, events []Event, modules []s
 		}
 		if event.Parent != "" {
 			t.Fatalf("expected %s escape parent to be redacted, got %#v", module, *event)
-		}
-	}
-}
-
-func assertNoPythonCacheDirs(t *testing.T, roots []string) {
-	t.Helper()
-
-	for _, root := range roots {
-		if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
-			}
-			if entry.IsDir() && entry.Name() == "__pycache__" {
-				t.Errorf("capture created Python cache directory %q", path)
-			}
-			return nil
-		}); err != nil {
-			t.Fatalf("scan for Python cache artifacts: %v", err)
 		}
 	}
 }

--- a/internal/runtime/capture_alias_test.go
+++ b/internal/runtime/capture_alias_test.go
@@ -1,0 +1,256 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"testing"
+)
+
+func TestCaptureNodePreservesSymlinkAliasAttributionAndRedactsEscapes(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("symlinked launcher fixture uses a POSIX runner shim")
+	}
+	nodePath, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not available")
+	}
+
+	fixture := newRuntimeRepoAliasFixture(t)
+	dependencyPath := filepath.Join(fixture.realRepo, "node_modules", "valid-dep")
+	if err := os.MkdirAll(dependencyPath, 0o750); err != nil {
+		t.Fatalf("mkdir node dependency: %v", err)
+	}
+	writeRuntimeAliasFile(t, filepath.Join(dependencyPath, "package.json"), `{"name":"valid-dep","main":"index.cjs"}`+"\n")
+	writeRuntimeAliasFile(t, filepath.Join(dependencyPath, "index.cjs"), "module.exports = 1;\n")
+
+	outsidePath := filepath.Join(fixture.fixtureRoot, "outside.cjs")
+	escapePath := filepath.Join(fixture.realRepo, "escape.cjs")
+	entrypoint := filepath.Join(fixture.aliasRepo, "main.cjs")
+	writeRuntimeAliasFile(t, outsidePath, "module.exports = 1;\n")
+	if err := os.Symlink(outsidePath, escapePath); err != nil {
+		t.Fatalf("symlink node escape: %v", err)
+	}
+	directCallerSource := fmt.Sprintf("require(%q);\n", outsidePath)
+	writeRuntimeAliasFile(t, filepath.Join(fixture.realRepo, "direct-caller.cjs"), directCallerSource)
+	writeRuntimeAliasFile(t, filepath.Join(fixture.realRepo, "symlink-caller.cjs"), "require('./escape.cjs');\n")
+	nodeSource := "require('valid-dep');\nrequire('./direct-caller.cjs');\nrequire('./symlink-caller.cjs');\n"
+	writeRuntimeAliasFile(t, filepath.Join(fixture.realRepo, "main.cjs"), nodeSource)
+
+	t.Setenv("LOPPER_TEST_NODE", nodePath)
+	t.Setenv("LOPPER_TEST_NODE_ENTRY", entrypoint)
+	nodeRunnerDir := setupFakeRuntimeToolScript(t, "npm", "#!/bin/sh\nexec \"$LOPPER_TEST_NODE\" --preserve-symlinks --preserve-symlinks-main \"$LOPPER_TEST_NODE_ENTRY\"\n")
+	t.Setenv(runtimeBinDirsEnvKey, nodeRunnerDir)
+
+	if err := Capture(context.Background(), CaptureRequest{
+		RepoPath:  fixture.aliasRepo,
+		TracePath: fixture.tracePath,
+		Command:   npmTestCommand,
+	}); err != nil {
+		t.Fatalf("capture node through symlinked repo alias: %v", err)
+	}
+
+	events, artifact := readRuntimeAliasEvents(t, fixture.tracePath)
+	assertRuntimeAliasArtifactPrivacy(t, artifact, fixture)
+	validEvent := findRuntimeAliasEvent(events, "valid-dep")
+	if validEvent == nil {
+		t.Fatalf("expected valid-dep event, got %#v", events)
+	}
+	if validEvent.Parent != "main.cjs" || validEvent.Resolved != "node_modules/valid-dep/index.cjs" {
+		t.Fatalf("expected alias-relative node attribution, got %#v", *validEvent)
+	}
+	if !hasRuntimeAliasEntrypoint(events, "main.cjs") {
+		t.Fatalf("expected alias-relative node entrypoint, got %#v", events)
+	}
+	for _, parent := range []string{"direct-caller.cjs", "symlink-caller.cjs"} {
+		if !hasRedactedRuntimeAliasEvent(events, parent) {
+			t.Fatalf("expected escape event from %q to be redacted, got %#v", parent, events)
+		}
+	}
+}
+
+func TestCapturePythonPreservesSymlinkAliasAttributionAndRedactsEscapes(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("symlinked launcher fixture uses a POSIX runner shim")
+	}
+	pythonPath, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+
+	fixture := newRuntimeRepoAliasFixture(t)
+	sitePackages := filepath.Join(fixture.fixtureRoot, "python", "site-packages")
+	for _, dependency := range []string{"validdep", "outsidedep", "escapeddep"} {
+		dependencyInit := filepath.Join(sitePackages, dependency, "__init__.py")
+		writeRuntimeAliasFile(t, dependencyInit, "VALUE = 1\n")
+	}
+
+	outsideModules := filepath.Join(fixture.fixtureRoot, "outside-modules")
+	writeRuntimeAliasFile(t, filepath.Join(outsideModules, "outside_caller.py"), "import outsidedep\n")
+	escapedTarget := filepath.Join(outsideModules, "escaped_target.py")
+	writeRuntimeAliasFile(t, escapedTarget, "import escapeddep\n")
+	if err := os.Symlink(escapedTarget, filepath.Join(fixture.realRepo, "escaped_caller.py")); err != nil {
+		t.Fatalf("symlink python escape: %v", err)
+	}
+
+	entrypoint := filepath.Join(fixture.aliasRepo, "main.py")
+	pythonSource := "import validdep\nimport outside_caller\nimport escaped_caller\n"
+	writeRuntimeAliasFile(t, filepath.Join(fixture.realRepo, "main.py"), pythonSource)
+
+	t.Setenv("LOPPER_TEST_PYTHON", pythonPath)
+	t.Setenv("LOPPER_TEST_PYTHON_ENTRY", entrypoint)
+	t.Setenv("PYTHONPATH", strings.Join([]string{sitePackages, outsideModules}, string(os.PathListSeparator)))
+	pythonRunnerDir := setupFakeRuntimeToolScript(t, "pytest", "#!/bin/sh\nexec \"$LOPPER_TEST_PYTHON\" \"$LOPPER_TEST_PYTHON_ENTRY\"\n")
+	t.Setenv(runtimeBinDirsEnvKey, pythonRunnerDir)
+
+	if err := Capture(context.Background(), CaptureRequest{
+		RepoPath:  fixture.aliasRepo,
+		TracePath: fixture.tracePath,
+		Command:   "pytest",
+		Provider:  CaptureProviderPython,
+	}); err != nil {
+		t.Fatalf("capture python through symlinked repo alias: %v", err)
+	}
+
+	events, artifact := readRuntimeAliasEvents(t, fixture.tracePath)
+	assertRuntimeAliasArtifactPrivacy(t, artifact, fixture)
+	validEvent := findRuntimeAliasEvent(events, "validdep")
+	if validEvent == nil {
+		t.Fatalf("expected validdep event, got %#v", events)
+	}
+	if validEvent.Parent != "main.py" || validEvent.Entrypoint != "main.py" {
+		t.Fatalf("expected alias-relative python attribution, got %#v", *validEvent)
+	}
+	for _, dependency := range []string{"outsidedep", "escapeddep"} {
+		event := findRuntimeAliasEvent(events, dependency)
+		if event == nil {
+			t.Fatalf("expected %s event, got %#v", dependency, events)
+		}
+		if event.Parent != "" {
+			t.Fatalf("expected %s escape parent to be redacted, got %#v", dependency, *event)
+		}
+	}
+	for _, root := range []string{fixture.realRepo, fixture.fixtureRoot} {
+		if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() && entry.Name() == "__pycache__" {
+				t.Errorf("capture created Python cache directory %q", path)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("scan for Python cache artifacts: %v", err)
+		}
+	}
+}
+
+type runtimeRepoAliasFixture struct {
+	fixtureRoot string
+	realRepo    string
+	aliasRepo   string
+	tracePath   string
+}
+
+func newRuntimeRepoAliasFixture(t *testing.T) runtimeRepoAliasFixture {
+	t.Helper()
+
+	fixtureRoot := t.TempDir()
+	realRepo := filepath.Join(fixtureRoot, "repo-real")
+	aliasRepo := filepath.Join(fixtureRoot, "repo-alias")
+	if err := os.MkdirAll(realRepo, 0o750); err != nil {
+		t.Fatalf("mkdir real repo: %v", err)
+	}
+	if err := os.Symlink(realRepo, aliasRepo); err != nil {
+		t.Fatalf("symlink repo alias: %v", err)
+	}
+	return runtimeRepoAliasFixture{
+		fixtureRoot: fixtureRoot,
+		realRepo:    realRepo,
+		aliasRepo:   aliasRepo,
+		tracePath:   filepath.Join(fixtureRoot, runtimeTraceNDJSON),
+	}
+}
+
+func writeRuntimeAliasFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir parent for %q: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+}
+
+func readRuntimeAliasEvents(t *testing.T, tracePath string) ([]Event, string) {
+	t.Helper()
+
+	content, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read runtime alias trace: %v", err)
+	}
+	artifact := string(content)
+	var events []Event
+	for index, line := range strings.Split(artifact, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var event Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("decode runtime alias event %d: %v", index+1, err)
+		}
+		events = append(events, event)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected runtime alias events")
+	}
+	return events, artifact
+}
+
+func assertRuntimeAliasArtifactPrivacy(t *testing.T, artifact string, fixture runtimeRepoAliasFixture) {
+	t.Helper()
+
+	for _, forbidden := range []string{
+		fixture.fixtureRoot,
+		fixture.realRepo,
+		fixture.aliasRepo,
+		"file://",
+	} {
+		if strings.Contains(artifact, forbidden) {
+			t.Fatalf("runtime alias artifact leaked %q: %s", forbidden, artifact)
+		}
+	}
+}
+
+func findRuntimeAliasEvent(events []Event, module string) *Event {
+	for index := range events {
+		if events[index].Module == module {
+			return &events[index]
+		}
+	}
+	return nil
+}
+
+func hasRuntimeAliasEntrypoint(events []Event, entrypoint string) bool {
+	for _, event := range events {
+		if event.Entrypoint == entrypoint {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRedactedRuntimeAliasEvent(events []Event, parent string) bool {
+	for _, event := range events {
+		if event.Parent == parent && event.Module == "" && event.Resolved == "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -113,8 +113,10 @@ func TestCapturePythonRuntimeImports(t *testing.T) {
 	if strings.Contains(string(content), "localmod") {
 		t.Fatalf("expected local module import to be filtered, got %s", content)
 	}
-	if strings.Contains(string(content), repo) || strings.Contains(string(content), "file://") {
-		t.Fatalf("expected python runtime trace context to avoid absolute paths and file urls, got %s", content)
+	for _, forbidden := range []string{repo, sitePackages, filepath.Dir(sitePackages), "site-packages", "file://"} {
+		if strings.Contains(string(content), forbidden) {
+			t.Fatalf("expected python runtime trace artifact to avoid %q, got %s", forbidden, content)
+		}
 	}
 
 	trace, err := Load(tracePath)
@@ -167,6 +169,8 @@ func TestCaptureNodeRuntimeContextPrivacy(t *testing.T) {
 	}
 	text := string(content)
 	for _, forbidden := range []string{
+		repo,
+		`file://`,
 		`"parent":"` + repo,
 		`"entrypoint":"` + repo,
 		`"parent":"file://`,
@@ -178,6 +182,13 @@ func TestCaptureNodeRuntimeContextPrivacy(t *testing.T) {
 	}
 	if !strings.Contains(text, `"parent":"main.js"`) || !strings.Contains(text, `"entrypoint":"main.js"`) {
 		t.Fatalf("expected repo-relative runtime context in trace, got %s", text)
+	}
+	trace, err := Load(tracePath)
+	if err != nil {
+		t.Fatalf("load captured node runtime trace: %v", err)
+	}
+	if trace.DependencyLoads["left-pad"] == 0 {
+		t.Fatalf("expected left-pad dependency correlation from sanitized trace, got %#v", trace.DependencyLoads)
 	}
 }
 

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -448,10 +448,13 @@ func TestParseRuntimeTraceStateValidation(t *testing.T) {
 	if _, ok := parseRuntimeTraceState([]byte(`{"schema":"wrong","command":"npm test"}`)); ok {
 		t.Fatalf("expected wrong runtime trace schema to be rejected")
 	}
-	if _, ok := parseRuntimeTraceState([]byte(`{"schema":"v2","command":"  ","provider":"node"}`)); ok {
+	if _, ok := parseRuntimeTraceState([]byte(`{"schema":"v2","command":"npm test","provider":"node"}`)); ok {
+		t.Fatalf("expected legacy runtime trace schema to be rejected")
+	}
+	if _, ok := parseRuntimeTraceState([]byte(`{"schema":"v3","command":"  ","provider":"node"}`)); ok {
 		t.Fatalf("expected blank runtime trace command to be rejected")
 	}
-	if _, ok := parseRuntimeTraceState([]byte(`{"schema":"v2","command":"npm test","provider":"ruby"}`)); ok {
+	if _, ok := parseRuntimeTraceState([]byte(`{"schema":"v3","command":"npm test","provider":"ruby"}`)); ok {
 		t.Fatalf("expected unsupported runtime trace provider to be rejected")
 	}
 }
@@ -465,6 +468,52 @@ func TestWriteRuntimeTraceStateAndReuseChecks(t *testing.T) {
 	assertRuntimeReuseResult(t, tracePath, npmTestCommand, CaptureProviderNode, true)
 	assertRuntimeReuseResult(t, tracePath, npmTestCommand, CaptureProviderPython, false)
 	assertRuntimeReuseResult(t, tracePath, "npm run test", CaptureProviderNode, false)
+}
+
+func TestCaptureReuseIfUnchangedInvalidatesLegacyV2State(t *testing.T) {
+	repo := t.TempDir()
+	tracePath := filepath.Join(repo, ".artifacts", runtimeTraceNDJSON)
+	counterPath := filepath.Join(repo, "counter.txt")
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "npm", "#!/bin/sh\ncount=$(cat \"$LOPPER_RUNTIME_COUNTER\" 2>/dev/null || echo 0)\ncount=$((count + 1))\nprintf '%s' \"$count\" > \"$LOPPER_RUNTIME_COUNTER\"\nprintf '{\"module\":\"lodash/map\"}\\n' > \"$LOPPER_RUNTIME_TRACE\"\n"))
+	t.Setenv("LOPPER_RUNTIME_COUNTER", counterPath)
+
+	if err := os.MkdirAll(filepath.Dir(tracePath), 0o750); err != nil {
+		t.Fatalf("mkdir trace parent: %v", err)
+	}
+	if err := os.WriteFile(tracePath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write trace fixture: %v", err)
+	}
+	if err := os.WriteFile(runtimeTraceStatePath(tracePath), []byte(`{"schema":"v2","command":"npm test","provider":"node"}`), 0o600); err != nil {
+		t.Fatalf("write legacy trace state: %v", err)
+	}
+
+	req := CaptureRequest{
+		RepoPath:         repo,
+		TracePath:        tracePath,
+		Command:          npmTestCommand,
+		Provider:         CaptureProviderNode,
+		ReuseIfUnchanged: true,
+	}
+	if err := Capture(context.Background(), req); err != nil {
+		t.Fatalf("capture with legacy state: %v", err)
+	}
+	if got := readCaptureCounter(t, counterPath); got != 1 {
+		t.Fatalf("expected legacy v2 state to force recapture, got %d executions", got)
+	}
+	stateData, err := os.ReadFile(runtimeTraceStatePath(tracePath))
+	if err != nil {
+		t.Fatalf("read rewritten runtime trace state: %v", err)
+	}
+	if _, ok := parseRuntimeTraceState(stateData); !ok {
+		t.Fatalf("expected recapture to rewrite runtime trace state with current schema")
+	}
+
+	if err := Capture(context.Background(), req); err != nil {
+		t.Fatalf("capture after recapture: %v", err)
+	}
+	if got := readCaptureCounter(t, counterPath); got != 1 {
+		t.Fatalf("expected rewritten v3 state to reuse trace, got %d executions", got)
+	}
 }
 
 func TestWriteRuntimeTraceStateFailsWhenParentMissing(t *testing.T) {

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -113,6 +113,9 @@ func TestCapturePythonRuntimeImports(t *testing.T) {
 	if strings.Contains(string(content), "localmod") {
 		t.Fatalf("expected local module import to be filtered, got %s", content)
 	}
+	if strings.Contains(string(content), repo) || strings.Contains(string(content), "file://") {
+		t.Fatalf("expected python runtime trace context to avoid absolute paths and file urls, got %s", content)
+	}
 
 	trace, err := Load(tracePath)
 	if err != nil {
@@ -121,6 +124,60 @@ func TestCapturePythonRuntimeImports(t *testing.T) {
 	key := DependencyKey{Language: runtimeLanguagePython, Name: "thirdparty"}
 	if trace.DependencyLoadsByLanguage[key] == 0 {
 		t.Fatalf("expected thirdparty load in parsed trace, got %#v", trace.DependencyLoadsByLanguage)
+	}
+}
+
+func TestCaptureNodeRuntimeContextPrivacy(t *testing.T) {
+	nodePath, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not available")
+	}
+
+	repo := t.TempDir()
+	tracePath := filepath.Join(repo, ".artifacts", runtimeTraceNDJSON)
+	if err := os.MkdirAll(filepath.Join(repo, "node_modules", "left-pad"), 0o755); err != nil {
+		t.Fatalf("mkdir node module: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "node_modules", "left-pad", "index.js"), []byte("module.exports = (s) => s;\n"), 0o600); err != nil {
+		t.Fatalf("write dependency: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte("{\"name\":\"privacy-test\",\"private\":true}\n"), 0o600); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	entrypoint := filepath.Join(repo, "main.js")
+	if err := os.WriteFile(entrypoint, []byte("require('left-pad');\n"), 0o600); err != nil {
+		t.Fatalf("write entrypoint: %v", err)
+	}
+
+	env, err := withNodeRuntimeTraceEnv(os.Environ(), tracePath, repo)
+	if err != nil {
+		t.Fatalf("node runtime env: %v", err)
+	}
+	cmd := exec.Command(nodePath, entrypoint)
+	cmd.Dir = repo
+	cmd.Env = env
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run node hook capture: %v: %s", err, output)
+	}
+
+	content, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read node runtime trace: %v", err)
+	}
+	text := string(content)
+	for _, forbidden := range []string{
+		`"parent":"` + repo,
+		`"entrypoint":"` + repo,
+		`"parent":"file://`,
+		`"entrypoint":"file://`,
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("expected node runtime context to avoid absolute paths and file urls, got %s", text)
+		}
+	}
+	if !strings.Contains(text, `"parent":"main.js"`) || !strings.Contains(text, `"entrypoint":"main.js"`) {
+		t.Fatalf("expected repo-relative runtime context in trace, got %s", text)
 	}
 }
 

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -88,6 +88,19 @@ func TestCapturePythonRuntimeImports(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "localmod.py"), []byte("VALUE = 1\n"), 0o600); err != nil {
 		t.Fatalf("write local module: %v", err)
 	}
+	hookDir, err := runtimePythonHookDirectory()
+	if err != nil {
+		t.Fatalf("runtime python hook directory: %v", err)
+	}
+	hookPycache := filepath.Join(hookDir, "__pycache__")
+	if err := os.RemoveAll(hookPycache); err != nil {
+		t.Fatalf("remove runtime hook pycache: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(hookPycache); err != nil && !os.IsNotExist(err) {
+			t.Errorf("remove runtime hook pycache: %v", err)
+		}
+	})
 
 	t.Setenv("LOPPER_TEST_PYTHON", pythonPath)
 	t.Setenv("PYTHONPATH", sitePackages)
@@ -126,6 +139,12 @@ func TestCapturePythonRuntimeImports(t *testing.T) {
 	key := DependencyKey{Language: runtimeLanguagePython, Name: "thirdparty"}
 	if trace.DependencyLoadsByLanguage[key] == 0 {
 		t.Fatalf("expected thirdparty load in parsed trace, got %#v", trace.DependencyLoadsByLanguage)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "__pycache__")); !os.IsNotExist(err) {
+		t.Fatalf("expected capture repo to avoid __pycache__ artifacts, stat err = %v", err)
+	}
+	if _, err := os.Stat(hookPycache); !os.IsNotExist(err) {
+		t.Fatalf("expected runtime hook capture to avoid hook __pycache__ artifacts, stat err = %v", err)
 	}
 }
 

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -76,39 +76,14 @@ func TestCapturePythonRuntimeImports(t *testing.T) {
 		t.Skip("python3 not available")
 	}
 
-	repo := t.TempDir()
-	tracePath := filepath.Join(repo, ".artifacts", runtimeTraceNDJSON)
-	sitePackages := filepath.Join(t.TempDir(), "lib", "python3.12", "site-packages")
-	if err := os.MkdirAll(filepath.Join(sitePackages, "thirdparty"), 0o750); err != nil {
-		t.Fatalf("mkdir thirdparty package: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sitePackages, "thirdparty", "__init__.py"), []byte("VALUE = 1\n"), 0o600); err != nil {
-		t.Fatalf("write thirdparty package: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(repo, "localmod.py"), []byte("VALUE = 1\n"), 0o600); err != nil {
-		t.Fatalf("write local module: %v", err)
-	}
-	hookDir, err := runtimePythonHookDirectory()
-	if err != nil {
-		t.Fatalf("runtime python hook directory: %v", err)
-	}
-	hookPycache := filepath.Join(hookDir, "__pycache__")
-	if err := os.RemoveAll(hookPycache); err != nil {
-		t.Fatalf("remove runtime hook pycache: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.RemoveAll(hookPycache); err != nil && !os.IsNotExist(err) {
-			t.Errorf("remove runtime hook pycache: %v", err)
-		}
-	})
-
+	fixture := newCapturePythonRuntimeFixture(t)
 	t.Setenv("LOPPER_TEST_PYTHON", pythonPath)
-	t.Setenv("PYTHONPATH", sitePackages)
+	t.Setenv("PYTHONPATH", fixture.sitePackages)
 	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", "#!/bin/sh\nexec \"$LOPPER_TEST_PYTHON\" -c 'import thirdparty; import localmod'\n"))
 
 	err = Capture(context.Background(), CaptureRequest{
-		RepoPath:  repo,
-		TracePath: tracePath,
+		RepoPath:  fixture.repo,
+		TracePath: fixture.tracePath,
 		Command:   "pytest",
 		Provider:  CaptureProviderPython,
 	})
@@ -116,23 +91,13 @@ func TestCapturePythonRuntimeImports(t *testing.T) {
 		t.Fatalf("capture python runtime trace: %v", err)
 	}
 
-	content, err := os.ReadFile(tracePath)
+	content, err := os.ReadFile(fixture.tracePath)
 	if err != nil {
 		t.Fatalf("read python runtime trace: %v", err)
 	}
-	if !strings.Contains(string(content), `"language":"python"`) || !strings.Contains(string(content), `"module":"thirdparty"`) {
-		t.Fatalf("expected third-party python import event, got %s", content)
-	}
-	if strings.Contains(string(content), "localmod") {
-		t.Fatalf("expected local module import to be filtered, got %s", content)
-	}
-	for _, forbidden := range []string{repo, sitePackages, filepath.Dir(sitePackages), "site-packages", "file://"} {
-		if strings.Contains(string(content), forbidden) {
-			t.Fatalf("expected python runtime trace artifact to avoid %q, got %s", forbidden, content)
-		}
-	}
+	assertCapturedPythonImportArtifact(t, string(content), fixture)
 
-	trace, err := Load(tracePath)
+	trace, err := Load(fixture.tracePath)
 	if err != nil {
 		t.Fatalf("load captured python runtime trace: %v", err)
 	}
@@ -140,12 +105,11 @@ func TestCapturePythonRuntimeImports(t *testing.T) {
 	if trace.DependencyLoadsByLanguage[key] == 0 {
 		t.Fatalf("expected thirdparty load in parsed trace, got %#v", trace.DependencyLoadsByLanguage)
 	}
-	if _, err := os.Stat(filepath.Join(repo, "__pycache__")); !os.IsNotExist(err) {
-		t.Fatalf("expected capture repo to avoid __pycache__ artifacts, stat err = %v", err)
+	pycachePaths := []string{
+		filepath.Join(fixture.repo, "__pycache__"),
+		fixture.hookPycache,
 	}
-	if _, err := os.Stat(hookPycache); !os.IsNotExist(err) {
-		t.Fatalf("expected runtime hook capture to avoid hook __pycache__ artifacts, stat err = %v", err)
-	}
+	assertPathsDoNotExist(t, pycachePaths, "expected python runtime capture to avoid __pycache__ artifacts")
 }
 
 func TestCaptureNodeRuntimeContextPrivacy(t *testing.T) {
@@ -615,4 +579,82 @@ func readCaptureCounter(t *testing.T, counterPath string) int {
 		t.Fatalf("parse capture counter: %v", err)
 	}
 	return value
+}
+
+type capturePythonRuntimeFixture struct {
+	repo         string
+	tracePath    string
+	sitePackages string
+	hookPycache  string
+}
+
+func newCapturePythonRuntimeFixture(t *testing.T) capturePythonRuntimeFixture {
+	t.Helper()
+
+	repo := t.TempDir()
+	tracePath := filepath.Join(repo, ".artifacts", runtimeTraceNDJSON)
+	sitePackages := filepath.Join(t.TempDir(), "lib", "python3.12", "site-packages")
+	writeRuntimeAliasFile(t, filepath.Join(sitePackages, "thirdparty", "__init__.py"), "VALUE = 1\n")
+	writeRuntimeAliasFile(t, filepath.Join(repo, "localmod.py"), "VALUE = 1\n")
+
+	hookDir, err := runtimePythonHookDirectory()
+	if err != nil {
+		t.Fatalf("runtime python hook directory: %v", err)
+	}
+	hookPycache := filepath.Join(hookDir, "__pycache__")
+	if err := os.RemoveAll(hookPycache); err != nil {
+		t.Fatalf("remove runtime hook pycache: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(hookPycache); err != nil && !os.IsNotExist(err) {
+			t.Errorf("remove runtime hook pycache: %v", err)
+		}
+	})
+
+	return capturePythonRuntimeFixture{
+		repo:         repo,
+		tracePath:    tracePath,
+		sitePackages: sitePackages,
+		hookPycache:  hookPycache,
+	}
+}
+
+func assertCapturedPythonImportArtifact(t *testing.T, artifact string, fixture capturePythonRuntimeFixture) {
+	t.Helper()
+
+	requiredFragments := []string{`"language":"python"`, `"module":"thirdparty"`}
+	for _, fragment := range requiredFragments {
+		if !strings.Contains(artifact, fragment) {
+			t.Fatalf("expected python runtime trace artifact to contain %q, got %s", fragment, artifact)
+		}
+	}
+	forbiddenFragments := []string{
+		"localmod",
+		fixture.repo,
+		fixture.sitePackages,
+		filepath.Dir(fixture.sitePackages),
+		"site-packages",
+		"file://",
+	}
+	assertArtifactExcludesStrings(t, artifact, forbiddenFragments, "python runtime trace artifact")
+}
+
+func assertArtifactExcludesStrings(t *testing.T, artifact string, forbidden []string, label string) {
+	t.Helper()
+
+	for _, fragment := range forbidden {
+		if strings.Contains(artifact, fragment) {
+			t.Fatalf("expected %s to avoid %q, got %s", label, fragment, artifact)
+		}
+	}
+}
+
+func assertPathsDoNotExist(t *testing.T, paths []string, message string) {
+	t.Helper()
+
+	for _, path := range paths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s, stat %q err = %v", message, path, err)
+		}
+	}
 }

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -271,6 +271,55 @@ func TestCaptureCommandFailureWithoutOutput(t *testing.T) {
 	}
 }
 
+func TestCaptureRunErrorWithoutCleanup(t *testing.T) {
+	sentinel := errors.New("command failed")
+	output := newRuntimeCommandOutput()
+	if _, err := output.Write([]byte("command diagnostic")); err != nil {
+		t.Fatalf("write command diagnostic: %v", err)
+	}
+
+	err := captureRunError(sentinel, nil, output)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected command error to remain primary, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "command diagnostic") {
+		t.Fatalf("expected command diagnostic, got %v", err)
+	}
+}
+
+func TestCaptureRunErrorWithSuccessfulCleanup(t *testing.T) {
+	sentinel := errors.New("command failed")
+	cleanupCalled := false
+	cleanup := func() error {
+		cleanupCalled = true
+		return nil
+	}
+	err := captureRunError(sentinel, cleanup, newRuntimeCommandOutput())
+
+	if !cleanupCalled {
+		t.Fatal("expected cleanup after command failure")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected command error to remain primary, got %v", err)
+	}
+}
+
+func TestCaptureRunErrorIncludesCleanupFailureNote(t *testing.T) {
+	runErr := errors.New("command failed")
+	cleanupErr := errors.New("cleanup failed")
+	cleanup := func() error {
+		return cleanupErr
+	}
+	err := captureRunError(runErr, cleanup, newRuntimeCommandOutput())
+
+	if !errors.Is(err, runErr) {
+		t.Fatalf("expected command error to remain primary, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "[runtime hook cleanup after failure: cleanup failed]") {
+		t.Fatalf("expected cleanup failure diagnostic, got %v", err)
+	}
+}
+
 func TestCapturePythonHookCleanupErrors(t *testing.T) {
 	sentinel := errors.New("forced cleanup failure")
 	previousChmod := runtimeHookDirChmod
@@ -288,19 +337,14 @@ func TestCapturePythonHookCleanupErrors(t *testing.T) {
 
 	t.Run("surfaces cleanup error after successful capture", func(t *testing.T) {
 		repo := t.TempDir()
-		tracePath := filepath.Join(repo, ".artifacts", runtimeTraceNDJSON)
 		script := "#!/bin/sh\nprintf '{\"module\":\"thirdparty\",\"language\":\"python\"}\\n' > \"$LOPPER_RUNTIME_TRACE\"\n"
-		t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", script))
-
-		err := Capture(context.Background(), CaptureRequest{
+		req := CaptureRequest{
 			RepoPath:  repo,
-			TracePath: tracePath,
+			TracePath: filepath.Join(repo, ".artifacts", runtimeTraceNDJSON),
 			Command:   "pytest",
 			Provider:  CaptureProviderPython,
-		})
-		if !errors.Is(err, sentinel) || !strings.Contains(err.Error(), "cleanup staged runtime python hook") {
-			t.Fatalf("expected staged hook cleanup error, got %v", err)
 		}
+		assertCaptureReturnsCleanupFailure(t, sentinel, req, script)
 	})
 
 	t.Run("does not reuse cleanup-failed state on next run", func(t *testing.T) {
@@ -318,10 +362,7 @@ func TestCapturePythonHookCleanupErrors(t *testing.T) {
 			Provider:         CaptureProviderPython,
 			ReuseIfUnchanged: true,
 		}
-		err := Capture(context.Background(), req)
-		if !errors.Is(err, sentinel) || !strings.Contains(err.Error(), "cleanup staged runtime python hook") {
-			t.Fatalf("expected staged hook cleanup error, got %v", err)
-		}
+		assertCaptureReturnsCleanupFailure(t, sentinel, req, script)
 		if got := readCaptureCounter(t, counterPath); got != 1 {
 			t.Fatalf("expected first cleanup-failed capture execution count 1, got %d", got)
 		}
@@ -341,24 +382,38 @@ func TestCapturePythonHookCleanupErrors(t *testing.T) {
 	})
 
 	t.Run("preserves primary capture error", func(t *testing.T) {
-		repo := t.TempDir()
-		t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", "#!/bin/sh\nexit 3\n"))
-
-		err := Capture(context.Background(), CaptureRequest{
-			RepoPath: repo,
-			Command:  "pytest",
-			Provider: CaptureProviderPython,
-		})
-		if err == nil {
-			t.Fatal("expected primary capture error")
-		}
-		if !strings.Contains(err.Error(), "runtime test command failed") {
-			t.Fatalf("expected primary capture error, got %v", err)
-		}
-		if strings.Contains(err.Error(), "cleanup staged runtime python hook") {
-			t.Fatalf("expected cleanup error to be suppressed when capture fails, got %v", err)
-		}
+		assertCaptureFailureSuppressesCleanupError(t)
 	})
+}
+
+func assertCaptureReturnsCleanupFailure(t *testing.T, sentinel error, req CaptureRequest, script string) {
+	t.Helper()
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", script))
+	err := Capture(context.Background(), req)
+	if !errors.Is(err, sentinel) || !strings.Contains(err.Error(), "cleanup staged runtime python hook") {
+		t.Fatalf("expected staged hook cleanup error, got %v", err)
+	}
+}
+
+func assertCaptureFailureSuppressesCleanupError(t *testing.T) {
+	t.Helper()
+	repo := t.TempDir()
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", "#!/bin/sh\nexit 3\n"))
+
+	err := Capture(context.Background(), CaptureRequest{
+		RepoPath: repo,
+		Command:  "pytest",
+		Provider: CaptureProviderPython,
+	})
+	if err == nil {
+		t.Fatal("expected primary capture error")
+	}
+	if !strings.Contains(err.Error(), "runtime test command failed") {
+		t.Fatalf("expected primary capture error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "cleanup staged runtime python hook") {
+		t.Fatalf("expected cleanup error to be suppressed when capture fails, got %v", err)
+	}
 }
 
 func TestCaptureHonorsContextCancellation(t *testing.T) {

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -303,6 +303,43 @@ func TestCapturePythonHookCleanupErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("does not reuse cleanup-failed state on next run", func(t *testing.T) {
+		repo := t.TempDir()
+		tracePath := filepath.Join(repo, ".artifacts", runtimeTraceNDJSON)
+		counterPath := filepath.Join(repo, "counter.txt")
+		script := "#!/bin/sh\ncount=$(cat \"$LOPPER_RUNTIME_COUNTER\" 2>/dev/null || echo 0)\ncount=$((count + 1))\nprintf '%s' \"$count\" > \"$LOPPER_RUNTIME_COUNTER\"\nprintf '{\"module\":\"thirdparty\",\"language\":\"python\"}\\n' > \"$LOPPER_RUNTIME_TRACE\"\n"
+		t.Setenv("LOPPER_RUNTIME_COUNTER", counterPath)
+		t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", script))
+
+		req := CaptureRequest{
+			RepoPath:         repo,
+			TracePath:        tracePath,
+			Command:          "pytest",
+			Provider:         CaptureProviderPython,
+			ReuseIfUnchanged: true,
+		}
+		err := Capture(context.Background(), req)
+		if !errors.Is(err, sentinel) || !strings.Contains(err.Error(), "cleanup staged runtime python hook") {
+			t.Fatalf("expected staged hook cleanup error, got %v", err)
+		}
+		if got := readCaptureCounter(t, counterPath); got != 1 {
+			t.Fatalf("expected first cleanup-failed capture execution count 1, got %d", got)
+		}
+		if _, statErr := os.Stat(runtimeTraceStatePath(tracePath)); !os.IsNotExist(statErr) {
+			t.Fatalf("expected cleanup-failed capture to leave no reusable state, stat err = %v", statErr)
+		}
+
+		runtimeHookDirChmod = previousChmod
+		runtimeHookDirRemoveAll = previousRemoveAll
+
+		if err := Capture(context.Background(), req); err != nil {
+			t.Fatalf("capture after cleanup failure: %v", err)
+		}
+		if got := readCaptureCounter(t, counterPath); got != 2 {
+			t.Fatalf("expected second capture to recapture instead of reuse, got %d executions", got)
+		}
+	})
+
 	t.Run("preserves primary capture error", func(t *testing.T) {
 		repo := t.TempDir()
 		t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", "#!/bin/sh\nexit 3\n"))
@@ -776,25 +813,7 @@ func assertPythonRuntimeBytecodeSemantics(t *testing.T, pyDontWriteBytecode stri
 	fixture := newCapturePythonRuntimeFixture(t)
 	t.Setenv("LOPPER_TEST_PYTHON", pythonPath)
 	t.Setenv("PYTHONPATH", fixture.sitePackages)
-	if pyDontWriteBytecode == "" {
-		previous, hadPrevious := os.LookupEnv("PYTHONDONTWRITEBYTECODE")
-		if err := os.Unsetenv("PYTHONDONTWRITEBYTECODE"); err != nil {
-			t.Fatalf("unset PYTHONDONTWRITEBYTECODE: %v", err)
-		}
-		t.Cleanup(func() {
-			if !hadPrevious {
-				if err := os.Unsetenv("PYTHONDONTWRITEBYTECODE"); err != nil {
-					t.Fatalf("cleanup PYTHONDONTWRITEBYTECODE: %v", err)
-				}
-				return
-			}
-			if err := os.Setenv("PYTHONDONTWRITEBYTECODE", previous); err != nil {
-				t.Fatalf("restore PYTHONDONTWRITEBYTECODE: %v", err)
-			}
-		})
-	} else {
-		t.Setenv("PYTHONDONTWRITEBYTECODE", pyDontWriteBytecode)
-	}
+	configurePythonBytecodeEnv(t, pyDontWriteBytecode)
 	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", "#!/bin/sh\nexec \"$LOPPER_TEST_PYTHON\" -c 'import thirdparty; import localmod'\n"))
 
 	err = Capture(context.Background(), CaptureRequest{
@@ -815,4 +834,35 @@ func assertPythonRuntimeBytecodeSemantics(t *testing.T, pyDontWriteBytecode stri
 		t.Fatalf("expected local module bytecode under normal python semantics, got none")
 	}
 	assertPathsDoNotExist(t, []string{fixture.hookPycache}, "expected runtime hook staging to avoid hook __pycache__ artifacts")
+}
+
+func configurePythonBytecodeEnv(t *testing.T, pyDontWriteBytecode string) {
+	t.Helper()
+
+	if pyDontWriteBytecode != "" {
+		t.Setenv("PYTHONDONTWRITEBYTECODE", pyDontWriteBytecode)
+		return
+	}
+
+	previous, hadPrevious := os.LookupEnv("PYTHONDONTWRITEBYTECODE")
+	if err := os.Unsetenv("PYTHONDONTWRITEBYTECODE"); err != nil {
+		t.Fatalf("unset PYTHONDONTWRITEBYTECODE: %v", err)
+	}
+	t.Cleanup(func() {
+		restorePythonBytecodeEnv(t, previous, hadPrevious)
+	})
+}
+
+func restorePythonBytecodeEnv(t *testing.T, previous string, hadPrevious bool) {
+	t.Helper()
+
+	if !hadPrevious {
+		if err := os.Unsetenv("PYTHONDONTWRITEBYTECODE"); err != nil {
+			t.Fatalf("cleanup PYTHONDONTWRITEBYTECODE: %v", err)
+		}
+		return
+	}
+	if err := os.Setenv("PYTHONDONTWRITEBYTECODE", previous); err != nil {
+		t.Fatalf("restore PYTHONDONTWRITEBYTECODE: %v", err)
+	}
 }

--- a/internal/runtime/capture_behavior_test.go
+++ b/internal/runtime/capture_behavior_test.go
@@ -105,11 +105,15 @@ func TestCapturePythonRuntimeImports(t *testing.T) {
 	if trace.DependencyLoadsByLanguage[key] == 0 {
 		t.Fatalf("expected thirdparty load in parsed trace, got %#v", trace.DependencyLoadsByLanguage)
 	}
-	pycachePaths := []string{
-		filepath.Join(fixture.repo, "__pycache__"),
-		fixture.hookPycache,
-	}
-	assertPathsDoNotExist(t, pycachePaths, "expected python runtime capture to avoid __pycache__ artifacts")
+	assertPathsDoNotExist(t, []string{fixture.hookPycache}, "expected python runtime capture to avoid hook __pycache__ artifacts")
+}
+
+func TestCapturePythonRuntimePreservesDefaultBytecodeSemantics(t *testing.T) {
+	assertPythonRuntimeBytecodeSemantics(t, "")
+}
+
+func TestCapturePythonRuntimePreservesExplicitBytecodeOptIn(t *testing.T) {
+	assertPythonRuntimeBytecodeSemantics(t, "0")
 }
 
 func TestCaptureNodeRuntimeContextPrivacy(t *testing.T) {
@@ -265,6 +269,59 @@ func TestCaptureCommandFailureWithoutOutput(t *testing.T) {
 	if strings.Contains(err.Error(), "\n") {
 		t.Fatalf("expected silent failure without command output, got %v", err)
 	}
+}
+
+func TestCapturePythonHookCleanupErrors(t *testing.T) {
+	sentinel := errors.New("forced cleanup failure")
+	previousChmod := runtimeHookDirChmod
+	previousRemoveAll := runtimeHookDirRemoveAll
+	runtimeHookDirChmod = func(path string, mode os.FileMode) error {
+		return sentinel
+	}
+	runtimeHookDirRemoveAll = func(path string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		runtimeHookDirChmod = previousChmod
+		runtimeHookDirRemoveAll = previousRemoveAll
+	})
+
+	t.Run("surfaces cleanup error after successful capture", func(t *testing.T) {
+		repo := t.TempDir()
+		tracePath := filepath.Join(repo, ".artifacts", runtimeTraceNDJSON)
+		script := "#!/bin/sh\nprintf '{\"module\":\"thirdparty\",\"language\":\"python\"}\\n' > \"$LOPPER_RUNTIME_TRACE\"\n"
+		t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", script))
+
+		err := Capture(context.Background(), CaptureRequest{
+			RepoPath:  repo,
+			TracePath: tracePath,
+			Command:   "pytest",
+			Provider:  CaptureProviderPython,
+		})
+		if !errors.Is(err, sentinel) || !strings.Contains(err.Error(), "cleanup staged runtime python hook") {
+			t.Fatalf("expected staged hook cleanup error, got %v", err)
+		}
+	})
+
+	t.Run("preserves primary capture error", func(t *testing.T) {
+		repo := t.TempDir()
+		t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", "#!/bin/sh\nexit 3\n"))
+
+		err := Capture(context.Background(), CaptureRequest{
+			RepoPath: repo,
+			Command:  "pytest",
+			Provider: CaptureProviderPython,
+		})
+		if err == nil {
+			t.Fatal("expected primary capture error")
+		}
+		if !strings.Contains(err.Error(), "runtime test command failed") {
+			t.Fatalf("expected primary capture error, got %v", err)
+		}
+		if strings.Contains(err.Error(), "cleanup staged runtime python hook") {
+			t.Fatalf("expected cleanup error to be suppressed when capture fails, got %v", err)
+		}
+	})
 }
 
 func TestCaptureHonorsContextCancellation(t *testing.T) {
@@ -706,4 +763,56 @@ func assertPathsDoNotExist(t *testing.T, paths []string, message string) {
 			t.Fatalf("%s, stat %q err = %v", message, path, err)
 		}
 	}
+}
+
+func assertPythonRuntimeBytecodeSemantics(t *testing.T, pyDontWriteBytecode string) {
+	t.Helper()
+
+	pythonPath, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+
+	fixture := newCapturePythonRuntimeFixture(t)
+	t.Setenv("LOPPER_TEST_PYTHON", pythonPath)
+	t.Setenv("PYTHONPATH", fixture.sitePackages)
+	if pyDontWriteBytecode == "" {
+		previous, hadPrevious := os.LookupEnv("PYTHONDONTWRITEBYTECODE")
+		if err := os.Unsetenv("PYTHONDONTWRITEBYTECODE"); err != nil {
+			t.Fatalf("unset PYTHONDONTWRITEBYTECODE: %v", err)
+		}
+		t.Cleanup(func() {
+			if !hadPrevious {
+				if err := os.Unsetenv("PYTHONDONTWRITEBYTECODE"); err != nil {
+					t.Fatalf("cleanup PYTHONDONTWRITEBYTECODE: %v", err)
+				}
+				return
+			}
+			if err := os.Setenv("PYTHONDONTWRITEBYTECODE", previous); err != nil {
+				t.Fatalf("restore PYTHONDONTWRITEBYTECODE: %v", err)
+			}
+		})
+	} else {
+		t.Setenv("PYTHONDONTWRITEBYTECODE", pyDontWriteBytecode)
+	}
+	t.Setenv(runtimeBinDirsEnvKey, setupFakeRuntimeToolScript(t, "pytest", "#!/bin/sh\nexec \"$LOPPER_TEST_PYTHON\" -c 'import thirdparty; import localmod'\n"))
+
+	err = Capture(context.Background(), CaptureRequest{
+		RepoPath:  fixture.repo,
+		TracePath: fixture.tracePath,
+		Command:   "pytest",
+		Provider:  CaptureProviderPython,
+	})
+	if err != nil {
+		t.Fatalf("capture python runtime trace: %v", err)
+	}
+
+	localPycache, err := filepath.Glob(filepath.Join(fixture.repo, "__pycache__", "localmod*.pyc"))
+	if err != nil {
+		t.Fatalf("glob local module pycache: %v", err)
+	}
+	if len(localPycache) == 0 {
+		t.Fatalf("expected local module bytecode under normal python semantics, got none")
+	}
+	assertPathsDoNotExist(t, []string{fixture.hookPycache}, "expected runtime hook staging to avoid hook __pycache__ artifacts")
 }

--- a/internal/runtime/capture_cov_branches_test.go
+++ b/internal/runtime/capture_cov_branches_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package runtime
 
 import (

--- a/internal/runtime/capture_cov_branches_test.go
+++ b/internal/runtime/capture_cov_branches_test.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"syscall"
 	"testing"
 )
@@ -49,29 +48,22 @@ func TestTrustedSearchDirsSkipsNonDirectories(t *testing.T) {
 }
 
 func TestRuntimeHookErrorsPropagate(t *testing.T) {
-	restoreRuntimeHookState(t)
 	sentinel := errors.New("hook lookup failed")
+	resolver := newFakeRuntimeHookPathResolver(func() (string, error) { return "", nil }, func(skip int) (uintptr, string, int, bool) { return 0, "", 0, false })
+	resolver.hookPaths.err = sentinel
+	resolver.hookPathsOnce.Do(func() {})
 
-	runtimeHookPathsOnce = sync.Once{}
-	runtimeHookPathsOnce.Do(func() {
-		runtimeRequireHookPath = ""
-		runtimeLoaderHookPath = ""
-		runtimeHookPathsErr = sentinel
-	})
-
-	if _, err := runtimeNodeHookOptions(); !errors.Is(err, sentinel) {
+	if _, err := resolver.runtimeNodeHookOptions(); !errors.Is(err, sentinel) {
 		t.Fatalf("expected runtime hook options error %v, got %v", sentinel, err)
 	}
 
-	_, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, "/tmp/runtime.ndjson", CaptureProviderNode, "/repo")
+	_, err := withRuntimeTraceEnvForResolver([]string{"PATH=/usr/bin"}, "/tmp/runtime.ndjson", CaptureProviderNode, "/repo", resolver)
 	if err == nil || !strings.Contains(err.Error(), "resolve runtime node hooks") {
 		t.Fatalf("expected wrapped runtime hook error, got %v", err)
 	}
 
-	err = Capture(context.Background(), CaptureRequest{
-		RepoPath: t.TempDir(),
-		Command:  "make test",
-	})
+	req := CaptureRequest{RepoPath: t.TempDir(), Command: "make test"}
+	err = captureWithRuntimeHookPathResolver(context.Background(), req, resolver)
 	if err == nil || !strings.Contains(err.Error(), "resolve runtime node hooks") {
 		t.Fatalf("expected capture to surface hook resolution error, got %v", err)
 	}
@@ -119,23 +111,6 @@ func TestConfigureRuntimeCommandCancelBranches(t *testing.T) {
 		if !errors.Is(err, os.ErrProcessDone) {
 			t.Fatalf("expected process-done error after exit, got %v", err)
 		}
-	})
-}
-
-func restoreRuntimeHookState(t *testing.T) {
-	t.Helper()
-
-	originalRequire := runtimeRequireHookPath
-	originalLoader := runtimeLoaderHookPath
-	originalErr := runtimeHookPathsErr
-
-	t.Cleanup(func() {
-		runtimeHookPathsOnce = sync.Once{}
-		runtimeHookPathsOnce.Do(func() {
-			runtimeRequireHookPath = originalRequire
-			runtimeLoaderHookPath = originalLoader
-			runtimeHookPathsErr = originalErr
-		})
 	})
 }
 

--- a/internal/runtime/capture_cov_branches_test.go
+++ b/internal/runtime/capture_cov_branches_test.go
@@ -63,7 +63,7 @@ func TestRuntimeHookErrorsPropagate(t *testing.T) {
 		t.Fatalf("expected runtime hook options error %v, got %v", sentinel, err)
 	}
 
-	_, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, "/tmp/runtime.ndjson", CaptureProviderNode)
+	_, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, "/tmp/runtime.ndjson", CaptureProviderNode, "/repo")
 	if err == nil || !strings.Contains(err.Error(), "resolve runtime node hooks") {
 		t.Fatalf("expected wrapped runtime hook error, got %v", err)
 	}

--- a/internal/runtime/capture_env.go
+++ b/internal/runtime/capture_env.go
@@ -14,33 +14,63 @@ const runtimeLoaderHookRelPath = "scripts/runtime/loader.mjs"
 const runtimePythonHookRelPath = "scripts/runtime/sitecustomize.py"
 const runtimeRepoRootEnvKey = "LOPPER_RUNTIME_REPO_ROOT"
 
-var (
-	runtimeHookPathsOnce   sync.Once
-	runtimeRequireHookPath string
-	runtimeLoaderHookPath  string
-	runtimeHookPathsErr    error
+type runtimeExecutablePathFunc func() (string, error)
+type runtimeCallerFunc func(skip int) (uintptr, string, int, bool)
 
-	runtimePythonHookDirOnce sync.Once
-	runtimePythonHookDirPath string
-	runtimePythonHookDirErr  error
-)
+type runtimeHookPathResolver struct {
+	executablePath runtimeExecutablePathFunc
+	caller         runtimeCallerFunc
 
-var runtimeExecutablePath = os.Executable
-var runtimeCaller = goruntime.Caller
+	hookPathsOnce sync.Once
+	hookPaths     struct {
+		requirePath string
+		loaderPath  string
+		err         error
+	}
+
+	pythonHookDirOnce sync.Once
+	pythonHookDir     struct {
+		path string
+		err  error
+	}
+}
+
+var defaultRuntimeHookPathResolver = newRuntimeHookPathResolver(os.Executable, goruntime.Caller)
+
+func newRuntimeHookPathResolver(executablePath runtimeExecutablePathFunc, caller runtimeCallerFunc) *runtimeHookPathResolver {
+	if executablePath == nil {
+		executablePath = os.Executable
+	}
+	if caller == nil {
+		caller = goruntime.Caller
+	}
+	return &runtimeHookPathResolver{
+		executablePath: executablePath,
+		caller:         caller,
+	}
+}
 
 func withRuntimeTraceEnv(base []string, tracePath string, provider CaptureProvider, repoPath string) ([]string, error) {
+	return withRuntimeTraceEnvForResolver(base, tracePath, provider, repoPath, defaultRuntimeHookPathResolver)
+}
+
+func withRuntimeTraceEnvForResolver(base []string, tracePath string, provider CaptureProvider, repoPath string, resolver *runtimeHookPathResolver) ([]string, error) {
 	switch normalizeCaptureProvider(provider) {
 	case CaptureProviderNode:
-		return withNodeRuntimeTraceEnv(base, tracePath, repoPath)
+		return withNodeRuntimeTraceEnvForResolver(base, tracePath, repoPath, resolver)
 	case CaptureProviderPython:
-		return withPythonRuntimeTraceEnv(base, tracePath, repoPath)
+		return withPythonRuntimeTraceEnvForResolver(base, tracePath, repoPath, resolver)
 	default:
 		return nil, fmt.Errorf("unsupported runtime capture provider %q", provider)
 	}
 }
 
 func withNodeRuntimeTraceEnv(base []string, tracePath string, repoPath string) ([]string, error) {
-	required, err := runtimeNodeHookOptions()
+	return withNodeRuntimeTraceEnvForResolver(base, tracePath, repoPath, defaultRuntimeHookPathResolver)
+}
+
+func withNodeRuntimeTraceEnvForResolver(base []string, tracePath string, repoPath string, resolver *runtimeHookPathResolver) ([]string, error) {
+	required, err := resolver.runtimeNodeHookOptions()
 	if err != nil {
 		return nil, fmt.Errorf("resolve runtime node hooks: %w", err)
 	}
@@ -48,7 +78,7 @@ func withNodeRuntimeTraceEnv(base []string, tracePath string, repoPath string) (
 	existing := readEnvValue(base, "NODE_OPTIONS")
 	updates := map[string]string{
 		"LOPPER_RUNTIME_TRACE": tracePath,
-		runtimeRepoRootEnvKey:  resolvedRuntimeRepoRoot(repoPath),
+		runtimeRepoRootEnvKey:  lexicalRuntimeRepoRoot(repoPath),
 	}
 	nodeOptions := strings.TrimSpace(existing)
 	if nodeOptions == "" {
@@ -60,7 +90,11 @@ func withNodeRuntimeTraceEnv(base []string, tracePath string, repoPath string) (
 }
 
 func withPythonRuntimeTraceEnv(base []string, tracePath string, repoPath string) ([]string, error) {
-	hookDir, err := runtimePythonHookDirectory()
+	return withPythonRuntimeTraceEnvForResolver(base, tracePath, repoPath, defaultRuntimeHookPathResolver)
+}
+
+func withPythonRuntimeTraceEnvForResolver(base []string, tracePath string, repoPath string, resolver *runtimeHookPathResolver) ([]string, error) {
+	hookDir, err := resolver.runtimePythonHookDirectory()
 	if err != nil {
 		return nil, fmt.Errorf("resolve runtime python hook: %w", err)
 	}
@@ -70,10 +104,23 @@ func withPythonRuntimeTraceEnv(base []string, tracePath string, repoPath string)
 		pythonPath += string(os.PathListSeparator) + existing
 	}
 	return mergeEnv(base, map[string]string{
-		"LOPPER_RUNTIME_TRACE": tracePath,
-		runtimeRepoRootEnvKey:  resolvedRuntimeRepoRoot(repoPath),
-		"PYTHONPATH":           pythonPath,
+		"LOPPER_RUNTIME_TRACE":    tracePath,
+		runtimeRepoRootEnvKey:     lexicalRuntimeRepoRoot(repoPath),
+		"PYTHONDONTWRITEBYTECODE": "1",
+		"PYTHONPATH":              pythonPath,
 	}), nil
+}
+
+func lexicalRuntimeRepoRoot(repoPath string) string {
+	trimmed := strings.TrimSpace(repoPath)
+	if trimmed == "" {
+		return ""
+	}
+	absPath, err := filepath.Abs(trimmed)
+	if err == nil && strings.TrimSpace(absPath) != "" {
+		return filepath.Clean(absPath)
+	}
+	return filepath.Clean(trimmed)
 }
 
 func resolvedRuntimeRepoRoot(repoPath string) string {
@@ -124,14 +171,6 @@ func readEnvValue(env []string, key string) string {
 	return ""
 }
 
-func runtimeNodeHookOptions() (string, error) {
-	requirePath, loaderPath, err := runtimeHookPaths()
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("--require=%s --loader=%s", quoteNodeOptionPath(requirePath), quoteNodeOptionPath(loaderPath)), nil
-}
-
 func quoteNodeOptionPath(path string) string {
 	if !strings.ContainsAny(path, " \t\r\n\"") {
 		return path
@@ -143,25 +182,19 @@ func quoteNodeOptionPath(path string) string {
 }
 
 func runtimeHookPaths() (string, string, error) {
-	runtimeHookPathsOnce.Do(func() {
-		runtimeRequireHookPath, runtimeLoaderHookPath, runtimeHookPathsErr = locateRuntimeHookPaths()
-	})
-	return runtimeRequireHookPath, runtimeLoaderHookPath, runtimeHookPathsErr
+	return defaultRuntimeHookPathResolver.runtimeHookPaths()
 }
 
 func runtimePythonHookDirectory() (string, error) {
-	runtimePythonHookDirOnce.Do(func() {
-		runtimePythonHookDirPath, runtimePythonHookDirErr = locateRuntimePythonHookDirectory()
-	})
-	return runtimePythonHookDirPath, runtimePythonHookDirErr
+	return defaultRuntimeHookPathResolver.runtimePythonHookDirectory()
 }
 
 func locateRuntimeHookPaths() (string, string, error) {
-	return locateRuntimeHookPathsInRoots(runtimeHookSearchRoots())
+	return locateRuntimeHookPathsInRoots(defaultRuntimeHookPathResolver.runtimeHookSearchRoots())
 }
 
 func locateRuntimePythonHookDirectory() (string, error) {
-	return locateRuntimePythonHookDirectoryInRoots(runtimeHookSearchRoots())
+	return locateRuntimePythonHookDirectoryInRoots(defaultRuntimeHookPathResolver.runtimeHookSearchRoots())
 }
 
 func locateRuntimeHookPathsInRoots(roots []string) (string, string, error) {
@@ -190,6 +223,32 @@ func locateRuntimePythonHookDirectoryInRoots(roots []string) (string, error) {
 }
 
 func runtimeHookSearchRoots() []string {
+	return defaultRuntimeHookPathResolver.runtimeHookSearchRoots()
+}
+
+func (r *runtimeHookPathResolver) runtimeNodeHookOptions() (string, error) {
+	requirePath, loaderPath, err := r.runtimeHookPaths()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("--require=%s --loader=%s", quoteNodeOptionPath(requirePath), quoteNodeOptionPath(loaderPath)), nil
+}
+
+func (r *runtimeHookPathResolver) runtimeHookPaths() (string, string, error) {
+	r.hookPathsOnce.Do(func() {
+		r.hookPaths.requirePath, r.hookPaths.loaderPath, r.hookPaths.err = locateRuntimeHookPathsInRoots(r.runtimeHookSearchRoots())
+	})
+	return r.hookPaths.requirePath, r.hookPaths.loaderPath, r.hookPaths.err
+}
+
+func (r *runtimeHookPathResolver) runtimePythonHookDirectory() (string, error) {
+	r.pythonHookDirOnce.Do(func() {
+		r.pythonHookDir.path, r.pythonHookDir.err = locateRuntimePythonHookDirectoryInRoots(r.runtimeHookSearchRoots())
+	})
+	return r.pythonHookDir.path, r.pythonHookDir.err
+}
+
+func (r *runtimeHookPathResolver) runtimeHookSearchRoots() []string {
 	seen := make(map[string]struct{})
 	roots := make([]string, 0)
 	addSearchPath := func(path string) {
@@ -211,12 +270,12 @@ func runtimeHookSearchRoots() []string {
 		roots = append(roots, dir)
 	}
 
-	if executablePath, err := runtimeExecutablePath(); err == nil {
+	if executablePath, err := r.executablePath(); err == nil {
 		executableDir := filepath.Dir(executablePath)
 		addSearchPath(filepath.Join(executableDir, "share", "lopper"))
 		addSearchPath(filepath.Join(executableDir, "..", "share", "lopper"))
 	}
-	if _, filename, _, ok := runtimeCaller(0); ok {
+	if _, filename, _, ok := r.caller(0); ok {
 		addSearchPath(filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..")))
 	}
 

--- a/internal/runtime/capture_env.go
+++ b/internal/runtime/capture_env.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -36,6 +37,12 @@ type runtimeHookPathResolver struct {
 }
 
 var defaultRuntimeHookPathResolver = newRuntimeHookPathResolver(os.Executable, goruntime.Caller)
+var runtimeHookFileRead = os.ReadFile
+var runtimeHookFileWrite = os.WriteFile
+var runtimeHookDirMkdirTemp = os.MkdirTemp
+var runtimeHookDirSeal = os.Chmod
+var runtimeHookDirChmod = os.Chmod
+var runtimeHookDirRemoveAll = os.RemoveAll
 
 func newRuntimeHookPathResolver(executablePath runtimeExecutablePathFunc, caller runtimeCallerFunc) *runtimeHookPathResolver {
 	if executablePath == nil {
@@ -62,6 +69,18 @@ func withRuntimeTraceEnvForResolver(base []string, tracePath string, provider Ca
 		return withPythonRuntimeTraceEnvForResolver(base, tracePath, repoPath, resolver)
 	default:
 		return nil, fmt.Errorf("unsupported runtime capture provider %q", provider)
+	}
+}
+
+func runtimeTraceEnvForCapture(base []string, tracePath string, provider CaptureProvider, repoPath string, resolver *runtimeHookPathResolver) ([]string, func() error, error) {
+	switch normalizeCaptureProvider(provider) {
+	case CaptureProviderNode:
+		env, err := withNodeRuntimeTraceEnvForResolver(base, tracePath, repoPath, resolver)
+		return env, nil, err
+	case CaptureProviderPython:
+		return withPreparedPythonRuntimeTraceEnvForResolver(base, tracePath, repoPath, resolver)
+	default:
+		return nil, nil, fmt.Errorf("unsupported runtime capture provider %q", provider)
 	}
 }
 
@@ -99,16 +118,27 @@ func withPythonRuntimeTraceEnvForResolver(base []string, tracePath string, repoP
 		return nil, fmt.Errorf("resolve runtime python hook: %w", err)
 	}
 
+	return withPythonRuntimeTraceEnvForHookDir(base, tracePath, repoPath, hookDir), nil
+}
+
+func withPreparedPythonRuntimeTraceEnvForResolver(base []string, tracePath string, repoPath string, resolver *runtimeHookPathResolver) ([]string, func() error, error) {
+	hookDir, cleanup, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stage runtime python hook: %w", err)
+	}
+	return withPythonRuntimeTraceEnvForHookDir(base, tracePath, repoPath, hookDir), cleanup, nil
+}
+
+func withPythonRuntimeTraceEnvForHookDir(base []string, tracePath string, repoPath string, hookDir string) []string {
 	pythonPath := hookDir
 	if existing := strings.TrimSpace(readEnvValue(base, "PYTHONPATH")); existing != "" {
 		pythonPath += string(os.PathListSeparator) + existing
 	}
 	return mergeEnv(base, map[string]string{
-		"LOPPER_RUNTIME_TRACE":    tracePath,
-		runtimeRepoRootEnvKey:     lexicalRuntimeRepoRoot(repoPath),
-		"PYTHONDONTWRITEBYTECODE": "1",
-		"PYTHONPATH":              pythonPath,
-	}), nil
+		"LOPPER_RUNTIME_TRACE": tracePath,
+		runtimeRepoRootEnvKey:  lexicalRuntimeRepoRoot(repoPath),
+		"PYTHONPATH":           pythonPath,
+	})
 }
 
 func lexicalRuntimeRepoRoot(repoPath string) string {
@@ -189,6 +219,10 @@ func runtimePythonHookDirectory() (string, error) {
 	return defaultRuntimeHookPathResolver.runtimePythonHookDirectory()
 }
 
+func stagePythonRuntimeHookDirectory() (string, func() error, error) {
+	return stagePythonRuntimeHookDirectoryForResolver(defaultRuntimeHookPathResolver)
+}
+
 func locateRuntimeHookPaths() (string, string, error) {
 	return locateRuntimeHookPathsInRoots(defaultRuntimeHookPathResolver.runtimeHookSearchRoots())
 }
@@ -246,6 +280,116 @@ func (r *runtimeHookPathResolver) runtimePythonHookDirectory() (string, error) {
 		r.pythonHookDir.path, r.pythonHookDir.err = locateRuntimePythonHookDirectoryInRoots(r.runtimeHookSearchRoots())
 	})
 	return r.pythonHookDir.path, r.pythonHookDir.err
+}
+
+func stagePythonRuntimeHookDirectoryForResolver(resolver *runtimeHookPathResolver) (string, func() error, error) {
+	hookDir, err := resolver.runtimePythonHookDirectory()
+	if err != nil {
+		return "", nil, err
+	}
+	sourcePath := filepath.Join(hookDir, filepath.Base(runtimePythonHookRelPath))
+	content, err := runtimeHookFileRead(sourcePath)
+	if err != nil {
+		return "", nil, fmt.Errorf("read runtime python hook: %w", sanitizeRuntimeHookStageError(err, sourcePath))
+	}
+	stagedDir, err := runtimeHookDirMkdirTemp("", "lopper-python-hook-")
+	if err != nil {
+		return "", nil, fmt.Errorf("create runtime python hook dir: %w", sanitizeRuntimeHookStageTempDirError(err))
+	}
+	cleanup := func() error {
+		var cleanupErrs []error
+		if err := runtimeHookDirChmod(stagedDir, 0o700); err != nil && !os.IsNotExist(err) {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("chmod staged runtime python hook dir: %w", sanitizeRuntimeHookStageError(err, stagedDir)))
+		}
+		if err := runtimeHookDirRemoveAll(stagedDir); err != nil && !os.IsNotExist(err) {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("remove staged runtime python hook dir: %w", sanitizeRuntimeHookStageError(err, stagedDir)))
+		}
+		return errors.Join(cleanupErrs...)
+	}
+	stagedPath := filepath.Join(stagedDir, filepath.Base(runtimePythonHookRelPath))
+	if err := runtimeHookFileWrite(stagedPath, content, 0o444); err != nil {
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			return "", nil, errors.Join(fmt.Errorf("write staged runtime python hook: %w", sanitizeRuntimeHookStageError(err, stagedPath)), fmt.Errorf("cleanup staged runtime python hook: %w", cleanupErr))
+		}
+		return "", nil, fmt.Errorf("write staged runtime python hook: %w", sanitizeRuntimeHookStageError(err, stagedPath))
+	}
+	if err := runtimeHookDirSeal(stagedDir, 0o555); err != nil {
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			return "", nil, errors.Join(fmt.Errorf("seal staged runtime python hook dir: %w", sanitizeRuntimeHookStageError(err, stagedDir)), fmt.Errorf("cleanup staged runtime python hook: %w", cleanupErr))
+		}
+		return "", nil, fmt.Errorf("seal staged runtime python hook dir: %w", sanitizeRuntimeHookStageError(err, stagedDir))
+	}
+	return stagedDir, cleanup, nil
+}
+
+type runtimeHookStageSanitizedError struct {
+	message string
+	err     error
+}
+
+func (e *runtimeHookStageSanitizedError) Error() string {
+	return e.message
+}
+
+func (e *runtimeHookStageSanitizedError) Unwrap() error {
+	return e.err
+}
+
+func sanitizeRuntimeHookStageError(err error, sensitivePaths ...string) error {
+	if err == nil {
+		return nil
+	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return &os.PathError{
+			Op:   pathErr.Op,
+			Path: sanitizeRuntimeHookStageText(pathErr.Path, sensitivePaths...),
+			Err:  sanitizeRuntimeHookStageError(pathErr.Err, sensitivePaths...),
+		}
+	}
+	message := sanitizeRuntimeHookStageText(err.Error(), sensitivePaths...)
+	if message == err.Error() {
+		return err
+	}
+	return &runtimeHookStageSanitizedError{message: message, err: err}
+}
+
+func sanitizeRuntimeHookStageTempDirError(err error) error {
+	if err == nil {
+		return nil
+	}
+	sensitivePaths := []string{os.TempDir()}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) && pathErr.Path != "" {
+		sensitivePaths = append(sensitivePaths, pathErr.Path)
+	}
+	return sanitizeRuntimeHookStageError(err, sensitivePaths...)
+}
+
+func sanitizeRuntimeHookStageText(text string, sensitivePaths ...string) string {
+	sanitized := text
+	for _, sensitivePath := range sensitivePaths {
+		for _, candidate := range runtimeHookSensitivePathVariants(sensitivePath) {
+			sanitized = strings.ReplaceAll(sanitized, candidate, "<path>")
+		}
+	}
+	return sanitized
+}
+
+func runtimeHookSensitivePathVariants(path string) []string {
+	if path == "" {
+		return nil
+	}
+	variants := []string{path}
+	cleanPath := filepath.Clean(path)
+	if cleanPath != path {
+		variants = append(variants, cleanPath)
+	}
+	slashPath := filepath.ToSlash(path)
+	if slashPath != path && slashPath != cleanPath {
+		variants = append(variants, slashPath)
+	}
+	return variants
 }
 
 func (r *runtimeHookPathResolver) runtimeHookSearchRoots() []string {

--- a/internal/runtime/capture_env.go
+++ b/internal/runtime/capture_env.go
@@ -12,6 +12,7 @@ import (
 const runtimeRequireHookRelPath = "scripts/runtime/require-hook.cjs"
 const runtimeLoaderHookRelPath = "scripts/runtime/loader.mjs"
 const runtimePythonHookRelPath = "scripts/runtime/sitecustomize.py"
+const runtimeRepoRootEnvKey = "LOPPER_RUNTIME_REPO_ROOT"
 
 var (
 	runtimeHookPathsOnce   sync.Once
@@ -27,18 +28,18 @@ var (
 var runtimeExecutablePath = os.Executable
 var runtimeCaller = goruntime.Caller
 
-func withRuntimeTraceEnv(base []string, tracePath string, provider CaptureProvider) ([]string, error) {
+func withRuntimeTraceEnv(base []string, tracePath string, provider CaptureProvider, repoPath string) ([]string, error) {
 	switch normalizeCaptureProvider(provider) {
 	case CaptureProviderNode:
-		return withNodeRuntimeTraceEnv(base, tracePath)
+		return withNodeRuntimeTraceEnv(base, tracePath, repoPath)
 	case CaptureProviderPython:
-		return withPythonRuntimeTraceEnv(base, tracePath)
+		return withPythonRuntimeTraceEnv(base, tracePath, repoPath)
 	default:
 		return nil, fmt.Errorf("unsupported runtime capture provider %q", provider)
 	}
 }
 
-func withNodeRuntimeTraceEnv(base []string, tracePath string) ([]string, error) {
+func withNodeRuntimeTraceEnv(base []string, tracePath string, repoPath string) ([]string, error) {
 	required, err := runtimeNodeHookOptions()
 	if err != nil {
 		return nil, fmt.Errorf("resolve runtime node hooks: %w", err)
@@ -47,6 +48,7 @@ func withNodeRuntimeTraceEnv(base []string, tracePath string) ([]string, error) 
 	existing := readEnvValue(base, "NODE_OPTIONS")
 	updates := map[string]string{
 		"LOPPER_RUNTIME_TRACE": tracePath,
+		runtimeRepoRootEnvKey:  resolvedRuntimeRepoRoot(repoPath),
 	}
 	nodeOptions := strings.TrimSpace(existing)
 	if nodeOptions == "" {
@@ -57,7 +59,7 @@ func withNodeRuntimeTraceEnv(base []string, tracePath string) ([]string, error) 
 	return mergeEnv(base, updates), nil
 }
 
-func withPythonRuntimeTraceEnv(base []string, tracePath string) ([]string, error) {
+func withPythonRuntimeTraceEnv(base []string, tracePath string, repoPath string) ([]string, error) {
 	hookDir, err := runtimePythonHookDirectory()
 	if err != nil {
 		return nil, fmt.Errorf("resolve runtime python hook: %w", err)
@@ -69,8 +71,25 @@ func withPythonRuntimeTraceEnv(base []string, tracePath string) ([]string, error
 	}
 	return mergeEnv(base, map[string]string{
 		"LOPPER_RUNTIME_TRACE": tracePath,
+		runtimeRepoRootEnvKey:  resolvedRuntimeRepoRoot(repoPath),
 		"PYTHONPATH":           pythonPath,
 	}), nil
+}
+
+func resolvedRuntimeRepoRoot(repoPath string) string {
+	trimmed := strings.TrimSpace(repoPath)
+	if trimmed == "" {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(trimmed)
+	if err == nil && strings.TrimSpace(resolved) != "" {
+		return filepath.Clean(resolved)
+	}
+	absPath, err := filepath.Abs(trimmed)
+	if err == nil && strings.TrimSpace(absPath) != "" {
+		return filepath.Clean(absPath)
+	}
+	return filepath.Clean(trimmed)
 }
 
 func mergeEnv(base []string, updates map[string]string) []string {

--- a/internal/runtime/capture_env_test.go
+++ b/internal/runtime/capture_env_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -41,7 +42,9 @@ func TestWithPythonRuntimeTraceEnv(t *testing.T) {
 
 	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
 	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, lexicalRuntimeRepoRoot("/repo"))
-	assertEnvEntryValue(t, env, "PYTHONDONTWRITEBYTECODE", "1")
+	if value, ok := lookupEnvEntry(env, "PYTHONDONTWRITEBYTECODE"); !ok || value != "0" {
+		t.Fatalf("expected PYTHONDONTWRITEBYTECODE to be preserved, got %q (set=%v)", value, ok)
+	}
 	pythonPath, ok := lookupEnvEntry(env, "PYTHONPATH")
 	if !ok {
 		t.Fatalf("expected PYTHONPATH to be set")
@@ -68,9 +71,299 @@ func TestWithPythonRuntimeTraceEnvWithoutExistingPythonPath(t *testing.T) {
 	}
 
 	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
-	assertEnvEntryValue(t, env, "PYTHONDONTWRITEBYTECODE", "1")
 	assertEnvEntryValue(t, env, "PYTHONPATH", hookDir)
 	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, lexicalRuntimeRepoRoot("/repo"))
+	if _, ok := lookupEnvEntry(env, "PYTHONDONTWRITEBYTECODE"); ok {
+		t.Fatalf("expected PYTHONDONTWRITEBYTECODE to remain unset")
+	}
+}
+
+func TestStagePythonRuntimeHookDirectory(t *testing.T) {
+	stagedDir, cleanup, err := stagePythonRuntimeHookDirectory()
+	if err != nil {
+		t.Fatalf("stage runtime python hook directory: %v", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("cleanup staged runtime python hook directory: %v", err)
+		}
+	}()
+
+	info, err := os.Stat(stagedDir)
+	if err != nil {
+		t.Fatalf("stat staged runtime python hook directory: %v", err)
+	}
+	if info.Mode().Perm() != 0o555 {
+		t.Fatalf("expected staged runtime python hook dir perms 0555, got %o", info.Mode().Perm())
+	}
+	hookPath := filepath.Join(stagedDir, filepath.Base(runtimePythonHookRelPath))
+	if _, err := os.Stat(hookPath); err != nil {
+		t.Fatalf("stat staged runtime python hook: %v", err)
+	}
+}
+
+func TestStagePythonRuntimeHookDirectoryCleanupReturnsError(t *testing.T) {
+	stagedDir, cleanup, err := stagePythonRuntimeHookDirectory()
+	if err != nil {
+		t.Fatalf("stage runtime python hook directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(stagedDir, 0o700); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("cleanup staged runtime python hook directory chmod: %v", err)
+		}
+		if err := os.RemoveAll(stagedDir); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("cleanup staged runtime python hook directory remove: %v", err)
+		}
+	})
+
+	previousChmod := runtimeHookDirChmod
+	previousRemoveAll := runtimeHookDirRemoveAll
+	removeAllCalled := false
+	runtimeHookDirChmod = func(path string, mode os.FileMode) error {
+		if path != stagedDir {
+			return previousChmod(path, mode)
+		}
+		return fmt.Errorf("forced chmod failure")
+	}
+	runtimeHookDirRemoveAll = func(path string) error {
+		if path != stagedDir {
+			return previousRemoveAll(path)
+		}
+		removeAllCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		runtimeHookDirChmod = previousChmod
+		runtimeHookDirRemoveAll = previousRemoveAll
+	})
+
+	err = cleanup()
+	if err == nil || !strings.Contains(err.Error(), "chmod staged runtime python hook dir") {
+		t.Fatalf("expected staged hook cleanup chmod error, got %v", err)
+	}
+	if !removeAllCalled {
+		t.Fatal("expected cleanup to remove staged runtime python hook dir after chmod failure")
+	}
+}
+
+func TestStagePythonRuntimeHookDirectorySanitizesPathErrors(t *testing.T) {
+	t.Run("read source", func(t *testing.T) {
+		resolver := newRuntimeHookPathResolver(nil, nil)
+		previousReadFile := runtimeHookFileRead
+		runtimeHookFileRead = func(path string) ([]byte, error) {
+			return nil, &os.PathError{Op: "open", Path: path, Err: os.ErrPermission}
+		}
+		t.Cleanup(func() {
+			runtimeHookFileRead = previousReadFile
+		})
+
+		_, _, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
+		assertRuntimeHookStagePathNeutralError(t, err, "read runtime python hook", "open <path>")
+	})
+
+	t.Run("write staged file", func(t *testing.T) {
+		resolver := newRuntimeHookPathResolver(nil, nil)
+		previousWriteFile := runtimeHookFileWrite
+		runtimeHookFileWrite = func(path string, _ []byte, _ os.FileMode) error {
+			return &os.PathError{Op: "open", Path: path, Err: os.ErrPermission}
+		}
+		t.Cleanup(func() {
+			runtimeHookFileWrite = previousWriteFile
+		})
+
+		_, _, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
+		assertRuntimeHookStagePathNeutralError(t, err, "write staged runtime python hook", "open <path>")
+	})
+
+	t.Run("create staged dir", func(t *testing.T) {
+		resolver := newRuntimeHookPathResolver(nil, nil)
+		previousMkdirTemp := runtimeHookDirMkdirTemp
+		tempRoot := filepath.Join(string(os.PathSeparator), "tmp", "lopper-path-neutral-test")
+		runtimeHookDirMkdirTemp = func(dir, pattern string) (string, error) {
+			return "", &os.PathError{
+				Op:   "mkdirtemp",
+				Path: filepath.Join(tempRoot, pattern+"123456789"),
+				Err:  os.ErrPermission,
+			}
+		}
+		t.Cleanup(func() {
+			runtimeHookDirMkdirTemp = previousMkdirTemp
+		})
+
+		_, _, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
+		assertRuntimeHookStagePathNeutralError(t, err, "create runtime python hook dir", "mkdirtemp <path>")
+		if strings.Contains(err.Error(), tempRoot) {
+			t.Fatalf("expected staged dir creation error to exclude temp root %q, got %q", tempRoot, err)
+		}
+		if !errors.Is(err, os.ErrPermission) {
+			t.Fatalf("expected staged dir creation error to preserve errors.Is(..., os.ErrPermission), got %v", err)
+		}
+	})
+
+	t.Run("seal staged dir", func(t *testing.T) {
+		resolver := newRuntimeHookPathResolver(nil, nil)
+		previousSealDir := runtimeHookDirSeal
+		runtimeHookDirSeal = func(path string, _ os.FileMode) error {
+			return &os.PathError{Op: "chmod", Path: path, Err: os.ErrPermission}
+		}
+		t.Cleanup(func() {
+			runtimeHookDirSeal = previousSealDir
+		})
+
+		_, _, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
+		assertRuntimeHookStagePathNeutralError(t, err, "seal staged runtime python hook dir", "chmod <path>")
+	})
+
+	t.Run("cleanup joins sanitized chmod and remove", func(t *testing.T) {
+		stagedDir, cleanup, err := stagePythonRuntimeHookDirectory()
+		if err != nil {
+			t.Fatalf("stage runtime python hook directory: %v", err)
+		}
+		t.Cleanup(func() {
+			if chmodErr := os.Chmod(stagedDir, 0o700); chmodErr != nil && !os.IsNotExist(chmodErr) {
+				t.Fatalf("cleanup staged runtime python hook directory chmod: %v", chmodErr)
+			}
+			if removeErr := os.RemoveAll(stagedDir); removeErr != nil && !os.IsNotExist(removeErr) {
+				t.Fatalf("cleanup staged runtime python hook directory remove: %v", removeErr)
+			}
+		})
+
+		previousChmod := runtimeHookDirChmod
+		previousRemoveAll := runtimeHookDirRemoveAll
+		runtimeHookDirChmod = func(path string, mode os.FileMode) error {
+			if path != stagedDir {
+				return previousChmod(path, mode)
+			}
+			return &os.PathError{Op: "chmod", Path: path, Err: os.ErrPermission}
+		}
+		runtimeHookDirRemoveAll = func(path string) error {
+			if path != stagedDir {
+				return previousRemoveAll(path)
+			}
+			return &os.PathError{Op: "remove", Path: path, Err: os.ErrPermission}
+		}
+		t.Cleanup(func() {
+			runtimeHookDirChmod = previousChmod
+			runtimeHookDirRemoveAll = previousRemoveAll
+		})
+
+		err = cleanup()
+		assertRuntimeHookStagePathNeutralError(t, err, "chmod staged runtime python hook dir", "chmod <path>")
+		assertRuntimeHookStagePathNeutralError(t, err, "remove staged runtime python hook dir", "remove <path>")
+	})
+}
+
+func TestWithPreparedPythonRuntimeTraceEnvForResolverWrapsStagingError(t *testing.T) {
+	sentinel := errors.New("python hook lookup failed")
+	resolver := newFakeRuntimeHookPathResolver(func() (string, error) { return "", nil }, func(skip int) (uintptr, string, int, bool) { return 0, "", 0, false })
+	resolver.pythonHookDir.err = sentinel
+	resolver.pythonHookDirOnce.Do(func() {})
+
+	env, cleanup, err := withPreparedPythonRuntimeTraceEnvForResolver([]string{"PATH=/usr/bin"}, "/tmp/python-runtime.ndjson", "/repo", resolver)
+	if len(env) != 0 {
+		t.Fatalf("expected nil env on staged hook error, got %v", env)
+	}
+	if cleanup != nil {
+		t.Fatal("expected nil cleanup on staged hook error")
+	}
+	if !errors.Is(err, sentinel) || !strings.Contains(err.Error(), "stage runtime python hook") {
+		t.Fatalf("expected wrapped staged hook error for %v, got %v", sentinel, err)
+	}
+}
+
+func TestStagePythonRuntimeHookDirectoryForResolverJoinsSanitizedWriteAndCleanupErrors(t *testing.T) {
+	resolver := newRuntimeHookPathResolver(nil, nil)
+
+	previousWriteFile := runtimeHookFileWrite
+	previousChmod := runtimeHookDirChmod
+	previousRemoveAll := runtimeHookDirRemoveAll
+	runtimeHookFileWrite = func(path string, _ []byte, _ os.FileMode) error {
+		return &os.PathError{Op: "open", Path: path, Err: os.ErrPermission}
+	}
+	runtimeHookDirChmod = func(path string, _ os.FileMode) error {
+		return &os.PathError{Op: "chmod", Path: path, Err: os.ErrPermission}
+	}
+	runtimeHookDirRemoveAll = func(path string) error {
+		return &os.PathError{Op: "remove", Path: path, Err: os.ErrPermission}
+	}
+	t.Cleanup(func() {
+		runtimeHookFileWrite = previousWriteFile
+		runtimeHookDirChmod = previousChmod
+		runtimeHookDirRemoveAll = previousRemoveAll
+	})
+
+	_, _, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
+	assertRuntimeHookStagePathNeutralError(t, err, "write staged runtime python hook", "cleanup staged runtime python hook", "open <path>", "chmod <path>", "remove <path>")
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("expected staged write error to preserve os.ErrPermission, got %v", err)
+	}
+}
+
+func TestStagePythonRuntimeHookDirectoryForResolverJoinsSanitizedSealAndCleanupErrors(t *testing.T) {
+	resolver := newRuntimeHookPathResolver(nil, nil)
+
+	previousSealDir := runtimeHookDirSeal
+	previousChmod := runtimeHookDirChmod
+	previousRemoveAll := runtimeHookDirRemoveAll
+	runtimeHookDirSeal = func(path string, _ os.FileMode) error {
+		return &os.PathError{Op: "chmod", Path: path, Err: os.ErrPermission}
+	}
+	runtimeHookDirChmod = func(path string, _ os.FileMode) error {
+		return &os.PathError{Op: "chmod", Path: path, Err: os.ErrPermission}
+	}
+	runtimeHookDirRemoveAll = func(path string) error {
+		return &os.PathError{Op: "remove", Path: path, Err: os.ErrPermission}
+	}
+	t.Cleanup(func() {
+		runtimeHookDirSeal = previousSealDir
+		runtimeHookDirChmod = previousChmod
+		runtimeHookDirRemoveAll = previousRemoveAll
+	})
+
+	_, _, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
+	assertRuntimeHookStagePathNeutralError(t, err, "seal staged runtime python hook dir", "cleanup staged runtime python hook", "chmod <path>", "remove <path>")
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("expected staged seal error to preserve os.ErrPermission, got %v", err)
+	}
+}
+
+func TestSanitizeRuntimeHookStageErrorReturnsNilForNilInput(t *testing.T) {
+	if err := sanitizeRuntimeHookStageError(nil, "/tmp/private"); err != nil {
+		t.Fatalf("expected nil sanitize error result, got %v", err)
+	}
+}
+
+func TestSanitizeRuntimeHookStageErrorWrapsSanitizedMessage(t *testing.T) {
+	sensitivePath := filepath.Join(string(os.PathSeparator), "tmp", "private-hook.py")
+	cause := fmt.Errorf("chmod %s: permission denied", sensitivePath)
+
+	err := sanitizeRuntimeHookStageError(cause, sensitivePath)
+
+	var sanitized *runtimeHookStageSanitizedError
+	if !errors.As(err, &sanitized) {
+		t.Fatalf("expected sanitized runtime hook error wrapper, got %T", err)
+	}
+	if sanitized.Error() != "chmod <path>: permission denied" {
+		t.Fatalf("expected sanitized message, got %q", sanitized.Error())
+	}
+	if !errors.Is(sanitized.Unwrap(), cause) {
+		t.Fatalf("expected sanitized error to unwrap original cause, got %v", sanitized.Unwrap())
+	}
+}
+
+func TestSanitizeRuntimeHookStageTempDirErrorReturnsNilForNilInput(t *testing.T) {
+	if err := sanitizeRuntimeHookStageTempDirError(nil); err != nil {
+		t.Fatalf("expected nil temp dir sanitize result, got %v", err)
+	}
+}
+
+func TestRuntimeHookSensitivePathVariantsReturnsCleanVariant(t *testing.T) {
+	path := string(os.PathSeparator) + filepath.Join("tmp", "nested") + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "hook.py"
+	variants := runtimeHookSensitivePathVariants(path)
+	want := []string{path, filepath.Clean(path)}
+	if !reflect.DeepEqual(variants, want) {
+		t.Fatalf("expected raw and clean variants, got %v", variants)
+	}
 }
 
 func TestLexicalRuntimeRepoRootPreservesAlias(t *testing.T) {
@@ -107,6 +400,12 @@ func TestResolvedRuntimeRepoRootFallsBackToAbsolutePathWhenSymlinkResolutionFail
 	want = filepath.Clean(want)
 	if got != want {
 		t.Fatalf("expected resolved repo root %q, got %q", want, got)
+	}
+}
+
+func TestResolvedRuntimeRepoRootReturnsBlankForBlankInput(t *testing.T) {
+	if got := resolvedRuntimeRepoRoot(" \n\t "); got != "" {
+		t.Fatalf("expected blank repo root to remain blank, got %q", got)
 	}
 }
 
@@ -154,6 +453,26 @@ func assertEnvEntryValue(t *testing.T, env []string, key, want string) {
 	}
 	if got != want {
 		t.Fatalf("expected %s=%q, got %q", key, want, got)
+	}
+}
+
+func assertRuntimeHookStagePathNeutralError(t *testing.T, err error, requiredSubstrings ...string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected runtime hook staging error")
+	}
+	for _, part := range requiredSubstrings {
+		if !strings.Contains(err.Error(), part) {
+			t.Fatalf("expected error %q to contain %q", err, part)
+		}
+	}
+	tempRoot := os.TempDir()
+	if strings.Contains(err.Error(), tempRoot) {
+		t.Fatalf("expected runtime hook staging error to exclude temp root %q, got %q", tempRoot, err)
+	}
+	if strings.Contains(err.Error(), runtimePythonHookRelPath) {
+		t.Fatalf("expected runtime hook staging error to redact hook path, got %q", err)
 	}
 }
 

--- a/internal/runtime/capture_env_test.go
+++ b/internal/runtime/capture_env_test.go
@@ -146,111 +146,115 @@ func TestStagePythonRuntimeHookDirectoryCleanupReturnsError(t *testing.T) {
 	}
 }
 
-func TestStagePythonRuntimeHookDirectorySanitizesPathErrors(t *testing.T) {
-	t.Run("read source", func(t *testing.T) {
-		resolver := newRuntimeHookPathResolver(nil, nil)
-		previousReadFile := runtimeHookFileRead
-		runtimeHookFileRead = func(path string) ([]byte, error) {
-			return nil, &os.PathError{Op: "open", Path: path, Err: os.ErrPermission}
-		}
-		t.Cleanup(func() {
-			runtimeHookFileRead = previousReadFile
-		})
-
-		_, _, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
-		assertRuntimeHookStagePathNeutralError(t, err, "read runtime python hook", "open <path>")
+func TestStagePythonRuntimeHookDirectorySanitizesReadSourcePathErrors(t *testing.T) {
+	previous := runtimeHookFileRead
+	runtimeHookFileRead = func(path string) ([]byte, error) {
+		return nil, &os.PathError{Op: "open", Path: path, Err: os.ErrPermission}
+	}
+	t.Cleanup(func() {
+		runtimeHookFileRead = previous
 	})
 
-	t.Run("write staged file", func(t *testing.T) {
-		resolver := newRuntimeHookPathResolver(nil, nil)
-		previousWriteFile := runtimeHookFileWrite
-		runtimeHookFileWrite = func(path string, _ []byte, _ os.FileMode) error {
-			return &os.PathError{Op: "open", Path: path, Err: os.ErrPermission}
-		}
-		t.Cleanup(func() {
-			runtimeHookFileWrite = previousWriteFile
-		})
+	assertStagePythonRuntimeHookDirectoryError(t, "read runtime python hook", "open <path>")
+}
 
-		_, _, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
-		assertRuntimeHookStagePathNeutralError(t, err, "write staged runtime python hook", "open <path>")
+func TestStagePythonRuntimeHookDirectorySanitizesWritePathErrors(t *testing.T) {
+	previous := runtimeHookFileWrite
+	runtimeHookFileWrite = func(path string, _ []byte, _ os.FileMode) error {
+		return &os.PathError{Op: "open", Path: path, Err: os.ErrPermission}
+	}
+	t.Cleanup(func() {
+		runtimeHookFileWrite = previous
 	})
 
-	t.Run("create staged dir", func(t *testing.T) {
-		resolver := newRuntimeHookPathResolver(nil, nil)
-		previousMkdirTemp := runtimeHookDirMkdirTemp
-		tempRoot := filepath.Join(string(os.PathSeparator), "tmp", "lopper-path-neutral-test")
-		runtimeHookDirMkdirTemp = func(dir, pattern string) (string, error) {
-			return "", &os.PathError{
-				Op:   "mkdirtemp",
-				Path: filepath.Join(tempRoot, pattern+"123456789"),
-				Err:  os.ErrPermission,
-			}
-		}
-		t.Cleanup(func() {
-			runtimeHookDirMkdirTemp = previousMkdirTemp
-		})
+	assertStagePythonRuntimeHookDirectoryError(t, "write staged runtime python hook", "open <path>")
+}
 
-		_, _, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
-		assertRuntimeHookStagePathNeutralError(t, err, "create runtime python hook dir", "mkdirtemp <path>")
-		if strings.Contains(err.Error(), tempRoot) {
-			t.Fatalf("expected staged dir creation error to exclude temp root %q, got %q", tempRoot, err)
+func TestStagePythonRuntimeHookDirectorySanitizesTempDirPathErrors(t *testing.T) {
+	previousMkdirTemp := runtimeHookDirMkdirTemp
+	tempRoot := filepath.Join(string(os.PathSeparator), "tmp", "lopper-path-neutral-test")
+	runtimeHookDirMkdirTemp = func(dir, pattern string) (string, error) {
+		return "", &os.PathError{
+			Op:   "mkdirtemp",
+			Path: filepath.Join(tempRoot, pattern+"123456789"),
+			Err:  os.ErrPermission,
 		}
-		if !errors.Is(err, os.ErrPermission) {
-			t.Fatalf("expected staged dir creation error to preserve errors.Is(..., os.ErrPermission), got %v", err)
+	}
+	t.Cleanup(func() {
+		runtimeHookDirMkdirTemp = previousMkdirTemp
+	})
+
+	err := stagePythonRuntimeHookDirectoryError(t)
+	assertRuntimeHookStagePathNeutralError(t, err, "create runtime python hook dir", "mkdirtemp <path>")
+	if strings.Contains(err.Error(), tempRoot) {
+		t.Fatalf("expected staged dir creation error to exclude temp root %q, got %q", tempRoot, err)
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("expected staged dir creation error to preserve errors.Is(..., os.ErrPermission), got %v", err)
+	}
+}
+
+func TestStagePythonRuntimeHookDirectorySanitizesSealPathErrors(t *testing.T) {
+	previous := runtimeHookDirSeal
+	runtimeHookDirSeal = func(path string, _ os.FileMode) error {
+		return &os.PathError{Op: "chmod", Path: path, Err: os.ErrPermission}
+	}
+	t.Cleanup(func() {
+		runtimeHookDirSeal = previous
+	})
+
+	assertStagePythonRuntimeHookDirectoryError(t, "seal staged runtime python hook dir", "chmod <path>")
+}
+
+func TestStagePythonRuntimeHookDirectoryCleanupSanitizesChmodAndRemoveErrors(t *testing.T) {
+	stagedDir, cleanup, err := stagePythonRuntimeHookDirectory()
+	if err != nil {
+		t.Fatalf("stage runtime python hook directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if chmodErr := os.Chmod(stagedDir, 0o700); chmodErr != nil && !os.IsNotExist(chmodErr) {
+			t.Fatalf("cleanup staged runtime python hook directory chmod: %v", chmodErr)
+		}
+		if removeErr := os.RemoveAll(stagedDir); removeErr != nil && !os.IsNotExist(removeErr) {
+			t.Fatalf("cleanup staged runtime python hook directory remove: %v", removeErr)
 		}
 	})
 
-	t.Run("seal staged dir", func(t *testing.T) {
-		resolver := newRuntimeHookPathResolver(nil, nil)
-		previousSealDir := runtimeHookDirSeal
-		runtimeHookDirSeal = func(path string, _ os.FileMode) error {
-			return &os.PathError{Op: "chmod", Path: path, Err: os.ErrPermission}
+	previousChmod := runtimeHookDirChmod
+	previousRemoveAll := runtimeHookDirRemoveAll
+	runtimeHookDirChmod = func(path string, mode os.FileMode) error {
+		if path != stagedDir {
+			return previousChmod(path, mode)
 		}
-		t.Cleanup(func() {
-			runtimeHookDirSeal = previousSealDir
-		})
-
-		_, _, err := stagePythonRuntimeHookDirectoryForResolver(resolver)
-		assertRuntimeHookStagePathNeutralError(t, err, "seal staged runtime python hook dir", "chmod <path>")
+		return &os.PathError{Op: "chmod", Path: path, Err: os.ErrPermission}
+	}
+	runtimeHookDirRemoveAll = func(path string) error {
+		if path != stagedDir {
+			return previousRemoveAll(path)
+		}
+		return &os.PathError{Op: "remove", Path: path, Err: os.ErrPermission}
+	}
+	t.Cleanup(func() {
+		runtimeHookDirChmod = previousChmod
+		runtimeHookDirRemoveAll = previousRemoveAll
 	})
 
-	t.Run("cleanup joins sanitized chmod and remove", func(t *testing.T) {
-		stagedDir, cleanup, err := stagePythonRuntimeHookDirectory()
-		if err != nil {
-			t.Fatalf("stage runtime python hook directory: %v", err)
-		}
-		t.Cleanup(func() {
-			if chmodErr := os.Chmod(stagedDir, 0o700); chmodErr != nil && !os.IsNotExist(chmodErr) {
-				t.Fatalf("cleanup staged runtime python hook directory chmod: %v", chmodErr)
-			}
-			if removeErr := os.RemoveAll(stagedDir); removeErr != nil && !os.IsNotExist(removeErr) {
-				t.Fatalf("cleanup staged runtime python hook directory remove: %v", removeErr)
-			}
-		})
+	err = cleanup()
+	assertRuntimeHookStagePathNeutralError(t, err, "chmod staged runtime python hook dir", "chmod <path>")
+	assertRuntimeHookStagePathNeutralError(t, err, "remove staged runtime python hook dir", "remove <path>")
+}
 
-		previousChmod := runtimeHookDirChmod
-		previousRemoveAll := runtimeHookDirRemoveAll
-		runtimeHookDirChmod = func(path string, mode os.FileMode) error {
-			if path != stagedDir {
-				return previousChmod(path, mode)
-			}
-			return &os.PathError{Op: "chmod", Path: path, Err: os.ErrPermission}
-		}
-		runtimeHookDirRemoveAll = func(path string) error {
-			if path != stagedDir {
-				return previousRemoveAll(path)
-			}
-			return &os.PathError{Op: "remove", Path: path, Err: os.ErrPermission}
-		}
-		t.Cleanup(func() {
-			runtimeHookDirChmod = previousChmod
-			runtimeHookDirRemoveAll = previousRemoveAll
-		})
+func stagePythonRuntimeHookDirectoryError(t *testing.T) error {
+	t.Helper()
 
-		err = cleanup()
-		assertRuntimeHookStagePathNeutralError(t, err, "chmod staged runtime python hook dir", "chmod <path>")
-		assertRuntimeHookStagePathNeutralError(t, err, "remove staged runtime python hook dir", "remove <path>")
-	})
+	_, _, err := stagePythonRuntimeHookDirectoryForResolver(newRuntimeHookPathResolver(nil, nil))
+	return err
+}
+
+func assertStagePythonRuntimeHookDirectoryError(t *testing.T, requiredSubstrings ...string) {
+	t.Helper()
+
+	assertRuntimeHookStagePathNeutralError(t, stagePythonRuntimeHookDirectoryError(t), requiredSubstrings...)
 }
 
 func TestWithPreparedPythonRuntimeTraceEnvForResolverWrapsStagingError(t *testing.T) {

--- a/internal/runtime/capture_env_test.go
+++ b/internal/runtime/capture_env_test.go
@@ -17,12 +17,13 @@ func TestWithRuntimeTraceEnv(t *testing.T) {
 		t.Fatalf("runtime hook paths: %v", err)
 	}
 
-	env, err := withRuntimeTraceEnv([]string{"NODE_OPTIONS=--max-old-space-size=4096", "PATH=/usr/bin"}, tracePath, CaptureProviderNode)
+	env, err := withRuntimeTraceEnv([]string{"NODE_OPTIONS=--max-old-space-size=4096", "PATH=/usr/bin"}, tracePath, CaptureProviderNode, "/repo")
 	if err != nil {
 		t.Fatalf("with runtime trace env: %v", err)
 	}
 
 	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
+	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, resolvedRuntimeRepoRoot("/repo"))
 	assertNodeOptionsEntry(t, env, requirePath, loaderPath)
 }
 
@@ -33,12 +34,13 @@ func TestWithPythonRuntimeTraceEnv(t *testing.T) {
 		t.Fatalf("runtime python hook directory: %v", err)
 	}
 
-	env, err := withRuntimeTraceEnv([]string{"PYTHONPATH=/existing/path", "NODE_OPTIONS=--max-old-space-size=4096"}, tracePath, CaptureProviderPython)
+	env, err := withRuntimeTraceEnv([]string{"PYTHONPATH=/existing/path", "NODE_OPTIONS=--max-old-space-size=4096"}, tracePath, CaptureProviderPython, "/repo")
 	if err != nil {
 		t.Fatalf("with python runtime trace env: %v", err)
 	}
 
 	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
+	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, resolvedRuntimeRepoRoot("/repo"))
 	pythonPath, ok := lookupEnvEntry(env, "PYTHONPATH")
 	if !ok {
 		t.Fatalf("expected PYTHONPATH to be set")
@@ -59,13 +61,14 @@ func TestWithPythonRuntimeTraceEnvWithoutExistingPythonPath(t *testing.T) {
 		t.Fatalf("runtime python hook directory: %v", err)
 	}
 
-	env, err := withPythonRuntimeTraceEnv([]string{"PATH=/usr/bin"}, tracePath)
+	env, err := withPythonRuntimeTraceEnv([]string{"PATH=/usr/bin"}, tracePath, "/repo")
 	if err != nil {
 		t.Fatalf("with python runtime trace env: %v", err)
 	}
 
 	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
 	assertEnvEntryValue(t, env, "PYTHONPATH", hookDir)
+	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, resolvedRuntimeRepoRoot("/repo"))
 }
 
 func TestRuntimeCaptureProviderValidationBranches(t *testing.T) {
@@ -79,7 +82,7 @@ func TestRuntimeCaptureProviderValidationBranches(t *testing.T) {
 		t.Fatalf("expected unsupported provider to normalize empty, got %q", got)
 	}
 
-	if _, err := withRuntimeTraceEnv(nil, "/tmp/runtime.ndjson", "ruby"); err == nil || !strings.Contains(err.Error(), "unsupported runtime capture provider") {
+	if _, err := withRuntimeTraceEnv(nil, "/tmp/runtime.ndjson", "ruby", "/repo"); err == nil || !strings.Contains(err.Error(), "unsupported runtime capture provider") {
 		t.Fatalf("expected unsupported provider env error, got %v", err)
 	}
 	if _, err := resolveCapturePlan(CaptureRequest{RepoPath: t.TempDir(), Command: "npm test", Provider: "ruby"}); err == nil || !strings.Contains(err.Error(), "unsupported runtime capture provider") {

--- a/internal/runtime/capture_env_test.go
+++ b/internal/runtime/capture_env_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -23,7 +23,7 @@ func TestWithRuntimeTraceEnv(t *testing.T) {
 	}
 
 	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
-	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, resolvedRuntimeRepoRoot("/repo"))
+	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, lexicalRuntimeRepoRoot("/repo"))
 	assertNodeOptionsEntry(t, env, requirePath, loaderPath)
 }
 
@@ -34,13 +34,14 @@ func TestWithPythonRuntimeTraceEnv(t *testing.T) {
 		t.Fatalf("runtime python hook directory: %v", err)
 	}
 
-	env, err := withRuntimeTraceEnv([]string{"PYTHONPATH=/existing/path", "NODE_OPTIONS=--max-old-space-size=4096"}, tracePath, CaptureProviderPython, "/repo")
+	env, err := withRuntimeTraceEnv([]string{"PYTHONDONTWRITEBYTECODE=0", "PYTHONPATH=/existing/path", "NODE_OPTIONS=--max-old-space-size=4096"}, tracePath, CaptureProviderPython, "/repo")
 	if err != nil {
 		t.Fatalf("with python runtime trace env: %v", err)
 	}
 
 	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
-	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, resolvedRuntimeRepoRoot("/repo"))
+	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, lexicalRuntimeRepoRoot("/repo"))
+	assertEnvEntryValue(t, env, "PYTHONDONTWRITEBYTECODE", "1")
 	pythonPath, ok := lookupEnvEntry(env, "PYTHONPATH")
 	if !ok {
 		t.Fatalf("expected PYTHONPATH to be set")
@@ -67,8 +68,46 @@ func TestWithPythonRuntimeTraceEnvWithoutExistingPythonPath(t *testing.T) {
 	}
 
 	assertEnvEntryValue(t, env, "LOPPER_RUNTIME_TRACE", tracePath)
+	assertEnvEntryValue(t, env, "PYTHONDONTWRITEBYTECODE", "1")
 	assertEnvEntryValue(t, env, "PYTHONPATH", hookDir)
-	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, resolvedRuntimeRepoRoot("/repo"))
+	assertEnvEntryValue(t, env, runtimeRepoRootEnvKey, lexicalRuntimeRepoRoot("/repo"))
+}
+
+func TestLexicalRuntimeRepoRootPreservesAlias(t *testing.T) {
+	if got := lexicalRuntimeRepoRoot(" \t "); got != "" {
+		t.Fatalf("expected blank repo root to remain blank, got %q", got)
+	}
+
+	root := t.TempDir()
+	realRepo := filepath.Join(root, "repo-real")
+	aliasRepo := filepath.Join(root, "repo-alias")
+	if err := os.MkdirAll(realRepo, 0o750); err != nil {
+		t.Fatalf("mkdir real repo: %v", err)
+	}
+	if err := os.Symlink(realRepo, aliasRepo); err != nil {
+		t.Skipf("repo symlinks unavailable: %v", err)
+	}
+	if got := lexicalRuntimeRepoRoot(aliasRepo); got != aliasRepo {
+		t.Fatalf("expected lexical repo alias %q, got %q", aliasRepo, got)
+	}
+	if got := lexicalRuntimeRepoRoot(aliasRepo); got == resolvedRuntimeRepoRoot(aliasRepo) {
+		t.Fatalf("expected lexical repo alias to differ from resolved root, got %q", got)
+	}
+}
+
+func TestResolvedRuntimeRepoRootFallsBackToAbsolutePathWhenSymlinkResolutionFails(t *testing.T) {
+	root := t.TempDir()
+	missingPath := filepath.Join(root, "missing", "..", "repo")
+
+	got := resolvedRuntimeRepoRoot(missingPath)
+	want, err := filepath.Abs(missingPath)
+	if err != nil {
+		t.Fatalf("abs missing repo path: %v", err)
+	}
+	want = filepath.Clean(want)
+	if got != want {
+		t.Fatalf("expected resolved repo root %q, got %q", want, got)
+	}
 }
 
 func TestRuntimeCaptureProviderValidationBranches(t *testing.T) {
@@ -87,6 +126,22 @@ func TestRuntimeCaptureProviderValidationBranches(t *testing.T) {
 	}
 	if _, err := resolveCapturePlan(CaptureRequest{RepoPath: t.TempDir(), Command: "npm test", Provider: "ruby"}); err == nil || !strings.Contains(err.Error(), "unsupported runtime capture provider") {
 		t.Fatalf("expected unsupported provider plan error, got %v", err)
+	}
+}
+
+func TestRuntimeHookResolverProductionWrappers(t *testing.T) {
+	resolver := newRuntimeHookPathResolver(nil, nil)
+	if _, err := resolver.runtimeNodeHookOptions(); err != nil {
+		t.Fatalf("runtime node hook options with default constructor: %v", err)
+	}
+	if _, _, err := locateRuntimeHookPaths(); err != nil {
+		t.Fatalf("locate runtime hook paths: %v", err)
+	}
+	if _, err := locateRuntimePythonHookDirectory(); err != nil {
+		t.Fatalf("locate runtime python hook directory: %v", err)
+	}
+	if len(runtimeHookSearchRoots()) == 0 {
+		t.Fatalf("expected runtime hook search roots from production wrapper")
 	}
 }
 
@@ -177,16 +232,12 @@ func TestRuntimeSearchDirsDefault(t *testing.T) {
 }
 
 func TestRuntimeHookSearchRootsAreAnchored(t *testing.T) {
-	restoreRuntimeHookPathProviders(t)
-
-	runtimeExecutablePath = func() (string, error) {
-		return filepath.Join("/tmp", "plant", "bin", "lopper"), nil
-	}
-	runtimeCaller = func(skip int) (uintptr, string, int, bool) {
+	executablePath := func() (string, error) { return filepath.Join("/tmp", "plant", "bin", "lopper"), nil }
+	caller := func(skip int) (uintptr, string, int, bool) {
 		return 0, filepath.Join("/tmp", "source", "internal", "runtime", "capture_env.go"), 0, true
 	}
-
-	roots := runtimeHookSearchRoots()
+	resolver := newFakeRuntimeHookPathResolver(executablePath, caller)
+	roots := resolver.runtimeHookSearchRoots()
 	want := []string{
 		filepath.Clean(filepath.Join("/tmp", "plant", "bin", "share", "lopper")),
 		filepath.Clean(filepath.Join("/tmp", "plant", "bin", "..", "share", "lopper")),
@@ -198,16 +249,10 @@ func TestRuntimeHookSearchRootsAreAnchored(t *testing.T) {
 }
 
 func TestRuntimeHookSearchRootsResolveRelativeCallerPaths(t *testing.T) {
-	restoreRuntimeHookPathProviders(t)
-
-	runtimeExecutablePath = func() (string, error) {
-		return filepath.Join("/tmp", "plant", "bin", "lopper"), nil
-	}
-	runtimeCaller = func(skip int) (uintptr, string, int, bool) {
-		return 0, "capture_env.go", 0, true
-	}
-
-	roots := runtimeHookSearchRoots()
+	executablePath := func() (string, error) { return filepath.Join("/tmp", "plant", "bin", "lopper"), nil }
+	caller := func(skip int) (uintptr, string, int, bool) { return 0, "capture_env.go", 0, true }
+	resolver := newFakeRuntimeHookPathResolver(executablePath, caller)
+	roots := resolver.runtimeHookSearchRoots()
 	wantRepoRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
 		t.Fatalf("abs repo root: %v", err)
@@ -237,54 +282,36 @@ func TestMergeEnvAndReadEnvValue(t *testing.T) {
 }
 
 func TestRuntimeNodeHookOptionsReturnsCachedError(t *testing.T) {
-	oldRequire := runtimeRequireHookPath
-	oldLoader := runtimeLoaderHookPath
-	oldErr := runtimeHookPathsErr
-	defer func() {
-		runtimeHookPathsOnce = sync.Once{}
-		runtimeHookPathsOnce.Do(func() {
-			runtimeRequireHookPath = oldRequire
-			runtimeLoaderHookPath = oldLoader
-			runtimeHookPathsErr = oldErr
-		})
-	}()
+	sentinel := errors.New("boom")
+	resolver := newFakeRuntimeHookPathResolver(func() (string, error) { return "", nil }, func(skip int) (uintptr, string, int, bool) { return 0, "", 0, false })
+	resolver.hookPaths.err = sentinel
+	resolver.hookPathsOnce.Do(func() {})
 
-	runtimeHookPathsOnce = sync.Once{}
-	runtimeHookPathsOnce.Do(func() {
-		runtimeRequireHookPath = ""
-		runtimeLoaderHookPath = ""
-		runtimeHookPathsErr = errors.New("boom")
-	})
-
-	_, err := runtimeNodeHookOptions()
+	_, err := resolver.runtimeNodeHookOptions()
 	if err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("expected cached runtime hook error, got %v", err)
 	}
 }
 
-func restoreRuntimeHookPathProviders(t *testing.T) {
-	t.Helper()
+func TestWithPythonRuntimeTraceEnvForResolverPropagatesError(t *testing.T) {
+	sentinel := errors.New("python hook lookup failed")
+	resolver := newFakeRuntimeHookPathResolver(func() (string, error) { return "", nil }, func(skip int) (uintptr, string, int, bool) { return 0, "", 0, false })
+	resolver.pythonHookDir.err = sentinel
+	resolver.pythonHookDirOnce.Do(func() {})
 
-	originalExecutable := runtimeExecutablePath
-	originalCaller := runtimeCaller
-
-	t.Cleanup(func() {
-		runtimeExecutablePath = originalExecutable
-		runtimeCaller = originalCaller
-	})
+	_, err := withPythonRuntimeTraceEnvForResolver([]string{"PATH=/usr/bin"}, "/tmp/python-runtime.ndjson", "/repo", resolver)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected python hook resolver error %v, got %v", sentinel, err)
+	}
 }
 
 func TestRuntimeNodeHookOptionsQuotesPathsWithSpaces(t *testing.T) {
-	restoreRuntimeHookState(t)
+	resolver := newFakeRuntimeHookPathResolver(func() (string, error) { return "", nil }, func(skip int) (uintptr, string, int, bool) { return 0, "", 0, false })
+	resolver.hookPaths.requirePath = "/tmp/hooks/require hook.cjs"
+	resolver.hookPaths.loaderPath = "/tmp/hooks/loader hook.mjs"
+	resolver.hookPathsOnce.Do(func() {})
 
-	runtimeHookPathsOnce = sync.Once{}
-	runtimeHookPathsOnce.Do(func() {
-		runtimeRequireHookPath = "/tmp/hooks/require hook.cjs"
-		runtimeLoaderHookPath = "/tmp/hooks/loader hook.mjs"
-		runtimeHookPathsErr = nil
-	})
-
-	got, err := runtimeNodeHookOptions()
+	got, err := resolver.runtimeNodeHookOptions()
 	if err != nil {
 		t.Fatalf("runtime node hook options: %v", err)
 	}
@@ -294,6 +321,49 @@ func TestRuntimeNodeHookOptionsQuotesPathsWithSpaces(t *testing.T) {
 	if !strings.Contains(got, `--loader="/tmp/hooks/loader hook.mjs"`) {
 		t.Fatalf("expected quoted loader path, got %q", got)
 	}
+}
+
+func TestRuntimeHookPathResolverCachesHookLookupsPerInstance(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	shareRoot := filepath.Join(root, "share", "lopper")
+	requirePath := filepath.Join(shareRoot, runtimeRequireHookRelPath)
+	loaderPath := filepath.Join(shareRoot, runtimeLoaderHookRelPath)
+	if err := os.MkdirAll(filepath.Dir(requirePath), 0o750); err != nil {
+		t.Fatalf("mkdir hook dir: %v", err)
+	}
+	if err := os.WriteFile(requirePath, []byte("module.exports = {};\n"), 0o600); err != nil {
+		t.Fatalf("write require hook: %v", err)
+	}
+	if err := os.WriteFile(loaderPath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write loader hook: %v", err)
+	}
+
+	var executableCalls atomic.Int32
+	executablePath := func() (string, error) {
+		executableCalls.Add(1)
+		return filepath.Join(root, "bin", "lopper"), nil
+	}
+	caller := func(skip int) (uintptr, string, int, bool) { return 0, "", 0, false }
+	resolver := newFakeRuntimeHookPathResolver(executablePath, caller)
+
+	for i := 0; i < 3; i++ {
+		gotRequire, gotLoader, err := resolver.runtimeHookPaths()
+		if err != nil {
+			t.Fatalf("runtime hook paths call %d: %v", i+1, err)
+		}
+		if gotRequire != requirePath || gotLoader != loaderPath {
+			t.Fatalf("unexpected cached hook paths on call %d: %q %q", i+1, gotRequire, gotLoader)
+		}
+	}
+	if executableCalls.Load() != 1 {
+		t.Fatalf("expected per-instance hook lookup cache to resolve once, got %d calls", executableCalls.Load())
+	}
+}
+
+func newFakeRuntimeHookPathResolver(executablePath runtimeExecutablePathFunc, caller runtimeCallerFunc) *runtimeHookPathResolver {
+	return newRuntimeHookPathResolver(executablePath, caller)
 }
 
 func TestQuoteNodeOptionPath(t *testing.T) {

--- a/internal/runtime/capture_output.go
+++ b/internal/runtime/capture_output.go
@@ -20,9 +20,13 @@ func newRuntimeCommandOutput() *boundedRuntimeCommandOutput {
 }
 
 func (b *boundedRuntimeCommandOutput) Write(p []byte) (int, error) {
+	return b.write(p), nil
+}
+
+func (b *boundedRuntimeCommandOutput) write(p []byte) int {
 	written := len(p)
 	if written == 0 {
-		return 0, nil
+		return 0
 	}
 
 	b.mu.Lock()
@@ -32,7 +36,7 @@ func (b *boundedRuntimeCommandOutput) Write(p []byte) (int, error) {
 		copy(b.data, p[written-len(b.data):])
 		b.start = 0
 		b.size = len(b.data)
-		return written, nil
+		return written
 	}
 
 	if overflow := b.size + written - len(b.data); overflow > 0 {
@@ -41,7 +45,7 @@ func (b *boundedRuntimeCommandOutput) Write(p []byte) (int, error) {
 		b.size -= overflow
 	}
 	b.append(p)
-	return written, nil
+	return written
 }
 
 func (b *boundedRuntimeCommandOutput) append(p []byte) {

--- a/internal/runtime/capture_state.go
+++ b/internal/runtime/capture_state.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const runtimeTraceStateSchema = "v2"
+const runtimeTraceStateSchema = "v3"
 const runtimeTraceStateSuffix = ".state.json"
 
 type runtimeTraceState struct {

--- a/internal/runtime/runtime_helpers_test.go
+++ b/internal/runtime/runtime_helpers_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRuntimeAdditionalHelperBranches(t *testing.T) {
 	tracePath := "/tmp/runtime.ndjson"
-	env, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, tracePath, CaptureProviderNode)
+	env, err := withRuntimeTraceEnv([]string{"PATH=/usr/bin"}, tracePath, CaptureProviderNode, "/repo")
 	if err != nil {
 		t.Fatalf("with runtime trace env: %v", err)
 	}

--- a/internal/runtime/trace_context.go
+++ b/internal/runtime/trace_context.go
@@ -38,7 +38,7 @@ func normalizeRuntimeContextValue(value string, opts traceLoadOptions) string {
 
 func normalizeRuntimeContextValueUncached(value string, opts traceLoadOptions) string {
 	if normalized, ok := normalizeRuntimeContextPath(value, opts); ok {
-		if normalized != "" || !looksLikePackageStyleRuntimeContextLabel(value) {
+		if normalized != "" || runtimeContextShouldStayRedacted(value, opts) || !looksLikePackageStyleRuntimeContextLabel(value) {
 			return normalized
 		}
 	}
@@ -69,6 +69,25 @@ func runtimeContextHasOuterWhitespaceOrControl(value string) bool {
 
 func runtimeContextIsOuterWhitespaceOrControl(r rune) bool {
 	return unicode.IsSpace(r) || unicode.IsControl(r)
+}
+
+func runtimeContextShouldStayRedacted(value string, opts traceLoadOptions) bool {
+	value, ok := runtimeContextFilesystemCandidate(value)
+	if !ok || value == "" {
+		return false
+	}
+	if runtimeContextHasDefiniteFilesystemSignal(value) {
+		return true
+	}
+	repoRoot, resolvedRepoRoot, ok := runtimeContextTrustedRepoRoots(opts)
+	if !ok {
+		return false
+	}
+	pathValue, ok := runtimeContextTrustedCandidatePath(value, repoRoot, resolvedRepoRoot)
+	if !ok {
+		return true
+	}
+	return resolveRuntimeContextPath(pathValue, opts.evalSymlinksFunc()) != ""
 }
 
 func normalizeRuntimeContextPath(value string, opts traceLoadOptions) (string, bool) {
@@ -299,6 +318,28 @@ func looksLikeFilesystemPath(value string) bool {
 	}
 	base := parts[len(parts)-1]
 	return looksLikePathStyleBase(base)
+}
+
+func runtimeContextHasDefiniteFilesystemSignal(value string) bool {
+	if filePath, isFileURL := runtimeContextFileURLPath(value); isFileURL {
+		return filePath != ""
+	}
+	if rejectsRuntimeContextScheme(value) || strings.Contains(value, "://") {
+		return true
+	}
+	if hasFilesystemPathPrefix(value) {
+		return true
+	}
+	value = filepath.ToSlash(strings.TrimSpace(value))
+	if !strings.Contains(value, "/") {
+		return false
+	}
+	parts := strings.Split(value, "/")
+	if runtimePathPartsContainTraversal(parts) {
+		return true
+	}
+	base := parts[len(parts)-1]
+	return base == "" || strings.HasPrefix(base, ".")
 }
 
 func hasFilesystemPathPrefix(value string) bool {

--- a/internal/runtime/trace_context.go
+++ b/internal/runtime/trace_context.go
@@ -25,52 +25,77 @@ func normalizeRuntimeContextValue(value string, opts traceLoadOptions) string {
 }
 
 func normalizeRuntimeContextPath(value string, opts traceLoadOptions) (string, bool) {
-	if filePath, isFileURL := runtimeContextFileURLPath(value); isFileURL {
-		if filePath == "" {
-			return "", true
-		}
-		value = filePath
-	} else if rejectsRuntimeContextScheme(value) || strings.Contains(value, "://") {
-		return "", true
-	}
-	if !looksLikeFilesystemPath(value) {
+	value, ok := runtimeContextFilesystemCandidate(value)
+	if !ok {
 		return "", false
 	}
-	if strings.TrimSpace(opts.repoRoot) == "" {
+	if value == "" {
 		return "", true
 	}
-	if looksLikeWindowsAbsoluteContextPath(value) && filepath.Separator != '\\' {
+	repoRoot, resolvedRepoRoot, ok := runtimeContextTrustedRepoRoots(opts)
+	if !ok || shouldRedactRuntimeContextPath(value) {
 		return "", true
 	}
-	repoRoot := opts.resolvedRepoRoot
-	if strings.TrimSpace(repoRoot) == "" {
-		repoRoot = opts.resolveRepoRootFunc()(opts.repoRoot)
-	}
-	if strings.TrimSpace(repoRoot) == "" {
+	pathValue, ok := runtimeContextTrustedCandidatePath(value, repoRoot, resolvedRepoRoot)
+	if !ok {
 		return "", true
-	}
-	pathValue := filepath.Clean(filepath.FromSlash(value))
-	if filepath.IsAbs(pathValue) {
-		if !runtimeContextWithinTrustedRoots(pathValue, opts.repoRoot, repoRoot) {
-			return "", true
-		}
-	} else {
-		pathValue = filepath.Join(repoRoot, pathValue)
-		if !runtimeContextLexicallyWithinRepo(repoRoot, pathValue) {
-			return "", true
-		}
 	}
 	resolvedPath := resolveRuntimeContextPath(pathValue, opts.evalSymlinksFunc())
 	if resolvedPath == "" {
 		return "", true
 	}
-	for _, trustedRoot := range []string{repoRoot, opts.repoRoot} {
+	return runtimeContextTrustedRelativePath(resolvedPath, resolvedRepoRoot, opts.repoRoot), true
+}
+
+func runtimeContextFilesystemCandidate(value string) (string, bool) {
+	if filePath, isFileURL := runtimeContextFileURLPath(value); isFileURL {
+		return filePath, true
+	}
+	if rejectsRuntimeContextScheme(value) || strings.Contains(value, "://") {
+		return "", true
+	}
+	if !looksLikeFilesystemPath(value) {
+		return "", false
+	}
+	return value, true
+}
+
+func runtimeContextTrustedRepoRoots(opts traceLoadOptions) (string, string, bool) {
+	lexicalRepoRoot := strings.TrimSpace(opts.repoRoot)
+	if lexicalRepoRoot == "" {
+		return "", "", false
+	}
+	resolvedRepoRoot := strings.TrimSpace(opts.resolvedRepoRoot)
+	if resolvedRepoRoot == "" {
+		resolvedRepoRoot = opts.resolveRepoRootFunc()(lexicalRepoRoot)
+	}
+	if strings.TrimSpace(resolvedRepoRoot) == "" {
+		return "", "", false
+	}
+	return lexicalRepoRoot, resolvedRepoRoot, true
+}
+
+func shouldRedactRuntimeContextPath(value string) bool {
+	return looksLikeWindowsAbsoluteContextPath(value) && filepath.Separator != '\\'
+}
+
+func runtimeContextTrustedCandidatePath(value, lexicalRepoRoot, resolvedRepoRoot string) (string, bool) {
+	pathValue := filepath.Clean(filepath.FromSlash(value))
+	if filepath.IsAbs(pathValue) {
+		return pathValue, runtimeContextWithinTrustedRoots(pathValue, lexicalRepoRoot, resolvedRepoRoot)
+	}
+	pathValue = filepath.Join(resolvedRepoRoot, pathValue)
+	return pathValue, runtimeContextLexicallyWithinRepo(resolvedRepoRoot, pathValue)
+}
+
+func runtimeContextTrustedRelativePath(resolvedPath string, trustedRoots ...string) string {
+	for _, trustedRoot := range trustedRoots {
 		rel, ok := runtimeContextRepoRelative(trustedRoot, resolvedPath)
 		if ok {
-			return rel, true
+			return rel
 		}
 	}
-	return "", true
+	return ""
 }
 
 func runtimeContextFileURLPath(value string) (string, bool) {

--- a/internal/runtime/trace_context.go
+++ b/internal/runtime/trace_context.go
@@ -1,0 +1,135 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type traceLoadOptions struct {
+	repoRoot string
+}
+
+func normalizeRuntimeContextValue(value string, opts traceLoadOptions) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if normalized, ok := normalizeRuntimeContextPath(value, opts); ok {
+		return normalized
+	}
+	return normalizeRuntimeContextLabel(value)
+}
+
+func normalizeRuntimeContextPath(value string, opts traceLoadOptions) (string, bool) {
+	value = strings.TrimPrefix(value, fileURLPrefix)
+	if !looksLikeFilesystemPath(value) {
+		return "", false
+	}
+	if strings.TrimSpace(opts.repoRoot) == "" {
+		return "", true
+	}
+	repoRoot := resolvedRuntimeRepoRoot(opts.repoRoot)
+	pathValue := filepath.FromSlash(value)
+	if !filepath.IsAbs(pathValue) {
+		pathValue = filepath.Join(repoRoot, pathValue)
+	}
+	resolvedPath := resolveRuntimeContextPath(pathValue)
+	if resolvedPath == "" {
+		return "", true
+	}
+	rel, ok := runtimeContextRepoRelative(repoRoot, resolvedPath)
+	if !ok {
+		return "", true
+	}
+	return rel, true
+}
+
+func normalizeRuntimeContextLabel(value string) string {
+	if strings.Contains(value, "://") {
+		return ""
+	}
+	if strings.Contains(value, "\\") {
+		return ""
+	}
+	value = filepath.ToSlash(value)
+	if strings.HasPrefix(value, "/") {
+		return ""
+	}
+	if strings.HasPrefix(value, "./") || strings.HasPrefix(value, "../") {
+		return ""
+	}
+	return value
+}
+
+func looksLikeFilesystemPath(value string) bool {
+	if strings.HasPrefix(value, "/") || strings.HasPrefix(value, "\\") {
+		return true
+	}
+	if strings.HasPrefix(value, "./") || strings.HasPrefix(value, "../") {
+		return true
+	}
+	if len(value) >= 3 && value[1] == ':' && (value[2] == '\\' || value[2] == '/') {
+		return true
+	}
+	value = filepath.ToSlash(strings.TrimSpace(value))
+	if !strings.Contains(value, "/") {
+		return false
+	}
+	parts := strings.Split(value, "/")
+	for _, part := range parts {
+		if part == "." || part == ".." {
+			return true
+		}
+	}
+	base := parts[len(parts)-1]
+	if base == "" || strings.HasPrefix(base, ".") {
+		return true
+	}
+	if ext := pathLikeExtension(base); ext != "" {
+		return true
+	}
+	return false
+}
+
+func pathLikeExtension(base string) string {
+	dot := strings.LastIndex(base, ".")
+	if dot <= 0 || dot == len(base)-1 {
+		return ""
+	}
+	ext := base[dot+1:]
+	for _, r := range ext {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') {
+			return ""
+		}
+	}
+	return ext
+}
+
+func resolveRuntimeContextPath(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(value)
+	if err == nil && strings.TrimSpace(resolved) != "" {
+		return filepath.Clean(resolved)
+	}
+	if info, statErr := os.Stat(value); statErr == nil && !info.IsDir() {
+		return filepath.Clean(value)
+	}
+	return filepath.Clean(value)
+}
+
+func runtimeContextRepoRelative(repoRoot string, value string) (string, bool) {
+	rel, err := filepath.Rel(repoRoot, value)
+	if err != nil {
+		return "", false
+	}
+	if rel == "." {
+		return ".", true
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.ToSlash(filepath.Clean(rel)), true
+}

--- a/internal/runtime/trace_context.go
+++ b/internal/runtime/trace_context.go
@@ -11,15 +11,27 @@ type traceLoadOptions struct {
 	resolvedRepoRoot string
 	resolveRepoRoot  func(string) string
 	evalSymlinks     func(string) (string, error)
+	contextCache     map[string]string
 }
 
 func normalizeRuntimeContextValue(value string, opts traceLoadOptions) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
+	rawValue := strings.TrimSpace(value)
+	if rawValue == "" {
 		return ""
 	}
+	if cached, ok := traceLoadContextCacheLookup(opts.contextCache, rawValue); ok {
+		return cached
+	}
+	normalized := normalizeRuntimeContextValueUncached(rawValue, opts)
+	traceLoadContextCacheStore(opts.contextCache, rawValue, normalized)
+	return normalized
+}
+
+func normalizeRuntimeContextValueUncached(value string, opts traceLoadOptions) string {
 	if normalized, ok := normalizeRuntimeContextPath(value, opts); ok {
-		return normalized
+		if normalized != "" || !looksLikePackageStyleRuntimeContextLabel(value) {
+			return normalized
+		}
 	}
 	return normalizeRuntimeContextLabel(value)
 }
@@ -151,7 +163,14 @@ func normalizeRuntimeContextLabel(value string) string {
 	if strings.HasPrefix(value, "./") || strings.HasPrefix(value, "../") {
 		return ""
 	}
+	if strings.Contains(value, "/") && !looksLikePackageStyleRuntimeContextLabel(value) {
+		return ""
+	}
 	return value
+}
+
+func looksLikePackageStyleRuntimeContextLabel(value string) bool {
+	return looksLikeSafeNodeBuiltinContextLabel(strings.TrimSpace(value)) || len(safeRuntimePackageSegments(value, false, 2)) != 0
 }
 
 func rejectsRuntimeContextScheme(value string) bool {
@@ -262,6 +281,21 @@ func (o *traceLoadOptions) evalSymlinksFunc() func(string) (string, error) {
 		return o.evalSymlinks
 	}
 	return filepath.EvalSymlinks
+}
+
+func traceLoadContextCacheLookup(cache map[string]string, value string) (string, bool) {
+	if cache == nil {
+		return "", false
+	}
+	normalized, ok := cache[value]
+	return normalized, ok
+}
+
+func traceLoadContextCacheStore(cache map[string]string, value string, normalized string) {
+	if cache == nil {
+		return
+	}
+	cache[value] = normalized
 }
 
 func resolveRuntimeContextPath(value string, evalSymlinks func(string) (string, error)) string {

--- a/internal/runtime/trace_context.go
+++ b/internal/runtime/trace_context.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -10,9 +9,9 @@ import (
 type traceLoadOptions struct {
 	repoRoot         string
 	resolvedRepoRoot string
+	resolveRepoRoot  func(string) string
+	evalSymlinks     func(string) (string, error)
 }
-
-var resolveTraceRepoRoot = resolvedRuntimeRepoRoot
 
 func normalizeRuntimeContextValue(value string, opts traceLoadOptions) string {
 	value = strings.TrimSpace(value)
@@ -45,24 +44,33 @@ func normalizeRuntimeContextPath(value string, opts traceLoadOptions) (string, b
 	}
 	repoRoot := opts.resolvedRepoRoot
 	if strings.TrimSpace(repoRoot) == "" {
-		repoRoot = resolveTraceRepoRoot(opts.repoRoot)
+		repoRoot = opts.resolveRepoRootFunc()(opts.repoRoot)
 	}
 	if strings.TrimSpace(repoRoot) == "" {
 		return "", true
 	}
-	pathValue := filepath.FromSlash(value)
-	if !filepath.IsAbs(pathValue) {
+	pathValue := filepath.Clean(filepath.FromSlash(value))
+	if filepath.IsAbs(pathValue) {
+		if !runtimeContextWithinTrustedRoots(pathValue, opts.repoRoot, repoRoot) {
+			return "", true
+		}
+	} else {
 		pathValue = filepath.Join(repoRoot, pathValue)
+		if !runtimeContextLexicallyWithinRepo(repoRoot, pathValue) {
+			return "", true
+		}
 	}
-	resolvedPath := resolveRuntimeContextPath(pathValue)
+	resolvedPath := resolveRuntimeContextPath(pathValue, opts.evalSymlinksFunc())
 	if resolvedPath == "" {
 		return "", true
 	}
-	rel, ok := runtimeContextRepoRelative(repoRoot, resolvedPath)
-	if !ok {
-		return "", true
+	for _, trustedRoot := range []string{repoRoot, opts.repoRoot} {
+		rel, ok := runtimeContextRepoRelative(trustedRoot, resolvedPath)
+		if ok {
+			return rel, true
+		}
 	}
-	return rel, true
+	return "", true
 }
 
 func runtimeContextFileURLPath(value string) (string, bool) {
@@ -217,18 +225,54 @@ func pathLikeExtension(base string) string {
 	return ext
 }
 
-func resolveRuntimeContextPath(value string) string {
+func (o *traceLoadOptions) resolveRepoRootFunc() func(string) string {
+	if o != nil && o.resolveRepoRoot != nil {
+		return o.resolveRepoRoot
+	}
+	return resolvedRuntimeRepoRoot
+}
+
+func (o *traceLoadOptions) evalSymlinksFunc() func(string) (string, error) {
+	if o != nil && o.evalSymlinks != nil {
+		return o.evalSymlinks
+	}
+	return filepath.EvalSymlinks
+}
+
+func resolveRuntimeContextPath(value string, evalSymlinks func(string) (string, error)) string {
 	if strings.TrimSpace(value) == "" {
 		return ""
 	}
-	resolved, err := filepath.EvalSymlinks(value)
+	if evalSymlinks == nil {
+		evalSymlinks = filepath.EvalSymlinks
+	}
+	resolved, err := evalSymlinks(value)
 	if err == nil && strings.TrimSpace(resolved) != "" {
 		return filepath.Clean(resolved)
 	}
-	if info, statErr := os.Stat(value); statErr == nil && !info.IsDir() {
-		return filepath.Clean(value)
+	return ""
+}
+
+func runtimeContextWithinTrustedRoots(pathValue string, roots ...string) bool {
+	for _, root := range roots {
+		if runtimeContextLexicallyWithinRepo(root, pathValue) {
+			return true
+		}
 	}
-	return filepath.Clean(value)
+	return false
+}
+
+func runtimeContextLexicallyWithinRepo(repoRoot, value string) bool {
+	repoRoot = strings.TrimSpace(repoRoot)
+	value = strings.TrimSpace(value)
+	if repoRoot == "" || value == "" {
+		return false
+	}
+	rel, err := filepath.Rel(repoRoot, value)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func runtimeContextRepoRelative(repoRoot, value string) (string, bool) {

--- a/internal/runtime/trace_context.go
+++ b/internal/runtime/trace_context.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 type traceLoadOptions struct {
@@ -15,15 +17,22 @@ type traceLoadOptions struct {
 }
 
 func normalizeRuntimeContextValue(value string, opts traceLoadOptions) string {
-	rawValue := strings.TrimSpace(value)
-	if rawValue == "" {
+	rawValue := value
+	trimmedValue := strings.TrimSpace(rawValue)
+	if trimmedValue == "" {
 		return ""
 	}
-	if cached, ok := traceLoadContextCacheLookup(opts.contextCache, rawValue); ok {
+	if normalized, ok := normalizeRuntimeContextValueWithOuterWhitespace(rawValue, trimmedValue, opts); ok {
+		if normalized != "" {
+			traceLoadContextCacheStore(opts.contextCache, trimmedValue, normalized)
+		}
+		return normalized
+	}
+	if cached, ok := traceLoadContextCacheLookup(opts.contextCache, trimmedValue); ok {
 		return cached
 	}
-	normalized := normalizeRuntimeContextValueUncached(rawValue, opts)
-	traceLoadContextCacheStore(opts.contextCache, rawValue, normalized)
+	normalized := normalizeRuntimeContextValueUncached(trimmedValue, opts)
+	traceLoadContextCacheStore(opts.contextCache, trimmedValue, normalized)
 	return normalized
 }
 
@@ -34,6 +43,32 @@ func normalizeRuntimeContextValueUncached(value string, opts traceLoadOptions) s
 		}
 	}
 	return normalizeRuntimeContextLabel(value)
+}
+
+func normalizeRuntimeContextValueWithOuterWhitespace(rawValue, trimmedValue string, opts traceLoadOptions) (string, bool) {
+	if rawValue == trimmedValue || !runtimeContextHasOuterWhitespaceOrControl(rawValue) {
+		return "", false
+	}
+	if normalized, ok := normalizeRuntimeContextPath(trimmedValue, opts); ok && normalized != "" {
+		return normalized, true
+	}
+	if looksLikePackageStyleRuntimeContextLabel(trimmedValue) {
+		return "", true
+	}
+	return "", false
+}
+
+func runtimeContextHasOuterWhitespaceOrControl(value string) bool {
+	if value == "" {
+		return false
+	}
+	first, _ := utf8.DecodeRuneInString(value)
+	last, _ := utf8.DecodeLastRuneInString(value)
+	return runtimeContextIsOuterWhitespaceOrControl(first) || runtimeContextIsOuterWhitespaceOrControl(last)
+}
+
+func runtimeContextIsOuterWhitespaceOrControl(r rune) bool {
+	return unicode.IsSpace(r) || unicode.IsControl(r)
 }
 
 func normalizeRuntimeContextPath(value string, opts traceLoadOptions) (string, bool) {
@@ -153,6 +188,9 @@ func normalizeRuntimeContextLabel(value string) string {
 	if rejectsRuntimeContextScheme(value) || strings.Contains(value, "://") {
 		return ""
 	}
+	if runtimeLabelContainsWhitespaceOrControl(value) {
+		return ""
+	}
 	if strings.Contains(value, "\\") {
 		return ""
 	}
@@ -170,7 +208,7 @@ func normalizeRuntimeContextLabel(value string) string {
 }
 
 func looksLikePackageStyleRuntimeContextLabel(value string) bool {
-	return looksLikeSafeNodeBuiltinContextLabel(strings.TrimSpace(value)) || len(safeRuntimePackageSegments(value, false, 2)) != 0
+	return looksLikeSafeNodeBuiltinContextLabel(value) || len(safeRuntimePackageSegments(value, false, 2)) != 0
 }
 
 func rejectsRuntimeContextScheme(value string) bool {

--- a/internal/runtime/trace_context.go
+++ b/internal/runtime/trace_context.go
@@ -86,7 +86,7 @@ func looksLikeFilesystemPath(value string) bool {
 	if base == "" || strings.HasPrefix(base, ".") {
 		return true
 	}
-	if ext := pathLikeExtension(base); ext != "" {
+	if pathLikeExtension(base) != "" {
 		return true
 	}
 	return false
@@ -120,7 +120,7 @@ func resolveRuntimeContextPath(value string) string {
 	return filepath.Clean(value)
 }
 
-func runtimeContextRepoRelative(repoRoot string, value string) (string, bool) {
+func runtimeContextRepoRelative(repoRoot, value string) (string, bool) {
 	rel, err := filepath.Rel(repoRoot, value)
 	if err != nil {
 		return "", false

--- a/internal/runtime/trace_context.go
+++ b/internal/runtime/trace_context.go
@@ -1,14 +1,18 @@
 package runtime
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
 type traceLoadOptions struct {
-	repoRoot string
+	repoRoot         string
+	resolvedRepoRoot string
 }
+
+var resolveTraceRepoRoot = resolvedRuntimeRepoRoot
 
 func normalizeRuntimeContextValue(value string, opts traceLoadOptions) string {
 	value = strings.TrimSpace(value)
@@ -22,14 +26,30 @@ func normalizeRuntimeContextValue(value string, opts traceLoadOptions) string {
 }
 
 func normalizeRuntimeContextPath(value string, opts traceLoadOptions) (string, bool) {
-	value = strings.TrimPrefix(value, fileURLPrefix)
+	if filePath, isFileURL := runtimeContextFileURLPath(value); isFileURL {
+		if filePath == "" {
+			return "", true
+		}
+		value = filePath
+	} else if rejectsRuntimeContextScheme(value) || strings.Contains(value, "://") {
+		return "", true
+	}
 	if !looksLikeFilesystemPath(value) {
 		return "", false
 	}
 	if strings.TrimSpace(opts.repoRoot) == "" {
 		return "", true
 	}
-	repoRoot := resolvedRuntimeRepoRoot(opts.repoRoot)
+	if looksLikeWindowsAbsoluteContextPath(value) && filepath.Separator != '\\' {
+		return "", true
+	}
+	repoRoot := opts.resolvedRepoRoot
+	if strings.TrimSpace(repoRoot) == "" {
+		repoRoot = resolveTraceRepoRoot(opts.repoRoot)
+	}
+	if strings.TrimSpace(repoRoot) == "" {
+		return "", true
+	}
 	pathValue := filepath.FromSlash(value)
 	if !filepath.IsAbs(pathValue) {
 		pathValue = filepath.Join(repoRoot, pathValue)
@@ -45,8 +65,47 @@ func normalizeRuntimeContextPath(value string, opts traceLoadOptions) (string, b
 	return rel, true
 }
 
+func runtimeContextFileURLPath(value string) (string, bool) {
+	const fileSchemePrefix = "file:"
+	if len(value) < len(fileSchemePrefix) || !strings.EqualFold(value[:len(fileSchemePrefix)], fileSchemePrefix) {
+		return "", false
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil ||
+		!strings.EqualFold(parsed.Scheme, "file") ||
+		parsed.Opaque != "" ||
+		parsed.User != nil ||
+		parsed.RawQuery != "" ||
+		parsed.ForceQuery ||
+		parsed.Fragment != "" {
+		return "", true
+	}
+	if parsed.Host != "" && !strings.EqualFold(parsed.Host, "localhost") {
+		return "", true
+	}
+
+	pathValue := parsed.Path
+	if pathValue == "" || strings.IndexByte(pathValue, 0) >= 0 {
+		return "", true
+	}
+	if strings.HasPrefix(pathValue, "/") && looksLikeWindowsAbsoluteContextPath(pathValue[1:]) {
+		pathValue = pathValue[1:]
+	}
+	return pathValue, true
+}
+
+func looksLikeWindowsAbsoluteContextPath(value string) bool {
+	value = strings.TrimSpace(value)
+	if len(value) >= 3 && value[1] == ':' && (value[2] == '\\' || value[2] == '/') {
+		drive := value[0]
+		return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
+	}
+	return hasLeadingWindowsUNCSeparators(value)
+}
+
 func normalizeRuntimeContextLabel(value string) string {
-	if strings.Contains(value, "://") {
+	if rejectsRuntimeContextScheme(value) || strings.Contains(value, "://") {
 		return ""
 	}
 	if strings.Contains(value, "\\") {
@@ -60,6 +119,58 @@ func normalizeRuntimeContextLabel(value string) string {
 		return ""
 	}
 	return value
+}
+
+func rejectsRuntimeContextScheme(value string) bool {
+	scheme, ok := runtimeContextScheme(value)
+	if !ok {
+		return false
+	}
+	return !strings.EqualFold(scheme, "node")
+}
+
+func runtimeContextScheme(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 {
+		return "", false
+	}
+	colon := strings.IndexByte(value, ':')
+	if colon <= 0 {
+		return "", false
+	}
+	if isWindowsAbsoluteDrivePrefix(value) {
+		return "", false
+	}
+	for i := 0; i < colon; i++ {
+		r := value[i]
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9' && i > 0) || (i > 0 && (r == '+' || r == '.' || r == '-')) {
+			continue
+		}
+		return "", false
+	}
+	return value[:colon], true
+}
+
+func isWindowsAbsoluteDrivePrefix(value string) bool {
+	if len(value) < 3 || value[1] != ':' {
+		return false
+	}
+	drive := value[0]
+	if (drive < 'a' || drive > 'z') && (drive < 'A' || drive > 'Z') {
+		return false
+	}
+	return value[2] == '\\' || value[2] == '/'
+}
+
+func hasLeadingWindowsUNCSeparators(value string) bool {
+	if len(value) < 2 {
+		return false
+	}
+	return isRuntimeContextSlash(value[0]) && isRuntimeContextSlash(value[1])
+}
+
+func isRuntimeContextSlash(b byte) bool {
+	return b == '\\' || b == '/'
 }
 
 func looksLikeFilesystemPath(value string) bool {

--- a/internal/runtime/trace_context.go
+++ b/internal/runtime/trace_context.go
@@ -152,25 +152,32 @@ func runtimeContextFileURLPath(value string) (string, bool) {
 	}
 
 	parsed, err := url.Parse(value)
-	if err != nil ||
-		!strings.EqualFold(parsed.Scheme, "file") ||
-		parsed.Opaque != "" ||
-		parsed.User != nil ||
-		parsed.RawQuery != "" ||
-		parsed.ForceQuery ||
-		parsed.Fragment != "" {
+	if err != nil || !isTrustedRuntimeContextFileURL(parsed) {
 		return "", true
 	}
-	if parsed.Host != "" && !strings.EqualFold(parsed.Host, "localhost") {
+	pathValue, ok := normalizedRuntimeContextFileURLPath(parsed.Path)
+	if !ok {
 		return "", true
 	}
+	return pathValue, true
+}
 
-	pathValue := parsed.Path
+func isTrustedRuntimeContextFileURL(parsed *url.URL) bool {
+	return strings.EqualFold(parsed.Scheme, "file") &&
+		parsed.Opaque == "" &&
+		parsed.User == nil &&
+		parsed.RawQuery == "" &&
+		!parsed.ForceQuery &&
+		parsed.Fragment == "" &&
+		(parsed.Host == "" || strings.EqualFold(parsed.Host, "localhost"))
+}
+
+func normalizedRuntimeContextFileURLPath(pathValue string) (string, bool) {
 	if pathValue == "" || strings.IndexByte(pathValue, 0) >= 0 {
-		return "", true
+		return "", false
 	}
 	if strings.HasPrefix(pathValue, "/") && looksLikeWindowsAbsoluteContextPath(pathValue[1:]) {
-		pathValue = pathValue[1:]
+		return pathValue[1:], true
 	}
 	return pathValue, true
 }
@@ -225,20 +232,35 @@ func runtimeContextScheme(value string) (string, bool) {
 		return "", false
 	}
 	colon := strings.IndexByte(value, ':')
-	if colon <= 0 {
+	if colon <= 0 || isWindowsAbsoluteDrivePrefix(value) {
 		return "", false
 	}
-	if isWindowsAbsoluteDrivePrefix(value) {
-		return "", false
-	}
-	for i := 0; i < colon; i++ {
-		r := value[i]
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9' && i > 0) || (i > 0 && (r == '+' || r == '.' || r == '-')) {
-			continue
-		}
+	if !isValidRuntimeContextScheme(value[:colon]) {
 		return "", false
 	}
 	return value[:colon], true
+}
+
+func isValidRuntimeContextScheme(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if !isValidRuntimeContextSchemeByte(value[i], i) {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidRuntimeContextSchemeByte(value byte, index int) bool {
+	if value >= 'a' && value <= 'z' {
+		return true
+	}
+	if value >= 'A' && value <= 'Z' {
+		return true
+	}
+	if index > 0 && value >= '0' && value <= '9' {
+		return true
+	}
+	return index > 0 && (value == '+' || value == '.' || value == '-')
 }
 
 func isWindowsAbsoluteDrivePrefix(value string) bool {
@@ -264,13 +286,7 @@ func isRuntimeContextSlash(b byte) bool {
 }
 
 func looksLikeFilesystemPath(value string) bool {
-	if strings.HasPrefix(value, "/") || strings.HasPrefix(value, "\\") {
-		return true
-	}
-	if strings.HasPrefix(value, "./") || strings.HasPrefix(value, "../") {
-		return true
-	}
-	if len(value) >= 3 && value[1] == ':' && (value[2] == '\\' || value[2] == '/') {
+	if hasFilesystemPathPrefix(value) {
 		return true
 	}
 	value = filepath.ToSlash(strings.TrimSpace(value))
@@ -278,19 +294,32 @@ func looksLikeFilesystemPath(value string) bool {
 		return false
 	}
 	parts := strings.Split(value, "/")
+	if runtimePathPartsContainTraversal(parts) {
+		return true
+	}
+	base := parts[len(parts)-1]
+	return looksLikePathStyleBase(base)
+}
+
+func hasFilesystemPathPrefix(value string) bool {
+	return strings.HasPrefix(value, "/") ||
+		strings.HasPrefix(value, "\\") ||
+		strings.HasPrefix(value, "./") ||
+		strings.HasPrefix(value, "../") ||
+		isWindowsAbsoluteDrivePrefix(value)
+}
+
+func runtimePathPartsContainTraversal(parts []string) bool {
 	for _, part := range parts {
 		if part == "." || part == ".." {
 			return true
 		}
 	}
-	base := parts[len(parts)-1]
-	if base == "" || strings.HasPrefix(base, ".") {
-		return true
-	}
-	if pathLikeExtension(base) != "" {
-		return true
-	}
 	return false
+}
+
+func looksLikePathStyleBase(base string) bool {
+	return base == "" || strings.HasPrefix(base, ".") || pathLikeExtension(base) != ""
 }
 
 func pathLikeExtension(base string) string {
@@ -383,5 +412,13 @@ func runtimeContextRepoRelative(repoRoot, value string) (string, bool) {
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", false
 	}
-	return filepath.ToSlash(filepath.Clean(rel)), true
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if runtimeContextHasControlWhitespace(rel) {
+		return "", false
+	}
+	return rel, true
+}
+
+func runtimeContextHasControlWhitespace(value string) bool {
+	return strings.ContainsAny(value, "\n\r\t")
 }

--- a/internal/runtime/trace_context_test.go
+++ b/internal/runtime/trace_context_test.go
@@ -1,0 +1,67 @@
+package runtime
+
+import "testing"
+
+func TestNormalizeRuntimeContextLabelReturnsEmptyForURLs(t *testing.T) {
+	if got := normalizeRuntimeContextLabel("https://example.com/app.js"); got != "" {
+		t.Fatalf("expected URL label to be redacted, got %q", got)
+	}
+}
+
+func TestNormalizeRuntimeContextLabelReturnsEmptyForBackslashValues(t *testing.T) {
+	if got := normalizeRuntimeContextLabel(`src\main.js`); got != "" {
+		t.Fatalf("expected backslash label to be redacted, got %q", got)
+	}
+}
+
+func TestNormalizeRuntimeContextLabelReturnsEmptyForAbsolutePaths(t *testing.T) {
+	if got := normalizeRuntimeContextLabel("/tmp/app.js"); got != "" {
+		t.Fatalf("expected absolute label to be redacted, got %q", got)
+	}
+}
+
+func TestNormalizeRuntimeContextLabelReturnsEmptyForDotRelativePaths(t *testing.T) {
+	if got := normalizeRuntimeContextLabel("../src/app.js"); got != "" {
+		t.Fatalf("expected dot-relative label to be redacted, got %q", got)
+	}
+}
+
+func TestLooksLikeFilesystemPathReturnsTrueForDotRelativePaths(t *testing.T) {
+	if !looksLikeFilesystemPath("./src/app.js") {
+		t.Fatalf("expected dot-relative path to be treated as filesystem path")
+	}
+}
+
+func TestLooksLikeFilesystemPathReturnsTrueForWindowsDrivePaths(t *testing.T) {
+	if !looksLikeFilesystemPath(`C:\repo\app.js`) {
+		t.Fatalf("expected Windows drive path to be treated as filesystem path")
+	}
+}
+
+func TestLooksLikeFilesystemPathReturnsTrueForHiddenBasePaths(t *testing.T) {
+	if !looksLikeFilesystemPath("config/.env") {
+		t.Fatalf("expected hidden base path to be treated as filesystem path")
+	}
+}
+
+func TestPathLikeExtensionReturnsEmptyForNonAlphanumericSuffix(t *testing.T) {
+	if got := pathLikeExtension("trace.j-s"); got != "" {
+		t.Fatalf("expected non-alphanumeric extension to be rejected, got %q", got)
+	}
+}
+
+func TestResolveRuntimeContextPathReturnsEmptyForBlankInput(t *testing.T) {
+	if got := resolveRuntimeContextPath("   "); got != "" {
+		t.Fatalf("expected blank path to normalize empty, got %q", got)
+	}
+}
+
+func TestRuntimeContextRepoRelativeReturnsDotForRepoRoot(t *testing.T) {
+	rel, ok := runtimeContextRepoRelative("/repo", "/repo")
+	if !ok {
+		t.Fatalf("expected repo root to resolve relative path")
+	}
+	if rel != "." {
+		t.Fatalf("expected repo root relative path '.', got %q", rel)
+	}
+}

--- a/internal/runtime/trace_context_test.go
+++ b/internal/runtime/trace_context_test.go
@@ -291,43 +291,57 @@ func TestNormalizeRuntimeContextValueRedactsRepoPathsWithControlWhitespace(t *te
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			modulePath := filepath.Join(srcDir, tc.filename)
-			if err := os.WriteFile(modulePath, []byte("export {};\n"), 0o600); err != nil {
-				t.Fatalf("write repo module: %v", err)
-			}
-			if got := normalizeRuntimeContextValue(modulePath, opts); got != tc.want {
-				t.Fatalf("normalize runtime context %q: got %q, want %q", modulePath, got, tc.want)
-			}
-			if tc.want != "" {
-				return
-			}
-
-			eventData, err := json.Marshal(Event{
-				Module:     lodashMapModule,
-				Parent:     modulePath,
-				Entrypoint: modulePath,
-			})
-			if err != nil {
-				t.Fatalf("marshal runtime event: %v", err)
-			}
-			trace, err := loadTraceFromContentInRepo(t, repo, string(eventData)+"\n")
-			if err != nil {
-				t.Fatalf(loadTraceErrFmt, err)
-			}
-			if got := trace.DependencyParents["lodash"]; len(got) != 0 {
-				t.Fatalf("control-whitespace parent entered trace correlation: %#v", got)
-			}
-			if got := trace.DependencyEntrypoints["lodash"]; len(got) != 0 {
-				t.Fatalf("control-whitespace entrypoint entered trace correlation: %#v", got)
-			}
-			key := DependencyKey{Language: runtimeLanguageJSTS, Name: "lodash"}
-			if got := trace.DependencyParentsByLanguage[key]; len(got) != 0 {
-				t.Fatalf("control-whitespace parent entered language trace correlation: %#v", got)
-			}
-			if got := trace.DependencyEntrypointsByLanguage[key]; len(got) != 0 {
-				t.Fatalf("control-whitespace entrypoint entered language trace correlation: %#v", got)
-			}
+			assertRuntimeContextWhitespaceCase(t, repo, srcDir, opts, tc.filename, tc.want)
 		})
+	}
+}
+
+func assertRuntimeContextWhitespaceCase(t *testing.T, repo, srcDir string, opts traceLoadOptions, filename, want string) {
+	t.Helper()
+	modulePath := filepath.Join(srcDir, filename)
+	if err := os.WriteFile(modulePath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write repo module: %v", err)
+	}
+	if got := normalizeRuntimeContextValue(modulePath, opts); got != want {
+		t.Fatalf("normalize runtime context %q: got %q, want %q", modulePath, got, want)
+	}
+	if want != "" {
+		return
+	}
+	assertRedactedRuntimeContextTrace(t, repo, modulePath)
+}
+
+func assertRedactedRuntimeContextTrace(t *testing.T, repo, modulePath string) {
+	t.Helper()
+	eventData, err := json.Marshal(Event{
+		Module:     lodashMapModule,
+		Parent:     modulePath,
+		Entrypoint: modulePath,
+	})
+	if err != nil {
+		t.Fatalf("marshal runtime event: %v", err)
+	}
+	trace, err := loadTraceFromContentInRepo(t, repo, string(eventData)+"\n")
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	assertEmptyRuntimeContextCorrelation(t, trace)
+}
+
+func assertEmptyRuntimeContextCorrelation(t *testing.T, trace Trace) {
+	t.Helper()
+	if got := trace.DependencyParents["lodash"]; len(got) != 0 {
+		t.Fatalf("control-whitespace parent entered trace correlation: %#v", got)
+	}
+	if got := trace.DependencyEntrypoints["lodash"]; len(got) != 0 {
+		t.Fatalf("control-whitespace entrypoint entered trace correlation: %#v", got)
+	}
+	key := DependencyKey{Language: runtimeLanguageJSTS, Name: "lodash"}
+	if got := trace.DependencyParentsByLanguage[key]; len(got) != 0 {
+		t.Fatalf("control-whitespace parent entered language trace correlation: %#v", got)
+	}
+	if got := trace.DependencyEntrypointsByLanguage[key]; len(got) != 0 {
+		t.Fatalf("control-whitespace entrypoint entered language trace correlation: %#v", got)
 	}
 }
 

--- a/internal/runtime/trace_context_test.go
+++ b/internal/runtime/trace_context_test.go
@@ -73,8 +73,28 @@ func TestPathLikeExtensionReturnsEmptyForNonAlphanumericSuffix(t *testing.T) {
 }
 
 func TestResolveRuntimeContextPathReturnsEmptyForBlankInput(t *testing.T) {
-	if got := resolveRuntimeContextPath("   "); got != "" {
+	if got := resolveRuntimeContextPath("   ", nil); got != "" {
 		t.Fatalf("expected blank path to normalize empty, got %q", got)
+	}
+}
+
+func TestResolveRuntimeContextPathUsesDefaultEvalSymlinksWhenResolverIsNil(t *testing.T) {
+	repo := t.TempDir()
+	modulePath := filepath.Join(repo, "src", "main.js")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(modulePath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write repo module: %v", err)
+	}
+
+	want, err := filepath.EvalSymlinks(modulePath)
+	if err != nil {
+		t.Fatalf("eval symlinks module path: %v", err)
+	}
+	want = filepath.Clean(want)
+	if got := resolveRuntimeContextPath(modulePath, nil); got != want {
+		t.Fatalf("expected default symlink resolution to produce %q, got %q", want, got)
 	}
 }
 
@@ -85,6 +105,30 @@ func TestRuntimeContextRepoRelativeReturnsDotForRepoRoot(t *testing.T) {
 	}
 	if rel != "." {
 		t.Fatalf("expected repo root relative path '.', got %q", rel)
+	}
+}
+
+func TestRuntimeContextLexicallyWithinRepoReturnsFalseForBlankInputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		repoRoot string
+		value    string
+	}{
+		{name: "blank repo root", repoRoot: " ", value: "/repo/src/main.js"},
+		{name: "blank value", repoRoot: "/repo", value: " "},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if runtimeContextLexicallyWithinRepo(tc.repoRoot, tc.value) {
+				t.Fatalf("expected lexical repo check to reject repoRoot=%q value=%q", tc.repoRoot, tc.value)
+			}
+		})
+	}
+}
+
+func TestRuntimeContextRepoRelativeReturnsFalseWhenRepoRootIsBlank(t *testing.T) {
+	if rel, ok := runtimeContextRepoRelative("", "/repo/src/main.js"); ok || rel != "" {
+		t.Fatalf("expected blank repo root to fail relative conversion, got (%q, %t)", rel, ok)
 	}
 }
 
@@ -181,17 +225,184 @@ func TestNormalizeRuntimeContextPathResolvesRepoRootOnDemand(t *testing.T) {
 }
 
 func TestNormalizeRuntimeContextPathRejectsUnresolvableRepoRoot(t *testing.T) {
-	original := resolveTraceRepoRoot
-	resolveTraceRepoRoot = func(string) string {
-		return ""
-	}
-	t.Cleanup(func() {
-		resolveTraceRepoRoot = original
+	got, ok := normalizeRuntimeContextPath("src/main.js", traceLoadOptions{
+		repoRoot:        "/repo",
+		resolveRepoRoot: func(string) string { return "" },
 	})
-
-	got, ok := normalizeRuntimeContextPath("src/main.js", traceLoadOptions{repoRoot: "/repo"})
 	if !ok || got != "" {
 		t.Fatalf("normalize context with unresolvable repo root = (%q, %t), want empty recognized path", got, ok)
+	}
+}
+
+func TestNormalizeRuntimeContextPathRejectsHostilePathsBeforeFilesystemProbe(t *testing.T) {
+	repo := t.TempDir()
+	var probed []string
+	evalSymlinks := func(path string) (string, error) {
+		probed = append(probed, filepath.Clean(path))
+		return "", os.ErrNotExist
+	}
+
+	tests := []string{
+		"/etc/passwd",
+		"../outside.js",
+		"./../../outside.js",
+		`\\server\share\secret.js`,
+		`//server/share/secret.js`,
+		`/\server/share/secret.js`,
+		`file:///etc/passwd`,
+		"file://localhost/etc/passwd",
+		strings.TrimSuffix(fileURLForRuntimeTest(repo, ""), "/") + "/src%2F..%2F..%2Foutside.js",
+	}
+	opts := traceLoadOptions{
+		repoRoot:         repo,
+		resolvedRepoRoot: resolvedRuntimeRepoRoot(repo),
+		evalSymlinks:     evalSymlinks,
+	}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			probed = nil
+			got, ok := normalizeRuntimeContextPath(value, opts)
+			if !ok || got != "" {
+				t.Fatalf("normalize hostile context %q = (%q, %t), want empty recognized path", value, got, ok)
+			}
+			if len(probed) != 0 {
+				t.Fatalf("expected hostile context %q to avoid filesystem probes, got %#v", value, probed)
+			}
+		})
+	}
+}
+
+func TestNormalizeRuntimeContextPathProbesTrustedRepoLocalCandidatesOnly(t *testing.T) {
+	repo := t.TempDir()
+	modulePath := filepath.Join(repo, "src", "main.js")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(modulePath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write repo module: %v", err)
+	}
+
+	var probed []string
+	evalSymlinks := func(path string) (string, error) {
+		probed = append(probed, filepath.Clean(path))
+		return filepath.EvalSymlinks(path)
+	}
+
+	opts := traceLoadOptions{
+		repoRoot:         repo,
+		resolvedRepoRoot: resolvedRuntimeRepoRoot(repo),
+		evalSymlinks:     evalSymlinks,
+	}
+	got, ok := normalizeRuntimeContextPath(fileURLForRuntimeTest(modulePath, ""), opts)
+	if !ok || got != "src/main.js" {
+		t.Fatalf("normalize trusted repo-local file URL = (%q, %t), want (%q, true)", got, ok, "src/main.js")
+	}
+	if len(probed) != 1 || probed[0] != filepath.Clean(modulePath) {
+		t.Fatalf("expected one probe for trusted candidate %q, got %#v", modulePath, probed)
+	}
+}
+
+func TestNormalizeRuntimeContextPathPreservesSymlinkAliasAttribution(t *testing.T) {
+	repoRoot := t.TempDir()
+	aliasRoot := filepath.Join(t.TempDir(), "repo-alias")
+	modulePath := filepath.Join(repoRoot, "src", "main.js")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(modulePath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write repo module: %v", err)
+	}
+	if err := os.Symlink(repoRoot, aliasRoot); err != nil {
+		t.Fatalf("symlink repo alias: %v", err)
+	}
+
+	got, ok := normalizeRuntimeContextPath(filepath.Join(aliasRoot, "src", "main.js"), traceLoadOptions{
+		repoRoot:         aliasRoot,
+		resolvedRepoRoot: resolvedRuntimeRepoRoot(aliasRoot),
+	})
+	if !ok || got != "src/main.js" {
+		t.Fatalf("normalize symlinked repo alias = (%q, %t), want (%q, true)", got, ok, "src/main.js")
+	}
+}
+
+func TestNormalizeRuntimeContextPathRedactsRemovedSymlinkAlias(t *testing.T) {
+	repoRoot := t.TempDir()
+	aliasParent := t.TempDir()
+	aliasRoot := filepath.Join(aliasParent, "repo-alias")
+	modulePath := filepath.Join(repoRoot, "src", "main.js")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(modulePath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write repo module: %v", err)
+	}
+	if err := os.Symlink(repoRoot, aliasRoot); err != nil {
+		t.Fatalf("symlink repo alias: %v", err)
+	}
+
+	opts := traceLoadOptions{
+		repoRoot:         aliasRoot,
+		resolvedRepoRoot: resolvedRuntimeRepoRoot(aliasRoot),
+	}
+	candidate := filepath.Join(aliasRoot, "src", "main.js")
+	if err := os.Remove(aliasRoot); err != nil {
+		t.Fatalf("remove repo alias: %v", err)
+	}
+
+	got, ok := normalizeRuntimeContextPath(candidate, opts)
+	if !ok || got != "" {
+		t.Fatalf("normalize removed repo alias = (%q, %t), want empty recognized path", got, ok)
+	}
+	for _, forbidden := range []string{repoRoot, aliasRoot, candidate} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("removed alias normalization leaked host path %q in %q", forbidden, got)
+		}
+	}
+}
+
+func TestNormalizeRuntimeContextPathRedactsRetargetedSymlinkAlias(t *testing.T) {
+	repoRoot := t.TempDir()
+	aliasParent := t.TempDir()
+	aliasRoot := filepath.Join(aliasParent, "repo-alias")
+	retargetRoot := filepath.Join(t.TempDir(), "private-root")
+	modulePath := filepath.Join(repoRoot, "src", "main.js")
+	privatePath := filepath.Join(retargetRoot, "src", "private.js")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(privatePath), 0o755); err != nil {
+		t.Fatalf("mkdir private src: %v", err)
+	}
+	if err := os.WriteFile(modulePath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write repo module: %v", err)
+	}
+	if err := os.WriteFile(privatePath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write private module: %v", err)
+	}
+	if err := os.Symlink(repoRoot, aliasRoot); err != nil {
+		t.Fatalf("symlink repo alias: %v", err)
+	}
+
+	opts := traceLoadOptions{
+		repoRoot:         aliasRoot,
+		resolvedRepoRoot: resolvedRuntimeRepoRoot(aliasRoot),
+	}
+	candidate := filepath.Join(aliasRoot, "src", "private.js")
+	if err := os.Remove(aliasRoot); err != nil {
+		t.Fatalf("remove repo alias before retarget: %v", err)
+	}
+	if err := os.Symlink(retargetRoot, aliasRoot); err != nil {
+		t.Fatalf("retarget repo alias: %v", err)
+	}
+
+	got, ok := normalizeRuntimeContextPath(candidate, opts)
+	if !ok || got != "" {
+		t.Fatalf("normalize retargeted repo alias = (%q, %t), want empty recognized path", got, ok)
+	}
+	for _, forbidden := range []string{repoRoot, aliasRoot, retargetRoot, candidate, privatePath} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("retargeted alias normalization leaked host path %q in %q", forbidden, got)
+		}
 	}
 }
 

--- a/internal/runtime/trace_context_test.go
+++ b/internal/runtime/trace_context_test.go
@@ -1,10 +1,32 @@
 package runtime
 
-import "testing"
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestNormalizeRuntimeContextLabelReturnsEmptyForURLs(t *testing.T) {
 	if got := normalizeRuntimeContextLabel("https://example.com/app.js"); got != "" {
 		t.Fatalf("expected URL label to be redacted, got %q", got)
+	}
+}
+
+func TestNormalizeRuntimeContextLabelReturnsEmptyForRejectedSchemes(t *testing.T) {
+	for _, value := range []string{
+		"x:private-token",
+		"a:foo/bar.js",
+		"C:Users/alice/private.js",
+		"data:text/plain,secret",
+		"mailto:test@example.com",
+		"https:foo",
+		"https:/foo",
+	} {
+		if got := normalizeRuntimeContextLabel(value); got != "" {
+			t.Fatalf("expected rejected scheme label %q to be redacted, got %q", value, got)
+		}
 	}
 }
 
@@ -64,4 +86,135 @@ func TestRuntimeContextRepoRelativeReturnsDotForRepoRoot(t *testing.T) {
 	if rel != "." {
 		t.Fatalf("expected repo root relative path '.', got %q", rel)
 	}
+}
+
+func TestNormalizeRuntimeContextValueParsesFileURLs(t *testing.T) {
+	repo := t.TempDir()
+	modulePath := filepath.Join(repo, "src", "hello world.js")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(modulePath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write repo module: %v", err)
+	}
+	outsidePath := filepath.Join(t.TempDir(), "outside.js")
+	if err := os.WriteFile(outsidePath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write outside module: %v", err)
+	}
+
+	repoURL := fileURLForRuntimeTest(repo, "")
+	opts := traceLoadOptions{repoRoot: repo, resolvedRepoRoot: resolvedRuntimeRepoRoot(repo)}
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "local unix path", value: fileURLForRuntimeTest(modulePath, ""), want: "src/hello world.js"},
+		{name: "localhost path", value: fileURLForRuntimeTest(modulePath, "LOCALHOST"), want: "src/hello world.js"},
+		{name: "outside unix path", value: fileURLForRuntimeTest(outsidePath, ""), want: ""},
+		{name: "remote host", value: "file://server/share/project/main.js", want: ""},
+		{name: "localhost windows drive", value: "file://localhost/C:/Users/alice/project/main.js", want: ""},
+		{name: "encoded windows drive", value: "file://localhost/%43%3A%2FUsers/alice/project/main.js", want: ""},
+		{name: "encoded UNC path", value: "file://localhost/%2F%2Fserver/share/project/main.js", want: ""},
+		{name: "empty file URL path", value: "file://localhost", want: ""},
+		{name: "reject one-letter pseudo-scheme label", value: "x:private-token", want: ""},
+		{name: "reject one-letter pseudo-scheme path", value: "a:foo/bar.js", want: ""},
+		{name: "reject drive-relative path", value: "C:Users/alice/private.js", want: ""},
+		{name: "rejected data scheme", value: "data:text/plain,secret", want: ""},
+		{name: "rejected mailto scheme", value: "mailto:test@example.com", want: ""},
+		{name: "rejected https opaque", value: "https:foo", want: ""},
+		{name: "rejected https single slash", value: "https:/foo", want: ""},
+		{name: "encoded traversal", value: strings.TrimSuffix(repoURL, "/") + "/src%2F..%2F..%2FUsers/alice/main.js", want: ""},
+		{name: "malformed escape", value: strings.TrimSuffix(repoURL, "/") + "/src/bad%ZZ.js", want: ""},
+		{name: "node package label", value: "node:internal/modules/cjs/loader", want: "node:internal/modules/cjs/loader"},
+		{name: "package subpath label", value: "lodash/map", want: "lodash/map"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeRuntimeContextValue(tc.value, opts); got != tc.want {
+				t.Fatalf("normalize runtime context %q: got %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRuntimeContextSchemeOnlyExemptsAbsoluteWindowsDrives(t *testing.T) {
+	tests := []struct {
+		value    string
+		want     string
+		wantOkay bool
+	}{
+		{value: `C:\Users\alice\main.js`, want: "", wantOkay: false},
+		{value: "D:/repo/main.js", want: "", wantOkay: false},
+		{value: "x:private-token", want: "x", wantOkay: true},
+		{value: "a:foo/bar.js", want: "a", wantOkay: true},
+		{value: "C:Users/alice/private.js", want: "C", wantOkay: true},
+		{value: "node:internal/modules/cjs/loader", want: "node", wantOkay: true},
+		{value: "x", want: "", wantOkay: false},
+		{value: "bad_scheme:value", want: "", wantOkay: false},
+		{value: "1:/private.js", want: "", wantOkay: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.value, func(t *testing.T) {
+			got, ok := runtimeContextScheme(tc.value)
+			if got != tc.want || ok != tc.wantOkay {
+				t.Fatalf("runtimeContextScheme(%q) = (%q, %t), want (%q, %t)", tc.value, got, ok, tc.want, tc.wantOkay)
+			}
+		})
+	}
+}
+
+func TestNormalizeRuntimeContextPathResolvesRepoRootOnDemand(t *testing.T) {
+	repo := t.TempDir()
+	modulePath := filepath.Join(repo, "src", "main.js")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(modulePath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write repo module: %v", err)
+	}
+
+	got, ok := normalizeRuntimeContextPath("src/main.js", traceLoadOptions{repoRoot: repo})
+	if !ok || got != "src/main.js" {
+		t.Fatalf("normalize context with lazy repo root = (%q, %t), want (%q, true)", got, ok, "src/main.js")
+	}
+}
+
+func TestNormalizeRuntimeContextPathRejectsUnresolvableRepoRoot(t *testing.T) {
+	original := resolveTraceRepoRoot
+	resolveTraceRepoRoot = func(string) string {
+		return ""
+	}
+	t.Cleanup(func() {
+		resolveTraceRepoRoot = original
+	})
+
+	got, ok := normalizeRuntimeContextPath("src/main.js", traceLoadOptions{repoRoot: "/repo"})
+	if !ok || got != "" {
+		t.Fatalf("normalize context with unresolvable repo root = (%q, %t), want empty recognized path", got, ok)
+	}
+}
+
+func TestLooksLikeWindowsAbsoluteContextPathRecognizesMixedUNCSeparators(t *testing.T) {
+	for _, value := range []string{
+		`\\server\share\project\main.js`,
+		`//server/share/project/main.js`,
+		`\/server/share/project/main.js`,
+		`/\server/share/project/main.js`,
+	} {
+		if !looksLikeWindowsAbsoluteContextPath(value) {
+			t.Fatalf("expected %q to be treated as UNC-like absolute context", value)
+		}
+	}
+	if looksLikeWindowsAbsoluteContextPath("/") {
+		t.Fatal("single slash must not be treated as a UNC-like absolute context")
+	}
+}
+
+func fileURLForRuntimeTest(pathValue, host string) string {
+	pathValue = filepath.ToSlash(pathValue)
+	if !strings.HasPrefix(pathValue, "/") {
+		pathValue = "/" + pathValue
+	}
+	return (&url.URL{Scheme: "file", Host: host, Path: pathValue}).String()
 }

--- a/internal/runtime/trace_context_test.go
+++ b/internal/runtime/trace_context_test.go
@@ -397,6 +397,92 @@ func TestNormalizeRuntimeContextPathRejectsUnresolvableRepoRoot(t *testing.T) {
 	}
 }
 
+func TestNormalizeRuntimeContextValueKeepsRecognizedRepoRelativeEscapeRedacted(t *testing.T) {
+	repo := t.TempDir()
+	outsideDir := t.TempDir()
+	linkPath := filepath.Join(repo, "src", "linked.js")
+	targetPath := filepath.Join(outsideDir, "secret.js")
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write outside target: %v", err)
+	}
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Fatalf("symlink escape: %v", err)
+	}
+
+	opts := traceLoadOptions{repoRoot: repo, resolvedRepoRoot: resolvedRuntimeRepoRoot(repo)}
+	if got := normalizeRuntimeContextValue("src/linked.js", opts); got != "" {
+		t.Fatalf("expected repo-relative symlink escape to stay redacted, got %q", got)
+	}
+}
+
+func TestNormalizeRuntimeContextValuePreservesPackageLabelWhenRepoRelativeProbeFails(t *testing.T) {
+	repo := t.TempDir()
+	opts := traceLoadOptions{repoRoot: repo, resolvedRepoRoot: resolvedRuntimeRepoRoot(repo)}
+
+	if got := normalizeRuntimeContextValue("lodash/fp.js", opts); got != "lodash/fp.js" {
+		t.Fatalf("expected package label to survive failed repo-relative probe, got %q", got)
+	}
+	if got := normalizeRuntimeContextValue("@scope/pkg/index.js", opts); got != "@scope/pkg/index.js" {
+		t.Fatalf("expected scoped package label to survive failed repo-relative probe, got %q", got)
+	}
+}
+
+func TestRuntimeContextHasDefiniteFilesystemSignal(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "file URL", value: "file:///repo/src/main.js", want: true},
+		{name: "rejected scheme", value: "https:/example.com/private.js", want: true},
+		{name: "absolute path", value: "/repo/src/main.js", want: true},
+		{name: "traversal path", value: "src/../main.js", want: true},
+		{name: "hidden base path", value: "config/.env", want: true},
+		{name: "package label", value: "lodash/fp.js", want: false},
+		{name: "scoped package label", value: "@scope/pkg/index.js", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := runtimeContextHasDefiniteFilesystemSignal(tc.value); got != tc.want {
+				t.Fatalf("runtimeContextHasDefiniteFilesystemSignal(%q) = %t, want %t", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRuntimeContextShouldStayRedacted(t *testing.T) {
+	repo := t.TempDir()
+	outsideDir := t.TempDir()
+	linkPath := filepath.Join(repo, "src", "linked.js")
+	targetPath := filepath.Join(outsideDir, "secret.js")
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("export {};\n"), 0o600); err != nil {
+		t.Fatalf("write outside target: %v", err)
+	}
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Fatalf("symlink escape: %v", err)
+	}
+
+	opts := traceLoadOptions{repoRoot: repo, resolvedRepoRoot: resolvedRuntimeRepoRoot(repo)}
+	if !runtimeContextShouldStayRedacted("src/linked.js", opts) {
+		t.Fatalf("expected repo-relative symlink escape to stay redacted")
+	}
+	if runtimeContextShouldStayRedacted("lodash/fp.js", opts) {
+		t.Fatalf("expected package label to remain eligible for label normalization")
+	}
+	if !runtimeContextShouldStayRedacted("/tmp/private.js", opts) {
+		t.Fatalf("expected definite filesystem path to stay redacted")
+	}
+	if runtimeContextShouldStayRedacted("src/main.js", traceLoadOptions{}) {
+		t.Fatalf("expected ambiguous path-like label without repo roots to remain unresolved")
+	}
+}
+
 func TestNormalizeRuntimeContextPathRejectsHostilePathsBeforeFilesystemProbe(t *testing.T) {
 	repo := t.TempDir()
 	var probed []string

--- a/internal/runtime/trace_context_test.go
+++ b/internal/runtime/trace_context_test.go
@@ -48,6 +48,20 @@ func TestNormalizeRuntimeContextLabelReturnsEmptyForDotRelativePaths(t *testing.
 	}
 }
 
+func TestNormalizeRuntimeContextLabelReturnsEmptyForWhitespaceAndControlCharacters(t *testing.T) {
+	for _, value := range []string{
+		"lodash map",
+		"lodash/map\nsecret",
+		"lodash/map\tsecret",
+		"lodash/map\x00secret",
+		" node:fs",
+	} {
+		if got := normalizeRuntimeContextLabel(value); got != "" {
+			t.Fatalf("expected whitespace/control label %q to be redacted, got %q", value, got)
+		}
+	}
+}
+
 func TestLooksLikePackageStyleRuntimeContextLabel(t *testing.T) {
 	tests := []struct {
 		value string
@@ -80,8 +94,12 @@ func TestLooksLikePackageStyleRuntimeContextLabel(t *testing.T) {
 		{value: "pkg/~/.ssh/id_rsa", want: false},
 		{value: "@scope", want: false},
 		{value: "pkg//index.js", want: false},
+		{value: "pkg/\nsecret.js", want: false},
+		{value: "pkg/\x00secret.js", want: false},
+		{value: "pkg/with space.js", want: false},
 		{value: "node:fs", want: true},
 		{value: "node:fs/promises", want: true},
+		{value: "node:fs/promises\t", want: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.value, func(t *testing.T) {
@@ -231,9 +249,13 @@ func TestNormalizeRuntimeContextValueParsesFileURLs(t *testing.T) {
 		{name: "encoded traversal", value: strings.TrimSuffix(repoURL, "/") + "/src%2F..%2F..%2FUsers/alice/main.js", want: ""},
 		{name: "malformed escape", value: strings.TrimSuffix(repoURL, "/") + "/src/bad%ZZ.js", want: ""},
 		{name: "node package label", value: "node:internal/modules/cjs/loader", want: "node:internal/modules/cjs/loader"},
+		{name: "reject leading whitespace around node package label", value: " node:internal/modules/cjs/loader", want: ""},
+		{name: "reject trailing whitespace around node package label", value: "node:internal/modules/cjs/loader ", want: ""},
 		{name: "package subpath label", value: "lodash/map", want: "lodash/map"},
 		{name: "package file label", value: "lodash/fp.js", want: "lodash/fp.js"},
 		{name: "scoped package file label", value: "@scope/pkg/index.js", want: "@scope/pkg/index.js"},
+		{name: "reject outer whitespace around scoped package file label", value: " @scope/pkg/index.js ", want: ""},
+		{name: "preserve outer whitespace around repo path", value: " src/hello world.js ", want: "src/hello world.js"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/runtime/trace_context_test.go
+++ b/internal/runtime/trace_context_test.go
@@ -48,6 +48,50 @@ func TestNormalizeRuntimeContextLabelReturnsEmptyForDotRelativePaths(t *testing.
 	}
 }
 
+func TestLooksLikePackageStyleRuntimeContextLabel(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{value: "lodash/fp.js", want: true},
+		{value: "@scope/pkg/index.js", want: true},
+		{value: "src/main.js", want: true},
+		{value: "C:/Users/alice/private.js", want: false},
+		{value: `C:\Users\alice\private.js`, want: false},
+		{value: "C:Users/alice/private.js", want: false},
+		{value: "//server/share/alice/private.js", want: false},
+		{value: `\\server\share\alice\private.js`, want: false},
+		{value: "//./C:/Users/alice/private.js", want: false},
+		{value: `\\.\C:\Users\alice\private.js`, want: false},
+		{value: "//?/C:/Users/alice/private.js", want: false},
+		{value: `\\?\C:\Users\alice\private.js`, want: false},
+		{value: "//?/UNC/server/share/alice/private.js", want: false},
+		{value: `\\?\UNC\server\share\alice\private.js`, want: false},
+		{value: "/??/C:/Users/alice/private.js", want: false},
+		{value: `\??\C:\Users\alice\private.js`, want: false},
+		{value: "/Device/HarddiskVolume1/Users/alice/private.js", want: false},
+		{value: `\Device\HarddiskVolume1\Users\alice\private.js`, want: false},
+		{value: "https:/example.com/private.js", want: false},
+		{value: "../src/main.js", want: false},
+		{value: "src/../../Users/alice/private.js", want: false},
+		{value: "/tmp/main.js", want: false},
+		{value: "~/private/main.js", want: false},
+		{value: "pkg/.env/private.js", want: false},
+		{value: "pkg/~/.ssh/id_rsa", want: false},
+		{value: "@scope", want: false},
+		{value: "pkg//index.js", want: false},
+		{value: "node:fs", want: true},
+		{value: "node:fs/promises", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.value, func(t *testing.T) {
+			if got := looksLikePackageStyleRuntimeContextLabel(tc.value); got != tc.want {
+				t.Fatalf("looksLikePackageStyleRuntimeContextLabel(%q) = %t, want %t", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLooksLikeFilesystemPathReturnsTrueForDotRelativePaths(t *testing.T) {
 	if !looksLikeFilesystemPath("./src/app.js") {
 		t.Fatalf("expected dot-relative path to be treated as filesystem path")
@@ -164,14 +208,32 @@ func TestNormalizeRuntimeContextValueParsesFileURLs(t *testing.T) {
 		{name: "reject one-letter pseudo-scheme label", value: "x:private-token", want: ""},
 		{name: "reject one-letter pseudo-scheme path", value: "a:foo/bar.js", want: ""},
 		{name: "reject drive-relative path", value: "C:Users/alice/private.js", want: ""},
+		{name: "reject forward slash windows drive path", value: "C:/Users/alice/private.js", want: ""},
+		{name: "reject backslash windows drive path", value: `C:\Users\alice\private.js`, want: ""},
+		{name: "reject forward slash UNC path", value: "//server/share/alice/private.js", want: ""},
+		{name: "reject backslash UNC path", value: `\\server\share\alice\private.js`, want: ""},
+		{name: "reject forward slash device path", value: "//./C:/Users/alice/private.js", want: ""},
+		{name: "reject backslash device path", value: `\\.\C:\Users\alice\private.js`, want: ""},
+		{name: "reject forward slash verbatim drive path", value: "//?/C:/Users/alice/private.js", want: ""},
+		{name: "reject backslash verbatim drive path", value: `\\?\C:\Users\alice\private.js`, want: ""},
+		{name: "reject forward slash verbatim UNC path", value: "//?/UNC/server/share/alice/private.js", want: ""},
+		{name: "reject backslash verbatim UNC path", value: `\\?\UNC\server\share\alice\private.js`, want: ""},
+		{name: "reject forward slash object manager alias", value: "/??/C:/Users/alice/private.js", want: ""},
+		{name: "reject backslash object manager alias", value: `\??\C:\Users\alice\private.js`, want: ""},
+		{name: "reject forward slash object manager path", value: "/Device/HarddiskVolume1/Users/alice/private.js", want: ""},
+		{name: "reject backslash object manager path", value: `\Device\HarddiskVolume1\Users\alice\private.js`, want: ""},
 		{name: "rejected data scheme", value: "data:text/plain,secret", want: ""},
 		{name: "rejected mailto scheme", value: "mailto:test@example.com", want: ""},
 		{name: "rejected https opaque", value: "https:foo", want: ""},
 		{name: "rejected https single slash", value: "https:/foo", want: ""},
+		{name: "relative traversal", value: "src/../../Users/alice/private.js", want: ""},
+		{name: "home relative path", value: "~/private/main.js", want: ""},
 		{name: "encoded traversal", value: strings.TrimSuffix(repoURL, "/") + "/src%2F..%2F..%2FUsers/alice/main.js", want: ""},
 		{name: "malformed escape", value: strings.TrimSuffix(repoURL, "/") + "/src/bad%ZZ.js", want: ""},
 		{name: "node package label", value: "node:internal/modules/cjs/loader", want: "node:internal/modules/cjs/loader"},
 		{name: "package subpath label", value: "lodash/map", want: "lodash/map"},
+		{name: "package file label", value: "lodash/fp.js", want: "lodash/fp.js"},
+		{name: "scoped package file label", value: "@scope/pkg/index.js", want: "@scope/pkg/index.js"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/runtime/trace_context_test.go
+++ b/internal/runtime/trace_context_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -261,6 +262,70 @@ func TestNormalizeRuntimeContextValueParsesFileURLs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := normalizeRuntimeContextValue(tc.value, opts); got != tc.want {
 				t.Fatalf("normalize runtime context %q: got %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeRuntimeContextValueRedactsRepoPathsWithControlWhitespace(t *testing.T) {
+	if filepath.Separator == '\\' {
+		t.Skip("Windows does not support control whitespace in filenames")
+	}
+
+	repo := t.TempDir()
+	srcDir := filepath.Join(repo, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	opts := traceLoadOptions{repoRoot: repo, resolvedRepoRoot: resolvedRuntimeRepoRoot(repo)}
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{name: "newline", filename: "main\ncontext.js"},
+		{name: "carriage return", filename: "main\rcontext.js"},
+		{name: "tab", filename: "main\tcontext.js"},
+		{name: "space and unicode", filename: "hello world-\u4e16\u754c.js", want: "src/hello world-\u4e16\u754c.js"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			modulePath := filepath.Join(srcDir, tc.filename)
+			if err := os.WriteFile(modulePath, []byte("export {};\n"), 0o600); err != nil {
+				t.Fatalf("write repo module: %v", err)
+			}
+			if got := normalizeRuntimeContextValue(modulePath, opts); got != tc.want {
+				t.Fatalf("normalize runtime context %q: got %q, want %q", modulePath, got, tc.want)
+			}
+			if tc.want != "" {
+				return
+			}
+
+			eventData, err := json.Marshal(Event{
+				Module:     lodashMapModule,
+				Parent:     modulePath,
+				Entrypoint: modulePath,
+			})
+			if err != nil {
+				t.Fatalf("marshal runtime event: %v", err)
+			}
+			trace, err := loadTraceFromContentInRepo(t, repo, string(eventData)+"\n")
+			if err != nil {
+				t.Fatalf(loadTraceErrFmt, err)
+			}
+			if got := trace.DependencyParents["lodash"]; len(got) != 0 {
+				t.Fatalf("control-whitespace parent entered trace correlation: %#v", got)
+			}
+			if got := trace.DependencyEntrypoints["lodash"]; len(got) != 0 {
+				t.Fatalf("control-whitespace entrypoint entered trace correlation: %#v", got)
+			}
+			key := DependencyKey{Language: runtimeLanguageJSTS, Name: "lodash"}
+			if got := trace.DependencyParentsByLanguage[key]; len(got) != 0 {
+				t.Fatalf("control-whitespace parent entered language trace correlation: %#v", got)
+			}
+			if got := trace.DependencyEntrypointsByLanguage[key]; len(got) != 0 {
+				t.Fatalf("control-whitespace entrypoint entered language trace correlation: %#v", got)
 			}
 		})
 	}

--- a/internal/runtime/trace_load.go
+++ b/internal/runtime/trace_load.go
@@ -32,6 +32,10 @@ func load(path string, opts traceLoadOptions) (_ Trace, err error) {
 		}
 	}()
 
+	if strings.TrimSpace(opts.repoRoot) != "" {
+		opts.resolvedRepoRoot = resolveTraceRepoRoot(opts.repoRoot)
+	}
+
 	trace := newTrace()
 	scanner := bufio.NewScanner(newRuntimeTraceByteLimitReader(file, maxRuntimeTraceBytes))
 	line := 0

--- a/internal/runtime/trace_load.go
+++ b/internal/runtime/trace_load.go
@@ -17,7 +17,7 @@ func Load(path string) (Trace, error) {
 	return load(path, traceLoadOptions{})
 }
 
-func LoadForRepo(path string, repoPath string) (Trace, error) {
+func LoadForRepo(path, repoPath string) (Trace, error) {
 	return load(path, traceLoadOptions{repoRoot: repoPath})
 }
 

--- a/internal/runtime/trace_load.go
+++ b/internal/runtime/trace_load.go
@@ -35,6 +35,7 @@ func load(path string, opts traceLoadOptions) (_ Trace, err error) {
 	if strings.TrimSpace(opts.repoRoot) != "" {
 		opts.resolvedRepoRoot = opts.resolveRepoRootFunc()(opts.repoRoot)
 	}
+	opts.contextCache = make(map[string]string)
 
 	trace := newTrace()
 	scanner := bufio.NewScanner(newRuntimeTraceByteLimitReader(file, maxRuntimeTraceBytes))

--- a/internal/runtime/trace_load.go
+++ b/internal/runtime/trace_load.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/safeio"
@@ -14,7 +13,15 @@ import (
 
 const maxRuntimeTraceBytes int64 = 8 * 1024 * 1024
 
-func Load(path string) (_ Trace, err error) {
+func Load(path string) (Trace, error) {
+	return load(path, traceLoadOptions{})
+}
+
+func LoadForRepo(path string, repoPath string) (Trace, error) {
+	return load(path, traceLoadOptions{repoRoot: repoPath})
+}
+
+func load(path string, opts traceLoadOptions) (_ Trace, err error) {
 	file, err := safeio.OpenFile(path)
 	if err != nil {
 		return Trace{}, err
@@ -48,7 +55,7 @@ func Load(path string) (_ Trace, err error) {
 		}
 		module := runtimeModuleFromEventForLanguage(event, language, dep)
 		symbol := runtimeSymbolFromModuleForLanguage(module, language, dep)
-		addRuntimeEvent(&trace, language, dep, module, runtimeContextValue(event.Parent), runtimeContextValue(event.Entrypoint), symbol)
+		addRuntimeEvent(&trace, language, dep, module, runtimeContextValue(event.Parent, opts), runtimeContextValue(event.Entrypoint, opts), symbol)
 	}
 	if err := scanner.Err(); err != nil {
 		return Trace{}, err
@@ -172,11 +179,6 @@ func addSymbolCountByKey(target map[DependencyKey]map[string]int, key Dependency
 	items[module+"\x00"+symbol]++
 }
 
-func runtimeContextValue(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-	value = strings.TrimPrefix(value, fileURLPrefix)
-	return filepath.ToSlash(value)
+func runtimeContextValue(value string, opts traceLoadOptions) string {
+	return normalizeRuntimeContextValue(value, opts)
 }

--- a/internal/runtime/trace_load.go
+++ b/internal/runtime/trace_load.go
@@ -33,7 +33,7 @@ func load(path string, opts traceLoadOptions) (_ Trace, err error) {
 	}()
 
 	if strings.TrimSpace(opts.repoRoot) != "" {
-		opts.resolvedRepoRoot = resolveTraceRepoRoot(opts.repoRoot)
+		opts.resolvedRepoRoot = opts.resolveRepoRootFunc()(opts.repoRoot)
 	}
 
 	trace := newTrace()

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -428,6 +428,73 @@ func TestLoadTracePreservesPackageStyleLabels(t *testing.T) {
 	}
 }
 
+func TestLoadTracePreservesModuleOnlyPackageEventsWhenResolvedPathIsRedacted(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "src", "main.js"), []byte("console.log('x')\n"), 0o600); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+
+	trace, err := loadTraceFromContentInRepo(t, repo, `{"module":"fixture-dep","resolved":"","parent":"src/main.js","entrypoint":"src/main.js"}`+"\n")
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyLoads["fixture-dep"]; got != 1 {
+		t.Fatalf("expected module-only dependency load to survive, got %d", got)
+	}
+	if got := trace.DependencyModules["fixture-dep"]["fixture-dep"]; got != 1 {
+		t.Fatalf("expected module-only dependency module attribution, got %#v", trace.DependencyModules["fixture-dep"])
+	}
+	if got := trace.DependencyParents["fixture-dep"]["src/main.js"]; got != 1 {
+		t.Fatalf("expected parent attribution to survive resolved redaction, got %#v", trace.DependencyParents["fixture-dep"])
+	}
+	if got := trace.DependencyEntrypoints["fixture-dep"]["src/main.js"]; got != 1 {
+		t.Fatalf("expected entrypoint attribution to survive resolved redaction, got %#v", trace.DependencyEntrypoints["fixture-dep"])
+	}
+}
+
+func TestLoadForRepoRejectsUnsafeJSDependencyValues(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	mainPath := filepath.Join(repo, "src", "main.js")
+	if err := os.WriteFile(mainPath, []byte("console.log('x')\n"), 0o600); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+
+	content :=
+		`{"dependency":"fixture-dep","parent":"` + mainPath + `","entrypoint":"` + mainPath + `"}` + "\n" +
+			`{"dependency":"fixture-dep/.env/private.js","parent":"` + mainPath + `","entrypoint":"` + mainPath + `"}` + "\n" +
+			`{"dependency":"C:\\Users\\alice\\private.js","parent":"` + mainPath + `","entrypoint":"` + mainPath + `"}` + "\n" +
+			`{"dependency":"../private.js","parent":"` + mainPath + `","entrypoint":"` + mainPath + `"}` + "\n" +
+			`{"dependency":"@scope/pkg/index.js","parent":"` + mainPath + `","entrypoint":"` + mainPath + `"}` + "\n" +
+			`{"dependency":"//server/share/private.js","module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"` + mainPath + `","entrypoint":"` + mainPath + `"}` + "\n"
+
+	tracePath := testutil.WriteTempFile(t, filepath.Join("runtime", "trace.ndjson"), content)
+	trace, err := LoadForRepo(tracePath, repo)
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+
+	if got := trace.DependencyLoads["fixture-dep"]; got != 1 {
+		t.Fatalf("expected safe bare dependency to survive, got %d", got)
+	}
+	if got := trace.DependencyLoads["@scope/pkg"]; got != 1 {
+		t.Fatalf("expected safe scoped dependency to normalize to package ID, got %d", got)
+	}
+	if got := trace.DependencyLoads["lodash"]; got != 1 {
+		t.Fatalf("expected unsafe dependency to fall back to safe module/resolved attribution, got %d", got)
+	}
+	for _, dep := range []string{"fixture-dep/.env/private.js", `C:\Users\alice\private.js`, "../private.js", "//server/share/private.js"} {
+		if got := trace.DependencyLoads[dep]; got != 0 {
+			t.Fatalf("expected unsafe dependency %q to be redacted, got load count %d", dep, got)
+		}
+	}
+}
+
 func TestLoadForRepoRedactsForeignAbsoluteRuntimeContexts(t *testing.T) {
 	repo := t.TempDir()
 	contexts := []string{

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -2,16 +2,35 @@ package runtime
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/safeio"
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 func TestLoadTrace(t *testing.T) {
-	trace, err := loadTraceFromContentInRepo(t, "/repo", `{"kind":"resolve","module":"`+lodashMapModule+`","resolved":"file:///repo/node_modules/lodash/map.js","parent":"file:///repo/src/index.js","entrypoint":"file:///repo/src/main.js"}`+"\n"+`{"kind":"require","module":"@scope/pkg/lib","resolved":"/repo/node_modules/@scope/pkg/lib/index.js","parent":"/repo/src/index.cjs","entrypoint":"/repo/src/start.cjs"}`+"\n")
+	repo := t.TempDir()
+	for _, path := range []string{
+		filepath.Join(repo, "src", "index.js"),
+		filepath.Join(repo, "src", "main.js"),
+		filepath.Join(repo, "src", "index.cjs"),
+		filepath.Join(repo, "src", "start.cjs"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir trace fixture parent: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("module.exports = 1\n"), 0o600); err != nil {
+			t.Fatalf("write trace fixture %q: %v", path, err)
+		}
+	}
+
+	traceContent := `{"kind":"resolve","module":"` + lodashMapModule + `","resolved":"file:///repo/node_modules/lodash/map.js","parent":"` + fileURLForRuntimeTest(filepath.Join(repo, "src", "index.js"), "") + `","entrypoint":"` + fileURLForRuntimeTest(filepath.Join(repo, "src", "main.js"), "") + `"}` + "\n" +
+		`{"kind":"require","module":"@scope/pkg/lib","resolved":"/repo/node_modules/@scope/pkg/lib/index.js","parent":"` + filepath.Join(repo, "src", "index.cjs") + `","entrypoint":"` + filepath.Join(repo, "src", "start.cjs") + `"}` + "\n"
+	trace, err := loadTraceFromContentInRepo(t, repo, traceContent)
 
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
@@ -37,7 +56,15 @@ func TestLoadTrace(t *testing.T) {
 }
 
 func TestLoadTracePythonLanguageEvents(t *testing.T) {
-	trace, err := loadTraceFromContentInRepo(t, "/repo", `{"language":"python","module":"requests.sessions","parent":"/repo/app.py","entrypoint":"/repo/app.py"}`+"\n"+`{"language":"python","dependency":"python-dateutil","module":"dateutil.parser","resolved":"/repo/.venv/lib/python3.12/site-packages/dateutil/parser.py"}`+"\n")
+	repo := t.TempDir()
+	appPath := filepath.Join(repo, "app.py")
+	if err := os.WriteFile(appPath, []byte("print('ok')\n"), 0o600); err != nil {
+		t.Fatalf("write python app fixture: %v", err)
+	}
+
+	traceContent := `{"language":"python","module":"requests.sessions","parent":"` + appPath + `","entrypoint":"` + appPath + `"}` + "\n" +
+		`{"language":"python","dependency":"python-dateutil","module":"dateutil.parser","resolved":"/repo/.venv/lib/python3.12/site-packages/dateutil/parser.py"}` + "\n"
+	trace, err := loadTraceFromContentInRepo(t, repo, traceContent)
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
 	}
@@ -108,6 +135,63 @@ func TestLoadTraceOversizedFile(t *testing.T) {
 	_, err := loadTraceFromContent(t, oversizedRuntimeTraceContent())
 	if !errors.Is(err, safeio.ErrFileTooLarge) {
 		t.Fatalf("expected oversized trace to fail with ErrFileTooLarge, got %v", err)
+	}
+}
+
+func TestRuntimeTraceByteLimitReaderReturnsZeroForEmptyDestination(t *testing.T) {
+	reader := &runtimeTraceByteLimitReader{reader: strings.NewReader("trace"), remaining: 4}
+
+	n, err := reader.Read(nil)
+	if n != 0 || err != nil {
+		t.Fatalf("expected empty destination read to return (0, nil), got (%d, %v)", n, err)
+	}
+}
+
+func TestRuntimeTraceByteLimitReaderRejectsReadsAfterBudgetExhaustion(t *testing.T) {
+	reader := &runtimeTraceByteLimitReader{reader: strings.NewReader("trace"), remaining: 0}
+
+	buf := make([]byte, 8)
+	n, err := reader.Read(buf)
+	if !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected exhausted reader to fail with ErrFileTooLarge, got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected exhausted reader to return zero bytes, got %d", n)
+	}
+	if reader.remaining != 0 {
+		t.Fatalf("expected exhausted reader budget to remain zero, got %d", reader.remaining)
+	}
+}
+
+func TestRuntimeTraceByteLimitReaderClampsNegativeRemainingBudget(t *testing.T) {
+	reader := &runtimeTraceByteLimitReader{reader: strings.NewReader("x"), remaining: -1}
+
+	buf := make([]byte, 1)
+	n, err := reader.Read(buf)
+	if !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected negative remaining budget to fail with ErrFileTooLarge, got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected negative remaining budget to return zero bytes, got %d", n)
+	}
+	if reader.remaining != 0 {
+		t.Fatalf("expected negative remaining budget to clamp to zero, got %d", reader.remaining)
+	}
+}
+
+func TestRuntimeTraceByteLimitReaderReturnsUnderlyingReadWhenWithinBudget(t *testing.T) {
+	reader := &runtimeTraceByteLimitReader{reader: strings.NewReader("ok"), remaining: 4}
+
+	buf := make([]byte, 4)
+	n, err := reader.Read(buf)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("expected within-budget read to preserve underlying result, got %v", err)
+	}
+	if got := string(buf[:n]); got != "ok" {
+		t.Fatalf("expected within-budget read to return payload, got %q", got)
+	}
+	if reader.remaining != 2 {
+		t.Fatalf("expected remaining budget 2 after read, got %d", reader.remaining)
 	}
 }
 
@@ -275,30 +359,27 @@ func TestLoadTraceCanonicalizesRepoRootOncePerLoad(t *testing.T) {
 		t.Fatalf("write repo file: %v", err)
 	}
 
-	original := resolveTraceRepoRoot
 	calls := 0
-	resolveTraceRepoRoot = func(repoPath string) string {
+	resolveRepoRoot := func(repoPath string) string {
 		calls++
-		return original(repoPath)
+		return resolvedRuntimeRepoRoot(repoPath)
 	}
-	defer func() {
-		resolveTraceRepoRoot = original
-	}()
 
 	content :=
 		`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
 			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n"
-	trace, err := loadTraceFromContentInRepo(t, repo, content)
+	tracePath := testutil.WriteTempFile(t, filepath.Join("runtime", "trace.ndjson"), content)
+	trace, err := load(tracePath, traceLoadOptions{repoRoot: repo, resolveRepoRoot: resolveRepoRoot})
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
 	}
 	if calls != 1 {
 		t.Fatalf("expected repo root to resolve once per load, got %d", calls)
 	}
-	if got := trace.DependencyParents["lodash"]["src/main.js"]; got != 2 {
+	if trace.DependencyParents["lodash"]["src/main.js"] != 2 {
 		t.Fatalf("expected both parent samples to be counted, got %#v", trace.DependencyParents["lodash"])
 	}
-	if got := trace.DependencyEntrypoints["lodash"]["src/main.js"]; got != 2 {
+	if trace.DependencyEntrypoints["lodash"]["src/main.js"] != 2 {
 		t.Fatalf("expected both entrypoint samples to be counted, got %#v", trace.DependencyEntrypoints["lodash"])
 	}
 }

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -406,7 +407,10 @@ func TestLoadTraceRedactsEmbeddedRelativeTraversal(t *testing.T) {
 }
 
 func TestLoadTracePreservesPackageStyleLabels(t *testing.T) {
-	trace, err := loadTraceFromContentInRepo(t, t.TempDir(), `{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"node:internal/modules/cjs/loader","entrypoint":"lodash/map"}`+"\n")
+	content :=
+		`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"node:internal/modules/cjs/loader","entrypoint":"lodash/map"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"lodash/fp.js","entrypoint":"@scope/pkg/index.js"}` + "\n"
+	trace, err := loadTraceFromContentInRepo(t, t.TempDir(), content)
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
 	}
@@ -415,6 +419,156 @@ func TestLoadTracePreservesPackageStyleLabels(t *testing.T) {
 	}
 	if trace.DependencyEntrypoints["lodash"]["lodash/map"] != 1 {
 		t.Fatalf("expected package-style entrypoint label to be preserved, got %#v", trace.DependencyEntrypoints["lodash"])
+	}
+	if trace.DependencyParents["lodash"]["lodash/fp.js"] != 1 {
+		t.Fatalf("expected file-like package parent label to be preserved, got %#v", trace.DependencyParents["lodash"])
+	}
+	if trace.DependencyEntrypoints["lodash"]["@scope/pkg/index.js"] != 1 {
+		t.Fatalf("expected scoped file-like package entrypoint label to be preserved, got %#v", trace.DependencyEntrypoints["lodash"])
+	}
+}
+
+func TestLoadForRepoRedactsForeignAbsoluteRuntimeContexts(t *testing.T) {
+	repo := t.TempDir()
+	contexts := []string{
+		"C:/Users/alice/private.js",
+		`C:\Users\alice\private.js`,
+		"C:Users/alice/private.js",
+		"//server/share/alice/private.js",
+		`\\server\share\alice\private.js`,
+		"//./C:/Users/alice/private.js",
+		`\\.\C:\Users\alice\private.js`,
+		"//?/C:/Users/alice/private.js",
+		`\\?\C:\Users\alice\private.js`,
+		"//?/UNC/server/share/alice/private.js",
+		`\\?\UNC\server\share\alice\private.js`,
+		"/??/C:/Users/alice/private.js",
+		`\??\C:\Users\alice\private.js`,
+		"/Device/HarddiskVolume1/Users/alice/private.js",
+		`\Device\HarddiskVolume1\Users\alice\private.js`,
+		"https:/example.com/private.js",
+		"src/../../Users/alice/private.js",
+		"~/private/main.js",
+		"pkg/.env/private.js",
+		"pkg/~/.ssh/id_rsa",
+	}
+
+	var content strings.Builder
+	for _, context := range contexts {
+		line, err := json.Marshal(Event{
+			Module:     lodashMapModule,
+			Resolved:   "file:///repo/node_modules/lodash/map.js",
+			Parent:     context,
+			Entrypoint: context,
+		})
+		if err != nil {
+			t.Fatalf("marshal runtime event for %q: %v", context, err)
+		}
+		content.Write(line)
+		content.WriteByte('\n')
+	}
+	for _, event := range []Event{
+		{Module: lodashMapModule, Parent: "lodash/fp.js", Entrypoint: "@scope/pkg/index.js"},
+		{Module: lodashMapModule, Parent: "@scope/pkg/index.js", Entrypoint: "lodash/fp.js"},
+	} {
+		line, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal package-label runtime event: %v", err)
+		}
+		content.Write(line)
+		content.WriteByte('\n')
+	}
+
+	tracePath := testutil.WriteTempFile(t, filepath.Join("runtime", "trace.ndjson"), content.String())
+	trace, err := LoadForRepo(tracePath, repo)
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyParents["lodash"]; got["lodash/fp.js"] != 1 || got["@scope/pkg/index.js"] != 1 || len(got) != 2 {
+		t.Fatalf("expected only package-style parent labels, got %#v", got)
+	}
+	if got := trace.DependencyEntrypoints["lodash"]; got["lodash/fp.js"] != 1 || got["@scope/pkg/index.js"] != 1 || len(got) != 2 {
+		t.Fatalf("expected only package-style entrypoint labels, got %#v", got)
+	}
+}
+
+func TestLoadForRepoSkipsUnsafeNodeModulesHybridResolvedPaths(t *testing.T) {
+	repo := t.TempDir()
+	traceContent :=
+		`{"resolved":"node_modules/fixture-dep/index.js","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"resolved":"node_modules/fixture-dep/C:/Users/alice/private.mjs","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"resolved":"node_modules/fixture-dep/https:/secret.mjs","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"resolved":"node_modules/fixture-dep/.env/private.mjs","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"resolved":"node_modules/fixture-dep/~/.ssh/id_rsa","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n"
+
+	trace, err := loadTraceFromContentInRepo(t, repo, traceContent)
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyLoads["fixture-dep"]; got != 1 {
+		t.Fatalf("expected only safe fixture-dep load to survive, got %d from %#v", got, trace.DependencyLoads)
+	}
+	if got := trace.DependencyModules["fixture-dep"]; len(got) != 1 || got["fixture-dep/index.js"] != 1 {
+		t.Fatalf("expected only safe runtime module, got %#v", got)
+	}
+	if got := trace.DependencySymbols["fixture-dep"]; len(got) != 1 || got["fixture-dep/index.js\x00index"] != 1 {
+		t.Fatalf("expected only safe runtime symbol, got %#v", got)
+	}
+}
+
+func TestLoadTraceCachesRuntimeContextNormalizationPerRawValue(t *testing.T) {
+	repo := t.TempDir()
+	mainPath := filepath.Join(repo, "src", "main.js")
+	workerPath := filepath.Join(repo, "src", "worker.js")
+	for _, path := range []string{mainPath, workerPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir repo src: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("console.log('x')\n"), 0o600); err != nil {
+			t.Fatalf("write repo file %q: %v", path, err)
+		}
+	}
+
+	var calls []string
+	content :=
+		`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"src/worker.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/worker.js","entrypoint":"src/main.js"}` + "\n"
+	tracePath := testutil.WriteTempFile(t, filepath.Join("runtime", "trace.ndjson"), content)
+
+	trace, err := load(tracePath, traceLoadOptions{
+		repoRoot:         repo,
+		resolvedRepoRoot: resolvedRuntimeRepoRoot(repo),
+		evalSymlinks: func(path string) (string, error) {
+			calls = append(calls, filepath.Clean(path))
+			return filepath.EvalSymlinks(path)
+		},
+	})
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyParents["lodash"]["src/main.js"]; got != 2 {
+		t.Fatalf("expected cached parent normalization to preserve both main.js counts, got %#v", trace.DependencyParents["lodash"])
+	}
+	if got := trace.DependencyParents["lodash"]["src/worker.js"]; got != 1 {
+		t.Fatalf("expected cached parent normalization to preserve worker.js count, got %#v", trace.DependencyParents["lodash"])
+	}
+	if got := trace.DependencyEntrypoints["lodash"]["src/main.js"]; got != 2 {
+		t.Fatalf("expected cached entrypoint normalization to preserve main.js counts, got %#v", trace.DependencyEntrypoints["lodash"])
+	}
+	if got := trace.DependencyEntrypoints["lodash"]["src/worker.js"]; got != 1 {
+		t.Fatalf("expected cached entrypoint normalization to preserve worker.js count, got %#v", trace.DependencyEntrypoints["lodash"])
+	}
+	resolvedMainPath, err := filepath.EvalSymlinks(mainPath)
+	if err != nil {
+		t.Fatalf("resolve main path symlinks: %v", err)
+	}
+	resolvedWorkerPath, err := filepath.EvalSymlinks(workerPath)
+	if err != nil {
+		t.Fatalf("resolve worker path symlinks: %v", err)
+	}
+	if want := []string{filepath.Clean(resolvedMainPath), filepath.Clean(resolvedWorkerPath)}; len(calls) != len(want) || calls[0] != want[0] || calls[1] != want[1] {
+		t.Fatalf("expected one filesystem probe per distinct raw context, got %#v want %#v", calls, want)
 	}
 }
 

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -428,6 +428,42 @@ func TestLoadTracePreservesPackageStyleLabels(t *testing.T) {
 	}
 }
 
+func TestLoadTraceKeepsRepoRelativeSymlinkEscapesRedactedWithoutPackageFallback(t *testing.T) {
+	repo := t.TempDir()
+	outsideDir := t.TempDir()
+	linkPath := filepath.Join(repo, "src", "linked.js")
+	targetPath := filepath.Join(outsideDir, "secret.js")
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("console.log('secret')\n"), 0o600); err != nil {
+		t.Fatalf("write outside target: %v", err)
+	}
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Fatalf("symlink escape: %v", err)
+	}
+
+	content :=
+		`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/linked.js","entrypoint":"src/linked.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"lodash/fp.js","entrypoint":"@scope/pkg/index.js"}` + "\n"
+	trace, err := loadTraceFromContentInRepo(t, repo, content)
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyParents["lodash"]["src/linked.js"]; got != 0 {
+		t.Fatalf("expected repo-relative symlink escape parent to stay redacted, got %#v", trace.DependencyParents["lodash"])
+	}
+	if got := trace.DependencyEntrypoints["lodash"]["src/linked.js"]; got != 0 {
+		t.Fatalf("expected repo-relative symlink escape entrypoint to stay redacted, got %#v", trace.DependencyEntrypoints["lodash"])
+	}
+	if got := trace.DependencyParents["lodash"]["lodash/fp.js"]; got != 1 {
+		t.Fatalf("expected legitimate package-style parent label to remain, got %#v", trace.DependencyParents["lodash"])
+	}
+	if got := trace.DependencyEntrypoints["lodash"]["@scope/pkg/index.js"]; got != 1 {
+		t.Fatalf("expected legitimate package-style entrypoint label to remain, got %#v", trace.DependencyEntrypoints["lodash"])
+	}
+}
+
 func TestLoadTracePreservesModuleOnlyPackageEventsWhenResolvedPathIsRedacted(t *testing.T) {
 	repo := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -547,16 +547,16 @@ func TestLoadTraceCachesRuntimeContextNormalizationPerRawValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
 	}
-	if got := trace.DependencyParents["lodash"]["src/main.js"]; got != 2 {
+	if trace.DependencyParents["lodash"]["src/main.js"] != 2 {
 		t.Fatalf("expected cached parent normalization to preserve both main.js counts, got %#v", trace.DependencyParents["lodash"])
 	}
-	if got := trace.DependencyParents["lodash"]["src/worker.js"]; got != 1 {
+	if trace.DependencyParents["lodash"]["src/worker.js"] != 1 {
 		t.Fatalf("expected cached parent normalization to preserve worker.js count, got %#v", trace.DependencyParents["lodash"])
 	}
-	if got := trace.DependencyEntrypoints["lodash"]["src/main.js"]; got != 2 {
+	if trace.DependencyEntrypoints["lodash"]["src/main.js"] != 2 {
 		t.Fatalf("expected cached entrypoint normalization to preserve main.js counts, got %#v", trace.DependencyEntrypoints["lodash"])
 	}
-	if got := trace.DependencyEntrypoints["lodash"]["src/worker.js"]; got != 1 {
+	if trace.DependencyEntrypoints["lodash"]["src/worker.js"] != 1 {
 		t.Fatalf("expected cached entrypoint normalization to preserve worker.js count, got %#v", trace.DependencyEntrypoints["lodash"])
 	}
 	resolvedMainPath, err := filepath.EvalSymlinks(mainPath)

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -161,7 +161,7 @@ func TestLoadTraceRedactsContextOutsideRepoBoundary(t *testing.T) {
 	if got := trace.DependencyParents["lodash"]; len(got) != 0 {
 		t.Fatalf("expected outside parent to be redacted, got %#v", got)
 	}
-	if got := trace.DependencyEntrypoints["lodash"]["src/main.js"]; got != 1 {
+	if trace.DependencyEntrypoints["lodash"]["src/main.js"] != 1 {
 		t.Fatalf("expected repo-relative entrypoint, got %#v", trace.DependencyEntrypoints["lodash"])
 	}
 }
@@ -208,7 +208,7 @@ func TestLoadTraceRedactsEmbeddedRelativeTraversal(t *testing.T) {
 	if got := trace.DependencyParents["lodash"]; len(got) != 0 {
 		t.Fatalf("expected embedded traversal parent to be redacted, got %#v", got)
 	}
-	if got := trace.DependencyEntrypoints["lodash"]["src/main.js"]; got != 1 {
+	if trace.DependencyEntrypoints["lodash"]["src/main.js"] != 1 {
 		t.Fatalf("expected normal repo-relative entrypoint to be preserved, got %#v", trace.DependencyEntrypoints["lodash"])
 	}
 }
@@ -218,10 +218,10 @@ func TestLoadTracePreservesPackageStyleLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
 	}
-	if got := trace.DependencyParents["lodash"]["node:internal/modules/cjs/loader"]; got != 1 {
+	if trace.DependencyParents["lodash"]["node:internal/modules/cjs/loader"] != 1 {
 		t.Fatalf("expected package-style parent label to be preserved, got %#v", trace.DependencyParents["lodash"])
 	}
-	if got := trace.DependencyEntrypoints["lodash"]["lodash/map"]; got != 1 {
+	if trace.DependencyEntrypoints["lodash"]["lodash/map"] != 1 {
 		t.Fatalf("expected package-style entrypoint label to be preserved, got %#v", trace.DependencyEntrypoints["lodash"])
 	}
 }

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -441,17 +441,22 @@ func TestLoadTracePreservesModuleOnlyPackageEventsWhenResolvedPathIsRedacted(t *
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
 	}
-	if got := trace.DependencyLoads["fixture-dep"]; got != 1 {
-		t.Fatalf("expected module-only dependency load to survive, got %d", got)
+	assertModuleOnlyPackageEvent(t, trace, "fixture-dep", "src/main.js")
+}
+
+func assertModuleOnlyPackageEvent(t *testing.T, trace Trace, dep, context string) {
+	t.Helper()
+	if trace.DependencyLoads[dep] != 1 {
+		t.Fatalf("expected module-only dependency load to survive, got %d", trace.DependencyLoads[dep])
 	}
-	if got := trace.DependencyModules["fixture-dep"]["fixture-dep"]; got != 1 {
-		t.Fatalf("expected module-only dependency module attribution, got %#v", trace.DependencyModules["fixture-dep"])
+	if trace.DependencyModules[dep][dep] != 1 {
+		t.Fatalf("expected module-only dependency module attribution, got %#v", trace.DependencyModules[dep])
 	}
-	if got := trace.DependencyParents["fixture-dep"]["src/main.js"]; got != 1 {
-		t.Fatalf("expected parent attribution to survive resolved redaction, got %#v", trace.DependencyParents["fixture-dep"])
+	if trace.DependencyParents[dep][context] != 1 {
+		t.Fatalf("expected parent attribution to survive resolved redaction, got %#v", trace.DependencyParents[dep])
 	}
-	if got := trace.DependencyEntrypoints["fixture-dep"]["src/main.js"]; got != 1 {
-		t.Fatalf("expected entrypoint attribution to survive resolved redaction, got %#v", trace.DependencyEntrypoints["fixture-dep"])
+	if trace.DependencyEntrypoints[dep][context] != 1 {
+		t.Fatalf("expected entrypoint attribution to survive resolved redaction, got %#v", trace.DependencyEntrypoints[dep])
 	}
 }
 

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -492,6 +492,26 @@ func TestLoadForRepoRedactsForeignAbsoluteRuntimeContexts(t *testing.T) {
 	}
 }
 
+func TestLoadForRepoRejectsOuterWhitespaceForPackageStyleContextsBeforeCacheLookup(t *testing.T) {
+	repo := t.TempDir()
+	content :=
+		`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"node:fs","entrypoint":"@scope/pkg/index.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":" node:fs","entrypoint":" @scope/pkg/index.js "}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"node:fs ","entrypoint":"@scope/pkg/index.js\t"}` + "\n"
+
+	tracePath := testutil.WriteTempFile(t, filepath.Join("runtime", "trace.ndjson"), content)
+	trace, err := LoadForRepo(tracePath, repo)
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyParents["lodash"]; got["node:fs"] != 1 || len(got) != 1 {
+		t.Fatalf("expected only clean node builtin parent label to survive, got %#v", got)
+	}
+	if got := trace.DependencyEntrypoints["lodash"]; got["@scope/pkg/index.js"] != 1 || len(got) != 1 {
+		t.Fatalf("expected only clean scoped package entrypoint label to survive, got %#v", got)
+	}
+}
+
 func TestLoadForRepoSkipsUnsafeNodeModulesHybridResolvedPaths(t *testing.T) {
 	repo := t.TempDir()
 	traceContent :=
@@ -499,7 +519,8 @@ func TestLoadForRepoSkipsUnsafeNodeModulesHybridResolvedPaths(t *testing.T) {
 			`{"resolved":"node_modules/fixture-dep/C:/Users/alice/private.mjs","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
 			`{"resolved":"node_modules/fixture-dep/https:/secret.mjs","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
 			`{"resolved":"node_modules/fixture-dep/.env/private.mjs","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
-			`{"resolved":"node_modules/fixture-dep/~/.ssh/id_rsa","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n"
+			`{"resolved":"node_modules/fixture-dep/~/.ssh/id_rsa","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"resolved":"packages/web/node_modules/fixture-dep/C:/Users/alice/private.mjs","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n"
 
 	trace, err := loadTraceFromContentInRepo(t, repo, traceContent)
 	if err != nil {

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -166,6 +166,80 @@ func TestLoadTraceRedactsContextOutsideRepoBoundary(t *testing.T) {
 	}
 }
 
+func TestLoadTraceRedactsWindowsAbsoluteContextOnAnyHost(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "src", "main.js"), []byte("console.log('x')\n"), 0o600); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+
+	content :=
+		`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"C:\\Users\\alice\\project\\main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"\\\\server\\share\\project\\main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"//server/share/project/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"\\/server/share/project/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"/\\server/share/project/main.js"}` + "\n"
+	trace, err := loadTraceFromContentInRepo(t, repo, content)
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyParents["lodash"]; got["src/main.js"] != 4 || len(got) != 1 {
+		t.Fatalf("expected only repo-relative parent to remain, got %#v", got)
+	}
+	if got := trace.DependencyEntrypoints["lodash"]; got["src/main.js"] != 1 || len(got) != 1 {
+		t.Fatalf("expected only repo-relative entrypoint to remain, got %#v", got)
+	}
+}
+
+func TestLoadTraceParsesAndConfinesFileURLContext(t *testing.T) {
+	repo := t.TempDir()
+	mainPath := filepath.Join(repo, "src", "main.js")
+	spacePath := filepath.Join(repo, "src", "hello world.js")
+	if err := os.MkdirAll(filepath.Dir(mainPath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	for _, path := range []string{mainPath, spacePath} {
+		if err := os.WriteFile(path, []byte("console.log('x')\n"), 0o600); err != nil {
+			t.Fatalf("write repo file: %v", err)
+		}
+	}
+	outsidePath := filepath.Join(t.TempDir(), "outside.js")
+	if err := os.WriteFile(outsidePath, []byte("console.log('y')\n"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	mainURL := fileURLForRuntimeTest(mainPath, "")
+	localhostSpaceURL := fileURLForRuntimeTest(spacePath, "LOCALHOST")
+	repoURL := fileURLForRuntimeTest(repo, "")
+	content :=
+		`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"` + mainURL + `","entrypoint":"` + localhostSpaceURL + `"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"file://localhost/C:/Users/alice/project/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"file://server/share/project/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"` + strings.TrimSuffix(repoURL, "/") + `/src/bad%ZZ.js","entrypoint":"file://localhost/%43%3A%2FUsers/alice/project/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"` + strings.TrimSuffix(repoURL, "/") + `/src%2F..%2F..%2FUsers/alice/main.js","entrypoint":"file://localhost/%2F%2Fserver/share/project/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"x:private-token","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"a:foo/bar.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"C:Users/alice/private.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"data:text/plain,secret","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"mailto:test@example.com","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"https:foo","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"https:/foo","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"node:internal/modules/cjs/loader","entrypoint":"lodash/map"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"` + fileURLForRuntimeTest(outsidePath, "") + `","entrypoint":"` + mainURL + `"}` + "\n"
+	trace, err := loadTraceFromContentInRepo(t, repo, content)
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyParents["lodash"]; got["src/main.js"] != 2 || got["node:internal/modules/cjs/loader"] != 1 || len(got) != 2 {
+		t.Fatalf("expected only local parent file URLs to remain, got %#v", got)
+	}
+	if got := trace.DependencyEntrypoints["lodash"]; got["src/main.js"] != 9 || got["src/hello world.js"] != 1 || got["lodash/map"] != 1 || len(got) != 3 {
+		t.Fatalf("expected only local entrypoint file URLs to remain decoded, got %#v", got)
+	}
+}
+
 func TestLoadTraceRejectsSymlinkEscapes(t *testing.T) {
 	repo := t.TempDir()
 	outsideDir := t.TempDir()
@@ -189,6 +263,43 @@ func TestLoadTraceRejectsSymlinkEscapes(t *testing.T) {
 	}
 	if got := trace.DependencyEntrypoints["lodash"]; len(got) != 0 {
 		t.Fatalf("expected symlink-escaped entrypoint to be redacted, got %#v", got)
+	}
+}
+
+func TestLoadTraceCanonicalizesRepoRootOncePerLoad(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "src", "main.js"), []byte("console.log('x')\n"), 0o600); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+
+	original := resolveTraceRepoRoot
+	calls := 0
+	resolveTraceRepoRoot = func(repoPath string) string {
+		calls++
+		return original(repoPath)
+	}
+	defer func() {
+		resolveTraceRepoRoot = original
+	}()
+
+	content :=
+		`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n" +
+			`{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"src/main.js"}` + "\n"
+	trace, err := loadTraceFromContentInRepo(t, repo, content)
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected repo root to resolve once per load, got %d", calls)
+	}
+	if got := trace.DependencyParents["lodash"]["src/main.js"]; got != 2 {
+		t.Fatalf("expected both parent samples to be counted, got %#v", trace.DependencyParents["lodash"])
+	}
+	if got := trace.DependencyEntrypoints["lodash"]["src/main.js"]; got != 2 {
+		t.Fatalf("expected both entrypoint samples to be counted, got %#v", trace.DependencyEntrypoints["lodash"])
 	}
 }
 

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLoadTrace(t *testing.T) {
-	trace, err := loadTraceFromContent(t, `{"kind":"resolve","module":"`+lodashMapModule+`","resolved":"file:///repo/node_modules/lodash/map.js","parent":"file:///repo/src/index.js","entrypoint":"file:///repo/src/main.js"}`+"\n"+`{"kind":"require","module":"@scope/pkg/lib","resolved":"/repo/node_modules/@scope/pkg/lib/index.js","parent":"/repo/src/index.cjs","entrypoint":"/repo/src/start.cjs"}`+"\n")
+	trace, err := loadTraceFromContentInRepo(t, "/repo", `{"kind":"resolve","module":"`+lodashMapModule+`","resolved":"file:///repo/node_modules/lodash/map.js","parent":"file:///repo/src/index.js","entrypoint":"file:///repo/src/main.js"}`+"\n"+`{"kind":"require","module":"@scope/pkg/lib","resolved":"/repo/node_modules/@scope/pkg/lib/index.js","parent":"/repo/src/index.cjs","entrypoint":"/repo/src/start.cjs"}`+"\n")
 
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
@@ -25,10 +25,10 @@ func TestLoadTrace(t *testing.T) {
 	if got := trace.DependencyModules["lodash"][lodashMapModule]; got != 1 {
 		t.Fatalf("expected lodash module count 1, got %d", got)
 	}
-	if got := trace.DependencyParents["lodash"]["/repo/src/index.js"]; got != 1 {
+	if got := trace.DependencyParents["lodash"]["src/index.js"]; got != 1 {
 		t.Fatalf("expected lodash parent count 1, got %d", got)
 	}
-	if got := trace.DependencyEntrypoints["lodash"]["/repo/src/main.js"]; got != 1 {
+	if got := trace.DependencyEntrypoints["lodash"]["src/main.js"]; got != 1 {
 		t.Fatalf("expected lodash entrypoint count 1, got %d", got)
 	}
 	if got := trace.DependencySymbols["lodash"][lodashMapModule+"\x00map"]; got != 1 {
@@ -37,7 +37,7 @@ func TestLoadTrace(t *testing.T) {
 }
 
 func TestLoadTracePythonLanguageEvents(t *testing.T) {
-	trace, err := loadTraceFromContent(t, `{"language":"python","module":"requests.sessions","parent":"/repo/app.py","entrypoint":"/repo/app.py"}`+"\n"+`{"language":"python","dependency":"python-dateutil","module":"dateutil.parser","resolved":"/repo/.venv/lib/python3.12/site-packages/dateutil/parser.py"}`+"\n")
+	trace, err := loadTraceFromContentInRepo(t, "/repo", `{"language":"python","module":"requests.sessions","parent":"/repo/app.py","entrypoint":"/repo/app.py"}`+"\n"+`{"language":"python","dependency":"python-dateutil","module":"dateutil.parser","resolved":"/repo/.venv/lib/python3.12/site-packages/dateutil/parser.py"}`+"\n")
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
 	}
@@ -52,7 +52,7 @@ func TestLoadTracePythonLanguageEvents(t *testing.T) {
 	if got := trace.DependencyModulesByLanguage[requestsKey]["requests.sessions"]; got != 1 {
 		t.Fatalf("expected python module count 1, got %d", got)
 	}
-	if got := trace.DependencyParentsByLanguage[requestsKey]["/repo/app.py"]; got != 1 {
+	if got := trace.DependencyParentsByLanguage[requestsKey]["app.py"]; got != 1 {
 		t.Fatalf("expected python parent count 1, got %d", got)
 	}
 	if got := trace.DependencySymbolsByLanguage[requestsKey]["requests.sessions\x00sessions"]; got != 1 {
@@ -138,6 +138,91 @@ func TestLoadTraceSkipsEventsWithoutDependencies(t *testing.T) {
 	}
 	if len(trace.DependencyLoads) != 0 || len(trace.DependencyModules) != 0 || len(trace.DependencySymbols) != 0 {
 		t.Fatalf("expected dependency-free events to be ignored, got %#v", trace)
+	}
+}
+
+func TestLoadTraceRedactsContextOutsideRepoBoundary(t *testing.T) {
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "src", "main.js"), []byte("console.log('x')\n"), 0o600); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+	if err := os.WriteFile(outside, []byte("console.log('y')\n"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	trace, err := loadTraceFromContentInRepo(t, repo, `{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"`+outside+`","entrypoint":"file://`+filepath.ToSlash(filepath.Join(repo, "src", "main.js"))+`"}`+"\n")
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyParents["lodash"]; len(got) != 0 {
+		t.Fatalf("expected outside parent to be redacted, got %#v", got)
+	}
+	if got := trace.DependencyEntrypoints["lodash"]["src/main.js"]; got != 1 {
+		t.Fatalf("expected repo-relative entrypoint, got %#v", trace.DependencyEntrypoints["lodash"])
+	}
+}
+
+func TestLoadTraceRejectsSymlinkEscapes(t *testing.T) {
+	repo := t.TempDir()
+	outsideDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideDir, "secret.js"), []byte("module.exports = 1\n"), 0o600); err != nil {
+		t.Fatalf("write outside secret: %v", err)
+	}
+	linkPath := filepath.Join(repo, "src", "linked.js")
+	if err := os.Symlink(filepath.Join(outsideDir, "secret.js"), linkPath); err != nil {
+		t.Fatalf("symlink escape: %v", err)
+	}
+
+	trace, err := loadTraceFromContentInRepo(t, repo, `{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"`+linkPath+`","entrypoint":"`+linkPath+`"}`+"\n")
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyParents["lodash"]; len(got) != 0 {
+		t.Fatalf("expected symlink-escaped parent to be redacted, got %#v", got)
+	}
+	if got := trace.DependencyEntrypoints["lodash"]; len(got) != 0 {
+		t.Fatalf("expected symlink-escaped entrypoint to be redacted, got %#v", got)
+	}
+}
+
+func TestLoadTraceRedactsEmbeddedRelativeTraversal(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "src", "main.js"), []byte("console.log('x')\n"), 0o600); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+
+	trace, err := loadTraceFromContentInRepo(t, repo, `{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"src/../../Users/name/file.js","entrypoint":"src/main.js"}`+"\n")
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyParents["lodash"]; len(got) != 0 {
+		t.Fatalf("expected embedded traversal parent to be redacted, got %#v", got)
+	}
+	if got := trace.DependencyEntrypoints["lodash"]["src/main.js"]; got != 1 {
+		t.Fatalf("expected normal repo-relative entrypoint to be preserved, got %#v", trace.DependencyEntrypoints["lodash"])
+	}
+}
+
+func TestLoadTracePreservesPackageStyleLabels(t *testing.T) {
+	trace, err := loadTraceFromContentInRepo(t, t.TempDir(), `{"module":"lodash/map","resolved":"file:///repo/node_modules/lodash/map.js","parent":"node:internal/modules/cjs/loader","entrypoint":"lodash/map"}`+"\n")
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	if got := trace.DependencyParents["lodash"]["node:internal/modules/cjs/loader"]; got != 1 {
+		t.Fatalf("expected package-style parent label to be preserved, got %#v", trace.DependencyParents["lodash"])
+	}
+	if got := trace.DependencyEntrypoints["lodash"]["lodash/map"]; got != 1 {
+		t.Fatalf("expected package-style entrypoint label to be preserved, got %#v", trace.DependencyEntrypoints["lodash"])
 	}
 }
 

--- a/internal/runtime/trace_resolution.go
+++ b/internal/runtime/trace_resolution.go
@@ -134,21 +134,13 @@ func jsDependencyFromEvent(event Event) string {
 }
 
 func dependencyFromSpecifier(specifier string) string {
-	specifier = strings.TrimSpace(specifier)
-	if specifier == "" {
+	parts := safeRuntimePackageSegments(strings.TrimSpace(specifier), false, 1)
+	if len(parts) == 0 {
 		return ""
 	}
-	if strings.HasPrefix(specifier, ".") || strings.HasPrefix(specifier, "/") || strings.Contains(specifier, ":") {
-		return ""
-	}
-	if strings.HasPrefix(specifier, "@") {
-		parts := strings.SplitN(specifier, "/", 3)
-		if len(parts) < 2 {
-			return ""
-		}
+	if strings.HasPrefix(parts[0], "@") {
 		return parts[0] + "/" + parts[1]
 	}
-	parts := strings.SplitN(specifier, "/", 2)
 	return parts[0]
 }
 
@@ -198,35 +190,48 @@ func looksLikeSafeNodeBuiltinContextLabel(value string) bool {
 }
 
 func safeRuntimePackageSegments(value string, allowNodeBuiltin bool, minParts int) []string {
-	if value == "" || strings.TrimSpace(value) != value || runtimeLabelContainsWhitespaceOrControl(value) {
+	if invalidRuntimePackageLabel(value) {
 		return nil
 	}
 	if allowNodeBuiltin && looksLikeSafeNodeBuiltinContextLabel(value) {
 		return []string{value}
 	}
+	if runtimePackageLooksLikePathPayload(value) {
+		return nil
+	}
+	parts := strings.Split(filepath.ToSlash(value), "/")
+	if len(parts) < minParts || !runtimePackageSegmentsAreSafe(parts) || invalidScopedRuntimePackageSegments(parts) {
+		return nil
+	}
+	return parts
+}
+
+func invalidRuntimePackageLabel(value string) bool {
+	return value == "" || strings.TrimSpace(value) != value || runtimeLabelContainsWhitespaceOrControl(value)
+}
+
+func runtimePackageLooksLikePathPayload(value string) bool {
 	// This path-derived fallback is privacy-sensitive: reject suffixes that look like paths, URLs, or traversal payloads.
-	if strings.ContainsAny(value, `\:%?#|`) ||
+	return strings.ContainsAny(value, `\:%?#|`) ||
 		strings.HasPrefix(value, "/") ||
 		strings.HasPrefix(value, "~") ||
 		strings.HasPrefix(value, "./") ||
 		strings.HasPrefix(value, "../") ||
 		looksLikeWindowsAbsoluteContextPath(value) ||
-		filepath.IsAbs(filepath.FromSlash(value)) {
-		return nil
-	}
-	parts := strings.Split(filepath.ToSlash(value), "/")
-	if len(parts) < minParts {
-		return nil
-	}
+		filepath.IsAbs(filepath.FromSlash(value))
+}
+
+func runtimePackageSegmentsAreSafe(parts []string) bool {
 	for _, part := range parts {
 		if !isSafeRuntimePackageSegment(part) {
-			return nil
+			return false
 		}
 	}
-	if strings.HasPrefix(parts[0], "@") && (parts[0] == "@" || len(parts) < 2) {
-		return nil
-	}
-	return parts
+	return true
+}
+
+func invalidScopedRuntimePackageSegments(parts []string) bool {
+	return strings.HasPrefix(parts[0], "@") && (parts[0] == "@" || len(parts) < 2)
 }
 
 func runtimeLabelContainsWhitespaceOrControl(value string) bool {
@@ -267,7 +272,7 @@ func normalizeRuntimeDependency(dependency, language string) string {
 	if normalizeRuntimeLanguage(language) == runtimeLanguagePython {
 		return normalizePythonRuntimeDependency(dependency)
 	}
-	return dependency
+	return dependencyFromSpecifier(dependency)
 }
 
 func pythonDependencyFromEvent(event Event) string {

--- a/internal/runtime/trace_resolution.go
+++ b/internal/runtime/trace_resolution.go
@@ -50,11 +50,10 @@ func runtimeModuleFromSpecifier(specifier, dependency string) string {
 }
 
 func runtimeModuleFromResolvedPath(value, dependency string) string {
-	rest := nodeModulesResolvedSuffix(value)
-	if rest == "" {
+	parts := nodeModulesResolvedParts(value)
+	if len(parts) == 0 {
 		return ""
 	}
-	parts := strings.Split(rest, "/")
 	if strings.HasPrefix(parts[0], "@") {
 		if len(parts) < 2 {
 			return ""
@@ -154,11 +153,10 @@ func dependencyFromSpecifier(specifier string) string {
 }
 
 func dependencyFromResolvedPath(value string) string {
-	rest := nodeModulesResolvedSuffix(value)
-	if rest == "" {
+	parts := nodeModulesResolvedParts(value)
+	if len(parts) == 0 {
 		return ""
 	}
-	parts := strings.Split(rest, "/")
 	if strings.HasPrefix(parts[0], "@") {
 		if len(parts) < 2 {
 			return ""
@@ -178,6 +176,68 @@ func nodeModulesResolvedSuffix(value string) string {
 		return value[pos+len(marker):]
 	}
 	return ""
+}
+
+func nodeModulesResolvedParts(value string) []string {
+	rest := nodeModulesResolvedSuffix(value)
+	if rest == "" || !looksLikeSafeNodeModulesPackagePath(rest) {
+		return nil
+	}
+	return strings.Split(rest, "/")
+}
+
+func looksLikeSafeNodeModulesPackagePath(value string) bool {
+	return len(safeRuntimePackageSegments(value, false, 1)) != 0
+}
+
+func looksLikeSafeNodeBuiltinContextLabel(value string) bool {
+	if !strings.HasPrefix(value, "node:") {
+		return false
+	}
+	return len(safeRuntimePackageSegments(strings.TrimPrefix(value, "node:"), false, 1)) != 0
+}
+
+func safeRuntimePackageSegments(value string, allowNodeBuiltin bool, minParts int) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if allowNodeBuiltin && looksLikeSafeNodeBuiltinContextLabel(value) {
+		return []string{value}
+	}
+	// This path-derived fallback is privacy-sensitive: reject suffixes that look like paths, URLs, or traversal payloads.
+	if strings.ContainsAny(value, `\:%?#|`) ||
+		strings.HasPrefix(value, "/") ||
+		strings.HasPrefix(value, "~") ||
+		strings.HasPrefix(value, "./") ||
+		strings.HasPrefix(value, "../") ||
+		looksLikeWindowsAbsoluteContextPath(value) ||
+		filepath.IsAbs(filepath.FromSlash(value)) {
+		return nil
+	}
+	parts := strings.Split(filepath.ToSlash(value), "/")
+	if len(parts) < minParts {
+		return nil
+	}
+	for _, part := range parts {
+		if !isSafeRuntimePackageSegment(part) {
+			return nil
+		}
+	}
+	if strings.HasPrefix(parts[0], "@") && (parts[0] == "@" || len(parts) < 2) {
+		return nil
+	}
+	return parts
+}
+
+func isSafeRuntimePackageSegment(part string) bool {
+	if part == "" || part == "." || part == ".." {
+		return false
+	}
+	if strings.HasPrefix(part, ".") || strings.HasPrefix(part, "~") {
+		return false
+	}
+	return !strings.ContainsAny(part, `\:%?#|`)
 }
 
 func normalizeRuntimeLanguage(language string) string {

--- a/internal/runtime/trace_resolution.go
+++ b/internal/runtime/trace_resolution.go
@@ -4,6 +4,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/ben-ranford/lopper/internal/report"
 )
@@ -49,19 +50,7 @@ func runtimeModuleFromSpecifier(specifier, dependency string) string {
 }
 
 func runtimeModuleFromResolvedPath(value, dependency string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-	value = strings.TrimPrefix(value, fileURLPrefix)
-	value = filepath.ToSlash(value)
-
-	marker := "/node_modules/"
-	pos := strings.LastIndex(value, marker)
-	if pos < 0 {
-		return ""
-	}
-	rest := value[pos+len(marker):]
+	rest := nodeModulesResolvedSuffix(value)
 	if rest == "" {
 		return ""
 	}
@@ -165,19 +154,7 @@ func dependencyFromSpecifier(specifier string) string {
 }
 
 func dependencyFromResolvedPath(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-	value = strings.TrimPrefix(value, fileURLPrefix)
-	value = filepath.ToSlash(value)
-
-	marker := "/node_modules/"
-	pos := strings.LastIndex(value, marker)
-	if pos < 0 {
-		return ""
-	}
-	rest := value[pos+len(marker):]
+	rest := nodeModulesResolvedSuffix(value)
 	if rest == "" {
 		return ""
 	}
@@ -189,6 +166,18 @@ func dependencyFromResolvedPath(value string) string {
 		return parts[0] + "/" + parts[1]
 	}
 	return parts[0]
+}
+
+func nodeModulesResolvedSuffix(value string) string {
+	value = filepath.ToSlash(strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(value), fileURLPrefix)))
+	if strings.HasPrefix(value, "node_modules/") {
+		return strings.TrimPrefix(value, "node_modules/")
+	}
+	const marker = "/node_modules/"
+	if pos := strings.LastIndex(value, marker); pos >= 0 {
+		return value[pos+len(marker):]
+	}
+	return ""
 }
 
 func normalizeRuntimeLanguage(language string) string {
@@ -288,6 +277,12 @@ func pythonModuleFromResolvedPath(value, dependency string) string {
 	if value == "" {
 		return ""
 	}
+	if module := sanitizedPythonModuleIdentifier(value); module != "" {
+		if dependency == "" || dependencyFromPythonModule(module) == dependency {
+			return module
+		}
+		return ""
+	}
 	value = strings.TrimPrefix(value, fileURLPrefix)
 	value = filepath.ToSlash(value)
 	for _, marker := range []string{"/site-packages/", "/dist-packages/"} {
@@ -311,6 +306,25 @@ func pythonModuleFromResolvedPath(value, dependency string) string {
 		return module
 	}
 	return ""
+}
+
+func sanitizedPythonModuleIdentifier(value string) string {
+	if strings.ContainsAny(value, `/\:`) {
+		return ""
+	}
+	parts := strings.Split(value, ".")
+	for _, part := range parts {
+		if part == "" {
+			return ""
+		}
+		for index, character := range part {
+			if character == '_' || unicode.IsLetter(character) || (index > 0 && unicode.IsDigit(character)) {
+				continue
+			}
+			return ""
+		}
+	}
+	return value
 }
 
 func normalizePythonRuntimeDependency(dependency string) string {

--- a/internal/runtime/trace_resolution.go
+++ b/internal/runtime/trace_resolution.go
@@ -286,19 +286,9 @@ func pythonModuleFromResolvedPath(value, dependency string) string {
 	value = strings.TrimPrefix(value, fileURLPrefix)
 	value = filepath.ToSlash(value)
 	for _, marker := range []string{"/site-packages/", "/dist-packages/"} {
-		pos := strings.LastIndex(value, marker)
-		if pos < 0 {
+		module := pythonModuleFromPackageMarker(value, marker)
+		if module == "" {
 			continue
-		}
-		rest := strings.TrimPrefix(value[pos+len(marker):], "/")
-		if rest == "" {
-			return ""
-		}
-		module := strings.TrimSuffix(strings.Split(rest, "/")[0], ".py")
-		module = strings.TrimSuffix(module, ".pyc")
-		module = strings.TrimSuffix(module, ".pyo")
-		if module == "__pycache__" || strings.HasSuffix(module, ".dist-info") || strings.HasSuffix(module, ".egg-info") {
-			return ""
 		}
 		if dependency != "" && dependencyFromPythonModule(module) != dependency {
 			return ""
@@ -306,6 +296,25 @@ func pythonModuleFromResolvedPath(value, dependency string) string {
 		return module
 	}
 	return ""
+}
+
+func pythonModuleFromPackageMarker(value, marker string) string {
+	pos := strings.LastIndex(value, marker)
+	if pos < 0 {
+		return ""
+	}
+	rest := strings.TrimPrefix(value[pos+len(marker):], "/")
+	if rest == "" {
+		return ""
+	}
+	module := strings.Split(rest, "/")[0]
+	for _, suffix := range []string{".py", ".pyc", ".pyo"} {
+		module = strings.TrimSuffix(module, suffix)
+	}
+	if module == "__pycache__" || strings.HasSuffix(module, ".dist-info") || strings.HasSuffix(module, ".egg-info") {
+		return ""
+	}
+	return module
 }
 
 func sanitizedPythonModuleIdentifier(value string) string {

--- a/internal/runtime/trace_resolution.go
+++ b/internal/runtime/trace_resolution.go
@@ -198,8 +198,7 @@ func looksLikeSafeNodeBuiltinContextLabel(value string) bool {
 }
 
 func safeRuntimePackageSegments(value string, allowNodeBuiltin bool, minParts int) []string {
-	value = strings.TrimSpace(value)
-	if value == "" {
+	if value == "" || strings.TrimSpace(value) != value || runtimeLabelContainsWhitespaceOrControl(value) {
 		return nil
 	}
 	if allowNodeBuiltin && looksLikeSafeNodeBuiltinContextLabel(value) {
@@ -228,6 +227,15 @@ func safeRuntimePackageSegments(value string, allowNodeBuiltin bool, minParts in
 		return nil
 	}
 	return parts
+}
+
+func runtimeLabelContainsWhitespaceOrControl(value string) bool {
+	for _, r := range value {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
 }
 
 func isSafeRuntimePackageSegment(part string) bool {

--- a/internal/runtime/trace_resolution_test.go
+++ b/internal/runtime/trace_resolution_test.go
@@ -37,6 +37,11 @@ func TestDependencyFromSpecifierAndResolvedPathEdgeCases(t *testing.T) {
 		{name: "empty node_modules suffix", got: dependencyFromResolvedPath("file:///repo/node_modules/"), want: ""},
 		{name: "malformed scoped resolved path", got: dependencyFromResolvedPath("file:///repo/node_modules/@scope"), want: ""},
 		{name: "package with subpath", got: dependencyFromResolvedPath("file:///repo/node_modules/pkg/sub/index.js"), want: "pkg"},
+		{name: "reject drive hybrid suffix", got: dependencyFromResolvedPath("node_modules/fixture-dep/C:/Users/alice/private.mjs"), want: ""},
+		{name: "reject scheme hybrid suffix", got: dependencyFromResolvedPath("node_modules/fixture-dep/https:/secret.mjs"), want: ""},
+		{name: "reject traversal hybrid suffix", got: dependencyFromResolvedPath("node_modules/fixture-dep/../secret.mjs"), want: ""},
+		{name: "reject hidden hybrid suffix", got: dependencyFromResolvedPath("node_modules/fixture-dep/.env/private.mjs"), want: ""},
+		{name: "reject home hybrid suffix", got: dependencyFromResolvedPath("node_modules/fixture-dep/~/.ssh/id_rsa"), want: ""},
 	}
 	for _, tc := range cases {
 		if tc.got != tc.want {

--- a/internal/runtime/trace_resolution_test.go
+++ b/internal/runtime/trace_resolution_test.go
@@ -42,6 +42,11 @@ func TestDependencyFromSpecifierAndResolvedPathEdgeCases(t *testing.T) {
 		{name: "reject traversal hybrid suffix", got: dependencyFromResolvedPath("node_modules/fixture-dep/../secret.mjs"), want: ""},
 		{name: "reject hidden hybrid suffix", got: dependencyFromResolvedPath("node_modules/fixture-dep/.env/private.mjs"), want: ""},
 		{name: "reject home hybrid suffix", got: dependencyFromResolvedPath("node_modules/fixture-dep/~/.ssh/id_rsa"), want: ""},
+		{name: "reject hidden package-like specifier", got: dependencyFromSpecifier("fixture-dep/.env/private.mjs"), want: ""},
+		{name: "reject traversal package-like specifier", got: dependencyFromSpecifier("fixture-dep/../private.mjs"), want: ""},
+		{name: "reject absolute package-like specifier", got: dependencyFromSpecifier("/tmp/private.mjs"), want: ""},
+		{name: "reject windows package-like specifier", got: dependencyFromSpecifier(`C:\Users\alice\private.mjs`), want: ""},
+		{name: "reject whitespace in package-like specifier", got: dependencyFromSpecifier("fixture-dep /private.mjs"), want: ""},
 	}
 	for _, tc := range cases {
 		if tc.got != tc.want {
@@ -57,6 +62,26 @@ func TestDependencyFromEventPrefersModule(t *testing.T) {
 	}
 	if dep := dependencyFromEvent(event); dep != leftPadDependency {
 		t.Fatalf("expected module-derived dependency, got %q", dep)
+	}
+}
+
+func TestDependencyFromEventRejectsUnsafeJSDependencyValues(t *testing.T) {
+	cases := []struct {
+		name  string
+		event Event
+		want  string
+	}{
+		{name: "safe bare dependency", event: Event{Dependency: "fixture-dep"}, want: "fixture-dep"},
+		{name: "safe scoped subpath dependency", event: Event{Dependency: "@scope/pkg/index.js"}, want: "@scope/pkg"},
+		{name: "unsafe absolute dependency falls back to module", event: Event{Dependency: "/tmp/private.js", Module: "lodash/map"}, want: "lodash"},
+		{name: "unsafe drive dependency falls back to resolved", event: Event{Dependency: `C:\Users\alice\private.js`, Resolved: "node_modules/react/index.js"}, want: "react"},
+		{name: "unsafe hidden dependency is rejected", event: Event{Dependency: "fixture-dep/.env/private.js"}, want: ""},
+		{name: "unsafe traversal dependency is rejected", event: Event{Dependency: "fixture-dep/../private.js"}, want: ""},
+	}
+	for _, tc := range cases {
+		if got := dependencyFromEvent(tc.event); got != tc.want {
+			t.Fatalf("%s: expected dependency %q, got %q", tc.name, tc.want, got)
+		}
 	}
 }
 
@@ -79,7 +104,16 @@ func TestPythonRuntimeSymbolStripsFileSuffixes(t *testing.T) {
 
 func TestPythonRuntimeResolutionBranches(t *testing.T) {
 	if got := normalizeRuntimeDependency("  My__Package  ", runtimeLanguageJSTS); got != "My__Package" {
-		t.Fatalf("expected non-Python dependency to preserve trimmed value, got %q", got)
+		t.Fatalf("expected package-style JS dependency to preserve package label, got %q", got)
+	}
+	if got := normalizeRuntimeDependency(" @scope/pkg/index.js ", runtimeLanguageJSTS); got != "@scope/pkg" {
+		t.Fatalf("expected JS dependency to collapse safe scoped subpath to package ID, got %q", got)
+	}
+	if got := normalizeRuntimeDependency(" /tmp/private.js ", runtimeLanguageJSTS); got != "" {
+		t.Fatalf("expected JS absolute dependency to be rejected, got %q", got)
+	}
+	if got := normalizeRuntimeDependency(" fixture-dep/.env/private.js ", runtimeLanguageJSTS); got != "" {
+		t.Fatalf("expected JS hidden-segment dependency to be rejected, got %q", got)
 	}
 	if got := normalizeRuntimeDependency("  ", runtimeLanguagePython); got != "" {
 		t.Fatalf("expected blank dependency to stay blank, got %q", got)

--- a/internal/runtime/trace_resolution_test.go
+++ b/internal/runtime/trace_resolution_test.go
@@ -13,8 +13,10 @@ func TestDependencyResolutionHelpers(t *testing.T) {
 		{name: "scoped specifier", got: dependencyFromSpecifier("@scope/pkg/path"), want: scopePkgDependency},
 		{name: "scoped resolved path", got: dependencyFromResolvedPath("file:///repo/node_modules/@scope/pkg/lib/index.js"), want: scopePkgDependency},
 		{name: "resolved lodash path", got: dependencyFromResolvedPath("/repo/node_modules/lodash/map.js"), want: "lodash"},
+		{name: "sanitized resolved lodash path", got: dependencyFromResolvedPath("node_modules/lodash/map.js"), want: "lodash"},
 		{name: "non node_modules path", got: dependencyFromResolvedPath("/repo/no-node-modules/here.js"), want: ""},
 		{name: "event fallback", got: dependencyFromEvent(Event{Resolved: "/repo/node_modules/react/index.js"}), want: "react"},
+		{name: "sanitized event fallback", got: dependencyFromEvent(Event{Resolved: "node_modules/react/index.js"}), want: "react"},
 	}
 	for _, tc := range cases {
 		if tc.got != tc.want {
@@ -86,6 +88,9 @@ func TestPythonRuntimeResolutionBranches(t *testing.T) {
 	if got := dependencyFromEventForLanguage(Event{Resolved: "file:///repo/.venv/lib/python3.12/site-packages/httpx/_client.py"}, runtimeLanguagePython); got != "httpx" {
 		t.Fatalf("expected Python dependency from resolved path, got %q", got)
 	}
+	if got := dependencyFromEventForLanguage(Event{Resolved: "httpx._client"}, runtimeLanguagePython); got != "httpx" {
+		t.Fatalf("expected Python dependency from sanitized resolved module, got %q", got)
+	}
 	if got := dependencyFromPythonResolvedPath("/repo/app.py"); got != "" {
 		t.Fatalf("expected non-site-packages path to be ignored, got %q", got)
 	}
@@ -116,6 +121,9 @@ func TestPythonRuntimeResolvedPathBranches(t *testing.T) {
 		{name: "dependency mismatch", resolved: "file:///repo/.venv/lib/python3.12/site-packages/requests/sessions.py", dependency: "httpx", want: ""},
 		{name: "dependency match", resolved: "file:///repo/.venv/lib/python3.12/site-packages/requests/sessions.py", dependency: "requests", want: "requests"},
 		{name: "dist packages", resolved: "/usr/lib/python3/dist-packages/httpx/_client.py", dependency: "httpx", want: "httpx"},
+		{name: "sanitized dependency mismatch", resolved: "httpx._client", dependency: "requests", want: ""},
+		{name: "sanitized empty segment", resolved: "httpx..client", want: ""},
+		{name: "sanitized invalid character", resolved: "httpx-client", want: ""},
 	}
 	for _, tc := range cases {
 		if got := pythonModuleFromResolvedPath(tc.resolved, tc.dependency); got != tc.want {

--- a/internal/runtime/trace_runtime_usage_test.go
+++ b/internal/runtime/trace_runtime_usage_test.go
@@ -27,6 +27,10 @@ func TestRuntimeModuleFromResolvedPathBranches(t *testing.T) {
 		{name: "scoped root", resolved: "/repo/node_modules/@scope/pkg/index.js", dependency: scopePkgDependency, want: scopePkgDependency + "/index.js"},
 		{name: "scoped mismatch", resolved: "/repo/node_modules/@scope/pkg/index.js", dependency: "@scope/other", want: ""},
 		{name: "simple root", resolved: "/repo/node_modules/lodash/index.js", dependency: "lodash", want: "lodash/index.js"},
+		{name: "reject drive hybrid suffix", resolved: "node_modules/fixture-dep/C:/Users/alice/private.mjs", dependency: "fixture-dep", want: ""},
+		{name: "reject scheme hybrid suffix", resolved: "node_modules/fixture-dep/https:/secret.mjs", dependency: "fixture-dep", want: ""},
+		{name: "reject hidden hybrid suffix", resolved: "node_modules/fixture-dep/.env/private.mjs", dependency: "fixture-dep", want: ""},
+		{name: "reject home hybrid suffix", resolved: "node_modules/fixture-dep/~/.ssh/id_rsa", dependency: "fixture-dep", want: ""},
 	}
 	for _, tc := range cases {
 		if got := runtimeModuleFromResolvedPath(tc.resolved, tc.dependency); got != tc.want {

--- a/internal/runtime/trace_test_helpers_test.go
+++ b/internal/runtime/trace_test_helpers_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/testutil"
@@ -21,4 +22,9 @@ const (
 func loadTraceFromContent(t *testing.T, content string) (Trace, error) {
 	t.Helper()
 	return Load(testutil.WriteTempFile(t, "runtime.ndjson", content))
+}
+
+func loadTraceFromContentInRepo(t *testing.T, repoPath string, content string) (Trace, error) {
+	t.Helper()
+	return LoadForRepo(testutil.WriteTempFile(t, filepath.Join("runtime", "trace.ndjson"), content), repoPath)
 }

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -5152,6 +5152,35 @@ type runtimeProofModule struct {
 	Module string `json:"module"`
 }
 
+type runtimeProofTraceFixtureRow struct {
+	parent     string
+	entrypoint string
+}
+
+func runtimeProofTraceFixtureContent(t *testing.T, repoURL string, rows []runtimeProofTraceFixtureRow) string {
+	t.Helper()
+	var content strings.Builder
+	for _, row := range rows {
+		payload, err := json.Marshal(struct {
+			Module     string `json:"module"`
+			Resolved   string `json:"resolved"`
+			Parent     string `json:"parent"`
+			Entrypoint string `json:"entrypoint"`
+		}{
+			Module:     "",
+			Resolved:   "node_modules/lodash/map.js",
+			Parent:     strings.ReplaceAll(row.parent, "{repo}", repoURL),
+			Entrypoint: row.entrypoint,
+		})
+		if err != nil {
+			t.Fatalf("marshal runtime proof fixture row: %v", err)
+		}
+		content.Write(payload)
+		content.WriteByte('\n')
+	}
+	return content.String()
+}
+
 func TestRuntimeTraceRedactsNonHostAbsoluteContext(t *testing.T) {
 	repo := t.TempDir()
 	mainPath := filepath.Join(repo, "src", "main.js")
@@ -5168,24 +5197,28 @@ func TestRuntimeTraceRedactsNonHostAbsoluteContext(t *testing.T) {
 	tracePath := filepath.Join(t.TempDir(), "runtime.ndjson")
 	mainURL := fileURLForRuntimeProof(mainPath, "")
 	localhostSpaceURL := fileURLForRuntimeProof(spacePath, "LOCALHOST")
-	repoURL := fileURLForRuntimeProof(repo, "")
-	content := `{"module":"","resolved":"node_modules/lodash/map.js","parent":"C:\\Users\\alice\\project\\main.js","entrypoint":"` + mainURL + `"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"` + localhostSpaceURL + `","entrypoint":"\\\\server\\share\\project\\main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"//server/share/project/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"\\/server/share/project/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"/\\server/share/project/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"file://localhost/C:/Users/alice/project/main.js","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"file://server/share/project/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"` + strings.TrimSuffix(repoURL, "/") + `/src/bad%ZZ.js","entrypoint":"file://localhost/%43%3A%2FUsers/alice/project/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"` + strings.TrimSuffix(repoURL, "/") + `/src%2F..%2F..%2FUsers/alice/main.js","entrypoint":"file://localhost/%2F%2Fserver/share/project/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"x:private-token","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"a:foo/bar.js","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"C:Users/alice/private.js","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"data:text/plain,secret","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"mailto:test@example.com","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"https:foo","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"https:/foo","entrypoint":"src/main.js"}` + "\n" +
-		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"node:internal/modules/cjs/loader","entrypoint":"lodash/map"}` + "\n"
+	content := runtimeProofTraceFixtureContent(t, strings.TrimSuffix(fileURLForRuntimeProof(repo, ""), "/"), []runtimeProofTraceFixtureRow{
+		{parent: "src/main.js", entrypoint: "https:/foo"},
+		{parent: "mailto:test@example.com", entrypoint: "src/main.js"},
+		{parent: "C:Users/alice/private.js", entrypoint: "src/main.js"},
+		{parent: "src/main.js", entrypoint: "file://server/share/project/main.js"},
+		{parent: "https:foo", entrypoint: "src/main.js"},
+		{parent: "data:text/plain,secret", entrypoint: "src/main.js"},
+		{parent: "x:private-token", entrypoint: "src/main.js"},
+		{parent: localhostSpaceURL, entrypoint: `\\server\share\project\main.js`},
+		{parent: "src/main.js", entrypoint: `\/server/share/project/main.js`},
+		{parent: "C:\\Users\\alice\\project\\main.js", entrypoint: mainURL},
+		{parent: "a:foo/bar.js", entrypoint: "src/main.js"},
+		{parent: "src/main.js", entrypoint: `//server/share/project/main.js`},
+		{parent: "{repo}/src/bad%ZZ.js", entrypoint: "file://localhost/%43%3A%2FUsers/alice/project/main.js"},
+		{parent: "src/main.js", entrypoint: `/\server/share/project/main.js`},
+		{parent: "file://localhost/C:/Users/alice/project/main.js", entrypoint: "src/main.js"},
+		{parent: "{repo}/src%2F..%2F..%2FUsers/alice/main.js", entrypoint: "file://localhost/%2F%2Fserver/share/project/main.js"},
+		{parent: "node:internal/modules/cjs/loader", entrypoint: "lodash/map"},
+	})
+	if !strings.Contains(localhostSpaceURL, "%20") || !strings.Contains(content, localhostSpaceURL) {
+		t.Fatalf("expected runtime proof fixture to retain percent-encoded file URL, got %q in %q", localhostSpaceURL, content)
+	}
 	if err := os.WriteFile(tracePath, []byte(content), 0o600); err != nil {
 		t.Fatalf("write runtime trace: %v", err)
 	}
@@ -5220,33 +5253,28 @@ func TestRuntimeTraceRedactsNonHostAbsoluteContext(t *testing.T) {
 }
 
 func fileURLForRuntimeProof(pathValue, host string) string {
-	pathValue = filepath.ToSlash(pathValue)
-	if !strings.HasPrefix(pathValue, "/") {
-		pathValue = "/" + pathValue
+	urlPath := filepath.ToSlash(pathValue)
+	if !strings.HasPrefix(urlPath, "/") {
+		urlPath = "/" + urlPath
 	}
-	return (&url.URL{Scheme: "file", Host: host, Path: pathValue}).String()
+	return (&url.URL{Scheme: "file", Host: host, Path: urlPath}).String()
 }
 
 func runtimeProofHasExactModules(got []runtimeProofModule, want ...string) bool {
-	if len(got) != len(want) {
-		return false
-	}
-	modules := make(map[string]struct{}, len(got))
+	gotModules := make([]string, 0, len(got))
 	for _, item := range got {
-		modules[item.Module] = struct{}{}
+		gotModules = append(gotModules, item.Module)
 	}
-	for _, module := range want {
-		if _, ok := modules[module]; !ok {
-			return false
-		}
-	}
-	return true
+	wantModules := append([]string(nil), want...)
+	slices.Sort(gotModules)
+	slices.Sort(wantModules)
+	return slices.Equal(gotModules, wantModules)
 }
 
 func assertTarValidatorRejects(t *testing.T, validator string, archivePath string, want string) {
 	t.Helper()
 
-	cmd := exec.Command("python3", "-", archivePath)
+	cmd := pythonNoBytecodeCommand("python3", "-", archivePath)
 	cmd.Stdin = strings.NewReader(validator)
 	output, err := cmd.CombinedOutput()
 	if err == nil {
@@ -5260,11 +5288,17 @@ func assertTarValidatorRejects(t *testing.T, validator string, archivePath strin
 func assertTarValidatorAccepts(t *testing.T, validator string, archivePath string) {
 	t.Helper()
 
-	cmd := exec.Command("python3", "-", archivePath)
+	cmd := pythonNoBytecodeCommand("python3", "-", archivePath)
 	cmd.Stdin = strings.NewReader(validator)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("tar validator rejected trusted archive %s: %v\n%s", archivePath, err, output)
 	}
+}
+
+func pythonNoBytecodeCommand(name string, arg ...string) *exec.Cmd {
+	cmd := exec.Command(name, arg...)
+	cmd.Env = append(os.Environ(), "PYTHONDONTWRITEBYTECODE=1")
+	return cmd
 }
 
 func repoRoot(t *testing.T) string {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"maps"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -3183,6 +3184,27 @@ func TestMakefileLockfiledriftHeadContract(t *testing.T) {
 	}
 }
 
+func TestMakefileTestTargetRunsRuntimeHookSuites(t *testing.T) {
+	t.Parallel()
+
+	makefile := readConfig(t, "Makefile")
+	targetPattern := regexp.MustCompile(`(?m)^test:\n(?:\t.*\n)+`)
+	target := targetPattern.FindString(makefile)
+	if target == "" {
+		t.Fatal("Makefile must define the test target")
+	}
+	for _, want := range []string{
+		`node --test scripts/runtime/context-helper_test.mjs scripts/runtime/hooks_test.mjs`,
+		`PYTHONDONTWRITEBYTECODE=1 python3 scripts/runtime/sitecustomize_test.py`,
+		`@pkgs=$$(GOFLAGS=-buildvcs=false $(GO_CMD) list ./... | grep -Ev '/internal/app$$'); \`,
+		`@$(MAKE) test-lockfiledrift-head`,
+	} {
+		if !strings.Contains(target, want) {
+			t.Fatalf("test target must contain %q", want)
+		}
+	}
+}
+
 func TestMakefileCoverageTargetsCreateConfiguredParentDirectories(t *testing.T) {
 	t.Parallel()
 
@@ -3237,7 +3259,6 @@ func TestMakefileCoverageTargetsCreateConfiguredParentDirectories(t *testing.T) 
 		assertFileExists(t, packageFailuresOutput)
 	})
 }
-
 func TestReleaseImageTagScriptSanitizesAndValidatesTags(t *testing.T) {
 	t.Parallel()
 
@@ -5127,6 +5148,101 @@ func writeTarFixture(t *testing.T, members []tarFixtureMember) string {
 	return archivePath
 }
 
+type runtimeProofModule struct {
+	Module string `json:"module"`
+}
+
+func TestRuntimeTraceRedactsNonHostAbsoluteContext(t *testing.T) {
+	repo := t.TempDir()
+	mainPath := filepath.Join(repo, "src", "main.js")
+	spacePath := filepath.Join(repo, "src", "hello world.js")
+	if err := os.MkdirAll(filepath.Dir(mainPath), 0o755); err != nil {
+		t.Fatalf("mkdir repo src: %v", err)
+	}
+	for _, path := range []string{mainPath, spacePath} {
+		if err := os.WriteFile(path, []byte("console.log('x')\n"), 0o600); err != nil {
+			t.Fatalf("write repo file: %v", err)
+		}
+	}
+
+	tracePath := filepath.Join(t.TempDir(), "runtime.ndjson")
+	mainURL := fileURLForRuntimeProof(mainPath, "")
+	localhostSpaceURL := fileURLForRuntimeProof(spacePath, "LOCALHOST")
+	repoURL := fileURLForRuntimeProof(repo, "")
+	content := `{"module":"","resolved":"node_modules/lodash/map.js","parent":"C:\\Users\\alice\\project\\main.js","entrypoint":"` + mainURL + `"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"` + localhostSpaceURL + `","entrypoint":"\\\\server\\share\\project\\main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"//server/share/project/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"\\/server/share/project/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"/\\server/share/project/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"file://localhost/C:/Users/alice/project/main.js","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"src/main.js","entrypoint":"file://server/share/project/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"` + strings.TrimSuffix(repoURL, "/") + `/src/bad%ZZ.js","entrypoint":"file://localhost/%43%3A%2FUsers/alice/project/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"` + strings.TrimSuffix(repoURL, "/") + `/src%2F..%2F..%2FUsers/alice/main.js","entrypoint":"file://localhost/%2F%2Fserver/share/project/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"x:private-token","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"a:foo/bar.js","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"C:Users/alice/private.js","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"data:text/plain,secret","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"mailto:test@example.com","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"https:foo","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"https:/foo","entrypoint":"src/main.js"}` + "\n" +
+		`{"module":"","resolved":"node_modules/lodash/map.js","parent":"node:internal/modules/cjs/loader","entrypoint":"lodash/map"}` + "\n"
+	if err := os.WriteFile(tracePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write runtime trace: %v", err)
+	}
+
+	cmd := exec.Command("go", "run", "./cmd/lopper", "analyse", "--repo", repo, "--top", "1", "--language", "js-ts", "--runtime-trace", tracePath, "--format", "json")
+	cmd.Dir = repoRoot(t)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run analyse with runtime trace: %v\n%s", err, output)
+	}
+
+	var payload struct {
+		Dependencies []struct {
+			RuntimeUsage struct {
+				ParentModules []runtimeProofModule `json:"parentModules"`
+				Entrypoints   []runtimeProofModule `json:"entrypoints"`
+			} `json:"runtimeUsage"`
+		} `json:"dependencies"`
+	}
+	if err := json.Unmarshal(output, &payload); err != nil {
+		t.Fatalf("parse analyse json: %v\n%s", err, output)
+	}
+	if len(payload.Dependencies) != 1 {
+		t.Fatalf("expected one runtime-only dependency, got %#v", payload.Dependencies)
+	}
+	if got := payload.Dependencies[0].RuntimeUsage.ParentModules; !runtimeProofHasExactModules(got, "node:internal/modules/cjs/loader", "src/hello world.js", "src/main.js") {
+		t.Fatalf("expected only local parent contexts, got %#v", got)
+	}
+	if got := payload.Dependencies[0].RuntimeUsage.Entrypoints; !runtimeProofHasExactModules(got, "lodash/map", "src/main.js") {
+		t.Fatalf("expected only local entrypoint contexts, got %#v", got)
+	}
+}
+
+func fileURLForRuntimeProof(pathValue, host string) string {
+	pathValue = filepath.ToSlash(pathValue)
+	if !strings.HasPrefix(pathValue, "/") {
+		pathValue = "/" + pathValue
+	}
+	return (&url.URL{Scheme: "file", Host: host, Path: pathValue}).String()
+}
+
+func runtimeProofHasExactModules(got []runtimeProofModule, want ...string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	modules := make(map[string]struct{}, len(got))
+	for _, item := range got {
+		modules[item.Module] = struct{}{}
+	}
+	for _, module := range want {
+		if _, ok := modules[module]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func assertTarValidatorRejects(t *testing.T, validator string, archivePath string, want string) {
 	t.Helper()
 
@@ -5149,6 +5265,15 @@ func assertTarValidatorAccepts(t *testing.T, validator string, archivePath strin
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("tar validator rejected trusted archive %s: %v\n%s", archivePath, err, output)
 	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, ".."))
 }
 
 func assertTarValidatorFixtures(t *testing.T, validator string, base []tarFixtureMember, fixtures []tarValidatorFixture) {

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3194,7 +3194,7 @@ func TestMakefileTestTargetRunsRuntimeHookSuites(t *testing.T) {
 		t.Fatal("Makefile must define the test target")
 	}
 	for _, want := range []string{
-		`node --test scripts/runtime/context-helper_test.mjs scripts/runtime/hooks_test.mjs`,
+		`node --test scripts/runtime/context-helper_test.mjs scripts/runtime/hooks_test.mjs scripts/runtime/test-link-helpers_test.mjs`,
 		`PYTHONDONTWRITEBYTECODE=1 python3 scripts/runtime/sitecustomize_test.py`,
 		`@pkgs=$$(GOFLAGS=-buildvcs=false $(GO_CMD) list ./... | grep -Ev '/internal/app$$'); \`,
 		`@$(MAKE) test-lockfiledrift-head`,

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3030,6 +3030,7 @@ func TestMakefileReleasePackagesRuntimeHooks(t *testing.T) {
 	}
 
 	for _, path := range []string{
+		"scripts/runtime/context-helper.cjs",
 		"scripts/runtime/require-hook.cjs",
 		"scripts/runtime/loader.mjs",
 		"scripts/runtime/sitecustomize.py",

--- a/scripts/runtime/context-helper.cjs
+++ b/scripts/runtime/context-helper.cjs
@@ -160,11 +160,11 @@ function isUnsafeModuleSegment(part) {
 
 function sanitizeNodeModulesResolvedPath(value) {
   const parts = value.split("/");
-  const nodeModulesIndex = parts.lastIndexOf("node_modules");
-  if (nodeModulesIndex === -1) {
+  const firstNodeModulesIndex = parts.indexOf("node_modules");
+  if (firstNodeModulesIndex === -1) {
     return value;
   }
-  const suffixParts = parts.slice(nodeModulesIndex + 1);
+  const suffixParts = parts.slice(firstNodeModulesIndex + 1);
   if (suffixParts.length === 0) {
     return "";
   }
@@ -260,4 +260,5 @@ module.exports = {
   normalizeRuntimeModuleValue,
   normalizeRuntimeResolvedValue,
   resolveContextPath,
+  sanitizeNodeModulesResolvedPath,
 };

--- a/scripts/runtime/context-helper.cjs
+++ b/scripts/runtime/context-helper.cjs
@@ -1,0 +1,97 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { fileURLToPath } = require("node:url");
+
+const windowsDrivePathPattern = /^[A-Za-z]:[\\/]/;
+const uncPathPattern = /^(?:\\\\|\/\/)[^\\/]+[\\/][^\\/]+/;
+const schemePattern = /^[A-Za-z][A-Za-z\d+.-]*:/;
+
+function createRuntimeTraceHelpers(env = process.env) {
+  const outPath = env.LOPPER_RUNTIME_TRACE;
+  const repoRoot = normalizeRoot(env.LOPPER_RUNTIME_REPO_ROOT || process.cwd());
+
+  return {
+    append(event) {
+      if (!outPath) return;
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
+      fs.appendFileSync(outPath, `${JSON.stringify(event)}\n`, "utf8");
+    },
+    normalizeContext(value) {
+      return normalizeContextValue(value, repoRoot);
+    },
+  };
+}
+
+function normalizeRoot(value) {
+  if (!value) return "";
+  try {
+    return fs.realpathSync.native(value);
+  } catch {
+    return path.resolve(value);
+  }
+}
+
+function normalizeContextValue(value, repoRoot) {
+  const resolvedPath = resolveContextPath(value);
+  if (!resolvedPath || !repoRoot) {
+    return "";
+  }
+  const rel = path.relative(repoRoot, resolvedPath);
+  if (!rel || rel === ".." || rel.startsWith(`..${path.sep}`)) {
+    return "";
+  }
+  return rel.split(path.sep).join("/");
+}
+
+function resolveContextPath(value) {
+  if (!value || typeof value !== "string") return "";
+  value = value.trim();
+  if (!value) return "";
+  if (looksLikeWindowsAbsolutePath(value)) {
+    return path.sep === "\\" ? normalizeAbsolutePath(value) : "";
+  }
+  if (value.startsWith("file://")) {
+    value = fileURLPath(value);
+    if (!value) return "";
+  } else if (hasNonFileScheme(value)) {
+    return "";
+  }
+  if (!path.isAbsolute(value)) {
+    return "";
+  }
+  return normalizeAbsolutePath(value);
+}
+
+function normalizeAbsolutePath(value) {
+  try {
+    return fs.realpathSync.native(value);
+  } catch {
+    try {
+      return path.resolve(value);
+    } catch {
+      return "";
+    }
+  }
+}
+
+function fileURLPath(value) {
+  try {
+    return fileURLToPath(value);
+  } catch {
+    return "";
+  }
+}
+
+function hasNonFileScheme(value) {
+  return schemePattern.test(value);
+}
+
+function looksLikeWindowsAbsolutePath(value) {
+  return windowsDrivePathPattern.test(value) || uncPathPattern.test(value);
+}
+
+module.exports = {
+  createRuntimeTraceHelpers,
+  normalizeContextValue,
+  resolveContextPath,
+};

--- a/scripts/runtime/context-helper.cjs
+++ b/scripts/runtime/context-helper.cjs
@@ -108,16 +108,20 @@ function normalizeContextValue(value, repoRoot, realpath = fs.realpathSync.nativ
   if (!rel) {
     return "";
   }
-  return normalizeRepoRelativePath(rel);
+  const normalized = normalizeRepoRelativePath(rel);
+  return hasControlWhitespace(normalized) ? "" : normalized;
 }
 
 function normalizeRuntimeModuleValue(value, resolved, repoRoot, realpath = fs.realpathSync.native) {
   const normalizedResolvedPath = normalizeContextValue(resolved, repoRoot, realpath);
+  const externalNodeModulesResolved = looksLikeNodeModulesResolvedContextValue(resolved, realpath);
   if (normalizedResolvedPath) {
     if (!looksLikeNodeModulesResolvedPath(normalizedResolvedPath)) {
       return "";
     }
-  } else if (looksLikeFilesystemContextValue(resolved) || (resolved && looksLikeFilesystemContextValue(value))) {
+  } else if (looksLikeFilesystemContextValue(resolved) && !externalNodeModulesResolved) {
+    return "";
+  } else if (resolved && looksLikeFilesystemContextValue(value) && !externalNodeModulesResolved) {
     return "";
   }
   const identifier = normalizeModuleIdentifier(value);
@@ -219,7 +223,7 @@ function looksLikeFilesystemContextValue(value) {
   }
   if (!value || typeof value !== "string") return false;
   value = value.trim();
-  if (!value || !value.includes("/")) {
+  if (!value?.includes("/")) {
     return false;
   }
   const parts = value.split("/");
@@ -227,6 +231,18 @@ function looksLikeFilesystemContextValue(value) {
     return true;
   }
   return path.posix.extname(parts[parts.length - 1]) !== "";
+}
+
+function looksLikeNodeModulesResolvedContextValue(value, realpath = fs.realpathSync.native) {
+  const resolvedPath = resolveContextPath(value);
+  if (!resolvedPath) {
+    return false;
+  }
+  const absolutePath = normalizeAbsolutePath(resolvedPath, realpath);
+  if (!absolutePath) {
+    return false;
+  }
+  return sanitizeNodeModulesResolvedPath(nodeModulesSuffix(absolutePath)) !== "";
 }
 
 function normalizeLexicalAbsolutePath(value) {
@@ -244,6 +260,18 @@ function normalizeAbsolutePath(value, realpath = fs.realpathSync.native) {
   } catch {
     return "";
   }
+}
+
+function nodeModulesSuffix(value) {
+  if (!value || typeof value !== "string") {
+    return "";
+  }
+  const parts = value.split(path.sep);
+  const firstNodeModulesIndex = parts.indexOf("node_modules");
+  if (firstNodeModulesIndex === -1) {
+    return "";
+  }
+  return parts.slice(firstNodeModulesIndex).join("/");
 }
 
 function fileURLPath(value) {
@@ -279,6 +307,10 @@ function isLexicallyConfinedToRepo(candidatePath, repoRoot) {
 
 function relStartsOutsideRepo(value) {
   return value === ".." || value.startsWith(`..${path.sep}`);
+}
+
+function hasControlWhitespace(value) {
+  return /[\n\r\t]/.test(value);
 }
 
 module.exports = {

--- a/scripts/runtime/context-helper.cjs
+++ b/scripts/runtime/context-helper.cjs
@@ -112,6 +112,14 @@ function normalizeContextValue(value, repoRoot, realpath = fs.realpathSync.nativ
 }
 
 function normalizeRuntimeModuleValue(value, resolved, repoRoot, realpath = fs.realpathSync.native) {
+  const normalizedResolvedPath = normalizeContextValue(resolved, repoRoot, realpath);
+  if (normalizedResolvedPath) {
+    if (!looksLikeNodeModulesResolvedPath(normalizedResolvedPath)) {
+      return "";
+    }
+  } else if (looksLikeFilesystemContextValue(resolved) || (resolved && looksLikeFilesystemContextValue(value))) {
+    return "";
+  }
   const identifier = normalizeModuleIdentifier(value);
   if (identifier) {
     return identifier;
@@ -205,6 +213,22 @@ function looksLikeContextReference(value) {
   return value.startsWith(".") || hasNonFileScheme(value);
 }
 
+function looksLikeFilesystemContextValue(value) {
+  if (looksLikeContextReference(value)) {
+    return true;
+  }
+  if (!value || typeof value !== "string") return false;
+  value = value.trim();
+  if (!value || !value.includes("/")) {
+    return false;
+  }
+  const parts = value.split("/");
+  if (parts.some((part) => part === "." || part === "..")) {
+    return true;
+  }
+  return path.posix.extname(parts[parts.length - 1]) !== "";
+}
+
 function normalizeLexicalAbsolutePath(value) {
   try {
     return path.resolve(value);
@@ -243,6 +267,10 @@ function isSafeRepoRelativePath(value) {
     return false;
   }
   return !path.isAbsolute(value) && !looksLikeWindowsAbsolutePath(value);
+}
+
+function looksLikeNodeModulesResolvedPath(value) {
+  return value.split("/").includes("node_modules");
 }
 
 function isLexicallyConfinedToRepo(candidatePath, repoRoot) {

--- a/scripts/runtime/context-helper.cjs
+++ b/scripts/runtime/context-helper.cjs
@@ -115,16 +115,25 @@ function normalizeContextValue(value, repoRoot, realpath = fs.realpathSync.nativ
 function normalizeRuntimeModuleValue(value, resolved, repoRoot, realpath = fs.realpathSync.native) {
   const normalizedResolvedPath = normalizeContextValue(resolved, repoRoot, realpath);
   const externalNodeModulesResolved = looksLikeNodeModulesResolvedContextValue(resolved, realpath);
+  const identifier = normalizeModuleIdentifier(value);
   if (normalizedResolvedPath) {
     if (!looksLikeNodeModulesResolvedPath(normalizedResolvedPath)) {
       return "";
     }
-  } else if (looksLikeFilesystemContextValue(resolved) && !externalNodeModulesResolved) {
+  } else if (
+    looksLikeFilesystemContextValue(resolved) &&
+    !externalNodeModulesResolved &&
+    !preservesLinkedPackageRequest(identifier, value)
+  ) {
     return "";
-  } else if (resolved && looksLikeFilesystemContextValue(value) && !externalNodeModulesResolved) {
+  } else if (
+    resolved &&
+    looksLikeFilesystemContextValue(value) &&
+    !externalNodeModulesResolved &&
+    !preservesLinkedPackageRequest(identifier, value)
+  ) {
     return "";
   }
-  const identifier = normalizeModuleIdentifier(value);
   if (identifier) {
     return identifier;
   }
@@ -161,6 +170,20 @@ function normalizeModuleIdentifier(value) {
     return "";
   }
   return value;
+}
+
+function preservesLinkedPackageRequest(identifier, rawValue) {
+  if (!identifier || identifier !== rawValue) {
+    return false;
+  }
+  if (identifier.startsWith("node:")) {
+    return false;
+  }
+  const parts = identifier.split("/");
+  if (identifier.startsWith("@")) {
+    return parts.length === 2;
+  }
+  return parts.length === 1;
 }
 
 function isUnsafeModuleSegment(part) {

--- a/scripts/runtime/context-helper.cjs
+++ b/scripts/runtime/context-helper.cjs
@@ -78,7 +78,8 @@ function normalizedRepoRoot(repoRoot, realpath = fs.realpathSync.native) {
 
 function repoRelativeUnderTrustedRoots(candidatePath, repoRoot, realpath = fs.realpathSync.native) {
   for (const trustedRoot of trustedRepoRoots(normalizedRepoRoot(repoRoot, realpath))) {
-    const rel = path.relative(trustedRoot, candidatePath);
+    const pathImpl = pathModuleForValue(candidatePath || trustedRoot);
+    const rel = pathImpl.relative(trustedRoot, candidatePath);
     if (isSafeRepoRelativePath(rel)) {
       return rel;
     }
@@ -88,7 +89,7 @@ function repoRelativeUnderTrustedRoots(candidatePath, repoRoot, realpath = fs.re
 
 function normalizeRepoRelativePath(value) {
   try {
-    return value.split(path.sep).join("/");
+    return value.replaceAll("\\", "/");
   } catch {
     return "";
   }
@@ -123,14 +124,16 @@ function normalizeRuntimeModuleValue(value, resolved, repoRoot, realpath = fs.re
   } else if (
     looksLikeFilesystemContextValue(resolved) &&
     !externalNodeModulesResolved &&
-    !preservesLinkedPackageRequest(identifier, value)
+    !preservesLinkedPackageRequest(identifier, value) &&
+    !preservesValidatedLinkedPackageSubpath(identifier, value, resolved, realpath)
   ) {
     return "";
   } else if (
     resolved &&
     looksLikeFilesystemContextValue(value) &&
     !externalNodeModulesResolved &&
-    !preservesLinkedPackageRequest(identifier, value)
+    !preservesLinkedPackageRequest(identifier, value) &&
+    !preservesValidatedLinkedPackageSubpath(identifier, value, resolved, realpath)
   ) {
     return "";
   }
@@ -184,6 +187,123 @@ function preservesLinkedPackageRequest(identifier, rawValue) {
     return parts.length === 2;
   }
   return parts.length === 1;
+}
+
+function preservesValidatedLinkedPackageSubpath(
+  identifier,
+  rawValue,
+  resolved,
+  realpath = fs.realpathSync.native,
+  options = {},
+) {
+  if (!identifier || identifier !== rawValue || identifier.startsWith("node:")) {
+    return false;
+  }
+  const packageRequest = parsePackageRequest(identifier);
+  if (!packageRequest || packageRequest.subpathParts.length === 0) {
+    return false;
+  }
+  const resolvedPath = looksLikeWindowsAbsolutePath(resolved) ? normalizeLexicalAbsolutePath(resolved) : resolveContextPath(resolved);
+  if (!resolvedPath) {
+    return false;
+  }
+  const absolutePath = normalizeAbsolutePath(resolvedPath, realpath);
+  if (!absolutePath) {
+    return false;
+  }
+  const packageRoot = findValidatedLinkedPackageRoot(absolutePath, packageRequest, realpath, options);
+  if (!packageRoot) {
+    return false;
+  }
+  const packageRelative = repoRelativeUnderTrustedRoots(absolutePath, { trusted: [packageRoot] }, realpath);
+  if (!packageRelative) {
+    return false;
+  }
+  return packageRelativeStartsWithSubpath(packageRelative, packageRequest.subpathParts);
+}
+
+function parsePackageRequest(identifier) {
+  const parts = identifier.split("/");
+  if (identifier.startsWith("@")) {
+    if (parts.length < 3) {
+      return null;
+    }
+    return {
+      packageName: `${parts[0]}/${parts[1]}`,
+      packageRootParts: [parts[0], parts[1]],
+      subpathParts: parts.slice(2),
+    };
+  }
+  if (parts.length < 2) {
+    return null;
+  }
+  return {
+    packageName: parts[0],
+    packageRootParts: [parts[0]],
+    subpathParts: parts.slice(1),
+  };
+}
+
+function findValidatedLinkedPackageRoot(absolutePath, packageRequest, realpath = fs.realpathSync.native, options = {}) {
+  const pathImpl = options.pathImpl || pathModuleForValue(absolutePath);
+  const root = pathImpl.parse(absolutePath).root;
+  const segments = splitAbsolutePathSegments(absolutePath, pathImpl);
+  for (let index = segments.length - packageRequest.packageRootParts.length; index >= 0; index -= 1) {
+    if (!matchesPackageRootSegments(segments, index, packageRequest.packageRootParts)) {
+      continue;
+    }
+    const candidateRoot = pathImpl.join(root, ...segments.slice(0, index + packageRequest.packageRootParts.length));
+    if (validatedPackageName(candidateRoot, realpath, options) === packageRequest.packageName) {
+      return candidateRoot;
+    }
+  }
+  return "";
+}
+
+function splitAbsolutePathSegments(absolutePath, pathImpl) {
+  const root = pathImpl.parse(absolutePath).root;
+  return absolutePath
+    .slice(root.length)
+    .split(pathImpl.sep)
+    .filter(Boolean);
+}
+
+function matchesPackageRootSegments(segments, index, packageRootParts) {
+  for (let offset = 0; offset < packageRootParts.length; offset += 1) {
+    if (segments[index + offset] !== packageRootParts[offset]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function validatedPackageName(packageRoot, realpath = fs.realpathSync.native, options = {}) {
+  const pathImpl = options.pathImpl || pathModuleForValue(packageRoot);
+  const fileOps = options.fs || fs;
+  const packageJSONPath = pathImpl.join(packageRoot, "package.json");
+  if (!fileOps.existsSync(packageJSONPath)) {
+    return "";
+  }
+  try {
+    const manifestPath = normalizeAbsolutePath(packageJSONPath, realpath) || packageJSONPath;
+    const manifest = JSON.parse(fileOps.readFileSync(manifestPath, "utf8"));
+    return typeof manifest?.name === "string" ? manifest.name.trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+function packageRelativeStartsWithSubpath(packageRelative, subpathParts) {
+  const relativeParts = packageRelative.split(/[\\/]+/).filter(Boolean);
+  if (relativeParts.length < subpathParts.length) {
+    return false;
+  }
+  for (let index = 0; index < subpathParts.length; index += 1) {
+    if (relativeParts[index] !== subpathParts[index]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function isUnsafeModuleSegment(part) {
@@ -270,7 +390,7 @@ function looksLikeNodeModulesResolvedContextValue(value, realpath = fs.realpathS
 
 function normalizeLexicalAbsolutePath(value) {
   try {
-    return path.resolve(value);
+    return pathModuleForValue(value).resolve(value);
   } catch {
     return "";
   }
@@ -317,7 +437,7 @@ function isSafeRepoRelativePath(value) {
   if (!value || relStartsOutsideRepo(value)) {
     return false;
   }
-  return !path.isAbsolute(value) && !looksLikeWindowsAbsolutePath(value);
+  return !path.isAbsolute(value) && !path.win32.isAbsolute(value) && !looksLikeWindowsAbsolutePath(value);
 }
 
 function looksLikeNodeModulesResolvedPath(value) {
@@ -329,7 +449,11 @@ function isLexicallyConfinedToRepo(candidatePath, repoRoot) {
 }
 
 function relStartsOutsideRepo(value) {
-  return value === ".." || value.startsWith(`..${path.sep}`);
+  return value === ".." || value.startsWith("../") || value.startsWith("..\\");
+}
+
+function pathModuleForValue(value) {
+  return looksLikeWindowsAbsolutePath(value) ? path.win32 : path;
 }
 
 function hasControlWhitespace(value) {
@@ -338,10 +462,12 @@ function hasControlWhitespace(value) {
 
 module.exports = {
   createRuntimeTraceHelpers,
+  findValidatedLinkedPackageRoot,
   isSafeRepoRelativePath,
   normalizeContextValue,
   normalizeRuntimeModuleValue,
   normalizeRuntimeResolvedValue,
+  preservesValidatedLinkedPackageSubpath,
   resolveContextPath,
   sanitizeNodeModulesResolvedPath,
 };

--- a/scripts/runtime/context-helper.cjs
+++ b/scripts/runtime/context-helper.cjs
@@ -116,9 +116,6 @@ function normalizeRuntimeModuleValue(value, resolved, repoRoot, realpath = fs.re
   if (identifier) {
     return identifier;
   }
-  if (looksLikeContextReference(value)) {
-    return normalizeContextValue(resolved || value, repoRoot, realpath);
-  }
   return "";
 }
 
@@ -162,18 +159,19 @@ function isUnsafeModuleSegment(part) {
 }
 
 function sanitizeNodeModulesResolvedPath(value) {
-  if (!value.startsWith("node_modules/")) {
+  const parts = value.split("/");
+  const nodeModulesIndex = parts.lastIndexOf("node_modules");
+  if (nodeModulesIndex === -1) {
     return value;
   }
-  const suffix = value.slice("node_modules/".length);
-  if (!suffix) {
+  const suffixParts = parts.slice(nodeModulesIndex + 1);
+  if (suffixParts.length === 0) {
     return "";
   }
-  const parts = suffix.split("/");
-  if (parts.some(isUnsafeModuleSegment)) {
+  if (suffixParts.some(isUnsafeModuleSegment)) {
     return "";
   }
-  if (parts[0].startsWith("@") && parts.length < 2) {
+  if (suffixParts[0].startsWith("@") && suffixParts.length < 2) {
     return "";
   }
   return value;

--- a/scripts/runtime/context-helper.cjs
+++ b/scripts/runtime/context-helper.cjs
@@ -9,7 +9,11 @@ const schemePattern = /^[A-Za-z][A-Za-z\d+.-]*:/;
 function createRuntimeTraceHelpers(env = process.env, options = {}) {
   const outPath = env.LOPPER_RUNTIME_TRACE;
   const realpath = typeof options.realpath === "function" ? options.realpath : fs.realpathSync.native;
-  const repoRoot = normalizeRoot(env.LOPPER_RUNTIME_REPO_ROOT || process.cwd(), realpath);
+  const repoRootValue =
+    typeof options.repoRoot === "string" && options.repoRoot.trim()
+      ? options.repoRoot
+      : env.LOPPER_RUNTIME_REPO_ROOT || "";
+  const repoRoot = normalizeRoot(repoRootValue, realpath);
 
   return {
     append(event) {
@@ -112,11 +116,18 @@ function normalizeRuntimeModuleValue(value, resolved, repoRoot, realpath = fs.re
   if (identifier) {
     return identifier;
   }
-  return normalizeContextValue(resolved || value, repoRoot, realpath);
+  if (looksLikeContextReference(value)) {
+    return normalizeContextValue(resolved || value, repoRoot, realpath);
+  }
+  return "";
 }
 
 function normalizeRuntimeResolvedValue(value, repoRoot, realpath = fs.realpathSync.native) {
-  return normalizeContextValue(value, repoRoot, realpath) || normalizeModuleIdentifier(value);
+  const normalizedPath = normalizeContextValue(value, repoRoot, realpath);
+  if (normalizedPath) {
+    return sanitizeNodeModulesResolvedPath(normalizedPath);
+  }
+  return normalizeModuleIdentifier(value);
 }
 
 function normalizeModuleIdentifier(value) {
@@ -134,10 +145,32 @@ function normalizeModuleIdentifier(value) {
 
   const label = value.startsWith("node:") ? value.slice("node:".length) : value;
   const parts = label.split("/");
-  if (
-    !label ||
-    parts.some((part) => !part || part === "." || part === ".." || /[\0-\x20\x7f%]/.test(part))
-  ) {
+  if (!label || parts.some(isUnsafeModuleSegment)) {
+    return "";
+  }
+  if (parts[0].startsWith("@") && parts.length < 2) {
+    return "";
+  }
+  return value;
+}
+
+function isUnsafeModuleSegment(part) {
+  if (!part || part === "." || part === ".." || /[\0-\x20\x7f%]/.test(part)) {
+    return true;
+  }
+  return part.startsWith(".") || part.startsWith("~") || part.includes(":");
+}
+
+function sanitizeNodeModulesResolvedPath(value) {
+  if (!value.startsWith("node_modules/")) {
+    return value;
+  }
+  const suffix = value.slice("node_modules/".length);
+  if (!suffix) {
+    return "";
+  }
+  const parts = suffix.split("/");
+  if (parts.some(isUnsafeModuleSegment)) {
     return "";
   }
   if (parts[0].startsWith("@") && parts.length < 2) {
@@ -163,6 +196,15 @@ function resolveContextPath(value) {
     return "";
   }
   return normalizeLexicalAbsolutePath(value);
+}
+
+function looksLikeContextReference(value) {
+  if (!value || typeof value !== "string") return false;
+  value = value.trim();
+  if (!value) return false;
+  if (value.startsWith("file://")) return true;
+  if (path.isAbsolute(value) || looksLikeWindowsAbsolutePath(value)) return true;
+  return value.startsWith(".") || hasNonFileScheme(value);
 }
 
 function normalizeLexicalAbsolutePath(value) {

--- a/scripts/runtime/context-helper.cjs
+++ b/scripts/runtime/context-helper.cjs
@@ -6,9 +6,10 @@ const windowsDrivePathPattern = /^[A-Za-z]:[\\/]/;
 const uncPathPattern = /^(?:[\\/]{2})[^\\/]+[\\/][^\\/]+/;
 const schemePattern = /^[A-Za-z][A-Za-z\d+.-]*:/;
 
-function createRuntimeTraceHelpers(env = process.env) {
+function createRuntimeTraceHelpers(env = process.env, options = {}) {
   const outPath = env.LOPPER_RUNTIME_TRACE;
-  const repoRoot = normalizeRoot(env.LOPPER_RUNTIME_REPO_ROOT || process.cwd());
+  const realpath = typeof options.realpath === "function" ? options.realpath : fs.realpathSync.native;
+  const repoRoot = normalizeRoot(env.LOPPER_RUNTIME_REPO_ROOT || process.cwd(), realpath);
 
   return {
     append(event) {
@@ -17,48 +18,105 @@ function createRuntimeTraceHelpers(env = process.env) {
       fs.appendFileSync(outPath, `${JSON.stringify(event)}\n`, "utf8");
     },
     normalizeContext(value) {
-      return normalizeContextValue(value, repoRoot);
+      return normalizeContextValue(value, repoRoot, realpath);
     },
     normalizeModule(value, resolved) {
-      return normalizeRuntimeModuleValue(value, resolved, repoRoot);
+      return normalizeRuntimeModuleValue(value, resolved, repoRoot, realpath);
     },
     normalizeResolved(value) {
-      return normalizeRuntimeResolvedValue(value, repoRoot);
+      return normalizeRuntimeResolvedValue(value, repoRoot, realpath);
     },
   };
 }
 
-function normalizeRoot(value) {
-  if (!value) return "";
+function normalizeRoot(value, realpath = fs.realpathSync.native) {
+  if (!value) return { original: "", resolved: "", trusted: [] };
+  const original = normalizeLexicalAbsolutePath(value);
+  if (!original) {
+    return { original: "", resolved: "", trusted: [] };
+  }
+  const resolved = normalizeAbsolutePath(original, realpath) || original;
+  const trusted = dedupeTrustedRoots([original, resolved]);
+  return { original, resolved, trusted };
+}
+
+function dedupeTrustedRoots(roots) {
+  const seen = new Set();
+  const trusted = [];
+  for (const value of roots) {
+    const normalized = normalizeLexicalAbsolutePath(value);
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    trusted.push(normalized);
+  }
+  return trusted;
+}
+
+function trustedRepoRoots(repoRoot) {
+  if (!repoRoot) return [];
+  if (Array.isArray(repoRoot.trusted)) {
+    return repoRoot.trusted;
+  }
+  if (typeof repoRoot === "string") {
+    return dedupeTrustedRoots([repoRoot]);
+  }
+  return [];
+}
+
+function normalizedRepoRoot(repoRoot, realpath = fs.realpathSync.native) {
+  if (repoRoot && typeof repoRoot === "object" && Array.isArray(repoRoot.trusted)) {
+    return repoRoot;
+  }
+  return normalizeRoot(repoRoot, realpath);
+}
+
+function repoRelativeUnderTrustedRoots(candidatePath, repoRoot, realpath = fs.realpathSync.native) {
+  for (const trustedRoot of trustedRepoRoots(normalizedRepoRoot(repoRoot, realpath))) {
+    const rel = path.relative(trustedRoot, candidatePath);
+    if (isSafeRepoRelativePath(rel)) {
+      return rel;
+    }
+  }
+  return "";
+}
+
+function normalizeRepoRelativePath(value) {
   try {
-    return fs.realpathSync.native(value);
+    return value.split(path.sep).join("/");
   } catch {
-    return path.resolve(value);
+    return "";
   }
 }
 
-function normalizeContextValue(value, repoRoot) {
-  const resolvedPath = resolveContextPath(value);
-  if (!resolvedPath || !repoRoot) {
+function normalizeContextValue(value, repoRoot, realpath = fs.realpathSync.native) {
+  repoRoot = normalizedRepoRoot(repoRoot, realpath);
+  const lexicalPath = resolveContextPath(value);
+  if (!lexicalPath || trustedRepoRoots(repoRoot).length === 0 || !isLexicallyConfinedToRepo(lexicalPath, repoRoot)) {
     return "";
   }
-  const rel = path.relative(repoRoot, resolvedPath);
-  if (!isSafeRepoRelativePath(rel)) {
+  const resolvedPath = normalizeAbsolutePath(lexicalPath, realpath);
+  if (!resolvedPath) {
     return "";
   }
-  return rel.split(path.sep).join("/");
+  const rel = repoRelativeUnderTrustedRoots(resolvedPath, repoRoot);
+  if (!rel) {
+    return "";
+  }
+  return normalizeRepoRelativePath(rel);
 }
 
-function normalizeRuntimeModuleValue(value, resolved, repoRoot) {
+function normalizeRuntimeModuleValue(value, resolved, repoRoot, realpath = fs.realpathSync.native) {
   const identifier = normalizeModuleIdentifier(value);
   if (identifier) {
     return identifier;
   }
-  return normalizeContextValue(resolved || value, repoRoot);
+  return normalizeContextValue(resolved || value, repoRoot, realpath);
 }
 
-function normalizeRuntimeResolvedValue(value, repoRoot) {
-  return normalizeContextValue(value, repoRoot) || normalizeModuleIdentifier(value);
+function normalizeRuntimeResolvedValue(value, repoRoot, realpath = fs.realpathSync.native) {
+  return normalizeContextValue(value, repoRoot, realpath) || normalizeModuleIdentifier(value);
 }
 
 function normalizeModuleIdentifier(value) {
@@ -93,7 +151,7 @@ function resolveContextPath(value) {
   value = value.trim();
   if (!value) return "";
   if (looksLikeWindowsAbsolutePath(value)) {
-    return path.sep === "\\" ? normalizeAbsolutePath(value) : "";
+    return path.sep === "\\" ? normalizeLexicalAbsolutePath(value) : "";
   }
   if (value.startsWith("file://")) {
     value = fileURLPath(value);
@@ -104,18 +162,23 @@ function resolveContextPath(value) {
   if (!path.isAbsolute(value)) {
     return "";
   }
-  return normalizeAbsolutePath(value);
+  return normalizeLexicalAbsolutePath(value);
 }
 
-function normalizeAbsolutePath(value) {
+function normalizeLexicalAbsolutePath(value) {
   try {
-    return fs.realpathSync.native(value);
+    return path.resolve(value);
   } catch {
-    try {
-      return path.resolve(value);
-    } catch {
-      return "";
-    }
+    return "";
+  }
+}
+
+function normalizeAbsolutePath(value, realpath = fs.realpathSync.native) {
+  try {
+    const resolved = realpath(value);
+    return typeof resolved === "string" ? normalizeLexicalAbsolutePath(resolved) : "";
+  } catch {
+    return "";
   }
 }
 
@@ -140,6 +203,10 @@ function isSafeRepoRelativePath(value) {
     return false;
   }
   return !path.isAbsolute(value) && !looksLikeWindowsAbsolutePath(value);
+}
+
+function isLexicallyConfinedToRepo(candidatePath, repoRoot) {
+  return repoRelativeUnderTrustedRoots(candidatePath, repoRoot) !== "";
 }
 
 function relStartsOutsideRepo(value) {

--- a/scripts/runtime/context-helper.cjs
+++ b/scripts/runtime/context-helper.cjs
@@ -3,7 +3,7 @@ const path = require("node:path");
 const { fileURLToPath } = require("node:url");
 
 const windowsDrivePathPattern = /^[A-Za-z]:[\\/]/;
-const uncPathPattern = /^(?:\\\\|\/\/)[^\\/]+[\\/][^\\/]+/;
+const uncPathPattern = /^(?:[\\/]{2})[^\\/]+[\\/][^\\/]+/;
 const schemePattern = /^[A-Za-z][A-Za-z\d+.-]*:/;
 
 function createRuntimeTraceHelpers(env = process.env) {
@@ -18,6 +18,12 @@ function createRuntimeTraceHelpers(env = process.env) {
     },
     normalizeContext(value) {
       return normalizeContextValue(value, repoRoot);
+    },
+    normalizeModule(value, resolved) {
+      return normalizeRuntimeModuleValue(value, resolved, repoRoot);
+    },
+    normalizeResolved(value) {
+      return normalizeRuntimeResolvedValue(value, repoRoot);
     },
   };
 }
@@ -37,10 +43,49 @@ function normalizeContextValue(value, repoRoot) {
     return "";
   }
   const rel = path.relative(repoRoot, resolvedPath);
-  if (!rel || rel === ".." || rel.startsWith(`..${path.sep}`)) {
+  if (!isSafeRepoRelativePath(rel)) {
     return "";
   }
   return rel.split(path.sep).join("/");
+}
+
+function normalizeRuntimeModuleValue(value, resolved, repoRoot) {
+  const identifier = normalizeModuleIdentifier(value);
+  if (identifier) {
+    return identifier;
+  }
+  return normalizeContextValue(resolved || value, repoRoot);
+}
+
+function normalizeRuntimeResolvedValue(value, repoRoot) {
+  return normalizeContextValue(value, repoRoot) || normalizeModuleIdentifier(value);
+}
+
+function normalizeModuleIdentifier(value) {
+  if (!value || typeof value !== "string") return "";
+  value = value.trim();
+  if (!value || path.isAbsolute(value) || looksLikeWindowsAbsolutePath(value)) {
+    return "";
+  }
+  if (value.startsWith(".") || value.includes("\\") || value.includes("://")) {
+    return "";
+  }
+  if (hasNonFileScheme(value) && !value.startsWith("node:")) {
+    return "";
+  }
+
+  const label = value.startsWith("node:") ? value.slice("node:".length) : value;
+  const parts = label.split("/");
+  if (
+    !label ||
+    parts.some((part) => !part || part === "." || part === ".." || /[\0-\x20\x7f%]/.test(part))
+  ) {
+    return "";
+  }
+  if (parts[0].startsWith("@") && parts.length < 2) {
+    return "";
+  }
+  return value;
 }
 
 function resolveContextPath(value) {
@@ -90,8 +135,22 @@ function looksLikeWindowsAbsolutePath(value) {
   return windowsDrivePathPattern.test(value) || uncPathPattern.test(value);
 }
 
+function isSafeRepoRelativePath(value) {
+  if (!value || relStartsOutsideRepo(value)) {
+    return false;
+  }
+  return !path.isAbsolute(value) && !looksLikeWindowsAbsolutePath(value);
+}
+
+function relStartsOutsideRepo(value) {
+  return value === ".." || value.startsWith(`..${path.sep}`);
+}
+
 module.exports = {
   createRuntimeTraceHelpers,
+  isSafeRepoRelativePath,
   normalizeContextValue,
+  normalizeRuntimeModuleValue,
+  normalizeRuntimeResolvedValue,
   resolveContextPath,
 };

--- a/scripts/runtime/context-helper_test.mjs
+++ b/scripts/runtime/context-helper_test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+import helpers from "./context-helper.cjs";
+
+const { normalizeContextValue } = helpers;
+
+test("rejects windows drive paths before repo-relative joining on any host", () => {
+  const repoRoot = path.resolve("/repo");
+  assert.equal(normalizeContextValue(String.raw`C:\Users\alice\project\main.js`, repoRoot), "");
+});
+
+test("rejects UNC paths before repo-relative joining on any host", () => {
+  const repoRoot = path.resolve("/repo");
+  assert.equal(normalizeContextValue(String.raw`\\server\share\project\main.js`, repoRoot), "");
+});
+
+test("rejects non-file URL schemes before filesystem normalization", () => {
+  const repoRoot = path.resolve("/repo");
+  assert.equal(normalizeContextValue("https://example.test/main.js", repoRoot), "");
+  assert.equal(normalizeContextValue("node:internal/modules/cjs/loader", repoRoot), "");
+});
+
+test("decodes percent-encoded file URLs with fileURLToPath", () => {
+  const repoRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
+  const srcDir = path.join(repoRoot, "src");
+  fs.mkdirSync(srcDir, { recursive: true });
+  const modulePath = path.join(srcDir, "hello world.js");
+  fs.writeFileSync(modulePath, "export {};\n", "utf8");
+
+  assert.equal(normalizeContextValue(pathToFileURL(modulePath).href, repoRoot), "src/hello world.js");
+
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+});

--- a/scripts/runtime/context-helper_test.mjs
+++ b/scripts/runtime/context-helper_test.mjs
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import helpers from "./context-helper.cjs";
 import { createDirectoryLinkSync, createFileLinkSync, removeDirectoryLinkSync, skipIfLinkUnsupported } from "./test-link-helpers.mjs";
@@ -66,6 +68,78 @@ test("decodes percent-encoded file URLs with fileURLToPath", () => {
   assert.equal(normalizeContextValue(pathToFileURL(modulePath).href, repoRoot), "src/hello world.js");
 
   fs.rmSync(repoRoot, { recursive: true, force: true });
+});
+
+test("redacts control whitespace from repo context helpers and runtime hook events", (t) => {
+  if (process.platform === "win32") {
+    t.skip("Windows does not support control whitespace in filenames");
+    return;
+  }
+
+  const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "lopper-runtime-controls-"));
+  t.after(() => fs.rmSync(testRoot, { recursive: true, force: true }));
+  const repoRoot = path.join(testRoot, "repo");
+  const packageRoot = path.join(repoRoot, "node_modules", "fixture-dep");
+  const dependencyPath = path.join(packageRoot, "index.cjs");
+  const hookPath = fileURLToPath(new URL("./require-hook.cjs", import.meta.url));
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({ name: "fixture-dep", version: "1.0.0", main: "index.cjs" }),
+    "utf8",
+  );
+  fs.writeFileSync(dependencyPath, "module.exports = 1;\n", "utf8");
+
+  const safePath = path.join(repoRoot, "hello world-\u4e16\u754c.cjs");
+  fs.writeFileSync(safePath, "module.exports = 1;\n", "utf8");
+  assert.equal(normalizeContextValue(safePath, repoRoot), "hello world-\u4e16\u754c.cjs");
+  assert.equal(normalizeRuntimeModuleValue("fixture-dep", dependencyPath, repoRoot), "fixture-dep");
+
+  const cases = [
+    { name: "newline", character: "\n" },
+    { name: "carriage return", character: "\r" },
+    { name: "tab", character: "\t" },
+  ];
+  for (const { name, character } of cases) {
+    const filename = `main${character}context.cjs`;
+    const entrypoint = path.join(repoRoot, filename);
+    const tracePath = path.join(testRoot, `${name.replaceAll(" ", "-")}.ndjson`);
+    fs.writeFileSync(entrypoint, 'require("fixture-dep");\n', "utf8");
+
+    assert.equal(normalizeContextValue(entrypoint, repoRoot), "", `${name} helper result`);
+    execFileSync(process.execPath, [`--require=${hookPath}`, entrypoint], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        LOPPER_RUNTIME_REPO_ROOT: repoRoot,
+        LOPPER_RUNTIME_TRACE: tracePath,
+      },
+      stdio: "pipe",
+    });
+
+    const artifact = fs.readFileSync(tracePath, "utf8");
+    const escapedFilename = JSON.stringify(filename).slice(1, -1);
+    assert.equal(artifact.includes(escapedFilename), false, `${name} filename entered runtime NDJSON`);
+    const events = artifact
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert.ok(
+      events.some((event) => event.module === "fixture-dep" && event.parent === ""),
+      `${name} dependency event must redact its parent`,
+    );
+    assert.ok(
+      events.some((event) => event.isMain && event.entrypoint === ""),
+      `${name} main event must redact its entrypoint`,
+    );
+    for (const event of events) {
+      for (const value of Object.values(event)) {
+        if (typeof value !== "string") continue;
+        assert.equal(/[\n\r\t]/.test(value), false, `${name} event field contains control whitespace`);
+      }
+    }
+  }
 });
 
 test("rejects hostile absolute and traversal inputs before realpath", (t) => {
@@ -214,6 +288,34 @@ test("redacts escaped repo-relative runtime module requests without demoting pac
     normalizeRuntimeModuleValue("fixture-dep/lib/index.js", packageResolvedPath, repoRoot, realpath),
     "fixture-dep/lib/index.js",
   );
+
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+test("preserves validated package specifiers when hoisted node_modules resolutions are redacted", () => {
+  const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
+  const repoRoot = path.join(testRoot, "repo");
+  const hoistedRoot = path.join(testRoot, "hoisted", "node_modules");
+  const hoistedDepPath = path.join(hoistedRoot, "fixture-dep", "index.mjs");
+  const hoistedDepSubpath = path.join(hoistedRoot, "@scope", "pkg", "index.js");
+  const localEscapePath = path.join(testRoot, "private.mjs");
+  const hiddenDepPath = path.join(hoistedRoot, "fixture-dep", ".env", "private.mjs");
+  fs.mkdirSync(path.dirname(hoistedDepPath), { recursive: true });
+  fs.mkdirSync(path.dirname(hoistedDepSubpath), { recursive: true });
+  fs.mkdirSync(path.dirname(hiddenDepPath), { recursive: true });
+  fs.writeFileSync(hoistedDepPath, "export default 1;\n", "utf8");
+  fs.writeFileSync(hoistedDepSubpath, "export default 2;\n", "utf8");
+  fs.writeFileSync(localEscapePath, "export default 3;\n", "utf8");
+  fs.writeFileSync(hiddenDepPath, "export default 4;\n", "utf8");
+
+  const { realpath } = trackRealpathCalls();
+  assert.equal(normalizeRuntimeModuleValue("fixture-dep", hoistedDepPath, repoRoot, realpath), "fixture-dep");
+  assert.equal(
+    normalizeRuntimeModuleValue("@scope/pkg/index.js", hoistedDepSubpath, repoRoot, realpath),
+    "@scope/pkg/index.js",
+  );
+  assert.equal(normalizeRuntimeModuleValue("src/escaped.mjs", localEscapePath, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeModuleValue("fixture-dep/.env/private.mjs", hiddenDepPath, repoRoot, realpath), "");
 
   fs.rmSync(testRoot, { recursive: true, force: true });
 });

--- a/scripts/runtime/context-helper_test.mjs
+++ b/scripts/runtime/context-helper_test.mjs
@@ -6,7 +6,12 @@ import { pathToFileURL } from "node:url";
 
 import helpers from "./context-helper.cjs";
 
-const { normalizeContextValue } = helpers;
+const {
+  isSafeRepoRelativePath,
+  normalizeContextValue,
+  normalizeRuntimeModuleValue,
+  normalizeRuntimeResolvedValue,
+} = helpers;
 
 test("rejects windows drive paths before repo-relative joining on any host", () => {
   const repoRoot = path.resolve("/repo");
@@ -16,11 +21,26 @@ test("rejects windows drive paths before repo-relative joining on any host", () 
 test("rejects UNC paths before repo-relative joining on any host", () => {
   const repoRoot = path.resolve("/repo");
   assert.equal(normalizeContextValue(String.raw`\\server\share\project\main.js`, repoRoot), "");
+  assert.equal(normalizeContextValue("//server/share/project/main.js", repoRoot), "");
+  assert.equal(normalizeContextValue(String.raw`\/server/share/project/main.js`, repoRoot), "");
+  assert.equal(normalizeContextValue(String.raw`/\server/share/project/main.js`, repoRoot), "");
+});
+
+test("rejects cross-volume absolute results returned from path.relative", () => {
+  assert.equal(isSafeRepoRelativePath(String.raw`C:\other\project\main.js`), false);
+  assert.equal(isSafeRepoRelativePath(String.raw`\\server\share\project\main.js`), false);
 });
 
 test("rejects non-file URL schemes before filesystem normalization", () => {
   const repoRoot = path.resolve("/repo");
+  assert.equal(normalizeContextValue("x:private-token", repoRoot), "");
+  assert.equal(normalizeContextValue("a:foo/bar.js", repoRoot), "");
+  assert.equal(normalizeContextValue("C:Users/alice/private.js", repoRoot), "");
   assert.equal(normalizeContextValue("https://example.test/main.js", repoRoot), "");
+  assert.equal(normalizeContextValue("data:text/plain,secret", repoRoot), "");
+  assert.equal(normalizeContextValue("mailto:test@example.com", repoRoot), "");
+  assert.equal(normalizeContextValue("https:foo", repoRoot), "");
+  assert.equal(normalizeContextValue("https:/foo", repoRoot), "");
   assert.equal(normalizeContextValue("node:internal/modules/cjs/loader", repoRoot), "");
 });
 
@@ -34,4 +54,33 @@ test("decodes percent-encoded file URLs with fileURLToPath", () => {
   assert.equal(normalizeContextValue(pathToFileURL(modulePath).href, repoRoot), "src/hello world.js");
 
   fs.rmSync(repoRoot, { recursive: true, force: true });
+});
+
+test("sanitizes runtime module and resolved artifact values", () => {
+  const repoRoot = path.resolve("/repo");
+
+  assert.equal(
+    normalizeRuntimeModuleValue("lodash/map", "/repo/node_modules/lodash/map.js", repoRoot),
+    "lodash/map",
+  );
+  assert.equal(
+    normalizeRuntimeModuleValue("file:///repo/src/main.mjs", "file:///repo/src/main.mjs", repoRoot),
+    "src/main.mjs",
+  );
+  assert.equal(
+    normalizeRuntimeResolvedValue("file:///repo/node_modules/lodash/map.js", repoRoot),
+    "node_modules/lodash/map.js",
+  );
+  for (const value of [
+    "/private/tmp/foreign.js",
+    "file:///private/tmp/foreign.js",
+    String.raw`C:\Users\alice\private.js`,
+    "C:Users/alice/private.js",
+    String.raw`\\server\share\private.js`,
+    "x:private-token",
+    "../private.js",
+  ]) {
+    assert.equal(normalizeRuntimeModuleValue(value, value, repoRoot), "");
+    assert.equal(normalizeRuntimeResolvedValue(value, repoRoot), "");
+  }
 });

--- a/scripts/runtime/context-helper_test.mjs
+++ b/scripts/runtime/context-helper_test.mjs
@@ -187,15 +187,31 @@ test("sanitizes runtime module and resolved artifact values", () => {
   const repoSrcDir = path.join(repoRoot, "src");
   const repoEntryPath = path.join(repoSrcDir, "main.mjs");
   const repoDepPath = path.join(repoRoot, "node_modules", "lodash", "map.js");
+  const nestedRepoDepPath = path.join(repoRoot, "packages", "web", "node_modules", "lodash", "map.js");
+  const nestedHybridDepPath = path.join(
+    repoRoot,
+    "packages",
+    "web",
+    "node_modules",
+    "fixture-dep",
+    "C:",
+    "Users",
+    "alice",
+    "private.mjs",
+  );
   const hiddenRepoDepPath = path.join(repoRoot, "node_modules", "fixture-dep", ".env", "private.mjs");
   const tildeRepoDepPath = path.join(repoRoot, "node_modules", "fixture-dep", "~", ".ssh", "id_rsa.mjs");
   const foreignPath = path.join(testRoot, "foreign.js");
   fs.mkdirSync(path.dirname(repoDepPath), { recursive: true });
+  fs.mkdirSync(path.dirname(nestedRepoDepPath), { recursive: true });
+  fs.mkdirSync(path.dirname(nestedHybridDepPath), { recursive: true });
   fs.mkdirSync(path.dirname(hiddenRepoDepPath), { recursive: true });
   fs.mkdirSync(path.dirname(tildeRepoDepPath), { recursive: true });
   fs.mkdirSync(repoSrcDir, { recursive: true });
   fs.writeFileSync(repoEntryPath, "export {};\n", "utf8");
   fs.writeFileSync(repoDepPath, "export default function map() {}\n", "utf8");
+  fs.writeFileSync(nestedRepoDepPath, "export default function nestedMap() {}\n", "utf8");
+  fs.writeFileSync(nestedHybridDepPath, "export default 7;\n", "utf8");
   fs.writeFileSync(hiddenRepoDepPath, "export default 2;\n", "utf8");
   fs.writeFileSync(tildeRepoDepPath, "export default 3;\n", "utf8");
   fs.writeFileSync(foreignPath, "export {};\n", "utf8");
@@ -212,17 +228,36 @@ test("sanitizes runtime module and resolved artifact values", () => {
       repoRoot,
       realpath,
     ),
-    "src/main.mjs",
+    "",
   );
   assert.equal(
     normalizeRuntimeResolvedValue(pathToFileURL(repoDepPath).href, repoRoot, realpath),
     "node_modules/lodash/map.js",
   );
+  assert.equal(
+    normalizeRuntimeResolvedValue(nestedRepoDepPath, repoRoot, realpath),
+    "packages/web/node_modules/lodash/map.js",
+  );
   assert.equal(normalizeRuntimeResolvedValue(pathToFileURL(hiddenRepoDepPath).href, repoRoot, realpath), "");
   assert.equal(normalizeRuntimeResolvedValue(pathToFileURL(tildeRepoDepPath).href, repoRoot, realpath), "");
+  assert.equal(
+    normalizeRuntimeResolvedValue(
+      nestedHybridDepPath,
+      repoRoot,
+      realpath,
+    ),
+    "",
+  );
   for (const value of ["lodash/fp.js", "@scope/pkg/index.js", "node:fs", "node:fs/promises"]) {
     assert.equal(normalizeRuntimeModuleValue(value, "", repoRoot, realpath), value);
     assert.equal(normalizeRuntimeResolvedValue(value, repoRoot, realpath), value);
+  }
+  for (const value of [
+    pathToFileURL(repoEntryPath).href,
+    "./src/main.mjs",
+    "../main.mjs",
+  ]) {
+    assert.equal(normalizeRuntimeModuleValue(value, value, repoRoot, realpath), "");
   }
   for (const value of [
     foreignPath,

--- a/scripts/runtime/context-helper_test.mjs
+++ b/scripts/runtime/context-helper_test.mjs
@@ -320,6 +320,44 @@ test("preserves validated package specifiers when hoisted node_modules resolutio
   fs.rmSync(testRoot, { recursive: true, force: true });
 });
 
+test("preserves bare and scoped linked package requests while redacting external realpaths", (t) => {
+  const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
+  const repoRoot = path.join(testRoot, "repo");
+  const linkedRoot = path.join(testRoot, "linked-packages");
+  const barePackagePath = path.join(linkedRoot, "fixture-dep", "index.js");
+  const scopedPackagePath = path.join(linkedRoot, "@scope", "pkg", "index.js");
+  fs.mkdirSync(path.dirname(barePackagePath), { recursive: true });
+  fs.mkdirSync(path.dirname(scopedPackagePath), { recursive: true });
+  fs.writeFileSync(barePackagePath, "module.exports = 1;\n", "utf8");
+  fs.writeFileSync(scopedPackagePath, "module.exports = 2;\n", "utf8");
+
+  const { realpath } = trackRealpathCalls();
+  assert.equal(normalizeRuntimeModuleValue("fixture-dep", barePackagePath, repoRoot, realpath), "fixture-dep");
+  assert.equal(normalizeRuntimeModuleValue("@scope/pkg", scopedPackagePath, repoRoot, realpath), "@scope/pkg");
+  assert.equal(normalizeRuntimeResolvedValue(barePackagePath, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeResolvedValue(scopedPackagePath, repoRoot, realpath), "");
+
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+test("rejects unsafe linked package requests when the realpath is redacted", () => {
+  const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
+  const repoRoot = path.join(testRoot, "repo");
+  const linkedRoot = path.join(testRoot, "linked-packages");
+  const barePackagePath = path.join(linkedRoot, "fixture-dep", "index.js");
+  const scopedPackagePath = path.join(linkedRoot, "@scope", "pkg", "index.js");
+  fs.mkdirSync(path.dirname(barePackagePath), { recursive: true });
+  fs.mkdirSync(path.dirname(scopedPackagePath), { recursive: true });
+  fs.writeFileSync(barePackagePath, "module.exports = 1;\n", "utf8");
+  fs.writeFileSync(scopedPackagePath, "module.exports = 2;\n", "utf8");
+
+  const { realpath } = trackRealpathCalls();
+  assert.equal(normalizeRuntimeModuleValue("fixture-dep/lib/index.js", barePackagePath, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeModuleValue("@scope/pkg/index.js", scopedPackagePath, repoRoot, realpath), "");
+
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
 test("sanitizes runtime module and resolved artifact values", () => {
   const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
   const repoRoot = path.join(testRoot, "repo");

--- a/scripts/runtime/context-helper_test.mjs
+++ b/scripts/runtime/context-helper_test.mjs
@@ -7,11 +7,25 @@ import { pathToFileURL } from "node:url";
 import helpers from "./context-helper.cjs";
 
 const {
+  createRuntimeTraceHelpers,
   isSafeRepoRelativePath,
   normalizeContextValue,
   normalizeRuntimeModuleValue,
   normalizeRuntimeResolvedValue,
 } = helpers;
+
+function trackRealpathCalls() {
+  const calls = [];
+  const realpath = (value) => {
+    calls.push(value);
+    return fs.realpathSync.native(value);
+  };
+  return { calls, realpath };
+}
+
+function symlinkType() {
+  return process.platform === "win32" ? "junction" : "dir";
+}
 
 test("rejects windows drive paths before repo-relative joining on any host", () => {
   const repoRoot = path.resolve("/repo");
@@ -56,31 +70,140 @@ test("decodes percent-encoded file URLs with fileURLToPath", () => {
   fs.rmSync(repoRoot, { recursive: true, force: true });
 });
 
+test("rejects hostile absolute and traversal inputs before realpath", (t) => {
+  const repoRoot = { trusted: [path.resolve("/repo")] };
+  const { calls, realpath } = trackRealpathCalls();
+
+  for (const value of ["/private.js", "file:///private.js", "/repo/../private.js"]) {
+    assert.equal(normalizeContextValue(value, repoRoot, realpath), "");
+  }
+  assert.deepEqual(calls, []);
+});
+
+test("realpaths trusted repo-local absolute and file URL inputs after lexical confinement", (t) => {
+  const repoRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
+  const srcDir = path.join(repoRoot, "src");
+  const modulePath = path.join(srcDir, "main.js");
+  fs.mkdirSync(srcDir, { recursive: true });
+  fs.writeFileSync(modulePath, "export {};\n", "utf8");
+
+  const { calls, realpath } = trackRealpathCalls();
+  assert.equal(normalizeContextValue(modulePath, repoRoot, realpath), "src/main.js");
+  assert.equal(normalizeContextValue(pathToFileURL(modulePath).href, repoRoot, realpath), "src/main.js");
+  assert.ok(calls.length >= 2);
+
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+});
+
+test("fails closed when a trusted candidate cannot be realpathed", () => {
+  const repoRoot = { trusted: [path.resolve("/repo")] };
+  const realpath = () => {
+    throw new Error("candidate changed before realpath");
+  };
+
+  assert.equal(normalizeContextValue(path.resolve("/repo/main.js"), repoRoot, realpath), "");
+});
+
+test("createRuntimeTraceHelpers accepts injected realpath without global monkeypatching", () => {
+  const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
+  const repoRoot = path.join(testRoot, "repo");
+  const modulePath = path.join(repoRoot, "src", "main.js");
+  fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+  fs.writeFileSync(modulePath, "export {};\n", "utf8");
+
+  const { calls, realpath } = trackRealpathCalls();
+  const runtimeHelpers = createRuntimeTraceHelpers(
+    { LOPPER_RUNTIME_REPO_ROOT: repoRoot, LOPPER_RUNTIME_TRACE: "" },
+    { realpath },
+  );
+
+  assert.equal(runtimeHelpers.normalizeContext(modulePath), "src/main.js");
+  assert.equal(runtimeHelpers.normalizeResolved(pathToFileURL(modulePath).href), "src/main.js");
+  assert.ok(calls.length >= 2);
+
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+test("preserves repo attribution for symlinked repo roots and redacts symlink escapes", () => {
+  const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
+  const realRepoRoot = path.join(testRoot, "repo-real");
+  const aliasRepoRoot = path.join(testRoot, "repo-alias");
+  const safeModulePath = path.join(realRepoRoot, "src", "main.js");
+  const escapedTargetPath = path.join(testRoot, "private.js");
+  const escapedLinkPath = path.join(realRepoRoot, "src", "escaped.js");
+  const retargetedRepoRoot = path.join(testRoot, "repo-private");
+  const retargetedModulePath = path.join(retargetedRepoRoot, "src", "private.js");
+  fs.mkdirSync(path.dirname(safeModulePath), { recursive: true });
+  fs.mkdirSync(path.dirname(retargetedModulePath), { recursive: true });
+  fs.writeFileSync(safeModulePath, "export {};\n", "utf8");
+  fs.writeFileSync(escapedTargetPath, "export {};\n", "utf8");
+  fs.writeFileSync(retargetedModulePath, "export {};\n", "utf8");
+  fs.symlinkSync(realRepoRoot, aliasRepoRoot, symlinkType());
+  fs.symlinkSync(escapedTargetPath, escapedLinkPath);
+
+  const { calls, realpath } = trackRealpathCalls();
+  const runtimeHelpers = createRuntimeTraceHelpers(
+    { LOPPER_RUNTIME_REPO_ROOT: aliasRepoRoot, LOPPER_RUNTIME_TRACE: "" },
+    { realpath },
+  );
+
+  assert.equal(runtimeHelpers.normalizeContext(safeModulePath), "src/main.js");
+  assert.equal(runtimeHelpers.normalizeContext(path.join(aliasRepoRoot, "src", "main.js")), "src/main.js");
+  assert.equal(runtimeHelpers.normalizeResolved(pathToFileURL(safeModulePath).href), "src/main.js");
+  assert.equal(runtimeHelpers.normalizeContext(path.join(aliasRepoRoot, "src", "escaped.js")), "");
+  assert.equal(runtimeHelpers.normalizeResolved(pathToFileURL(escapedLinkPath).href), "");
+
+  fs.unlinkSync(aliasRepoRoot);
+  fs.symlinkSync(retargetedRepoRoot, aliasRepoRoot, symlinkType());
+  assert.equal(runtimeHelpers.normalizeContext(path.join(aliasRepoRoot, "src", "private.js")), "");
+  assert.ok(calls.length >= 5);
+
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
 test("sanitizes runtime module and resolved artifact values", () => {
-  const repoRoot = path.resolve("/repo");
+  const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
+  const repoRoot = path.join(testRoot, "repo");
+  const repoSrcDir = path.join(repoRoot, "src");
+  const repoEntryPath = path.join(repoSrcDir, "main.mjs");
+  const repoDepPath = path.join(repoRoot, "node_modules", "lodash", "map.js");
+  const foreignPath = path.join(testRoot, "foreign.js");
+  fs.mkdirSync(path.dirname(repoDepPath), { recursive: true });
+  fs.mkdirSync(repoSrcDir, { recursive: true });
+  fs.writeFileSync(repoEntryPath, "export {};\n", "utf8");
+  fs.writeFileSync(repoDepPath, "export default function map() {}\n", "utf8");
+  fs.writeFileSync(foreignPath, "export {};\n", "utf8");
+  const { realpath } = trackRealpathCalls();
 
   assert.equal(
-    normalizeRuntimeModuleValue("lodash/map", "/repo/node_modules/lodash/map.js", repoRoot),
+    normalizeRuntimeModuleValue("lodash/map", repoDepPath, repoRoot, realpath),
     "lodash/map",
   );
   assert.equal(
-    normalizeRuntimeModuleValue("file:///repo/src/main.mjs", "file:///repo/src/main.mjs", repoRoot),
+    normalizeRuntimeModuleValue(
+      pathToFileURL(repoEntryPath).href,
+      pathToFileURL(repoEntryPath).href,
+      repoRoot,
+      realpath,
+    ),
     "src/main.mjs",
   );
   assert.equal(
-    normalizeRuntimeResolvedValue("file:///repo/node_modules/lodash/map.js", repoRoot),
+    normalizeRuntimeResolvedValue(pathToFileURL(repoDepPath).href, repoRoot, realpath),
     "node_modules/lodash/map.js",
   );
   for (const value of [
-    "/private/tmp/foreign.js",
-    "file:///private/tmp/foreign.js",
+    foreignPath,
+    pathToFileURL(foreignPath).href,
     String.raw`C:\Users\alice\private.js`,
     "C:Users/alice/private.js",
     String.raw`\\server\share\private.js`,
     "x:private-token",
     "../private.js",
   ]) {
-    assert.equal(normalizeRuntimeModuleValue(value, value, repoRoot), "");
-    assert.equal(normalizeRuntimeResolvedValue(value, repoRoot), "");
+    assert.equal(normalizeRuntimeModuleValue(value, value, repoRoot, realpath), "");
+    assert.equal(normalizeRuntimeResolvedValue(value, repoRoot, realpath), "");
   }
+
+  fs.rmSync(testRoot, { recursive: true, force: true });
 });

--- a/scripts/runtime/context-helper_test.mjs
+++ b/scripts/runtime/context-helper_test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import { pathToFileURL } from "node:url";
 
 import helpers from "./context-helper.cjs";
+import { createDirectoryLinkSync, createFileLinkSync, removeDirectoryLinkSync, skipIfLinkUnsupported } from "./test-link-helpers.mjs";
 
 const {
   createRuntimeTraceHelpers,
@@ -22,10 +23,6 @@ function trackRealpathCalls() {
     return fs.realpathSync.native(value);
   };
   return { calls, realpath };
-}
-
-function symlinkType() {
-  return process.platform === "win32" ? "junction" : "dir";
 }
 
 test("rejects windows drive paths before repo-relative joining on any host", () => {
@@ -145,7 +142,7 @@ test("manual helpers fail closed without an explicit repo root", () => {
   }
 });
 
-test("preserves repo attribution for symlinked repo roots and redacts symlink escapes", () => {
+test("preserves repo attribution for symlinked repo roots and redacts symlink escapes", (t) => {
   const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
   const realRepoRoot = path.join(testRoot, "repo-real");
   const aliasRepoRoot = path.join(testRoot, "repo-alias");
@@ -159,8 +156,16 @@ test("preserves repo attribution for symlinked repo roots and redacts symlink es
   fs.writeFileSync(safeModulePath, "export {};\n", "utf8");
   fs.writeFileSync(escapedTargetPath, "export {};\n", "utf8");
   fs.writeFileSync(retargetedModulePath, "export {};\n", "utf8");
-  fs.symlinkSync(realRepoRoot, aliasRepoRoot, symlinkType());
-  fs.symlinkSync(escapedTargetPath, escapedLinkPath);
+  try {
+    createDirectoryLinkSync(realRepoRoot, aliasRepoRoot);
+    createFileLinkSync(escapedTargetPath, escapedLinkPath);
+  } catch (error) {
+    if (skipIfLinkUnsupported(t, error)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+      return;
+    }
+    throw error;
+  }
 
   const { calls, realpath } = trackRealpathCalls();
   const runtimeHelpers = createRuntimeTraceHelpers(
@@ -174,10 +179,41 @@ test("preserves repo attribution for symlinked repo roots and redacts symlink es
   assert.equal(runtimeHelpers.normalizeContext(path.join(aliasRepoRoot, "src", "escaped.js")), "");
   assert.equal(runtimeHelpers.normalizeResolved(pathToFileURL(escapedLinkPath).href), "");
 
-  fs.unlinkSync(aliasRepoRoot);
-  fs.symlinkSync(retargetedRepoRoot, aliasRepoRoot, symlinkType());
+  removeDirectoryLinkSync(aliasRepoRoot);
+  createDirectoryLinkSync(retargetedRepoRoot, aliasRepoRoot);
   assert.equal(runtimeHelpers.normalizeContext(path.join(aliasRepoRoot, "src", "private.js")), "");
   assert.ok(calls.length >= 5);
+
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+test("redacts escaped repo-relative runtime module requests without demoting package subpaths", (t) => {
+  const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
+  const repoRoot = path.join(testRoot, "repo");
+  const repoSrcDir = path.join(repoRoot, "src");
+  const escapedTargetPath = path.join(testRoot, "private.js");
+  const escapedLinkPath = path.join(repoSrcDir, "escaped.js");
+  const packageResolvedPath = path.join(repoRoot, "node_modules", "fixture-dep", "lib", "index.js");
+  fs.mkdirSync(repoSrcDir, { recursive: true });
+  fs.mkdirSync(path.dirname(packageResolvedPath), { recursive: true });
+  fs.writeFileSync(escapedTargetPath, "export {};\n", "utf8");
+  fs.writeFileSync(packageResolvedPath, "export {};\n", "utf8");
+  try {
+    createFileLinkSync(escapedTargetPath, escapedLinkPath);
+  } catch (error) {
+    if (skipIfLinkUnsupported(t, error)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+      return;
+    }
+    throw error;
+  }
+
+  const { realpath } = trackRealpathCalls();
+  assert.equal(normalizeRuntimeModuleValue("src/escaped.js", escapedLinkPath, repoRoot, realpath), "");
+  assert.equal(
+    normalizeRuntimeModuleValue("fixture-dep/lib/index.js", packageResolvedPath, repoRoot, realpath),
+    "fixture-dep/lib/index.js",
+  );
 
   fs.rmSync(testRoot, { recursive: true, force: true });
 });

--- a/scripts/runtime/context-helper_test.mjs
+++ b/scripts/runtime/context-helper_test.mjs
@@ -11,10 +11,12 @@ import { createDirectoryLinkSync, createFileLinkSync, removeDirectoryLinkSync, s
 
 const {
   createRuntimeTraceHelpers,
+  findValidatedLinkedPackageRoot,
   isSafeRepoRelativePath,
   normalizeContextValue,
   normalizeRuntimeModuleValue,
   normalizeRuntimeResolvedValue,
+  preservesValidatedLinkedPackageSubpath,
   sanitizeNodeModulesResolvedPath,
 } = helpers;
 
@@ -320,42 +322,177 @@ test("preserves validated package specifiers when hoisted node_modules resolutio
   fs.rmSync(testRoot, { recursive: true, force: true });
 });
 
-test("preserves bare and scoped linked package requests while redacting external realpaths", (t) => {
+test("preserves bare, scoped, and validated linked package subpath requests while redacting external realpaths", (t) => {
   const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
   const repoRoot = path.join(testRoot, "repo");
   const linkedRoot = path.join(testRoot, "linked-packages");
   const barePackagePath = path.join(linkedRoot, "fixture-dep", "index.js");
+  const barePackageSubpath = path.join(linkedRoot, "fixture-dep", "lib", "index.js");
   const scopedPackagePath = path.join(linkedRoot, "@scope", "pkg", "index.js");
+  const scopedPackageSubpath = path.join(linkedRoot, "@scope", "pkg", "client", "index.js");
   fs.mkdirSync(path.dirname(barePackagePath), { recursive: true });
+  fs.mkdirSync(path.dirname(barePackageSubpath), { recursive: true });
   fs.mkdirSync(path.dirname(scopedPackagePath), { recursive: true });
+  fs.mkdirSync(path.dirname(scopedPackageSubpath), { recursive: true });
+  fs.writeFileSync(path.join(linkedRoot, "fixture-dep", "package.json"), JSON.stringify({ name: "fixture-dep" }), "utf8");
+  fs.writeFileSync(path.join(linkedRoot, "@scope", "pkg", "package.json"), JSON.stringify({ name: "@scope/pkg" }), "utf8");
   fs.writeFileSync(barePackagePath, "module.exports = 1;\n", "utf8");
-  fs.writeFileSync(scopedPackagePath, "module.exports = 2;\n", "utf8");
+  fs.writeFileSync(barePackageSubpath, "module.exports = 2;\n", "utf8");
+  fs.writeFileSync(scopedPackagePath, "module.exports = 3;\n", "utf8");
+  fs.writeFileSync(scopedPackageSubpath, "module.exports = 4;\n", "utf8");
 
   const { realpath } = trackRealpathCalls();
   assert.equal(normalizeRuntimeModuleValue("fixture-dep", barePackagePath, repoRoot, realpath), "fixture-dep");
+  assert.equal(normalizeRuntimeModuleValue("fixture-dep/lib", barePackageSubpath, repoRoot, realpath), "fixture-dep/lib");
   assert.equal(normalizeRuntimeModuleValue("@scope/pkg", scopedPackagePath, repoRoot, realpath), "@scope/pkg");
+  assert.equal(
+    normalizeRuntimeModuleValue("@scope/pkg/client", scopedPackageSubpath, repoRoot, realpath),
+    "@scope/pkg/client",
+  );
   assert.equal(normalizeRuntimeResolvedValue(barePackagePath, repoRoot, realpath), "");
   assert.equal(normalizeRuntimeResolvedValue(scopedPackagePath, repoRoot, realpath), "");
 
   fs.rmSync(testRoot, { recursive: true, force: true });
 });
 
-test("rejects unsafe linked package requests when the realpath is redacted", () => {
+test("rejects unsafe or phantom linked package requests when the realpath is redacted", () => {
   const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
   const repoRoot = path.join(testRoot, "repo");
   const linkedRoot = path.join(testRoot, "linked-packages");
   const barePackagePath = path.join(linkedRoot, "fixture-dep", "index.js");
+  const barePackageSubpath = path.join(linkedRoot, "fixture-dep", "lib", "index.js");
   const scopedPackagePath = path.join(linkedRoot, "@scope", "pkg", "index.js");
+  const phantomPackagePath = path.join(linkedRoot, "src", "client", "index.js");
   fs.mkdirSync(path.dirname(barePackagePath), { recursive: true });
+  fs.mkdirSync(path.dirname(barePackageSubpath), { recursive: true });
   fs.mkdirSync(path.dirname(scopedPackagePath), { recursive: true });
+  fs.mkdirSync(path.dirname(phantomPackagePath), { recursive: true });
+  fs.writeFileSync(path.join(linkedRoot, "fixture-dep", "package.json"), JSON.stringify({ name: "fixture-dep" }), "utf8");
+  fs.writeFileSync(path.join(linkedRoot, "@scope", "pkg", "package.json"), JSON.stringify({ name: "@scope/pkg" }), "utf8");
   fs.writeFileSync(barePackagePath, "module.exports = 1;\n", "utf8");
-  fs.writeFileSync(scopedPackagePath, "module.exports = 2;\n", "utf8");
+  fs.writeFileSync(barePackageSubpath, "module.exports = 2;\n", "utf8");
+  fs.writeFileSync(scopedPackagePath, "module.exports = 3;\n", "utf8");
+  fs.writeFileSync(phantomPackagePath, "module.exports = 4;\n", "utf8");
 
   const { realpath } = trackRealpathCalls();
   assert.equal(normalizeRuntimeModuleValue("fixture-dep/lib/index.js", barePackagePath, repoRoot, realpath), "");
-  assert.equal(normalizeRuntimeModuleValue("@scope/pkg/index.js", scopedPackagePath, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeModuleValue("@scope/pkg/client", scopedPackagePath, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeModuleValue("fixture-dep/\nlib", barePackageSubpath, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeModuleValue("fixture-dep/.env", barePackageSubpath, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeModuleValue("@scope/pkg/../client", scopedPackagePath, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeModuleValue("src/client", phantomPackagePath, repoRoot, realpath), "");
 
   fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+test("preserves linked package subpaths for drive-letter realpaths without duplicating the Windows root", () => {
+  const manifests = new Map([
+    [String.raw`C:\linked\fixture-dep\package.json`, JSON.stringify({ name: "fixture-dep" })],
+    [String.raw`C:\linked\@scope\pkg\package.json`, JSON.stringify({ name: "@scope/pkg" })],
+  ]);
+  const windowsFs = {
+    existsSync(value) {
+      return manifests.has(value);
+    },
+    readFileSync(value) {
+      const manifest = manifests.get(value);
+      if (manifest === undefined) {
+        throw new Error(`missing manifest: ${value}`);
+      }
+      return manifest;
+    },
+  };
+  const identityRealpath = (value) => value;
+
+  assert.equal(
+    findValidatedLinkedPackageRoot(
+      String.raw`C:\linked\fixture-dep\lib\index.js`,
+      { packageName: "fixture-dep", packageRootParts: ["fixture-dep"], subpathParts: ["lib"] },
+      identityRealpath,
+      { fs: windowsFs, pathImpl: path.win32 },
+    ),
+    String.raw`C:\linked\fixture-dep`,
+  );
+  assert.equal(
+    preservesValidatedLinkedPackageSubpath(
+      "fixture-dep/lib",
+      "fixture-dep/lib",
+      String.raw`C:\linked\fixture-dep\lib\index.js`,
+      identityRealpath,
+      { fs: windowsFs, pathImpl: path.win32 },
+    ),
+    true,
+  );
+  assert.equal(
+    preservesValidatedLinkedPackageSubpath(
+      "@scope/pkg/client",
+      "@scope/pkg/client",
+      String.raw`C:\linked\@scope\pkg\client\index.js`,
+      identityRealpath,
+      { fs: windowsFs, pathImpl: path.win32 },
+    ),
+    true,
+  );
+});
+
+test("redacts malformed or escaping drive-letter linked package subpaths", () => {
+  const manifests = new Map([
+    [String.raw`C:\linked\fixture-dep\package.json`, JSON.stringify({ name: "fixture-dep" })],
+    [String.raw`C:\linked\@scope\pkg\package.json`, JSON.stringify({ name: "@scope/pkg" })],
+  ]);
+  const windowsFs = {
+    existsSync(value) {
+      return manifests.has(value);
+    },
+    readFileSync(value) {
+      const manifest = manifests.get(value);
+      if (manifest === undefined) {
+        throw new Error(`missing manifest: ${value}`);
+      }
+      return manifest;
+    },
+  };
+  const identityRealpath = (value) => value;
+
+  assert.equal(
+    findValidatedLinkedPackageRoot(
+      String.raw`C:\linked\fixture-dep\lib\index.js`,
+      { packageName: "fixture-dep", packageRootParts: ["fixture-dep"], subpathParts: ["lib"] },
+      identityRealpath,
+      { fs: windowsFs, pathImpl: path.win32 },
+    ).includes("C:\\C:\\"),
+    false,
+  );
+  assert.equal(
+    preservesValidatedLinkedPackageSubpath(
+      "fixture-dep/lib",
+      "fixture-dep/lib",
+      String.raw`C:\linked\fixture-dep\..\private\lib\index.js`,
+      identityRealpath,
+      { fs: windowsFs, pathImpl: path.win32 },
+    ),
+    false,
+  );
+  assert.equal(
+    preservesValidatedLinkedPackageSubpath(
+      "@scope/pkg/client",
+      "@scope/pkg/client",
+      String.raw`C:\linked\@scope\pkg\..\private\client\index.js`,
+      identityRealpath,
+      { fs: windowsFs, pathImpl: path.win32 },
+    ),
+    false,
+  );
+  assert.equal(
+    preservesValidatedLinkedPackageSubpath(
+      "fixture-dep/lib",
+      "fixture-dep/lib",
+      String.raw`C:\linked\fixture-dep\C:\private\index.js`,
+      identityRealpath,
+      { fs: windowsFs, pathImpl: path.win32 },
+    ),
+    false,
+  );
 });
 
 test("sanitizes runtime module and resolved artifact values", () => {

--- a/scripts/runtime/context-helper_test.mjs
+++ b/scripts/runtime/context-helper_test.mjs
@@ -12,6 +12,7 @@ const {
   normalizeContextValue,
   normalizeRuntimeModuleValue,
   normalizeRuntimeResolvedValue,
+  sanitizeNodeModulesResolvedPath,
 } = helpers;
 
 function trackRealpathCalls() {
@@ -188,6 +189,15 @@ test("sanitizes runtime module and resolved artifact values", () => {
   const repoEntryPath = path.join(repoSrcDir, "main.mjs");
   const repoDepPath = path.join(repoRoot, "node_modules", "lodash", "map.js");
   const nestedRepoDepPath = path.join(repoRoot, "packages", "web", "node_modules", "lodash", "map.js");
+  const nestedValidDepPath = path.join(
+    repoRoot,
+    "node_modules",
+    "fixture-dep",
+    "lib",
+    "node_modules",
+    "child",
+    "index.mjs",
+  );
   const nestedHybridDepPath = path.join(
     repoRoot,
     "packages",
@@ -199,19 +209,57 @@ test("sanitizes runtime module and resolved artifact values", () => {
     "alice",
     "private.mjs",
   );
+  const nestedHiddenDepPath = path.join(
+    repoRoot,
+    "node_modules",
+    "fixture-dep",
+    ".env",
+    "node_modules",
+    "child",
+    "index.mjs",
+  );
+  const nestedTildeDepPath = path.join(
+    repoRoot,
+    "node_modules",
+    "fixture-dep",
+    "~",
+    ".ssh",
+    "node_modules",
+    "child",
+    "index.mjs",
+  );
+  const nestedDriveLikeDepPath = path.join(
+    repoRoot,
+    "node_modules",
+    "fixture-dep",
+    "C:",
+    "Users",
+    "alice",
+    "node_modules",
+    "child",
+    "index.mjs",
+  );
   const hiddenRepoDepPath = path.join(repoRoot, "node_modules", "fixture-dep", ".env", "private.mjs");
   const tildeRepoDepPath = path.join(repoRoot, "node_modules", "fixture-dep", "~", ".ssh", "id_rsa.mjs");
   const foreignPath = path.join(testRoot, "foreign.js");
   fs.mkdirSync(path.dirname(repoDepPath), { recursive: true });
   fs.mkdirSync(path.dirname(nestedRepoDepPath), { recursive: true });
+  fs.mkdirSync(path.dirname(nestedValidDepPath), { recursive: true });
   fs.mkdirSync(path.dirname(nestedHybridDepPath), { recursive: true });
+  fs.mkdirSync(path.dirname(nestedHiddenDepPath), { recursive: true });
+  fs.mkdirSync(path.dirname(nestedTildeDepPath), { recursive: true });
+  fs.mkdirSync(path.dirname(nestedDriveLikeDepPath), { recursive: true });
   fs.mkdirSync(path.dirname(hiddenRepoDepPath), { recursive: true });
   fs.mkdirSync(path.dirname(tildeRepoDepPath), { recursive: true });
   fs.mkdirSync(repoSrcDir, { recursive: true });
   fs.writeFileSync(repoEntryPath, "export {};\n", "utf8");
   fs.writeFileSync(repoDepPath, "export default function map() {}\n", "utf8");
   fs.writeFileSync(nestedRepoDepPath, "export default function nestedMap() {}\n", "utf8");
+  fs.writeFileSync(nestedValidDepPath, "export default 11;\n", "utf8");
   fs.writeFileSync(nestedHybridDepPath, "export default 7;\n", "utf8");
+  fs.writeFileSync(nestedHiddenDepPath, "export default 12;\n", "utf8");
+  fs.writeFileSync(nestedTildeDepPath, "export default 13;\n", "utf8");
+  fs.writeFileSync(nestedDriveLikeDepPath, "export default 14;\n", "utf8");
   fs.writeFileSync(hiddenRepoDepPath, "export default 2;\n", "utf8");
   fs.writeFileSync(tildeRepoDepPath, "export default 3;\n", "utf8");
   fs.writeFileSync(foreignPath, "export {};\n", "utf8");
@@ -238,6 +286,10 @@ test("sanitizes runtime module and resolved artifact values", () => {
     normalizeRuntimeResolvedValue(nestedRepoDepPath, repoRoot, realpath),
     "packages/web/node_modules/lodash/map.js",
   );
+  assert.equal(
+    normalizeRuntimeResolvedValue(nestedValidDepPath, repoRoot, realpath),
+    "node_modules/fixture-dep/lib/node_modules/child/index.mjs",
+  );
   assert.equal(normalizeRuntimeResolvedValue(pathToFileURL(hiddenRepoDepPath).href, repoRoot, realpath), "");
   assert.equal(normalizeRuntimeResolvedValue(pathToFileURL(tildeRepoDepPath).href, repoRoot, realpath), "");
   assert.equal(
@@ -248,6 +300,9 @@ test("sanitizes runtime module and resolved artifact values", () => {
     ),
     "",
   );
+  assert.equal(normalizeRuntimeResolvedValue(nestedHiddenDepPath, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeResolvedValue(nestedTildeDepPath, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeResolvedValue(nestedDriveLikeDepPath, repoRoot, realpath), "");
   for (const value of ["lodash/fp.js", "@scope/pkg/index.js", "node:fs", "node:fs/promises"]) {
     assert.equal(normalizeRuntimeModuleValue(value, "", repoRoot, realpath), value);
     assert.equal(normalizeRuntimeResolvedValue(value, repoRoot, realpath), value);
@@ -278,4 +333,19 @@ test("sanitizes runtime module and resolved artifact values", () => {
   }
 
   fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+test("sanitizes nested node_modules suffixes from the first marker onward", () => {
+  const validNestedPath = "node_modules/pkg/lib/node_modules/child/index.js";
+  assert.equal(sanitizeNodeModulesResolvedPath(validNestedPath), validNestedPath);
+
+  for (const value of [
+    "node_modules/pkg/.env/node_modules/child/index.js",
+    "node_modules/pkg/~/.ssh/node_modules/child/index.js",
+    "node_modules/pkg/C:/Users/alice/node_modules/child/index.js",
+    "node_modules/pkg/../node_modules/child/index.js",
+    `node_modules/pkg/\u0001private/node_modules/child/index.js`,
+  ]) {
+    assert.equal(sanitizeNodeModulesResolvedPath(value), "");
+  }
 });

--- a/scripts/runtime/context-helper_test.mjs
+++ b/scripts/runtime/context-helper_test.mjs
@@ -124,6 +124,26 @@ test("createRuntimeTraceHelpers accepts injected realpath without global monkeyp
   fs.rmSync(testRoot, { recursive: true, force: true });
 });
 
+test("manual helpers fail closed without an explicit repo root", () => {
+  const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
+  const repoRoot = path.join(testRoot, "repo");
+  const nestedRoot = path.join(repoRoot, "packages", "nested");
+  const modulePath = path.join(nestedRoot, "src", "main.js");
+  fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+  fs.writeFileSync(modulePath, "export {};\n", "utf8");
+
+  const previousCwd = process.cwd();
+  process.chdir(nestedRoot);
+  try {
+    const runtimeHelpers = createRuntimeTraceHelpers({ LOPPER_RUNTIME_TRACE: "" });
+    assert.equal(runtimeHelpers.normalizeContext(modulePath), "");
+    assert.equal(runtimeHelpers.normalizeResolved(pathToFileURL(modulePath).href), "");
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("preserves repo attribution for symlinked repo roots and redacts symlink escapes", () => {
   const testRoot = fs.mkdtempSync(path.join(process.cwd(), ".runtime-context-"));
   const realRepoRoot = path.join(testRoot, "repo-real");
@@ -167,11 +187,17 @@ test("sanitizes runtime module and resolved artifact values", () => {
   const repoSrcDir = path.join(repoRoot, "src");
   const repoEntryPath = path.join(repoSrcDir, "main.mjs");
   const repoDepPath = path.join(repoRoot, "node_modules", "lodash", "map.js");
+  const hiddenRepoDepPath = path.join(repoRoot, "node_modules", "fixture-dep", ".env", "private.mjs");
+  const tildeRepoDepPath = path.join(repoRoot, "node_modules", "fixture-dep", "~", ".ssh", "id_rsa.mjs");
   const foreignPath = path.join(testRoot, "foreign.js");
   fs.mkdirSync(path.dirname(repoDepPath), { recursive: true });
+  fs.mkdirSync(path.dirname(hiddenRepoDepPath), { recursive: true });
+  fs.mkdirSync(path.dirname(tildeRepoDepPath), { recursive: true });
   fs.mkdirSync(repoSrcDir, { recursive: true });
   fs.writeFileSync(repoEntryPath, "export {};\n", "utf8");
   fs.writeFileSync(repoDepPath, "export default function map() {}\n", "utf8");
+  fs.writeFileSync(hiddenRepoDepPath, "export default 2;\n", "utf8");
+  fs.writeFileSync(tildeRepoDepPath, "export default 3;\n", "utf8");
   fs.writeFileSync(foreignPath, "export {};\n", "utf8");
   const { realpath } = trackRealpathCalls();
 
@@ -192,6 +218,12 @@ test("sanitizes runtime module and resolved artifact values", () => {
     normalizeRuntimeResolvedValue(pathToFileURL(repoDepPath).href, repoRoot, realpath),
     "node_modules/lodash/map.js",
   );
+  assert.equal(normalizeRuntimeResolvedValue(pathToFileURL(hiddenRepoDepPath).href, repoRoot, realpath), "");
+  assert.equal(normalizeRuntimeResolvedValue(pathToFileURL(tildeRepoDepPath).href, repoRoot, realpath), "");
+  for (const value of ["lodash/fp.js", "@scope/pkg/index.js", "node:fs", "node:fs/promises"]) {
+    assert.equal(normalizeRuntimeModuleValue(value, "", repoRoot, realpath), value);
+    assert.equal(normalizeRuntimeResolvedValue(value, repoRoot, realpath), value);
+  }
   for (const value of [
     foreignPath,
     pathToFileURL(foreignPath).href,
@@ -200,6 +232,11 @@ test("sanitizes runtime module and resolved artifact values", () => {
     String.raw`\\server\share\private.js`,
     "x:private-token",
     "../private.js",
+    "fixture-dep/C:/Users/alice/private.cjs",
+    "pkg/https:/secret",
+    "pkg/~/.ssh/id_rsa",
+    "pkg/./secret",
+    "pkg/../secret",
   ]) {
     assert.equal(normalizeRuntimeModuleValue(value, value, repoRoot, realpath), "");
     assert.equal(normalizeRuntimeResolvedValue(value, repoRoot, realpath), "");

--- a/scripts/runtime/hooks_test.mjs
+++ b/scripts/runtime/hooks_test.mjs
@@ -115,6 +115,34 @@ test("runtime hooks redact symlink-escaped parent and entrypoint contexts", (t) 
   }
 });
 
+test("runtime hooks preserve hoisted external node_modules dependencies while redacting resolved paths", (t) => {
+  for (const format of ["cjs", "esm"]) {
+    const fixture = createNodeHoistedDependencyFixture(t, format);
+    const events = captureNodeHookEvents(
+      fixture,
+      format === "cjs" ? "--require" : "--loader",
+      format === "cjs" ? "require-hook.cjs" : "loader.mjs",
+    );
+
+    assertArtifactPrivacy(events, fixture);
+    assert.ok(
+      events.some(
+        (event) =>
+          event.module === "fixture-dep" &&
+          event.resolved === "" &&
+          event.parent === `main.${format === "cjs" ? "cjs" : "mjs"}` &&
+          event.entrypoint === "",
+      ),
+      `${format} hook should keep the hoisted dependency specifier even when resolved is redacted`,
+    );
+    assert.equal(
+      JSON.stringify(events).includes(path.join(fixture.fixtureRoot, "external-store")),
+      false,
+      `${format} hook should not leak the hoisted node_modules path`,
+    );
+  }
+});
+
 function createNodeFixture(t, format) {
   const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), `lopper-runtime-${format}-`));
   t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
@@ -213,6 +241,41 @@ function createNodeFixture(t, format) {
           'require("../outside.cjs");',
           "",
         ].join("\n"),
+  );
+
+  return { entrypoint, fixtureRoot, repoRoot, tracePath };
+}
+
+function createNodeHoistedDependencyFixture(t, format) {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), `lopper-runtime-hoisted-${format}-`));
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  const repoRoot = path.join(fixtureRoot, "repo");
+  const externalStoreRoot = path.join(fixtureRoot, "external-store");
+  const outsideNodeModules = path.join(externalStoreRoot, "node_modules");
+  const packageRoot = path.join(outsideNodeModules, "fixture-dep");
+  const extension = format === "esm" ? "mjs" : "cjs";
+  const entrypoint = path.join(repoRoot, `main.${extension}`);
+  const tracePath = path.join(fixtureRoot, `${format}.ndjson`);
+
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      name: "fixture-dep",
+      version: "1.0.0",
+      ...(format === "esm" ? { type: "module", main: "index.mjs" } : { main: "index.cjs" }),
+    }),
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, `index.${extension}`),
+    format === "esm" ? "export default 1;\n" : "module.exports = 1;\n",
+  );
+  fs.mkdirSync(repoRoot, { recursive: true });
+  createDirectoryLinkSync(outsideNodeModules, path.join(repoRoot, "node_modules"));
+  fs.writeFileSync(
+    entrypoint,
+    format === "esm" ? 'import "fixture-dep";\n' : 'require("fixture-dep");\n',
   );
 
   return { entrypoint, fixtureRoot, repoRoot, tracePath };

--- a/scripts/runtime/hooks_test.mjs
+++ b/scripts/runtime/hooks_test.mjs
@@ -20,14 +20,32 @@ test("CommonJS hook persists only sanitized artifact values", (t) => {
       entrypoint: "",
       isMain: false,
     },
+    expectedNestedDependencyEvent: {
+      kind: "require",
+      module: "fixture-dep/safe/node_modules/child/index.cjs",
+      resolved: "node_modules/fixture-dep/safe/node_modules/child/index.cjs",
+      parent: "main.cjs",
+      entrypoint: "",
+      isMain: false,
+    },
     expectedMainParent: "main.cjs",
     disallowedResolvedValues: [
       "node_modules/fixture-dep/C:/Users/alice/private.cjs",
       "node_modules/fixture-dep/https:/secret.cjs",
       "node_modules/fixture-dep/.env/private.cjs",
       "node_modules/fixture-dep/~/.ssh/id_rsa.cjs",
+      "node_modules/fixture-dep/C:/Users/alice/node_modules/child/index.cjs",
+      "node_modules/fixture-dep/.env/node_modules/child/index.cjs",
+      "node_modules/fixture-dep/~/.ssh/node_modules/child/index.cjs",
     ],
-    disallowedModuleValues: ["main.cjs", "local.cjs"],
+    disallowedModuleValues: [
+      "main.cjs",
+      "local.cjs",
+      "fixture-dep/C:/Users/alice/node_modules/child/index.cjs",
+      "fixture-dep/.env/node_modules/child/index.cjs",
+      "fixture-dep/~/.ssh/node_modules/child/index.cjs",
+    ],
+    expectedRedactedMainParentCount: 8,
     redactedMessage: "outside-root require must be recorded without its path",
   });
 });
@@ -43,14 +61,31 @@ test("ESM loader persists only sanitized artifact values", (t) => {
       parent: "main.mjs",
       entrypoint: "",
     },
+    expectedNestedDependencyEvent: {
+      kind: "resolve",
+      module: "fixture-dep/safe/node_modules/child/index.mjs",
+      resolved: "node_modules/fixture-dep/safe/node_modules/child/index.mjs",
+      parent: "main.mjs",
+      entrypoint: "",
+    },
     expectedMainParent: "main.mjs",
     disallowedResolvedValues: [
       "node_modules/fixture-dep/C:/Users/alice/private.mjs",
       "node_modules/fixture-dep/https:/secret.mjs",
       "node_modules/fixture-dep/.env/private.mjs",
       "node_modules/fixture-dep/~/.ssh/id_rsa.mjs",
+      "node_modules/fixture-dep/C:/Users/alice/node_modules/child/index.mjs",
+      "node_modules/fixture-dep/.env/node_modules/child/index.mjs",
+      "node_modules/fixture-dep/~/.ssh/node_modules/child/index.mjs",
     ],
-    disallowedModuleValues: ["main.mjs", "local.mjs"],
+    disallowedModuleValues: [
+      "main.mjs",
+      "local.mjs",
+      "fixture-dep/C:/Users/alice/node_modules/child/index.mjs",
+      "fixture-dep/.env/node_modules/child/index.mjs",
+      "fixture-dep/~/.ssh/node_modules/child/index.mjs",
+    ],
+    expectedRedactedMainParentCount: 8,
     redactedMessage: "outside-root import must be recorded without its path",
   });
 });
@@ -81,12 +116,20 @@ function createNodeFixture(t, format) {
     format === "esm" ? "export default 1;\n" : "module.exports = 1;\n",
   );
   fs.mkdirSync(path.join(packageRoot, "C:", "Users", "alice"), { recursive: true });
+  fs.mkdirSync(path.join(packageRoot, "C:", "Users", "alice", "node_modules", "child"), { recursive: true });
   fs.mkdirSync(path.join(packageRoot, "https:"), { recursive: true });
   fs.mkdirSync(path.join(packageRoot, ".env"), { recursive: true });
+  fs.mkdirSync(path.join(packageRoot, ".env", "node_modules", "child"), { recursive: true });
   fs.mkdirSync(path.join(packageRoot, "~", ".ssh"), { recursive: true });
+  fs.mkdirSync(path.join(packageRoot, "~", ".ssh", "node_modules", "child"), { recursive: true });
+  fs.mkdirSync(path.join(packageRoot, "safe", "node_modules", "child"), { recursive: true });
   fs.writeFileSync(
     path.join(packageRoot, "C:", "Users", "alice", `private.${extension}`),
     format === "esm" ? "export default 2;\n" : "module.exports = 2;\n",
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, "C:", "Users", "alice", "node_modules", "child", `index.${extension}`),
+    format === "esm" ? "export default 7;\n" : "module.exports = 7;\n",
   );
   fs.writeFileSync(
     path.join(packageRoot, "https:", `secret.${extension}`),
@@ -97,8 +140,20 @@ function createNodeFixture(t, format) {
     format === "esm" ? "export default 4;\n" : "module.exports = 4;\n",
   );
   fs.writeFileSync(
+    path.join(packageRoot, ".env", "node_modules", "child", `index.${extension}`),
+    format === "esm" ? "export default 8;\n" : "module.exports = 8;\n",
+  );
+  fs.writeFileSync(
     path.join(packageRoot, "~", ".ssh", `id_rsa.${extension}`),
     format === "esm" ? "export default 5;\n" : "module.exports = 5;\n",
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, "~", ".ssh", "node_modules", "child", `index.${extension}`),
+    format === "esm" ? "export default 9;\n" : "module.exports = 9;\n",
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, "safe", "node_modules", "child", `index.${extension}`),
+    format === "esm" ? "export default 10;\n" : "module.exports = 10;\n",
   );
   fs.writeFileSync(outsidePath, format === "esm" ? "export default 1;\n" : "module.exports = 1;\n");
   fs.writeFileSync(localPath, format === "esm" ? "export default 6;\n" : "module.exports = 6;\n");
@@ -112,6 +167,10 @@ function createNodeFixture(t, format) {
           'import "fixture-dep/https:/secret.mjs";',
           'import "fixture-dep/.env/private.mjs";',
           'import "fixture-dep/~/.ssh/id_rsa.mjs";',
+          'import "fixture-dep/safe/node_modules/child/index.mjs";',
+          'import "fixture-dep/C:/Users/alice/node_modules/child/index.mjs";',
+          'import "fixture-dep/.env/node_modules/child/index.mjs";',
+          'import "fixture-dep/~/.ssh/node_modules/child/index.mjs";',
           'import "../outside.mjs";',
           "",
         ].join("\n")
@@ -122,6 +181,10 @@ function createNodeFixture(t, format) {
           'require("fixture-dep/https:/secret.cjs");',
           'require("fixture-dep/.env/private.cjs");',
           'require("fixture-dep/~/.ssh/id_rsa.cjs");',
+          'require("fixture-dep/safe/node_modules/child/index.cjs");',
+          'require("fixture-dep/C:/Users/alice/node_modules/child/index.cjs");',
+          'require("fixture-dep/.env/node_modules/child/index.cjs");',
+          'require("fixture-dep/~/.ssh/node_modules/child/index.cjs");',
           'require("../outside.cjs");',
           "",
         ].join("\n"),
@@ -183,6 +246,10 @@ function assertArtifactPrivacy(events, fixture) {
 function assertSanitizedRuntimeArtifact(events, fixture, expectations) {
   assertArtifactPrivacy(events, fixture);
   assert.deepEqual(events.find((event) => event.module === "fixture-dep"), expectations.expectedDependencyEvent);
+  assert.deepEqual(
+    events.find((event) => event.module === expectations.expectedNestedDependencyEvent.module),
+    expectations.expectedNestedDependencyEvent,
+  );
   assert.ok(
     events.some((event) => event.module === "" && event.resolved === ""),
     expectations.redactedMessage,
@@ -191,7 +258,7 @@ function assertSanitizedRuntimeArtifact(events, fixture, expectations) {
   assert.equal(
     events.filter((event) => event.parent === expectations.expectedMainParent && event.module === "" && event.resolved === "")
       .length,
-    5,
+    expectations.expectedRedactedMainParentCount,
   );
   assert.deepEqual(findModuleEvents(events, expectations.disallowedModuleValues), []);
 }

--- a/scripts/runtime/hooks_test.mjs
+++ b/scripts/runtime/hooks_test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const hookDir = path.dirname(fileURLToPath(import.meta.url));
+
+test("CommonJS hook persists only sanitized artifact values", (t) => {
+  const fixture = createNodeFixture(t, "cjs");
+  const hookPath = path.join(hookDir, "require-hook.cjs");
+
+  execFileSync(process.execPath, [`--require=${hookPath}`, fixture.entrypoint], {
+    cwd: fixture.repoRoot,
+    env: runtimeEnv(fixture),
+    stdio: "pipe",
+  });
+
+  const events = readEvents(fixture.tracePath);
+  assertArtifactPrivacy(events, fixture);
+  assert.deepEqual(
+    events.find((event) => event.module === "fixture-dep"),
+    {
+      kind: "require",
+      module: "fixture-dep",
+      resolved: "node_modules/fixture-dep/index.cjs",
+      parent: "main.cjs",
+      entrypoint: "",
+      isMain: false,
+    },
+  );
+  assert.ok(
+    events.some((event) => event.module === "" && event.resolved === ""),
+    "outside-root require must be recorded without its path",
+  );
+});
+
+test("ESM loader persists only sanitized artifact values", (t) => {
+  const fixture = createNodeFixture(t, "esm");
+  const hookPath = path.join(hookDir, "loader.mjs");
+
+  execFileSync(process.execPath, [`--loader=${hookPath}`, fixture.entrypoint], {
+    cwd: fixture.repoRoot,
+    env: runtimeEnv(fixture),
+    stdio: "pipe",
+  });
+
+  const events = readEvents(fixture.tracePath);
+  assertArtifactPrivacy(events, fixture);
+  assert.deepEqual(
+    events.find((event) => event.module === "fixture-dep"),
+    {
+      kind: "resolve",
+      module: "fixture-dep",
+      resolved: "node_modules/fixture-dep/index.mjs",
+      parent: "main.mjs",
+      entrypoint: "",
+    },
+  );
+  assert.ok(
+    events.some((event) => event.module === "" && event.resolved === ""),
+    "outside-root import must be recorded without its path",
+  );
+});
+
+function createNodeFixture(t, format) {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), `lopper-runtime-${format}-`));
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  const repoRoot = path.join(fixtureRoot, "repo");
+  const packageRoot = path.join(repoRoot, "node_modules", "fixture-dep");
+  const extension = format === "esm" ? "mjs" : "cjs";
+  const entrypoint = path.join(repoRoot, `main.${extension}`);
+  const outsidePath = path.join(fixtureRoot, `outside.${extension}`);
+  const tracePath = path.join(fixtureRoot, `${format}.ndjson`);
+
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      name: "fixture-dep",
+      version: "1.0.0",
+      ...(format === "esm"
+        ? { type: "module", exports: "./index.mjs" }
+        : { main: "index.cjs" }),
+    }),
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, `index.${extension}`),
+    format === "esm" ? "export default 1;\n" : "module.exports = 1;\n",
+  );
+  fs.writeFileSync(outsidePath, format === "esm" ? "export default 1;\n" : "module.exports = 1;\n");
+  fs.writeFileSync(
+    entrypoint,
+    format === "esm"
+      ? 'import "fixture-dep";\nimport "../outside.mjs";\n'
+      : 'require("fixture-dep");\nrequire("../outside.cjs");\n',
+  );
+
+  return { entrypoint, fixtureRoot, repoRoot, tracePath };
+}
+
+function runtimeEnv(fixture) {
+  const env = { ...process.env };
+  delete env.NODE_OPTIONS;
+  env.LOPPER_RUNTIME_REPO_ROOT = fixture.repoRoot;
+  env.LOPPER_RUNTIME_TRACE = fixture.tracePath;
+  return env;
+}
+
+function readEvents(tracePath) {
+  return fs
+    .readFileSync(tracePath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function assertArtifactPrivacy(events, fixture) {
+  assert.ok(events.length > 0, "hook must emit at least one event");
+  const artifact = JSON.stringify(events);
+  for (const forbidden of [fixture.fixtureRoot, fixture.repoRoot, hookDir, "file://"]) {
+    assert.equal(artifact.includes(forbidden), false, `artifact leaked ${forbidden}`);
+  }
+  for (const event of events) {
+    for (const value of Object.values(event)) {
+      if (typeof value !== "string") continue;
+      assert.equal(path.isAbsolute(value), false, `artifact persisted absolute path ${value}`);
+      assert.equal(value === ".." || value.startsWith("../"), false, `artifact persisted traversal ${value}`);
+    }
+  }
+}

--- a/scripts/runtime/hooks_test.mjs
+++ b/scripts/runtime/hooks_test.mjs
@@ -10,19 +10,9 @@ const hookDir = path.dirname(fileURLToPath(import.meta.url));
 
 test("CommonJS hook persists only sanitized artifact values", (t) => {
   const fixture = createNodeFixture(t, "cjs");
-  const hookPath = path.join(hookDir, "require-hook.cjs");
-
-  execFileSync(process.execPath, [`--require=${hookPath}`, fixture.entrypoint], {
-    cwd: fixture.repoRoot,
-    env: runtimeEnv(fixture),
-    stdio: "pipe",
-  });
-
-  const events = readEvents(fixture.tracePath);
-  assertArtifactPrivacy(events, fixture);
-  assert.deepEqual(
-    events.find((event) => event.module === "fixture-dep"),
-    {
+  const events = captureNodeHookEvents(fixture, "--require", "require-hook.cjs");
+  assertSanitizedRuntimeArtifact(events, fixture, {
+    expectedDependencyEvent: {
       kind: "require",
       module: "fixture-dep",
       resolved: "node_modules/fixture-dep/index.cjs",
@@ -30,67 +20,39 @@ test("CommonJS hook persists only sanitized artifact values", (t) => {
       entrypoint: "",
       isMain: false,
     },
-  );
-  assert.ok(
-    events.some((event) => event.module === "" && event.resolved === ""),
-    "outside-root require must be recorded without its path",
-  );
-  assert.deepEqual(
-    findResolvedEvents(events, [
+    expectedMainParent: "main.cjs",
+    disallowedResolvedValues: [
       "node_modules/fixture-dep/C:/Users/alice/private.cjs",
       "node_modules/fixture-dep/https:/secret.cjs",
       "node_modules/fixture-dep/.env/private.cjs",
       "node_modules/fixture-dep/~/.ssh/id_rsa.cjs",
-    ]),
-    [],
-  );
-  assert.equal(
-    events.filter((event) => event.parent === "main.cjs" && event.module === "" && event.resolved === "").length,
-    5,
-  );
-  assert.deepEqual(findModuleEvents(events, ["main.cjs", "local.cjs"]), []);
+    ],
+    disallowedModuleValues: ["main.cjs", "local.cjs"],
+    redactedMessage: "outside-root require must be recorded without its path",
+  });
 });
 
 test("ESM loader persists only sanitized artifact values", (t) => {
   const fixture = createNodeFixture(t, "esm");
-  const hookPath = path.join(hookDir, "loader.mjs");
-
-  execFileSync(process.execPath, [`--loader=${hookPath}`, fixture.entrypoint], {
-    cwd: fixture.repoRoot,
-    env: runtimeEnv(fixture),
-    stdio: "pipe",
-  });
-
-  const events = readEvents(fixture.tracePath);
-  assertArtifactPrivacy(events, fixture);
-  assert.deepEqual(
-    events.find((event) => event.module === "fixture-dep"),
-    {
+  const events = captureNodeHookEvents(fixture, "--loader", "loader.mjs");
+  assertSanitizedRuntimeArtifact(events, fixture, {
+    expectedDependencyEvent: {
       kind: "resolve",
       module: "fixture-dep",
       resolved: "node_modules/fixture-dep/index.mjs",
       parent: "main.mjs",
       entrypoint: "",
     },
-  );
-  assert.ok(
-    events.some((event) => event.module === "" && event.resolved === ""),
-    "outside-root import must be recorded without its path",
-  );
-  assert.deepEqual(
-    findResolvedEvents(events, [
+    expectedMainParent: "main.mjs",
+    disallowedResolvedValues: [
       "node_modules/fixture-dep/C:/Users/alice/private.mjs",
       "node_modules/fixture-dep/https:/secret.mjs",
       "node_modules/fixture-dep/.env/private.mjs",
       "node_modules/fixture-dep/~/.ssh/id_rsa.mjs",
-    ]),
-    [],
-  );
-  assert.equal(
-    events.filter((event) => event.parent === "main.mjs" && event.module === "" && event.resolved === "").length,
-    5,
-  );
-  assert.deepEqual(findModuleEvents(events, ["main.mjs", "local.mjs"]), []);
+    ],
+    disallowedModuleValues: ["main.mjs", "local.mjs"],
+    redactedMessage: "outside-root import must be recorded without its path",
+  });
 });
 
 function createNodeFixture(t, format) {
@@ -176,6 +138,16 @@ function runtimeEnv(fixture) {
   return env;
 }
 
+function captureNodeHookEvents(fixture, flag, hookFile) {
+  const hookPath = path.join(hookDir, hookFile);
+  execFileSync(process.execPath, [`${flag}=${hookPath}`, fixture.entrypoint], {
+    cwd: fixture.repoRoot,
+    env: runtimeEnv(fixture),
+    stdio: "pipe",
+  });
+  return readEvents(fixture.tracePath);
+}
+
 function readEvents(tracePath) {
   return fs
     .readFileSync(tracePath, "utf8")
@@ -206,4 +178,20 @@ function assertArtifactPrivacy(events, fixture) {
       assert.equal(value === ".." || value.startsWith("../"), false, `artifact persisted traversal ${value}`);
     }
   }
+}
+
+function assertSanitizedRuntimeArtifact(events, fixture, expectations) {
+  assertArtifactPrivacy(events, fixture);
+  assert.deepEqual(events.find((event) => event.module === "fixture-dep"), expectations.expectedDependencyEvent);
+  assert.ok(
+    events.some((event) => event.module === "" && event.resolved === ""),
+    expectations.redactedMessage,
+  );
+  assert.deepEqual(findResolvedEvents(events, expectations.disallowedResolvedValues), []);
+  assert.equal(
+    events.filter((event) => event.parent === expectations.expectedMainParent && event.module === "" && event.resolved === "")
+      .length,
+    5,
+  );
+  assert.deepEqual(findModuleEvents(events, expectations.disallowedModuleValues), []);
 }

--- a/scripts/runtime/hooks_test.mjs
+++ b/scripts/runtime/hooks_test.mjs
@@ -4,7 +4,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { createDirectoryLinkSync, createFileLinkSync, skipIfLinkUnsupported } from "./test-link-helpers.mjs";
 
 const hookDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -88,6 +90,29 @@ test("ESM loader persists only sanitized artifact values", (t) => {
     expectedRedactedMainParentCount: 8,
     redactedMessage: "outside-root import must be recorded without its path",
   });
+});
+
+test("runtime hooks redact symlink-escaped parent and entrypoint contexts", (t) => {
+  for (const format of ["cjs", "esm"]) {
+    const fixture = createNodeSymlinkEscapeFixture(t, format);
+    if (!fixture) {
+      return;
+    }
+    const events = captureNodeHookEvents(
+      fixture,
+      format === "cjs" ? "--require" : "--loader",
+      format === "cjs" ? "require-hook.cjs" : "loader.mjs",
+    );
+
+    assert.ok(
+      events.some((event) => event.parent === "" && event.module === "fixture-dep"),
+      `${format} dependency event should redact escaped parent context`,
+    );
+    assert.ok(
+      events.some((event) => event.entrypoint === "" && event.parent === "" && event.module === "" && event.resolved === ""),
+      `${format} main event should redact escaped entrypoint context`,
+    );
+  }
 });
 
 function createNodeFixture(t, format) {
@@ -189,6 +214,64 @@ function createNodeFixture(t, format) {
           "",
         ].join("\n"),
   );
+
+  return { entrypoint, fixtureRoot, repoRoot, tracePath };
+}
+
+function createNodeSymlinkEscapeFixture(t, format) {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), `lopper-runtime-symlink-${format}-`));
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  const repoRoot = path.join(fixtureRoot, "repo");
+  const packageRoot = path.join(repoRoot, "node_modules", "fixture-dep");
+  const extension = format === "esm" ? "mjs" : "cjs";
+  const tracePath = path.join(fixtureRoot, `${format}.ndjson`);
+  const outsideNodeModules = path.join(fixtureRoot, "node_modules");
+  const parentTarget = path.join(fixtureRoot, `outside-parent.${extension}`);
+  const parentLink = path.join(repoRoot, `link-parent.${extension}`);
+  const entrypointTarget = path.join(fixtureRoot, `outside-entry.${extension}`);
+  const entrypoint = path.join(repoRoot, `run.${extension}`);
+
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      name: "fixture-dep",
+      version: "1.0.0",
+      ...(format === "esm" ? { type: "module", main: "index.mjs" } : { main: "index.cjs" }),
+    }),
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, `index.${extension}`),
+    format === "esm" ? "export default 1;\n" : "module.exports = 1;\n",
+  );
+  try {
+    createDirectoryLinkSync(path.join(repoRoot, "node_modules"), outsideNodeModules);
+  } catch (error) {
+    if (skipIfLinkUnsupported(t, error)) {
+      return null;
+    }
+    throw error;
+  }
+  fs.writeFileSync(
+    parentTarget,
+    format === "esm" ? 'import "fixture-dep";\n' : 'require("fixture-dep");\n',
+  );
+  const parentSpecifier =
+    format === "esm" ? pathToFileURL(parentLink).href : JSON.stringify(parentLink);
+  fs.writeFileSync(
+    entrypointTarget,
+    format === "esm" ? `import ${JSON.stringify(parentSpecifier)};\n` : `require(${parentSpecifier});\n`,
+  );
+  try {
+    createFileLinkSync(parentTarget, parentLink);
+    createFileLinkSync(entrypointTarget, entrypoint);
+  } catch (error) {
+    if (skipIfLinkUnsupported(t, error)) {
+      return null;
+    }
+    throw error;
+  }
 
   return { entrypoint, fixtureRoot, repoRoot, tracePath };
 }

--- a/scripts/runtime/hooks_test.mjs
+++ b/scripts/runtime/hooks_test.mjs
@@ -35,6 +35,19 @@ test("CommonJS hook persists only sanitized artifact values", (t) => {
     events.some((event) => event.module === "" && event.resolved === ""),
     "outside-root require must be recorded without its path",
   );
+  assert.deepEqual(
+    findResolvedEvents(events, [
+      "node_modules/fixture-dep/C:/Users/alice/private.cjs",
+      "node_modules/fixture-dep/https:/secret.cjs",
+      "node_modules/fixture-dep/.env/private.cjs",
+      "node_modules/fixture-dep/~/.ssh/id_rsa.cjs",
+    ]),
+    [],
+  );
+  assert.equal(
+    events.filter((event) => event.parent === "main.cjs" && event.module === "" && event.resolved === "").length,
+    5,
+  );
 });
 
 test("ESM loader persists only sanitized artifact values", (t) => {
@@ -63,6 +76,19 @@ test("ESM loader persists only sanitized artifact values", (t) => {
     events.some((event) => event.module === "" && event.resolved === ""),
     "outside-root import must be recorded without its path",
   );
+  assert.deepEqual(
+    findResolvedEvents(events, [
+      "node_modules/fixture-dep/C:/Users/alice/private.mjs",
+      "node_modules/fixture-dep/https:/secret.mjs",
+      "node_modules/fixture-dep/.env/private.mjs",
+      "node_modules/fixture-dep/~/.ssh/id_rsa.mjs",
+    ]),
+    [],
+  );
+  assert.equal(
+    events.filter((event) => event.parent === "main.mjs" && event.module === "" && event.resolved === "").length,
+    5,
+  );
 });
 
 function createNodeFixture(t, format) {
@@ -82,21 +108,55 @@ function createNodeFixture(t, format) {
     JSON.stringify({
       name: "fixture-dep",
       version: "1.0.0",
-      ...(format === "esm"
-        ? { type: "module", exports: "./index.mjs" }
-        : { main: "index.cjs" }),
+      ...(format === "esm" ? { type: "module", main: "index.mjs" } : { main: "index.cjs" }),
     }),
   );
   fs.writeFileSync(
     path.join(packageRoot, `index.${extension}`),
     format === "esm" ? "export default 1;\n" : "module.exports = 1;\n",
   );
+  fs.mkdirSync(path.join(packageRoot, "C:", "Users", "alice"), { recursive: true });
+  fs.mkdirSync(path.join(packageRoot, "https:"), { recursive: true });
+  fs.mkdirSync(path.join(packageRoot, ".env"), { recursive: true });
+  fs.mkdirSync(path.join(packageRoot, "~", ".ssh"), { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "C:", "Users", "alice", `private.${extension}`),
+    format === "esm" ? "export default 2;\n" : "module.exports = 2;\n",
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, "https:", `secret.${extension}`),
+    format === "esm" ? "export default 3;\n" : "module.exports = 3;\n",
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, ".env", `private.${extension}`),
+    format === "esm" ? "export default 4;\n" : "module.exports = 4;\n",
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, "~", ".ssh", `id_rsa.${extension}`),
+    format === "esm" ? "export default 5;\n" : "module.exports = 5;\n",
+  );
   fs.writeFileSync(outsidePath, format === "esm" ? "export default 1;\n" : "module.exports = 1;\n");
   fs.writeFileSync(
     entrypoint,
     format === "esm"
-      ? 'import "fixture-dep";\nimport "../outside.mjs";\n'
-      : 'require("fixture-dep");\nrequire("../outside.cjs");\n',
+      ? [
+          'import "fixture-dep";',
+          'import "fixture-dep/C:/Users/alice/private.mjs";',
+          'import "fixture-dep/https:/secret.mjs";',
+          'import "fixture-dep/.env/private.mjs";',
+          'import "fixture-dep/~/.ssh/id_rsa.mjs";',
+          'import "../outside.mjs";',
+          "",
+        ].join("\n")
+      : [
+          'require("fixture-dep");',
+          'require("fixture-dep/C:/Users/alice/private.cjs");',
+          'require("fixture-dep/https:/secret.cjs");',
+          'require("fixture-dep/.env/private.cjs");',
+          'require("fixture-dep/~/.ssh/id_rsa.cjs");',
+          'require("../outside.cjs");',
+          "",
+        ].join("\n"),
   );
 
   return { entrypoint, fixtureRoot, repoRoot, tracePath };
@@ -117,6 +177,10 @@ function readEvents(tracePath) {
     .split("\n")
     .filter(Boolean)
     .map((line) => JSON.parse(line));
+}
+
+function findResolvedEvents(events, resolvedValues) {
+  return events.filter((event) => resolvedValues.includes(event.resolved));
 }
 
 function assertArtifactPrivacy(events, fixture) {

--- a/scripts/runtime/hooks_test.mjs
+++ b/scripts/runtime/hooks_test.mjs
@@ -48,6 +48,7 @@ test("CommonJS hook persists only sanitized artifact values", (t) => {
     events.filter((event) => event.parent === "main.cjs" && event.module === "" && event.resolved === "").length,
     5,
   );
+  assert.deepEqual(findModuleEvents(events, ["main.cjs", "local.cjs"]), []);
 });
 
 test("ESM loader persists only sanitized artifact values", (t) => {
@@ -89,6 +90,7 @@ test("ESM loader persists only sanitized artifact values", (t) => {
     events.filter((event) => event.parent === "main.mjs" && event.module === "" && event.resolved === "").length,
     5,
   );
+  assert.deepEqual(findModuleEvents(events, ["main.mjs", "local.mjs"]), []);
 });
 
 function createNodeFixture(t, format) {
@@ -100,6 +102,7 @@ function createNodeFixture(t, format) {
   const extension = format === "esm" ? "mjs" : "cjs";
   const entrypoint = path.join(repoRoot, `main.${extension}`);
   const outsidePath = path.join(fixtureRoot, `outside.${extension}`);
+  const localPath = path.join(repoRoot, `local.${extension}`);
   const tracePath = path.join(fixtureRoot, `${format}.ndjson`);
 
   fs.mkdirSync(packageRoot, { recursive: true });
@@ -136,10 +139,12 @@ function createNodeFixture(t, format) {
     format === "esm" ? "export default 5;\n" : "module.exports = 5;\n",
   );
   fs.writeFileSync(outsidePath, format === "esm" ? "export default 1;\n" : "module.exports = 1;\n");
+  fs.writeFileSync(localPath, format === "esm" ? "export default 6;\n" : "module.exports = 6;\n");
   fs.writeFileSync(
     entrypoint,
     format === "esm"
       ? [
+          'import "./local.mjs";',
           'import "fixture-dep";',
           'import "fixture-dep/C:/Users/alice/private.mjs";',
           'import "fixture-dep/https:/secret.mjs";',
@@ -149,6 +154,7 @@ function createNodeFixture(t, format) {
           "",
         ].join("\n")
       : [
+          'require("./local.cjs");',
           'require("fixture-dep");',
           'require("fixture-dep/C:/Users/alice/private.cjs");',
           'require("fixture-dep/https:/secret.cjs");',
@@ -181,6 +187,10 @@ function readEvents(tracePath) {
 
 function findResolvedEvents(events, resolvedValues) {
   return events.filter((event) => resolvedValues.includes(event.resolved));
+}
+
+function findModuleEvents(events, moduleValues) {
+  return events.filter((event) => moduleValues.includes(event.module));
 }
 
 function assertArtifactPrivacy(events, fixture) {

--- a/scripts/runtime/hooks_test.mjs
+++ b/scripts/runtime/hooks_test.mjs
@@ -143,6 +143,44 @@ test("runtime hooks preserve hoisted external node_modules dependencies while re
   }
 });
 
+test("runtime hooks preserve validated linked package subpaths while redacting external realpaths", (t) => {
+  for (const format of ["cjs", "esm"]) {
+    const fixture = createNodeLinkedSubpathFixture(t, format);
+    const events = captureNodeHookEvents(
+      fixture,
+      format === "cjs" ? "--require" : "--loader",
+      format === "cjs" ? "require-hook.cjs" : "loader.mjs",
+    );
+
+    assertArtifactPrivacy(events, fixture);
+    assert.ok(
+      events.some(
+        (event) =>
+          event.module === "fixture-dep/lib" &&
+          event.resolved === "" &&
+          event.parent === `main.${format === "cjs" ? "cjs" : "mjs"}` &&
+          event.entrypoint === "",
+      ),
+      `${format} hook should preserve linked bare subpath identity while redacting resolved path`,
+    );
+    assert.ok(
+      events.some(
+        (event) =>
+          event.module === "@scope/pkg/client" &&
+          event.resolved === "" &&
+          event.parent === `main.${format === "cjs" ? "cjs" : "mjs"}` &&
+          event.entrypoint === "",
+      ),
+      `${format} hook should preserve linked scoped subpath identity while redacting resolved path`,
+    );
+    assert.equal(
+      JSON.stringify(events).includes(path.join(fixture.fixtureRoot, "linked-store")),
+      false,
+      `${format} hook should not leak the linked package store path`,
+    );
+  }
+});
+
 function createNodeFixture(t, format) {
   const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), `lopper-runtime-${format}-`));
   t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
@@ -276,6 +314,69 @@ function createNodeHoistedDependencyFixture(t, format) {
   fs.writeFileSync(
     entrypoint,
     format === "esm" ? 'import "fixture-dep";\n' : 'require("fixture-dep");\n',
+  );
+
+  return { entrypoint, fixtureRoot, repoRoot, tracePath };
+}
+
+function createNodeLinkedSubpathFixture(t, format) {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), `lopper-runtime-linked-${format}-`));
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  const repoRoot = path.join(fixtureRoot, "repo");
+  const linkedStoreRoot = path.join(fixtureRoot, "linked-store");
+  const linkedNodeModules = path.join(linkedStoreRoot, "node_modules");
+  const barePackageRoot = path.join(linkedNodeModules, "fixture-dep");
+  const scopedPackageRoot = path.join(linkedNodeModules, "@scope", "pkg");
+  const extension = format === "esm" ? "mjs" : "cjs";
+  const entrypoint = path.join(repoRoot, `main.${extension}`);
+  const tracePath = path.join(fixtureRoot, `${format}.ndjson`);
+
+  fs.mkdirSync(path.join(barePackageRoot, "lib"), { recursive: true });
+  fs.mkdirSync(path.join(scopedPackageRoot, "client"), { recursive: true });
+  fs.writeFileSync(
+    path.join(barePackageRoot, "package.json"),
+    JSON.stringify({
+      name: "fixture-dep",
+      version: "1.0.0",
+      ...(format === "esm"
+        ? { type: "module", main: "index.mjs", exports: { ".": "./index.mjs", "./lib": "./lib/index.mjs" } }
+        : { main: "index.cjs", exports: { ".": "./index.cjs", "./lib": "./lib/index.cjs" } }),
+    }),
+  );
+  fs.writeFileSync(
+    path.join(scopedPackageRoot, "package.json"),
+    JSON.stringify({
+      name: "@scope/pkg",
+      version: "1.0.0",
+      ...(format === "esm"
+        ? { type: "module", main: "index.mjs", exports: { ".": "./index.mjs", "./client": "./client/index.mjs" } }
+        : { main: "index.cjs", exports: { ".": "./index.cjs", "./client": "./client/index.cjs" } }),
+    }),
+  );
+  fs.writeFileSync(
+    path.join(barePackageRoot, `index.${extension}`),
+    format === "esm" ? "export default 1;\n" : "module.exports = 1;\n",
+  );
+  fs.writeFileSync(
+    path.join(barePackageRoot, "lib", `index.${extension}`),
+    format === "esm" ? "export default 2;\n" : "module.exports = 2;\n",
+  );
+  fs.writeFileSync(
+    path.join(scopedPackageRoot, `index.${extension}`),
+    format === "esm" ? "export default 3;\n" : "module.exports = 3;\n",
+  );
+  fs.writeFileSync(
+    path.join(scopedPackageRoot, "client", `index.${extension}`),
+    format === "esm" ? "export default 4;\n" : "module.exports = 4;\n",
+  );
+  fs.mkdirSync(repoRoot, { recursive: true });
+  createDirectoryLinkSync(linkedNodeModules, path.join(repoRoot, "node_modules"));
+  fs.writeFileSync(
+    entrypoint,
+    format === "esm"
+      ? 'import "fixture-dep/lib";\nimport "@scope/pkg/client";\n'
+      : 'require("fixture-dep/lib");\nrequire("@scope/pkg/client");\n',
   );
 
   return { entrypoint, fixtureRoot, repoRoot, tracePath };

--- a/scripts/runtime/loader.mjs
+++ b/scripts/runtime/loader.mjs
@@ -2,11 +2,51 @@ import fs from "node:fs";
 import path from "node:path";
 
 const outPath = process.env.LOPPER_RUNTIME_TRACE;
+const repoRoot = normalizeRoot(process.env.LOPPER_RUNTIME_REPO_ROOT || process.cwd());
 
 function append(event) {
   if (!outPath) return;
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.appendFileSync(outPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+function normalizeRoot(value) {
+  if (!value) return "";
+  try {
+    return fs.realpathSync.native(value);
+  } catch {
+    return path.resolve(value);
+  }
+}
+
+function normalizeContext(value) {
+  if (!value || typeof value !== "string") return "";
+  if (value.startsWith("file://")) {
+    try {
+      value = new URL(value);
+      value = value.pathname;
+    } catch {
+      value = value.slice("file://".length);
+    }
+  }
+  if (!path.isAbsolute(value)) {
+    return "";
+  }
+  let resolved;
+  try {
+    resolved = fs.realpathSync.native(value);
+  } catch {
+    try {
+      resolved = path.resolve(value);
+    } catch {
+      return "";
+    }
+  }
+  const rel = path.relative(repoRoot, resolved);
+  if (!rel || rel === ".." || rel.startsWith(`..${path.sep}`)) {
+    return "";
+  }
+  return rel.split(path.sep).join("/");
 }
 
 export async function resolve(specifier, context, nextResolve) {
@@ -15,8 +55,8 @@ export async function resolve(specifier, context, nextResolve) {
     kind: "resolve",
     module: specifier,
     resolved: resolved.url || "",
-    parent: context.parentURL || "",
-    entrypoint: context.parentURL ? "" : resolved.url || "",
+    parent: normalizeContext(context.parentURL || ""),
+    entrypoint: context.parentURL ? "" : normalizeContext(resolved.url || ""),
   });
   return resolved;
 }

--- a/scripts/runtime/loader.mjs
+++ b/scripts/runtime/loader.mjs
@@ -2,16 +2,18 @@ import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 const { createRuntimeTraceHelpers } = require("./context-helper.cjs");
-const { append, normalizeContext } = createRuntimeTraceHelpers(process.env);
+const { append, normalizeContext, normalizeModule, normalizeResolved } =
+  createRuntimeTraceHelpers(process.env);
 
 export async function resolve(specifier, context, nextResolve) {
   const resolved = await nextResolve(specifier, context);
+  const rawResolved = resolved.url || "";
   append({
     kind: "resolve",
-    module: specifier,
-    resolved: resolved.url || "",
+    module: normalizeModule(specifier, rawResolved),
+    resolved: normalizeResolved(rawResolved),
     parent: normalizeContext(context.parentURL || ""),
-    entrypoint: context.parentURL ? "" : normalizeContext(resolved.url || ""),
+    entrypoint: context.parentURL ? "" : normalizeContext(rawResolved),
   });
   return resolved;
 }

--- a/scripts/runtime/loader.mjs
+++ b/scripts/runtime/loader.mjs
@@ -1,53 +1,8 @@
-import fs from "node:fs";
-import path from "node:path";
+import { createRequire } from "node:module";
 
-const outPath = process.env.LOPPER_RUNTIME_TRACE;
-const repoRoot = normalizeRoot(process.env.LOPPER_RUNTIME_REPO_ROOT || process.cwd());
-
-function append(event) {
-  if (!outPath) return;
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.appendFileSync(outPath, `${JSON.stringify(event)}\n`, "utf8");
-}
-
-function normalizeRoot(value) {
-  if (!value) return "";
-  try {
-    return fs.realpathSync.native(value);
-  } catch {
-    return path.resolve(value);
-  }
-}
-
-function normalizeContext(value) {
-  if (!value || typeof value !== "string") return "";
-  if (value.startsWith("file://")) {
-    try {
-      value = new URL(value);
-      value = value.pathname;
-    } catch {
-      value = value.slice("file://".length);
-    }
-  }
-  if (!path.isAbsolute(value)) {
-    return "";
-  }
-  let resolved;
-  try {
-    resolved = fs.realpathSync.native(value);
-  } catch {
-    try {
-      resolved = path.resolve(value);
-    } catch {
-      return "";
-    }
-  }
-  const rel = path.relative(repoRoot, resolved);
-  if (!rel || rel === ".." || rel.startsWith(`..${path.sep}`)) {
-    return "";
-  }
-  return rel.split(path.sep).join("/");
-}
+const require = createRequire(import.meta.url);
+const { createRuntimeTraceHelpers } = require("./context-helper.cjs");
+const { append, normalizeContext } = createRuntimeTraceHelpers(process.env);
 
 export async function resolve(specifier, context, nextResolve) {
   const resolved = await nextResolve(specifier, context);

--- a/scripts/runtime/require-hook.cjs
+++ b/scripts/runtime/require-hook.cjs
@@ -1,23 +1,24 @@
 const Module = require("node:module");
 const { createRuntimeTraceHelpers } = require("./context-helper.cjs");
 
-const { append, normalizeContext } = createRuntimeTraceHelpers(process.env);
+const { append, normalizeContext, normalizeModule, normalizeResolved } =
+  createRuntimeTraceHelpers(process.env);
 
 const originalLoad = Module._load;
 Module._load = function patchedLoad(request, parent, isMain) {
   const loaded = originalLoad.apply(this, arguments);
-  let resolved = "";
+  let rawResolved = "";
   try {
-    resolved = Module._resolveFilename(request, parent);
+    rawResolved = Module._resolveFilename(request, parent);
   } catch {
-    resolved = "";
+    rawResolved = "";
   }
   append({
     kind: "require",
-    module: request,
-    resolved,
+    module: normalizeModule(request, rawResolved),
+    resolved: normalizeResolved(rawResolved),
     parent: normalizeContext(parent?.filename ?? ""),
-    entrypoint: isMain ? normalizeContext(resolved || "") : "",
+    entrypoint: isMain ? normalizeContext(rawResolved) : "",
     isMain: Boolean(isMain),
   });
   return loaded;

--- a/scripts/runtime/require-hook.cjs
+++ b/scripts/runtime/require-hook.cjs
@@ -3,12 +3,53 @@ const path = require("node:path");
 const Module = require("node:module");
 
 const outPath = process.env.LOPPER_RUNTIME_TRACE;
+const repoRoot = normalizeRoot(process.env.LOPPER_RUNTIME_REPO_ROOT || process.cwd());
 
 function append(event) {
   if (!outPath) return;
   const payload = JSON.stringify(event) + "\n";
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.appendFileSync(outPath, payload, "utf8");
+}
+
+function normalizeRoot(value) {
+  if (!value) return "";
+  try {
+    return fs.realpathSync.native(value);
+  } catch {
+    return path.resolve(value);
+  }
+}
+
+function normalizeContext(value) {
+  if (!value) return "";
+  if (typeof value !== "string") return "";
+  if (value.startsWith("file://")) {
+    try {
+      value = new URL(value);
+      value = value.pathname;
+    } catch {
+      value = value.slice("file://".length);
+    }
+  }
+  if (!path.isAbsolute(value)) {
+    return "";
+  }
+  let resolved;
+  try {
+    resolved = fs.realpathSync.native(value);
+  } catch {
+    try {
+      resolved = path.resolve(value);
+    } catch {
+      return "";
+    }
+  }
+  const rel = path.relative(repoRoot, resolved);
+  if (!rel || rel === ".." || rel.startsWith(`..${path.sep}`)) {
+    return "";
+  }
+  return rel.split(path.sep).join("/");
 }
 
 const originalLoad = Module._load;
@@ -24,8 +65,8 @@ Module._load = function patchedLoad(request, parent, isMain) {
     kind: "require",
     module: request,
     resolved,
-    parent: parent?.filename ?? "",
-    entrypoint: isMain ? resolved || request : "",
+    parent: normalizeContext(parent?.filename ?? ""),
+    entrypoint: isMain ? normalizeContext(resolved || "") : "",
     isMain: Boolean(isMain),
   });
   return loaded;

--- a/scripts/runtime/require-hook.cjs
+++ b/scripts/runtime/require-hook.cjs
@@ -1,56 +1,7 @@
-const fs = require("node:fs");
-const path = require("node:path");
 const Module = require("node:module");
+const { createRuntimeTraceHelpers } = require("./context-helper.cjs");
 
-const outPath = process.env.LOPPER_RUNTIME_TRACE;
-const repoRoot = normalizeRoot(process.env.LOPPER_RUNTIME_REPO_ROOT || process.cwd());
-
-function append(event) {
-  if (!outPath) return;
-  const payload = JSON.stringify(event) + "\n";
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.appendFileSync(outPath, payload, "utf8");
-}
-
-function normalizeRoot(value) {
-  if (!value) return "";
-  try {
-    return fs.realpathSync.native(value);
-  } catch {
-    return path.resolve(value);
-  }
-}
-
-function normalizeContext(value) {
-  if (!value) return "";
-  if (typeof value !== "string") return "";
-  if (value.startsWith("file://")) {
-    try {
-      value = new URL(value);
-      value = value.pathname;
-    } catch {
-      value = value.slice("file://".length);
-    }
-  }
-  if (!path.isAbsolute(value)) {
-    return "";
-  }
-  let resolved;
-  try {
-    resolved = fs.realpathSync.native(value);
-  } catch {
-    try {
-      resolved = path.resolve(value);
-    } catch {
-      return "";
-    }
-  }
-  const rel = path.relative(repoRoot, resolved);
-  if (!rel || rel === ".." || rel.startsWith(`..${path.sep}`)) {
-    return "";
-  }
-  return rel.split(path.sep).join("/");
-}
+const { append, normalizeContext } = createRuntimeTraceHelpers(process.env);
 
 const originalLoad = Module._load;
 Module._load = function patchedLoad(request, parent, isMain) {

--- a/scripts/runtime/sitecustomize.py
+++ b/scripts/runtime/sitecustomize.py
@@ -54,7 +54,7 @@ def _caller_frame():
 
 
 def _record_import(name: str, caller) -> None:
-    module_name = (name or "").strip()
+    module_name = _module_identifier(name)
     if not module_name:
         return
     module = sys.modules.get(module_name)
@@ -69,9 +69,9 @@ def _record_import(name: str, caller) -> None:
 
     event = {
         "language": "python",
-        "dependency": _dependency_for_module(module_name),
+        "dependency": _dependency_identifier(_dependency_for_module(module_name)),
         "module": module_name,
-        "resolved": _abs_path(resolved),
+        "resolved": module_name,
         "parent": _parent_from_frame(caller),
         "entrypoint": ENTRYPOINT,
         "kind": "import",
@@ -102,6 +102,25 @@ def _dependency_for_module(module_name: str) -> str:
     return top_level
 
 
+def _module_identifier(value: str) -> str:
+    candidate = (value or "").strip()
+    if not candidate:
+        return ""
+    parts = candidate.split(".")
+    if any(not part or not part.isidentifier() for part in parts):
+        return ""
+    return ".".join(parts)
+
+
+def _dependency_identifier(value: str) -> str:
+    candidate = (value or "").strip()
+    if candidate in {"", ".", ".."}:
+        return ""
+    if any(not (character.isalnum() or character in "._-") for character in candidate):
+        return ""
+    return candidate
+
+
 def _package_distributions():
     global PACKAGE_DISTRIBUTIONS
     if PACKAGE_DISTRIBUTIONS is not None:
@@ -123,7 +142,7 @@ def _parent_from_frame(frame) -> str:
     if filename:
         return _normalize_repo_context(str(filename))
     module_name = frame.f_globals.get("__name__", "")
-    return str(module_name or "")
+    return _module_identifier(str(module_name or ""))
 
 
 def _append_event(event) -> None:
@@ -167,6 +186,8 @@ def _normalize_repo_context(path: str) -> str:
         return ""
     if not REPO_ROOT:
         return ""
+    if _rejects_non_native_path(candidate):
+        return ""
     try:
         root = _real_path(REPO_ROOT)
         resolved = _real_path(candidate)
@@ -176,6 +197,40 @@ def _normalize_repo_context(path: str) -> str:
     if relative in {".", ".."} or relative.startswith(".." + os.sep):
         return ""
     return relative.replace(os.sep, "/")
+
+
+def _rejects_non_native_path(value: str) -> bool:
+    if "\0" in value:
+        return True
+    if _has_path_scheme(value) and not _is_native_windows_absolute(value):
+        return True
+    if os.name != "nt" and (_is_windows_absolute(value) or _has_unc_prefix(value)):
+        return True
+    return os.name != "nt" and "\\" in value
+
+
+def _has_path_scheme(value: str) -> bool:
+    separator = value.find(":")
+    if separator <= 0 or not value[0].isalpha():
+        return False
+    return all(character.isalnum() or character in "+.-" for character in value[1:separator])
+
+
+def _is_native_windows_absolute(value: str) -> bool:
+    return os.name == "nt" and (_is_windows_absolute(value) or _has_unc_prefix(value))
+
+
+def _is_windows_absolute(value: str) -> bool:
+    return (
+        len(value) >= 3
+        and value[0].isalpha()
+        and value[1] == ":"
+        and value[2] in "\\/"
+    )
+
+
+def _has_unc_prefix(value: str) -> bool:
+    return len(value) >= 2 and value[0] in "\\/" and value[1] in "\\/"
 
 
 def _chain_project_sitecustomize() -> None:

--- a/scripts/runtime/sitecustomize.py
+++ b/scripts/runtime/sitecustomize.py
@@ -23,6 +23,7 @@ SITE_MARKERS = ("/site-packages/", "/dist-packages/")
 WRITE_LOCK = threading.Lock()
 STATE = threading.local()
 PACKAGE_DISTRIBUTIONS = None
+TRUSTED_REPO_ROOTS = ()
 
 
 def _entrypoint() -> str:
@@ -180,21 +181,64 @@ def _slash_path(path: str) -> str:
     return _abs_path(path).replace(os.sep, "/")
 
 
+def _lexical_path(path: str) -> str:
+    if not path:
+        return ""
+    try:
+        return os.path.normcase(os.path.normpath(os.path.abspath(path)))
+    except Exception:
+        return ""
+
+
+def _lexical_candidate_path(path: str, repo_root: str) -> str:
+    if not path:
+        return ""
+    if os.path.isabs(path) or _is_native_windows_absolute(path):
+        return _lexical_path(path)
+    return _lexical_path(os.path.join(repo_root, path))
+
+
+def _trusted_repo_roots(repo_root: str):
+    original = _lexical_path(repo_root)
+    if not original:
+        return ()
+    try:
+        resolved = _real_path(original)
+    except Exception:
+        resolved = ""
+    return tuple(dict.fromkeys(root for root in (original, resolved) if root))
+
+
+def _repo_relative_under_trusted_roots(path: str) -> str:
+    for root in TRUSTED_REPO_ROOTS:
+        try:
+            relative = os.path.relpath(path, root)
+        except (OSError, ValueError):
+            continue
+        if not _repo_relative_starts_outside(relative):
+            return relative
+    return ""
+
+
 def _normalize_repo_context(path: str) -> str:
     candidate = (path or "").strip()
     if not candidate:
         return ""
-    if not REPO_ROOT:
+    if not TRUSTED_REPO_ROOTS:
         return ""
     if _rejects_non_native_path(candidate):
         return ""
+    lexical_candidate = _lexical_candidate_path(candidate, TRUSTED_REPO_ROOTS[0])
+    if not lexical_candidate:
+        return ""
+    if not _repo_relative_under_trusted_roots(lexical_candidate):
+        return ""
     try:
-        root = _real_path(REPO_ROOT)
-        resolved = _real_path(candidate)
-        relative = os.path.relpath(resolved, root)
+        resolved = _real_path(lexical_candidate)
     except Exception:
         return ""
-    if relative in {".", ".."} or relative.startswith(".." + os.sep):
+    relative = _repo_relative_under_trusted_roots(resolved)
+    if not relative:
         return ""
     return relative.replace(os.sep, "/")
 
@@ -233,6 +277,10 @@ def _has_unc_prefix(value: str) -> bool:
     return len(value) >= 2 and value[0] in "\\/" and value[1] in "\\/"
 
 
+def _repo_relative_starts_outside(value: str) -> bool:
+    return value in {".", ".."} or value.startswith(".." + os.sep)
+
+
 def _chain_project_sitecustomize() -> None:
     hook_dir = _real_path(os.path.dirname(__file__))
     search_path = [entry for entry in sys.path if _real_path(entry) != hook_dir]
@@ -248,6 +296,9 @@ def _chain_project_sitecustomize() -> None:
 def _real_path(path: str) -> str:
     candidate = path or os.getcwd()
     return os.path.normcase(os.path.realpath(os.path.abspath(candidate)))
+
+
+TRUSTED_REPO_ROOTS = _trusted_repo_roots(REPO_ROOT)
 
 
 if TRACE_PATH:

--- a/scripts/runtime/sitecustomize.py
+++ b/scripts/runtime/sitecustomize.py
@@ -240,7 +240,14 @@ def _normalize_repo_context(path: str) -> str:
     relative = _repo_relative_under_trusted_roots(resolved)
     if not relative:
         return ""
-    return relative.replace(os.sep, "/")
+    normalized = relative.replace(os.sep, "/")
+    if _has_control_whitespace(normalized):
+        return ""
+    return normalized
+
+
+def _has_control_whitespace(value: str) -> bool:
+    return any(character in value for character in "\n\r\t")
 
 
 def _rejects_non_native_path(value: str) -> bool:

--- a/scripts/runtime/sitecustomize.py
+++ b/scripts/runtime/sitecustomize.py
@@ -17,6 +17,7 @@ except Exception:
 
 
 TRACE_PATH = os.environ.get("LOPPER_RUNTIME_TRACE", "").strip()
+REPO_ROOT = os.environ.get("LOPPER_RUNTIME_REPO_ROOT", "").strip()
 ORIGINAL_IMPORT = builtins.__import__
 SITE_MARKERS = ("/site-packages/", "/dist-packages/")
 WRITE_LOCK = threading.Lock()
@@ -30,7 +31,7 @@ def _entrypoint() -> str:
     entry = sys.argv[0]
     if not entry:
         return ""
-    return _abs_path(entry)
+    return _normalize_repo_context(entry)
 
 
 def _patched_import(name, globals=None, locals=None, fromlist=(), level=0):
@@ -120,7 +121,7 @@ def _parent_from_frame(frame) -> str:
         return ""
     filename = frame.f_globals.get("__file__", "")
     if filename:
-        return _abs_path(str(filename))
+        return _normalize_repo_context(str(filename))
     module_name = frame.f_globals.get("__name__", "")
     return str(module_name or "")
 
@@ -158,6 +159,23 @@ def _abs_path(path: str) -> str:
 
 def _slash_path(path: str) -> str:
     return _abs_path(path).replace(os.sep, "/")
+
+
+def _normalize_repo_context(path: str) -> str:
+    candidate = (path or "").strip()
+    if not candidate:
+        return ""
+    if not REPO_ROOT:
+        return ""
+    try:
+        root = _real_path(REPO_ROOT)
+        resolved = _real_path(candidate)
+        relative = os.path.relpath(resolved, root)
+    except Exception:
+        return ""
+    if relative in {".", ".."} or relative.startswith(".." + os.sep):
+        return ""
+    return relative.replace(os.sep, "/")
 
 
 def _chain_project_sitecustomize() -> None:

--- a/scripts/runtime/sitecustomize_test.py
+++ b/scripts/runtime/sitecustomize_test.py
@@ -209,6 +209,68 @@ class SitecustomizeArtifactPrivacyTest(unittest.TestCase):
             self.assertEqual(module._normalize_repo_context(str(entrypoint)), "main.py")
             self.assertGreaterEqual(len(calls), 2)
 
+    @unittest.skipIf(os.name == "nt", "Windows does not support control whitespace in filenames")
+    def test_redacts_control_whitespace_from_context_helpers_and_import_events(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="lopper-runtime-python-controls-") as fixture:
+            fixture_root = Path(fixture)
+            repo_root = fixture_root / "repo"
+            site_packages = fixture_root / "python" / "site-packages"
+            package_root = site_packages / "thirdparty"
+            package_root.mkdir(parents=True)
+            repo_root.mkdir()
+            (package_root / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+            module_name, module = load_sitecustomize_module(repo_root)
+            self.addCleanup(sys.modules.pop, module_name, None)
+
+            safe_path = repo_root / "hello world-\u4e16\u754c.py"
+            safe_path.write_text("print('ok')\n", encoding="utf-8")
+            self.assertEqual(
+                module._normalize_repo_context(str(safe_path)),
+                "hello world-\u4e16\u754c.py",
+            )
+
+            cases = (
+                ("newline", "\n"),
+                ("carriage return", "\r"),
+                ("tab", "\t"),
+            )
+            for name, character in cases:
+                with self.subTest(name=name):
+                    entrypoint = repo_root / f"main{character}context.py"
+                    trace_path = fixture_root / f"{name.replace(' ', '-')}.ndjson"
+                    entrypoint.write_text("import thirdparty\n", encoding="utf-8")
+                    self.assertEqual(module._normalize_repo_context(str(entrypoint)), "")
+
+                    env = os.environ.copy()
+                    env.pop("PYTHONHOME", None)
+                    env["LOPPER_RUNTIME_REPO_ROOT"] = str(repo_root)
+                    env["LOPPER_RUNTIME_TRACE"] = str(trace_path)
+                    env["PYTHONDONTWRITEBYTECODE"] = "1"
+                    env["PYTHONPATH"] = os.pathsep.join((str(HOOK_DIR), str(site_packages)))
+                    subprocess.run(
+                        [sys.executable, str(entrypoint)],
+                        cwd=repo_root,
+                        env=env,
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                    )
+
+                    artifact = trace_path.read_text(encoding="utf-8")
+                    escaped_filename = json.dumps(entrypoint.name)[1:-1]
+                    self.assertNotIn(escaped_filename, artifact)
+                    events = [
+                        json.loads(line)
+                        for line in artifact.splitlines()
+                        if line.strip()
+                    ]
+                    event = next(item for item in events if item.get("module") == "thirdparty")
+                    self.assertEqual(event["parent"], "")
+                    self.assertEqual(event["entrypoint"], "")
+                    for field in ("parent", "entrypoint"):
+                        self.assertFalse(any(control in event[field] for control in "\n\r\t"))
+
     def test_symlinked_repo_root_trust_is_stable_and_escape_safe(self) -> None:
         with tempfile.TemporaryDirectory(prefix="lopper-runtime-python-") as fixture:
             fixture_root = Path(fixture)

--- a/scripts/runtime/sitecustomize_test.py
+++ b/scripts/runtime/sitecustomize_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -9,12 +10,125 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import uuid
 
 
 HOOK_DIR = Path(__file__).resolve().parent
 
 
+def load_sitecustomize_module(repo_root: Path):
+    module_name = f"sitecustomize_test_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, HOOK_DIR / "sitecustomize.py")
+    if spec is None or spec.loader is None:
+        raise RuntimeError("load sitecustomize spec")
+
+    old_trace = os.environ.get("LOPPER_RUNTIME_TRACE")
+    old_repo_root = os.environ.get("LOPPER_RUNTIME_REPO_ROOT")
+    os.environ.pop("LOPPER_RUNTIME_TRACE", None)
+    os.environ["LOPPER_RUNTIME_REPO_ROOT"] = str(repo_root)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if old_trace is None:
+            os.environ.pop("LOPPER_RUNTIME_TRACE", None)
+        else:
+            os.environ["LOPPER_RUNTIME_TRACE"] = old_trace
+        if old_repo_root is None:
+            os.environ.pop("LOPPER_RUNTIME_REPO_ROOT", None)
+        else:
+            os.environ["LOPPER_RUNTIME_REPO_ROOT"] = old_repo_root
+    return module_name, module
+
+
 class SitecustomizeArtifactPrivacyTest(unittest.TestCase):
+    def test_normalize_repo_context_rejects_hostile_paths_before_realpath(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="lopper-runtime-python-") as fixture:
+            fixture_root = Path(fixture)
+            repo_root = fixture_root / "repo"
+            repo_root.mkdir()
+            module_name, module = load_sitecustomize_module(repo_root)
+            self.addCleanup(sys.modules.pop, module_name, None)
+
+            calls: list[str] = []
+
+            def fail_real_path(path: str) -> str:
+                calls.append(path)
+                raise AssertionError(f"_real_path should not be called for hostile input: {path}")
+
+            module._real_path = fail_real_path
+            for value in (
+                str(fixture_root / "private.py"),
+                str(repo_root / ".." / "private.py"),
+                "../private.py",
+            ):
+                self.assertEqual(module._normalize_repo_context(value), "")
+            self.assertEqual(calls, [])
+
+    def test_normalize_repo_context_realpaths_trusted_repo_local_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="lopper-runtime-python-") as fixture:
+            fixture_root = Path(fixture)
+            repo_root = fixture_root / "repo"
+            entrypoint = repo_root / "main.py"
+            repo_root.mkdir()
+            entrypoint.write_text("print('ok')\n", encoding="utf-8")
+
+            module_name, module = load_sitecustomize_module(repo_root)
+            self.addCleanup(sys.modules.pop, module_name, None)
+
+            original_real_path = module._real_path
+            calls: list[str] = []
+
+            def track_real_path(path: str) -> str:
+                calls.append(path)
+                return original_real_path(path)
+
+            module._real_path = track_real_path
+            cwd = os.getcwd()
+            try:
+                os.chdir(repo_root)
+                self.assertEqual(module._normalize_repo_context("main.py"), "main.py")
+            finally:
+                os.chdir(cwd)
+            self.assertEqual(module._normalize_repo_context(str(entrypoint)), "main.py")
+            self.assertGreaterEqual(len(calls), 2)
+
+    def test_symlinked_repo_root_trust_is_stable_and_escape_safe(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="lopper-runtime-python-") as fixture:
+            fixture_root = Path(fixture)
+            repo_root = fixture_root / "repo-real"
+            alias_root = fixture_root / "repo-alias"
+            outside_root = fixture_root / "outside"
+            entrypoint = repo_root / "src" / "main.py"
+            escaped_target = outside_root / "private.py"
+            escaped_link = repo_root / "src" / "escaped.py"
+
+            entrypoint.parent.mkdir(parents=True)
+            outside_root.mkdir()
+            entrypoint.write_text("print('ok')\n", encoding="utf-8")
+            escaped_target.write_text("print('private')\n", encoding="utf-8")
+            alias_root.symlink_to(repo_root, target_is_directory=True)
+            escaped_link.symlink_to(escaped_target)
+
+            module_name, module = load_sitecustomize_module(alias_root)
+            self.addCleanup(sys.modules.pop, module_name, None)
+
+            self.assertEqual(
+                module._normalize_repo_context(os.path.realpath(entrypoint)),
+                "src/main.py",
+            )
+            self.assertEqual(
+                module._normalize_repo_context(str(alias_root / "src" / "main.py")),
+                "src/main.py",
+            )
+            self.assertEqual(module._normalize_repo_context(str(escaped_link)), "")
+
+            alias_root.unlink()
+            alias_root.symlink_to(outside_root, target_is_directory=True)
+            self.assertEqual(module._normalize_repo_context(str(alias_root / "private.py")), "")
+
     def test_persists_module_identifiers_without_host_paths(self) -> None:
         with tempfile.TemporaryDirectory(prefix="lopper-runtime-python-") as fixture:
             fixture_root = Path(fixture)

--- a/scripts/runtime/sitecustomize_test.py
+++ b/scripts/runtime/sitecustomize_test.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import errno
 import subprocess
 import sys
 import tempfile
@@ -14,6 +15,53 @@ import uuid
 
 
 HOOK_DIR = Path(__file__).resolve().parent
+
+
+def _is_skippable_symlink_error(error: OSError) -> bool:
+    return error.errno in {errno.EPERM, errno.EACCES} or getattr(error, "winerror", None) == 1314
+
+
+def _create_windows_directory_junction(link_path: Path, target_path: Path) -> None:
+    result = subprocess.run(
+        ["cmd.exe", "/d", "/c", "mklink", "/J", str(link_path), str(target_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        stdout = (result.stdout or "").strip()
+        detail = stderr or stdout or f"exit status {result.returncode}"
+        raise OSError(f"failed to create junction {link_path} -> {target_path}: {detail}")
+
+
+def _remove_directory_alias(link_path: Path) -> None:
+    if os.name == "nt":
+        result = subprocess.run(
+            ["cmd.exe", "/d", "/c", "rmdir", str(link_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            stdout = (result.stdout or "").strip()
+            detail = stderr or stdout or f"exit status {result.returncode}"
+            raise OSError(f"failed to remove directory alias {link_path}: {detail}")
+        return
+    link_path.unlink()
+
+
+def _create_test_symlink(test_case: unittest.TestCase, link_path: Path, target_path: Path, *, is_dir: bool = False) -> None:
+    if is_dir and os.name == "nt":
+        _create_windows_directory_junction(link_path, target_path)
+        return
+    try:
+        link_path.symlink_to(target_path, target_is_directory=is_dir)
+    except OSError as error:
+        if _is_skippable_symlink_error(error):
+            test_case.skipTest("symlink creation requires elevated privileges or Developer Mode on this platform")
+        raise
 
 
 def load_sitecustomize_module(repo_root: Path):
@@ -44,6 +92,72 @@ def load_sitecustomize_module(repo_root: Path):
 
 
 class SitecustomizeArtifactPrivacyTest(unittest.TestCase):
+    def test_create_windows_directory_junction_uses_safe_argv(self) -> None:
+        if os.name != "nt":
+            self.skipTest("Windows-only junction coverage")
+
+        captured: dict[str, object] = {}
+        original_run = subprocess.run
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+            class Result:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return Result()
+
+        subprocess.run = fake_run
+        try:
+            _create_windows_directory_junction(Path(r"C:\repo-alias"), Path(r"C:\repo-real"))
+        finally:
+            subprocess.run = original_run
+
+        self.assertEqual(
+            captured["args"],
+            ["cmd.exe", "/d", "/c", "mklink", "/J", r"C:\repo-alias", r"C:\repo-real"],
+        )
+        self.assertEqual(
+            captured["kwargs"],
+            {"capture_output": True, "text": True, "check": False},
+        )
+
+    def test_remove_directory_alias_uses_safe_argv(self) -> None:
+        if os.name != "nt":
+            self.skipTest("Windows-only junction coverage")
+
+        captured: dict[str, object] = {}
+        original_run = subprocess.run
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+            class Result:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return Result()
+
+        subprocess.run = fake_run
+        try:
+            _remove_directory_alias(Path(r"C:\repo-alias"))
+        finally:
+            subprocess.run = original_run
+
+        self.assertEqual(
+            captured["args"],
+            ["cmd.exe", "/d", "/c", "rmdir", r"C:\repo-alias"],
+        )
+        self.assertEqual(
+            captured["kwargs"],
+            {"capture_output": True, "text": True, "check": False},
+        )
+
     def test_normalize_repo_context_rejects_hostile_paths_before_realpath(self) -> None:
         with tempfile.TemporaryDirectory(prefix="lopper-runtime-python-") as fixture:
             fixture_root = Path(fixture)
@@ -109,8 +223,8 @@ class SitecustomizeArtifactPrivacyTest(unittest.TestCase):
             outside_root.mkdir()
             entrypoint.write_text("print('ok')\n", encoding="utf-8")
             escaped_target.write_text("print('private')\n", encoding="utf-8")
-            alias_root.symlink_to(repo_root, target_is_directory=True)
-            escaped_link.symlink_to(escaped_target)
+            _create_test_symlink(self, alias_root, repo_root, is_dir=True)
+            _create_test_symlink(self, escaped_link, escaped_target)
 
             module_name, module = load_sitecustomize_module(alias_root)
             self.addCleanup(sys.modules.pop, module_name, None)
@@ -125,8 +239,8 @@ class SitecustomizeArtifactPrivacyTest(unittest.TestCase):
             )
             self.assertEqual(module._normalize_repo_context(str(escaped_link)), "")
 
-            alias_root.unlink()
-            alias_root.symlink_to(outside_root, target_is_directory=True)
+            _remove_directory_alias(alias_root)
+            _create_test_symlink(self, alias_root, outside_root, is_dir=True)
             self.assertEqual(module._normalize_repo_context(str(alias_root / "private.py")), "")
 
     def test_persists_module_identifiers_without_host_paths(self) -> None:

--- a/scripts/runtime/sitecustomize_test.py
+++ b/scripts/runtime/sitecustomize_test.py
@@ -1,0 +1,71 @@
+"""Artifact-level regression tests for the Python runtime import hook."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+HOOK_DIR = Path(__file__).resolve().parent
+
+
+class SitecustomizeArtifactPrivacyTest(unittest.TestCase):
+    def test_persists_module_identifiers_without_host_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="lopper-runtime-python-") as fixture:
+            fixture_root = Path(fixture)
+            repo_root = fixture_root / "repo"
+            site_packages = fixture_root / "python" / "site-packages"
+            package_root = site_packages / "thirdparty"
+            trace_path = fixture_root / "python.ndjson"
+            entrypoint = repo_root / "main.py"
+
+            package_root.mkdir(parents=True)
+            repo_root.mkdir()
+            (package_root / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+            entrypoint.write_text("import thirdparty\n", encoding="utf-8")
+
+            env = os.environ.copy()
+            env.pop("PYTHONHOME", None)
+            env["LOPPER_RUNTIME_REPO_ROOT"] = str(repo_root)
+            env["LOPPER_RUNTIME_TRACE"] = str(trace_path)
+            env["PYTHONPATH"] = os.pathsep.join((str(HOOK_DIR), str(site_packages)))
+            subprocess.run(
+                [sys.executable, str(entrypoint)],
+                cwd=repo_root,
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            events = [
+                json.loads(line)
+                for line in trace_path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            self.assertTrue(events)
+            artifact = json.dumps(events, sort_keys=True)
+            for forbidden in (
+                str(fixture_root),
+                str(repo_root),
+                str(site_packages),
+                str(HOOK_DIR),
+                "site-packages",
+                "file://",
+            ):
+                self.assertNotIn(forbidden, artifact)
+
+            event = next(item for item in events if item.get("module") == "thirdparty")
+            self.assertEqual(event["language"], "python")
+            self.assertEqual(event["dependency"], "thirdparty")
+            self.assertEqual(event["resolved"], "thirdparty")
+            self.assertEqual(event["entrypoint"], "main.py")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/runtime/test-link-helpers.mjs
+++ b/scripts/runtime/test-link-helpers.mjs
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const FILE_SYMLINK_CAPABILITY = Symbol("file-symlink-capability");
+
+function isSkippableSymlinkError(error) {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  return error.code === "EPERM" || error.code === "EACCES";
+}
+
+function createSkipError(kind, error) {
+  const reason =
+    process.platform === "win32"
+      ? `${kind} links require symlink privileges or Developer Mode on Windows`
+      : `unable to create ${kind} link in test fixture`;
+  const skipError = new Error(reason);
+  skipError.code = "ERR_TEST_SKIP";
+  skipError.cause = error;
+  return skipError;
+}
+
+function createDirectoryLinkSync(targetPath, linkPath) {
+  fs.symlinkSync(targetPath, linkPath, process.platform === "win32" ? "junction" : "dir");
+}
+
+function canCreateFileSymlink() {
+  if (canCreateFileSymlink[FILE_SYMLINK_CAPABILITY] !== undefined) {
+    return canCreateFileSymlink[FILE_SYMLINK_CAPABILITY];
+  }
+
+  const probeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "lopper-file-symlink-"));
+  const targetPath = path.join(probeRoot, "target.txt");
+  const linkPath = path.join(probeRoot, "link.txt");
+  try {
+    fs.writeFileSync(targetPath, "ok\n", "utf8");
+    fs.symlinkSync(targetPath, linkPath);
+    canCreateFileSymlink[FILE_SYMLINK_CAPABILITY] = true;
+  } catch (error) {
+    if (isSkippableSymlinkError(error)) {
+      canCreateFileSymlink[FILE_SYMLINK_CAPABILITY] = false;
+    } else {
+      throw error;
+    }
+  } finally {
+    fs.rmSync(probeRoot, { recursive: true, force: true });
+  }
+
+  return canCreateFileSymlink[FILE_SYMLINK_CAPABILITY];
+}
+
+function createFileLinkSync(targetPath, linkPath) {
+  if (!canCreateFileSymlink()) {
+    throw createSkipError("file", Object.assign(new Error("file symlink unsupported"), { code: "EPERM" }));
+  }
+  try {
+    fs.symlinkSync(targetPath, linkPath);
+  } catch (error) {
+    if (isSkippableSymlinkError(error)) {
+      throw createSkipError("file", error);
+    }
+    throw error;
+  }
+}
+
+function removeDirectoryLinkSync(linkPath) {
+  if (process.platform === "win32") {
+    fs.rmdirSync(linkPath);
+    return;
+  }
+  fs.unlinkSync(linkPath);
+}
+
+function skipIfLinkUnsupported(t, error) {
+  if (error?.code === "ERR_TEST_SKIP") {
+    t.skip(error.message);
+    return true;
+  }
+  return false;
+}
+
+export { createDirectoryLinkSync, createFileLinkSync, removeDirectoryLinkSync, skipIfLinkUnsupported };

--- a/scripts/runtime/test-link-helpers_test.mjs
+++ b/scripts/runtime/test-link-helpers_test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+function createHelpersImportHref(baseUrl = import.meta.url, caseId = `${Date.now()}-${Math.random()}`) {
+  const helperUrl = new URL("./test-link-helpers.mjs", baseUrl);
+  helperUrl.searchParams.set("case", caseId);
+  return helperUrl.href;
+}
+
+async function loadHelpers(baseUrl = import.meta.url, caseId) {
+  return import(createHelpersImportHref(baseUrl, caseId));
+}
+
+test("createDirectoryLinkSync surfaces Windows junction privilege failures", async (t) => {
+  if (process.platform !== "win32") {
+    t.skip("Windows-only junction failure coverage");
+  }
+
+  const originalSymlinkSync = fs.symlinkSync;
+  const error = Object.assign(new Error("privilege missing"), { code: "EPERM" });
+  fs.symlinkSync = () => {
+    throw error;
+  };
+  t.after(() => {
+    fs.symlinkSync = originalSymlinkSync;
+  });
+
+  const { createDirectoryLinkSync } = await loadHelpers();
+  assert.throws(() => createDirectoryLinkSync("target", "link"), (caught) => caught === error);
+});
+
+test("createFileLinkSync preserves skip semantics for file symlink privilege failures", async (t) => {
+  const originalSymlinkSync = fs.symlinkSync;
+  const originalWriteFileSync = fs.writeFileSync;
+  const originalMkdtempSync = fs.mkdtempSync;
+  const originalRmSync = fs.rmSync;
+  const error = Object.assign(new Error("privilege missing"), { code: "EPERM" });
+
+  fs.mkdtempSync = () => "/tmp/lopper-file-symlink-probe";
+  fs.writeFileSync = () => {};
+  fs.rmSync = () => {};
+  fs.symlinkSync = () => {
+    throw error;
+  };
+  t.after(() => {
+    fs.symlinkSync = originalSymlinkSync;
+    fs.writeFileSync = originalWriteFileSync;
+    fs.mkdtempSync = originalMkdtempSync;
+    fs.rmSync = originalRmSync;
+  });
+
+  const { createFileLinkSync, skipIfLinkUnsupported } = await loadHelpers();
+  let skipped = false;
+  let thrown;
+  try {
+    createFileLinkSync("target", "link");
+  } catch (error) {
+    thrown = error;
+  }
+  assert.ok(thrown);
+  const didSkip = skipIfLinkUnsupported(
+    {
+      skip(message) {
+        skipped = true;
+        assert.match(message, /file links require symlink privileges|unable to create file link/);
+      },
+    },
+    thrown,
+  );
+
+  assert.equal(didSkip, true);
+  assert.equal(skipped, true);
+});
+
+test("loadHelpers preserves spaced and escaped file URL segments", async (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "lopper test-link-helpers %23 "));
+  t.after(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  const runtimeDir = path.join(tempRoot, "runtime fixtures");
+  fs.mkdirSync(runtimeDir, { recursive: true });
+
+  const helperSourcePath = new URL("./test-link-helpers.mjs", import.meta.url);
+  const helperTargetPath = path.join(runtimeDir, "test-link-helpers.mjs");
+  fs.copyFileSync(helperSourcePath, helperTargetPath);
+
+  const syntheticTestPath = path.join(runtimeDir, "test-link-helpers_test.mjs");
+  const syntheticBaseUrl = pathToFileURL(syntheticTestPath).href;
+  const helpers = await loadHelpers(syntheticBaseUrl, "spaced-escaped");
+
+  assert.equal(typeof helpers.createDirectoryLinkSync, "function");
+  assert.equal(typeof helpers.createFileLinkSync, "function");
+
+  const importedUrl = new URL(createHelpersImportHref(syntheticBaseUrl, "spaced-escaped"));
+  assert.match(importedUrl.href, /runtime%20fixtures/);
+  assert.match(importedUrl.href, /%2523/);
+});

--- a/scripts/runtime/test-link-helpers_test.mjs
+++ b/scripts/runtime/test-link-helpers_test.mjs
@@ -5,14 +5,22 @@ import path from "node:path";
 import test from "node:test";
 import { pathToFileURL } from "node:url";
 
-function createHelpersImportHref(baseUrl = import.meta.url, caseId = `${Date.now()}-${Math.random()}`) {
+function createHelpersImportHref(caseId = "default", baseUrl = import.meta.url) {
   const helperUrl = new URL("./test-link-helpers.mjs", baseUrl);
   helperUrl.searchParams.set("case", caseId);
   return helperUrl.href;
 }
 
-async function loadHelpers(baseUrl = import.meta.url, caseId) {
-  return import(createHelpersImportHref(baseUrl, caseId));
+async function loadHelpers(caseId = "default", baseUrl = import.meta.url) {
+  return import(createHelpersImportHref(caseId, baseUrl));
+}
+
+function createPrivateTempDir(prefix) {
+  const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), "lopper-runtime-"));
+  fs.chmodSync(parentDir, 0o700);
+  const tempDir = path.join(parentDir, prefix);
+  fs.mkdirSync(tempDir, { mode: 0o700 });
+  return { parentDir, tempDir };
 }
 
 test("createDirectoryLinkSync surfaces Windows junction privilege failures", async (t) => {
@@ -29,7 +37,7 @@ test("createDirectoryLinkSync surfaces Windows junction privilege failures", asy
     fs.symlinkSync = originalSymlinkSync;
   });
 
-  const { createDirectoryLinkSync } = await loadHelpers();
+  const { createDirectoryLinkSync } = await loadHelpers("windows-junction-privilege");
   assert.throws(() => createDirectoryLinkSync("target", "link"), (caught) => caught === error);
 });
 
@@ -40,7 +48,7 @@ test("createFileLinkSync preserves skip semantics for file symlink privilege fai
   const originalRmSync = fs.rmSync;
   const error = Object.assign(new Error("privilege missing"), { code: "EPERM" });
 
-  fs.mkdtempSync = () => "/tmp/lopper-file-symlink-probe";
+  fs.mkdtempSync = () => path.join(os.tmpdir(), "lopper-file-symlink-probe");
   fs.writeFileSync = () => {};
   fs.rmSync = () => {};
   fs.symlinkSync = () => {
@@ -53,7 +61,7 @@ test("createFileLinkSync preserves skip semantics for file symlink privilege fai
     fs.rmSync = originalRmSync;
   });
 
-  const { createFileLinkSync, skipIfLinkUnsupported } = await loadHelpers();
+  const { createFileLinkSync, skipIfLinkUnsupported } = await loadHelpers("file-symlink-privilege");
   let skipped = false;
   let thrown;
   try {
@@ -77,9 +85,9 @@ test("createFileLinkSync preserves skip semantics for file symlink privilege fai
 });
 
 test("loadHelpers preserves spaced and escaped file URL segments", async (t) => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "lopper test-link-helpers %23 "));
+  const { parentDir, tempDir: tempRoot } = createPrivateTempDir("lopper test-link-helpers %23");
   t.after(() => {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.rmSync(parentDir, { recursive: true, force: true });
   });
 
   const runtimeDir = path.join(tempRoot, "runtime fixtures");
@@ -91,12 +99,12 @@ test("loadHelpers preserves spaced and escaped file URL segments", async (t) => 
 
   const syntheticTestPath = path.join(runtimeDir, "test-link-helpers_test.mjs");
   const syntheticBaseUrl = pathToFileURL(syntheticTestPath).href;
-  const helpers = await loadHelpers(syntheticBaseUrl, "spaced-escaped");
+  const helpers = await loadHelpers("spaced-escaped", syntheticBaseUrl);
 
   assert.equal(typeof helpers.createDirectoryLinkSync, "function");
   assert.equal(typeof helpers.createFileLinkSync, "function");
 
-  const importedUrl = new URL(createHelpersImportHref(syntheticBaseUrl, "spaced-escaped"));
+  const importedUrl = new URL(createHelpersImportHref("spaced-escaped", syntheticBaseUrl));
   assert.match(importedUrl.href, /runtime%20fixtures/);
   assert.match(importedUrl.href, /%2523/);
 });


### PR DESCRIPTION
## Summary

Redact absolute runtime parent-module, resolved-artifact, and entrypoint paths before they can reach reports, while preserving useful repo-relative and package-style context.

Closes #1279

## Changes

- normalize Node and Python runtime context against the trusted repository root
- redact absolute, URL-like, traversal, symlink-escape, and resolved-artifact values at capture and load boundaries
- preserve safe repo-relative paths and package-style labels across runtime, table, and SARIF output
- retain the merged bounded runtime-trace loader behavior

## Validation

- full local `make ci` pre-commit gate
- targeted runtime, analysis, report, scripts, Node hook, and Python hook tests after rebasing onto current `main`
- runtime package coverage: 98.1%
- total coverage: 98.3%
- new-code duplication: 0.00%
- `git diff --check`

Regression-Test: ./scripts::TestRuntimeTraceRedactsNonHostAbsoluteContext

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None expected; normalization is bounded to captured runtime context values.
- Memory benchmark impact: None; the local memory benchmark gate passed.
- package-style runtime labels remain unchanged
- safe repo-relative paths remain available to users
- absolute and escaping paths are intentionally redacted
- runtime trace byte bounds and oversized-input errors from current `main` remain intact

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
