### PR TITLE
fix(ci): run identical benchmark definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ MEMORY_BENCH_MAX_ALLOCS_PCT ?= 10
 BENCH_OUTPUT ?= .artifacts/bench.out
 BENCH_BASE_OUTPUT ?= .artifacts/bench-base.out
 BENCH_HEAD_OUTPUT ?= .artifacts/bench-head.out
+MEMORY_BENCH_DEFINITION_DIR ?= .artifacts/memory-bench-definition
+MEMORY_BENCH_DEFINITION ?= $(MEMORY_BENCH_DEFINITION_DIR)/definition.json
+MEMORY_BENCH_OVERLAY_DIR ?= $(dir $(MEMORY_BENCH_DEFINITION))overlay
 MEMORY_BENCH_SUMMARY ?= .artifacts/memory-bench-summary.md
 MEMORY_BENCH_STATUS ?= .artifacts/memory-bench-status.txt
 MEMORY_BENCH_ENFORCE ?= 1
@@ -191,12 +194,25 @@ test-race-lockfiledrift-head:
 	$(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -race -tags "$(LOCKFILEDRIFT_HEAD_TAG)" $(LOCKFILEDRIFT_HEAD_PACKAGE)
 
 bench-mem:
-	@mkdir -p $$(dirname "$(BENCH_OUTPUT)"); \
+	@set -eu; \
+	mkdir -p $$(dirname "$(BENCH_OUTPUT)"); \
+	work_dir=$$(mktemp -d); \
+	head_tree="$$work_dir/head"; \
 	bench_output_tmp=$$(mktemp); \
-	trap 'rm -f "$$bench_output_tmp"' EXIT INT TERM; \
-	if ! GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES) > "$$bench_output_tmp" 2>&1; then \
-		cat "$$bench_output_tmp"; \
-		exit 1; \
+	bench_log_tmp=$$(mktemp); \
+	cleanup() { (unset GIT_INDEX_FILE; git worktree remove --force "$$head_tree" >/dev/null 2>&1 || true); rm -rf "$$work_dir"; rm -f "$$bench_output_tmp" "$$bench_log_tmp"; }; \
+	trap cleanup EXIT INT TERM; \
+	if ! (unset GIT_INDEX_FILE; git worktree add --detach "$$head_tree" HEAD >/dev/null); then \
+		echo "Failed to create memory benchmark worktree for HEAD."; \
+		exit 2; \
+	fi; \
+	if ! $(GO_CMD) run ./tools/benchdelta resolve $(foreach p,$(MEMORY_BENCH_PACKAGES),-package $(p)) -count $(BENCH_COUNT) -benchtime $(BENCH_TIME) -out "$(abspath $(MEMORY_BENCH_DEFINITION))" -overlay-dir "$(abspath $(MEMORY_BENCH_OVERLAY_DIR))"; then \
+		exit 2; \
+	fi; \
+	if ! (cd "$(CURDIR)" && $(GO_CMD) run ./tools/benchdelta run $(if $(strip $(GO_TEST_LDFLAGS)),-ldflags "$(GO_TEST_LDFLAGS)") -repo "$$head_tree" -definition "$(abspath $(MEMORY_BENCH_DEFINITION))" -output "$$bench_output_tmp") > "$$bench_log_tmp" 2>&1; then \
+		cat "$$bench_log_tmp"; \
+		cat "$$bench_output_tmp" 2>/dev/null || true; \
+		exit 2; \
 	fi; \
 	cat "$$bench_output_tmp"; \
 	cp "$$bench_output_tmp" "$(BENCH_OUTPUT)"
@@ -229,30 +245,42 @@ bench-gate:
 	fi; \
 	bench_dir=$$(mktemp -d); \
 	base_tree="$$bench_dir/base"; \
+	head_tree="$$bench_dir/head"; \
+	benchdelta_bin="$$bench_dir/benchdelta"; \
 	base_output_tmp=$$(mktemp); \
 	head_output_tmp=$$(mktemp); \
-	cleanup() { (unset GIT_INDEX_FILE; git worktree remove --force "$$base_tree" >/dev/null 2>&1 || true); rm -rf "$$bench_dir"; rm -f "$$base_output_tmp" "$$head_output_tmp"; }; \
+	base_log_tmp=$$(mktemp); \
+	head_log_tmp=$$(mktemp); \
+	cleanup() { (unset GIT_INDEX_FILE; git worktree remove --force "$$base_tree" >/dev/null 2>&1 || true); (unset GIT_INDEX_FILE; git worktree remove --force "$$head_tree" >/dev/null 2>&1 || true); rm -rf "$$bench_dir"; rm -f "$$base_output_tmp" "$$head_output_tmp" "$$base_log_tmp" "$$head_log_tmp"; }; \
 	trap cleanup EXIT INT TERM; \
 	if [ "$$used_fallback" -eq 1 ]; then \
 		echo "Running memory benchmark delta against fallback base $$base_ref (requested $$requested_base_ref)."; \
 	else \
 		echo "Running memory benchmark delta against $$base_ref."; \
 	fi; \
+	GOFLAGS=-buildvcs=false $(GO_CMD) build -o "$$benchdelta_bin" ./tools/benchdelta; \
 	(unset GIT_INDEX_FILE; git worktree add --detach "$$base_tree" "$$base_commit" >/dev/null); \
-	if ! (cd "$$base_tree" && GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES)) > "$$base_output_tmp" 2>&1; then \
+	if ! (unset GIT_INDEX_FILE; git worktree add --detach "$$head_tree" HEAD >/dev/null); then \
+		echo "Failed to create head memory benchmark worktree."; \
+		exit 2; \
+	fi; \
+	if ! "$$benchdelta_bin" resolve -repo "$(CURDIR)" $(foreach p,$(MEMORY_BENCH_PACKAGES),-package $(p)) -count $(BENCH_COUNT) -benchtime $(BENCH_TIME) -out "$(abspath $(MEMORY_BENCH_DEFINITION))" -overlay-dir "$(abspath $(MEMORY_BENCH_OVERLAY_DIR))"; then \
+		exit 2; \
+	fi; \
+	if ! "$$benchdelta_bin" run $(if $(strip $(GO_TEST_LDFLAGS)),-ldflags "$(GO_TEST_LDFLAGS)") -repo "$$base_tree" -definition "$(abspath $(MEMORY_BENCH_DEFINITION))" -output "$$base_output_tmp" > "$$base_log_tmp" 2>&1; then \
+		cat "$$base_log_tmp"; \
 		cat "$$base_output_tmp"; \
-		exit 1; \
+		exit 2; \
 	fi; \
 	cat "$$base_output_tmp"; \
 	cp "$$base_output_tmp" "$(BENCH_BASE_OUTPUT)"; \
-	if ! GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES) > "$$head_output_tmp" 2>&1; then \
+	if ! "$$benchdelta_bin" run $(if $(strip $(GO_TEST_LDFLAGS)),-ldflags "$(GO_TEST_LDFLAGS)") -repo "$$head_tree" -definition "$(abspath $(MEMORY_BENCH_DEFINITION))" -output "$$head_output_tmp" > "$$head_log_tmp" 2>&1; then \
+		cat "$$head_log_tmp"; \
 		cat "$$head_output_tmp"; \
-		exit 1; \
+		exit 2; \
 	fi; \
 	cat "$$head_output_tmp"; \
 	cp "$$head_output_tmp" "$(BENCH_HEAD_OUTPUT)"; \
-	benchdelta_bin="$$bench_dir/benchdelta"; \
-	GOFLAGS=-buildvcs=false $(GO_CMD) build -o "$$benchdelta_bin" ./tools/benchdelta; \
 	set +e; \
 	"$$benchdelta_bin" -base "$(BENCH_BASE_OUTPUT)" -head "$(BENCH_HEAD_OUTPUT)" -max-bytes-pct "$(MEMORY_BENCH_MAX_BYTES_PCT)" -max-allocs-pct "$(MEMORY_BENCH_MAX_ALLOCS_PCT)" -summary-out "$(MEMORY_BENCH_SUMMARY)"; \
 	status=$$?; \
@@ -271,8 +299,8 @@ benchdelta-cov:
 	@GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) ./tools/benchdelta -covermode=atomic -coverprofile=".artifacts/benchdelta-coverage.out"
 	@GOFLAGS=-buildvcs=false $(GO_CMD) run ./tools/coveragegate \
 		-coverprofile=".artifacts/benchdelta-coverage.out" \
-		-min=97.0 \
-		-package-min=97.0 \
+		-min=98.0 \
+		-package-min=98.0 \
 		-total-out=".artifacts/benchdelta-coverage-total.txt" \
 		-packages-out=".artifacts/benchdelta-coverage-packages.txt" \
 		-package-failures-out=".artifacts/benchdelta-coverage-package-failures.txt"

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3053,8 +3053,8 @@ func TestMakefileBenchdeltaCoverageRatchet(t *testing.T) {
 	for _, want := range []string{
 		`./tools/benchdelta -covermode=atomic -coverprofile=".artifacts/benchdelta-coverage.out"`,
 		`$(GO_CMD) run ./tools/coveragegate`,
-		`-min=97.0`,
-		`-package-min=97.0`,
+		`-min=98.0`,
+		`-package-min=98.0`,
 		`-total-out=".artifacts/benchdelta-coverage-total.txt"`,
 		`-packages-out=".artifacts/benchdelta-coverage-packages.txt"`,
 		`-package-failures-out=".artifacts/benchdelta-coverage-package-failures.txt"`,
@@ -3091,6 +3091,8 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 	for _, want := range []string{
 		`benchdelta_bin="$$bench_dir/benchdelta"`,
 		`$(GO_CMD) build -o "$$benchdelta_bin" ./tools/benchdelta`,
+		`"$$benchdelta_bin" resolve -repo "$(CURDIR)"`,
+		`"$$benchdelta_bin" run`,
 		`"$$benchdelta_bin" -base "$(BENCH_BASE_OUTPUT)" -head "$(BENCH_HEAD_OUTPUT)"`,
 		`printf "%s\n" "$$status" > "$(MEMORY_BENCH_STATUS)"`,
 		`if [ "$(MEMORY_BENCH_ENFORCE)" = "0" ]; then`,

--- a/tools/benchdelta/definition.go
+++ b/tools/benchdelta/definition.go
@@ -1,0 +1,1616 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+const (
+	definitionVersion        = 1
+	defaultRunPattern        = "^$"
+	defaultOverlayDir        = "overlay"
+	maxBenchmarkHarnessBytes = 2 * 1024 * 1024
+	maxBenchmarkHarnessTotal = 16 * 1024 * 1024
+)
+
+type benchmarkDefinition struct {
+	Version        int                    `json:"version"`
+	ResolvedFrom   string                 `json:"resolved_from"`
+	ResolvedCommit string                 `json:"resolved_commit,omitempty"`
+	PackageTargets []string               `json:"package_targets"`
+	Benchmarks     []resolvedBenchmark    `json:"benchmarks"`
+	BenchPattern   string                 `json:"bench_pattern"`
+	RunPattern     string                 `json:"run_pattern"`
+	Count          int                    `json:"count"`
+	Benchtime      string                 `json:"benchtime"`
+	BenchMem       bool                   `json:"benchmem"`
+	HarnessFiles   []benchmarkHarnessFile `json:"harness_files"`
+	OverlayDir     string                 `json:"overlay_dir"`
+}
+
+type resolvedBenchmark struct {
+	PackageTarget string `json:"package_target"`
+	Name          string `json:"name"`
+}
+
+type benchmarkHarnessFile struct {
+	Path        string `json:"path"`
+	SHA256      string `json:"sha256"`
+	OverlayPath string `json:"overlay_path"`
+}
+
+type stagedBenchmarkHarness struct {
+	targetPath string
+	content    []byte
+}
+
+type benchmarkSetWrite struct {
+	targetPath string
+	content    []byte
+	perm       os.FileMode
+	parentPerm os.FileMode
+	errorPath  string
+	errorLabel string
+}
+
+type benchmarkTargetSnapshot struct {
+	targetPath string
+	absPath    string
+	content    []byte
+	mode       os.FileMode
+	existed    bool
+}
+
+type benchmarkPromotedPath struct {
+	liveRel      string
+	stagedRel    string
+	backupRel    string
+	discardRel   string
+	backupExists bool
+	promoted     bool
+	errorLabel   string
+}
+
+type confinedWriteRoot interface {
+	WriteFileCreatingParents(targetPath string, data []byte, perm, parentPerm os.FileMode) error
+	Close() error
+}
+
+var openCanonicalWriteRoot = func(rootDir string) (confinedWriteRoot, error) {
+	canonicalRoot, err := evalSymlinks(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("canonicalize root: %w", err)
+	}
+	return safeio.OpenCanonicalWriteRoot(canonicalRoot)
+}
+
+var (
+	readFile = os.ReadFile
+	readDir  = os.ReadDir
+
+	marshalIndent = json.MarshalIndent
+
+	absPath      = filepath.Abs
+	relPath      = filepath.Rel
+	evalSymlinks = filepath.EvalSymlinks
+
+	openOSRoot = os.OpenRoot
+	sameFile   = os.SameFile
+
+	rootLstat = func(root *os.Root, name string) (os.FileInfo, error) {
+		return root.Lstat(name)
+	}
+	rootOpenRoot = func(root *os.Root, name string) (*os.Root, error) {
+		return root.OpenRoot(name)
+	}
+	rootOpen = func(root *os.Root, name string) (*os.File, error) {
+		return root.Open(name)
+	}
+	rootMkdir = func(root *os.Root, name string, perm os.FileMode) error {
+		return root.Mkdir(name, perm)
+	}
+	rootRename = func(root *os.Root, oldName, newName string) error {
+		return root.Rename(oldName, newName)
+	}
+	rootRemove = func(root *os.Root, name string) error {
+		return root.Remove(name)
+	}
+	closeOSRoot = func(root *os.Root) error {
+		return root.Close()
+	}
+
+	resolveStageWriteSeam = func(string) error { return nil }
+	resolvePromoteSeam    = func(int, string) error { return nil }
+	applyStageWriteSeam   = func(string) error { return nil }
+	applyPromoteSeam      = func(int, string) error { return nil }
+)
+
+type packageListFlag []string
+
+func (f *packageListFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *packageListFlag) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("package target cannot be empty")
+	}
+	*f = append(*f, value)
+	return nil
+}
+
+func runResolveCommand(args []string) error {
+	fs := flag.NewFlagSet("benchdelta resolve", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	repoPath := fs.String("repo", ".", "repository root to resolve benchmark definition from")
+	outPath := fs.String("out", "", "path to write benchmark definition manifest")
+	overlayDir := fs.String("overlay-dir", "", "directory to write benchmark harness overlay files")
+	count := fs.Int("count", 3, "benchmark count")
+	benchtime := fs.String("benchtime", "200ms", "benchmark benchtime")
+	var packageTargets packageListFlag
+	fs.Var(&packageTargets, "package", "package target to include (repeatable)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*outPath) == "" {
+		return errors.New("resolve requires -out")
+	}
+	if len(packageTargets) == 0 {
+		return errors.New("resolve requires at least one -package")
+	}
+	if *count < 1 {
+		return errors.New("resolve requires -count >= 1")
+	}
+	if strings.TrimSpace(*benchtime) == "" {
+		return errors.New("resolve requires -benchtime")
+	}
+	resolvedOverlayDir := strings.TrimSpace(*overlayDir)
+	if resolvedOverlayDir == "" {
+		resolvedOverlayDir = filepath.Join(filepath.Dir(*outPath), defaultOverlayDir)
+	}
+
+	definition, overlayFiles, err := resolveBenchmarkDefinition(*repoPath, []string(packageTargets), *count, *benchtime)
+	if err != nil {
+		return fmt.Errorf("resolve benchmark definition: %w", err)
+	}
+	if err := writeBenchmarkDefinition(*outPath, resolvedOverlayDir, definition, overlayFiles); err != nil {
+		return err
+	}
+
+	manifestBytes, err := os.ReadFile(*outPath)
+	if err != nil {
+		return fmt.Errorf("read written benchmark definition: %w", err)
+	}
+	fmt.Print(formatDefinitionMetadata(filepath.Clean(*outPath), definition, definitionDigest(manifestBytes)))
+	return nil
+}
+
+func runBenchmarkCommand(args []string) error {
+	fs := flag.NewFlagSet("benchdelta run", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	repoPath := fs.String("repo", ".", "repository root to apply benchmark definition to")
+	definitionPath := fs.String("definition", "", "path to benchmark definition manifest")
+	outputPath := fs.String("output", "", "path to write benchmark output")
+	ldflags := fs.String("ldflags", "", "ldflags value passed through to go test")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*definitionPath) == "" {
+		return errors.New("run requires -definition")
+	}
+
+	definition, manifestBytes, err := readBenchmarkDefinition(*definitionPath)
+	if err != nil {
+		return err
+	}
+	if err := applyBenchmarkOverlay(*repoPath, *definitionPath, definition); err != nil {
+		return fmt.Errorf("apply benchmark definition: %w", err)
+	}
+	header := formatDefinitionMetadata(filepath.Clean(*definitionPath), definition, definitionDigest(manifestBytes))
+	output, err := executeBenchmarkDefinition(*repoPath, definition, strings.TrimSpace(*ldflags))
+	combined := append([]byte(header), output...)
+	fmt.Print(string(combined))
+	if strings.TrimSpace(*outputPath) != "" {
+		if writeErr := os.WriteFile(*outputPath, combined, 0o600); writeErr != nil {
+			return fmt.Errorf("write benchmark output: %w", writeErr)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("run benchmark definition: %w", err)
+	}
+	return nil
+}
+
+func resolveBenchmarkDefinition(repoPath string, packageTargets []string, count int, benchtime string) (benchmarkDefinition, map[string][]byte, error) {
+	repoRoot, err := absPath(repoPath)
+	if err != nil {
+		return benchmarkDefinition{}, nil, fmt.Errorf("resolve repo path: %w", err)
+	}
+	headCommit, err := gitHeadCommit(repoRoot)
+	if err != nil {
+		return benchmarkDefinition{}, nil, fmt.Errorf("resolve HEAD commit: %w", err)
+	}
+	repoRootHandle, err := openManifestRootNoFollow(repoRoot)
+	if err != nil {
+		return benchmarkDefinition{}, nil, fmt.Errorf("open repo root: %w", err)
+	}
+	defer func() {
+		if closeErr := closeOSRoot(repoRootHandle); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	definition := benchmarkDefinition{
+		Version:        definitionVersion,
+		ResolvedFrom:   headCommit,
+		ResolvedCommit: headCommit,
+		PackageTargets: append([]string(nil), packageTargets...),
+		RunPattern:     defaultRunPattern,
+		Count:          count,
+		Benchtime:      benchtime,
+		BenchMem:       true,
+	}
+	overlayFiles := make(map[string][]byte)
+	benchmarkNames := make([]string, 0)
+	seenNames := make(map[string]struct{})
+	seenFiles := make(map[string]struct{})
+	remainingBytes := int64(maxBenchmarkHarnessTotal)
+
+	for _, packageTarget := range packageTargets {
+		harnesses, capturedFiles, benchmarks, resolveErr := resolvePackageBenchmarksWithinRoot(repoRoot, repoRootHandle, packageTarget, &remainingBytes)
+		if resolveErr != nil {
+			err = resolveErr
+			return benchmarkDefinition{}, nil, err
+		}
+		if err != nil {
+			return benchmarkDefinition{}, nil, err
+		}
+		for _, benchmarkName := range benchmarks {
+			definition.Benchmarks = append(definition.Benchmarks, resolvedBenchmark{
+				PackageTarget: packageTarget,
+				Name:          benchmarkName,
+			})
+			if _, ok := seenNames[benchmarkName]; !ok {
+				seenNames[benchmarkName] = struct{}{}
+				benchmarkNames = append(benchmarkNames, benchmarkName)
+			}
+		}
+		for _, harness := range harnesses {
+			if _, ok := seenFiles[harness.Path]; ok {
+				continue
+			}
+			seenFiles[harness.Path] = struct{}{}
+			definition.HarnessFiles = append(definition.HarnessFiles, harness)
+			overlayFiles[harness.OverlayPath] = capturedFiles[harness.OverlayPath]
+		}
+	}
+	if len(definition.Benchmarks) == 0 {
+		return benchmarkDefinition{}, nil, errors.New("no benchmarks resolved from package targets")
+	}
+	sort.Slice(definition.Benchmarks, func(i, j int) bool {
+		if definition.Benchmarks[i].PackageTarget == definition.Benchmarks[j].PackageTarget {
+			return definition.Benchmarks[i].Name < definition.Benchmarks[j].Name
+		}
+		return definition.Benchmarks[i].PackageTarget < definition.Benchmarks[j].PackageTarget
+	})
+	sort.Slice(definition.HarnessFiles, func(i, j int) bool {
+		return definition.HarnessFiles[i].Path < definition.HarnessFiles[j].Path
+	})
+	slices.Sort(benchmarkNames)
+	definition.BenchPattern = buildBenchmarkPattern(benchmarkNames)
+	dirtyHarnesses, err := gitStatusPorcelainV2HasPaths(repoRoot, harnessPaths(definition.HarnessFiles))
+	if err != nil {
+		return benchmarkDefinition{}, nil, fmt.Errorf("resolve benchmark identity: %w", err)
+	}
+	if dirtyHarnesses {
+		definition.ResolvedFrom = benchmarkCapturedContentIdentity(definition.PackageTargets, definition.HarnessFiles, overlayFiles)
+	}
+	return definition, overlayFiles, nil
+}
+
+func resolvePackageBenchmarks(repoRoot, packageTarget string) (harnesses []benchmarkHarnessFile, benchmarks []string, err error) {
+	repoRootHandle, err := openManifestRootNoFollow(repoRoot)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open repo root: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, closeOSRoot(repoRootHandle))
+	}()
+	remainingBytes := int64(maxBenchmarkHarnessTotal)
+	harnesses, _, benchmarks, err = resolvePackageBenchmarksWithinRoot(repoRoot, repoRootHandle, packageTarget, &remainingBytes)
+	return harnesses, benchmarks, err
+}
+
+func resolvePackageBenchmarksWithinRoot(repoRoot string, repoRootHandle *os.Root, packageTarget string, remainingBytes *int64) (harnesses []benchmarkHarnessFile, overlayFiles map[string][]byte, benchmarks []string, err error) {
+	packageDir, packageRel, packageRoot, err := openPackageTargetRootNoFollow(repoRoot, repoRootHandle, packageTarget)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	defer func() {
+		err = errors.Join(err, closeOSRoot(packageRoot))
+	}()
+	entries, err := readRootDir(packageRoot)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("read package %s: %w", packageTarget, err)
+	}
+
+	harnesses = make([]benchmarkHarnessFile, 0)
+	overlayFiles = make(map[string][]byte)
+	benchmarks = make([]string, 0)
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		info, err := rootLstat(packageRoot, entry.Name())
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("read package %s: %w", packageTarget, err)
+		}
+		harnessRel := filepath.ToSlash(filepath.Join(packageRel, entry.Name()))
+		harnessAbs := filepath.Join(packageDir, entry.Name())
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, nil, nil, fmt.Errorf("benchmark harness path is a symlink: %s", harnessAbs)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, nil, nil, fmt.Errorf("benchmark harness path is not a regular file: %s", harnessAbs)
+		}
+		content, err := readCapturedHarnessBytes(repoRootHandle, harnessRel, remainingBytes)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("read benchmark harness %s: %w", harnessAbs, err)
+		}
+		fileBenchmarks, err := benchmarkFunctionsInBytes(harnessAbs, content)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("parse benchmark harness %s: %w", harnessAbs, err)
+		}
+		benchmarks = append(benchmarks, fileBenchmarks...)
+		harnesses = append(harnesses, benchmarkHarnessFile{
+			Path:        harnessRel,
+			SHA256:      bytesDigest(content),
+			OverlayPath: harnessRel,
+		})
+		overlayFiles[harnessRel] = append([]byte(nil), content...)
+	}
+	sort.Slice(harnesses, func(i, j int) bool {
+		return harnesses[i].Path < harnesses[j].Path
+	})
+	slices.Sort(benchmarks)
+	if len(benchmarks) == 0 {
+		return nil, nil, nil, fmt.Errorf("package %s does not define any benchmarks", packageTarget)
+	}
+	return harnesses, overlayFiles, benchmarks, nil
+}
+
+func benchmarkFunctionsInFile(path string) ([]string, error) {
+	content, err := safeio.ReadFileLimit(path, maxBenchmarkHarnessBytes)
+	if err != nil {
+		return nil, err
+	}
+	return benchmarkFunctionsInBytes(path, content)
+}
+
+func benchmarkFunctionsInBytes(path string, content []byte) ([]string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, content, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+	benchmarks := make([]string, 0)
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv != nil || fn.Name == nil || !strings.HasPrefix(fn.Name.Name, "Benchmark") {
+			continue
+		}
+		if fn.Type == nil || fn.Type.Params == nil || len(fn.Type.Params.List) != 1 {
+			continue
+		}
+		param := fn.Type.Params.List[0]
+		star, ok := param.Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		selector, ok := star.X.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		pkgIdent, ok := selector.X.(*ast.Ident)
+		if !ok || pkgIdent.Name != "testing" || selector.Sel == nil || selector.Sel.Name != "B" {
+			continue
+		}
+		benchmarks = append(benchmarks, fn.Name.Name)
+	}
+	return benchmarks, nil
+}
+
+func openPackageTargetRootNoFollow(repoRoot string, repoRootHandle *os.Root, packageTarget string) (string, string, *os.Root, error) {
+	packageDir, err := packageTargetDir(repoRoot, packageTarget)
+	if err != nil {
+		return "", "", nil, err
+	}
+	packageRel, err := relPath(repoRoot, packageDir)
+	if err != nil {
+		return "", "", nil, err
+	}
+	if packageRel == "." {
+		return "", "", nil, fmt.Errorf("package target %q must not resolve to repo root", packageTarget)
+	}
+
+	current := repoRootHandle
+	owned := false
+	currentPath := repoRoot
+	for _, part := range strings.Split(packageRel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		currentPath = filepath.Join(currentPath, part)
+		next, err := openRootChildNoFollow(current, part, currentPath)
+		if err != nil {
+			return "", "", nil, closeOwnedRootWithError(current, owned, fmt.Errorf("read package %s: %w", packageTarget, err))
+		}
+		if owned {
+			if err := closeOSRoot(current); err != nil {
+				return "", "", nil, closeOSRootWithError(next, err)
+			}
+		}
+		current = next
+		owned = true
+	}
+	if !owned {
+		return "", "", nil, fmt.Errorf("package target %q must not resolve to repo root", packageTarget)
+	}
+	return packageDir, packageRel, current, nil
+}
+
+func readRootDir(root *os.Root) (entries []os.DirEntry, err error) {
+	dir, err := rootOpen(root, ".")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = errors.Join(err, dir.Close())
+	}()
+	return dir.ReadDir(-1)
+}
+
+func readCapturedHarnessBytes(repoRootHandle *os.Root, harnessRel string, remainingBytes *int64) ([]byte, error) {
+	content, err := readRootFileLimit(repoRootHandle, filepath.FromSlash(harnessRel), maxBenchmarkHarnessBytes)
+	if err != nil {
+		return nil, err
+	}
+	if remainingBytes != nil {
+		if int64(len(content)) > *remainingBytes {
+			return nil, fmt.Errorf("captured benchmark harness bytes exceed total limit of %d", maxBenchmarkHarnessTotal)
+		}
+		*remainingBytes -= int64(len(content))
+	}
+	return content, nil
+}
+
+func readRootFileLimit(root *os.Root, rel string, maxBytes int64) (content []byte, err error) {
+	file, err := rootOpen(root, rel)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = errors.Join(err, file.Close())
+	}()
+	if info, err := file.Stat(); err == nil && info.Mode().IsRegular() && info.Size() > maxBytes {
+		return nil, safeio.ErrFileTooLarge
+	}
+	content, err = io.ReadAll(io.LimitReader(file, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(content)) > maxBytes {
+		return nil, safeio.ErrFileTooLarge
+	}
+	return content, nil
+}
+
+func harnessPaths(harnesses []benchmarkHarnessFile) []string {
+	paths := make([]string, 0, len(harnesses))
+	for _, harness := range harnesses {
+		paths = append(paths, harness.Path)
+	}
+	return paths
+}
+
+func benchmarkCapturedContentIdentity(packageTargets []string, harnesses []benchmarkHarnessFile, overlayFiles map[string][]byte) string {
+	contentIdentity := make([]byte, 0, len(packageTargets)*16+len(harnesses)*64)
+	for _, packageTarget := range packageTargets {
+		contentIdentity = append(contentIdentity, "package:"...)
+		contentIdentity = append(contentIdentity, packageTarget...)
+		contentIdentity = append(contentIdentity, '\n')
+	}
+	for _, harness := range harnesses {
+		contentIdentity = append(contentIdentity, "harness:"...)
+		contentIdentity = append(contentIdentity, harness.Path...)
+		contentIdentity = append(contentIdentity, "\nsha256:"...)
+		contentIdentity = append(contentIdentity, harness.SHA256...)
+		contentIdentity = append(contentIdentity, '\n')
+		contentIdentity = append(contentIdentity, overlayFiles[harness.OverlayPath]...)
+		contentIdentity = append(contentIdentity, '\n')
+	}
+	sum := sha256.Sum256(contentIdentity)
+	return "content-sha256:" + hex.EncodeToString(sum[:])
+}
+
+func packageTargetDir(repoRoot, packageTarget string) (string, error) {
+	cleaned := filepath.Clean(strings.TrimSpace(packageTarget))
+	switch {
+	case cleaned == ".", cleaned == "":
+		return "", fmt.Errorf("package target %q must not resolve to repo root", packageTarget)
+	case cleaned == "..", strings.HasPrefix(cleaned, ".."+string(filepath.Separator)):
+		return "", fmt.Errorf("package target %q escapes repository root", packageTarget)
+	case filepath.IsAbs(cleaned):
+		return "", fmt.Errorf("package target %q must be relative", packageTarget)
+	}
+	return filepath.Join(repoRoot, strings.TrimPrefix(cleaned, "."+string(filepath.Separator))), nil
+}
+
+func buildBenchmarkPattern(benchmarkNames []string) string {
+	escaped := make([]string, 0, len(benchmarkNames))
+	for _, name := range benchmarkNames {
+		escaped = append(escaped, regexp.QuoteMeta(name))
+	}
+	return "^(" + strings.Join(escaped, "|") + ")$"
+}
+
+func writeBenchmarkDefinition(outPath, overlayDir string, definition benchmarkDefinition, overlayFiles map[string][]byte) (returnErr error) {
+	rootDir, definitionRel, overlayRel, _, err := resolveManifestLayout(outPath, overlayDir)
+	if err != nil {
+		return err
+	}
+	if err := validateManifestRootPathNoFollow(rootDir); err != nil {
+		return fmt.Errorf("open benchmark manifest root: %w", err)
+	}
+	if err := os.MkdirAll(rootDir, 0o750); err != nil {
+		return fmt.Errorf("create benchmark definition directory: %w", err)
+	}
+	canonicalRootDir, err := evalSymlinks(rootDir)
+	if err != nil {
+		return fmt.Errorf("canonicalize benchmark manifest root: %w", err)
+	}
+	manifestRoot, err := openManifestRootNoFollow(canonicalRootDir)
+	if err != nil {
+		return fmt.Errorf("open benchmark manifest root: %w", err)
+	}
+	defer func() {
+		if closeErr := closeOSRoot(manifestRoot); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+	root, err := openCanonicalWriteRoot(rootDir)
+	if err != nil {
+		return fmt.Errorf("open benchmark manifest root: %w", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+	definition.OverlayDir = overlayRel
+	if err := normalizeDefinitionPaths(&definition); err != nil {
+		return err
+	}
+	manifestBytes, err := marshalIndent(definition, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal benchmark definition: %w", err)
+	}
+	manifestBytes = append(manifestBytes, '\n')
+
+	stageRootRel, err := createBenchmarkTempDir(rootDir, ".benchdelta-resolve-stage-")
+	if err != nil {
+		return fmt.Errorf("create benchmark staging root: %w", err)
+	}
+	backupRootRel, err := createBenchmarkTempDir(rootDir, ".benchdelta-resolve-backup-")
+	if err != nil {
+		cleanupErr := removeManifestSubtree(manifestRoot, stageRootRel)
+		return errors.Join(fmt.Errorf("create benchmark backup root: %w", err), cleanupErr)
+	}
+
+	stageWrites, err := buildResolveStageWrites(rootDir, definitionRel, overlayRel, definition, overlayFiles, manifestBytes, stageRootRel)
+	if err != nil {
+		cleanupErr := cleanupBenchmarkSetRoots(manifestRoot, stageRootRel, backupRootRel)
+		return errors.Join(err, cleanupErr)
+	}
+	if err := validateManifestSubtreePathNoFollow(manifestRoot, overlayRel); err != nil {
+		cleanupErr := cleanupBenchmarkSetRoots(manifestRoot, stageRootRel, backupRootRel)
+		return errors.Join(fmt.Errorf("clear benchmark overlay: %w", err), cleanupErr)
+	}
+	if err := writeBenchmarkSet(root, stageWrites, resolveStageWriteSeam); err != nil {
+		cleanupErr := cleanupBenchmarkSetRoots(manifestRoot, stageRootRel, backupRootRel)
+		return errors.Join(err, cleanupErr)
+	}
+
+	promotions := []benchmarkPromotedPath{
+		{
+			liveRel:    overlayRel,
+			stagedRel:  filepath.Join(stageRootRel, filepath.FromSlash(overlayRel)),
+			backupRel:  filepath.Join(backupRootRel, filepath.FromSlash(overlayRel)),
+			discardRel: filepath.Join(stageRootRel, "discard", filepath.FromSlash(overlayRel)),
+			errorLabel: "clear benchmark overlay",
+		},
+		{
+			liveRel:    definitionRel,
+			stagedRel:  filepath.Join(stageRootRel, definitionRel),
+			backupRel:  filepath.Join(backupRootRel, definitionRel),
+			discardRel: filepath.Join(stageRootRel, "discard", definitionRel),
+			errorLabel: "write benchmark definition",
+		},
+	}
+	if err := promoteBenchmarkSet(manifestRoot, promotions, resolvePromoteSeam); err != nil {
+		cleanupErr := cleanupBenchmarkSetRoots(manifestRoot, stageRootRel, backupRootRel)
+		return errors.Join(err, cleanupErr)
+	}
+	return cleanupBenchmarkSetRoots(manifestRoot, stageRootRel, backupRootRel)
+}
+
+func readBenchmarkDefinition(definitionPath string) (benchmarkDefinition, []byte, error) {
+	content, err := safeio.ReadFile(definitionPath)
+	if err != nil {
+		return benchmarkDefinition{}, nil, fmt.Errorf("read benchmark definition: %w", err)
+	}
+	var definition benchmarkDefinition
+	if err := json.Unmarshal(content, &definition); err != nil {
+		return benchmarkDefinition{}, nil, fmt.Errorf("parse benchmark definition: %w", err)
+	}
+	if definition.Version != definitionVersion {
+		return benchmarkDefinition{}, nil, fmt.Errorf("unsupported benchmark definition version %d", definition.Version)
+	}
+	if len(definition.PackageTargets) == 0 || len(definition.Benchmarks) == 0 || len(definition.HarnessFiles) == 0 {
+		return benchmarkDefinition{}, nil, errors.New("benchmark definition is incomplete")
+	}
+	if strings.TrimSpace(definition.BenchPattern) == "" || strings.TrimSpace(definition.RunPattern) == "" || definition.Count < 1 || strings.TrimSpace(definition.Benchtime) == "" {
+		return benchmarkDefinition{}, nil, errors.New("benchmark definition is missing required execution fields")
+	}
+	if strings.TrimSpace(definition.OverlayDir) == "" {
+		definition.OverlayDir = defaultOverlayDir
+	}
+	if err := normalizeDefinitionPaths(&definition); err != nil {
+		return benchmarkDefinition{}, nil, err
+	}
+	return definition, content, nil
+}
+
+func applyBenchmarkOverlay(repoPath, definitionPath string, definition benchmarkDefinition) (returnErr error) {
+	repoRoot, err := absPath(repoPath)
+	if err != nil {
+		return fmt.Errorf("resolve repo path: %w", err)
+	}
+	if err := normalizeDefinitionPaths(&definition); err != nil {
+		return err
+	}
+	definitionDir, err := absPath(filepath.Dir(definitionPath))
+	if err != nil {
+		return fmt.Errorf("resolve benchmark definition directory: %w", err)
+	}
+	stagedHarnesses, err := stageBenchmarkOverlay(repoRoot, definitionDir, definition)
+	if err != nil {
+		return err
+	}
+	canonicalRepoRoot, err := evalSymlinks(repoRoot)
+	if err != nil {
+		return fmt.Errorf("open benchmark repo root: %w", err)
+	}
+	writeRoot, err := openCanonicalWriteRoot(repoRoot)
+	if err != nil {
+		return fmt.Errorf("open benchmark repo root: %w", err)
+	}
+	defer func() {
+		if closeErr := writeRoot.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+	repoRootHandle, err := openManifestRootNoFollow(canonicalRepoRoot)
+	if err != nil {
+		return fmt.Errorf("open benchmark repo root: %w", err)
+	}
+	defer func() {
+		if closeErr := closeOSRoot(repoRootHandle); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+
+	stageRootRel, err := createBenchmarkTempDir(canonicalRepoRoot, ".benchdelta-apply-stage-")
+	if err != nil {
+		return fmt.Errorf("create benchmark staging root: %w", err)
+	}
+	backupRootRel, err := createBenchmarkTempDir(canonicalRepoRoot, ".benchdelta-apply-backup-")
+	if err != nil {
+		cleanupErr := removeManifestSubtree(repoRootHandle, stageRootRel)
+		return errors.Join(fmt.Errorf("create benchmark backup root: %w", err), cleanupErr)
+	}
+
+	_, stageWrites, promotions, err := buildApplyStagePlan(repoRootHandle, canonicalRepoRoot, stageRootRel, backupRootRel, stagedHarnesses)
+	if err != nil {
+		cleanupErr := cleanupBenchmarkSetRoots(repoRootHandle, stageRootRel, backupRootRel)
+		return errors.Join(err, cleanupErr)
+	}
+	if err := writeBenchmarkSet(writeRoot, stageWrites, applyStageWriteSeam); err != nil {
+		cleanupErr := cleanupBenchmarkSetRoots(repoRootHandle, stageRootRel, backupRootRel)
+		return errors.Join(err, cleanupErr)
+	}
+	if err := promoteBenchmarkSet(repoRootHandle, promotions, applyPromoteSeam); err != nil {
+		cleanupErr := cleanupBenchmarkSetRoots(repoRootHandle, stageRootRel, backupRootRel)
+		return errors.Join(err, cleanupErr)
+	}
+	return cleanupBenchmarkSetRoots(repoRootHandle, stageRootRel, backupRootRel)
+}
+
+func stageBenchmarkOverlay(repoRoot, definitionDir string, definition benchmarkDefinition) ([]stagedBenchmarkHarness, error) {
+	if err := validateBenchmarkHarnessTargets(repoRoot, definition); err != nil {
+		return nil, err
+	}
+
+	staged := make([]stagedBenchmarkHarness, 0, len(definition.HarnessFiles))
+	for _, harness := range definition.HarnessFiles {
+		sourcePath := filepath.Join(definitionDir, filepath.FromSlash(definition.OverlayDir), filepath.FromSlash(harness.OverlayPath))
+		content, err := safeio.ReadFileUnderLimit(definitionDir, sourcePath, maxBenchmarkHarnessBytes)
+		if err != nil {
+			return nil, fmt.Errorf("read overlay file %s: %w", harness.OverlayPath, err)
+		}
+		if got := bytesDigest(content); got != harness.SHA256 {
+			return nil, fmt.Errorf("overlay file %s digest mismatch: got %s want %s", harness.OverlayPath, got, harness.SHA256)
+		}
+		staged = append(staged, stagedBenchmarkHarness{
+			targetPath: harness.Path,
+			content:    content,
+		})
+	}
+	return staged, nil
+}
+
+func resolveManifestLayout(outPath, overlayDir string) (string, string, string, string, error) {
+	outAbs, err := absPath(outPath)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("resolve benchmark definition path: %w", err)
+	}
+	overlayAbs, err := absPath(overlayDir)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("resolve benchmark overlay path: %w", err)
+	}
+	rootDir := filepath.Dir(outAbs)
+	definitionRel := filepath.Base(outAbs)
+	overlayRel, err := relPath(rootDir, overlayAbs)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("resolve benchmark overlay path: %w", err)
+	}
+	overlayRel, err = normalizeManifestRelativePath("overlay directory", overlayRel)
+	if err != nil {
+		return "", "", "", "", err
+	}
+	return rootDir, definitionRel, overlayRel, overlayAbs, nil
+}
+
+func createBenchmarkTempDir(rootDir, pattern string) (string, error) {
+	stageDir, err := os.MkdirTemp(rootDir, pattern)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Base(stageDir), nil
+}
+
+func buildResolveStageWrites(rootDir, definitionRel, overlayRel string, definition benchmarkDefinition, overlayFiles map[string][]byte, manifestBytes []byte, stageRootRel string) ([]benchmarkSetWrite, error) {
+	writes := make([]benchmarkSetWrite, 0, len(overlayFiles)+1)
+	manifestPerm, err := existingRegularFilePerm(filepath.Join(rootDir, definitionRel), 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("write benchmark definition: %w", err)
+	}
+	overlayPaths := make([]string, 0, len(overlayFiles))
+	for overlayPath := range overlayFiles {
+		overlayPaths = append(overlayPaths, overlayPath)
+	}
+	slices.Sort(overlayPaths)
+	for _, overlayPath := range overlayPaths {
+		content := overlayFiles[overlayPath]
+		normalizedOverlayPath, err := normalizeManifestRelativePath("overlay file path", overlayPath)
+		if err != nil {
+			return nil, err
+		}
+		liveOverlayAbs := filepath.Join(rootDir, filepath.FromSlash(overlayRel), filepath.FromSlash(normalizedOverlayPath))
+		filePerm, err := existingRegularFilePerm(liveOverlayAbs, 0o600)
+		if err != nil {
+			return nil, fmt.Errorf("write overlay file %s: %w", overlayPath, err)
+		}
+		writes = append(writes, benchmarkSetWrite{
+			targetPath: filepath.Join(stageRootRel, filepath.FromSlash(overlayRel), filepath.FromSlash(normalizedOverlayPath)),
+			content:    content,
+			perm:       filePerm,
+			parentPerm: 0o755,
+			errorPath:  normalizedOverlayPath,
+			errorLabel: "write overlay file",
+		})
+	}
+	writes = append(writes, benchmarkSetWrite{
+		targetPath: filepath.Join(stageRootRel, definitionRel),
+		content:    manifestBytes,
+		perm:       manifestPerm,
+		parentPerm: 0o755,
+		errorLabel: "write benchmark definition",
+	})
+	return writes, nil
+}
+
+func buildApplyStagePlan(repoRootHandle *os.Root, repoRoot, stageRootRel, backupRootRel string, stagedHarnesses []stagedBenchmarkHarness) ([]benchmarkTargetSnapshot, []benchmarkSetWrite, []benchmarkPromotedPath, error) {
+	snapshots := make([]benchmarkTargetSnapshot, 0, len(stagedHarnesses))
+	stageWrites := make([]benchmarkSetWrite, 0, len(stagedHarnesses))
+	promotions := make([]benchmarkPromotedPath, 0, len(stagedHarnesses))
+	for _, harness := range stagedHarnesses {
+		if err := ensureRootPathNoFollow(repoRootHandle, filepath.Dir(filepath.FromSlash(harness.targetPath)), false, 0); err != nil {
+			return nil, nil, nil, fmt.Errorf("write benchmark harness %s: %w", harness.targetPath, err)
+		}
+		targetAbs := filepath.Join(repoRoot, filepath.FromSlash(harness.targetPath))
+		snapshot, err := captureBenchmarkTargetSnapshot(repoRootHandle, targetAbs, harness.targetPath)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("write benchmark harness %s: %w", harness.targetPath, err)
+		}
+		snapshots = append(snapshots, snapshot)
+		stageWrites = append(stageWrites, benchmarkSetWrite{
+			targetPath: filepath.Join(stageRootRel, filepath.FromSlash(harness.targetPath)),
+			content:    harness.content,
+			perm:       snapshot.mode,
+			parentPerm: 0o755,
+			errorPath:  harness.targetPath,
+			errorLabel: "write benchmark harness",
+		})
+		promotions = append(promotions, benchmarkPromotedPath{
+			liveRel:      filepath.FromSlash(harness.targetPath),
+			stagedRel:    filepath.Join(stageRootRel, filepath.FromSlash(harness.targetPath)),
+			backupRel:    filepath.Join(backupRootRel, filepath.FromSlash(harness.targetPath)),
+			discardRel:   filepath.Join(stageRootRel, "discard", filepath.FromSlash(harness.targetPath)),
+			backupExists: snapshot.existed,
+			errorLabel:   "write benchmark harness " + harness.targetPath,
+		})
+	}
+	sort.Slice(stageWrites, func(i, j int) bool {
+		return stageWrites[i].targetPath < stageWrites[j].targetPath
+	})
+	return snapshots, stageWrites, promotions, nil
+}
+
+func captureBenchmarkTargetSnapshot(root *os.Root, targetAbs, targetPath string) (benchmarkTargetSnapshot, error) {
+	info, err := rootLstat(root, filepath.FromSlash(targetPath))
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return benchmarkTargetSnapshot{}, fmt.Errorf("target path is a symlink: %s", targetAbs)
+		}
+		if !info.Mode().IsRegular() {
+			return benchmarkTargetSnapshot{}, fmt.Errorf("target path is not a regular file: %s", targetAbs)
+		}
+		file, err := rootOpen(root, filepath.FromSlash(targetPath))
+		if err != nil {
+			return benchmarkTargetSnapshot{}, err
+		}
+		content, readErr := io.ReadAll(file)
+		closeErr := file.Close()
+		if readErr == nil && closeErr != nil {
+			readErr = closeErr
+		} else if closeErr != nil {
+			readErr = errors.Join(readErr, closeErr)
+		}
+		if readErr != nil {
+			return benchmarkTargetSnapshot{}, readErr
+		}
+		return benchmarkTargetSnapshot{
+			targetPath: targetPath,
+			absPath:    targetAbs,
+			content:    content,
+			mode:       info.Mode().Perm(),
+			existed:    true,
+		}, nil
+	case os.IsNotExist(err):
+		return benchmarkTargetSnapshot{
+			targetPath: targetPath,
+			absPath:    targetAbs,
+			mode:       0o600,
+			existed:    false,
+		}, nil
+	default:
+		return benchmarkTargetSnapshot{}, err
+	}
+}
+
+func existingRegularFilePerm(path string, fallback os.FileMode) (os.FileMode, error) {
+	info, err := os.Lstat(path)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return 0, fmt.Errorf("target path is a symlink: %s", path)
+		}
+		if !info.Mode().IsRegular() {
+			return 0, fmt.Errorf("target path is not a regular file: %s", path)
+		}
+		return info.Mode().Perm(), nil
+	case os.IsNotExist(err):
+		return fallback, nil
+	default:
+		return 0, err
+	}
+}
+
+func writeBenchmarkSet(root confinedWriteRoot, writes []benchmarkSetWrite, seam func(string) error) error {
+	for _, write := range writes {
+		if seam != nil {
+			if err := seam(filepath.ToSlash(write.targetPath)); err != nil {
+				return benchmarkWriteError(write, err)
+			}
+		}
+		if err := root.WriteFileCreatingParents(write.targetPath, write.content, write.perm, write.parentPerm); err != nil {
+			return benchmarkWriteError(write, err)
+		}
+	}
+	return nil
+}
+
+func benchmarkWriteError(write benchmarkSetWrite, err error) error {
+	if write.errorPath != "" {
+		return fmt.Errorf("%s %s: %w", write.errorLabel, filepath.ToSlash(write.errorPath), err)
+	}
+	return fmt.Errorf("%s: %w", write.errorLabel, err)
+}
+
+func promoteBenchmarkSet(root *os.Root, promotions []benchmarkPromotedPath, seam func(int, string) error) (returnErr error) {
+	for i := range promotions {
+		exists, err := rootPathExists(root, promotions[i].liveRel)
+		if err != nil {
+			return benchmarkRollbackCleanup(root, promotions, i-1, fmt.Errorf("%s: %w", promotions[i].errorLabel, err))
+		}
+		promotions[i].backupExists = promotions[i].backupExists || exists
+		if exists {
+			if err := renameWithinRoot(root, promotions[i].liveRel, promotions[i].backupRel); err != nil {
+				return benchmarkRollbackCleanup(root, promotions, i-1, fmt.Errorf("%s: %w", promotions[i].errorLabel, err))
+			}
+		}
+		if err := renameWithinRoot(root, promotions[i].stagedRel, promotions[i].liveRel); err != nil {
+			return benchmarkRollbackCleanup(root, promotions, i, fmt.Errorf("%s: %w", promotions[i].errorLabel, err))
+		}
+		promotions[i].promoted = true
+		if seam != nil {
+			if err := seam(i+1, filepath.ToSlash(promotions[i].liveRel)); err != nil {
+				return benchmarkRollbackCleanup(root, promotions, i, fmt.Errorf("%s: %w", promotions[i].errorLabel, err))
+			}
+		}
+	}
+	return nil
+}
+
+func benchmarkRollbackCleanup(root *os.Root, promotions []benchmarkPromotedPath, last int, cause error) error {
+	rollbackErr := rollbackBenchmarkPromotions(root, promotions, last)
+	if rollbackErr != nil {
+		return errors.Join(cause, rollbackErr)
+	}
+	return cause
+}
+
+func rollbackBenchmarkPromotions(root *os.Root, promotions []benchmarkPromotedPath, last int) (returnErr error) {
+	for i := last; i >= 0; i-- {
+		if promotions[i].promoted {
+			if err := renameWithinRoot(root, promotions[i].liveRel, promotions[i].discardRel); err != nil {
+				returnErr = errors.Join(returnErr, err)
+			}
+		}
+		if promotions[i].backupExists {
+			if err := renameWithinRoot(root, promotions[i].backupRel, promotions[i].liveRel); err != nil {
+				returnErr = errors.Join(returnErr, err)
+			}
+		}
+	}
+	return returnErr
+}
+
+func cleanupBenchmarkSetRoots(root *os.Root, relPaths ...string) (returnErr error) {
+	for _, relPath := range relPaths {
+		if strings.TrimSpace(relPath) == "" {
+			continue
+		}
+		if err := removeManifestSubtree(root, relPath); err != nil && !os.IsNotExist(err) {
+			returnErr = errors.Join(returnErr, err)
+		}
+	}
+	return returnErr
+}
+
+func openManifestRootNoFollow(rootDir string) (*os.Root, error) {
+	rootAbs, err := canonicalizeTrustedManifestRoot(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve root path: %w", err)
+	}
+	volumeRoot := filepath.VolumeName(rootAbs) + string(os.PathSeparator)
+	rel, err := relPath(volumeRoot, rootAbs)
+	if err != nil {
+		return nil, err
+	}
+	root, err := openOSRoot(volumeRoot)
+	if err != nil {
+		return nil, err
+	}
+	if rel == "." {
+		return root, nil
+	}
+
+	currentPath := volumeRoot
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		currentPath = filepath.Join(currentPath, part)
+		next, err := openRootChildNoFollow(root, part, currentPath)
+		if err != nil {
+			return nil, closeOSRootWithError(root, err)
+		}
+		if err := closeOSRoot(root); err != nil {
+			return nil, closeOSRootWithError(next, err)
+		}
+		root = next
+	}
+	return root, nil
+}
+
+func validateManifestRootPathNoFollow(rootDir string) error {
+	rootAbs, err := canonicalizeTrustedManifestRoot(rootDir)
+	if err != nil {
+		return fmt.Errorf("resolve root path: %w", err)
+	}
+	volumeRoot := filepath.VolumeName(rootAbs) + string(os.PathSeparator)
+	currentPath := filepath.Clean(volumeRoot)
+
+	info, err := os.Lstat(currentPath)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("root contains symlink: %s", currentPath)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("root is not a directory: %s", currentPath)
+	}
+
+	rel, err := relPath(volumeRoot, rootAbs)
+	if err != nil {
+		return err
+	}
+	if rel == "." {
+		return nil
+	}
+
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		currentPath = filepath.Join(currentPath, part)
+		info, err := os.Lstat(currentPath)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("root contains symlink: %s", currentPath)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("root is not a directory: %s", currentPath)
+		}
+	}
+	return nil
+}
+
+func canonicalizeTrustedManifestRoot(rootDir string) (string, error) {
+	rootAbs, err := absPath(rootDir)
+	if err != nil {
+		return "", err
+	}
+	for _, aliasRoot := range []string{"/tmp", "/var"} {
+		if !hasPathPrefix(rootAbs, aliasRoot) {
+			continue
+		}
+		canonicalAlias, err := evalSymlinks(aliasRoot)
+		if err != nil {
+			return "", err
+		}
+		rel, err := relPath(aliasRoot, rootAbs)
+		if err != nil {
+			return "", err
+		}
+		if rel == "." {
+			return canonicalAlias, nil
+		}
+		return filepath.Join(canonicalAlias, rel), nil
+	}
+	return rootAbs, nil
+}
+
+func hasPathPrefix(path, prefix string) bool {
+	cleanPath := filepath.Clean(path)
+	cleanPrefix := filepath.Clean(prefix)
+	return cleanPath == cleanPrefix || strings.HasPrefix(cleanPath, cleanPrefix+string(os.PathSeparator))
+}
+
+func openRootChildNoFollow(root *os.Root, name, path string) (*os.Root, error) {
+	info, err := rootLstat(root, name)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("root contains symlink: %s", path)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("root is not a directory: %s", path)
+	}
+
+	next, err := rootOpenRoot(root, name)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := rootLstat(next, ".")
+	if err != nil {
+		return nil, closeOSRootWithError(next, err)
+	}
+	if !sameFile(info, openedInfo) {
+		return nil, closeOSRootWithError(next, fmt.Errorf("root changed while opening: %s", path))
+	}
+	return next, nil
+}
+
+func closeOSRootWithError(root *os.Root, err error) error {
+	if closeErr := closeOSRoot(root); closeErr != nil {
+		return errors.Join(err, closeErr)
+	}
+	return err
+}
+
+func rootPathExists(root *os.Root, rel string) (bool, error) {
+	_, err := rootLstat(root, filepath.Clean(rel))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func renameWithinRoot(root *os.Root, fromRel, toRel string) error {
+	fromRel = filepath.Clean(fromRel)
+	toRel = filepath.Clean(toRel)
+	if err := ensureRootPathNoFollow(root, filepath.Dir(toRel), true, 0o755); err != nil {
+		return err
+	}
+	return rootRename(root, fromRel, toRel)
+}
+
+func ensureRootPathNoFollow(root *os.Root, rel string, create bool, perm os.FileMode) (returnErr error) {
+	rel = filepath.Clean(rel)
+	if rel == "." || rel == "" {
+		return nil
+	}
+
+	current := root
+	owned := false
+	currentPath := string(os.PathSeparator)
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		currentPath = filepath.Join(currentPath, part)
+		info, err := rootLstat(current, part)
+		if os.IsNotExist(err) && create {
+			if err := rootMkdir(current, part, perm); err != nil && !os.IsExist(err) {
+				return closeOwnedRootWithError(current, owned, err)
+			}
+			info, err = rootLstat(current, part)
+		}
+		if err != nil {
+			return closeOwnedRootWithError(current, owned, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return closeOwnedRootWithError(current, owned, fmt.Errorf("output parent contains symlink: %s", currentPath))
+		}
+		if !info.IsDir() {
+			return closeOwnedRootWithError(current, owned, fmt.Errorf("output parent is not a directory: %s", currentPath))
+		}
+		next, err := rootOpenRoot(current, part)
+		if err != nil {
+			return closeOwnedRootWithError(current, owned, err)
+		}
+		if owned {
+			if err := closeOSRoot(current); err != nil {
+				return closeOSRootWithError(next, err)
+			}
+		}
+		current = next
+		owned = true
+	}
+	if owned {
+		return closeOSRoot(current)
+	}
+	return nil
+}
+
+func closeOwnedRootWithError(root *os.Root, owned bool, err error) error {
+	if !owned {
+		return err
+	}
+	return closeOSRootWithError(root, err)
+}
+
+func removeManifestSubtree(root *os.Root, relPath string) error {
+	parts := strings.Split(filepath.FromSlash(relPath), string(os.PathSeparator))
+	return removeManifestSubtreeParts(root, parts, relPath)
+}
+
+func validateManifestSubtreePathNoFollow(root *os.Root, relPath string) error {
+	parts := strings.Split(filepath.FromSlash(relPath), string(os.PathSeparator))
+	return validateManifestSubtreePathParts(root, parts, relPath)
+}
+
+func validateManifestSubtreePathParts(root *os.Root, parts []string, displayPath string) error {
+	if len(parts) == 0 {
+		return nil
+	}
+	name := parts[0]
+	info, err := rootLstat(root, name)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(parts) > 1 {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("overlay path contains symlink: %s", filepath.Clean(displayPath))
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("overlay path component is not a directory: %s", filepath.Clean(displayPath))
+		}
+		child, err := openRootChildNoFollow(root, name, filepath.Clean(displayPath))
+		if err != nil {
+			return err
+		}
+		err = validateManifestSubtreePathParts(child, parts[1:], displayPath)
+		return closeOSRootWithError(child, err)
+	}
+	return nil
+}
+
+func removeManifestSubtreeParts(root *os.Root, parts []string, displayPath string) error {
+	if len(parts) == 0 {
+		return nil
+	}
+	name := parts[0]
+	info, err := rootLstat(root, name)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(parts) > 1 {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("overlay path contains symlink: %s", filepath.Clean(displayPath))
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("overlay path component is not a directory: %s", filepath.Clean(displayPath))
+		}
+		child, err := openRootChildNoFollow(root, name, filepath.Clean(displayPath))
+		if err != nil {
+			return err
+		}
+		err = removeManifestSubtreeParts(child, parts[1:], displayPath)
+		return closeOSRootWithError(child, err)
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		if err := rootRemove(root, name); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+
+	child, err := openRootChildNoFollow(root, name, filepath.Clean(displayPath))
+	if err != nil {
+		return err
+	}
+	dir, err := rootOpen(child, ".")
+	if err != nil {
+		return closeOSRootWithError(child, err)
+	}
+	entries, err := dir.ReadDir(-1)
+	closeErr := dir.Close()
+	if err == nil && closeErr != nil {
+		err = closeErr
+	} else if closeErr != nil {
+		err = errors.Join(err, closeErr)
+	}
+	if err != nil {
+		return closeOSRootWithError(child, err)
+	}
+	for _, entry := range entries {
+		if err := removeManifestSubtreeParts(child, []string{entry.Name()}, filepath.Join(displayPath, entry.Name())); err != nil {
+			return closeOSRootWithError(child, err)
+		}
+	}
+	if err := closeOSRoot(child); err != nil {
+		return err
+	}
+	if err := rootRemove(root, name); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func normalizeDefinitionPaths(definition *benchmarkDefinition) error {
+	overlayDir, err := normalizeManifestRelativePath("overlay directory", definition.OverlayDir)
+	if err != nil {
+		return err
+	}
+	definition.OverlayDir = overlayDir
+	seenTargets := make(map[string]int, len(definition.HarnessFiles))
+	seenOverlays := make(map[string]int, len(definition.HarnessFiles))
+	for i := range definition.HarnessFiles {
+		targetPath, err := normalizeManifestRelativePath("benchmark harness path", definition.HarnessFiles[i].Path)
+		if err != nil {
+			return err
+		}
+		overlayPath, err := normalizeManifestRelativePath("benchmark harness overlay path", definition.HarnessFiles[i].OverlayPath)
+		if err != nil {
+			return err
+		}
+		if firstIndex, exists := seenTargets[targetPath]; exists {
+			return fmt.Errorf("duplicate benchmark harness path %q at entries %d and %d", targetPath, firstIndex+1, i+1)
+		}
+		if firstIndex, exists := seenOverlays[overlayPath]; exists {
+			return fmt.Errorf("duplicate benchmark harness overlay path %q at entries %d and %d", overlayPath, firstIndex+1, i+1)
+		}
+		seenTargets[targetPath] = i
+		seenOverlays[overlayPath] = i
+		definition.HarnessFiles[i].Path = targetPath
+		definition.HarnessFiles[i].OverlayPath = overlayPath
+	}
+	return nil
+}
+
+func validateBenchmarkHarnessTargets(repoRoot string, definition benchmarkDefinition) error {
+	allowedTargets := make(map[string]struct{}, len(definition.HarnessFiles))
+	packagePrefixes := make([]string, 0, len(definition.PackageTargets))
+	for _, packageTarget := range definition.PackageTargets {
+		packageDir, err := packageTargetDir(repoRoot, packageTarget)
+		if err != nil {
+			return err
+		}
+		packagePrefix := filepath.ToSlash(strings.TrimPrefix(packageDir, repoRoot+string(filepath.Separator)))
+		packagePrefixes = append(packagePrefixes, packagePrefix)
+	}
+	for _, harness := range definition.HarnessFiles {
+		if !strings.HasSuffix(harness.Path, "_test.go") {
+			return fmt.Errorf("benchmark harness path must reference a package _test.go file: %s", harness.Path)
+		}
+		if !pathUnderAnyPrefix(harness.Path, packagePrefixes) {
+			return fmt.Errorf("benchmark harness path %q is outside benchmark package targets", harness.Path)
+		}
+		allowedTargets[harness.Path] = struct{}{}
+	}
+
+	unexpected := make([]string, 0)
+	for i, packageTarget := range definition.PackageTargets {
+		packageDir, err := packageTargetDir(repoRoot, packageTarget)
+		if err != nil {
+			return err
+		}
+		info, err := os.Lstat(packageDir)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("inspect package %s: %w", packageTarget, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("inspect package %s: package directory is not a directory: %s", packageTarget, packageDir)
+		}
+
+		entries, err := readDir(packageDir)
+		if err != nil {
+			return fmt.Errorf("read package %s: %w", packageTarget, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+				continue
+			}
+			targetPath := packagePrefixes[i] + "/" + entry.Name()
+			if _, ok := allowedTargets[targetPath]; !ok {
+				unexpected = append(unexpected, targetPath)
+			}
+		}
+	}
+	if len(unexpected) > 0 {
+		slices.Sort(unexpected)
+		return fmt.Errorf("package test files not in benchmark manifest: %s", strings.Join(unexpected, ", "))
+	}
+	return nil
+}
+
+func pathUnderAnyPrefix(path string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if hasPathPrefix(filepath.FromSlash(path), filepath.FromSlash(prefix)) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeManifestRelativePath(label, value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", fmt.Errorf("%s must not be empty", label)
+	}
+	if filepath.IsAbs(filepath.FromSlash(trimmed)) {
+		return "", fmt.Errorf("%s must be relative: %s", label, value)
+	}
+	cleaned := filepath.Clean(filepath.FromSlash(trimmed))
+	switch {
+	case cleaned == ".", cleaned == "":
+		return "", fmt.Errorf("%s must not resolve to the root directory: %s", label, value)
+	case cleaned == "..", strings.HasPrefix(cleaned, ".."+string(filepath.Separator)):
+		return "", fmt.Errorf("%s escapes its root: %s", label, value)
+	}
+	return filepath.ToSlash(cleaned), nil
+}
+
+func executeBenchmarkDefinition(repoPath string, definition benchmarkDefinition, ldflags string) ([]byte, error) {
+	args := []string{"test"}
+	if ldflags != "" {
+		args = append(args, "-ldflags", ldflags)
+	}
+	args = append(args, "-run", definition.RunPattern, "-bench", definition.BenchPattern)
+	if definition.BenchMem {
+		args = append(args, "-benchmem")
+	}
+	args = append(args, "-count", strconv.Itoa(definition.Count), "-benchtime", definition.Benchtime)
+	args = append(args, definition.PackageTargets...)
+
+	cmd := exec.Command("go", args...)
+	cmd.Dir = repoPath
+	cmd.Env = withGoFlagsDisabledBuildVCS(os.Environ())
+	return cmd.CombinedOutput()
+}
+
+func withGoFlagsDisabledBuildVCS(env []string) []string {
+	result := make([]string, 0, len(env)+1)
+	replaced := false
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, "GOFLAGS=") {
+			result = append(result, entry)
+			continue
+		}
+		value := strings.TrimPrefix(entry, "GOFLAGS=")
+		if !strings.Contains(value, "-buildvcs=false") {
+			value = strings.TrimSpace(value + " -buildvcs=false")
+		}
+		result = append(result, "GOFLAGS="+value)
+		replaced = true
+	}
+	if !replaced {
+		result = append(result, "GOFLAGS=-buildvcs=false")
+	}
+	return result
+}
+
+func gitHeadCommit(repoRoot string) (string, error) {
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "HEAD")
+	cmd.Env = envWithoutGitOverrides(os.Environ())
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func gitStatusPorcelainV2HasPaths(repoRoot string, paths []string) (bool, error) {
+	if len(paths) == 0 {
+		return false, nil
+	}
+	args := []string{
+		"-C", repoRoot,
+		"status",
+		"--porcelain=v2",
+		"-z",
+		"--untracked-files=all",
+		"--ignored=no",
+		"--no-renames",
+		"--",
+	}
+	args = append(args, paths...)
+	// #nosec G204 -- repo-local git status is constrained to explicit subcommands and normalized repository-relative paths.
+	cmd := exec.Command("git", args...)
+	cmd.Env = envWithoutGitOverrides(os.Environ())
+	output, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	return len(output) != 0, nil
+}
+
+func envWithoutGitOverrides(env []string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "GIT_") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func formatDefinitionMetadata(definitionPath string, definition benchmarkDefinition, digest string) string {
+	var buf strings.Builder
+	buf.WriteString("lopper-bench-definition: ")
+	buf.WriteString(definitionPath)
+	buf.WriteByte('\n')
+	buf.WriteString("lopper-bench-definition-sha256: ")
+	buf.WriteString(digest)
+	buf.WriteByte('\n')
+	buf.WriteString("lopper-bench-resolved-from: ")
+	buf.WriteString(definition.ResolvedFrom)
+	buf.WriteByte('\n')
+	if strings.TrimSpace(definition.ResolvedCommit) != "" {
+		buf.WriteString("lopper-bench-resolved-commit: ")
+		buf.WriteString(definition.ResolvedCommit)
+		buf.WriteByte('\n')
+	}
+	buf.WriteString("lopper-bench-packages: ")
+	buf.WriteString(strings.Join(definition.PackageTargets, ","))
+	buf.WriteByte('\n')
+	buf.WriteString("lopper-bench-selection: ")
+	buf.WriteString(definition.BenchPattern)
+	buf.WriteByte('\n')
+	buf.WriteString("lopper-bench-run: ")
+	buf.WriteString(definition.RunPattern)
+	buf.WriteByte('\n')
+	buf.WriteString("lopper-bench-count: ")
+	buf.WriteString(strconv.Itoa(definition.Count))
+	buf.WriteByte('\n')
+	buf.WriteString("lopper-bench-benchtime: ")
+	buf.WriteString(definition.Benchtime)
+	buf.WriteByte('\n')
+	buf.WriteString("lopper-bench-benchmem: ")
+	buf.WriteString(strconv.FormatBool(definition.BenchMem))
+	buf.WriteByte('\n')
+	for _, harness := range definition.HarnessFiles {
+		buf.WriteString("lopper-bench-harness: ")
+		buf.WriteString(harness.Path)
+		buf.WriteByte(' ')
+		buf.WriteString(harness.SHA256)
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}
+
+func definitionDigest(content []byte) string {
+	return bytesDigest(content)
+}
+
+func bytesDigest(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}

--- a/tools/benchdelta/definition_coverage_test.go
+++ b/tools/benchdelta/definition_coverage_test.go
@@ -1,0 +1,454 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalize temp dir: %v", err)
+	}
+	return dir
+}
+
+func TestRunCompareCommandReturnsFlagParseError(t *testing.T) {
+	if err := runCompareCommand([]string{"-unknown"}); err == nil {
+		t.Fatal("expected flag parse error")
+	}
+}
+
+func TestRunCompareCommandReturnsHeadParseError(t *testing.T) {
+	dir, basePath, _ := writeMatchingBenchmarkFixtures(t)
+
+	err := runCompareCommand([]string{
+		"-base", basePath,
+		"-head", filepath.Join(dir, "missing.txt"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "parse head benchmarks") {
+		t.Fatalf("expected head benchmark parse error, got %v", err)
+	}
+}
+
+func TestRunCompareCommandReturnsNilForMatchingBenchmarks(t *testing.T) {
+	_, basePath, headPath := writeMatchingBenchmarkFixtures(t)
+
+	if err := runCompareCommand([]string{"-base", basePath, "-head", headPath}); err != nil {
+		t.Fatalf("runCompareCommand returned error: %v", err)
+	}
+}
+
+func TestParseBenchmarkFileSkipsInvalidBenchmarkLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	lines := []string{
+		"goos: darwin",
+		"pkg: example.com/benchrepo/benchpkg",
+		"BenchmarkBroken-8 1000 25000 ns/op",
+		"BenchmarkValid-8 1000 25000 ns/op 128 B/op 3 allocs/op",
+	}
+	content := strings.Join(lines, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write benchmark file: %v", err)
+	}
+
+	data, err := parseBenchmarkFile(path)
+	if err != nil {
+		t.Fatalf("parseBenchmarkFile returned error: %v", err)
+	}
+	if len(data.data) != 1 {
+		t.Fatalf("benchmark entries = %#v, want 1", data.data)
+	}
+}
+
+func TestParseBenchmarkFileReturnsScannerError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	content := "pkg: example.com/benchrepo/benchpkg\n" + strings.Repeat("a", 70*1024) + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write oversized benchmark file: %v", err)
+	}
+
+	if _, err := parseBenchmarkFile(path); err == nil || !strings.Contains(err.Error(), "token too long") {
+		t.Fatalf("expected scanner error, got %v", err)
+	}
+}
+
+func TestRunResolveCommandDefaultsOverlayDir(t *testing.T) {
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {}
+`,
+		},
+		commit: true,
+	})
+	artifactDir := canonicalTempDir(t)
+	definitionPath := filepath.Join(artifactDir, "artifacts", "definition.json")
+
+	if err := runResolveCommand([]string{
+		"-repo", headRepo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", definitionPath,
+	}); err != nil {
+		t.Fatalf("runResolveCommand returned error: %v", err)
+	}
+
+	definition, _, err := readBenchmarkDefinition(definitionPath)
+	if err != nil {
+		t.Fatalf("readBenchmarkDefinition returned error: %v", err)
+	}
+	if definition.OverlayDir != defaultOverlayDir {
+		t.Fatalf("overlay dir = %q, want %q", definition.OverlayDir, defaultOverlayDir)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(definitionPath), defaultOverlayDir, "benchpkg", "head_benchmark_test.go")); err != nil {
+		t.Fatalf("expected default overlay file to exist: %v", err)
+	}
+}
+
+func TestRunResolveCommandWrapsResolutionError(t *testing.T) {
+	repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {}
+`,
+		},
+	})
+
+	err := runResolveCommand([]string{
+		"-repo", repo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", filepath.Join(t.TempDir(), "definition.json"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "resolve benchmark definition: resolve HEAD commit") {
+		t.Fatalf("expected wrapped resolution error, got %v", err)
+	}
+}
+
+func TestRunResolveCommandReturnsWriteError(t *testing.T) {
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {}
+`,
+		},
+		commit: true,
+	})
+	blocker := filepath.Join(canonicalTempDir(t), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	err := runResolveCommand([]string{
+		"-repo", headRepo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", filepath.Join(blocker, "definition.json"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "root is not a directory") {
+		t.Fatalf("expected definition write error, got %v", err)
+	}
+}
+
+func TestRunBenchmarkCommandReturnsApplyError(t *testing.T) {
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {}
+`,
+		},
+		commit: true,
+	})
+	definition, overlayFiles, err := resolveBenchmarkDefinition(headRepo, []string{"./benchpkg"}, 1, "1x")
+	if err != nil {
+		t.Fatalf("resolveBenchmarkDefinition returned error: %v", err)
+	}
+
+	artifactDir := canonicalTempDir(t)
+	definitionPath := filepath.Join(artifactDir, "definition.json")
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	definition.OverlayDir = filepath.Base(overlayDir)
+	if err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, overlayFiles); err != nil {
+		t.Fatalf("writeBenchmarkDefinition returned error: %v", err)
+	}
+	if err := os.Remove(filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go")); err != nil {
+		t.Fatalf("remove overlay file: %v", err)
+	}
+
+	err = runBenchmarkCommand([]string{
+		"-repo", t.TempDir(),
+		"-definition", definitionPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "apply benchmark definition: read overlay file") {
+		t.Fatalf("expected wrapped apply error, got %v", err)
+	}
+}
+
+func TestMainReturnsAfterResolveCommand(t *testing.T) {
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {}
+`,
+		},
+		commit: true,
+	})
+	definitionPath := filepath.Join(canonicalTempDir(t), "definition.json")
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{
+		oldArgs[0],
+		"resolve",
+		"-repo", headRepo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", definitionPath,
+	}
+
+	main()
+
+	if _, err := os.Stat(definitionPath); err != nil {
+		t.Fatalf("expected definition output from main resolve path: %v", err)
+	}
+}
+
+func TestMainReturnsAfterRunCommand(t *testing.T) {
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {}
+`,
+		},
+		commit: true,
+	})
+	definition, overlayFiles, err := resolveBenchmarkDefinition(headRepo, []string{"./benchpkg"}, 1, "1x")
+	if err != nil {
+		t.Fatalf("resolveBenchmarkDefinition returned error: %v", err)
+	}
+	artifactDir := canonicalTempDir(t)
+	definitionPath := filepath.Join(artifactDir, "definition.json")
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	definition.OverlayDir = filepath.Base(overlayDir)
+	if err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, overlayFiles); err != nil {
+		t.Fatalf("writeBenchmarkDefinition returned error: %v", err)
+	}
+
+	baseRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+		},
+	})
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{
+		oldArgs[0],
+		"run",
+		"-repo", baseRepo,
+		"-definition", definitionPath,
+	}
+
+	main()
+}
+
+func TestResolveBenchmarkDefinitionDeduplicatesHarnessFiles(t *testing.T) {
+	repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkZulu(b *testing.B) {}
+func BenchmarkAlpha(b *testing.B) {}
+`,
+		},
+		commit: true,
+	})
+
+	definition, overlayFiles, err := resolveBenchmarkDefinition(repo, []string{"./benchpkg", "./benchpkg"}, 1, "1x")
+	if err != nil {
+		t.Fatalf("resolveBenchmarkDefinition returned error: %v", err)
+	}
+
+	if len(definition.HarnessFiles) != 1 {
+		t.Fatalf("harness files = %#v, want 1", definition.HarnessFiles)
+	}
+	if len(overlayFiles) != 1 {
+		t.Fatalf("overlay files = %#v, want 1", overlayFiles)
+	}
+	names := make([]string, 0, len(definition.Benchmarks))
+	for _, benchmark := range definition.Benchmarks {
+		names = append(names, benchmark.Name)
+	}
+	if want := []string{"BenchmarkAlpha", "BenchmarkAlpha", "BenchmarkZulu", "BenchmarkZulu"}; !slices.Equal(names, want) {
+		t.Fatalf("benchmark names = %#v, want %#v", names, want)
+	}
+	if definition.BenchPattern != "^(BenchmarkAlpha|BenchmarkZulu)$" {
+		t.Fatalf("bench pattern = %q", definition.BenchPattern)
+	}
+}
+
+func TestResolvePackageBenchmarksIncludesHelperOnlyAndTestMainFiles(t *testing.T) {
+	repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/bench_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkValid(b *testing.B) {}
+`,
+			"benchpkg/goleak_test.go": `package benchpkg
+
+import "testing"
+
+func TestMain(m *testing.M) {
+	testing.Init()
+	m.Run()
+}
+`,
+			"benchpkg/helpers_test.go": `package benchpkg
+
+func benchmarkHelperName() string { return "helper" }
+`,
+		},
+	})
+
+	harnesses, benchmarks, err := resolvePackageBenchmarks(repo, "./benchpkg")
+	if err != nil {
+		t.Fatalf("resolvePackageBenchmarks returned error: %v", err)
+	}
+
+	wantHarnessPaths := []string{
+		"benchpkg/bench_test.go",
+		"benchpkg/goleak_test.go",
+		"benchpkg/helpers_test.go",
+	}
+	gotHarnessPaths := make([]string, 0, len(harnesses))
+	for _, harness := range harnesses {
+		gotHarnessPaths = append(gotHarnessPaths, harness.Path)
+	}
+	if !slices.Equal(gotHarnessPaths, wantHarnessPaths) {
+		t.Fatalf("harness paths = %#v, want %#v", gotHarnessPaths, wantHarnessPaths)
+	}
+	if want := []string{"BenchmarkValid"}; !slices.Equal(benchmarks, want) {
+		t.Fatalf("benchmarks = %#v, want %#v", benchmarks, want)
+	}
+}
+
+func TestResolvePackageBenchmarksRejectsRootTarget(t *testing.T) {
+	if _, _, err := resolvePackageBenchmarks(t.TempDir(), "."); err == nil || !strings.Contains(err.Error(), "repo root") {
+		t.Fatalf("expected repo root rejection, got %v", err)
+	}
+}
+
+func TestBenchmarkFunctionsInFileSkipsStarIdentParameter(t *testing.T) {
+	repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkStarIdent(b *testing) {}
+func BenchmarkValid(b *testing.B) {}
+`,
+		},
+	})
+
+	names, err := benchmarkFunctionsInFile(filepath.Join(repo, "benchpkg", "head_benchmark_test.go"))
+	if err != nil {
+		t.Fatalf("benchmarkFunctionsInFile returned error: %v", err)
+	}
+	if want := []string{"BenchmarkValid"}; !slices.Equal(names, want) {
+		t.Fatalf("benchmark names = %#v, want %#v", names, want)
+	}
+}
+
+func TestWriteBenchmarkDefinitionReturnsOverlayCreateError(t *testing.T) {
+	parent := canonicalTempDir(t)
+	blocker := filepath.Join(parent, "blocked")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(blocker, "overlay"), benchmarkDefinition{Version: definitionVersion}, nil)
+	if err == nil || (!strings.Contains(err.Error(), "clear benchmark overlay") && !strings.Contains(err.Error(), "create benchmark overlay")) {
+		t.Fatalf("expected overlay setup error, got %v", err)
+	}
+}
+
+func TestWriteBenchmarkDefinitionReturnsEmptyOverlayDirError(t *testing.T) {
+	err := writeBenchmarkDefinition(filepath.Join(canonicalTempDir(t), "definition.json"), "", benchmarkDefinition{Version: definitionVersion}, nil)
+	if err == nil || !strings.Contains(err.Error(), "overlay directory escapes its root") {
+		t.Fatalf("expected empty overlay dir error, got %v", err)
+	}
+}
+
+func TestWriteBenchmarkDefinitionReturnsOverlaySubdirCreateError(t *testing.T) {
+	parent := canonicalTempDir(t)
+	if err := os.WriteFile(filepath.Join(parent, "blocked"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, map[string][]byte{"../blocked/child.go": []byte("package benchpkg\n")})
+	if err == nil || !strings.Contains(err.Error(), "overlay file path escapes its root") {
+		t.Fatalf("expected overlay subdir create error, got %v", err)
+	}
+}
+
+func TestWriteBenchmarkDefinitionReturnsOverlayWriteError(t *testing.T) {
+	parent := canonicalTempDir(t)
+	err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, map[string][]byte{".": []byte("package benchpkg\n")})
+	if err == nil || !strings.Contains(err.Error(), "overlay file path must not resolve to the root directory") {
+		t.Fatalf("expected overlay write error, got %v", err)
+	}
+}
+
+func TestWriteBenchmarkDefinitionReturnsManifestWriteError(t *testing.T) {
+	parent := canonicalTempDir(t)
+	outPath := filepath.Join(parent, "definition.json")
+	if err := os.MkdirAll(outPath, 0o755); err != nil {
+		t.Fatalf("mkdir out path: %v", err)
+	}
+
+	err := writeBenchmarkDefinition(outPath, filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, nil)
+	if err == nil || !strings.Contains(err.Error(), "write benchmark definition") {
+		t.Fatalf("expected manifest write error, got %v", err)
+	}
+}

--- a/tools/benchdelta/definition_coverage_test.go
+++ b/tools/benchdelta/definition_coverage_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 func canonicalTempDir(t *testing.T) string {
@@ -451,4 +454,1540 @@ func TestWriteBenchmarkDefinitionReturnsManifestWriteError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "write benchmark definition") {
 		t.Fatalf("expected manifest write error, got %v", err)
 	}
+}
+
+func TestBenchmarkFunctionsInFileReturnsFileTooLarge(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oversized_benchmark_test.go")
+	if err := os.WriteFile(path, []byte(strings.Repeat("a", maxBenchmarkHarnessBytes+1)), 0o600); err != nil {
+		t.Fatalf("write oversized benchmark file: %v", err)
+	}
+
+	_, err := benchmarkFunctionsInFile(path)
+	if !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected ErrFileTooLarge, got %v", err)
+	}
+}
+
+func TestOpenPackageTargetRootNoFollowReturnsRelativePathError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		repoRoot := t.TempDir()
+		repoRootHandle, err := os.OpenRoot(repoRoot)
+		if err != nil {
+			t.Fatalf("open repo root: %v", err)
+		}
+		defer func() {
+			if closeErr := repoRootHandle.Close(); closeErr != nil {
+				t.Fatalf("close repo root: %v", closeErr)
+			}
+		}()
+
+		relPath = func(string, string) (string, error) {
+			return "", errors.New("relative package path failed")
+		}
+
+		_, _, packageRoot, err := openPackageTargetRootNoFollow(repoRoot, repoRootHandle, "./benchpkg")
+		if packageRoot != nil {
+			t.Fatal("expected nil package root on relative-path failure")
+		}
+		if err == nil || !strings.Contains(err.Error(), "relative package path failed") {
+			t.Fatalf("expected relative-path error, got %v", err)
+		}
+	})
+}
+
+func TestOpenPackageTargetRootNoFollowReturnsOwnedRootCloseError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, "pkgroot", "benchpkg"), 0o755); err != nil {
+			t.Fatalf("mkdir package root: %v", err)
+		}
+		repoRootHandle, err := os.OpenRoot(repoRoot)
+		if err != nil {
+			t.Fatalf("open repo root: %v", err)
+		}
+		defer func() {
+			if closeErr := repoRootHandle.Close(); closeErr != nil {
+				t.Fatalf("close repo root: %v", closeErr)
+			}
+		}()
+
+		closeCalls := 0
+		closeOSRoot = func(root *os.Root) error {
+			closeCalls++
+			if closeCalls == 1 {
+				return errors.New("close owned root failed")
+			}
+			return root.Close()
+		}
+
+		_, _, packageRoot, err := openPackageTargetRootNoFollow(repoRoot, repoRootHandle, "./pkgroot/benchpkg")
+		if packageRoot != nil {
+			t.Fatal("expected nil package root on owned-root close failure")
+		}
+		if err == nil || !strings.Contains(err.Error(), "close owned root failed") {
+			t.Fatalf("expected owned-root close error, got %v", err)
+		}
+	})
+}
+
+func TestReadRootDirReturnsOpenError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		root, err := os.OpenRoot(t.TempDir())
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			return nil, errors.New("open dir failed")
+		}
+
+		if _, err := readRootDir(root); err == nil || !strings.Contains(err.Error(), "open dir failed") {
+			t.Fatalf("expected readRootDir open error, got %v", err)
+		}
+	})
+}
+
+func TestReadCapturedHarnessBytesReturnsTotalLimitError(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootDir, "bench_test.go"), []byte("package benchpkg\n"), 0o600); err != nil {
+		t.Fatalf("write harness file: %v", err)
+	}
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	remainingBytes := int64(4)
+	_, err = readCapturedHarnessBytes(root, "bench_test.go", &remainingBytes)
+	if err == nil || !strings.Contains(err.Error(), "captured benchmark harness bytes exceed total limit") {
+		t.Fatalf("expected total-limit error, got %v", err)
+	}
+}
+
+func TestReadRootFileLimitReturnsOpenError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		root, err := os.OpenRoot(t.TempDir())
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			return nil, errors.New("open file failed")
+		}
+
+		if _, err := readRootFileLimit(root, "bench_test.go", 16); err == nil || !strings.Contains(err.Error(), "open file failed") {
+			t.Fatalf("expected root open error, got %v", err)
+		}
+	})
+}
+
+func TestReadRootFileLimitReturnsFileTooLargeFromStat(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootDir, "bench_test.go"), []byte(strings.Repeat("a", 32)), 0o600); err != nil {
+		t.Fatalf("write harness file: %v", err)
+	}
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	_, err = readRootFileLimit(root, "bench_test.go", 8)
+	if !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected ErrFileTooLarge, got %v", err)
+	}
+}
+
+func TestCreateBenchmarkTempDirReturnsError(t *testing.T) {
+	if _, err := createBenchmarkTempDir(filepath.Join(t.TempDir(), "missing"), ".benchdelta-test-"); err == nil {
+		t.Fatal("expected temp-dir creation error")
+	}
+}
+
+func TestCaptureBenchmarkTargetSnapshotReturnsMissingSnapshot(t *testing.T) {
+	rootDir := t.TempDir()
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	snapshot, err := captureBenchmarkTargetSnapshot(root, filepath.Join(rootDir, "benchpkg", "bench_test.go"), "benchpkg/bench_test.go")
+	if err != nil {
+		t.Fatalf("captureBenchmarkTargetSnapshot returned error: %v", err)
+	}
+	if snapshot.existed {
+		t.Fatalf("snapshot.existed = %v, want false", snapshot.existed)
+	}
+	if snapshot.mode != 0o600 {
+		t.Fatalf("snapshot.mode = %o, want %o", snapshot.mode, 0o600)
+	}
+}
+
+func TestCaptureBenchmarkTargetSnapshotRejectsNonRegularTarget(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(rootDir, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir package dir: %v", err)
+	}
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	_, err = captureBenchmarkTargetSnapshot(root, filepath.Join(rootDir, "benchpkg"), "benchpkg")
+	if err == nil || !strings.Contains(err.Error(), "target path is not a regular file") {
+		t.Fatalf("expected non-regular target rejection, got %v", err)
+	}
+}
+
+func TestCaptureBenchmarkTargetSnapshotReturnsOpenError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(rootDir, "bench_test.go"), []byte("package benchpkg\n"), 0o600); err != nil {
+			t.Fatalf("write harness file: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			return nil, errors.New("open snapshot target failed")
+		}
+
+		_, err = captureBenchmarkTargetSnapshot(root, filepath.Join(rootDir, "bench_test.go"), "bench_test.go")
+		if err == nil || !strings.Contains(err.Error(), "open snapshot target failed") {
+			t.Fatalf("expected snapshot open error, got %v", err)
+		}
+	})
+}
+
+func TestPromoteBenchmarkSetReturnsLivePathLookupError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		root, err := os.OpenRoot(t.TempDir())
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootLstat = func(*os.Root, string) (os.FileInfo, error) {
+			return nil, errors.New("live path lookup failed")
+		}
+
+		promotions := []benchmarkPromotedPath{{
+			liveRel:    "overlay",
+			stagedRel:  "stage/overlay",
+			backupRel:  "backup/overlay",
+			errorLabel: "clear benchmark overlay",
+		}}
+		err = promoteBenchmarkSet(root, promotions, nil)
+		if err == nil || !strings.Contains(err.Error(), "clear benchmark overlay: live path lookup failed") {
+			t.Fatalf("expected live-path lookup error, got %v", err)
+		}
+	})
+}
+
+func TestBenchmarkRollbackCleanupJoinsRollbackError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(rootDir, "live"), 0o755); err != nil {
+			t.Fatalf("mkdir live dir: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(rootDir, "backup"), 0o755); err != nil {
+			t.Fatalf("mkdir backup dir: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootRename = func(*os.Root, string, string) error {
+			return errors.New("rollback rename failed")
+		}
+
+		promotions := []benchmarkPromotedPath{{
+			liveRel:      "live/current",
+			discardRel:   "discard/current",
+			backupRel:    "backup/current",
+			promoted:     true,
+			backupExists: true,
+		}}
+		err = benchmarkRollbackCleanup(root, promotions, 0, errors.New("promote failed"))
+		if err == nil || !strings.Contains(err.Error(), "promote failed") || !strings.Contains(err.Error(), "rollback rename failed") {
+			t.Fatalf("expected joined rollback cleanup error, got %v", err)
+		}
+	})
+}
+
+func TestCleanupBenchmarkSetRootsSkipsEmptyPathAndJoinsErrors(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "overlay"), 0o755); err != nil {
+			t.Fatalf("mkdir overlay dir: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootRemove = func(*os.Root, string) error {
+			return errors.New("cleanup remove failed")
+		}
+
+		err = cleanupBenchmarkSetRoots(root, "", "overlay")
+		if err == nil || !strings.Contains(err.Error(), "cleanup remove failed") {
+			t.Fatalf("expected cleanup error, got %v", err)
+		}
+	})
+}
+
+func TestValidateManifestRootPathNoFollowReturnsMissingDescendantNil(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := validateManifestRootPathNoFollow(filepath.Join(rootDir, "missing", "child")); err != nil {
+		t.Fatalf("expected missing descendant to be allowed, got %v", err)
+	}
+}
+
+func TestValidateManifestRootPathNoFollowRejectsNonDirectoryDescendant(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootDir, "file"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file descendant: %v", err)
+	}
+
+	err := validateManifestRootPathNoFollow(filepath.Join(rootDir, "file", "child"))
+	if err == nil || !strings.Contains(err.Error(), "root is not a directory") {
+		t.Fatalf("expected non-directory descendant rejection, got %v", err)
+	}
+}
+
+func TestCanonicalizeTrustedManifestRootReturnsAliasRoot(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absPath = func(string) (string, error) { return "/tmp", nil }
+		evalSymlinks = func(string) (string, error) { return "/private/tmp", nil }
+		relPath = func(string, string) (string, error) { return ".", nil }
+
+		got, err := canonicalizeTrustedManifestRoot("ignored")
+		if err != nil {
+			t.Fatalf("canonicalizeTrustedManifestRoot returned error: %v", err)
+		}
+		if got != "/private/tmp" {
+			t.Fatalf("canonicalized root = %q, want %q", got, "/private/tmp")
+		}
+	})
+}
+
+func TestCanonicalizeTrustedManifestRootReturnsAliasEvalError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absPath = func(string) (string, error) { return "/tmp/work", nil }
+		evalSymlinks = func(string) (string, error) { return "", errors.New("alias eval failed") }
+
+		if _, err := canonicalizeTrustedManifestRoot("ignored"); err == nil || !strings.Contains(err.Error(), "alias eval failed") {
+			t.Fatalf("expected alias eval error, got %v", err)
+		}
+	})
+}
+
+func TestOpenManifestRootNoFollowReturnsVolumeRoot(t *testing.T) {
+	root, err := openManifestRootNoFollow(string(os.PathSeparator))
+	if err != nil {
+		t.Fatalf("openManifestRootNoFollow returned error: %v", err)
+	}
+	if err := root.Close(); err != nil {
+		t.Fatalf("close root: %v", err)
+	}
+}
+
+func TestValidateManifestRootPathNoFollowReturnsRelativePathError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		relPath = func(string, string) (string, error) {
+			return "", errors.New("manifest relative failed")
+		}
+
+		err := validateManifestRootPathNoFollow(filepath.Join(rootDir, "nested"))
+		if err == nil || !strings.Contains(err.Error(), "manifest relative failed") {
+			t.Fatalf("expected relative-path error, got %v", err)
+		}
+	})
+}
+
+func TestValidateManifestRootPathNoFollowReturnsCanonicalizeError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absPath = func(string) (string, error) {
+			return "", errors.New("manifest resolve failed")
+		}
+
+		err := validateManifestRootPathNoFollow("ignored")
+		if err == nil || !strings.Contains(err.Error(), "resolve root path: manifest resolve failed") {
+			t.Fatalf("expected canonicalize error, got %v", err)
+		}
+	})
+}
+
+func TestReadRootFileLimitReturnsReadError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		root, err := os.OpenRoot(t.TempDir())
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			return os.Open(t.TempDir())
+		}
+
+		if _, err := readRootFileLimit(root, "bench_test.go", 16); err == nil || !strings.Contains(err.Error(), "is a directory") {
+			t.Fatalf("expected read error, got %v", err)
+		}
+	})
+}
+
+func TestExistingRegularFilePermRejectsSymlink(t *testing.T) {
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	rootDir := t.TempDir()
+	target := filepath.Join(rootDir, "target.txt")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	link := filepath.Join(rootDir, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	if _, err := existingRegularFilePerm(link, 0o600); err == nil || !strings.Contains(err.Error(), "target path is a symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func TestPromoteBenchmarkSetReturnsBackupRenameError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(rootDir, "overlay"), 0o755); err != nil {
+			t.Fatalf("mkdir overlay dir: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(rootDir, "backup"), 0o755); err != nil {
+			t.Fatalf("mkdir backup dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(rootDir, "overlay", "live.txt"), []byte("live"), 0o600); err != nil {
+			t.Fatalf("write live file: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		realRootRename := rootRename
+		rootRename = func(root *os.Root, oldName, newName string) error {
+			if oldName == filepath.Clean("overlay/live.txt") && newName == filepath.Clean("backup/live.txt") {
+				return errors.New("backup rename failed")
+			}
+			return realRootRename(root, oldName, newName)
+		}
+
+		promotions := []benchmarkPromotedPath{{
+			liveRel:    "overlay/live.txt",
+			stagedRel:  "stage/live.txt",
+			backupRel:  "backup/live.txt",
+			errorLabel: "write benchmark harness overlay/live.txt",
+		}}
+		err = promoteBenchmarkSet(root, promotions, nil)
+		if err == nil || !strings.Contains(err.Error(), "backup rename failed") {
+			t.Fatalf("expected backup rename error, got %v", err)
+		}
+	})
+}
+
+func TestResolveBenchmarkDefinitionReturnsRepoPathError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absPath = func(string) (string, error) {
+			return "", errors.New("resolve repo failed")
+		}
+
+		if _, _, err := resolveBenchmarkDefinition(".", []string{"./benchpkg"}, 1, "1x"); err == nil || !strings.Contains(err.Error(), "resolve repo path: resolve repo failed") {
+			t.Fatalf("expected repo path error, got %v", err)
+		}
+	})
+}
+
+func TestResolveBenchmarkDefinitionReturnsOpenRepoRootError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) {}\n",
+			},
+			commit: true,
+		})
+		openOSRoot = func(string) (*os.Root, error) {
+			return nil, errors.New("open repo root failed")
+		}
+
+		if _, _, err := resolveBenchmarkDefinition(repo, []string{"./benchpkg"}, 1, "1x"); err == nil || !strings.Contains(err.Error(), "open repo root: open repo root failed") {
+			t.Fatalf("expected repo root open error, got %v", err)
+		}
+	})
+}
+
+func TestResolvePackageBenchmarksReturnsOpenRepoRootError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		openOSRoot = func(string) (*os.Root, error) {
+			return nil, errors.New("open package repo root failed")
+		}
+
+		if _, _, err := resolvePackageBenchmarks(t.TempDir(), "./benchpkg"); err == nil || !strings.Contains(err.Error(), "open repo root: open package repo root failed") {
+			t.Fatalf("expected resolvePackageBenchmarks open error, got %v", err)
+		}
+	})
+}
+
+func TestResolvePackageBenchmarksReturnsCloseError(t *testing.T) {
+	repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) {}\n",
+		},
+	})
+
+	withBenchdeltaFSHooks(t, func() {
+		closeCalls := 0
+		closeOSRoot = func(root *os.Root) error {
+			closeCalls++
+			if closeCalls == 1 {
+				return errors.New("close package root failed")
+			}
+			return root.Close()
+		}
+
+		if _, _, err := resolvePackageBenchmarks(repo, "./benchpkg"); err == nil || !strings.Contains(err.Error(), "close package root failed") {
+			t.Fatalf("expected close error, got %v", err)
+		}
+	})
+}
+
+func TestResolvePackageBenchmarksWithinRootRejectsNonRegularHarness(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module example.com/benchrepo\n\ngo 1.26.0\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, "benchpkg", "dir_test.go"), 0o755); err != nil {
+		t.Fatalf("mkdir invalid harness dir: %v", err)
+	}
+	repoRootHandle, err := os.OpenRoot(repoRoot)
+	if err != nil {
+		t.Fatalf("open repo root: %v", err)
+	}
+	defer func() {
+		if closeErr := repoRootHandle.Close(); closeErr != nil {
+			t.Fatalf("close repo root: %v", closeErr)
+		}
+	}()
+
+	remainingBytes := int64(maxBenchmarkHarnessTotal)
+	if _, _, _, err := resolvePackageBenchmarksWithinRoot(repoRoot, repoRootHandle, "./benchpkg", &remainingBytes); err == nil || !strings.Contains(err.Error(), "benchmark harness path is not a regular file") {
+		t.Fatalf("expected non-regular harness rejection, got %v", err)
+	}
+}
+
+func TestResolvePackageBenchmarksWithinRootReturnsReadHarnessError(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module example.com/benchrepo\n\ngo 1.26.0\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir package dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, "benchpkg", "head_benchmark_test.go"), []byte("package benchpkg\n"), 0o600); err != nil {
+		t.Fatalf("write harness file: %v", err)
+	}
+	repoRootHandle, err := os.OpenRoot(repoRoot)
+	if err != nil {
+		t.Fatalf("open repo root: %v", err)
+	}
+	defer func() {
+		if closeErr := repoRootHandle.Close(); closeErr != nil {
+			t.Fatalf("close repo root: %v", closeErr)
+		}
+	}()
+
+	remainingBytes := int64(1)
+	if _, _, _, err := resolvePackageBenchmarksWithinRoot(repoRoot, repoRootHandle, "./benchpkg", &remainingBytes); err == nil || !strings.Contains(err.Error(), "read benchmark harness") {
+		t.Fatalf("expected read harness error, got %v", err)
+	}
+}
+
+func TestValidateBenchmarkHarnessTargetsRejectsNonTestHarnessPath(t *testing.T) {
+	err := validateBenchmarkHarnessTargets(t.TempDir(), benchmarkDefinition{
+		PackageTargets: []string{"./benchpkg"},
+		HarnessFiles: []benchmarkHarnessFile{{
+			Path: "benchpkg/helper.go",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "must reference a package _test.go file") {
+		t.Fatalf("expected non-test harness rejection, got %v", err)
+	}
+}
+
+func TestValidateBenchmarkHarnessTargetsRejectsHarnessOutsideTargets(t *testing.T) {
+	err := validateBenchmarkHarnessTargets(t.TempDir(), benchmarkDefinition{
+		PackageTargets: []string{"./benchpkg"},
+		HarnessFiles: []benchmarkHarnessFile{{
+			Path: "otherpkg/head_benchmark_test.go",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "outside benchmark package targets") {
+		t.Fatalf("expected outside-target rejection, got %v", err)
+	}
+}
+
+func TestValidateBenchmarkHarnessTargetsReturnsPackageReadError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, "benchpkg"), 0o755); err != nil {
+			t.Fatalf("mkdir package dir: %v", err)
+		}
+		readDir = func(string) ([]os.DirEntry, error) {
+			return nil, errors.New("read package failed")
+		}
+
+		err := validateBenchmarkHarnessTargets(repoRoot, benchmarkDefinition{
+			PackageTargets: []string{"./benchpkg"},
+			HarnessFiles: []benchmarkHarnessFile{{
+				Path: "benchpkg/head_benchmark_test.go",
+			}},
+		})
+		if err == nil || !strings.Contains(err.Error(), "read package ./benchpkg: read package failed") {
+			t.Fatalf("expected package read error, got %v", err)
+		}
+	})
+}
+
+func TestValidateBenchmarkHarnessTargetsRejectsPackageDirectoryFile(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoRoot, "benchpkg"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write package file: %v", err)
+	}
+
+	err := validateBenchmarkHarnessTargets(repoRoot, benchmarkDefinition{
+		PackageTargets: []string{"./benchpkg"},
+		HarnessFiles: []benchmarkHarnessFile{{
+			Path: "benchpkg/head_benchmark_test.go",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "package directory is not a directory") {
+		t.Fatalf("expected package-directory file rejection, got %v", err)
+	}
+}
+
+func TestGitStatusPorcelainV2HasPathsReturnsFalseForEmptyPaths(t *testing.T) {
+	dirty, err := gitStatusPorcelainV2HasPaths(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("gitStatusPorcelainV2HasPaths returned error: %v", err)
+	}
+	if dirty {
+		t.Fatal("expected empty path list to be clean")
+	}
+}
+
+func TestGitStatusPorcelainV2HasPathsReturnsErrorForInvalidRepo(t *testing.T) {
+	if _, err := gitStatusPorcelainV2HasPaths(t.TempDir(), []string{"benchpkg/head_benchmark_test.go"}); err == nil {
+		t.Fatal("expected git status error for non-repo path")
+	}
+}
+
+func TestGitStatusPorcelainV2HasPathsDetectsDirtyHarness(t *testing.T) {
+	repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) {}\n",
+		},
+		commit: true,
+	})
+	if err := os.WriteFile(filepath.Join(repo, "benchpkg", "head_benchmark_test.go"), []byte("package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkDirty(b *testing.B) {}\n"), 0o600); err != nil {
+		t.Fatalf("rewrite harness file: %v", err)
+	}
+
+	dirty, err := gitStatusPorcelainV2HasPaths(repo, []string{"benchpkg/head_benchmark_test.go"})
+	if err != nil {
+		t.Fatalf("gitStatusPorcelainV2HasPaths returned error: %v", err)
+	}
+	if !dirty {
+		t.Fatal("expected dirty harness to be reported")
+	}
+}
+
+func TestOpenCanonicalWriteRootReturnsCanonicalizeError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		originalOpenCanonicalWriteRoot := openCanonicalWriteRoot
+		openCanonicalWriteRoot = originalOpenCanonicalWriteRoot
+		evalSymlinks = func(string) (string, error) {
+			return "", errors.New("canonicalize write root failed")
+		}
+
+		root, err := openCanonicalWriteRoot(t.TempDir())
+		if root != nil {
+			t.Fatal("expected nil write root on canonicalize failure")
+		}
+		if err == nil || !strings.Contains(err.Error(), "canonicalize root: canonicalize write root failed") {
+			t.Fatalf("expected canonicalize error, got %v", err)
+		}
+	})
+}
+
+func TestOpenPackageTargetRootNoFollowRejectsRootRelativePath(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		repoRoot := t.TempDir()
+		repoRootHandle, err := os.OpenRoot(repoRoot)
+		if err != nil {
+			t.Fatalf("open repo root: %v", err)
+		}
+		defer func() {
+			if closeErr := repoRootHandle.Close(); closeErr != nil {
+				t.Fatalf("close repo root: %v", closeErr)
+			}
+		}()
+
+		relPath = func(string, string) (string, error) { return ".", nil }
+
+		if _, _, packageRoot, err := openPackageTargetRootNoFollow(repoRoot, repoRootHandle, "./benchpkg"); err == nil || !strings.Contains(err.Error(), "must not resolve to repo root") || packageRoot != nil {
+			t.Fatalf("expected repo-root rejection, got root=%v err=%v", packageRoot, err)
+		}
+	})
+}
+
+func TestOpenPackageTargetRootNoFollowSkipsCurrentDirectoryPathPart(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, "benchpkg"), 0o755); err != nil {
+			t.Fatalf("mkdir package dir: %v", err)
+		}
+		repoRootHandle, err := os.OpenRoot(repoRoot)
+		if err != nil {
+			t.Fatalf("open repo root: %v", err)
+		}
+		defer func() {
+			if closeErr := repoRootHandle.Close(); closeErr != nil {
+				t.Fatalf("close repo root: %v", closeErr)
+			}
+		}()
+
+		relPath = func(string, string) (string, error) { return filepath.Join(".", "benchpkg"), nil }
+
+		packageDir, packageRel, packageRoot, err := openPackageTargetRootNoFollow(repoRoot, repoRootHandle, "./benchpkg")
+		if err != nil {
+			t.Fatalf("openPackageTargetRootNoFollow returned error: %v", err)
+		}
+		if packageDir != filepath.Join(repoRoot, "benchpkg") || packageRel != filepath.Join(".", "benchpkg") {
+			t.Fatalf("unexpected package resolution: dir=%q rel=%q", packageDir, packageRel)
+		}
+		if err := packageRoot.Close(); err != nil {
+			t.Fatalf("close package root: %v", err)
+		}
+	})
+}
+
+func TestReadCapturedHarnessBytesReturnsReadError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			return nil, errors.New("open captured harness failed")
+		}
+
+		remainingBytes := int64(maxBenchmarkHarnessTotal)
+		if _, err := readCapturedHarnessBytes(root, "bench_test.go", &remainingBytes); err == nil || !strings.Contains(err.Error(), "open captured harness failed") {
+			t.Fatalf("expected readCapturedHarnessBytes error, got %v", err)
+		}
+	})
+}
+
+func TestReadRootFileLimitReturnsFileTooLargeFromReader(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	withBenchdeltaFSHooks(t, func() {
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			return os.Open("/dev/zero")
+		}
+
+		if _, err := readRootFileLimit(root, "bench_test.go", 8); !errors.Is(err, safeio.ErrFileTooLarge) {
+			t.Fatalf("expected ErrFileTooLarge from reader limit, got %v", err)
+		}
+	})
+}
+
+func TestCaptureBenchmarkTargetSnapshotReturnsRootStatError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		root, err := os.OpenRoot(t.TempDir())
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootLstat = func(*os.Root, string) (os.FileInfo, error) {
+			return nil, errors.New("snapshot lstat failed")
+		}
+
+		if _, err := captureBenchmarkTargetSnapshot(root, "/tmp/bench_test.go", "bench_test.go"); err == nil || !strings.Contains(err.Error(), "snapshot lstat failed") {
+			t.Fatalf("expected snapshot lstat error, got %v", err)
+		}
+	})
+}
+
+func TestCaptureBenchmarkTargetSnapshotReturnsJoinedReadAndCloseError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(rootDir, "bench_test.go"), []byte("package benchpkg\n"), 0o600); err != nil {
+			t.Fatalf("write harness file: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			file, err := os.Open(filepath.Join(rootDir, "bench_test.go"))
+			if err != nil {
+				return nil, err
+			}
+			if err := file.Close(); err != nil {
+				return nil, err
+			}
+			return file, nil
+		}
+
+		if _, err := captureBenchmarkTargetSnapshot(root, filepath.Join(rootDir, "bench_test.go"), "bench_test.go"); err == nil || !strings.Contains(err.Error(), "file already closed") {
+			t.Fatalf("expected joined read/close error, got %v", err)
+		}
+	})
+}
+
+func TestEnsureRootPathNoFollowReturnsNilForCurrentDirectory(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := ensureRootPathNoFollow(root, ".", true, 0o755); err != nil {
+		t.Fatalf("ensureRootPathNoFollow returned error: %v", err)
+	}
+}
+
+func TestEnsureRootPathNoFollowReturnsLstatErrorWhenCreateDisabled(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := ensureRootPathNoFollow(root, "missing/child", false, 0o755); err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected not-exist error, got %v", err)
+	}
+}
+
+func TestEnsureRootPathNoFollowReturnsCreateError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		root, err := os.OpenRoot(t.TempDir())
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootMkdir = func(*os.Root, string, os.FileMode) error {
+			return errors.New("mkdir parent failed")
+		}
+
+		if err := ensureRootPathNoFollow(root, "nested", true, 0o755); err == nil || !strings.Contains(err.Error(), "mkdir parent failed") {
+			t.Fatalf("expected mkdir error, got %v", err)
+		}
+	})
+}
+
+func TestEnsureRootPathNoFollowRejectsNonDirectoryParent(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootDir, "file"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write parent file: %v", err)
+	}
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := ensureRootPathNoFollow(root, "file/child", false, 0o755); err == nil || !strings.Contains(err.Error(), "output parent is not a directory") {
+		t.Fatalf("expected non-directory parent error, got %v", err)
+	}
+}
+
+func TestEnsureRootPathNoFollowReturnsOpenRootError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "nested"), 0o755); err != nil {
+			t.Fatalf("mkdir nested dir: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpenRoot = func(*os.Root, string) (*os.Root, error) {
+			return nil, errors.New("open ensured root failed")
+		}
+
+		if err := ensureRootPathNoFollow(root, "nested", false, 0o755); err == nil || !strings.Contains(err.Error(), "open ensured root failed") {
+			t.Fatalf("expected open root error, got %v", err)
+		}
+	})
+}
+
+func TestEnsureRootPathNoFollowReturnsOwnedCloseError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(rootDir, "nested", "child"), 0o755); err != nil {
+			t.Fatalf("mkdir nested child: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		closeCalls := 0
+		closeOSRoot = func(root *os.Root) error {
+			closeCalls++
+			if closeCalls == 1 {
+				return errors.New("close ensured root failed")
+			}
+			return root.Close()
+		}
+
+		if err := ensureRootPathNoFollow(root, "nested/child", false, 0o755); err == nil || !strings.Contains(err.Error(), "close ensured root failed") {
+			t.Fatalf("expected owned close error, got %v", err)
+		}
+	})
+}
+
+func TestEnsureRootPathNoFollowReturnsFinalCloseError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "nested"), 0o755); err != nil {
+			t.Fatalf("mkdir nested dir: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		closeOSRoot = func(*os.Root) error {
+			return errors.New("final ensured close failed")
+		}
+
+		if err := ensureRootPathNoFollow(root, "nested", false, 0o755); err == nil || !strings.Contains(err.Error(), "final ensured close failed") {
+			t.Fatalf("expected final close error, got %v", err)
+		}
+	})
+}
+
+func TestRenameWithinRootReturnsEnsureError(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootDir, "file"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write path blocker: %v", err)
+	}
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := renameWithinRoot(root, "from", filepath.Join("file", "child")); err == nil || !strings.Contains(err.Error(), "output parent is not a directory") {
+		t.Fatalf("expected ensure-path error, got %v", err)
+	}
+}
+
+func TestValidateManifestSubtreePathPartsReturnsNilForEmptyParts(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := validateManifestSubtreePathParts(root, nil, "overlay"); err != nil {
+		t.Fatalf("expected empty path parts to be ignored, got %v", err)
+	}
+}
+
+func TestValidateManifestSubtreePathPartsReturnsRootError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		root, err := os.OpenRoot(t.TempDir())
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootLstat = func(*os.Root, string) (os.FileInfo, error) {
+			return nil, errors.New("validate subtree lstat failed")
+		}
+
+		if err := validateManifestSubtreePathParts(root, []string{"overlay"}, "overlay"); err == nil || !strings.Contains(err.Error(), "validate subtree lstat failed") {
+			t.Fatalf("expected subtree lstat error, got %v", err)
+		}
+	})
+}
+
+func TestValidateManifestSubtreePathPartsReturnsOpenError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "overlay"), 0o755); err != nil {
+			t.Fatalf("mkdir overlay dir: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpenRoot = func(*os.Root, string) (*os.Root, error) {
+			return nil, errors.New("validate subtree open failed")
+		}
+
+		if err := validateManifestSubtreePathParts(root, []string{"overlay", "child"}, "overlay/child"); err == nil || !strings.Contains(err.Error(), "validate subtree open failed") {
+			t.Fatalf("expected subtree open error, got %v", err)
+		}
+	})
+}
+
+func TestRemoveManifestSubtreePartsIgnoresMissingLeafOnRemove(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(rootDir, "overlay-file"), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write overlay leaf: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootRemove = func(*os.Root, string) error {
+			return os.ErrNotExist
+		}
+
+		if err := removeManifestSubtreeParts(root, []string{"overlay-file"}, "overlay-file"); err != nil {
+			t.Fatalf("expected missing leaf remove to be ignored, got %v", err)
+		}
+	})
+}
+
+func TestRemoveManifestSubtreePartsReturnsDirectoryOpenErrorWithCloseError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "overlay"), 0o755); err != nil {
+			t.Fatalf("mkdir overlay dir: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		tmpFile := filepath.Join(rootDir, "tmpfile")
+		if err := os.WriteFile(tmpFile, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			file, err := os.Open(tmpFile)
+			if err != nil {
+				return nil, err
+			}
+			if err := file.Close(); err != nil {
+				return nil, err
+			}
+			return file, nil
+		}
+
+		if err := removeManifestSubtreeParts(root, []string{"overlay"}, "overlay"); err == nil || !strings.Contains(err.Error(), "file already closed") {
+			t.Fatalf("expected closed-file directory read error, got %v", err)
+		}
+	})
+}
+
+func TestValidateBenchmarkHarnessTargetsReturnsPackageTargetError(t *testing.T) {
+	err := validateBenchmarkHarnessTargets(t.TempDir(), benchmarkDefinition{
+		PackageTargets: []string{"."},
+		HarnessFiles: []benchmarkHarnessFile{{
+			Path: "benchpkg/head_benchmark_test.go",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "must not resolve to repo root") {
+		t.Fatalf("expected package target error, got %v", err)
+	}
+}
+
+func TestResolvePackageBenchmarksWithinRootReturnsReadPackageError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		repoRoot := t.TempDir()
+		if err := os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module example.com/benchrepo\n\ngo 1.26.0\n"), 0o600); err != nil {
+			t.Fatalf("write go.mod: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(repoRoot, "benchpkg"), 0o755); err != nil {
+			t.Fatalf("mkdir package dir: %v", err)
+		}
+		repoRootHandle, err := os.OpenRoot(repoRoot)
+		if err != nil {
+			t.Fatalf("open repo root: %v", err)
+		}
+		defer func() {
+			if closeErr := repoRootHandle.Close(); closeErr != nil {
+				t.Fatalf("close repo root: %v", closeErr)
+			}
+		}()
+
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			return nil, errors.New("open package dir failed")
+		}
+
+		remainingBytes := int64(maxBenchmarkHarnessTotal)
+		if _, _, _, err := resolvePackageBenchmarksWithinRoot(repoRoot, repoRootHandle, "./benchpkg", &remainingBytes); err == nil || !strings.Contains(err.Error(), "read package ./benchpkg: open package dir failed") {
+			t.Fatalf("expected read package error, got %v", err)
+		}
+	})
+}
+
+func TestResolvePackageBenchmarksWithinRootReturnsHarnessStatError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		repoRoot := t.TempDir()
+		if err := os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module example.com/benchrepo\n\ngo 1.26.0\n"), 0o600); err != nil {
+			t.Fatalf("write go.mod: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(repoRoot, "benchpkg"), 0o755); err != nil {
+			t.Fatalf("mkdir package dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repoRoot, "benchpkg", "head_benchmark_test.go"), []byte("package benchpkg\n"), 0o600); err != nil {
+			t.Fatalf("write harness file: %v", err)
+		}
+		repoRootHandle, err := os.OpenRoot(repoRoot)
+		if err != nil {
+			t.Fatalf("open repo root: %v", err)
+		}
+		defer func() {
+			if closeErr := repoRootHandle.Close(); closeErr != nil {
+				t.Fatalf("close repo root: %v", closeErr)
+			}
+		}()
+
+		realRootLstat := rootLstat
+		rootLstat = func(root *os.Root, name string) (os.FileInfo, error) {
+			if name == "head_benchmark_test.go" {
+				return nil, errors.New("harness lstat failed")
+			}
+			return realRootLstat(root, name)
+		}
+
+		remainingBytes := int64(maxBenchmarkHarnessTotal)
+		if _, _, _, err := resolvePackageBenchmarksWithinRoot(repoRoot, repoRootHandle, "./benchpkg", &remainingBytes); err == nil || !strings.Contains(err.Error(), "read package ./benchpkg: harness lstat failed") {
+			t.Fatalf("expected harness stat error, got %v", err)
+		}
+	})
+}
+
+func TestWriteBenchmarkDefinitionReturnsMarshalError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		marshalIndent = func(any, string, string) ([]byte, error) {
+			return nil, errors.New("marshal manifest failed")
+		}
+
+		parent := canonicalTempDir(t)
+		err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, nil)
+		if err == nil || !strings.Contains(err.Error(), "marshal benchmark definition: marshal manifest failed") {
+			t.Fatalf("expected marshal error, got %v", err)
+		}
+	})
+}
+
+func TestApplyBenchmarkOverlayReturnsManifestRootOpenError(t *testing.T) {
+	artifactDir := canonicalTempDir(t)
+	definitionPath, definition := writeOverlayDefinitionFixture(t, artifactDir)
+
+	withBenchdeltaFSHooks(t, func() {
+		originalOpenCanonicalWriteRoot := openCanonicalWriteRoot
+		openCanonicalWriteRoot = func(string) (confinedWriteRoot, error) {
+			return &fakeConfinedWriteRoot{}, nil
+		}
+		defer func() { openCanonicalWriteRoot = originalOpenCanonicalWriteRoot }()
+		openOSRoot = func(string) (*os.Root, error) {
+			return nil, errors.New("open apply manifest root failed")
+		}
+
+		err := applyBenchmarkOverlay(t.TempDir(), definitionPath, definition)
+		if err == nil || !strings.Contains(err.Error(), "open benchmark repo root: open apply manifest root failed") {
+			t.Fatalf("expected repo manifest root open error, got %v", err)
+		}
+	})
+}
+
+func TestOpenManifestRootNoFollowReturnsRelativePathErrorDirect(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absPath = func(string) (string, error) {
+			return filepath.Join(string(os.PathSeparator), "tmp"), nil
+		}
+		relPath = func(string, string) (string, error) {
+			return "", errors.New("open root relative failed")
+		}
+
+		if _, err := openManifestRootNoFollow("ignored"); err == nil || !strings.Contains(err.Error(), "open root relative failed") {
+			t.Fatalf("expected relative-path error, got %v", err)
+		}
+	})
+}
+
+func TestOpenManifestRootNoFollowSkipsCurrentDirectoryComponentOnExistingPath(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absPath = func(string) (string, error) {
+			return filepath.Join(string(os.PathSeparator), "missing"), nil
+		}
+		relPath = func(base, target string) (string, error) {
+			return "." + string(os.PathSeparator) + "missing", nil
+		}
+
+		root, err := openManifestRootNoFollow("ignored")
+		if root != nil {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}
+		if err == nil || !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected missing-path error after dot-prefix skip, got %v", err)
+		}
+	})
+}
+
+func TestValidateManifestRootPathNoFollowReturnsRelativePathErrorDirect(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absPath = func(string) (string, error) {
+			return filepath.Join(string(os.PathSeparator), "tmp"), nil
+		}
+		relPath = func(string, string) (string, error) {
+			return "", errors.New("validate root relative failed")
+		}
+
+		err := validateManifestRootPathNoFollow("ignored")
+		if err == nil || !strings.Contains(err.Error(), "validate root relative failed") {
+			t.Fatalf("expected relative-path error, got %v", err)
+		}
+	})
+}
+
+func TestValidateManifestRootPathNoFollowReturnsNilForVolumeRoot(t *testing.T) {
+	if err := validateManifestRootPathNoFollow(string(os.PathSeparator)); err != nil {
+		t.Fatalf("validateManifestRootPathNoFollow returned error: %v", err)
+	}
+}
+
+func TestValidateManifestRootPathNoFollowSkipsCurrentDirectoryPart(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absPath = func(string) (string, error) {
+			return filepath.Join(string(os.PathSeparator), "missing"), nil
+		}
+		relPath = func(base, target string) (string, error) {
+			return "." + string(os.PathSeparator) + "missing", nil
+		}
+
+		if err := validateManifestRootPathNoFollow("ignored"); err != nil {
+			t.Fatalf("validateManifestRootPathNoFollow returned error: %v", err)
+		}
+	})
+}
+
+func TestEnsureRootPathNoFollowSkipsCurrentDirectoryPart(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(rootDir, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := ensureRootPathNoFollow(root, filepath.Join(".", "nested"), false, 0o755); err != nil {
+		t.Fatalf("ensureRootPathNoFollow returned error: %v", err)
+	}
+}
+
+func TestEnsureRootPathNoFollowReturnsNilForSlashOnly(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := ensureRootPathNoFollow(root, string(os.PathSeparator), false, 0o755); err != nil {
+		t.Fatalf("ensureRootPathNoFollow returned error: %v", err)
+	}
+}
+
+func TestRemoveManifestSubtreePartsReturnsNilForMissingLeaf(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := removeManifestSubtreeParts(root, []string{"missing"}, "missing"); err != nil {
+		t.Fatalf("expected missing leaf to be ignored, got %v", err)
+	}
+}
+
+func TestOpenManifestRootNoFollowReturnsRelativePathErrorForNonAliasRoot(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := filepath.Join(t.TempDir(), "manifest-root")
+		absPath = func(string) (string, error) {
+			return rootDir, nil
+		}
+		relPath = func(base, target string) (string, error) {
+			if base == string(os.PathSeparator) {
+				return "", errors.New("non-alias relative failed")
+			}
+			return filepath.Rel(base, target)
+		}
+
+		if _, err := openManifestRootNoFollow("ignored"); err == nil || !strings.Contains(err.Error(), "non-alias relative failed") {
+			t.Fatalf("expected non-alias relative-path error, got %v", err)
+		}
+	})
+}
+
+func TestValidateManifestRootPathNoFollowReturnsRelativePathErrorForNonAliasRoot(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := filepath.Join(t.TempDir(), "manifest-root")
+		absPath = func(string) (string, error) {
+			return rootDir, nil
+		}
+		relPath = func(base, target string) (string, error) {
+			if base == string(os.PathSeparator) {
+				return "", errors.New("validate non-alias relative failed")
+			}
+			return filepath.Rel(base, target)
+		}
+
+		err := validateManifestRootPathNoFollow("ignored")
+		if err == nil || !strings.Contains(err.Error(), "validate non-alias relative failed") {
+			t.Fatalf("expected non-alias relative-path error, got %v", err)
+		}
+	})
+}
+
+func TestWriteBenchmarkDefinitionReturnsStageRootCreateError(t *testing.T) {
+	parent := canonicalTempDir(t)
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatalf("chmod parent read-only: %v", err)
+	}
+	defer func() {
+		if err := os.Chmod(parent, 0o700); err != nil {
+			t.Fatalf("restore parent perms: %v", err)
+		}
+	}()
+
+	err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, nil)
+	if err == nil || !strings.Contains(err.Error(), "create benchmark staging root") {
+		t.Fatalf("expected stage-root creation error, got %v", err)
+	}
+}
+
+func TestApplyBenchmarkOverlayReturnsStageRootCreateError(t *testing.T) {
+	artifactDir := canonicalTempDir(t)
+	definitionPath, definition := writeOverlayDefinitionFixture(t, artifactDir)
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir repo package: %v", err)
+	}
+	if err := os.Chmod(repo, 0o500); err != nil {
+		t.Fatalf("chmod repo read-only: %v", err)
+	}
+	defer func() {
+		if err := os.Chmod(repo, 0o700); err != nil {
+			t.Fatalf("restore repo perms: %v", err)
+		}
+	}()
+
+	err := applyBenchmarkOverlay(repo, definitionPath, definition)
+	if err == nil || !strings.Contains(err.Error(), "create benchmark staging root") {
+		t.Fatalf("expected apply stage-root creation error, got %v", err)
+	}
+}
+
+func TestRemoveManifestSubtreePartsReturnsRootOpenError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "overlay"), 0o755); err != nil {
+			t.Fatalf("mkdir overlay dir: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			return nil, errors.New("open overlay listing failed")
+		}
+
+		if err := removeManifestSubtreeParts(root, []string{"overlay"}, "overlay"); err == nil || !strings.Contains(err.Error(), "open overlay listing failed") {
+			t.Fatalf("expected rootOpen error, got %v", err)
+		}
+	})
 }

--- a/tools/benchdelta/main.go
+++ b/tools/benchdelta/main.go
@@ -83,24 +83,47 @@ type comparisonSummary struct {
 }
 
 func main() {
-	basePath := flag.String("base", "", "path to base benchmark output")
-	headPath := flag.String("head", "", "path to head benchmark output")
-	maxBytesPct := flag.Float64("max-bytes-pct", 15, "maximum allowed bytes/op increase percentage")
-	maxAllocsPct := flag.Float64("max-allocs-pct", 10, "maximum allowed allocs/op increase percentage")
-	summaryOut := flag.String("summary-out", "", "path to write markdown summary")
-	flag.Parse()
-
-	if strings.TrimSpace(*basePath) == "" || strings.TrimSpace(*headPath) == "" {
-		exitErr(errors.New("both -base and -head are required"))
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "resolve":
+			if err := runResolveCommand(os.Args[2:]); err != nil {
+				exitErr(err)
+			}
+			return
+		case "run":
+			if err := runBenchmarkCommand(os.Args[2:]); err != nil {
+				exitErr(err)
+			}
+			return
+		}
 	}
+	if err := runCompareCommand(os.Args[1:]); err != nil {
+		exitErr(err)
+	}
+}
 
+func runCompareCommand(args []string) error {
+	fs := flag.NewFlagSet("benchdelta", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	basePath := fs.String("base", "", "path to base benchmark output")
+	headPath := fs.String("head", "", "path to head benchmark output")
+	maxBytesPct := fs.Float64("max-bytes-pct", 15, "maximum allowed bytes/op increase percentage")
+	maxAllocsPct := fs.Float64("max-allocs-pct", 10, "maximum allowed allocs/op increase percentage")
+	summaryOut := fs.String("summary-out", "", "path to write markdown summary")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*basePath) == "" || strings.TrimSpace(*headPath) == "" {
+		return errors.New("both -base and -head are required")
+	}
 	baseInput, err := parseBenchmarkFile(*basePath)
 	if err != nil {
-		exitErr(fmt.Errorf("parse base benchmarks: %w", err))
+		return fmt.Errorf("parse base benchmarks: %w", err)
 	}
 	headInput, err := parseBenchmarkFile(*headPath)
 	if err != nil {
-		exitErr(fmt.Errorf("parse head benchmarks: %w", err))
+		return fmt.Errorf("parse head benchmarks: %w", err)
 	}
 
 	limits := deltaThresholds{
@@ -111,12 +134,13 @@ func main() {
 	fmt.Print(summary)
 	if *summaryOut != "" {
 		if err := os.WriteFile(*summaryOut, []byte(summary), 0o600); err != nil {
-			exitErr(fmt.Errorf("write summary: %w", err))
+			return fmt.Errorf("write summary: %w", err)
 		}
 	}
 	if statusCode != exitCodePassed {
 		os.Exit(statusCode)
 	}
+	return nil
 }
 
 func exitErr(err error) {

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"math"
 	"os"
@@ -647,6 +648,861 @@ func TestMainSummaryWriteSuccess(t *testing.T) {
 	}
 }
 
+func TestResolveBenchmarkDefinitionCapturesExactHeadDefinition(t *testing.T) {
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SharedValue()
+	}
+}
+`,
+			"benchpkg/helper_test.go": `package benchpkg
+
+import "testing"
+
+func TestHelper(t *testing.T) {}
+`,
+			"benchpkg/goleak_test.go": `package benchpkg
+
+import "testing"
+
+func TestMain(m *testing.M) {
+	testing.Init()
+	m.Run()
+}
+`,
+			"benchpkg2/subject.go": "package benchpkg2\n\nfunc SharedValue() int { return 7 }\n",
+			"benchpkg2/second_benchmark_test.go": `package benchpkg2
+
+import "testing"
+
+func BenchmarkSecond(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SharedValue()
+	}
+}
+`,
+		},
+		commit: true,
+	})
+
+	definition, overlayFiles, err := resolveBenchmarkDefinition(headRepo, []string{"./benchpkg", "./benchpkg2"}, 7, "450ms")
+	if err != nil {
+		t.Fatalf("resolve benchmark definition: %v", err)
+	}
+
+	if definition.Version != definitionVersion || definition.Count != 7 || definition.Benchtime != "450ms" || !definition.BenchMem {
+		t.Fatalf("unexpected execution definition: %#v", definition)
+	}
+	if definition.RunPattern != defaultRunPattern {
+		t.Fatalf("run pattern = %q, want %q", definition.RunPattern, defaultRunPattern)
+	}
+	if want := []string{"./benchpkg", "./benchpkg2"}; !slices.Equal(definition.PackageTargets, want) {
+		t.Fatalf("package targets = %#v, want %#v", definition.PackageTargets, want)
+	}
+	if want := []resolvedBenchmark{
+		{PackageTarget: "./benchpkg", Name: "BenchmarkHeadOnly"},
+		{PackageTarget: "./benchpkg2", Name: "BenchmarkSecond"},
+	}; !slices.Equal(definition.Benchmarks, want) {
+		t.Fatalf("benchmarks = %#v, want %#v", definition.Benchmarks, want)
+	}
+	if definition.BenchPattern != "^(BenchmarkHeadOnly|BenchmarkSecond)$" {
+		t.Fatalf("bench pattern = %q", definition.BenchPattern)
+	}
+	headCommit := strings.TrimSpace(runGitOutput(t, headRepo, "rev-parse", "HEAD"))
+	if definition.ResolvedFrom != headCommit {
+		t.Fatalf("resolved from = %q, want %q", definition.ResolvedFrom, headCommit)
+	}
+	if definition.ResolvedCommit != headCommit {
+		t.Fatalf("resolved commit = %q, want %q", definition.ResolvedCommit, headCommit)
+	}
+	wantHarnessPaths := []string{
+		"benchpkg/goleak_test.go",
+		"benchpkg/head_benchmark_test.go",
+		"benchpkg/helper_test.go",
+		"benchpkg2/second_benchmark_test.go",
+	}
+	gotHarnessPaths := make([]string, 0, len(definition.HarnessFiles))
+	for _, harness := range definition.HarnessFiles {
+		gotHarnessPaths = append(gotHarnessPaths, harness.Path)
+	}
+	if !slices.Equal(gotHarnessPaths, wantHarnessPaths) {
+		t.Fatalf("harness paths = %#v, want %#v", gotHarnessPaths, wantHarnessPaths)
+	}
+	for _, harness := range definition.HarnessFiles {
+		content, ok := overlayFiles[harness.OverlayPath]
+		if !ok {
+			t.Fatalf("missing overlay content for %s", harness.OverlayPath)
+		}
+		if got := bytesDigest(content); got != harness.SHA256 {
+			t.Fatalf("overlay digest for %s = %s, want %s", harness.Path, got, harness.SHA256)
+		}
+	}
+}
+
+func TestResolveBenchmarkDefinitionKeepsHeadIdentityForUnrelatedDirtyFiles(t *testing.T) {
+	repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) {}\n",
+		},
+		commit: true,
+	})
+	headCommit := strings.TrimSpace(runGitOutput(t, repo, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("dirty but unrelated\n"), 0o600); err != nil {
+		t.Fatalf("write unrelated dirty file: %v", err)
+	}
+
+	definition, _, err := resolveBenchmarkDefinition(repo, []string{"./benchpkg"}, 1, "1x")
+	if err != nil {
+		t.Fatalf("resolve benchmark definition: %v", err)
+	}
+	if definition.ResolvedFrom != headCommit {
+		t.Fatalf("resolved from = %q, want HEAD commit %q for unrelated dirt", definition.ResolvedFrom, headCommit)
+	}
+	if definition.ResolvedCommit != headCommit {
+		t.Fatalf("resolved commit = %q, want %q", definition.ResolvedCommit, headCommit)
+	}
+}
+
+func TestResolveBenchmarkDefinitionUsesContentIdentityForDirtyHarnessInputs(t *testing.T) {
+	repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) {}\n",
+		},
+		commit: true,
+	})
+	headCommit := strings.TrimSpace(runGitOutput(t, repo, "rev-parse", "HEAD"))
+	dirtyHarness := []byte("package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkDirty(b *testing.B) {}\n")
+	harnessPath := filepath.Join(repo, "benchpkg", "head_benchmark_test.go")
+	if err := os.WriteFile(harnessPath, dirtyHarness, 0o600); err != nil {
+		t.Fatalf("write dirty harness: %v", err)
+	}
+	runGitCommand(t, repo, "add", "benchpkg/head_benchmark_test.go")
+
+	definition, overlayFiles, err := resolveBenchmarkDefinition(repo, []string{"./benchpkg"}, 1, "1x")
+	if err != nil {
+		t.Fatalf("resolve benchmark definition: %v", err)
+	}
+	if definition.ResolvedFrom == headCommit || !strings.HasPrefix(definition.ResolvedFrom, "content-sha256:") {
+		t.Fatalf("resolved from = %q, want content identity distinct from HEAD %q", definition.ResolvedFrom, headCommit)
+	}
+	if definition.ResolvedCommit != headCommit {
+		t.Fatalf("resolved commit = %q, want HEAD commit %q", definition.ResolvedCommit, headCommit)
+	}
+	if got := overlayFiles["benchpkg/head_benchmark_test.go"]; !bytes.Equal(got, dirtyHarness) {
+		t.Fatalf("captured harness bytes = %q, want %q", got, dirtyHarness)
+	}
+}
+
+func TestRunDefinitionUsesResolvedHeadHarnessOnBase(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SharedValue()
+	}
+}
+`,
+		},
+		commit: true,
+	})
+	definition, overlayFiles, err := resolveBenchmarkDefinition(headRepo, []string{"./benchpkg"}, 1, "1x")
+	if err != nil {
+		t.Fatalf("resolve benchmark definition: %v", err)
+	}
+
+	artifactDir := canonicalTempDir(t)
+	definitionPath := filepath.Join(artifactDir, "definition.json")
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	definition.OverlayDir = filepath.Base(overlayDir)
+	if err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, overlayFiles); err != nil {
+		t.Fatalf("write benchmark definition: %v", err)
+	}
+
+	baseRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkBaseOnly(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SharedValue()
+	}
+}
+`,
+		},
+	})
+
+	outputPath := filepath.Join(t.TempDir(), "bench.out")
+	output, exitCode := runBenchdeltaHelper(t, "TestRunDefinitionUsesResolvedHeadHarnessOnBase", "run", "-repo", baseRepo, "-definition", definitionPath, "-output", outputPath)
+	assertBenchdeltaHelperExit(t, output, exitCode, 0)
+	assertBenchdeltaHelperOutput(t, output, "BenchmarkHeadOnly")
+	if strings.Contains(string(output), "BenchmarkBaseOnly") {
+		t.Fatalf("expected run output to use resolved head harness only, got:\n%s", output)
+	}
+
+	writtenOutput, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read bench output: %v", err)
+	}
+	assertBenchdeltaHelperOutput(t, writtenOutput, "lopper-bench-definition:")
+	assertBenchdeltaHelperOutput(t, writtenOutput, "lopper-bench-resolved-from:")
+	assertBenchdeltaHelperOutput(t, writtenOutput, "lopper-bench-resolved-commit:")
+	assertBenchdeltaHelperOutput(t, writtenOutput, "lopper-bench-selection: ^(BenchmarkHeadOnly)$")
+	assertBenchdeltaHelperOutput(t, writtenOutput, "lopper-bench-harness: benchpkg/head_benchmark_test.go")
+}
+
+func TestRunDefinitionRejectsBaseOnlyPackageTestFilesBeforeGoTest(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SharedValue()
+	}
+}
+`,
+		},
+		commit: true,
+	})
+	definition, overlayFiles, err := resolveBenchmarkDefinition(headRepo, []string{"./benchpkg"}, 1, "1x")
+	if err != nil {
+		t.Fatalf("resolve benchmark definition: %v", err)
+	}
+
+	artifactDir := canonicalTempDir(t)
+	definitionPath := filepath.Join(artifactDir, "definition.json")
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	definition.OverlayDir = filepath.Base(overlayDir)
+	if err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, overlayFiles); err != nil {
+		t.Fatalf("write benchmark definition: %v", err)
+	}
+
+	sentinelPath := filepath.Join(t.TempDir(), "unexpected-execution.txt")
+	baseRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/base_testmain_test.go": `package benchpkg
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_ = os.WriteFile(os.Getenv("BENCHDELTA_SENTINEL"), []byte("testmain"), 0o600)
+	os.Exit(m.Run())
+}
+`,
+			"benchpkg/base_init_test.go": `package benchpkg
+
+import "os"
+
+func init() {
+	_ = os.WriteFile(os.Getenv("BENCHDELTA_SENTINEL"), []byte("init"), 0o600)
+}
+`,
+			"benchpkg/base_helper_test.go": `package benchpkg
+
+var _ = missingHelperSymbol
+`,
+		},
+	})
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunDefinitionRejectsBaseOnlyPackageTestFilesBeforeGoTest", "--", "run", "-repo", baseRepo, "-definition", definitionPath)
+	cmd.Env = make([]string, 0, len(os.Environ())+2)
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "GO_WANT_BENCHDELTA_HELPER=") || strings.HasPrefix(entry, "BENCHDELTA_SENTINEL=") {
+			continue
+		}
+		cmd.Env = append(cmd.Env, entry)
+	}
+	cmd.Env = append(cmd.Env, "GO_WANT_BENCHDELTA_HELPER=1", "BENCHDELTA_SENTINEL="+sentinelPath)
+
+	output, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected subprocess exit error, got %v\n%s", err, output)
+	}
+	if exitErr.ExitCode() != 2 {
+		t.Fatalf("exit code = %d, want 2\n%s", exitErr.ExitCode(), output)
+	}
+	assertBenchdeltaHelperOutput(t, output, "package test files not in benchmark manifest")
+	assertBenchdeltaHelperOutput(t, output, "benchpkg/base_helper_test.go")
+	assertBenchdeltaHelperOutput(t, output, "benchpkg/base_init_test.go")
+	assertBenchdeltaHelperOutput(t, output, "benchpkg/base_testmain_test.go")
+	if strings.Contains(string(output), "undefined: missingHelperSymbol") {
+		t.Fatalf("expected fail-closed manifest rejection before go test compilation, got:\n%s", output)
+	}
+	if _, statErr := os.Stat(sentinelPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected sentinel to remain absent, got %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(baseRepo, "benchpkg", "head_benchmark_test.go")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected overlay target to remain absent after rejection, got %v", statErr)
+	}
+}
+
+func TestRunDefinitionApplicationFailureExitsStatusTwo(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SharedValue()
+	}
+}
+`,
+		},
+		commit: true,
+	})
+	definition, overlayFiles, err := resolveBenchmarkDefinition(headRepo, []string{"./benchpkg"}, 1, "1x")
+	if err != nil {
+		t.Fatalf("resolve benchmark definition: %v", err)
+	}
+
+	artifactDir := canonicalTempDir(t)
+	definitionPath := filepath.Join(artifactDir, "definition.json")
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	definition.OverlayDir = filepath.Base(overlayDir)
+	if err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, overlayFiles); err != nil {
+		t.Fatalf("write benchmark definition: %v", err)
+	}
+
+	baseRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go": "package benchpkg\n\nfunc DifferentValue() int { return 7 }\n",
+		},
+	})
+
+	output, exitCode := runBenchdeltaHelper(t, "TestRunDefinitionApplicationFailureExitsStatusTwo", "run", "-repo", baseRepo, "-definition", definitionPath)
+	assertBenchdeltaHelperExit(t, output, exitCode, 2)
+	assertBenchdeltaHelperOutput(t, output, "run benchmark definition")
+	assertBenchdeltaHelperOutput(t, output, "undefined: SharedValue")
+}
+
+func TestMainResolveExitCodesAndOutput(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SharedValue()
+	}
+}
+`,
+		},
+		commit: true,
+	})
+	artifactDir := canonicalTempDir(t)
+	definitionPath := filepath.Join(artifactDir, "definition.json")
+	output, exitCode := runBenchdeltaHelper(t, "TestMainResolveExitCodesAndOutput", "resolve", "-repo", headRepo, "-package", "./benchpkg", "-count", "1", "-benchtime", "1x", "-out", definitionPath)
+	assertBenchdeltaHelperExit(t, output, exitCode, 0)
+	assertBenchdeltaHelperOutput(t, output, "lopper-bench-definition:")
+
+	output, exitCode = runBenchdeltaHelper(t, "TestMainResolveExitCodesAndOutput", "resolve", "-repo", headRepo, "-package", "./benchpkg")
+	assertBenchdeltaHelperExit(t, output, exitCode, 2)
+	assertBenchdeltaHelperOutput(t, output, "resolve requires -out")
+}
+
+func TestDefinitionHelpers(t *testing.T) {
+	t.Run("package flag string and set", func(t *testing.T) {
+		var flags packageListFlag
+		if err := flags.Set("./benchpkg"); err != nil {
+			t.Fatalf("set package flag: %v", err)
+		}
+		if got := flags.String(); got != "./benchpkg" {
+			t.Fatalf("package flag string = %q", got)
+		}
+		if err := flags.Set(" "); err == nil {
+			t.Fatal("expected empty package target to fail")
+		}
+	})
+
+	t.Run("package target confinement", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if _, err := packageTargetDir(repoRoot, "../escape"); err == nil || !strings.Contains(err.Error(), "escapes repository root") {
+			t.Fatalf("expected package target escape error, got %v", err)
+		}
+		if _, err := packageTargetDir(repoRoot, "."); err == nil || !strings.Contains(err.Error(), "repo root") {
+			t.Fatalf("expected repo root rejection, got %v", err)
+		}
+		if _, err := packageTargetDir(repoRoot, "/tmp/abs"); err == nil || !strings.Contains(err.Error(), "must be relative") {
+			t.Fatalf("expected absolute path rejection, got %v", err)
+		}
+	})
+
+	t.Run("goflags injection", func(t *testing.T) {
+		env := withGoFlagsDisabledBuildVCS([]string{"PATH=/bin", "GOFLAGS=-mod=readonly"})
+		if !slices.Contains(env, "GOFLAGS=-mod=readonly -buildvcs=false") {
+			t.Fatalf("expected GOFLAGS injection, got %#v", env)
+		}
+		env = withGoFlagsDisabledBuildVCS([]string{"PATH=/bin"})
+		if !slices.Contains(env, "GOFLAGS=-buildvcs=false") {
+			t.Fatalf("expected default GOFLAGS injection, got %#v", env)
+		}
+	})
+
+	t.Run("invalid definition rejected", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "definition.json")
+		if err := os.WriteFile(path, []byte(`{"version":1}`), 0o600); err != nil {
+			t.Fatalf("write invalid definition: %v", err)
+		}
+		if _, _, err := readBenchmarkDefinition(path); err == nil || !strings.Contains(err.Error(), "incomplete") {
+			t.Fatalf("expected incomplete definition error, got %v", err)
+		}
+	})
+
+	t.Run("resolve and run command success", func(t *testing.T) {
+		headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+				"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SharedValue()
+	}
+}
+`,
+			},
+			commit: true,
+		})
+		artifactDir := canonicalTempDir(t)
+		definitionPath := filepath.Join(artifactDir, "definition.json")
+		overlayDir := filepath.Join(artifactDir, "overlay")
+		if err := runResolveCommand([]string{
+			"-repo", headRepo,
+			"-package", "./benchpkg",
+			"-count", "2",
+			"-benchtime", "1x",
+			"-out", definitionPath,
+			"-overlay-dir", overlayDir,
+		}); err != nil {
+			t.Fatalf("runResolveCommand: %v", err)
+		}
+
+		definition, _, err := readBenchmarkDefinition(definitionPath)
+		if err != nil {
+			t.Fatalf("readBenchmarkDefinition: %v", err)
+		}
+		if definition.OverlayDir != "overlay" {
+			t.Fatalf("overlay dir = %q", definition.OverlayDir)
+		}
+
+		baseRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+				"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkBaseOnly(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SharedValue()
+	}
+}
+`,
+			},
+		})
+		outputPath := filepath.Join(t.TempDir(), "bench.out")
+		if err := runBenchmarkCommand([]string{
+			"-repo", baseRepo,
+			"-definition", definitionPath,
+			"-output", outputPath,
+		}); err != nil {
+			t.Fatalf("runBenchmarkCommand: %v", err)
+		}
+		output, err := os.ReadFile(outputPath)
+		if err != nil {
+			t.Fatalf("read benchmark output: %v", err)
+		}
+		assertBenchdeltaHelperOutput(t, output, "BenchmarkHeadOnly")
+	})
+
+	t.Run("resolve validation errors", func(t *testing.T) {
+		cases := [][]string{
+			{"-unknown"},
+			{"-package", "./benchpkg"},
+			{"-out", filepath.Join(t.TempDir(), "definition.json")},
+			{"-out", filepath.Join(t.TempDir(), "definition.json"), "-package", "./benchpkg", "-count", "0"},
+			{"-out", filepath.Join(t.TempDir(), "definition.json"), "-package", "./benchpkg", "-benchtime", " "},
+		}
+		for _, args := range cases {
+			if err := runResolveCommand(args); err == nil {
+				t.Fatalf("expected resolve command error for args %#v", args)
+			}
+		}
+	})
+
+	t.Run("run validation errors", func(t *testing.T) {
+		if err := runBenchmarkCommand(nil); err == nil || !strings.Contains(err.Error(), "run requires -definition") {
+			t.Fatalf("expected missing definition error, got %v", err)
+		}
+		if err := runBenchmarkCommand([]string{"-unknown"}); err == nil {
+			t.Fatal("expected flag parse error")
+		}
+
+		definitionPath := filepath.Join(t.TempDir(), "definition.json")
+		if err := os.WriteFile(definitionPath, []byte(`{"version":99,"package_targets":["./benchpkg"],"benchmarks":[{"package_target":"./benchpkg","name":"BenchmarkHeadOnly"}],"bench_pattern":"^(BenchmarkHeadOnly)$","run_pattern":"^$","count":1,"benchtime":"1x","benchmem":true,"harness_files":[{"path":"benchpkg/head_benchmark_test.go","sha256":"abc","overlay_path":"benchpkg/head_benchmark_test.go"}]}`), 0o600); err != nil {
+			t.Fatalf("write definition: %v", err)
+		}
+		if err := runBenchmarkCommand([]string{"-definition", definitionPath}); err == nil || !strings.Contains(err.Error(), "unsupported benchmark definition version") {
+			t.Fatalf("expected unsupported version error, got %v", err)
+		}
+		definitionPath = filepath.Join(t.TempDir(), "bad-definition.json")
+		if err := os.WriteFile(definitionPath, []byte("{"), 0o600); err != nil {
+			t.Fatalf("write invalid json: %v", err)
+		}
+		if err := runBenchmarkCommand([]string{"-definition", definitionPath}); err == nil || !strings.Contains(err.Error(), "parse benchmark definition") {
+			t.Fatalf("expected parse definition error, got %v", err)
+		}
+	})
+
+	t.Run("definition write and apply errors", func(t *testing.T) {
+		headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+				"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SharedValue()
+	}
+}
+`,
+			},
+			commit: true,
+		})
+		definition, overlayFiles, err := resolveBenchmarkDefinition(headRepo, []string{"./benchpkg"}, 1, "1x")
+		if err != nil {
+			t.Fatalf("resolve benchmark definition: %v", err)
+		}
+
+		blocker := filepath.Join(canonicalTempDir(t), "blocker")
+		if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write blocker: %v", err)
+		}
+		if err := writeBenchmarkDefinition(filepath.Join(blocker, "definition.json"), filepath.Join(canonicalTempDir(t), "overlay"), definition, overlayFiles); err == nil {
+			t.Fatal("expected writeBenchmarkDefinition to fail for blocked path")
+		}
+
+		artifactDir := canonicalTempDir(t)
+		definitionPath := filepath.Join(artifactDir, "definition.json")
+		overlayDir := filepath.Join(artifactDir, "overlay")
+		definition.OverlayDir = filepath.Base(overlayDir)
+		if err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, overlayFiles); err != nil {
+			t.Fatalf("write benchmark definition: %v", err)
+		}
+		if err := os.Remove(filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go")); err != nil {
+			t.Fatalf("remove overlay: %v", err)
+		}
+		if err := applyBenchmarkOverlay(t.TempDir(), definitionPath, definition); err == nil || !strings.Contains(err.Error(), "read overlay file") {
+			t.Fatalf("expected missing overlay error, got %v", err)
+		}
+
+		if err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, overlayFiles); err != nil {
+			t.Fatalf("rewrite benchmark definition: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go"), []byte("corrupt"), 0o600); err != nil {
+			t.Fatalf("corrupt overlay: %v", err)
+		}
+		if err := applyBenchmarkOverlay(t.TempDir(), definitionPath, definition); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+			t.Fatalf("expected digest mismatch, got %v", err)
+		}
+
+		outputBlocker := filepath.Join(t.TempDir(), "blocker")
+		if err := os.WriteFile(outputBlocker, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write output blocker: %v", err)
+		}
+		validRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/subject.go": "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			},
+		})
+		if err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, overlayFiles); err != nil {
+			t.Fatalf("rewrite definition for output error: %v", err)
+		}
+		if err := runBenchmarkCommand([]string{
+			"-repo", validRepo,
+			"-definition", definitionPath,
+			"-output", filepath.Join(outputBlocker, "bench.out"),
+		}); err == nil || !strings.Contains(err.Error(), "write benchmark output") {
+			t.Fatalf("expected write benchmark output error, got %v", err)
+		}
+	})
+
+	t.Run("resolution parsing errors", func(t *testing.T) {
+		repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/bad_benchmark_test.go": "package benchpkg\n\nfunc BenchmarkBroken(\n",
+			},
+			commit: true,
+		})
+		if _, _, err := resolveBenchmarkDefinition(repo, []string{"./benchpkg"}, 1, "1x"); err == nil || !strings.Contains(err.Error(), "parse benchmark harness") {
+			t.Fatalf("expected parse error, got %v", err)
+		}
+
+		noBenchRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/helper_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc TestOnly(t *testing.T) {}\n",
+			},
+			commit: true,
+		})
+		if _, _, err := resolveBenchmarkDefinition(noBenchRepo, []string{"./benchpkg"}, 1, "1x"); err == nil || !strings.Contains(err.Error(), "does not define any benchmarks") {
+			t.Fatalf("expected no benchmark error, got %v", err)
+		}
+
+		noGitRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {}
+`,
+			},
+		})
+		if _, _, err := resolveBenchmarkDefinition(noGitRepo, []string{"./benchpkg"}, 1, "1x"); err == nil || !strings.Contains(err.Error(), "resolve HEAD commit") {
+			t.Fatalf("expected missing git HEAD error, got %v", err)
+		}
+
+		validRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {}
+`,
+			},
+			commit: true,
+		})
+		if _, _, err := resolveBenchmarkDefinition(validRepo, nil, 1, "1x"); err == nil || !strings.Contains(err.Error(), "no benchmarks resolved") {
+			t.Fatalf("expected no package benchmark resolution error, got %v", err)
+		}
+	})
+
+	t.Run("resolve and parse helpers", func(t *testing.T) {
+		repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+type receiver struct{}
+
+func (receiver) BenchmarkMethod(b *testing.B) {}
+func benchmarkLower(b *testing.B) {}
+func BenchmarkNoParams() {}
+func BenchmarkWrongParam(b testing.B) {}
+func BenchmarkWrongSelector(b *benchpkg.B) {}
+func BenchmarkValid(b *testing.B) {}
+`,
+			},
+			commit: true,
+		})
+		names, err := benchmarkFunctionsInFile(filepath.Join(repo, "benchpkg", "head_benchmark_test.go"))
+		if err != nil {
+			t.Fatalf("benchmarkFunctionsInFile: %v", err)
+		}
+		if want := []string{"BenchmarkValid"}; !slices.Equal(names, want) {
+			t.Fatalf("benchmark names = %#v, want %#v", names, want)
+		}
+
+		if _, _, err := resolvePackageBenchmarks(repo, "./missing"); err == nil || !strings.Contains(err.Error(), "read package") {
+			t.Fatalf("expected missing package read error, got %v", err)
+		}
+	})
+
+	t.Run("read definition defaults overlay and requires execution fields", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "definition.json")
+		content := `{"version":1,"package_targets":["./benchpkg"],"benchmarks":[{"package_target":"./benchpkg","name":"BenchmarkHeadOnly"}],"bench_pattern":"^(BenchmarkHeadOnly)$","run_pattern":"^$","count":1,"benchtime":"1x","benchmem":true,"harness_files":[{"path":"benchpkg/head_benchmark_test.go","sha256":"abc","overlay_path":"benchpkg/head_benchmark_test.go"}]}`
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write definition: %v", err)
+		}
+		definition, _, err := readBenchmarkDefinition(path)
+		if err != nil {
+			t.Fatalf("readBenchmarkDefinition default overlay: %v", err)
+		}
+		if definition.OverlayDir != defaultOverlayDir {
+			t.Fatalf("default overlay dir = %q, want %q", definition.OverlayDir, defaultOverlayDir)
+		}
+
+		badPath := filepath.Join(t.TempDir(), "bad.json")
+		if err := os.WriteFile(badPath, []byte(`{"version":1,"package_targets":["./benchpkg"],"benchmarks":[{"package_target":"./benchpkg","name":"BenchmarkHeadOnly"}],"bench_pattern":"","run_pattern":"^$","count":1,"benchtime":"1x","benchmem":true,"harness_files":[{"path":"benchpkg/head_benchmark_test.go","sha256":"abc","overlay_path":"benchpkg/head_benchmark_test.go"}]}`), 0o600); err != nil {
+			t.Fatalf("write bad definition: %v", err)
+		}
+		if _, _, err := readBenchmarkDefinition(badPath); err == nil || !strings.Contains(err.Error(), "missing required execution fields") {
+			t.Fatalf("expected missing execution fields error, got %v", err)
+		}
+
+		if _, _, err := readBenchmarkDefinition(filepath.Join(t.TempDir(), "missing.json")); err == nil || !strings.Contains(err.Error(), "read benchmark definition") {
+			t.Fatalf("expected missing definition read error, got %v", err)
+		}
+	})
+
+	t.Run("overlay and manifest path collisions", func(t *testing.T) {
+		parent := canonicalTempDir(t)
+		definition := benchmarkDefinition{
+			Version:        definitionVersion,
+			ResolvedFrom:   "deadbeef",
+			PackageTargets: []string{"./benchpkg"},
+			Benchmarks:     []resolvedBenchmark{{PackageTarget: "./benchpkg", Name: "BenchmarkHeadOnly"}},
+			BenchPattern:   "^(BenchmarkHeadOnly)$",
+			RunPattern:     "^$",
+			Count:          1,
+			Benchtime:      "1x",
+			BenchMem:       true,
+			HarnessFiles:   []benchmarkHarnessFile{{Path: "benchpkg/head_benchmark_test.go", SHA256: bytesDigest([]byte("package benchpkg")), OverlayPath: "benchpkg/head_benchmark_test.go"}},
+			OverlayDir:     "overlay",
+		}
+
+		blockedOverlayRoot := filepath.Join(parent, "blocked")
+		if err := os.WriteFile(blockedOverlayRoot, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write blocked overlay root: %v", err)
+		}
+		if err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(blockedOverlayRoot, "overlay"), definition, map[string][]byte{"benchpkg/head_benchmark_test.go": []byte("package benchpkg")}); err == nil || !strings.Contains(err.Error(), "clear benchmark overlay") && !strings.Contains(err.Error(), "write overlay file") {
+			t.Fatalf("expected create benchmark overlay error, got %v", err)
+		}
+
+	})
+
+	t.Run("apply overlay blocked target paths", func(t *testing.T) {
+		artifactDir := t.TempDir()
+		overlayDir := filepath.Join(artifactDir, "overlay")
+		if err := os.MkdirAll(filepath.Join(overlayDir, "benchpkg"), 0o755); err != nil {
+			t.Fatalf("mkdir overlay package dir: %v", err)
+		}
+		content := []byte("package benchpkg\n")
+		if err := os.WriteFile(filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go"), content, 0o600); err != nil {
+			t.Fatalf("write overlay content: %v", err)
+		}
+		definition := benchmarkDefinition{
+			Version:        definitionVersion,
+			ResolvedFrom:   "deadbeef",
+			PackageTargets: []string{"./benchpkg"},
+			Benchmarks:     []resolvedBenchmark{{PackageTarget: "./benchpkg", Name: "BenchmarkHeadOnly"}},
+			BenchPattern:   "^(BenchmarkHeadOnly)$",
+			RunPattern:     "^$",
+			Count:          1,
+			Benchtime:      "1x",
+			BenchMem:       true,
+			HarnessFiles:   []benchmarkHarnessFile{{Path: "blocked/head_benchmark_test.go", SHA256: bytesDigest(content), OverlayPath: "benchpkg/head_benchmark_test.go"}},
+			OverlayDir:     "overlay",
+		}
+		definitionPath := filepath.Join(artifactDir, "definition.json")
+		if err := os.WriteFile(definitionPath, []byte(`{}`), 0o600); err != nil {
+			t.Fatalf("write placeholder definition: %v", err)
+		}
+
+		repo := t.TempDir()
+		if err := os.WriteFile(filepath.Join(repo, "blocked"), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write blocked repo file: %v", err)
+		}
+		if err := applyBenchmarkOverlay(repo, definitionPath, definition); err == nil || !strings.Contains(err.Error(), `benchmark harness path "blocked/head_benchmark_test.go" is outside benchmark package targets`) {
+			t.Fatalf("expected apply mkdir error, got %v", err)
+		}
+
+		definition.HarnessFiles[0].Path = "benchpkg"
+		repo = t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repo, "benchpkg"), 0o755); err != nil {
+			t.Fatalf("mkdir benchpkg dir: %v", err)
+		}
+		if err := applyBenchmarkOverlay(repo, definitionPath, definition); err == nil || !strings.Contains(err.Error(), "benchmark harness path must reference a package _test.go file") {
+			t.Fatalf("expected apply write error, got %v", err)
+		}
+	})
+
+	t.Run("parse benchmark file and execute options", func(t *testing.T) {
+		if _, err := parseBenchmarkFile(filepath.Join(t.TempDir(), "missing.txt")); err == nil || !strings.Contains(err.Error(), "file does not exist") {
+			t.Fatalf("expected parseBenchmarkFile open error, got %v", err)
+		}
+
+		repo := newBenchmarkRepo(t, benchmarkRepoSpec{
+			modulePath: "example.com/benchrepo",
+			files: map[string]string{
+				"benchpkg/head_benchmark_test.go": `package benchpkg
+
+import "testing"
+
+func BenchmarkHeadOnly(b *testing.B) {}
+`,
+			},
+		})
+		output, err := executeBenchmarkDefinition(repo, benchmarkDefinition{PackageTargets: []string{"./benchpkg"}, BenchPattern: "^(BenchmarkHeadOnly)$", RunPattern: "^$", Count: 1, Benchtime: "1x", BenchMem: false}, "-X example.com/benchrepo/internal/version.buildChannel=test")
+		if err != nil {
+			t.Fatalf("executeBenchmarkDefinition: %v\n%s", err, output)
+		}
+		if !strings.Contains(string(output), "BenchmarkHeadOnly") {
+			t.Fatalf("expected benchmark output, got:\n%s", output)
+		}
+	})
+}
+
 func runBenchdeltaMainIfRequested(t *testing.T) bool {
 	t.Helper()
 	if os.Getenv("GO_WANT_BENCHDELTA_HELPER") != "1" {
@@ -746,6 +1602,71 @@ func runBenchdeltaHelper(t *testing.T, testName string, args ...string) ([]byte,
 		t.Fatalf("expected subprocess exit error or success, got %v\n%s", err, output)
 	}
 	return output, exitErr.ExitCode()
+}
+
+type benchmarkRepoSpec struct {
+	modulePath string
+	files      map[string]string
+	commit     bool
+}
+
+func newBenchmarkRepo(t *testing.T, spec benchmarkRepoSpec) string {
+	t.Helper()
+
+	repo := t.TempDir()
+	modulePath := spec.modulePath
+	if modulePath == "" {
+		modulePath = "example.com/benchrepo"
+	}
+	files := map[string]string{
+		"go.mod": "module " + modulePath + "\n\ngo 1.26.0\n",
+	}
+	for path, content := range spec.files {
+		files[path] = content
+	}
+	for path, content := range files {
+		absPath := filepath.Join(repo, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+			t.Fatalf("create directory for %s: %v", path, err)
+		}
+		if err := os.WriteFile(absPath, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	if spec.commit {
+		initGitRepo(t, repo)
+	}
+	return repo
+}
+
+func initGitRepo(t *testing.T, repo string) {
+	t.Helper()
+	runGitCommand(t, repo, "init", "-b", "main")
+	runGitCommand(t, repo, "config", "user.name", "Bench Delta Test")
+	runGitCommand(t, repo, "config", "user.email", "benchdelta@example.com")
+	runGitCommand(t, repo, "add", ".")
+	runGitCommand(t, repo, "commit", "-m", "fixture")
+}
+
+func runGitCommand(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	cmd.Env = envWithoutGitOverrides(os.Environ())
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func runGitOutput(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	cmd.Env = envWithoutGitOverrides(os.Environ())
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
 }
 
 func assertBenchdeltaHelperExit(t *testing.T, output []byte, gotCode, wantCode int) {

--- a/tools/benchdelta/makefile_pinning_test.go
+++ b/tools/benchdelta/makefile_pinning_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBenchMemMakeTargetRunsBenchdeltaFromRepoRoot(t *testing.T) {
+	makefile := readRepoMakefile(t)
+	if !strings.Contains(makefile, `(cd "$(CURDIR)" && $(GO_CMD) run ./tools/benchdelta run`) {
+		t.Fatal("expected bench-mem to run benchdelta from the head repo root")
+	}
+	if !strings.Contains(makefile, `-repo "$$head_tree"`) {
+		t.Fatal("expected bench-mem to pass the detached head worktree through -repo")
+	}
+	if strings.Contains(makefile, `run "$(CURDIR)/tools/benchdelta"`) {
+		t.Fatal("expected Makefile to avoid absolute go run tool paths")
+	}
+	if strings.Contains(makefile, `> /dev/null 2>&1`) {
+		t.Fatal("expected Makefile benchdelta invocations to retain actionable command output")
+	}
+}
+
+func TestBenchGateMakeTargetRunsBenchdeltaAgainstBaseWorktree(t *testing.T) {
+	target := makeTargetBody(t, "bench-gate")
+	if !strings.Contains(target, `benchdelta_bin="$$bench_dir/benchdelta"`) {
+		t.Fatal("expected bench-gate to build a reusable benchdelta binary inside the temp bench dir")
+	}
+	if !strings.Contains(target, `GOFLAGS=-buildvcs=false $(GO_CMD) build -o "$$benchdelta_bin" ./tools/benchdelta`) {
+		t.Fatal("expected bench-gate to build tools/benchdelta once before resolve/run/compare")
+	}
+	if !strings.Contains(target, `"$$benchdelta_bin" resolve -repo "$(CURDIR)"`) {
+		t.Fatal("expected bench-gate to resolve benchmark definitions with the single built binary")
+	}
+	if !strings.Contains(target, `-repo "$$base_tree"`) {
+		t.Fatal("expected bench-gate to run the head-resolved definition against the base worktree via -repo")
+	}
+	if !strings.Contains(target, `"$$benchdelta_bin" run`) {
+		t.Fatal("expected bench-gate to execute pinned benchmark runs with the single built binary")
+	}
+	if !strings.Contains(target, `base_log_tmp=$$(mktemp)`) || !strings.Contains(target, `head_log_tmp=$$(mktemp)`) {
+		t.Fatal("expected bench-gate to capture separate base/head benchdelta logs")
+	}
+	if strings.Contains(target, `$(GO_CMD) run ./tools/benchdelta resolve`) || strings.Contains(target, `$(GO_CMD) run ./tools/benchdelta run`) {
+		t.Fatal("expected bench-gate to avoid go run for resolve/run once the pinned binary is built")
+	}
+}
+
+func TestBenchdeltaCoverageGatePinnedTo98Percent(t *testing.T) {
+	makefile := readRepoMakefile(t)
+	if !strings.Contains(makefile, `-min=98.0`) {
+		t.Fatal("expected benchdelta total coverage gate to be pinned to 98.0")
+	}
+	if !strings.Contains(makefile, `-package-min=98.0`) {
+		t.Fatal("expected benchdelta per-package coverage gate to be pinned to 98.0")
+	}
+}
+
+func TestBenchTargetsAcceptAbsoluteDefinitionOverrides(t *testing.T) {
+	tempDir := t.TempDir()
+	tests := []struct {
+		name           string
+		override       string
+		definitionPath string
+		overlayPath    string
+	}{
+		{
+			name:           "definition path",
+			override:       "MEMORY_BENCH_DEFINITION=" + filepath.Join(tempDir, "custom", "benchmark.json"),
+			definitionPath: filepath.Join(tempDir, "custom", "benchmark.json"),
+			overlayPath:    filepath.Join(tempDir, "custom", "overlay"),
+		},
+		{
+			name:           "definition directory",
+			override:       "MEMORY_BENCH_DEFINITION_DIR=" + filepath.Join(tempDir, "directory"),
+			definitionPath: filepath.Join(tempDir, "directory", "definition.json"),
+			overlayPath:    filepath.Join(tempDir, "directory", "overlay"),
+		},
+	}
+
+	for _, test := range tests {
+		for _, target := range []string{"bench-mem", "bench-gate"} {
+			t.Run(test.name+"/"+target, func(t *testing.T) {
+				output := dryRunMakeTarget(t, target, test.override)
+				for _, expected := range []string{
+					`-out "` + test.definitionPath + `"`,
+					`-overlay-dir "` + test.overlayPath + `"`,
+					`-definition "` + test.definitionPath + `"`,
+				} {
+					if !strings.Contains(output, expected) {
+						t.Fatalf("make %s output does not contain %q:\n%s", target, expected, output)
+					}
+				}
+				brokenPath := repoRoot(t) + string(filepath.Separator) + test.definitionPath
+				if strings.Contains(output, brokenPath) {
+					t.Fatalf("make %s prepends the repo root to absolute path %q:\n%s", target, test.definitionPath, output)
+				}
+			})
+		}
+	}
+}
+
+func dryRunMakeTarget(t *testing.T, target, override string) string {
+	t.Helper()
+	cmd := exec.Command("make", "--no-print-directory", "-n", target, override)
+	cmd.Dir = repoRoot(t)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dry-run make %s: %v\n%s", target, err, output)
+	}
+	return string(output)
+}
+
+func readRepoMakefile(t *testing.T) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(repoRoot(t), "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	return string(content)
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test file path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func makeTargetBody(t *testing.T, target string) string {
+	t.Helper()
+	pattern := regexp.MustCompile(`(?ms)^` + regexp.QuoteMeta(target) + `:\n(?:\t.*\n)+`)
+	body := pattern.FindString(readRepoMakefile(t))
+	if body == "" {
+		t.Fatalf("Makefile target %s not found", target)
+	}
+	return body
+}

--- a/tools/benchdelta/overlay_security_test.go
+++ b/tools/benchdelta/overlay_security_test.go
@@ -1,0 +1,2238 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func withBenchdeltaFSHooks(t *testing.T, fn func()) {
+	t.Helper()
+
+	originalReadFile := readFile
+	originalReadDir := readDir
+	originalMarshalIndent := marshalIndent
+	originalAbsPath := absPath
+	originalRelPath := relPath
+	originalEvalSymlinks := evalSymlinks
+	originalOpenOSRoot := openOSRoot
+	originalSameFile := sameFile
+	originalRootLstat := rootLstat
+	originalRootOpenRoot := rootOpenRoot
+	originalRootOpen := rootOpen
+	originalRootMkdir := rootMkdir
+	originalRootRename := rootRename
+	originalRootRemove := rootRemove
+	originalCloseOSRoot := closeOSRoot
+	originalResolveStageWriteSeam := resolveStageWriteSeam
+	originalResolvePromoteSeam := resolvePromoteSeam
+	originalApplyStageWriteSeam := applyStageWriteSeam
+	originalApplyPromoteSeam := applyPromoteSeam
+
+	t.Cleanup(func() {
+		readFile = originalReadFile
+		readDir = originalReadDir
+		marshalIndent = originalMarshalIndent
+		absPath = originalAbsPath
+		relPath = originalRelPath
+		evalSymlinks = originalEvalSymlinks
+		openOSRoot = originalOpenOSRoot
+		sameFile = originalSameFile
+		rootLstat = originalRootLstat
+		rootOpenRoot = originalRootOpenRoot
+		rootOpen = originalRootOpen
+		rootMkdir = originalRootMkdir
+		rootRename = originalRootRename
+		rootRemove = originalRootRemove
+		closeOSRoot = originalCloseOSRoot
+		resolveStageWriteSeam = originalResolveStageWriteSeam
+		resolvePromoteSeam = originalResolvePromoteSeam
+		applyStageWriteSeam = originalApplyStageWriteSeam
+		applyPromoteSeam = originalApplyPromoteSeam
+	})
+
+	fn()
+}
+
+const (
+	absoluteHarnessDefinitionTemplate = `{
+  "version": %d,
+  "resolved_from": "deadbeef",
+  "package_targets": ["./benchpkg"],
+  "benchmarks": [{"package_target":"./benchpkg","name":"BenchmarkHeadOnly"}],
+  "bench_pattern": "^(BenchmarkHeadOnly)$",
+  "run_pattern": "^$",
+  "count": 1,
+  "benchtime": "1x",
+  "benchmem": true,
+  "overlay_dir": "overlay",
+  "harness_files": [{"path":"/tmp/head_benchmark_test.go","sha256":"abc","overlay_path":"benchpkg/head_benchmark_test.go"}]
+}`
+	overlayTraversalDefinitionTemplate = `{
+  "version": %d,
+  "resolved_from": "deadbeef",
+  "package_targets": ["./benchpkg"],
+  "benchmarks": [{"package_target":"./benchpkg","name":"BenchmarkHeadOnly"}],
+  "bench_pattern": "^(BenchmarkHeadOnly)$",
+  "run_pattern": "^$",
+  "count": 1,
+  "benchtime": "1x",
+  "benchmem": true,
+  "overlay_dir": "overlay",
+  "harness_files": [{"path":"benchpkg/head_benchmark_test.go","sha256":"abc","overlay_path":"../escape.go"}]
+}`
+)
+
+func TestReadBenchmarkDefinitionRejectsAbsoluteHarnessPath(t *testing.T) {
+	definitionPath := filepath.Join(t.TempDir(), "definition.json")
+	content := fmt.Sprintf(absoluteHarnessDefinitionTemplate, definitionVersion)
+	writeDefinitionJSON(t, definitionPath, content)
+
+	if _, _, err := readBenchmarkDefinition(definitionPath); err == nil || !strings.Contains(err.Error(), "benchmark harness path must be relative") {
+		t.Fatalf("expected absolute harness path rejection, got %v", err)
+	}
+}
+
+func TestReadBenchmarkDefinitionRejectsOverlayPathTraversal(t *testing.T) {
+	definitionPath := filepath.Join(t.TempDir(), "definition.json")
+	content := fmt.Sprintf(overlayTraversalDefinitionTemplate, definitionVersion)
+	writeDefinitionJSON(t, definitionPath, content)
+
+	if _, _, err := readBenchmarkDefinition(definitionPath); err == nil || !strings.Contains(err.Error(), "benchmark harness overlay path escapes its root") {
+		t.Fatalf("expected overlay traversal rejection, got %v", err)
+	}
+}
+
+func TestReadBenchmarkDefinitionRejectsDuplicateHarnessPaths(t *testing.T) {
+	tests := []struct {
+		name         string
+		harnessFiles []benchmarkHarnessFile
+		wantError    string
+	}{
+		{
+			name: "target path",
+			harnessFiles: []benchmarkHarnessFile{
+				{Path: "benchpkg/head_benchmark_test.go", SHA256: "first", OverlayPath: "source/first.go"},
+				{Path: "benchpkg/./head_benchmark_test.go", SHA256: "second", OverlayPath: "source/second.go"},
+			},
+			wantError: `duplicate benchmark harness path "benchpkg/head_benchmark_test.go"`,
+		},
+		{
+			name: "overlay path",
+			harnessFiles: []benchmarkHarnessFile{
+				{Path: "benchpkg/first_test.go", SHA256: "first", OverlayPath: "source/head_benchmark_test.go"},
+				{Path: "benchpkg/second_test.go", SHA256: "second", OverlayPath: "source/./head_benchmark_test.go"},
+			},
+			wantError: `duplicate benchmark harness overlay path "source/head_benchmark_test.go"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			definition := benchmarkDefinition{
+				Version:        definitionVersion,
+				ResolvedFrom:   "deadbeef",
+				PackageTargets: []string{"./benchpkg"},
+				Benchmarks:     []resolvedBenchmark{{PackageTarget: "./benchpkg", Name: "BenchmarkHeadOnly"}},
+				BenchPattern:   "^(BenchmarkHeadOnly)$",
+				RunPattern:     "^$",
+				Count:          1,
+				Benchtime:      "1x",
+				BenchMem:       true,
+				HarnessFiles:   test.harnessFiles,
+				OverlayDir:     "overlay",
+			}
+			content, err := json.Marshal(definition)
+			if err != nil {
+				t.Fatalf("marshal benchmark definition: %v", err)
+			}
+			definitionPath := filepath.Join(t.TempDir(), "definition.json")
+			writeDefinitionJSON(t, definitionPath, string(content))
+
+			if _, _, err := readBenchmarkDefinition(definitionPath); err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("expected %s rejection, got %v", test.name, err)
+			}
+		})
+	}
+}
+
+func TestRunResolveCommandPersistsManifestRelativeOverlayDir(t *testing.T) {
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go":             "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) { _ = SharedValue() }\n",
+		},
+		commit: true,
+	})
+	artifactDir := canonicalTempDir(t)
+	definitionPath := filepath.Join(artifactDir, "manifests", "definition.json")
+	overlayDir := filepath.Join(artifactDir, "manifests", "nested", "custom-overlay")
+
+	if err := runResolveCommand([]string{
+		"-repo", headRepo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", definitionPath,
+		"-overlay-dir", overlayDir,
+	}); err != nil {
+		t.Fatalf("runResolveCommand returned error: %v", err)
+	}
+
+	definition, _, err := readBenchmarkDefinition(definitionPath)
+	if err != nil {
+		t.Fatalf("readBenchmarkDefinition returned error: %v", err)
+	}
+	if definition.OverlayDir != "nested/custom-overlay" {
+		t.Fatalf("overlay dir = %q, want %q", definition.OverlayDir, "nested/custom-overlay")
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(definitionPath), "nested", "custom-overlay", "benchpkg", "head_benchmark_test.go")); err != nil {
+		t.Fatalf("expected nested overlay file to exist: %v", err)
+	}
+}
+
+func TestRunResolveCommandRejectsOverlayDirOutsideManifestRoot(t *testing.T) {
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) {}\n",
+		},
+		commit: true,
+	})
+	artifactDir := canonicalTempDir(t)
+	definitionPath := filepath.Join(artifactDir, "manifests", "definition.json")
+	overlayDir := filepath.Join(artifactDir, "outside-overlay")
+
+	err := runResolveCommand([]string{
+		"-repo", headRepo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", definitionPath,
+		"-overlay-dir", overlayDir,
+	})
+	if err == nil || !strings.Contains(err.Error(), "overlay directory escapes its root") {
+		t.Fatalf("expected out-of-root overlay rejection, got %v", err)
+	}
+}
+
+func TestMainResolveRejectsSymlinkedOverlayAncestorWithoutMutatingExternalDir(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go":             "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) { _ = SharedValue() }\n",
+		},
+		commit: true,
+	})
+
+	artifactDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalize artifact dir: %v", err)
+	}
+	externalRoot := filepath.Join(artifactDir, "external-root")
+	if err := os.MkdirAll(filepath.Join(externalRoot, "overlay"), 0o755); err != nil {
+		t.Fatalf("mkdir external overlay: %v", err)
+	}
+	staleOverlayPath := filepath.Join(externalRoot, "overlay", "stale.txt")
+	if err := os.WriteFile(staleOverlayPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write stale overlay file: %v", err)
+	}
+	sentinelPath := filepath.Join(externalRoot, "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("sentinel"), 0o600); err != nil {
+		t.Fatalf("write sentinel file: %v", err)
+	}
+
+	root := filepath.Join(artifactDir, "manifest-root")
+	if err := os.MkdirAll(filepath.Join(root, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir manifest nested dir: %v", err)
+	}
+	overlayAncestor := filepath.Join(root, "nested", "escape")
+	if err := os.Symlink(externalRoot, overlayAncestor); err != nil {
+		t.Fatalf("create overlay ancestor symlink: %v", err)
+	}
+
+	args := []string{
+		"resolve",
+		"-repo", headRepo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", filepath.Join(root, "definition.json"),
+		"-overlay-dir", filepath.Join(overlayAncestor, "overlay"),
+	}
+	output, exitCode := runBenchdeltaHelper(t, "TestMainResolveRejectsSymlinkedOverlayAncestorWithoutMutatingExternalDir", args...)
+	assertBenchdeltaHelperExit(t, output, exitCode, 2)
+	assertBenchdeltaHelperOutput(t, output, "clear benchmark overlay")
+	assertBenchdeltaHelperOutput(t, output, "overlay path contains symlink")
+	assertFileContainsBytes(t, staleOverlayPath, []byte("keep me"))
+	assertFileContainsBytes(t, sentinelPath, []byte("sentinel"))
+	if _, err := os.Stat(filepath.Join(externalRoot, "benchpkg")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected external overlay content to remain absent, got %v", err)
+	}
+}
+
+func TestMainResolveRejectsSymlinkedManifestRootWithoutMutatingExternalDir(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go":             "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) { _ = SharedValue() }\n",
+		},
+		commit: true,
+	})
+
+	artifactDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalize artifact dir: %v", err)
+	}
+	externalRoot := filepath.Join(artifactDir, "external-root")
+	if err := os.MkdirAll(filepath.Join(externalRoot, "overlay"), 0o755); err != nil {
+		t.Fatalf("mkdir external overlay: %v", err)
+	}
+	staleOverlayPath := filepath.Join(externalRoot, "overlay", "stale.txt")
+	if err := os.WriteFile(staleOverlayPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write stale overlay file: %v", err)
+	}
+	sentinelPath := filepath.Join(externalRoot, "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("sentinel"), 0o600); err != nil {
+		t.Fatalf("write sentinel file: %v", err)
+	}
+
+	linkedRoot := filepath.Join(artifactDir, "linked-root")
+	if err := os.Symlink(externalRoot, linkedRoot); err != nil {
+		t.Fatalf("create manifest root symlink: %v", err)
+	}
+
+	args := []string{
+		"resolve",
+		"-repo", headRepo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", filepath.Join(linkedRoot, "definition.json"),
+		"-overlay-dir", filepath.Join(linkedRoot, "overlay"),
+	}
+	output, exitCode := runBenchdeltaHelper(t, "TestMainResolveRejectsSymlinkedManifestRootWithoutMutatingExternalDir", args...)
+	assertBenchdeltaHelperExit(t, output, exitCode, 2)
+	assertBenchdeltaHelperOutput(t, output, "open benchmark manifest root")
+	assertBenchdeltaHelperOutput(t, output, "root contains symlink")
+	assertFileContainsBytes(t, staleOverlayPath, []byte("keep me"))
+	assertFileContainsBytes(t, sentinelPath, []byte("sentinel"))
+	if _, err := os.Stat(filepath.Join(externalRoot, "definition.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected external manifest to remain absent, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(externalRoot, "overlay", "benchpkg")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected external overlay content to remain absent, got %v", err)
+	}
+}
+
+func TestMainResolveRejectsSymlinkedManifestRootAncestorWithExistingDescendantWithoutMutatingExternalDir(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go":             "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) { _ = SharedValue() }\n",
+		},
+		commit: true,
+	})
+
+	artifactDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalize artifact dir: %v", err)
+	}
+	externalRoot := filepath.Join(artifactDir, "external-root")
+	existingRoot := filepath.Join(externalRoot, "existing")
+	if err := os.MkdirAll(filepath.Join(existingRoot, "overlay"), 0o755); err != nil {
+		t.Fatalf("mkdir external overlay: %v", err)
+	}
+	staleOverlayPath := filepath.Join(existingRoot, "overlay", "stale.txt")
+	if err := os.WriteFile(staleOverlayPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write stale overlay file: %v", err)
+	}
+	sentinelPath := filepath.Join(externalRoot, "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("sentinel"), 0o600); err != nil {
+		t.Fatalf("write sentinel file: %v", err)
+	}
+
+	root := filepath.Join(artifactDir, "manifest-root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir manifest root: %v", err)
+	}
+	if err := os.Symlink(externalRoot, filepath.Join(root, "escape")); err != nil {
+		t.Fatalf("create manifest ancestor symlink: %v", err)
+	}
+
+	args := []string{
+		"resolve",
+		"-repo", headRepo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", filepath.Join(root, "escape", "existing", "definition.json"),
+		"-overlay-dir", filepath.Join(root, "escape", "existing", "overlay"),
+	}
+	output, exitCode := runBenchdeltaHelper(t, "TestMainResolveRejectsSymlinkedManifestRootAncestorWithExistingDescendantWithoutMutatingExternalDir", args...)
+	assertBenchdeltaHelperExit(t, output, exitCode, 2)
+	assertBenchdeltaHelperOutput(t, output, "open benchmark manifest root")
+	assertBenchdeltaHelperOutput(t, output, "root contains symlink")
+	assertFileContainsBytes(t, staleOverlayPath, []byte("keep me"))
+	assertFileContainsBytes(t, sentinelPath, []byte("sentinel"))
+	if _, err := os.Stat(filepath.Join(existingRoot, "definition.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected external manifest to remain absent, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(existingRoot, "overlay", "benchpkg")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected external overlay content to remain absent, got %v", err)
+	}
+}
+
+func TestMainResolveRejectsSymlinkedManifestRootAncestorWithMissingDescendantWithoutMutatingExternalDir(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go":             "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) { _ = SharedValue() }\n",
+		},
+		commit: true,
+	})
+
+	artifactDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalize artifact dir: %v", err)
+	}
+	externalRoot := filepath.Join(artifactDir, "external-root")
+	if err := os.MkdirAll(externalRoot, 0o755); err != nil {
+		t.Fatalf("mkdir external root: %v", err)
+	}
+	sentinelPath := filepath.Join(externalRoot, "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("sentinel"), 0o600); err != nil {
+		t.Fatalf("write sentinel file: %v", err)
+	}
+
+	root := filepath.Join(artifactDir, "manifest-root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir manifest root: %v", err)
+	}
+	if err := os.Symlink(externalRoot, filepath.Join(root, "escape")); err != nil {
+		t.Fatalf("create manifest ancestor symlink: %v", err)
+	}
+
+	args := []string{
+		"resolve",
+		"-repo", headRepo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", filepath.Join(root, "escape", "missing", "nested", "definition.json"),
+		"-overlay-dir", filepath.Join(root, "escape", "missing", "nested", "overlay"),
+	}
+	output, exitCode := runBenchdeltaHelper(t, "TestMainResolveRejectsSymlinkedManifestRootAncestorWithMissingDescendantWithoutMutatingExternalDir", args...)
+	assertBenchdeltaHelperExit(t, output, exitCode, 2)
+	assertBenchdeltaHelperOutput(t, output, "open benchmark manifest root")
+	assertBenchdeltaHelperOutput(t, output, "root contains symlink")
+	assertFileContainsBytes(t, sentinelPath, []byte("sentinel"))
+	if _, err := os.Stat(filepath.Join(externalRoot, "missing", "nested", "definition.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected external manifest to remain absent, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(externalRoot, "missing", "nested", "overlay")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected external overlay content to remain absent, got %v", err)
+	}
+}
+
+func TestMainResolveSupportsTrustedMacOSAliasPath(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/subject.go":             "package benchpkg\n\nfunc SharedValue() int { return 42 }\n",
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) { _ = SharedValue() }\n",
+		},
+		commit: true,
+	})
+
+	artifactDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalize artifact dir: %v", err)
+	}
+	aliasDir, ok := trustedMacOSAliasPath(artifactDir)
+	if !ok {
+		t.Skip("trusted macOS alias path unavailable")
+	}
+	if err := os.MkdirAll(aliasDir, 0o755); err != nil {
+		t.Fatalf("mkdir alias artifact dir: %v", err)
+	}
+
+	definitionPath := filepath.Join(aliasDir, "definition.json")
+	overlayDir := filepath.Join(aliasDir, "overlay")
+	output, exitCode := runBenchdeltaHelper(t, "TestMainResolveSupportsTrustedMacOSAliasPath", "resolve", "-repo", headRepo, "-package", "./benchpkg", "-count", "1", "-benchtime", "1x", "-out", definitionPath, "-overlay-dir", overlayDir)
+	assertBenchdeltaHelperExit(t, output, exitCode, 0)
+	assertBenchdeltaHelperOutput(t, output, "lopper-bench-definition:")
+
+	if _, err := os.Stat(filepath.Join(artifactDir, "definition.json")); err != nil {
+		t.Fatalf("expected canonical manifest path to exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(artifactDir, "overlay", "benchpkg", "head_benchmark_test.go")); err != nil {
+		t.Fatalf("expected canonical overlay path to exist: %v", err)
+	}
+}
+
+func TestResolveManifestLayoutNormalizesManifestRelativeOverlayDir(t *testing.T) {
+	root := t.TempDir()
+	definitionPath := filepath.Join(root, "artifacts", "definition.json")
+	overlayPath := filepath.Join(root, "artifacts", "nested", ".", "overlay")
+	definitionDir, definitionRel, overlayRel, overlayRoot, err := resolveManifestLayout(definitionPath, overlayPath)
+	if err != nil {
+		t.Fatalf("resolveManifestLayout returned error: %v", err)
+	}
+	if definitionDir != filepath.Join(root, "artifacts") {
+		t.Fatalf("definition dir = %q", definitionDir)
+	}
+	if definitionRel != "definition.json" {
+		t.Fatalf("definition rel = %q", definitionRel)
+	}
+	if overlayRel != "nested/overlay" {
+		t.Fatalf("overlay rel = %q", overlayRel)
+	}
+	if overlayRoot != filepath.Join(root, "artifacts", "nested", "overlay") {
+		t.Fatalf("overlay root = %q", overlayRoot)
+	}
+}
+
+func TestResolveManifestLayoutRejectsOverlayDirAtManifestRoot(t *testing.T) {
+	root := t.TempDir()
+	_, _, _, _, err := resolveManifestLayout(filepath.Join(root, "artifacts", "definition.json"), filepath.Join(root, "artifacts"))
+	if err == nil || !strings.Contains(err.Error(), "overlay directory must not resolve to the root directory") {
+		t.Fatalf("expected manifest-root overlay rejection, got %v", err)
+	}
+}
+
+func TestNormalizeManifestRelativePathCases(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		if _, err := normalizeManifestRelativePath("overlay directory", " "); err == nil || !strings.Contains(err.Error(), "must not be empty") {
+			t.Fatalf("expected empty path rejection, got %v", err)
+		}
+	})
+
+	t.Run("normalized", func(t *testing.T) {
+		got, err := normalizeManifestRelativePath("overlay directory", "./nested/../overlay/file.go")
+		if err != nil {
+			t.Fatalf("normalizeManifestRelativePath returned error: %v", err)
+		}
+		if got != "overlay/file.go" {
+			t.Fatalf("normalized path = %q", got)
+		}
+	})
+}
+
+func TestPackageTargetDirReturnsNormalizedDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	got, err := packageTargetDir(repoRoot, "./benchpkg")
+	if err != nil {
+		t.Fatalf("packageTargetDir returned error: %v", err)
+	}
+	if got != filepath.Join(repoRoot, "benchpkg") {
+		t.Fatalf("package dir = %q", got)
+	}
+}
+
+func TestNormalizeDefinitionPathsRejectsInvalidOverlayDir(t *testing.T) {
+	definition := benchmarkDefinition{
+		OverlayDir: "/tmp/overlay",
+		HarnessFiles: []benchmarkHarnessFile{{
+			Path:        "benchpkg/head_benchmark_test.go",
+			OverlayPath: "benchpkg/head_benchmark_test.go",
+		}},
+	}
+	if err := normalizeDefinitionPaths(&definition); err == nil || !strings.Contains(err.Error(), "overlay directory must be relative") {
+		t.Fatalf("expected invalid overlay dir rejection, got %v", err)
+	}
+}
+
+func TestWriteBenchmarkDefinitionRejectsInvalidHarnessPath(t *testing.T) {
+	parent := canonicalTempDir(t)
+	definition := benchmarkDefinition{
+		Version:    definitionVersion,
+		OverlayDir: "overlay",
+		HarnessFiles: []benchmarkHarnessFile{{
+			Path:        "/tmp/escape.go",
+			OverlayPath: "benchpkg/head_benchmark_test.go",
+		}},
+	}
+	err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), definition, nil)
+	if err == nil || !strings.Contains(err.Error(), "benchmark harness path must be relative") {
+		t.Fatalf("expected invalid harness path rejection, got %v", err)
+	}
+}
+
+func TestWriteBenchmarkDefinitionReturnsOpenRootError(t *testing.T) {
+	parent := canonicalTempDir(t)
+	originalOpenCanonicalWriteRoot := openCanonicalWriteRoot
+	openCanonicalWriteRoot = func(string) (confinedWriteRoot, error) {
+		return nil, errors.New("open root failed")
+	}
+	defer func() { openCanonicalWriteRoot = originalOpenCanonicalWriteRoot }()
+
+	err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, nil)
+	if err == nil || !strings.Contains(err.Error(), "open benchmark manifest root: open root failed") {
+		t.Fatalf("expected open root error, got %v", err)
+	}
+}
+
+func TestWriteBenchmarkDefinitionReturnsCanonicalizeRootError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		evalSymlinks = func(string) (string, error) {
+			return "", errors.New("canonicalize failed")
+		}
+
+		parent := canonicalTempDir(t)
+		err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, nil)
+		if err == nil || !strings.Contains(err.Error(), "canonicalize benchmark manifest root: canonicalize failed") {
+			t.Fatalf("expected canonicalize root error, got %v", err)
+		}
+	})
+}
+
+func TestWriteBenchmarkDefinitionReturnsManifestRootOpenError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		openOSRoot = func(string) (*os.Root, error) {
+			return nil, errors.New("open manifest root failed")
+		}
+
+		parent := canonicalTempDir(t)
+		err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, nil)
+		if err == nil || !strings.Contains(err.Error(), "open benchmark manifest root: open manifest root failed") {
+			t.Fatalf("expected manifest root open error, got %v", err)
+		}
+	})
+}
+
+func TestWriteBenchmarkDefinitionReturnsOverlayWriteRootError(t *testing.T) {
+	parent := canonicalTempDir(t)
+	originalOpenCanonicalWriteRoot := openCanonicalWriteRoot
+	openCanonicalWriteRoot = func(string) (confinedWriteRoot, error) {
+		return &fakeConfinedWriteRoot{failOnWrite: 1, err: errors.New("overlay write failed")}, nil
+	}
+	defer func() { openCanonicalWriteRoot = originalOpenCanonicalWriteRoot }()
+
+	err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, map[string][]byte{"benchpkg/head_benchmark_test.go": []byte("package benchpkg\n")})
+	if err == nil || !strings.Contains(err.Error(), "write overlay file benchpkg/head_benchmark_test.go: overlay write failed") {
+		t.Fatalf("expected overlay write error, got %v", err)
+	}
+}
+
+func TestWriteBenchmarkDefinitionReturnsCloseError(t *testing.T) {
+	parent := canonicalTempDir(t)
+	originalOpenCanonicalWriteRoot := openCanonicalWriteRoot
+	openCanonicalWriteRoot = func(string) (confinedWriteRoot, error) {
+		return &fakeConfinedWriteRoot{closeErr: errors.New("close failed")}, nil
+	}
+	defer func() { openCanonicalWriteRoot = originalOpenCanonicalWriteRoot }()
+
+	err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, nil)
+	if err == nil || !strings.Contains(err.Error(), "close failed") {
+		t.Fatalf("expected close error, got %v", err)
+	}
+}
+
+func TestWriteBenchmarkDefinitionReturnsManifestRootCloseError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		closeCalls := 0
+		closeOSRoot = func(root *os.Root) error {
+			closeCalls++
+			if closeCalls == 1 {
+				return errors.New("close manifest root failed")
+			}
+			return root.Close()
+		}
+
+		parent := canonicalTempDir(t)
+		err := writeBenchmarkDefinition(filepath.Join(parent, "definition.json"), filepath.Join(parent, "overlay"), benchmarkDefinition{Version: definitionVersion}, nil)
+		if err == nil || !strings.Contains(err.Error(), "close manifest root failed") {
+			t.Fatalf("expected manifest root close error, got %v", err)
+		}
+	})
+}
+
+func TestWriteBenchmarkDefinitionReturnsCreateDirectoryError(t *testing.T) {
+	parent := canonicalTempDir(t)
+	blocker := filepath.Join(parent, "blocked")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	err := writeBenchmarkDefinition(filepath.Join(blocker, "definition.json"), filepath.Join(blocker, "overlay"), benchmarkDefinition{Version: definitionVersion}, nil)
+	if err == nil || !strings.Contains(err.Error(), "root is not a directory") {
+		t.Fatalf("expected create definition dir error, got %v", err)
+	}
+}
+
+func TestApplyBenchmarkOverlayRejectsSymlinkTargetEscape(t *testing.T) {
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	artifactDir := canonicalTempDir(t)
+	definitionPath, definition := writeOverlayDefinitionFixture(t, artifactDir)
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir repo package dir: %v", err)
+	}
+	outsidePath := filepath.Join(t.TempDir(), "outside.go")
+	if err := os.WriteFile(outsidePath, []byte("outside"), 0o600); err != nil {
+		t.Fatalf("write outside target: %v", err)
+	}
+	targetPath := filepath.Join(repo, "benchpkg", "head_benchmark_test.go")
+	if err := os.Symlink(outsidePath, targetPath); err != nil {
+		t.Fatalf("create target symlink: %v", err)
+	}
+
+	err := applyBenchmarkOverlay(repo, definitionPath, definition)
+	if err == nil || !strings.Contains(err.Error(), "target path is a symlink") {
+		t.Fatalf("expected symlink target rejection, got %v", err)
+	}
+	assertFileContainsBytes(t, outsidePath, []byte("outside"))
+}
+
+func TestApplyBenchmarkOverlayRejectsSymlinkAncestorEscape(t *testing.T) {
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	artifactDir := canonicalTempDir(t)
+	definitionPath, definition := writeOverlayDefinitionFixture(t, artifactDir)
+	repo := t.TempDir()
+	outsideDir := t.TempDir()
+	if err := os.Symlink(outsideDir, filepath.Join(repo, "benchpkg")); err != nil {
+		t.Fatalf("create ancestor symlink: %v", err)
+	}
+
+	err := applyBenchmarkOverlay(repo, definitionPath, definition)
+	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
+		t.Fatalf("expected symlink ancestor rejection, got %v", err)
+	}
+	if entries, err := os.ReadDir(outsideDir); err != nil {
+		t.Fatalf("read outside dir: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("expected outside dir to remain untouched, found %d entries", len(entries))
+	}
+}
+
+func TestRunResolveCommandRejectsSymlinkedPackageDirWithoutOverlayMutation(t *testing.T) {
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module example.com/benchrepo\n\ngo 1.26.0\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	initGitRepo(t, repo)
+	externalRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(externalRoot, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir external package: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(externalRoot, "benchpkg", "head_benchmark_test.go"), []byte("package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkExternal(b *testing.B) {}\n"), 0o600); err != nil {
+		t.Fatalf("write external harness: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(externalRoot, "benchpkg"), filepath.Join(repo, "benchpkg")); err != nil {
+		t.Fatalf("create package dir symlink: %v", err)
+	}
+
+	artifactDir := canonicalTempDir(t)
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	staleOverlayPath := filepath.Join(overlayDir, "stale.txt")
+	if err := os.MkdirAll(overlayDir, 0o755); err != nil {
+		t.Fatalf("mkdir overlay dir: %v", err)
+	}
+	if err := os.WriteFile(staleOverlayPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write stale overlay file: %v", err)
+	}
+
+	err := runResolveCommand([]string{
+		"-repo", repo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", filepath.Join(artifactDir, "definition.json"),
+		"-overlay-dir", overlayDir,
+	})
+	if err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected symlinked package dir rejection, got %v", err)
+	}
+	assertFileContainsBytes(t, staleOverlayPath, []byte("keep me"))
+	if _, err := os.Stat(filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go")); !os.IsNotExist(err) {
+		t.Fatalf("expected overlay harness to remain absent, got %v", err)
+	}
+}
+
+func TestRunResolveCommandRejectsSymlinkedPackageAncestorWithoutOverlayMutation(t *testing.T) {
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module example.com/benchrepo\n\ngo 1.26.0\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "pkgroot"), 0o755); err != nil {
+		t.Fatalf("mkdir pkgroot: %v", err)
+	}
+	initGitRepo(t, repo)
+	externalRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(externalRoot, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir external package: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(externalRoot, "benchpkg", "head_benchmark_test.go"), []byte("package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkExternal(b *testing.B) {}\n"), 0o600); err != nil {
+		t.Fatalf("write external harness: %v", err)
+	}
+	if err := os.Symlink(externalRoot, filepath.Join(repo, "pkgroot", "escape")); err != nil {
+		t.Fatalf("create package ancestor symlink: %v", err)
+	}
+
+	artifactDir := canonicalTempDir(t)
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	staleOverlayPath := filepath.Join(overlayDir, "stale.txt")
+	if err := os.MkdirAll(overlayDir, 0o755); err != nil {
+		t.Fatalf("mkdir overlay dir: %v", err)
+	}
+	if err := os.WriteFile(staleOverlayPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write stale overlay file: %v", err)
+	}
+
+	err := runResolveCommand([]string{
+		"-repo", repo,
+		"-package", "./pkgroot/escape/benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", filepath.Join(artifactDir, "definition.json"),
+		"-overlay-dir", overlayDir,
+	})
+	if err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected symlinked package ancestor rejection, got %v", err)
+	}
+	assertFileContainsBytes(t, staleOverlayPath, []byte("keep me"))
+	if _, err := os.Stat(filepath.Join(overlayDir, "pkgroot", "escape", "benchpkg", "head_benchmark_test.go")); !os.IsNotExist(err) {
+		t.Fatalf("expected overlay harness to remain absent, got %v", err)
+	}
+}
+
+func TestRunResolveCommandRejectsSymlinkedHarnessWithoutOverlayMutation(t *testing.T) {
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir repo package: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module example.com/benchrepo\n\ngo 1.26.0\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	externalHarness := filepath.Join(t.TempDir(), "external_benchmark_test.go")
+	if err := os.WriteFile(externalHarness, []byte("package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkExternal(b *testing.B) {}\n"), 0o600); err != nil {
+		t.Fatalf("write external harness: %v", err)
+	}
+	if err := os.Symlink(externalHarness, filepath.Join(repo, "benchpkg", "head_benchmark_test.go")); err != nil {
+		t.Fatalf("create harness symlink: %v", err)
+	}
+	initGitRepo(t, repo)
+
+	artifactDir := canonicalTempDir(t)
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	staleOverlayPath := filepath.Join(overlayDir, "stale.txt")
+	if err := os.MkdirAll(overlayDir, 0o755); err != nil {
+		t.Fatalf("mkdir overlay dir: %v", err)
+	}
+	if err := os.WriteFile(staleOverlayPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write stale overlay file: %v", err)
+	}
+
+	err := runResolveCommand([]string{
+		"-repo", repo,
+		"-package", "./benchpkg",
+		"-count", "1",
+		"-benchtime", "1x",
+		"-out", filepath.Join(artifactDir, "definition.json"),
+		"-overlay-dir", overlayDir,
+	})
+	if err == nil || !strings.Contains(err.Error(), "benchmark harness path is a symlink") {
+		t.Fatalf("expected symlinked harness rejection, got %v", err)
+	}
+	assertFileContainsBytes(t, staleOverlayPath, []byte("keep me"))
+	if _, err := os.Stat(filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go")); !os.IsNotExist(err) {
+		t.Fatalf("expected overlay harness to remain absent, got %v", err)
+	}
+	assertFileContainsBytes(t, externalHarness, []byte("package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkExternal(b *testing.B) {}\n"))
+}
+
+func TestApplyBenchmarkOverlayLateFailureDoesNotMutateEarlierTargets(t *testing.T) {
+	artifactDir := canonicalTempDir(t)
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	if err := os.MkdirAll(filepath.Join(overlayDir, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir overlay dir: %v", err)
+	}
+	alphaOverlay := []byte("package benchpkg\n\nfunc alphaOverlay() string { return \"alpha\" }\n")
+	betaOverlay := []byte("package benchpkg\n\nfunc betaOverlay() string { return \"beta\" }\n")
+	if err := os.WriteFile(filepath.Join(overlayDir, "benchpkg", "alpha_test.go"), alphaOverlay, 0o600); err != nil {
+		t.Fatalf("write alpha overlay: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "benchpkg", "beta_test.go"), betaOverlay, 0o600); err != nil {
+		t.Fatalf("write beta overlay: %v", err)
+	}
+
+	definitionPath := filepath.Join(artifactDir, "definition.json")
+	definition := benchmarkDefinition{
+		Version:        definitionVersion,
+		ResolvedFrom:   "deadbeef",
+		PackageTargets: []string{"./benchpkg"},
+		Benchmarks:     []resolvedBenchmark{{PackageTarget: "./benchpkg", Name: "BenchmarkHeadOnly"}},
+		BenchPattern:   "^(BenchmarkHeadOnly)$",
+		RunPattern:     "^$",
+		Count:          1,
+		Benchtime:      "1x",
+		BenchMem:       true,
+		OverlayDir:     "overlay",
+		HarnessFiles: []benchmarkHarnessFile{
+			{Path: "benchpkg/alpha_test.go", SHA256: bytesDigest(alphaOverlay), OverlayPath: "benchpkg/alpha_test.go"},
+			{Path: "benchpkg/beta_test.go", SHA256: bytesDigest([]byte("different")), OverlayPath: "benchpkg/beta_test.go"},
+		},
+	}
+	content, err := json.Marshal(definition)
+	if err != nil {
+		t.Fatalf("marshal definition: %v", err)
+	}
+	writeDefinitionJSON(t, definitionPath, string(content))
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir repo package dir: %v", err)
+	}
+	alphaTarget := filepath.Join(repo, "benchpkg", "alpha_test.go")
+	betaTarget := filepath.Join(repo, "benchpkg", "beta_test.go")
+	if err := os.WriteFile(alphaTarget, []byte("original alpha"), 0o600); err != nil {
+		t.Fatalf("write alpha target: %v", err)
+	}
+	if err := os.WriteFile(betaTarget, []byte("original beta"), 0o600); err != nil {
+		t.Fatalf("write beta target: %v", err)
+	}
+
+	err = applyBenchmarkOverlay(repo, definitionPath, definition)
+	if err == nil || !strings.Contains(err.Error(), "overlay file benchpkg/beta_test.go digest mismatch") {
+		t.Fatalf("expected late digest mismatch, got %v", err)
+	}
+	assertFileContainsBytes(t, alphaTarget, []byte("original alpha"))
+	assertFileContainsBytes(t, betaTarget, []byte("original beta"))
+}
+
+func TestWriteBenchmarkDefinitionStageWriteFailureRestoresPriorSet(t *testing.T) {
+	parent := canonicalTempDir(t)
+	definitionPath := filepath.Join(parent, "definition.json")
+	overlayDir := filepath.Join(parent, "overlay")
+	if err := os.MkdirAll(filepath.Join(overlayDir, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir overlay dir: %v", err)
+	}
+	originalManifest := []byte("{\"stale\":true}\n")
+	originalOverlay := []byte("package benchpkg\n\nfunc stale() string { return \"old\" }\n")
+	staleOverlay := []byte("keep me")
+	if err := os.WriteFile(definitionPath, originalManifest, 0o640); err != nil {
+		t.Fatalf("write original manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go"), originalOverlay, 0o644); err != nil {
+		t.Fatalf("write original overlay: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "stale.txt"), staleOverlay, 0o600); err != nil {
+		t.Fatalf("write stale overlay: %v", err)
+	}
+
+	definition := benchmarkDefinition{
+		Version:        definitionVersion,
+		ResolvedFrom:   "deadbeef",
+		PackageTargets: []string{"./benchpkg"},
+		Benchmarks:     []resolvedBenchmark{{PackageTarget: "./benchpkg", Name: "BenchmarkHeadOnly"}},
+		BenchPattern:   "^(BenchmarkHeadOnly)$",
+		RunPattern:     "^$",
+		Count:          1,
+		Benchtime:      "1x",
+		BenchMem:       true,
+		OverlayDir:     "overlay",
+		HarnessFiles: []benchmarkHarnessFile{{
+			Path:        "benchpkg/head_benchmark_test.go",
+			SHA256:      bytesDigest([]byte("package benchpkg\n")),
+			OverlayPath: "benchpkg/head_benchmark_test.go",
+		}},
+	}
+
+	withBenchdeltaFSHooks(t, func() {
+		writes := 0
+		resolveStageWriteSeam = func(string) error {
+			writes++
+			if writes == 2 {
+				return errors.New("late resolve stage write failed")
+			}
+			return nil
+		}
+		err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, map[string][]byte{
+			"benchpkg/head_benchmark_test.go": []byte("package benchpkg\n"),
+		})
+		if err == nil || !strings.Contains(err.Error(), "write benchmark definition: late resolve stage write failed") {
+			t.Fatalf("expected late stage write error, got %v", err)
+		}
+	})
+
+	assertFileContainsBytes(t, definitionPath, originalManifest)
+	assertFileMode(t, definitionPath, 0o640)
+	assertFileContainsBytes(t, filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go"), originalOverlay)
+	assertFileMode(t, filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go"), 0o644)
+	assertFileContainsBytes(t, filepath.Join(overlayDir, "stale.txt"), staleOverlay)
+	assertNoBenchdeltaTemps(t, parent, ".benchdelta-resolve-*")
+}
+
+func TestWriteBenchmarkDefinitionPromotionFailureRestoresPriorSet(t *testing.T) {
+	parent := canonicalTempDir(t)
+	definitionPath := filepath.Join(parent, "definition.json")
+	overlayDir := filepath.Join(parent, "overlay")
+	if err := os.MkdirAll(filepath.Join(overlayDir, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir overlay dir: %v", err)
+	}
+	originalManifest := []byte("{\"stale\":true}\n")
+	originalOverlay := []byte("package benchpkg\n\nfunc stale() string { return \"old\" }\n")
+	staleOverlay := []byte("keep me")
+	if err := os.WriteFile(definitionPath, originalManifest, 0o640); err != nil {
+		t.Fatalf("write original manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go"), originalOverlay, 0o644); err != nil {
+		t.Fatalf("write original overlay: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "stale.txt"), staleOverlay, 0o600); err != nil {
+		t.Fatalf("write stale overlay: %v", err)
+	}
+
+	newOverlay := []byte("package benchpkg\n\nfunc fresh() string { return \"new\" }\n")
+	definition := benchmarkDefinition{
+		Version:        definitionVersion,
+		ResolvedFrom:   "deadbeef",
+		PackageTargets: []string{"./benchpkg"},
+		Benchmarks:     []resolvedBenchmark{{PackageTarget: "./benchpkg", Name: "BenchmarkHeadOnly"}},
+		BenchPattern:   "^(BenchmarkHeadOnly)$",
+		RunPattern:     "^$",
+		Count:          1,
+		Benchtime:      "1x",
+		BenchMem:       true,
+		OverlayDir:     "overlay",
+		HarnessFiles: []benchmarkHarnessFile{{
+			Path:        "benchpkg/head_benchmark_test.go",
+			SHA256:      bytesDigest(newOverlay),
+			OverlayPath: "benchpkg/head_benchmark_test.go",
+		}},
+	}
+
+	withBenchdeltaFSHooks(t, func() {
+		resolvePromoteSeam = func(step int, livePath string) error {
+			if step == 1 && livePath == "overlay" {
+				return errors.New("resolve promote failed")
+			}
+			return nil
+		}
+		err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, map[string][]byte{
+			"benchpkg/head_benchmark_test.go": newOverlay,
+		})
+		if err == nil || !strings.Contains(err.Error(), "clear benchmark overlay: resolve promote failed") {
+			t.Fatalf("expected promotion error, got %v", err)
+		}
+	})
+
+	assertFileContainsBytes(t, definitionPath, originalManifest)
+	assertFileMode(t, definitionPath, 0o640)
+	assertFileContainsBytes(t, filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go"), originalOverlay)
+	assertFileMode(t, filepath.Join(overlayDir, "benchpkg", "head_benchmark_test.go"), 0o644)
+	assertFileContainsBytes(t, filepath.Join(overlayDir, "stale.txt"), staleOverlay)
+	assertNoBenchdeltaTemps(t, parent, ".benchdelta-resolve-*")
+}
+
+func TestApplyBenchmarkOverlayStageWriteFailureRestoresTargetsAndRemovesTemps(t *testing.T) {
+	artifactDir := canonicalTempDir(t)
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	if err := os.MkdirAll(filepath.Join(overlayDir, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir overlay dir: %v", err)
+	}
+	alphaOverlay := []byte("package benchpkg\n\nfunc alphaOverlay() string { return \"alpha\" }\n")
+	gammaOverlay := []byte("package benchpkg\n\nfunc gammaOverlay() string { return \"gamma\" }\n")
+	if err := os.WriteFile(filepath.Join(overlayDir, "benchpkg", "alpha_test.go"), alphaOverlay, 0o600); err != nil {
+		t.Fatalf("write alpha overlay: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "benchpkg", "gamma_test.go"), gammaOverlay, 0o600); err != nil {
+		t.Fatalf("write gamma overlay: %v", err)
+	}
+	definitionPath := filepath.Join(artifactDir, "definition.json")
+	definition := benchmarkDefinition{
+		Version:        definitionVersion,
+		ResolvedFrom:   "deadbeef",
+		PackageTargets: []string{"./benchpkg"},
+		Benchmarks:     []resolvedBenchmark{{PackageTarget: "./benchpkg", Name: "BenchmarkHeadOnly"}},
+		BenchPattern:   "^(BenchmarkHeadOnly)$",
+		RunPattern:     "^$",
+		Count:          1,
+		Benchtime:      "1x",
+		BenchMem:       true,
+		OverlayDir:     "overlay",
+		HarnessFiles: []benchmarkHarnessFile{
+			{Path: "benchpkg/alpha_test.go", SHA256: bytesDigest(alphaOverlay), OverlayPath: "benchpkg/alpha_test.go"},
+			{Path: "benchpkg/gamma_test.go", SHA256: bytesDigest(gammaOverlay), OverlayPath: "benchpkg/gamma_test.go"},
+		},
+	}
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir repo package dir: %v", err)
+	}
+	alphaTarget := filepath.Join(repo, "benchpkg", "alpha_test.go")
+	gammaTarget := filepath.Join(repo, "benchpkg", "gamma_test.go")
+	if err := os.WriteFile(alphaTarget, []byte("original alpha"), 0o644); err != nil {
+		t.Fatalf("write alpha target: %v", err)
+	}
+
+	withBenchdeltaFSHooks(t, func() {
+		writes := 0
+		applyStageWriteSeam = func(string) error {
+			writes++
+			if writes == 2 {
+				return errors.New("late apply stage write failed")
+			}
+			return nil
+		}
+		err := applyBenchmarkOverlay(repo, definitionPath, definition)
+		if err == nil || !strings.Contains(err.Error(), "write benchmark harness benchpkg/gamma_test.go: late apply stage write failed") {
+			t.Fatalf("expected stage write failure, got %v", err)
+		}
+	})
+
+	assertFileContainsBytes(t, alphaTarget, []byte("original alpha"))
+	assertFileMode(t, alphaTarget, 0o644)
+	if _, err := os.Stat(gammaTarget); !os.IsNotExist(err) {
+		t.Fatalf("expected gamma target to remain absent, got %v", err)
+	}
+	assertNoBenchdeltaTemps(t, repo, ".benchdelta-apply-*")
+}
+
+func TestApplyBenchmarkOverlayPromotionFailureRestoresTargetsAndRemovesNewFiles(t *testing.T) {
+	artifactDir := canonicalTempDir(t)
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	if err := os.MkdirAll(filepath.Join(overlayDir, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir overlay dir: %v", err)
+	}
+	alphaOverlay := []byte("package benchpkg\n\nfunc alphaOverlay() string { return \"alpha\" }\n")
+	gammaOverlay := []byte("package benchpkg\n\nfunc gammaOverlay() string { return \"gamma\" }\n")
+	if err := os.WriteFile(filepath.Join(overlayDir, "benchpkg", "alpha_test.go"), alphaOverlay, 0o600); err != nil {
+		t.Fatalf("write alpha overlay: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "benchpkg", "gamma_test.go"), gammaOverlay, 0o600); err != nil {
+		t.Fatalf("write gamma overlay: %v", err)
+	}
+	definitionPath := filepath.Join(artifactDir, "definition.json")
+	definition := benchmarkDefinition{
+		Version:        definitionVersion,
+		ResolvedFrom:   "deadbeef",
+		PackageTargets: []string{"./benchpkg"},
+		Benchmarks:     []resolvedBenchmark{{PackageTarget: "./benchpkg", Name: "BenchmarkHeadOnly"}},
+		BenchPattern:   "^(BenchmarkHeadOnly)$",
+		RunPattern:     "^$",
+		Count:          1,
+		Benchtime:      "1x",
+		BenchMem:       true,
+		OverlayDir:     "overlay",
+		HarnessFiles: []benchmarkHarnessFile{
+			{Path: "benchpkg/alpha_test.go", SHA256: bytesDigest(alphaOverlay), OverlayPath: "benchpkg/alpha_test.go"},
+			{Path: "benchpkg/gamma_test.go", SHA256: bytesDigest(gammaOverlay), OverlayPath: "benchpkg/gamma_test.go"},
+		},
+	}
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "benchpkg"), 0o755); err != nil {
+		t.Fatalf("mkdir repo package dir: %v", err)
+	}
+	alphaTarget := filepath.Join(repo, "benchpkg", "alpha_test.go")
+	gammaTarget := filepath.Join(repo, "benchpkg", "gamma_test.go")
+	if err := os.WriteFile(alphaTarget, []byte("original alpha"), 0o644); err != nil {
+		t.Fatalf("write alpha target: %v", err)
+	}
+
+	withBenchdeltaFSHooks(t, func() {
+		applyPromoteSeam = func(step int, livePath string) error {
+			if step == 2 && livePath == "benchpkg/gamma_test.go" {
+				return errors.New("apply promote failed")
+			}
+			return nil
+		}
+		err := applyBenchmarkOverlay(repo, definitionPath, definition)
+		if err == nil || !strings.Contains(err.Error(), "write benchmark harness benchpkg/gamma_test.go: apply promote failed") {
+			t.Fatalf("expected promotion failure, got %v", err)
+		}
+	})
+
+	assertFileContainsBytes(t, alphaTarget, []byte("original alpha"))
+	assertFileMode(t, alphaTarget, 0o644)
+	if _, err := os.Stat(gammaTarget); !os.IsNotExist(err) {
+		t.Fatalf("expected gamma target to be removed after rollback, got %v", err)
+	}
+	assertNoBenchdeltaTemps(t, repo, ".benchdelta-apply-*")
+}
+
+func TestApplyBenchmarkOverlayReturnsOpenRootError(t *testing.T) {
+	artifactDir := canonicalTempDir(t)
+	definitionPath, definition := writeOverlayDefinitionFixture(t, artifactDir)
+	originalOpenCanonicalWriteRoot := openCanonicalWriteRoot
+	openCanonicalWriteRoot = func(string) (confinedWriteRoot, error) {
+		return nil, errors.New("open root failed")
+	}
+	defer func() { openCanonicalWriteRoot = originalOpenCanonicalWriteRoot }()
+
+	err := applyBenchmarkOverlay(t.TempDir(), definitionPath, definition)
+	if err == nil || !strings.Contains(err.Error(), "open benchmark repo root: open root failed") {
+		t.Fatalf("expected open repo root error, got %v", err)
+	}
+}
+
+func TestApplyBenchmarkOverlayReturnsRepoPathResolutionError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absCalls := 0
+		absPath = func(path string) (string, error) {
+			absCalls++
+			if absCalls == 1 {
+				return "", errors.New("resolve repo failed")
+			}
+			return filepath.Abs(path)
+		}
+
+		err := applyBenchmarkOverlay(".", "definition.json", benchmarkDefinition{
+			OverlayDir: "overlay",
+			HarnessFiles: []benchmarkHarnessFile{{
+				Path:        "benchpkg/head_benchmark_test.go",
+				SHA256:      "abc",
+				OverlayPath: "benchpkg/head_benchmark_test.go",
+			}},
+		})
+		if err == nil || !strings.Contains(err.Error(), "resolve repo path: resolve repo failed") {
+			t.Fatalf("expected repo path resolution error, got %v", err)
+		}
+	})
+}
+
+func TestApplyBenchmarkOverlayReturnsDefinitionDirectoryResolutionError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		repo := t.TempDir()
+		absCalls := 0
+		absPath = func(path string) (string, error) {
+			absCalls++
+			if absCalls == 2 {
+				return "", errors.New("resolve definition dir failed")
+			}
+			return filepath.Abs(path)
+		}
+
+		err := applyBenchmarkOverlay(repo, "definition.json", benchmarkDefinition{
+			OverlayDir: "overlay",
+			HarnessFiles: []benchmarkHarnessFile{{
+				Path:        "benchpkg/head_benchmark_test.go",
+				SHA256:      "abc",
+				OverlayPath: "benchpkg/head_benchmark_test.go",
+			}},
+		})
+		if err == nil || !strings.Contains(err.Error(), "resolve benchmark definition directory: resolve definition dir failed") {
+			t.Fatalf("expected definition directory resolution error, got %v", err)
+		}
+	})
+}
+
+func TestApplyBenchmarkOverlayRejectsInvalidHarnessPath(t *testing.T) {
+	artifactDir := canonicalTempDir(t)
+	definitionPath, definition := writeOverlayDefinitionFixture(t, artifactDir)
+	definition.HarnessFiles[0].Path = "/tmp/escape.go"
+
+	err := applyBenchmarkOverlay(t.TempDir(), definitionPath, definition)
+	if err == nil || !strings.Contains(err.Error(), "benchmark harness path must be relative") {
+		t.Fatalf("expected invalid harness path rejection, got %v", err)
+	}
+}
+
+func TestApplyBenchmarkOverlayReturnsRepoPathResolutionErrorWhenWorkingDirRemoved(t *testing.T) {
+	artifactDir := canonicalTempDir(t)
+	definitionPath, definition := writeOverlayDefinitionFixture(t, artifactDir)
+	withRemovedWorkingDir(t, func() {
+		err := applyBenchmarkOverlay(".", definitionPath, definition)
+		if err == nil || !strings.Contains(err.Error(), "open benchmark repo root") {
+			t.Fatalf("expected repo root open error, got %v", err)
+		}
+	})
+}
+
+func TestApplyBenchmarkOverlayReturnsCloseError(t *testing.T) {
+	artifactDir := canonicalTempDir(t)
+	definitionPath, definition := writeOverlayDefinitionFixture(t, artifactDir)
+	originalOpenCanonicalWriteRoot := openCanonicalWriteRoot
+	openCanonicalWriteRoot = func(string) (confinedWriteRoot, error) {
+		return &fakeConfinedWriteRoot{closeErr: errors.New("close failed")}, nil
+	}
+	defer func() { openCanonicalWriteRoot = originalOpenCanonicalWriteRoot }()
+
+	err := applyBenchmarkOverlay(t.TempDir(), definitionPath, definition)
+	if err == nil || !strings.Contains(err.Error(), "close failed") {
+		t.Fatalf("expected close error, got %v", err)
+	}
+}
+
+func TestRunResolveCommandReturnsReadWrittenDefinitionErrorWhenWorkingDirRemoved(t *testing.T) {
+	headRepo := newBenchmarkRepo(t, benchmarkRepoSpec{
+		modulePath: "example.com/benchrepo",
+		files: map[string]string{
+			"benchpkg/head_benchmark_test.go": "package benchpkg\n\nimport \"testing\"\n\nfunc BenchmarkHeadOnly(b *testing.B) {}\n",
+		},
+		commit: true,
+	})
+	withRemovedWorkingDir(t, func() {
+		err := runResolveCommand([]string{
+			"-repo", headRepo,
+			"-package", "./benchpkg",
+			"-count", "1",
+			"-benchtime", "1x",
+			"-out", "definition.json",
+		})
+		if err == nil || !strings.Contains(err.Error(), "read written benchmark definition") {
+			t.Fatalf("expected manifest readback error, got %v", err)
+		}
+	})
+}
+
+func TestOpenManifestRootNoFollowReturnsRootForCanonicalDirectory(t *testing.T) {
+	rootDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalize temp root: %v", err)
+	}
+	root, err := openManifestRootNoFollow(rootDir)
+	if err != nil {
+		t.Fatalf("openManifestRootNoFollow returned error: %v", err)
+	}
+	if err := root.Close(); err != nil {
+		t.Fatalf("close root: %v", err)
+	}
+}
+
+func TestResolveManifestLayoutReturnsDefinitionPathResolutionError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absCalls := 0
+		absPath = func(path string) (string, error) {
+			absCalls++
+			if absCalls == 1 {
+				return "", errors.New("resolve definition path failed")
+			}
+			return filepath.Abs(path)
+		}
+
+		_, _, _, _, err := resolveManifestLayout("definition.json", "overlay")
+		if err == nil || !strings.Contains(err.Error(), "resolve benchmark definition path: resolve definition path failed") {
+			t.Fatalf("expected definition path resolution error, got %v", err)
+		}
+	})
+}
+
+func TestResolveManifestLayoutReturnsOverlayPathResolutionError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absCalls := 0
+		absPath = func(path string) (string, error) {
+			absCalls++
+			if absCalls == 2 {
+				return "", errors.New("resolve overlay path failed")
+			}
+			return filepath.Abs(path)
+		}
+
+		_, _, _, _, err := resolveManifestLayout(filepath.Join(t.TempDir(), "definition.json"), "overlay")
+		if err == nil || !strings.Contains(err.Error(), "resolve benchmark overlay path: resolve overlay path failed") {
+			t.Fatalf("expected overlay path resolution error, got %v", err)
+		}
+	})
+}
+
+func TestResolveManifestLayoutReturnsOverlayRelativeError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		relPath = func(string, string) (string, error) {
+			return "", errors.New("relative path failed")
+		}
+
+		_, _, _, _, err := resolveManifestLayout(filepath.Join(t.TempDir(), "definition.json"), filepath.Join(t.TempDir(), "overlay"))
+		if err == nil || !strings.Contains(err.Error(), "resolve benchmark overlay path: relative path failed") {
+			t.Fatalf("expected overlay relative-path error, got %v", err)
+		}
+	})
+}
+
+func TestOpenManifestRootNoFollowReturnsRootPathResolutionError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		absPath = func(string) (string, error) {
+			return "", errors.New("resolve root failed")
+		}
+
+		root, err := openManifestRootNoFollow("manifest-root")
+		if root != nil {
+			t.Fatal("expected nil root on path resolution failure")
+		}
+		if err == nil || !strings.Contains(err.Error(), "resolve root path: resolve root failed") {
+			t.Fatalf("expected root path resolution error, got %v", err)
+		}
+	})
+}
+
+func TestOpenManifestRootNoFollowReturnsRelativePathError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		relPath = func(string, string) (string, error) {
+			return "", errors.New("relative root failed")
+		}
+
+		root, err := openManifestRootNoFollow(filepath.Join(t.TempDir(), "manifest-root"))
+		if root != nil {
+			t.Fatal("expected nil root on relative-path failure")
+		}
+		if err == nil || !strings.Contains(err.Error(), "relative root failed") {
+			t.Fatalf("expected relative-path error, got %v", err)
+		}
+	})
+}
+
+func TestOpenManifestRootNoFollowReturnsOpenError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		openOSRoot = func(string) (*os.Root, error) {
+			return nil, errors.New("open volume root failed")
+		}
+
+		root, err := openManifestRootNoFollow(filepath.Join(t.TempDir(), "manifest-root"))
+		if root != nil {
+			t.Fatal("expected nil root on open failure")
+		}
+		if err == nil || !strings.Contains(err.Error(), "open volume root failed") {
+			t.Fatalf("expected volume-root open error, got %v", err)
+		}
+	})
+}
+
+func TestOpenManifestRootNoFollowSkipsCurrentDirectoryComponent(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		actualRelPath := relPath
+		relPath = func(base, target string) (string, error) {
+			rel, err := actualRelPath(base, target)
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(".", rel), nil
+		}
+
+		rootDir, err := filepath.EvalSymlinks(t.TempDir())
+		if err != nil {
+			t.Fatalf("canonicalize temp root: %v", err)
+		}
+		root, err := openManifestRootNoFollow(filepath.Join(rootDir, "nested"))
+		if err == nil {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}
+		if err == nil || !strings.Contains(err.Error(), "no such file or directory") {
+			t.Fatalf("expected nested lookup after dot-prefix path, got root=%v err=%v", root, err)
+		}
+	})
+}
+
+func TestOpenManifestRootNoFollowReturnsCloseErrorAfterOpeningChild(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir, err := filepath.EvalSymlinks(t.TempDir())
+		if err != nil {
+			t.Fatalf("canonicalize temp root: %v", err)
+		}
+		childDir := filepath.Join(rootDir, "nested")
+		if err := os.MkdirAll(childDir, 0o755); err != nil {
+			t.Fatalf("mkdir child dir: %v", err)
+		}
+		closeCalls := 0
+		closeOSRoot = func(root *os.Root) error {
+			closeCalls++
+			if closeCalls == 1 {
+				return errors.New("close parent failed")
+			}
+			return root.Close()
+		}
+
+		root, err := openManifestRootNoFollow(childDir)
+		if root != nil {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}
+		if err == nil || !strings.Contains(err.Error(), "close parent failed") {
+			t.Fatalf("expected parent close error, got %v", err)
+		}
+	})
+}
+
+func TestOpenManifestRootNoFollowRejectsSymlinkedPathComponent(t *testing.T) {
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	parent := t.TempDir()
+	target := t.TempDir()
+	symlinkPath := filepath.Join(parent, "escape")
+	if err := os.Symlink(target, symlinkPath); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	root, err := openManifestRootNoFollow(filepath.Join(symlinkPath, "child"))
+	if root != nil {
+		t.Fatal("expected nil root when symlinked path is rejected")
+	}
+	if err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected symlink path rejection, got %v", err)
+	}
+}
+
+func TestOpenRootChildNoFollowReturnsLstatError(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	child, err := openRootChildNoFollow(root, "missing", "/tmp/missing")
+	if child != nil {
+		t.Fatal("expected nil child for missing path")
+	}
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected not-exist error, got %v", err)
+	}
+}
+
+func trustedMacOSAliasPath(path string) (string, bool) {
+	for _, prefix := range []string{"/private/tmp/", "/private/var/"} {
+		if strings.HasPrefix(path, prefix) {
+			return strings.TrimPrefix(path, "/private"), true
+		}
+	}
+	if path == "/private/tmp" || path == "/private/var" {
+		return strings.TrimPrefix(path, "/private"), true
+	}
+	return "", false
+}
+
+func TestOpenRootChildNoFollowRejectsSymlink(t *testing.T) {
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	rootDir := t.TempDir()
+	target := filepath.Join(rootDir, "target")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(rootDir, "escape")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	child, err := openRootChildNoFollow(root, "escape", filepath.Join(rootDir, "escape"))
+	if child != nil {
+		t.Fatal("expected nil child for symlink")
+	}
+	if err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func TestOpenRootChildNoFollowRejectsFile(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootDir, "file.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	child, err := openRootChildNoFollow(root, "file.txt", filepath.Join(rootDir, "file.txt"))
+	if child != nil {
+		t.Fatal("expected nil child for regular file")
+	}
+	if err == nil || !strings.Contains(err.Error(), "root is not a directory") {
+		t.Fatalf("expected non-directory rejection, got %v", err)
+	}
+}
+
+func TestOpenRootChildNoFollowReturnsOpenRootError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "nested"), 0o755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpenRoot = func(*os.Root, string) (*os.Root, error) {
+			return nil, errors.New("open child failed")
+		}
+
+		child, err := openRootChildNoFollow(root, "nested", filepath.Join(rootDir, "nested"))
+		if child != nil {
+			t.Fatal("expected nil child on OpenRoot failure")
+		}
+		if err == nil || !strings.Contains(err.Error(), "open child failed") {
+			t.Fatalf("expected OpenRoot failure, got %v", err)
+		}
+	})
+}
+
+func TestOpenRootChildNoFollowReturnsOpenedInfoError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "nested"), 0o755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		realRootLstat := rootLstat
+		callCount := 0
+		rootLstat = func(root *os.Root, name string) (os.FileInfo, error) {
+			callCount++
+			if callCount == 2 && name == "." {
+				return nil, errors.New("opened lstat failed")
+			}
+			return realRootLstat(root, name)
+		}
+
+		child, err := openRootChildNoFollow(root, "nested", filepath.Join(rootDir, "nested"))
+		if child != nil {
+			if closeErr := child.Close(); closeErr != nil {
+				t.Fatalf("close child root: %v", closeErr)
+			}
+			t.Fatal("expected nil child on opened-info failure")
+		}
+		if err == nil || !strings.Contains(err.Error(), "opened lstat failed") {
+			t.Fatalf("expected opened-info error, got %v", err)
+		}
+	})
+}
+
+func TestOpenRootChildNoFollowDetectsExternalMutation(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "nested"), 0o755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		sameFile = func(os.FileInfo, os.FileInfo) bool { return false }
+
+		child, err := openRootChildNoFollow(root, "nested", filepath.Join(rootDir, "nested"))
+		if child != nil {
+			if closeErr := child.Close(); closeErr != nil {
+				t.Fatalf("close child root: %v", closeErr)
+			}
+			t.Fatal("expected nil child on SameFile mismatch")
+		}
+		if err == nil || !strings.Contains(err.Error(), "root changed while opening") {
+			t.Fatalf("expected SameFile mismatch error, got %v", err)
+		}
+	})
+}
+
+func TestCloseOSRootWithErrorReturnsOriginalError(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	originalErr := errors.New("boom")
+	if got := closeOSRootWithError(root, originalErr); !errors.Is(got, originalErr) {
+		t.Fatalf("expected original error to be returned, got %v", got)
+	}
+}
+
+func TestCloseOSRootWithErrorJoinsCloseError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		root, err := os.OpenRoot(t.TempDir())
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := root.Close(); err != nil {
+				t.Fatalf("close root: %v", err)
+			}
+		})
+		closeOSRoot = func(*os.Root) error {
+			return errors.New("close root failed")
+		}
+
+		got := closeOSRootWithError(root, errors.New("boom"))
+		if got == nil || !strings.Contains(got.Error(), "boom") || !strings.Contains(got.Error(), "close root failed") {
+			t.Fatalf("expected joined close error, got %v", got)
+		}
+	})
+}
+
+func TestRemoveManifestSubtreePartsReturnsNilForEmptyParts(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := removeManifestSubtreeParts(root, nil, "overlay"); err != nil {
+		t.Fatalf("expected empty parts to be ignored, got %v", err)
+	}
+}
+
+func TestRemoveManifestSubtreePartsReturnsRootError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		root, err := os.OpenRoot(t.TempDir())
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootLstat = func(*os.Root, string) (os.FileInfo, error) {
+			return nil, errors.New("lstat root failed")
+		}
+
+		if err := removeManifestSubtreeParts(root, []string{"overlay"}, "overlay"); err == nil || !strings.Contains(err.Error(), "lstat root failed") {
+			t.Fatalf("expected root lstat error, got %v", err)
+		}
+	})
+}
+
+func TestRemoveManifestSubtreePartsRejectsNestedSymlink(t *testing.T) {
+	if !supportsSymlink(t) {
+		t.Skip("symlinks unavailable")
+	}
+
+	rootDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rootDir, "overlay"), 0o755); err != nil {
+		t.Fatalf("mkdir overlay: %v", err)
+	}
+	target := filepath.Join(rootDir, "target")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(rootDir, "overlay", "escape")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	err = removeManifestSubtreeParts(root, []string{"overlay", "escape", "child"}, "overlay/escape/child")
+	if err == nil || !strings.Contains(err.Error(), "overlay path contains symlink") {
+		t.Fatalf("expected nested symlink rejection, got %v", err)
+	}
+}
+
+func TestRemoveManifestSubtreePartsRejectsNestedFileComponent(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootDir, "overlay"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write overlay file: %v", err)
+	}
+
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	err = removeManifestSubtreeParts(root, []string{"overlay", "child"}, "overlay/child")
+	if err == nil || !strings.Contains(err.Error(), "overlay path component is not a directory") {
+		t.Fatalf("expected nested file rejection, got %v", err)
+	}
+}
+
+func TestRemoveManifestSubtreePartsRemovesLeafFile(t *testing.T) {
+	rootDir := t.TempDir()
+	leafPath := filepath.Join(rootDir, "overlay-file")
+	if err := os.WriteFile(leafPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write leaf file: %v", err)
+	}
+
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := removeManifestSubtreeParts(root, []string{"overlay-file"}, "overlay-file"); err != nil {
+		t.Fatalf("removeManifestSubtreeParts returned error: %v", err)
+	}
+	if _, err := os.Stat(leafPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected leaf file to be removed, got %v", err)
+	}
+}
+
+func TestRemoveManifestSubtreePartsReturnsLeafRemoveError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		leafPath := filepath.Join(rootDir, "overlay-file")
+		if err := os.WriteFile(leafPath, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write leaf file: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootRemove = func(*os.Root, string) error {
+			return errors.New("remove leaf failed")
+		}
+
+		err = removeManifestSubtreeParts(root, []string{"overlay-file"}, "overlay-file")
+		if err == nil || !strings.Contains(err.Error(), "remove leaf failed") {
+			t.Fatalf("expected leaf remove error, got %v", err)
+		}
+	})
+}
+
+func TestRemoveManifestSubtreePartsRemovesDirectoryTree(t *testing.T) {
+	rootDir := t.TempDir()
+	nestedFile := filepath.Join(rootDir, "overlay", "benchpkg", "head_benchmark_test.go")
+	if err := os.MkdirAll(filepath.Dir(nestedFile), 0o755); err != nil {
+		t.Fatalf("mkdir nested directory: %v", err)
+	}
+	if err := os.WriteFile(nestedFile, []byte("package benchpkg\n"), 0o600); err != nil {
+		t.Fatalf("write nested file: %v", err)
+	}
+
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close root: %v", closeErr)
+		}
+	}()
+
+	if err := removeManifestSubtreeParts(root, []string{"overlay"}, "overlay"); err != nil {
+		t.Fatalf("removeManifestSubtreeParts returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rootDir, "overlay")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected overlay directory to be removed, got %v", err)
+	}
+}
+
+func TestRemoveManifestSubtreePartsReturnsNestedOpenError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(rootDir, "overlay", "nested"), 0o755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpenRoot = func(*os.Root, string) (*os.Root, error) {
+			return nil, errors.New("open nested failed")
+		}
+
+		err = removeManifestSubtreeParts(root, []string{"overlay", "nested"}, "overlay/nested")
+		if err == nil || !strings.Contains(err.Error(), "open nested failed") {
+			t.Fatalf("expected nested open error, got %v", err)
+		}
+	})
+}
+
+func TestRemoveManifestSubtreePartsReturnsDirectoryOpenError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "overlay"), 0o755); err != nil {
+			t.Fatalf("mkdir overlay: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		rootOpenRoot = func(*os.Root, string) (*os.Root, error) {
+			return nil, errors.New("open overlay failed")
+		}
+
+		err = removeManifestSubtreeParts(root, []string{"overlay"}, "overlay")
+		if err == nil || !strings.Contains(err.Error(), "open overlay failed") {
+			t.Fatalf("expected directory open error, got %v", err)
+		}
+	})
+}
+
+func TestRemoveManifestSubtreePartsReturnsDirectoryReadError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "overlay"), 0o755); err != nil {
+			t.Fatalf("mkdir overlay: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		tmpFile := filepath.Join(t.TempDir(), "file.txt")
+		if err := os.WriteFile(tmpFile, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+		rootOpen = func(*os.Root, string) (*os.File, error) {
+			return os.Open(tmpFile)
+		}
+
+		err = removeManifestSubtreeParts(root, []string{"overlay"}, "overlay")
+		if err == nil || !strings.Contains(err.Error(), "not a directory") {
+			t.Fatalf("expected directory read error, got %v", err)
+		}
+	})
+}
+
+func TestRemoveManifestSubtreePartsReturnsRecursiveChildError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		nestedDir := filepath.Join(rootDir, "overlay", "child")
+		if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+			t.Fatalf("mkdir nested child: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(nestedDir, "leaf.txt"), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write leaf: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		realRootRemove := rootRemove
+		rootRemove = func(root *os.Root, name string) error {
+			if name == "leaf.txt" {
+				return errors.New("remove nested leaf failed")
+			}
+			return realRootRemove(root, name)
+		}
+
+		err = removeManifestSubtreeParts(root, []string{"overlay"}, "overlay")
+		if err == nil || !strings.Contains(err.Error(), "remove nested leaf failed") {
+			t.Fatalf("expected recursive child error, got %v", err)
+		}
+	})
+}
+
+func TestRemoveManifestSubtreePartsReturnsChildCloseError(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "overlay"), 0o755); err != nil {
+			t.Fatalf("mkdir overlay: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		closeCalls := 0
+		closeOSRoot = func(root *os.Root) error {
+			closeCalls++
+			if closeCalls == 1 {
+				return errors.New("close child failed")
+			}
+			return root.Close()
+		}
+
+		err = removeManifestSubtreeParts(root, []string{"overlay"}, "overlay")
+		if err == nil || !strings.Contains(err.Error(), "close child failed") {
+			t.Fatalf("expected child close error, got %v", err)
+		}
+	})
+}
+
+func TestRemoveManifestSubtreePartsReturnsRootRemoveErrorAfterDirectoryCleanup(t *testing.T) {
+	withBenchdeltaFSHooks(t, func() {
+		rootDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(rootDir, "overlay"), 0o755); err != nil {
+			t.Fatalf("mkdir overlay: %v", err)
+		}
+		root, err := os.OpenRoot(rootDir)
+		if err != nil {
+			t.Fatalf("open root: %v", err)
+		}
+		defer func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Fatalf("close root: %v", closeErr)
+			}
+		}()
+
+		realRootRemove := rootRemove
+		rootRemove = func(root *os.Root, name string) error {
+			if name == "overlay" {
+				return errors.New("remove overlay failed")
+			}
+			return realRootRemove(root, name)
+		}
+
+		err = removeManifestSubtreeParts(root, []string{"overlay"}, "overlay")
+		if err == nil || !strings.Contains(err.Error(), "remove overlay failed") {
+			t.Fatalf("expected root remove error, got %v", err)
+		}
+	})
+}
+
+func writeDefinitionJSON(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write definition json: %v", err)
+	}
+}
+
+func writeOverlayDefinitionFixture(t *testing.T, artifactDir string) (string, benchmarkDefinition) {
+	t.Helper()
+	content := []byte("package benchpkg\n")
+	definition := benchmarkDefinition{
+		Version:        definitionVersion,
+		ResolvedFrom:   "deadbeef",
+		PackageTargets: []string{"./benchpkg"},
+		Benchmarks:     []resolvedBenchmark{{PackageTarget: "./benchpkg", Name: "BenchmarkHeadOnly"}},
+		BenchPattern:   "^(BenchmarkHeadOnly)$",
+		RunPattern:     "^$",
+		Count:          1,
+		Benchtime:      "1x",
+		BenchMem:       true,
+		HarnessFiles: []benchmarkHarnessFile{{
+			Path:        "benchpkg/head_benchmark_test.go",
+			SHA256:      bytesDigest(content),
+			OverlayPath: "benchpkg/head_benchmark_test.go",
+		}},
+		OverlayDir: "overlay",
+	}
+	overlayDir := filepath.Join(artifactDir, "overlay")
+	definitionPath := filepath.Join(artifactDir, "definition.json")
+	if err := writeBenchmarkDefinition(definitionPath, overlayDir, definition, map[string][]byte{
+		"benchpkg/head_benchmark_test.go": content,
+	}); err != nil {
+		t.Fatalf("write overlay definition fixture: %v", err)
+	}
+	return definitionPath, definition
+}
+
+func supportsSymlink(t *testing.T) bool {
+	t.Helper()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write symlink target probe: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		return false
+	}
+	return true
+}
+
+func withRemovedWorkingDir(t *testing.T, fn func()) {
+	t.Helper()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove temp dir: %v", err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(originalWD); chdirErr != nil {
+			t.Fatalf("restore working directory: %v", chdirErr)
+		}
+	}()
+	fn()
+}
+
+type fakeConfinedWriteRoot struct {
+	failOnWrite int
+	writes      int
+	err         error
+	closeErr    error
+}
+
+func (f *fakeConfinedWriteRoot) WriteFileCreatingParents(string, []byte, os.FileMode, os.FileMode) error {
+	f.writes++
+	if f.writes == f.failOnWrite {
+		return f.err
+	}
+	return nil
+}
+
+func (f *fakeConfinedWriteRoot) Close() error {
+	return f.closeErr
+}
+
+func assertFileContainsBytes(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("file %s = %q, want %q", path, got, want)
+	}
+}
+
+func assertFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("file %s mode = %o, want %o", path, got, want)
+	}
+}
+
+func assertNoBenchdeltaTemps(t *testing.T, root, pattern string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, pattern))
+	if err != nil {
+		t.Fatalf("glob %s: %v", pattern, err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no leftover benchdelta temps matching %q, found %v", pattern, matches)
+	}
+}

--- a/tools/regressionproof/benchdelta_resolve_regressionproof_test.go
+++ b/tools/regressionproof/benchdelta_resolve_regressionproof_test.go
@@ -1,0 +1,467 @@
+package main
+
+import "testing"
+
+func TestRegressionProofBenchdeltaResolveRejectsSymlinkedOverlayAncestor(t *testing.T) {
+	scenario := regressionProofScenario{
+		baseFiles: benchdeltaProofBaseFiles(),
+		headFiles: benchdeltaProofHeadFiles(),
+	}
+	runBenchdeltaRegressionProof(t, scenario, "fix(benchdelta): reject symlinked overlay escape", "./buggy::TestRejectsSymlinkedOverlayAncestorWithoutExternalMutation")
+}
+
+func TestRegressionProofBenchdeltaResolveRejectsSymlinkedManifestRoot(t *testing.T) {
+	scenario := regressionProofScenario{
+		baseFiles: benchdeltaManifestRootProofBaseFiles(),
+		headFiles: benchdeltaManifestRootProofHeadFiles(),
+	}
+	runBenchdeltaRegressionProof(t, scenario, "fix(benchdelta): reject symlinked manifest root escape", "./buggy::TestRejectsSymlinkedManifestRootWithoutExternalMutation")
+}
+
+func TestRegressionProofBenchdeltaResolveRejectsSymlinkedManifestAncestorWithExistingDescendant(t *testing.T) {
+	scenario := regressionProofScenario{
+		baseFiles: benchdeltaManifestAncestorExistingProofBaseFiles(),
+		headFiles: benchdeltaManifestAncestorExistingProofHeadFiles(),
+	}
+	runBenchdeltaRegressionProof(t, scenario, "fix(benchdelta): reject symlinked manifest ancestor with existing descendant", "./buggy::TestRejectsSymlinkedManifestAncestorWithExistingDescendantWithoutExternalMutation")
+}
+
+func TestRegressionProofBenchdeltaResolveRejectsSymlinkedManifestAncestorWithMissingDescendant(t *testing.T) {
+	scenario := regressionProofScenario{
+		baseFiles: benchdeltaManifestAncestorMissingProofBaseFiles(),
+		headFiles: benchdeltaManifestAncestorMissingProofHeadFiles(),
+	}
+	runBenchdeltaRegressionProof(t, scenario, "fix(benchdelta): reject symlinked manifest ancestor with missing descendant", "./buggy::TestRejectsSymlinkedManifestAncestorWithMissingDescendantWithoutExternalMutation")
+}
+
+func runBenchdeltaRegressionProof(t *testing.T, scenario regressionProofScenario, title, regressionTest string) {
+	t.Helper()
+
+	repo := newRegressionProofRepo(t, scenario)
+	body := "## Validation\n\nRegression-Test: " + regressionTest
+	code, stderr := runRegressionProof(t, repo, regressionProofInvocation{
+		title: title,
+		body:  body,
+	})
+	if code != 0 {
+		t.Fatalf("run returned %d, want 0; stderr=%s", code, stderr)
+	}
+}
+
+func benchdeltaProofBaseFiles() map[string]string {
+	return map[string]string{
+		"go.mod": "module example.com/regressionproof\n\ngo 1.26.0\n",
+		"buggy/overlay.go": `package buggy
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func resolveOverlay(manifestRoot, externalRoot string) error {
+	overlayPath := filepath.Join(manifestRoot, "nested", "escape", "overlay", "mutated.txt")
+	return os.WriteFile(overlayPath, []byte("mutated"), 0o600)
+}
+`,
+	}
+}
+
+func benchdeltaProofHeadFiles() map[string]string {
+	files := benchdeltaProofBaseFiles()
+	files["buggy/overlay.go"] = `package buggy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func resolveOverlay(manifestRoot, externalRoot string) error {
+	overlayAncestor := filepath.Join(manifestRoot, "nested", "escape")
+	info, err := os.Lstat(overlayAncestor)
+	if err != nil {
+		return fmt.Errorf("lstat overlay ancestor: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("overlay path contains symlink: %s", overlayAncestor)
+	}
+	overlayPath := filepath.Join(overlayAncestor, "overlay", "mutated.txt")
+	return os.WriteFile(overlayPath, []byte("mutated"), 0o600)
+}
+`
+	files["buggy/overlay_test.go"] = `package buggy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRejectsSymlinkedOverlayAncestorWithoutExternalMutation(t *testing.T) {
+	artifactDir := t.TempDir()
+	externalRoot := filepath.Join(artifactDir, "external-root")
+	if err := os.MkdirAll(filepath.Join(externalRoot, "overlay"), 0o755); err != nil {
+		t.Fatalf("mkdir external overlay: %v", err)
+	}
+	staleOverlayPath := filepath.Join(externalRoot, "overlay", "stale.txt")
+	if err := os.WriteFile(staleOverlayPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write stale overlay file: %v", err)
+	}
+	sentinelPath := filepath.Join(externalRoot, "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("sentinel"), 0o600); err != nil {
+		t.Fatalf("write sentinel file: %v", err)
+	}
+
+	manifestRoot := filepath.Join(artifactDir, "manifest-root")
+	if err := os.MkdirAll(filepath.Join(manifestRoot, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir manifest nested dir: %v", err)
+	}
+	if err := os.Symlink(externalRoot, filepath.Join(manifestRoot, "nested", "escape")); err != nil {
+		t.Fatalf("create overlay ancestor symlink: %v", err)
+	}
+
+	err := resolveOverlay(manifestRoot, externalRoot)
+	if err == nil || !strings.Contains(err.Error(), "overlay path contains symlink") {
+		t.Fatalf("expected symlinked overlay ancestor to be rejected, got %v", err)
+	}
+	assertFileContent(t, staleOverlayPath, "keep me")
+	assertFileContent(t, sentinelPath, "sentinel")
+	if _, err := os.Stat(filepath.Join(externalRoot, "overlay", "mutated.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected external mutation to remain absent, got %v", err)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("file %s = %q, want %q", path, got, want)
+	}
+}
+`
+	return files
+}
+
+func benchdeltaManifestRootProofBaseFiles() map[string]string {
+	return map[string]string{
+		"go.mod": "module example.com/regressionproof\n\ngo 1.26.0\n",
+		"buggy/manifest.go": `package buggy
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func resolveManifest(outPath string) error {
+	overlayPath := filepath.Join(filepath.Dir(outPath), "overlay", "mutated.txt")
+	if err := os.WriteFile(overlayPath, []byte("mutated"), 0o600); err != nil {
+		return err
+	}
+	return os.WriteFile(outPath, []byte("manifest"), 0o600)
+}
+`,
+	}
+}
+
+func benchdeltaManifestRootProofHeadFiles() map[string]string {
+	files := benchdeltaManifestRootProofBaseFiles()
+	files["buggy/manifest.go"] = `package buggy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func resolveManifest(outPath string) error {
+	rootDir := filepath.Dir(outPath)
+	info, err := os.Lstat(rootDir)
+	if err != nil {
+		return fmt.Errorf("lstat manifest root: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("root contains symlink: %s", rootDir)
+	}
+	overlayPath := filepath.Join(rootDir, "overlay", "mutated.txt")
+	if err := os.WriteFile(overlayPath, []byte("mutated"), 0o600); err != nil {
+		return err
+	}
+	return os.WriteFile(outPath, []byte("manifest"), 0o600)
+}
+`
+	files["buggy/manifest_test.go"] = `package buggy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRejectsSymlinkedManifestRootWithoutExternalMutation(t *testing.T) {
+	artifactDir := t.TempDir()
+	externalRoot := filepath.Join(artifactDir, "external-root")
+	if err := os.MkdirAll(filepath.Join(externalRoot, "overlay"), 0o755); err != nil {
+		t.Fatalf("mkdir external overlay: %v", err)
+	}
+	staleOverlayPath := filepath.Join(externalRoot, "overlay", "stale.txt")
+	if err := os.WriteFile(staleOverlayPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write stale overlay file: %v", err)
+	}
+	sentinelPath := filepath.Join(externalRoot, "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("sentinel"), 0o600); err != nil {
+		t.Fatalf("write sentinel file: %v", err)
+	}
+
+	linkedRoot := filepath.Join(artifactDir, "linked-root")
+	if err := os.Symlink(externalRoot, linkedRoot); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	err := resolveManifest(filepath.Join(linkedRoot, "definition.json"))
+	if err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected symlinked manifest root to be rejected, got %v", err)
+	}
+	assertFileContent(t, staleOverlayPath, "keep me")
+	assertFileContent(t, sentinelPath, "sentinel")
+	if _, err := os.Stat(filepath.Join(externalRoot, "definition.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected external manifest to remain absent, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(externalRoot, "overlay", "mutated.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected external overlay mutation to remain absent, got %v", err)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("file %s = %q, want %q", path, got, want)
+	}
+}
+`
+	return files
+}
+
+func benchdeltaManifestAncestorExistingProofBaseFiles() map[string]string {
+	return map[string]string{
+		"go.mod": "module example.com/regressionproof\n\ngo 1.26.0\n",
+		"buggy/manifest.go": `package buggy
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func resolveManifest(rootDir string) error {
+	overlayPath := filepath.Join(rootDir, "overlay", "mutated.txt")
+	if err := os.WriteFile(overlayPath, []byte("mutated"), 0o600); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(rootDir, "definition.json"), []byte("manifest"), 0o600)
+}
+`,
+	}
+}
+
+func benchdeltaManifestAncestorExistingProofHeadFiles() map[string]string {
+	files := benchdeltaManifestAncestorExistingProofBaseFiles()
+	files["buggy/manifest.go"] = `package buggy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func resolveManifest(rootDir string) error {
+	if err := validateRootPathNoFollow(rootDir); err != nil {
+		return err
+	}
+	overlayPath := filepath.Join(rootDir, "overlay", "mutated.txt")
+	if err := os.WriteFile(overlayPath, []byte("mutated"), 0o600); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(rootDir, "definition.json"), []byte("manifest"), 0o600)
+}
+
+func validateRootPathNoFollow(rootDir string) error {
+	rootAbs, err := filepath.Abs(rootDir)
+	if err != nil {
+		return fmt.Errorf("resolve root path: %w", err)
+	}
+	volumeRoot := filepath.VolumeName(rootAbs) + string(os.PathSeparator)
+	currentPath := filepath.Clean(volumeRoot)
+
+	info, err := os.Lstat(currentPath)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("root contains symlink: %s", currentPath)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("root is not a directory: %s", currentPath)
+	}
+
+	rel, err := filepath.Rel(volumeRoot, rootAbs)
+	if err != nil {
+		return err
+	}
+	if rel == "." {
+		return nil
+	}
+
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		currentPath = filepath.Join(currentPath, part)
+		info, err := os.Lstat(currentPath)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("root contains symlink: %s", currentPath)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("root is not a directory: %s", currentPath)
+		}
+	}
+	return nil
+}
+`
+	files["buggy/manifest_test.go"] = `package buggy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRejectsSymlinkedManifestAncestorWithExistingDescendantWithoutExternalMutation(t *testing.T) {
+	artifactDir := t.TempDir()
+	externalRoot := filepath.Join(artifactDir, "external-root")
+	existingRoot := filepath.Join(externalRoot, "existing")
+	if err := os.MkdirAll(filepath.Join(existingRoot, "overlay"), 0o755); err != nil {
+		t.Fatalf("mkdir external overlay: %v", err)
+	}
+	staleOverlayPath := filepath.Join(existingRoot, "overlay", "stale.txt")
+	if err := os.WriteFile(staleOverlayPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write stale overlay file: %v", err)
+	}
+	sentinelPath := filepath.Join(externalRoot, "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("sentinel"), 0o600); err != nil {
+		t.Fatalf("write sentinel file: %v", err)
+	}
+
+	manifestRoot := filepath.Join(artifactDir, "manifest-root")
+	if err := os.MkdirAll(manifestRoot, 0o755); err != nil {
+		t.Fatalf("mkdir manifest root: %v", err)
+	}
+	if err := os.Symlink(externalRoot, filepath.Join(manifestRoot, "escape")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	err := resolveManifest(filepath.Join(manifestRoot, "escape", "existing"))
+	if err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected symlinked manifest ancestor to be rejected, got %v", err)
+	}
+	assertFileContent(t, staleOverlayPath, "keep me")
+	assertFileContent(t, sentinelPath, "sentinel")
+	if _, err := os.Stat(filepath.Join(existingRoot, "definition.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected external manifest to remain absent, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(existingRoot, "overlay", "mutated.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected external overlay mutation to remain absent, got %v", err)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("file %s = %q, want %q", path, got, want)
+	}
+}
+`
+	return files
+}
+
+func benchdeltaManifestAncestorMissingProofBaseFiles() map[string]string {
+	files := benchdeltaManifestAncestorExistingProofBaseFiles()
+	return files
+}
+
+func benchdeltaManifestAncestorMissingProofHeadFiles() map[string]string {
+	files := benchdeltaManifestAncestorExistingProofBaseFiles()
+	files["buggy/manifest.go"] = benchdeltaManifestAncestorExistingProofHeadFiles()["buggy/manifest.go"]
+	files["buggy/manifest_test.go"] = `package buggy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRejectsSymlinkedManifestAncestorWithMissingDescendantWithoutExternalMutation(t *testing.T) {
+	artifactDir := t.TempDir()
+	externalRoot := filepath.Join(artifactDir, "external-root")
+	if err := os.MkdirAll(externalRoot, 0o755); err != nil {
+		t.Fatalf("mkdir external root: %v", err)
+	}
+	sentinelPath := filepath.Join(externalRoot, "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("sentinel"), 0o600); err != nil {
+		t.Fatalf("write sentinel file: %v", err)
+	}
+
+	manifestRoot := filepath.Join(artifactDir, "manifest-root")
+	if err := os.MkdirAll(manifestRoot, 0o755); err != nil {
+		t.Fatalf("mkdir manifest root: %v", err)
+	}
+	if err := os.Symlink(externalRoot, filepath.Join(manifestRoot, "escape")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	err := resolveManifest(filepath.Join(manifestRoot, "escape", "missing", "nested"))
+	if err == nil || !strings.Contains(err.Error(), "root contains symlink") {
+		t.Fatalf("expected symlinked manifest ancestor to be rejected, got %v", err)
+	}
+	assertFileContent(t, sentinelPath, "sentinel")
+	if _, err := os.Stat(filepath.Join(externalRoot, "missing", "nested", "definition.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected external manifest to remain absent, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(externalRoot, "missing", "nested", "overlay", "mutated.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected external overlay mutation to remain absent, got %v", err)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("file %s = %q, want %q", path, got, want)
+	}
+}
+`
+	return files
+}


### PR DESCRIPTION
## Summary

Run base and head memory benchmarks from one benchmark definition resolved from the head revision, so comparisons cannot silently measure different workloads.

Closes #1402

## Changes

- resolve package targets, benchmark selection, flags, and harness files into one explicit definition
- pin and hash the resolved definition, then apply it unchanged to base and head worktrees
- fail with status 2 when resolution, validation, overlay application, or either benchmark setup is incomplete
- emit the exact definition, resolved commit, digest, and harness hashes in logs and artifacts
- reject revision-specific discovery, unsafe overlays, symlink escapes, and mismatched benchmark sets

## Validation

- full local `make ci` pre-commit gate
- targeted normal and race tests after rebasing onto current `main`
- `tools/benchdelta` coverage: 98.2%
- repository total coverage: 98.3%, with every package at least 98%
- new-code duplication: 2.90%
- security, vulnerability, memory, build, and benchmark-definition gates passed

Regression-Test: ./tools/benchdelta::TestResolveBenchmarkDefinition

## Risk and compatibility

- Breaking changes: none for valid benchmark configurations; incomplete or inconsistent comparisons now fail closed.
- Migration required: none.
- Performance impact: benchmark setup performs bounded definition validation and hashing before running the existing benchmark workload.
- Memory benchmark impact: the repository memory benchmark gate passed with no regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
