### PR TITLE
fix(jvm): bound symlinked Gradle and source reads

### DIFF
--- a/internal/advisory/publication_lock_unix.go
+++ b/internal/advisory/publication_lock_unix.go
@@ -1,0 +1,35 @@
+//go:build darwin || linux
+
+package advisory
+
+import (
+	"errors"
+	"syscall"
+)
+
+type advisoryNativePublicationLock struct {
+	fd uintptr
+}
+
+func newAdvisoryNativePublicationLock(fd uintptr) (*advisoryNativePublicationLock, error) {
+	return &advisoryNativePublicationLock{fd: fd}, nil
+}
+
+func (l *advisoryNativePublicationLock) tryAcquire() (bool, error) {
+	err := syscall.Flock(int(l.fd), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (l *advisoryNativePublicationLock) release() error {
+	return syscall.Flock(int(l.fd), syscall.LOCK_UN)
+}
+
+func (*advisoryNativePublicationLock) close() error {
+	return nil
+}

--- a/internal/advisory/publication_lock_windows.go
+++ b/internal/advisory/publication_lock_windows.go
@@ -1,0 +1,85 @@
+//go:build windows
+
+package advisory
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32CreateMutexW = syscall.NewLazyDLL("kernel32.dll").NewProc("CreateMutexW")
+	kernel32ReleaseMutex = syscall.NewLazyDLL("kernel32.dll").NewProc("ReleaseMutex")
+)
+
+type advisoryNativePublicationLock struct {
+	handle syscall.Handle
+	held   bool
+}
+
+func newAdvisoryNativePublicationLock(fd uintptr) (*advisoryNativePublicationLock, error) {
+	var info syscall.ByHandleFileInformation
+	if err := syscall.GetFileInformationByHandle(syscall.Handle(fd), &info); err != nil {
+		return nil, err
+	}
+	name := fmt.Sprintf(`Global\lopper-advisory-cache-%08x-%08x%08x`, info.VolumeSerialNumber, info.FileIndexHigh, info.FileIndexLow)
+	namePtr, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, err
+	}
+	result, _, callErr := kernel32CreateMutexW.Call(0, 0, uintptr(unsafe.Pointer(namePtr)))
+	if result == 0 {
+		return nil, normalizeWindowsLockError(callErr)
+	}
+	return &advisoryNativePublicationLock{handle: syscall.Handle(result)}, nil
+}
+
+func (l *advisoryNativePublicationLock) tryAcquire() (bool, error) {
+	runtime.LockOSThread()
+	event, err := syscall.WaitForSingleObject(l.handle, 0)
+	if err != nil {
+		runtime.UnlockOSThread()
+		return false, err
+	}
+	switch event {
+	case syscall.WAIT_OBJECT_0, syscall.WAIT_ABANDONED:
+		l.held = true
+		return true, nil
+	case syscall.WAIT_TIMEOUT:
+		runtime.UnlockOSThread()
+		return false, nil
+	default:
+		runtime.UnlockOSThread()
+		return false, syscall.EINVAL
+	}
+}
+
+func (l *advisoryNativePublicationLock) release() error {
+	if !l.held {
+		return nil
+	}
+	defer runtime.UnlockOSThread()
+	l.held = false
+	result, _, callErr := kernel32ReleaseMutex.Call(uintptr(l.handle))
+	if result == 0 {
+		return normalizeWindowsLockError(callErr)
+	}
+	return nil
+}
+
+func (l *advisoryNativePublicationLock) close() error {
+	return syscall.CloseHandle(l.handle)
+}
+
+func normalizeWindowsLockError(err error) error {
+	if errors.Is(err, syscall.Errno(0)) {
+		return syscall.EINVAL
+	}
+	if err == nil {
+		return nil
+	}
+	return err
+}

--- a/internal/advisory/sync.go
+++ b/internal/advisory/sync.go
@@ -24,6 +24,7 @@ import (
 const (
 	DefaultOSVSourceURL          = "https://osv-vulnerabilities.storage.googleapis.com/all.zip"
 	defaultHTTPTimeout           = 15 * time.Minute
+	maxCacheManifestBytes int64  = 8 * 1024 * 1024
 	maxSyncMetadataBytes         = 64 * 1024 * 1024
 	maxSyncSnapshotBytes  int64  = 4 * 1024 * 1024 * 1024
 	maxOSVZipEntries             = 2_000_000
@@ -72,17 +73,37 @@ type fetchedSnapshot struct {
 	sizeBytes  int64
 }
 
-var syncAfterDownloadTestHook func(cachePath, tempRel string)
+var (
+	syncAfterDownloadTestHook       func(cachePath, tempRel string)
+	syncBeforeSnapshotPlacementHook func(cachePath, snapshotRel string)
+	syncAfterSnapshotPlacementHook  func(cachePath, snapshotRel string)
+	syncPublicationLockWaitTestHook func()
+	syncUpdateManifestTestHook      = updateManifest
+	openAdvisoryCacheRootHook       = openAdvisoryCacheRoot
+	openAdvisoryCacheAncestor       = safeio.OpenRootExistingAncestorNoFollow
+)
+
+var (
+	errAdvisorySnapshotContentMismatch = errors.New("advisory snapshot content mismatch")
+	errAdvisorySnapshotOwnershipLost   = errors.New("advisory snapshot ownership lost")
+)
+
+type advisorySnapshotOwnership struct {
+	name string
+	info os.FileInfo
+}
+
+type advisoryPublicationLock struct {
+	identity safeio.File
+	native   *advisoryNativePublicationLock
+}
 
 func SyncOSV(ctx context.Context, opts SyncOptions) (snapshot CacheSnapshot, err error) {
 	sourceURL, cachePath, now, err := resolveSyncOptions(opts)
 	if err != nil {
 		return CacheSnapshot{}, err
 	}
-	if err := os.MkdirAll(cachePath, 0o750); err != nil {
-		return CacheSnapshot{}, fmt.Errorf("create advisory cache: %w", err)
-	}
-	root, err := safeio.OpenRoot(cachePath)
+	root, err := prepareAdvisoryCacheRoot(cachePath)
 	if err != nil {
 		return CacheSnapshot{}, fmt.Errorf("create advisory cache: %w", err)
 	}
@@ -91,35 +112,151 @@ func SyncOSV(ctx context.Context, opts SyncOptions) (snapshot CacheSnapshot, err
 			err = errors.Join(err, closeErr)
 		}
 	}()
+	return syncOSVWithinCacheRoot(ctx, sourceURL, cachePath, now, opts.Client, root)
+}
+
+func syncOSVWithinCacheRoot(ctx context.Context, sourceURL, cachePath string, now time.Time, client *http.Client, root safeio.Root) (snapshot CacheSnapshot, err error) {
 	if err := root.MkdirAll("snapshots", 0o750); err != nil {
 		return CacheSnapshot{}, fmt.Errorf("create advisory cache: %w", err)
 	}
-	fetched, err := downloadSnapshotUnderRoot(ctx, sourceURL, opts.Client, root)
+	snapshotsRoot, err := advisoryOpenOrCreatePinnedChild(root, cachePath, "snapshots")
+	if err != nil {
+		return CacheSnapshot{}, fmt.Errorf("create advisory cache: %w", err)
+	}
+	defer func() {
+		if closeErr := snapshotsRoot.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+	fetched, err := downloadSnapshotUnderRoot(ctx, sourceURL, client, snapshotsRoot)
 	if err != nil {
 		return CacheSnapshot{}, err
 	}
-	tempOwned := true
 	defer func() {
-		if !tempOwned {
-			return
-		}
-		err = errors.Join(err, safeio.CleanupTempFileWithinRoot(root, fetched.tempRel, nil))
+		err = errors.Join(err, safeio.CleanupTempFileWithinRoot(snapshotsRoot, fetched.tempRel, nil))
 	}()
+	tempCacheRel := filepath.Join("snapshots", fetched.tempRel)
 	if syncAfterDownloadTestHook != nil {
-		syncAfterDownloadTestHook(cachePath, fetched.tempRel)
+		syncAfterDownloadTestHook(cachePath, tempCacheRel)
 	}
+	return publishAdvisorySnapshot(ctx, sourceURL, cachePath, now, root, snapshotsRoot, fetched)
+}
 
+func publishAdvisorySnapshot(ctx context.Context, sourceURL, cachePath string, now time.Time, root, snapshotsRoot safeio.Root, fetched fetchedSnapshot) (snapshot CacheSnapshot, err error) {
 	id := snapshotIDFromDigest(fetched.digest)
-	snapshotRel := filepath.Join("snapshots", id+snapshotExtension(fetched.schema))
-	if err := safeio.MoveFileWithinRoot(root, fetched.tempRel, snapshotRel, 0o750, 0o640); err != nil {
+	snapshotName := id + snapshotExtension(fetched.schema)
+	snapshotRel := filepath.Join("snapshots", snapshotName)
+	publicationLock, err := acquireAdvisoryPublicationLock(ctx, root)
+	if err != nil {
+		return CacheSnapshot{}, fmt.Errorf("lock advisory cache publication: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, publicationLock.Close())
+	}()
+	if _, err := advisorySnapshotAbsent(snapshotsRoot, snapshotName); err != nil {
 		return CacheSnapshot{}, fmt.Errorf("write advisory snapshot: %w", err)
 	}
-	tempOwned = false
+	if syncBeforeSnapshotPlacementHook != nil {
+		syncBeforeSnapshotPlacementHook(cachePath, snapshotRel)
+	}
+	ownership, err := advisoryPlaceSnapshotNoReplace(snapshotsRoot, fetched.tempRel, snapshotName, fetched.digest, fetched.sizeBytes)
+	if err != nil {
+		return CacheSnapshot{}, fmt.Errorf("write advisory snapshot: %w", err)
+	}
 	snapshot = buildCacheSnapshot(id, sourceURL, now, snapshotRel, fetched)
-	if err := updateManifest(root, snapshot, now); err != nil {
+	if syncAfterSnapshotPlacementHook != nil {
+		syncAfterSnapshotPlacementHook(cachePath, snapshotRel)
+	}
+	if err := advisoryVerifyPinnedSnapshotsChild(root, snapshotsRoot); err != nil {
+		placementErr := fmt.Errorf("write advisory snapshot: %w", err)
+		if ownership != nil {
+			placementErr = rollbackOwnedSnapshot(snapshotsRoot, ownership, placementErr)
+		}
+		return CacheSnapshot{}, placementErr
+	}
+	if err := syncUpdateManifestTestHook(root, snapshot, now); err != nil {
+		if ownership != nil {
+			err = rollbackOwnedSnapshot(snapshotsRoot, ownership, err)
+		}
 		return CacheSnapshot{}, err
 	}
 	return snapshot, nil
+}
+
+func acquireAdvisoryPublicationLock(ctx context.Context, root safeio.Root) (*advisoryPublicationLock, error) {
+	identity, err := openAdvisoryCacheIdentity(root)
+	if err != nil {
+		return nil, err
+	}
+	osFile, ok := identity.(*os.File)
+	if !ok {
+		return nil, errors.Join(errors.New("advisory cache identity has no descriptor"), identity.Close())
+	}
+	native, err := newAdvisoryNativePublicationLock(osFile.Fd())
+	if err != nil {
+		return nil, errors.Join(err, identity.Close())
+	}
+	lock := &advisoryPublicationLock{identity: identity, native: native}
+	if err := lock.acquire(ctx); err != nil {
+		return nil, errors.Join(err, native.close(), identity.Close())
+	}
+	if err := verifyAdvisoryCacheIdentity(root, identity); err != nil {
+		return nil, errors.Join(err, lock.Close())
+	}
+	return lock, nil
+}
+
+func openAdvisoryCacheIdentity(root safeio.Root) (safeio.File, error) {
+	return safeio.OpenPinnedDirectory(root, ".")
+}
+
+func verifyAdvisoryCacheIdentity(root safeio.Root, identity safeio.File) error {
+	pathInfo, err := root.Lstat(".")
+	if err != nil {
+		return err
+	}
+	openedInfo, err := identity.Stat()
+	if err != nil {
+		return err
+	}
+	if !pathInfo.IsDir() || !openedInfo.IsDir() {
+		return errors.New("advisory cache identity is not a directory")
+	}
+	if !os.SameFile(pathInfo, openedInfo) {
+		return errors.New("advisory cache identity changed while locking")
+	}
+	return nil
+}
+
+func (l *advisoryPublicationLock) acquire(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	waitNotified := false
+	for {
+		acquired, err := l.native.tryAcquire()
+		if err != nil {
+			return err
+		}
+		if acquired {
+			return nil
+		}
+		if !waitNotified && syncPublicationLockWaitTestHook != nil {
+			syncPublicationLockWaitTestHook()
+			waitNotified = true
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (l *advisoryPublicationLock) Close() error {
+	return errors.Join(l.native.release(), l.native.close(), l.identity.Close())
 }
 
 func resolveSyncOptions(opts SyncOptions) (sourceURL, cachePath string, now time.Time, err error) {
@@ -163,6 +300,122 @@ func buildCacheSnapshot(id, sourceURL string, now time.Time, snapshotRel string,
 	}
 }
 
+func advisorySnapshotAbsent(root safeio.Root, snapshotName string) (bool, error) {
+	info, err := root.Lstat(snapshotName)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return false, fmt.Errorf("snapshot path is a symlink: %s", snapshotName)
+		}
+		if !info.Mode().IsRegular() {
+			return false, fmt.Errorf("snapshot path is not a regular file: %s", snapshotName)
+		}
+		return false, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	return false, err
+}
+
+func advisoryPlaceSnapshotNoReplace(root safeio.Root, tempName, snapshotName, digest string, sizeBytes int64) (*advisorySnapshotOwnership, error) {
+	tempInfo, err := root.Lstat(tempName)
+	if err != nil {
+		return nil, err
+	}
+	if !tempInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("snapshot temp path is not a regular file: %s", tempName)
+	}
+	if err := root.Chmod(tempName, 0o640); err != nil {
+		return nil, err
+	}
+	if err := root.Link(tempName, snapshotName); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			absent, validateErr := advisorySnapshotAbsent(root, snapshotName)
+			if validateErr != nil {
+				return nil, validateErr
+			}
+			if absent {
+				return nil, errors.New("snapshot path disappeared during no-replace placement")
+			}
+			return nil, advisoryVerifyExistingSnapshot(root, snapshotName, digest, sizeBytes)
+		}
+		return nil, err
+	}
+	ownership := &advisorySnapshotOwnership{name: snapshotName, info: tempInfo}
+	publishedInfo, err := root.Lstat(snapshotName)
+	if err != nil {
+		return nil, rollbackOwnedSnapshot(root, ownership, err)
+	}
+	if !os.SameFile(tempInfo, publishedInfo) {
+		ownershipErr := fmt.Errorf("%w: %s", errAdvisorySnapshotOwnershipLost, snapshotName)
+		return nil, rollbackOwnedSnapshot(root, ownership, ownershipErr)
+	}
+	return ownership, nil
+}
+
+func advisoryVerifyExistingSnapshot(root safeio.Root, snapshotName, digest string, sizeBytes int64) (err error) {
+	file, err := safeio.OpenPinnedFile(root, snapshotName)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, file.Close())
+	}()
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: snapshot path is not a regular file: %s", errAdvisorySnapshotContentMismatch, snapshotName)
+	}
+	if info.Size() != sizeBytes {
+		return fmt.Errorf("%w: snapshot size %d does not match downloaded size %d: %s", errAdvisorySnapshotContentMismatch, info.Size(), sizeBytes, snapshotName)
+	}
+	hasher := sha256.New()
+	copied, err := io.Copy(hasher, file)
+	if err != nil {
+		return err
+	}
+	actualDigest := sha256Prefix + hex.EncodeToString(hasher.Sum(nil))
+	if copied != sizeBytes || actualDigest != digest {
+		return fmt.Errorf("%w: snapshot digest or size does not match download: %s", errAdvisorySnapshotContentMismatch, snapshotName)
+	}
+	return nil
+}
+
+func advisoryVerifyPinnedSnapshotsChild(root, snapshotsRoot safeio.Root) error {
+	pathInfo, err := root.Lstat("snapshots")
+	if err != nil {
+		return err
+	}
+	openedInfo, err := snapshotsRoot.Lstat(".")
+	if err != nil {
+		return err
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.IsDir() || !os.SameFile(pathInfo, openedInfo) {
+		return errors.New("snapshots directory changed during publication")
+	}
+	return nil
+}
+
+func rollbackOwnedSnapshot(root safeio.Root, ownership *advisorySnapshotOwnership, publicationErr error) error {
+	currentInfo, err := root.Lstat(ownership.name)
+	if errors.Is(err, os.ErrNotExist) {
+		return publicationErr
+	}
+	if err != nil {
+		return errors.Join(publicationErr, fmt.Errorf("rollback advisory snapshot: %w", err))
+	}
+	if !os.SameFile(ownership.info, currentInfo) {
+		return errors.Join(publicationErr, fmt.Errorf("%w: %s", errAdvisorySnapshotOwnershipLost, ownership.name))
+	}
+	removeErr := root.Remove(ownership.name)
+	if removeErr == nil || errors.Is(removeErr, os.ErrNotExist) {
+		return publicationErr
+	}
+	return errors.Join(publicationErr, fmt.Errorf("rollback advisory snapshot: %w", removeErr))
+}
+
 func snapshotExtension(schema string) string {
 	switch schema {
 	case schemaOSVZip:
@@ -172,8 +425,124 @@ func snapshotExtension(schema string) string {
 	}
 }
 
-func LoadCacheManifest(cachePath string) (CacheManifest, error) {
-	data, err := safeio.ReadFileUnder(cachePath, filepath.Join(cachePath, manifestFileName))
+func LoadCacheManifest(cachePath string) (manifest CacheManifest, err error) {
+	root, err := openAdvisoryCacheRootHook(cachePath)
+	if err != nil {
+		return CacheManifest{}, err
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+	data, err := readCacheManifestData(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return CacheManifest{}, &os.PathError{
+				Op:   "open",
+				Path: filepath.Join(cachePath, manifestFileName),
+				Err:  os.ErrNotExist,
+			}
+		}
+		return CacheManifest{}, err
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return CacheManifest{}, fmt.Errorf("parse advisory cache manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func prepareAdvisoryCacheRoot(cachePath string) (safeio.Root, error) {
+	root, currentPath, missingParts, err := openAdvisoryCacheAncestor(cachePath)
+	if err != nil {
+		return nil, err
+	}
+	if len(missingParts) == 0 {
+		return root, nil
+	}
+	current, err := openMissingAdvisoryCacheParts(root, currentPath, missingParts)
+	if err != nil {
+		return nil, err
+	}
+	if err := root.Close(); err != nil {
+		return nil, advisoryJoinCloseError(err, current)
+	}
+	return current, nil
+}
+
+func openMissingAdvisoryCacheParts(root safeio.Root, currentPath string, missingParts []string) (safeio.Root, error) {
+	current := root
+	for index, part := range missingParts {
+		next, err := advisoryOpenOrCreatePinnedChild(current, currentPath, part)
+		if err != nil {
+			if index == 0 {
+				return nil, advisoryJoinCloseError(err, root)
+			}
+			return nil, advisoryJoinCloseError(err, current, root)
+		}
+		if index > 0 {
+			if err := current.Close(); err != nil {
+				return nil, advisoryJoinCloseError(err, next, root)
+			}
+		}
+		current = next
+		currentPath = filepath.Join(currentPath, part)
+	}
+	return current, nil
+}
+
+func openAdvisoryCacheRoot(cachePath string) (safeio.Root, error) {
+	return safeio.OpenRootNoFollow(cachePath)
+}
+
+func advisoryOpenOrCreatePinnedChild(root safeio.Root, parentPath, name string) (safeio.Root, error) {
+	childPath := filepath.Join(parentPath, name)
+	info, err := root.Lstat(name)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		if mkdirErr := root.Mkdir(name, 0o750); mkdirErr != nil && !errors.Is(mkdirErr, os.ErrExist) {
+			return nil, mkdirErr
+		}
+		info, err = root.Lstat(name)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("root contains symlink: %s", childPath)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("root is not a directory: %s", childPath)
+	}
+
+	next, err := root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := next.Lstat(".")
+	if err != nil {
+		return nil, advisoryJoinCloseError(err, next)
+	}
+	if !os.SameFile(info, openedInfo) {
+		return nil, advisoryJoinCloseError(fmt.Errorf("root changed while opening: %s", childPath), next)
+	}
+	return next, nil
+}
+
+func advisoryJoinCloseError(err error, closers ...io.Closer) error {
+	for _, closer := range closers {
+		if closer == nil {
+			continue
+		}
+		err = errors.Join(err, closer.Close())
+	}
+	return err
+}
+
+func loadCacheManifestWithinRoot(root safeio.Root) (CacheManifest, error) {
+	data, err := readCacheManifestData(root)
 	if err != nil {
 		return CacheManifest{}, err
 	}
@@ -184,16 +553,12 @@ func LoadCacheManifest(cachePath string) (CacheManifest, error) {
 	return manifest, nil
 }
 
-func loadCacheManifestWithinRoot(root safeio.Root) (CacheManifest, error) {
-	data, err := safeio.ReadFileWithinRoot(root, manifestFileName)
-	if err != nil {
-		return CacheManifest{}, err
+func readCacheManifestData(root safeio.Root) ([]byte, error) {
+	data, err := safeio.ReadFileWithinRootLimit(root, manifestFileName, maxCacheManifestBytes)
+	if errors.Is(err, safeio.ErrFileTooLarge) {
+		return nil, fmt.Errorf("read advisory cache manifest: %w", err)
 	}
-	var manifest CacheManifest
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return CacheManifest{}, fmt.Errorf("parse advisory cache manifest: %w", err)
-	}
-	return manifest, nil
+	return data, err
 }
 
 func validateSyncURL(raw string) error {
@@ -252,7 +617,7 @@ func downloadSnapshotUnderRoot(ctx context.Context, sourceURL string, client *ht
 		}
 	}()
 	openTempSnapshot := func() (io.ReadCloser, error) {
-		file, openErr := root.Open(tempRel)
+		file, openErr := safeio.OpenFileWithinRoot(root, tempRel)
 		return file, openErr
 	}
 	loadTempMetadata := func(sizeBytes int64, schema string) ([]string, int) {
@@ -481,22 +846,9 @@ func loadSnapshotMetadataFromReader(schema string, sizeBytes int64, read func() 
 	return snapshotEcosystems(data), snapshotEntryCount(data)
 }
 
-func readAllAndClose(file io.ReadCloser) ([]byte, error) {
-	data, err := io.ReadAll(file)
-	closeErr := file.Close()
-	if err != nil || closeErr != nil {
-		return nil, errors.Join(err, closeErr)
-	}
-	return data, nil
-}
-
 func loadSnapshotMetadataUnderRoot(root safeio.Root, path string, sizeBytes int64, schema string) ([]string, int) {
 	return loadSnapshotMetadataFromReader(schema, sizeBytes, func() ([]byte, error) {
-		file, err := root.Open(path)
-		if err != nil {
-			return nil, err
-		}
-		return readAllAndClose(file)
+		return safeio.ReadFileWithinRootLimit(root, path, maxSyncMetadataBytes)
 	})
 }
 
@@ -529,6 +881,9 @@ func updateManifest(root safeio.Root, snapshot CacheSnapshot, now time.Time) err
 		return err
 	}
 	payload = append(payload, '\n')
+	if int64(len(payload)) > maxCacheManifestBytes {
+		return fmt.Errorf("write advisory cache manifest: serialized size %d exceeds %d-byte limit: %w", len(payload), maxCacheManifestBytes, safeio.ErrFileTooLarge)
+	}
 	return safeio.WriteFileWithinRoot(root, manifestFileName, payload, 0o640)
 }
 

--- a/internal/advisory/sync_darwin_test.go
+++ b/internal/advisory/sync_darwin_test.go
@@ -1,0 +1,61 @@
+//go:build darwin
+
+package advisory
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrepareAdvisoryCacheRootAllowsTrustedTmpAliasCreation(t *testing.T) {
+	testPrepareAdvisoryCacheRootAllowsTrustedDarwinAliasCreation(t, filepath.Join(string(os.PathSeparator), "tmp"), filepath.Join(string(os.PathSeparator), "private", "tmp"))
+}
+
+func TestPrepareAdvisoryCacheRootAllowsTrustedVarAliasCreation(t *testing.T) {
+	testPrepareAdvisoryCacheRootAllowsTrustedDarwinAliasCreation(t, filepath.Join(string(os.PathSeparator), "var", "tmp"), filepath.Join(string(os.PathSeparator), "private", "var", "tmp"))
+}
+
+func testPrepareAdvisoryCacheRootAllowsTrustedDarwinAliasCreation(t *testing.T, aliasParent, resolvedParent string) {
+	topDir, err := os.MkdirTemp(aliasParent, "lopper-advisory-")
+	if err != nil {
+		t.Fatalf("create advisory cache test directory under %q: %v", aliasParent, err)
+	}
+	cachePath := filepath.Join(topDir, "cache")
+	t.Cleanup(func() {
+		if err := os.RemoveAll(topDir); err != nil {
+			t.Errorf("remove advisory cache test directory: %v", err)
+		}
+	})
+
+	root, err := prepareAdvisoryCacheRoot(cachePath)
+	if err != nil {
+		t.Fatalf("prepareAdvisoryCacheRoot returned error: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close advisory cache root: %v", closeErr)
+		}
+	}()
+
+	openedInfo, err := root.Lstat(".")
+	if err != nil {
+		t.Fatalf("lstat advisory cache root: %v", err)
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(cachePath)
+	if err != nil {
+		t.Fatalf("eval symlinks for advisory cache root: %v", err)
+	}
+	targetInfo, err := os.Stat(resolvedPath)
+	if err != nil {
+		t.Fatalf("stat resolved advisory cache root: %v", err)
+	}
+	if !os.SameFile(openedInfo, targetInfo) {
+		t.Fatalf("expected advisory cache root to pin resolved path %q", resolvedPath)
+	}
+	if !strings.HasPrefix(resolvedPath, resolvedParent+string(os.PathSeparator)) {
+		t.Fatalf("expected resolved advisory cache root under %q, got %q", resolvedParent, resolvedPath)
+	}
+}

--- a/internal/advisory/sync_error_contract_test.go
+++ b/internal/advisory/sync_error_contract_test.go
@@ -1,0 +1,206 @@
+package advisory
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+func TestLoadCacheManifestRejectsInvalidJSON(t *testing.T) {
+	cachePath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cachePath, manifestFileName), []byte(`{"schemaVersion":`), 0o600); err != nil {
+		t.Fatalf("write invalid advisory manifest: %v", err)
+	}
+
+	manifest, err := LoadCacheManifest(cachePath)
+	if manifest.SchemaVersion != "" || manifest.Latest != "" || len(manifest.Snapshots) != 0 {
+		t.Fatalf("expected invalid manifest to return no parsed state, got %#v", manifest)
+	}
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatalf("expected JSON syntax error identity, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "parse advisory cache manifest") {
+		t.Fatalf("expected advisory manifest parse context, got %v", err)
+	}
+}
+
+func TestPrepareAdvisoryCacheRootJoinsFirstChildFailureWithAncestorClose(t *testing.T) {
+	lookupErr := errors.New("lookup first advisory cache child")
+	closeErr := errors.New("close advisory cache ancestor")
+	cachePath := filepath.Join(string(os.PathSeparator), "cache")
+	requestedPath := filepath.Join(cachePath, "leaf")
+	closeCalls := 0
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected advisory cache child lookup %q", name)
+			}
+			return nil, lookupErr
+		},
+		close: func() error {
+			closeCalls++
+			return closeErr
+		},
+	}
+	original := openAdvisoryCacheAncestor
+	openAdvisoryCacheAncestor = func(string) (safeio.Root, string, []string, error) {
+		return root, cachePath, []string{"leaf"}, nil
+	}
+	t.Cleanup(func() {
+		openAdvisoryCacheAncestor = original
+	})
+
+	opened, err := prepareAdvisoryCacheRoot(requestedPath)
+	if opened != nil {
+		t.Fatalf("expected first-child failure to return no cache root, got %#v", opened)
+	}
+	if !errors.Is(err, lookupErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected child lookup and ancestor close identities, got %v", err)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("expected failed advisory cache ancestor to close once, got %d", closeCalls)
+	}
+}
+
+func TestAdvisoryOpenOrCreatePinnedChildPropagatesMkdirFailure(t *testing.T) {
+	mkdirErr := errors.New("create advisory cache child")
+	lstatCalls := 0
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected advisory child lookup %q", name)
+			}
+			lstatCalls++
+			return nil, os.ErrNotExist
+		},
+		mkdir: func(name string, perm os.FileMode) error {
+			if name != "leaf" || perm != 0o750 {
+				t.Fatalf("unexpected advisory child mkdir %q with mode %#o", name, perm)
+			}
+			return mkdirErr
+		},
+		openRoot: func(string) (safeio.Root, error) {
+			t.Fatal("advisory child root must not open after mkdir failure")
+			return nil, nil
+		},
+	}
+
+	child, err := advisoryOpenOrCreatePinnedChild(root, "/cache", "leaf")
+	if child != nil {
+		t.Fatalf("expected mkdir failure to return no child root, got %#v", child)
+	}
+	if !errors.Is(err, mkdirErr) {
+		t.Fatalf("expected mkdir error identity, got %v", err)
+	}
+	if lstatCalls != 1 {
+		t.Fatalf("expected no post-mkdir lookup after failure, got %d lookups", lstatCalls)
+	}
+}
+
+func TestAdvisoryOpenOrCreatePinnedChildPropagatesPostCreateLookupFailure(t *testing.T) {
+	lookupErr := errors.New("lookup newly created advisory child")
+	lstatCalls := 0
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected advisory child lookup %q", name)
+			}
+			lstatCalls++
+			if lstatCalls == 1 {
+				return nil, os.ErrNotExist
+			}
+			return nil, lookupErr
+		},
+		mkdir: func(name string, perm os.FileMode) error {
+			if name != "leaf" || perm != 0o750 {
+				t.Fatalf("unexpected advisory child mkdir %q with mode %#o", name, perm)
+			}
+			return nil
+		},
+		openRoot: func(string) (safeio.Root, error) {
+			t.Fatal("advisory child root must not open after post-create lookup failure")
+			return nil, nil
+		},
+	}
+
+	child, err := advisoryOpenOrCreatePinnedChild(root, "/cache", "leaf")
+	if child != nil {
+		t.Fatalf("expected post-create lookup failure to return no child root, got %#v", child)
+	}
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("expected post-create lookup error identity, got %v", err)
+	}
+	if lstatCalls != 2 {
+		t.Fatalf("expected lookup before and after child creation, got %d", lstatCalls)
+	}
+}
+
+func TestAdvisoryOpenOrCreatePinnedChildRejectsNonDirectory(t *testing.T) {
+	parentPath := filepath.Join(string(os.PathSeparator), "cache")
+	filePath := filepath.Join(t.TempDir(), "cache-child")
+	if err := os.WriteFile(filePath, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write advisory cache child fixture: %v", err)
+	}
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat advisory cache child fixture: %v", err)
+	}
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected advisory child lookup %q", name)
+			}
+			return fileInfo, nil
+		},
+		openRoot: func(string) (safeio.Root, error) {
+			t.Fatal("non-directory advisory child must not be opened as a root")
+			return nil, nil
+		},
+	}
+
+	child, err := advisoryOpenOrCreatePinnedChild(root, parentPath, "leaf")
+	if child != nil {
+		t.Fatalf("expected non-directory advisory child to be rejected, got %#v", child)
+	}
+	wantErr := "root is not a directory: " + filepath.Join(parentPath, "leaf")
+	if err == nil || err.Error() != wantErr {
+		t.Fatalf("expected exact non-directory path context, got %v", err)
+	}
+}
+
+func TestAdvisoryOpenOrCreatePinnedChildPropagatesOpenRootFailure(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat advisory child directory fixture: %v", err)
+	}
+	openErr := errors.New("open advisory cache child root")
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected advisory child lookup %q", name)
+			}
+			return dirInfo, nil
+		},
+		openRoot: func(name string) (safeio.Root, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected advisory child root open %q", name)
+			}
+			return nil, openErr
+		},
+	}
+
+	child, err := advisoryOpenOrCreatePinnedChild(root, "/cache", "leaf")
+	if child != nil {
+		t.Fatalf("expected child root open failure to return no root, got %#v", child)
+	}
+	if !errors.Is(err, openErr) {
+		t.Fatalf("expected child root open error identity, got %v", err)
+	}
+}

--- a/internal/advisory/sync_test.go
+++ b/internal/advisory/sync_test.go
@@ -1419,13 +1419,65 @@ func advisoryWriteLegacyLockPath(t *testing.T, path, contents string) fs.FileInf
 
 func advisoryReplaceLegacyLockPath(t *testing.T, path string, original fs.FileInfo) {
 	t.Helper()
+	replacementPath, replacementInfo := advisoryCreateDistinctLegacyLockReplacement(t, path, original)
 	if err := os.Remove(path); err != nil {
 		t.Fatalf("unlink legacy publication lock path: %v", err)
 	}
-	replacement := advisoryWriteLegacyLockPath(t, path, "replacement")
-	if os.SameFile(original, replacement) {
-		t.Fatal("legacy publication lock replacement reused the original identity")
+	if err := os.Rename(replacementPath, path); err != nil {
+		t.Fatalf("rename distinct legacy publication lock replacement: %v", err)
 	}
+	renamedInfo, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat renamed legacy publication lock replacement: %v", err)
+	}
+	if !os.SameFile(replacementInfo, renamedInfo) {
+		t.Fatal("legacy publication lock replacement changed identity during rename")
+	}
+}
+
+func advisoryCreateDistinctLegacyLockReplacement(t *testing.T, path string, original fs.FileInfo) (string, fs.FileInfo) {
+	t.Helper()
+
+	dir := filepath.Dir(path)
+	pattern := filepath.Base(path) + ".replacement-*"
+	for attempt := 0; attempt < 8; attempt++ {
+		file, err := os.CreateTemp(dir, pattern)
+		if err != nil {
+			t.Fatalf("create distinct legacy publication lock replacement: %v", err)
+		}
+		replacementPath := file.Name()
+		if _, err := file.WriteString("replacement"); err != nil {
+			if closeErr := file.Close(); closeErr != nil {
+				t.Logf("close failed replacement file after write error: %v", closeErr)
+			}
+			if removeErr := os.Remove(replacementPath); removeErr != nil {
+				t.Logf("remove failed replacement file after write error: %v", removeErr)
+			}
+			t.Fatalf("write distinct legacy publication lock replacement: %v", err)
+		}
+		if err := file.Close(); err != nil {
+			if removeErr := os.Remove(replacementPath); removeErr != nil {
+				t.Logf("remove failed replacement file after close error: %v", removeErr)
+			}
+			t.Fatalf("close distinct legacy publication lock replacement: %v", err)
+		}
+		replacementInfo, err := os.Lstat(replacementPath)
+		if err != nil {
+			if removeErr := os.Remove(replacementPath); removeErr != nil {
+				t.Logf("remove failed replacement file after lstat error: %v", removeErr)
+			}
+			t.Fatalf("lstat distinct legacy publication lock replacement: %v", err)
+		}
+		if os.SameFile(original, replacementInfo) {
+			if removeErr := os.Remove(replacementPath); removeErr != nil {
+				t.Logf("remove failed reused-identity replacement file: %v", removeErr)
+			}
+			continue
+		}
+		return replacementPath, replacementInfo
+	}
+	t.Fatal("failed to create a distinct legacy publication lock replacement")
+	return "", nil
 }
 
 func advisoryPublicationLockChildCommand(t *testing.T, mode, cachePath, markerPath, testName string) (*exec.Cmd, *bytes.Buffer) {

--- a/internal/advisory/sync_test.go
+++ b/internal/advisory/sync_test.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"net/http"
@@ -23,7 +25,22 @@ import (
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
-const downloadSnapshotWriteErrorChildEnv = "LOPPER_DOWNLOAD_SNAPSHOT_WRITE_ERROR_CHILD"
+const (
+	downloadSnapshotWriteErrorChildEnv    = "LOPPER_DOWNLOAD_SNAPSHOT_WRITE_ERROR_CHILD"
+	publicationLockChildModeEnv           = "LOPPER_PUBLICATION_LOCK_CHILD_MODE"
+	publicationLockChildCacheEnv          = "LOPPER_PUBLICATION_LOCK_CHILD_CACHE"
+	publicationLockChildMarkerEnv         = "LOPPER_PUBLICATION_LOCK_CHILD_MARKER"
+	publicationLockChildModeSync          = "sync"
+	publicationLockChildModeExitWhileHeld = "exit-while-held"
+	legacyPublicationLockFileName         = ".publication.lock"
+)
+
+var publicationLockChildNow = time.Date(2026, time.July, 20, 3, 0, 0, 0, time.UTC)
+
+type advisorySyncResult struct {
+	snapshot CacheSnapshot
+	err      error
+}
 
 func testOSVAdvisory(id string) string {
 	return `{"id":"` + id + `","affected":[{"package":{"ecosystem":"Go","name":"example.com/lib"},"ranges":[{"type":"SEMVER","events":[{"introduced":"0"}]}]}]}`
@@ -37,6 +54,12 @@ type testOSVZipEntry struct {
 	name    string
 	payload string
 	method  uint16
+}
+
+type closerFunc func() error
+
+func (fn closerFunc) Close() error {
+	return fn()
 }
 
 func testOSVZip(t *testing.T, name, payload string) []byte {
@@ -720,7 +743,15 @@ func TestSyncOSVUpdateAndFilesystemErrors(t *testing.T) {
 		}
 	}))
 	defer server.Close()
+	advisoryTestSyncInvalidManifest(t, server)
+	advisoryTestSyncOversizedManifest(t, server)
+	advisoryTestSyncFileCachePath(t, server)
+	advisoryTestSyncSnapshotPlacementFailure(t, server)
+	advisoryTestSyncDownloadFailure(t)
+}
 
+func advisoryTestSyncInvalidManifest(t *testing.T, server *httptest.Server) {
+	t.Helper()
 	cachePath := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cachePath, manifestFileName), []byte("{"), 0o600); err != nil {
 		t.Fatalf("write invalid manifest: %v", err)
@@ -728,7 +759,25 @@ func TestSyncOSVUpdateAndFilesystemErrors(t *testing.T) {
 	if _, err := SyncOSV(context.Background(), SyncOptions{SourceURL: server.URL, CachePath: cachePath, Client: server.Client()}); err == nil || !strings.Contains(err.Error(), "parse advisory cache manifest") {
 		t.Fatalf("expected manifest parse error, got %v", err)
 	}
+}
 
+func advisoryTestSyncOversizedManifest(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	oversizedManifestCache := t.TempDir()
+	if err := writeOversizedValidManifest(filepath.Join(oversizedManifestCache, manifestFileName), maxCacheManifestBytes+1); err != nil {
+		t.Fatalf("write oversized manifest: %v", err)
+	}
+	_, err := SyncOSV(context.Background(), SyncOptions{SourceURL: server.URL, CachePath: oversizedManifestCache, Client: server.Client()})
+	if !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected oversized manifest error during update merge, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "read advisory cache manifest") {
+		t.Fatalf("expected advisory manifest read context during update merge, got %v", err)
+	}
+}
+
+func advisoryTestSyncFileCachePath(t *testing.T, server *httptest.Server) {
+	t.Helper()
 	fileCache := filepath.Join(t.TempDir(), "cache-file")
 	if err := os.WriteFile(fileCache, []byte("x"), 0o600); err != nil {
 		t.Fatalf("write file cache: %v", err)
@@ -736,7 +785,10 @@ func TestSyncOSVUpdateAndFilesystemErrors(t *testing.T) {
 	if _, err := SyncOSV(context.Background(), SyncOptions{SourceURL: server.URL, CachePath: fileCache, Client: server.Client()}); err == nil || !strings.Contains(err.Error(), "create advisory cache") {
 		t.Fatalf("expected cache directory error, got %v", err)
 	}
+}
 
+func advisoryTestSyncSnapshotPlacementFailure(t *testing.T, server *httptest.Server) {
+	t.Helper()
 	data := []byte(`{"vulns":[]}`)
 	sum := sha256.Sum256(data)
 	id := hex.EncodeToString(sum[:12])
@@ -747,12 +799,213 @@ func TestSyncOSVUpdateAndFilesystemErrors(t *testing.T) {
 	if _, err := SyncOSV(context.Background(), SyncOptions{SourceURL: server.URL, CachePath: writeFailCache, Client: server.Client()}); err == nil || !strings.Contains(err.Error(), "write advisory snapshot") {
 		t.Fatalf("expected snapshot write error, got %v", err)
 	}
+}
 
+func advisoryTestSyncDownloadFailure(t *testing.T) {
+	t.Helper()
 	downloadFailClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("snapshot unavailable")
 	})}
 	if _, err := SyncOSV(context.Background(), SyncOptions{SourceURL: "https://example.test/osv.json", CachePath: t.TempDir(), Client: downloadFailClient}); err == nil || !strings.Contains(err.Error(), "download advisory snapshot") {
 		t.Fatalf("expected snapshot download error, got %v", err)
+	}
+}
+
+func TestSyncOSVManifestWriteSizeLimit(t *testing.T) {
+	snapshotPayload := []byte(`{"vulns":[]}`)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write(snapshotPayload); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, time.July, 13, 0, 0, 0, 0, time.UTC)
+	digestSum := sha256.Sum256(snapshotPayload)
+	digest := sha256Prefix + hex.EncodeToString(digestSum[:])
+	snapshotID := snapshotIDFromDigest(digest)
+	snapshot := CacheSnapshot{
+		ID:          snapshotID,
+		SourceURL:   server.URL,
+		RetrievedAt: now.Format(time.RFC3339),
+		Digest:      digest,
+		Path:        filepath.ToSlash(filepath.Join("snapshots", snapshotID+".json")),
+		Schema:      schemaOSVJSON,
+		EntryCount:  0,
+		SizeBytes:   int64(len(snapshotPayload)),
+	}
+
+	for _, tc := range []advisoryManifestSizeCase{
+		{name: "exact limit succeeds", target: maxCacheManifestBytes},
+		{name: "one byte over limit preserves prior manifest", target: maxCacheManifestBytes + 1, wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runAdvisoryManifestSizeCase(t, server, now, snapshot, tc)
+		})
+	}
+}
+
+type advisoryManifestSizeCase struct {
+	name      string
+	target    int64
+	wantError bool
+}
+
+type advisoryManifestSizeFixture struct {
+	cachePath        string
+	manifestPath     string
+	priorManifest    CacheManifest
+	priorPayload     []byte
+	wantFinalPayload []byte
+	snapshot         CacheSnapshot
+}
+
+func runAdvisoryManifestSizeCase(t *testing.T, server *httptest.Server, now time.Time, snapshot CacheSnapshot, tc advisoryManifestSizeCase) {
+	t.Helper()
+	fixture := newAdvisoryManifestSizeFixture(t, now, snapshot, tc.target)
+	_, err := SyncOSV(context.Background(), SyncOptions{
+		SourceURL: server.URL,
+		CachePath: fixture.cachePath,
+		Now:       now,
+		Client:    server.Client(),
+	})
+	gotPayload, readErr := os.ReadFile(fixture.manifestPath)
+	if readErr != nil {
+		t.Fatalf("read manifest after sync: %v", readErr)
+	}
+	if tc.wantError {
+		advisoryAssertRejectedManifestSizeUpdate(t, fixture, gotPayload, err)
+		return
+	}
+	if err != nil {
+		t.Fatalf("sync OSV at manifest size limit: %v", err)
+	}
+	if !bytes.Equal(gotPayload, fixture.wantFinalPayload) {
+		t.Fatal("manifest at size limit did not match expected serialized payload")
+	}
+	if _, loadErr := LoadCacheManifest(fixture.cachePath); loadErr != nil {
+		t.Fatalf("load manifest at exact size limit: %v", loadErr)
+	}
+}
+
+func newAdvisoryManifestSizeFixture(t *testing.T, now time.Time, snapshot CacheSnapshot, target int64) advisoryManifestSizeFixture {
+	t.Helper()
+	paddingSnapshot := CacheSnapshot{ID: "zz-padding", Path: "snapshots/zz-padding.json"}
+	finalManifest := CacheManifest{
+		SchemaVersion: manifestSchemaVersion,
+		UpdatedAt:     now.Format(time.RFC3339),
+		Latest:        snapshot.ID,
+		Snapshots:     []CacheSnapshot{snapshot, paddingSnapshot},
+	}
+	basePayload := testCacheManifestPayload(t, finalManifest)
+	paddingBytes := target - int64(len(basePayload))
+	if paddingBytes <= 0 {
+		t.Fatalf("manifest fixture has no room for padding: base=%d target=%d", len(basePayload), target)
+	}
+	paddingSnapshot.SourceURL = strings.Repeat("a", int(paddingBytes))
+	finalManifest.Snapshots[1] = paddingSnapshot
+	wantFinalPayload := testCacheManifestPayload(t, finalManifest)
+	if int64(len(wantFinalPayload)) != target {
+		t.Fatalf("manifest fixture size=%d, want %d", len(wantFinalPayload), target)
+	}
+	priorManifest := CacheManifest{
+		SchemaVersion: manifestSchemaVersion,
+		UpdatedAt:     "2026-07-12T00:00:00Z",
+		Latest:        paddingSnapshot.ID,
+		Snapshots:     []CacheSnapshot{paddingSnapshot},
+	}
+	priorPayload := testCacheManifestPayload(t, priorManifest)
+	if int64(len(priorPayload)) > maxCacheManifestBytes {
+		t.Fatalf("prior manifest size=%d exceeds read limit", len(priorPayload))
+	}
+	cachePath := t.TempDir()
+	manifestPath := filepath.Join(cachePath, manifestFileName)
+	if err := os.WriteFile(manifestPath, priorPayload, 0o600); err != nil {
+		t.Fatalf("write prior manifest: %v", err)
+	}
+	return advisoryManifestSizeFixture{
+		cachePath:        cachePath,
+		manifestPath:     manifestPath,
+		priorManifest:    priorManifest,
+		priorPayload:     priorPayload,
+		wantFinalPayload: wantFinalPayload,
+		snapshot:         snapshot,
+	}
+}
+
+func advisoryAssertRejectedManifestSizeUpdate(t *testing.T, fixture advisoryManifestSizeFixture, gotPayload []byte, syncErr error) {
+	t.Helper()
+	if !errors.Is(syncErr, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected manifest size error, got %v", syncErr)
+	}
+	if !strings.Contains(syncErr.Error(), "write advisory cache manifest") {
+		t.Fatalf("expected advisory manifest write context, got %v", syncErr)
+	}
+	if !bytes.Equal(gotPayload, fixture.priorPayload) {
+		t.Fatal("rejected manifest update replaced the prior manifest")
+	}
+	if _, statErr := os.Stat(filepath.Join(fixture.cachePath, fixture.snapshot.Path)); !os.IsNotExist(statErr) {
+		t.Fatalf("expected rejected manifest update to remove new snapshot %q, got %v", fixture.snapshot.Path, statErr)
+	}
+	manifest, loadErr := LoadCacheManifest(fixture.cachePath)
+	if loadErr != nil {
+		t.Fatalf("load prior manifest after rejected update: %v", loadErr)
+	}
+	if manifest.Latest != fixture.priorManifest.Latest || len(manifest.Snapshots) != 1 {
+		t.Fatalf("unexpected prior manifest after rejected update: latest=%q snapshots=%d", manifest.Latest, len(manifest.Snapshots))
+	}
+}
+
+func TestSyncOSVManifestWriteFailureKeepsPreexistingSnapshot(t *testing.T) {
+	snapshotPayload := []byte(`{"vulns":[]}`)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write(snapshotPayload); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, time.July, 13, 0, 0, 0, 0, time.UTC)
+	digestSum := sha256.Sum256(snapshotPayload)
+	digest := sha256Prefix + hex.EncodeToString(digestSum[:])
+	snapshotID := snapshotIDFromDigest(digest)
+	snapshotRel := filepath.ToSlash(filepath.Join("snapshots", snapshotID+".json"))
+
+	paddingSnapshot := CacheSnapshot{
+		ID:        "zz-padding",
+		Path:      "snapshots/zz-padding.json",
+		SourceURL: strings.Repeat("a", int(maxCacheManifestBytes)),
+	}
+	priorManifest := CacheManifest{
+		SchemaVersion: manifestSchemaVersion,
+		UpdatedAt:     "2026-07-12T00:00:00Z",
+		Latest:        paddingSnapshot.ID,
+		Snapshots:     []CacheSnapshot{paddingSnapshot},
+	}
+	cachePath := t.TempDir()
+	manifestPath := filepath.Join(cachePath, manifestFileName)
+	if err := os.WriteFile(manifestPath, testCacheManifestPayload(t, priorManifest), 0o600); err != nil {
+		t.Fatalf("write oversized prior manifest: %v", err)
+	}
+	existingSnapshotPath := filepath.Join(cachePath, filepath.FromSlash(snapshotRel))
+	if err := os.MkdirAll(filepath.Dir(existingSnapshotPath), 0o750); err != nil {
+		t.Fatalf("mkdir snapshot dir: %v", err)
+	}
+	if err := os.WriteFile(existingSnapshotPath, snapshotPayload, 0o640); err != nil {
+		t.Fatalf("write existing snapshot: %v", err)
+	}
+
+	_, err := SyncOSV(context.Background(), SyncOptions{
+		SourceURL: server.URL,
+		CachePath: cachePath,
+		Now:       now,
+		Client:    server.Client(),
+	})
+	if !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected manifest size error, got %v", err)
+	}
+	if _, statErr := os.Stat(existingSnapshotPath); statErr != nil {
+		t.Fatalf("expected preexisting snapshot to remain after manifest failure, got %v", statErr)
 	}
 }
 
@@ -810,6 +1063,487 @@ func TestSyncOSVRejectsSnapshotsDirSwapAfterDownload(t *testing.T) {
 
 	advisoryAssertDirEmpty(t, paths.outsideDir)
 	advisoryAssertNoSafeIOTempFiles(t, paths.cachePath)
+}
+
+func TestSyncOSVRollsBackThroughPinnedSnapshotsRootAfterDirectoryReplacement(t *testing.T) {
+	server := advisoryEmptyOSVTLSServer(t)
+	defer server.Close()
+
+	cachePath := t.TempDir()
+	holdingPath := filepath.Join(cachePath, "snapshots-published")
+	replacementPath := filepath.Join(cachePath, "snapshots")
+	replacementMarker := filepath.Join(replacementPath, "concurrent.json")
+	advisorySetSyncAfterSnapshotPlacementHook(t, func(cacheRoot, snapshotRel string) {
+		if _, err := os.Stat(filepath.Join(cacheRoot, snapshotRel)); err != nil {
+			t.Fatalf("stat published snapshot before directory replacement: %v", err)
+		}
+		if err := os.Rename(filepath.Join(cacheRoot, "snapshots"), holdingPath); err != nil {
+			t.Fatalf("move published snapshots directory aside: %v", err)
+		}
+		if err := os.Mkdir(replacementPath, 0o750); err != nil {
+			t.Fatalf("create replacement snapshots directory: %v", err)
+		}
+		if err := os.WriteFile(replacementMarker, []byte("concurrent"), 0o640); err != nil {
+			t.Fatalf("write replacement snapshot marker: %v", err)
+		}
+	})
+
+	_, err := SyncOSV(context.Background(), SyncOptions{
+		SourceURL: server.URL,
+		CachePath: cachePath,
+		Client:    server.Client(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "snapshots directory changed during publication") {
+		t.Fatalf("expected snapshots directory replacement error, got %v", err)
+	}
+	holdingEntries, readErr := os.ReadDir(holdingPath)
+	if readErr != nil {
+		t.Fatalf("read original pinned snapshots directory: %v", readErr)
+	}
+	if len(holdingEntries) != 0 {
+		t.Fatalf("expected pinned snapshots directory rollback and cleanup, got %#v", holdingEntries)
+	}
+	marker, readErr := os.ReadFile(replacementMarker)
+	if readErr != nil || string(marker) != "concurrent" {
+		t.Fatalf("expected replacement snapshots directory to stay untouched, content=%q err=%v", marker, readErr)
+	}
+}
+
+func TestSyncOSVRejectsMismatchedNoReplaceWinnerBeforeManifestUpdate(t *testing.T) {
+	snapshotPayload := []byte(`{"vulns":[]}`)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write(snapshotPayload); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	cachePath := t.TempDir()
+	manifestPath := filepath.Join(cachePath, manifestFileName)
+	if err := writeOversizedValidManifest(manifestPath, maxCacheManifestBytes+1); err != nil {
+		t.Fatalf("write manifest failure fixture: %v", err)
+	}
+	manifestBefore, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest failure fixture: %v", err)
+	}
+	concurrentPayload := bytes.Repeat([]byte("x"), len(snapshotPayload))
+	var concurrentPath string
+	advisorySetSyncBeforeSnapshotPlacementHook(t, func(cacheRoot, snapshotRel string) {
+		concurrentPath = filepath.Join(cacheRoot, filepath.FromSlash(snapshotRel))
+		if err := os.WriteFile(concurrentPath, concurrentPayload, 0o640); err != nil {
+			t.Fatalf("publish concurrent snapshot: %v", err)
+		}
+	})
+
+	_, err = SyncOSV(context.Background(), SyncOptions{
+		SourceURL: server.URL,
+		CachePath: cachePath,
+		Client:    server.Client(),
+	})
+	if !errors.Is(err, errAdvisorySnapshotContentMismatch) || errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected same-size snapshot digest mismatch before manifest loading, got %v", err)
+	}
+	got, readErr := os.ReadFile(concurrentPath)
+	if readErr != nil || !bytes.Equal(got, concurrentPayload) {
+		t.Fatalf("expected concurrent snapshot to survive, content=%q err=%v", got, readErr)
+	}
+	manifestAfter, readErr := os.ReadFile(manifestPath)
+	if readErr != nil || !bytes.Equal(manifestAfter, manifestBefore) {
+		t.Fatalf("expected old manifest to stay byte-identical, equal=%v err=%v", bytes.Equal(manifestAfter, manifestBefore), readErr)
+	}
+	advisoryAssertNoSafeIOTempFiles(t, cachePath)
+}
+
+func TestSyncOSVAcceptsMatchingNoReplaceWinner(t *testing.T) {
+	snapshotPayload := []byte(`{"vulns":[]}`)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write(snapshotPayload); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	cachePath := t.TempDir()
+	var winnerPath string
+	advisorySetSyncBeforeSnapshotPlacementHook(t, func(cacheRoot, snapshotRel string) {
+		winnerPath = filepath.Join(cacheRoot, filepath.FromSlash(snapshotRel))
+		if err := os.WriteFile(winnerPath, snapshotPayload, 0o640); err != nil {
+			t.Fatalf("publish matching snapshot winner: %v", err)
+		}
+	})
+
+	snapshot, err := SyncOSV(context.Background(), SyncOptions{
+		SourceURL: server.URL,
+		CachePath: cachePath,
+		Client:    server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("accept matching snapshot winner: %v", err)
+	}
+	winnerData, err := os.ReadFile(winnerPath)
+	if err != nil || !bytes.Equal(winnerData, snapshotPayload) {
+		t.Fatalf("expected matching winner content, content=%q err=%v", winnerData, err)
+	}
+	manifest, err := LoadCacheManifest(cachePath)
+	if err != nil {
+		t.Fatalf("load matching-winner manifest: %v", err)
+	}
+	if manifest.Latest != snapshot.ID || len(manifest.Snapshots) != 1 {
+		t.Fatalf("expected matching winner in manifest, got %#v", manifest)
+	}
+	advisoryAssertNoSafeIOTempFiles(t, cachePath)
+}
+
+func TestSyncOSVSerializesRollbackBeforeConcurrentPublication(t *testing.T) {
+	snapshotPayload := []byte(`{"vulns":[]}`)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write(snapshotPayload); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	cachePath := t.TempDir()
+	firstAtManifest := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondWaiting := make(chan struct{})
+	firstManifestErr := errors.New("first manifest publication failed")
+	var manifestCalls atomic.Int32
+	var waitCalls atomic.Int32
+	syncUpdateManifestTestHook = advisoryBlockingFirstManifestHook(firstAtManifest, releaseFirst, firstManifestErr, &manifestCalls)
+	syncPublicationLockWaitTestHook = advisoryFirstLockWaitHook(secondWaiting, &waitCalls)
+	t.Cleanup(func() {
+		syncUpdateManifestTestHook = updateManifest
+		syncPublicationLockWaitTestHook = nil
+	})
+
+	firstNow := time.Date(2026, time.July, 20, 1, 0, 0, 0, time.UTC)
+	secondNow := firstNow.Add(time.Hour)
+	firstResult := make(chan advisorySyncResult, 1)
+	secondResult := make(chan advisorySyncResult, 1)
+	go func() {
+		firstResult <- runAdvisorySync(server.URL, cachePath, firstNow, server.Client())
+	}()
+	advisoryWaitForSignal(t, firstAtManifest, "first sync did not reach manifest publication")
+	go func() {
+		secondResult <- runAdvisorySync(server.URL, cachePath, secondNow, server.Client())
+	}()
+	advisoryWaitForSignal(t, secondWaiting, "second sync did not wait for cache publication lock")
+	close(releaseFirst)
+
+	first := <-firstResult
+	second := <-secondResult
+	advisoryAssertSerializedSyncResults(t, cachePath, snapshotPayload, secondNow, first, second, firstManifestErr)
+	if manifestCalls.Load() != 2 || waitCalls.Load() != 1 {
+		t.Fatalf("expected one serialized waiter and two manifest attempts, waits=%d manifests=%d", waitCalls.Load(), manifestCalls.Load())
+	}
+}
+
+func TestSyncOSVPublicationLockSurvivesPathReplacementAcrossProcesses(t *testing.T) {
+	if os.Getenv(publicationLockChildModeEnv) == publicationLockChildModeSync {
+		runPublicationLockSyncChild(t)
+		return
+	}
+
+	const sourceURL = "https://example.test/osv.json"
+	snapshotPayload := []byte(`{"vulns":[]}`)
+	cachePath := t.TempDir()
+	legacyLockPath := filepath.Join(cachePath, legacyPublicationLockFileName)
+	legacyLockInfo := advisoryWriteLegacyLockPath(t, legacyLockPath, "original")
+	markerPath := filepath.Join(t.TempDir(), "child-waiting")
+	firstAtManifest := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstManifestErr := errors.New("first process manifest publication failed")
+	var manifestCalls atomic.Int32
+	syncUpdateManifestTestHook = advisoryBlockingFirstManifestHook(firstAtManifest, releaseFirst, firstManifestErr, &manifestCalls)
+	t.Cleanup(func() {
+		syncUpdateManifestTestHook = updateManifest
+	})
+
+	firstResult := make(chan advisorySyncResult, 1)
+	go func() {
+		firstResult <- runAdvisorySync(sourceURL, cachePath, publicationLockChildNow.Add(-time.Hour), advisoryStaticSnapshotClient(snapshotPayload))
+	}()
+	advisoryWaitForSignal(t, firstAtManifest, "first process did not reach manifest publication")
+	advisoryReplaceLegacyLockPath(t, legacyLockPath, legacyLockInfo)
+
+	command, output := advisoryPublicationLockChildCommand(t, publicationLockChildModeSync, cachePath, markerPath, "TestSyncOSVPublicationLockSurvivesPathReplacementAcrossProcesses")
+	if err := command.Start(); err != nil {
+		close(releaseFirst)
+		t.Fatalf("start concurrent SyncOSV process: %v", err)
+	}
+	if err := advisoryWaitForFile(markerPath, 5*time.Second); err != nil {
+		close(releaseFirst)
+		advisoryStopChildProcess(t, command)
+		t.Fatalf("wait for concurrent process lock contention: %v\n%s", err, output.String())
+	}
+	close(releaseFirst)
+
+	first := <-firstResult
+	if !errors.Is(first.err, firstManifestErr) {
+		t.Fatalf("expected first process manifest failure, got %v", first.err)
+	}
+	if err := command.Wait(); err != nil {
+		t.Fatalf("concurrent SyncOSV process failed: %v\n%s", err, output.String())
+	}
+	advisoryAssertSuccessfulChildPublication(t, cachePath, snapshotPayload)
+}
+
+func TestAdvisoryPublicationLockReleasesAfterProcessExit(t *testing.T) {
+	if os.Getenv(publicationLockChildModeEnv) == publicationLockChildModeExitWhileHeld {
+		runPublicationLockExitChild(t)
+		return
+	}
+
+	cachePath := t.TempDir()
+	markerPath := filepath.Join(t.TempDir(), "child-locked")
+	command, output := advisoryPublicationLockChildCommand(t, publicationLockChildModeExitWhileHeld, cachePath, markerPath, "TestAdvisoryPublicationLockReleasesAfterProcessExit")
+	if err := command.Start(); err != nil {
+		t.Fatalf("start lock-holder process: %v", err)
+	}
+	if err := advisoryWaitForFile(markerPath, 5*time.Second); err != nil {
+		advisoryStopChildProcess(t, command)
+		t.Fatalf("wait for lock-holder process: %v\n%s", err, output.String())
+	}
+	if err := command.Wait(); err != nil {
+		t.Fatalf("lock-holder process failed: %v\n%s", err, output.String())
+	}
+
+	root := advisoryOpenTestRoot(t, cachePath)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	lock, err := acquireAdvisoryPublicationLock(ctx, root)
+	if err != nil {
+		t.Fatalf("acquire publication lock after holder exit: %v", err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("release publication lock after holder exit: %v", err)
+	}
+	if _, err := root.Lstat(legacyPublicationLockFileName); !os.IsNotExist(err) {
+		t.Fatalf("cache identity lock must not leave a replaceable lock path, got %v", err)
+	}
+}
+
+func advisoryBlockingFirstManifestHook(firstAtManifest chan<- struct{}, releaseFirst <-chan struct{}, firstErr error, calls *atomic.Int32) func(safeio.Root, CacheSnapshot, time.Time) error {
+	return func(root safeio.Root, snapshot CacheSnapshot, now time.Time) error {
+		if calls.Add(1) == 1 {
+			close(firstAtManifest)
+			<-releaseFirst
+			return firstErr
+		}
+		return updateManifest(root, snapshot, now)
+	}
+}
+
+func advisoryFirstLockWaitHook(waiting chan<- struct{}, calls *atomic.Int32) func() {
+	return func() {
+		if calls.Add(1) == 1 {
+			close(waiting)
+		}
+	}
+}
+
+func runAdvisorySync(sourceURL, cachePath string, now time.Time, client *http.Client) advisorySyncResult {
+	snapshot, err := SyncOSV(context.Background(), SyncOptions{
+		SourceURL: sourceURL,
+		CachePath: cachePath,
+		Now:       now,
+		Client:    client,
+	})
+	return advisorySyncResult{snapshot: snapshot, err: err}
+}
+
+func advisoryWaitForSignal(t *testing.T, signal <-chan struct{}, failureMessage string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatal(failureMessage)
+	}
+}
+
+func advisoryAssertSerializedSyncResults(t *testing.T, cachePath string, snapshotPayload []byte, secondNow time.Time, first, second advisorySyncResult, firstManifestErr error) {
+	t.Helper()
+	if !errors.Is(first.err, firstManifestErr) {
+		t.Fatalf("expected first manifest failure, got %v", first.err)
+	}
+	if second.err != nil {
+		t.Fatalf("expected second sync to publish after rollback, got %v", second.err)
+	}
+	snapshotData, err := os.ReadFile(filepath.Join(cachePath, filepath.FromSlash(second.snapshot.Path)))
+	if err != nil || !bytes.Equal(snapshotData, snapshotPayload) {
+		t.Fatalf("expected second snapshot to survive, content=%q err=%v", snapshotData, err)
+	}
+	manifest, err := LoadCacheManifest(cachePath)
+	if err != nil {
+		t.Fatalf("load second publisher manifest: %v", err)
+	}
+	if manifest.Latest != second.snapshot.ID || len(manifest.Snapshots) != 1 || manifest.Snapshots[0].RetrievedAt != secondNow.Format(time.RFC3339) {
+		t.Fatalf("expected manifest to describe only the successful publisher, got %#v", manifest)
+	}
+	advisoryAssertNoSafeIOTempFiles(t, cachePath)
+}
+
+func advisoryAssertSuccessfulChildPublication(t *testing.T, cachePath string, snapshotPayload []byte) {
+	t.Helper()
+	manifest, err := LoadCacheManifest(cachePath)
+	if err != nil {
+		t.Fatalf("load child publisher manifest: %v", err)
+	}
+	if len(manifest.Snapshots) != 1 || manifest.Latest != manifest.Snapshots[0].ID {
+		t.Fatalf("expected one successful child publication, got %#v", manifest)
+	}
+	snapshot := manifest.Snapshots[0]
+	if snapshot.RetrievedAt != publicationLockChildNow.Format(time.RFC3339) {
+		t.Fatalf("expected child publication timestamp %q, got %q", publicationLockChildNow.Format(time.RFC3339), snapshot.RetrievedAt)
+	}
+	snapshotData, err := os.ReadFile(filepath.Join(cachePath, filepath.FromSlash(snapshot.Path)))
+	if err != nil || !bytes.Equal(snapshotData, snapshotPayload) {
+		t.Fatalf("expected child snapshot to survive, content=%q err=%v", snapshotData, err)
+	}
+	advisoryAssertNoSafeIOTempFiles(t, cachePath)
+}
+
+func advisoryWriteLegacyLockPath(t *testing.T, path, contents string) fs.FileInfo {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write legacy publication lock path: %v", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat legacy publication lock path: %v", err)
+	}
+	return info
+}
+
+func advisoryReplaceLegacyLockPath(t *testing.T, path string, original fs.FileInfo) {
+	t.Helper()
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("unlink legacy publication lock path: %v", err)
+	}
+	replacement := advisoryWriteLegacyLockPath(t, path, "replacement")
+	if os.SameFile(original, replacement) {
+		t.Fatal("legacy publication lock replacement reused the original identity")
+	}
+}
+
+func advisoryPublicationLockChildCommand(t *testing.T, mode, cachePath, markerPath, testName string) (*exec.Cmd, *bytes.Buffer) {
+	t.Helper()
+	command := exec.Command(os.Args[0], "-test.run=^"+testName+"$")
+	command.Env = append(os.Environ(), publicationLockChildModeEnv+"="+mode, publicationLockChildCacheEnv+"="+cachePath, publicationLockChildMarkerEnv+"="+markerPath)
+	output := &bytes.Buffer{}
+	command.Stdout = output
+	command.Stderr = output
+	return command, output
+}
+
+func advisoryStopChildProcess(t *testing.T, command *exec.Cmd) {
+	t.Helper()
+	if err := command.Process.Kill(); err != nil {
+		t.Logf("kill child process after test failure: %v", err)
+	}
+	if err := command.Wait(); err != nil {
+		t.Logf("wait for killed child process: %v", err)
+	}
+}
+
+func advisoryWaitForFile(path string, timeout time.Duration) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for %s", path)
+		case <-ticker.C:
+			if _, err := os.Stat(path); err == nil {
+				return nil
+			} else if !os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+}
+
+func runPublicationLockSyncChild(t *testing.T) {
+	cachePath := os.Getenv(publicationLockChildCacheEnv)
+	markerPath := os.Getenv(publicationLockChildMarkerEnv)
+	var markerErr error
+	syncPublicationLockWaitTestHook = func() {
+		markerErr = os.WriteFile(markerPath, []byte("waiting"), 0o600)
+	}
+	t.Cleanup(func() {
+		syncPublicationLockWaitTestHook = nil
+	})
+	result := runAdvisorySync("https://example.test/osv.json", cachePath, publicationLockChildNow, advisoryStaticSnapshotClient([]byte(`{"vulns":[]}`)))
+	if markerErr != nil {
+		t.Fatalf("write publication lock contention marker: %v", markerErr)
+	}
+	if result.err != nil {
+		t.Fatalf("publish advisory snapshot from child: %v", result.err)
+	}
+}
+
+func runPublicationLockExitChild(t *testing.T) {
+	cachePath := os.Getenv(publicationLockChildCacheEnv)
+	markerPath := os.Getenv(publicationLockChildMarkerEnv)
+	root, err := openAdvisoryCacheRoot(cachePath)
+	if err != nil {
+		t.Fatalf("open child publication root: %v", err)
+	}
+	if _, err := acquireAdvisoryPublicationLock(context.Background(), root); err != nil {
+		t.Fatalf("acquire child publication lock: %v", err)
+	}
+	if err := os.WriteFile(markerPath, []byte("locked"), 0o600); err != nil {
+		t.Fatalf("write child publication marker: %v", err)
+	}
+	os.Exit(0)
+}
+
+func advisoryStaticSnapshotClient(payload []byte) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(payload)),
+		}, nil
+	})}
+}
+
+func TestSyncOSVRollbackPreservesSnapshotWhenOwnershipIdentityChanges(t *testing.T) {
+	server := advisoryEmptyOSVTLSServer(t)
+	defer server.Close()
+
+	cachePath := t.TempDir()
+	if err := writeOversizedValidManifest(filepath.Join(cachePath, manifestFileName), maxCacheManifestBytes+1); err != nil {
+		t.Fatalf("write manifest failure fixture: %v", err)
+	}
+	concurrentPayload := []byte("replacement publisher")
+	var snapshotPath string
+	advisorySetSyncAfterSnapshotPlacementHook(t, func(cacheRoot, snapshotRel string) {
+		snapshotPath = filepath.Join(cacheRoot, filepath.FromSlash(snapshotRel))
+		if err := os.Remove(snapshotPath); err != nil {
+			t.Fatalf("remove originally published snapshot: %v", err)
+		}
+		if err := os.WriteFile(snapshotPath, concurrentPayload, 0o640); err != nil {
+			t.Fatalf("publish replacement snapshot: %v", err)
+		}
+	})
+
+	_, err := SyncOSV(context.Background(), SyncOptions{
+		SourceURL: server.URL,
+		CachePath: cachePath,
+		Client:    server.Client(),
+	})
+	if !errors.Is(err, safeio.ErrFileTooLarge) || !errors.Is(err, errAdvisorySnapshotOwnershipLost) {
+		t.Fatalf("expected manifest and ownership-loss identities, got %v", err)
+	}
+	got, readErr := os.ReadFile(snapshotPath)
+	if readErr != nil || !bytes.Equal(got, concurrentPayload) {
+		t.Fatalf("expected replacement snapshot to survive rollback, content=%q err=%v", got, readErr)
+	}
+	advisoryAssertNoSafeIOTempFiles(t, cachePath)
 }
 
 func TestSyncOSVCleansDownloadedTempWhenPlacementSetupFails(t *testing.T) {
@@ -1193,6 +1927,1045 @@ func TestLoadCacheManifestMissingFile(t *testing.T) {
 	}
 }
 
+func TestLoadCacheManifestMissingFileUsesManifestPath(t *testing.T) {
+	cachePath := t.TempDir()
+
+	_, err := LoadCacheManifest(cachePath)
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected missing manifest path error, got %#v", err)
+	}
+	if pathErr.Op != "open" || pathErr.Path != filepath.Join(cachePath, manifestFileName) {
+		t.Fatalf("unexpected missing manifest path error: %#v", pathErr)
+	}
+}
+
+func TestLoadCacheManifestRejectsOversizedManifest(t *testing.T) {
+	cachePath := t.TempDir()
+	if err := writeOversizedValidManifest(filepath.Join(cachePath, manifestFileName), maxCacheManifestBytes+1); err != nil {
+		t.Fatalf("write oversized manifest: %v", err)
+	}
+
+	_, err := LoadCacheManifest(cachePath)
+	if !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected oversized manifest read to fail with ErrFileTooLarge, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "read advisory cache manifest") {
+		t.Fatalf("expected advisory manifest read context, got %v", err)
+	}
+}
+
+func TestLoadCacheManifestJoinsRootCloseError(t *testing.T) {
+	closeErr := errors.New("close advisory cache root")
+	manifestPayload := []byte(`{"schemaVersion":"` + manifestSchemaVersion + `","latest":"snapshot-1"}`)
+	infoPath := filepath.Join(t.TempDir(), manifestFileName)
+	if err := os.WriteFile(infoPath, manifestPayload, 0o600); err != nil {
+		t.Fatalf("write manifest fixture: %v", err)
+	}
+	info, err := os.Stat(infoPath)
+	if err != nil {
+		t.Fatalf("stat manifest fixture: %v", err)
+	}
+
+	withOpenAdvisoryCacheRootHook(t, func(string) (safeio.Root, error) {
+		return &advisoryFakeRoot{
+			lstat: func(string) (fs.FileInfo, error) { return info, nil },
+			open: func(string) (safeio.File, error) {
+				return &advisoryStaticFile{info: info, payload: manifestPayload}, nil
+			},
+			close: func() error { return closeErr },
+		}, nil
+	})
+
+	manifest, err := LoadCacheManifest(filepath.Join(t.TempDir(), "cache"))
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("expected root close error, got %v", err)
+	}
+	if manifest.SchemaVersion != manifestSchemaVersion || manifest.Latest != "snapshot-1" {
+		t.Fatalf("expected parsed manifest alongside close error, got %#v", manifest)
+	}
+}
+
+func TestAdvisoryCachePublicCallersRejectSymlinkedCacheRoots(t *testing.T) {
+	server := advisoryEmptyOSVTLSServer(t)
+	defer server.Close()
+
+	realCache := filepath.Join(t.TempDir(), "real-cache")
+	if err := os.MkdirAll(realCache, 0o750); err != nil {
+		t.Fatalf("create real cache root: %v", err)
+	}
+	cacheLink := filepath.Join(t.TempDir(), "cache-link")
+	if err := os.Symlink(realCache, cacheLink); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "SyncOSV",
+			call: func() error {
+				_, err := SyncOSV(context.Background(), SyncOptions{SourceURL: server.URL, CachePath: cacheLink, Client: server.Client()})
+				return err
+			},
+		},
+		{
+			name: "LoadCacheManifest",
+			call: func() error {
+				_, err := LoadCacheManifest(cacheLink)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+				t.Fatalf("expected symlinked cache root rejection, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPrepareAdvisoryCacheRootRejectsSymlinkAncestorWithoutCreatingChildren(t *testing.T) {
+	parentDir := t.TempDir()
+	outsideDir := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(outsideDir, 0o750); err != nil {
+		t.Fatalf("create outside dir: %v", err)
+	}
+	linkPath := filepath.Join(parentDir, "cache-link")
+	if err := os.Symlink(outsideDir, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cachePath := filepath.Join(linkPath, "nested", "cache")
+	root, err := prepareAdvisoryCacheRoot(cachePath)
+	if root != nil {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close unexpected advisory cache root: %v", closeErr)
+		}
+		t.Fatal("expected symlinked ancestor cache root acquisition to fail")
+	}
+	if err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected symlinked ancestor rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outsideDir, "nested")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no outside-root child creation, stat err=%v", statErr)
+	}
+}
+
+func TestPrepareAdvisoryCacheRootJoinsNestedCreateCloseFailures(t *testing.T) {
+	rootCloseErr := errors.New("close root")
+	currentCloseErr := errors.New("close current")
+	createErr := errors.New("create child")
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "nested" {
+				t.Fatalf("unexpected first lstat %q", name)
+			}
+			return dirInfo, nil
+		},
+		close: func() error { return rootCloseErr },
+	}
+	current := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "." {
+				return dirInfo, nil
+			}
+			if name != "leaf" {
+				t.Fatalf("unexpected nested lstat %q", name)
+			}
+			return nil, createErr
+		},
+		close: func() error { return currentCloseErr },
+	}
+	root.openRoot = func(name string) (safeio.Root, error) {
+		if name != "nested" {
+			t.Fatalf("unexpected first child %q", name)
+		}
+		return current, nil
+	}
+	realHook := openAdvisoryCacheAncestor
+	openAdvisoryCacheAncestor = func(string) (safeio.Root, string, []string, error) {
+		return root, "/cache", []string{"nested", "leaf"}, nil
+	}
+	t.Cleanup(func() {
+		openAdvisoryCacheAncestor = realHook
+	})
+
+	opened, err := prepareAdvisoryCacheRoot("/cache/nested/leaf")
+	if opened != nil {
+		t.Fatal("expected nested create failure to return no root")
+	}
+	if !errors.Is(err, createErr) || !errors.Is(err, currentCloseErr) || !errors.Is(err, rootCloseErr) {
+		t.Fatalf("expected create failure joined with current and root close errors, got %v", err)
+	}
+}
+
+func TestPrepareAdvisoryCacheRootJoinsNestedOpenCloseFailures(t *testing.T) {
+	rootCloseErr := errors.New("close root")
+	currentCloseErr := errors.New("close current")
+	nextCloseErr := errors.New("close next")
+	rootDirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	current := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "." {
+				return rootDirInfo, nil
+			}
+			if name != "leaf" {
+				t.Fatalf("unexpected nested lstat %q", name)
+			}
+			return rootDirInfo, nil
+		},
+		openRoot: func(string) (safeio.Root, error) {
+			return &advisoryFakeRoot{
+				lstat: func(string) (fs.FileInfo, error) { return rootDirInfo, nil },
+				close: func() error { return nextCloseErr },
+			}, nil
+		},
+		close: func() error { return currentCloseErr },
+	}
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "nested" {
+				t.Fatalf("unexpected first lstat %q", name)
+			}
+			return rootDirInfo, nil
+		},
+		close: func() error { return rootCloseErr },
+		openRoot: func(name string) (safeio.Root, error) {
+			if name != "nested" {
+				t.Fatalf("unexpected first child %q", name)
+			}
+			return current, nil
+		},
+	}
+	realHook := openAdvisoryCacheAncestor
+	openAdvisoryCacheAncestor = func(string) (safeio.Root, string, []string, error) {
+		return root, "/cache", []string{"nested", "leaf"}, nil
+	}
+	t.Cleanup(func() {
+		openAdvisoryCacheAncestor = realHook
+	})
+
+	opened, err := prepareAdvisoryCacheRoot("/cache/nested/leaf")
+	if opened != nil {
+		t.Fatal("expected nested open failure to return no root")
+	}
+	if !errors.Is(err, currentCloseErr) || !errors.Is(err, nextCloseErr) || !errors.Is(err, rootCloseErr) {
+		t.Fatalf("expected current close failure joined with next and root close errors, got %v", err)
+	}
+}
+
+func TestAdvisoryOpenOrCreatePinnedChildJoinsTypeMismatchCloseFailure(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	filePath := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(filePath, []byte("content"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat temp file: %v", err)
+	}
+	closeErr := errors.New("close mismatched child")
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "child" {
+				t.Fatalf("unexpected lstat name %q", name)
+			}
+			return dirInfo, nil
+		},
+		openRoot: func(name string) (safeio.Root, error) {
+			if name != "child" {
+				t.Fatalf("unexpected openRoot name %q", name)
+			}
+			return &advisoryFakeRoot{
+				lstat: func(string) (fs.FileInfo, error) { return fileInfo, nil },
+				close: func() error { return closeErr },
+			}, nil
+		},
+	}
+
+	child, err := advisoryOpenOrCreatePinnedChild(root, "/cache", "child")
+	if child != nil {
+		t.Fatal("expected type mismatch to return no child root")
+	}
+	if !strings.Contains(err.Error(), "root changed while opening") || !errors.Is(err, closeErr) {
+		t.Fatalf("expected type mismatch error joined with child close failure, got %v", err)
+	}
+}
+
+func TestPrepareAdvisoryCacheRootReturnsAncestorWhenPathAlreadyExists(t *testing.T) {
+	root := &advisoryFakeRoot{}
+	realHook := openAdvisoryCacheAncestor
+	openAdvisoryCacheAncestor = func(string) (safeio.Root, string, []string, error) {
+		return root, "/cache", nil, nil
+	}
+	t.Cleanup(func() {
+		openAdvisoryCacheAncestor = realHook
+	})
+
+	opened, err := prepareAdvisoryCacheRoot("/cache")
+	if err != nil {
+		t.Fatalf("prepare existing advisory cache root: %v", err)
+	}
+	if opened != root {
+		t.Fatalf("expected existing ancestor root to be returned, got %#v", opened)
+	}
+}
+
+func TestAdvisoryOpenOrCreatePinnedChildCreatesMissingDirectory(t *testing.T) {
+	fixture := newAdvisoryPinnedChildCreationFixture(t)
+	opened, err := advisoryOpenOrCreatePinnedChild(fixture.root, "/cache", "child")
+	if err != nil {
+		t.Fatalf("open or create missing advisory child: %v", err)
+	}
+	if opened != fixture.child {
+		t.Fatalf("expected child root to be returned, got %#v", opened)
+	}
+	if fixture.mkdirCalls != 1 || fixture.lstatCalls != 2 {
+		t.Fatalf("expected one mkdir and two lstat calls, got mkdir=%d lstat=%d", fixture.mkdirCalls, fixture.lstatCalls)
+	}
+}
+
+type advisoryPinnedChildCreationFixture struct {
+	root       *advisoryFakeRoot
+	child      *advisoryFakeRoot
+	mkdirCalls int
+	lstatCalls int
+	directory  fs.FileInfo
+}
+
+func newAdvisoryPinnedChildCreationFixture(t *testing.T) *advisoryPinnedChildCreationFixture {
+	t.Helper()
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	fixture := &advisoryPinnedChildCreationFixture{directory: dirInfo}
+	fixture.child = &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "." {
+				t.Fatalf("unexpected child lstat %q", name)
+			}
+			return fixture.directory, nil
+		},
+	}
+	fixture.root = &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "child" {
+				t.Fatalf("unexpected root lstat %q", name)
+			}
+			fixture.lstatCalls++
+			if fixture.lstatCalls == 1 {
+				return nil, os.ErrNotExist
+			}
+			return fixture.directory, nil
+		},
+		mkdir: func(name string, perm os.FileMode) error {
+			if name != "child" || perm != 0o750 {
+				t.Fatalf("unexpected mkdir call %q perm %#o", name, perm)
+			}
+			fixture.mkdirCalls++
+			return os.ErrExist
+		},
+		openRoot: func(name string) (safeio.Root, error) {
+			if name != "child" {
+				t.Fatalf("unexpected openRoot %q", name)
+			}
+			return fixture.child, nil
+		},
+	}
+	return fixture
+}
+
+func TestAdvisoryJoinCloseErrorSkipsNilClosers(t *testing.T) {
+	primary := errors.New("primary advisory error")
+	closeErr := errors.New("close advisory root")
+	err := advisoryJoinCloseError(primary, nil, io.NopCloser(strings.NewReader("")), closerFunc(func() error { return closeErr }))
+	if !errors.Is(err, primary) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected advisory join to preserve primary and close errors, got %v", err)
+	}
+}
+
+func TestSnapshotIDFromDigestReturnsFullShortDigest(t *testing.T) {
+	const digest = "sha256:deadbeef"
+	if got := snapshotIDFromDigest(digest); got != "deadbeef" {
+		t.Fatalf("expected short digest to remain intact, got %q", got)
+	}
+}
+
+func TestAdvisorySnapshotAbsentRejectsSymlinkAndLookupFailure(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), "target.txt")
+	if err := os.WriteFile(targetPath, []byte("target"), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	linkPath := filepath.Join(t.TempDir(), "snapshot-link")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	linkInfo, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat snapshot symlink: %v", err)
+	}
+
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return linkInfo, nil },
+	}
+	absent, err := advisorySnapshotAbsent(root, "snapshot.json")
+	if absent || err == nil || !strings.Contains(err.Error(), "snapshot path is a symlink") {
+		t.Fatalf("expected symlinked snapshot rejection, absent=%v err=%v", absent, err)
+	}
+
+	lookupErr := errors.New("lookup snapshot")
+	root = &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, lookupErr },
+	}
+	absent, err = advisorySnapshotAbsent(root, "snapshot.json")
+	if absent || !errors.Is(err, lookupErr) {
+		t.Fatalf("expected snapshot lookup error, absent=%v err=%v", absent, err)
+	}
+}
+
+func TestAdvisoryPlaceSnapshotNoReplaceErrorAndIdentityBranches(t *testing.T) {
+	tempPath := filepath.Join(t.TempDir(), "temp.json")
+	if err := os.WriteFile(tempPath, []byte("temp"), 0o600); err != nil {
+		t.Fatalf("write snapshot temp fixture: %v", err)
+	}
+	tempInfo, err := os.Stat(tempPath)
+	if err != nil {
+		t.Fatalf("stat snapshot temp fixture: %v", err)
+	}
+	otherPath := filepath.Join(t.TempDir(), "other.json")
+	if err := os.WriteFile(otherPath, []byte("other"), 0o600); err != nil {
+		t.Fatalf("write other snapshot fixture: %v", err)
+	}
+	otherInfo, err := os.Stat(otherPath)
+	if err != nil {
+		t.Fatalf("stat other snapshot fixture: %v", err)
+	}
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat directory fixture: %v", err)
+	}
+	tempDigestSum := sha256.Sum256([]byte("temp"))
+	fixture := &advisoryPlaceSnapshotFixture{
+		tempInfo:  tempInfo,
+		otherInfo: otherInfo,
+		dirInfo:   dirInfo,
+		digest:    sha256Prefix + hex.EncodeToString(tempDigestSum[:]),
+		size:      int64(len("temp")),
+	}
+	t.Run("temp is not regular", fixture.testTempNotRegular)
+	t.Run("chmod failure", fixture.testChmodFailure)
+	t.Run("link failure", fixture.testLinkFailure)
+	t.Run("existing target disappears", fixture.testExistingTargetDisappears)
+	t.Run("post-link lookup failure rolls back owned target", fixture.testPostLinkLookupFailure)
+	t.Run("post-link identity mismatch preserves unknown target", fixture.testPostLinkIdentityMismatch)
+}
+
+type advisoryPlaceSnapshotFixture struct {
+	tempInfo  fs.FileInfo
+	otherInfo fs.FileInfo
+	dirInfo   fs.FileInfo
+	digest    string
+	size      int64
+}
+
+func (f *advisoryPlaceSnapshotFixture) place(root safeio.Root) (*advisorySnapshotOwnership, error) {
+	return advisoryPlaceSnapshotNoReplace(root, "temp", "snapshot.json", f.digest, f.size)
+}
+
+func (f *advisoryPlaceSnapshotFixture) testTempNotRegular(t *testing.T) {
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return f.dirInfo, nil },
+	}
+	ownership, err := f.place(root)
+	if ownership != nil || err == nil || !strings.Contains(err.Error(), "snapshot temp path is not a regular file") {
+		t.Fatalf("expected non-regular temp rejection, ownership=%#v err=%v", ownership, err)
+	}
+}
+
+func (f *advisoryPlaceSnapshotFixture) testChmodFailure(t *testing.T) {
+	chmodErr := errors.New("chmod snapshot temp")
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return f.tempInfo, nil },
+		chmod: func(string, os.FileMode) error {
+			return chmodErr
+		},
+	}
+	ownership, err := f.place(root)
+	if ownership != nil || !errors.Is(err, chmodErr) {
+		t.Fatalf("expected chmod error, ownership=%#v err=%v", ownership, err)
+	}
+}
+
+func (f *advisoryPlaceSnapshotFixture) testLinkFailure(t *testing.T) {
+	linkErr := errors.New("link snapshot")
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return f.tempInfo, nil },
+		link:  func(string, string) error { return linkErr },
+	}
+	ownership, err := f.place(root)
+	if ownership != nil || !errors.Is(err, linkErr) {
+		t.Fatalf("expected link error, ownership=%#v err=%v", ownership, err)
+	}
+}
+
+func (f *advisoryPlaceSnapshotFixture) testExistingTargetDisappears(t *testing.T) {
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "temp" {
+				return f.tempInfo, nil
+			}
+			return nil, os.ErrNotExist
+		},
+		link: func(string, string) error { return os.ErrExist },
+	}
+	ownership, err := f.place(root)
+	if ownership != nil || err == nil || !strings.Contains(err.Error(), "disappeared during no-replace placement") {
+		t.Fatalf("expected disappeared-target error, ownership=%#v err=%v", ownership, err)
+	}
+}
+
+func (f *advisoryPlaceSnapshotFixture) testPostLinkLookupFailure(t *testing.T) {
+	lookupErr := errors.New("lookup published snapshot")
+	targetLookups := 0
+	removed := false
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "temp" {
+				return f.tempInfo, nil
+			}
+			targetLookups++
+			if targetLookups == 1 {
+				return nil, lookupErr
+			}
+			return f.tempInfo, nil
+		},
+		link: func(string, string) error { return nil },
+		remove: func(string) error {
+			removed = true
+			return nil
+		},
+	}
+	ownership, err := f.place(root)
+	if ownership != nil || !errors.Is(err, lookupErr) || !removed {
+		t.Fatalf("expected post-link lookup rollback, ownership=%#v removed=%v err=%v", ownership, removed, err)
+	}
+}
+
+func (f *advisoryPlaceSnapshotFixture) testPostLinkIdentityMismatch(t *testing.T) {
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "temp" {
+				return f.tempInfo, nil
+			}
+			return f.otherInfo, nil
+		},
+		link: func(string, string) error { return nil },
+		remove: func(string) error {
+			t.Fatal("identity-mismatched target must not be removed")
+			return nil
+		},
+	}
+	ownership, err := f.place(root)
+	if ownership != nil || !errors.Is(err, errAdvisorySnapshotOwnershipLost) {
+		t.Fatalf("expected ownership-loss error, ownership=%#v err=%v", ownership, err)
+	}
+}
+
+func TestAdvisoryPublicationLockCancellationAndReacquisition(t *testing.T) {
+	cachePath := t.TempDir()
+	firstRoot := advisoryOpenTestRoot(t, cachePath)
+	secondRoot := advisoryOpenTestRoot(t, cachePath)
+	firstLock, err := acquireAdvisoryPublicationLock(context.Background(), firstRoot)
+	if err != nil {
+		t.Fatalf("acquire first publication lock: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	blockedLock, err := acquireAdvisoryPublicationLock(ctx, secondRoot)
+	if blockedLock != nil {
+		if closeErr := blockedLock.Close(); closeErr != nil {
+			t.Errorf("close unexpectedly acquired canceled lock: %v", closeErr)
+		}
+	}
+	if blockedLock != nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled publication lock waiter, lock=%v err=%v", blockedLock != nil, err)
+	}
+	if err := firstLock.Close(); err != nil {
+		t.Fatalf("release first publication lock: %v", err)
+	}
+	var nilContext context.Context
+	reacquired, err := acquireAdvisoryPublicationLock(nilContext, secondRoot)
+	if err != nil {
+		t.Fatalf("reacquire publication lock: %v", err)
+	}
+	if err := reacquired.Close(); err != nil {
+		t.Fatalf("release reacquired publication lock: %v", err)
+	}
+}
+
+func TestAdvisoryPublicationLockIgnoresReplaceableLegacyPath(t *testing.T) {
+	cachePath := t.TempDir()
+	outsidePath := filepath.Join(t.TempDir(), "outside-lock")
+	if err := os.WriteFile(outsidePath, []byte("outside"), 0o600); err != nil {
+		t.Fatalf("write outside lock fixture: %v", err)
+	}
+	if err := os.Symlink(outsidePath, filepath.Join(cachePath, legacyPublicationLockFileName)); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	root := advisoryOpenTestRoot(t, cachePath)
+	lock, err := acquireAdvisoryPublicationLock(context.Background(), root)
+	if err != nil {
+		t.Fatalf("acquire cache identity lock with replaceable legacy path: %v", err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("release cache identity lock with replaceable legacy path: %v", err)
+	}
+	data, readErr := os.ReadFile(outsidePath)
+	if readErr != nil || string(data) != "outside" {
+		t.Fatalf("expected outside lock fixture to stay unchanged, content=%q err=%v", data, readErr)
+	}
+}
+
+func TestAdvisoryPublicationLockOpenAndDescriptorFailures(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat advisory cache identity fixture: %v", err)
+	}
+	openErr := errors.New("open advisory cache identity")
+	lock, err := acquireAdvisoryPublicationLock(context.Background(), &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		open:  func(string) (safeio.File, error) { return nil, openErr },
+	})
+	if lock != nil || !errors.Is(err, openErr) {
+		t.Fatalf("expected cache identity open failure, lock=%v err=%v", lock != nil, err)
+	}
+
+	closed := false
+	file := &advisoryFakeDirectory{advisoryFakeFile: &advisoryFakeFile{
+		stat: func() (fs.FileInfo, error) { return dirInfo, nil },
+		close: func() error {
+			closed = true
+			return nil
+		},
+	}}
+	root := &advisoryFakeRoot{
+		open:  func(string) (safeio.File, error) { return file, nil },
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+	}
+	lock, err = acquireAdvisoryPublicationLock(context.Background(), root)
+	if lock != nil || err == nil || !strings.Contains(err.Error(), "has no descriptor") || !closed {
+		t.Fatalf("expected descriptor rejection and close, lock=%v closed=%v err=%v", lock != nil, closed, err)
+	}
+}
+
+func TestVerifyAdvisoryCacheIdentityErrors(t *testing.T) {
+	firstInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat first advisory cache identity: %v", err)
+	}
+	secondInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat second advisory cache identity: %v", err)
+	}
+	fileInfo := advisoryRegularFileInfo(t, "not-a-directory")
+	lookupErr := errors.New("relookup advisory cache identity")
+	statErr := errors.New("restat advisory cache identity")
+	tests := []struct {
+		name string
+		root safeio.Root
+		file safeio.File
+		want error
+	}{
+		{
+			name: "lookup",
+			root: &advisoryFakeRoot{lstat: func(string) (fs.FileInfo, error) {
+				return nil, lookupErr
+			}},
+			file: &advisoryFakeFile{},
+			want: lookupErr,
+		},
+		{
+			name: "stat",
+			root: &advisoryFakeRoot{lstat: func(string) (fs.FileInfo, error) {
+				return firstInfo, nil
+			}},
+			file: &advisoryFakeFile{stat: func() (fs.FileInfo, error) { return nil, statErr }},
+			want: statErr,
+		},
+		{
+			name: "non-regular",
+			root: &advisoryFakeRoot{lstat: func(string) (fs.FileInfo, error) {
+				return fileInfo, nil
+			}},
+			file: &advisoryFakeFile{stat: func() (fs.FileInfo, error) { return fileInfo, nil }},
+		},
+		{
+			name: "identity",
+			root: &advisoryFakeRoot{lstat: func(string) (fs.FileInfo, error) {
+				return firstInfo, nil
+			}},
+			file: &advisoryFakeFile{stat: func() (fs.FileInfo, error) { return secondInfo, nil }},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := verifyAdvisoryCacheIdentity(test.root, test.file)
+			if err == nil || test.want != nil && !errors.Is(err, test.want) {
+				t.Fatalf("expected cache identity verification failure %v, got %v", test.want, err)
+			}
+		})
+	}
+}
+
+func advisoryRegularFileInfo(t *testing.T, contents string) fs.FileInfo {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "lock")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write publication lock info fixture: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat publication lock info fixture: %v", err)
+	}
+	return info
+}
+
+func TestAdvisoryVerifyExistingSnapshotFailureBranches(t *testing.T) {
+	fixture := newAdvisoryExistingSnapshotFixture(t)
+	t.Run("open", fixture.assertOpenFailure)
+	t.Run("stat", fixture.assertStatFailure)
+	t.Run("size", fixture.assertSizeFailure)
+	t.Run("read", fixture.assertReadFailure)
+}
+
+type advisoryExistingSnapshotFixture struct {
+	payload     []byte
+	fixturePath string
+	info        fs.FileInfo
+	digest      string
+}
+
+func newAdvisoryExistingSnapshotFixture(t *testing.T) *advisoryExistingSnapshotFixture {
+	t.Helper()
+	payload := []byte("winner")
+	fixturePath := filepath.Join(t.TempDir(), "winner.json")
+	if err := os.WriteFile(fixturePath, payload, 0o600); err != nil {
+		t.Fatalf("write existing snapshot fixture: %v", err)
+	}
+	info, err := os.Stat(fixturePath)
+	if err != nil {
+		t.Fatalf("stat existing snapshot fixture: %v", err)
+	}
+	digestSum := sha256.Sum256(payload)
+	digest := sha256Prefix + hex.EncodeToString(digestSum[:])
+	return &advisoryExistingSnapshotFixture{
+		payload:     payload,
+		fixturePath: fixturePath,
+		info:        info,
+		digest:      digest,
+	}
+}
+
+func (f *advisoryExistingSnapshotFixture) assertOpenFailure(t *testing.T) {
+	openErr := errors.New("open existing snapshot")
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return f.info, nil },
+		open:  func(string) (safeio.File, error) { return nil, openErr },
+	}
+	if err := advisoryVerifyExistingSnapshot(root, "winner.json", f.digest, int64(len(f.payload))); !errors.Is(err, openErr) {
+		t.Fatalf("expected existing snapshot open failure, got %v", err)
+	}
+}
+
+func (f *advisoryExistingSnapshotFixture) assertStatFailure(t *testing.T) {
+	statErr := errors.New("restat existing snapshot")
+	statCalls := 0
+	file := &advisoryFakeFile{
+		stat: func() (fs.FileInfo, error) {
+			statCalls++
+			if statCalls == 1 {
+				return f.info, nil
+			}
+			return nil, statErr
+		},
+	}
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return f.info, nil },
+		open:  func(string) (safeio.File, error) { return file, nil },
+	}
+	if err := advisoryVerifyExistingSnapshot(root, "winner.json", f.digest, int64(len(f.payload))); !errors.Is(err, statErr) {
+		t.Fatalf("expected existing snapshot stat failure, got %v", err)
+	}
+}
+
+func (f *advisoryExistingSnapshotFixture) assertSizeFailure(t *testing.T) {
+	root, err := safeio.OpenRoot(filepath.Dir(f.fixturePath))
+	if err != nil {
+		t.Fatalf("open existing snapshot root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close existing snapshot root: %v", closeErr)
+		}
+	}()
+	err = advisoryVerifyExistingSnapshot(root, filepath.Base(f.fixturePath), f.digest, int64(len(f.payload)+1))
+	if !errors.Is(err, errAdvisorySnapshotContentMismatch) || !strings.Contains(err.Error(), "snapshot size") {
+		t.Fatalf("expected existing snapshot size mismatch, got %v", err)
+	}
+}
+
+func (f *advisoryExistingSnapshotFixture) assertReadFailure(t *testing.T) {
+	readErr := errors.New("hash existing snapshot")
+	file := &advisoryFakeFile{
+		read: func([]byte) (int, error) { return 0, readErr },
+		stat: func() (fs.FileInfo, error) {
+			return f.info, nil
+		},
+	}
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return f.info, nil },
+		open:  func(string) (safeio.File, error) { return file, nil },
+	}
+	if err := advisoryVerifyExistingSnapshot(root, "winner.json", f.digest, int64(len(f.payload))); !errors.Is(err, readErr) {
+		t.Fatalf("expected existing snapshot hash read failure, got %v", err)
+	}
+}
+
+func TestAdvisoryVerifyPinnedSnapshotsChildPropagatesLookups(t *testing.T) {
+	lookupErr := errors.New("lookup snapshots path")
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, lookupErr },
+	}
+	if err := advisoryVerifyPinnedSnapshotsChild(root, &advisoryFakeRoot{}); !errors.Is(err, lookupErr) {
+		t.Fatalf("expected parent lookup error, got %v", err)
+	}
+
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat snapshots directory fixture: %v", err)
+	}
+	openedLookupErr := errors.New("lookup pinned snapshots root")
+	root = &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+	}
+	snapshotsRoot := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, openedLookupErr },
+	}
+	err = advisoryVerifyPinnedSnapshotsChild(root, snapshotsRoot)
+	if !errors.Is(err, openedLookupErr) {
+		t.Fatalf("expected pinned-root lookup error, got %v", err)
+	}
+}
+
+func TestRollbackOwnedSnapshotMissingLookupAndRemoveErrors(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), "snapshot.json")
+	if err := os.WriteFile(targetPath, []byte("snapshot"), 0o600); err != nil {
+		t.Fatalf("write rollback identity fixture: %v", err)
+	}
+	targetInfo, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatalf("stat rollback identity fixture: %v", err)
+	}
+	ownership := &advisorySnapshotOwnership{name: "snapshot.json", info: targetInfo}
+	publicationErr := errors.New("manifest publication")
+
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+	}
+	if err := rollbackOwnedSnapshot(root, ownership, publicationErr); !errors.Is(err, publicationErr) {
+		t.Fatalf("expected missing owned target to preserve publication error, got %v", err)
+	}
+
+	lookupErr := errors.New("lookup rollback target")
+	root = &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, lookupErr },
+	}
+	err = rollbackOwnedSnapshot(root, ownership, publicationErr)
+	if !errors.Is(err, publicationErr) || !errors.Is(err, lookupErr) {
+		t.Fatalf("expected publication and rollback lookup errors, got %v", err)
+	}
+
+	removeErr := errors.New("remove rollback target")
+	root = &advisoryFakeRoot{
+		lstat:  func(string) (fs.FileInfo, error) { return targetInfo, nil },
+		remove: func(string) error { return removeErr },
+	}
+	err = rollbackOwnedSnapshot(root, ownership, publicationErr)
+	if !errors.Is(err, publicationErr) || !errors.Is(err, removeErr) {
+		t.Fatalf("expected publication and rollback removal errors, got %v", err)
+	}
+}
+
+func TestPrepareAdvisoryCacheRootClosesOriginalRootAfterCreatingChild(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	lstatCalls := 0
+	rootClosed := 0
+	child := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "." {
+				t.Fatalf("unexpected child lstat %q", name)
+			}
+			return dirInfo, nil
+		},
+	}
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected root lstat %q", name)
+			}
+			lstatCalls++
+			if lstatCalls == 1 {
+				return nil, os.ErrNotExist
+			}
+			return dirInfo, nil
+		},
+		mkdir: func(string, os.FileMode) error { return nil },
+		openRoot: func(name string) (safeio.Root, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected openRoot %q", name)
+			}
+			return child, nil
+		},
+		close: func() error {
+			rootClosed++
+			return nil
+		},
+	}
+	realHook := openAdvisoryCacheAncestor
+	openAdvisoryCacheAncestor = func(string) (safeio.Root, string, []string, error) {
+		return root, "/cache", []string{"leaf"}, nil
+	}
+	t.Cleanup(func() {
+		openAdvisoryCacheAncestor = realHook
+	})
+
+	opened, err := prepareAdvisoryCacheRoot("/cache/leaf")
+	if err != nil {
+		t.Fatalf("prepare advisory cache root after child create: %v", err)
+	}
+	if opened != child {
+		t.Fatalf("expected created child root, got %#v", opened)
+	}
+	if rootClosed != 1 {
+		t.Fatalf("expected original root to close once, got %d", rootClosed)
+	}
+}
+
+func TestPrepareAdvisoryCacheRootJoinsRootAndOwnedCloseErrorsAfterCreatingChild(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	rootCloseErr := errors.New("close advisory ancestor")
+	childCloseErr := errors.New("close created advisory root")
+	lstatCalls := 0
+	child := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		close: func() error { return childCloseErr },
+	}
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) {
+			lstatCalls++
+			if lstatCalls == 1 {
+				return nil, os.ErrNotExist
+			}
+			return dirInfo, nil
+		},
+		mkdir:    func(string, os.FileMode) error { return nil },
+		openRoot: func(string) (safeio.Root, error) { return child, nil },
+		close:    func() error { return rootCloseErr },
+	}
+	realHook := openAdvisoryCacheAncestor
+	openAdvisoryCacheAncestor = func(string) (safeio.Root, string, []string, error) {
+		return root, "/cache", []string{"leaf"}, nil
+	}
+	t.Cleanup(func() {
+		openAdvisoryCacheAncestor = realHook
+	})
+
+	opened, err := prepareAdvisoryCacheRoot("/cache/leaf")
+	if opened != nil {
+		t.Fatal("expected root close failure to return no opened root")
+	}
+	if !errors.Is(err, rootCloseErr) || !errors.Is(err, childCloseErr) {
+		t.Fatalf("expected root and child close errors to be joined, got %v", err)
+	}
+}
+
+func TestAdvisoryOpenOrCreatePinnedChildRejectsSymlink(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), "outside")
+	if err := os.WriteFile(targetPath, []byte("content"), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	linkPath := filepath.Join(t.TempDir(), "child-link")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	linkInfo, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat symlink: %v", err)
+	}
+	root := &advisoryFakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "child" {
+				t.Fatalf("unexpected lstat %q", name)
+			}
+			return linkInfo, nil
+		},
+	}
+
+	child, err := advisoryOpenOrCreatePinnedChild(root, "/cache", "child")
+	if child != nil {
+		t.Fatal("expected symlinked advisory child to be rejected")
+	}
+	if err == nil || !strings.Contains(err.Error(), "root contains symlink: /cache/child") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func TestAdvisoryOpenOrCreatePinnedChildJoinsOpenedRootLookupAndCloseError(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	lookupErr := errors.New("lstat opened advisory child")
+	closeErr := errors.New("close opened advisory child")
+	root := &advisoryFakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (safeio.Root, error) {
+			return &advisoryFakeRoot{
+				lstat: func(string) (fs.FileInfo, error) { return nil, lookupErr },
+				close: func() error { return closeErr },
+			}, nil
+		},
+	}
+
+	child, err := advisoryOpenOrCreatePinnedChild(root, "/cache", "child")
+	if child != nil {
+		t.Fatal("expected opened-child lookup failure to return no root")
+	}
+	if !errors.Is(err, lookupErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected lookup and close errors to be joined, got %v", err)
+	}
+}
+
 func TestLoadSnapshotMetadataRejectsSymlinkPath(t *testing.T) {
 	parentDir := t.TempDir()
 	outsidePath := filepath.Join(parentDir, "outside.json")
@@ -1250,6 +3023,105 @@ func TestDownloadSnapshotUnderRootUsesDefaultClient(t *testing.T) {
 	}
 	if fetched.schema != "osv-json" || fetched.entryCount != 1 || len(fetched.ecosystems) != 1 || fetched.ecosystems[0] != "Go" {
 		t.Fatalf("unexpected fetched metadata: %#v", fetched)
+	}
+}
+
+func TestDownloadSnapshotUnderRootRejectsTempSymlinkSwapBeforeValidation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(testOSVSnapshot("OSV-1"))); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	rootDir := t.TempDir()
+	realRoot := advisoryOpenTestRoot(t, rootDir)
+	outsidePath := filepath.Join(t.TempDir(), "outside.json")
+	if err := os.WriteFile(outsidePath, []byte(testOSVSnapshot("OSV-2")), 0o600); err != nil {
+		t.Fatalf("write outside snapshot: %v", err)
+	}
+
+	swapped := false
+	root := &advisoryFakeRoot{
+		open:     realRoot.Open,
+		openFile: realRoot.OpenFile,
+		openRoot: realRoot.OpenRoot,
+		lstat: func(name string) (fs.FileInfo, error) {
+			if !swapped && strings.HasPrefix(filepath.Base(name), ".safeio-atomic-") {
+				swapped = true
+				tempPath := filepath.Join(rootDir, name)
+				if err := os.Remove(tempPath); err != nil {
+					t.Fatalf("remove temp snapshot before symlink swap: %v", err)
+				}
+				if err := os.Symlink(outsidePath, tempPath); err != nil {
+					t.Fatalf("replace temp snapshot with symlink: %v", err)
+				}
+			}
+			return realRoot.Lstat(name)
+		},
+		remove: realRoot.Remove,
+	}
+
+	_, err := downloadSnapshotUnderRoot(context.Background(), server.URL, nil, root)
+	if !errors.Is(err, safeio.ErrTargetPathSymlink) {
+		t.Fatalf("expected target symlink sentinel, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid OSV JSON snapshot") {
+		t.Fatalf("expected validation error context, got %v", err)
+	}
+	advisoryAssertNoSafeIOTempFiles(t, rootDir)
+}
+
+func TestDownloadSnapshotUnderRootSuppressesMetadataFromOversizedReopenedTemp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(testOSVSnapshot("OSV-1"))); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	rootDir := t.TempDir()
+	realRoot := advisoryOpenTestRoot(t, rootDir)
+	metadataGrew := false
+	root := &advisoryFakeRoot{
+		open: func(name string) (safeio.File, error) {
+			file, err := realRoot.Open(name)
+			if err != nil {
+				return nil, err
+			}
+			if metadataGrew || !strings.HasPrefix(filepath.Base(name), ".safeio-atomic-") {
+				return file, nil
+			}
+			tempPath := filepath.Join(rootDir, name)
+			return &advisoryWrappedFile{
+				File: file,
+				closeHook: func() error {
+					metadataGrew = true
+					return writeOversizedValidSnapshot(tempPath, maxSyncMetadataBytes+1024)
+				},
+			}, nil
+		},
+		openFile: realRoot.OpenFile,
+		openRoot: realRoot.OpenRoot,
+		lstat:    realRoot.Lstat,
+		remove:   realRoot.Remove,
+	}
+
+	fetched, err := downloadSnapshotUnderRoot(context.Background(), server.URL, nil, root)
+	if err != nil {
+		t.Fatalf("downloadSnapshotUnderRoot with oversized reopened metadata: %v", err)
+	}
+	if !metadataGrew {
+		t.Fatal("expected metadata growth hook to run")
+	}
+	if fetched.schema != schemaOSVJSON {
+		t.Fatalf("expected JSON schema, got %#v", fetched)
+	}
+	if fetched.sizeBytes >= maxSyncMetadataBytes {
+		t.Fatalf("expected streamed size below metadata limit, got %d", fetched.sizeBytes)
+	}
+	if len(fetched.ecosystems) != 0 || fetched.entryCount != 0 {
+		t.Fatalf("expected oversized reopened metadata to be suppressed, got ecosystems=%v entryCount=%d", fetched.ecosystems, fetched.entryCount)
 	}
 }
 
@@ -1502,7 +3374,7 @@ func TestUpdateManifestReturnsWriteError(t *testing.T) {
 
 	root := advisoryOpenTestRoot(t, cachePath)
 	err := updateManifest(root, CacheSnapshot{ID: "new", Path: "snapshots/new.json"}, time.Date(2026, time.July, 13, 0, 0, 0, 0, time.UTC))
-	if err == nil || !strings.Contains(err.Error(), "is a directory") {
+	if !errors.Is(err, fs.ErrInvalid) {
 		t.Fatalf("expected manifest write error, got %v", err)
 	}
 }
@@ -1719,6 +3591,31 @@ func advisorySetSyncAfterDownloadHook(t *testing.T, hook func(cacheRoot, tempRel
 	})
 }
 
+func advisorySetSyncBeforeSnapshotPlacementHook(t *testing.T, hook func(cacheRoot, snapshotRel string)) {
+	t.Helper()
+	syncBeforeSnapshotPlacementHook = hook
+	t.Cleanup(func() {
+		syncBeforeSnapshotPlacementHook = nil
+	})
+}
+
+func advisorySetSyncAfterSnapshotPlacementHook(t *testing.T, hook func(cacheRoot, snapshotRel string)) {
+	t.Helper()
+	syncAfterSnapshotPlacementHook = hook
+	t.Cleanup(func() {
+		syncAfterSnapshotPlacementHook = nil
+	})
+}
+
+func withOpenAdvisoryCacheRootHook(t *testing.T, hook func(string) (safeio.Root, error)) {
+	t.Helper()
+	original := openAdvisoryCacheRootHook
+	openAdvisoryCacheRootHook = hook
+	t.Cleanup(func() {
+		openAdvisoryCacheRootHook = original
+	})
+}
+
 func advisoryRequireTempPresent(t *testing.T, cacheRoot, tempRel, context string) {
 	t.Helper()
 	if _, err := os.Stat(filepath.Join(cacheRoot, tempRel)); err != nil {
@@ -1754,6 +3651,11 @@ func advisoryAssertNoSafeIOTempFiles(t *testing.T, cachePath string) {
 	if err != nil {
 		t.Fatalf("glob temp files: %v", err)
 	}
+	nestedMatches, err := filepath.Glob(filepath.Join(cachePath, "snapshots", ".safeio-atomic-*"))
+	if err != nil {
+		t.Fatalf("glob nested temp files: %v", err)
+	}
+	matches = append(matches, nestedMatches...)
 	if len(matches) != 0 {
 		t.Fatalf("expected downloaded temp to be cleaned up, got %v", matches)
 	}
@@ -1762,6 +3664,11 @@ func advisoryAssertNoSafeIOTempFiles(t *testing.T, cachePath string) {
 func advisoryRootWithoutManifest(root *advisoryFakeRoot) *advisoryFakeRoot {
 	root.open = func(string) (safeio.File, error) {
 		return nil, os.ErrNotExist
+	}
+	if root.lstat == nil {
+		root.lstat = func(string) (fs.FileInfo, error) {
+			return nil, os.ErrNotExist
+		}
 	}
 	return root
 }
@@ -1851,6 +3758,7 @@ type advisoryFakeRoot struct {
 	mkdir    func(name string, perm os.FileMode) error
 	chmod    func(name string, perm os.FileMode) error
 	mkdirAll func(name string, perm os.FileMode) error
+	link     func(oldName, newName string) error
 	rename   func(oldName, newName string) error
 	remove   func(name string) error
 	close    func() error
@@ -1905,6 +3813,13 @@ func (r *advisoryFakeRoot) MkdirAll(name string, perm os.FileMode) error {
 	return nil
 }
 
+func (r *advisoryFakeRoot) Link(oldName, newName string) error {
+	if r.link != nil {
+		return r.link(oldName, newName)
+	}
+	return errors.New("unexpected link")
+}
+
 func (r *advisoryFakeRoot) Rename(oldName, newName string) error {
 	if r.rename != nil {
 		return r.rename(oldName, newName)
@@ -1930,7 +3845,16 @@ type advisoryFakeFile struct {
 	read  func([]byte) (int, error)
 	write func([]byte) (int, error)
 	close func() error
+	stat  func() (fs.FileInfo, error)
 	chmod func(os.FileMode) error
+}
+
+type advisoryFakeDirectory struct {
+	*advisoryFakeFile
+}
+
+func (*advisoryFakeDirectory) ReadDir(int) ([]fs.DirEntry, error) {
+	return nil, io.EOF
 }
 
 func (f *advisoryFakeFile) Read(p []byte) (int, error) {
@@ -1955,6 +3879,9 @@ func (f *advisoryFakeFile) Close() error {
 }
 
 func (f *advisoryFakeFile) Stat() (os.FileInfo, error) {
+	if f.stat != nil {
+		return f.stat()
+	}
 	return nil, errors.New("unexpected stat")
 }
 
@@ -1963,4 +3890,148 @@ func (f *advisoryFakeFile) Chmod(perm os.FileMode) error {
 		return f.chmod(perm)
 	}
 	return nil
+}
+
+type advisoryStaticFile struct {
+	info    fs.FileInfo
+	payload []byte
+	offset  int
+}
+
+func (f *advisoryStaticFile) Read(p []byte) (int, error) {
+	if f.offset >= len(f.payload) {
+		return 0, io.EOF
+	}
+	count := copy(p, f.payload[f.offset:])
+	f.offset += count
+	if f.offset >= len(f.payload) {
+		return count, io.EOF
+	}
+	return count, nil
+}
+
+func (f *advisoryStaticFile) Write([]byte) (int, error) {
+	return 0, errors.New("unexpected write")
+}
+
+func (f *advisoryStaticFile) Close() error {
+	return nil
+}
+
+func (f *advisoryStaticFile) Stat() (os.FileInfo, error) {
+	return f.info, nil
+}
+
+func (f *advisoryStaticFile) Chmod(os.FileMode) error {
+	return nil
+}
+
+type advisoryWrappedFile struct {
+	safeio.File
+	closeHook func() error
+}
+
+func (f *advisoryWrappedFile) Close() error {
+	closeErr := f.File.Close()
+	if f.closeHook == nil {
+		return closeErr
+	}
+	return errors.Join(closeErr, f.closeHook())
+}
+
+func writeOversizedValidSnapshot(path string, sizeBytes int64) (returnErr error) {
+	if sizeBytes <= 0 {
+		return fmt.Errorf("invalid oversized snapshot size %d", sizeBytes)
+	}
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
+	if err != nil {
+		return err
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			returnErr = errors.Join(returnErr, file.Close())
+		}
+	}()
+
+	prefix := `{"vulns":[{"id":"GO-OVERSIZED","affected":[{"package":{"ecosystem":"Go"}}],"details":"`
+	suffix := `"}]}`
+	if _, err := file.WriteString(prefix); err != nil {
+		return err
+	}
+
+	remaining := sizeBytes - int64(len(prefix)) - int64(len(suffix))
+	if remaining < 0 {
+		return fmt.Errorf("oversized snapshot target too small: %d", sizeBytes)
+	}
+	chunk := strings.Repeat("a", 1<<20)
+	for remaining > 0 {
+		writeLen := len(chunk)
+		if int64(writeLen) > remaining {
+			writeLen = int(remaining)
+		}
+		if _, err := file.WriteString(chunk[:writeLen]); err != nil {
+			return err
+		}
+		remaining -= int64(writeLen)
+	}
+	if _, err := file.WriteString(suffix); err != nil {
+		return err
+	}
+	closed = true
+	return file.Close()
+}
+
+func writeOversizedValidManifest(path string, sizeBytes int64) (returnErr error) {
+	if sizeBytes <= 0 {
+		return fmt.Errorf("invalid oversized manifest size %d", sizeBytes)
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			returnErr = errors.Join(returnErr, file.Close())
+		}
+	}()
+
+	prefix := `{"schemaVersion":"` + manifestSchemaVersion + `","updatedAt":"2026-07-13T00:00:00Z","latest":"`
+	suffix := `","snapshots":[]}`
+	if _, err := file.WriteString(prefix); err != nil {
+		return err
+	}
+
+	remaining := sizeBytes - int64(len(prefix)) - int64(len(suffix))
+	if remaining < 0 {
+		return fmt.Errorf("oversized manifest target too small: %d", sizeBytes)
+	}
+	chunk := strings.Repeat("a", 1<<20)
+	for remaining > 0 {
+		writeLen := len(chunk)
+		if int64(writeLen) > remaining {
+			writeLen = int(remaining)
+		}
+		if _, err := file.WriteString(chunk[:writeLen]); err != nil {
+			return err
+		}
+		remaining -= int64(writeLen)
+	}
+	if _, err := file.WriteString(suffix); err != nil {
+		return err
+	}
+	closed = true
+	return file.Close()
+}
+
+func testCacheManifestPayload(t *testing.T, manifest CacheManifest) []byte {
+	t.Helper()
+	payload, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal cache manifest fixture: %v", err)
+	}
+	return append(payload, '\n')
 }

--- a/internal/advisory/sync_test.go
+++ b/internal/advisory/sync_test.go
@@ -1441,43 +1441,57 @@ func advisoryCreateDistinctLegacyLockReplacement(t *testing.T, path string, orig
 	dir := filepath.Dir(path)
 	pattern := filepath.Base(path) + ".replacement-*"
 	for attempt := 0; attempt < 8; attempt++ {
-		file, err := os.CreateTemp(dir, pattern)
-		if err != nil {
-			t.Fatalf("create distinct legacy publication lock replacement: %v", err)
+		replacementPath, replacementInfo := advisoryCreateLegacyLockReplacementAttempt(t, dir, pattern)
+		if !os.SameFile(original, replacementInfo) {
+			return replacementPath, replacementInfo
 		}
-		replacementPath := file.Name()
-		if _, err := file.WriteString("replacement"); err != nil {
-			if closeErr := file.Close(); closeErr != nil {
-				t.Logf("close failed replacement file after write error: %v", closeErr)
-			}
-			if removeErr := os.Remove(replacementPath); removeErr != nil {
-				t.Logf("remove failed replacement file after write error: %v", removeErr)
-			}
-			t.Fatalf("write distinct legacy publication lock replacement: %v", err)
-		}
-		if err := file.Close(); err != nil {
-			if removeErr := os.Remove(replacementPath); removeErr != nil {
-				t.Logf("remove failed replacement file after close error: %v", removeErr)
-			}
-			t.Fatalf("close distinct legacy publication lock replacement: %v", err)
-		}
-		replacementInfo, err := os.Lstat(replacementPath)
-		if err != nil {
-			if removeErr := os.Remove(replacementPath); removeErr != nil {
-				t.Logf("remove failed replacement file after lstat error: %v", removeErr)
-			}
-			t.Fatalf("lstat distinct legacy publication lock replacement: %v", err)
-		}
-		if os.SameFile(original, replacementInfo) {
-			if removeErr := os.Remove(replacementPath); removeErr != nil {
-				t.Logf("remove failed reused-identity replacement file: %v", removeErr)
-			}
-			continue
-		}
-		return replacementPath, replacementInfo
+		advisoryRemoveLegacyLockReplacementFile(t, replacementPath, "remove failed reused-identity replacement file")
 	}
 	t.Fatal("failed to create a distinct legacy publication lock replacement")
 	return "", nil
+}
+
+func advisoryCreateLegacyLockReplacementAttempt(t *testing.T, dir, pattern string) (string, fs.FileInfo) {
+	t.Helper()
+	file, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		t.Fatalf("create distinct legacy publication lock replacement: %v", err)
+	}
+	replacementPath := file.Name()
+	advisoryWriteLegacyLockReplacementContents(t, file, replacementPath)
+	replacementInfo, err := os.Lstat(replacementPath)
+	if err != nil {
+		advisoryRemoveLegacyLockReplacementFile(t, replacementPath, "remove failed replacement file after lstat error")
+		t.Fatalf("lstat distinct legacy publication lock replacement: %v", err)
+	}
+	return replacementPath, replacementInfo
+}
+
+func advisoryWriteLegacyLockReplacementContents(t *testing.T, file *os.File, replacementPath string) {
+	t.Helper()
+	if _, err := file.WriteString("replacement"); err != nil {
+		advisoryCloseLegacyLockReplacementOnWriteError(t, file)
+		advisoryRemoveLegacyLockReplacementFile(t, replacementPath, "remove failed replacement file after write error")
+		t.Fatalf("write distinct legacy publication lock replacement: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		advisoryRemoveLegacyLockReplacementFile(t, replacementPath, "remove failed replacement file after close error")
+		t.Fatalf("close distinct legacy publication lock replacement: %v", err)
+	}
+}
+
+func advisoryCloseLegacyLockReplacementOnWriteError(t *testing.T, file *os.File) {
+	t.Helper()
+	if err := file.Close(); err != nil {
+		t.Logf("close failed replacement file after write error: %v", err)
+	}
+}
+
+func advisoryRemoveLegacyLockReplacementFile(t *testing.T, path, failureMessage string) {
+	t.Helper()
+	if err := os.Remove(path); err != nil {
+		t.Logf("%s: %v", failureMessage, err)
+	}
 }
 
 func advisoryPublicationLockChildCommand(t *testing.T, mode, cachePath, markerPath, testName string) (*exec.Cmd, *bytes.Buffer) {

--- a/internal/lang/jvm/adapter.go
+++ b/internal/lang/jvm/adapter.go
@@ -2,10 +2,12 @@ package jvm
 
 import (
 	"context"
+	"errors"
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/safeio"
 	"github.com/ben-ranford/lopper/internal/workspace"
 )
 
@@ -13,12 +15,20 @@ type Adapter struct {
 	language.AdapterLifecycle
 }
 
+var afterJVMAnalyseRootOpen = func(string) error { return nil }
+
 const (
-	pomXMLName                = "pom.xml"
-	buildGradleName           = "build.gradle"
-	buildGradleKTSName        = "build.gradle.kts"
-	maxScannableJVMBuildFile  = shared.GradleManifestByteLimit
-	maxScannableJVMSourceFile = 2 * 1024 * 1024
+	pomXMLName                   = "pom.xml"
+	buildGradleName              = "build.gradle"
+	buildGradleKTSName           = "build.gradle.kts"
+	maxScannableJVMBuildFile     = shared.GradleManifestByteLimit
+	maxScannableJVMSourceFile    = 2 * 1024 * 1024
+	maxJVMBuildTraversalEntries  = 8192
+	maxJVMBuildFiles             = 2048
+	maxJVMBuildWorkItems         = 2048
+	maxJVMSourceTraversalEntries = 32768
+	maxJVMSourceFiles            = 8192
+	maxJVMSourceWorkItems        = 8192
 )
 
 var jvmSkippedDirectories = map[string]bool{
@@ -36,20 +46,34 @@ func NewAdapter() *Adapter {
 	return adapter
 }
 
-func (a *Adapter) Analyse(ctx context.Context, req language.Request) (report.Result, error) {
+func (a *Adapter) Analyse(ctx context.Context, req language.Request) (result report.Result, err error) {
 	repoPath, err := workspace.NormalizeRepoPath(req.RepoPath)
 	if err != nil {
 		return report.Report{}, err
 	}
+	root, err := safeio.OpenRootNoFollow(repoPath)
+	if err != nil {
+		return report.Report{}, err
+	}
+	defer func() {
+		err = errors.Join(err, root.Close())
+	}()
 
-	result := report.Report{
+	if err := afterJVMAnalyseRootOpen(repoPath); err != nil {
+		return report.Report{}, err
+	}
+
+	result = report.Report{
 		GeneratedAt: a.Clock(),
 		RepoPath:    repoPath,
 	}
 
-	declaredDependencies, depPrefixes, depAliases, declarationWarnings := collectDeclaredDependencies(repoPath)
+	declaredDependencies, depPrefixes, depAliases, declarationWarnings, err := collectDeclaredDependenciesWithinRoot(ctx, repoPath, root)
+	if err != nil {
+		return report.Report{}, err
+	}
 	result.Warnings = append(result.Warnings, declarationWarnings...)
-	scanResult, err := scanRepo(ctx, repoPath, depPrefixes, depAliases)
+	scanResult, err := scanRepoWithinRoot(ctx, repoPath, root, depPrefixes, depAliases)
 	if err != nil {
 		return report.Report{}, err
 	}

--- a/internal/lang/jvm/adapter.go
+++ b/internal/lang/jvm/adapter.go
@@ -14,9 +14,11 @@ type Adapter struct {
 }
 
 const (
-	pomXMLName         = "pom.xml"
-	buildGradleName    = "build.gradle"
-	buildGradleKTSName = "build.gradle.kts"
+	pomXMLName                = "pom.xml"
+	buildGradleName           = "build.gradle"
+	buildGradleKTSName        = "build.gradle.kts"
+	maxScannableJVMBuildFile  = shared.GradleManifestByteLimit
+	maxScannableJVMSourceFile = 2 * 1024 * 1024
 )
 
 var jvmSkippedDirectories = map[string]bool{

--- a/internal/lang/jvm/adapter_cov_warning_collector_test.go
+++ b/internal/lang/jvm/adapter_cov_warning_collector_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBuildFileWarningCollectorVisitPropagatesWalkError(t *testing.T) {
-	repo := t.TempDir()
+	repo := canonicalRepoPath(t)
 	walkErr := errors.New("walk failed")
 	collector := newBuildFileWarningCollector(repo)
 	if err := collector.visit("", nil, walkErr); !errors.Is(err, walkErr) {
@@ -21,8 +21,8 @@ func TestBuildFileWarningCollectorVisitPropagatesWalkError(t *testing.T) {
 }
 
 func TestBuildFileWarningCollectorVisitWarnsOnOutsideBuildFile(t *testing.T) {
-	repo := t.TempDir()
-	outside := t.TempDir()
+	repo := canonicalRepoPath(t)
+	outside := canonicalRepoPath(t)
 	outsideBuild := filepath.Join(outside, buildGradleName)
 	testutil.MustWriteFile(t, outsideBuild, `implementation "org.example:demo:1.0.0"`)
 
@@ -37,7 +37,7 @@ func TestBuildFileWarningCollectorVisitWarnsOnOutsideBuildFile(t *testing.T) {
 }
 
 func TestBuildFileWarningCollectorVisitSkipsGradleDir(t *testing.T) {
-	repo := t.TempDir()
+	repo := canonicalRepoPath(t)
 	collector := newBuildFileWarningCollector(repo)
 	skipDir := filepath.Join(repo, ".gradle")
 	if err := os.MkdirAll(skipDir, 0o755); err != nil {
@@ -50,7 +50,7 @@ func TestBuildFileWarningCollectorVisitSkipsGradleDir(t *testing.T) {
 }
 
 func TestBuildFileWarningCollectorVisitCollectsRepoBuildFile(t *testing.T) {
-	repo := t.TempDir()
+	repo := canonicalRepoPath(t)
 	collector := newBuildFileWarningCollector(repo)
 	insideBuild := filepath.Join(repo, buildGradleName)
 	testutil.MustWriteFile(t, insideBuild, `implementation "org.example:demo:1.0.0"`)
@@ -67,7 +67,7 @@ func TestBuildFileWarningCollectorVisitCollectsRepoBuildFile(t *testing.T) {
 }
 
 func TestFormatBuildFileReadWarningIncludesPathAndError(t *testing.T) {
-	repo := t.TempDir()
+	repo := canonicalRepoPath(t)
 	insideBuild := filepath.Join(repo, buildGradleName)
 	warning := formatBuildFileReadWarning(repo, insideBuild, fs.ErrPermission)
 	if !strings.Contains(warning, buildGradleName) || !strings.Contains(warning, fs.ErrPermission.Error()) {

--- a/internal/lang/jvm/adapter_reachability_paths_test.go
+++ b/internal/lang/jvm/adapter_reachability_paths_test.go
@@ -62,7 +62,7 @@ func testJVMMissingDetectionPathAndSkippedDirHelper(t *testing.T) {
 	if dirEntry == nil {
 		t.Fatalf("expected .gradle entry")
 	}
-	if err := walkJVMDetectionEntry(skipDir, dirEntry, map[string]struct{}{}, &language.Detection{}, new(int), 8); !errors.Is(err, filepath.SkipDir) {
+	if err := walkJVMDetectionEntry(repo, skipDir, dirEntry, map[string]struct{}{}, &language.Detection{}, new(int), 8); !errors.Is(err, filepath.SkipDir) {
 		t.Fatalf("expected detection walker to skip .gradle, got %v", err)
 	}
 	if _, err := scanRepo(context.Background(), repo, nil, nil); err != nil {

--- a/internal/lang/jvm/adapter_reachability_paths_test.go
+++ b/internal/lang/jvm/adapter_reachability_paths_test.go
@@ -43,10 +43,24 @@ func testJVMMissingDetectionPathAndSkippedDirHelper(t *testing.T) {
 		t.Fatalf("expected missing repo to fail detection walk")
 	}
 
-	repo := t.TempDir()
+	repo := canonicalRepoPath(t)
 	dirEntry := mustReadJVMDirEntry(t, repo, ".gradle")
-	if err := walkJVMDetectionEntry(repo, filepath.Join(repo, dirEntry.Name()), dirEntry, map[string]struct{}{}, &language.Detection{}, new(int), 8); !errors.Is(err, filepath.SkipDir) {
+	budget := defaultJVMDetectionBudget()
+	if err := walkJVMDetectionEntry(repo, filepath.Join(repo, dirEntry.Name()), dirEntry, map[string]struct{}{}, &language.Detection{}, budget); !errors.Is(err, filepath.SkipDir) {
 		t.Fatalf("expected detection walker to skip .gradle, got %v", err)
+	}
+	if budget.traversalEntriesSeen != 1 {
+		t.Fatalf("expected skipped directory to consume one traversal entry, got %d", budget.traversalEntriesSeen)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".gradle", "Main.java"), []byte("class Main {}\n"), 0o644); err != nil {
+		t.Fatalf("write skipped JVM source: %v", err)
+	}
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect with skipped directory: %v", err)
+	}
+	if detection.Matched {
+		t.Fatalf("expected detection walker not to descend into .gradle, got %#v", detection)
 	}
 	if _, err := scanRepo(context.Background(), repo, nil, nil); err != nil {
 		t.Fatalf("scan empty repo: %v", err)

--- a/internal/lang/jvm/adapter_reachability_paths_test.go
+++ b/internal/lang/jvm/adapter_reachability_paths_test.go
@@ -44,25 +44,8 @@ func testJVMMissingDetectionPathAndSkippedDirHelper(t *testing.T) {
 	}
 
 	repo := t.TempDir()
-	skipDir := filepath.Join(repo, ".gradle")
-	if err := os.MkdirAll(skipDir, 0o755); err != nil {
-		t.Fatalf("mkdir skip dir: %v", err)
-	}
-	entries, err := os.ReadDir(repo)
-	if err != nil {
-		t.Fatalf("read repo dir: %v", err)
-	}
-	var dirEntry os.DirEntry
-	for _, entry := range entries {
-		if entry.Name() == ".gradle" {
-			dirEntry = entry
-			break
-		}
-	}
-	if dirEntry == nil {
-		t.Fatalf("expected .gradle entry")
-	}
-	if err := walkJVMDetectionEntry(repo, skipDir, dirEntry, map[string]struct{}{}, &language.Detection{}, new(int), 8); !errors.Is(err, filepath.SkipDir) {
+	dirEntry := mustReadJVMDirEntry(t, repo, ".gradle")
+	if err := walkJVMDetectionEntry(repo, filepath.Join(repo, dirEntry.Name()), dirEntry, map[string]struct{}{}, &language.Detection{}, new(int), 8); !errors.Is(err, filepath.SkipDir) {
 		t.Fatalf("expected detection walker to skip .gradle, got %v", err)
 	}
 	if _, err := scanRepo(context.Background(), repo, nil, nil); err != nil {
@@ -79,4 +62,24 @@ func testJVMRootlessSourceLayoutAndCustomWeights(t *testing.T) {
 	if got == report.DefaultRemovalCandidateWeights() {
 		t.Fatalf("expected non-nil removal weights to normalize instead of using defaults")
 	}
+}
+
+func mustReadJVMDirEntry(t *testing.T, repo, name string) os.DirEntry {
+	t.Helper()
+
+	path := filepath.Join(repo, name)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", name, err)
+	}
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read repo dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return entry
+		}
+	}
+	t.Fatalf("expected %s entry", name)
+	return nil
 }

--- a/internal/lang/jvm/adapter_scan_error_paths_test.go
+++ b/internal/lang/jvm/adapter_scan_error_paths_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
@@ -240,7 +241,7 @@ func TestJVMScanCallbackAndParseBranches(t *testing.T) {
 }
 
 func TestJVMSourceScanSkipsExpectedSymlinkReadErrors(t *testing.T) {
-	tests := []struct {
+	for _, test := range []struct {
 		name        string
 		readErr     error
 		wantWarning string
@@ -255,30 +256,63 @@ func TestJVMSourceScanSkipsExpectedSymlinkReadErrors(t *testing.T) {
 			readErr:     &fs.PathError{Op: "openat", Path: "Unreadable.java", Err: fs.ErrPermission},
 			wantWarning: "target unreadable",
 		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assertSkippedJVMSourceReadError(t, strings.ReplaceAll(test.name, " ", "-")+".java", test.readErr, test.wantWarning)
+		})
 	}
+}
 
-	for _, test := range tests {
+func TestJVMSourceScanSkipsSymlinkLoopReadErrors(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		wantSkips int
+		buildLoop func(*testing.T, string)
+	}{
+		{
+			name:      "self loop",
+			wantSkips: 1,
+			buildLoop: func(t *testing.T, repo string) {
+				t.Helper()
+				loopPath := filepath.Join(repo, "Loop.java")
+				if err := os.Symlink(filepath.Base(loopPath), loopPath); err != nil {
+					t.Skipf("symlink not supported: %v", err)
+				}
+			},
+		},
+		{
+			name:      "multi link loop",
+			wantSkips: 2,
+			buildLoop: func(t *testing.T, repo string) {
+				t.Helper()
+				first := filepath.Join(repo, "LoopA.java")
+				second := filepath.Join(repo, "LoopB.java")
+				if err := os.Symlink(filepath.Base(second), first); err != nil {
+					t.Skipf("symlink not supported: %v", err)
+				}
+				if err := os.Symlink(filepath.Base(first), second); err != nil {
+					t.Skipf("symlink not supported: %v", err)
+				}
+			},
+		},
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			repo := t.TempDir()
-			sourceLink := createJVMSourceSymlink(t, repo, strings.ReplaceAll(test.name, " ", "-")+".java")
-			readSource := func(rootDir, targetPath string, maxBytes int64) ([]byte, error) {
-				if rootDir != repo || targetPath != sourceLink || maxBytes != maxScannableJVMSourceFile {
-					t.Fatalf("unexpected source read: root=%q path=%q limit=%d", rootDir, targetPath, maxBytes)
-				}
-				return nil, test.readErr
-			}
-			result, err := scanRepoWithSourceReader(context.Background(), repo, nil, nil, readSource)
+			testutil.MustWriteFile(t, filepath.Join(repo, mainJavaFile), "class Main {}\n")
+			test.buildLoop(t, repo)
+
+			result, err := scanRepo(context.Background(), repo, nil, nil)
 			if err != nil {
-				t.Fatalf("expected symlink read error to be skipped: %v", err)
+				t.Fatalf("expected symlink loop to be downgraded, got %v", err)
 			}
-			if result.SkippedSymlinks != 1 {
-				t.Fatalf("expected one skipped symlink, got %#v", result)
+			if len(result.Files) != 1 || result.Files[0].Path != mainJavaFile {
+				t.Fatalf("expected regular JVM source to remain scannable, got %#v", result.Files)
 			}
-			warnings := strings.Join(result.Warnings, "\n")
-			if !strings.Contains(warnings, "skipped JVM source symlink") ||
-				!strings.Contains(warnings, test.wantWarning) ||
-				!strings.Contains(warnings, "skipped 1 unreadable or untrusted JVM source symlink(s)") {
-				t.Fatalf("expected symlink warnings for %s, got %#v", test.name, result.Warnings)
+			if result.SkippedSymlinks != test.wantSkips {
+				t.Fatalf("expected %d skipped symlink loop(s), got %#v", test.wantSkips, result)
+			}
+			if !strings.Contains(strings.Join(result.Warnings, "\n"), "target loops through symlinks") {
+				t.Fatalf("expected symlink loop warning, got %#v", result.Warnings)
 			}
 		})
 	}
@@ -304,18 +338,38 @@ func TestJVMSourceScanPropagatesUnexpectedSymlinkReadFailure(t *testing.T) {
 	}
 }
 
-func TestJVMClassifySkippableSourceReadErrorRequiresSymlink(t *testing.T) {
-	repo := t.TempDir()
-	regularSource := filepath.Join(repo, "Regular.java")
-	testutil.MustWriteFile(t, regularSource, "class Regular {}\n")
+func TestJVMClassifySkippableSourceReadErrorRejectsRegularFiles(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "permission",
+			err: &fs.PathError{
+				Op:   "openat",
+				Path: "Regular.java",
+				Err:  fs.ErrPermission,
+			},
+		},
+		{
+			name: "symlink loop",
+			err: &fs.PathError{
+				Op:   "open",
+				Path: "Regular.java",
+				Err:  syscall.ELOOP,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repo := t.TempDir()
+			regularSource := filepath.Join(repo, "Regular.java")
+			testutil.MustWriteFile(t, regularSource, "class Regular {}\n")
 
-	warning, skip := classifySkippableJVMSourceReadError(repo, regularSource, &fs.PathError{
-		Op:   "openat",
-		Path: regularSource,
-		Err:  fs.ErrPermission,
-	})
-	if skip || warning != "" {
-		t.Fatalf("expected regular files not to be downgraded as symlink skips, warning=%q skip=%v", warning, skip)
+			warning, skip := classifySkippableJVMSourceReadError(repo, regularSource, test.err)
+			if skip || warning != "" {
+				t.Fatalf("expected regular-file read errors to propagate, warning=%q skip=%v", warning, skip)
+			}
+		})
 	}
 }
 
@@ -377,6 +431,33 @@ func createJVMSourceSymlink(t *testing.T, repo, name string) string {
 		t.Skipf("symlink not supported: %v", err)
 	}
 	return sourceLink
+}
+
+func assertSkippedJVMSourceReadError(t *testing.T, name string, readErr error, wantWarning string) {
+	t.Helper()
+
+	repo := t.TempDir()
+	sourceLink := createJVMSourceSymlink(t, repo, name)
+	readSource := func(rootDir, targetPath string, maxBytes int64) ([]byte, error) {
+		if rootDir != repo || targetPath != sourceLink || maxBytes != maxScannableJVMSourceFile {
+			t.Fatalf("unexpected source read: root=%q path=%q limit=%d", rootDir, targetPath, maxBytes)
+		}
+		return nil, readErr
+	}
+
+	result, err := scanRepoWithSourceReader(context.Background(), repo, nil, nil, readSource)
+	if err != nil {
+		t.Fatalf("expected symlink read error to be skipped: %v", err)
+	}
+	if result.SkippedSymlinks != 1 {
+		t.Fatalf("expected one skipped symlink, got %#v", result)
+	}
+	warnings := strings.Join(result.Warnings, "\n")
+	if !strings.Contains(warnings, "skipped JVM source symlink") ||
+		!strings.Contains(warnings, wantWarning) ||
+		!strings.Contains(warnings, "skipped 1 unreadable or untrusted JVM source symlink(s)") {
+		t.Fatalf("expected symlink warnings for %s, got %#v", name, result.Warnings)
+	}
 }
 
 func TestJVMAnalyseWarningAndErrorBranches(t *testing.T) {

--- a/internal/lang/jvm/adapter_scan_error_paths_test.go
+++ b/internal/lang/jvm/adapter_scan_error_paths_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/safeio"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
@@ -264,57 +265,95 @@ func TestJVMSourceScanSkipsExpectedSymlinkReadErrors(t *testing.T) {
 }
 
 func TestJVMSourceScanSkipsSymlinkLoopReadErrors(t *testing.T) {
-	for _, test := range []struct {
-		name      string
-		wantSkips int
-		buildLoop func(*testing.T, string)
-	}{
-		{
-			name:      "self loop",
-			wantSkips: 1,
-			buildLoop: func(t *testing.T, repo string) {
-				t.Helper()
-				loopPath := filepath.Join(repo, "Loop.java")
-				if err := os.Symlink(filepath.Base(loopPath), loopPath); err != nil {
-					t.Skipf("symlink not supported: %v", err)
-				}
-			},
-		},
-		{
-			name:      "multi link loop",
-			wantSkips: 2,
-			buildLoop: func(t *testing.T, repo string) {
-				t.Helper()
-				first := filepath.Join(repo, "LoopA.java")
-				second := filepath.Join(repo, "LoopB.java")
-				if err := os.Symlink(filepath.Base(second), first); err != nil {
-					t.Skipf("symlink not supported: %v", err)
-				}
-				if err := os.Symlink(filepath.Base(first), second); err != nil {
-					t.Skipf("symlink not supported: %v", err)
-				}
-			},
-		},
+	for _, test := range []jvmSymlinkLoopTest{
+		{name: "self loop", wantSkips: 1, buildLoop: buildJVMSelfSymlinkLoop},
+		{name: "multi link loop", wantSkips: 2, buildLoop: buildJVMMultiSymlinkLoop},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			repo := t.TempDir()
-			testutil.MustWriteFile(t, filepath.Join(repo, mainJavaFile), "class Main {}\n")
-			test.buildLoop(t, repo)
-
-			result, err := scanRepo(context.Background(), repo, nil, nil)
-			if err != nil {
-				t.Fatalf("expected symlink loop to be downgraded, got %v", err)
-			}
-			if len(result.Files) != 1 || result.Files[0].Path != mainJavaFile {
-				t.Fatalf("expected regular JVM source to remain scannable, got %#v", result.Files)
-			}
-			if result.SkippedSymlinks != test.wantSkips {
-				t.Fatalf("expected %d skipped symlink loop(s), got %#v", test.wantSkips, result)
-			}
-			if !strings.Contains(strings.Join(result.Warnings, "\n"), "target loops through symlinks") {
-				t.Fatalf("expected symlink loop warning, got %#v", result.Warnings)
-			}
+			assertJVMSourceScanSkipsSymlinkLoop(t, test)
 		})
+	}
+}
+
+type jvmSymlinkLoopTest struct {
+	name      string
+	wantSkips int
+	buildLoop func(*testing.T, string)
+}
+
+func buildJVMSelfSymlinkLoop(t *testing.T, repo string) {
+	t.Helper()
+	loopPath := filepath.Join(repo, "Loop.java")
+	if err := os.Symlink(filepath.Base(loopPath), loopPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+}
+
+func buildJVMMultiSymlinkLoop(t *testing.T, repo string) {
+	t.Helper()
+	first := filepath.Join(repo, "LoopA.java")
+	second := filepath.Join(repo, "LoopB.java")
+	if err := os.Symlink(filepath.Base(second), first); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if err := os.Symlink(filepath.Base(first), second); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+}
+
+func assertJVMSourceScanSkipsSymlinkLoop(t *testing.T, test jvmSymlinkLoopTest) {
+	t.Helper()
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, mainJavaFile), "class Main {}\n")
+	test.buildLoop(t, repo)
+
+	result, err := scanRepo(context.Background(), repo, nil, nil)
+	if err != nil {
+		t.Fatalf("expected symlink loop to be downgraded, got %v", err)
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != mainJavaFile {
+		t.Fatalf("expected regular JVM source to remain scannable, got %#v", result.Files)
+	}
+	if result.SkippedSymlinks != test.wantSkips {
+		t.Fatalf("expected %d skipped symlink loop(s), got %#v", test.wantSkips, result)
+	}
+	if !strings.Contains(strings.Join(result.Warnings, "\n"), "target is an untrusted symlink") {
+		t.Fatalf("expected pinned leaf-symlink warning, got %#v", result.Warnings)
+	}
+}
+
+func TestJVMSourceScanSkipsLeafSymlinkViaPinnedPathReader(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, mainJavaFile), "class Main {}\n")
+
+	outsideSource := filepath.Join(t.TempDir(), "Linked.java")
+	testutil.MustWriteFile(t, outsideSource, "class Linked {}\n")
+
+	sourceLink := filepath.Join(repo, "Linked.java")
+	if err := os.Symlink(outsideSource, sourceLink); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	root := openJVMTestRoot(t, repo)
+	if _, err := safeio.ReadFileWithinRootLimit(root, filepath.Base(sourceLink), maxScannableJVMSourceFile); !errors.Is(err, syscall.ELOOP) || !errors.Is(err, safeio.ErrTargetPathSymlink) {
+		t.Fatalf("expected actual symlink entry to classify as ELOOP and target symlink, got %v", err)
+	}
+
+	result, err := scanRepoWithinRoot(context.Background(), repo, root, nil, nil)
+	if err != nil {
+		t.Fatalf("expected leaf symlink read to be downgraded, got %v", err)
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != mainJavaFile {
+		t.Fatalf("expected regular JVM source to remain scannable, got %#v", result.Files)
+	}
+	if result.SkippedSymlinks != 1 {
+		t.Fatalf("expected one skipped symlink, got %#v", result)
+	}
+	wantWarnings := []string{
+		"skipped JVM source symlink Linked.java: target is an untrusted symlink",
+		"skipped 1 unreadable or untrusted JVM source symlink(s)",
+	}
+	if len(result.Warnings) != len(wantWarnings) || result.Warnings[0] != wantWarnings[0] || result.Warnings[1] != wantWarnings[1] {
+		t.Fatalf("expected exact leaf-symlink warnings %#v, got %#v", wantWarnings, result.Warnings)
 	}
 }
 
@@ -365,7 +404,7 @@ func TestJVMClassifySkippableSourceReadErrorRejectsRegularFiles(t *testing.T) {
 			regularSource := filepath.Join(repo, "Regular.java")
 			testutil.MustWriteFile(t, regularSource, "class Regular {}\n")
 
-			warning, skip := classifySkippableJVMSourceReadError(repo, regularSource, test.err)
+			warning, skip := classifySkippableJVMSourceReadError(repo, regularSource, nil, test.err)
 			if skip || warning != "" {
 				t.Fatalf("expected regular-file read errors to propagate, warning=%q skip=%v", warning, skip)
 			}
@@ -377,7 +416,7 @@ func TestJVMClassifySkippableSourceReadErrorClassifiesRepoEscapeSentinel(t *test
 	repo := t.TempDir()
 	sourceLink := createJVMSourceSymlink(t, repo, "EscapesRoot.java")
 
-	warning, skip := classifySkippableJVMSourceReadError(repo, sourceLink, errors.New("path escapes root: /private/tmp/outside.java"))
+	warning, skip := classifySkippableJVMSourceReadError(repo, sourceLink, mustReadJVMSourceDirEntry(t, repo, filepath.Base(sourceLink)), safeio.ErrPathEscapesRoot)
 	if !skip {
 		t.Fatalf("expected repo-escape sentinel error to be downgraded for source symlink")
 	}
@@ -390,10 +429,10 @@ func TestJVMClassifySkippableSourceReadErrorClassifiesParentEscapePathError(t *t
 	repo := t.TempDir()
 	sourceLink := createJVMSourceSymlink(t, repo, "EscapesParent.java")
 
-	warning, skip := classifySkippableJVMSourceReadError(repo, sourceLink, &fs.PathError{
+	warning, skip := classifySkippableJVMSourceReadError(repo, sourceLink, mustReadJVMSourceDirEntry(t, repo, filepath.Base(sourceLink)), &fs.PathError{
 		Op:   "openat",
 		Path: sourceLink,
-		Err:  errors.New("path escapes from parent"),
+		Err:  safeio.ErrPathEscapesRoot,
 	})
 	if !skip {
 		t.Fatalf("expected parent-escape path error to be downgraded for source symlink")
@@ -407,7 +446,7 @@ func TestJVMClassifySkippableSourceReadErrorIgnoresCanceledContext(t *testing.T)
 	repo := t.TempDir()
 	sourceLink := createJVMSourceSymlink(t, repo, "Canceled.java")
 
-	warning, skip := classifySkippableJVMSourceReadError(repo, sourceLink, context.Canceled)
+	warning, skip := classifySkippableJVMSourceReadError(repo, sourceLink, mustReadJVMSourceDirEntry(t, repo, filepath.Base(sourceLink)), context.Canceled)
 	if skip || warning != "" {
 		t.Fatalf("expected canceled reads not to be downgraded, warning=%q skip=%v", warning, skip)
 	}
@@ -431,6 +470,22 @@ func createJVMSourceSymlink(t *testing.T, repo, name string) string {
 		t.Skipf("symlink not supported: %v", err)
 	}
 	return sourceLink
+}
+
+func mustReadJVMSourceDirEntry(t *testing.T, repo, name string) fs.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read source repo dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return entry
+		}
+	}
+	t.Fatalf("expected %s entry", name)
+	return nil
 }
 
 func assertSkippedJVMSourceReadError(t *testing.T, name string, readErr error, wantWarning string) {

--- a/internal/lang/jvm/adapter_scan_error_paths_test.go
+++ b/internal/lang/jvm/adapter_scan_error_paths_test.go
@@ -3,6 +3,7 @@ package jvm
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -236,6 +237,146 @@ func TestJVMScanCallbackAndParseBranches(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected scanRepo error for missing path")
 	}
+}
+
+func TestJVMSourceScanSkipsExpectedSymlinkReadErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		readErr     error
+		wantWarning string
+	}{
+		{
+			name:        "missing target",
+			readErr:     &fs.PathError{Op: "openat", Path: "Missing.java", Err: fs.ErrNotExist},
+			wantWarning: "target missing",
+		},
+		{
+			name:        "unreadable target",
+			readErr:     &fs.PathError{Op: "openat", Path: "Unreadable.java", Err: fs.ErrPermission},
+			wantWarning: "target unreadable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo := t.TempDir()
+			sourceLink := createJVMSourceSymlink(t, repo, strings.ReplaceAll(test.name, " ", "-")+".java")
+			readSource := func(rootDir, targetPath string, maxBytes int64) ([]byte, error) {
+				if rootDir != repo || targetPath != sourceLink || maxBytes != maxScannableJVMSourceFile {
+					t.Fatalf("unexpected source read: root=%q path=%q limit=%d", rootDir, targetPath, maxBytes)
+				}
+				return nil, test.readErr
+			}
+			result, err := scanRepoWithSourceReader(context.Background(), repo, nil, nil, readSource)
+			if err != nil {
+				t.Fatalf("expected symlink read error to be skipped: %v", err)
+			}
+			if result.SkippedSymlinks != 1 {
+				t.Fatalf("expected one skipped symlink, got %#v", result)
+			}
+			warnings := strings.Join(result.Warnings, "\n")
+			if !strings.Contains(warnings, "skipped JVM source symlink") ||
+				!strings.Contains(warnings, test.wantWarning) ||
+				!strings.Contains(warnings, "skipped 1 unreadable or untrusted JVM source symlink(s)") {
+				t.Fatalf("expected symlink warnings for %s, got %#v", test.name, result.Warnings)
+			}
+		})
+	}
+}
+
+func TestJVMSourceScanPropagatesUnexpectedSymlinkReadFailure(t *testing.T) {
+	repo := t.TempDir()
+	sourceLink := createJVMSourceSymlink(t, repo, "Unexpected.java")
+	unexpectedErr := errors.New("injected unexpected JVM source read failure")
+
+	readSource := func(rootDir, targetPath string, maxBytes int64) ([]byte, error) {
+		if rootDir != repo || targetPath != sourceLink || maxBytes != maxScannableJVMSourceFile {
+			t.Fatalf("unexpected source read: root=%q path=%q limit=%d", rootDir, targetPath, maxBytes)
+		}
+		return nil, &fs.PathError{Op: "read", Path: targetPath, Err: unexpectedErr}
+	}
+	result, err := scanRepoWithSourceReader(context.Background(), repo, nil, nil, readSource)
+	if !errors.Is(err, unexpectedErr) {
+		t.Fatalf("expected unexpected symlink read failure to propagate, got %v", err)
+	}
+	if result.SkippedSymlinks != 0 || len(result.Warnings) != 0 {
+		t.Fatalf("expected no downgraded warning for unexpected read failure, got %#v", result)
+	}
+}
+
+func TestJVMClassifySkippableSourceReadErrorRequiresSymlink(t *testing.T) {
+	repo := t.TempDir()
+	regularSource := filepath.Join(repo, "Regular.java")
+	testutil.MustWriteFile(t, regularSource, "class Regular {}\n")
+
+	warning, skip := classifySkippableJVMSourceReadError(repo, regularSource, &fs.PathError{
+		Op:   "openat",
+		Path: regularSource,
+		Err:  fs.ErrPermission,
+	})
+	if skip || warning != "" {
+		t.Fatalf("expected regular files not to be downgraded as symlink skips, warning=%q skip=%v", warning, skip)
+	}
+}
+
+func TestJVMClassifySkippableSourceReadErrorClassifiesRepoEscapeSentinel(t *testing.T) {
+	repo := t.TempDir()
+	sourceLink := createJVMSourceSymlink(t, repo, "EscapesRoot.java")
+
+	warning, skip := classifySkippableJVMSourceReadError(repo, sourceLink, errors.New("path escapes root: /private/tmp/outside.java"))
+	if !skip {
+		t.Fatalf("expected repo-escape sentinel error to be downgraded for source symlink")
+	}
+	if !strings.Contains(warning, "skipped JVM source symlink EscapesRoot.java: target escapes repo root") {
+		t.Fatalf("expected repo-escape warning, got %q", warning)
+	}
+}
+
+func TestJVMClassifySkippableSourceReadErrorClassifiesParentEscapePathError(t *testing.T) {
+	repo := t.TempDir()
+	sourceLink := createJVMSourceSymlink(t, repo, "EscapesParent.java")
+
+	warning, skip := classifySkippableJVMSourceReadError(repo, sourceLink, &fs.PathError{
+		Op:   "openat",
+		Path: sourceLink,
+		Err:  errors.New("path escapes from parent"),
+	})
+	if !skip {
+		t.Fatalf("expected parent-escape path error to be downgraded for source symlink")
+	}
+	if !strings.Contains(warning, "skipped JVM source symlink EscapesParent.java: target escapes repo root") {
+		t.Fatalf("expected parent-escape warning, got %q", warning)
+	}
+}
+
+func TestJVMClassifySkippableSourceReadErrorIgnoresCanceledContext(t *testing.T) {
+	repo := t.TempDir()
+	sourceLink := createJVMSourceSymlink(t, repo, "Canceled.java")
+
+	warning, skip := classifySkippableJVMSourceReadError(repo, sourceLink, context.Canceled)
+	if skip || warning != "" {
+		t.Fatalf("expected canceled reads not to be downgraded, warning=%q skip=%v", warning, skip)
+	}
+}
+
+func TestJVMRelativeSourceScanPathReturnsOriginalWhenRelFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Outside.java")
+
+	relativePath := relativeSourceScanPath("relative-repo-root", path)
+	if relativePath != path {
+		t.Fatalf("expected rel fallback to preserve original path, got %q want %q", relativePath, path)
+	}
+}
+
+func createJVMSourceSymlink(t *testing.T, repo, name string) string {
+	t.Helper()
+	target := filepath.Join(repo, "source-target.txt")
+	testutil.MustWriteFile(t, target, "not scanned\n")
+	sourceLink := filepath.Join(repo, name)
+	if err := os.Symlink(filepath.Base(target), sourceLink); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	return sourceLink
 }
 
 func TestJVMAnalyseWarningAndErrorBranches(t *testing.T) {

--- a/internal/lang/jvm/adapter_seams_test.go
+++ b/internal/lang/jvm/adapter_seams_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestJVMSeamUnitsComposeForDeclaredDependencyUsage(t *testing.T) {
-	repo := t.TempDir()
+	repo := canonicalRepoPath(t)
 	writeJVMPomFile(t, repo, `
 <project>
   <dependencies>

--- a/internal/lang/jvm/adapter_test.go
+++ b/internal/lang/jvm/adapter_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
@@ -95,28 +96,16 @@ func TestAdapterAnalyseDependencyFromMavenDependencyManagement(t *testing.T) {
 	testutil.MustWriteFile(t, filepath.Join(repo, "src", "test", "java", "ManagedExampleTest.java"), `
 import org.junit.jupiter.api.Test;
 
-class ManagedExampleTest {
-  @Test
-  void runs() {}
-}
-`)
+	class ManagedExampleTest {
+	  @Test
+	  void runs() {}
+	}
+	`)
 
-	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
-		RepoPath:   repo,
-		Dependency: "junit-jupiter-api",
-	})
-	if err != nil {
-		t.Fatalf(errAnalyseFmt, err)
-	}
-	if len(reportData.Dependencies) != 1 {
-		t.Fatalf("expected one dependency report, got %d", len(reportData.Dependencies))
-	}
-	if reportData.Dependencies[0].UsedExportsCount == 0 {
-		t.Fatalf("expected managed Maven dependency usage to be recorded")
-	}
-	if strings.Contains(strings.Join(reportData.Warnings, "\n"), "unable to resolve managed Maven version") {
-		t.Fatalf("did not expect managed-version warning, got %#v", reportData.Warnings)
-	}
+	req := language.Request{RepoPath: repo, Dependency: "junit-jupiter-api"}
+	unexpectedWarning := "unable to resolve managed Maven version"
+	usageFailure := "expected managed Maven dependency usage to be recorded"
+	assertSingleUsedDependencyReportWithoutWarning(t, req, unexpectedWarning, usageFailure)
 }
 
 func TestAdapterAnalyseTopN(t *testing.T) {
@@ -169,27 +158,15 @@ dependencies {
 	testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "kotlin", testFileMainKT), `
 import okhttp3.OkHttpClient
 
-fun run() {
-  OkHttpClient()
-}
-`)
+	fun run() {
+	  OkHttpClient()
+	}
+	`)
 
-	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
-		RepoPath:   repo,
-		Dependency: "okhttp",
-	})
-	if err != nil {
-		t.Fatalf(errAnalyseFmt, err)
-	}
-	if len(reportData.Dependencies) != 1 {
-		t.Fatalf("expected one dependency report, got %d", len(reportData.Dependencies))
-	}
-	if reportData.Dependencies[0].UsedExportsCount == 0 {
-		t.Fatalf("expected catalog-backed dependency usage to be recorded")
-	}
-	if strings.Contains(strings.Join(reportData.Warnings, "\n"), "unable to resolve Gradle version catalog") {
-		t.Fatalf("did not expect unresolved catalog warning, got %#v", reportData.Warnings)
-	}
+	req := language.Request{RepoPath: repo, Dependency: "okhttp"}
+	unexpectedWarning := "unable to resolve Gradle version catalog"
+	usageFailure := "expected catalog-backed dependency usage to be recorded"
+	assertSingleUsedDependencyReportWithoutWarning(t, req, unexpectedWarning, usageFailure)
 }
 
 func TestAdapterMetadataAndDetect(t *testing.T) {
@@ -296,55 +273,42 @@ func TestAdapterAnalyseSkipsOversizedGradleManifest(t *testing.T) {
 }
 
 func TestAdapterAnalyseSkipsOversizedGradleCatalogInputs(t *testing.T) {
-	t.Run("oversized settings.gradle.kts", func(t *testing.T) {
-		repo := t.TempDir()
-		testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), `
+	for _, tc := range []struct {
+		name        string
+		oversized   string
+		warningText string
+	}{
+		{
+			name:        "oversized settings.gradle.kts",
+			oversized:   "settings.gradle.kts",
+			warningText: "unable to read settings.gradle.kts: file exceeds size limit",
+		},
+		{
+			name:        "oversized gradle/libs.versions.toml",
+			oversized:   filepath.Join("gradle", "libs.versions.toml"),
+			warningText: "unable to read gradle/libs.versions.toml: file exceeds size limit",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), `
 dependencies {
   implementation("com.squareup.okhttp3:okhttp:4.12.0")
 }
 `)
-		testutil.MustWriteFile(t, filepath.Join(repo, "settings.gradle.kts"), strings.Repeat("a", shared.GradleManifestByteLimit+1))
-		testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "kotlin", testFileMainKT), `
+			testutil.MustWriteFile(t, filepath.Join(repo, tc.oversized), strings.Repeat("a", shared.GradleManifestByteLimit+1))
+			testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "kotlin", testFileMainKT), `
 import okhttp3.OkHttpClient
 fun runClient() { OkHttpClient() }
 `)
 
-		reportData, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 5})
-		if err != nil {
-			t.Fatalf(errAnalyseFmt, err)
-		}
-		if !strings.Contains(strings.Join(reportData.Warnings, "\n"), "unable to read settings.gradle.kts: file exceeds size limit") {
-			t.Fatalf("expected oversized settings warning, got %#v", reportData.Warnings)
-		}
-		if len(reportData.Dependencies) != 1 || reportData.Dependencies[0].Name != "okhttp" || reportData.Dependencies[0].UsedExportsCount == 0 {
-			t.Fatalf("expected direct Gradle dependency analysis to continue, got %#v", reportData.Dependencies)
-		}
-	})
-
-	t.Run("oversized gradle/libs.versions.toml", func(t *testing.T) {
-		repo := t.TempDir()
-		testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), `
-dependencies {
-  implementation("com.squareup.okhttp3:okhttp:4.12.0")
-}
-`)
-		testutil.MustWriteFile(t, filepath.Join(repo, "gradle", "libs.versions.toml"), strings.Repeat("a", shared.GradleManifestByteLimit+1))
-		testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "kotlin", testFileMainKT), `
-import okhttp3.OkHttpClient
-fun runClient() { OkHttpClient() }
-`)
-
-		reportData, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 5})
-		if err != nil {
-			t.Fatalf(errAnalyseFmt, err)
-		}
-		if !strings.Contains(strings.Join(reportData.Warnings, "\n"), "unable to read gradle/libs.versions.toml: file exceeds size limit") {
-			t.Fatalf("expected oversized catalog warning, got %#v", reportData.Warnings)
-		}
-		if len(reportData.Dependencies) != 1 || reportData.Dependencies[0].Name != "okhttp" || reportData.Dependencies[0].UsedExportsCount == 0 {
-			t.Fatalf("expected direct Gradle dependency analysis to continue, got %#v", reportData.Dependencies)
-		}
-	})
+			reportData := analyseJVMReport(t, language.Request{RepoPath: repo, TopN: 5})
+			if !strings.Contains(strings.Join(reportData.Warnings, "\n"), tc.warningText) {
+				t.Fatalf("expected oversized manifest warning, got %#v", reportData.Warnings)
+			}
+			assertSingleDependencyUsage(t, reportData.Dependencies, "okhttp", "expected direct Gradle dependency analysis to continue")
+		})
+	}
 }
 
 func safeReadTooLargeMessage() string {
@@ -418,17 +382,7 @@ class Outside { void use() { SecretApi.call(); } }
 	}
 
 	adapter := NewAdapter()
-	first, err := adapter.Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 10})
-	if err != nil {
-		t.Fatalf("analyse first pass: %v", err)
-	}
-	second, err := adapter.Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 10})
-	if err != nil {
-		t.Fatalf("analyse second pass: %v", err)
-	}
-	if !reflect.DeepEqual(first.Dependencies, second.Dependencies) {
-		t.Fatalf("expected stable dependency reporting across runs")
-	}
+	first := analyseJVMReportTwiceAndRequireStableDependencies(t, adapter, language.Request{RepoPath: repo, TopN: 10})
 
 	warnings := strings.Join(first.Warnings, "\n")
 	if !strings.Contains(warnings, "skipped JVM source symlink src/main/java/Outside.java") {
@@ -485,18 +439,7 @@ fun runClient() { Client() }
 `)
 
 	adapter := NewAdapter()
-	first, err := adapter.Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 10})
-	if err != nil {
-		t.Fatalf("analyse first pass: %v", err)
-	}
-	second, err := adapter.Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 10})
-	if err != nil {
-		t.Fatalf("analyse second pass: %v", err)
-	}
-
-	if !reflect.DeepEqual(first.Dependencies, second.Dependencies) {
-		t.Fatalf("expected stable dependency reporting across runs")
-	}
+	first := analyseJVMReportTwiceAndRequireStableDependencies(t, adapter, language.Request{RepoPath: repo, TopN: 10})
 	names := make([]string, 0, len(first.Dependencies))
 	okhttpUsed := false
 	for _, dependency := range first.Dependencies {
@@ -524,5 +467,53 @@ func TestSourceLayoutModuleRootUsesInnermostSourceLayout(t *testing.T) {
 	want := filepath.Join(string(filepath.Separator), "tmp", "src", "workspace", "repo", "module")
 	if got := sourceLayoutModuleRoot(path); got != want {
 		t.Fatalf("unexpected source layout root: got %q want %q", got, want)
+	}
+}
+
+func analyseJVMReport(t *testing.T, req language.Request) report.Result {
+	t.Helper()
+
+	reportData, err := NewAdapter().Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf(errAnalyseFmt, err)
+	}
+	return reportData
+}
+
+func analyseJVMReportTwiceAndRequireStableDependencies(t *testing.T, adapter *Adapter, req language.Request) report.Result {
+	t.Helper()
+
+	first, err := adapter.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("analyse first pass: %v", err)
+	}
+	second, err := adapter.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("analyse second pass: %v", err)
+	}
+	if !reflect.DeepEqual(first.Dependencies, second.Dependencies) {
+		t.Fatalf("expected stable dependency reporting across runs")
+	}
+	return first
+}
+
+func assertSingleUsedDependencyReportWithoutWarning(t *testing.T, req language.Request, unexpectedWarning, usageFailure string) {
+	t.Helper()
+
+	reportData := analyseJVMReport(t, req)
+	assertSingleDependencyUsage(t, reportData.Dependencies, req.Dependency, usageFailure)
+	if strings.Contains(strings.Join(reportData.Warnings, "\n"), unexpectedWarning) {
+		t.Fatalf("did not expect %q warning, got %#v", unexpectedWarning, reportData.Warnings)
+	}
+}
+
+func assertSingleDependencyUsage(t *testing.T, dependencies []report.DependencyReport, wantName, failureMessage string) {
+	t.Helper()
+
+	if len(dependencies) != 1 {
+		t.Fatalf("expected one dependency report, got %d", len(dependencies))
+	}
+	if dependencies[0].Name != wantName || dependencies[0].UsedExportsCount == 0 {
+		t.Fatalf("%s, got %#v", failureMessage, dependencies)
 	}
 }

--- a/internal/lang/jvm/adapter_test.go
+++ b/internal/lang/jvm/adapter_test.go
@@ -2,12 +2,14 @@ package jvm
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
@@ -19,6 +21,7 @@ const (
 	testFileMainKT         = "Main.kt"
 	errDetectFmt           = "detect: %v"
 	errAnalyseFmt          = "analyse: %v"
+	errSymlinkFmt          = "symlink not supported: %v"
 )
 
 func TestAdapterDetectWithGradleAndJava(t *testing.T) {
@@ -228,6 +231,239 @@ func TestAdapterDetectWithMixedGradleMavenKotlinModules(t *testing.T) {
 	}
 	if !slices.Contains(detection.Roots, gradleModule) || !slices.Contains(detection.Roots, mavenModule) {
 		t.Fatalf("expected module roots in detection output, got %#v", detection.Roots)
+	}
+}
+
+func TestAdapterDetectRejectsEscapingSymlinkSignals(t *testing.T) {
+	t.Run("root gradle symlink", func(t *testing.T) {
+		repo := t.TempDir()
+		outside := filepath.Join(t.TempDir(), buildGradleName)
+		testutil.MustWriteFile(t, outside, "dependencies { implementation 'org.junit.jupiter:junit-jupiter-api:5.10.0' }\n")
+		if err := os.Symlink(outside, filepath.Join(repo, buildGradleName)); err != nil {
+			t.Skipf(errSymlinkFmt, err)
+		}
+
+		detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+		if err != nil {
+			t.Fatalf(errDetectFmt, err)
+		}
+		if detection.Matched {
+			t.Fatalf("expected escaping build.gradle symlink to be ignored, got %#v", detection)
+		}
+	})
+
+	t.Run("source symlink", func(t *testing.T) {
+		repo := t.TempDir()
+		outside := filepath.Join(t.TempDir(), testFileAppJava)
+		testutil.MustWriteFile(t, outside, "class App {}\n")
+		sourceLink := filepath.Join(repo, "src", "main", "java", testFileAppJava)
+		if err := os.MkdirAll(filepath.Dir(sourceLink), 0o755); err != nil {
+			t.Fatalf("mkdir source dir: %v", err)
+		}
+		if err := os.Symlink(outside, sourceLink); err != nil {
+			t.Skipf(errSymlinkFmt, err)
+		}
+
+		detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+		if err != nil {
+			t.Fatalf(errDetectFmt, err)
+		}
+		if detection.Matched {
+			t.Fatalf("expected escaping source symlink to be ignored, got %#v", detection)
+		}
+	})
+}
+
+func TestAdapterAnalyseSkipsOversizedGradleManifest(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), strings.Repeat("a", maxScannableJVMBuildFile+1))
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "java", testFileAppJava), "class App {}\n")
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath: repo,
+		TopN:     1,
+	})
+	if err != nil {
+		t.Fatalf(errAnalyseFmt, err)
+	}
+	warnings := strings.Join(reportData.Warnings, "\n")
+	if !strings.Contains(warnings, "unable to read build.gradle: "+safeReadTooLargeMessage()) {
+		t.Fatalf("expected oversized build warning, got %#v", reportData.Warnings)
+	}
+	if !strings.Contains(warnings, "no JVM dependencies discovered") {
+		t.Fatalf("expected dependency-discovery warning after oversized build skip, got %#v", reportData.Warnings)
+	}
+}
+
+func TestAdapterAnalyseSkipsOversizedGradleCatalogInputs(t *testing.T) {
+	t.Run("oversized settings.gradle.kts", func(t *testing.T) {
+		repo := t.TempDir()
+		testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), `
+dependencies {
+  implementation("com.squareup.okhttp3:okhttp:4.12.0")
+}
+`)
+		testutil.MustWriteFile(t, filepath.Join(repo, "settings.gradle.kts"), strings.Repeat("a", shared.GradleManifestByteLimit+1))
+		testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "kotlin", testFileMainKT), `
+import okhttp3.OkHttpClient
+fun runClient() { OkHttpClient() }
+`)
+
+		reportData, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 5})
+		if err != nil {
+			t.Fatalf(errAnalyseFmt, err)
+		}
+		if !strings.Contains(strings.Join(reportData.Warnings, "\n"), "unable to read settings.gradle.kts: file exceeds size limit") {
+			t.Fatalf("expected oversized settings warning, got %#v", reportData.Warnings)
+		}
+		if len(reportData.Dependencies) != 1 || reportData.Dependencies[0].Name != "okhttp" || reportData.Dependencies[0].UsedExportsCount == 0 {
+			t.Fatalf("expected direct Gradle dependency analysis to continue, got %#v", reportData.Dependencies)
+		}
+	})
+
+	t.Run("oversized gradle/libs.versions.toml", func(t *testing.T) {
+		repo := t.TempDir()
+		testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), `
+dependencies {
+  implementation("com.squareup.okhttp3:okhttp:4.12.0")
+}
+`)
+		testutil.MustWriteFile(t, filepath.Join(repo, "gradle", "libs.versions.toml"), strings.Repeat("a", shared.GradleManifestByteLimit+1))
+		testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "kotlin", testFileMainKT), `
+import okhttp3.OkHttpClient
+fun runClient() { OkHttpClient() }
+`)
+
+		reportData, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 5})
+		if err != nil {
+			t.Fatalf(errAnalyseFmt, err)
+		}
+		if !strings.Contains(strings.Join(reportData.Warnings, "\n"), "unable to read gradle/libs.versions.toml: file exceeds size limit") {
+			t.Fatalf("expected oversized catalog warning, got %#v", reportData.Warnings)
+		}
+		if len(reportData.Dependencies) != 1 || reportData.Dependencies[0].Name != "okhttp" || reportData.Dependencies[0].UsedExportsCount == 0 {
+			t.Fatalf("expected direct Gradle dependency analysis to continue, got %#v", reportData.Dependencies)
+		}
+	})
+}
+
+func safeReadTooLargeMessage() string {
+	return "file exceeds size limit"
+}
+
+func TestJVMSourceScanSkipsOversizedFiles(t *testing.T) {
+	repo := t.TempDir()
+	writeJVMPomFile(t, repo, `
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.10.0</version>
+    </dependency>
+  </dependencies>
+</project>
+`)
+	largeSource := filepath.Join(repo, "src", "main", "java", testFileAppJava)
+	testutil.MustWriteFile(t, largeSource, strings.Repeat("a", maxScannableJVMSourceFile+1))
+
+	result, err := scanRepo(context.Background(), repo, map[string]string{}, map[string]string{})
+	if err != nil {
+		t.Fatalf("scan repo: %v", err)
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("expected oversized source to be skipped, got %#v", result.Files)
+	}
+	if !strings.Contains(strings.Join(result.Warnings, "\n"), "skipped 1 large JVM file(s) above") {
+		t.Fatalf("expected oversized-source warning, got %#v", result.Warnings)
+	}
+}
+
+func TestJVMGuardedReadsRejectEscapingSymlinks(t *testing.T) {
+	repo := t.TempDir()
+	outsideDir := t.TempDir()
+
+	outsideGradle := filepath.Join(outsideDir, buildGradleName)
+	testutil.MustWriteFile(t, outsideGradle, "dependencies { implementation 'org.junit.jupiter:junit-jupiter-api:5.10.0' }\n")
+	if err := os.Symlink(outsideGradle, filepath.Join(repo, buildGradleName)); err != nil {
+		t.Skipf(errSymlinkFmt, err)
+	}
+	_, warnings := parseGradleDependenciesWithWarnings(repo)
+	if len(warnings) == 0 || !strings.Contains(strings.Join(warnings, "\n"), buildGradleName) {
+		t.Fatalf("expected escaping build.gradle symlink warning, got %#v", warnings)
+	}
+}
+
+func TestAdapterAnalyseSkipsEscapingSourceSymlinkWithoutConsumingExternalContent(t *testing.T) {
+	repo := t.TempDir()
+	outsideDir := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), `
+dependencies {
+  implementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
+  implementation("com.outside:secret:1.0.0")
+}
+`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "java", testFileAppJava), `
+import org.junit.jupiter.api.Assertions;
+class App { void run() { Assertions.assertTrue(true); } }
+`)
+	outsideSource := filepath.Join(outsideDir, "Outside.java")
+	testutil.MustWriteFile(t, outsideSource, `
+import com.outside.SecretApi;
+class Outside { void use() { SecretApi.call(); } }
+`)
+	sourceLink := filepath.Join(repo, "src", "main", "java", "Outside.java")
+	if err := os.Symlink(outsideSource, sourceLink); err != nil {
+		t.Skipf(errSymlinkFmt, err)
+	}
+
+	adapter := NewAdapter()
+	first, err := adapter.Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 10})
+	if err != nil {
+		t.Fatalf("analyse first pass: %v", err)
+	}
+	second, err := adapter.Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 10})
+	if err != nil {
+		t.Fatalf("analyse second pass: %v", err)
+	}
+	if !reflect.DeepEqual(first.Dependencies, second.Dependencies) {
+		t.Fatalf("expected stable dependency reporting across runs")
+	}
+
+	warnings := strings.Join(first.Warnings, "\n")
+	if !strings.Contains(warnings, "skipped JVM source symlink src/main/java/Outside.java") {
+		t.Fatalf("expected source symlink skip warning, got %#v", first.Warnings)
+	}
+	if !strings.Contains(warnings, "skipped 1 unreadable or untrusted JVM source symlink(s)") {
+		t.Fatalf("expected source symlink skip counter, got %#v", first.Warnings)
+	}
+
+	usageByDep := map[string]int{}
+	for _, dependency := range first.Dependencies {
+		usageByDep[dependency.Name] = dependency.UsedExportsCount
+	}
+	if usageByDep["junit-jupiter-api"] == 0 {
+		t.Fatalf("expected in-repo dependency usage to be preserved, got %#v", first.Dependencies)
+	}
+	if usageByDep["secret"] != 0 {
+		t.Fatalf("expected escaping source symlink content to be ignored, got %#v", first.Dependencies)
+	}
+}
+
+func TestJVMSourceReadEmptyRepoPathStillBoundsLargeFiles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), testFileAppJava)
+	testutil.MustWriteFile(t, path, strings.Repeat("a", maxScannableJVMSourceFile+1))
+
+	result := &scanResult{}
+	err := scanJVMSourceFile("", path, nil, nil, result)
+	if err != nil {
+		t.Fatalf("expected bounded empty-root source scan to skip, got %v", err)
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("expected no scanned files from oversized empty-root source")
+	}
+	if result.SkippedLargeFiles != 1 {
+		t.Fatalf("expected one skipped large file, got %#v", result)
 	}
 }
 

--- a/internal/lang/jvm/build_parsing.go
+++ b/internal/lang/jvm/build_parsing.go
@@ -470,7 +470,7 @@ func parseBuildFileEntry(repoPath string, path string, entry fs.DirEntry, names 
 		return nil
 	}
 
-	content, err := safeio.ReadFileUnder(repoPath, path)
+	content, err := safeio.ReadFileUnderLimit(repoPath, path, maxScannableJVMBuildFile)
 	if err != nil {
 		return nil
 	}
@@ -507,7 +507,7 @@ func (c *buildFileWarningCollector) visit(path string, entry fs.DirEntry, err er
 	if !matchesBuildFile(strings.ToLower(entry.Name()), c.names) {
 		return nil
 	}
-	content, readErr := safeio.ReadFileUnder(c.repoPath, path)
+	content, readErr := safeio.ReadFileUnderLimit(c.repoPath, path, maxScannableJVMBuildFile)
 	if readErr != nil {
 		c.warnings = append(c.warnings, formatBuildFileReadWarning(c.repoPath, path, readErr))
 		return nil

--- a/internal/lang/jvm/build_parsing.go
+++ b/internal/lang/jvm/build_parsing.go
@@ -1,6 +1,7 @@
 package jvm
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io/fs"
@@ -71,6 +72,16 @@ func collectDeclaredDependencies(repoPath string) ([]dependencyDescriptor, map[s
 	return descriptors, prefixes, aliases, warnings
 }
 
+func collectDeclaredDependenciesWithinRoot(ctx context.Context, repoPath string, root safeio.Root) ([]dependencyDescriptor, map[string]string, map[string]string, []string, error) {
+	descriptors, warnings, err := collectBuildDescriptorsWithinRoot(ctx, repoPath, root)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	descriptors = dedupeAndSortDescriptors(descriptors)
+	prefixes, aliases := buildDescriptorLookups(descriptors)
+	return descriptors, prefixes, aliases, warnings, nil
+}
+
 func collectBuildDescriptors(repoPath string) ([]dependencyDescriptor, []string) {
 	catalogResolver, warnings := shared.LoadGradleCatalogResolver(repoPath)
 	buildParser := func(path, content string) ([]dependencyDescriptor, []string) {
@@ -96,6 +107,39 @@ func collectBuildDescriptors(repoPath string) ([]dependencyDescriptor, []string)
 	descriptors, parseWarnings := parseBuildFilesWithWarnings(repoPath, buildParser, pomXMLName, buildGradleName, buildGradleKTSName)
 	warnings = append(warnings, parseWarnings...)
 	return descriptors, shared.DedupeWarnings(warnings)
+}
+
+func collectBuildDescriptorsWithinRoot(ctx context.Context, repoPath string, root safeio.Root) ([]dependencyDescriptor, []string, error) {
+	catalogResolver, warnings, err := shared.LoadGradleCatalogResolverWithinRoot(ctx, repoPath, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	buildParser := func(path, content string) ([]dependencyDescriptor, []string) {
+		switch strings.ToLower(filepath.Base(path)) {
+		case pomXMLName:
+			return parsePomDependencyContent(relativeBuildFilePath(repoPath, path), content)
+		case buildGradleName, buildGradleKTSName:
+			descriptors := parseGradleDependencyContent(path, content)
+			catalogDescriptors, catalogWarnings := catalogResolver.ParseDependencyReferences(path, content)
+			for _, descriptor := range catalogDescriptors {
+				descriptors = append(descriptors, dependencyDescriptor{
+					Name:     descriptor.Artifact,
+					Group:    descriptor.Group,
+					Artifact: descriptor.Artifact,
+				})
+			}
+			return dedupeAndSortDescriptors(descriptors), catalogWarnings
+		default:
+			return nil, nil
+		}
+	}
+
+	descriptors, parseWarnings, err := parseBuildFilesWithWarningsWithinRoot(ctx, repoPath, root, buildParser, pomXMLName, buildGradleName, buildGradleKTSName)
+	if err != nil {
+		return nil, nil, err
+	}
+	warnings = append(warnings, parseWarnings...)
+	return descriptors, shared.DedupeWarnings(warnings), nil
 }
 
 func dedupeAndSortDescriptors(descriptors []dependencyDescriptor) []dependencyDescriptor {
@@ -458,6 +502,34 @@ func parseBuildFilesWithWarnings(repoPath string, parser func(path, content stri
 	return collector.descriptors, shared.DedupeWarnings(collector.warnings)
 }
 
+func parseBuildFilesWithWarningsWithinRoot(ctx context.Context, repoPath string, root safeio.Root, parser func(path, content string) ([]dependencyDescriptor, []string), names ...string) ([]dependencyDescriptor, []string, error) {
+	collector := buildFileWarningCollector{
+		repoPath: repoPath,
+		parser:   parser,
+		names:    names,
+		seen:     make(map[string]struct{}),
+	}
+	budget := shared.RootedWalkBudget{
+		MaxTraversalEntries: maxJVMBuildTraversalEntries,
+		MaxFiles:            maxJVMBuildFiles,
+		MaxWorkItems:        maxJVMBuildWorkItems,
+		CountCandidate: func(path string, entry fs.DirEntry) bool {
+			return matchesBuildFile(strings.ToLower(entry.Name()), names)
+		},
+	}
+	err := shared.WalkRepoFilesWithinRootPinned(ctx, repoPath, root, budget, shouldSkipDir, func(file shared.RootedWalkFile) error {
+		return collector.visitWithinRoot(file.Parent, file.Leaf, file.Path, file.Entry)
+	})
+	if err != nil {
+		if warning, limited := shared.RootedWalkBudgetWarning("JVM build file scan", budget, err); limited {
+			collector.warnings = append(collector.warnings, warning)
+		} else {
+			return nil, nil, err
+		}
+	}
+	return collector.descriptors, shared.DedupeWarnings(collector.warnings), nil
+}
+
 func parseBuildFileEntry(repoPath string, path string, entry fs.DirEntry, names []string, parser func(content string) []dependencyDescriptor, seen map[string]struct{}, descriptors *[]dependencyDescriptor) error {
 	if entry.IsDir() {
 		if shouldSkipDir(entry.Name()) {
@@ -523,6 +595,50 @@ func (c *buildFileWarningCollector) visit(path string, entry fs.DirEntry, err er
 		c.descriptors = append(c.descriptors, descriptor)
 	}
 	return nil
+}
+
+func (c *buildFileWarningCollector) visitWithinRoot(parent safeio.Root, leaf, path string, entry fs.DirEntry) error {
+	if !matchesBuildFile(strings.ToLower(entry.Name()), c.names) {
+		return nil
+	}
+	content, readErr := safeio.ReadFileWithinRootLimit(parent, leaf, maxScannableJVMBuildFile)
+	if readErr != nil {
+		if !isPureJVMBuildFileReadWarning(readErr) {
+			return readErr
+		}
+		c.warnings = append(c.warnings, formatBuildFileReadWarning(c.repoPath, path, readErr))
+		return nil
+	}
+	items, parseWarnings := c.parser(path, string(content))
+	c.warnings = append(c.warnings, parseWarnings...)
+	for _, descriptor := range items {
+		key := descriptor.Group + ":" + descriptor.Artifact
+		if _, ok := c.seen[key]; ok {
+			continue
+		}
+		c.seen[key] = struct{}{}
+		c.descriptors = append(c.descriptors, descriptor)
+	}
+	return nil
+}
+
+func isPureJVMBuildFileReadWarning(err error) bool {
+	allowed := []error{
+		safeio.ErrFileTooLarge,
+		safeio.ErrTargetPathSymlink,
+		safeio.ErrPathEscapesRoot,
+		fs.ErrNotExist,
+		fs.ErrPermission,
+	}
+	return shared.IsPureSentinelError(err, allowed...)
+}
+
+func readJVMBuildFileWithinRoot(root safeio.Root, repoPath, path string) ([]byte, error) {
+	relativePath, err := filepath.Rel(repoPath, path)
+	if err != nil {
+		return nil, err
+	}
+	return safeio.ReadFileWithinRootLimit(root, relativePath, maxScannableJVMBuildFile)
 }
 
 func formatBuildFileReadWarning(repoPath, path string, err error) string {

--- a/internal/lang/jvm/detection.go
+++ b/internal/lang/jvm/detection.go
@@ -44,12 +44,12 @@ func walkJVMDetectionEntry(repoPath, path string, entry fs.DirEntry, roots map[s
 		}
 		return nil
 	}
+	if !shared.IsPathWithin(repoPath, path) {
+		return nil
+	}
 	(*visited)++
 	if *visited > maxFiles {
 		return fs.SkipAll
-	}
-	if !shared.IsPathWithin(repoPath, path) {
-		return nil
 	}
 	updateJVMDetection(path, entry, roots, detection)
 	return nil

--- a/internal/lang/jvm/detection.go
+++ b/internal/lang/jvm/detection.go
@@ -3,64 +3,436 @@ package jvm
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
-func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (language.Detection, error) {
+var (
+	errJVMDetectionTraversalLimit = errors.New("jvm detection traversal limit exceeded")
+	afterJVMDetectRootSignals     = func(string) error { return nil }
+	openJVMDetectionRootHook      = openJVMDetectionRoot
+)
+
+func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (detection language.Detection, err error) {
 	_ = ctx
 	repoPath = shared.DefaultRepoPath(repoPath)
 
-	detection := language.Detection{}
+	detection = language.Detection{}
 	roots := make(map[string]struct{})
-	if err := applyJVMRootSignals(repoPath, &detection, roots); err != nil {
+	root, err := openJVMDetectionRootHook(repoPath)
+	if err != nil {
+		return language.Detection{}, err
+	}
+	defer func() {
+		err = errors.Join(err, root.Close())
+	}()
+
+	if err := applyJVMRootSignalsWithinRoot(repoPath, root, &detection, roots); err != nil {
+		return language.Detection{}, err
+	}
+	if err := afterJVMDetectRootSignals(repoPath); err != nil {
 		return language.Detection{}, err
 	}
 
-	const maxFiles = 1024
-	visited := 0
-	err := filepath.WalkDir(repoPath, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		return walkJVMDetectionEntry(repoPath, path, entry, roots, &detection, &visited, maxFiles)
-	})
-	if err != nil && !errors.Is(err, fs.SkipAll) {
+	budget := defaultJVMDetectionBudget()
+	walker := newJVMDetectionWalker(repoPath, roots, &detection, budget)
+	err = walker.walkPinned(root)
+	if err != nil && !shared.IsPureSentinelError(err, fs.SkipAll, errJVMDetectionTraversalLimit) {
 		return language.Detection{}, err
 	}
 
 	return shared.FinalizeDetection(repoPath, detection, roots), nil
 }
 
-func walkJVMDetectionEntry(repoPath, path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection, visited *int, maxFiles int) error {
+type jvmDetectionBudget struct {
+	maxTraversalEntries    int
+	maxConfinedCandidates  int
+	traversalEntriesSeen   int
+	traversalEntriesQueued int
+	confinedCandidatesSeen int
+}
+
+const (
+	// The traversal limit counts the root plus every queued or visited entry.
+	// Four times the candidate limit leaves headroom for rejected entries.
+	defaultJVMMaxTraversalEntries   = 4096
+	defaultJVMMaxConfinedCandidates = 1024
+	// ReadDir allocations stay fixed-size except for the final remaining budget.
+	jvmDetectionReadBatchSize = 128
+)
+
+func defaultJVMDetectionBudget() *jvmDetectionBudget {
+	return &jvmDetectionBudget{
+		maxTraversalEntries:   defaultJVMMaxTraversalEntries,
+		maxConfinedCandidates: defaultJVMMaxConfinedCandidates,
+	}
+}
+
+func (b *jvmDetectionBudget) countTraversalEntry() error {
+	if b.traversalBudgetExhausted() {
+		return errJVMDetectionTraversalLimit
+	}
+	b.traversalEntriesSeen++
+	return nil
+}
+
+func (b *jvmDetectionBudget) traversalReadSize() int {
+	if b.maxTraversalEntries <= 0 {
+		return jvmDetectionReadBatchSize
+	}
+	remaining := b.maxTraversalEntries - b.totalTraversalEntries()
+	return min(jvmDetectionReadBatchSize, max(remaining, 0))
+}
+
+func (b *jvmDetectionBudget) queueTraversalEntries(count int) bool {
+	if count < 0 || (b.maxTraversalEntries > 0 && b.totalTraversalEntries()+count > b.maxTraversalEntries) {
+		return false
+	}
+	b.traversalEntriesQueued += count
+	return true
+}
+
+func (b *jvmDetectionBudget) dequeueTraversalEntry() bool {
+	if b.traversalEntriesQueued == 0 {
+		return false
+	}
+	b.traversalEntriesQueued--
+	return true
+}
+
+func (b *jvmDetectionBudget) traversalBudgetExhausted() bool {
+	return b.maxTraversalEntries > 0 && b.totalTraversalEntries() >= b.maxTraversalEntries
+}
+
+func (b *jvmDetectionBudget) totalTraversalEntries() int {
+	return b.traversalEntriesSeen + b.traversalEntriesQueued
+}
+
+func (b *jvmDetectionBudget) countConfinedCandidate() error {
+	b.confinedCandidatesSeen++
+	if b.maxConfinedCandidates > 0 && b.confinedCandidatesSeen > b.maxConfinedCandidates {
+		return fs.SkipAll
+	}
+	return nil
+}
+
+type jvmDetectionDirectory interface {
+	ReadDir(count int) ([]fs.DirEntry, error)
+	Stat() (fs.FileInfo, error)
+	Close() error
+}
+
+type jvmDetectionRoot interface {
+	Open(name string) (jvmDetectionDirectory, error)
+	OpenRoot(name string) (jvmDetectionRoot, error)
+	Lstat(name string) (fs.FileInfo, error)
+	Close() error
+}
+
+type jvmRootSignalReader interface {
+	Lstat(name string) (fs.FileInfo, error)
+	Close() error
+}
+
+type jvmDetectionWalker struct {
+	repoPath      string
+	roots         map[string]struct{}
+	detection     *language.Detection
+	budget        *jvmDetectionBudget
+	openRoot      func(string) (jvmDetectionRoot, error)
+	openDirectory func(jvmDetectionRoot, string) (jvmDetectionDirectory, error)
+}
+
+func newJVMDetectionWalker(repoPath string, roots map[string]struct{}, detection *language.Detection, budget *jvmDetectionBudget) *jvmDetectionWalker {
+	return &jvmDetectionWalker{
+		repoPath:      repoPath,
+		roots:         roots,
+		detection:     detection,
+		budget:        budget,
+		openRoot:      openJVMDetectionRoot,
+		openDirectory: openJVMDetectionDirectory,
+	}
+}
+
+type osJVMDetectionRoot struct {
+	root safeio.Root
+}
+
+func openJVMDetectionRoot(path string) (jvmDetectionRoot, error) {
+	root, err := safeio.OpenRootNoFollow(path)
+	if err != nil {
+		return nil, err
+	}
+	return &osJVMDetectionRoot{root: root}, nil
+}
+
+func (r *osJVMDetectionRoot) Open(name string) (jvmDetectionDirectory, error) {
+	file, err := safeio.OpenPinnedDirectory(r.root, name)
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func (r *osJVMDetectionRoot) OpenRoot(name string) (jvmDetectionRoot, error) {
+	root, err := r.root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	return &osJVMDetectionRoot{root: root}, nil
+}
+
+func (r *osJVMDetectionRoot) Lstat(name string) (fs.FileInfo, error) {
+	return r.root.Lstat(name)
+}
+
+func (r *osJVMDetectionRoot) Close() error {
+	return r.root.Close()
+}
+
+func openJVMDetectionDirectory(root jvmDetectionRoot, path string) (jvmDetectionDirectory, error) {
+	return root.Open(path)
+}
+
+func (w *jvmDetectionWalker) walk() (returnErr error) {
+	root, err := w.openRoot(w.repoPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, root.Close())
+	}()
+
+	return w.walkPinned(root)
+}
+
+func (w *jvmDetectionWalker) walkPinned(root jvmDetectionRoot) error {
+	info, err := root.Lstat(".")
+	if err != nil {
+		return err
+	}
+	return w.walkEntry(root, w.repoPath, fs.FileInfoToDirEntry(info))
+}
+
+func (w *jvmDetectionWalker) walkEntry(root jvmDetectionRoot, path string, entry fs.DirEntry) error {
+	err := walkJVMDetectionEntry(w.repoPath, path, entry, w.roots, w.detection, w.budget)
+	if errors.Is(err, filepath.SkipDir) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !entry.IsDir() {
+		return nil
+	}
+	return w.walkDirectory(root, path, ".")
+}
+
+func (w *jvmDetectionWalker) walkDirectory(root jvmDetectionRoot, path, relativePath string) error {
+	entries, err := w.readDirectory(root, path)
+	if err != nil {
+		return err
+	}
+	for _, child := range entries {
+		if !w.budget.dequeueTraversalEntry() {
+			return fs.ErrInvalid
+		}
+		childPath := filepath.Join(path, child.Name())
+		err := walkJVMDetectionEntry(w.repoPath, childPath, child, w.roots, w.detection, w.budget)
+		if errors.Is(err, filepath.SkipDir) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if !child.IsDir() {
+			continue
+		}
+
+		childRelativePath := filepath.Join(relativePath, child.Name())
+		childRoot, err := openJVMDetectionChildRoot(root, child.Name(), childRelativePath)
+		if err != nil {
+			return err
+		}
+		walkErr := w.walkDirectory(childRoot, childPath, childRelativePath)
+		if err := errors.Join(walkErr, childRoot.Close()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *jvmDetectionWalker) readDirectory(root jvmDetectionRoot, path string) ([]fs.DirEntry, error) {
+	directory, err := w.openDirectory(root, ".")
+	if err != nil {
+		return nil, err
+	}
+
+	entries, readErr := w.readDirectoryEntries(path, directory)
+	closeErr := directory.Close()
+	if err := errors.Join(readErr, closeErr); err != nil {
+		return nil, err
+	}
+	// Only complete directories are sorted and processed.
+	slices.SortFunc(entries, func(left, right fs.DirEntry) int {
+		return strings.Compare(left.Name(), right.Name())
+	})
+	return entries, nil
+}
+
+func openJVMDetectionChildRoot(root jvmDetectionRoot, name, path string) (jvmDetectionRoot, error) {
+	info, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("root contains symlink: %s", path)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("root is not a directory: %s", path)
+	}
+
+	child, err := root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := child.Lstat(".")
+	if err != nil {
+		return nil, errors.Join(err, child.Close())
+	}
+	if !os.SameFile(info, openedInfo) {
+		return nil, errors.Join(fmt.Errorf("path changed while opening: %s", path), child.Close())
+	}
+	return child, nil
+}
+
+func (w *jvmDetectionWalker) readDirectoryEntries(path string, directory jvmDetectionDirectory) ([]fs.DirEntry, error) {
+	var entries []fs.DirEntry
+	for {
+		readSize := w.budget.traversalReadSize()
+		if readSize == 0 {
+			return entries, w.probeDirectoryLimit(path, directory)
+		}
+		batch, done, err := w.readDirectoryBatch(path, directory, readSize)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, batch...)
+		if done {
+			return entries, nil
+		}
+	}
+}
+
+func (w *jvmDetectionWalker) readDirectoryBatch(path string, directory jvmDetectionDirectory, readSize int) ([]fs.DirEntry, bool, error) {
+	batch, err := directory.ReadDir(readSize)
+	if len(batch) > readSize || !w.budget.queueTraversalEntries(len(batch)) {
+		return nil, false, jvmDetectionReadLimitError(path, w.budget.maxTraversalEntries, err)
+	}
+	if shared.IsPureSentinelError(err, io.EOF) {
+		return batch, true, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if len(batch) == 0 {
+		return nil, false, io.ErrNoProgress
+	}
+	return batch, false, nil
+}
+
+func jvmDetectionReadLimitError(path string, limit int, readErr error) error {
+	limitErr := newJVMDetectionTraversalLimitError(path, limit)
+	if readErr != nil && !shared.IsPureSentinelError(readErr, io.EOF) {
+		return errors.Join(limitErr, readErr)
+	}
+	return limitErr
+}
+
+func (w *jvmDetectionWalker) probeDirectoryLimit(path string, directory jvmDetectionDirectory) error {
+	entries, err := directory.ReadDir(1)
+	if len(entries) > 0 {
+		limitErr := newJVMDetectionTraversalLimitError(path, w.budget.maxTraversalEntries)
+		if err != nil && !shared.IsPureSentinelError(err, io.EOF) {
+			return errors.Join(limitErr, err)
+		}
+		return limitErr
+	}
+	if shared.IsPureSentinelError(err, io.EOF) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return io.ErrNoProgress
+}
+
+func newJVMDetectionTraversalLimitError(path string, limit int) error {
+	return fmt.Errorf("%w at %q (maximum entries: %d)", errJVMDetectionTraversalLimit, path, limit)
+}
+
+func walkJVMDetectionEntry(repoPath, path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection, budget *jvmDetectionBudget) error {
+	if err := budget.countTraversalEntry(); err != nil {
+		return newJVMDetectionTraversalLimitError(path, budget.maxTraversalEntries)
+	}
 	if entry.IsDir() {
 		if shouldSkipDir(entry.Name()) {
 			return filepath.SkipDir
 		}
 		return nil
 	}
-	if !shared.IsPathWithin(repoPath, path) {
+	if entry.Type()&os.ModeSymlink != 0 {
 		return nil
 	}
-	(*visited)++
-	if *visited > maxFiles {
-		return fs.SkipAll
+	if !isJVMDetectionCandidate(path, entry) {
+		return nil
+	}
+	if err := budget.countConfinedCandidate(); err != nil {
+		return err
 	}
 	updateJVMDetection(path, entry, roots, detection)
 	return nil
 }
 
-func applyJVMRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
+func isJVMDetectionCandidate(path string, entry fs.DirEntry) bool {
+	name := strings.ToLower(entry.Name())
+	if name == pomXMLName || name == buildGradleName || name == buildGradleKTSName {
+		return true
+	}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".java", ".kt", ".kts":
+		return true
+	default:
+		return false
+	}
+}
+
+func applyJVMRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) (err error) {
+	root, err := safeio.OpenRootNoFollow(repoPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, root.Close())
+	}()
+
+	return applyJVMRootSignalsWithinRoot(repoPath, root, detection, roots)
+}
+
+func applyJVMRootSignalsWithinRoot(repoPath string, root jvmRootSignalReader, detection *language.Detection, roots map[string]struct{}) error {
 	for _, signal := range jvmRootSignals {
-		path := filepath.Join(repoPath, signal.Name)
-		info, err := os.Stat(path)
-		if err == nil {
-			if info.IsDir() || !shared.IsPathWithin(repoPath, path) {
+		info, signalErr := root.Lstat(signal.Name)
+		if signalErr == nil {
+			if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 				continue
 			}
 			if detection != nil {
@@ -72,8 +444,8 @@ func applyJVMRootSignals(repoPath string, detection *language.Detection, roots m
 			}
 			continue
 		}
-		if !os.IsNotExist(err) {
-			return err
+		if !os.IsNotExist(signalErr) {
+			return signalErr
 		}
 	}
 	return nil

--- a/internal/lang/jvm/detection.go
+++ b/internal/lang/jvm/detection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -27,7 +28,7 @@ func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (la
 		if err != nil {
 			return err
 		}
-		return walkJVMDetectionEntry(path, entry, roots, &detection, &visited, maxFiles)
+		return walkJVMDetectionEntry(repoPath, path, entry, roots, &detection, &visited, maxFiles)
 	})
 	if err != nil && !errors.Is(err, fs.SkipAll) {
 		return language.Detection{}, err
@@ -36,7 +37,7 @@ func (a *Adapter) DetectWithConfidence(ctx context.Context, repoPath string) (la
 	return shared.FinalizeDetection(repoPath, detection, roots), nil
 }
 
-func walkJVMDetectionEntry(path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection, visited *int, maxFiles int) error {
+func walkJVMDetectionEntry(repoPath, path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection, visited *int, maxFiles int) error {
 	if entry.IsDir() {
 		if shouldSkipDir(entry.Name()) {
 			return filepath.SkipDir
@@ -47,12 +48,35 @@ func walkJVMDetectionEntry(path string, entry fs.DirEntry, roots map[string]stru
 	if *visited > maxFiles {
 		return fs.SkipAll
 	}
+	if !shared.IsPathWithin(repoPath, path) {
+		return nil
+	}
 	updateJVMDetection(path, entry, roots, detection)
 	return nil
 }
 
 func applyJVMRootSignals(repoPath string, detection *language.Detection, roots map[string]struct{}) error {
-	return shared.ApplyRootSignals(repoPath, jvmRootSignals, detection, roots)
+	for _, signal := range jvmRootSignals {
+		path := filepath.Join(repoPath, signal.Name)
+		info, err := os.Stat(path)
+		if err == nil {
+			if info.IsDir() || !shared.IsPathWithin(repoPath, path) {
+				continue
+			}
+			if detection != nil {
+				detection.Matched = true
+				detection.Confidence += signal.Confidence
+			}
+			if roots != nil {
+				roots[repoPath] = struct{}{}
+			}
+			continue
+		}
+		if !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 var jvmRootSignals = []shared.RootSignal{

--- a/internal/lang/jvm/detection_rooted_edges_test.go
+++ b/internal/lang/jvm/detection_rooted_edges_test.go
@@ -1,0 +1,711 @@
+package jvm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/safeio"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestJVMDetectWithConfidencePropagatesHookError(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	writeJVMPomFile(t, repo, "<project></project>\n")
+	hookErr := errors.New("detect hook failed")
+	withJVMDetectRootSignalsHook(t, func(string) error { return hookErr })
+
+	_, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if !errors.Is(err, hookErr) {
+		t.Fatalf("expected detect hook error, got %v", err)
+	}
+}
+
+func TestJVMDetectWithConfidencePropagatesTraversalLimitCloseError(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	testutil.MustWriteFile(t, filepath.Join(repo, "ignored.txt"), "ignored\n")
+	entry := testutil.MustFirstFileEntry(t, repo)
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	closeErr := errors.New("close overflowing detection directory")
+	directory := &jvmDetectionTestDirectory{
+		fillEntry:    entry,
+		extraEntries: 1,
+		closeErr:     closeErr,
+	}
+	root := &jvmDetectionLimitTestRoot{info: info, directory: directory}
+	withOpenJVMDetectionRootHook(t, func(string) (jvmDetectionRoot, error) {
+		return root, nil
+	})
+
+	_, err = NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if !errors.Is(err, errJVMDetectionTraversalLimit) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined detection traversal-limit and close error, got %v", err)
+	}
+	if directory.closeCalls != 1 || root.closeCalls != 1 {
+		t.Fatalf("expected directory and root to close once, got directory=%d root=%d", directory.closeCalls, root.closeCalls)
+	}
+}
+
+func TestJVMDetectWithConfidenceIgnoresConfinedCandidateLimitStop(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	for index := 0; index < defaultJVMMaxConfinedCandidates+1; index++ {
+		testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "java", "pkg", "Main"+strconv.Itoa(index)+".java"), "class Main {}\n")
+	}
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect with confidence: %v", err)
+	}
+	if !detection.Matched || detection.Confidence == 0 {
+		t.Fatalf("expected confined candidate limit stop to preserve detection, got %#v", detection)
+	}
+}
+
+func TestJVMDetectWithConfidenceIgnoresUnrelatedFileFloodBeforeValidSignal(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	for index := 0; index < defaultJVMMaxConfinedCandidates+64; index++ {
+		testutil.MustWriteFile(t, filepath.Join(repo, "docs", "note"+strconv.Itoa(index)+".txt"), "ignored\n")
+	}
+	testutil.MustWriteFile(t, filepath.Join(repo, "z-module", "src", "main", "java", "pkg", "Main.java"), "class Main {}\n")
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect with confidence after unrelated file flood: %v", err)
+	}
+	if !detection.Matched || detection.Confidence == 0 {
+		t.Fatalf("expected later valid JVM signal to survive unrelated file flood, got %#v", detection)
+	}
+}
+
+func TestOSJVMDetectionRootOpenRejectsNonDirectoryAndCloseErrors(t *testing.T) {
+	rootInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	childPath := filepath.Join(t.TempDir(), "child.txt")
+	if err := os.WriteFile(childPath, []byte("content"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	fileInfo, err := os.Stat(childPath)
+	if err != nil {
+		t.Fatalf("stat temp file: %v", err)
+	}
+	closeErr := errors.New("close non-directory")
+	root := &osJVMDetectionRoot{root: &jvmRootedTestRoot{
+		info: rootInfo,
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "child" {
+				return fileInfo, nil
+			}
+			return rootInfo, nil
+		},
+		open: func(string) (safeio.File, error) {
+			return &jvmRootedTestFile{
+				close: func() error { return closeErr },
+				stat:  func() (fs.FileInfo, error) { return fileInfo, nil },
+			}, nil
+		},
+	}}
+
+	if _, err := root.Open("child"); !errors.Is(err, fs.ErrInvalid) {
+		t.Fatalf("expected invalid-directory error from non-directory open, got %v", err)
+	}
+
+	root = &osJVMDetectionRoot{root: &jvmRootedTestRoot{
+		info: rootInfo,
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "child" {
+				return fileInfo, nil
+			}
+			return rootInfo, nil
+		},
+		open: func(string) (safeio.File, error) {
+			return &jvmRootedTestFile{
+				stat: func() (fs.FileInfo, error) { return fileInfo, nil },
+			}, nil
+		},
+	}}
+	_, err = root.Open("child")
+	if !errors.Is(err, fs.ErrInvalid) {
+		t.Fatalf("expected non-directory error, got %v", err)
+	}
+}
+
+func TestOSJVMDetectionRootOpenReturnsDirectory(t *testing.T) {
+	info, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	directory := &jvmRootedTestDirectory{
+		jvmRootedTestFile: jvmRootedTestFile{
+			stat: func() (fs.FileInfo, error) { return info, nil },
+		},
+	}
+	root := &osJVMDetectionRoot{root: &jvmRootedTestRoot{
+		info:  info,
+		lstat: func(string) (fs.FileInfo, error) { return info, nil },
+		open: func(string) (safeio.File, error) {
+			return directory, nil
+		},
+	}}
+
+	opened, err := root.Open("child")
+	if err != nil {
+		t.Fatalf("expected directory open to succeed, got %v", err)
+	}
+	if opened != directory {
+		t.Fatalf("expected opened directory handle to be returned unchanged, got %#v", opened)
+	}
+}
+
+func TestOSJVMDetectionRootOpenPropagatesOpenError(t *testing.T) {
+	info, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	openErr := errors.New("open rooted directory")
+	root := &osJVMDetectionRoot{root: &jvmRootedTestRoot{
+		info:  info,
+		lstat: func(string) (fs.FileInfo, error) { return info, nil },
+		open:  func(string) (safeio.File, error) { return nil, openErr },
+	}}
+
+	opened, err := root.Open("child")
+	if opened != nil {
+		t.Fatal("expected open failure to return no directory handle")
+	}
+	if !errors.Is(err, openErr) {
+		t.Fatalf("expected open error, got %v", err)
+	}
+}
+
+func TestOSJVMDetectionRootOpenRootPropagatesOpenError(t *testing.T) {
+	openErr := errors.New("open pinned child root")
+	root := &osJVMDetectionRoot{root: &jvmRootedTestRoot{
+		openRoot: func(string) (safeio.Root, error) { return nil, openErr },
+	}}
+
+	opened, err := root.OpenRoot("child")
+	if opened != nil || !errors.Is(err, openErr) {
+		t.Fatalf("expected child-root open error, got root=%#v err=%v", opened, err)
+	}
+}
+
+func TestJVMDetectionWalkerRejectsDirectoryReplacementBetweenEnumerationAndOpen(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	originalDir := filepath.Join(repo, "src")
+	testutil.MustWriteFile(t, filepath.Join(originalDir, "main", "java", "pkg", "Main.java"), "class Main {}\n")
+	root := newReplacingJVMDetectionRoot(t, repo, originalDir)
+
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, defaultJVMDetectionBudget())
+	err := walker.walkPinned(root)
+	if err == nil || !strings.Contains(err.Error(), "path changed while opening: src") {
+		t.Fatalf("expected pinned directory replacement error, got %v", err)
+	}
+}
+
+func TestOpenJVMDetectionChildRootRejectsUnsafeAndFailedChildren(t *testing.T) {
+	fixture := newJVMDetectionChildRootFixture(t)
+	for _, tc := range fixture.cases() {
+		t.Run(tc.name, func(t *testing.T) {
+			assertOpenJVMDetectionChildRootFailure(t, tc)
+		})
+	}
+}
+
+type jvmDetectionDirectoryReplacement struct {
+	t           *testing.T
+	repo        string
+	originalDir string
+	realRoot    safeio.Root
+	swapped     bool
+}
+
+func newReplacingJVMDetectionRoot(t *testing.T, repo, originalDir string) jvmDetectionRoot {
+	t.Helper()
+	realRoot := openJVMTestRoot(t, repo)
+	repoInfo, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	replacement := &jvmDetectionDirectoryReplacement{
+		t:           t,
+		repo:        repo,
+		originalDir: originalDir,
+		realRoot:    realRoot,
+	}
+	return &osJVMDetectionRoot{root: &jvmRootedTestRoot{
+		Root:     realRoot,
+		info:     repoInfo,
+		open:     realRoot.Open,
+		openRoot: replacement.openRoot,
+		lstat:    realRoot.Lstat,
+	}}
+}
+
+func (r *jvmDetectionDirectoryReplacement) openRoot(name string) (safeio.Root, error) {
+	if name == "src" && !r.swapped {
+		r.swapped = true
+		r.replace()
+	}
+	return r.realRoot.OpenRoot(name)
+}
+
+func (r *jvmDetectionDirectoryReplacement) replace() {
+	r.t.Helper()
+	if err := os.Rename(r.originalDir, filepath.Join(r.repo, "src-original")); err != nil {
+		r.t.Fatalf("rename original dir: %v", err)
+	}
+	replacementDir := filepath.Join(r.repo, "src")
+	if err := os.MkdirAll(replacementDir, 0o755); err != nil {
+		r.t.Fatalf("mkdir replacement dir: %v", err)
+	}
+	testutil.MustWriteFile(r.t, filepath.Join(replacementDir, "main", "java", "pkg", "Replacement.java"), "class Replacement {}\n")
+}
+
+type jvmDetectionChildRootCase struct {
+	name       string
+	root       jvmDetectionRoot
+	wantErr    error
+	wantText   string
+	wantJoined error
+}
+
+type jvmDetectionChildRootFixture struct {
+	dirInfo         fs.FileInfo
+	fileInfo        fs.FileInfo
+	linkInfo        fs.FileInfo
+	lookupErr       error
+	openErr         error
+	openedLookupErr error
+	closeErr        error
+}
+
+func newJVMDetectionChildRootFixture(t *testing.T) *jvmDetectionChildRootFixture {
+	t.Helper()
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat directory fixture: %v", err)
+	}
+	filePath := filepath.Join(t.TempDir(), "child.txt")
+	testutil.MustWriteFile(t, filePath, "child\n")
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat file fixture: %v", err)
+	}
+	linkPath := filepath.Join(t.TempDir(), "child-link")
+	if err := os.Symlink(filePath, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	linkInfo, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat symlink fixture: %v", err)
+	}
+	return &jvmDetectionChildRootFixture{
+		dirInfo:         dirInfo,
+		fileInfo:        fileInfo,
+		linkInfo:        linkInfo,
+		lookupErr:       errors.New("lookup child root"),
+		openErr:         errors.New("open child root"),
+		openedLookupErr: errors.New("lookup opened child root"),
+		closeErr:        errors.New("close failed child root"),
+	}
+}
+
+func (f *jvmDetectionChildRootFixture) cases() []jvmDetectionChildRootCase {
+	return []jvmDetectionChildRootCase{
+		{
+			name: "lookup error",
+			root: &jvmDetectionChildTestRoot{
+				lstat: func(string) (fs.FileInfo, error) { return nil, f.lookupErr },
+			},
+			wantErr: f.lookupErr,
+		},
+		{
+			name: "symlink",
+			root: &jvmDetectionChildTestRoot{
+				lstat: func(string) (fs.FileInfo, error) { return f.linkInfo, nil },
+			},
+			wantText: "root contains symlink",
+		},
+		{
+			name: "non-directory",
+			root: &jvmDetectionChildTestRoot{
+				lstat: func(string) (fs.FileInfo, error) { return f.fileInfo, nil },
+			},
+			wantText: "root is not a directory",
+		},
+		{
+			name: "open error",
+			root: &jvmDetectionChildTestRoot{
+				lstat:    func(string) (fs.FileInfo, error) { return f.dirInfo, nil },
+				openRoot: func(string) (jvmDetectionRoot, error) { return nil, f.openErr },
+			},
+			wantErr: f.openErr,
+		},
+		{
+			name: "opened lookup and close errors",
+			root: &jvmDetectionChildTestRoot{
+				lstat: func(string) (fs.FileInfo, error) { return f.dirInfo, nil },
+				openRoot: func(string) (jvmDetectionRoot, error) {
+					return &jvmDetectionChildTestRoot{
+						lstat: func(string) (fs.FileInfo, error) { return nil, f.openedLookupErr },
+						close: func() error { return f.closeErr },
+					}, nil
+				},
+			},
+			wantErr:    f.openedLookupErr,
+			wantJoined: f.closeErr,
+		},
+	}
+}
+
+func assertOpenJVMDetectionChildRootFailure(t *testing.T, test jvmDetectionChildRootCase) {
+	t.Helper()
+	child, err := openJVMDetectionChildRoot(test.root, "child", filepath.Join("nested", "child"))
+	if child != nil {
+		t.Fatalf("expected failed child-root acquisition, got %#v", child)
+	}
+	if test.wantErr != nil && !errors.Is(err, test.wantErr) {
+		t.Fatalf("expected error identity %v, got %v", test.wantErr, err)
+	}
+	if test.wantJoined != nil && !errors.Is(err, test.wantJoined) {
+		t.Fatalf("expected joined error identity %v, got %v", test.wantJoined, err)
+	}
+	if test.wantText != "" && !strings.Contains(err.Error(), test.wantText) {
+		t.Fatalf("expected error containing %q, got %v", test.wantText, err)
+	}
+}
+
+func TestJVMDetectionWalkerWalkEntryPreservesSkipErrorAndFileBehavior(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	dirInfo, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo fixture: %v", err)
+	}
+	filePath := filepath.Join(repo, "note.txt")
+	testutil.MustWriteFile(t, filePath, "not JVM\n")
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat file fixture: %v", err)
+	}
+
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, defaultJVMDetectionBudget())
+	skippedEntry := fs.FileInfoToDirEntry(&jvmDetectionNamedFileInfo{FileInfo: dirInfo, name: "target"})
+	if err := walker.walkEntry(&jvmDetectionChildTestRoot{}, filepath.Join(repo, "target"), skippedEntry); err != nil {
+		t.Fatalf("expected skipped directory to avoid opening, got %v", err)
+	}
+
+	fileEntry := fs.FileInfoToDirEntry(fileInfo)
+	if err := walker.walkEntry(&jvmDetectionChildTestRoot{}, filePath, fileEntry); err != nil {
+		t.Fatalf("expected ordinary file entry to complete without directory open, got %v", err)
+	}
+
+	exhaustedBudget := &jvmDetectionBudget{maxTraversalEntries: 1, traversalEntriesSeen: 1}
+	exhaustedWalker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, exhaustedBudget)
+	if err := exhaustedWalker.walkEntry(&jvmDetectionChildTestRoot{}, filePath, fileEntry); !errors.Is(err, errJVMDetectionTraversalLimit) {
+		t.Fatalf("expected traversal-limit error to propagate, got %v", err)
+	}
+}
+
+func TestJVMDetectionWalkerUsesLinearPinnedRootOperationsForDeepWideTree(t *testing.T) {
+	const (
+		depth = 20
+		width = 7
+	)
+
+	repo := canonicalRepoPath(t)
+	directoryCount, fileCount := createJVMDetectionDeepWideTree(t, repo, depth, width)
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open detection operation-count root: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Fatalf("close detection operation-count root: %v", closeErr)
+		}
+	})
+
+	counts := &jvmDetectionOperationCounts{}
+	countingRoot := &countingJVMDetectionRoot{Root: root, counts: counts}
+	budget := defaultJVMDetectionBudget()
+	detection := &language.Detection{}
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, detection, budget)
+	if err := walker.walkPinned(&osJVMDetectionRoot{root: countingRoot}); err != nil {
+		t.Fatalf("walk deep and wide detection tree: %v", err)
+	}
+
+	if detection.Matched {
+		t.Fatalf("expected non-JVM fixture to remain unmatched, got %#v", detection)
+	}
+	if budget.traversalEntriesSeen != directoryCount+fileCount {
+		t.Fatalf("expected every fixture entry to be visited once, got %d want %d", budget.traversalEntriesSeen, directoryCount+fileCount)
+	}
+	if counts.openRoot != directoryCount-1 {
+		t.Fatalf("expected one pinned child-root open per non-root directory, got %d want %d", counts.openRoot, directoryCount-1)
+	}
+	if counts.open != directoryCount {
+		t.Fatalf("expected one directory read open per directory, got %d want %d", counts.open, directoryCount)
+	}
+	if counts.lstat != 3*directoryCount-1 {
+		t.Fatalf("expected linear identity checks, got %d want %d", counts.lstat, 3*directoryCount-1)
+	}
+	if counts.close != directoryCount-1 {
+		t.Fatalf("expected each pinned child root to close once, got %d want %d", counts.close, directoryCount-1)
+	}
+}
+
+func TestJVMDetectionHelpersPropagatePinnedErrors(t *testing.T) {
+	lstatErr := errors.New("root lstat failed")
+	walker := newJVMDetectionWalker(t.TempDir(), map[string]struct{}{}, &language.Detection{}, defaultJVMDetectionBudget())
+	if err := walker.walkPinned(&jvmDetectionTestRootWithError{err: lstatErr}); !errors.Is(err, lstatErr) {
+		t.Fatalf("expected pinned lstat error, got %v", err)
+	}
+
+	statErr := errors.New("root signal stat failed")
+	if err := applyJVMRootSignalsWithinRoot(t.TempDir(), &jvmDetectionStatRootWithError{err: statErr}, &language.Detection{}, map[string]struct{}{}); !errors.Is(err, statErr) {
+		t.Fatalf("expected root signal stat error, got %v", err)
+	}
+}
+
+func TestJVMDetectionWalkerReadDirectoryJoinsCloseError(t *testing.T) {
+	repo := t.TempDir()
+	closeErr := errors.New("close rooted directory")
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, defaultJVMDetectionBudget())
+	walker.openDirectory = func(jvmDetectionRoot, string) (jvmDetectionDirectory, error) {
+		return &jvmRootedTestDirectory{
+			jvmRootedTestFile: jvmRootedTestFile{
+				close: func() error { return closeErr },
+			},
+		}, nil
+	}
+
+	_, err := walker.readDirectory(&jvmDetectionTestRootWithError{}, repo)
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("expected close error from rooted directory read, got %v", err)
+	}
+}
+
+func TestJVMDetectWithConfidencePreservesRootSignalWhenTraversalBudgetStopsWalk(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	writeJVMPomFile(t, repo, "<project></project>\n")
+	for index := 0; index < defaultJVMMaxTraversalEntries+1; index++ {
+		testutil.MustWriteFile(t, filepath.Join(repo, "flat", "note"+strconv.Itoa(index)+".txt"), "ignored\n")
+	}
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect with confidence after traversal stop: %v", err)
+	}
+	if !detection.Matched || detection.Confidence != 55 {
+		t.Fatalf("expected root pom.xml signal to survive traversal stop, got %#v", detection)
+	}
+}
+
+func TestJVMDetectWithConfidenceReturnsEmptyDetectionWhenTraversalBudgetStopsWithoutSignal(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	for index := 0; index < defaultJVMMaxTraversalEntries+1; index++ {
+		testutil.MustWriteFile(t, filepath.Join(repo, "flat", "note"+strconv.Itoa(index)+".txt"), "ignored\n")
+	}
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect with confidence without root signal: %v", err)
+	}
+	if detection.Matched || detection.Confidence != 0 {
+		t.Fatalf("expected bounded traversal stop to remain non-matching without a root signal, got %#v", detection)
+	}
+}
+
+func TestScanRepoWithSourceReaderHonorsCanceledContext(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "Main.java"), "class Main {}\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := scanRepoWithSourceReader(ctx, repo, map[string]string{}, map[string]string{}, safeio.ReadFileUnderLimit)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled source scan, got %v", err)
+	}
+}
+
+type jvmDetectionTestRootWithError struct {
+	err error
+}
+
+func (*jvmDetectionTestRootWithError) Open(string) (jvmDetectionDirectory, error) {
+	return nil, errors.New("unexpected open")
+}
+
+func (*jvmDetectionTestRootWithError) OpenRoot(string) (jvmDetectionRoot, error) {
+	return nil, errors.New("unexpected child root open")
+}
+
+func (r *jvmDetectionTestRootWithError) Lstat(string) (fs.FileInfo, error) {
+	return nil, r.err
+}
+
+func (*jvmDetectionTestRootWithError) Close() error { return nil }
+
+type jvmDetectionStatRootWithError struct {
+	err error
+}
+
+func (*jvmDetectionStatRootWithError) Open(string) (jvmDetectionDirectory, error) {
+	return nil, errors.New("unexpected open")
+}
+
+func (*jvmDetectionStatRootWithError) OpenRoot(string) (jvmDetectionRoot, error) {
+	return nil, errors.New("unexpected child root open")
+}
+
+func (r *jvmDetectionStatRootWithError) Lstat(string) (fs.FileInfo, error) {
+	return nil, r.err
+}
+
+func (*jvmDetectionStatRootWithError) Close() error { return nil }
+
+type jvmDetectionLimitTestRoot struct {
+	info       fs.FileInfo
+	directory  jvmDetectionDirectory
+	closeCalls int
+}
+
+func (r *jvmDetectionLimitTestRoot) Open(string) (jvmDetectionDirectory, error) {
+	return r.directory, nil
+}
+
+func (*jvmDetectionLimitTestRoot) OpenRoot(string) (jvmDetectionRoot, error) {
+	return nil, errors.New("unexpected child root open")
+}
+
+func (r *jvmDetectionLimitTestRoot) Lstat(name string) (fs.FileInfo, error) {
+	if name == "." {
+		return r.info, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func (r *jvmDetectionLimitTestRoot) Close() error {
+	r.closeCalls++
+	return nil
+}
+
+func withOpenJVMDetectionRootHook(t *testing.T, hook func(string) (jvmDetectionRoot, error)) {
+	t.Helper()
+	original := openJVMDetectionRootHook
+	openJVMDetectionRootHook = hook
+	t.Cleanup(func() {
+		openJVMDetectionRootHook = original
+	})
+}
+
+func createJVMDetectionDeepWideTree(t *testing.T, repo string, depth, width int) (directoryCount, fileCount int) {
+	t.Helper()
+	directoryCount = 1
+	current := repo
+	for level := range depth {
+		for branch := range width {
+			branchDir := filepath.Join(current, fmt.Sprintf("branch-%02d-%02d", level, branch))
+			if err := os.Mkdir(branchDir, 0o755); err != nil {
+				t.Fatalf("mkdir wide detection branch: %v", err)
+			}
+			testutil.MustWriteFile(t, filepath.Join(branchDir, "note.txt"), "not JVM\n")
+			directoryCount++
+			fileCount++
+		}
+		next := filepath.Join(current, fmt.Sprintf("level-%02d", level))
+		if err := os.Mkdir(next, 0o755); err != nil {
+			t.Fatalf("mkdir deep detection level: %v", err)
+		}
+		directoryCount++
+		current = next
+	}
+	return directoryCount, fileCount
+}
+
+type jvmDetectionOperationCounts struct {
+	open     int
+	openRoot int
+	lstat    int
+	close    int
+}
+
+type countingJVMDetectionRoot struct {
+	safeio.Root
+	counts *jvmDetectionOperationCounts
+}
+
+func (r *countingJVMDetectionRoot) Open(name string) (safeio.File, error) {
+	r.counts.open++
+	return r.Root.Open(name)
+}
+
+func (r *countingJVMDetectionRoot) OpenRoot(name string) (safeio.Root, error) {
+	r.counts.openRoot++
+	child, err := r.Root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	return &countingJVMDetectionRoot{Root: child, counts: r.counts}, nil
+}
+
+func (r *countingJVMDetectionRoot) Lstat(name string) (fs.FileInfo, error) {
+	r.counts.lstat++
+	return r.Root.Lstat(name)
+}
+
+func (r *countingJVMDetectionRoot) Close() error {
+	r.counts.close++
+	return r.Root.Close()
+}
+
+type jvmDetectionChildTestRoot struct {
+	lstat    func(string) (fs.FileInfo, error)
+	openRoot func(string) (jvmDetectionRoot, error)
+	close    func() error
+}
+
+func (*jvmDetectionChildTestRoot) Open(string) (jvmDetectionDirectory, error) {
+	return nil, errors.New("unexpected directory open")
+}
+
+func (r *jvmDetectionChildTestRoot) OpenRoot(name string) (jvmDetectionRoot, error) {
+	if r.openRoot != nil {
+		return r.openRoot(name)
+	}
+	return nil, errors.New("unexpected child root open")
+}
+
+func (r *jvmDetectionChildTestRoot) Lstat(name string) (fs.FileInfo, error) {
+	if r.lstat != nil {
+		return r.lstat(name)
+	}
+	return nil, errors.New("unexpected child root lstat")
+}
+
+func (r *jvmDetectionChildTestRoot) Close() error {
+	if r.close != nil {
+		return r.close()
+	}
+	return nil
+}
+
+type jvmDetectionNamedFileInfo struct {
+	fs.FileInfo
+	name string
+}
+
+func (i *jvmDetectionNamedFileInfo) Name() string {
+	return i.name
+}

--- a/internal/lang/jvm/helpers_test.go
+++ b/internal/lang/jvm/helpers_test.go
@@ -265,6 +265,34 @@ dependencies {
 	}
 }
 
+func TestJVMParseGradleDependenciesWarnsOnOversizedKTSBuildFile(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), strings.Repeat("a", maxScannableJVMBuildFile+1))
+
+	descriptors, warnings := parseGradleDependenciesWithWarnings(repo)
+	if len(descriptors) != 0 {
+		t.Fatalf("expected no gradle descriptors from oversized build.gradle.kts, got %#v", descriptors)
+	}
+	warningText := strings.Join(warnings, "\n")
+	if !strings.Contains(warningText, "unable to read "+buildGradleKTSName+": file exceeds size limit") {
+		t.Fatalf("expected oversized build.gradle.kts warning, got %#v", warnings)
+	}
+}
+
+func TestJVMParseGradleDependenciesWarnsOnOversizedBuildGradleFile(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), strings.Repeat("a", maxScannableJVMBuildFile+1))
+
+	descriptors, warnings := parseGradleDependenciesWithWarnings(repo)
+	if len(descriptors) != 0 {
+		t.Fatalf("expected no gradle descriptors from oversized build.gradle, got %#v", descriptors)
+	}
+	warningText := strings.Join(warnings, "\n")
+	if !strings.Contains(warningText, "unable to read "+buildGradleName+": file exceeds size limit") {
+		t.Fatalf("expected oversized build.gradle warning, got %#v", warnings)
+	}
+}
+
 func TestJVMParsePomDependenciesIncludesManagedAndBOMEntries(t *testing.T) {
 	repo := t.TempDir()
 	properties := `
@@ -508,7 +536,7 @@ func TestJVMDetectAndWalkBranches(t *testing.T) {
 		visited := 1
 		roots := map[string]struct{}{}
 		detect := &language.Detection{}
-		err := walkJVMDetectionEntry(filepath.Join(repo, entry.Name()), entry, roots, detect, &visited, 1)
+		err := walkJVMDetectionEntry(repo, filepath.Join(repo, entry.Name()), entry, roots, detect, &visited, 1)
 		if !errors.Is(err, fs.SkipAll) {
 			t.Fatalf("expected fs.SkipAll when maxFiles exceeded, got %v", err)
 		}

--- a/internal/lang/jvm/helpers_test.go
+++ b/internal/lang/jvm/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -27,6 +28,16 @@ func writeJVMPomFile(t *testing.T, repo, content string) {
 	t.Helper()
 
 	testutil.MustWriteFile(t, filepath.Join(repo, "pom.xml"), content)
+}
+
+func canonicalRepoPath(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(repo)
+	if err == nil && resolved != "" {
+		return resolved
+	}
+	return repo
 }
 
 func managedDependencyManagementPOM(properties, junitVersion, springVersion string) string {
@@ -104,6 +115,47 @@ import com.acme.lib.Widget;
 	}
 	if imports[1].Module != "com.acme.lib.Widget" {
 		t.Fatalf("expected non-commented import to parse, got %#v", imports[1])
+	}
+}
+
+func TestJVMScanRepoInfersFallbackDependenciesForUnmappedImports(t *testing.T) {
+	repo := t.TempDir()
+	sourcePath := filepath.Join(repo, "src", "App.kt")
+	testutil.MustWriteFile(t, sourcePath, `package com.example.app
+import com.example.app.LocalType
+import custom.deep.feature.Type
+import vendor.tools.Helper as AliasHelper
+import single
+
+fun use(input: Type, helper: AliasHelper) {
+    println(input)
+    println(helper)
+}
+`)
+
+	result, err := scanRepo(context.Background(), repo, nil, nil)
+	if err != nil {
+		t.Fatalf("scan repo with fallback imports: %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("expected no warnings for fallback import scan, got %#v", result.Warnings)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("expected one scanned file, got %#v", result.Files)
+	}
+
+	imports := result.Files[0].Imports
+	if len(imports) != 3 {
+		t.Fatalf("expected same-package import to be ignored while fallback imports remain, got %#v", imports)
+	}
+	if imports[0].Dependency != "custom.deep" || imports[0].Name != "Type" || imports[0].Local != "Type" {
+		t.Fatalf("expected dotted fallback dependency to resolve first two segments, got %#v", imports[0])
+	}
+	if imports[1].Dependency != "vendor.tools" || imports[1].Local != "AliasHelper" {
+		t.Fatalf("expected aliased fallback dependency to keep alias-local name, got %#v", imports[1])
+	}
+	if imports[2].Dependency != "single" || imports[2].Name != "single" {
+		t.Fatalf("expected single-segment fallback dependency to survive scan, got %#v", imports[2])
 	}
 }
 
@@ -282,6 +334,36 @@ func TestJVMParseGradleDependenciesWarnsOnOversizedBuildFiles(t *testing.T) {
 				t.Fatalf("expected oversized %s warning, got %#v", name, warnings)
 			}
 		})
+	}
+}
+
+func TestJVMCollectBuildDescriptorsResolveCatalogReferencesOutsideRoot(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "settings.gradle.kts"), `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(files("gradle/test-libs.versions.toml"))
+    }
+  }
+}
+`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "gradle", "test-libs.versions.toml"), `
+[libraries]
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.10.0" }
+`)
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), `
+dependencies {
+  implementation(testLibs.junit.jupiter)
+}
+`)
+
+	descriptors, warnings := collectBuildDescriptors(repo)
+	if len(warnings) != 0 {
+		t.Fatalf("expected catalog-backed build descriptor parsing without warnings, got %#v", warnings)
+	}
+	if len(descriptors) != 1 || descriptors[0].Name != "junit-jupiter-api" {
+		t.Fatalf("expected catalog-backed build descriptor, got %#v", descriptors)
 	}
 }
 
@@ -521,39 +603,573 @@ func TestJVMDetectAndWalkBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("max file walk budget", func(t *testing.T) {
-		repo := t.TempDir()
-		testutil.MustWriteFile(t, filepath.Join(repo, "Main.java"), "class Main {}")
-		entry := testutil.MustFirstFileEntry(t, repo)
-		visited := 1
-		roots := map[string]struct{}{}
-		detect := &language.Detection{}
-		err := walkJVMDetectionEntry(repo, filepath.Join(repo, entry.Name()), entry, roots, detect, &visited, 1)
-		if !errors.Is(err, fs.SkipAll) {
-			t.Fatalf("expected fs.SkipAll when maxFiles exceeded, got %v", err)
-		}
-	})
-
+	t.Run("max file walk budget", testJVMMaxTraversalWalkBudget)
 	t.Run("escaping symlinks do not consume file budget", func(t *testing.T) {
-		repo := t.TempDir()
-		outsideSource := filepath.Join(t.TempDir(), "Outside.java")
-		testutil.MustWriteFile(t, outsideSource, "class Outside {}\n")
-		for index := 0; index < 1024; index++ {
-			linkPath := filepath.Join(repo, fmt.Sprintf("a-%04d.java", index))
-			if err := os.Symlink(outsideSource, linkPath); err != nil {
-				t.Skipf("symlink not supported: %v", err)
-			}
-		}
-		testutil.MustWriteFile(t, filepath.Join(repo, "z-module", "src", "main", "java", "Main.java"), "class Main {}\n")
-
-		detection, err := adapter.DetectWithConfidence(context.Background(), repo)
-		if err != nil {
-			t.Fatalf("detect with confidence after escaping symlink flood: %v", err)
-		}
-		if !detection.Matched {
-			t.Fatalf("expected legitimate later JVM file to remain detectable, got %#v", detection)
-		}
+		testJVMEscapingSymlinkFloodDoesNotConsumeCandidateBudget(t, adapter)
 	})
+	t.Run("oversized directory fails closed", testJVMOversizedDirectoryFailsClosed)
+	t.Run("exact traversal budget completes", testJVMExactTraversalBudgetCompletes)
+	t.Run("directory enumeration errors propagate", testJVMDetectionDirectoryErrors)
+	t.Run("traversal budget guards queued entries", testJVMDetectionBudgetGuards)
+	t.Run("traversal budget stops rejected-entry flood", testJVMTraversalBudgetStopsRejectedEntryFlood)
+	t.Run("confined candidate budget still stops ordinary file flood", testJVMConfinedCandidateBudgetStopsOrdinaryFileFlood)
+	t.Run("broken and escaping entries count toward traversal only", testJVMBrokenAndEscapingEntriesCountTowardTraversalOnly)
+}
+
+func testJVMMaxTraversalWalkBudget(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "Main.java"), "class Main {}")
+	entry := testutil.MustFirstFileEntry(t, repo)
+	budget := &jvmDetectionBudget{maxTraversalEntries: 1, traversalEntriesSeen: 1}
+	roots := map[string]struct{}{}
+	detect := &language.Detection{}
+	err := walkJVMDetectionEntry(repo, filepath.Join(repo, entry.Name()), entry, roots, detect, budget)
+	if !errors.Is(err, errJVMDetectionTraversalLimit) {
+		t.Fatalf("expected traversal-limit error, got %v", err)
+	}
+}
+
+func testJVMOversizedDirectoryFailsClosed(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, "z-seed"), 0o755); err != nil {
+		t.Fatalf("mkdir seed directory: %v", err)
+	}
+	testutil.MustWriteFile(t, filepath.Join(repo, "a-Main.java"), "class Main {}\n")
+	rawEntries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read flood entries: %v", err)
+	}
+	markerEntry := rawEntries[0]
+	fillEntry := rawEntries[1]
+
+	budget := defaultJVMDetectionBudget()
+	wantChildren := budget.maxTraversalEntries - 1
+	directory := &jvmDetectionTestDirectory{
+		fillEntry:     fillEntry,
+		repeatEntries: wantChildren,
+		overflowEntry: markerEntry,
+	}
+	roots := map[string]struct{}{}
+	detect := &language.Detection{}
+	walker := newJVMDetectionWalker(repo, roots, detect, budget)
+	openCalls := 0
+	walker.openRoot = func(string) (jvmDetectionRoot, error) {
+		return newJVMDetectionTestRoot(t, repo), nil
+	}
+	walker.openDirectory = func(jvmDetectionRoot, string) (jvmDetectionDirectory, error) {
+		openCalls++
+		return directory, nil
+	}
+
+	err = walker.walk()
+	assertJVMOversizedDirectoryOutcome(t, repo, err, markerEntry, fillEntry, directory, budget, detect, openCalls)
+	assertJVMOversizedDirectoryReads(t, directory, wantChildren)
+}
+
+func assertJVMOversizedDirectoryOutcome(t *testing.T, repo string, err error, markerEntry, fillEntry fs.DirEntry, directory *jvmDetectionTestDirectory, budget *jvmDetectionBudget, detect *language.Detection, openCalls int) {
+	t.Helper()
+
+	wantChildren := budget.maxTraversalEntries - 1
+	if !errors.Is(err, errJVMDetectionTraversalLimit) {
+		t.Fatalf("expected explicit traversal-limit error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), repo) {
+		t.Fatalf("expected traversal-limit error to contain directory path %q, got %v", repo, err)
+	}
+	if markerEntry.Name() >= fillEntry.Name() || !directory.overflowReturned {
+		t.Fatalf("expected lexically early JVM marker to appear only in overflow probe, marker=%q fill=%q", markerEntry.Name(), fillEntry.Name())
+	}
+	if directory.entriesReturned != wantChildren+1 {
+		t.Fatalf("expected %d bounded children plus one overflow probe, got %d", wantChildren, directory.entriesReturned)
+	}
+	if budget.traversalEntriesSeen != 1 || budget.traversalEntriesQueued != wantChildren {
+		t.Fatalf("expected root visited and %d children bounded in queue, got seen=%d queued=%d", wantChildren, budget.traversalEntriesSeen, budget.traversalEntriesQueued)
+	}
+	if budget.confinedCandidatesSeen != 0 {
+		t.Fatalf("expected overflow marker not to consume candidate budget, got %d", budget.confinedCandidatesSeen)
+	}
+	if detect.Matched {
+		t.Fatalf("expected overflow marker not to produce a partial detection, got %#v", detect)
+	}
+	if openCalls != 1 || directory.closeCalls != 1 {
+		t.Fatalf("expected one directory open/close, got opens=%d closes=%d", openCalls, directory.closeCalls)
+	}
+}
+
+func assertJVMOversizedDirectoryReads(t *testing.T, directory *jvmDetectionTestDirectory, wantChildren int) {
+	t.Helper()
+
+	wantBudgetReads := (wantChildren + jvmDetectionReadBatchSize - 1) / jvmDetectionReadBatchSize
+	if len(directory.readSizes) != wantBudgetReads+1 {
+		t.Fatalf("expected %d bounded reads plus one overflow probe, got %d", wantBudgetReads, len(directory.readSizes))
+	}
+	for index, size := range directory.readSizes[:wantBudgetReads] {
+		if size <= 0 || size > jvmDetectionReadBatchSize {
+			t.Fatalf("read %d requested invalid batch size %d", index, size)
+		}
+	}
+	if got := directory.readSizes[wantBudgetReads-1]; got != wantChildren%jvmDetectionReadBatchSize {
+		t.Fatalf("expected final bounded read size %d, got %d", wantChildren%jvmDetectionReadBatchSize, got)
+	}
+	if got := directory.readSizes[wantBudgetReads]; got != 1 {
+		t.Fatalf("expected one-entry overflow probe, got %d", got)
+	}
+}
+
+func testJVMExactTraversalBudgetCompletes(t *testing.T) {
+	repo := t.TempDir()
+	for _, name := range []string{"a", "b"} {
+		if err := os.Mkdir(filepath.Join(repo, name), 0o755); err != nil {
+			t.Fatalf("mkdir exact-budget directory %s: %v", name, err)
+		}
+	}
+
+	budget := &jvmDetectionBudget{maxTraversalEntries: 3, maxConfinedCandidates: 2}
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, budget)
+	if err := walker.walk(); err != nil {
+		t.Fatalf("expected complete tree at exact traversal budget to succeed, got %v", err)
+	}
+	if budget.traversalEntriesSeen != 3 || budget.traversalEntriesQueued != 0 {
+		t.Fatalf("expected exact budget to drain all entries, got seen=%d queued=%d", budget.traversalEntriesSeen, budget.traversalEntriesQueued)
+	}
+}
+
+func testJVMDetectionDirectoryErrors(t *testing.T) {
+	t.Run("root open", testJVMDetectionRootOpenError)
+	t.Run("open", testJVMDetectionDirectoryOpenError)
+	t.Run("read and close", testJVMDetectionDirectoryReadAndCloseErrors)
+	t.Run("no progress", testJVMDetectionDirectoryNoProgress)
+	t.Run("oversized batch", testJVMDetectionDirectoryOversizedBatch)
+	t.Run("limit probe read error", testJVMDetectionLimitProbeReadError)
+	t.Run("limit probe entry and read error", testJVMDetectionLimitProbeEntryAndReadError)
+	t.Run("limit probe no progress", testJVMDetectionLimitProbeNoProgress)
+}
+
+func testJVMDetectionRootOpenError(t *testing.T) {
+	openErr := errors.New("open root")
+	walker := newJVMDetectionWalker(t.TempDir(), map[string]struct{}{}, &language.Detection{}, defaultJVMDetectionBudget())
+	walker.openRoot = func(string) (jvmDetectionRoot, error) {
+		return nil, openErr
+	}
+	if err := walker.walk(); !errors.Is(err, openErr) {
+		t.Fatalf("expected root open error, got %v", err)
+	}
+}
+
+func testJVMDetectionDirectoryOpenError(t *testing.T) {
+	openErr := errors.New("open directory")
+	repo := t.TempDir()
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, defaultJVMDetectionBudget())
+	walker.openRoot = func(string) (jvmDetectionRoot, error) {
+		return newJVMDetectionTestRoot(t, repo), nil
+	}
+	walker.openDirectory = func(jvmDetectionRoot, string) (jvmDetectionDirectory, error) {
+		return nil, openErr
+	}
+	if err := walker.walk(); !errors.Is(err, openErr) {
+		t.Fatalf("expected directory open error, got %v", err)
+	}
+}
+
+func testJVMDetectionDirectoryReadAndCloseErrors(t *testing.T) {
+	readErr := errors.New("read directory")
+	closeErr := errors.New("close directory")
+	directory := &jvmDetectionTestDirectory{readErr: readErr, closeErr: closeErr}
+	repo := t.TempDir()
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, defaultJVMDetectionBudget())
+	walker.openRoot = func(string) (jvmDetectionRoot, error) {
+		return newJVMDetectionTestRoot(t, repo), nil
+	}
+	walker.openDirectory = func(jvmDetectionRoot, string) (jvmDetectionDirectory, error) {
+		return directory, nil
+	}
+	err := walker.walk()
+	if !errors.Is(err, readErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined read and close errors, got %v", err)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected failed reader to close once, got %d", directory.closeCalls)
+	}
+}
+
+func testJVMDetectionDirectoryNoProgress(t *testing.T) {
+	directory := &jvmDetectionTestDirectory{noProgress: true}
+	repo := t.TempDir()
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, defaultJVMDetectionBudget())
+	walker.openRoot = func(string) (jvmDetectionRoot, error) {
+		return newJVMDetectionTestRoot(t, repo), nil
+	}
+	walker.openDirectory = func(jvmDetectionRoot, string) (jvmDetectionDirectory, error) {
+		return directory, nil
+	}
+	if err := walker.walk(); !errors.Is(err, io.ErrNoProgress) {
+		t.Fatalf("expected no-progress error, got %v", err)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected no-progress reader to close once, got %d", directory.closeCalls)
+	}
+}
+
+func testJVMDetectionDirectoryOversizedBatch(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, "seed"), 0o755); err != nil {
+		t.Fatalf("mkdir oversized batch seed: %v", err)
+	}
+	seedEntries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read oversized batch seed: %v", err)
+	}
+	readErr := errors.New("read oversized detection batch")
+	directory := &jvmDetectionTestDirectory{
+		fillEntry:          seedEntries[0],
+		extraEntries:       1,
+		readErrWithEntries: errors.Join(io.EOF, readErr),
+	}
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, defaultJVMDetectionBudget())
+	walker.openRoot = func(string) (jvmDetectionRoot, error) {
+		return newJVMDetectionTestRoot(t, repo), nil
+	}
+	walker.openDirectory = func(jvmDetectionRoot, string) (jvmDetectionDirectory, error) {
+		return directory, nil
+	}
+	if err := walker.walk(); !errors.Is(err, errJVMDetectionTraversalLimit) || !errors.Is(err, io.EOF) || !errors.Is(err, readErr) {
+		t.Fatalf("expected joined oversized-batch traversal-limit, EOF, and read error, got %v", err)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected oversized batch reader to close once, got %d", directory.closeCalls)
+	}
+}
+
+func testJVMDetectionLimitProbeReadError(t *testing.T) {
+	readErr := errors.New("probe directory")
+	directory := &jvmDetectionTestDirectory{readErr: readErr}
+	budget := &jvmDetectionBudget{maxTraversalEntries: 1, maxConfinedCandidates: 1}
+	repo := t.TempDir()
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, budget)
+	walker.openRoot = func(string) (jvmDetectionRoot, error) {
+		return newJVMDetectionTestRoot(t, repo), nil
+	}
+	walker.openDirectory = func(jvmDetectionRoot, string) (jvmDetectionDirectory, error) {
+		return directory, nil
+	}
+	if err := walker.walk(); !errors.Is(err, readErr) {
+		t.Fatalf("expected limit probe read error, got %v", err)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected failed limit probe to close once, got %d", directory.closeCalls)
+	}
+}
+
+func testJVMDetectionLimitProbeEntryAndReadError(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "entry"), []byte("entry"), 0o600); err != nil {
+		t.Fatalf("write probe entry: %v", err)
+	}
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read probe entry: %v", err)
+	}
+	readErr := errors.New("read overflowing detection probe")
+	directory := &jvmDetectionTestDirectory{
+		fillEntry:          entries[0],
+		overflowEntry:      entries[0],
+		readErrWithEntries: readErr,
+	}
+	budget := &jvmDetectionBudget{maxTraversalEntries: 1, maxConfinedCandidates: 1}
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, budget)
+	walker.openRoot = func(string) (jvmDetectionRoot, error) {
+		return newJVMDetectionTestRoot(t, repo), nil
+	}
+	walker.openDirectory = func(jvmDetectionRoot, string) (jvmDetectionDirectory, error) {
+		return directory, nil
+	}
+
+	err = walker.walk()
+	if !errors.Is(err, errJVMDetectionTraversalLimit) || !errors.Is(err, readErr) {
+		t.Fatalf("expected joined probe traversal-limit and read error, got %v", err)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected overflowing probe directory to close once, got %d", directory.closeCalls)
+	}
+}
+
+func testJVMDetectionLimitProbeNoProgress(t *testing.T) {
+	directory := &jvmDetectionTestDirectory{noProgress: true}
+	budget := &jvmDetectionBudget{maxTraversalEntries: 1, maxConfinedCandidates: 1}
+	repo := t.TempDir()
+	walker := newJVMDetectionWalker(repo, map[string]struct{}{}, &language.Detection{}, budget)
+	walker.openRoot = func(string) (jvmDetectionRoot, error) {
+		return newJVMDetectionTestRoot(t, repo), nil
+	}
+	walker.openDirectory = func(jvmDetectionRoot, string) (jvmDetectionDirectory, error) {
+		return directory, nil
+	}
+	if err := walker.walk(); !errors.Is(err, io.ErrNoProgress) {
+		t.Fatalf("expected limit probe no-progress error, got %v", err)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected no-progress limit probe to close once, got %d", directory.closeCalls)
+	}
+}
+
+type jvmDetectionTestDirectory struct {
+	fillEntry          fs.DirEntry
+	readErr            error
+	readErrWithEntries error
+	closeErr           error
+	noProgress         bool
+	extraEntries       int
+	repeatEntries      int
+	overflowEntry      fs.DirEntry
+	overflowReturned   bool
+	readSizes          []int
+	entriesReturned    int
+	closeCalls         int
+}
+
+func (d *jvmDetectionTestDirectory) Stat() (fs.FileInfo, error) {
+	if d.fillEntry != nil {
+		return d.fillEntry.Info()
+	}
+	if d.overflowEntry != nil {
+		return d.overflowEntry.Info()
+	}
+	return nil, errors.New("unexpected stat")
+}
+
+func (d *jvmDetectionTestDirectory) ReadDir(count int) ([]fs.DirEntry, error) {
+	d.readSizes = append(d.readSizes, count)
+	if d.readErr != nil {
+		return nil, d.readErr
+	}
+	if d.noProgress {
+		return nil, nil
+	}
+	if d.fillEntry == nil {
+		return nil, io.EOF
+	}
+
+	if d.repeatEntries > 0 {
+		entryCount := min(count, d.repeatEntries)
+		entries := make([]fs.DirEntry, entryCount)
+		for index := range entries {
+			entries[index] = d.fillEntry
+		}
+		d.repeatEntries -= entryCount
+		d.entriesReturned += len(entries)
+		return entries, d.readErrWithEntries
+	}
+	if d.overflowEntry != nil && !d.overflowReturned {
+		d.overflowReturned = true
+		d.entriesReturned++
+		return []fs.DirEntry{d.overflowEntry}, d.readErrWithEntries
+	}
+
+	entries := make([]fs.DirEntry, count+d.extraEntries)
+	for index := range entries {
+		entries[index] = d.fillEntry
+	}
+	d.entriesReturned += len(entries)
+	return entries, d.readErrWithEntries
+}
+
+func (d *jvmDetectionTestDirectory) Close() error {
+	d.closeCalls++
+	return d.closeErr
+}
+
+type jvmDetectionTestRoot struct {
+	info fs.FileInfo
+}
+
+func (*jvmDetectionTestRoot) Open(string) (jvmDetectionDirectory, error) {
+	return nil, errors.New("unexpected root open")
+}
+
+func (*jvmDetectionTestRoot) OpenRoot(string) (jvmDetectionRoot, error) {
+	return nil, errors.New("unexpected child root open")
+}
+
+func (r *jvmDetectionTestRoot) Lstat(name string) (fs.FileInfo, error) {
+	if name == "." && r.info != nil {
+		return r.info, nil
+	}
+	return nil, errors.New("unexpected root lstat")
+}
+
+func (*jvmDetectionTestRoot) Close() error {
+	return nil
+}
+
+func newJVMDetectionTestRoot(t testing.TB, path string) *jvmDetectionTestRoot {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat detection test root %s: %v", path, err)
+	}
+	return &jvmDetectionTestRoot{info: info}
+}
+
+func testJVMDetectionBudgetGuards(t *testing.T) {
+	unlimited := &jvmDetectionBudget{}
+	if got := unlimited.traversalReadSize(); got != jvmDetectionReadBatchSize {
+		t.Fatalf("expected unlimited budget batch size %d, got %d", jvmDetectionReadBatchSize, got)
+	}
+	if !unlimited.queueTraversalEntries(1) || !unlimited.dequeueTraversalEntry() {
+		t.Fatal("expected unlimited budget to queue and dequeue an entry")
+	}
+	if unlimited.dequeueTraversalEntry() {
+		t.Fatal("expected empty traversal queue dequeue to fail")
+	}
+
+	bounded := &jvmDetectionBudget{maxTraversalEntries: 1}
+	if !bounded.queueTraversalEntries(1) {
+		t.Fatal("expected bounded budget to queue its final entry")
+	}
+	if bounded.queueTraversalEntries(1) || bounded.queueTraversalEntries(-1) {
+		t.Fatal("expected bounded budget to reject over-limit and negative entries")
+	}
+}
+
+func testJVMEscapingSymlinkFloodDoesNotConsumeCandidateBudget(t *testing.T, adapter *Adapter) {
+	repo := t.TempDir()
+	outsideSource := filepath.Join(t.TempDir(), "Outside.java")
+	testutil.MustWriteFile(t, outsideSource, "class Outside {}\n")
+	for index := 0; index < 1024; index++ {
+		linkPath := filepath.Join(repo, fmt.Sprintf("a-%04d.java", index))
+		if err := os.Symlink(outsideSource, linkPath); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+	}
+	testutil.MustWriteFile(t, filepath.Join(repo, "z-module", "src", "main", "java", "Main.java"), "class Main {}\n")
+
+	detection, err := adapter.DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect with confidence after escaping symlink flood: %v", err)
+	}
+	if !detection.Matched {
+		t.Fatalf("expected legitimate later JVM file to remain detectable, got %#v", detection)
+	}
+}
+
+func testJVMTraversalBudgetStopsRejectedEntryFlood(t *testing.T) {
+	repo := t.TempDir()
+	outsideSource := filepath.Join(t.TempDir(), "Outside.java")
+	testutil.MustWriteFile(t, outsideSource, "class Outside {}\n")
+	for index := 0; index < 4; index++ {
+		linkPath := filepath.Join(repo, fmt.Sprintf("escape-%04d.java", index))
+		if err := os.Symlink(outsideSource, linkPath); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+	}
+	testutil.MustWriteFile(t, filepath.Join(repo, "z-module", "src", "main", "java", "Main.java"), "class Main {}\n")
+
+	entries, err := sortedJVMRepoEntries(repo)
+	if err != nil {
+		t.Fatalf("read repo dir: %v", err)
+	}
+
+	budget := &jvmDetectionBudget{maxTraversalEntries: 2, maxConfinedCandidates: 1024}
+	roots := map[string]struct{}{}
+	detect := &language.Detection{}
+	stopPath := ""
+	for _, entry := range entries {
+		path := filepath.Join(repo, entry.Name())
+		err := walkJVMDetectionEntry(repo, path, entry, roots, detect, budget)
+		if errors.Is(err, errJVMDetectionTraversalLimit) {
+			stopPath = path
+			break
+		}
+		if err != nil {
+			t.Fatalf("walk detection entry %s: %v", entry.Name(), err)
+		}
+	}
+
+	if stopPath == "" {
+		t.Fatal("expected traversal budget flood to stop the walker")
+	}
+	if budget.traversalEntriesSeen != 2 {
+		t.Fatalf("expected traversal budget to stop after bounded work, got %d", budget.traversalEntriesSeen)
+	}
+	if budget.confinedCandidatesSeen != 0 {
+		t.Fatalf("expected rejected entries to avoid confined candidate budget, got %d", budget.confinedCandidatesSeen)
+	}
+	if detect.Matched {
+		t.Fatalf("expected traversal stop before legitimate file update, got %#v", detect)
+	}
+}
+
+func testJVMConfinedCandidateBudgetStopsOrdinaryFileFlood(t *testing.T) {
+	repo := t.TempDir()
+	for index := 0; index < 4; index++ {
+		testutil.MustWriteFile(t, filepath.Join(repo, fmt.Sprintf("Main%04d.java", index)), "class Main {}\n")
+	}
+
+	budget := &jvmDetectionBudget{maxTraversalEntries: 8, maxConfinedCandidates: 2}
+	roots := map[string]struct{}{}
+	detect := &language.Detection{}
+	walker := newJVMDetectionWalker(repo, roots, detect, budget)
+	if err := walker.walk(); !errors.Is(err, fs.SkipAll) {
+		t.Fatalf("expected confined candidate budget flood to stop the walker, got %v", err)
+	}
+	if budget.traversalEntriesSeen != 4 || budget.traversalEntriesQueued != 1 {
+		t.Fatalf("expected root and three visited files with one bounded queued file, got seen=%d queued=%d", budget.traversalEntriesSeen, budget.traversalEntriesQueued)
+	}
+	if budget.confinedCandidatesSeen != 3 {
+		t.Fatalf("expected confined candidate budget to stop after bounded work, got %d", budget.confinedCandidatesSeen)
+	}
+	if !detect.Matched {
+		t.Fatalf("expected ordinary confined files to update detection before the stop, got %#v", detect)
+	}
+}
+
+func testJVMBrokenAndEscapingEntriesCountTowardTraversalOnly(t *testing.T) {
+	repo := t.TempDir()
+	outsideSource := filepath.Join(t.TempDir(), "Outside.java")
+	testutil.MustWriteFile(t, outsideSource, "class Outside {}\n")
+
+	escapingLink := filepath.Join(repo, "Escaping.java")
+	if err := os.Symlink(outsideSource, escapingLink); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	brokenLink := filepath.Join(repo, "Broken.java")
+	if err := os.Symlink(filepath.Join(repo, "missing", "Broken.java"), brokenLink); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	entries, err := sortedJVMRepoEntries(repo)
+	if err != nil {
+		t.Fatalf("read repo dir: %v", err)
+	}
+	budget := &jvmDetectionBudget{maxTraversalEntries: 8, maxConfinedCandidates: 8}
+	roots := map[string]struct{}{}
+	detect := &language.Detection{}
+	for _, entry := range entries {
+		if err := walkJVMDetectionEntry(repo, filepath.Join(repo, entry.Name()), entry, roots, detect, budget); err != nil {
+			t.Fatalf("walk detection entry %s: %v", entry.Name(), err)
+		}
+	}
+
+	if budget.traversalEntriesSeen != 2 {
+		t.Fatalf("expected broken and escaping links to count toward traversal budget, got %d", budget.traversalEntriesSeen)
+	}
+	if budget.confinedCandidatesSeen != 0 {
+		t.Fatalf("expected broken and escaping links to avoid confined candidate budget, got %d", budget.confinedCandidatesSeen)
+	}
+	if detect.Matched {
+		t.Fatalf("expected rejected links to keep detection unmatched, got %#v", detect)
+	}
+}
+
+func sortedJVMRepoEntries(repo string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		return nil, err
+	}
+	slices.SortFunc(entries, func(left, right os.DirEntry) int {
+		return strings.Compare(left.Name(), right.Name())
+	})
+	return entries, nil
 }
 
 func TestJVMParseHelpersEdgeBranches(t *testing.T) {
@@ -572,5 +1188,24 @@ func TestJVMParseHelpersEdgeBranches(t *testing.T) {
 	}
 	if got := lastModuleSegment(""); got != "" {
 		t.Fatalf("expected empty last module segment for empty module, got %q", got)
+	}
+	if got := fallbackDependency("a.b"); got != "a.b" {
+		t.Fatalf("expected two-segment fallback dependency to keep both segments, got %q", got)
+	}
+	if got := relativeSourceScanPath("", "Main.java"); got != "Main.java" {
+		t.Fatalf("expected empty rooted source path to preserve original path, got %q", got)
+	}
+
+	token, replacement, ok := pomPropertyReplacement([]string{"${missing}"}, map[string]string{"missing": "ignored"})
+	if ok || token != "" || replacement != "" {
+		t.Fatalf("expected malformed pom property match to be rejected, got token=%q replacement=%q ok=%v", token, replacement, ok)
+	}
+	token, replacement, ok = pomPropertyReplacement([]string{"${empty}", "empty"}, map[string]string{"empty": "   "})
+	if ok || token != "${empty}" || replacement != "" {
+		t.Fatalf("expected empty pom property replacement to be rejected, got token=%q replacement=%q ok=%v", token, replacement, ok)
+	}
+	descriptors, warnings := parseBuildFilesWithWarnings(filepath.Join(t.TempDir(), "missing"), func(string, string) ([]dependencyDescriptor, []string) { return nil, nil }, buildGradleName)
+	if len(descriptors) != 0 || len(warnings) != 1 {
+		t.Fatalf("expected missing rooted build walk to return one warning, got descriptors=%#v warnings=%#v", descriptors, warnings)
 	}
 }

--- a/internal/lang/jvm/helpers_test.go
+++ b/internal/lang/jvm/helpers_test.go
@@ -265,31 +265,23 @@ dependencies {
 	}
 }
 
-func TestJVMParseGradleDependenciesWarnsOnOversizedKTSBuildFile(t *testing.T) {
-	repo := t.TempDir()
-	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), strings.Repeat("a", maxScannableJVMBuildFile+1))
+func TestJVMParseGradleDependenciesWarnsOnOversizedBuildFiles(t *testing.T) {
+	t.Parallel()
 
-	descriptors, warnings := parseGradleDependenciesWithWarnings(repo)
-	if len(descriptors) != 0 {
-		t.Fatalf("expected no gradle descriptors from oversized build.gradle.kts, got %#v", descriptors)
-	}
-	warningText := strings.Join(warnings, "\n")
-	if !strings.Contains(warningText, "unable to read "+buildGradleKTSName+": file exceeds size limit") {
-		t.Fatalf("expected oversized build.gradle.kts warning, got %#v", warnings)
-	}
-}
+	for _, name := range []string{buildGradleName, buildGradleKTSName} {
+		t.Run(name, func(t *testing.T) {
+			repo := t.TempDir()
+			testutil.MustWriteFile(t, filepath.Join(repo, name), strings.Repeat("a", maxScannableJVMBuildFile+1))
 
-func TestJVMParseGradleDependenciesWarnsOnOversizedBuildGradleFile(t *testing.T) {
-	repo := t.TempDir()
-	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), strings.Repeat("a", maxScannableJVMBuildFile+1))
-
-	descriptors, warnings := parseGradleDependenciesWithWarnings(repo)
-	if len(descriptors) != 0 {
-		t.Fatalf("expected no gradle descriptors from oversized build.gradle, got %#v", descriptors)
-	}
-	warningText := strings.Join(warnings, "\n")
-	if !strings.Contains(warningText, "unable to read "+buildGradleName+": file exceeds size limit") {
-		t.Fatalf("expected oversized build.gradle warning, got %#v", warnings)
+			descriptors, warnings := parseGradleDependenciesWithWarnings(repo)
+			if len(descriptors) != 0 {
+				t.Fatalf("expected no gradle descriptors from oversized %s, got %#v", name, descriptors)
+			}
+			warningText := strings.Join(warnings, "\n")
+			if !strings.Contains(warningText, "unable to read "+name+": file exceeds size limit") {
+				t.Fatalf("expected oversized %s warning, got %#v", name, warnings)
+			}
+		})
 	}
 }
 

--- a/internal/lang/jvm/helpers_test.go
+++ b/internal/lang/jvm/helpers_test.go
@@ -662,37 +662,57 @@ func testJVMOversizedDirectoryFailsClosed(t *testing.T) {
 	}
 
 	err = walker.walk()
-	assertJVMOversizedDirectoryOutcome(t, repo, err, markerEntry, fillEntry, directory, budget, detect, openCalls)
+	assertJVMOversizedDirectoryOutcome(t, jvmOversizedDirectoryOutcome{
+		repo:        repo,
+		err:         err,
+		markerEntry: markerEntry,
+		fillEntry:   fillEntry,
+		directory:   directory,
+		budget:      budget,
+		detect:      detect,
+		openCalls:   openCalls,
+	})
 	assertJVMOversizedDirectoryReads(t, directory, wantChildren)
 }
 
-func assertJVMOversizedDirectoryOutcome(t *testing.T, repo string, err error, markerEntry, fillEntry fs.DirEntry, directory *jvmDetectionTestDirectory, budget *jvmDetectionBudget, detect *language.Detection, openCalls int) {
+type jvmOversizedDirectoryOutcome struct {
+	repo        string
+	err         error
+	markerEntry fs.DirEntry
+	fillEntry   fs.DirEntry
+	directory   *jvmDetectionTestDirectory
+	budget      *jvmDetectionBudget
+	detect      *language.Detection
+	openCalls   int
+}
+
+func assertJVMOversizedDirectoryOutcome(t *testing.T, outcome jvmOversizedDirectoryOutcome) {
 	t.Helper()
 
-	wantChildren := budget.maxTraversalEntries - 1
-	if !errors.Is(err, errJVMDetectionTraversalLimit) {
-		t.Fatalf("expected explicit traversal-limit error, got %v", err)
+	wantChildren := outcome.budget.maxTraversalEntries - 1
+	if !errors.Is(outcome.err, errJVMDetectionTraversalLimit) {
+		t.Fatalf("expected explicit traversal-limit error, got %v", outcome.err)
 	}
-	if !strings.Contains(err.Error(), repo) {
-		t.Fatalf("expected traversal-limit error to contain directory path %q, got %v", repo, err)
+	if !strings.Contains(outcome.err.Error(), outcome.repo) {
+		t.Fatalf("expected traversal-limit error to contain directory path %q, got %v", outcome.repo, outcome.err)
 	}
-	if markerEntry.Name() >= fillEntry.Name() || !directory.overflowReturned {
-		t.Fatalf("expected lexically early JVM marker to appear only in overflow probe, marker=%q fill=%q", markerEntry.Name(), fillEntry.Name())
+	if outcome.markerEntry.Name() >= outcome.fillEntry.Name() || !outcome.directory.overflowReturned {
+		t.Fatalf("expected lexically early JVM marker to appear only in overflow probe, marker=%q fill=%q", outcome.markerEntry.Name(), outcome.fillEntry.Name())
 	}
-	if directory.entriesReturned != wantChildren+1 {
-		t.Fatalf("expected %d bounded children plus one overflow probe, got %d", wantChildren, directory.entriesReturned)
+	if outcome.directory.entriesReturned != wantChildren+1 {
+		t.Fatalf("expected %d bounded children plus one overflow probe, got %d", wantChildren, outcome.directory.entriesReturned)
 	}
-	if budget.traversalEntriesSeen != 1 || budget.traversalEntriesQueued != wantChildren {
-		t.Fatalf("expected root visited and %d children bounded in queue, got seen=%d queued=%d", wantChildren, budget.traversalEntriesSeen, budget.traversalEntriesQueued)
+	if outcome.budget.traversalEntriesSeen != 1 || outcome.budget.traversalEntriesQueued != wantChildren {
+		t.Fatalf("expected root visited and %d children bounded in queue, got seen=%d queued=%d", wantChildren, outcome.budget.traversalEntriesSeen, outcome.budget.traversalEntriesQueued)
 	}
-	if budget.confinedCandidatesSeen != 0 {
-		t.Fatalf("expected overflow marker not to consume candidate budget, got %d", budget.confinedCandidatesSeen)
+	if outcome.budget.confinedCandidatesSeen != 0 {
+		t.Fatalf("expected overflow marker not to consume candidate budget, got %d", outcome.budget.confinedCandidatesSeen)
 	}
-	if detect.Matched {
-		t.Fatalf("expected overflow marker not to produce a partial detection, got %#v", detect)
+	if outcome.detect.Matched {
+		t.Fatalf("expected overflow marker not to produce a partial detection, got %#v", outcome.detect)
 	}
-	if openCalls != 1 || directory.closeCalls != 1 {
-		t.Fatalf("expected one directory open/close, got opens=%d closes=%d", openCalls, directory.closeCalls)
+	if outcome.openCalls != 1 || outcome.directory.closeCalls != 1 {
+		t.Fatalf("expected one directory open/close, got opens=%d closes=%d", outcome.openCalls, outcome.directory.closeCalls)
 	}
 }
 

--- a/internal/lang/jvm/helpers_test.go
+++ b/internal/lang/jvm/helpers_test.go
@@ -533,6 +533,27 @@ func TestJVMDetectAndWalkBranches(t *testing.T) {
 			t.Fatalf("expected fs.SkipAll when maxFiles exceeded, got %v", err)
 		}
 	})
+
+	t.Run("escaping symlinks do not consume file budget", func(t *testing.T) {
+		repo := t.TempDir()
+		outsideSource := filepath.Join(t.TempDir(), "Outside.java")
+		testutil.MustWriteFile(t, outsideSource, "class Outside {}\n")
+		for index := 0; index < 1024; index++ {
+			linkPath := filepath.Join(repo, fmt.Sprintf("a-%04d.java", index))
+			if err := os.Symlink(outsideSource, linkPath); err != nil {
+				t.Skipf("symlink not supported: %v", err)
+			}
+		}
+		testutil.MustWriteFile(t, filepath.Join(repo, "z-module", "src", "main", "java", "Main.java"), "class Main {}\n")
+
+		detection, err := adapter.DetectWithConfidence(context.Background(), repo)
+		if err != nil {
+			t.Fatalf("detect with confidence after escaping symlink flood: %v", err)
+		}
+		if !detection.Matched {
+			t.Fatalf("expected legitimate later JVM file to remain detectable, got %#v", detection)
+		}
+	})
 }
 
 func TestJVMParseHelpersEdgeBranches(t *testing.T) {

--- a/internal/lang/jvm/root_swap_test.go
+++ b/internal/lang/jvm/root_swap_test.go
@@ -1,0 +1,201 @@
+package jvm
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestJVMDetectPinsRootAcrossRepoSwap(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	writeJVMPomFile(t, repo, "<project></project>\n")
+
+	withJVMDetectRootSignalsHook(t, func(rootPath string) error {
+		swapRepoPath(t, rootPath, func(replacement string) {
+			testutil.MustWriteFile(t, filepath.Join(replacement, "modules", "replacement", "src", "main", "java", "Main.java"), "class Main {}\n")
+		})
+		return nil
+	})
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect with pinned root: %v", err)
+	}
+	if !detection.Matched {
+		t.Fatalf("expected original root signal to remain visible, got %#v", detection)
+	}
+	if detection.Confidence != 65 {
+		t.Fatalf("expected original pom signal and original pom traversal hit only, got %#v", detection)
+	}
+	if len(detection.Roots) != 1 || detection.Roots[0] != repo {
+		t.Fatalf("expected replacement source tree to stay unread, got %#v", detection.Roots)
+	}
+}
+
+func TestJVMAnalysePinsRootAcrossRepoSwap(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), `
+dependencies {
+  implementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
+}
+`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "java", "com", "example", "Main.java"), `
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+class Main {
+  @Test void ok() {}
+}
+`)
+
+	withJVMAnalyseRootOpenHook(t, func(rootPath string) error {
+		swapRepoPath(t, rootPath, func(replacement string) {
+			testutil.MustWriteFile(t, filepath.Join(replacement, buildGradleName), `
+dependencies {
+  implementation "com.evil:replacement:1.0.0"
+}
+`)
+			testutil.MustWriteFile(t, filepath.Join(replacement, "src", "main", "java", "com", "evil", "Replacement.java"), `
+package com.evil;
+
+import com.evil.Replacement;
+
+class Replacement {}
+`)
+		})
+		return nil
+	})
+
+	result, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 10})
+	if err != nil {
+		t.Fatalf("analyse with pinned root: %v", err)
+	}
+	if len(result.Dependencies) != 1 || result.Dependencies[0].Name != "junit-jupiter-api" {
+		t.Fatalf("expected original dependency only, got %#v", result.Dependencies)
+	}
+}
+
+func TestJVMAnalysePinsCatalogResolverAcrossRepoSwap(t *testing.T) {
+	for _, settingsFileName := range []string{"settings.gradle", "settings.gradle.kts"} {
+		t.Run(settingsFileName, func(t *testing.T) {
+			repo := canonicalRepoPath(t)
+			testutil.MustWriteFile(t, filepath.Join(repo, settingsFileName), `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(files("gradle/test-libs.versions.toml"))
+    }
+  }
+}
+`)
+			testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), `
+dependencies {
+  implementation(testLibs.junit.jupiter)
+}
+`)
+			testutil.MustWriteFile(t, filepath.Join(repo, "gradle", "test-libs.versions.toml"), `
+[versions]
+junit = "5.10.0"
+
+[libraries]
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
+`)
+			testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "java", "com", "example", "Main.java"), `
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+class Main {
+  @Test void ok() {}
+}
+`)
+
+			withJVMAnalyseRootOpenHook(t, func(rootPath string) error {
+				swapRepoPath(t, rootPath, func(replacement string) {
+					testutil.MustWriteFile(t, filepath.Join(replacement, settingsFileName), `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(files("gradle/evil.versions.toml"))
+    }
+  }
+}
+`)
+					testutil.MustWriteFile(t, filepath.Join(replacement, buildGradleKTSName), `
+dependencies {
+  implementation(testLibs.junit.jupiter)
+}
+`)
+					testutil.MustWriteFile(t, filepath.Join(replacement, "gradle", "evil.versions.toml"), `
+[libraries]
+junit-jupiter = { group = "com.evil", name = "replacement", version = "1.0.0" }
+`)
+					testutil.MustWriteFile(t, filepath.Join(replacement, "src", "main", "java", "com", "evil", "Replacement.java"), `
+package com.evil;
+
+import com.evil.Replacement;
+
+class Replacement {}
+`)
+				})
+				return nil
+			})
+
+			result, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 10})
+			if err != nil {
+				t.Fatalf("analyse with pinned catalog root: %v", err)
+			}
+			if len(result.Dependencies) != 1 || result.Dependencies[0].Name != "junit-jupiter-api" {
+				t.Fatalf("expected original catalog dependency only, got %#v", result.Dependencies)
+			}
+		})
+	}
+}
+
+func TestJVMAnalysePropagatesRootOpenHookError(t *testing.T) {
+	repo := canonicalRepoPath(t)
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), `dependencies { implementation("org.junit.jupiter:junit-jupiter-api:5.10.0") }`)
+	hookErr := errors.New("analyse root hook failed")
+	withJVMAnalyseRootOpenHook(t, func(string) error { return hookErr })
+
+	_, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 1})
+	if !errors.Is(err, hookErr) {
+		t.Fatalf("expected analyse root hook error, got %v", err)
+	}
+}
+
+func withJVMDetectRootSignalsHook(t *testing.T, hook func(string) error) {
+	t.Helper()
+	original := afterJVMDetectRootSignals
+	afterJVMDetectRootSignals = hook
+	t.Cleanup(func() {
+		afterJVMDetectRootSignals = original
+	})
+}
+
+func withJVMAnalyseRootOpenHook(t *testing.T, hook func(string) error) {
+	t.Helper()
+	original := afterJVMAnalyseRootOpen
+	afterJVMAnalyseRootOpen = hook
+	t.Cleanup(func() {
+		afterJVMAnalyseRootOpen = original
+	})
+}
+
+func swapRepoPath(t *testing.T, repoPath string, writeReplacement func(string)) {
+	t.Helper()
+	originalPath := repoPath + "-original"
+	if err := os.Rename(repoPath, originalPath); err != nil {
+		t.Skipf("repo swap unsupported: %v", err)
+	}
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("recreate swapped repo root: %v", err)
+	}
+	writeReplacement(repoPath)
+}

--- a/internal/lang/jvm/rooted_analysis_test.go
+++ b/internal/lang/jvm/rooted_analysis_test.go
@@ -1,0 +1,869 @@
+package jvm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
+	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/safeio"
+	"github.com/ben-ranford/lopper/internal/testutil"
+)
+
+func TestCollectDeclaredDependenciesWithinRootHonorsCancellation(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), `dependencies { implementation("org.junit.jupiter:junit-jupiter-api:5.10.0") }`)
+	root := openJVMTestRoot(t, repo)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, _, _, err := collectDeclaredDependenciesWithinRoot(ctx, repo, root)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled dependency collection, got %v", err)
+	}
+}
+
+func TestParseBuildFilesWithWarningsWithinRootHonorsCancellation(t *testing.T) {
+	repo := t.TempDir()
+	root := openJVMTestRoot(t, repo)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	descriptors, warnings, err := parseBuildFilesWithWarningsWithinRoot(ctx, repo, root, func(string, string) ([]dependencyDescriptor, []string) { return nil, nil }, pomXMLName, buildGradleName, buildGradleKTSName)
+	if len(descriptors) != 0 || len(warnings) != 0 {
+		t.Fatalf("expected canceled rooted parse to return nil results, got descriptors=%#v warnings=%#v", descriptors, warnings)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled rooted build parse, got %v", err)
+	}
+}
+
+func TestCollectDeclaredDependenciesWithinRootPropagatesDirectoryCloseError(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	closeErr := errors.New("close dependency directory")
+	root := &jvmRootedTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) {
+			return &jvmRootedTestDirectory{
+				jvmRootedTestFile: jvmRootedTestFile{
+					close: func() error { return closeErr },
+				},
+			}, nil
+		},
+	}
+
+	_, _, _, _, err = collectDeclaredDependenciesWithinRoot(context.Background(), repo, root)
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("expected dependency directory close error, got %v", err)
+	}
+}
+
+func TestParseBuildFilesWithWarningsWithinRootPropagatesTraversalLimitCloseError(t *testing.T) {
+	repo := t.TempDir()
+	closeErr := errors.New("close overflowing build directory")
+	root := newJVMRootedTraversalLimitRoot(t, repo, closeErr)
+
+	descriptors, warnings, err := parseBuildFilesWithWarningsWithinRoot(context.Background(), repo, root, func(string, string) ([]dependencyDescriptor, []string) { return nil, nil }, pomXMLName, buildGradleName, buildGradleKTSName)
+	if !errors.Is(err, closeErr) || !strings.Contains(err.Error(), "rooted walk traversal limit exceeded") {
+		t.Fatalf("expected joined build traversal-limit and close error, got %v", err)
+	}
+	if len(descriptors) != 0 || len(warnings) != 0 {
+		t.Fatalf("expected operational failure not to be downgraded, got descriptors=%#v warnings=%#v", descriptors, warnings)
+	}
+}
+
+func TestCollectDeclaredDependenciesWithinRootReadsBuildFilesWithinRoot(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), `dependencies { implementation("org.junit.jupiter:junit-jupiter-api:5.10.0") }`)
+	root := openJVMTestRoot(t, repo)
+
+	descriptors, prefixes, aliases, warnings, err := collectDeclaredDependenciesWithinRoot(context.Background(), repo, root)
+	if err != nil {
+		t.Fatalf("collect rooted dependencies: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no rooted dependency warnings, got %#v", warnings)
+	}
+	if len(descriptors) != 1 || descriptors[0].Name != "junit-jupiter-api" {
+		t.Fatalf("expected rooted build descriptor, got %#v", descriptors)
+	}
+	if prefixes["org.junit.jupiter.junit.jupiter.api"] == "" || aliases["junit.jupiter.api"] == "" {
+		t.Fatalf("expected rooted dependency lookups, got prefixes=%#v aliases=%#v", prefixes, aliases)
+	}
+}
+
+func TestScanRepoWithinRootPropagatesDirectoryCloseError(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	closeErr := errors.New("close source directory")
+	root := &jvmRootedTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) {
+			return &jvmRootedTestDirectory{
+				jvmRootedTestFile: jvmRootedTestFile{
+					close: func() error { return closeErr },
+				},
+			}, nil
+		},
+	}
+
+	_, err = scanRepoWithinRoot(context.Background(), repo, root, map[string]string{}, map[string]string{})
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("expected source directory close error, got %v", err)
+	}
+}
+
+func TestScanRepoWithinRootPropagatesTraversalLimitCloseError(t *testing.T) {
+	repo := t.TempDir()
+	closeErr := errors.New("close overflowing source directory")
+	root := newJVMRootedTraversalLimitRoot(t, repo, closeErr)
+
+	result, err := scanRepoWithinRoot(context.Background(), repo, root, map[string]string{}, map[string]string{})
+	if !errors.Is(err, closeErr) || !strings.Contains(err.Error(), "rooted walk traversal limit exceeded") {
+		t.Fatalf("expected joined source traversal-limit and close error, got %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("expected operational failure not to be downgraded to warnings, got %#v", result.Warnings)
+	}
+}
+
+func TestScanRepoWithinRootDowngradesPureTraversalLimitToWarning(t *testing.T) {
+	repo := t.TempDir()
+	root := newJVMRootedTraversalLimitRoot(t, repo, nil)
+
+	result, err := scanRepoWithinRoot(context.Background(), repo, root, map[string]string{}, map[string]string{})
+	if err != nil {
+		t.Fatalf("expected pure rooted source traversal limit to downgrade to warnings, got %v", err)
+	}
+	joinedWarnings := strings.Join(result.Warnings, "\n")
+	if !strings.Contains(joinedWarnings, "JVM source scan reached the rooted walk limit") {
+		t.Fatalf("expected rooted source traversal warning, got %#v", result.Warnings)
+	}
+}
+
+func TestScanRepoWithinRootPropagatesFileLimitCloseError(t *testing.T) {
+	repo := t.TempDir()
+	sourcePath := filepath.Join(repo, "Main.java")
+	testutil.MustWriteFile(t, sourcePath, "class Main {}\n")
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		t.Fatalf("stat source: %v", err)
+	}
+	closeErr := errors.New("close oversized source")
+	closeCalls := 0
+	statCalls := 0
+	root := newJVMRootedReadTestRoot(t, repo, filepath.Base(sourcePath), &jvmRootedTestFile{
+		close: func() error {
+			closeCalls++
+			return closeErr
+		},
+		stat: func() (fs.FileInfo, error) {
+			statCalls++
+			if statCalls == 1 {
+				return info, nil
+			}
+			return &jvmRootedSizedFileInfo{FileInfo: info, size: maxScannableJVMSourceFile + 1}, nil
+		},
+	})
+
+	result, err := scanRepoWithinRoot(context.Background(), repo, root, map[string]string{}, map[string]string{})
+	if !errors.Is(err, safeio.ErrFileTooLarge) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined source file-limit and close error, got %v", err)
+	}
+	if result.SkippedLargeFiles != 0 || len(result.Warnings) != 0 {
+		t.Fatalf("expected impure source read failure not to be downgraded, got %#v", result)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("expected oversized source to close once, got %d", closeCalls)
+	}
+}
+
+func TestScanRepoWithSourceReaderPropagatesImpureSymlinkError(t *testing.T) {
+	repo := t.TempDir()
+	sourceLink := createJVMSourceSymlink(t, repo, "Linked.java")
+	closeErr := errors.New("close source symlink")
+	readSource := func(string, string, int64) ([]byte, error) {
+		return nil, errors.Join(safeio.ErrTargetPathSymlink, closeErr)
+	}
+	result, err := scanRepoWithSourceReader(context.Background(), repo, map[string]string{}, map[string]string{}, readSource)
+
+	if !errors.Is(err, safeio.ErrTargetPathSymlink) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined source symlink and close error for %s, got %v", sourceLink, err)
+	}
+	if result.SkippedSymlinks != 0 || len(result.Warnings) != 0 {
+		t.Fatalf("expected impure source symlink failure not to be downgraded, got %#v", result)
+	}
+}
+
+func TestScanRepoWithSourceReaderPropagatesTextOnlySymlinkError(t *testing.T) {
+	repo := t.TempDir()
+	createJVMSourceSymlink(t, repo, "Linked.java")
+	readErr := errors.New("too many symlinks while opening source")
+	readSource := func(string, string, int64) ([]byte, error) {
+		return nil, readErr
+	}
+
+	result, err := scanRepoWithSourceReader(context.Background(), repo, map[string]string{}, map[string]string{}, readSource)
+	if !errors.Is(err, readErr) {
+		t.Fatalf("expected non-sentinel symlink error to propagate, got %v", err)
+	}
+	if result.SkippedSymlinks != 0 || len(result.Warnings) != 0 {
+		t.Fatalf("expected non-sentinel symlink error not to be downgraded, got %#v", result)
+	}
+}
+
+func TestScanJVMSourceFileWithReaderPropagatesImpureMissingPath(t *testing.T) {
+	repo := t.TempDir()
+	sourceDir := filepath.Join(repo, "src")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	closeErr := errors.New("close source ancestor")
+	root := newJVMNestedMissingReadRoot(t, repo, "src", closeErr)
+	sourcePath := filepath.Join(repo, "src", "Main.java")
+	result := &scanResult{}
+	readSource := func(repoPath, targetPath string, maxBytes int64) ([]byte, error) {
+		relativePath, err := filepath.Rel(repoPath, targetPath)
+		if err != nil {
+			return nil, err
+		}
+		return safeio.ReadFileWithinRootLimit(root, relativePath, maxBytes)
+	}
+
+	err := scanJVMSourceFileWithReader(repo, sourcePath, nil, nil, nil, result, readSource)
+	if err == nil {
+		t.Fatal("expected impure missing source read to propagate")
+	}
+	if !errors.Is(err, os.ErrNotExist) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected missing source and close identities to survive, got %v", err)
+	}
+	if len(result.Warnings) != 0 || result.SkippedSymlinks != 0 || result.SkippedLargeFiles != 0 {
+		t.Fatalf("expected impure missing source read not to downgrade, got %#v", result)
+	}
+
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected source path error, got %#v", err)
+	}
+	if pathErr.Path != filepath.Join("src", "Main.java") {
+		t.Fatalf("expected rooted source path to propagate, got %q", pathErr.Path)
+	}
+}
+
+func TestBuildFileWarningCollectorVisitWithinRootPropagatesImpureMissingPath(t *testing.T) {
+	repo := t.TempDir()
+	buildDir := filepath.Join(repo, "app")
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		t.Fatalf("mkdir build dir: %v", err)
+	}
+	closeErr := errors.New("close build ancestor")
+	root := newJVMNestedMissingReadRoot(t, repo, "app", closeErr)
+	buildPath := filepath.Join(repo, "app", buildGradleName)
+	collector := buildFileWarningCollector{
+		repoPath: repo,
+		parser: func(string, string) ([]dependencyDescriptor, []string) {
+			return nil, nil
+		},
+		names: []string{buildGradleName},
+		seen:  map[string]struct{}{},
+	}
+
+	err := collector.visitWithinRoot(root, filepath.Join("app", buildGradleName), buildPath, &jvmRootedTestDirEntry{name: buildGradleName})
+	if err == nil {
+		t.Fatal("expected impure missing build read to propagate")
+	}
+	if !errors.Is(err, os.ErrNotExist) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected missing build and close identities to survive, got %v", err)
+	}
+	if len(collector.warnings) != 0 {
+		t.Fatalf("expected impure missing build read not to downgrade, got %#v", collector.warnings)
+	}
+
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected build path error, got %#v", err)
+	}
+	if pathErr.Path != filepath.Join("app", buildGradleName) {
+		t.Fatalf("expected rooted build path to propagate, got %q", pathErr.Path)
+	}
+}
+
+func TestScanRepoWithinRootSuccessAndEmptyRepoGuards(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "java", "com", "example", "Main.java"), "package com.example;\nimport org.junit.jupiter.api.Test;\nclass Main {}\n")
+	root := openJVMTestRoot(t, repo)
+
+	result, err := scanRepoWithinRoot(context.Background(), repo, root, map[string]string{"org.junit.jupiter": "junit-jupiter-api"}, map[string]string{})
+	if err != nil {
+		t.Fatalf("scan rooted repo: %v", err)
+	}
+	if len(result.Files) != 1 || result.Files[0].Imports[0].Dependency != "junit-jupiter-api" {
+		t.Fatalf("expected rooted scan result, got %#v", result)
+	}
+
+	if _, err := scanRepoWithinRoot(context.Background(), "", root, map[string]string{}, map[string]string{}); !errors.Is(err, fs.ErrInvalid) {
+		t.Fatalf("expected invalid empty repo path, got %v", err)
+	}
+}
+
+func TestJVMAnalyseIgnoresUnrelatedFileFloodForCandidateBudgets(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), `dependencies { implementation("org.junit.jupiter:junit-jupiter-api:5.10.0") }`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "java", "com", "example", "Main.java"), "package com.example;\nimport org.junit.jupiter.api.Test;\nclass Main {}\n")
+	for index := 0; index < maxJVMBuildFiles+32; index++ {
+		testutil.MustWriteFile(t, filepath.Join(repo, "docs", fmt.Sprintf("note-%04d.txt", index)), "ignored\n")
+	}
+
+	result, err := NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repo, TopN: 1})
+	if err != nil {
+		t.Fatalf("analyse repo with unrelated file flood: %v", err)
+	}
+	if len(result.Dependencies) == 0 || result.Dependencies[0].Name != "junit-jupiter-api" {
+		t.Fatalf("expected declared/scanned JVM dependency to survive unrelated file flood, got %#v", result.Dependencies)
+	}
+	warnings := strings.Join(result.Warnings, "\n")
+	if strings.Contains(warnings, "rooted walk limit") || strings.Contains(warnings, "no JVM dependencies discovered") {
+		t.Fatalf("expected unrelated flood not to trip candidate-budget warnings, got %#v", result.Warnings)
+	}
+}
+
+func TestScanRepoWithinRootIgnoresSourceSymlinkDecoyFloodForCandidateBudget(t *testing.T) {
+	repo := t.TempDir()
+	outsideSource := filepath.Join(t.TempDir(), "Outside.java")
+	testutil.MustWriteFile(t, outsideSource, "class Outside {}\n")
+	for index := 0; index < maxJVMSourceFiles+32; index++ {
+		linkPath := filepath.Join(repo, "decoys", fmt.Sprintf("Link%04d.java", index))
+		if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+			t.Fatalf("mkdir source decoy dir: %v", err)
+		}
+		if err := os.Symlink(outsideSource, linkPath); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+	}
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "main", "java", "com", "example", "Main.java"), "package com.example;\nclass Main {}\n")
+	root := openJVMTestRoot(t, repo)
+
+	result, err := scanRepoWithinRoot(context.Background(), repo, root, map[string]string{}, map[string]string{})
+	if err != nil {
+		t.Fatalf("scan rooted repo with source symlink flood: %v", err)
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != filepath.Join("src", "main", "java", "com", "example", "Main.java") {
+		t.Fatalf("expected legitimate later source file to be scanned, got %#v", result.Files)
+	}
+	joinedWarnings := strings.Join(result.Warnings, "\n")
+	if strings.Contains(joinedWarnings, "rooted walk limit") {
+		t.Fatalf("expected source symlink decoys not to consume rooted-walk candidate budget, got %#v", result.Warnings)
+	}
+}
+
+func TestCollectDeclaredDependenciesWithinRootIgnoresBuildSymlinkDecoyFloodForCandidateBudget(t *testing.T) {
+	repo := t.TempDir()
+	outsideBuild := filepath.Join(t.TempDir(), buildGradleName)
+	testutil.MustWriteFile(t, outsideBuild, `dependencies { implementation("org.fake:fake:1.0.0") }`)
+	for index := 0; index <= maxJVMBuildFiles/3+8; index++ {
+		decoyDir := filepath.Join(repo, "decoys", fmt.Sprintf("module-%04d", index))
+		if err := os.MkdirAll(decoyDir, 0o755); err != nil {
+			t.Fatalf("mkdir build decoy dir: %v", err)
+		}
+		for _, name := range []string{pomXMLName, buildGradleName, buildGradleKTSName} {
+			if err := os.Symlink(outsideBuild, filepath.Join(decoyDir, name)); err != nil {
+				t.Skipf("symlink not supported: %v", err)
+			}
+		}
+	}
+	testutil.MustWriteFile(t, filepath.Join(repo, "app", buildGradleName), `dependencies { implementation("org.junit.jupiter:junit-jupiter-api:5.10.0") }`)
+	root := openJVMTestRoot(t, repo)
+
+	descriptors, _, _, warnings, err := collectDeclaredDependenciesWithinRoot(context.Background(), repo, root)
+	if err != nil {
+		t.Fatalf("collect rooted dependencies with build symlink flood: %v", err)
+	}
+	if len(descriptors) != 1 || descriptors[0].Name != "junit-jupiter-api" {
+		t.Fatalf("expected legitimate later build file to be parsed, got %#v", descriptors)
+	}
+	joinedWarnings := strings.Join(warnings, "\n")
+	if strings.Contains(joinedWarnings, "rooted walk limit") {
+		t.Fatalf("expected build symlink decoys not to consume rooted-walk candidate budget, got %#v", warnings)
+	}
+}
+
+func TestCollectDeclaredDependenciesWithinRootDowngradesTraversalLimitToWarning(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "app", buildGradleName), `dependencies { implementation("org.junit.jupiter:junit-jupiter-api:5.10.0") }`)
+	for index := 0; index < maxJVMBuildTraversalEntries+16; index++ {
+		testutil.MustWriteFile(t, filepath.Join(repo, "flood", fmt.Sprintf("entry-%05d.txt", index)), "ignored\n")
+	}
+	root := openJVMTestRoot(t, repo)
+
+	descriptors, _, _, warnings, err := collectDeclaredDependenciesWithinRoot(context.Background(), repo, root)
+	if err != nil {
+		t.Fatalf("collect rooted dependencies under traversal cap: %v", err)
+	}
+	if len(descriptors) != 1 || descriptors[0].Name != "junit-jupiter-api" {
+		t.Fatalf("expected rooted dependency descriptors before traversal cap, got %#v", descriptors)
+	}
+	joinedWarnings := strings.Join(warnings, "\n")
+	if !strings.Contains(joinedWarnings, "JVM build file scan reached the rooted walk limit") {
+		t.Fatalf("expected partial rooted-walk warning, got %#v", warnings)
+	}
+}
+
+func TestScanRepoWithinRootReportsSkippedAndEmptyWarnings(t *testing.T) {
+	repo := t.TempDir()
+	largeSource := filepath.Join(repo, "src", "main", "java", "com", "example", "Large.java")
+	testutil.MustWriteFile(t, largeSource, strings.Repeat("a", int(maxScannableJVMSourceFile)+1))
+	outsideSource := filepath.Join(t.TempDir(), "Outside.java")
+	testutil.MustWriteFile(t, outsideSource, "class Outside {}\n")
+	linkPath := filepath.Join(repo, "src", "main", "java", "com", "example", "Linked.java")
+	if err := os.Symlink(outsideSource, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	root := openJVMTestRoot(t, repo)
+
+	result, err := scanRepoWithinRoot(context.Background(), repo, root, map[string]string{}, map[string]string{})
+	if err != nil {
+		t.Fatalf("scan rooted repo warnings: %v", err)
+	}
+	if result.SkippedLargeFiles != 1 || result.SkippedSymlinks != 1 || len(result.Files) != 0 {
+		t.Fatalf("expected one large skip, one symlink skip, and no scanned files, got %#v", result)
+	}
+	if len(result.Warnings) != 4 {
+		t.Fatalf("expected aggregate skipped and empty warnings, got %#v", result.Warnings)
+	}
+}
+
+func TestCollectDeclaredDependenciesWithinRootReportsWarnings(t *testing.T) {
+	repo := t.TempDir()
+	settingsPath := filepath.Join(repo, buildGradleKTSName)
+	testutil.MustWriteFile(t, settingsPath, `dependencies { implementation(libs.okhttp) }`)
+	root := openJVMTestRoot(t, repo)
+
+	collector := buildFileWarningCollector{
+		repoPath: repo,
+		parser: func(path, content string) ([]dependencyDescriptor, []string) {
+			return []dependencyDescriptor{{Name: "okhttp", Group: "com.squareup.okhttp3", Artifact: "okhttp"}}, []string{"parse warning"}
+		},
+		names: []string{buildGradleKTSName},
+		seen:  make(map[string]struct{}),
+	}
+	if err := collector.visitWithinRoot(root, filepath.Join("..", buildGradleKTSName), filepath.Join(repo, "..", buildGradleKTSName), mustReadJVMSourceDirEntry(t, repo, filepath.Base(settingsPath))); err != nil {
+		t.Fatalf("visit escaping rooted build file: %v", err)
+	}
+	if len(collector.warnings) != 1 || !strings.Contains(collector.warnings[0], "unable to read ../build.gradle.kts") {
+		t.Fatalf("expected rooted build warning for escaping path, got %#v", collector.warnings)
+	}
+
+	collector = buildFileWarningCollector{
+		repoPath: repo,
+		parser: func(path, content string) ([]dependencyDescriptor, []string) {
+			return []dependencyDescriptor{{Name: "okhttp", Group: "com.squareup.okhttp3", Artifact: "okhttp"}}, []string{"parse warning"}
+		},
+		names: []string{buildGradleKTSName},
+		seen:  make(map[string]struct{}),
+	}
+	if err := collector.visitWithinRoot(root, filepath.Base(settingsPath), settingsPath, mustReadJVMSourceDirEntry(t, repo, filepath.Base(settingsPath))); err != nil {
+		t.Fatalf("visit rooted build file: %v", err)
+	}
+	if len(collector.descriptors) != 1 || len(collector.warnings) != 1 || collector.warnings[0] != "parse warning" {
+		t.Fatalf("expected rooted build parse warning and descriptor, got descriptors=%#v warnings=%#v", collector.descriptors, collector.warnings)
+	}
+}
+
+func TestBuildFileWarningCollectorVisitWithinRootSkipsDuplicateDescriptor(t *testing.T) {
+	repo := t.TempDir()
+	settingsPath := filepath.Join(repo, buildGradleKTSName)
+	testutil.MustWriteFile(t, settingsPath, `dependencies { implementation("com.squareup.okhttp3:okhttp:4.12.0") }`)
+	root := openJVMTestRoot(t, repo)
+	collector := buildFileWarningCollector{
+		repoPath: repo,
+		parser: func(string, string) ([]dependencyDescriptor, []string) {
+			return []dependencyDescriptor{{Name: "okhttp", Group: "com.squareup.okhttp3", Artifact: "okhttp"}}, nil
+		},
+		names: []string{buildGradleKTSName},
+		seen:  map[string]struct{}{"com.squareup.okhttp3:okhttp": {}},
+	}
+
+	if err := collector.visitWithinRoot(root, filepath.Base(settingsPath), settingsPath, mustReadJVMSourceDirEntry(t, repo, filepath.Base(settingsPath))); err != nil {
+		t.Fatalf("visit duplicate rooted build file: %v", err)
+	}
+
+	if len(collector.descriptors) != 0 {
+		t.Fatalf("expected duplicate rooted descriptor to be skipped, got %#v", collector.descriptors)
+	}
+}
+
+func TestParseBuildFilesWithinRootPropagatesImpureReadErrors(t *testing.T) {
+	for _, test := range []jvmImpureBuildReadTest{
+		{
+			name:       "file limit with close error",
+			newFile:    newOversizedJVMBuildTestFile,
+			wantRead:   safeio.ErrFileTooLarge,
+			closeLabel: "oversized build file",
+		},
+		{
+			name:       "symlink sentinel with close error",
+			newFile:    newSymlinkJVMBuildTestFile,
+			wantRead:   safeio.ErrTargetPathSymlink,
+			closeLabel: "build file after stat failure",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assertImpureJVMBuildReadError(t, test)
+		})
+	}
+}
+
+type jvmImpureBuildReadTest struct {
+	name       string
+	newFile    func(fs.FileInfo, error, *int) safeio.File
+	wantRead   error
+	closeLabel string
+}
+
+func newOversizedJVMBuildTestFile(info fs.FileInfo, closeErr error, closeCalls *int) safeio.File {
+	statCalls := 0
+	return &jvmRootedTestFile{
+		close: func() error {
+			(*closeCalls)++
+			return closeErr
+		},
+		stat: func() (fs.FileInfo, error) {
+			statCalls++
+			if statCalls == 1 {
+				return info, nil
+			}
+			return &jvmRootedSizedFileInfo{FileInfo: info, size: maxScannableJVMBuildFile + 1}, nil
+		},
+	}
+}
+
+func newSymlinkJVMBuildTestFile(_ fs.FileInfo, closeErr error, closeCalls *int) safeio.File {
+	return &jvmRootedTestFile{
+		close: func() error {
+			(*closeCalls)++
+			return closeErr
+		},
+		stat: func() (fs.FileInfo, error) {
+			return nil, safeio.ErrTargetPathSymlink
+		},
+	}
+}
+
+func assertImpureJVMBuildReadError(t *testing.T, test jvmImpureBuildReadTest) {
+	t.Helper()
+	repo := t.TempDir()
+	buildPath := filepath.Join(repo, buildGradleName)
+	testutil.MustWriteFile(t, buildPath, `dependencies { implementation("org.example:example:1.0.0") }`)
+	info, err := os.Stat(buildPath)
+	if err != nil {
+		t.Fatalf("stat build file: %v", err)
+	}
+	closeErr := errors.New("close " + test.closeLabel)
+	closeCalls := 0
+	root := newJVMRootedReadTestRoot(t, repo, filepath.Base(buildPath), test.newFile(info, closeErr, &closeCalls))
+
+	parser := func(string, string) ([]dependencyDescriptor, []string) {
+		t.Fatal("parser must not run after rooted read failure")
+		return nil, nil
+	}
+	descriptors, warnings, err := parseBuildFilesWithWarningsWithinRoot(context.Background(), repo, root, parser, buildGradleName)
+	if !errors.Is(err, test.wantRead) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined rooted build read and close error, got %v", err)
+	}
+	if len(descriptors) != 0 || len(warnings) != 0 {
+		t.Fatalf("expected impure build read failure not to be downgraded, got descriptors=%#v warnings=%#v", descriptors, warnings)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("expected failed build file to close once, got %d", closeCalls)
+	}
+}
+
+func TestRootedReadersRejectEscapingPaths(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleName), `dependencies { implementation("org.junit.jupiter:junit-jupiter-api:5.10.0") }`)
+	root := openJVMTestRoot(t, repo)
+
+	if content, err := readJVMBuildFileWithinRoot(root, repo, filepath.Join(repo, buildGradleName)); err != nil || !strings.Contains(string(content), "junit-jupiter-api") {
+		t.Fatalf("expected rooted build reader success, got content=%q err=%v", string(content), err)
+	}
+	if _, err := readJVMBuildFileWithinRoot(root, repo, filepath.Join(repo, "..", buildGradleName)); err == nil || !strings.Contains(err.Error(), "path escapes root") {
+		t.Fatalf("expected rooted build reader to reject escaping path, got %v", err)
+	}
+
+	if _, _, err := shared.LoadGradleCatalogResolverWithinRoot(context.Background(), "", root); err != nil {
+		t.Fatalf("expected empty rooted Gradle resolver to succeed, got %v", err)
+	}
+	if _, err := readJVMBuildFileWithinRoot(root, "relative-repo", filepath.Join(repo, buildGradleName)); err == nil {
+		t.Fatal("expected rooted build reader relative-path rel error")
+	}
+}
+
+func TestCollectDeclaredDependenciesWithinRootResolvesCatalogReferences(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "settings.gradle.kts"), `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(files("gradle/test-libs.versions.toml"))
+    }
+  }
+}
+`)
+	testutil.MustWriteFile(t, filepath.Join(repo, "gradle", "test-libs.versions.toml"), `
+[libraries]
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.10.0" }
+`)
+	testutil.MustWriteFile(t, filepath.Join(repo, buildGradleKTSName), `
+dependencies {
+  implementation(testLibs.junit.jupiter)
+}
+`)
+	root := openJVMTestRoot(t, repo)
+
+	descriptors, prefixes, aliases, warnings, err := collectDeclaredDependenciesWithinRoot(context.Background(), repo, root)
+	if err != nil {
+		t.Fatalf("collect rooted catalog dependencies: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected rooted catalog dependency resolution without warnings, got %#v", warnings)
+	}
+	if len(descriptors) != 1 || descriptors[0].Name != "junit-jupiter-api" {
+		t.Fatalf("expected rooted catalog descriptor, got %#v", descriptors)
+	}
+	if prefixes["org.junit.jupiter.junit.jupiter.api"] == "" || aliases["junit.jupiter.api"] == "" {
+		t.Fatalf("expected rooted catalog descriptor lookups, got prefixes=%#v aliases=%#v", prefixes, aliases)
+	}
+}
+
+func openJVMTestRoot(t *testing.T, repo string) safeio.Root {
+	t.Helper()
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	})
+	return root
+}
+
+type jvmRootedTestRoot struct {
+	safeio.Root
+	info     fs.FileInfo
+	lstat    func(string) (fs.FileInfo, error)
+	open     func(string) (safeio.File, error)
+	openRoot func(string) (safeio.Root, error)
+	close    func() error
+}
+
+func (r *jvmRootedTestRoot) Open(name string) (safeio.File, error) {
+	if r.open != nil {
+		return r.open(name)
+	}
+	return nil, errors.New("unexpected open: " + name)
+}
+
+func (*jvmRootedTestRoot) OpenFile(string, int, os.FileMode) (safeio.File, error) {
+	return nil, errors.New("unexpected open file")
+}
+
+func (r *jvmRootedTestRoot) OpenRoot(name string) (safeio.Root, error) {
+	if r.openRoot != nil {
+		return r.openRoot(name)
+	}
+	if r.Root != nil {
+		return r.Root.OpenRoot(name)
+	}
+	return nil, errors.New("unexpected open root")
+}
+
+func (r *jvmRootedTestRoot) Lstat(name string) (fs.FileInfo, error) {
+	if r.lstat != nil {
+		return r.lstat(name)
+	}
+	if name == "." && r.info != nil {
+		return r.info, nil
+	}
+	return nil, errors.New("unexpected lstat: " + name)
+}
+
+func (*jvmRootedTestRoot) Mkdir(string, os.FileMode) error { return errors.New("unexpected mkdir") }
+func (*jvmRootedTestRoot) Chmod(string, os.FileMode) error { return errors.New("unexpected chmod") }
+func (*jvmRootedTestRoot) MkdirAll(string, os.FileMode) error {
+	return errors.New("unexpected mkdir all")
+}
+func (*jvmRootedTestRoot) Rename(string, string) error { return errors.New("unexpected rename") }
+func (*jvmRootedTestRoot) Remove(string) error         { return errors.New("unexpected remove") }
+func (r *jvmRootedTestRoot) Close() error {
+	if r.close != nil {
+		return r.close()
+	}
+	if r.Root != nil {
+		return r.Root.Close()
+	}
+	return nil
+}
+
+type jvmRootedTestFile struct {
+	close func() error
+	stat  func() (fs.FileInfo, error)
+}
+
+func (*jvmRootedTestFile) Read([]byte) (int, error)    { return 0, io.EOF }
+func (*jvmRootedTestFile) Write(p []byte) (int, error) { return len(p), nil }
+func (f *jvmRootedTestFile) Close() error {
+	if f.close != nil {
+		return f.close()
+	}
+	return nil
+}
+func (f *jvmRootedTestFile) Stat() (fs.FileInfo, error) {
+	if f.stat != nil {
+		return f.stat()
+	}
+	return nil, errors.New("unexpected stat")
+}
+func (*jvmRootedTestFile) Chmod(os.FileMode) error { return nil }
+
+type jvmRootedSizedFileInfo struct {
+	fs.FileInfo
+	size int64
+}
+
+func (i *jvmRootedSizedFileInfo) Size() int64 {
+	return i.size
+}
+
+type jvmRootedTestDirectory struct {
+	jvmRootedTestFile
+	fillEntry    fs.DirEntry
+	extraEntries int
+	readErr      error
+	noProgress   bool
+}
+
+func (d *jvmRootedTestDirectory) ReadDir(count int) ([]fs.DirEntry, error) {
+	if d.readErr != nil {
+		return nil, d.readErr
+	}
+	if d.noProgress {
+		return nil, nil
+	}
+	if d.fillEntry != nil {
+		entries := make([]fs.DirEntry, count+d.extraEntries)
+		for index := range entries {
+			entries[index] = d.fillEntry
+		}
+		d.fillEntry = nil
+		return entries, nil
+	}
+	return nil, io.EOF
+}
+
+type jvmRootedTestDirEntry struct {
+	name string
+}
+
+func (e *jvmRootedTestDirEntry) Name() string    { return e.name }
+func (*jvmRootedTestDirEntry) IsDir() bool       { return false }
+func (*jvmRootedTestDirEntry) Type() fs.FileMode { return 0 }
+func (e *jvmRootedTestDirEntry) Info() (fs.FileInfo, error) {
+	return &jvmRootedTestFileInfo{name: e.name}, nil
+}
+
+type jvmRootedTestFileInfo struct {
+	name string
+}
+
+func (i *jvmRootedTestFileInfo) Name() string     { return i.name }
+func (*jvmRootedTestFileInfo) Size() int64        { return 0 }
+func (*jvmRootedTestFileInfo) Mode() fs.FileMode  { return 0 }
+func (*jvmRootedTestFileInfo) ModTime() time.Time { return time.Time{} }
+func (*jvmRootedTestFileInfo) IsDir() bool        { return false }
+func (*jvmRootedTestFileInfo) Sys() any           { return nil }
+
+func newJVMNestedMissingReadRoot(t *testing.T, repo, dirName string, closeErr error) safeio.Root {
+	t.Helper()
+	repoRoot := openJVMTestRoot(t, repo)
+	dirRoot := openJVMTestRoot(t, filepath.Join(repo, dirName))
+	return &jvmRootedTestRoot{
+		Root:  repoRoot,
+		lstat: repoRoot.Lstat,
+		open:  repoRoot.Open,
+		openRoot: func(name string) (safeio.Root, error) {
+			if name != dirName {
+				return repoRoot.OpenRoot(name)
+			}
+			return &jvmRootedTestRoot{
+				Root:  dirRoot,
+				lstat: dirRoot.Lstat,
+				open:  dirRoot.Open,
+				close: func() error {
+					if err := dirRoot.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+						return err
+					}
+					return closeErr
+				},
+			}, nil
+		},
+	}
+}
+
+func newJVMRootedReadTestRoot(t *testing.T, repo, targetName string, targetFile safeio.File) safeio.Root {
+	t.Helper()
+	realRoot := openJVMTestRoot(t, repo)
+	return &jvmRootedTestRoot{
+		Root:  realRoot,
+		lstat: realRoot.Lstat,
+		open: func(name string) (safeio.File, error) {
+			if name == targetName {
+				return targetFile, nil
+			}
+			return realRoot.Open(name)
+		},
+	}
+}
+
+func newJVMRootedTraversalLimitRoot(t *testing.T, repo string, closeErr error) safeio.Root {
+	t.Helper()
+	testutil.MustWriteFile(t, filepath.Join(repo, "ignored.txt"), "ignored\n")
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatalf("read traversal-limit fixture directory: %v", err)
+	}
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat traversal-limit fixture directory: %v", err)
+	}
+	directory := &jvmRootedTestDirectory{
+		jvmRootedTestFile: jvmRootedTestFile{
+			close: func() error { return closeErr },
+			stat:  func() (fs.FileInfo, error) { return info, nil },
+		},
+		fillEntry:    entries[0],
+		extraEntries: 1,
+	}
+	return &jvmRootedTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) {
+			return directory, nil
+		},
+	}
+}

--- a/internal/lang/jvm/rooted_candidate_pinning_test.go
+++ b/internal/lang/jvm/rooted_candidate_pinning_test.go
@@ -117,7 +117,7 @@ func testRootedBuildCandidateReadSurvivesSwap(t *testing.T) {
 	writeJVMRootedCandidate(t, filepath.Join(repo, parentRel, leaf), original)
 	swap, root := openSwappingJVMRoot(t, repo, parentRel, leaf, replacement, 1)
 	var parsedContent string
-	parser := func(_ string, content string) ([]dependencyDescriptor, []string) {
+	parser := func(_, content string) ([]dependencyDescriptor, []string) {
 		parsedContent = content
 		return nil, nil
 	}

--- a/internal/lang/jvm/rooted_candidate_pinning_test.go
+++ b/internal/lang/jvm/rooted_candidate_pinning_test.go
@@ -1,0 +1,358 @@
+package jvm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/lang/shared"
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+func TestRootedAnalysisCandidateReadsHaveBoundedOperationCounts(t *testing.T) {
+	const (
+		depth = 6
+		width = 6
+	)
+
+	t.Run("source", func(t *testing.T) {
+		repo := t.TempDir()
+		candidates := createJVMDeepWideCandidateTree(t, repo, depth, width, func(dir string, level, branch int) {
+			name := fmt.Sprintf("Source_%02d_%02d.java", level, branch)
+			writeJVMRootedCandidate(t, filepath.Join(dir, name), "package bounded;\nclass Source {}\n")
+		})
+		counts, root := openCountingJVMRoot(t, repo)
+
+		result, err := scanRepoWithinRoot(context.Background(), repo, root, nil, nil)
+		if err != nil {
+			t.Fatalf("scan deep-wide rooted sources: %v", err)
+		}
+		assertJVMRootedOperationCounts(t, repo, counts, candidates, 1)
+		if len(result.Files) != candidates {
+			t.Fatalf("expected %d source candidates, got %d", candidates, len(result.Files))
+		}
+	})
+
+	t.Run("build", func(t *testing.T) {
+		repo := t.TempDir()
+		candidates := createJVMDeepWideCandidateTree(t, repo, depth, width, func(dir string, level, branch int) {
+			content := fmt.Sprintf("dependencies { implementation(\"example:artifact-%02d-%02d:1\") }\n", level, branch)
+			writeJVMRootedCandidate(t, filepath.Join(dir, buildGradleName), content)
+		})
+		counts, root := openCountingJVMRoot(t, repo)
+		parserCalls := 0
+		parser := func(string, string) ([]dependencyDescriptor, []string) {
+			parserCalls++
+			return nil, nil
+		}
+
+		_, warnings, err := parseBuildFilesWithWarningsWithinRoot(context.Background(), repo, root, parser, buildGradleName)
+		if err != nil {
+			t.Fatalf("scan deep-wide rooted builds: %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no rooted build warnings, got %#v", warnings)
+		}
+		assertJVMRootedOperationCounts(t, repo, counts, candidates, 1)
+		if parserCalls != candidates {
+			t.Fatalf("expected %d build candidates, got %d parser calls", candidates, parserCalls)
+		}
+	})
+
+	t.Run("catalog", func(t *testing.T) {
+		repo := t.TempDir()
+		candidates := createJVMDeepWideCandidateTree(t, repo, depth, width, func(dir string, level, branch int) {
+			catalogPath := filepath.Join(dir, "gradle", "libs.versions.toml")
+			content := fmt.Sprintf("[libraries]\nentry_%02d_%02d = \"example:artifact-%02d-%02d:1\"\n", level, branch, level, branch)
+			writeJVMRootedCandidate(t, catalogPath, content)
+		})
+		counts, root := openCountingJVMRoot(t, repo)
+
+		_, warnings, err := shared.LoadGradleCatalogResolverWithinRoot(context.Background(), repo, root)
+		if err != nil {
+			t.Fatalf("scan deep-wide rooted catalogs: %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no rooted catalog warnings, got %#v", warnings)
+		}
+		assertJVMRootedOperationCounts(t, repo, counts, candidates, 2)
+	})
+}
+
+func TestRootedAnalysisCandidateReadsSurviveEnumerationNamespaceSwaps(t *testing.T) {
+	t.Run("source", testRootedSourceCandidateReadSurvivesSwap)
+	t.Run("build", testRootedBuildCandidateReadSurvivesSwap)
+	t.Run("catalog", testRootedCatalogCandidateReadSurvivesSwap)
+}
+
+func testRootedSourceCandidateReadSurvivesSwap(t *testing.T) {
+	repo := t.TempDir()
+	parentRel := filepath.Join("deep", "src")
+	leaf := "Main.java"
+	replacement := "package replacement;\nclass Main {}\n"
+	writeJVMRootedCandidate(t, filepath.Join(repo, parentRel, leaf), "package original;\nclass Main {}\n")
+	swap, root := openSwappingJVMRoot(t, repo, parentRel, leaf, replacement, 1)
+
+	result, err := scanRepoWithinRoot(context.Background(), repo, root, nil, nil)
+	if err != nil {
+		t.Fatalf("scan source through swapped namespace: %v", err)
+	}
+	if !swap.swapped || len(result.Files) != 1 || result.Files[0].Package != "original" {
+		t.Fatalf("expected pinned original source after swap, swapped=%v files=%#v", swap.swapped, result.Files)
+	}
+	assertJVMRootedNamespaceContains(t, repo, parentRel, leaf, replacement)
+}
+
+func testRootedBuildCandidateReadSurvivesSwap(t *testing.T) {
+	repo := t.TempDir()
+	parentRel := filepath.Join("deep", "app")
+	leaf := buildGradleName
+	original := `dependencies { implementation("original:artifact:1") }`
+	replacement := `dependencies { implementation("replacement:artifact:1") }`
+	writeJVMRootedCandidate(t, filepath.Join(repo, parentRel, leaf), original)
+	swap, root := openSwappingJVMRoot(t, repo, parentRel, leaf, replacement, 1)
+	var parsedContent string
+	parser := func(_ string, content string) ([]dependencyDescriptor, []string) {
+		parsedContent = content
+		return nil, nil
+	}
+
+	_, _, err := parseBuildFilesWithWarningsWithinRoot(context.Background(), repo, root, parser, buildGradleName)
+	if err != nil {
+		t.Fatalf("scan build through swapped namespace: %v", err)
+	}
+	if !swap.swapped || parsedContent != original {
+		t.Fatalf("expected pinned original build after swap, swapped=%v content=%q", swap.swapped, parsedContent)
+	}
+	assertJVMRootedNamespaceContains(t, repo, parentRel, leaf, replacement)
+}
+
+func testRootedCatalogCandidateReadSurvivesSwap(t *testing.T) {
+	repo := t.TempDir()
+	parentRel := filepath.Join("deep", "app", "gradle")
+	leaf := "libs.versions.toml"
+	original := "[libraries]\noriginal = \"original:artifact:1\"\n"
+	replacement := "[libraries]\nreplacement = \"replacement:artifact:1\"\n"
+	writeJVMRootedCandidate(t, filepath.Join(repo, parentRel, leaf), original)
+	swap, root := openSwappingJVMRoot(t, repo, parentRel, leaf, replacement, 2)
+
+	resolver, warnings, err := shared.LoadGradleCatalogResolverWithinRoot(context.Background(), repo, root)
+	if err != nil {
+		t.Fatalf("scan catalog through swapped namespace: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no rooted catalog warnings, got %#v", warnings)
+	}
+	buildPath := filepath.Join(repo, "deep", "app", buildGradleName)
+	libraries, parseWarnings := resolver.ParseDependencyReferences(buildPath, "dependencies { implementation(libs.original) }")
+	if !swap.swapped || len(parseWarnings) != 0 || len(libraries) != 1 || libraries[0].Group != "original" {
+		t.Fatalf("expected pinned original catalog after swap, swapped=%v libraries=%#v warnings=%#v", swap.swapped, libraries, parseWarnings)
+	}
+	assertJVMRootedNamespaceContains(t, repo, parentRel, leaf, replacement)
+}
+
+type jvmRootOperationCounts struct {
+	openRootCalls int
+	fileOpenCalls int
+}
+
+type countingJVMRoot struct {
+	safeio.Root
+	counts *jvmRootOperationCounts
+}
+
+func openCountingJVMRoot(t *testing.T, repo string) (*jvmRootOperationCounts, safeio.Root) {
+	t.Helper()
+	root := openJVMTestRoot(t, repo)
+	counts := &jvmRootOperationCounts{}
+	return counts, &countingJVMRoot{Root: root, counts: counts}
+}
+
+func (r *countingJVMRoot) Open(name string) (safeio.File, error) {
+	if name != "." {
+		r.counts.fileOpenCalls++
+	}
+	return r.Root.Open(name)
+}
+
+func (r *countingJVMRoot) OpenRoot(name string) (safeio.Root, error) {
+	r.counts.openRootCalls++
+	child, err := r.Root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	return &countingJVMRoot{Root: child, counts: r.counts}, nil
+}
+
+func assertJVMRootedOperationCounts(t *testing.T, repo string, counts *jvmRootOperationCounts, candidates, traversalPasses int) {
+	t.Helper()
+	directories := countJVMRootedDirectories(t, repo)
+	expectedRootOpens := traversalPasses * (directories - 1)
+	if counts.openRootCalls != expectedRootOpens {
+		t.Fatalf("expected %d pinned child-root opens for %d pass(es), got %d", expectedRootOpens, traversalPasses, counts.openRootCalls)
+	}
+	if counts.fileOpenCalls != candidates {
+		t.Fatalf("expected %d callback-scoped candidate opens, got %d", candidates, counts.fileOpenCalls)
+	}
+}
+
+func createJVMDeepWideCandidateTree(t *testing.T, repo string, depth, width int, writeCandidate func(dir string, level, branch int)) int {
+	t.Helper()
+	current := repo
+	candidates := 0
+	for level := 0; level < depth; level++ {
+		current = filepath.Join(current, fmt.Sprintf("level-%02d", level))
+		if err := os.MkdirAll(current, 0o755); err != nil {
+			t.Fatalf("create deep directory: %v", err)
+		}
+		for branch := 0; branch < width; branch++ {
+			branchDir := filepath.Join(current, fmt.Sprintf("branch-%02d", branch))
+			if err := os.MkdirAll(branchDir, 0o755); err != nil {
+				t.Fatalf("create wide directory: %v", err)
+			}
+			writeCandidate(branchDir, level, branch)
+			candidates++
+		}
+	}
+	return candidates
+}
+
+func writeJVMRootedCandidate(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create candidate parent: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write rooted candidate: %v", err)
+	}
+}
+
+func countJVMRootedDirectories(t *testing.T, repo string) int {
+	t.Helper()
+	count := 0
+	err := filepath.WalkDir(repo, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("count rooted directories: %v", err)
+	}
+	return count
+}
+
+type jvmEnumerationSwap struct {
+	t                  *testing.T
+	repo               string
+	parentRel          string
+	leaf               string
+	replacementContent string
+	triggerEnumeration int
+	enumerations       int
+	swapped            bool
+}
+
+type swappingJVMRoot struct {
+	safeio.Root
+	relativePath string
+	swap         *jvmEnumerationSwap
+}
+
+type swappingJVMDirectory struct {
+	safeio.ReadDirFile
+	swap *jvmEnumerationSwap
+}
+
+func openSwappingJVMRoot(t *testing.T, repo, parentRel, leaf, replacementContent string, triggerEnumeration int) (*jvmEnumerationSwap, safeio.Root) {
+	t.Helper()
+	root := openJVMTestRoot(t, repo)
+	swap := &jvmEnumerationSwap{
+		t:                  t,
+		repo:               repo,
+		parentRel:          filepath.Clean(parentRel),
+		leaf:               leaf,
+		replacementContent: replacementContent,
+		triggerEnumeration: triggerEnumeration,
+	}
+	return swap, &swappingJVMRoot{Root: root, relativePath: ".", swap: swap}
+}
+
+func (r *swappingJVMRoot) Open(name string) (safeio.File, error) {
+	file, err := r.Root.Open(name)
+	if err != nil || name != "." || filepath.Clean(r.relativePath) != r.swap.parentRel {
+		return file, err
+	}
+	directory, ok := file.(safeio.ReadDirFile)
+	if !ok {
+		return nil, errors.Join(fs.ErrInvalid, file.Close())
+	}
+	return &swappingJVMDirectory{ReadDirFile: directory, swap: r.swap}, nil
+}
+
+func (r *swappingJVMRoot) OpenRoot(name string) (safeio.Root, error) {
+	child, err := r.Root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	return &swappingJVMRoot{
+		Root:         child,
+		relativePath: filepath.Join(r.relativePath, name),
+		swap:         r.swap,
+	}, nil
+}
+
+func (d *swappingJVMDirectory) ReadDir(count int) ([]fs.DirEntry, error) {
+	entries, err := d.ReadDirFile.ReadDir(count)
+	if containsJVMRootedEntry(entries, d.swap.leaf) {
+		d.swap.observeCandidateEnumeration()
+	}
+	return entries, err
+}
+
+func containsJVMRootedEntry(entries []fs.DirEntry, name string) bool {
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *jvmEnumerationSwap) observeCandidateEnumeration() {
+	s.enumerations++
+	if s.swapped || s.enumerations != s.triggerEnumeration {
+		return
+	}
+	parentPath := filepath.Join(s.repo, s.parentRel)
+	holdingPath := parentPath + "-pinned-original"
+	if err := os.Rename(parentPath, holdingPath); err != nil {
+		s.t.Fatalf("rename enumerated candidate parent: %v", err)
+	}
+	if err := os.MkdirAll(parentPath, 0o755); err != nil {
+		s.t.Fatalf("create replacement candidate parent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(parentPath, s.leaf), []byte(s.replacementContent), 0o600); err != nil {
+		s.t.Fatalf("write replacement candidate: %v", err)
+	}
+	s.swapped = true
+}
+
+func assertJVMRootedNamespaceContains(t *testing.T, repo, parentRel, leaf, want string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repo, parentRel, leaf))
+	if err != nil {
+		t.Fatalf("read replacement namespace candidate: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != strings.TrimSpace(want) {
+		t.Fatalf("expected replacement namespace content %q, got %q", want, data)
+	}
+}

--- a/internal/lang/jvm/source_scan.go
+++ b/internal/lang/jvm/source_scan.go
@@ -2,7 +2,10 @@ package jvm
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -21,11 +24,19 @@ type fileScan struct {
 }
 
 type scanResult struct {
-	Files    []fileScan
-	Warnings []string
+	Files             []fileScan
+	Warnings          []string
+	SkippedLargeFiles int
+	SkippedSymlinks   int
 }
 
 func scanRepo(ctx context.Context, repoPath string, depPrefixes map[string]string, depAliases map[string]string) (scanResult, error) {
+	return scanRepoWithSourceReader(ctx, repoPath, depPrefixes, depAliases, safeio.ReadFileUnderLimit)
+}
+
+type jvmSourceReader func(rootDir, targetPath string, maxBytes int64) ([]byte, error)
+
+func scanRepoWithSourceReader(ctx context.Context, repoPath string, depPrefixes map[string]string, depAliases map[string]string, readSource jvmSourceReader) (scanResult, error) {
 	result := scanResult{}
 	if repoPath == "" {
 		return result, fs.ErrInvalid
@@ -44,12 +55,18 @@ func scanRepo(ctx context.Context, repoPath string, depPrefixes map[string]strin
 			}
 			return nil
 		}
-		return scanJVMSourceFile(repoPath, path, depPrefixes, depAliases, &result)
+		return scanJVMSourceFileWithReader(repoPath, path, depPrefixes, depAliases, &result, readSource)
 	})
 	if err != nil {
 		return result, err
 	}
 
+	if result.SkippedLargeFiles > 0 {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("skipped %d large JVM file(s) above %d bytes", result.SkippedLargeFiles, maxScannableJVMSourceFile))
+	}
+	if result.SkippedSymlinks > 0 {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("skipped %d unreadable or untrusted JVM source symlink(s)", result.SkippedSymlinks))
+	}
 	if len(result.Files) == 0 {
 		result.Warnings = append(result.Warnings, "no Java/Kotlin source files found for analysis")
 	}
@@ -57,6 +74,10 @@ func scanRepo(ctx context.Context, repoPath string, depPrefixes map[string]strin
 }
 
 func scanJVMSourceFile(repoPath string, path string, depPrefixes map[string]string, depAliases map[string]string, result *scanResult) error {
+	return scanJVMSourceFileWithReader(repoPath, path, depPrefixes, depAliases, result, safeio.ReadFileUnderLimit)
+}
+
+func scanJVMSourceFileWithReader(repoPath string, path string, depPrefixes map[string]string, depAliases map[string]string, result *scanResult, readSource jvmSourceReader) error {
 	if !isSourceFile(path) {
 		return nil
 	}
@@ -65,11 +86,24 @@ func scanJVMSourceFile(repoPath string, path string, depPrefixes map[string]stri
 		err     error
 	)
 	if strings.TrimSpace(repoPath) == "" {
-		content, err = safeio.ReadFile(path)
+		content, err = safeio.ReadFileLimit(path, maxScannableJVMSourceFile)
 	} else {
-		content, err = safeio.ReadFileUnder(repoPath, path)
+		content, err = readSource(repoPath, path, maxScannableJVMSourceFile)
+	}
+	if errors.Is(err, safeio.ErrFileTooLarge) {
+		if result != nil {
+			result.SkippedLargeFiles++
+		}
+		return nil
 	}
 	if err != nil {
+		if warning, skip := classifySkippableJVMSourceReadError(repoPath, path, err); skip {
+			if result != nil {
+				result.SkippedSymlinks++
+				result.Warnings = append(result.Warnings, warning)
+			}
+			return nil
+		}
 		return err
 	}
 	relativePath, err := filepath.Rel(repoPath, path)
@@ -86,6 +120,59 @@ func scanJVMSourceFile(repoPath string, path string, depPrefixes map[string]stri
 		Usage:   countUsage(content, imports),
 	})
 	return nil
+}
+
+func classifySkippableJVMSourceReadError(repoPath, path string, err error) (string, bool) {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return "", false
+	}
+
+	description, expected := describeExpectedJVMSourceReadError(err)
+	if !expected {
+		return "", false
+	}
+
+	info, statErr := os.Lstat(path)
+	if statErr != nil || info.Mode()&os.ModeSymlink == 0 {
+		return "", false
+	}
+
+	return fmt.Sprintf("skipped JVM source symlink %s: %s", relativeSourceScanPath(repoPath, path), description), true
+}
+
+func relativeSourceScanPath(repoPath, path string) string {
+	if strings.TrimSpace(repoPath) == "" {
+		return path
+	}
+	relativePath, relErr := filepath.Rel(repoPath, path)
+	if relErr != nil {
+		return path
+	}
+	return relativePath
+}
+
+func describeExpectedJVMSourceReadError(err error) (string, bool) {
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return "target missing", true
+	case errors.Is(err, fs.ErrPermission):
+		return "target unreadable", true
+	case isJVMSourceRepoRootEscapeError(err):
+		return "target escapes repo root", true
+	default:
+		return "", false
+	}
+}
+
+func isJVMSourceRepoRootEscapeError(err error) bool {
+	if strings.HasPrefix(err.Error(), "path escapes root: ") {
+		return true
+	}
+
+	var pathErr *fs.PathError
+	return errors.As(err, &pathErr) &&
+		pathErr.Err != nil &&
+		pathErr.Err.Error() == "path escapes from parent"
 }
 
 func isSourceFile(path string) bool {

--- a/internal/lang/jvm/source_scan.go
+++ b/internal/lang/jvm/source_scan.go
@@ -35,7 +35,51 @@ func scanRepo(ctx context.Context, repoPath string, depPrefixes map[string]strin
 	return scanRepoWithSourceReader(ctx, repoPath, depPrefixes, depAliases, safeio.ReadFileUnderLimit)
 }
 
+func scanRepoWithinRoot(ctx context.Context, repoPath string, root safeio.Root, depPrefixes map[string]string, depAliases map[string]string) (scanResult, error) {
+	result := scanResult{}
+	if repoPath == "" {
+		return result, fs.ErrInvalid
+	}
+
+	budget := shared.RootedWalkBudget{
+		MaxTraversalEntries: maxJVMSourceTraversalEntries,
+		MaxFiles:            maxJVMSourceFiles,
+		MaxWorkItems:        maxJVMSourceWorkItems,
+		CountCandidate: func(path string, _ fs.DirEntry) bool {
+			return isSourceFile(path)
+		},
+	}
+	err := shared.WalkRepoFilesWithinRootPinned(ctx, repoPath, root, budget, shouldSkipDir, func(file shared.RootedWalkFile) error {
+		readSource := rootedJVMSourceReader(file.Parent, file.Leaf)
+		return scanJVMSourceFileWithReader(repoPath, file.Path, file.Entry, depPrefixes, depAliases, &result, readSource)
+	})
+	if err != nil {
+		if warning, limited := shared.RootedWalkBudgetWarning("JVM source scan", budget, err); limited {
+			result.Warnings = append(result.Warnings, warning)
+		} else {
+			return result, err
+		}
+	}
+
+	if result.SkippedLargeFiles > 0 {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("skipped %d large JVM file(s) above %d bytes", result.SkippedLargeFiles, maxScannableJVMSourceFile))
+	}
+	if result.SkippedSymlinks > 0 {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("skipped %d unreadable or untrusted JVM source symlink(s)", result.SkippedSymlinks))
+	}
+	if len(result.Files) == 0 {
+		result.Warnings = append(result.Warnings, "no Java/Kotlin source files found for analysis")
+	}
+	return result, nil
+}
+
 type jvmSourceReader func(rootDir, targetPath string, maxBytes int64) ([]byte, error)
+
+func rootedJVMSourceReader(parent safeio.Root, leaf string) jvmSourceReader {
+	return func(_, _ string, maxBytes int64) ([]byte, error) {
+		return safeio.ReadFileWithinRootLimit(parent, leaf, maxBytes)
+	}
+}
 
 func scanRepoWithSourceReader(ctx context.Context, repoPath string, depPrefixes map[string]string, depAliases map[string]string, readSource jvmSourceReader) (scanResult, error) {
 	result := scanResult{}
@@ -56,7 +100,7 @@ func scanRepoWithSourceReader(ctx context.Context, repoPath string, depPrefixes 
 			}
 			return nil
 		}
-		return scanJVMSourceFileWithReader(repoPath, path, depPrefixes, depAliases, &result, readSource)
+		return scanJVMSourceFileWithReader(repoPath, path, entry, depPrefixes, depAliases, &result, readSource)
 	})
 	if err != nil {
 		return result, err
@@ -75,10 +119,10 @@ func scanRepoWithSourceReader(ctx context.Context, repoPath string, depPrefixes 
 }
 
 func scanJVMSourceFile(repoPath string, path string, depPrefixes map[string]string, depAliases map[string]string, result *scanResult) error {
-	return scanJVMSourceFileWithReader(repoPath, path, depPrefixes, depAliases, result, safeio.ReadFileUnderLimit)
+	return scanJVMSourceFileWithReader(repoPath, path, nil, depPrefixes, depAliases, result, safeio.ReadFileUnderLimit)
 }
 
-func scanJVMSourceFileWithReader(repoPath string, path string, depPrefixes map[string]string, depAliases map[string]string, result *scanResult, readSource jvmSourceReader) error {
+func scanJVMSourceFileWithReader(repoPath string, path string, entry fs.DirEntry, depPrefixes map[string]string, depAliases map[string]string, result *scanResult, readSource jvmSourceReader) error {
 	if !isSourceFile(path) {
 		return nil
 	}
@@ -91,14 +135,14 @@ func scanJVMSourceFileWithReader(repoPath string, path string, depPrefixes map[s
 	} else {
 		content, err = readSource(repoPath, path, maxScannableJVMSourceFile)
 	}
-	if errors.Is(err, safeio.ErrFileTooLarge) {
+	if shared.IsPureSentinelError(err, safeio.ErrFileTooLarge) {
 		if result != nil {
 			result.SkippedLargeFiles++
 		}
 		return nil
 	}
 	if err != nil {
-		if warning, skip := classifySkippableJVMSourceReadError(repoPath, path, err); skip {
+		if warning, skip := classifySkippableJVMSourceReadError(repoPath, path, entry, err); skip {
 			if result != nil {
 				result.SkippedSymlinks++
 				result.Warnings = append(result.Warnings, warning)
@@ -123,7 +167,7 @@ func scanJVMSourceFileWithReader(repoPath string, path string, depPrefixes map[s
 	return nil
 }
 
-func classifySkippableJVMSourceReadError(repoPath, path string, err error) (string, bool) {
+func classifySkippableJVMSourceReadError(repoPath, path string, entry fs.DirEntry, err error) (string, bool) {
 	if err == nil || errors.Is(err, context.Canceled) {
 		return "", false
 	}
@@ -132,9 +176,7 @@ func classifySkippableJVMSourceReadError(repoPath, path string, err error) (stri
 	if !expected {
 		return "", false
 	}
-
-	info, statErr := os.Lstat(path)
-	if statErr != nil || info.Mode()&os.ModeSymlink == 0 {
+	if entry == nil || entry.Type()&os.ModeSymlink == 0 {
 		return "", false
 	}
 
@@ -154,10 +196,12 @@ func relativeSourceScanPath(repoPath, path string) string {
 
 func describeExpectedJVMSourceReadError(err error) (string, bool) {
 	switch {
-	case errors.Is(err, fs.ErrNotExist):
+	case shared.IsPureSentinelError(err, fs.ErrNotExist):
 		return "target missing", true
-	case errors.Is(err, fs.ErrPermission):
+	case shared.IsPureSentinelError(err, fs.ErrPermission):
 		return "target unreadable", true
+	case shared.IsPureSentinelError(err, safeio.ErrTargetPathSymlink):
+		return "target is an untrusted symlink", true
 	case isJVMSourceSymlinkLoopError(err):
 		return "target loops through symlinks", true
 	case isJVMSourceRepoRootEscapeError(err):
@@ -168,24 +212,11 @@ func describeExpectedJVMSourceReadError(err error) (string, bool) {
 }
 
 func isJVMSourceRepoRootEscapeError(err error) bool {
-	if strings.HasPrefix(err.Error(), "path escapes root: ") {
-		return true
-	}
-
-	var pathErr *fs.PathError
-	return errors.As(err, &pathErr) &&
-		pathErr.Err != nil &&
-		pathErr.Err.Error() == "path escapes from parent"
+	return shared.IsPureSentinelError(err, safeio.ErrPathEscapesRoot)
 }
 
 func isJVMSourceSymlinkLoopError(err error) bool {
-	if errors.Is(err, syscall.ELOOP) {
-		return true
-	}
-
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "too many levels of symbolic links") ||
-		strings.Contains(message, "too many symlinks")
+	return shared.IsPureSentinelError(err, syscall.ELOOP)
 }
 
 func isSourceFile(path string) bool {

--- a/internal/lang/jvm/source_scan.go
+++ b/internal/lang/jvm/source_scan.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/safeio"
@@ -157,6 +158,8 @@ func describeExpectedJVMSourceReadError(err error) (string, bool) {
 		return "target missing", true
 	case errors.Is(err, fs.ErrPermission):
 		return "target unreadable", true
+	case isJVMSourceSymlinkLoopError(err):
+		return "target loops through symlinks", true
 	case isJVMSourceRepoRootEscapeError(err):
 		return "target escapes repo root", true
 	default:
@@ -173,6 +176,16 @@ func isJVMSourceRepoRootEscapeError(err error) bool {
 	return errors.As(err, &pathErr) &&
 		pathErr.Err != nil &&
 		pathErr.Err.Error() == "path escapes from parent"
+}
+
+func isJVMSourceSymlinkLoopError(err error) bool {
+	if errors.Is(err, syscall.ELOOP) {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "too many levels of symbolic links") ||
+		strings.Contains(message, "too many symlinks")
 }
 
 func isSourceFile(path string) bool {

--- a/internal/lang/shared/adapter_scaffold_walk_context_test.go
+++ b/internal/lang/shared/adapter_scaffold_walk_context_test.go
@@ -5,11 +5,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestNewReportAndWalkContextErrAdditionalBranches(t *testing.T) {
 	if err := WalkContextErr(nilContext(), nil); err != nil {
 		t.Fatalf("expected nil walk/context error when context is nil, got %v", err)
+	}
+	if IsPathWithin("\x00", filepath.Join(t.TempDir(), "child")) {
+		t.Fatalf("expected invalid root path to be rejected")
 	}
 }
 
@@ -50,5 +54,38 @@ func TestResolvePathWithMissingLeaf(t *testing.T) {
 	}
 	if pathWithin(repo, repo+"-sibling") {
 		t.Fatalf("expected pathWithin to reject sibling paths with matching prefixes")
+	}
+}
+
+func TestNewReportUsesDefaultWorkingDirectoryForEmptyRepoPath(t *testing.T) {
+	repoPath, got, err := NewReport("", time.Now)
+	if err != nil {
+		t.Fatalf("NewReport returned error: %v", err)
+	}
+	if repoPath == "" || got.RepoPath != repoPath {
+		t.Fatalf("expected normalized repo path to be recorded, got repoPath=%q report=%#v", repoPath, got)
+	}
+}
+
+func TestIsPathWithinRejectsBrokenRootSymlink(t *testing.T) {
+	linkPath := filepath.Join(t.TempDir(), "repo-link")
+	if err := os.Symlink(filepath.Join(t.TempDir(), "missing-target"), linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if IsPathWithin(linkPath, filepath.Join(linkPath, "child.txt")) {
+		t.Fatal("expected broken root symlink to be rejected")
+	}
+}
+
+func TestIsPathWithinRejectsBrokenCandidateSymlink(t *testing.T) {
+	repo := t.TempDir()
+	candidate := filepath.Join(repo, "broken-child")
+	if err := os.Symlink(filepath.Join(repo, "missing-target"), candidate); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if IsPathWithin(repo, candidate) {
+		t.Fatal("expected broken candidate symlink to be rejected")
 	}
 }

--- a/internal/lang/shared/dependency_usage_test.go
+++ b/internal/lang/shared/dependency_usage_test.go
@@ -279,6 +279,22 @@ func TestDeclarationAndMaskingHelpers(t *testing.T) {
 	}
 }
 
+func TestClampUsageCountsResetsNegativeUsageToZero(t *testing.T) {
+	usage := map[string]int{
+		"alpha": -2,
+		"beta":  3,
+	}
+
+	clampUsageCounts(map[string]int{"alpha": 1, "beta": 1}, usage)
+
+	if usage["alpha"] != 0 {
+		t.Fatalf("expected negative usage to clamp to zero, got %d", usage["alpha"])
+	}
+	if usage["beta"] != 3 {
+		t.Fatalf("expected non-negative usage to remain unchanged, got %d", usage["beta"])
+	}
+}
+
 func BenchmarkCountUsage(b *testing.B) {
 	imports, content := benchmarkImportsAndContent()
 	b.ReportAllocs()

--- a/internal/lang/shared/error_classification.go
+++ b/internal/lang/shared/error_classification.go
@@ -23,7 +23,7 @@ func IsPureSentinelError(err error, sentinels ...error) bool {
 	return matchesSentinel(err, sentinels)
 }
 
-func arePureSentinelCauses(causes []error, sentinels []error) bool {
+func arePureSentinelCauses(causes, sentinels []error) bool {
 	found := false
 	for _, cause := range causes {
 		if cause == nil {

--- a/internal/lang/shared/error_classification.go
+++ b/internal/lang/shared/error_classification.go
@@ -1,0 +1,47 @@
+package shared
+
+import "errors"
+
+type multiError interface {
+	error
+	Unwrap() []error
+}
+
+// IsPureSentinelError reports whether every terminal error in err's unwrap
+// tree matches at least one sentinel.
+func IsPureSentinelError(err error, sentinels ...error) bool {
+	if err == nil || len(sentinels) == 0 {
+		return false
+	}
+	var wrapped multiError
+	if errors.As(err, &wrapped) {
+		return arePureSentinelCauses(wrapped.Unwrap(), sentinels)
+	}
+	if cause := errors.Unwrap(err); cause != nil {
+		return IsPureSentinelError(cause, sentinels...)
+	}
+	return matchesSentinel(err, sentinels)
+}
+
+func arePureSentinelCauses(causes []error, sentinels []error) bool {
+	found := false
+	for _, cause := range causes {
+		if cause == nil {
+			continue
+		}
+		found = true
+		if !IsPureSentinelError(cause, sentinels...) {
+			return false
+		}
+	}
+	return found
+}
+
+func matchesSentinel(err error, sentinels []error) bool {
+	for _, sentinel := range sentinels {
+		if sentinel != nil && errors.Is(err, sentinel) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/lang/shared/gradle_build_test.go
+++ b/internal/lang/shared/gradle_build_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/kotlin"
 )
 
 func TestParseGradleDependencyCoordinatesForGroovyAndKotlin(t *testing.T) {
@@ -87,6 +88,25 @@ func TestGradleBuildParserDefensiveHelpers(t *testing.T) {
 	assertGradleCoordinateParsing(t)
 	assertGradleNodeWalking(t)
 	assertGradleCatalogDefensiveParsing(t)
+}
+
+func TestGradleDependencyArgumentExpressionsIgnoreStringArguments(t *testing.T) {
+	node, source := parseFirstKotlinValueArgument(t, `dependencies { implementation("com.example:demo:1.0.0") }`)
+
+	if got := gradleDependencyArgumentExpressions(node, source); len(got) != 0 {
+		t.Fatalf("expected string dependency argument to produce no expression text, got %#v", got)
+	}
+}
+
+func TestCollectGradleNamedArgumentIgnoresIncompleteValueArgument(t *testing.T) {
+	node, source := parseFirstKotlinValueArgument(t, `dependencies { implementation(group = "com.example") }`)
+	fields := map[string]string{}
+
+	collectGradleNamedArgument(fields, node.NamedChild(0), source)
+
+	if len(fields) != 0 {
+		t.Fatalf("expected incomplete named argument to be ignored, got %#v", fields)
+	}
 }
 
 func assertGradleNilInputs(t *testing.T) {
@@ -214,4 +234,29 @@ func assertGradleCatalogReference(t *testing.T, references []gradleCatalogRefere
 		}
 	}
 	t.Fatalf("expected Gradle catalog reference catalog=%q alias=%q bundle=%t unsupported=%q in %#v", catalogName, alias, bundle, unsupported, references)
+}
+
+func parseFirstKotlinValueArgument(t *testing.T, content string) (*sitter.Node, []byte) {
+	t.Helper()
+	parser := sitter.NewParser()
+	parser.SetLanguage(kotlin.GetLanguage())
+	source := []byte(content)
+	tree, err := parser.ParseCtx(t.Context(), nil, source)
+	if err != nil {
+		t.Fatalf("parse kotlin source: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("expected kotlin parse tree")
+	}
+
+	var found *sitter.Node
+	walkGradleNode(tree.RootNode(), func(node *sitter.Node) {
+		if found == nil && node.Type() == "value_argument" {
+			found = node
+		}
+	})
+	if found == nil {
+		t.Fatal("expected Kotlin value_argument node")
+	}
+	return found, source
 }

--- a/internal/lang/shared/gradle_catalog.go
+++ b/internal/lang/shared/gradle_catalog.go
@@ -22,6 +22,9 @@ const (
 	defaultGradleCatalogMaxTraversalEntries = 4096
 	defaultGradleCatalogMaxFiles            = 1024
 	defaultGradleCatalogMaxWorkItems        = 1024
+	gradleCatalogScanOperation              = "Gradle version catalog scan"
+	settingsGradleFileName                  = "settings.gradle"
+	settingsGradleKTSFileName               = "settings.gradle.kts"
 	gradleCatalogReadWarningFormat          = "unable to read %s: %v"
 	unsupportedGradleCatalogLibraryFormat   = "unsupported Gradle version catalog library %q in %s"
 	unsupportedGradleCatalogModuleFormat    = "unsupported Gradle version catalog module %q in %s"
@@ -128,7 +131,7 @@ func LoadGradleCatalogResolverWithinRoot(ctx context.Context, repoPath string, r
 	}
 	registry := newGradleCatalogRegistry(repoPath)
 	if err := registry.collectSourcesWithinRoot(ctx, root); err != nil {
-		if warning, limited := RootedWalkBudgetWarning("Gradle version catalog scan", rootedGradleCatalogWalkBudget(), err); limited {
+		if warning, limited := RootedWalkBudgetWarning(gradleCatalogScanOperation, rootedGradleCatalogWalkBudget(), err); limited {
 			registry.warnings = append(registry.warnings, warning)
 		} else {
 			return GradleCatalogResolver{}, nil, err
@@ -161,7 +164,7 @@ func (r *gradleCatalogRegistry) collectSourcesWithinRoot(ctx context.Context, ro
 	budget := rootedGradleCatalogWalkBudget()
 	walkErr := WalkRepoFilesWithinRootPinned(ctx, r.repoPath, root, budget, maybeSkipGradleCatalogDirectoryName, func(file RootedWalkFile) error {
 		switch strings.ToLower(file.Leaf) {
-		case "settings.gradle", "settings.gradle.kts":
+		case settingsGradleFileName, settingsGradleKTSFileName:
 			return r.loadSettingsFileWithinPinnedParent(file.Parent, file.Leaf, file.Path)
 		case defaultGradleCatalogFileName:
 			r.registerDefaultCatalog(file.Path)
@@ -169,13 +172,13 @@ func (r *gradleCatalogRegistry) collectSourcesWithinRoot(ctx context.Context, ro
 		return nil
 	})
 	if walkErr != nil {
-		if _, limited := RootedWalkBudgetWarning("Gradle version catalog scan", budget, walkErr); !limited {
+		if _, limited := RootedWalkBudgetWarning(gradleCatalogScanOperation, budget, walkErr); !limited {
 			return walkErr
 		}
 	}
 	sourceWalkErr := r.captureSourcesWithinRoot(ctx, root)
 	if sourceWalkErr != nil {
-		if _, limited := RootedWalkBudgetWarning("Gradle version catalog scan", budget, sourceWalkErr); !limited {
+		if _, limited := RootedWalkBudgetWarning(gradleCatalogScanOperation, budget, sourceWalkErr); !limited {
 			return sourceWalkErr
 		}
 	}
@@ -229,7 +232,7 @@ func rootedGradleCatalogWalkBudget() RootedWalkBudget {
 		MaxWorkItems:        defaultGradleCatalogMaxWorkItems,
 		CountCandidate: func(_ string, entry fs.DirEntry) bool {
 			switch strings.ToLower(entry.Name()) {
-			case "settings.gradle", "settings.gradle.kts", defaultGradleCatalogFileName:
+			case settingsGradleFileName, settingsGradleKTSFileName, defaultGradleCatalogFileName:
 				return true
 			default:
 				return false
@@ -246,7 +249,7 @@ func (r *gradleCatalogRegistry) visit(path string, entry fs.DirEntry, err error)
 		return maybeSkipGradleCatalogDirectory(entry)
 	}
 	switch strings.ToLower(entry.Name()) {
-	case "settings.gradle", "settings.gradle.kts":
+	case settingsGradleFileName, settingsGradleKTSFileName:
 		r.loadSettingsFile(path)
 	case defaultGradleCatalogFileName:
 		r.registerDefaultCatalog(path)

--- a/internal/lang/shared/gradle_catalog.go
+++ b/internal/lang/shared/gradle_catalog.go
@@ -193,12 +193,17 @@ func (r *gradleCatalogRegistry) captureSourcesWithinRoot(ctx context.Context, ro
 	if len(keysByPath) == 0 {
 		return nil
 	}
+	captureDirectories := gradleCatalogCaptureDirectories(r.repoPath, keysByPath)
 	budget := rootedGradleCatalogWalkBudget()
 	budget.CountCandidate = func(path string, _ fs.DirEntry) bool {
 		_, ok := keysByPath[filepath.Clean(path)]
 		return ok
 	}
-	return WalkRepoFilesWithinRootPinned(ctx, r.repoPath, root, budget, maybeSkipGradleCatalogDirectoryName, func(file RootedWalkFile) error {
+	skipDirectory := func(path, _ string) bool {
+		_, capture := captureDirectories[filepath.Clean(path)]
+		return !capture
+	}
+	captureSource := func(file RootedWalkFile) error {
 		keys := keysByPath[filepath.Clean(file.Path)]
 		if len(keys) == 0 {
 			return nil
@@ -212,7 +217,23 @@ func (r *gradleCatalogRegistry) captureSourcesWithinRoot(ctx context.Context, ro
 			r.sources[key] = source
 		}
 		return nil
-	})
+	}
+	return walkRepoFilesWithinRootPinnedWithPathSkip(ctx, r.repoPath, root, budget, skipDirectory, captureSource)
+}
+
+func gradleCatalogCaptureDirectories(repoPath string, keysByPath map[string][]string) map[string]struct{} {
+	repoPath = filepath.Clean(repoPath)
+	directories := make(map[string]struct{})
+	for path := range keysByPath {
+		relativePath, err := filepath.Rel(repoPath, path)
+		if err != nil || gradleCatalogRelativePathEscapesRepo(relativePath) {
+			continue
+		}
+		for directory := filepath.Dir(relativePath); directory != "."; directory = filepath.Dir(directory) {
+			directories[filepath.Join(repoPath, directory)] = struct{}{}
+		}
+	}
+	return directories
 }
 
 func (r *gradleCatalogRegistry) sourceKeysByPath() map[string][]string {
@@ -480,10 +501,14 @@ func uncapturedGradleCatalogSourceError(repoPath, path string) error {
 	if err != nil {
 		return err
 	}
-	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) || filepath.IsAbs(relativePath) {
+	if gradleCatalogRelativePathEscapesRepo(relativePath) {
 		return fmt.Errorf("%w: %s", safeio.ErrPathEscapesRoot, path)
 	}
 	return &fs.PathError{Op: "open", Path: relativePath, Err: fs.ErrNotExist}
+}
+
+func gradleCatalogRelativePathEscapesRepo(path string) bool {
+	return path == ".." || strings.HasPrefix(path, ".."+string(filepath.Separator)) || filepath.IsAbs(path)
 }
 
 func isPureGradleCatalogReadWarning(err error) bool {

--- a/internal/lang/shared/gradle_catalog.go
+++ b/internal/lang/shared/gradle_catalog.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -18,6 +19,9 @@ const gradleCatalogScopeKeySeparator = "\x00"
 const (
 	GradleManifestByteLimit                 = 2 * 1024 * 1024
 	defaultGradleCatalogFileName            = "libs.versions.toml"
+	defaultGradleCatalogMaxTraversalEntries = 4096
+	defaultGradleCatalogMaxFiles            = 1024
+	defaultGradleCatalogMaxWorkItems        = 1024
 	gradleCatalogReadWarningFormat          = "unable to read %s: %v"
 	unsupportedGradleCatalogLibraryFormat   = "unsupported Gradle version catalog library %q in %s"
 	unsupportedGradleCatalogModuleFormat    = "unsupported Gradle version catalog module %q in %s"
@@ -54,9 +58,12 @@ type gradleCatalogLookupIndex struct {
 }
 
 type gradleCatalogSource struct {
-	root string
-	name string
-	path string
+	root          string
+	name          string
+	path          string
+	rootedContent []byte
+	rootedReadErr error
+	rootedLoaded  bool
 }
 
 type gradleCatalogSettingRef struct {
@@ -115,6 +122,25 @@ func LoadGradleCatalogResolver(repoPath string) (GradleCatalogResolver, []string
 	return registry.buildResolver(), dedupeGradleCatalogWarnings(registry.warnings)
 }
 
+func LoadGradleCatalogResolverWithinRoot(ctx context.Context, repoPath string, root safeio.Root) (GradleCatalogResolver, []string, error) {
+	if strings.TrimSpace(repoPath) == "" {
+		return GradleCatalogResolver{knownCatalogs: make(map[string]struct{})}, nil, nil
+	}
+	registry := newGradleCatalogRegistry(repoPath)
+	if err := registry.collectSourcesWithinRoot(ctx, root); err != nil {
+		if warning, limited := RootedWalkBudgetWarning("Gradle version catalog scan", rootedGradleCatalogWalkBudget(), err); limited {
+			registry.warnings = append(registry.warnings, warning)
+		} else {
+			return GradleCatalogResolver{}, nil, err
+		}
+	}
+	resolver, err := registry.buildResolverWithinRoot()
+	if err != nil {
+		return GradleCatalogResolver{}, nil, err
+	}
+	return resolver, dedupeGradleCatalogWarnings(registry.warnings), nil
+}
+
 func newGradleCatalogRegistry(repoPath string) *gradleCatalogRegistry {
 	return &gradleCatalogRegistry{
 		repoPath:      repoPath,
@@ -128,6 +154,87 @@ func (r *gradleCatalogRegistry) collectSources() {
 	walkErr := filepath.WalkDir(r.repoPath, r.visit)
 	if walkErr != nil {
 		r.warnings = append(r.warnings, fmt.Sprintf("unable to scan Gradle version catalogs: %v", walkErr))
+	}
+}
+
+func (r *gradleCatalogRegistry) collectSourcesWithinRoot(ctx context.Context, root safeio.Root) error {
+	budget := rootedGradleCatalogWalkBudget()
+	walkErr := WalkRepoFilesWithinRootPinned(ctx, r.repoPath, root, budget, maybeSkipGradleCatalogDirectoryName, func(file RootedWalkFile) error {
+		switch strings.ToLower(file.Leaf) {
+		case "settings.gradle", "settings.gradle.kts":
+			return r.loadSettingsFileWithinPinnedParent(file.Parent, file.Leaf, file.Path)
+		case defaultGradleCatalogFileName:
+			r.registerDefaultCatalog(file.Path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		if _, limited := RootedWalkBudgetWarning("Gradle version catalog scan", budget, walkErr); !limited {
+			return walkErr
+		}
+	}
+	sourceWalkErr := r.captureSourcesWithinRoot(ctx, root)
+	if sourceWalkErr != nil {
+		if _, limited := RootedWalkBudgetWarning("Gradle version catalog scan", budget, sourceWalkErr); !limited {
+			return sourceWalkErr
+		}
+	}
+	if walkErr != nil {
+		return walkErr
+	}
+	return sourceWalkErr
+}
+
+func (r *gradleCatalogRegistry) captureSourcesWithinRoot(ctx context.Context, root safeio.Root) error {
+	keysByPath := r.sourceKeysByPath()
+	if len(keysByPath) == 0 {
+		return nil
+	}
+	budget := rootedGradleCatalogWalkBudget()
+	budget.CountCandidate = func(path string, _ fs.DirEntry) bool {
+		_, ok := keysByPath[filepath.Clean(path)]
+		return ok
+	}
+	return WalkRepoFilesWithinRootPinned(ctx, r.repoPath, root, budget, maybeSkipGradleCatalogDirectoryName, func(file RootedWalkFile) error {
+		keys := keysByPath[filepath.Clean(file.Path)]
+		if len(keys) == 0 {
+			return nil
+		}
+		content, readErr := safeio.ReadFileWithinRootLimit(file.Parent, file.Leaf, GradleManifestByteLimit)
+		for _, key := range keys {
+			source := r.sources[key]
+			source.rootedContent = content
+			source.rootedReadErr = readErr
+			source.rootedLoaded = true
+			r.sources[key] = source
+		}
+		return nil
+	})
+}
+
+func (r *gradleCatalogRegistry) sourceKeysByPath() map[string][]string {
+	keysByPath := make(map[string][]string, len(r.sources))
+	for _, key := range r.sortedSourceKeys() {
+		source := r.sources[key]
+		path := filepath.Clean(source.path)
+		keysByPath[path] = append(keysByPath[path], key)
+	}
+	return keysByPath
+}
+
+func rootedGradleCatalogWalkBudget() RootedWalkBudget {
+	return RootedWalkBudget{
+		MaxTraversalEntries: defaultGradleCatalogMaxTraversalEntries,
+		MaxFiles:            defaultGradleCatalogMaxFiles,
+		MaxWorkItems:        defaultGradleCatalogMaxWorkItems,
+		CountCandidate: func(_ string, entry fs.DirEntry) bool {
+			switch strings.ToLower(entry.Name()) {
+			case "settings.gradle", "settings.gradle.kts", defaultGradleCatalogFileName:
+				return true
+			default:
+				return false
+			}
+		},
 	}
 }
 
@@ -148,11 +255,18 @@ func (r *gradleCatalogRegistry) visit(path string, entry fs.DirEntry, err error)
 }
 
 func maybeSkipGradleCatalogDirectory(entry fs.DirEntry) error {
-	name := strings.ToLower(entry.Name())
-	if ShouldSkipDir(name, gradleCatalogSkippedDirectories) || ShouldSkipCommonDir(name) {
+	if maybeSkipGradleCatalogDirectoryName(entry.Name()) {
 		return filepath.SkipDir
 	}
 	return nil
+}
+
+func maybeSkipGradleCatalogDirectoryName(name string) bool {
+	name = strings.ToLower(name)
+	if ShouldSkipDir(name, gradleCatalogSkippedDirectories) || ShouldSkipCommonDir(name) {
+		return true
+	}
+	return false
 }
 
 func (r *gradleCatalogRegistry) loadSettingsFile(path string) {
@@ -163,6 +277,41 @@ func (r *gradleCatalogRegistry) loadSettingsFile(path string) {
 	}
 	root := filepath.Dir(path)
 	refs, parseWarnings := parseGradleSettingsCatalogRefs(string(content), relativeGradleCatalogPath(r.repoPath, path))
+	r.warnings = append(r.warnings, parseWarnings...)
+	for _, ref := range refs {
+		r.trackKnownCatalog(ref.Name)
+		if strings.TrimSpace(ref.Path) == "" {
+			continue
+		}
+		r.registerSource(root, ref.Name, resolveGradleCatalogSourcePath(root, ref.Path))
+	}
+}
+
+func (r *gradleCatalogRegistry) loadSettingsFileWithinRoot(root safeio.Root, path string) error {
+	content, readErr := readGradleCatalogFileWithinRoot(root, r.repoPath, path)
+	return r.loadSettingsFileResult(path, content, readErr)
+}
+
+func (r *gradleCatalogRegistry) loadSettingsFileWithinPinnedParent(parent safeio.Root, leaf, path string) error {
+	content, readErr := safeio.ReadFileWithinRootLimit(parent, leaf, GradleManifestByteLimit)
+	return r.loadSettingsFileResult(path, content, readErr)
+}
+
+func (r *gradleCatalogRegistry) loadSettingsFileResult(path string, content []byte, readErr error) error {
+	if readErr != nil {
+		if !isPureGradleCatalogReadWarning(readErr) {
+			return readErr
+		}
+		r.warnings = append(r.warnings, formatGradleCatalogReadWarning(r.repoPath, path, readErr))
+		return nil
+	}
+	r.loadSettingsFileContent(path, string(content))
+	return nil
+}
+
+func (r *gradleCatalogRegistry) loadSettingsFileContent(path, content string) {
+	root := filepath.Dir(path)
+	refs, parseWarnings := parseGradleSettingsCatalogRefs(content, relativeGradleCatalogPath(r.repoPath, path))
 	r.warnings = append(r.warnings, parseWarnings...)
 	for _, ref := range refs {
 		r.trackKnownCatalog(ref.Name)
@@ -215,6 +364,17 @@ func (r *gradleCatalogRegistry) trackKnownCatalog(name string) {
 
 func (r *gradleCatalogRegistry) buildResolver() GradleCatalogResolver {
 	r.parseSources()
+	return r.finalizeResolver()
+}
+
+func (r *gradleCatalogRegistry) buildResolverWithinRoot() (GradleCatalogResolver, error) {
+	if err := r.parseSourcesWithinRoot(); err != nil {
+		return GradleCatalogResolver{}, err
+	}
+	return r.finalizeResolver(), nil
+}
+
+func (r *gradleCatalogRegistry) finalizeResolver() GradleCatalogResolver {
 	scopes := r.sortedScopes()
 	resolver := GradleCatalogResolver{
 		knownCatalogs: r.knownCatalogs,
@@ -225,9 +385,36 @@ func (r *gradleCatalogRegistry) buildResolver() GradleCatalogResolver {
 }
 
 func (r *gradleCatalogRegistry) parseSources() {
-	for _, source := range r.sources {
+	for _, source := range r.sortedSources() {
 		r.loadSource(source)
 	}
+}
+
+func (r *gradleCatalogRegistry) parseSourcesWithinRoot() error {
+	for _, source := range r.sortedSources() {
+		if err := r.loadCapturedSourceWithinRoot(source); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *gradleCatalogRegistry) sortedSources() []gradleCatalogSource {
+	keys := r.sortedSourceKeys()
+	sources := make([]gradleCatalogSource, 0, len(keys))
+	for _, key := range keys {
+		sources = append(sources, r.sources[key])
+	}
+	return sources
+}
+
+func (r *gradleCatalogRegistry) sortedSourceKeys() []string {
+	keys := make([]string, 0, len(r.sources))
+	for key := range r.sources {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (r *gradleCatalogRegistry) sortedScopes() []gradleCatalogScope {
@@ -255,6 +442,64 @@ func (r *gradleCatalogRegistry) loadSource(source gradleCatalogSource) {
 	scope := r.ensureScope(source.root)
 	r.mergeLibraries(scope, source, parsed.libraries)
 	r.mergeBundles(scope, source, parsed.bundles)
+}
+
+func (r *gradleCatalogRegistry) loadSourceWithinRoot(root safeio.Root, source gradleCatalogSource) error {
+	content, readErr := readGradleCatalogFileWithinRoot(root, r.repoPath, source.path)
+	return r.loadSourceResult(source, content, readErr)
+}
+
+func (r *gradleCatalogRegistry) loadCapturedSourceWithinRoot(source gradleCatalogSource) error {
+	if !source.rootedLoaded {
+		source.rootedReadErr = uncapturedGradleCatalogSourceError(r.repoPath, source.path)
+	}
+	return r.loadSourceResult(source, source.rootedContent, source.rootedReadErr)
+}
+
+func (r *gradleCatalogRegistry) loadSourceResult(source gradleCatalogSource, content []byte, readErr error) error {
+	if readErr != nil {
+		if !isPureGradleCatalogReadWarning(readErr) {
+			return readErr
+		}
+		r.warnings = append(r.warnings, formatGradleCatalogReadWarning(r.repoPath, source.path, readErr))
+		return nil
+	}
+	parsed, parseWarnings := parseGradleCatalogFile(string(content), source.name, relativeGradleCatalogPath(r.repoPath, source.path))
+	r.warnings = append(r.warnings, parseWarnings...)
+	scope := r.ensureScope(source.root)
+	r.mergeLibraries(scope, source, parsed.libraries)
+	r.mergeBundles(scope, source, parsed.bundles)
+	return nil
+}
+
+func uncapturedGradleCatalogSourceError(repoPath, path string) error {
+	relativePath, err := filepath.Rel(repoPath, path)
+	if err != nil {
+		return err
+	}
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) || filepath.IsAbs(relativePath) {
+		return fmt.Errorf("%w: %s", safeio.ErrPathEscapesRoot, path)
+	}
+	return &fs.PathError{Op: "open", Path: relativePath, Err: fs.ErrNotExist}
+}
+
+func isPureGradleCatalogReadWarning(err error) bool {
+	allowed := []error{
+		safeio.ErrFileTooLarge,
+		safeio.ErrTargetPathSymlink,
+		safeio.ErrPathEscapesRoot,
+		fs.ErrNotExist,
+		fs.ErrPermission,
+	}
+	return IsPureSentinelError(err, allowed...)
+}
+
+func readGradleCatalogFileWithinRoot(root safeio.Root, repoPath, path string) ([]byte, error) {
+	relativePath, err := filepath.Rel(repoPath, path)
+	if err != nil {
+		return nil, err
+	}
+	return safeio.ReadFileWithinRootLimit(root, relativePath, GradleManifestByteLimit)
 }
 
 func (r *gradleCatalogRegistry) ensureScope(root string) *gradleCatalogScope {

--- a/internal/lang/shared/gradle_catalog.go
+++ b/internal/lang/shared/gradle_catalog.go
@@ -16,6 +16,7 @@ import (
 const gradleCatalogScopeKeySeparator = "\x00"
 
 const (
+	GradleManifestByteLimit                 = 2 * 1024 * 1024
 	defaultGradleCatalogFileName            = "libs.versions.toml"
 	gradleCatalogReadWarningFormat          = "unable to read %s: %v"
 	unsupportedGradleCatalogLibraryFormat   = "unsupported Gradle version catalog library %q in %s"
@@ -155,7 +156,7 @@ func maybeSkipGradleCatalogDirectory(entry fs.DirEntry) error {
 }
 
 func (r *gradleCatalogRegistry) loadSettingsFile(path string) {
-	content, readErr := safeio.ReadFileUnder(r.repoPath, path)
+	content, readErr := safeio.ReadFileUnderLimit(r.repoPath, path, GradleManifestByteLimit)
 	if readErr != nil {
 		r.warnings = append(r.warnings, formatGradleCatalogReadWarning(r.repoPath, path, readErr))
 		return
@@ -244,7 +245,7 @@ func (r *gradleCatalogRegistry) sortedScopes() []gradleCatalogScope {
 }
 
 func (r *gradleCatalogRegistry) loadSource(source gradleCatalogSource) {
-	content, readErr := safeio.ReadFileUnder(r.repoPath, source.path)
+	content, readErr := safeio.ReadFileUnderLimit(r.repoPath, source.path, GradleManifestByteLimit)
 	if readErr != nil {
 		r.warnings = append(r.warnings, formatGradleCatalogReadWarning(r.repoPath, source.path, readErr))
 		return

--- a/internal/lang/shared/gradle_catalog_internal_test.go
+++ b/internal/lang/shared/gradle_catalog_internal_test.go
@@ -512,6 +512,9 @@ func TestGradleCatalogPathAndWarningHelpers(t *testing.T) {
 	if got := formatGradleCatalogReadWarning(testRepoRoot, testRepoCatalogPath, fs.ErrPermission); got != fmt.Sprintf("unable to read %s: %v", gradleDefaultCatalogPath, fs.ErrPermission) {
 		t.Fatalf("expected read warning to be repo-relative, got %q", got)
 	}
+	if GradleManifestByteLimit != 2*1024*1024 {
+		t.Fatalf("expected shared Gradle manifest limit to remain explicit and stable, got %d", GradleManifestByteLimit)
+	}
 
 	if warnings := DedupeWarnings(nil); len(warnings) != 0 {
 		t.Fatalf("expected nil warning slice to stay nil, got %#v", warnings)

--- a/internal/lang/shared/gradle_catalog_internal_test.go
+++ b/internal/lang/shared/gradle_catalog_internal_test.go
@@ -1,12 +1,16 @@
 package shared
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 type stubGradleCatalogDirEntry struct {
@@ -392,6 +396,330 @@ func assertGradleCatalogLookupIndexResolveCases(t *testing.T) {
 	}
 }
 
+func TestGradleCatalogWithinRootReaders(t *testing.T) {
+	repo := t.TempDir()
+	catalogPath := filepath.Join(repo, "gradle", gradleDefaultCatalogFileName)
+	writeGradleCatalogTestFile(t, catalogPath, "[libraries]\nokhttp = \"com.squareup.okhttp3:okhttp:4.12.0\"\n")
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open rooted gradle repo: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close rooted gradle repo: %v", closeErr)
+		}
+	})
+
+	content, err := readGradleCatalogFileWithinRoot(root, repo, catalogPath)
+	if err != nil || !strings.Contains(string(content), "okhttp") {
+		t.Fatalf("expected rooted gradle catalog read success, got content=%q err=%v", string(content), err)
+	}
+	if _, err := readGradleCatalogFileWithinRoot(root, repo, filepath.Join(repo, "..", gradleDefaultCatalogFileName)); err == nil || !strings.Contains(err.Error(), "path escapes root") {
+		t.Fatalf("expected rooted gradle catalog path rejection, got %v", err)
+	}
+	if _, err := readGradleCatalogFileWithinRoot(root, "relative-repo", catalogPath); err == nil {
+		t.Fatal("expected rooted gradle catalog relative-path rel error")
+	}
+
+	resolver, warnings, err := LoadGradleCatalogResolverWithinRoot(context.Background(), repo, root)
+	if err != nil {
+		t.Fatalf("load rooted gradle resolver: %v", err)
+	}
+	if len(warnings) != 0 || len(resolver.scopes) == 0 {
+		t.Fatalf("expected rooted gradle resolver to discover scopes, got resolver=%#v warnings=%#v", resolver, warnings)
+	}
+}
+
+func TestGradleCatalogWithinRootLoadsSettingsAndWarnings(t *testing.T) {
+	repo := t.TempDir()
+	settingsPath := filepath.Join(repo, gradleSettingsFileName)
+	catalogPath := filepath.Join(repo, "gradle", gradleDefaultCatalogFileName)
+	writeGradleCatalogTestFile(t, settingsPath, `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(files("gradle/libs.versions.toml"))
+    }
+    create("dynamic") {
+      from(dynamicCatalogProvider())
+    }
+  }
+}
+`)
+	writeGradleCatalogTestFile(t, catalogPath, "[libraries]\nokhttp = \"com.squareup.okhttp3:okhttp:4.12.0\"\n")
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open rooted gradle repo: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close rooted gradle repo: %v", closeErr)
+		}
+	})
+
+	registry := newGradleCatalogRegistry(repo)
+	if err := registry.loadSettingsFileWithinRoot(root, settingsPath); err != nil {
+		t.Fatalf("load rooted Gradle settings: %v", err)
+	}
+	if _, ok := registry.knownCatalogs["testlibs"]; !ok {
+		t.Fatalf("expected rooted settings load to track catalog names, got %#v", registry.knownCatalogs)
+	}
+	if len(registry.sources) != 1 {
+		t.Fatalf("expected rooted settings load to register one rooted source, got %#v", registry.sources)
+	}
+	assertGradleCatalogWarningsContain(t, registry.warnings, "unsupported Gradle version catalog source for dynamic in "+gradleSettingsFileName)
+
+	registry = newGradleCatalogRegistry(repo)
+	if err := registry.loadSettingsFileWithinRoot(root, filepath.Join(repo, "missing", gradleSettingsFileName)); err != nil {
+		t.Fatalf("load missing rooted Gradle settings: %v", err)
+	}
+	assertGradleCatalogWarningsContain(t, registry.warnings, "unable to read missing/"+gradleSettingsFileName+":")
+
+	registry = newGradleCatalogRegistry(repo)
+	if err := registry.loadSourceWithinRoot(root, gradleCatalogSource{
+		root: repo,
+		name: gradleCatalogName,
+		path: filepath.Join(repo, "gradle", "missing.versions.toml"),
+	}); err != nil {
+		t.Fatalf("load missing rooted Gradle catalog: %v", err)
+	}
+	assertGradleCatalogWarningsContain(t, registry.warnings, "unable to read gradle/missing.versions.toml:")
+}
+
+func TestLoadGradleCatalogResolverWithinRootPropagatesImpureSettingsReadError(t *testing.T) {
+	repo := t.TempDir()
+	settingsPath := filepath.Join(repo, gradleSettingsFileName)
+	writeGradleCatalogTestFile(t, settingsPath, "dependencyResolutionManagement {}\n")
+	info, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatalf("stat rooted Gradle settings: %v", err)
+	}
+	closeErr := errors.New("close oversized Gradle settings")
+	closeCalls := 0
+	statCalls := 0
+	root := newSharedRootedReadTestRoot(t, repo, filepath.Base(settingsPath), &sharedWalkTestFile{
+		close: func() error {
+			closeCalls++
+			return closeErr
+		},
+		stat: func() (fs.FileInfo, error) {
+			statCalls++
+			if statCalls == 1 {
+				return info, nil
+			}
+			return &sharedSizedFileInfo{FileInfo: info, size: GradleManifestByteLimit + 1}, nil
+		},
+	})
+
+	_, warnings, err := LoadGradleCatalogResolverWithinRoot(context.Background(), repo, root)
+	if !errors.Is(err, safeio.ErrFileTooLarge) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined Gradle settings file-limit and close error, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected impure Gradle settings failure not to be downgraded, got %#v", warnings)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("expected oversized Gradle settings to close once, got %d", closeCalls)
+	}
+}
+
+func TestLoadGradleCatalogResolverWithinRootPropagatesImpureSourceReadError(t *testing.T) {
+	repo := t.TempDir()
+	settingsPath := filepath.Join(repo, gradleSettingsFileName)
+	catalogPath := filepath.Join(repo, "custom.versions.toml")
+	writeGradleCatalogTestFile(t, settingsPath, `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(files("custom.versions.toml"))
+    }
+  }
+}
+`)
+	writeGradleCatalogTestFile(t, catalogPath, "[libraries]\nokhttp = \"com.squareup.okhttp3:okhttp:4.12.0\"\n")
+	closeErr := errors.New("close Gradle catalog after symlink sentinel")
+	closeCalls := 0
+	root := newSharedRootedReadTestRoot(t, repo, filepath.Base(catalogPath), &sharedWalkTestFile{
+		close: func() error {
+			closeCalls++
+			return closeErr
+		},
+		stat: func() (fs.FileInfo, error) {
+			return nil, safeio.ErrTargetPathSymlink
+		},
+	})
+
+	_, warnings, err := LoadGradleCatalogResolverWithinRoot(context.Background(), repo, root)
+	if !errors.Is(err, safeio.ErrTargetPathSymlink) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined Gradle catalog symlink and close error, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected impure Gradle catalog failure not to be downgraded, got %#v", warnings)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("expected failed Gradle catalog to close once, got %d", closeCalls)
+	}
+}
+
+func TestGradleCatalogRegistryLoadSourceWithinRootPropagatesImpureMissingPath(t *testing.T) {
+	repo := t.TempDir()
+	gradleDir := filepath.Join(repo, "gradle")
+	if err := os.MkdirAll(gradleDir, 0o755); err != nil {
+		t.Fatalf("mkdir gradle dir: %v", err)
+	}
+	closeErr := errors.New("close catalog ancestor")
+	root := newSharedNestedMissingReadRoot(t, repo, "gradle", closeErr)
+	registry := newGradleCatalogRegistry(repo)
+	sourcePath := filepath.Join(repo, "gradle", "custom.versions.toml")
+
+	err := registry.loadSourceWithinRoot(root, gradleCatalogSource{
+		root: repo,
+		name: gradleCatalogName,
+		path: sourcePath,
+	})
+	if err == nil {
+		t.Fatal("expected impure missing Gradle catalog read to propagate")
+	}
+	if !errors.Is(err, os.ErrNotExist) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected missing catalog and close identities to survive, got %v", err)
+	}
+	if len(registry.warnings) != 0 {
+		t.Fatalf("expected impure missing Gradle catalog read not to downgrade, got %#v", registry.warnings)
+	}
+
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected catalog path error, got %#v", err)
+	}
+	if pathErr.Path != filepath.Join("gradle", "custom.versions.toml") {
+		t.Fatalf("expected rooted catalog path to propagate, got %q", pathErr.Path)
+	}
+}
+
+func newSharedNestedMissingReadRoot(t *testing.T, repo, dirName string, closeErr error) safeio.Root {
+	t.Helper()
+	repoRoot := openSharedTestRoot(t, repo)
+	dirRoot := openSharedTestRoot(t, filepath.Join(repo, dirName))
+	return &sharedWalkSwapRoot{
+		Root: repoRoot,
+		openRoot: func(name string) (safeio.Root, error) {
+			if name != dirName {
+				return repoRoot.OpenRoot(name)
+			}
+			return &sharedWalkSwapRoot{
+				Root: dirRoot,
+				close: func() error {
+					if err := dirRoot.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+						return err
+					}
+					return closeErr
+				},
+			}, nil
+		},
+	}
+}
+
+func TestLoadGradleCatalogResolverWithinRootPropagatesCancellation(t *testing.T) {
+	repo := t.TempDir()
+	writeGradleCatalogTestFile(t, filepath.Join(repo, "gradle", gradleDefaultCatalogFileName), "[libraries]\nokhttp = \"com.squareup.okhttp3:okhttp:4.12.0\"\n")
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open rooted gradle repo: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close rooted gradle repo: %v", closeErr)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err = LoadGradleCatalogResolverWithinRoot(ctx, repo, root)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected rooted resolver cancellation, got %v", err)
+	}
+}
+
+func TestGradleCatalogCollectSourcesWithinRootFindsSettingsAndDefaultCatalog(t *testing.T) {
+	repo := t.TempDir()
+	writeGradleCatalogTestFile(t, filepath.Join(repo, gradleSettingsFileName), `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(files("gradle/libs.versions.toml"))
+    }
+  }
+}
+`)
+	writeGradleCatalogTestFile(t, filepath.Join(repo, "gradle", gradleDefaultCatalogFileName), "[libraries]\nokhttp = \"com.squareup.okhttp3:okhttp:4.12.0\"\n")
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open rooted gradle repo: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close rooted gradle repo: %v", closeErr)
+		}
+	})
+
+	registry := newGradleCatalogRegistry(repo)
+	if err := registry.collectSourcesWithinRoot(context.Background(), root); err != nil {
+		t.Fatalf("collect rooted sources: %v", err)
+	}
+	if _, ok := registry.knownCatalogs["testlibs"]; !ok {
+		t.Fatalf("expected rooted collection to track settings catalogs, got %#v", registry.knownCatalogs)
+	}
+	if len(registry.sources) != 2 {
+		t.Fatalf("expected rooted collection to register settings and default catalogs, got %#v", registry.sources)
+	}
+}
+
+func TestLoadGradleCatalogResolverWithinRootIgnoresCatalogSymlinkDecoyFloodForCandidateBudget(t *testing.T) {
+	repo := t.TempDir()
+	outsideCatalog := filepath.Join(t.TempDir(), "outside.versions.toml")
+	writeGradleCatalogTestFile(t, outsideCatalog, "[libraries]\noutside = \"dev.example:outside:1.0.0\"\n")
+	for index := 0; index < defaultGradleCatalogMaxFiles+32; index++ {
+		linkPath := filepath.Join(repo, "decoys", fmt.Sprintf("module-%04d", index), "gradle", gradleDefaultCatalogFileName)
+		if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+			t.Fatalf("mkdir catalog decoy dir: %v", err)
+		}
+		if err := os.Symlink(outsideCatalog, linkPath); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+	}
+	writeGradleCatalogTestFile(t, filepath.Join(repo, gradleSettingsFileName), `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(files("gradle/libs.versions.toml"))
+    }
+  }
+}
+`)
+	writeGradleCatalogTestFile(t, filepath.Join(repo, "gradle", gradleDefaultCatalogFileName), "[libraries]\nokhttp = \"com.squareup.okhttp3:okhttp:4.12.0\"\n")
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open rooted gradle repo: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close rooted gradle repo: %v", closeErr)
+		}
+	})
+
+	resolver, warnings, err := LoadGradleCatalogResolverWithinRoot(context.Background(), repo, root)
+	if err != nil {
+		t.Fatalf("load rooted gradle resolver with catalog symlink flood: %v", err)
+	}
+	if len(resolver.scopes) == 0 {
+		t.Fatalf("expected legitimate later catalog to be discovered, got resolver=%#v", resolver)
+	}
+	joinedWarnings := strings.Join(warnings, "\n")
+	if strings.Contains(joinedWarnings, "rooted walk limit") {
+		t.Fatalf("expected catalog symlink decoys not to consume rooted-walk candidate budget, got %#v", warnings)
+	}
+}
+
 func TestGradleCatalogLibraryEntryHelpers(t *testing.T) {
 	library, warnings := parseGradleCatalogLibraryValue(gradleToolsCatalogName, "cli", "dev.example:cli:1.0.0", nil, gradleToolsCatalogPath)
 	if len(warnings) != 0 || library.Group != "dev.example" || library.Artifact != "cli" || library.Version != "1.0.0" {
@@ -572,5 +900,28 @@ func assertGradleCatalogWarningsContain(t *testing.T, warnings []string, wants .
 		if !strings.Contains(joined, want) {
 			t.Fatalf("expected warning %q in %q", want, joined)
 		}
+	}
+}
+
+type sharedSizedFileInfo struct {
+	fs.FileInfo
+	size int64
+}
+
+func (i *sharedSizedFileInfo) Size() int64 {
+	return i.size
+}
+
+func newSharedRootedReadTestRoot(t *testing.T, repo, targetName string, targetFile safeio.File) safeio.Root {
+	t.Helper()
+	realRoot := openSharedTestRoot(t, repo)
+	return &sharedWalkSwapRoot{
+		Root: realRoot,
+		open: func(name string) (safeio.File, error) {
+			if name == targetName {
+				return targetFile, nil
+			}
+			return realRoot.Open(name)
+		},
 	}
 }

--- a/internal/lang/shared/gradle_catalog_rooted_contract_test.go
+++ b/internal/lang/shared/gradle_catalog_rooted_contract_test.go
@@ -1,0 +1,176 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+func TestLoadGradleCatalogResolverWithinRootTreatsBlankRepoPathAsNoop(t *testing.T) {
+	resolver, warnings, err := LoadGradleCatalogResolverWithinRoot(context.Background(), " \t ", nil)
+	if err != nil {
+		t.Fatalf("load blank rooted Gradle catalog resolver: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for blank repo path, got %#v", warnings)
+	}
+	if resolver.knownCatalogs == nil || len(resolver.knownCatalogs) != 0 {
+		t.Fatalf("expected initialized empty catalog set, got %#v", resolver.knownCatalogs)
+	}
+}
+
+func TestLoadGradleCatalogResolverWithinRootReturnsPartialResultAtTraversalLimit(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat rooted Gradle repository: %v", err)
+	}
+	directory := &sharedWalkTestDirectory{
+		sharedWalkTestFile: sharedWalkTestFile{
+			stat: func() (fs.FileInfo, error) {
+				return info, nil
+			},
+		},
+		fillEntry:     &sharedWalkTestDirEntry{name: "ignored.txt"},
+		overflowEntry: &sharedWalkTestDirEntry{name: "overflow.txt"},
+		repeatEntries: defaultGradleCatalogMaxTraversalEntries - 1,
+	}
+	root := &sharedWalkTestRoot{
+		info: info,
+		open: func(name string) (safeio.File, error) {
+			if name != "." {
+				t.Fatalf("unexpected rooted Gradle directory open %q", name)
+			}
+			return directory, nil
+		},
+	}
+
+	resolver, warnings, err := LoadGradleCatalogResolverWithinRoot(context.Background(), repo, root)
+	if err != nil {
+		t.Fatalf("expected pure traversal limit to return a partial resolver, got %v", err)
+	}
+	const wantWarning = "Gradle version catalog scan reached the rooted walk limit of 4096 traversal entries; results may be partial"
+	if len(warnings) != 1 || warnings[0] != wantWarning {
+		t.Fatalf("expected exact partial-result warning %q, got %#v", wantWarning, warnings)
+	}
+	if resolver.knownCatalogs == nil || len(resolver.knownCatalogs) != 0 {
+		t.Fatalf("expected partial resolver with no discovered catalogs, got %#v", resolver.knownCatalogs)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected limited rooted directory to close once, got %d", directory.closeCalls)
+	}
+	if !directory.overflowServed {
+		t.Fatal("expected rooted walk to probe past the configured traversal limit")
+	}
+}
+
+func TestGradleCatalogRegistryParseSourcesWithinRootSortsSourceKeysBeforeFatalFailure(t *testing.T) {
+	repo := t.TempDir()
+	expected := errors.New("fatal alpha source failure")
+	sourceByKey := map[string]gradleCatalogSource{
+		buildGradleCatalogScopeKey(filepath.Join(repo, "zeta"), "libs"):  {root: filepath.Join(repo, "zeta"), name: "libs", path: filepath.Join(repo, "zeta.versions.toml"), rootedReadErr: errors.New("fatal zeta source failure"), rootedLoaded: true},
+		buildGradleCatalogScopeKey(filepath.Join(repo, "alpha"), "libs"): {root: filepath.Join(repo, "alpha"), name: "libs", path: filepath.Join(repo, "alpha.versions.toml"), rootedReadErr: expected, rootedLoaded: true},
+		buildGradleCatalogScopeKey(filepath.Join(repo, "beta"), "libs"):  {root: filepath.Join(repo, "beta"), name: "libs", path: filepath.Join(repo, "beta.versions.toml"), rootedReadErr: errors.New("fatal beta source failure"), rootedLoaded: true},
+	}
+	sortedKeys := make([]string, 0, len(sourceByKey))
+	for key := range sourceByKey {
+		sortedKeys = append(sortedKeys, key)
+	}
+	sort.Strings(sortedKeys)
+	if got := sourceByKey[sortedKeys[0]].path; filepath.Base(got) != "alpha.versions.toml" {
+		t.Fatalf("expected alpha source to sort first, got %q", got)
+	}
+
+	for iteration := 0; iteration < 16; iteration++ {
+		registry := newGradleCatalogRegistry(repo)
+		keys := append([]string(nil), sortedKeys...)
+		if iteration%2 == 1 {
+			for left, right := 0, len(keys)-1; left < right; left, right = left+1, right-1 {
+				keys[left], keys[right] = keys[right], keys[left]
+			}
+		}
+		offset := iteration % len(keys)
+		keys = append(keys[offset:], keys[:offset]...)
+		for _, key := range keys {
+			registry.sources[key] = sourceByKey[key]
+		}
+
+		err := registry.parseSourcesWithinRoot()
+		if !errors.Is(err, expected) {
+			t.Fatalf("iteration %d: expected deterministic alpha failure, got %v", iteration, err)
+		}
+	}
+}
+
+func TestGradleCatalogRegistryLoadCapturedSourceWithinRootClassifiesUncapturedPaths(t *testing.T) {
+	repo := t.TempDir()
+	insidePath := filepath.Join(repo, "gradle", "missing.versions.toml")
+	registry := newGradleCatalogRegistry(repo)
+	err := registry.loadCapturedSourceWithinRoot(gradleCatalogSource{
+		root: repo,
+		name: "libs",
+		path: insidePath,
+	})
+	if err != nil {
+		t.Fatalf("classify uncaptured in-root catalog: %v", err)
+	}
+	if len(registry.warnings) != 1 || !strings.Contains(registry.warnings[0], "gradle/missing.versions.toml") || !strings.Contains(registry.warnings[0], fs.ErrNotExist.Error()) {
+		t.Fatalf("expected missing in-root catalog warning, got %#v", registry.warnings)
+	}
+
+	outsidePath := filepath.Join(filepath.Dir(repo), "outside.versions.toml")
+	registry = newGradleCatalogRegistry(repo)
+	err = registry.loadCapturedSourceWithinRoot(gradleCatalogSource{
+		root: repo,
+		name: "libs",
+		path: outsidePath,
+	})
+	if err != nil {
+		t.Fatalf("classify uncaptured escaping catalog: %v", err)
+	}
+	if len(registry.warnings) != 1 || !strings.Contains(registry.warnings[0], safeio.ErrPathEscapesRoot.Error()) {
+		t.Fatalf("expected escaping catalog warning, got %#v", registry.warnings)
+	}
+}
+
+func TestGradleCatalogCollectSourcesWithinRootPropagatesSecondPassOpenError(t *testing.T) {
+	repo := t.TempDir()
+	catalogPath := filepath.Join(repo, "gradle", defaultGradleCatalogFileName)
+	if err := os.MkdirAll(filepath.Dir(catalogPath), 0o755); err != nil {
+		t.Fatalf("create catalog directory: %v", err)
+	}
+	if err := os.WriteFile(catalogPath, []byte("[libraries]\nentry = \"example:artifact:1\"\n"), 0o600); err != nil {
+		t.Fatalf("write catalog fixture: %v", err)
+	}
+	realRoot := openSharedTestRoot(t, repo)
+	captureErr := errors.New("open catalog directory during capture")
+	gradleOpenCalls := 0
+	root := &sharedWalkSwapRoot{
+		Root: realRoot,
+		openRoot: func(name string) (safeio.Root, error) {
+			if name == "gradle" {
+				gradleOpenCalls++
+				if gradleOpenCalls == 2 {
+					return nil, captureErr
+				}
+			}
+			return realRoot.OpenRoot(name)
+		},
+	}
+	registry := newGradleCatalogRegistry(repo)
+
+	err := registry.collectSourcesWithinRoot(context.Background(), root)
+	if !errors.Is(err, captureErr) {
+		t.Fatalf("expected second-pass catalog traversal failure, got %v", err)
+	}
+	if len(registry.sources) != 1 || gradleOpenCalls != 2 {
+		t.Fatalf("expected discovery before second-pass failure, sources=%#v opens=%d", registry.sources, gradleOpenCalls)
+	}
+}

--- a/internal/lang/shared/gradle_catalog_rooted_contract_test.go
+++ b/internal/lang/shared/gradle_catalog_rooted_contract_test.go
@@ -26,6 +26,124 @@ func TestLoadGradleCatalogResolverWithinRootTreatsBlankRepoPathAsNoop(t *testing
 	}
 }
 
+func TestLoadGradleCatalogResolverWithinRootLoadsConfiguredCatalogBelowSkippedDirectory(t *testing.T) {
+	repo := t.TempDir()
+	writeGradleCatalogTestFile(t, filepath.Join(repo, gradleSettingsFileName), `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("tools") {
+      from(files("build/tools.toml"))
+    }
+  }
+}
+`)
+	writeGradleCatalogTestFile(t, filepath.Join(repo, "build", "tools.toml"), "[libraries]\ncli = \"dev.example:cli:1.0.0\"\n")
+	writeGradleCatalogTestFile(t, filepath.Join(repo, "build", "generated", "gradle", defaultGradleCatalogFileName), "[libraries]\ndecoy = \"dev.example:decoy:9.9.9\"\n")
+
+	rejectErr := errors.New("opened non-configured catalog directory")
+	root := &rejectingGradleCatalogRoot{
+		Root:         openSharedTestRoot(t, repo),
+		rejectedPath: filepath.Join("build", "generated"),
+		rejectErr:    rejectErr,
+	}
+	resolver, warnings, err := LoadGradleCatalogResolverWithinRoot(context.Background(), repo, root)
+	if err != nil {
+		t.Fatalf("load configured catalog below skipped directory: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected configured skipped-directory catalog without warnings, got %#v", warnings)
+	}
+	if _, discovered := resolver.knownCatalogs["libs"]; discovered {
+		t.Fatalf("expected non-configured skipped-directory catalog to remain undiscovered, got %#v", resolver.knownCatalogs)
+	}
+
+	libraries, parseWarnings := resolver.ParseDependencyReferences(filepath.Join(repo, "build.gradle.kts"), "dependencies { implementation(tools.cli) }")
+	want := GradleCatalogLibrary{Alias: "cli", Catalog: "tools", Group: "dev.example", Artifact: "cli", Version: "1.0.0"}
+	if len(parseWarnings) != 0 || len(libraries) != 1 || libraries[0] != want {
+		t.Fatalf("expected configured skipped-directory dependency %#v, got libraries=%#v warnings=%#v", want, libraries, parseWarnings)
+	}
+}
+
+func TestLoadGradleCatalogResolverWithinRootRejectsEscapingConfiguredCatalog(t *testing.T) {
+	workspace := t.TempDir()
+	repo := filepath.Join(workspace, "repo")
+	writeGradleCatalogTestFile(t, filepath.Join(repo, gradleSettingsFileName), `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("tools") {
+      from(files("../outside.toml"))
+    }
+  }
+}
+`)
+	writeGradleCatalogTestFile(t, filepath.Join(workspace, "outside.toml"), "[libraries]\nevil = \"dev.example:evil:9.9.9\"\n")
+
+	assertConfiguredGradleCatalogRejected(t, repo, safeio.ErrPathEscapesRoot.Error())
+}
+
+func TestLoadGradleCatalogResolverWithinRootRejectsSymlinkedConfiguredCatalog(t *testing.T) {
+	repo := t.TempDir()
+	writeGradleCatalogTestFile(t, filepath.Join(repo, gradleSettingsFileName), `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("tools") {
+      from(files("build/tools.toml"))
+    }
+  }
+}
+`)
+	outsideCatalog := filepath.Join(t.TempDir(), "outside.toml")
+	writeGradleCatalogTestFile(t, outsideCatalog, "[libraries]\nevil = \"dev.example:evil:9.9.9\"\n")
+	catalogPath := filepath.Join(repo, "build", "tools.toml")
+	if err := os.MkdirAll(filepath.Dir(catalogPath), 0o750); err != nil {
+		t.Fatalf("create configured catalog parent: %v", err)
+	}
+	if err := os.Symlink(outsideCatalog, catalogPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	assertConfiguredGradleCatalogRejected(t, repo, safeio.ErrTargetPathSymlink.Error())
+}
+
+func assertConfiguredGradleCatalogRejected(t *testing.T, repo, wantWarning string) {
+	t.Helper()
+	resolver, warnings, err := LoadGradleCatalogResolverWithinRoot(context.Background(), repo, openSharedTestRoot(t, repo))
+	if err != nil {
+		t.Fatalf("load resolver with untrusted configured catalog: %v", err)
+	}
+	if !strings.Contains(strings.Join(warnings, "\n"), wantWarning) {
+		t.Fatalf("expected configured catalog warning containing %q, got %#v", wantWarning, warnings)
+	}
+	libraries, _ := resolver.ParseDependencyReferences(filepath.Join(repo, "build.gradle.kts"), "dependencies { implementation(tools.evil) }")
+	if len(libraries) != 0 {
+		t.Fatalf("expected untrusted configured catalog to contribute no dependencies, got %#v", libraries)
+	}
+}
+
+type rejectingGradleCatalogRoot struct {
+	safeio.Root
+	relativePath string
+	rejectedPath string
+	rejectErr    error
+}
+
+func (r *rejectingGradleCatalogRoot) OpenRoot(name string) (safeio.Root, error) {
+	relativePath := filepath.Join(r.relativePath, name)
+	if relativePath == r.rejectedPath {
+		return nil, r.rejectErr
+	}
+	child, err := r.Root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	return &rejectingGradleCatalogRoot{
+		Root:         child,
+		relativePath: relativePath,
+		rejectedPath: r.rejectedPath,
+		rejectErr:    r.rejectErr,
+	}, nil
+}
+
 func TestLoadGradleCatalogResolverWithinRootReturnsPartialResultAtTraversalLimit(t *testing.T) {
 	repo := t.TempDir()
 	info, err := os.Stat(repo)

--- a/internal/lang/shared/gradle_catalog_test.go
+++ b/internal/lang/shared/gradle_catalog_test.go
@@ -96,6 +96,34 @@ dependencies {
 	}
 }
 
+func TestGradleCatalogResolverSkipsOversizedManifestInputs(t *testing.T) {
+	t.Run("settings.gradle.kts", func(t *testing.T) {
+		repo := t.TempDir()
+		writeGradleCatalogTestFile(t, filepath.Join(repo, "settings.gradle.kts"), strings.Repeat("a", GradleManifestByteLimit+1))
+
+		resolver, warnings := LoadGradleCatalogResolver(repo)
+		if len(resolver.scopes) != 0 {
+			t.Fatalf("expected oversized settings file to skip catalog loading, got %#v", resolver)
+		}
+		if joined := strings.Join(warnings, "\n"); !strings.Contains(joined, "unable to read settings.gradle.kts: file exceeds size limit") {
+			t.Fatalf("expected oversized settings warning, got %#v", warnings)
+		}
+	})
+
+	t.Run("gradle/libs.versions.toml", func(t *testing.T) {
+		repo := t.TempDir()
+		writeGradleCatalogTestFile(t, filepath.Join(repo, "gradle", testGradleCatalogFileName), strings.Repeat("a", GradleManifestByteLimit+1))
+
+		resolver, warnings := LoadGradleCatalogResolver(repo)
+		if len(resolver.scopes) != 0 {
+			t.Fatalf("expected oversized catalog file to skip catalog loading, got %#v", resolver)
+		}
+		if joined := strings.Join(warnings, "\n"); !strings.Contains(joined, "unable to read gradle/libs.versions.toml: file exceeds size limit") {
+			t.Fatalf("expected oversized catalog warning, got %#v", warnings)
+		}
+	})
+}
+
 func TestIsGradleVersionCatalogFile(t *testing.T) {
 	if !IsGradleVersionCatalogFile(testGradleCatalogFileName) {
 		t.Fatalf("expected %s to be treated as a cache-relevant Gradle catalog", testGradleCatalogFileName)

--- a/internal/lang/shared/module_helpers_extra_test.go
+++ b/internal/lang/shared/module_helpers_extra_test.go
@@ -1,0 +1,19 @@
+package shared
+
+import "testing"
+
+func TestFallbackDependencyReturnsNormalizedModulePrefix(t *testing.T) {
+	got := FallbackDependency("com.example.module", func(value string) string {
+		return "normalized:" + value
+	})
+	if got != "normalized:com.example" {
+		t.Fatalf("unexpected fallback dependency: %q", got)
+	}
+}
+
+func TestRootedWalkBudgetWarningTrimsScopeWhenLimitIsUnset(t *testing.T) {
+	warning := rootedWalkBudgetWarning("  Gradle version catalog scan  ", "traversal entries", 0)
+	if warning != "Gradle version catalog scan reached a rooted walk limit; results may be partial" {
+		t.Fatalf("unexpected zero-limit rooted walk warning: %q", warning)
+	}
+}

--- a/internal/lang/shared/rooted_walk.go
+++ b/internal/lang/shared/rooted_walk.go
@@ -44,6 +44,8 @@ type RootedWalkFile struct {
 
 type RootedWalkVisit func(file RootedWalkFile) error
 
+type rootedWalkDirectorySkip func(path, name string) bool
+
 // WalkRepoFilesWithinRoot traverses repoPath using an already-open confined
 // root and emits synthetic absolute paths rooted at repoPath.
 func WalkRepoFilesWithinRoot(ctx context.Context, repoPath string, root safeio.Root, budget RootedWalkBudget, skipDir func(string) bool, visit func(path string, entry fs.DirEntry) error) error {
@@ -55,8 +57,12 @@ func WalkRepoFilesWithinRoot(ctx context.Context, repoPath string, root safeio.R
 // WalkRepoFilesWithinRootPinned traverses repoPath and exposes each entry
 // through its callback-scoped pinned parent root and leaf name.
 func WalkRepoFilesWithinRootPinned(ctx context.Context, repoPath string, root safeio.Root, budget RootedWalkBudget, skipDir func(string) bool, visit RootedWalkVisit) error {
+	return walkRepoFilesWithinRootPinnedWithPathSkip(ctx, repoPath, root, budget, rootedWalkDirectoryNameSkip(skipDir), visit)
+}
+
+func walkRepoFilesWithinRootPinnedWithPathSkip(ctx context.Context, repoPath string, root safeio.Root, budget RootedWalkBudget, skipDir rootedWalkDirectorySkip, visit RootedWalkVisit) error {
 	if skipDir == nil {
-		skipDir = ShouldSkipCommonDir
+		skipDir = rootedWalkDirectoryNameSkip(nil)
 	}
 
 	info, err := root.Lstat(".")
@@ -80,10 +86,19 @@ func WalkRepoFilesWithinRootPinned(ctx context.Context, repoPath string, root sa
 	return nil
 }
 
+func rootedWalkDirectoryNameSkip(skipDir func(string) bool) rootedWalkDirectorySkip {
+	if skipDir == nil {
+		skipDir = ShouldSkipCommonDir
+	}
+	return func(_ string, name string) bool {
+		return skipDir(name)
+	}
+}
+
 type rootedRepoWalker struct {
 	repoPath string
 	budget   RootedWalkBudget
-	skipDir  func(string) bool
+	skipDir  rootedWalkDirectorySkip
 	visit    RootedWalkVisit
 	state    rootedWalkBudgetState
 }
@@ -109,7 +124,7 @@ func (w *rootedRepoWalker) walk(ctx context.Context, parentRoot safeio.Root, rel
 }
 
 func (w *rootedRepoWalker) walkDirectory(ctx context.Context, parentRoot safeio.Root, relPath, path string, entry fs.DirEntry) (err error) {
-	if relPath != "." && w.skipDir(entry.Name()) {
+	if relPath != "." && w.skipDir(path, entry.Name()) {
 		return nil
 	}
 	if relPath == "." {

--- a/internal/lang/shared/rooted_walk.go
+++ b/internal/lang/shared/rooted_walk.go
@@ -90,7 +90,7 @@ func rootedWalkDirectoryNameSkip(skipDir func(string) bool) rootedWalkDirectoryS
 	if skipDir == nil {
 		skipDir = ShouldSkipCommonDir
 	}
-	return func(_ string, name string) bool {
+	return func(_, name string) bool {
 		return skipDir(name)
 	}
 }

--- a/internal/lang/shared/rooted_walk.go
+++ b/internal/lang/shared/rooted_walk.go
@@ -1,0 +1,380 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+type rootedReadDirFile interface {
+	safeio.ReadDirFile
+}
+
+var (
+	errRootedWalkTraversalLimit = errors.New("rooted walk traversal limit exceeded")
+	errRootedWalkFileLimit      = errors.New("rooted walk file limit exceeded")
+	errRootedWalkWorkLimit      = errors.New("rooted walk work limit exceeded")
+)
+
+const rootedWalkReadBatchSize = 128
+
+type RootedWalkBudget struct {
+	MaxTraversalEntries int
+	MaxFiles            int
+	MaxWorkItems        int
+	CountCandidate      func(path string, entry fs.DirEntry) bool
+}
+
+// RootedWalkFile identifies a non-directory entry and its pinned parent.
+// Parent is valid only for the duration of the visit callback.
+type RootedWalkFile struct {
+	Parent safeio.Root
+	Leaf   string
+	Path   string
+	Entry  fs.DirEntry
+}
+
+type RootedWalkVisit func(file RootedWalkFile) error
+
+// WalkRepoFilesWithinRoot traverses repoPath using an already-open confined
+// root and emits synthetic absolute paths rooted at repoPath.
+func WalkRepoFilesWithinRoot(ctx context.Context, repoPath string, root safeio.Root, budget RootedWalkBudget, skipDir func(string) bool, visit func(path string, entry fs.DirEntry) error) error {
+	return WalkRepoFilesWithinRootPinned(ctx, repoPath, root, budget, skipDir, func(file RootedWalkFile) error {
+		return visit(file.Path, file.Entry)
+	})
+}
+
+// WalkRepoFilesWithinRootPinned traverses repoPath and exposes each entry
+// through its callback-scoped pinned parent root and leaf name.
+func WalkRepoFilesWithinRootPinned(ctx context.Context, repoPath string, root safeio.Root, budget RootedWalkBudget, skipDir func(string) bool, visit RootedWalkVisit) error {
+	if skipDir == nil {
+		skipDir = ShouldSkipCommonDir
+	}
+
+	info, err := root.Lstat(".")
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fs.ErrInvalid
+	}
+
+	walker := rootedRepoWalker{
+		repoPath: filepath.Clean(repoPath),
+		budget:   budget,
+		skipDir:  skipDir,
+		visit:    visit,
+	}
+	err = walker.walk(ctx, root, ".", walker.repoPath, fs.FileInfoToDirEntry(info))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type rootedRepoWalker struct {
+	repoPath string
+	budget   RootedWalkBudget
+	skipDir  func(string) bool
+	visit    RootedWalkVisit
+	state    rootedWalkBudgetState
+}
+
+type rootedWalkBudgetState struct {
+	traversalEntriesSeen   int
+	traversalEntriesQueued int
+	filesSeen              int
+	workItemsSeen          int
+}
+
+func (w *rootedRepoWalker) walk(ctx context.Context, parentRoot safeio.Root, relPath, path string, entry fs.DirEntry) (err error) {
+	if err := walkContextErr(ctx); err != nil {
+		return err
+	}
+	if err := w.countTraversalEntry(path); err != nil {
+		return err
+	}
+	if entry.IsDir() {
+		return w.walkDirectory(ctx, parentRoot, relPath, path, entry)
+	}
+	return w.walkFile(parentRoot, path, entry)
+}
+
+func (w *rootedRepoWalker) walkDirectory(ctx context.Context, parentRoot safeio.Root, relPath, path string, entry fs.DirEntry) (err error) {
+	if relPath != "." && w.skipDir(entry.Name()) {
+		return nil
+	}
+	if relPath == "." {
+		return w.walkDirectoryChildren(ctx, parentRoot, relPath, path)
+	}
+	currentRoot, err := openPinnedChildRoot(parentRoot, entry.Name(), relPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, currentRoot.Close())
+	}()
+	return w.walkDirectoryChildren(ctx, currentRoot, relPath, path)
+}
+
+func (w *rootedRepoWalker) walkDirectoryChildren(ctx context.Context, root safeio.Root, relPath, path string) error {
+	entries, err := w.readDir(ctx, root, path)
+	if err != nil {
+		return err
+	}
+	for _, child := range entries {
+		if !w.dequeueTraversalEntry() {
+			return fs.ErrInvalid
+		}
+		childRelPath := filepath.Join(relPath, child.Name())
+		childPath := filepath.Join(path, child.Name())
+		if err := w.walk(ctx, root, childRelPath, childPath, child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *rootedRepoWalker) walkFile(parentRoot safeio.Root, path string, entry fs.DirEntry) error {
+	if w.shouldCountCandidate(path, entry) {
+		if err := w.countFile(path); err != nil {
+			return err
+		}
+		if err := w.countWorkItem(path); err != nil {
+			return err
+		}
+	}
+	return w.visit(RootedWalkFile{
+		Parent: parentRoot,
+		Leaf:   entry.Name(),
+		Path:   path,
+		Entry:  entry,
+	})
+}
+
+func (w *rootedRepoWalker) readDir(ctx context.Context, root safeio.Root, path string) (entries []fs.DirEntry, err error) {
+	if err := walkContextErr(ctx); err != nil {
+		return nil, err
+	}
+	file, err := safeio.OpenPinnedDirectory(root, ".")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = errors.Join(err, file.Close())
+	}()
+	defer func() {
+		if err == nil {
+			sortRootedWalkEntries(entries)
+		}
+	}()
+
+	for {
+		if err := walkContextErr(ctx); err != nil {
+			return nil, err
+		}
+		readSize := w.traversalReadSize()
+		if readSize == 0 {
+			return entries, w.probeDirectoryLimit(ctx, path, file)
+		}
+		batch, done, readErr := w.readDirBatch(path, file, readSize)
+		if readErr != nil {
+			return nil, readErr
+		}
+		entries = append(entries, batch...)
+		if done {
+			return entries, nil
+		}
+	}
+}
+
+func (w *rootedRepoWalker) readDirBatch(path string, file rootedReadDirFile, readSize int) ([]fs.DirEntry, bool, error) {
+	batch, err := file.ReadDir(readSize)
+	if len(batch) > readSize || !w.queueTraversalEntries(len(batch)) {
+		return nil, false, rootedWalkReadLimitError(path, w.budget.MaxTraversalEntries, err)
+	}
+	if IsPureSentinelError(err, io.EOF) {
+		return batch, true, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if len(batch) == 0 {
+		return nil, false, io.ErrNoProgress
+	}
+	return batch, false, nil
+}
+
+func rootedWalkReadLimitError(path string, limit int, readErr error) error {
+	limitErr := newRootedWalkTraversalLimitError(path, limit)
+	if readErr != nil && !IsPureSentinelError(readErr, io.EOF) {
+		return errors.Join(limitErr, readErr)
+	}
+	return limitErr
+}
+
+func sortRootedWalkEntries(entries []fs.DirEntry) {
+	slices.SortFunc(entries, func(left, right fs.DirEntry) int {
+		return strings.Compare(left.Name(), right.Name())
+	})
+}
+
+func walkContextErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}
+
+func (w *rootedRepoWalker) totalTraversalEntries() int {
+	return w.state.traversalEntriesSeen + w.state.traversalEntriesQueued
+}
+
+func (w *rootedRepoWalker) countTraversalEntry(path string) error {
+	if w.budget.MaxTraversalEntries > 0 && w.totalTraversalEntries() >= w.budget.MaxTraversalEntries {
+		return newRootedWalkTraversalLimitError(path, w.budget.MaxTraversalEntries)
+	}
+	w.state.traversalEntriesSeen++
+	return nil
+}
+
+func (w *rootedRepoWalker) traversalReadSize() int {
+	if w.budget.MaxTraversalEntries <= 0 {
+		return rootedWalkReadBatchSize
+	}
+	remaining := w.budget.MaxTraversalEntries - w.totalTraversalEntries()
+	return min(rootedWalkReadBatchSize, max(remaining, 0))
+}
+
+func (w *rootedRepoWalker) queueTraversalEntries(count int) bool {
+	if count < 0 {
+		return false
+	}
+	if w.budget.MaxTraversalEntries > 0 && w.totalTraversalEntries()+count > w.budget.MaxTraversalEntries {
+		return false
+	}
+	w.state.traversalEntriesQueued += count
+	return true
+}
+
+func (w *rootedRepoWalker) dequeueTraversalEntry() bool {
+	if w.state.traversalEntriesQueued == 0 {
+		return false
+	}
+	w.state.traversalEntriesQueued--
+	return true
+}
+
+func (w *rootedRepoWalker) countFile(path string) error {
+	w.state.filesSeen++
+	if w.budget.MaxFiles > 0 && w.state.filesSeen > w.budget.MaxFiles {
+		return newRootedWalkFileLimitError(path, w.budget.MaxFiles)
+	}
+	return nil
+}
+
+func (w *rootedRepoWalker) countWorkItem(path string) error {
+	w.state.workItemsSeen++
+	if w.budget.MaxWorkItems > 0 && w.state.workItemsSeen > w.budget.MaxWorkItems {
+		return newRootedWalkWorkLimitError(path, w.budget.MaxWorkItems)
+	}
+	return nil
+}
+
+func (w *rootedRepoWalker) shouldCountCandidate(path string, entry fs.DirEntry) bool {
+	if entry.Type()&fs.ModeSymlink != 0 {
+		return false
+	}
+	if w.budget.CountCandidate == nil {
+		return true
+	}
+	return w.budget.CountCandidate(path, entry)
+}
+
+func (w *rootedRepoWalker) probeDirectoryLimit(ctx context.Context, path string, dir rootedReadDirFile) error {
+	if err := walkContextErr(ctx); err != nil {
+		return err
+	}
+	entries, err := dir.ReadDir(1)
+	if len(entries) > 0 {
+		limitErr := newRootedWalkTraversalLimitError(path, w.budget.MaxTraversalEntries)
+		if err != nil && !IsPureSentinelError(err, io.EOF) {
+			return errors.Join(limitErr, err)
+		}
+		return limitErr
+	}
+	if IsPureSentinelError(err, io.EOF) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return io.ErrNoProgress
+}
+
+func openPinnedChildRoot(root safeio.Root, name, path string) (safeio.Root, error) {
+	info, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("root contains symlink: %s", path)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("root is not a directory: %s", path)
+	}
+
+	child, err := root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := child.Lstat(".")
+	if err != nil {
+		return nil, errors.Join(err, child.Close())
+	}
+	if !os.SameFile(info, openedInfo) {
+		return nil, errors.Join(fmt.Errorf("root changed while opening: %s", path), child.Close())
+	}
+	return child, nil
+}
+
+func newRootedWalkTraversalLimitError(path string, limit int) error {
+	return fmt.Errorf("%w at %q (maximum entries: %d)", errRootedWalkTraversalLimit, path, limit)
+}
+
+func newRootedWalkFileLimitError(path string, limit int) error {
+	return fmt.Errorf("%w at %q (maximum files: %d)", errRootedWalkFileLimit, path, limit)
+}
+
+func newRootedWalkWorkLimitError(path string, limit int) error {
+	return fmt.Errorf("%w at %q (maximum work items: %d)", errRootedWalkWorkLimit, path, limit)
+}
+
+func RootedWalkBudgetWarning(scope string, budget RootedWalkBudget, err error) (string, bool) {
+	switch {
+	case IsPureSentinelError(err, errRootedWalkTraversalLimit):
+		return rootedWalkBudgetWarning(scope, "traversal entries", budget.MaxTraversalEntries), true
+	case IsPureSentinelError(err, errRootedWalkFileLimit):
+		return rootedWalkBudgetWarning(scope, "candidate files", budget.MaxFiles), true
+	case IsPureSentinelError(err, errRootedWalkWorkLimit):
+		return rootedWalkBudgetWarning(scope, "candidate work items", budget.MaxWorkItems), true
+	default:
+		return "", false
+	}
+}
+
+func rootedWalkBudgetWarning(scope, unit string, limit int) string {
+	scope = strings.TrimSpace(scope)
+	if limit > 0 {
+		return fmt.Sprintf("%s reached the rooted walk limit of %d %s; results may be partial", scope, limit, unit)
+	}
+	return fmt.Sprintf("%s reached a rooted walk limit; results may be partial", scope)
+}

--- a/internal/lang/shared/rooted_walk_test.go
+++ b/internal/lang/shared/rooted_walk_test.go
@@ -1,0 +1,1186 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+func TestWalkRepoFilesWithinRootHonorsCancellation(t *testing.T) {
+	root := openSharedTestRoot(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	budget := RootedWalkBudget{MaxTraversalEntries: 8, MaxFiles: 8, MaxWorkItems: 8}
+	err := WalkRepoFilesWithinRoot(ctx, t.TempDir(), root, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled context error, got %v", err)
+	}
+}
+
+func TestWalkRepoFilesWithinRootRejectsTraversalBudgetOverflow(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	directory := &sharedWalkTestDirectory{
+		fillEntry:     fs.FileInfoToDirEntry(info),
+		overflowEntry: fs.FileInfoToDirEntry(info),
+		repeatEntries: 1,
+	}
+	root := &sharedWalkTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) { return directory, nil },
+	}
+
+	budget := RootedWalkBudget{MaxTraversalEntries: 1, MaxFiles: 8, MaxWorkItems: 8}
+	err = WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if !errors.Is(err, errRootedWalkTraversalLimit) {
+		t.Fatalf("expected traversal-limit error, got %v", err)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected overflowing directory to close once, got %d", directory.closeCalls)
+	}
+}
+
+func TestWalkRepoFilesWithinRootJoinsOversizedBatchReadError(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	readErr := errors.New("read oversized rooted-walk batch")
+	directory := &sharedWalkTestDirectory{
+		sharedWalkTestFile: sharedWalkTestFile{
+			stat: func() (fs.FileInfo, error) { return info, nil },
+		},
+		fillEntry:          fs.FileInfoToDirEntry(info),
+		extraEntries:       1,
+		readErrWithEntries: errors.Join(io.EOF, readErr),
+	}
+	root := &sharedWalkTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) { return directory, nil },
+	}
+
+	budget := RootedWalkBudget{MaxTraversalEntries: 2, MaxFiles: 8, MaxWorkItems: 8}
+	err = WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if !errors.Is(err, errRootedWalkTraversalLimit) || !errors.Is(err, io.EOF) || !errors.Is(err, readErr) {
+		t.Fatalf("expected joined oversized-batch limit, EOF, and read error, got %v", err)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected oversized-batch directory to close once, got %d", directory.closeCalls)
+	}
+}
+
+func TestWalkRepoFilesWithinRootRejectsFileAndWorkBudgetOverflow(t *testing.T) {
+	repo := t.TempDir()
+	fileA := filepath.Join(repo, "a.txt")
+	fileB := filepath.Join(repo, "b.txt")
+	if err := os.WriteFile(fileA, []byte("a"), 0o600); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	if err := os.WriteFile(fileB, []byte("b"), 0o600); err != nil {
+		t.Fatalf("write b.txt: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		budget RootedWalkBudget
+		want   error
+	}{
+		{
+			name: "file limit",
+			budget: RootedWalkBudget{
+				MaxTraversalEntries: 8,
+				MaxFiles:            1,
+				MaxWorkItems:        8,
+			},
+			want: errRootedWalkFileLimit,
+		},
+		{
+			name: "work limit",
+			budget: RootedWalkBudget{
+				MaxTraversalEntries: 8,
+				MaxFiles:            8,
+				MaxWorkItems:        1,
+			},
+			want: errRootedWalkWorkLimit,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := openSharedTestRoot(t, repo)
+			err := WalkRepoFilesWithinRoot(context.Background(), repo, root, tc.budget, nil, func(string, fs.DirEntry) error { return nil })
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("expected %v, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestWalkRepoFilesWithinRootCountsOnlyMatchingCandidates(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "ignore.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write ignore.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "keep.java"), []byte("class Keep {}\n"), 0o600); err != nil {
+		t.Fatalf("write keep.java: %v", err)
+	}
+
+	root := openSharedTestRoot(t, repo)
+	budget := RootedWalkBudget{
+		MaxTraversalEntries: 8,
+		MaxFiles:            1,
+		MaxWorkItems:        1,
+		CountCandidate: func(path string, _ fs.DirEntry) bool {
+			return strings.HasSuffix(path, ".java")
+		},
+	}
+
+	var visited []string
+	err := WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(path string, _ fs.DirEntry) error {
+		visited = append(visited, filepath.Base(path))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo with candidate filter: %v", err)
+	}
+	if len(visited) != 2 {
+		t.Fatalf("expected both files to be visited, got %#v", visited)
+	}
+}
+
+func TestIsPureSentinelError(t *testing.T) {
+	first := errors.New("first limit")
+	second := errors.New("second limit")
+	closeErr := errors.New("close directory")
+
+	if !IsPureSentinelError(fmt.Errorf("wrapped: %w", first), first) {
+		t.Fatal("expected wrapped sentinel to be pure")
+	}
+	if !IsPureSentinelError(errors.Join(first, fmt.Errorf("wrapped: %w", second)), first, second) {
+		t.Fatal("expected joined allowed sentinels to be pure")
+	}
+	joined := fmt.Errorf("walk failed: %w", errors.Join(fmt.Errorf("limit: %w", first), closeErr))
+	if IsPureSentinelError(joined, first) {
+		t.Fatal("expected joined non-sentinel cause to make the error impure")
+	}
+	if !errors.Is(joined, first) || !errors.Is(joined, closeErr) {
+		t.Fatalf("expected original joined causes to remain discoverable, got %v", joined)
+	}
+	if IsPureSentinelError(nil, first) || IsPureSentinelError(first) || IsPureSentinelError(closeErr, first) {
+		t.Fatal("expected nil, missing-target, and operational errors to be impure")
+	}
+}
+
+func TestRootedWalkBudgetWarning(t *testing.T) {
+	budget := RootedWalkBudget{MaxTraversalEntries: 7, MaxFiles: 5, MaxWorkItems: 3}
+
+	assertRootedWalkBudgetWarning(t, budget, newRootedWalkTraversalLimitError("/repo", budget.MaxTraversalEntries), "7 traversal entries")
+	assertRootedWalkBudgetWarning(t, budget, newRootedWalkFileLimitError("/repo/Main.java", budget.MaxFiles), "5 candidate files")
+	assertRootedWalkBudgetWarning(t, budget, newRootedWalkWorkLimitError("/repo/Main.java", budget.MaxWorkItems), "3 candidate work items")
+	assertNoRootedWalkBudgetWarning(t, budget, io.EOF)
+
+	closeErr := errors.New("close rooted directory")
+	for _, tc := range []struct {
+		name   string
+		limit  error
+		target error
+	}{
+		{name: "traversal", limit: newRootedWalkTraversalLimitError("/repo", budget.MaxTraversalEntries), target: errRootedWalkTraversalLimit},
+		{name: "file", limit: newRootedWalkFileLimitError("/repo/Main.java", budget.MaxFiles), target: errRootedWalkFileLimit},
+		{name: "work", limit: newRootedWalkWorkLimitError("/repo/Main.java", budget.MaxWorkItems), target: errRootedWalkWorkLimit},
+	} {
+		t.Run(tc.name+" limit joined with close error", func(t *testing.T) {
+			assertJoinedRootedWalkLimitIsNotWarning(t, budget, tc.limit, tc.target, closeErr)
+		})
+	}
+}
+
+func assertRootedWalkBudgetWarning(t *testing.T, budget RootedWalkBudget, err error, want string) {
+	t.Helper()
+	warning, ok := RootedWalkBudgetWarning("JVM source scan", budget, err)
+	if !ok || !strings.Contains(warning, want) {
+		t.Fatalf("expected warning containing %q, got %q ok=%v", want, warning, ok)
+	}
+}
+
+func assertNoRootedWalkBudgetWarning(t *testing.T, budget RootedWalkBudget, err error) {
+	t.Helper()
+	if warning, ok := RootedWalkBudgetWarning("JVM source scan", budget, err); ok || warning != "" {
+		t.Fatalf("expected non-budget error to stay unclassified, got %q ok=%v", warning, ok)
+	}
+}
+
+func assertJoinedRootedWalkLimitIsNotWarning(t *testing.T, budget RootedWalkBudget, limit, target, closeErr error) {
+	t.Helper()
+	joined := errors.Join(limit, closeErr)
+	if warning, ok := RootedWalkBudgetWarning("JVM source scan", budget, joined); ok || warning != "" {
+		t.Fatalf("expected joined close error to prevent limit downgrade, got %q ok=%v", warning, ok)
+	}
+	if !errors.Is(joined, target) || !errors.Is(joined, closeErr) {
+		t.Fatalf("expected joined limit and close causes to remain discoverable, got %v", joined)
+	}
+}
+
+func TestLoadGradleCatalogResolverWithinRootPropagatesTraversalLimitCloseError(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	closeErr := errors.New("close Gradle catalog directory")
+	directory := &sharedWalkTestDirectory{
+		sharedWalkTestFile: sharedWalkTestFile{
+			stat:  func() (fs.FileInfo, error) { return info, nil },
+			close: func() error { return closeErr },
+		},
+		fillEntry:    &sharedWalkTestDirEntry{name: "ignored.txt"},
+		extraEntries: 1,
+	}
+	root := &sharedWalkTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) { return directory, nil },
+	}
+
+	_, warnings, err := LoadGradleCatalogResolverWithinRoot(context.Background(), repo, root)
+	if !errors.Is(err, closeErr) || !strings.Contains(err.Error(), "rooted walk traversal limit exceeded") {
+		t.Fatalf("expected joined traversal-limit and close error, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected operational failure not to be downgraded to warnings, got %#v", warnings)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected overflowing directory to close once, got %d", directory.closeCalls)
+	}
+}
+
+func TestWalkRepoFilesWithinRootRejectsNonDirectoryOpenAndJoinsCloseError(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	closeErr := errors.New("close directory")
+	filePath := filepath.Join(repo, "child.txt")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write child file: %v", err)
+	}
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat child file: %v", err)
+	}
+	root := &sharedWalkTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) {
+			return &sharedWalkTestFile{
+				stat:  func() (fs.FileInfo, error) { return fileInfo, nil },
+				close: func() error { return closeErr },
+			}, nil
+		},
+	}
+
+	budget := RootedWalkBudget{MaxTraversalEntries: 4, MaxFiles: 4, MaxWorkItems: 4}
+	err = WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if !errors.Is(err, fs.ErrInvalid) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected invalid directory and close error, got %v", err)
+	}
+}
+
+func TestWalkRepoFilesWithinRootSortsEntriesAndSkipsDirs(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "b.txt"), []byte("b"), 0o600); err != nil {
+		t.Fatalf("write b.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("a"), 0o600); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "skip-me"), 0o755); err != nil {
+		t.Fatalf("mkdir skip-me: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "skip-me", "ignored.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write ignored.txt: %v", err)
+	}
+	root := openSharedTestRoot(t, repo)
+
+	var visited []string
+	budget := RootedWalkBudget{MaxTraversalEntries: 8, MaxFiles: 8, MaxWorkItems: 8}
+	err := WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, func(name string) bool { return name == "skip-me" }, func(path string, entry fs.DirEntry) error {
+		visited = append(visited, filepath.Base(path))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk sorted repo: %v", err)
+	}
+	if len(visited) != 2 || visited[0] != "a.txt" || visited[1] != "b.txt" {
+		t.Fatalf("expected sorted visible files only, got %#v", visited)
+	}
+}
+
+func TestWalkRepoFilesWithinRootSortsExactBudgetProbeSuccessBranch(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	fileA := &sharedWalkTestDirEntry{name: "a.txt"}
+	fileB := &sharedWalkTestDirEntry{name: "b.txt"}
+	directory := &sharedWalkTestDirectory{
+		sharedWalkTestFile: sharedWalkTestFile{
+			stat: func() (fs.FileInfo, error) { return info, nil },
+		},
+		entries: []fs.DirEntry{fileB, fileA},
+	}
+	root := &sharedWalkTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) { return directory, nil },
+	}
+
+	var visited []string
+	budget := RootedWalkBudget{MaxTraversalEntries: 3, MaxFiles: 8, MaxWorkItems: 8}
+	err = WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(path string, entry fs.DirEntry) error {
+		visited = append(visited, filepath.Base(path))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk exact-budget probe branch: %v", err)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected exact-budget directory to close once, got %d", directory.closeCalls)
+	}
+	if directory.readDirCalls != 2 {
+		t.Fatalf("expected exact-budget branch to probe after filling budget, got %d ReadDir calls", directory.readDirCalls)
+	}
+	if len(visited) != 2 || visited[0] != "a.txt" || visited[1] != "b.txt" {
+		t.Fatalf("expected lexical visitation after probe-success branch, got %#v", visited)
+	}
+}
+
+func TestWalkRepoFilesWithinRootPropagatesVisitAndReadErrors(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "visit.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write visit.txt: %v", err)
+	}
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	visitErr := errors.New("visit failed")
+	root := openSharedTestRoot(t, repo)
+	budget := RootedWalkBudget{MaxTraversalEntries: 4, MaxFiles: 4, MaxWorkItems: 4}
+	err = WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(string, fs.DirEntry) error { return visitErr })
+	if err == nil {
+		t.Fatal("expected visit error")
+	}
+
+	directory := &sharedWalkTestDirectory{
+		sharedWalkTestFile: sharedWalkTestFile{
+			stat: func() (fs.FileInfo, error) { return info, nil },
+		},
+		readErr: errors.New("read dir failed"),
+	}
+	fakeRoot := &sharedWalkTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) { return directory, nil },
+	}
+	err = WalkRepoFilesWithinRoot(context.Background(), repo, fakeRoot, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if !errors.Is(err, directory.readErr) {
+		t.Fatalf("expected readDir error, got %v", err)
+	}
+}
+
+func TestWalkRepoFilesWithinRootPropagatesOpenError(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	openErr := errors.New("open rooted directory failed")
+	root := &sharedWalkTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) { return nil, openErr },
+	}
+
+	budget := RootedWalkBudget{MaxTraversalEntries: 4, MaxFiles: 4, MaxWorkItems: 4}
+	err = WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if !errors.Is(err, openErr) {
+		t.Fatalf("expected open error, got %v", err)
+	}
+}
+
+func TestWalkRepoFilesWithinRootTraversesNestedDirectories(t *testing.T) {
+	repo := t.TempDir()
+	nestedFile := filepath.Join(repo, "src", "main", "App.java")
+	if err := os.MkdirAll(filepath.Dir(nestedFile), 0o755); err != nil {
+		t.Fatalf("mkdir nested source dir: %v", err)
+	}
+	if err := os.WriteFile(nestedFile, []byte("class App {}"), 0o600); err != nil {
+		t.Fatalf("write nested source file: %v", err)
+	}
+	root := openSharedTestRoot(t, repo)
+
+	var visited []string
+	budget := RootedWalkBudget{MaxTraversalEntries: 8, MaxFiles: 8, MaxWorkItems: 8}
+	err := WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(path string, entry fs.DirEntry) error {
+		visited = append(visited, filepath.ToSlash(path))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk nested repo: %v", err)
+	}
+	if len(visited) != 1 || !strings.HasSuffix(visited[0], "src/main/App.java") {
+		t.Fatalf("expected nested file visit only, got %#v", visited)
+	}
+}
+
+func TestWalkRepoFilesWithinRootUsesLinearPinnedRootOperationsForDeepWideTree(t *testing.T) {
+	repo := t.TempDir()
+	const (
+		depth = 5
+		width = 3
+	)
+	dirCount, fileCount := createSharedWalkDeepWideTree(t, repo, depth, width)
+	counts := &sharedWalkOperationCounts{}
+	root := newCountingSharedWalkRoot(t, repo, counts)
+
+	visitedFiles := 0
+	budget := RootedWalkBudget{
+		MaxTraversalEntries: dirCount + fileCount,
+		MaxFiles:            fileCount,
+		MaxWorkItems:        fileCount,
+	}
+	err := WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(string, fs.DirEntry) error {
+		visitedFiles++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk deep+wide repo: %v", err)
+	}
+	if visitedFiles != fileCount {
+		t.Fatalf("expected to visit %d files, got %d", fileCount, visitedFiles)
+	}
+	if counts.openRootCalls != dirCount-1 {
+		t.Fatalf("expected one child root open per non-root directory (%d), got %d", dirCount-1, counts.openRootCalls)
+	}
+	if counts.openCalls != dirCount {
+		t.Fatalf("expected one directory handle open per directory (%d), got %d", dirCount, counts.openCalls)
+	}
+	if counts.lstatCalls != 3*dirCount-1 {
+		t.Fatalf("expected bounded rooted lstat count %d, got %d", 3*dirCount-1, counts.lstatCalls)
+	}
+}
+
+func TestWalkRepoFilesWithinRootRejectsDirectoryReplacementBetweenEnumerationAndOpen(t *testing.T) {
+	repo := t.TempDir()
+	root := newSharedWalkDirectoryReplacementRoot(t, repo)
+
+	budget := RootedWalkBudget{MaxTraversalEntries: 8, MaxFiles: 8, MaxWorkItems: 8}
+	err := WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "root changed while opening: src") {
+		t.Fatalf("expected pinned directory replacement error, got %v", err)
+	}
+}
+
+type sharedWalkDirectoryReplacement struct {
+	t           *testing.T
+	repo        string
+	originalDir string
+	realRoot    safeio.Root
+	swapped     bool
+}
+
+func newSharedWalkDirectoryReplacementRoot(t *testing.T, repo string) safeio.Root {
+	t.Helper()
+	originalDir := filepath.Join(repo, "src")
+	if err := os.MkdirAll(originalDir, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(originalDir, "Original.java"), []byte("class Original {}\n"), 0o600); err != nil {
+		t.Fatalf("write original source: %v", err)
+	}
+	replacement := &sharedWalkDirectoryReplacement{
+		t:           t,
+		repo:        repo,
+		originalDir: originalDir,
+		realRoot:    openSharedTestRoot(t, repo),
+	}
+	return &sharedWalkSwapRoot{Root: replacement.realRoot, openRoot: replacement.openRoot}
+}
+
+func (r *sharedWalkDirectoryReplacement) openRoot(name string) (safeio.Root, error) {
+	if name == "src" && !r.swapped {
+		r.swapped = true
+		r.replace()
+	}
+	return r.realRoot.OpenRoot(name)
+}
+
+func (r *sharedWalkDirectoryReplacement) replace() {
+	r.t.Helper()
+	if err := os.Rename(r.originalDir, filepath.Join(r.repo, "src-original")); err != nil {
+		r.t.Fatalf("rename original dir: %v", err)
+	}
+	replacementDir := filepath.Join(r.repo, "src")
+	if err := os.MkdirAll(replacementDir, 0o755); err != nil {
+		r.t.Fatalf("mkdir replacement dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(replacementDir, "Replacement.java"), []byte("class Replacement {}\n"), 0o600); err != nil {
+		r.t.Fatalf("write replacement source: %v", err)
+	}
+}
+
+func TestWalkRepoFilesWithinRootRejectsAncestorReplacementBeforeNestedDirectoryOpen(t *testing.T) {
+	repo := t.TempDir()
+	originalDir := filepath.Join(repo, "src", "main")
+	if err := os.MkdirAll(originalDir, 0o755); err != nil {
+		t.Fatalf("mkdir src/main: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(originalDir, "Original.java"), []byte("class Original {}\n"), 0o600); err != nil {
+		t.Fatalf("write original source: %v", err)
+	}
+
+	realRoot := openSharedTestRoot(t, repo)
+	root := &sharedWalkSwapRoot{
+		Root: realRoot,
+		openRoot: func(name string) (safeio.Root, error) {
+			if name == "src" {
+				originalPath := filepath.Join(repo, "src-original")
+				if err := os.Rename(filepath.Join(repo, "src"), originalPath); err != nil {
+					t.Fatalf("rename original src: %v", err)
+				}
+				replacementDir := filepath.Join(repo, "src", "main")
+				if err := os.MkdirAll(replacementDir, 0o755); err != nil {
+					t.Fatalf("mkdir replacement src/main: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(replacementDir, "Replacement.java"), []byte("class Replacement {}\n"), 0o600); err != nil {
+					t.Fatalf("write replacement source: %v", err)
+				}
+			}
+			return realRoot.OpenRoot(name)
+		},
+	}
+
+	budget := RootedWalkBudget{MaxTraversalEntries: 8, MaxFiles: 8, MaxWorkItems: 8}
+	err := WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "root changed while opening: src") {
+		t.Fatalf("expected nested ancestor replacement error, got %v", err)
+	}
+}
+
+func TestWalkRepoFilesWithinRootBudgetHelpers(t *testing.T) {
+	exhausted := rootedRepoWalker{budget: RootedWalkBudget{MaxTraversalEntries: 1}}
+	if err := exhausted.countTraversalEntry("repo"); err != nil {
+		t.Fatalf("count first traversal entry: %v", err)
+	}
+	if err := exhausted.countTraversalEntry("repo"); !errors.Is(err, errRootedWalkTraversalLimit) {
+		t.Fatalf("expected traversal limit error, got %v", err)
+	}
+	if got := exhausted.traversalReadSize(); got != 0 {
+		t.Fatalf("expected exhausted traversal read size 0, got %d", got)
+	}
+	walker := rootedRepoWalker{budget: RootedWalkBudget{MaxTraversalEntries: 1}}
+	if !walker.queueTraversalEntries(1) {
+		t.Fatal("expected traversal queue to accept final entry")
+	}
+	if walker.queueTraversalEntries(1) || walker.queueTraversalEntries(-1) {
+		t.Fatal("expected traversal queue to reject invalid entries")
+	}
+	if !walker.dequeueTraversalEntry() || walker.dequeueTraversalEntry() {
+		t.Fatal("expected traversal dequeue bookkeeping to stay balanced")
+	}
+	var nilCtx context.Context
+	if err := walkContextErr(nilCtx); err != nil {
+		t.Fatalf("expected nil context to be ignored, got %v", err)
+	}
+
+	unlimited := rootedRepoWalker{}
+	if got := unlimited.traversalReadSize(); got != rootedWalkReadBatchSize {
+		t.Fatalf("expected unlimited traversal read size %d, got %d", rootedWalkReadBatchSize, got)
+	}
+}
+
+func openSharedTestRoot(t *testing.T, repo string) safeio.Root {
+	t.Helper()
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	})
+	return root
+}
+
+type sharedWalkTestRoot struct {
+	info fs.FileInfo
+	open func(string) (safeio.File, error)
+}
+
+type sharedWalkOperationCounts struct {
+	lstatCalls    int
+	openCalls     int
+	openRootCalls int
+}
+
+type sharedWalkSwapRoot struct {
+	safeio.Root
+	open     func(string) (safeio.File, error)
+	openRoot func(string) (safeio.Root, error)
+	close    func() error
+}
+
+type sharedPinnedChildRoot struct {
+	lstat    func(string) (fs.FileInfo, error)
+	openRoot func(string) (safeio.Root, error)
+	close    func() error
+}
+
+func (r *sharedWalkSwapRoot) Open(name string) (safeio.File, error) {
+	if r.open != nil {
+		return r.open(name)
+	}
+	return r.Root.Open(name)
+}
+
+func (r *sharedWalkSwapRoot) OpenRoot(name string) (safeio.Root, error) {
+	if r.openRoot != nil {
+		return r.openRoot(name)
+	}
+	return r.Root.OpenRoot(name)
+}
+
+func (r *sharedWalkSwapRoot) Close() error {
+	if r.close != nil {
+		return r.close()
+	}
+	return r.Root.Close()
+}
+
+func (*sharedPinnedChildRoot) Open(string) (safeio.File, error) {
+	return nil, errors.New("unexpected open")
+}
+
+func (*sharedPinnedChildRoot) OpenFile(string, int, os.FileMode) (safeio.File, error) {
+	return nil, errors.New("unexpected open file")
+}
+
+func (r *sharedPinnedChildRoot) OpenRoot(name string) (safeio.Root, error) {
+	if r.openRoot != nil {
+		return r.openRoot(name)
+	}
+	return nil, errors.New("unexpected open root: " + name)
+}
+
+func (r *sharedPinnedChildRoot) Lstat(name string) (fs.FileInfo, error) {
+	if r.lstat != nil {
+		return r.lstat(name)
+	}
+	return nil, errors.New("unexpected lstat: " + name)
+}
+
+func (*sharedPinnedChildRoot) Mkdir(string, os.FileMode) error { return errors.New("unexpected mkdir") }
+func (*sharedPinnedChildRoot) Chmod(string, os.FileMode) error { return errors.New("unexpected chmod") }
+func (*sharedPinnedChildRoot) MkdirAll(string, os.FileMode) error {
+	return errors.New("unexpected mkdir all")
+}
+func (*sharedPinnedChildRoot) Link(string, string) error   { return errors.New("unexpected link") }
+func (*sharedPinnedChildRoot) Rename(string, string) error { return errors.New("unexpected rename") }
+func (*sharedPinnedChildRoot) Remove(string) error         { return errors.New("unexpected remove") }
+func (r *sharedPinnedChildRoot) Close() error {
+	if r.close != nil {
+		return r.close()
+	}
+	return nil
+}
+
+func (r *sharedWalkTestRoot) Open(name string) (safeio.File, error) {
+	if r.open != nil {
+		return r.open(name)
+	}
+	return nil, errors.New("unexpected open: " + name)
+}
+
+func (*sharedWalkTestRoot) OpenFile(string, int, os.FileMode) (safeio.File, error) {
+	return nil, errors.New("unexpected open file")
+}
+
+func (*sharedWalkTestRoot) OpenRoot(string) (safeio.Root, error) {
+	return nil, errors.New("unexpected open root")
+}
+
+func (r *sharedWalkTestRoot) Lstat(name string) (fs.FileInfo, error) {
+	if name == "." && r.info != nil {
+		return r.info, nil
+	}
+	return nil, errors.New("unexpected lstat: " + name)
+}
+
+func (*sharedWalkTestRoot) Mkdir(string, os.FileMode) error { return errors.New("unexpected mkdir") }
+func (*sharedWalkTestRoot) Chmod(string, os.FileMode) error { return errors.New("unexpected chmod") }
+func (*sharedWalkTestRoot) MkdirAll(string, os.FileMode) error {
+	return errors.New("unexpected mkdir all")
+}
+func (*sharedWalkTestRoot) Link(string, string) error   { return errors.New("unexpected link") }
+func (*sharedWalkTestRoot) Rename(string, string) error { return errors.New("unexpected rename") }
+func (*sharedWalkTestRoot) Remove(string) error         { return errors.New("unexpected remove") }
+func (*sharedWalkTestRoot) Close() error                { return nil }
+
+type countingSharedWalkRoot struct {
+	underlying safeio.Root
+	counts     *sharedWalkOperationCounts
+}
+
+func newCountingSharedWalkRoot(t *testing.T, repo string, counts *sharedWalkOperationCounts) safeio.Root {
+	t.Helper()
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open counting root: %v", err)
+	}
+	wrapped := &countingSharedWalkRoot{underlying: root, counts: counts}
+	t.Cleanup(func() {
+		if closeErr := wrapped.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Fatalf("close counting root: %v", closeErr)
+		}
+	})
+	return wrapped
+}
+
+func (r *countingSharedWalkRoot) Open(name string) (safeio.File, error) {
+	r.counts.openCalls++
+	return r.underlying.Open(name)
+}
+
+func (r *countingSharedWalkRoot) OpenFile(name string, flag int, perm os.FileMode) (safeio.File, error) {
+	return r.underlying.OpenFile(name, flag, perm)
+}
+
+func (r *countingSharedWalkRoot) OpenRoot(name string) (safeio.Root, error) {
+	r.counts.openRootCalls++
+	child, err := r.underlying.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	return &countingSharedWalkRoot{underlying: child, counts: r.counts}, nil
+}
+
+func (r *countingSharedWalkRoot) Lstat(name string) (fs.FileInfo, error) {
+	r.counts.lstatCalls++
+	return r.underlying.Lstat(name)
+}
+
+func (r *countingSharedWalkRoot) Mkdir(name string, perm os.FileMode) error {
+	return r.underlying.Mkdir(name, perm)
+}
+
+func (r *countingSharedWalkRoot) Chmod(name string, perm os.FileMode) error {
+	return r.underlying.Chmod(name, perm)
+}
+
+func (r *countingSharedWalkRoot) MkdirAll(name string, perm os.FileMode) error {
+	return r.underlying.MkdirAll(name, perm)
+}
+
+func (r *countingSharedWalkRoot) Link(oldName, newName string) error {
+	return r.underlying.Link(oldName, newName)
+}
+
+func (r *countingSharedWalkRoot) Rename(oldName, newName string) error {
+	return r.underlying.Rename(oldName, newName)
+}
+
+func (r *countingSharedWalkRoot) Remove(name string) error {
+	return r.underlying.Remove(name)
+}
+
+func (r *countingSharedWalkRoot) Close() error {
+	return r.underlying.Close()
+}
+
+type sharedWalkTestFile struct {
+	read  func([]byte) (int, error)
+	write func([]byte) (int, error)
+	close func() error
+	stat  func() (fs.FileInfo, error)
+	chmod func(os.FileMode) error
+}
+
+func (f *sharedWalkTestFile) Read(p []byte) (int, error) {
+	if f.read != nil {
+		return f.read(p)
+	}
+	return 0, io.EOF
+}
+
+func (f *sharedWalkTestFile) Write(p []byte) (int, error) {
+	if f.write != nil {
+		return f.write(p)
+	}
+	return len(p), nil
+}
+
+func (f *sharedWalkTestFile) Close() error {
+	if f.close != nil {
+		return f.close()
+	}
+	return nil
+}
+
+func (f *sharedWalkTestFile) Stat() (fs.FileInfo, error) {
+	if f.stat != nil {
+		return f.stat()
+	}
+	return nil, errors.New("unexpected stat")
+}
+
+func (f *sharedWalkTestFile) Chmod(perm os.FileMode) error {
+	if f.chmod != nil {
+		return f.chmod(perm)
+	}
+	return nil
+}
+
+type sharedWalkTestDirectory struct {
+	sharedWalkTestFile
+	fillEntry          fs.DirEntry
+	overflowEntry      fs.DirEntry
+	entries            []fs.DirEntry
+	entryIndex         int
+	repeatEntries      int
+	extraEntries       int
+	noProgress         bool
+	readErr            error
+	readErrWithEntries error
+	closeCalls         int
+	readDirCalls       int
+	overflowServed     bool
+}
+
+func (d *sharedWalkTestDirectory) Stat() (fs.FileInfo, error) {
+	if d.stat != nil {
+		return d.stat()
+	}
+	if d.fillEntry != nil {
+		return d.fillEntry.Info()
+	}
+	if d.overflowEntry != nil {
+		return d.overflowEntry.Info()
+	}
+	return nil, errors.New("unexpected stat")
+}
+
+func (d *sharedWalkTestDirectory) ReadDir(count int) ([]fs.DirEntry, error) {
+	d.readDirCalls++
+	if d.readErr != nil {
+		return nil, d.readErr
+	}
+	if d.noProgress {
+		return nil, nil
+	}
+	if d.fillEntry != nil && d.extraEntries > 0 {
+		entries := make([]fs.DirEntry, count+d.extraEntries)
+		for index := range entries {
+			entries[index] = d.fillEntry
+		}
+		d.extraEntries = 0
+		return entries, d.readErrWithEntries
+	}
+	if d.entryIndex < len(d.entries) {
+		remaining := len(d.entries) - d.entryIndex
+		entryCount := min(count, remaining)
+		entries := make([]fs.DirEntry, entryCount)
+		copy(entries, d.entries[d.entryIndex:d.entryIndex+entryCount])
+		d.entryIndex += entryCount
+		return entries, d.readErrWithEntries
+	}
+	if d.repeatEntries > 0 {
+		entryCount := min(count, d.repeatEntries)
+		entries := make([]fs.DirEntry, entryCount)
+		for index := range entries {
+			entries[index] = d.fillEntry
+		}
+		d.repeatEntries -= entryCount
+		return entries, d.readErrWithEntries
+	}
+	if d.overflowEntry != nil && !d.overflowServed {
+		d.overflowServed = true
+		return []fs.DirEntry{d.overflowEntry}, d.readErrWithEntries
+	}
+	return nil, io.EOF
+}
+
+func (d *sharedWalkTestDirectory) Close() error {
+	d.closeCalls++
+	if d.close != nil {
+		return d.close()
+	}
+	return nil
+}
+
+type sharedWalkTestDirEntry struct {
+	name string
+}
+
+func (e *sharedWalkTestDirEntry) Name() string    { return e.name }
+func (*sharedWalkTestDirEntry) IsDir() bool       { return false }
+func (*sharedWalkTestDirEntry) Type() fs.FileMode { return 0 }
+func (e *sharedWalkTestDirEntry) Info() (fs.FileInfo, error) {
+	return &sharedWalkTestFileInfo{name: e.name}, nil
+}
+
+type sharedWalkTestFileInfo struct {
+	name string
+}
+
+func (i *sharedWalkTestFileInfo) Name() string     { return i.name }
+func (*sharedWalkTestFileInfo) Size() int64        { return 0 }
+func (*sharedWalkTestFileInfo) Mode() fs.FileMode  { return 0 }
+func (*sharedWalkTestFileInfo) ModTime() time.Time { return time.Time{} }
+func (*sharedWalkTestFileInfo) IsDir() bool        { return false }
+func (*sharedWalkTestFileInfo) Sys() any           { return nil }
+
+func createSharedWalkDeepWideTree(t *testing.T, repo string, depth, width int) (dirCount int, fileCount int) {
+	t.Helper()
+	var createLevel func(path string, level int)
+	createLevel = func(path string, level int) {
+		dirCount++
+		fileName := filepath.Join(path, "level-file.txt")
+		if err := os.WriteFile(fileName, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write tree file %s: %v", fileName, err)
+		}
+		fileCount++
+		if level == depth {
+			return
+		}
+		for idx := 0; idx < width; idx++ {
+			child := filepath.Join(path, "level-"+strconv.Itoa(level)+"-child-"+strconv.Itoa(idx))
+			if err := os.MkdirAll(child, 0o755); err != nil {
+				t.Fatalf("mkdir tree dir %s: %v", child, err)
+			}
+			createLevel(child, level+1)
+		}
+	}
+	createLevel(repo, 0)
+	return dirCount, fileCount
+}
+
+func TestWalkRepoFilesWithinRootProbeNoProgress(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	directory := &sharedWalkTestDirectory{
+		sharedWalkTestFile: sharedWalkTestFile{
+			stat: func() (fs.FileInfo, error) { return info, nil },
+		},
+		noProgress: true,
+	}
+	root := &sharedWalkTestRoot{
+		info: info,
+		open: func(string) (safeio.File, error) { return directory, nil },
+	}
+
+	budget := RootedWalkBudget{MaxTraversalEntries: 1, MaxFiles: 1, MaxWorkItems: 1}
+	err = WalkRepoFilesWithinRoot(context.Background(), repo, root, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if !errors.Is(err, io.ErrNoProgress) {
+		t.Fatalf("expected no-progress error, got %v", err)
+	}
+	if directory.closeCalls != 1 {
+		t.Fatalf("expected no-progress directory to close once, got %d", directory.closeCalls)
+	}
+}
+
+func TestWalkRepoFilesWithinRootProbeLimitBranches(t *testing.T) {
+	repo := t.TempDir()
+	info, err := os.Stat(repo)
+	if err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	walker := rootedRepoWalker{budget: RootedWalkBudget{MaxTraversalEntries: 1}}
+	entryDirectory := &sharedWalkTestDirectory{
+		overflowEntry: fs.FileInfoToDirEntry(info),
+	}
+	if err := walker.probeDirectoryLimit(context.Background(), repo, entryDirectory); !errors.Is(err, errRootedWalkTraversalLimit) {
+		t.Fatalf("expected traversal limit from probe, got %v", err)
+	}
+
+	readErr := errors.New("read overflowing probe")
+	entryDirectory = &sharedWalkTestDirectory{
+		overflowEntry:      fs.FileInfoToDirEntry(info),
+		readErrWithEntries: readErr,
+	}
+	if err := walker.probeDirectoryLimit(context.Background(), repo, entryDirectory); !errors.Is(err, errRootedWalkTraversalLimit) || !errors.Is(err, readErr) {
+		t.Fatalf("expected joined probe traversal-limit and read error, got %v", err)
+	}
+
+	eofDirectory := &sharedWalkTestDirectory{}
+	if err := walker.probeDirectoryLimit(context.Background(), repo, eofDirectory); err != nil {
+		t.Fatalf("expected eof probe to succeed, got %v", err)
+	}
+}
+
+func TestWalkRepoFilesWithinRootProbeHonorsCancellationAndReadErrors(t *testing.T) {
+	repo := t.TempDir()
+	if _, err := os.Stat(repo); err != nil {
+		t.Fatalf("stat repo: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	walker := rootedRepoWalker{budget: RootedWalkBudget{MaxTraversalEntries: 1}}
+	directory := &sharedWalkTestDirectory{}
+	if err := walker.probeDirectoryLimit(ctx, repo, directory); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled probe, got %v", err)
+	}
+
+	readErr := errors.New("probe read failure")
+	directory = &sharedWalkTestDirectory{readErr: readErr}
+	if err := walker.probeDirectoryLimit(context.Background(), repo, directory); !errors.Is(err, readErr) {
+		t.Fatalf("expected probe read error, got %v", err)
+	}
+}
+
+func TestWalkRepoFilesWithinRootPropagatesRootLstatError(t *testing.T) {
+	root := &sharedWalkTestRoot{}
+
+	budget := RootedWalkBudget{MaxTraversalEntries: 1, MaxFiles: 1, MaxWorkItems: 1}
+	err := WalkRepoFilesWithinRoot(context.Background(), t.TempDir(), root, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "unexpected lstat") {
+		t.Fatalf("expected root lstat error, got %v", err)
+	}
+}
+
+func TestWalkRepoFilesWithinRootRootMustBeDirectory(t *testing.T) {
+	repo := t.TempDir()
+	filePath := filepath.Join(repo, "repo.txt")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write root file: %v", err)
+	}
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat root file: %v", err)
+	}
+	root := &sharedWalkTestRoot{info: info}
+	budget := RootedWalkBudget{MaxTraversalEntries: 1, MaxFiles: 1, MaxWorkItems: 1}
+
+	err = WalkRepoFilesWithinRoot(context.Background(), filePath, root, budget, nil, func(string, fs.DirEntry) error { return nil })
+	if !errors.Is(err, fs.ErrInvalid) {
+		t.Fatalf("expected invalid-root error, got %v", err)
+	}
+}
+
+func TestOpenPinnedChildRootBranchCoverage(t *testing.T) {
+	t.Run("lookup error", testOpenPinnedChildRootLookupError)
+	t.Run("symlink rejection", testOpenPinnedChildRootSymlinkRejection)
+	t.Run("non-directory rejection", testOpenPinnedChildRootNonDirectory)
+	t.Run("open root failure", testOpenPinnedChildRootOpenFailure)
+	t.Run("child lookup close join", testOpenPinnedChildRootLookupCloseJoin)
+}
+
+func testOpenPinnedChildRootLookupError(t *testing.T) {
+	lookupErr := errors.New("lookup child")
+	root := &sharedPinnedChildRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "child" {
+				t.Fatalf("unexpected child lookup %q", name)
+			}
+			return nil, lookupErr
+		},
+	}
+	child, err := openPinnedChildRoot(root, "child", "child")
+	if child != nil || !errors.Is(err, lookupErr) {
+		t.Fatalf("expected lookup error, got child=%v err=%v", child, err)
+	}
+}
+
+func testOpenPinnedChildRootSymlinkRejection(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "target")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	linkPath := filepath.Join(parent, "child")
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	linkInfo, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	root := &sharedPinnedChildRoot{
+		lstat: func(string) (fs.FileInfo, error) { return linkInfo, nil },
+	}
+	child, err := openPinnedChildRoot(root, "child", "child")
+	if child != nil || err == nil || !strings.Contains(err.Error(), "root contains symlink: child") {
+		t.Fatalf("expected symlink rejection, got child=%v err=%v", child, err)
+	}
+}
+
+func testOpenPinnedChildRootNonDirectory(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "child.txt")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	root := &sharedPinnedChildRoot{
+		lstat: func(string) (fs.FileInfo, error) { return fileInfo, nil },
+	}
+	child, err := openPinnedChildRoot(root, "child", "child")
+	if child != nil || err == nil || !strings.Contains(err.Error(), "root is not a directory: child") {
+		t.Fatalf("expected non-directory rejection, got child=%v err=%v", child, err)
+	}
+}
+
+func testOpenPinnedChildRootOpenFailure(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	openErr := errors.New("open child root")
+	root := &sharedPinnedChildRoot{
+		lstat:    func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (safeio.Root, error) { return nil, openErr },
+	}
+	child, err := openPinnedChildRoot(root, "child", "child")
+	if child != nil || !errors.Is(err, openErr) {
+		t.Fatalf("expected open root error, got child=%v err=%v", child, err)
+	}
+}
+
+func testOpenPinnedChildRootLookupCloseJoin(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	lstatErr := errors.New("lstat opened child")
+	closeErr := errors.New("close opened child")
+	root := &sharedPinnedChildRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (safeio.Root, error) {
+			return &sharedPinnedChildRoot{
+				lstat: func(string) (fs.FileInfo, error) { return nil, lstatErr },
+				close: func() error { return closeErr },
+			}, nil
+		},
+	}
+	child, err := openPinnedChildRoot(root, "child", "child")
+	if child != nil || !errors.Is(err, lstatErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined child lookup and close errors, got child=%v err=%v", child, err)
+	}
+}

--- a/internal/safeio/filesystem.go
+++ b/internal/safeio/filesystem.go
@@ -7,7 +7,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 )
 
 // FileSystem captures the filesystem operations safeio needs.
@@ -27,6 +29,7 @@ type Root interface {
 	Mkdir(name string, perm os.FileMode) error
 	Chmod(name string, perm os.FileMode) error
 	MkdirAll(name string, perm os.FileMode) error
+	Link(oldName, newName string) error
 	Rename(oldName, newName string) error
 	Remove(name string) error
 	Close() error
@@ -41,11 +44,33 @@ type File interface {
 	Chmod(perm os.FileMode) error
 }
 
+type ReadDirFile interface {
+	File
+	ReadDir(count int) ([]fs.DirEntry, error)
+}
+
+var ErrTargetPathSymlink = errors.New("target path is a symlink")
+
 var fileSystem FileSystem = &osFileSystem{}
 
 // OpenRoot opens a confined filesystem root.
 func OpenRoot(name string) (Root, error) {
 	return fileSystem.OpenRoot(name)
+}
+
+// OpenRootNoFollow opens a confined filesystem root without following symlinks
+// in any component of name.
+func OpenRootNoFollow(name string) (Root, error) {
+	return fileSystem.OpenRootNoFollow(name)
+}
+
+// OpenRootExistingAncestorNoFollow opens the deepest existing ancestor for
+// name without following untrusted symlinks. It returns the opened ancestor,
+// that ancestor's canonical path, and any remaining missing path components.
+func OpenRootExistingAncestorNoFollow(name string) (Root, string, []string, error) {
+	return openRootExistingAncestorNoFollowWith(name, fileSystem.Abs, filepath.Rel, fileSystem.OpenRoot, func(root Root, childName, requestedPath string) (Root, string, error) {
+		return openRootChildPinnedWith(root, childName, requestedPath, fileSystem.OpenRootNoFollow, os.Stat, os.SameFile)
+	})
 }
 
 type osFileSystem struct{}
@@ -67,12 +92,21 @@ func (*osFileSystem) OpenRoot(name string) (Root, error) {
 }
 
 func (f *osFileSystem) OpenRootNoFollow(name string) (Root, error) {
-	volumeRoot := filepath.VolumeName(name) + string(os.PathSeparator)
-	rel, err := filepath.Rel(volumeRoot, name)
+	return openRootNoFollowWith(name, f.Abs, filepath.Rel, f.OpenRoot, f.openRootChildPinned)
+}
+
+func openRootNoFollowWith(name string, absFn func(string) (string, error), relFn func(string, string) (string, error), openRootFn func(string) (Root, error), openRootChildFn func(Root, string, string) (Root, string, error)) (Root, error) {
+	absName, err := absFn(name)
 	if err != nil {
 		return nil, err
 	}
-	root, err := f.OpenRoot(volumeRoot)
+
+	volumeRoot := filepath.VolumeName(absName) + string(os.PathSeparator)
+	rel, err := relFn(volumeRoot, absName)
+	if err != nil {
+		return nil, err
+	}
+	root, err := openRootFn(volumeRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +119,8 @@ func (f *osFileSystem) OpenRootNoFollow(name string) (Root, error) {
 		if part == "" || part == "." {
 			continue
 		}
-		currentPath = filepath.Join(currentPath, part)
-		next, err := openRootChildNoFollow(root, part, currentPath)
+		requestedPath := filepath.Join(currentPath, part)
+		next, nextPath, err := openRootChildFn(root, part, requestedPath)
 		if err != nil {
 			return nil, closeRootWithError(root, err)
 		}
@@ -94,8 +128,65 @@ func (f *osFileSystem) OpenRootNoFollow(name string) (Root, error) {
 			return nil, closeRootWithError(next, err)
 		}
 		root = next
+		currentPath = nextPath
 	}
 	return root, nil
+}
+
+func (f *osFileSystem) openRootChildPinned(root Root, name, requestedPath string) (Root, string, error) {
+	return openRootChildPinnedWith(root, name, requestedPath, f.OpenRootNoFollow, os.Stat, os.SameFile)
+}
+
+func openRootChildPinnedWith(root Root, name, requestedPath string, openRootNoFollowFn func(string) (Root, error), statFn func(string) (fs.FileInfo, error), sameFileFn func(fs.FileInfo, fs.FileInfo) bool) (Root, string, error) {
+	info, err := root.Lstat(name)
+	if err != nil {
+		return nil, "", err
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		next, err := openRootChildNoFollow(root, name, requestedPath)
+		return next, requestedPath, err
+	}
+
+	targetPath, ok := trustedRootAliasTarget(requestedPath)
+	if !ok {
+		return nil, "", fmt.Errorf("root contains symlink: %s", requestedPath)
+	}
+
+	return openPinnedRootAliasWith(targetPath, requestedPath, openRootNoFollowFn, statFn, sameFileFn)
+}
+
+func openPinnedRootAliasWith(targetPath string, requestedPath string, openRootNoFollowFn func(string) (Root, error), statFn func(string) (fs.FileInfo, error), sameFileFn func(fs.FileInfo, fs.FileInfo) bool) (Root, string, error) {
+	next, err := openRootNoFollowFn(targetPath)
+	if err != nil {
+		return nil, "", err
+	}
+	targetInfo, err := statFn(targetPath)
+	if err != nil {
+		return nil, "", closeRootWithError(next, err)
+	}
+	openedInfo, err := next.Lstat(".")
+	if err != nil {
+		return nil, "", closeRootWithError(next, err)
+	}
+	if !sameFileFn(targetInfo, openedInfo) {
+		return nil, "", closeRootWithError(next, fmt.Errorf("root changed while opening: %s", requestedPath))
+	}
+	return next, targetPath, nil
+}
+
+func trustedRootAliasTarget(requestedPath string) (string, bool) {
+	if runtime.GOOS != "darwin" {
+		return "", false
+	}
+
+	switch filepath.Clean(requestedPath) {
+	case filepath.Join(string(os.PathSeparator), "tmp"):
+		return filepath.Join(string(os.PathSeparator), "private", "tmp"), true
+	case filepath.Join(string(os.PathSeparator), "var"):
+		return filepath.Join(string(os.PathSeparator), "private", "var"), true
+	default:
+		return "", false
+	}
 }
 
 func openRootChildNoFollow(root Root, name, path string) (Root, error) {
@@ -124,6 +215,62 @@ func openRootChildNoFollow(root Root, name, path string) (Root, error) {
 	return next, nil
 }
 
+func openRootExistingAncestorNoFollowWith(name string, absFn func(string) (string, error), relFn func(string, string) (string, error), openRootFn func(string) (Root, error), openRootChildFn func(Root, string, string) (Root, string, error)) (Root, string, []string, error) {
+	absName, err := absFn(name)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	volumeRoot := filepath.VolumeName(absName) + string(os.PathSeparator)
+	rel, err := relFn(volumeRoot, absName)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	root, err := openRootFn(volumeRoot)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	if rel == "." {
+		return root, volumeRoot, nil, nil
+	}
+	_, parts := splitPinnedPath(rel)
+	return openExistingRootAncestors(root, volumeRoot, parts, openRootChildFn)
+}
+
+func openExistingRootAncestors(root Root, currentPath string, parts []string, openRootChildFn func(Root, string, string) (Root, string, error)) (Root, string, []string, error) {
+	for idx, part := range parts {
+		requestedPath := filepath.Join(currentPath, part)
+		exists, err := rootChildExists(root, part)
+		if err != nil {
+			return nil, "", nil, closeRootWithError(root, err)
+		}
+		if !exists {
+			return root, currentPath, parts[idx:], nil
+		}
+		next, nextPath, err := openRootChildFn(root, part, requestedPath)
+		if err != nil {
+			return nil, "", nil, closeRootWithError(root, err)
+		}
+		if err := root.Close(); err != nil {
+			return nil, "", nil, closeRootWithError(next, err)
+		}
+		root = next
+		currentPath = nextPath
+	}
+	return root, currentPath, nil, nil
+}
+
+func rootChildExists(root Root, name string) (bool, error) {
+	_, err := root.Lstat(name)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
 func closeRootWithError(root Root, err error) error {
 	if closeErr := root.Close(); closeErr != nil {
 		return errors.Join(err, closeErr)
@@ -133,6 +280,182 @@ func closeRootWithError(root Root, err error) error {
 
 type osRoot struct {
 	root *os.Root
+}
+
+func OpenPinnedFile(root Root, name string) (_ File, err error) {
+	file, roots, err := openPinnedPath(root, name, pinnedChildExpectFile)
+	if err != nil {
+		return nil, err
+	}
+	if len(roots) == 0 {
+		return file, nil
+	}
+	return &pinnedFile{File: file, roots: roots}, nil
+}
+
+func OpenPinnedDirectory(root Root, name string) (_ ReadDirFile, err error) {
+	file, roots, err := openPinnedPath(root, name, pinnedChildExpectDirectory)
+	if err != nil {
+		return nil, err
+	}
+	dir, ok := file.(ReadDirFile)
+	if ok {
+		if len(roots) == 0 {
+			return dir, nil
+		}
+		return &pinnedReadDirFile{ReadDirFile: dir, roots: roots}, nil
+	}
+	if len(roots) > 0 {
+		err = closeRootsWithError(roots, fs.ErrInvalid)
+	} else {
+		err = fs.ErrInvalid
+	}
+	if closeErr := file.Close(); closeErr != nil {
+		return nil, errors.Join(err, closeErr)
+	}
+	return nil, err
+}
+
+type pinnedFile struct {
+	File
+	roots []Root
+}
+
+func (f *pinnedFile) Close() error {
+	return closeRootsWithError(f.roots, f.File.Close())
+}
+
+type pinnedReadDirFile struct {
+	ReadDirFile
+	roots []Root
+}
+
+func (f *pinnedReadDirFile) Close() error {
+	return closeRootsWithError(f.roots, f.ReadDirFile.Close())
+}
+
+func openPinnedPath(root Root, name string, kind pinnedChildKind) (_ File, _ []Root, err error) {
+	cleanName, parts := splitPinnedPath(name)
+	if len(parts) <= 1 {
+		file, err := openPinnedChildAtPath(root, cleanName, cleanName, kind)
+		return file, nil, err
+	}
+
+	roots, leafRoot, leafName, leafPath, err := openPinnedAncestors(root, parts)
+	if err != nil {
+		return nil, nil, err
+	}
+	file, err := openPinnedChildAtPath(leafRoot, leafName, leafPath, kind)
+	if err != nil {
+		return nil, nil, closeRootsWithError(roots, err)
+	}
+	return file, roots, nil
+}
+
+func splitPinnedPath(name string) (string, []string) {
+	cleanName := filepath.Clean(name)
+	if cleanName == "." {
+		return cleanName, nil
+	}
+
+	rawParts := strings.Split(cleanName, string(os.PathSeparator))
+	parts := make([]string, 0, len(rawParts))
+	for _, part := range rawParts {
+		if part == "" || part == "." {
+			continue
+		}
+		parts = append(parts, part)
+	}
+	return cleanName, parts
+}
+
+func openPinnedAncestors(root Root, parts []string) (_ []Root, _ Root, _ string, _ string, err error) {
+	opened := make([]Root, 0, len(parts)-1)
+	current := root
+	currentPath := ""
+	for _, part := range parts[:len(parts)-1] {
+		currentPath = filepath.Join(currentPath, part)
+		next, openErr := openRootChildNoFollow(current, part, currentPath)
+		if openErr != nil {
+			return nil, nil, "", "", closeRootsWithError(opened, openErr)
+		}
+		opened = append(opened, next)
+		current = next
+	}
+	return opened, current, parts[len(parts)-1], filepath.Join(parts...), nil
+}
+
+func closeRootsWithError(roots []Root, err error) error {
+	for idx := len(roots) - 1; idx >= 0; idx-- {
+		err = errors.Join(err, roots[idx].Close())
+	}
+	return err
+}
+
+func openPinnedChildAtPath(root Root, name, path string, kind pinnedChildKind) (_ File, err error) {
+	info, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, &targetPathSymlinkError{path: path}
+	}
+	if kind == pinnedChildExpectFile && info.IsDir() {
+		return nil, fs.ErrInvalid
+	}
+	if kind == pinnedChildExpectDirectory && !info.IsDir() {
+		return nil, fs.ErrInvalid
+	}
+
+	file, err := root.Open(name)
+	if err != nil {
+		return nil, normalizePathEscapesRootError(path, err)
+	}
+
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return nil, closeFileWithError(file, err)
+	}
+	if kind == pinnedChildExpectFile && openedInfo.IsDir() {
+		return nil, closeFileWithError(file, fs.ErrInvalid)
+	}
+	if kind == pinnedChildExpectDirectory && !openedInfo.IsDir() {
+		return nil, closeFileWithError(file, fs.ErrInvalid)
+	}
+	if !os.SameFile(info, openedInfo) {
+		return nil, closeFileWithError(file, fmt.Errorf("path changed while opening: %s", path))
+	}
+	return file, nil
+}
+
+type pinnedChildKind int
+
+const (
+	pinnedChildExpectFile pinnedChildKind = iota
+	pinnedChildExpectDirectory
+)
+
+type targetPathSymlinkError struct {
+	path string
+}
+
+func (e *targetPathSymlinkError) Error() string {
+	return fmt.Sprintf("%s: %s", ErrTargetPathSymlink, e.path)
+}
+
+func (*targetPathSymlinkError) Unwrap() error {
+	return ErrTargetPathSymlink
+}
+
+func (*targetPathSymlinkError) Is(target error) bool {
+	return target == syscall.ELOOP
+}
+
+func closeFileWithError(file File, err error) error {
+	if closeErr := file.Close(); closeErr != nil {
+		return errors.Join(err, closeErr)
+	}
+	return err
 }
 
 func (r *osRoot) Open(name string) (File, error) {
@@ -165,6 +488,10 @@ func (r *osRoot) Chmod(name string, perm os.FileMode) error {
 
 func (r *osRoot) MkdirAll(name string, perm os.FileMode) error {
 	return r.root.MkdirAll(name, perm)
+}
+
+func (r *osRoot) Link(oldName, newName string) error {
+	return r.root.Link(oldName, newName)
 }
 
 func (r *osRoot) Rename(oldName, newName string) error {

--- a/internal/safeio/filesystem_branches_test.go
+++ b/internal/safeio/filesystem_branches_test.go
@@ -1,0 +1,727 @@
+package safeio
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeReadDirFile struct {
+	*fakeFile
+	readDir func(count int) ([]fs.DirEntry, error)
+}
+
+func (f *fakeReadDirFile) ReadDir(count int) ([]fs.DirEntry, error) {
+	if f.readDir != nil {
+		return f.readDir(count)
+	}
+	return nil, nil
+}
+
+func TestOpenPinnedDirectoryReadsNestedDirectoryAndClosesAncestors(t *testing.T) {
+	repo := t.TempDir()
+	leafDir := filepath.Join(repo, "nested", "leaf")
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("mkdir leaf dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(leafDir, "child.txt"), []byte("content"), 0o600); err != nil {
+		t.Fatalf("write child file: %v", err)
+	}
+
+	root := openTestRoot(t, repo)
+	dir, err := OpenPinnedDirectory(root, filepath.Join("nested", "leaf"))
+	if err != nil {
+		t.Fatalf("open pinned directory: %v", err)
+	}
+
+	entries, err := dir.ReadDir(-1)
+	if err != nil {
+		t.Fatalf("read pinned directory: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "child.txt" {
+		t.Fatalf("unexpected pinned directory entries: %#v", entries)
+	}
+	if err := dir.Close(); err != nil {
+		t.Fatalf("close pinned directory: %v", err)
+	}
+}
+
+func TestOpenPinnedDirectoryRejectsNonReadDirFileAndJoinsCloseErrors(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	fileCloseErr := errors.New("close opened file")
+	rootCloseErr := errors.New("close pinned ancestor")
+	childRoot := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "." || name == "leaf" {
+				return dirInfo, nil
+			}
+			if name != "leaf" {
+				t.Fatalf("unexpected child lstat %q", name)
+			}
+			return nil, fs.ErrNotExist
+		},
+		open: func(name string) (File, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected child open %q", name)
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return dirInfo, nil },
+				close: func() error { return fileCloseErr },
+			}, nil
+		},
+		close: func() error { return rootCloseErr },
+	}
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "nested" {
+				t.Fatalf("unexpected root lstat %q", name)
+			}
+			return dirInfo, nil
+		},
+		openRoot: func(name string) (Root, error) {
+			if name != "nested" {
+				t.Fatalf("unexpected root openRoot %q", name)
+			}
+			return childRoot, nil
+		},
+	}
+
+	dir, err := OpenPinnedDirectory(root, filepath.Join("nested", "leaf"))
+	if dir != nil {
+		t.Fatal("expected invalid pinned directory wrapper to return nil")
+	}
+	if !errors.Is(err, fs.ErrInvalid) || !errors.Is(err, fileCloseErr) || !errors.Is(err, rootCloseErr) {
+		t.Fatalf("expected invalid directory joined with file and root close errors, got %v", err)
+	}
+}
+
+func TestOpenPinnedDirectoryRejectsRootDirectoryHandleWithoutReadDir(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	closeErr := errors.New("close root directory file")
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected root lstat %q", name)
+			}
+			return dirInfo, nil
+		},
+		open: func(name string) (File, error) {
+			if name != "leaf" {
+				t.Fatalf("unexpected root open %q", name)
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return dirInfo, nil },
+				close: func() error { return closeErr },
+			}, nil
+		},
+	}
+
+	dir, err := OpenPinnedDirectory(root, "leaf")
+	if dir != nil {
+		t.Fatal("expected invalid root directory wrapper to return nil")
+	}
+	if !errors.Is(err, fs.ErrInvalid) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected invalid directory joined with file close error, got %v", err)
+	}
+}
+
+func TestTargetPathSymlinkErrorFormatsSentinelAndPath(t *testing.T) {
+	err := &targetPathSymlinkError{path: "nested/link"}
+	if !errors.Is(err, ErrTargetPathSymlink) {
+		t.Fatalf("expected symlink sentinel identity, got %v", err)
+	}
+	if got := err.Error(); !strings.Contains(got, ErrTargetPathSymlink.Error()) || !strings.Contains(got, "nested/link") {
+		t.Fatalf("unexpected symlink error text: %q", got)
+	}
+}
+
+func TestCloseFileWithErrorPreservesPrimaryErrorWhenCloseSucceeds(t *testing.T) {
+	primary := errors.New("primary")
+	err := closeFileWithError(&fakeFile{close: func() error { return nil }}, primary)
+	if !errors.Is(err, primary) {
+		t.Fatalf("expected primary error to survive, got %v", err)
+	}
+}
+
+func TestCloseFileWithErrorJoinsCloseError(t *testing.T) {
+	primary := errors.New("primary")
+	closeErr := errors.New("close file")
+	err := closeFileWithError(&fakeFile{close: func() error { return closeErr }}, primary)
+	if !errors.Is(err, primary) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected closeFileWithError to join primary and close errors, got %v", err)
+	}
+}
+
+func TestNormalizePathEscapesRootErrorReturnsNilForNilError(t *testing.T) {
+	if err := normalizePathEscapesRootError("child.txt", nil); err != nil {
+		t.Fatalf("expected nil error to stay nil, got %v", err)
+	}
+}
+
+func TestNormalizePathEscapesRootErrorPreservesExistingSentinel(t *testing.T) {
+	err := newPathEscapesRootError("child.txt")
+	got := normalizePathEscapesRootError("other.txt", err)
+	var pathErr *pathEscapesRootError
+	if !errors.As(got, &pathErr) || pathErr.path != "child.txt" {
+		t.Fatalf("expected existing sentinel payload to be preserved, got %#v", got)
+	}
+}
+
+func TestPathEscapesRootInvariantRejectsBlankPath(t *testing.T) {
+	if pathEscapesRootInvariant("   ") {
+		t.Fatal("expected blank path not to be treated as an escape invariant")
+	}
+}
+
+func TestIsPureSentinelErrorRecognizesDirectAndJoinedSentinels(t *testing.T) {
+	if !isPureSentinelError(fs.ErrNotExist, fs.ErrNotExist) {
+		t.Fatal("expected direct sentinel match to be pure")
+	}
+	if !isPureSentinelError(errors.Join(nil, fs.ErrNotExist), fs.ErrNotExist) {
+		t.Fatal("expected joined sentinel with nil cause to be pure")
+	}
+}
+
+func TestIsPureSentinelErrorRejectsNilErrorAndMissingSentinels(t *testing.T) {
+	if isPureSentinelError(nil, fs.ErrNotExist) {
+		t.Fatal("expected nil error to be impure")
+	}
+	if isPureSentinelError(fs.ErrNotExist) {
+		t.Fatal("expected missing sentinel set to be impure")
+	}
+}
+
+func TestOpenPinnedChildAtPathNormalizesRootEscapeOpenError(t *testing.T) {
+	fixturePath := filepath.Join(t.TempDir(), "fixture.txt")
+	if err := os.WriteFile(fixturePath, []byte("fixture"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	fileInfo := statTestPath(t, fixturePath)
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "child.txt" {
+				t.Fatalf("unexpected lstat %q", name)
+			}
+			return fileInfo, nil
+		},
+		open: func(name string) (File, error) {
+			if name != "child.txt" {
+				t.Fatalf("unexpected open %q", name)
+			}
+			return nil, &fs.PathError{
+				Op:   "openat",
+				Path: filepath.Join("..", "child.txt"),
+				Err:  errors.New("localized rooted-open escape"),
+			}
+		},
+	}
+
+	file, err := openPinnedChildAtPath(root, "child.txt", "child.txt", pinnedChildExpectFile)
+	if file != nil {
+		t.Fatalf("expected escaped open to return no file, got %#v", file)
+	}
+	if !errors.Is(err, ErrPathEscapesRoot) {
+		t.Fatalf("expected path escape sentinel, got %v", err)
+	}
+}
+
+func TestOpenPinnedChildAtPathRejectsNonDirectoryWhenDirectoryExpected(t *testing.T) {
+	fixturePath := filepath.Join(t.TempDir(), "fixture.txt")
+	if err := os.WriteFile(fixturePath, []byte("fixture"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	fileInfo := statTestPath(t, fixturePath)
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return fileInfo, nil },
+	}
+
+	file, err := openPinnedChildAtPath(root, "child.txt", "child.txt", pinnedChildExpectDirectory)
+	if file != nil {
+		t.Fatalf("expected non-directory to be rejected, got %#v", file)
+	}
+	if !errors.Is(err, fs.ErrInvalid) {
+		t.Fatalf("expected invalid directory error, got %v", err)
+	}
+}
+
+func TestOpenPinnedChildAtPathJoinsStatAndCloseErrors(t *testing.T) {
+	fixturePath := filepath.Join(t.TempDir(), "fixture.txt")
+	if err := os.WriteFile(fixturePath, []byte("fixture"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	fileInfo := statTestPath(t, fixturePath)
+	statErr := errors.New("stat opened file")
+	closeErr := errors.New("close opened file")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return fileInfo, nil },
+		open: func(string) (File, error) {
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return nil, statErr },
+				close: func() error { return closeErr },
+			}, nil
+		},
+	}
+
+	file, err := openPinnedChildAtPath(root, "child.txt", "child.txt", pinnedChildExpectFile)
+	if file != nil {
+		t.Fatalf("expected stat failure to return no file, got %#v", file)
+	}
+	if !errors.Is(err, statErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected stat and close errors to be joined, got %v", err)
+	}
+}
+
+func TestOpenPinnedChildAtPathRejectsDirectoryWhenFileExpected(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "fixture.txt")
+	if err := os.WriteFile(filePath, []byte("fixture"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	fileInfo := statTestPath(t, filePath)
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	closeErr := errors.New("close opened directory")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return fileInfo, nil },
+		open: func(string) (File, error) {
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return dirInfo, nil },
+				close: func() error { return closeErr },
+			}, nil
+		},
+	}
+
+	file, err := openPinnedChildAtPath(root, "child.txt", "child.txt", pinnedChildExpectFile)
+	if file != nil {
+		t.Fatalf("expected opened directory to be rejected as file, got %#v", file)
+	}
+	if !errors.Is(err, fs.ErrInvalid) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected invalid file type joined with close error, got %v", err)
+	}
+}
+
+func TestOpenRootExistingAncestorNoFollowWithReturnsMissingSuffix(t *testing.T) {
+	targetPath := filepath.Join(string(os.PathSeparator), "repo", "nested", "cache")
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "repo" {
+				t.Fatalf("unexpected lstat %q", name)
+			}
+			return nil, os.ErrNotExist
+		},
+	}
+	absFn := func(string) (string, error) { return targetPath, nil }
+	openRootFn := func(string) (Root, error) { return root, nil }
+	openChildFn := func(Root, string, string) (Root, string, error) {
+		t.Fatal("unexpected child open")
+		return nil, "", nil
+	}
+
+	opened, ancestorPath, missingParts, err := openRootExistingAncestorNoFollowWith(targetPath, absFn, filepath.Rel, openRootFn, openChildFn)
+	if err != nil {
+		t.Fatalf("open existing ancestor with missing suffix: %v", err)
+	}
+	if opened != root {
+		t.Fatalf("expected existing ancestor root, got %#v", opened)
+	}
+	if ancestorPath != string(os.PathSeparator) {
+		t.Fatalf("expected volume root ancestor, got %q", ancestorPath)
+	}
+	if len(missingParts) != 3 || missingParts[0] != "repo" || missingParts[2] != "cache" {
+		t.Fatalf("unexpected missing suffix: %#v", missingParts)
+	}
+}
+
+func TestOpenRootExistingAncestorNoFollowWithJoinsLookupAndCloseErrors(t *testing.T) {
+	targetPath := filepath.Join(string(os.PathSeparator), "repo", "nested")
+	lookupErr := errors.New("lookup existing ancestor")
+	closeErr := errors.New("close ancestor root")
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "repo" {
+				t.Fatalf("unexpected lstat %q", name)
+			}
+			return nil, lookupErr
+		},
+		close: func() error { return closeErr },
+	}
+	absFn := func(string) (string, error) { return targetPath, nil }
+	openRootFn := func(string) (Root, error) { return root, nil }
+	openChildFn := func(Root, string, string) (Root, string, error) {
+		t.Fatal("unexpected child open")
+		return nil, "", nil
+	}
+
+	opened, ancestorPath, missingParts, err := openRootExistingAncestorNoFollowWith(targetPath, absFn, filepath.Rel, openRootFn, openChildFn)
+	if opened != nil || ancestorPath != "" || len(missingParts) != 0 {
+		t.Fatalf("expected failed ancestor lookup to return no state, got root=%#v path=%q missing=%#v", opened, ancestorPath, missingParts)
+	}
+	if !errors.Is(err, lookupErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected lookup and close errors to be joined, got %v", err)
+	}
+}
+
+func TestOpenRootNoFollowWithPropagatesRelativePathError(t *testing.T) {
+	relErr := errors.New("compute relative path")
+	absFn := func(string) (string, error) { return "/repo", nil }
+	relFn := func(string, string) (string, error) { return "", relErr }
+	openRootFn := func(string) (Root, error) {
+		t.Fatal("unexpected root open")
+		return nil, nil
+	}
+	openChildFn := func(Root, string, string) (Root, string, error) {
+		t.Fatal("unexpected child open")
+		return nil, "", nil
+	}
+
+	root, err := openRootNoFollowWith("/repo", absFn, relFn, openRootFn, openChildFn)
+	if root != nil || !errors.Is(err, relErr) {
+		t.Fatalf("expected relative-path error, got root=%#v err=%v", root, err)
+	}
+}
+
+func TestOpenRootNoFollowWithReturnsOpenedVolumeRootForExactMatch(t *testing.T) {
+	root := &fakeRoot{close: func() error { return nil }}
+	absFn := func(string) (string, error) { return "/", nil }
+	openRootFn := func(string) (Root, error) { return root, nil }
+	openChildFn := func(Root, string, string) (Root, string, error) {
+		t.Fatal("unexpected child open")
+		return nil, "", nil
+	}
+
+	opened, err := openRootNoFollowWith("/", absFn, filepath.Rel, openRootFn, openChildFn)
+	if err != nil {
+		t.Fatalf("open exact volume root: %v", err)
+	}
+	if opened != root {
+		t.Fatalf("expected exact-match volume root, got %#v", opened)
+	}
+}
+
+func TestOpenRootNoFollowWithSkipsDotSegments(t *testing.T) {
+	root := &fakeRoot{close: func() error { return nil }}
+	childInfo := statTestPath(t, t.TempDir())
+	child := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return childInfo, nil },
+		close: func() error { return nil },
+	}
+	openCalls := 0
+	absFn := func(string) (string, error) { return "/repo/child", nil }
+	relFn := func(string, string) (string, error) { return filepath.Join(".", "repo", ".", "child"), nil }
+	openRootFn := func(string) (Root, error) { return root, nil }
+	openChildFn := func(current Root, name, requestedPath string) (Root, string, error) {
+		openCalls++
+		if openCalls == 1 {
+			return child, "/repo", nil
+		}
+		return &fakeRoot{
+			lstat: func(string) (fs.FileInfo, error) { return childInfo, nil },
+			close: func() error { return nil },
+		}, requestedPath, nil
+	}
+
+	opened, err := openRootNoFollowWith("/repo/child", absFn, relFn, openRootFn, openChildFn)
+	if err != nil {
+		t.Fatalf("open rooted path with dot segments: %v", err)
+	}
+	if opened == nil || openCalls != 2 {
+		t.Fatalf("expected two child opens after skipping dot segments, got root=%#v opens=%d", opened, openCalls)
+	}
+}
+
+func TestOpenRootNoFollowWithJoinsRootAndNextCloseErrors(t *testing.T) {
+	rootCloseErr := errors.New("close volume root")
+	nextCloseErr := errors.New("close opened child")
+	root := &fakeRoot{close: func() error { return rootCloseErr }}
+	next := &fakeRoot{close: func() error { return nextCloseErr }}
+	absFn := func(string) (string, error) { return "/repo", nil }
+	relFn := func(string, string) (string, error) { return "repo", nil }
+	openRootFn := func(string) (Root, error) { return root, nil }
+	openChildFn := func(Root, string, string) (Root, string, error) { return next, "/repo", nil }
+
+	opened, err := openRootNoFollowWith("/repo", absFn, relFn, openRootFn, openChildFn)
+	if opened != nil {
+		t.Fatalf("expected close failure to return no root, got %#v", opened)
+	}
+	if !errors.Is(err, rootCloseErr) || !errors.Is(err, nextCloseErr) {
+		t.Fatalf("expected root and next close errors to be joined, got %v", err)
+	}
+}
+
+func TestOpenPinnedRootAliasWithJoinsOpenedRootLookupCloseError(t *testing.T) {
+	lookupErr := errors.New("lstat opened alias")
+	closeErr := errors.New("close alias root")
+	targetInfo := statTestPath(t, t.TempDir())
+	openRootFn := func(string) (Root, error) {
+		return &fakeRoot{
+			lstat: func(string) (fs.FileInfo, error) { return nil, lookupErr },
+			close: func() error { return closeErr },
+		}, nil
+	}
+	statFn := func(string) (fs.FileInfo, error) { return targetInfo, nil }
+
+	opened, path, err := openPinnedRootAliasWith("/private/tmp", "/tmp", openRootFn, statFn, os.SameFile)
+	if opened != nil || path != "" {
+		t.Fatalf("expected alias root lookup failure to return no root, got root=%#v path=%q", opened, path)
+	}
+	if !errors.Is(err, lookupErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected alias lookup and close errors to be joined, got %v", err)
+	}
+}
+
+func TestOpenRootExistingAncestorNoFollowWithReturnsVolumeRootForExactMatch(t *testing.T) {
+	root := &fakeRoot{close: func() error { return nil }}
+	absFn := func(string) (string, error) { return "/", nil }
+	openRootFn := func(string) (Root, error) { return root, nil }
+	openChildFn := func(Root, string, string) (Root, string, error) {
+		t.Fatal("unexpected child open")
+		return nil, "", nil
+	}
+
+	opened, ancestorPath, missingParts, err := openRootExistingAncestorNoFollowWith("/", absFn, filepath.Rel, openRootFn, openChildFn)
+	if err != nil {
+		t.Fatalf("open exact existing ancestor: %v", err)
+	}
+	if opened != root || ancestorPath != string(os.PathSeparator) || len(missingParts) != 0 {
+		t.Fatalf("unexpected exact ancestor result: root=%#v path=%q missing=%#v", opened, ancestorPath, missingParts)
+	}
+}
+
+func TestOpenRootExistingAncestorNoFollowWithSkipsDotSegments(t *testing.T) {
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return statTestPath(t, t.TempDir()), nil },
+		close: func() error { return nil },
+	}
+	childInfo := statTestPath(t, t.TempDir())
+	child := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return childInfo, nil },
+		close: func() error { return nil },
+	}
+	openCalls := 0
+	absFn := func(string) (string, error) { return "/repo/child", nil }
+	relFn := func(string, string) (string, error) { return filepath.Join(".", "repo", ".", "child"), nil }
+	openRootFn := func(string) (Root, error) { return root, nil }
+	openChildFn := func(current Root, name, requestedPath string) (Root, string, error) {
+		openCalls++
+		if openCalls == 1 {
+			return child, "/repo", nil
+		}
+		return &fakeRoot{
+			lstat: func(string) (fs.FileInfo, error) { return childInfo, nil },
+			close: func() error { return nil },
+		}, requestedPath, nil
+	}
+
+	opened, ancestorPath, missingParts, err := openRootExistingAncestorNoFollowWith("/repo/child", absFn, relFn, openRootFn, openChildFn)
+	if err != nil {
+		t.Fatalf("open existing ancestor with dot segments: %v", err)
+	}
+	if opened == nil || ancestorPath != "/repo/child" || len(missingParts) != 0 || openCalls != 2 {
+		t.Fatalf("unexpected ancestor traversal result: root=%#v path=%q missing=%#v opens=%d", opened, ancestorPath, missingParts, openCalls)
+	}
+}
+
+func TestOpenRootExistingAncestorNoFollowWithJoinsCurrentAndNextCloseErrors(t *testing.T) {
+	currentCloseErr := errors.New("close current ancestor")
+	nextCloseErr := errors.New("close next ancestor")
+	rootInfo := statTestPath(t, t.TempDir())
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return rootInfo, nil },
+		close: func() error { return currentCloseErr },
+	}
+	next := &fakeRoot{close: func() error { return nextCloseErr }}
+	absFn := func(string) (string, error) { return "/repo", nil }
+	relFn := func(string, string) (string, error) { return "repo", nil }
+	openRootFn := func(string) (Root, error) { return root, nil }
+	openChildFn := func(Root, string, string) (Root, string, error) { return next, "/repo", nil }
+
+	opened, ancestorPath, missingParts, err := openRootExistingAncestorNoFollowWith("/repo", absFn, relFn, openRootFn, openChildFn)
+	if opened != nil || ancestorPath != "" || len(missingParts) != 0 {
+		t.Fatalf("expected failed ancestor close to return no state, got root=%#v path=%q missing=%#v", opened, ancestorPath, missingParts)
+	}
+	if !errors.Is(err, currentCloseErr) || !errors.Is(err, nextCloseErr) {
+		t.Fatalf("expected current and next close errors to be joined, got %v", err)
+	}
+}
+
+func TestOpenPinnedDirectoryReturnsDirectReadDirHandleForRootPath(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	dirFile := &fakeReadDirFile{
+		fakeFile: &fakeFile{stat: func() (fs.FileInfo, error) { return dirInfo, nil }},
+	}
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		open:  func(string) (File, error) { return dirFile, nil },
+	}
+
+	opened, err := OpenPinnedDirectory(root, "leaf")
+	if err != nil {
+		t.Fatalf("open direct read-dir handle: %v", err)
+	}
+	if opened != dirFile {
+		t.Fatalf("expected direct read-dir handle, got %#v", opened)
+	}
+}
+
+func TestOpenPinnedDirectoryRejectsRootDirectoryHandleWithoutReadDirWhenCloseSucceeds(t *testing.T) {
+	dirInfo, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		open: func(string) (File, error) {
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return dirInfo, nil },
+				close: func() error { return nil },
+			}, nil
+		},
+	}
+
+	dir, err := OpenPinnedDirectory(root, "leaf")
+	if dir != nil {
+		t.Fatal("expected invalid root directory wrapper to return nil")
+	}
+	if !errors.Is(err, fs.ErrInvalid) {
+		t.Fatalf("expected invalid directory error, got %v", err)
+	}
+}
+
+func TestSplitPinnedPathSkipsEmptyAndDotSegments(t *testing.T) {
+	cleanName, parts := splitPinnedPath(filepath.Join(".", "nested", ".", "leaf"))
+	if cleanName != filepath.Join("nested", "leaf") {
+		t.Fatalf("unexpected clean name: %q", cleanName)
+	}
+	if len(parts) != 2 || parts[0] != "nested" || parts[1] != "leaf" {
+		t.Fatalf("unexpected split parts: %#v", parts)
+	}
+}
+
+func TestOpenRootExistingAncestorNoFollowWithPropagatesSetupErrors(t *testing.T) {
+	absErr := errors.New("resolve absolute ancestor path")
+	relErr := errors.New("resolve relative ancestor path")
+	openErr := errors.New("open ancestor volume root")
+
+	tests := []struct {
+		name       string
+		absFn      func(string) (string, error)
+		relFn      func(string, string) (string, error)
+		openRootFn func(string) (Root, error)
+		wantErr    error
+	}{
+		{
+			name: "absolute path",
+			absFn: func(string) (string, error) {
+				return "", absErr
+			},
+			relFn: func(string, string) (string, error) {
+				t.Fatal("relative path resolution must not run after absolute path failure")
+				return "", nil
+			},
+			openRootFn: func(string) (Root, error) {
+				t.Fatal("volume root open must not run after absolute path failure")
+				return nil, nil
+			},
+			wantErr: absErr,
+		},
+		{
+			name: "relative path",
+			absFn: func(string) (string, error) {
+				return filepath.Join(string(os.PathSeparator), "repo"), nil
+			},
+			relFn: func(string, string) (string, error) {
+				return "", relErr
+			},
+			openRootFn: func(string) (Root, error) {
+				t.Fatal("volume root open must not run after relative path failure")
+				return nil, nil
+			},
+			wantErr: relErr,
+		},
+		{
+			name: "volume root open",
+			absFn: func(string) (string, error) {
+				return filepath.Join(string(os.PathSeparator), "repo"), nil
+			},
+			relFn: func(string, string) (string, error) {
+				return "repo", nil
+			},
+			openRootFn: func(string) (Root, error) {
+				return nil, openErr
+			},
+			wantErr: openErr,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			openChildFn := func(Root, string, string) (Root, string, error) {
+				t.Fatal("child open must not run after ancestor setup failure")
+				return nil, "", nil
+			}
+			opened, ancestorPath, missingParts, err := openRootExistingAncestorNoFollowWith("repo", tc.absFn, tc.relFn, tc.openRootFn, openChildFn)
+			if opened != nil || ancestorPath != "" || len(missingParts) != 0 {
+				t.Fatalf("expected setup failure to return no ancestor state, got root=%#v path=%q missing=%#v", opened, ancestorPath, missingParts)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected setup error %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestOpenPinnedDirectoryRejectsPostOpenFileTypeChange(t *testing.T) {
+	dirInfo := statTestPath(t, t.TempDir())
+	filePath := filepath.Join(t.TempDir(), "replacement.txt")
+	if err := os.WriteFile(filePath, []byte("replacement"), 0o600); err != nil {
+		t.Fatalf("write replacement file: %v", err)
+	}
+	fileInfo := statTestPath(t, filePath)
+	closeCalls := 0
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != "child" {
+				t.Fatalf("unexpected directory lookup %q", name)
+			}
+			return dirInfo, nil
+		},
+		open: func(name string) (File, error) {
+			if name != "child" {
+				t.Fatalf("unexpected directory open %q", name)
+			}
+			return &fakeFile{
+				stat: func() (fs.FileInfo, error) {
+					return fileInfo, nil
+				},
+				close: func() error {
+					closeCalls++
+					return nil
+				},
+			}, nil
+		},
+	}
+
+	opened, err := OpenPinnedDirectory(root, "child")
+	if opened != nil {
+		t.Fatalf("expected replacement file to be rejected, got %#v", opened)
+	}
+	if !errors.Is(err, fs.ErrInvalid) {
+		t.Fatalf("expected post-open file type change to fail with fs.ErrInvalid, got %v", err)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("expected rejected replacement file to close once, got %d", closeCalls)
+	}
+}

--- a/internal/safeio/path.go
+++ b/internal/safeio/path.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+var ErrPathEscapesRoot = errors.New("path escapes root")
+
 type rootedTarget struct {
 	rootAbs string
 	rel     string
@@ -27,9 +29,48 @@ type exactFileTarget struct {
 	fileName  string
 }
 
+type pathEscapesRootError struct {
+	path string
+}
+
+func (e *pathEscapesRootError) Error() string {
+	return fmt.Sprintf("%s: %s", ErrPathEscapesRoot, e.path)
+}
+
+func (*pathEscapesRootError) Unwrap() error {
+	return ErrPathEscapesRoot
+}
+
+func newPathEscapesRootError(path string) error {
+	return &pathEscapesRootError{path: path}
+}
+
+func normalizePathEscapesRootError(path string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrPathEscapesRoot) {
+		return err
+	}
+
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) && pathEscapesRootInvariant(pathErr.Path) {
+		return newPathEscapesRootError(path)
+	}
+	return err
+}
+
+func pathEscapesRootInvariant(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	_, err := resolveRelativeTarget(path, allowRootTarget)
+	return errors.Is(err, ErrPathEscapesRoot)
+}
+
 func resolveRelativeTarget(targetPath string, policy rootedTargetPolicy) (string, error) {
 	if filepath.IsAbs(targetPath) {
-		return "", fmt.Errorf("path escapes root: %s", targetPath)
+		return "", newPathEscapesRootError(targetPath)
 	}
 	return normalizeRootedTarget(targetPath, filepath.Clean(targetPath), policy)
 }
@@ -83,7 +124,7 @@ func normalizeRootedTarget(targetPath, rel string, policy rootedTargetPolicy) (s
 			return "", fmt.Errorf("target path resolves to root directory: %s", targetPath)
 		}
 	case rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)):
-		return "", fmt.Errorf("path escapes root: %s", targetPath)
+		return "", newPathEscapesRootError(targetPath)
 	}
 
 	return filepath.Clean(rel), nil
@@ -91,7 +132,53 @@ func normalizeRootedTarget(targetPath, rel string, policy rootedTargetPolicy) (s
 
 func translateOpenNotExist(err error, targetPath string) error {
 	if errors.Is(err, fs.ErrNotExist) {
-		return &fs.PathError{Op: "open", Path: targetPath, Err: os.ErrNotExist}
+		pathErr := &fs.PathError{Op: "open", Path: targetPath, Err: err}
+		if isPureSentinelError(err, fs.ErrNotExist) {
+			pathErr.Err = os.ErrNotExist
+		}
+		return pathErr
 	}
 	return err
+}
+
+type multiError interface {
+	error
+	Unwrap() []error
+}
+
+func isPureSentinelError(err error, sentinels ...error) bool {
+	if err == nil || len(sentinels) == 0 {
+		return false
+	}
+	var wrapped multiError
+	if errors.As(err, &wrapped) {
+		return arePureSentinelCauses(wrapped.Unwrap(), sentinels)
+	}
+	if cause := errors.Unwrap(err); cause != nil {
+		return isPureSentinelError(cause, sentinels...)
+	}
+	return matchesSentinel(err, sentinels)
+}
+
+func arePureSentinelCauses(causes []error, sentinels []error) bool {
+	found := false
+	for _, cause := range causes {
+		if cause == nil {
+			continue
+		}
+		found = true
+		if !isPureSentinelError(cause, sentinels...) {
+			return false
+		}
+	}
+	return found
+}
+
+func matchesSentinel(err error, sentinels []error) bool {
+	for _, sentinel := range sentinels {
+		if sentinel != nil && errors.Is(err, sentinel) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/safeio/path.go
+++ b/internal/safeio/path.go
@@ -160,7 +160,7 @@ func isPureSentinelError(err error, sentinels ...error) bool {
 	return matchesSentinel(err, sentinels)
 }
 
-func arePureSentinelCauses(causes []error, sentinels []error) bool {
+func arePureSentinelCauses(causes, sentinels []error) bool {
 	found := false
 	for _, cause := range causes {
 		if cause == nil {

--- a/internal/safeio/read.go
+++ b/internal/safeio/read.go
@@ -40,17 +40,26 @@ func ReadFileWithinRoot(root Root, targetPath string) (_ []byte, err error) {
 	return ReadFileWithinRootLimit(root, targetPath, 0)
 }
 
-// ReadFileWithinRootLimit reads targetPath using an already-open confined root
-// and does not exceed maxBytes when a positive limit is provided.
-func ReadFileWithinRootLimit(root Root, targetPath string, maxBytes int64) (_ []byte, err error) {
+// OpenFileWithinRoot opens targetPath using an already-open confined root.
+func OpenFileWithinRoot(root Root, targetPath string) (File, error) {
 	targetRel, err := resolveRelativeTarget(targetPath, allowRootTarget)
 	if err != nil {
 		return nil, err
 	}
 
-	file, err := root.Open(targetRel)
+	file, err := OpenPinnedFile(root, targetRel)
 	if err != nil {
 		return nil, translateOpenNotExist(err, targetPath)
+	}
+	return file, nil
+}
+
+// ReadFileWithinRootLimit reads targetPath using an already-open confined root
+// and does not exceed maxBytes when a positive limit is provided.
+func ReadFileWithinRootLimit(root Root, targetPath string, maxBytes int64) (_ []byte, err error) {
+	file, err := OpenFileWithinRoot(root, targetPath)
+	if err != nil {
+		return nil, err
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
@@ -69,9 +78,9 @@ func ReadFileUnderLimit(rootDir, targetPath string, maxBytes int64) (_ []byte, e
 		return nil, err
 	}
 
-	root, err := fileSystem.OpenRoot(target.rootAbs)
+	root, err := openReadRootNoFollow(target.rootAbs, "root")
 	if err != nil {
-		return nil, fmt.Errorf("open root: %w", err)
+		return nil, err
 	}
 	defer func() {
 		if closeErr := root.Close(); closeErr != nil {
@@ -79,7 +88,7 @@ func ReadFileUnderLimit(rootDir, targetPath string, maxBytes int64) (_ []byte, e
 		}
 	}()
 
-	file, err := root.Open(target.rel)
+	file, err := OpenPinnedFile(root, target.rel)
 	if err != nil {
 		return nil, translateOpenNotExist(err, targetPath)
 	}
@@ -99,9 +108,9 @@ func ReadFileLimit(targetPath string, maxBytes int64) (data []byte, err error) {
 		return nil, err
 	}
 
-	root, err := fileSystem.OpenRoot(target.parentDir)
+	root, err := openReadRootNoFollow(target.parentDir, "parent")
 	if err != nil {
-		return nil, fmt.Errorf("open parent root: %w", err)
+		return nil, err
 	}
 	defer func() {
 		if closeErr := root.Close(); closeErr != nil {
@@ -109,7 +118,7 @@ func ReadFileLimit(targetPath string, maxBytes int64) (data []byte, err error) {
 		}
 	}()
 
-	file, err := root.Open(target.fileName)
+	file, err := OpenPinnedFile(root, target.fileName)
 	if err != nil {
 		return nil, translateOpenNotExist(err, targetPath)
 	}
@@ -144,12 +153,12 @@ func OpenFile(targetPath string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	root, err := fileSystem.OpenRoot(target.parentDir)
+	root, err := openReadRootNoFollow(target.parentDir, "parent")
 	if err != nil {
-		return nil, fmt.Errorf("open parent root: %w", err)
+		return nil, err
 	}
 
-	file, err := root.Open(target.fileName)
+	file, err := OpenPinnedFile(root, target.fileName)
 	if err != nil {
 		err = translateOpenNotExist(err, targetPath)
 		if closeErr := root.Close(); closeErr != nil {
@@ -158,6 +167,14 @@ func OpenFile(targetPath string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	return &rootedReadCloser{file: file, root: root}, nil
+}
+
+func openReadRootNoFollow(rootDir, label string) (Root, error) {
+	root, err := fileSystem.OpenRootNoFollow(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("open %s root: %w", label, err)
+	}
+	return root, nil
 }
 
 func readOpenedFile(file File, maxBytes int64) ([]byte, error) {

--- a/internal/safeio/read_test.go
+++ b/internal/safeio/read_test.go
@@ -2,7 +2,9 @@ package safeio
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -19,7 +21,51 @@ const (
 )
 
 func TestReadFileUnderReadsFileInsideRoot(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
+	targetPath := filepath.Join(rootDir, "nested", writeTestFileName)
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create parent dir: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("hello"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+
+	data, err := ReadFileUnder(rootDir, targetPath)
+	if err != nil {
+		t.Fatalf("ReadFileUnder returned error: %v", err)
+	}
+	if got := string(data); got != "hello" {
+		t.Fatalf(unexpectedContentFmt, got)
+	}
+}
+
+func TestReadFileUnderRejectsSymlinkedRoot(t *testing.T) {
+	canonicalRoot := t.TempDir()
+	targetPath := filepath.Join(canonicalRoot, writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("hello"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+
+	rootLink := filepath.Join(t.TempDir(), "repo-link")
+	if err := os.Symlink(canonicalRoot, rootLink); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := ReadFileUnder(rootLink, filepath.Join(rootLink, writeTestFileName))
+	if err == nil {
+		t.Fatal("expected symlinked root to be rejected")
+	}
+	if !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf(unexpectedErrFmt, err)
+	}
+}
+
+func TestReadFileUnderReadsFileInsideTrustedTempAliasRoot(t *testing.T) {
+	rootDir, _, ok := tempDirAliasPair(t)
+	if !ok {
+		t.Skip("trusted temp alias unavailable")
+	}
+
 	targetPath := filepath.Join(rootDir, "nested", writeTestFileName)
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 		t.Fatalf("create parent dir: %v", err)
@@ -71,7 +117,7 @@ func TestRootedReadCloserReadAtRejectsUnsupportedFile(t *testing.T) {
 }
 
 func TestReadFileUnderLimitReadsFileInsideRoot(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, "nested", writeTestFileName)
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 		t.Fatalf("create parent dir: %v", err)
@@ -90,7 +136,7 @@ func TestReadFileUnderLimitReadsFileInsideRoot(t *testing.T) {
 }
 
 func TestReadFileUnderLimitRejectsOversizedFile(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, "large.txt")
 	if err := os.WriteFile(targetPath, []byte("hello"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
@@ -103,7 +149,7 @@ func TestReadFileUnderLimitRejectsOversizedFile(t *testing.T) {
 }
 
 func TestReadFileWithinRootReadsRelativeFile(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	if err := os.WriteFile(filepath.Join(rootDir, writeTestFileName), []byte("hello"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
 	}
@@ -118,24 +164,53 @@ func TestReadFileWithinRootReadsRelativeFile(t *testing.T) {
 	}
 }
 
-func TestReadFileWithinRootRejectsAbsolutePath(t *testing.T) {
-	root := openTestRoot(t, t.TempDir())
+func TestOpenFileWithinRootReadsRelativeFile(t *testing.T) {
+	rootDir := canonicalTempDir(t)
+	if err := os.WriteFile(filepath.Join(rootDir, writeTestFileName), []byte("hello"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
 
-	_, err := ReadFileWithinRoot(root, filepath.Join(t.TempDir(), writeTestFileName))
-	if err == nil || !strings.Contains(err.Error(), escapesRootErr) {
+	root := openTestRoot(t, rootDir)
+	file, err := OpenFileWithinRoot(root, writeTestFileName)
+	if err != nil {
+		t.Fatalf("OpenFileWithinRoot returned error: %v", err)
+	}
+
+	data, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil || closeErr != nil {
+		t.Fatalf("OpenFileWithinRoot read/close error: %v", errors.Join(readErr, closeErr))
+	}
+	if got := string(data); got != "hello" {
+		t.Fatalf(unexpectedContentFmt, got)
+	}
+}
+
+func TestReadFileWithinRootRejectsAbsolutePath(t *testing.T) {
+	root := openTestRoot(t, canonicalTempDir(t))
+
+	_, err := ReadFileWithinRoot(root, filepath.Join(canonicalTempDir(t), writeTestFileName))
+	if err == nil || !strings.Contains(err.Error(), escapesRootErr) || !errors.Is(err, ErrPathEscapesRoot) {
 		t.Fatalf("expected absolute path rejection, got %v", err)
 	}
 }
 
 func TestReadFileWithinRootCloseError(t *testing.T) {
 	expectedErr := errors.New("close failure")
+	path := filepath.Join(t.TempDir(), "close.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+	info := statTestPath(t, path)
 	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return info, nil },
 		open: func(string) (File, error) {
 			return &fakeFile{
 				read: func(p []byte) (int, error) {
 					copy(p, "hello")
 					return len("hello"), io.EOF
 				},
+				stat:  func() (fs.FileInfo, error) { return info, nil },
 				close: func() error { return expectedErr },
 			}, nil
 		},
@@ -147,8 +222,306 @@ func TestReadFileWithinRootCloseError(t *testing.T) {
 	}
 }
 
+func TestReadFileWithinRootLimitTranslatesMissingFileAndJoinsReadCloseErrors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		root := &fakeRoot{
+			lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+			open:  func(string) (File, error) { return nil, os.ErrNotExist },
+		}
+
+		_, err := ReadFileWithinRootLimit(root, writeTestFileName, 1)
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected missing file error, got %v", err)
+		}
+	})
+
+	t.Run("read and close errors", func(t *testing.T) {
+		readErr := errors.New("read failure")
+		closeErr := errors.New("close failure")
+		path := filepath.Join(t.TempDir(), "read-close.txt")
+		if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+			t.Fatalf(writeFileErrFmt, err)
+		}
+		info := statTestPath(t, path)
+		root := &fakeRoot{
+			lstat: func(string) (fs.FileInfo, error) { return info, nil },
+			open: func(string) (File, error) {
+				return &fakeFile{
+					read:  func([]byte) (int, error) { return 0, readErr },
+					stat:  func() (fs.FileInfo, error) { return info, nil },
+					close: func() error { return closeErr },
+				}, nil
+			},
+		}
+
+		_, err := ReadFileWithinRootLimit(root, writeTestFileName, 0)
+		if !errors.Is(err, readErr) || !errors.Is(err, closeErr) {
+			t.Fatalf("expected joined read and close errors, got %v", err)
+		}
+	})
+}
+
+func TestReadFileWithinRootLimitMarksParentEscapeWithSentinel(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "child.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+	info := statTestPath(t, path)
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) {
+			return info, nil
+		},
+		open: func(string) (File, error) {
+			return nil, &fs.PathError{
+				Op:   "openat",
+				Path: filepath.Join("..", "child.txt"),
+				Err:  errors.New("localized rooted-open escape"),
+			}
+		},
+	}
+
+	_, err := ReadFileWithinRootLimit(root, "child.txt", 1)
+	if !errors.Is(err, ErrPathEscapesRoot) {
+		t.Fatalf("expected path escape sentinel, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "path escapes root: child.txt") {
+		t.Fatalf("expected normalized path escape wording, got %v", err)
+	}
+}
+
+func TestNormalizePathEscapesRootErrorUsesPathInvariant(t *testing.T) {
+	err := normalizePathEscapesRootError("child.txt", &fs.PathError{
+		Op:   "openat",
+		Path: filepath.Join("..", "child.txt"),
+		Err:  errors.New("localized rooted-open escape"),
+	})
+	if !errors.Is(err, ErrPathEscapesRoot) {
+		t.Fatalf("expected structural escape path to normalize, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "path escapes root: child.txt") {
+		t.Fatalf("expected normalized structural escape wording, got %v", err)
+	}
+}
+
+func TestNormalizePathEscapesRootErrorPreservesNonEscapingPathErrors(t *testing.T) {
+	pathErr := &fs.PathError{
+		Op:   "openat",
+		Path: "child.txt",
+		Err:  errors.New("localized rooted-open escape"),
+	}
+	err := normalizePathEscapesRootError("child.txt", pathErr)
+	if !errors.Is(err, pathErr) {
+		t.Fatalf("expected non-escaping path error to stay unchanged, got %#v", err)
+	}
+}
+
+func TestTranslateOpenNotExistDowngradesPureMissingTree(t *testing.T) {
+	targetPath := filepath.Join("nested", "missing.txt")
+	err := translateOpenNotExist(fmt.Errorf("wrapped missing: %w", os.ErrNotExist), targetPath)
+
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected path error, got %#v", err)
+	}
+	if pathErr.Path != targetPath {
+		t.Fatalf("expected translated path %q, got %q", targetPath, pathErr.Path)
+	}
+	if !errors.Is(pathErr.Err, os.ErrNotExist) {
+		t.Fatalf("expected pure missing tree to downgrade to os.ErrNotExist, got %#v", pathErr.Err)
+	}
+}
+
+func TestReadFileWithinRootLimitPreservesNestedMissingTargetAndAncestorCloseError(t *testing.T) {
+	repo := canonicalTempDir(t)
+	nestedDir := filepath.Join(repo, "nested")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+
+	repoRoot := openTestRoot(t, repo)
+	nestedRoot := openTestRoot(t, nestedDir)
+	ancestorCloseErr := errors.New("close nested ancestor")
+	root := &fakeRoot{
+		Root:  repoRoot,
+		lstat: repoRoot.Lstat,
+		openRoot: func(name string) (Root, error) {
+			if name != "nested" {
+				return repoRoot.OpenRoot(name)
+			}
+			return &fakeRoot{
+				Root:  nestedRoot,
+				lstat: nestedRoot.Lstat,
+				close: func() error {
+					if err := nestedRoot.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+						return err
+					}
+					return ancestorCloseErr
+				},
+			}, nil
+		},
+	}
+
+	targetPath := filepath.Join("nested", missingFileName)
+	_, err := ReadFileWithinRootLimit(root, targetPath, 1)
+	if err == nil {
+		t.Fatal("expected missing nested target error")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing identity, got %v", err)
+	}
+	if !errors.Is(err, ancestorCloseErr) {
+		t.Fatalf("expected ancestor close identity, got %v", err)
+	}
+
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected path error, got %#v", err)
+	}
+	if pathErr.Path != targetPath {
+		t.Fatalf("expected nested target path %q, got %q", targetPath, pathErr.Path)
+	}
+	if !errors.Is(pathErr.Err, os.ErrNotExist) {
+		t.Fatalf("expected impure missing tree to preserve missing identity, got %#v", pathErr.Err)
+	}
+	if !errors.Is(pathErr.Err, os.ErrNotExist) || !errors.Is(pathErr.Err, ancestorCloseErr) {
+		t.Fatalf("expected path error cause to preserve missing and ancestor close identities, got %v", pathErr.Err)
+	}
+}
+
+func TestReadFileWithinRootLimitRejectsFileReplacementBetweenLstatAndOpen(t *testing.T) {
+	rootDir := canonicalTempDir(t)
+	targetName := "swap.txt"
+	targetPath := filepath.Join(rootDir, targetName)
+	if err := os.WriteFile(targetPath, []byte("original"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+
+	realRoot := openTestRoot(t, rootDir)
+	swapped := false
+	root := &fakeRoot{
+		Root: realRoot,
+		open: func(name string) (File, error) {
+			if !swapped {
+				swapped = true
+				originalPath := filepath.Join(rootDir, "swap-original.txt")
+				if err := os.Rename(targetPath, originalPath); err != nil {
+					t.Fatalf("rename original file: %v", err)
+				}
+				if err := os.WriteFile(targetPath, []byte("replacement"), 0o600); err != nil {
+					t.Fatalf("write replacement file: %v", err)
+				}
+			}
+			return realRoot.Open(name)
+		},
+	}
+
+	_, err := ReadFileWithinRootLimit(root, targetName, 0)
+	if err == nil || !strings.Contains(err.Error(), "path changed while opening: "+targetName) {
+		t.Fatalf("expected pinned file replacement error, got %v", err)
+	}
+}
+
+func TestPublicPathReadersRejectLeafSymlinks(t *testing.T) {
+	outsidePath := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte("outside"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+
+	for _, reader := range pinnedPathReaders() {
+		t.Run(reader.name, func(t *testing.T) {
+			rootDir := canonicalTempDir(t)
+			targetPath := filepath.Join(rootDir, "leaf.txt")
+			if err := os.Symlink(outsidePath, targetPath); err != nil {
+				t.Skipf("symlink not supported: %v", err)
+			}
+
+			_, err := reader.read(rootDir, targetPath)
+			if !errors.Is(err, ErrTargetPathSymlink) {
+				t.Fatalf("expected target symlink sentinel, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPublicPathReadersRejectLeafReplacementBetweenCheckAndOpen(t *testing.T) {
+	for _, reader := range pinnedPathReaders() {
+		t.Run(reader.name, func(t *testing.T) {
+			rootDir := canonicalTempDir(t)
+			targetPath := filepath.Join(rootDir, "swap.txt")
+			if err := os.WriteFile(targetPath, []byte("original"), 0o600); err != nil {
+				t.Fatalf(writeFileErrFmt, err)
+			}
+
+			withPinnedPublicReaderSwap(t, reader.rootOpenPath(rootDir, targetPath), targetPath)
+
+			_, err := reader.read(rootDir, targetPath)
+			if err == nil || !strings.Contains(err.Error(), "path changed while opening: "+filepath.Base(targetPath)) {
+				t.Fatalf("expected pinned replacement error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestReadFileWithinRootLimitRejectsAncestorReplacementBeforeNestedOpen(t *testing.T) {
+	root, targetName := newReadAncestorReplacementFixture(t)
+	_, err := ReadFileWithinRootLimit(root, targetName, 0)
+	if err == nil || !strings.Contains(err.Error(), "root changed while opening: src") {
+		t.Fatalf("expected nested ancestor replacement error, got %v", err)
+	}
+}
+
+type readAncestorReplacementFixture struct {
+	t        *testing.T
+	rootDir  string
+	realRoot Root
+	swapped  bool
+}
+
+func newReadAncestorReplacementFixture(t *testing.T) (Root, string) {
+	t.Helper()
+	rootDir := canonicalTempDir(t)
+	targetName := filepath.Join("src", "main", "Main.java")
+	targetPath := filepath.Join(rootDir, targetName)
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("mkdir nested source dir: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("class Main {}\n"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+
+	realRoot := openTestRoot(t, rootDir)
+	fixture := &readAncestorReplacementFixture{
+		t:        t,
+		rootDir:  rootDir,
+		realRoot: realRoot,
+	}
+	return &fakeRoot{Root: realRoot, openRoot: fixture.openRoot}, targetName
+}
+
+func (f *readAncestorReplacementFixture) openRoot(name string) (Root, error) {
+	if name == "src" && !f.swapped {
+		f.swapped = true
+		f.replace()
+	}
+	return f.realRoot.OpenRoot(name)
+}
+
+func (f *readAncestorReplacementFixture) replace() {
+	f.t.Helper()
+	if err := os.Rename(filepath.Join(f.rootDir, "src"), filepath.Join(f.rootDir, "src-original")); err != nil {
+		f.t.Fatalf("rename original src: %v", err)
+	}
+	replacementPath := filepath.Join(f.rootDir, "src", "main")
+	if err := os.MkdirAll(replacementPath, 0o755); err != nil {
+		f.t.Fatalf("mkdir replacement source dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(replacementPath, "Main.java"), []byte("class Replacement {}\n"), 0o600); err != nil {
+		f.t.Fatalf("write replacement source file: %v", err)
+	}
+}
+
 func TestReadFileLimitReadsFile(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 	if err := os.WriteFile(targetPath, []byte("hello"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
@@ -164,7 +537,7 @@ func TestReadFileLimitReadsFile(t *testing.T) {
 }
 
 func TestReadFileLimitRejectsOversizedFile(t *testing.T) {
-	targetPath := filepath.Join(t.TempDir(), "large.txt")
+	targetPath := filepath.Join(canonicalTempDir(t), "large.txt")
 	if err := os.WriteFile(targetPath, []byte("hello"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
 	}
@@ -182,7 +555,7 @@ func TestReadFileLimitRejectsEmptyPath(t *testing.T) {
 }
 
 func TestReadFileLimitTargetAbsFailureViaFileSystem(t *testing.T) {
-	targetPath := filepath.Join(t.TempDir(), writeTestFileName)
+	targetPath := filepath.Join(canonicalTempDir(t), writeTestFileName)
 	withFileSystem(t, &fakeFileSystem{abs: func(path string) (string, error) {
 		if path == targetPath {
 			return "", errors.New("target abs failure")
@@ -200,7 +573,7 @@ func TestReadFileLimitTargetAbsFailureViaFileSystem(t *testing.T) {
 }
 
 func TestReadFileLimitRejectsMissingParentDirectory(t *testing.T) {
-	targetPath := filepath.Join(t.TempDir(), "missing", "file.txt")
+	targetPath := filepath.Join(canonicalTempDir(t), "missing", "file.txt")
 
 	_, err := ReadFileLimit(targetPath, 1)
 	if err == nil {
@@ -211,8 +584,32 @@ func TestReadFileLimitRejectsMissingParentDirectory(t *testing.T) {
 	}
 }
 
+func TestReadFileLimitRejectsSymlinkedParentAncestor(t *testing.T) {
+	canonicalParent := filepath.Join(t.TempDir(), "actual")
+	if err := os.MkdirAll(canonicalParent, 0o755); err != nil {
+		t.Fatalf("mkdir canonical parent: %v", err)
+	}
+	targetPath := filepath.Join(canonicalParent, writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("hello"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+
+	ancestorLink := filepath.Join(t.TempDir(), "ancestor-link")
+	if err := os.Symlink(filepath.Dir(canonicalParent), ancestorLink); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := ReadFileLimit(filepath.Join(ancestorLink, filepath.Base(canonicalParent), writeTestFileName), 5)
+	if err == nil {
+		t.Fatal("expected symlinked parent ancestor to be rejected")
+	}
+	if !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf(unexpectedErrFmt, err)
+	}
+}
+
 func TestReadFileLimitRejectsMissingFile(t *testing.T) {
-	targetPath := filepath.Join(t.TempDir(), "missing.txt")
+	targetPath := filepath.Join(canonicalTempDir(t), "missing.txt")
 
 	_, err := ReadFileLimit(targetPath, 1)
 	if !errors.Is(err, os.ErrNotExist) {
@@ -221,7 +618,7 @@ func TestReadFileLimitRejectsMissingFile(t *testing.T) {
 }
 
 func TestReadFileLimitCloseRootError(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 	if err := os.WriteFile(targetPath, []byte("hi"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
@@ -240,7 +637,7 @@ func TestReadFileLimitCloseRootError(t *testing.T) {
 }
 
 func TestReadFileLimitCloseFileError(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 	if err := os.WriteFile(targetPath, []byte("hi"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
@@ -355,7 +752,7 @@ func TestReadOpenedFileDirectoryReadError(t *testing.T) {
 }
 
 func TestReadFileUnderRejectsPathTraversalOutsideRoot(t *testing.T) {
-	parentDir := t.TempDir()
+	parentDir := canonicalTempDir(t)
 	rootDir := filepath.Join(parentDir, "root")
 	if err := os.MkdirAll(rootDir, 0o755); err != nil {
 		t.Fatalf("create root dir: %v", err)
@@ -376,7 +773,7 @@ func TestReadFileUnderRejectsPathTraversalOutsideRoot(t *testing.T) {
 }
 
 func TestReadFileUnderRejectsParentDirectoryTarget(t *testing.T) {
-	parentDir := t.TempDir()
+	parentDir := canonicalTempDir(t)
 	rootDir := filepath.Join(parentDir, "root")
 	if err := os.MkdirAll(rootDir, 0o755); err != nil {
 		t.Fatalf("create root dir: %v", err)
@@ -392,7 +789,7 @@ func TestReadFileUnderRejectsParentDirectoryTarget(t *testing.T) {
 }
 
 func TestReadFileUnderReturnsErrorForMissingFile(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	missingPath := filepath.Join(rootDir, missingFileName)
 
 	_, err := ReadFileUnder(rootDir, missingPath)
@@ -402,7 +799,7 @@ func TestReadFileUnderReturnsErrorForMissingFile(t *testing.T) {
 }
 
 func TestReadFileUnderRejectsNonDirectoryRoot(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	rootFile := filepath.Join(rootDir, "root-file")
 	if err := os.WriteFile(rootFile, []byte("not-a-dir"), 0o600); err != nil {
 		t.Fatalf("write root file: %v", err)
@@ -430,7 +827,7 @@ func TestReadFileUnderRootAbsFailureWhenCWDRemoved(t *testing.T) {
 }
 
 func TestReadFileUnderTargetAbsFailureWhenCWDRemoved(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	withRemovedWorkingDir(t, "dead-target")
 
 	_, err := ReadFileUnder(rootDir, "relative-target.txt")
@@ -443,7 +840,7 @@ func TestReadFileUnderTargetAbsFailureWhenCWDRemoved(t *testing.T) {
 }
 
 func TestReadFileUnderDirectoryTargetReturnsReadError(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	dirTarget := filepath.Join(rootDir, "nested")
 	if err := os.MkdirAll(dirTarget, 0o755); err != nil {
 		t.Fatalf("create dir target: %v", err)
@@ -456,7 +853,7 @@ func TestReadFileUnderDirectoryTargetReturnsReadError(t *testing.T) {
 }
 
 func TestReadFileUnderRootPathAsTargetReturnsError(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	_, err := ReadFileUnder(rootDir, rootDir)
 	if err == nil {
 		t.Fatal("expected error when target is root directory")
@@ -464,7 +861,7 @@ func TestReadFileUnderRootPathAsTargetReturnsError(t *testing.T) {
 }
 
 func TestPathReadersReadAbsoluteAndRelativePaths(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, "target.txt")
 	if err := os.WriteFile(targetPath, []byte("content"), 0o600); err != nil {
 		t.Fatalf("write target file: %v", err)
@@ -480,7 +877,7 @@ func TestPathReadersReadAbsoluteAndRelativePaths(t *testing.T) {
 }
 
 func TestPathReadersReturnErrorForMissingFile(t *testing.T) {
-	missingPath := filepath.Join(t.TempDir(), missingFileName)
+	missingPath := filepath.Join(canonicalTempDir(t), missingFileName)
 	for _, reader := range pathReaders() {
 		t.Run(reader.name, func(t *testing.T) {
 			if _, err := reader.read(missingPath); err == nil {
@@ -491,7 +888,7 @@ func TestPathReadersReturnErrorForMissingFile(t *testing.T) {
 }
 
 func TestReadFileReturnsErrorWhenParentIsNotDirectory(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	parentFile := filepath.Join(rootDir, "not-a-dir")
 	if err := os.WriteFile(parentFile, []byte("x"), 0o600); err != nil {
 		t.Fatalf("write parent file: %v", err)
@@ -519,7 +916,7 @@ func TestReadFileTargetAbsFailureWhenCWDRemoved(t *testing.T) {
 }
 
 func TestReadFileUnderRootAbsFailureViaFileSystem(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 
 	withFileSystem(t, &fakeFileSystem{abs: func(path string) (string, error) {
@@ -539,7 +936,7 @@ func TestReadFileUnderRootAbsFailureViaFileSystem(t *testing.T) {
 }
 
 func TestReadFileUnderTargetAbsFailureViaFileSystem(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 
 	withFileSystem(t, &fakeFileSystem{abs: func(path string) (string, error) {
@@ -559,7 +956,7 @@ func TestReadFileUnderTargetAbsFailureViaFileSystem(t *testing.T) {
 }
 
 func TestReadFileUnderRelFailureViaFileSystem(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 	if err := os.WriteFile(targetPath, []byte("hi"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
@@ -574,6 +971,27 @@ func TestReadFileUnderRelFailureViaFileSystem(t *testing.T) {
 		t.Fatal("expected relative path resolution error")
 	}
 	if !strings.Contains(err.Error(), "compute relative path") {
+		t.Fatalf(unexpectedErrFmt, err)
+	}
+}
+
+func TestReadFileUnderPropagatesNoFollowRootOpenError(t *testing.T) {
+	rootDir := canonicalTempDir(t)
+	targetPath := filepath.Join(rootDir, writeTestFileName)
+
+	withFileSystem(t, &fakeFileSystem{
+		abs: (&osFileSystem{}).Abs,
+		rel: (&osFileSystem{}).Rel,
+		openRootNoFollow: func(string) (Root, error) {
+			return nil, errors.New("root changed while opening: " + rootDir)
+		},
+	})
+
+	_, err := ReadFileUnder(rootDir, targetPath)
+	if err == nil {
+		t.Fatal("expected root-open failure to be returned")
+	}
+	if !strings.Contains(err.Error(), "root changed while opening") {
 		t.Fatalf(unexpectedErrFmt, err)
 	}
 }
@@ -626,7 +1044,7 @@ func withOpenedFileCloseError(t *testing.T, expectedErr error) {
 }
 
 func TestReadFileUnderCloseRootError(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 	if err := os.WriteFile(targetPath, []byte("hi"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
@@ -645,7 +1063,7 @@ func TestReadFileUnderCloseRootError(t *testing.T) {
 }
 
 func TestReadFileUnderCloseFileError(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 	if err := os.WriteFile(targetPath, []byte("hi"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
@@ -664,7 +1082,7 @@ func TestReadFileUnderCloseFileError(t *testing.T) {
 }
 
 func TestReadFileCloseError(t *testing.T) {
-	rootDir := t.TempDir()
+	rootDir := canonicalTempDir(t)
 	targetPath := filepath.Join(rootDir, writeTestFileName)
 	if err := os.WriteFile(targetPath, []byte("hi"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
@@ -683,7 +1101,7 @@ func TestReadFileCloseError(t *testing.T) {
 }
 
 func TestOpenFileTargetAbsFailureViaFileSystem(t *testing.T) {
-	targetPath := filepath.Join(t.TempDir(), writeTestFileName)
+	targetPath := filepath.Join(canonicalTempDir(t), writeTestFileName)
 
 	withFileSystem(t, &fakeFileSystem{abs: func(path string) (string, error) {
 		if path == targetPath {
@@ -702,7 +1120,7 @@ func TestOpenFileTargetAbsFailureViaFileSystem(t *testing.T) {
 }
 
 func TestOpenFileMissingFileCloseRootError(t *testing.T) {
-	targetPath := filepath.Join(t.TempDir(), missingFileName)
+	targetPath := filepath.Join(canonicalTempDir(t), missingFileName)
 
 	expectedErr := errors.New("open parent root close failure")
 	withFileSystem(t, &fakeFileSystem{openRoot: func(name string) (Root, error) {
@@ -737,11 +1155,13 @@ func TestOpenFileMissingFileCloseRootError(t *testing.T) {
 }
 
 func TestOpenFileOpenErrorCloseRootError(t *testing.T) {
-	targetDir := t.TempDir()
+	targetDir := canonicalTempDir(t)
 	targetPath := filepath.Join(targetDir, "child.txt")
-	if err := os.WriteFile(filepath.Join(targetDir, "marker"), []byte("x"), 0o600); err != nil {
+	markerPath := filepath.Join(targetDir, "marker")
+	if err := os.WriteFile(markerPath, []byte("x"), 0o600); err != nil {
 		t.Fatalf(writeFileErrFmt, err)
 	}
+	markerInfo := statTestPath(t, markerPath)
 
 	openErr := errors.New("open child failure")
 	expectedErr := errors.New("open root close failure")
@@ -752,6 +1172,9 @@ func TestOpenFileOpenErrorCloseRootError(t *testing.T) {
 		}
 		return &fakeRoot{
 			Root: root,
+			lstat: func(string) (fs.FileInfo, error) {
+				return markerInfo, nil
+			},
 			open: func(string) (File, error) {
 				return nil, openErr
 			},
@@ -781,10 +1204,51 @@ type pathReaderCase struct {
 	read func(string) (string, error)
 }
 
+type pinnedPathReaderCase struct {
+	name         string
+	read         func(rootDir, path string) (string, error)
+	rootOpenPath func(rootDir, path string) string
+}
+
 func pathReaders() []pathReaderCase {
 	return []pathReaderCase{
 		{name: "read-file", read: readFileContent},
 		{name: "open-file", read: openFileContent},
+	}
+}
+
+func pinnedPathReaders() []pinnedPathReaderCase {
+	return []pinnedPathReaderCase{
+		{
+			name: "read-file-under-limit",
+			read: func(rootDir, path string) (string, error) {
+				data, err := ReadFileUnderLimit(rootDir, path, 0)
+				return string(data), err
+			},
+			rootOpenPath: func(rootDir, _ string) string { return rootDir },
+		},
+		{
+			name: "read-file-limit",
+			read: func(_ string, path string) (string, error) {
+				data, err := ReadFileLimit(path, 0)
+				return string(data), err
+			},
+			rootOpenPath: func(_ string, path string) string { return filepath.Dir(path) },
+		},
+		{
+			name: "open-file",
+			read: func(_ string, path string) (string, error) {
+				return openFileContent(path)
+			},
+			rootOpenPath: func(_ string, path string) string { return filepath.Dir(path) },
+		},
+		{
+			name: "open-file-within-root",
+			read: func(rootDir, path string) (string, error) {
+				return openFileWithinRootContent(rootDir, filepath.Base(path))
+			},
+			rootOpenPath: func(rootDir, _ string) string { return rootDir },
+		},
 	}
 }
 
@@ -807,6 +1271,80 @@ func openFileContent(path string) (string, error) {
 		return "", errors.Join(readErr, closeErr)
 	}
 	return string(content), nil
+}
+
+func openFileWithinRootContent(rootDir, relPath string) (string, error) {
+	root, err := OpenRootNoFollow(rootDir)
+	if err != nil {
+		return "", err
+	}
+	file, err := OpenFileWithinRoot(root, relPath)
+	if err != nil {
+		closeErr := root.Close()
+		return "", errors.Join(err, closeErr)
+	}
+	content, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	rootCloseErr := root.Close()
+	if readErr != nil || closeErr != nil || rootCloseErr != nil {
+		return "", errors.Join(readErr, closeErr, rootCloseErr)
+	}
+	return string(content), nil
+}
+
+func withPinnedPublicReaderSwap(t *testing.T, rootPath, targetPath string) {
+	t.Helper()
+	fixture := &pinnedPublicReaderSwapFixture{
+		t:          t,
+		rootPath:   rootPath,
+		targetPath: targetPath,
+		targetName: filepath.Base(targetPath),
+	}
+	withFileSystem(t, &fakeFileSystem{
+		openRootNoFollow: fixture.openRootNoFollow,
+	})
+}
+
+type pinnedPublicReaderSwapFixture struct {
+	t          *testing.T
+	rootPath   string
+	targetPath string
+	targetName string
+	swapped    bool
+}
+
+func (f *pinnedPublicReaderSwapFixture) openRootNoFollow(name string) (Root, error) {
+	root, err := (&osFileSystem{}).OpenRootNoFollow(name)
+	if err != nil {
+		return nil, err
+	}
+	if name != f.rootPath {
+		return root, nil
+	}
+	return &fakeRoot{
+		Root: root,
+		open: func(child string) (File, error) {
+			return f.open(root, child)
+		},
+	}, nil
+}
+
+func (f *pinnedPublicReaderSwapFixture) open(root Root, child string) (File, error) {
+	if child == f.targetName && !f.swapped {
+		f.swapped = true
+		f.replace()
+	}
+	return root.Open(child)
+}
+
+func (f *pinnedPublicReaderSwapFixture) replace() {
+	f.t.Helper()
+	if err := os.Rename(f.targetPath, f.targetPath+".original"); err != nil {
+		f.t.Fatalf("rename original file: %v", err)
+	}
+	if err := os.WriteFile(f.targetPath, []byte("replacement"), 0o600); err != nil {
+		f.t.Fatalf("write replacement file: %v", err)
+	}
 }
 
 func assertReadContent(t *testing.T, read func(string) (string, error), path, want string) {

--- a/internal/safeio/read_test.go
+++ b/internal/safeio/read_test.go
@@ -1229,18 +1229,18 @@ func pinnedPathReaders() []pinnedPathReaderCase {
 		},
 		{
 			name: "read-file-limit",
-			read: func(_ string, path string) (string, error) {
+			read: func(_, path string) (string, error) {
 				data, err := ReadFileLimit(path, 0)
 				return string(data), err
 			},
-			rootOpenPath: func(_ string, path string) string { return filepath.Dir(path) },
+			rootOpenPath: func(_, path string) string { return filepath.Dir(path) },
 		},
 		{
 			name: "open-file",
-			read: func(_ string, path string) (string, error) {
+			read: func(_, path string) (string, error) {
 				return openFileContent(path)
 			},
-			rootOpenPath: func(_ string, path string) string { return filepath.Dir(path) },
+			rootOpenPath: func(_, path string) string { return filepath.Dir(path) },
 		},
 		{
 			name: "open-file-within-root",

--- a/internal/safeio/test_helpers_test.go
+++ b/internal/safeio/test_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -78,6 +79,47 @@ func openTestRoot(t *testing.T, rootDir string) Root {
 		}
 	})
 	return root
+}
+
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err == nil && resolved != "" {
+		return resolved
+	}
+	return dir
+}
+
+func tempDirAliasPair(t *testing.T) (string, string, bool) {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		return "", "", false
+	}
+
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil || resolved == "" || resolved == dir {
+		return "", "", false
+	}
+	return dir, resolved, true
+}
+
+func uniqueTrustedAliasMissingPath(t *testing.T, leaf string) string {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		return ""
+	}
+
+	dir, err := os.MkdirTemp(filepath.Join(string(os.PathSeparator), "tmp"), "lopper-safeio-")
+	if err != nil {
+		t.Skipf("trusted temp alias unavailable: %v", err)
+	}
+	base := filepath.Base(dir)
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove trusted alias fixture %s: %v", dir, err)
+	}
+	return filepath.Join(string(os.PathSeparator), "tmp", base, leaf)
 }
 
 func assertFileContent(t *testing.T, path, want string) {
@@ -155,6 +197,7 @@ type fakeRoot struct {
 	openRoot func(name string) (Root, error)
 	lstat    func(name string) (fs.FileInfo, error)
 	mkdir    func(name string, perm os.FileMode) error
+	link     func(oldName, newName string) error
 	rename   func(oldName, newName string) error
 	remove   func(name string) error
 	close    func() error
@@ -207,6 +250,13 @@ func (r *fakeRoot) MkdirAll(name string, perm os.FileMode) error {
 		return r.mkdirAll(name, perm)
 	}
 	return r.Root.MkdirAll(name, perm)
+}
+
+func (r *fakeRoot) Link(oldName, newName string) error {
+	if r.link != nil {
+		return r.link(oldName, newName)
+	}
+	return r.Root.Link(oldName, newName)
 }
 
 func (r *fakeRoot) Rename(oldName, newName string) error {

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -526,6 +526,50 @@ func TestOpenRootNoFollowOpensVolumeRoot(t *testing.T) {
 	}
 }
 
+func TestOpenRootNoFollowOpensNestedPathWithDotSegments(t *testing.T) {
+	parent := t.TempDir()
+	nested := filepath.Join(parent, "nested", "child")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested path: %v", err)
+	}
+
+	root, err := (&osFileSystem{}).OpenRootNoFollow(filepath.Join(parent, ".", "nested", ".", "child"))
+	if err != nil {
+		t.Fatalf("OpenRootNoFollow returned error for nested path: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close nested no-follow root: %v", closeErr)
+		}
+	}()
+
+	openedInfo, err := root.Lstat(".")
+	if err != nil {
+		t.Fatalf("lstat nested no-follow root: %v", err)
+	}
+	if !os.SameFile(openedInfo, statTestPath(t, nested)) {
+		t.Fatalf("expected nested no-follow root to pin the requested directory")
+	}
+}
+
+func TestOpenRootNoFollowDelegatesToConfiguredFileSystem(t *testing.T) {
+	expected := &fakeRoot{}
+	withFileSystem(t, &fakeFileSystem{openRootNoFollow: func(name string) (Root, error) {
+		if name != "/delegated" {
+			t.Fatalf("expected delegated path, got %q", name)
+		}
+		return expected, nil
+	}})
+
+	root, err := OpenRootNoFollow("/delegated")
+	if err != nil {
+		t.Fatalf("OpenRootNoFollow returned error: %v", err)
+	}
+	if root != expected {
+		t.Fatalf("expected delegated root, got %#v", root)
+	}
+}
+
 func TestOpenRootNoFollowRejectsInvalidComponents(t *testing.T) {
 	parent, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
@@ -564,6 +608,311 @@ func TestOpenRootNoFollowRejectsInvalidComponents(t *testing.T) {
 	}
 }
 
+func TestOpenRootNoFollowAllowsTrustedTempAlias(t *testing.T) {
+	aliasPath, resolvedPath, ok := tempDirAliasPair(t)
+	if !ok {
+		t.Skip("trusted temp alias unavailable")
+	}
+
+	root, err := (&osFileSystem{}).OpenRootNoFollow(aliasPath)
+	if err != nil {
+		t.Fatalf("OpenRootNoFollow returned error: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close trusted alias root: %v", closeErr)
+		}
+	}()
+
+	aliasInfo, err := os.Stat(resolvedPath)
+	if err != nil {
+		t.Fatalf("stat resolved trusted alias path: %v", err)
+	}
+	openedInfo, err := root.Lstat(".")
+	if err != nil {
+		t.Fatalf("lstat opened trusted alias root: %v", err)
+	}
+	if !os.SameFile(aliasInfo, openedInfo) {
+		t.Fatalf("expected trusted alias root to pin resolved directory identity")
+	}
+}
+
+func TestOpenRootExistingAncestorNoFollowRejectsUntrustedSymlinkAncestor(t *testing.T) {
+	parentDir := t.TempDir()
+	outsideDir := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("mkdir outside dir: %v", err)
+	}
+	linkPath := filepath.Join(parentDir, "cache-link")
+	if err := os.Symlink(outsideDir, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	root, ancestorPath, missingParts, err := OpenRootExistingAncestorNoFollow(filepath.Join(linkPath, "nested", "cache"))
+	if root != nil {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close unexpected root: %v", closeErr)
+		}
+		t.Fatal("expected untrusted symlink ancestor to be rejected")
+	}
+	if ancestorPath != "" || len(missingParts) != 0 {
+		t.Fatalf("expected rejected ancestor walk to return no path state, got path=%q missing=%v", ancestorPath, missingParts)
+	}
+	if err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func TestOpenRootExistingAncestorNoFollowAllowsTrustedAliasAncestor(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("trusted aliases are only enabled on darwin")
+	}
+
+	requestedPath := uniqueTrustedAliasMissingPath(t, "cache")
+	root, ancestorPath, missingParts, err := OpenRootExistingAncestorNoFollow(requestedPath)
+	if err != nil {
+		t.Fatalf("OpenRootExistingAncestorNoFollow returned error: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close trusted alias ancestor root: %v", closeErr)
+		}
+	}()
+
+	wantAncestorPath := filepath.Join(string(os.PathSeparator), "private", "tmp")
+	if ancestorPath != wantAncestorPath {
+		t.Fatalf("expected trusted alias ancestor path %q, got %q", wantAncestorPath, ancestorPath)
+	}
+	if len(missingParts) != 2 || missingParts[0] == "" || missingParts[1] != "cache" {
+		t.Fatalf("unexpected missing parts: %v", missingParts)
+	}
+
+	openedInfo, err := root.Lstat(".")
+	if err != nil {
+		t.Fatalf("lstat trusted alias ancestor root: %v", err)
+	}
+	targetInfo, err := os.Stat(wantAncestorPath)
+	if err != nil {
+		t.Fatalf("stat trusted alias target: %v", err)
+	}
+	if !os.SameFile(openedInfo, targetInfo) {
+		t.Fatalf("expected ancestor root to pin %q", wantAncestorPath)
+	}
+}
+
+func TestTrustedRootAliasTargetGuards(t *testing.T) {
+	untrustedTarget, ok := trustedRootAliasTarget(filepath.Join(string(os.PathSeparator), "tmp", "nested"))
+	if ok || untrustedTarget != "" {
+		t.Fatalf("expected nested alias path to be rejected, got target=%q ok=%v", untrustedTarget, ok)
+	}
+
+	expectedTmpTarget := filepath.Join(string(os.PathSeparator), "private", "tmp")
+	tmpTarget, tmpOK := trustedRootAliasTarget(filepath.Join(string(os.PathSeparator), "tmp"))
+	if runtime.GOOS == "darwin" {
+		if !tmpOK || tmpTarget != expectedTmpTarget {
+			t.Fatalf("expected /tmp alias target %q, got target=%q ok=%v", expectedTmpTarget, tmpTarget, tmpOK)
+		}
+		expectedVarTarget := filepath.Join(string(os.PathSeparator), "private", "var")
+		varTarget, varOK := trustedRootAliasTarget(filepath.Join(string(os.PathSeparator), "var"))
+		if !varOK || varTarget != expectedVarTarget {
+			t.Fatalf("expected /var alias target %q, got target=%q ok=%v", expectedVarTarget, varTarget, varOK)
+		}
+		return
+	}
+	if tmpOK || tmpTarget != "" {
+		t.Fatalf("expected trusted aliases to be disabled on %s, got target=%q ok=%v", runtime.GOOS, tmpTarget, tmpOK)
+	}
+}
+
+func TestOpenRootChildPinnedBranches(t *testing.T) {
+	dirInfo := statTestPath(t, t.TempDir())
+	child := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		close: func() error { return nil },
+	}
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) {
+			return child, nil
+		},
+	}
+
+	opened, openedPath, err := (&osFileSystem{}).openRootChildPinned(root, "child", "/root/child")
+	if err != nil || opened == nil || openedPath != "/root/child" {
+		t.Fatalf("expected non-symlink child to open unchanged, got root=%v path=%q err=%v", opened, openedPath, err)
+	}
+	if closeErr := opened.Close(); closeErr != nil {
+		t.Fatalf("close opened child: %v", closeErr)
+	}
+
+	linkDir := t.TempDir()
+	linkInfoPath := filepath.Join(linkDir, "link-target")
+	testFile := filepath.Join(linkInfoPath, "target")
+	if err := os.MkdirAll(linkInfoPath, 0o755); err != nil {
+		t.Fatalf("mkdir link target: %v", err)
+	}
+	linkPath := filepath.Join(linkDir, "link")
+	if err := os.Symlink(testFile, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	symlinkInfo, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat symlink: %v", err)
+	}
+	untrustedRoot := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return symlinkInfo, nil },
+	}
+	rejected, rejectedPath, err := (&osFileSystem{}).openRootChildPinned(untrustedRoot, "link", filepath.Join(string(os.PathSeparator), "repo", "link"))
+	if rejected != nil || rejectedPath != "" || err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected untrusted symlink child rejection, got root=%v path=%q err=%v", rejected, rejectedPath, err)
+	}
+}
+
+func TestOpenRootChildPinnedPropagatesLookupError(t *testing.T) {
+	lookupErr := errors.New("pinned child lookup failure")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, lookupErr },
+	}
+
+	opened, openedPath, err := (&osFileSystem{}).openRootChildPinned(root, "child", "/root/child")
+	if opened != nil || openedPath != "" {
+		t.Fatalf("expected lookup failure to return no child root, got root=%v path=%q", opened, openedPath)
+	}
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("expected lookup error, got %v", err)
+	}
+}
+
+func TestOpenRootNoFollowWithPropagatesAbsAndVolumeOpenErrors(t *testing.T) {
+	absErr := errors.New("abs path failure")
+	absFn := func(string) (string, error) { return "", absErr }
+	openRootFn := func(string) (Root, error) {
+		t.Fatal("unexpected volume root open")
+		return nil, nil
+	}
+	openChildFn := func(Root, string, string) (Root, string, error) {
+		t.Fatal("unexpected child open")
+		return nil, "", nil
+	}
+	root, err := openRootNoFollowWith("repo", absFn, filepath.Rel, openRootFn, openChildFn)
+	if root != nil || !errors.Is(err, absErr) {
+		t.Fatalf("expected abs error, got root=%v err=%v", root, err)
+	}
+
+	openErr := errors.New("open volume root")
+	absFn = func(string) (string, error) { return filepath.Join(string(os.PathSeparator), "repo"), nil }
+	openRootFn = func(string) (Root, error) {
+		return nil, openErr
+	}
+	openChildFn = func(Root, string, string) (Root, string, error) {
+		t.Fatal("unexpected child open after volume-root failure")
+		return nil, "", nil
+	}
+	root, err = openRootNoFollowWith("repo", absFn, filepath.Rel, openRootFn, openChildFn)
+	if root != nil || !errors.Is(err, openErr) {
+		t.Fatalf("expected volume-root open error, got root=%v err=%v", root, err)
+	}
+}
+
+func TestOpenRootNoFollowWithJoinsOwnedRootCloseError(t *testing.T) {
+	closeErr := errors.New("close traversed root")
+	childErr := errors.New("open child failure")
+	root := &fakeRoot{
+		close: func() error { return closeErr },
+	}
+	absFn := func(string) (string, error) { return filepath.Join(string(os.PathSeparator), "repo", "child"), nil }
+	openRootFn := func(string) (Root, error) { return root, nil }
+	openChildFn := func(Root, string, string) (Root, string, error) { return nil, "", childErr }
+
+	opened, err := openRootNoFollowWith(filepath.Join(string(os.PathSeparator), "repo", "child"), absFn, filepath.Rel, openRootFn, openChildFn)
+	if opened != nil {
+		t.Fatalf("expected traversal failure to return no root, got %#v", opened)
+	}
+	if !errors.Is(err, childErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined child and close errors, got %v", err)
+	}
+}
+
+func TestOpenPinnedRootAliasWithPropagatesAliasRootAndStatErrors(t *testing.T) {
+	openErr := errors.New("open trusted alias")
+	openRootNoFollowFn := func(string) (Root, error) { return nil, openErr }
+	opened, path, err := openPinnedRootAliasWith("/private/tmp", "/tmp", openRootNoFollowFn, os.Stat, os.SameFile)
+	if opened != nil || path != "" || !errors.Is(err, openErr) {
+		t.Fatalf("expected trusted-alias open error, got root=%v path=%q err=%v", opened, path, err)
+	}
+
+	statErr := errors.New("stat trusted alias")
+	closeErr := errors.New("close trusted alias root")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return statTestPath(t, t.TempDir()), nil },
+		close: func() error { return closeErr },
+	}
+	openRootNoFollowFn = func(string) (Root, error) { return root, nil }
+	statFn := func(string) (fs.FileInfo, error) {
+		return nil, statErr
+	}
+	opened, path, err = openPinnedRootAliasWith("/private/tmp", "/tmp", openRootNoFollowFn, statFn, os.SameFile)
+	if opened != nil || path != "" {
+		t.Fatalf("expected stat failure to return no trusted-alias root, got root=%v path=%q", opened, path)
+	}
+	if !errors.Is(err, statErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined stat and close errors, got %v", err)
+	}
+}
+
+func TestOpenPinnedRootAliasWithRejectsChangedDirectoryIdentity(t *testing.T) {
+	targetInfo := statTestPath(t, t.TempDir())
+	openedInfo := statTestPath(t, t.TempDir())
+	closeErr := errors.New("close changed alias root")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return openedInfo, nil },
+		close: func() error { return closeErr },
+	}
+	openRootNoFollowFn := func(string) (Root, error) { return root, nil }
+	statFn := func(string) (fs.FileInfo, error) { return targetInfo, nil }
+	sameFileFn := func(fs.FileInfo, fs.FileInfo) bool { return false }
+
+	opened, path, err := openPinnedRootAliasWith("/private/tmp", "/tmp", openRootNoFollowFn, statFn, sameFileFn)
+	if opened != nil || path != "" {
+		t.Fatalf("expected changed trusted-alias root to be rejected, got root=%v path=%q", opened, path)
+	}
+	if err == nil || !strings.Contains(err.Error(), "root changed while opening") || !errors.Is(err, closeErr) {
+		t.Fatalf("expected changed trusted-alias root error with close failure, got %v", err)
+	}
+}
+
+func TestOpenRootChildPinnedAllowsTrustedAliasTarget(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("trusted aliases are only enabled on darwin")
+	}
+
+	aliasInfo, err := os.Lstat(filepath.Join(string(os.PathSeparator), "tmp"))
+	if err != nil {
+		t.Fatalf("lstat /tmp alias: %v", err)
+	}
+	if aliasInfo.Mode()&os.ModeSymlink == 0 {
+		t.Skip("/tmp is not exposed as a symlink on this host")
+	}
+
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return aliasInfo, nil },
+	}
+	opened, openedPath, err := (&osFileSystem{}).openRootChildPinned(root, "tmp", filepath.Join(string(os.PathSeparator), "tmp"))
+	if err != nil {
+		t.Fatalf("expected trusted alias child open to succeed, got %v", err)
+	}
+	defer func() {
+		if closeErr := opened.Close(); closeErr != nil {
+			t.Fatalf("close trusted alias child: %v", closeErr)
+		}
+	}()
+
+	wantPath := filepath.Join(string(os.PathSeparator), "private", "tmp")
+	if openedPath != wantPath {
+		t.Fatalf("expected trusted alias target %q, got %q", wantPath, openedPath)
+	}
+}
+
 func TestOpenRootChildNoFollowPropagatesLookupError(t *testing.T) {
 	expectedErr := errors.New("child lookup failure")
 	root := &fakeRoot{lstat: func(string) (fs.FileInfo, error) {
@@ -576,6 +925,32 @@ func TestOpenRootChildNoFollowPropagatesLookupError(t *testing.T) {
 	}
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected child lookup error, got %v", err)
+	}
+}
+
+func TestOpenRootChildNoFollowRejectsSymlinkAndNonDirectory(t *testing.T) {
+	linkDir := t.TempDir()
+	targetPath := filepath.Join(linkDir, "target")
+	if err := os.WriteFile(targetPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	linkPath := filepath.Join(linkDir, "link")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	symlinkInfo, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat symlink: %v", err)
+	}
+	root := &fakeRoot{lstat: func(string) (fs.FileInfo, error) { return symlinkInfo, nil }}
+	if _, err := openRootChildNoFollow(root, "link", "/root/link"); err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+
+	fileInfo := statTestPath(t, targetPath)
+	root = &fakeRoot{lstat: func(string) (fs.FileInfo, error) { return fileInfo, nil }}
+	if _, err := openRootChildNoFollow(root, "file", "/root/file"); err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("expected non-directory rejection, got %v", err)
 	}
 }
 
@@ -847,6 +1222,23 @@ func TestOpenTargetParentClosesOwnedParentAfterDescendantError(t *testing.T) {
 	}
 	if !ownedClosed {
 		t.Fatal("expected owned parent root to be closed")
+	}
+}
+
+func TestOpenTargetParentReturnsExistingRootForTopLevelTarget(t *testing.T) {
+	root := &fakeRoot{}
+	writeRoot := &WriteRoot{root: root, rootAbs: "/root"}
+	target := rootedTarget{rootAbs: "/root", rel: writeTestFileName}
+
+	parent, closeParent, err := writeRoot.openTargetParent(target, false, 0)
+	if err != nil {
+		t.Fatalf("expected top-level target parent lookup to succeed, got %v", err)
+	}
+	if parent != root {
+		t.Fatalf("expected top-level target to reuse the write root, got %#v", parent)
+	}
+	if closeParent {
+		t.Fatal("expected top-level target parent to remain caller-owned")
 	}
 }
 
@@ -1536,6 +1928,33 @@ func TestOpenPinnedReplacementTargetReturnsOpenError(t *testing.T) {
 	}
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected open target error, got %v", err)
+	}
+}
+
+func TestOpenPinnedReplacementTargetReturnsOpenedFile(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), "target")
+	if err := os.WriteFile(targetPath, []byte("target"), 0o600); err != nil {
+		t.Fatalf("seed pinned target: %v", err)
+	}
+	expectedInfo := statTestPath(t, targetPath)
+	root := &fakeRoot{
+		openFile: func(string, int, os.FileMode) (File, error) {
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return expectedInfo, nil },
+				close: closeWithoutError,
+			}, nil
+		},
+	}
+
+	file, err := openPinnedReplacementTarget(root, writeTestFileName, expectedInfo)
+	if err != nil {
+		t.Fatalf("expected pinned target open success, got %v", err)
+	}
+	if file == nil {
+		t.Fatal("expected opened pinned target file")
+	}
+	if closeErr := file.Close(); closeErr != nil {
+		t.Fatalf("close opened pinned target: %v", closeErr)
 	}
 }
 

--- a/scripts/jvm_symlink_regression_test.go
+++ b/scripts/jvm_symlink_regression_test.go
@@ -1,0 +1,30 @@
+package scripts
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/lang/jvm"
+)
+
+func TestJVMGradleSymlinkedInputIsNotConsumed(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "build.gradle")
+
+	writeFile(t, outside, "dependencies { implementation 'org.junit.jupiter:junit-jupiter-api:5.10.0' }\n")
+	if err := os.Symlink(outside, filepath.Join(repo, "build.gradle")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	detection, err := jvm.NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if detection.Matched {
+		t.Fatalf("expected escaping build.gradle symlink to be ignored, got %#v", detection)
+	}
+}

--- a/scripts/jvm_symlink_regression_test.go
+++ b/scripts/jvm_symlink_regression_test.go
@@ -2,11 +2,13 @@ package scripts
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/lang/jvm"
+	"github.com/ben-ranford/lopper/internal/language"
 )
 
 func TestJVMGradleSymlinkedInputIsNotConsumed(t *testing.T) {
@@ -27,4 +29,159 @@ func TestJVMGradleSymlinkedInputIsNotConsumed(t *testing.T) {
 	if detection.Matched {
 		t.Fatalf("expected escaping build.gradle symlink to be ignored, got %#v", detection)
 	}
+}
+
+func TestJVMEscapingSymlinkFloodStillDetectsLaterLegitimateFile(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "Outside.java")
+
+	writeFile(t, outside, "class Outside {}\n")
+	for index := 0; index < 1024; index++ {
+		linkPath := filepath.Join(repo, fmt.Sprintf("escape-%04d.java", index))
+		if err := os.Symlink(outside, linkPath); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+	}
+	writeFile(t, filepath.Join(repo, "module", "src", "main", "java", "Main.java"), "class Main {}\n")
+
+	detection, err := jvm.NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if !detection.Matched {
+		t.Fatalf("expected later legitimate JVM file to remain detectable after escaping symlink flood, got %#v", detection)
+	}
+}
+
+func TestJVMEscapingSymlinkedDirectoryIsNotTraversed(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside-module")
+
+	writeFile(t, filepath.Join(outside, "src", "main", "java", "Outside.java"), "class Outside {}\n")
+	if err := os.Symlink(outside, filepath.Join(repo, "linked-module")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	detection, err := jvm.NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if detection.Matched {
+		t.Fatalf("expected escaping symlinked directory to stay outside rooted traversal, got %#v", detection)
+	}
+}
+
+func TestJVMSymlinkedRepoRootFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	canonicalRepo := t.TempDir()
+	writeFile(t, filepath.Join(canonicalRepo, "src", "main", "java", "Main.java"), "class Main {}\n")
+
+	repoLink := filepath.Join(t.TempDir(), "repo-link")
+	if err := os.Symlink(canonicalRepo, repoLink); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := jvm.NewAdapter().DetectWithConfidence(context.Background(), repoLink)
+	if err == nil {
+		t.Fatal("expected symlinked repo root to be rejected")
+	}
+}
+
+func TestJVMSymlinkedRepoAncestorFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	canonicalParent := filepath.Join(t.TempDir(), "canonical-parent")
+	repo := filepath.Join(canonicalParent, "repo")
+	writeFile(t, filepath.Join(repo, "src", "main", "java", "Main.java"), "class Main {}\n")
+
+	ancestorLink := filepath.Join(t.TempDir(), "ancestor-link")
+	if err := os.Symlink(canonicalParent, ancestorLink); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := jvm.NewAdapter().DetectWithConfidence(context.Background(), filepath.Join(ancestorLink, "repo"))
+	if err == nil {
+		t.Fatal("expected symlinked repo ancestor to be rejected")
+	}
+}
+
+func TestJVMRelativeRepoPathDetectsInDefaultTempDir(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	writeFile(t, filepath.Join(repo, "src", "main", "java", "Main.java"), "class Main {}\n")
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Fatalf("restore wd %s: %v", originalWD, err)
+		}
+	})
+	if err := os.Chdir(parent); err != nil {
+		t.Fatalf("chdir %s: %v", parent, err)
+	}
+
+	detection, err := jvm.NewAdapter().DetectWithConfidence(context.Background(), "repo")
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if !detection.Matched {
+		t.Fatalf("expected relative repo path to detect JVM sources, got %#v", detection)
+	}
+}
+
+func TestJVMAnalyseRejectsSymlinkedRepoRootAndAcceptsRealRoots(t *testing.T) {
+	t.Parallel()
+
+	canonicalRepo := t.TempDir()
+	writeFile(t, filepath.Join(canonicalRepo, "src", "main", "java", "Main.java"), "class Main {}\n")
+
+	t.Run("real raw tempdir root", func(t *testing.T) {
+		if _, err := jvm.NewAdapter().Analyse(context.Background(), language.Request{RepoPath: canonicalRepo, TopN: 1}); err != nil {
+			t.Fatalf("analyse raw tempdir root: %v", err)
+		}
+	})
+
+	t.Run("real canonical root", func(t *testing.T) {
+		realRepo, err := filepath.EvalSymlinks(canonicalRepo)
+		if err != nil {
+			t.Fatalf("eval symlinks: %v", err)
+		}
+		if _, err := jvm.NewAdapter().Analyse(context.Background(), language.Request{RepoPath: realRepo, TopN: 1}); err != nil {
+			t.Fatalf("analyse canonical root: %v", err)
+		}
+	})
+
+	t.Run("symlinked repo root", func(t *testing.T) {
+		repoLink := filepath.Join(t.TempDir(), "repo-link")
+		if err := os.Symlink(canonicalRepo, repoLink); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+
+		if _, err := jvm.NewAdapter().Analyse(context.Background(), language.Request{RepoPath: repoLink, TopN: 1}); err == nil {
+			t.Fatal("expected analyse to reject symlinked repo root")
+		}
+	})
+
+	t.Run("symlinked repo ancestor", func(t *testing.T) {
+		canonicalParent := filepath.Join(t.TempDir(), "canonical-parent")
+		realRepo := filepath.Join(canonicalParent, "repo")
+		writeFile(t, filepath.Join(realRepo, "src", "main", "java", "Main.java"), "class Main {}\n")
+
+		ancestorLink := filepath.Join(t.TempDir(), "ancestor-link")
+		if err := os.Symlink(canonicalParent, ancestorLink); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+
+		if _, err := jvm.NewAdapter().Analyse(context.Background(), language.Request{RepoPath: filepath.Join(ancestorLink, "repo"), TopN: 1}); err == nil {
+			t.Fatal("expected analyse to reject symlinked repo ancestor")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Bound JVM build, catalog, and source reads and keep symlinked inputs outside the repository from influencing detection or analysis.

Closes #1273

## Changes

- use bounded, repo-confined reads for Gradle build files, version catalogs, and JVM source files
- ignore escaping root signals and expected untrusted source-symlink failures while preserving unrelated read errors
- report oversized or skipped source inputs and add deterministic symlink and size-limit coverage

## Validation

Commands and checks run:

```bash
make ci
go test ./internal/lang/jvm ./internal/lang/shared ./scripts -count=1
go test -race ./internal/lang/jvm ./internal/lang/shared ./scripts -count=1
make lint
make dup-check DUPLICATION_BASE=origin/main
go run ./tools/regressionproof --repo . --body-file .codex-pr-1273.md --title "fix(jvm): bound symlinked Gradle and source reads" --base-sha "$BASE_SHA" --regression-exempt-label false
```

Additional manual validation:

- confirmed the public proof fails on the base because an escaping `build.gradle` symlink triggers JVM detection and passes on the branch because the symlink is ignored

Regression-Test: ./scripts::TestJVMGradleSymlinkedInputIsNotConsumed

## Risk and compatibility

- Breaking changes: oversized or untrusted JVM inputs are skipped instead of consumed
- Migration required: none
- Performance impact: reduced worst-case file-read work through explicit byte limits
- Memory benchmark impact: none

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
