### PR TITLE
fix(ci): reject incomplete benchmark comparisons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,8 +232,10 @@ bench-gate:
 	fi; \
 	cat "$$head_output_tmp"; \
 	cp "$$head_output_tmp" "$(BENCH_HEAD_OUTPUT)"; \
+	benchdelta_bin="$$bench_dir/benchdelta"; \
+	GOFLAGS=-buildvcs=false $(GO_CMD) build -o "$$benchdelta_bin" ./tools/benchdelta; \
 	set +e; \
-	$(GO_CMD) run ./tools/benchdelta -base "$(BENCH_BASE_OUTPUT)" -head "$(BENCH_HEAD_OUTPUT)" -max-bytes-pct "$(MEMORY_BENCH_MAX_BYTES_PCT)" -max-allocs-pct "$(MEMORY_BENCH_MAX_ALLOCS_PCT)" -summary-out "$(MEMORY_BENCH_SUMMARY)"; \
+	"$$benchdelta_bin" -base "$(BENCH_BASE_OUTPUT)" -head "$(BENCH_HEAD_OUTPUT)" -max-bytes-pct "$(MEMORY_BENCH_MAX_BYTES_PCT)" -max-allocs-pct "$(MEMORY_BENCH_MAX_ALLOCS_PCT)" -summary-out "$(MEMORY_BENCH_SUMMARY)"; \
 	status=$$?; \
 	set -e; \
 	printf "%s\n" "$$status" > "$(MEMORY_BENCH_STATUS)"; \

--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -24,6 +24,8 @@ var forcedGitConfigOverrides = []gitConfigOverride{
 	{key: "core.quotePath", value: "false"},
 	{key: "diff.external", value: ""},
 	{key: "interactive.diffFilter", value: ""},
+	// Keep git commit from detaching background maintenance into temp repos.
+	{key: "maintenance.auto", value: "false"},
 	{key: "core.pager", value: "cat"},
 }
 

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -15,7 +15,7 @@ const keepMeEnvEntry = "KEEP_ME=1"
 
 func TestSafeConfigArgsForcesNonExecutableGitConfig(t *testing.T) {
 	args := SafeConfigArgs()
-	for _, expected := range []string{"core.fsmonitor=false", "diff.external="} {
+	for _, expected := range []string{"core.fsmonitor=false", "diff.external=", "maintenance.auto=false"} {
 		if !containsArgPair(args, "-c", expected) {
 			t.Fatalf("expected safe config arg %q in %#v", expected, args)
 		}
@@ -166,6 +166,47 @@ func TestExecutableAvailable(t *testing.T) {
 	}
 	if !ExecutableAvailable(filePath) {
 		t.Fatalf("expected executable file to be available")
+	}
+}
+
+func TestSanitizedEnvPreventsDetachedGitMaintenanceOnCommit(t *testing.T) {
+	gitPath, err := ResolveBinaryPath()
+	if err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo := t.TempDir()
+	tracePath := filepath.Join(t.TempDir(), "trace2.json")
+	run := func(args ...string) {
+		t.Helper()
+
+		command, err := CommandContext(context.Background(), gitPath, append([]string{"-C", repo}, args...)...)
+		if err != nil {
+			t.Fatalf("construct git %s: %v", strings.Join(args, " "), err)
+		}
+		command.Env = append(SanitizedEnv(), "GIT_TRACE2_EVENT="+tracePath)
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, string(output))
+		}
+	}
+
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("hi\n"), 0o600); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+	run("add", ".")
+	run("commit", "-m", "init")
+
+	trace, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read trace2 output: %v", err)
+	}
+	traceText := string(trace)
+	if strings.Contains(traceText, `"hierarchy":"commit/maintenance"`) {
+		t.Fatalf("expected sanitized env to suppress detached git maintenance, trace=%s", traceText)
 	}
 }
 

--- a/scripts/benchdelta_workflow_test.go
+++ b/scripts/benchdelta_workflow_test.go
@@ -5,37 +5,25 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
+
+const workflowReportPkg = "github.com/ben-ranford/lopper/internal/report"
 
 func TestBenchdeltaRejectsInvalidAndIncompleteInputs(t *testing.T) {
 	t.Parallel()
 
 	repoRoot := repoPath(t, "")
 	dir := t.TempDir()
-	binaryPath := filepath.Join(dir, "benchdelta")
-	build := exec.Command("go", "build", "-o", binaryPath, "./tools/benchdelta")
-	build.Dir = repoRoot
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build benchdelta: %v\n%s", err, output)
-	}
+	binaryPath := buildBenchdeltaBinary(t, repoRoot, dir)
 
-	tests := []struct {
-		name         string
-		baseLines    []string
-		headLines    []string
-		wantCode     int
-		wantContains []string
-	}{
+	tests := []workflowComparisonCase{
 		{
-			name: "empty comparison invalid",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-			},
+			name:     "empty comparison invalid",
+			baseID:   "empty",
+			headID:   "empty",
 			wantCode: 2,
 			wantContains: []string{
 				"Comparison status: invalid",
@@ -43,16 +31,9 @@ func TestBenchdeltaRejectsInvalidAndIncompleteInputs(t *testing.T) {
 			},
 		},
 		{
-			name: "head only invalid",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-				"BenchmarkFormatHeadOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
+			name:     "head only invalid",
+			baseID:   "shared",
+			headID:   "head-only",
 			wantCode: 2,
 			wantContains: []string{
 				"Comparison status: invalid",
@@ -60,16 +41,9 @@ func TestBenchdeltaRejectsInvalidAndIncompleteInputs(t *testing.T) {
 			},
 		},
 		{
-			name: "base only invalid",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-				"BenchmarkFormatBaseOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
+			name:     "base only invalid",
+			baseID:   "base-only",
+			headID:   "shared",
 			wantCode: 2,
 			wantContains: []string{
 				"Comparison status: invalid",
@@ -77,15 +51,9 @@ func TestBenchdeltaRejectsInvalidAndIncompleteInputs(t *testing.T) {
 			},
 		},
 		{
-			name: "zero overlap invalid",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkBaseOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkHeadOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
+			name:     "zero overlap invalid",
+			baseID:   "zero-overlap-base",
+			headID:   "zero-overlap-head",
 			wantCode: 2,
 			wantContains: []string{
 				"Comparison status: invalid",
@@ -93,91 +61,232 @@ func TestBenchdeltaRejectsInvalidAndIncompleteInputs(t *testing.T) {
 			},
 		},
 		{
-			name: "base bytes only incomplete",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
+			name:     "base bytes only incomplete",
+			baseID:   "base-bytes-only",
+			headID:   "shared",
 			wantCode: 2,
 			wantContains: []string{
 				"Comparison status: incomplete",
-				"base: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing allocs/op",
+				"base: " + workflowMissingMetric("Format", "allocs/op"),
 			},
+			wantOmit: workflowIncompleteInvalidDiagnostics(),
 		},
 		{
-			name: "head allocs only incomplete",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 1 allocs/op",
-			},
+			name:     "head allocs only incomplete",
+			baseID:   "shared",
+			headID:   "head-allocs-only",
 			wantCode: 2,
 			wantContains: []string{
 				"Comparison status: incomplete",
-				"head: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing B/op",
+				"head: " + workflowMissingMetric("Format", "B/op"),
 			},
+			wantOmit: workflowIncompleteInvalidDiagnostics(),
 		},
 		{
-			name: "complete plus partial duplicates stay incomplete",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-				"BenchmarkFormat-8 1000 100 ns/op 130 B/op",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-				"BenchmarkFormat-8 1000 100 ns/op 4 allocs/op",
-			},
+			name:     "base ns only incomplete",
+			baseID:   "base-ns-only",
+			headID:   "shared",
 			wantCode: 2,
 			wantContains: []string{
 				"Comparison status: incomplete",
-				"| `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` | 100.0 | 100.0 | +0.0% | 1.0 | 1.0 | +0.0% | ok |",
-				"base: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing allocs/op",
-				"head: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing B/op",
+				"base: " + workflowMissingMetric("Format", "B/op and allocs/op"),
 			},
+			wantOmit: workflowIncompleteInvalidDiagnostics(),
+		},
+		{
+			name:     "sample count mismatch incomplete",
+			baseID:   "count-mismatch-base",
+			headID:   "count-mismatch-head",
+			wantCode: 2,
+			wantContains: []string{
+				"Comparison status: incomplete",
+				workflowSampleCountMismatch("Format", 3, 1),
+			},
+			wantOmit: workflowIncompleteInvalidDiagnostics(),
+		},
+		{
+			name:     "complete plus partial duplicates stay incomplete",
+			baseID:   "partial-base",
+			headID:   "partial-head",
+			wantCode: 2,
+			wantContains: []string{
+				"Comparison status: incomplete",
+				workflowOKRow("Format"),
+				"base: " + workflowMissingMetric("Format", "allocs/op"),
+				"head: " + workflowMissingMetric("Format", "B/op"),
+			},
+			wantOmit: workflowIncompleteInvalidDiagnostics(),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			basePath := filepath.Join(dir, strings.ReplaceAll(tc.name, " ", "-")+"-base.txt")
-			headPath := filepath.Join(dir, strings.ReplaceAll(tc.name, " ", "-")+"-head.txt")
-			baseContent := append([]string{"goos: darwin"}, tc.baseLines...)
-			if err := os.WriteFile(basePath, []byte(strings.Join(baseContent, "\n")+"\n"), 0o644); err != nil {
-				t.Fatalf("write base fixture: %v", err)
-			}
-			headContent := append([]string{"goos: darwin"}, tc.headLines...)
-			if err := os.WriteFile(headPath, []byte(strings.Join(headContent, "\n")+"\n"), 0o644); err != nil {
-				t.Fatalf("write head fixture: %v", err)
-			}
-
-			cmd := exec.Command(binaryPath, "-base", basePath, "-head", headPath)
-			cmd.Dir = repoRoot
-			output, err := cmd.CombinedOutput()
-			exitCode := 0
-			if err != nil {
-				var exitErr *exec.ExitError
-				if !errors.As(err, &exitErr) {
-					t.Fatalf("run benchdelta: %v\n%s", err, output)
-				}
-				exitCode = exitErr.ExitCode()
-			}
-			if exitCode != tc.wantCode {
-				t.Fatalf("exit code = %d, want %d\n%s", exitCode, tc.wantCode, output)
-			}
-			for _, want := range tc.wantContains {
-				if !strings.Contains(string(output), want) {
-					t.Fatalf("expected output to contain %q, got:\n%s", want, output)
-				}
-			}
+			assertWorkflowBenchdeltaCase(t, repoRoot, dir, binaryPath, tc)
 		})
+	}
+}
+
+type workflowComparisonCase struct {
+	name         string
+	baseID       string
+	headID       string
+	wantCode     int
+	wantContains []string
+	wantOmit     []string
+}
+
+func buildBenchdeltaBinary(t *testing.T, repoRoot, dir string) string {
+	t.Helper()
+
+	binaryPath := filepath.Join(dir, "benchdelta")
+	build := exec.Command("go", "build", "-o", binaryPath, "./tools/benchdelta")
+	build.Dir = repoRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build benchdelta: %v\n%s", err, output)
+	}
+	return binaryPath
+}
+
+func assertWorkflowBenchdeltaCase(t *testing.T, repoRoot, dir, binaryPath string, tc workflowComparisonCase) {
+	t.Helper()
+
+	basePath := filepath.Join(dir, strings.ReplaceAll(tc.name, " ", "-")+"-base.txt")
+	headPath := filepath.Join(dir, strings.ReplaceAll(tc.name, " ", "-")+"-head.txt")
+	writeWorkflowFixture(t, basePath, tc.baseID)
+	writeWorkflowFixture(t, headPath, tc.headID)
+
+	output, exitCode := runWorkflowBenchdelta(t, repoRoot, binaryPath, basePath, headPath)
+	if exitCode != tc.wantCode {
+		t.Fatalf("exit code = %d, want %d\n%s", exitCode, tc.wantCode, output)
+	}
+	assertWorkflowOutputContainsAll(t, string(output), tc.wantContains)
+	assertWorkflowOutputOmitsAll(t, string(output), tc.wantOmit)
+}
+
+func runWorkflowBenchdelta(t *testing.T, repoRoot, binaryPath, basePath, headPath string) ([]byte, int) {
+	t.Helper()
+
+	cmd := exec.Command(binaryPath, "-base", basePath, "-head", headPath)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return output, 0
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("run benchdelta: %v\n%s", err, output)
+	}
+	return output, exitErr.ExitCode()
+}
+
+func assertWorkflowOutputContainsAll(t *testing.T, output string, expected []string) {
+	t.Helper()
+	for _, want := range expected {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, output)
+		}
+	}
+}
+
+func assertWorkflowOutputOmitsAll(t *testing.T, output string, omitted []string) {
+	t.Helper()
+	for _, omit := range omitted {
+		if strings.Contains(output, omit) {
+			t.Fatalf("expected output to omit %q, got:\n%s", omit, output)
+		}
+	}
+}
+
+func writeWorkflowFixture(t *testing.T, path, fixtureID string) {
+	t.Helper()
+	content := append([]string{"goos: darwin"}, workflowFixtureLines(fixtureID)...)
+	if err := os.WriteFile(path, []byte(strings.Join(content, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write workflow fixture %q: %v", fixtureID, err)
+	}
+}
+
+func workflowFixtureLines(fixtureID string) []string {
+	switch fixtureID {
+	case "empty":
+		return workflowReportFixture()
+	case "shared":
+		return workflowReportFixture(workflowCompleteBenchmark("Format"))
+	case "head-only":
+		return workflowReportFixture(workflowCompleteBenchmark("Format"), workflowCompleteBenchmark("FormatHeadOnly"))
+	case "base-only":
+		return workflowReportFixture(workflowCompleteBenchmark("Format"), workflowCompleteBenchmark("FormatBaseOnly"))
+	case "zero-overlap-base":
+		return workflowReportFixture(workflowCompleteBenchmark("BaseOnly"))
+	case "zero-overlap-head":
+		return workflowReportFixture(workflowCompleteBenchmark("HeadOnly"))
+	case "base-bytes-only":
+		return workflowReportFixture(workflowBytesOnlyBenchmark("Format", "100"))
+	case "head-allocs-only":
+		return workflowReportFixture(workflowAllocsOnlyBenchmark("Format", "1"))
+	case "base-ns-only":
+		return workflowReportFixture(workflowNsOnlyBenchmark("Format"))
+	case "partial-base":
+		return workflowReportFixture(workflowCompleteBenchmark("Format"), workflowBytesOnlyBenchmark("Format", "130"))
+	case "partial-head":
+		return workflowReportFixture(workflowCompleteBenchmark("Format"), workflowAllocsOnlyBenchmark("Format", "4"))
+	case "count-mismatch-base":
+		return workflowReportFixture(workflowRepeatedCompleteBenchmarks("Format", 3)...)
+	case "count-mismatch-head":
+		return workflowReportFixture(workflowCompleteBenchmark("Format"))
+	default:
+		return nil
+	}
+}
+
+func workflowReportFixture(lines ...string) []string {
+	return append([]string{"pkg: " + workflowReportPkg}, lines...)
+}
+
+func workflowCompleteBenchmark(name string) string {
+	return workflowBenchmarkLine(name, "1000", "100", "ns/op", "100", "B/op", "1", "allocs/op")
+}
+
+func workflowBytesOnlyBenchmark(name, bytes string) string {
+	return workflowBenchmarkLine(name, "1000", "100", "ns/op", bytes, "B/op")
+}
+
+func workflowAllocsOnlyBenchmark(name, allocs string) string {
+	return workflowBenchmarkLine(name, "1000", "100", "ns/op", allocs, "allocs/op")
+}
+
+func workflowNsOnlyBenchmark(name string) string {
+	return workflowBenchmarkLine(name, "1000", "100", "ns/op")
+}
+
+func workflowBenchmarkLine(name string, parts ...string) string {
+	return "Benchmark" + name + "-8 " + strings.Join(parts, " ")
+}
+
+func workflowRepeatedCompleteBenchmarks(name string, count int) []string {
+	lines := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		lines = append(lines, workflowCompleteBenchmark(name))
+	}
+	return lines
+}
+
+func workflowMissingMetric(name, metric string) string {
+	return "`" + workflowReportPkg + "/Benchmark" + name + "` missing " + metric
+}
+
+func workflowOKRow(name string) string {
+	return "| `" + workflowReportPkg + "/Benchmark" + name + "` | 100.0 | 100.0 | +0.0% | 1.0 | 1.0 | +0.0% | ok |"
+}
+
+func workflowSampleCountMismatch(name string, baseCount, headCount int) string {
+	return "sample-count mismatch for `" + workflowReportPkg + "/Benchmark" + name + "`: base=" + strconv.Itoa(baseCount) + " head=" + strconv.Itoa(headCount)
+}
+
+func workflowIncompleteInvalidDiagnostics() []string {
+	return []string{
+		"Head-only benchmarks (missing on base):",
+		"Base-only benchmarks (missing on head):",
+		"No overlapping benchmark names were found between base and head.",
 	}
 }

--- a/scripts/benchdelta_workflow_test.go
+++ b/scripts/benchdelta_workflow_test.go
@@ -1,0 +1,183 @@
+package scripts
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBenchdeltaRejectsInvalidAndIncompleteInputs(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := repoPath(t, "")
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "benchdelta")
+	build := exec.Command("go", "build", "-o", binaryPath, "./tools/benchdelta")
+	build.Dir = repoRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build benchdelta: %v\n%s", err, output)
+	}
+
+	tests := []struct {
+		name         string
+		baseLines    []string
+		headLines    []string
+		wantCode     int
+		wantContains []string
+	}{
+		{
+			name: "empty comparison invalid",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+			},
+			wantCode: 2,
+			wantContains: []string{
+				"Comparison status: invalid",
+				"No overlapping benchmark names were found between base and head.",
+			},
+		},
+		{
+			name: "head only invalid",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+				"BenchmarkFormatHeadOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			wantCode: 2,
+			wantContains: []string{
+				"Comparison status: invalid",
+				"Head-only benchmarks (missing on base):",
+			},
+		},
+		{
+			name: "base only invalid",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+				"BenchmarkFormatBaseOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			wantCode: 2,
+			wantContains: []string{
+				"Comparison status: invalid",
+				"Base-only benchmarks (missing on head):",
+			},
+		},
+		{
+			name: "zero overlap invalid",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkBaseOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkHeadOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			wantCode: 2,
+			wantContains: []string{
+				"Comparison status: invalid",
+				"No overlapping benchmark names were found between base and head.",
+			},
+		},
+		{
+			name: "base bytes only incomplete",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			wantCode: 2,
+			wantContains: []string{
+				"Comparison status: incomplete",
+				"base: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing allocs/op",
+			},
+		},
+		{
+			name: "head allocs only incomplete",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 1 allocs/op",
+			},
+			wantCode: 2,
+			wantContains: []string{
+				"Comparison status: incomplete",
+				"head: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing B/op",
+			},
+		},
+		{
+			name: "complete plus partial duplicates stay incomplete",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+				"BenchmarkFormat-8 1000 100 ns/op 130 B/op",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+				"BenchmarkFormat-8 1000 100 ns/op 4 allocs/op",
+			},
+			wantCode: 2,
+			wantContains: []string{
+				"Comparison status: incomplete",
+				"| `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` | 100.0 | 100.0 | +0.0% | 1.0 | 1.0 | +0.0% | ok |",
+				"base: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing allocs/op",
+				"head: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing B/op",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			basePath := filepath.Join(dir, strings.ReplaceAll(tc.name, " ", "-")+"-base.txt")
+			headPath := filepath.Join(dir, strings.ReplaceAll(tc.name, " ", "-")+"-head.txt")
+			baseContent := append([]string{"goos: darwin"}, tc.baseLines...)
+			if err := os.WriteFile(basePath, []byte(strings.Join(baseContent, "\n")+"\n"), 0o644); err != nil {
+				t.Fatalf("write base fixture: %v", err)
+			}
+			headContent := append([]string{"goos: darwin"}, tc.headLines...)
+			if err := os.WriteFile(headPath, []byte(strings.Join(headContent, "\n")+"\n"), 0o644); err != nil {
+				t.Fatalf("write head fixture: %v", err)
+			}
+
+			cmd := exec.Command(binaryPath, "-base", basePath, "-head", headPath)
+			cmd.Dir = repoRoot
+			output, err := cmd.CombinedOutput()
+			exitCode := 0
+			if err != nil {
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) {
+					t.Fatalf("run benchdelta: %v\n%s", err, output)
+				}
+				exitCode = exitErr.ExitCode()
+			}
+			if exitCode != tc.wantCode {
+				t.Fatalf("exit code = %d, want %d\n%s", exitCode, tc.wantCode, output)
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(string(output), want) {
+					t.Fatalf("expected output to contain %q, got:\n%s", want, output)
+				}
+			}
+		})
+	}
+}

--- a/scripts/benchdelta_workflow_test.go
+++ b/scripts/benchdelta_workflow_test.go
@@ -20,103 +20,15 @@ func TestBenchdeltaRejectsInvalidAndIncompleteInputs(t *testing.T) {
 	binaryPath := buildBenchdeltaBinary(t, repoRoot, dir)
 
 	tests := []workflowComparisonCase{
-		{
-			name:     "empty comparison invalid",
-			baseID:   "empty",
-			headID:   "empty",
-			wantCode: 2,
-			wantContains: []string{
-				"Comparison status: invalid",
-				"No overlapping benchmark names were found between base and head.",
-			},
-		},
-		{
-			name:     "head only invalid",
-			baseID:   "shared",
-			headID:   "head-only",
-			wantCode: 2,
-			wantContains: []string{
-				"Comparison status: invalid",
-				"Head-only benchmarks (missing on base):",
-			},
-		},
-		{
-			name:     "base only invalid",
-			baseID:   "base-only",
-			headID:   "shared",
-			wantCode: 2,
-			wantContains: []string{
-				"Comparison status: invalid",
-				"Base-only benchmarks (missing on head):",
-			},
-		},
-		{
-			name:     "zero overlap invalid",
-			baseID:   "zero-overlap-base",
-			headID:   "zero-overlap-head",
-			wantCode: 2,
-			wantContains: []string{
-				"Comparison status: invalid",
-				"No overlapping benchmark names were found between base and head.",
-			},
-		},
-		{
-			name:     "base bytes only incomplete",
-			baseID:   "base-bytes-only",
-			headID:   "shared",
-			wantCode: 2,
-			wantContains: []string{
-				"Comparison status: incomplete",
-				"base: " + workflowMissingMetric("Format", "allocs/op"),
-			},
-			wantOmit: workflowIncompleteInvalidDiagnostics(),
-		},
-		{
-			name:     "head allocs only incomplete",
-			baseID:   "shared",
-			headID:   "head-allocs-only",
-			wantCode: 2,
-			wantContains: []string{
-				"Comparison status: incomplete",
-				"head: " + workflowMissingMetric("Format", "B/op"),
-			},
-			wantOmit: workflowIncompleteInvalidDiagnostics(),
-		},
-		{
-			name:     "base ns only incomplete",
-			baseID:   "base-ns-only",
-			headID:   "shared",
-			wantCode: 2,
-			wantContains: []string{
-				"Comparison status: incomplete",
-				"base: " + workflowMissingMetric("Format", "B/op and allocs/op"),
-			},
-			wantOmit: workflowIncompleteInvalidDiagnostics(),
-		},
-		{
-			name:     "sample count mismatch incomplete",
-			baseID:   "count-mismatch-base",
-			headID:   "count-mismatch-head",
-			wantCode: 2,
-			wantContains: []string{
-				"Comparison status: incomplete",
-				workflowSampleCountMismatch("Format", 3, 1),
-			},
-			wantOmit: workflowIncompleteInvalidDiagnostics(),
-		},
-		{
-			name:     "complete plus partial duplicates stay incomplete",
-			baseID:   "partial-base",
-			headID:   "partial-head",
-			wantCode: 2,
-			wantContains: []string{
-				"Comparison status: incomplete",
-				workflowOKRow("Format"),
-				"base: " + workflowMissingMetric("Format", "allocs/op"),
-				"head: " + workflowMissingMetric("Format", "B/op"),
-			},
-			wantOmit: workflowIncompleteInvalidDiagnostics(),
-		},
+		workflowInvalidCase("empty comparison invalid", "empty", "empty", "No overlapping benchmark names were found between base and head."),
+		workflowInvalidCase("head only invalid", "shared", "head-only", "Head-only benchmarks (missing on base):"),
+		workflowInvalidCase("base only invalid", "base-only", "shared", "Base-only benchmarks (missing on head):"),
+		workflowInvalidCase("zero overlap invalid", "zero-overlap-base", "zero-overlap-head", "No overlapping benchmark names were found between base and head."),
+		workflowIncompleteCase("base bytes only incomplete", "base-bytes-only", "shared", "base: "+workflowMissingMetric("Format", "allocs/op")),
+		workflowIncompleteCase("head allocs only incomplete", "shared", "head-allocs-only", "head: "+workflowMissingMetric("Format", "B/op")),
+		workflowIncompleteCase("base ns only incomplete", "base-ns-only", "shared", "base: "+workflowMissingMetric("Format", "B/op and allocs/op")),
+		workflowIncompleteCase("sample count mismatch incomplete", "count-mismatch-base", "count-mismatch-head", workflowSampleCountMismatch("Format", 3, 1)),
+		workflowIncompleteCase("complete plus partial duplicates stay incomplete", "partial-base", "partial-head", workflowOKRow("Format"), "base: "+workflowMissingMetric("Format", "allocs/op"), "head: "+workflowMissingMetric("Format", "B/op")),
 	}
 
 	for _, tc := range tests {
@@ -133,6 +45,27 @@ type workflowComparisonCase struct {
 	wantCode     int
 	wantContains []string
 	wantOmit     []string
+}
+
+func workflowInvalidCase(name, baseID, headID string, expected ...string) workflowComparisonCase {
+	return workflowComparisonCase{
+		name:         name,
+		baseID:       baseID,
+		headID:       headID,
+		wantCode:     2,
+		wantContains: append([]string{"Comparison status: invalid"}, expected...),
+	}
+}
+
+func workflowIncompleteCase(name, baseID, headID string, expected ...string) workflowComparisonCase {
+	return workflowComparisonCase{
+		name:         name,
+		baseID:       baseID,
+		headID:       headID,
+		wantCode:     2,
+		wantContains: append([]string{"Comparison status: incomplete"}, expected...),
+		wantOmit:     workflowIncompleteInvalidDiagnostics(),
+	}
 }
 
 func buildBenchdeltaBinary(t *testing.T, repoRoot, dir string) string {
@@ -210,33 +143,43 @@ func workflowFixtureLines(fixtureID string) []string {
 	switch fixtureID {
 	case "empty":
 		return workflowReportFixture()
-	case "shared":
-		return workflowReportFixture(workflowCompleteBenchmark("Format"))
+	case "shared", "count-mismatch-head":
+		return workflowCompleteFixture("Format")
 	case "head-only":
-		return workflowReportFixture(workflowCompleteBenchmark("Format"), workflowCompleteBenchmark("FormatHeadOnly"))
+		return workflowCompleteFixture("Format", "FormatHeadOnly")
 	case "base-only":
-		return workflowReportFixture(workflowCompleteBenchmark("Format"), workflowCompleteBenchmark("FormatBaseOnly"))
+		return workflowCompleteFixture("Format", "FormatBaseOnly")
 	case "zero-overlap-base":
-		return workflowReportFixture(workflowCompleteBenchmark("BaseOnly"))
+		return workflowCompleteFixture("BaseOnly")
 	case "zero-overlap-head":
-		return workflowReportFixture(workflowCompleteBenchmark("HeadOnly"))
+		return workflowCompleteFixture("HeadOnly")
 	case "base-bytes-only":
-		return workflowReportFixture(workflowBytesOnlyBenchmark("Format", "100"))
+		return workflowBenchmarkFixture(workflowBytesOnlyBenchmark("Format", "100"))
 	case "head-allocs-only":
-		return workflowReportFixture(workflowAllocsOnlyBenchmark("Format", "1"))
+		return workflowBenchmarkFixture(workflowAllocsOnlyBenchmark("Format", "1"))
 	case "base-ns-only":
-		return workflowReportFixture(workflowNsOnlyBenchmark("Format"))
+		return workflowBenchmarkFixture(workflowNsOnlyBenchmark("Format"))
 	case "partial-base":
-		return workflowReportFixture(workflowCompleteBenchmark("Format"), workflowBytesOnlyBenchmark("Format", "130"))
+		return workflowBenchmarkFixture(workflowCompleteBenchmark("Format"), workflowBytesOnlyBenchmark("Format", "130"))
 	case "partial-head":
-		return workflowReportFixture(workflowCompleteBenchmark("Format"), workflowAllocsOnlyBenchmark("Format", "4"))
+		return workflowBenchmarkFixture(workflowCompleteBenchmark("Format"), workflowAllocsOnlyBenchmark("Format", "4"))
 	case "count-mismatch-base":
 		return workflowReportFixture(workflowRepeatedCompleteBenchmarks("Format", 3)...)
-	case "count-mismatch-head":
-		return workflowReportFixture(workflowCompleteBenchmark("Format"))
 	default:
 		return nil
 	}
+}
+
+func workflowCompleteFixture(names ...string) []string {
+	lines := make([]string, 0, len(names))
+	for _, name := range names {
+		lines = append(lines, workflowCompleteBenchmark(name))
+	}
+	return workflowBenchmarkFixture(lines...)
+}
+
+func workflowBenchmarkFixture(lines ...string) []string {
+	return workflowReportFixture(lines...)
 }
 
 func workflowReportFixture(lines ...string) []string {

--- a/scripts/check_inline_suppressions_test.go
+++ b/scripts/check_inline_suppressions_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 const mainGoPath = "main.go"
@@ -178,6 +180,11 @@ func runSuppressionCheck(repoDir string) (string, error) {
 
 func runCommand(t *testing.T, dir string, name string, args ...string) string {
 	t.Helper()
+
+	if name == "git" {
+		testutil.RunGit(t, dir, args...)
+		return ""
+	}
 
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -258,6 +258,29 @@ func TestCIWorkflowRunsRegressionProofGateInVerifyJob(t *testing.T) {
 	})
 }
 
+func TestCIWorkflowOnlyAllowsMemoryApprovalForStatusOne(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/ci.yml", &workflow)
+
+	runCI := workflowStepByName(t, workflow.Jobs, "verify", "Run CI target")
+	assertWorkflowStepRunContainsAll(t, runCI, "ci verify run target", []string{
+		`export MEMORY_BENCH_ENFORCE=0`,
+		`make ci`,
+	})
+
+	failUnapproved := workflowStepByName(t, workflow.Jobs, "verify", "Fail on unapproved memory regression")
+	assertWorkflowStepRunContainsAll(t, failUnapproved, "ci unapproved memory regression gate", []string{
+		`status="$(tr -d '[:space:]' < .artifacts/memory-bench-status.txt)"`,
+		`if [ "$status" = "1" ]; then`,
+	})
+	assertWorkflowStepRunOmitsAll(t, failUnapproved, "ci unapproved memory regression gate", []string{
+		`if [ "$status" = "2" ]`,
+		`if [ "$status" -eq 2 ]`,
+	})
+}
+
 func TestPRMetadataWorkflowPassesMaintainerExemptionLabel(t *testing.T) {
 	t.Parallel()
 	assertPullRequestTriggerTypes(t, ".github/workflows/pr-metadata.yml")

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3078,6 +3078,40 @@ func TestMakefileBenchdeltaCoverageRatchet(t *testing.T) {
 	}
 }
 
+func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
+	t.Parallel()
+
+	makefile := readConfig(t, "Makefile")
+	targetPattern := regexp.MustCompile(`(?m)^bench-gate:\n(?:\t.*\n)+`)
+	target := targetPattern.FindString(makefile)
+	if target == "" {
+		t.Fatal("Makefile must define the bench-gate target")
+	}
+
+	for _, want := range []string{
+		`benchdelta_bin="$$bench_dir/benchdelta"`,
+		`$(GO_CMD) build -o "$$benchdelta_bin" ./tools/benchdelta`,
+		`"$$benchdelta_bin" -base "$(BENCH_BASE_OUTPUT)" -head "$(BENCH_HEAD_OUTPUT)"`,
+		`printf "%s\n" "$$status" > "$(MEMORY_BENCH_STATUS)"`,
+		`if [ "$(MEMORY_BENCH_ENFORCE)" = "0" ]; then`,
+		`if [ "$$status" -eq 1 ]; then`,
+		`exit "$$status"`,
+	} {
+		if !strings.Contains(target, want) {
+			t.Fatalf("bench-gate target must contain %q", want)
+		}
+	}
+
+	for _, omit := range []string{
+		`$(GO_CMD) run ./tools/benchdelta`,
+		`if [ "$$status" -eq 2 ]; then`,
+	} {
+		if strings.Contains(target, omit) {
+			t.Fatalf("bench-gate target must not contain %q", omit)
+		}
+	}
+}
+
 func TestReleaseImageTagScriptSanitizesAndValidatesTags(t *testing.T) {
 	t.Parallel()
 

--- a/tools/benchdelta/main.go
+++ b/tools/benchdelta/main.go
@@ -64,6 +64,16 @@ type comparisonOutcome struct {
 	diagnostics []string
 }
 
+type comparisonSummary struct {
+	rows          []comparisonRow
+	baseCount     int
+	headCount     int
+	headOnlyNames []string
+	baseOnlyNames []string
+	limits        deltaThresholds
+	outcome       comparisonOutcome
+}
+
 func main() {
 	basePath := flag.String("base", "", "path to base benchmark output")
 	headPath := flag.String("head", "", "path to head benchmark output")
@@ -227,7 +237,15 @@ func compareBenchmarks(baseInput, headInput benchmarkInput, limits deltaThreshol
 	outcome := classifyComparisonOutcome(baseInput, headInput, mismatchDiagnostics, matchedNames, headOnlyNames, baseOnlyNames, hasRegression)
 
 	var buf bytes.Buffer
-	writeComparisonSummary(&buf, rows, len(baseInput.data), len(headInput.data), headOnlyNames, baseOnlyNames, limits, outcome)
+	writeComparisonSummary(&buf, comparisonSummary{
+		rows:          rows,
+		baseCount:     len(baseInput.data),
+		headCount:     len(headInput.data),
+		headOnlyNames: headOnlyNames,
+		baseOnlyNames: baseOnlyNames,
+		limits:        limits,
+		outcome:       outcome,
+	})
 
 	return buf.String(), outcome.exitCode
 }
@@ -266,30 +284,30 @@ func newComparisonRow(name string, baseSample, headSample samples, limits deltaT
 	}
 }
 
-func writeComparisonSummary(buf *bytes.Buffer, rows []comparisonRow, baseCount, headCount int, headOnlyNames, baseOnlyNames []string, limits deltaThresholds, outcome comparisonOutcome) {
+func writeComparisonSummary(buf *bytes.Buffer, summary comparisonSummary) {
 	buf.WriteString("## Memory Benchmarks\n\n")
-	fmt.Fprintf(buf, "Thresholds: bytes/op <= +%.1f%%, allocs/op <= +%.1f%%\n\n", limits.bytesPct, limits.allocsPct)
-	fmt.Fprintf(buf, "Base benchmarks: %s\n", benchmarkCountLabel(baseCount))
-	fmt.Fprintf(buf, "Head benchmarks: %s\n\n", benchmarkCountLabel(headCount))
+	fmt.Fprintf(buf, "Thresholds: bytes/op <= +%.1f%%, allocs/op <= +%.1f%%\n\n", summary.limits.bytesPct, summary.limits.allocsPct)
+	fmt.Fprintf(buf, "Base benchmarks: %s\n", benchmarkCountLabel(summary.baseCount))
+	fmt.Fprintf(buf, "Head benchmarks: %s\n\n", benchmarkCountLabel(summary.headCount))
 
-	showInvalidOnlySections := outcome.status != "incomplete"
-	writeComparisonTable(buf, rows, showInvalidOnlySections)
+	showInvalidOnlySections := summary.outcome.status != "incomplete"
+	writeComparisonTable(buf, summary.rows, showInvalidOnlySections)
 	if showInvalidOnlySections {
-		writeList(buf, "Head-only benchmarks (missing on base):", headOnlyNames, func(item string) string {
+		writeList(buf, "Head-only benchmarks (missing on base):", summary.headOnlyNames, func(item string) string {
 			return fmt.Sprintf("`%s`", item)
 		})
-		writeList(buf, "Base-only benchmarks (missing on head):", baseOnlyNames, func(item string) string {
+		writeList(buf, "Base-only benchmarks (missing on head):", summary.baseOnlyNames, func(item string) string {
 			return fmt.Sprintf("`%s`", item)
 		})
 	}
-	writeList(buf, "Incomplete benchmark samples:", outcome.diagnostics, func(item string) string {
+	writeList(buf, "Incomplete benchmark samples:", summary.outcome.diagnostics, func(item string) string {
 		return item
 	})
 
-	switch outcome.status {
+	switch summary.outcome.status {
 	case "incomplete", "invalid":
-		fmt.Fprintf(buf, "Comparison status: %s\n", outcome.status)
-		fmt.Fprintf(buf, "%s\n", outcome.result)
+		fmt.Fprintf(buf, "Comparison status: %s\n", summary.outcome.status)
+		fmt.Fprintf(buf, "%s\n", summary.outcome.result)
 	case "regression":
 		buf.WriteString("Result: memory benchmark regression detected.\n")
 	default:

--- a/tools/benchdelta/main.go
+++ b/tools/benchdelta/main.go
@@ -159,6 +159,7 @@ func parseBenchmarkLine(currentPkg, line string) (string, samples, benchmarkLine
 	}
 	key := currentPkg + "/" + benchmarkName
 	var sample samples
+	var hasNsPerOp bool
 	var hasBytes bool
 	var hasAllocs bool
 
@@ -168,6 +169,8 @@ func parseBenchmarkLine(currentPkg, line string) (string, samples, benchmarkLine
 			continue
 		}
 		switch fields[i+1] {
+		case "ns/op":
+			hasNsPerOp = true
 		case "B/op":
 			hasBytes = true
 			sample.bytesPerOp = append(sample.bytesPerOp, value)
@@ -178,6 +181,9 @@ func parseBenchmarkLine(currentPkg, line string) (string, samples, benchmarkLine
 	}
 
 	if !hasBytes && !hasAllocs {
+		if hasNsPerOp {
+			return key, samples{}, benchmarkLineIncomplete, incompleteSampleDiagnostic(key, true, true)
+		}
 		return "", samples{}, benchmarkLineIgnored, ""
 	}
 	if !hasBytes || !hasAllocs {
@@ -213,14 +219,15 @@ func incompleteSampleDiagnostic(name string, missingBytes, missingAllocs bool) s
 
 func compareBenchmarks(baseInput, headInput benchmarkInput, limits deltaThresholds) (string, int) {
 	matchedNames := intersectKeys(baseInput.data, headInput.data)
+	comparableNames, mismatchDiagnostics := comparableMatchedNames(matchedNames, baseInput.data, headInput.data)
 	headOnlyNames := differenceKeys(headInput.data, baseInput.data)
 	baseOnlyNames := differenceKeys(baseInput.data, headInput.data)
 
-	rows, hasRegression := buildComparisonRows(matchedNames, baseInput.data, headInput.data, limits)
-	outcome := classifyComparisonOutcome(baseInput, headInput, matchedNames, headOnlyNames, baseOnlyNames, hasRegression)
+	rows, hasRegression := buildComparisonRows(comparableNames, baseInput.data, headInput.data, limits)
+	outcome := classifyComparisonOutcome(baseInput, headInput, mismatchDiagnostics, matchedNames, headOnlyNames, baseOnlyNames, hasRegression)
 
 	var buf bytes.Buffer
-	writeComparisonSummary(&buf, rows, headOnlyNames, baseOnlyNames, limits, outcome)
+	writeComparisonSummary(&buf, rows, len(baseInput.data), len(headInput.data), headOnlyNames, baseOnlyNames, limits, outcome)
 
 	return buf.String(), outcome.exitCode
 }
@@ -259,19 +266,22 @@ func newComparisonRow(name string, baseSample, headSample samples, limits deltaT
 	}
 }
 
-func writeComparisonSummary(buf *bytes.Buffer, rows []comparisonRow, headOnlyNames, baseOnlyNames []string, limits deltaThresholds, outcome comparisonOutcome) {
+func writeComparisonSummary(buf *bytes.Buffer, rows []comparisonRow, baseCount, headCount int, headOnlyNames, baseOnlyNames []string, limits deltaThresholds, outcome comparisonOutcome) {
 	buf.WriteString("## Memory Benchmarks\n\n")
 	fmt.Fprintf(buf, "Thresholds: bytes/op <= +%.1f%%, allocs/op <= +%.1f%%\n\n", limits.bytesPct, limits.allocsPct)
-	fmt.Fprintf(buf, "Base benchmarks: %s\n", benchmarkCountLabel(len(rows)+len(baseOnlyNames)))
-	fmt.Fprintf(buf, "Head benchmarks: %s\n\n", benchmarkCountLabel(len(rows)+len(headOnlyNames)))
+	fmt.Fprintf(buf, "Base benchmarks: %s\n", benchmarkCountLabel(baseCount))
+	fmt.Fprintf(buf, "Head benchmarks: %s\n\n", benchmarkCountLabel(headCount))
 
-	writeComparisonTable(buf, rows)
-	writeList(buf, "Head-only benchmarks (missing on base):", headOnlyNames, func(item string) string {
-		return fmt.Sprintf("`%s`", item)
-	})
-	writeList(buf, "Base-only benchmarks (missing on head):", baseOnlyNames, func(item string) string {
-		return fmt.Sprintf("`%s`", item)
-	})
+	showInvalidOnlySections := outcome.status != "incomplete"
+	writeComparisonTable(buf, rows, showInvalidOnlySections)
+	if showInvalidOnlySections {
+		writeList(buf, "Head-only benchmarks (missing on base):", headOnlyNames, func(item string) string {
+			return fmt.Sprintf("`%s`", item)
+		})
+		writeList(buf, "Base-only benchmarks (missing on head):", baseOnlyNames, func(item string) string {
+			return fmt.Sprintf("`%s`", item)
+		})
+	}
 	writeList(buf, "Incomplete benchmark samples:", outcome.diagnostics, func(item string) string {
 		return item
 	})
@@ -287,9 +297,11 @@ func writeComparisonSummary(buf *bytes.Buffer, rows []comparisonRow, headOnlyNam
 	}
 }
 
-func writeComparisonTable(buf *bytes.Buffer, rows []comparisonRow) {
+func writeComparisonTable(buf *bytes.Buffer, rows []comparisonRow, showEmptyMessage bool) {
 	if len(rows) == 0 {
-		buf.WriteString("No overlapping benchmark names were found between base and head.\n\n")
+		if showEmptyMessage {
+			buf.WriteString("No overlapping benchmark names were found between base and head.\n\n")
+		}
 		return
 	}
 
@@ -321,8 +333,8 @@ func benchmarkCountLabel(total int) string {
 	return strconv.Itoa(total)
 }
 
-func classifyComparisonOutcome(baseInput, headInput benchmarkInput, matchedNames, headOnlyNames, baseOnlyNames []string, hasRegression bool) comparisonOutcome {
-	if diagnostics := incompleteDiagnostics(baseInput, headInput); len(diagnostics) > 0 {
+func classifyComparisonOutcome(baseInput, headInput benchmarkInput, mismatchDiagnostics, matchedNames, headOnlyNames, baseOnlyNames []string, hasRegression bool) comparisonOutcome {
+	if diagnostics := incompleteDiagnostics(baseInput, headInput, mismatchDiagnostics); len(diagnostics) > 0 {
 		return comparisonOutcome{
 			exitCode:    exitCodeInvalid,
 			status:      "incomplete",
@@ -343,15 +355,39 @@ func classifyComparisonOutcome(baseInput, headInput benchmarkInput, matchedNames
 	return comparisonOutcome{exitCode: exitCodePassed, status: "passed"}
 }
 
-func incompleteDiagnostics(baseInput, headInput benchmarkInput) []string {
-	diagnostics := make([]string, 0, len(baseInput.incomplete)+len(headInput.incomplete))
+func incompleteDiagnostics(baseInput, headInput benchmarkInput, mismatchDiagnostics []string) []string {
+	diagnostics := make([]string, 0, len(baseInput.incomplete)+len(headInput.incomplete)+len(mismatchDiagnostics))
 	for _, diagnostic := range baseInput.incomplete {
 		diagnostics = append(diagnostics, "base: "+diagnostic)
 	}
 	for _, diagnostic := range headInput.incomplete {
 		diagnostics = append(diagnostics, "head: "+diagnostic)
 	}
+	diagnostics = append(diagnostics, mismatchDiagnostics...)
 	return diagnostics
+}
+
+func comparableMatchedNames(matchedNames []string, baseData, headData benchmarkData) ([]string, []string) {
+	comparableNames := make([]string, 0, len(matchedNames))
+	diagnostics := make([]string, 0)
+	for _, name := range matchedNames {
+		baseCount := sampleCount(baseData[name])
+		headCount := sampleCount(headData[name])
+		if baseCount != headCount {
+			diagnostics = append(diagnostics, sampleCountMismatchDiagnostic(name, baseCount, headCount))
+			continue
+		}
+		comparableNames = append(comparableNames, name)
+	}
+	return comparableNames, diagnostics
+}
+
+func sampleCount(sample samples) int {
+	return len(sample.bytesPerOp)
+}
+
+func sampleCountMismatchDiagnostic(name string, baseCount, headCount int) string {
+	return fmt.Sprintf("sample-count mismatch for `%s`: base=%d head=%d", name, baseCount, headCount)
 }
 
 func comparisonStatus(row comparisonRow) string {

--- a/tools/benchdelta/main.go
+++ b/tools/benchdelta/main.go
@@ -49,6 +49,10 @@ const (
 	exitCodePassed     = 0
 	exitCodeRegression = 1
 	exitCodeInvalid    = 2
+
+	benchmarkMetricNsPerOp     = "ns/op"
+	benchmarkMetricBytesPerOp  = "B/op"
+	benchmarkMetricAllocsPerOp = "allocs/op"
 )
 
 type benchmarkLineStatus uint8
@@ -175,41 +179,59 @@ func parseBenchmarkLine(currentPkg, line string) (string, samples, benchmarkLine
 	}
 	key := currentPkg + "/" + benchmarkName
 	var sample samples
-	var hasNsPerOp bool
-	var hasBytes bool
-	var hasAllocs bool
+	flags := benchmarkSampleFlags{}
 
 	for i := 2; i+1 < len(fields); i += 2 {
-		value, err := strconv.ParseFloat(fields[i], 64)
-		if err != nil {
-			continue
-		}
-		switch fields[i+1] {
-		case "ns/op":
-			hasNsPerOp = true
-		case "B/op":
-			if !isFinite(value) {
-				return key, samples{}, benchmarkLineInvalid, invalidSampleDiagnostic(key, "B/op", fields[i])
-			}
-			hasBytes = true
-			sample.bytesPerOp = append(sample.bytesPerOp, value)
-		case "allocs/op":
-			if !isFinite(value) {
-				return key, samples{}, benchmarkLineInvalid, invalidSampleDiagnostic(key, "allocs/op", fields[i])
-			}
-			hasAllocs = true
-			sample.allocsPerOp = append(sample.allocsPerOp, value)
+		status, diagnostic := collectBenchmarkMetric(fields[i+1], fields[i], key, &sample, &flags)
+		if status != benchmarkLineComplete {
+			return key, samples{}, status, diagnostic
 		}
 	}
 
-	if !hasBytes && !hasAllocs {
-		if hasNsPerOp {
+	return finalizeBenchmarkLine(key, sample, flags)
+}
+
+type benchmarkSampleFlags struct {
+	hasNsPerOp bool
+	hasBytes   bool
+	hasAllocs  bool
+}
+
+func collectBenchmarkMetric(unit, rawValue, key string, sample *samples, flags *benchmarkSampleFlags) (benchmarkLineStatus, string) {
+	value, err := strconv.ParseFloat(rawValue, 64)
+	if err != nil {
+		return benchmarkLineComplete, ""
+	}
+
+	switch unit {
+	case benchmarkMetricNsPerOp:
+		flags.hasNsPerOp = true
+	case benchmarkMetricBytesPerOp:
+		if !isFinite(value) {
+			return benchmarkLineInvalid, invalidSampleDiagnostic(key, benchmarkMetricBytesPerOp, rawValue)
+		}
+		flags.hasBytes = true
+		sample.bytesPerOp = append(sample.bytesPerOp, value)
+	case benchmarkMetricAllocsPerOp:
+		if !isFinite(value) {
+			return benchmarkLineInvalid, invalidSampleDiagnostic(key, benchmarkMetricAllocsPerOp, rawValue)
+		}
+		flags.hasAllocs = true
+		sample.allocsPerOp = append(sample.allocsPerOp, value)
+	}
+
+	return benchmarkLineComplete, ""
+}
+
+func finalizeBenchmarkLine(key string, sample samples, flags benchmarkSampleFlags) (string, samples, benchmarkLineStatus, string) {
+	if !flags.hasBytes && !flags.hasAllocs {
+		if flags.hasNsPerOp {
 			return key, samples{}, benchmarkLineIncomplete, incompleteSampleDiagnostic(key, true, true)
 		}
 		return "", samples{}, benchmarkLineIgnored, ""
 	}
-	if !hasBytes || !hasAllocs {
-		return key, samples{}, benchmarkLineIncomplete, incompleteSampleDiagnostic(key, !hasBytes, !hasAllocs)
+	if !flags.hasBytes || !flags.hasAllocs {
+		return key, samples{}, benchmarkLineIncomplete, incompleteSampleDiagnostic(key, !flags.hasBytes, !flags.hasAllocs)
 	}
 	return key, sample, benchmarkLineComplete, ""
 }
@@ -231,10 +253,10 @@ func normalizeBenchmarkName(name string) string {
 func incompleteSampleDiagnostic(name string, missingBytes, missingAllocs bool) string {
 	missing := make([]string, 0, 2)
 	if missingBytes {
-		missing = append(missing, "B/op")
+		missing = append(missing, benchmarkMetricBytesPerOp)
 	}
 	if missingAllocs {
-		missing = append(missing, "allocs/op")
+		missing = append(missing, benchmarkMetricAllocsPerOp)
 	}
 	return fmt.Sprintf("`%s` missing %s", name, strings.Join(missing, " and "))
 }

--- a/tools/benchdelta/main.go
+++ b/tools/benchdelta/main.go
@@ -21,6 +21,11 @@ type samples struct {
 
 type benchmarkData map[string]samples
 
+type benchmarkInput struct {
+	data       benchmarkData
+	incomplete []string
+}
+
 type deltaThresholds struct {
 	bytesPct  float64
 	allocsPct float64
@@ -38,6 +43,27 @@ type comparisonRow struct {
 	regressedAllocs bool
 }
 
+const (
+	exitCodePassed     = 0
+	exitCodeRegression = 1
+	exitCodeInvalid    = 2
+)
+
+type benchmarkLineStatus uint8
+
+const (
+	benchmarkLineIgnored benchmarkLineStatus = iota
+	benchmarkLineComplete
+	benchmarkLineIncomplete
+)
+
+type comparisonOutcome struct {
+	exitCode    int
+	status      string
+	result      string
+	diagnostics []string
+}
+
 func main() {
 	basePath := flag.String("base", "", "path to base benchmark output")
 	headPath := flag.String("head", "", "path to head benchmark output")
@@ -50,11 +76,11 @@ func main() {
 		exitErr(errors.New("both -base and -head are required"))
 	}
 
-	baseData, err := parseBenchmarkFile(*basePath)
+	baseInput, err := parseBenchmarkFile(*basePath)
 	if err != nil {
 		exitErr(fmt.Errorf("parse base benchmarks: %w", err))
 	}
-	headData, err := parseBenchmarkFile(*headPath)
+	headInput, err := parseBenchmarkFile(*headPath)
 	if err != nil {
 		exitErr(fmt.Errorf("parse head benchmarks: %w", err))
 	}
@@ -63,27 +89,27 @@ func main() {
 		bytesPct:  *maxBytesPct,
 		allocsPct: *maxAllocsPct,
 	}
-	summary, hasRegression := compareBenchmarks(baseData, headData, limits)
+	summary, statusCode := compareBenchmarks(baseInput, headInput, limits)
 	fmt.Print(summary)
 	if *summaryOut != "" {
 		if err := os.WriteFile(*summaryOut, []byte(summary), 0o600); err != nil {
 			exitErr(fmt.Errorf("write summary: %w", err))
 		}
 	}
-	if hasRegression {
-		os.Exit(1)
+	if statusCode != exitCodePassed {
+		os.Exit(statusCode)
 	}
 }
 
 func exitErr(err error) {
 	fmt.Fprintln(os.Stderr, err)
-	os.Exit(2)
+	os.Exit(exitCodeInvalid)
 }
 
-func parseBenchmarkFile(path string) (result benchmarkData, err error) {
+func parseBenchmarkFile(path string) (result benchmarkInput, err error) {
 	file, err := safeio.OpenFile(path)
 	if err != nil {
-		return nil, err
+		return benchmarkInput{}, err
 	}
 	defer func() {
 		closeErr := file.Close()
@@ -92,7 +118,7 @@ func parseBenchmarkFile(path string) (result benchmarkData, err error) {
 		}
 	}()
 
-	result = make(benchmarkData)
+	result = benchmarkInput{data: make(benchmarkData)}
 	currentPkg := ""
 
 	scanner := bufio.NewScanner(file)
@@ -102,27 +128,29 @@ func parseBenchmarkFile(path string) (result benchmarkData, err error) {
 		case strings.HasPrefix(line, "pkg: "):
 			currentPkg = strings.TrimSpace(strings.TrimPrefix(line, "pkg: "))
 		case strings.HasPrefix(line, "Benchmark"):
-			name, sample, ok := parseBenchmarkLine(currentPkg, line)
-			if !ok {
-				continue
+			name, sample, status, diagnostic := parseBenchmarkLine(currentPkg, line)
+			switch status {
+			case benchmarkLineComplete:
+				existing := result.data[name]
+				existing.bytesPerOp = append(existing.bytesPerOp, sample.bytesPerOp...)
+				existing.allocsPerOp = append(existing.allocsPerOp, sample.allocsPerOp...)
+				result.data[name] = existing
+			case benchmarkLineIncomplete:
+				result.incomplete = append(result.incomplete, diagnostic)
 			}
-			existing := result[name]
-			existing.bytesPerOp = append(existing.bytesPerOp, sample.bytesPerOp...)
-			existing.allocsPerOp = append(existing.allocsPerOp, sample.allocsPerOp...)
-			result[name] = existing
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, err
+		return benchmarkInput{}, err
 	}
 	return result, nil
 }
 
-func parseBenchmarkLine(currentPkg, line string) (string, samples, bool) {
+func parseBenchmarkLine(currentPkg, line string) (string, samples, benchmarkLineStatus, string) {
 	fields := strings.Fields(line)
 	if len(fields) < 4 {
-		return "", samples{}, false
+		return "", samples{}, benchmarkLineIgnored, ""
 	}
 
 	benchmarkName := normalizeBenchmarkName(fields[0])
@@ -131,6 +159,8 @@ func parseBenchmarkLine(currentPkg, line string) (string, samples, bool) {
 	}
 	key := currentPkg + "/" + benchmarkName
 	var sample samples
+	var hasBytes bool
+	var hasAllocs bool
 
 	for i := 2; i+1 < len(fields); i += 2 {
 		value, err := strconv.ParseFloat(fields[i], 64)
@@ -139,16 +169,21 @@ func parseBenchmarkLine(currentPkg, line string) (string, samples, bool) {
 		}
 		switch fields[i+1] {
 		case "B/op":
+			hasBytes = true
 			sample.bytesPerOp = append(sample.bytesPerOp, value)
 		case "allocs/op":
+			hasAllocs = true
 			sample.allocsPerOp = append(sample.allocsPerOp, value)
 		}
 	}
 
-	if len(sample.bytesPerOp) == 0 && len(sample.allocsPerOp) == 0 {
-		return "", samples{}, false
+	if !hasBytes && !hasAllocs {
+		return "", samples{}, benchmarkLineIgnored, ""
 	}
-	return key, sample, true
+	if !hasBytes || !hasAllocs {
+		return key, samples{}, benchmarkLineIncomplete, incompleteSampleDiagnostic(key, !hasBytes, !hasAllocs)
+	}
+	return key, sample, benchmarkLineComplete, ""
 }
 
 func normalizeBenchmarkName(name string) string {
@@ -165,17 +200,29 @@ func normalizeBenchmarkName(name string) string {
 	return name[:idx]
 }
 
-func compareBenchmarks(baseData, headData benchmarkData, limits deltaThresholds) (string, bool) {
-	matchedNames := intersectKeys(baseData, headData)
-	newOnlyNames := differenceKeys(headData, baseData)
-	baseOnlyNames := differenceKeys(baseData, headData)
+func incompleteSampleDiagnostic(name string, missingBytes, missingAllocs bool) string {
+	missing := make([]string, 0, 2)
+	if missingBytes {
+		missing = append(missing, "B/op")
+	}
+	if missingAllocs {
+		missing = append(missing, "allocs/op")
+	}
+	return fmt.Sprintf("`%s` missing %s", name, strings.Join(missing, " and "))
+}
 
-	rows, hasRegression := buildComparisonRows(matchedNames, baseData, headData, limits)
+func compareBenchmarks(baseInput, headInput benchmarkInput, limits deltaThresholds) (string, int) {
+	matchedNames := intersectKeys(baseInput.data, headInput.data)
+	headOnlyNames := differenceKeys(headInput.data, baseInput.data)
+	baseOnlyNames := differenceKeys(baseInput.data, headInput.data)
+
+	rows, hasRegression := buildComparisonRows(matchedNames, baseInput.data, headInput.data, limits)
+	outcome := classifyComparisonOutcome(baseInput, headInput, matchedNames, headOnlyNames, baseOnlyNames, hasRegression)
 
 	var buf bytes.Buffer
-	writeComparisonSummary(&buf, rows, newOnlyNames, baseOnlyNames, limits, hasRegression)
+	writeComparisonSummary(&buf, rows, headOnlyNames, baseOnlyNames, limits, outcome)
 
-	return buf.String(), hasRegression
+	return buf.String(), outcome.exitCode
 }
 
 func buildComparisonRows(matchedNames []string, baseData, headData benchmarkData, limits deltaThresholds) ([]comparisonRow, bool) {
@@ -212,19 +259,32 @@ func newComparisonRow(name string, baseSample, headSample samples, limits deltaT
 	}
 }
 
-func writeComparisonSummary(buf *bytes.Buffer, rows []comparisonRow, newOnlyNames, baseOnlyNames []string, limits deltaThresholds, hasRegression bool) {
+func writeComparisonSummary(buf *bytes.Buffer, rows []comparisonRow, headOnlyNames, baseOnlyNames []string, limits deltaThresholds, outcome comparisonOutcome) {
 	buf.WriteString("## Memory Benchmarks\n\n")
 	fmt.Fprintf(buf, "Thresholds: bytes/op <= +%.1f%%, allocs/op <= +%.1f%%\n\n", limits.bytesPct, limits.allocsPct)
+	fmt.Fprintf(buf, "Base benchmarks: %s\n", benchmarkCountLabel(len(rows)+len(baseOnlyNames)))
+	fmt.Fprintf(buf, "Head benchmarks: %s\n\n", benchmarkCountLabel(len(rows)+len(headOnlyNames)))
 
 	writeComparisonTable(buf, rows)
-	writeBenchmarkNameList(buf, "New-only benchmarks (reported, not gated until present on base):", newOnlyNames)
-	writeBenchmarkNameList(buf, "Base-only benchmarks (not compared on head):", baseOnlyNames)
+	writeList(buf, "Head-only benchmarks (missing on base):", headOnlyNames, func(item string) string {
+		return fmt.Sprintf("`%s`", item)
+	})
+	writeList(buf, "Base-only benchmarks (missing on head):", baseOnlyNames, func(item string) string {
+		return fmt.Sprintf("`%s`", item)
+	})
+	writeList(buf, "Incomplete benchmark samples:", outcome.diagnostics, func(item string) string {
+		return item
+	})
 
-	if hasRegression {
+	switch outcome.status {
+	case "incomplete", "invalid":
+		fmt.Fprintf(buf, "Comparison status: %s\n", outcome.status)
+		fmt.Fprintf(buf, "%s\n", outcome.result)
+	case "regression":
 		buf.WriteString("Result: memory benchmark regression detected.\n")
-		return
+	default:
+		buf.WriteString("Result: memory benchmark gate passed.\n")
 	}
-	buf.WriteString("Result: memory benchmark gate passed.\n")
 }
 
 func writeComparisonTable(buf *bytes.Buffer, rows []comparisonRow) {
@@ -241,17 +301,57 @@ func writeComparisonTable(buf *bytes.Buffer, rows []comparisonRow) {
 	buf.WriteString("\n")
 }
 
-func writeBenchmarkNameList(buf *bytes.Buffer, title string, names []string) {
-	if len(names) == 0 {
+func writeList(buf *bytes.Buffer, title string, items []string, formatItem func(string) string) {
+	if len(items) == 0 {
 		return
 	}
 
 	buf.WriteString(title)
 	buf.WriteString("\n")
-	for _, name := range names {
-		fmt.Fprintf(buf, "- `%s`\n", name)
+	for _, item := range items {
+		fmt.Fprintf(buf, "- %s\n", formatItem(item))
 	}
 	buf.WriteString("\n")
+}
+
+func benchmarkCountLabel(total int) string {
+	if total == 0 {
+		return "none"
+	}
+	return strconv.Itoa(total)
+}
+
+func classifyComparisonOutcome(baseInput, headInput benchmarkInput, matchedNames, headOnlyNames, baseOnlyNames []string, hasRegression bool) comparisonOutcome {
+	if diagnostics := incompleteDiagnostics(baseInput, headInput); len(diagnostics) > 0 {
+		return comparisonOutcome{
+			exitCode:    exitCodeInvalid,
+			status:      "incomplete",
+			result:      "Result: benchmark input contained incomplete memory samples; each benchmark line must include both B/op and allocs/op.",
+			diagnostics: diagnostics,
+		}
+	}
+	if len(baseInput.data) == 0 || len(headInput.data) == 0 || len(matchedNames) == 0 || len(headOnlyNames) > 0 || len(baseOnlyNames) > 0 {
+		return comparisonOutcome{
+			exitCode: exitCodeInvalid,
+			status:   "invalid",
+			result:   "Result: every selected benchmark must be present on both base and head.",
+		}
+	}
+	if hasRegression {
+		return comparisonOutcome{exitCode: exitCodeRegression, status: "regression"}
+	}
+	return comparisonOutcome{exitCode: exitCodePassed, status: "passed"}
+}
+
+func incompleteDiagnostics(baseInput, headInput benchmarkInput) []string {
+	diagnostics := make([]string, 0, len(baseInput.incomplete)+len(headInput.incomplete))
+	for _, diagnostic := range baseInput.incomplete {
+		diagnostics = append(diagnostics, "base: "+diagnostic)
+	}
+	for _, diagnostic := range headInput.incomplete {
+		diagnostics = append(diagnostics, "head: "+diagnostic)
+	}
+	return diagnostics
 }
 
 func comparisonStatus(row comparisonRow) string {

--- a/tools/benchdelta/main.go
+++ b/tools/benchdelta/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -24,6 +25,7 @@ type benchmarkData map[string]samples
 type benchmarkInput struct {
 	data       benchmarkData
 	incomplete []string
+	invalid    []string
 }
 
 type deltaThresholds struct {
@@ -55,13 +57,15 @@ const (
 	benchmarkLineIgnored benchmarkLineStatus = iota
 	benchmarkLineComplete
 	benchmarkLineIncomplete
+	benchmarkLineInvalid
 )
 
 type comparisonOutcome struct {
-	exitCode    int
-	status      string
-	result      string
-	diagnostics []string
+	exitCode         int
+	status           string
+	result           string
+	diagnostics      []string
+	diagnosticsTitle string
 }
 
 type comparisonSummary struct {
@@ -147,6 +151,8 @@ func parseBenchmarkFile(path string) (result benchmarkInput, err error) {
 				result.data[name] = existing
 			case benchmarkLineIncomplete:
 				result.incomplete = append(result.incomplete, diagnostic)
+			case benchmarkLineInvalid:
+				result.invalid = append(result.invalid, diagnostic)
 			}
 		}
 	}
@@ -182,9 +188,15 @@ func parseBenchmarkLine(currentPkg, line string) (string, samples, benchmarkLine
 		case "ns/op":
 			hasNsPerOp = true
 		case "B/op":
+			if !isFinite(value) {
+				return key, samples{}, benchmarkLineInvalid, invalidSampleDiagnostic(key, "B/op", fields[i])
+			}
 			hasBytes = true
 			sample.bytesPerOp = append(sample.bytesPerOp, value)
 		case "allocs/op":
+			if !isFinite(value) {
+				return key, samples{}, benchmarkLineInvalid, invalidSampleDiagnostic(key, "allocs/op", fields[i])
+			}
 			hasAllocs = true
 			sample.allocsPerOp = append(sample.allocsPerOp, value)
 		}
@@ -225,6 +237,10 @@ func incompleteSampleDiagnostic(name string, missingBytes, missingAllocs bool) s
 		missing = append(missing, "allocs/op")
 	}
 	return fmt.Sprintf("`%s` missing %s", name, strings.Join(missing, " and "))
+}
+
+func invalidSampleDiagnostic(name, metric, value string) string {
+	return fmt.Sprintf("`%s` has non-finite %s value %q", name, metric, value)
 }
 
 func compareBenchmarks(baseInput, headInput benchmarkInput, limits deltaThresholds) (string, int) {
@@ -290,7 +306,7 @@ func writeComparisonSummary(buf *bytes.Buffer, summary comparisonSummary) {
 	fmt.Fprintf(buf, "Base benchmarks: %s\n", benchmarkCountLabel(summary.baseCount))
 	fmt.Fprintf(buf, "Head benchmarks: %s\n\n", benchmarkCountLabel(summary.headCount))
 
-	showInvalidOnlySections := summary.outcome.status != "incomplete"
+	showInvalidOnlySections := summary.outcome.diagnosticsTitle == ""
 	writeComparisonTable(buf, summary.rows, showInvalidOnlySections)
 	if showInvalidOnlySections {
 		writeList(buf, "Head-only benchmarks (missing on base):", summary.headOnlyNames, func(item string) string {
@@ -300,9 +316,7 @@ func writeComparisonSummary(buf *bytes.Buffer, summary comparisonSummary) {
 			return fmt.Sprintf("`%s`", item)
 		})
 	}
-	writeList(buf, "Incomplete benchmark samples:", summary.outcome.diagnostics, func(item string) string {
-		return item
-	})
+	writeList(buf, summary.outcome.diagnosticsTitle, summary.outcome.diagnostics, func(item string) string { return item })
 
 	switch summary.outcome.status {
 	case "incomplete", "invalid":
@@ -352,12 +366,22 @@ func benchmarkCountLabel(total int) string {
 }
 
 func classifyComparisonOutcome(baseInput, headInput benchmarkInput, mismatchDiagnostics, matchedNames, headOnlyNames, baseOnlyNames []string, hasRegression bool) comparisonOutcome {
+	if diagnostics := invalidDiagnostics(baseInput, headInput); len(diagnostics) > 0 {
+		return comparisonOutcome{
+			exitCode:         exitCodeInvalid,
+			status:           "invalid",
+			result:           "Result: benchmark input contained invalid memory samples; each B/op and allocs/op value must be finite.",
+			diagnostics:      diagnostics,
+			diagnosticsTitle: "Invalid benchmark samples:",
+		}
+	}
 	if diagnostics := incompleteDiagnostics(baseInput, headInput, mismatchDiagnostics); len(diagnostics) > 0 {
 		return comparisonOutcome{
-			exitCode:    exitCodeInvalid,
-			status:      "incomplete",
-			result:      "Result: benchmark input contained incomplete memory samples; each benchmark line must include both B/op and allocs/op.",
-			diagnostics: diagnostics,
+			exitCode:         exitCodeInvalid,
+			status:           "incomplete",
+			result:           "Result: benchmark input contained incomplete memory samples; each benchmark line must include both B/op and allocs/op.",
+			diagnostics:      diagnostics,
+			diagnosticsTitle: "Incomplete benchmark samples:",
 		}
 	}
 	if len(baseInput.data) == 0 || len(headInput.data) == 0 || len(matchedNames) == 0 || len(headOnlyNames) > 0 || len(baseOnlyNames) > 0 {
@@ -371,6 +395,17 @@ func classifyComparisonOutcome(baseInput, headInput benchmarkInput, mismatchDiag
 		return comparisonOutcome{exitCode: exitCodeRegression, status: "regression"}
 	}
 	return comparisonOutcome{exitCode: exitCodePassed, status: "passed"}
+}
+
+func invalidDiagnostics(baseInput, headInput benchmarkInput) []string {
+	diagnostics := make([]string, 0, len(baseInput.invalid)+len(headInput.invalid))
+	for _, diagnostic := range baseInput.invalid {
+		diagnostics = append(diagnostics, "base: "+diagnostic)
+	}
+	for _, diagnostic := range headInput.invalid {
+		diagnostics = append(diagnostics, "head: "+diagnostic)
+	}
+	return diagnostics
 }
 
 func incompleteDiagnostics(baseInput, headInput benchmarkInput, mismatchDiagnostics []string) []string {
@@ -446,6 +481,10 @@ func average(values []float64) float64 {
 		total += value
 	}
 	return total / float64(len(values))
+}
+
+func isFinite(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
 }
 
 func percentDelta(base, head, limit float64) (string, bool) {

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"errors"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -130,6 +132,83 @@ func TestParseBenchmarkLineRejectsIncompleteMetrics(t *testing.T) {
 				t.Fatalf("parseBenchmarkLine(%q) diagnostic = %q, want %q", tc.line, diagnostic, tc.wantDiagnostic)
 			}
 		})
+	}
+}
+
+func TestParseBenchmarkLineRejectsNonFiniteMemoryMetrics(t *testing.T) {
+	t.Parallel()
+
+	spellings := acceptedNonFiniteSpellings(t)
+	metrics := []struct {
+		name        string
+		metric      string
+		bytesValue  string
+		allocsValue string
+	}{
+		{
+			name:        "bytes",
+			metric:      "B/op",
+			allocsValue: "3",
+		},
+		{
+			name:       "allocs",
+			metric:     "allocs/op",
+			bytesValue: "128",
+		},
+	}
+
+	for _, metric := range metrics {
+		t.Run(metric.name, func(t *testing.T) {
+			for _, spelling := range spellings {
+				bytesValue, allocsValue := metric.bytesValue, metric.allocsValue
+				if metric.metric == "B/op" {
+					bytesValue = spelling
+				} else {
+					allocsValue = spelling
+				}
+				line := bytesAllocsBenchmark("NonFinite", bytesValue, allocsValue)
+
+				name, sample, status, diagnostic := parseBenchmarkLine("pkg", line)
+				if status != benchmarkLineInvalid {
+					t.Fatalf("parseBenchmarkLine(%q) status = %v, want invalid", line, status)
+				}
+				if name == "" || len(sample.bytesPerOp) != 0 || len(sample.allocsPerOp) != 0 {
+					t.Fatalf("parseBenchmarkLine(%q) returned unexpected sample %#v for %q", line, sample, name)
+				}
+				wantDiagnostic := invalidBenchmarkMetric("pkg", "NonFinite", metric.metric, spelling)
+				if diagnostic != wantDiagnostic {
+					t.Fatalf("parseBenchmarkLine(%q) diagnostic = %q, want %q", line, diagnostic, wantDiagnostic)
+				}
+			}
+		})
+	}
+}
+
+func TestAcceptedNonFiniteSpellings(t *testing.T) {
+	t.Parallel()
+
+	spellings := acceptedNonFiniteSpellings(t)
+	wantCount := (1 << len("nan")) + 3*(1<<len("inf")) + 3*(1<<len("infinity"))
+	if len(spellings) != wantCount {
+		t.Fatalf("acceptedNonFiniteSpellings() returned %d spellings, want %d", len(spellings), wantCount)
+	}
+
+	unique := make(map[string]struct{}, len(spellings))
+	for _, spelling := range spellings {
+		if _, exists := unique[spelling]; exists {
+			t.Fatalf("acceptedNonFiniteSpellings() returned duplicate %q", spelling)
+		}
+		unique[spelling] = struct{}{}
+	}
+	for _, representative := range []string{"nAn", "iNf", "+iNf", "-iNf", "iNfInItY", "+iNfInItY", "-iNfInItY"} {
+		if !slices.Contains(spellings, representative) {
+			t.Errorf("acceptedNonFiniteSpellings() omitted %q", representative)
+		}
+	}
+	for _, signedNaN := range []string{"+nAn", "-nAn"} {
+		if slices.Contains(spellings, signedNaN) {
+			t.Errorf("acceptedNonFiniteSpellings() unexpectedly included %q", signedNaN)
+		}
 	}
 }
 
@@ -342,7 +421,59 @@ func TestCompareBenchmarksRejectsIncompleteSamples(t *testing.T) {
 	}
 }
 
+func TestCompareBenchmarksRejectsInvalidSamples(t *testing.T) {
+	t.Parallel()
+
+	tests := []comparisonScenario{
+		{
+			name:      "base bytes nan is invalid",
+			baseLines: reportFixture(bytesAllocsBenchmark("Format", "NaN", "1")),
+			headLines: reportFixture(completeBenchmark("Format")),
+			wantContains: []string{
+				"Comparison status: invalid",
+				"base: " + invalidBenchmarkMetric(reportBenchmarkPkg, "Format", "B/op", "NaN"),
+				"Result: benchmark input contained invalid memory samples; each B/op and allocs/op value must be finite.",
+			},
+			wantOmit: incompleteInvalidDiagnostics(),
+		},
+		{
+			name:      "head allocs inf is invalid",
+			baseLines: reportFixture(completeBenchmark("Format")),
+			headLines: reportFixture(bytesAllocsBenchmark("Format", "100", "+Inf")),
+			wantContains: []string{
+				"Comparison status: invalid",
+				"head: " + invalidBenchmarkMetric(reportBenchmarkPkg, "Format", "allocs/op", "+Inf"),
+				"Result: benchmark input contained invalid memory samples; each B/op and allocs/op value must be finite.",
+			},
+			wantOmit: incompleteInvalidDiagnostics(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assertComparisonScenario(t, tc)
+		})
+	}
+}
+
 func TestParseBenchmarkFileBranches(t *testing.T) {
+	t.Run("records non-finite benchmark lines as invalid", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bench.txt")
+		writeBenchmarkFixture(t, path, reportFixture(bytesAllocsBenchmark("Invalid", "nan", "1")))
+
+		input, err := parseBenchmarkFile(path)
+		if err != nil {
+			t.Fatalf("parse benchmark file: %v", err)
+		}
+		wantDiagnostic := invalidBenchmarkMetric(reportBenchmarkPkg, "Invalid", "B/op", "nan")
+		if !slices.Equal(input.invalid, []string{wantDiagnostic}) {
+			t.Fatalf("invalid diagnostics = %#v, want %#v", input.invalid, []string{wantDiagnostic})
+		}
+		if len(input.incomplete) != 0 || len(input.data) != 0 {
+			t.Fatalf("non-finite line classified outside invalid: data=%#v incomplete=%#v", input.data, input.incomplete)
+		}
+	})
+
 	t.Run("skips invalid benchmark lines in file", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "bench.txt")
 		writeBenchmarkFixture(t, path, reportFixture(benchmarkFixtureLine("Ignored", "1000", "100", "ns/op"), completeBenchmark("Format")))
@@ -451,6 +582,18 @@ func TestMainExitCodesAndErrorPaths(t *testing.T) {
 			wantOmit:   incompleteInvalidDiagnostics(),
 		},
 		{
+			name:       "bytes nan invalid",
+			args:       []string{"-base", filepath.Join(dir, "base-bytes-nan.txt"), "-head", headPath},
+			wantCode:   exitCodeInvalid,
+			wantOutput: invalidBenchmarkMetric(reportBenchmarkPkg, "Format", "B/op", "NaN"),
+		},
+		{
+			name:       "allocs signed mixed-case infinity invalid",
+			args:       []string{"-base", basePath, "-head", filepath.Join(dir, "head-allocs-mixed-infinity.txt")},
+			wantCode:   exitCodeInvalid,
+			wantOutput: invalidBenchmarkMetric(reportBenchmarkPkg, "Format", "allocs/op", "-iNfInItY"),
+		},
+		{
 			name:       "missing args",
 			args:       nil,
 			wantCode:   exitCodeInvalid,
@@ -481,6 +624,8 @@ func TestMainExitCodesAndErrorPaths(t *testing.T) {
 	writeBenchmarkFixture(t, filepath.Join(dir, "base-ns-only.txt"), reportFixture(benchmarkFixtureLine("Format", "1000", "100", "ns/op")))
 	writeBenchmarkFixture(t, filepath.Join(dir, "count-mismatch-base.txt"), reportFixture(repeatedCompleteBenchmark("Format", 3)...))
 	writeBenchmarkFixture(t, filepath.Join(dir, "count-mismatch-head.txt"), reportFixture(completeBenchmark("Format")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "base-bytes-nan.txt"), reportFixture(bytesAllocsBenchmark("Format", "NaN", "1")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "head-allocs-mixed-infinity.txt"), reportFixture(bytesAllocsBenchmark("Format", "100", "-iNfInItY")))
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -718,6 +863,45 @@ func benchmarkRef(pkg, name string) string {
 
 func benchmarkMissingMetric(pkg, name, metric string) string {
 	return benchmarkRef(pkg, name) + " missing " + metric
+}
+
+func invalidBenchmarkMetric(pkg, name, metric, value string) string {
+	return benchmarkRef(pkg, name) + " has non-finite " + metric + " value " + strconv.Quote(value)
+}
+
+func acceptedNonFiniteSpellings(t *testing.T) []string {
+	t.Helper()
+
+	var accepted []string
+	for _, token := range []string{"nan", "inf", "infinity"} {
+		for _, permutation := range asciiCasePermutations(token) {
+			for _, sign := range []string{"", "+", "-"} {
+				candidate := sign + permutation
+				value, err := strconv.ParseFloat(candidate, 64)
+				if err == nil && (math.IsNaN(value) || math.IsInf(value, 0)) {
+					accepted = append(accepted, candidate)
+				}
+			}
+		}
+	}
+	if len(accepted) == 0 {
+		t.Fatal("strconv.ParseFloat accepted no non-finite spellings")
+	}
+	return accepted
+}
+
+func asciiCasePermutations(token string) []string {
+	permutations := make([]string, 0, 1<<len(token))
+	for mask := 0; mask < 1<<len(token); mask++ {
+		permutation := []byte(token)
+		for i := range permutation {
+			if mask&(1<<i) != 0 {
+				permutation[i] -= 'a' - 'A'
+			}
+		}
+		permutations = append(permutations, string(permutation))
+	}
+	return permutations
 }
 
 func completeBenchmarkSample() samples {

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -23,7 +23,6 @@ func TestParseBenchmarkFileAndCompare(t *testing.T) {
 		"pkg: github.com/ben-ranford/lopper/internal/report",
 		"BenchmarkFormatLargeTable-8    500   90000 ns/op   64000 B/op   120 allocs/op",
 	}
-	base := strings.Join(baseLines, "\n")
 	headLines := []string{
 		"goos: darwin",
 		"pkg: github.com/ben-ranford/lopper/internal/lang/shared",
@@ -31,39 +30,28 @@ func TestParseBenchmarkFileAndCompare(t *testing.T) {
 		"BenchmarkCountUsage-8    1000   25500 ns/op   30000 B/op   430 allocs/op",
 		"pkg: github.com/ben-ranford/lopper/internal/report",
 		"BenchmarkFormatLargeTable-8    500   90000 ns/op   64000 B/op   120 allocs/op",
-		"pkg: github.com/ben-ranford/lopper/internal/notify",
-		"BenchmarkNotifyDispatch-8    1000   12000 ns/op   1024 B/op   12 allocs/op",
 	}
-	head := strings.Join(headLines, "\n")
+	writeBenchmarkFixture(t, basePath, baseLines[1:])
+	writeBenchmarkFixture(t, headPath, headLines[1:])
 
-	if err := os.WriteFile(basePath, []byte(base), 0o644); err != nil {
-		t.Fatalf("write base: %v", err)
-	}
-	if err := os.WriteFile(headPath, []byte(head), 0o644); err != nil {
-		t.Fatalf("write head: %v", err)
-	}
-
-	baseData, err := parseBenchmarkFile(basePath)
+	baseInput, err := parseBenchmarkFile(basePath)
 	if err != nil {
 		t.Fatalf("parse base: %v", err)
 	}
-	headData, err := parseBenchmarkFile(headPath)
+	headInput, err := parseBenchmarkFile(headPath)
 	if err != nil {
 		t.Fatalf("parse head: %v", err)
 	}
 
-	summary, hasRegression := compareBenchmarks(baseData, headData, deltaThresholds{
+	summary, statusCode := compareBenchmarks(baseInput, headInput, deltaThresholds{
 		bytesPct:  15,
 		allocsPct: 10,
 	})
-	if !hasRegression {
-		t.Fatalf("expected regression from increased bytes/op and allocs/op")
+	if statusCode != exitCodeRegression {
+		t.Fatalf("expected regression status 1 from increased bytes/op and allocs/op, got %d\n%s", statusCode, summary)
 	}
 	if !strings.Contains(summary, "BenchmarkCountUsage") {
 		t.Fatalf("expected matched benchmark in summary, got:\n%s", summary)
-	}
-	if !strings.Contains(summary, "New-only benchmarks") {
-		t.Fatalf("expected new-only benchmarks note, got:\n%s", summary)
 	}
 	if !strings.Contains(summary, "regression") {
 		t.Fatalf("expected regression status, got:\n%s", summary)
@@ -83,9 +71,9 @@ func TestPercentDelta(t *testing.T) {
 }
 
 func TestBenchmarkParsingAndFormattingBranches(t *testing.T) {
-	name, sample, ok := parseBenchmarkLine("", "BenchmarkFresh-8 1000 25000 ns/op 128 B/op 3 allocs/op")
-	if !ok || name != "unknown-package/BenchmarkFresh" {
-		t.Fatalf("expected unknown-package fallback benchmark, got name=%q ok=%v", name, ok)
+	name, sample, status, diagnostic := parseBenchmarkLine("", "BenchmarkFresh-8 1000 25000 ns/op 128 B/op 3 allocs/op")
+	if status != benchmarkLineComplete || diagnostic != "" || name != "unknown-package/BenchmarkFresh" {
+		t.Fatalf("expected unknown-package fallback benchmark, got name=%q status=%v diagnostic=%q", name, status, diagnostic)
 	}
 	if len(sample.bytesPerOp) != 1 || len(sample.allocsPerOp) != 1 {
 		t.Fatalf("expected bytes and allocs samples, got %#v", sample)
@@ -96,8 +84,33 @@ func TestBenchmarkParsingAndFormattingBranches(t *testing.T) {
 		"BenchmarkNoMetrics-8 1000 25000 ns/op",
 		"BenchmarkBadValue-8 1000 nope B/op",
 	} {
-		if _, _, ok := parseBenchmarkLine("pkg", line); ok {
+		if _, _, status, _ := parseBenchmarkLine("pkg", line); status != benchmarkLineIgnored {
 			t.Fatalf("expected parseBenchmarkLine(%q) to be ignored", line)
+		}
+	}
+
+	for _, tc := range []struct {
+		line           string
+		wantDiagnostic string
+	}{
+		{
+			line:           "BenchmarkBytesOnly-8 1000 25000 ns/op 128 B/op",
+			wantDiagnostic: "`pkg/BenchmarkBytesOnly` missing allocs/op",
+		},
+		{
+			line:           "BenchmarkAllocsOnly-8 1000 25000 ns/op 3 allocs/op",
+			wantDiagnostic: "`pkg/BenchmarkAllocsOnly` missing B/op",
+		},
+	} {
+		name, sample, status, diagnostic := parseBenchmarkLine("pkg", tc.line)
+		if status != benchmarkLineIncomplete {
+			t.Fatalf("parseBenchmarkLine(%q) status = %v, want incomplete", tc.line, status)
+		}
+		if name == "" || len(sample.bytesPerOp) != 0 || len(sample.allocsPerOp) != 0 {
+			t.Fatalf("parseBenchmarkLine(%q) returned unexpected sample %#v for %q", tc.line, sample, name)
+		}
+		if diagnostic != tc.wantDiagnostic {
+			t.Fatalf("parseBenchmarkLine(%q) diagnostic = %q, want %q", tc.line, diagnostic, tc.wantDiagnostic)
 		}
 	}
 
@@ -113,14 +126,264 @@ func TestBenchmarkParsingAndFormattingBranches(t *testing.T) {
 	if got := average([]float64{2, 4, 6}); got != 4 {
 		t.Fatalf("expected average 4, got %.1f", got)
 	}
+}
 
-	summary, hasRegression := compareBenchmarks(benchmarkData{}, benchmarkData{}, deltaThresholds{bytesPct: 15, allocsPct: 10})
-	if hasRegression {
-		t.Fatalf("expected empty comparison to pass, got summary %q", summary)
+func TestIssue1403CompareRejectsMissingBenchmarks(t *testing.T) {
+	tests := []struct {
+		name           string
+		base           benchmarkInput
+		head           benchmarkInput
+		wantStatusCode int
+		wantContains   []string
+	}{
+		{
+			name:           "both empty",
+			base:           benchmarkInput{data: benchmarkData{}},
+			head:           benchmarkInput{data: benchmarkData{}},
+			wantStatusCode: exitCodeInvalid,
+			wantContains: []string{
+				"Comparison status: invalid",
+				"Base benchmarks: none",
+				"Head benchmarks: none",
+				"No overlapping benchmark names were found between base and head.",
+			},
+		},
+		{
+			name: "head-only",
+			base: benchmarkInput{data: benchmarkData{
+				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkShared": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
+			}},
+			head: benchmarkInput{data: benchmarkData{
+				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkShared":   {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
+				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkHeadOnly": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
+			}},
+			wantStatusCode: exitCodeInvalid,
+			wantContains: []string{
+				"Comparison status: invalid",
+				"Head-only benchmarks (missing on base):",
+				"`github.com/ben-ranford/lopper/pkg/bench/BenchmarkHeadOnly`",
+			},
+		},
+		{
+			name: "base-only",
+			base: benchmarkInput{data: benchmarkData{
+				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkShared":   {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
+				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkBaseOnly": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
+			}},
+			head: benchmarkInput{data: benchmarkData{
+				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkShared": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
+			}},
+			wantStatusCode: exitCodeInvalid,
+			wantContains: []string{
+				"Comparison status: invalid",
+				"Base-only benchmarks (missing on head):",
+				"`github.com/ben-ranford/lopper/pkg/bench/BenchmarkBaseOnly`",
+			},
+		},
+		{
+			name: "zero overlap",
+			base: benchmarkInput{data: benchmarkData{
+				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkBaseOnly": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
+			}},
+			head: benchmarkInput{data: benchmarkData{
+				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkHeadOnly": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
+			}},
+			wantStatusCode: exitCodeInvalid,
+			wantContains: []string{
+				"Comparison status: invalid",
+				"Base-only benchmarks (missing on head):",
+				"Head-only benchmarks (missing on base):",
+				"No overlapping benchmark names were found between base and head.",
+			},
+		},
 	}
-	if !strings.Contains(summary, "No overlapping benchmark names were found") || !strings.Contains(summary, "Result: memory benchmark gate passed.") {
-		t.Fatalf("expected empty comparison summary, got %q", summary)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			summary, statusCode := compareBenchmarks(tc.base, tc.head, deltaThresholds{bytesPct: 15, allocsPct: 10})
+			if statusCode != tc.wantStatusCode {
+				t.Fatalf("status code = %d, want %d\n%s", statusCode, tc.wantStatusCode, summary)
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(summary, want) {
+					t.Fatalf("expected summary to contain %q, got:\n%s", want, summary)
+				}
+			}
+		})
 	}
+}
+
+func TestIssue1403RejectsIncompleteBenchmarkSamples(t *testing.T) {
+	t.Run("parse file excludes partial duplicates from aggregation", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bench.txt")
+		writeBenchmarkFixture(t, path, []string{
+			"pkg: github.com/ben-ranford/lopper/internal/report",
+			"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			"BenchmarkFormat-8 1000 100 ns/op 130 B/op",
+			"BenchmarkAllocsOnly-8 1000 100 ns/op 4 allocs/op",
+		})
+
+		input, err := parseBenchmarkFile(path)
+		if err != nil {
+			t.Fatalf("parse benchmark file: %v", err)
+		}
+		sample := input.data["github.com/ben-ranford/lopper/internal/report/BenchmarkFormat"]
+		if len(sample.bytesPerOp) != 1 || len(sample.allocsPerOp) != 1 {
+			t.Fatalf("expected only complete sample to be aggregated, got %#v", sample)
+		}
+		if sample.bytesPerOp[0] != 100 || sample.allocsPerOp[0] != 1 {
+			t.Fatalf("aggregated complete sample = %#v, want bytes=100 allocs=1", sample)
+		}
+		if got, want := input.incomplete, []string{
+			"`github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing allocs/op",
+			"`github.com/ben-ranford/lopper/internal/report/BenchmarkAllocsOnly` missing B/op",
+		}; !slices.Equal(got, want) {
+			t.Fatalf("incomplete diagnostics = %#v, want %#v", got, want)
+		}
+	})
+
+	tests := []struct {
+		name         string
+		baseLines    []string
+		headLines    []string
+		wantContains []string
+		wantOmit     []string
+	}{
+		{
+			name: "base bytes-only sample is incomplete",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			wantContains: []string{
+				"Comparison status: incomplete",
+				"Incomplete benchmark samples:",
+				"base: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing allocs/op",
+			},
+		},
+		{
+			name: "head allocs-only sample is incomplete",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 1 allocs/op",
+			},
+			wantContains: []string{
+				"Comparison status: incomplete",
+				"head: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing B/op",
+			},
+		},
+		{
+			name: "base complete plus partial duplicate stays incomplete and averages only complete sample",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+				"BenchmarkFormat-8 1000 100 ns/op 130 B/op",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			wantContains: []string{
+				"Comparison status: incomplete",
+				"| `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` | 100.0 | 100.0 | +0.0% | 1.0 | 1.0 | +0.0% | ok |",
+				"base: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing allocs/op",
+			},
+			wantOmit: []string{"115.0"},
+		},
+		{
+			name: "head complete plus partial duplicate stays incomplete and averages only complete sample",
+			baseLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+			},
+			headLines: []string{
+				"pkg: github.com/ben-ranford/lopper/internal/report",
+				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+				"BenchmarkFormat-8 1000 100 ns/op 4 allocs/op",
+			},
+			wantContains: []string{
+				"Comparison status: incomplete",
+				"| `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` | 100.0 | 100.0 | +0.0% | 1.0 | 1.0 | +0.0% | ok |",
+				"head: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing B/op",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			basePath := filepath.Join(dir, "base.txt")
+			headPath := filepath.Join(dir, "head.txt")
+			writeBenchmarkFixture(t, basePath, tc.baseLines)
+			writeBenchmarkFixture(t, headPath, tc.headLines)
+
+			baseInput, err := parseBenchmarkFile(basePath)
+			if err != nil {
+				t.Fatalf("parse base: %v", err)
+			}
+			headInput, err := parseBenchmarkFile(headPath)
+			if err != nil {
+				t.Fatalf("parse head: %v", err)
+			}
+
+			summary, statusCode := compareBenchmarks(baseInput, headInput, deltaThresholds{bytesPct: 15, allocsPct: 10})
+			if statusCode != exitCodeInvalid {
+				t.Fatalf("status code = %d, want %d\n%s", statusCode, exitCodeInvalid, summary)
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(summary, want) {
+					t.Fatalf("expected summary to contain %q, got:\n%s", want, summary)
+				}
+			}
+			for _, omit := range tc.wantOmit {
+				if strings.Contains(summary, omit) {
+					t.Fatalf("expected summary to omit %q, got:\n%s", omit, summary)
+				}
+			}
+		})
+	}
+}
+
+func TestParseBenchmarkFileBranches(t *testing.T) {
+	t.Run("skips invalid benchmark lines in file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bench.txt")
+		writeBenchmarkFixture(t, path, []string{
+			"pkg: github.com/ben-ranford/lopper/internal/report",
+			"BenchmarkIgnored-8 1000 100 ns/op",
+			"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+		})
+
+		input, err := parseBenchmarkFile(path)
+		if err != nil {
+			t.Fatalf("parse benchmark file: %v", err)
+		}
+		if len(input.data) != 1 {
+			t.Fatalf("expected only one parsed benchmark, got %#v", input.data)
+		}
+		if len(input.incomplete) != 0 {
+			t.Fatalf("expected no incomplete diagnostics, got %#v", input.incomplete)
+		}
+	})
+
+	t.Run("scanner error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "too-large.txt")
+		content := strings.Repeat("x", 70*1024) + "\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write oversized benchmark file: %v", err)
+		}
+
+		if _, err := parseBenchmarkFile(path); err == nil {
+			t.Fatal("expected scanner error for oversized benchmark line")
+		}
+	})
 }
 
 func TestMainExitCodesAndErrorPaths(t *testing.T) {
@@ -139,32 +402,103 @@ func TestMainExitCodesAndErrorPaths(t *testing.T) {
 		{
 			name:       "success",
 			args:       []string{"-base", basePath, "-head", headPath},
-			wantCode:   0,
+			wantCode:   exitCodePassed,
 			wantOutput: "Result: memory benchmark gate passed.",
 		},
 		{
 			name:       "regression",
 			args:       []string{"-base", basePath, "-head", filepath.Join(dir, "regressed.txt")},
-			wantCode:   1,
+			wantCode:   exitCodeRegression,
 			wantOutput: "Result: memory benchmark regression detected.",
+		},
+		{
+			name:       "issue 1403 empty comparison invalid",
+			args:       []string{"-base", filepath.Join(dir, "empty.txt"), "-head", filepath.Join(dir, "empty.txt")},
+			wantCode:   exitCodeInvalid,
+			wantOutput: "Comparison status: invalid",
+		},
+		{
+			name:       "issue 1403 head-only invalid",
+			args:       []string{"-base", basePath, "-head", filepath.Join(dir, "head-only.txt")},
+			wantCode:   exitCodeInvalid,
+			wantOutput: "Head-only benchmarks (missing on base):",
+		},
+		{
+			name:       "issue 1403 base-only invalid",
+			args:       []string{"-base", filepath.Join(dir, "base-only.txt"), "-head", headPath},
+			wantCode:   exitCodeInvalid,
+			wantOutput: "Base-only benchmarks (missing on head):",
+		},
+		{
+			name:       "issue 1403 zero overlap invalid",
+			args:       []string{"-base", filepath.Join(dir, "zero-overlap-base.txt"), "-head", filepath.Join(dir, "zero-overlap-head.txt")},
+			wantCode:   exitCodeInvalid,
+			wantOutput: "No overlapping benchmark names were found between base and head.",
+		},
+		{
+			name:       "issue 1403 base bytes-only incomplete",
+			args:       []string{"-base", filepath.Join(dir, "base-bytes-only.txt"), "-head", headPath},
+			wantCode:   exitCodeInvalid,
+			wantOutput: "Comparison status: incomplete",
+		},
+		{
+			name:       "issue 1403 head allocs-only incomplete",
+			args:       []string{"-base", basePath, "-head", filepath.Join(dir, "head-allocs-only.txt")},
+			wantCode:   exitCodeInvalid,
+			wantOutput: "Comparison status: incomplete",
 		},
 		{
 			name:       "missing args",
 			args:       nil,
-			wantCode:   2,
+			wantCode:   exitCodeInvalid,
 			wantOutput: "both -base and -head are required",
 		},
 		{
 			name:       "missing base file",
 			args:       []string{"-base", filepath.Join(dir, "missing.txt"), "-head", headPath},
-			wantCode:   2,
+			wantCode:   exitCodeInvalid,
 			wantOutput: "parse base benchmarks",
+		},
+		{
+			name:       "missing head file",
+			args:       []string{"-base", basePath, "-head", filepath.Join(dir, "missing-head.txt")},
+			wantCode:   exitCodeInvalid,
+			wantOutput: "parse head benchmarks",
 		},
 	}
 
 	writeBenchmarkFixture(t, filepath.Join(dir, "regressed.txt"), []string{
 		"pkg: github.com/ben-ranford/lopper/internal/report",
 		"BenchmarkFormat-8 1000 100 ns/op 130 B/op 2 allocs/op",
+	})
+	writeBenchmarkFixture(t, filepath.Join(dir, "empty.txt"), []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+	})
+	writeBenchmarkFixture(t, filepath.Join(dir, "head-only.txt"), []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+		"BenchmarkFormatHeadOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
+	})
+	writeBenchmarkFixture(t, filepath.Join(dir, "base-only.txt"), []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
+		"BenchmarkFormatBaseOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
+	})
+	writeBenchmarkFixture(t, filepath.Join(dir, "zero-overlap-base.txt"), []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkBaseOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
+	})
+	writeBenchmarkFixture(t, filepath.Join(dir, "zero-overlap-head.txt"), []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkHeadOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
+	})
+	writeBenchmarkFixture(t, filepath.Join(dir, "base-bytes-only.txt"), []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkFormat-8 1000 100 ns/op 100 B/op",
+	})
+	writeBenchmarkFixture(t, filepath.Join(dir, "head-allocs-only.txt"), []string{
+		"pkg: github.com/ben-ranford/lopper/internal/report",
+		"BenchmarkFormat-8 1000 100 ns/op 1 allocs/op",
 	})
 
 	for _, tc := range tests {
@@ -189,8 +523,29 @@ func TestMainSummaryWriteErrorExit(t *testing.T) {
 	}
 
 	output, exitCode := runBenchdeltaHelper(t, "TestMainSummaryWriteErrorExit", "-base", basePath, "-head", headPath, "-summary-out", filepath.Join(blocker, "summary.md"))
-	assertBenchdeltaHelperExit(t, output, exitCode, 2)
+	assertBenchdeltaHelperExit(t, output, exitCode, exitCodeInvalid)
 	assertBenchdeltaHelperOutput(t, output, "write summary")
+}
+
+func TestMainSummaryWriteSuccess(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+
+	dir, basePath, headPath := writeMatchingBenchmarkFixtures(t)
+	summaryPath := filepath.Join(dir, "summary.md")
+
+	output, exitCode := runBenchdeltaHelper(t, "TestMainSummaryWriteSuccess", "-base", basePath, "-head", headPath, "-summary-out", summaryPath)
+	assertBenchdeltaHelperExit(t, output, exitCode, exitCodePassed)
+	assertBenchdeltaHelperOutput(t, output, "Result: memory benchmark gate passed.")
+
+	summaryBytes, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	if !strings.Contains(string(summaryBytes), "Result: memory benchmark gate passed.") {
+		t.Fatalf("expected written summary to contain pass result, got:\n%s", summaryBytes)
+	}
 }
 
 func runBenchdeltaMainIfRequested(t *testing.T) bool {

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -139,20 +139,15 @@ func TestParseBenchmarkLineRejectsNonFiniteMemoryMetrics(t *testing.T) {
 	t.Parallel()
 
 	spellings := acceptedNonFiniteSpellings(t)
-	metrics := []struct {
-		name        string
-		metric      string
-		bytesValue  string
-		allocsValue string
-	}{
+	metrics := []nonFiniteMetricCase{
 		{
 			name:        "bytes",
-			metric:      "B/op",
+			metric:      benchmarkMetricBytesPerOp,
 			allocsValue: "3",
 		},
 		{
 			name:       "allocs",
-			metric:     "allocs/op",
+			metric:     benchmarkMetricAllocsPerOp,
 			bytesValue: "128",
 		},
 	}
@@ -160,28 +155,17 @@ func TestParseBenchmarkLineRejectsNonFiniteMemoryMetrics(t *testing.T) {
 	for _, metric := range metrics {
 		t.Run(metric.name, func(t *testing.T) {
 			for _, spelling := range spellings {
-				bytesValue, allocsValue := metric.bytesValue, metric.allocsValue
-				if metric.metric == "B/op" {
-					bytesValue = spelling
-				} else {
-					allocsValue = spelling
-				}
-				line := bytesAllocsBenchmark("NonFinite", bytesValue, allocsValue)
-
-				name, sample, status, diagnostic := parseBenchmarkLine("pkg", line)
-				if status != benchmarkLineInvalid {
-					t.Fatalf("parseBenchmarkLine(%q) status = %v, want invalid", line, status)
-				}
-				if name == "" || len(sample.bytesPerOp) != 0 || len(sample.allocsPerOp) != 0 {
-					t.Fatalf("parseBenchmarkLine(%q) returned unexpected sample %#v for %q", line, sample, name)
-				}
-				wantDiagnostic := invalidBenchmarkMetric("pkg", "NonFinite", metric.metric, spelling)
-				if diagnostic != wantDiagnostic {
-					t.Fatalf("parseBenchmarkLine(%q) diagnostic = %q, want %q", line, diagnostic, wantDiagnostic)
-				}
+				assertNonFiniteMetricRejected(t, metric, spelling)
 			}
 		})
 	}
+}
+
+type nonFiniteMetricCase struct {
+	name        string
+	metric      string
+	bytesValue  string
+	allocsValue string
 }
 
 func TestAcceptedNonFiniteSpellings(t *testing.T) {
@@ -458,13 +442,7 @@ func TestCompareBenchmarksRejectsInvalidSamples(t *testing.T) {
 
 func TestParseBenchmarkFileBranches(t *testing.T) {
 	t.Run("records non-finite benchmark lines as invalid", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "bench.txt")
-		writeBenchmarkFixture(t, path, reportFixture(bytesAllocsBenchmark("Invalid", "nan", "1")))
-
-		input, err := parseBenchmarkFile(path)
-		if err != nil {
-			t.Fatalf("parse benchmark file: %v", err)
-		}
+		input := parseBenchmarkFixture(t, reportFixture(bytesAllocsBenchmark("Invalid", "nan", "1")))
 		wantDiagnostic := invalidBenchmarkMetric(reportBenchmarkPkg, "Invalid", "B/op", "nan")
 		if !slices.Equal(input.invalid, []string{wantDiagnostic}) {
 			t.Fatalf("invalid diagnostics = %#v, want %#v", input.invalid, []string{wantDiagnostic})
@@ -475,13 +453,7 @@ func TestParseBenchmarkFileBranches(t *testing.T) {
 	})
 
 	t.Run("skips invalid benchmark lines in file", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "bench.txt")
-		writeBenchmarkFixture(t, path, reportFixture(benchmarkFixtureLine("Ignored", "1000", "100", "ns/op"), completeBenchmark("Format")))
-
-		input, err := parseBenchmarkFile(path)
-		if err != nil {
-			t.Fatalf("parse benchmark file: %v", err)
-		}
+		input := parseBenchmarkFixture(t, reportFixture(benchmarkFixtureLine("Ignored", "1000", "100", benchmarkMetricNsPerOp), completeBenchmark("Format")))
 		if len(input.data) != 1 || len(input.incomplete) != 1 {
 			t.Fatalf("expected one parsed benchmark and one incomplete diagnostic, got data=%#v incomplete=%#v", input.data, input.incomplete)
 		}
@@ -693,6 +665,44 @@ func runBenchdeltaMainIfRequested(t *testing.T) bool {
 	return true
 }
 
+func assertNonFiniteMetricRejected(t *testing.T, metric nonFiniteMetricCase, spelling string) {
+	t.Helper()
+
+	bytesValue, allocsValue := nonFiniteMetricSampleValues(metric, spelling)
+	line := bytesAllocsBenchmark("NonFinite", bytesValue, allocsValue)
+	name, sample, status, diagnostic := parseBenchmarkLine("pkg", line)
+	if status != benchmarkLineInvalid {
+		t.Fatalf("parseBenchmarkLine(%q) status = %v, want invalid", line, status)
+	}
+	if name == "" || len(sample.bytesPerOp) != 0 || len(sample.allocsPerOp) != 0 {
+		t.Fatalf("parseBenchmarkLine(%q) returned unexpected sample %#v for %q", line, sample, name)
+	}
+	wantDiagnostic := invalidBenchmarkMetric("pkg", "NonFinite", metric.metric, spelling)
+	if diagnostic != wantDiagnostic {
+		t.Fatalf("parseBenchmarkLine(%q) diagnostic = %q, want %q", line, diagnostic, wantDiagnostic)
+	}
+}
+
+func nonFiniteMetricSampleValues(tc nonFiniteMetricCase, spelling string) (string, string) {
+	if tc.metric == benchmarkMetricBytesPerOp {
+		return spelling, tc.allocsValue
+	}
+	return tc.bytesValue, spelling
+}
+
+func parseBenchmarkFixture(t *testing.T, lines []string) benchmarkInput {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	writeBenchmarkFixture(t, path, lines)
+
+	input, err := parseBenchmarkFile(path)
+	if err != nil {
+		t.Fatalf("parse benchmark file: %v", err)
+	}
+	return input
+}
+
 func writeBenchmarkFixture(t *testing.T, path string, lines []string) {
 	t.Helper()
 	content := append([]string{"goos: darwin"}, lines...)
@@ -834,15 +844,15 @@ func completeBenchmark(name string) string {
 }
 
 func bytesAllocsBenchmark(name, bytes, allocs string) string {
-	return benchmarkFixtureLine(name, "1000", "100", "ns/op", bytes, "B/op", allocs, "allocs/op")
+	return benchmarkFixtureLine(name, "1000", "100", benchmarkMetricNsPerOp, bytes, benchmarkMetricBytesPerOp, allocs, benchmarkMetricAllocsPerOp)
 }
 
 func bytesOnlyBenchmark(name, bytes string) string {
-	return benchmarkFixtureLine(name, "1000", "100", "ns/op", bytes, "B/op")
+	return benchmarkFixtureLine(name, "1000", "100", benchmarkMetricNsPerOp, bytes, benchmarkMetricBytesPerOp)
 }
 
 func allocsOnlyBenchmark(name, allocs string) string {
-	return benchmarkFixtureLine(name, "1000", "100", "ns/op", allocs, "allocs/op")
+	return benchmarkFixtureLine(name, "1000", "100", benchmarkMetricNsPerOp, allocs, benchmarkMetricAllocsPerOp)
 }
 
 func repeatedCompleteBenchmark(name string, count int) []string {

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -10,29 +10,32 @@ import (
 	"testing"
 )
 
+const (
+	reportBenchmarkPkg = "github.com/ben-ranford/lopper/internal/report"
+	benchBenchmarkPkg  = "github.com/ben-ranford/lopper/pkg/bench"
+)
+
 func TestParseBenchmarkFileAndCompare(t *testing.T) {
 	dir := t.TempDir()
 	basePath := filepath.Join(dir, "base.txt")
 	headPath := filepath.Join(dir, "head.txt")
 
 	baseLines := []string{
-		"goos: darwin",
-		"pkg: github.com/ben-ranford/lopper/internal/lang/shared",
-		"BenchmarkCountUsage-8    1000   25000 ns/op   25632 B/op   375 allocs/op",
-		"BenchmarkCountUsage-8    1000   25500 ns/op   25632 B/op   375 allocs/op",
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormatLargeTable-8    500   90000 ns/op   64000 B/op   120 allocs/op",
+		packageLine("github.com/ben-ranford/lopper/internal/lang/shared"),
+		benchmarkFixtureLine("CountUsage", "1000", "25000", "ns/op", "25632", "B/op", "375", "allocs/op"),
+		benchmarkFixtureLine("CountUsage", "1000", "25500", "ns/op", "25632", "B/op", "375", "allocs/op"),
+		packageLine(reportBenchmarkPkg),
+		benchmarkFixtureLine("FormatLargeTable", "500", "90000", "ns/op", "64000", "B/op", "120", "allocs/op"),
 	}
 	headLines := []string{
-		"goos: darwin",
-		"pkg: github.com/ben-ranford/lopper/internal/lang/shared",
-		"BenchmarkCountUsage-8    1000   25000 ns/op   30000 B/op   430 allocs/op",
-		"BenchmarkCountUsage-8    1000   25500 ns/op   30000 B/op   430 allocs/op",
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormatLargeTable-8    500   90000 ns/op   64000 B/op   120 allocs/op",
+		packageLine("github.com/ben-ranford/lopper/internal/lang/shared"),
+		benchmarkFixtureLine("CountUsage", "1000", "25000", "ns/op", "30000", "B/op", "430", "allocs/op"),
+		benchmarkFixtureLine("CountUsage", "1000", "25500", "ns/op", "30000", "B/op", "430", "allocs/op"),
+		packageLine(reportBenchmarkPkg),
+		benchmarkFixtureLine("FormatLargeTable", "500", "90000", "ns/op", "64000", "B/op", "120", "allocs/op"),
 	}
-	writeBenchmarkFixture(t, basePath, baseLines[1:])
-	writeBenchmarkFixture(t, headPath, headLines[1:])
+	writeBenchmarkFixture(t, basePath, baseLines)
+	writeBenchmarkFixture(t, headPath, headLines)
 
 	baseInput, err := parseBenchmarkFile(basePath)
 	if err != nil {
@@ -70,7 +73,7 @@ func TestPercentDelta(t *testing.T) {
 	}
 }
 
-func TestBenchmarkParsingAndFormattingBranches(t *testing.T) {
+func TestParseBenchmarkLineFallbackAndIgnoredBranches(t *testing.T) {
 	name, sample, status, diagnostic := parseBenchmarkLine("", "BenchmarkFresh-8 1000 25000 ns/op 128 B/op 3 allocs/op")
 	if status != benchmarkLineComplete || diagnostic != "" || name != "unknown-package/BenchmarkFresh" {
 		t.Fatalf("expected unknown-package fallback benchmark, got name=%q status=%v diagnostic=%q", name, status, diagnostic)
@@ -81,39 +84,56 @@ func TestBenchmarkParsingAndFormattingBranches(t *testing.T) {
 
 	for _, line := range []string{
 		"BenchmarkShort",
-		"BenchmarkNoMetrics-8 1000 25000 ns/op",
 		"BenchmarkBadValue-8 1000 nope B/op",
 	} {
 		if _, _, status, _ := parseBenchmarkLine("pkg", line); status != benchmarkLineIgnored {
 			t.Fatalf("expected parseBenchmarkLine(%q) to be ignored", line)
 		}
 	}
+}
 
-	for _, tc := range []struct {
+func TestParseBenchmarkLineRejectsIncompleteMetrics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
 		line           string
 		wantDiagnostic string
 	}{
 		{
-			line:           "BenchmarkBytesOnly-8 1000 25000 ns/op 128 B/op",
-			wantDiagnostic: "`pkg/BenchmarkBytesOnly` missing allocs/op",
+			name:           "bytes only",
+			line:           benchmarkFixtureLine("BytesOnly", "1000", "25000", "ns/op", "128", "B/op"),
+			wantDiagnostic: benchmarkMissingMetric("pkg", "BytesOnly", "allocs/op"),
 		},
 		{
-			line:           "BenchmarkAllocsOnly-8 1000 25000 ns/op 3 allocs/op",
-			wantDiagnostic: "`pkg/BenchmarkAllocsOnly` missing B/op",
+			name:           "allocs only",
+			line:           benchmarkFixtureLine("AllocsOnly", "1000", "25000", "ns/op", "3", "allocs/op"),
+			wantDiagnostic: benchmarkMissingMetric("pkg", "AllocsOnly", "B/op"),
 		},
-	} {
-		name, sample, status, diagnostic := parseBenchmarkLine("pkg", tc.line)
-		if status != benchmarkLineIncomplete {
-			t.Fatalf("parseBenchmarkLine(%q) status = %v, want incomplete", tc.line, status)
-		}
-		if name == "" || len(sample.bytesPerOp) != 0 || len(sample.allocsPerOp) != 0 {
-			t.Fatalf("parseBenchmarkLine(%q) returned unexpected sample %#v for %q", tc.line, sample, name)
-		}
-		if diagnostic != tc.wantDiagnostic {
-			t.Fatalf("parseBenchmarkLine(%q) diagnostic = %q, want %q", tc.line, diagnostic, tc.wantDiagnostic)
-		}
+		{
+			name:           "ns only",
+			line:           benchmarkFixtureLine("NsOnly", "1000", "25000", "ns/op"),
+			wantDiagnostic: benchmarkMissingMetric("pkg", "NsOnly", "B/op and allocs/op"),
+		},
 	}
 
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name, sample, status, diagnostic := parseBenchmarkLine("pkg", tc.line)
+			if status != benchmarkLineIncomplete {
+				t.Fatalf("parseBenchmarkLine(%q) status = %v, want incomplete", tc.line, status)
+			}
+			if name == "" || len(sample.bytesPerOp) != 0 || len(sample.allocsPerOp) != 0 {
+				t.Fatalf("parseBenchmarkLine(%q) returned unexpected sample %#v for %q", tc.line, sample, name)
+			}
+			if diagnostic != tc.wantDiagnostic {
+				t.Fatalf("parseBenchmarkLine(%q) diagnostic = %q, want %q", tc.line, diagnostic, tc.wantDiagnostic)
+			}
+		})
+	}
+}
+
+func TestBenchmarkHelpers(t *testing.T) {
 	if got := normalizeBenchmarkName("BenchmarkDash-foo"); got != "BenchmarkDash-foo" {
 		t.Fatalf("expected non-numeric suffix to remain, got %q", got)
 	}
@@ -150,44 +170,36 @@ func TestIssue1403CompareRejectsMissingBenchmarks(t *testing.T) {
 		},
 		{
 			name: "head-only",
-			base: benchmarkInput{data: benchmarkData{
-				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkShared": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
-			}},
+			base: benchmarkInput{data: benchmarkData{benchmarkKey(benchBenchmarkPkg, "Shared"): completeBenchmarkSample()}},
 			head: benchmarkInput{data: benchmarkData{
-				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkShared":   {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
-				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkHeadOnly": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
+				benchmarkKey(benchBenchmarkPkg, "Shared"):   completeBenchmarkSample(),
+				benchmarkKey(benchBenchmarkPkg, "HeadOnly"): completeBenchmarkSample(),
 			}},
 			wantStatusCode: exitCodeInvalid,
 			wantContains: []string{
 				"Comparison status: invalid",
 				"Head-only benchmarks (missing on base):",
-				"`github.com/ben-ranford/lopper/pkg/bench/BenchmarkHeadOnly`",
+				benchmarkRef(benchBenchmarkPkg, "HeadOnly"),
 			},
 		},
 		{
 			name: "base-only",
 			base: benchmarkInput{data: benchmarkData{
-				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkShared":   {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
-				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkBaseOnly": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
+				benchmarkKey(benchBenchmarkPkg, "Shared"):   completeBenchmarkSample(),
+				benchmarkKey(benchBenchmarkPkg, "BaseOnly"): completeBenchmarkSample(),
 			}},
-			head: benchmarkInput{data: benchmarkData{
-				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkShared": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
-			}},
+			head:           benchmarkInput{data: benchmarkData{benchmarkKey(benchBenchmarkPkg, "Shared"): completeBenchmarkSample()}},
 			wantStatusCode: exitCodeInvalid,
 			wantContains: []string{
 				"Comparison status: invalid",
 				"Base-only benchmarks (missing on head):",
-				"`github.com/ben-ranford/lopper/pkg/bench/BenchmarkBaseOnly`",
+				benchmarkRef(benchBenchmarkPkg, "BaseOnly"),
 			},
 		},
 		{
-			name: "zero overlap",
-			base: benchmarkInput{data: benchmarkData{
-				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkBaseOnly": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
-			}},
-			head: benchmarkInput{data: benchmarkData{
-				"github.com/ben-ranford/lopper/pkg/bench/BenchmarkHeadOnly": {bytesPerOp: []float64{100}, allocsPerOp: []float64{1}},
-			}},
+			name:           "zero overlap",
+			base:           benchmarkInput{data: benchmarkData{benchmarkKey(benchBenchmarkPkg, "BaseOnly"): completeBenchmarkSample()}},
+			head:           benchmarkInput{data: benchmarkData{benchmarkKey(benchBenchmarkPkg, "HeadOnly"): completeBenchmarkSample()}},
 			wantStatusCode: exitCodeInvalid,
 			wantContains: []string{
 				"Comparison status: invalid",
@@ -213,141 +225,119 @@ func TestIssue1403CompareRejectsMissingBenchmarks(t *testing.T) {
 	}
 }
 
-func TestIssue1403RejectsIncompleteBenchmarkSamples(t *testing.T) {
-	t.Run("parse file excludes partial duplicates from aggregation", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "bench.txt")
-		writeBenchmarkFixture(t, path, []string{
-			"pkg: github.com/ben-ranford/lopper/internal/report",
-			"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			"BenchmarkFormat-8 1000 100 ns/op 130 B/op",
-			"BenchmarkAllocsOnly-8 1000 100 ns/op 4 allocs/op",
-		})
+func TestParseBenchmarkFileExcludesPartialDuplicatesFromAggregation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	writeBenchmarkFixture(t, path, reportFixture(completeBenchmark("Format"), bytesOnlyBenchmark("Format", "130"), allocsOnlyBenchmark("AllocsOnly", "4")))
 
-		input, err := parseBenchmarkFile(path)
-		if err != nil {
-			t.Fatalf("parse benchmark file: %v", err)
-		}
-		sample := input.data["github.com/ben-ranford/lopper/internal/report/BenchmarkFormat"]
-		if len(sample.bytesPerOp) != 1 || len(sample.allocsPerOp) != 1 {
-			t.Fatalf("expected only complete sample to be aggregated, got %#v", sample)
-		}
-		if sample.bytesPerOp[0] != 100 || sample.allocsPerOp[0] != 1 {
-			t.Fatalf("aggregated complete sample = %#v, want bytes=100 allocs=1", sample)
-		}
-		if got, want := input.incomplete, []string{
-			"`github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing allocs/op",
-			"`github.com/ben-ranford/lopper/internal/report/BenchmarkAllocsOnly` missing B/op",
-		}; !slices.Equal(got, want) {
-			t.Fatalf("incomplete diagnostics = %#v, want %#v", got, want)
-		}
-	})
+	input, err := parseBenchmarkFile(path)
+	if err != nil {
+		t.Fatalf("parse benchmark file: %v", err)
+	}
+	sample := input.data[benchmarkKey(reportBenchmarkPkg, "Format")]
+	if len(sample.bytesPerOp) != 1 || len(sample.allocsPerOp) != 1 {
+		t.Fatalf("expected only complete sample to be aggregated, got %#v", sample)
+	}
+	if sample.bytesPerOp[0] != 100 || sample.allocsPerOp[0] != 1 {
+		t.Fatalf("aggregated complete sample = %#v, want bytes=100 allocs=1", sample)
+	}
+	if got, want := input.incomplete, []string{
+		benchmarkMissingMetric(reportBenchmarkPkg, "Format", "allocs/op"),
+		benchmarkMissingMetric(reportBenchmarkPkg, "AllocsOnly", "B/op"),
+	}; !slices.Equal(got, want) {
+		t.Fatalf("incomplete diagnostics = %#v, want %#v", got, want)
+	}
+}
 
-	tests := []struct {
-		name         string
-		baseLines    []string
-		headLines    []string
-		wantContains []string
-		wantOmit     []string
-	}{
+func TestParseBenchmarkFileRecordsNsOnlyBenchmarksAsIncomplete(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	writeBenchmarkFixture(t, path, reportFixture(completeBenchmark("Format"), benchmarkFixtureLine("NsOnly", "1000", "100", "ns/op")))
+
+	input, err := parseBenchmarkFile(path)
+	if err != nil {
+		t.Fatalf("parse benchmark file: %v", err)
+	}
+	if len(input.data) != 1 {
+		t.Fatalf("expected one complete benchmark to remain, got %#v", input.data)
+	}
+	if got, want := input.incomplete, []string{
+		benchmarkMissingMetric(reportBenchmarkPkg, "NsOnly", "B/op and allocs/op"),
+	}; !slices.Equal(got, want) {
+		t.Fatalf("incomplete diagnostics = %#v, want %#v", got, want)
+	}
+}
+
+func TestCompareBenchmarksRejectsIncompleteSamples(t *testing.T) {
+	t.Parallel()
+
+	tests := []comparisonScenario{
 		{
-			name: "base bytes-only sample is incomplete",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
+			name:      "base bytes-only sample is incomplete",
+			baseLines: reportFixture(bytesOnlyBenchmark("Format", "100")),
+			headLines: reportFixture(completeBenchmark("Format")),
 			wantContains: []string{
 				"Comparison status: incomplete",
 				"Incomplete benchmark samples:",
-				"base: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing allocs/op",
+				"base: " + benchmarkMissingMetric(reportBenchmarkPkg, "Format", "allocs/op"),
 			},
+			wantOmit: incompleteInvalidDiagnostics(),
 		},
 		{
-			name: "head allocs-only sample is incomplete",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 1 allocs/op",
-			},
+			name:      "head allocs-only sample is incomplete",
+			baseLines: reportFixture(completeBenchmark("Format")),
+			headLines: reportFixture(allocsOnlyBenchmark("Format", "1")),
 			wantContains: []string{
 				"Comparison status: incomplete",
-				"head: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing B/op",
+				"head: " + benchmarkMissingMetric(reportBenchmarkPkg, "Format", "B/op"),
 			},
+			wantOmit: incompleteInvalidDiagnostics(),
 		},
 		{
-			name: "base complete plus partial duplicate stays incomplete and averages only complete sample",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-				"BenchmarkFormat-8 1000 100 ns/op 130 B/op",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
+			name:      "base ns-only sample is incomplete",
+			baseLines: reportFixture(benchmarkFixtureLine("Format", "1000", "100", "ns/op")),
+			headLines: reportFixture(completeBenchmark("Format")),
 			wantContains: []string{
 				"Comparison status: incomplete",
-				"| `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` | 100.0 | 100.0 | +0.0% | 1.0 | 1.0 | +0.0% | ok |",
-				"base: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing allocs/op",
+				"base: " + benchmarkMissingMetric(reportBenchmarkPkg, "Format", "B/op and allocs/op"),
 			},
-			wantOmit: []string{"115.0"},
+			wantOmit: incompleteInvalidDiagnostics(),
 		},
 		{
-			name: "head complete plus partial duplicate stays incomplete and averages only complete sample",
-			baseLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-			},
-			headLines: []string{
-				"pkg: github.com/ben-ranford/lopper/internal/report",
-				"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-				"BenchmarkFormat-8 1000 100 ns/op 4 allocs/op",
-			},
+			name:      "base complete plus partial duplicate stays incomplete and averages only complete sample",
+			baseLines: reportFixture(completeBenchmark("Format"), bytesOnlyBenchmark("Format", "130")),
+			headLines: reportFixture(completeBenchmark("Format")),
 			wantContains: []string{
 				"Comparison status: incomplete",
-				"| `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` | 100.0 | 100.0 | +0.0% | 1.0 | 1.0 | +0.0% | ok |",
-				"head: `github.com/ben-ranford/lopper/internal/report/BenchmarkFormat` missing B/op",
+				okComparisonRow(reportBenchmarkPkg, "Format"),
+				"base: " + benchmarkMissingMetric(reportBenchmarkPkg, "Format", "allocs/op"),
 			},
+			wantOmit: append(incompleteInvalidDiagnostics(), "115.0"),
+		},
+		{
+			name:      "head complete plus partial duplicate stays incomplete and averages only complete sample",
+			baseLines: reportFixture(completeBenchmark("Format")),
+			headLines: reportFixture(completeBenchmark("Format"), allocsOnlyBenchmark("Format", "4")),
+			wantContains: []string{
+				"Comparison status: incomplete",
+				okComparisonRow(reportBenchmarkPkg, "Format"),
+				"head: " + benchmarkMissingMetric(reportBenchmarkPkg, "Format", "B/op"),
+			},
+			wantOmit: incompleteInvalidDiagnostics(),
+		},
+		{
+			name:      "mismatched sample counts are incomplete",
+			baseLines: reportFixture(repeatedCompleteBenchmark("Format", 3)...),
+			headLines: reportFixture(completeBenchmark("Format")),
+			wantContains: []string{
+				"Comparison status: incomplete",
+				sampleCountMismatchDiagnostic(benchmarkKey(reportBenchmarkPkg, "Format"), 3, 1),
+			},
+			wantOmit: incompleteInvalidDiagnostics(),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			basePath := filepath.Join(dir, "base.txt")
-			headPath := filepath.Join(dir, "head.txt")
-			writeBenchmarkFixture(t, basePath, tc.baseLines)
-			writeBenchmarkFixture(t, headPath, tc.headLines)
-
-			baseInput, err := parseBenchmarkFile(basePath)
-			if err != nil {
-				t.Fatalf("parse base: %v", err)
-			}
-			headInput, err := parseBenchmarkFile(headPath)
-			if err != nil {
-				t.Fatalf("parse head: %v", err)
-			}
-
-			summary, statusCode := compareBenchmarks(baseInput, headInput, deltaThresholds{bytesPct: 15, allocsPct: 10})
-			if statusCode != exitCodeInvalid {
-				t.Fatalf("status code = %d, want %d\n%s", statusCode, exitCodeInvalid, summary)
-			}
-			for _, want := range tc.wantContains {
-				if !strings.Contains(summary, want) {
-					t.Fatalf("expected summary to contain %q, got:\n%s", want, summary)
-				}
-			}
-			for _, omit := range tc.wantOmit {
-				if strings.Contains(summary, omit) {
-					t.Fatalf("expected summary to omit %q, got:\n%s", omit, summary)
-				}
-			}
+			assertComparisonScenario(t, tc)
 		})
 	}
 }
@@ -355,21 +345,17 @@ func TestIssue1403RejectsIncompleteBenchmarkSamples(t *testing.T) {
 func TestParseBenchmarkFileBranches(t *testing.T) {
 	t.Run("skips invalid benchmark lines in file", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "bench.txt")
-		writeBenchmarkFixture(t, path, []string{
-			"pkg: github.com/ben-ranford/lopper/internal/report",
-			"BenchmarkIgnored-8 1000 100 ns/op",
-			"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-		})
+		writeBenchmarkFixture(t, path, reportFixture(benchmarkFixtureLine("Ignored", "1000", "100", "ns/op"), completeBenchmark("Format")))
 
 		input, err := parseBenchmarkFile(path)
 		if err != nil {
 			t.Fatalf("parse benchmark file: %v", err)
 		}
-		if len(input.data) != 1 {
-			t.Fatalf("expected only one parsed benchmark, got %#v", input.data)
+		if len(input.data) != 1 || len(input.incomplete) != 1 {
+			t.Fatalf("expected one parsed benchmark and one incomplete diagnostic, got data=%#v incomplete=%#v", input.data, input.incomplete)
 		}
-		if len(input.incomplete) != 0 {
-			t.Fatalf("expected no incomplete diagnostics, got %#v", input.incomplete)
+		if input.incomplete[0] != benchmarkMissingMetric(reportBenchmarkPkg, "Ignored", "B/op and allocs/op") {
+			t.Fatalf("unexpected incomplete diagnostic: %#v", input.incomplete)
 		}
 	})
 
@@ -398,6 +384,7 @@ func TestMainExitCodesAndErrorPaths(t *testing.T) {
 		args       []string
 		wantCode   int
 		wantOutput string
+		wantOmit   []string
 	}{
 		{
 			name:       "success",
@@ -440,12 +427,28 @@ func TestMainExitCodesAndErrorPaths(t *testing.T) {
 			args:       []string{"-base", filepath.Join(dir, "base-bytes-only.txt"), "-head", headPath},
 			wantCode:   exitCodeInvalid,
 			wantOutput: "Comparison status: incomplete",
+			wantOmit:   incompleteInvalidDiagnostics(),
 		},
 		{
 			name:       "issue 1403 head allocs-only incomplete",
 			args:       []string{"-base", basePath, "-head", filepath.Join(dir, "head-allocs-only.txt")},
 			wantCode:   exitCodeInvalid,
 			wantOutput: "Comparison status: incomplete",
+			wantOmit:   incompleteInvalidDiagnostics(),
+		},
+		{
+			name:       "ns-only incomplete",
+			args:       []string{"-base", filepath.Join(dir, "base-ns-only.txt"), "-head", headPath},
+			wantCode:   exitCodeInvalid,
+			wantOutput: benchmarkMissingMetric(reportBenchmarkPkg, "Format", "B/op and allocs/op"),
+			wantOmit:   incompleteInvalidDiagnostics(),
+		},
+		{
+			name:       "sample count mismatch incomplete",
+			args:       []string{"-base", filepath.Join(dir, "count-mismatch-base.txt"), "-head", filepath.Join(dir, "count-mismatch-head.txt")},
+			wantCode:   exitCodeInvalid,
+			wantOutput: sampleCountMismatchDiagnostic(benchmarkKey(reportBenchmarkPkg, "Format"), 3, 1),
+			wantOmit:   incompleteInvalidDiagnostics(),
 		},
 		{
 			name:       "missing args",
@@ -467,45 +470,24 @@ func TestMainExitCodesAndErrorPaths(t *testing.T) {
 		},
 	}
 
-	writeBenchmarkFixture(t, filepath.Join(dir, "regressed.txt"), []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormat-8 1000 100 ns/op 130 B/op 2 allocs/op",
-	})
-	writeBenchmarkFixture(t, filepath.Join(dir, "empty.txt"), []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-	})
-	writeBenchmarkFixture(t, filepath.Join(dir, "head-only.txt"), []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-		"BenchmarkFormatHeadOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
-	})
-	writeBenchmarkFixture(t, filepath.Join(dir, "base-only.txt"), []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-		"BenchmarkFormatBaseOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
-	})
-	writeBenchmarkFixture(t, filepath.Join(dir, "zero-overlap-base.txt"), []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkBaseOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
-	})
-	writeBenchmarkFixture(t, filepath.Join(dir, "zero-overlap-head.txt"), []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkHeadOnly-8 1000 100 ns/op 100 B/op 1 allocs/op",
-	})
-	writeBenchmarkFixture(t, filepath.Join(dir, "base-bytes-only.txt"), []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormat-8 1000 100 ns/op 100 B/op",
-	})
-	writeBenchmarkFixture(t, filepath.Join(dir, "head-allocs-only.txt"), []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormat-8 1000 100 ns/op 1 allocs/op",
-	})
+	writeBenchmarkFixture(t, filepath.Join(dir, "regressed.txt"), reportFixture(bytesAllocsBenchmark("Format", "130", "2")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "empty.txt"), reportFixture())
+	writeBenchmarkFixture(t, filepath.Join(dir, "head-only.txt"), reportFixture(completeBenchmark("Format"), completeBenchmark("FormatHeadOnly")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "base-only.txt"), reportFixture(completeBenchmark("Format"), completeBenchmark("FormatBaseOnly")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "zero-overlap-base.txt"), reportFixture(completeBenchmark("BaseOnly")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "zero-overlap-head.txt"), reportFixture(completeBenchmark("HeadOnly")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "base-bytes-only.txt"), reportFixture(bytesOnlyBenchmark("Format", "100")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "head-allocs-only.txt"), reportFixture(allocsOnlyBenchmark("Format", "1")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "base-ns-only.txt"), reportFixture(benchmarkFixtureLine("Format", "1000", "100", "ns/op")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "count-mismatch-base.txt"), reportFixture(repeatedCompleteBenchmark("Format", 3)...))
+	writeBenchmarkFixture(t, filepath.Join(dir, "count-mismatch-head.txt"), reportFixture(completeBenchmark("Format")))
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			output, exitCode := runBenchdeltaHelper(t, "TestMainExitCodesAndErrorPaths", tc.args...)
 			assertBenchdeltaHelperExit(t, output, exitCode, tc.wantCode)
 			assertBenchdeltaHelperOutput(t, output, tc.wantOutput)
+			assertBenchdeltaHelperOutputOmitsAll(t, output, tc.wantOmit)
 		})
 	}
 }
@@ -580,10 +562,7 @@ func writeMatchingBenchmarkFixtures(t *testing.T) (string, string, string) {
 	dir := t.TempDir()
 	basePath := filepath.Join(dir, "base.txt")
 	headPath := filepath.Join(dir, "head.txt")
-	lines := []string{
-		"pkg: github.com/ben-ranford/lopper/internal/report",
-		"BenchmarkFormat-8 1000 100 ns/op 100 B/op 1 allocs/op",
-	}
+	lines := reportFixture(completeBenchmark("Format"))
 	writeBenchmarkFixture(t, basePath, lines)
 	writeBenchmarkFixture(t, headPath, lines)
 	return dir, basePath, headPath
@@ -626,4 +605,125 @@ func assertBenchdeltaHelperOutput(t *testing.T, output []byte, want string) {
 	if !strings.Contains(string(output), want) {
 		t.Fatalf("expected output to contain %q, got %q", want, string(output))
 	}
+}
+
+func assertBenchdeltaHelperOutputOmitsAll(t *testing.T, output []byte, omitted []string) {
+	t.Helper()
+	assertSummaryOmitsAll(t, string(output), omitted)
+}
+
+type comparisonScenario struct {
+	name         string
+	baseLines    []string
+	headLines    []string
+	wantContains []string
+	wantOmit     []string
+}
+
+func assertComparisonScenario(t *testing.T, tc comparisonScenario) {
+	t.Helper()
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.txt")
+	headPath := filepath.Join(dir, "head.txt")
+	writeBenchmarkFixture(t, basePath, tc.baseLines)
+	writeBenchmarkFixture(t, headPath, tc.headLines)
+
+	baseInput, err := parseBenchmarkFile(basePath)
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	headInput, err := parseBenchmarkFile(headPath)
+	if err != nil {
+		t.Fatalf("parse head: %v", err)
+	}
+
+	summary, statusCode := compareBenchmarks(baseInput, headInput, deltaThresholds{bytesPct: 15, allocsPct: 10})
+	if statusCode != exitCodeInvalid {
+		t.Fatalf("status code = %d, want %d\n%s", statusCode, exitCodeInvalid, summary)
+	}
+	assertSummaryContainsAll(t, summary, tc.wantContains)
+	assertSummaryOmitsAll(t, summary, tc.wantOmit)
+}
+
+func assertSummaryContainsAll(t *testing.T, summary string, expected []string) {
+	t.Helper()
+	for _, want := range expected {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("expected summary to contain %q, got:\n%s", want, summary)
+		}
+	}
+}
+
+func assertSummaryOmitsAll(t *testing.T, summary string, omitted []string) {
+	t.Helper()
+	for _, omit := range omitted {
+		if strings.Contains(summary, omit) {
+			t.Fatalf("expected summary to omit %q, got:\n%s", omit, summary)
+		}
+	}
+}
+
+func incompleteInvalidDiagnostics() []string {
+	return []string{
+		"Head-only benchmarks (missing on base):",
+		"Base-only benchmarks (missing on head):",
+		"No overlapping benchmark names were found between base and head.",
+	}
+}
+
+func packageLine(pkg string) string {
+	return "pkg: " + pkg
+}
+
+func benchmarkFixtureLine(name string, parts ...string) string {
+	return "Benchmark" + name + "-8 " + strings.Join(parts, " ")
+}
+
+func reportFixture(lines ...string) []string {
+	return append([]string{packageLine(reportBenchmarkPkg)}, lines...)
+}
+
+func completeBenchmark(name string) string {
+	return bytesAllocsBenchmark(name, "100", "1")
+}
+
+func bytesAllocsBenchmark(name, bytes, allocs string) string {
+	return benchmarkFixtureLine(name, "1000", "100", "ns/op", bytes, "B/op", allocs, "allocs/op")
+}
+
+func bytesOnlyBenchmark(name, bytes string) string {
+	return benchmarkFixtureLine(name, "1000", "100", "ns/op", bytes, "B/op")
+}
+
+func allocsOnlyBenchmark(name, allocs string) string {
+	return benchmarkFixtureLine(name, "1000", "100", "ns/op", allocs, "allocs/op")
+}
+
+func repeatedCompleteBenchmark(name string, count int) []string {
+	lines := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		lines = append(lines, completeBenchmark(name))
+	}
+	return lines
+}
+
+func benchmarkKey(pkg, name string) string {
+	return pkg + "/Benchmark" + name
+}
+
+func benchmarkRef(pkg, name string) string {
+	return "`" + benchmarkKey(pkg, name) + "`"
+}
+
+func benchmarkMissingMetric(pkg, name, metric string) string {
+	return benchmarkRef(pkg, name) + " missing " + metric
+}
+
+func completeBenchmarkSample() samples {
+	return samples{bytesPerOp: []float64{100}, allocsPerOp: []float64{1}}
+}
+
+func okComparisonRow(pkg, name string) string {
+	return "| " + benchmarkRef(pkg, name) + " | 100.0 | 100.0 | +0.0% | 1.0 | 1.0 | +0.0% | ok |"
 }


### PR DESCRIPTION
## Summary

Make the memory benchmark gate fail closed when a comparison is incomplete, so disappearing, one-sided, empty, or non-overlapping benchmark results cannot be reported as a pass.

Closes #1403

## Changes

- reject empty, base-only, head-only, and zero-overlap benchmark comparisons with exit status 2
- reject incomplete B/op or allocs/op samples while keeping malformed input distinct from threshold regressions
- add deterministic fixture coverage for every incomplete-comparison shape

## Validation

Commands and checks run:

```bash
make ci
go test ./tools/benchdelta ./scripts -count=1
go test -race ./tools/benchdelta ./scripts -count=1
make lint
make dup-check DUPLICATION_BASE=origin/main
go run ./tools/regressionproof --repo . --body-file .codex-pr-1403.md --title "fix(ci): reject incomplete benchmark comparisons" --base-sha "$BASE_SHA" --regression-exempt-label false
```

Additional manual validation:

- confirmed incomplete comparisons use status 2 and identify the missing side or metric

Regression-Test: ./scripts::TestBenchdeltaRejectsInvalidAndIncompleteInputs

## Risk and compatibility

- Breaking changes: incomplete benchmark result sets now fail instead of passing
- Migration required: none
- Performance impact: negligible; validation is linear in parsed benchmark names
- Memory benchmark impact: none

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
