### PR TITLE
fix(cache): confine MCP cache paths to pinned roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -794,6 +794,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+          - windows-latest
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -809,7 +810,12 @@ jobs:
           go-version-file: go.mod
 
       - name: Run smoke checks
+        if: ${{ matrix.os != 'windows-latest' }}
         run: make smoke
+
+      - name: Run Windows safeio smoke checks
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: go test ./internal/safeio -run '^(TestWindowsOpenRootNoFollowTraversesNestedDirectoryWithRealHandles|TestWindowsOpenRelativeWriteRootTraversesNestedDirectoryWithRealHandles|TestWindowsOpenRelativeWriteRootRejectsIdentityErrorsFromRealHandles)$'
 
   vscode-smoke:
     name: vscode-smoke (${{ matrix.os }})

--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -48,14 +48,9 @@ const defaultAnalysisCacheDirName = ".lopper-cache"
 
 func newAnalysisCache(req Request, repoPath string) *analysisCache {
 	options := resolveCacheOptions(req.Cache, repoPath)
-	metadata := report.CacheMetadata{
-		Enabled:  options.Enabled,
-		Path:     options.Path,
-		ReadOnly: options.ReadOnly,
-	}
 	cache := &analysisCache{
 		options:          options,
-		metadata:         metadata,
+		metadata:         newAnalysisCacheMetadata(options),
 		warnings:         make([]string, 0),
 		analysisRootPath: filepath.Clean(repoPath),
 	}
@@ -63,35 +58,62 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 		cache.cacheable = false
 		return cache
 	}
-	if req.Cache != nil && strings.TrimSpace(req.Cache.PinnedPath) != "" {
-		if strings.TrimSpace(req.RepoPath) != "" {
-			repoRootPath := filepath.Clean(req.RepoPath)
-			if repoRootPath != cache.analysisRootPath {
-				cache.stableKeyRepoPath = repoRootPath
-			}
-		}
-		if strings.TrimSpace(req.Cache.Path) == "" {
-			cache.metadata.Path = options.WritePath
-		}
-	}
-	writePath := options.writePath()
-	if req.Cache == nil || (strings.TrimSpace(req.Cache.Path) == "" && strings.TrimSpace(req.Cache.PinnedPath) == "") {
-		if cachePathEscapesRepo(writePath, repoPath) {
-			cache.cacheable = false
-			cache.warn(analysisCacheUnavailablePrefix + "cache path escapes repository root")
-			return cache
-		}
-	}
-	writeRootPath, writeRootInfo, err := ensurePinnedCacheLayout(writePath)
-	if err != nil {
-		cache.cacheable = false
-		cache.warn(analysisCacheUnavailablePrefix + err.Error())
+	cache.configureStablePaths(req)
+	if !cache.validateDefaultWritePath(req, repoPath) {
 		return cache
 	}
-	cache.writeRootPath = writeRootPath
-	cache.writeRootInfo = writeRootInfo
-	cache.cacheable = true
+	cache.initializeWriteRoot(options.writePath())
 	return cache
+}
+
+func newAnalysisCacheMetadata(options resolvedCacheOptions) report.CacheMetadata {
+	return report.CacheMetadata{
+		Enabled:  options.Enabled,
+		Path:     options.Path,
+		ReadOnly: options.ReadOnly,
+	}
+}
+
+func (c *analysisCache) configureStablePaths(req Request) {
+	if c == nil {
+		return
+	}
+	if repoRootPath := strings.TrimSpace(req.RepoPath); repoRootPath != "" {
+		repoRootPath = filepath.Clean(repoRootPath)
+		if repoRootPath != c.analysisRootPath {
+			c.stableKeyRepoPath = repoRootPath
+		}
+	}
+	if req.Cache != nil && strings.TrimSpace(req.Cache.PinnedPath) != "" && strings.TrimSpace(req.Cache.Path) == "" {
+		c.metadata.Path = c.options.WritePath
+	}
+}
+
+func (c *analysisCache) validateDefaultWritePath(req Request, repoPath string) bool {
+	if c == nil {
+		return false
+	}
+	if req.Cache != nil && (strings.TrimSpace(req.Cache.Path) != "" || strings.TrimSpace(req.Cache.PinnedPath) != "") {
+		return true
+	}
+	if cachePathEscapesRepo(c.options.writePath(), repoPath) {
+		c.cacheable = false
+		c.warn(analysisCacheUnavailablePrefix + "cache path escapes repository root")
+		return false
+	}
+	return true
+}
+
+func (c *analysisCache) initializeWriteRoot(writePath string) {
+	writeRootPath, writeRootInfo, err := ensurePinnedCacheLayout(writePath)
+	if err != nil {
+		c.cacheable = false
+		c.warn(analysisCacheUnavailablePrefix + err.Error())
+		return
+	}
+	c.writeRootPath = writeRootPath
+	c.writeRootInfo = writeRootInfo
+	c.cacheable = true
 }
 
 func (c *analysisCache) stableCacheRoot(normalizedRoot string) string {

--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/safeio"
+	"github.com/ben-ranford/lopper/internal/workspace"
 )
 
 type resolvedCacheOptions struct {
@@ -36,17 +37,55 @@ type analysisCache struct {
 	stableKeyRepoPath string
 	writeRootPath     string
 	writeRootInfo     fs.FileInfo
+	writeRootOpener   func() (*safeio.WriteRoot, error)
 }
 
 const analysisCacheUnavailablePrefix = "analysis cache unavailable: "
 
-var (
-	cacheInitBeforeObjectsEnsureFn = func() error { return nil }
+var cacheInitBeforeObjectsEnsureFn = func() error { return nil }
+
+type trustedCachePathValidationKind uint8
+
+const (
+	trustedCachePathValidationExternal trustedCachePathValidationKind = iota + 1
+	trustedCachePathValidationSymlinkEscape
 )
 
 const defaultAnalysisCacheDirName = ".lopper-cache"
 
-func newAnalysisCache(req Request, repoPath string) *analysisCache {
+// CachePathExternal reports whether validation authenticated a cache target
+// that remains outside the canonical repository.
+func CachePathExternal(err error) bool {
+	return trustedCachePathErrorHasKind(err, trustedCachePathValidationExternal)
+}
+
+// CachePathSymlinkEscape reports whether a lexically in-repository
+// cache target escaped the canonical repository through a symlink.
+func CachePathSymlinkEscape(err error) bool {
+	return trustedCachePathErrorHasKind(err, trustedCachePathValidationSymlinkEscape)
+}
+
+// AuthenticatedExternalCacheOptions verifies that options and an external-path
+// classification came from the same trust-boundary resolution.
+func AuthenticatedExternalCacheOptions(options *CacheOptions, err error) bool {
+	if options == nil || options.trustedPin == nil || options.trustedPin.kind != trustedCachePathExternal {
+		return false
+	}
+	var validationErr *trustedCachePathValidationError
+	return CachePathExternal(err) &&
+		errors.As(err, &validationErr) &&
+		validationErr.trustedPin == options.trustedPin
+}
+
+// InRepoCacheOptions reports whether options carry an authenticated
+// canonical cache target inside their bound repository.
+func InRepoCacheOptions(options *CacheOptions) bool {
+	return options != nil &&
+		options.trustedPin != nil &&
+		options.trustedPin.kind == trustedCachePathInRepo
+}
+
+func newAnalysisCache(req Request, repoPath string, repositoryViews ...*RepositoryView) *analysisCache {
 	options := resolveCacheOptions(req.Cache, repoPath)
 	cache := &analysisCache{
 		options:          options,
@@ -62,7 +101,11 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 	if !cache.validateDefaultWritePath(req, repoPath) {
 		return cache
 	}
-	cache.initializeWriteRoot(options.writePath())
+	var repositoryView *RepositoryView
+	if len(repositoryViews) > 0 {
+		repositoryView = repositoryViews[0]
+	}
+	cache.initializeWriteRoot(options.writePath(), req.Cache, repositoryView)
 	return cache
 }
 
@@ -84,7 +127,7 @@ func (c *analysisCache) configureStablePaths(req Request) {
 			c.stableKeyRepoPath = repoRootPath
 		}
 	}
-	if req.Cache != nil && strings.TrimSpace(req.Cache.PinnedPath) != "" && strings.TrimSpace(req.Cache.Path) == "" {
+	if req.Cache.hasTrustedPin() && strings.TrimSpace(req.Cache.Path) == "" {
 		c.metadata.Path = c.options.WritePath
 	}
 }
@@ -93,7 +136,7 @@ func (c *analysisCache) validateDefaultWritePath(req Request, repoPath string) b
 	if c == nil {
 		return false
 	}
-	if req.Cache != nil && (strings.TrimSpace(req.Cache.Path) != "" || strings.TrimSpace(req.Cache.PinnedPath) != "") {
+	if req.Cache != nil && (strings.TrimSpace(req.Cache.Path) != "" || req.Cache.hasTrustedPin()) {
 		return true
 	}
 	if cachePathEscapesRepo(c.options.writePath(), repoPath) {
@@ -104,8 +147,26 @@ func (c *analysisCache) validateDefaultWritePath(req Request, repoPath string) b
 	return true
 }
 
-func (c *analysisCache) initializeWriteRoot(writePath string) {
-	writeRootPath, writeRootInfo, err := ensurePinnedCacheLayout(writePath)
+func (c *analysisCache) initializeWriteRoot(writePath string, options *CacheOptions, repositoryView *RepositoryView) {
+	var (
+		writeRootPath string
+		writeRootInfo fs.FileInfo
+		err           error
+	)
+	switch {
+	case InRepoCacheOptions(options) && repositoryView != nil && repositoryView.state != nil && repositoryView.state == options.trustedPin.repositoryState:
+		writeRootPath = options.trustedPinnedPath()
+		writeRootInfo, err = c.ensureRepositoryCacheLayout(repositoryView, options.trustedPin.repoRelativePath)
+		if err == nil {
+			c.writeRootOpener = func() (*safeio.WriteRoot, error) {
+				return repositoryView.OpenWriteRoot(options.trustedPin.repoRelativePath, false)
+			}
+		}
+	case options.hasTrustedPin():
+		writeRootPath, writeRootInfo, err = ensureTrustedPinnedCacheLayout(writePath)
+	default:
+		writeRootPath, writeRootInfo, err = ensurePinnedCacheLayout(writePath)
+	}
 	if err != nil {
 		c.cacheable = false
 		c.warn(analysisCacheUnavailablePrefix + err.Error())
@@ -114,6 +175,26 @@ func (c *analysisCache) initializeWriteRoot(writePath string) {
 	c.writeRootPath = writeRootPath
 	c.writeRootInfo = writeRootInfo
 	c.cacheable = true
+}
+
+func (c *analysisCache) ensureRepositoryCacheLayout(repositoryView *RepositoryView, relativePath string) (_ fs.FileInfo, returnErr error) {
+	root, err := repositoryView.OpenWriteRoot(relativePath, true)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, root.Close())
+	}()
+	if err := root.EnsureDir("keys", 0o750); err != nil {
+		return nil, err
+	}
+	if err := cacheInitBeforeObjectsEnsureFn(); err != nil {
+		return nil, err
+	}
+	if err := root.EnsureDir("objects", 0o750); err != nil {
+		return nil, err
+	}
+	return root.Lstat(".")
 }
 
 func (c *analysisCache) stableCacheRoot(normalizedRoot string) string {
@@ -163,16 +244,16 @@ func resolveCacheOptions(req *CacheOptions, repoPath string) resolvedCacheOption
 		return options
 	}
 	options.Enabled = req.Enabled
-	if strings.TrimSpace(req.PinnedPath) != "" {
-		pinnedPath := filepath.Clean(strings.TrimSpace(req.PinnedPath))
+	pinnedPath := req.trustedPinnedPath()
+	if pinnedPath != "" {
 		options.Path = pinnedPath
 		options.WritePath = pinnedPath
 	}
 	if strings.TrimSpace(req.Path) != "" {
 		options.Path = strings.TrimSpace(req.Path)
 		switch {
-		case req.PinnedPath != "":
-			options.WritePath = req.PinnedPath
+		case pinnedPath != "":
+			options.WritePath = pinnedPath
 		case filepath.IsAbs(options.Path):
 			options.WritePath = filepath.Clean(options.Path)
 		default:
@@ -183,28 +264,68 @@ func resolveCacheOptions(req *CacheOptions, repoPath string) resolvedCacheOption
 	return options
 }
 
-func ResolveTrustedDefaultCachePath(repoPath string) (string, error) {
-	return pinTrustedCachePath(repoPath, filepath.Join(repoPath, defaultAnalysisCacheDirName), "cachePath")
+func ResolveTrustedDefaultCacheOptions(repoPath string, readOnly bool) (*CacheOptions, error) {
+	repository, err := ResolveTrustedRepository(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	return ResolveTrustedDefaultCacheOptionsForRepository(repository, readOnly)
 }
 
-// ResolveTrustedCacheOptions normalizes enabled cache options so writes stay
-// within the trusted repository root. Empty paths are left empty so callers can
-// preserve default cache-path behavior.
+// ResolveTrustedDefaultCacheOptionsForRepository pins the default cache path
+// using an already-established repository authorization.
+func ResolveTrustedDefaultCacheOptionsForRepository(repository *RepositoryAuthorization, readOnly bool) (*CacheOptions, error) {
+	state := repository.authorizationState()
+	if state == nil {
+		return nil, errors.New("trusted repository authorization is required")
+	}
+	pin, err := pinTrustedCachePathForRepository(repository, filepath.Join(state.paths.requestedPath, defaultAnalysisCacheDirName), "cachePath")
+	if err != nil {
+		return nil, err
+	}
+	return &CacheOptions{
+		Enabled:    true,
+		ReadOnly:   readOnly,
+		trustedPin: pin,
+	}, nil
+}
+
+// ResolveTrustedCacheOptions pins enabled cache options to canonical paths.
+// Genuine external targets return paired authenticated options and a
+// CachePathExternal error; empty paths preserve default cache-path behavior.
 func ResolveTrustedCacheOptions(repoPath string, req *CacheOptions) (*CacheOptions, error) {
 	if req == nil {
 		return nil, nil
 	}
+	if req.hasTrustedPin() {
+		return useTrustedCacheOptions(repoPath, req)
+	}
+	repository, err := ResolveTrustedRepository(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	return ResolveTrustedCacheOptionsForRepository(repository, req)
+}
+
+// ResolveTrustedCacheOptionsForRepository resolves cache options using an
+// already-established repository authorization.
+func ResolveTrustedCacheOptionsForRepository(repository *RepositoryAuthorization, req *CacheOptions) (*CacheOptions, error) {
+	if req == nil {
+		return nil, nil
+	}
+	state := repository.authorizationState()
+	if state == nil {
+		return nil, errors.New("trusted repository authorization is required")
+	}
 	options := *req
 	options.Path = strings.TrimSpace(options.Path)
-	options.PinnedPath = strings.TrimSpace(options.PinnedPath)
-	if !options.Enabled {
+	if options.hasTrustedPin() {
+		if options.trustedPin.repositoryState != repository.authorizationState() {
+			return nil, errors.New("trusted cache pin does not match repository authorization")
+		}
 		return &options, nil
 	}
-	if options.PinnedPath != "" {
-		options.PinnedPath = filepath.Clean(options.PinnedPath)
-		if err := validateTrustedCachePath(repoPath, options.PinnedPath, "cachePath"); err != nil {
-			return nil, err
-		}
+	if !options.Enabled {
 		return &options, nil
 	}
 	if options.Path == "" {
@@ -212,15 +333,49 @@ func ResolveTrustedCacheOptions(repoPath string, req *CacheOptions) (*CacheOptio
 	}
 	cachePath := options.Path
 	if !filepath.IsAbs(cachePath) {
-		cachePath = filepath.Join(repoPath, cachePath)
+		cachePath = filepath.Join(state.paths.requestedPath, cachePath)
 	}
 	cachePath = filepath.Clean(cachePath)
-	pinnedPath, err := pinTrustedCachePath(repoPath, cachePath, "cachePath")
+	pin, err := pinTrustedCachePathForRepository(repository, cachePath, "cachePath")
 	if err != nil {
+		if CachePathExternal(err) && !filepath.IsAbs(options.Path) {
+			return nil, err
+		}
+		if pin != nil {
+			options.trustedPin = pin
+			return &options, err
+		}
 		return nil, err
 	}
-	options.PinnedPath = pinnedPath
+	options.trustedPin = pin
 	return &options, nil
+}
+
+func normalizeTrustedRepoPath(repoPath string) (string, error) {
+	return workspace.NormalizeRepoPath(strings.TrimSpace(repoPath))
+}
+
+func useTrustedCacheOptions(repoPath string, req *CacheOptions) (*CacheOptions, error) {
+	if req == nil || !req.hasTrustedPin() {
+		return nil, errors.New("trusted cache options require an authenticated pin")
+	}
+	repository := newRepositoryAuthorization(req.trustedPin.repositoryState)
+	if err := useTrustedRepository(repoPath, repository); err != nil {
+		return nil, err
+	}
+	options := *req
+	return &options, nil
+}
+
+func (o *CacheOptions) hasTrustedPin() bool {
+	return o != nil && o.trustedPin != nil
+}
+
+func (o *CacheOptions) trustedPinnedPath() string {
+	if !o.hasTrustedPin() {
+		return ""
+	}
+	return o.trustedPin.canonicalPath
 }
 
 func (c *analysisCache) warn(message string) {
@@ -269,7 +424,15 @@ func ensurePinnedCacheLayout(rootPath string) (_ string, _ fs.FileInfo, returnEr
 	if err != nil {
 		return "", nil, err
 	}
-	ancestorRoot, rootRel, err := safeio.OpenExistingCanonicalWriteRoot(canonicalRootPath, true)
+	return ensureCanonicalCacheLayout(canonicalRootPath)
+}
+
+func ensureTrustedPinnedCacheLayout(rootPath string) (_ string, _ fs.FileInfo, returnErr error) {
+	return ensureCanonicalCacheLayout(filepath.Clean(rootPath))
+}
+
+func ensureCanonicalCacheLayout(rootPath string) (_ string, _ fs.FileInfo, returnErr error) {
+	ancestorRoot, rootRel, err := safeio.OpenExistingCanonicalWriteRoot(rootPath, true)
 	if err != nil {
 		return "", nil, err
 	}
@@ -320,6 +483,9 @@ func (c *analysisCache) validateWriteRoot() error {
 	if c == nil || c.writeRootInfo == nil {
 		return nil
 	}
+	if c.writeRootOpener != nil {
+		return nil
+	}
 	writePath := c.pinnedWritePath()
 	info, err := os.Lstat(writePath)
 	if err != nil {
@@ -331,11 +497,161 @@ func (c *analysisCache) validateWriteRoot() error {
 	return nil
 }
 
-func pinTrustedCachePath(repoPath, cachePath, field string) (string, error) {
-	if err := validateTrustedCachePath(repoPath, cachePath, field); err != nil {
-		return "", err
+func pinTrustedCachePath(repoPath, cachePath, field string) (*trustedCachePin, error) {
+	if !validTrustedCacheCandidate(cachePath) {
+		return nil, trustedCachePathError(field, trustedCachePathValidationSymlinkEscape)
 	}
-	return resolvePathWithinExistingTree(cachePath)
+	repository, err := ResolveTrustedRepository(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	return pinTrustedCachePathForRepository(repository, cachePath, field)
+}
+
+func pinTrustedCachePathForRepository(repository *RepositoryAuthorization, cachePath, field string) (*trustedCachePin, error) {
+	state := repository.authorizationState()
+	if state == nil || !validTrustedCacheCandidate(cachePath) {
+		return nil, trustedCachePathError(field, trustedCachePathValidationSymlinkEscape)
+	}
+	repoPaths := state.paths
+	candidatePath := normalizeTrustedCacheCandidate(repoPaths.requestedPath, cachePath)
+	lexicallyInRepo := pathWithinTrustedRepresentations(repoPaths, candidatePath)
+	resolution, err := resolveTrustedCacheCandidate(repoPaths, candidatePath)
+	if err != nil {
+		return nil, err
+	}
+	if resolution.escapedRepository {
+		return nil, trustedCachePathError(field, trustedCachePathValidationSymlinkEscape)
+	}
+	canonicalPath := resolution.path
+	if !pathWithinDir(repoPaths.canonicalPath, canonicalPath) {
+		if lexicallyInRepo || resolution.enteredRepository {
+			return nil, trustedCachePathError(field, trustedCachePathValidationSymlinkEscape)
+		}
+		pin := newTrustedCachePin(trustedCachePathExternal, repository, canonicalPath, "")
+		return pin, trustedExternalCachePathError(field, pin)
+	}
+	relativePath, err := filepath.Rel(repoPaths.canonicalPath, canonicalPath)
+	if err != nil {
+		return nil, trustedCachePathError(field, trustedCachePathValidationSymlinkEscape)
+	}
+	return newTrustedCachePin(trustedCachePathInRepo, repository, canonicalPath, relativePath), nil
+}
+
+func newTrustedCachePin(kind trustedCachePathKind, repository *RepositoryAuthorization, canonicalPath, relativePath string) *trustedCachePin {
+	if relativePath != "" {
+		relativePath = filepath.Clean(relativePath)
+	}
+	return &trustedCachePin{
+		kind:             kind,
+		repositoryState:  repository.authorizationState(),
+		canonicalPath:    filepath.Clean(canonicalPath),
+		repoRelativePath: relativePath,
+	}
+}
+
+type trustedCacheCandidateResolution struct {
+	path              string
+	enteredRepository bool
+	escapedRepository bool
+	missingPath       bool
+	symlinkExpansions int
+}
+
+const maxTrustedCacheSymlinkExpansions = 255
+
+func resolveTrustedCacheCandidate(repoPaths trustedRepoPaths, candidatePath string) (trustedCacheCandidateResolution, error) {
+	return resolveTrustedAbsolutePath(filepath.Clean(candidatePath), repoPaths, 0)
+}
+
+func resolveTrustedAbsolutePath(path string, repoPaths trustedRepoPaths, symlinkExpansions int) (trustedCacheCandidateResolution, error) {
+	if symlinkExpansions > maxTrustedCacheSymlinkExpansions {
+		return trustedCacheCandidateResolution{}, errors.New("too many symlinks while resolving cachePath")
+	}
+	volumeRoot := filepath.VolumeName(path) + string(os.PathSeparator)
+	relativePath, err := filepath.Rel(volumeRoot, path)
+	if err != nil {
+		return trustedCacheCandidateResolution{}, err
+	}
+	walk := trustedCachePathWalk{
+		repoPaths:         repoPaths,
+		segments:          strings.Split(relativePath, string(filepath.Separator)),
+		currentPath:       volumeRoot,
+		enteredRepository: pathWithinTrustedRepresentations(repoPaths, volumeRoot),
+		symlinkExpansions: symlinkExpansions,
+	}
+	for index, segment := range walk.segments {
+		resolution, done, err := walk.resolveSegment(index, segment)
+		if err != nil || done {
+			return resolution, err
+		}
+	}
+	return trustedCacheCandidateResolution{
+		path:              filepath.Clean(walk.currentPath),
+		enteredRepository: walk.enteredRepository,
+		symlinkExpansions: walk.symlinkExpansions,
+	}, nil
+}
+
+type trustedCachePathWalk struct {
+	repoPaths         trustedRepoPaths
+	segments          []string
+	currentPath       string
+	enteredRepository bool
+	symlinkExpansions int
+}
+
+func (w *trustedCachePathWalk) resolveSegment(index int, segment string) (trustedCacheCandidateResolution, bool, error) {
+	if segment == "" || segment == "." {
+		return trustedCacheCandidateResolution{}, false, nil
+	}
+	nextPath := filepath.Join(w.currentPath, segment)
+	info, err := os.Lstat(nextPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return w.missingPathResolution(index, nextPath), true, nil
+	}
+	if err != nil {
+		return trustedCacheCandidateResolution{}, false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return w.resolveSymlink(nextPath)
+	}
+	w.currentPath = nextPath
+	w.enteredRepository = w.enteredRepository || pathWithinTrustedRepresentations(w.repoPaths, nextPath)
+	return trustedCacheCandidateResolution{}, false, nil
+}
+
+func (w *trustedCachePathWalk) missingPathResolution(index int, nextPath string) trustedCacheCandidateResolution {
+	resolvedPath := filepath.Join(append([]string{nextPath}, w.segments[index+1:]...)...)
+	return trustedCacheCandidateResolution{
+		path:              resolvedPath,
+		enteredRepository: w.enteredRepository || pathWithinTrustedRepresentations(w.repoPaths, resolvedPath),
+		missingPath:       true,
+		symlinkExpansions: w.symlinkExpansions,
+	}
+}
+
+func (w *trustedCachePathWalk) resolveSymlink(path string) (trustedCacheCandidateResolution, bool, error) {
+	linkTarget, err := os.Readlink(path)
+	if err != nil {
+		return trustedCacheCandidateResolution{}, false, err
+	}
+	if !filepath.IsAbs(linkTarget) {
+		linkTarget = filepath.Join(filepath.Dir(path), linkTarget)
+	}
+	target, err := resolveTrustedAbsolutePath(filepath.Clean(linkTarget), w.repoPaths, w.symlinkExpansions+1)
+	if err != nil {
+		return trustedCacheCandidateResolution{}, false, err
+	}
+	targetInside := pathWithinTrustedRepresentations(w.repoPaths, target.path)
+	if target.missingPath || target.escapedRepository || w.enteredRepository && !targetInside {
+		target.escapedRepository = true
+		return target, true, nil
+	}
+	w.enteredRepository = w.enteredRepository || target.enteredRepository || targetInside
+	w.symlinkExpansions = target.symlinkExpansions
+	w.currentPath = target.path
+	return trustedCacheCandidateResolution{}, false, nil
 }
 
 func openConfinedWriteRootUnder(rootPath, targetPath string) (*safeio.WriteRoot, string, error) {
@@ -392,92 +708,97 @@ func validateTrustedCachePath(repoPath, cachePath, field string) error {
 	if cachePath == "" {
 		return nil
 	}
-	if !pathWithinTrustedRoot(repoPath, cachePath) {
-		return fmt.Errorf("%s must stay within repoPath", field)
-	}
-	return validateNoSymlinkEscape(repoPath, cachePath, field)
+	_, err := pinTrustedCachePath(repoPath, cachePath, field)
+	return err
 }
 
 func pathWithinTrustedRoot(repoPath, candidatePath string) bool {
-	cleanRepoPath := filepath.Clean(repoPath)
-	cleanCandidatePath := filepath.Clean(candidatePath)
-	if pathWithinDir(cleanRepoPath, cleanCandidatePath) {
-		return true
-	}
-	resolvedRepoPath, err := filepath.EvalSymlinks(cleanRepoPath)
-	if err != nil {
+	if !validTrustedCacheCandidate(candidatePath) {
 		return false
 	}
-	resolvedCandidatePath, err := resolvePathWithinExistingTree(cleanCandidatePath)
+	pin, err := pinTrustedCachePath(repoPath, candidatePath, "cachePath")
+	return err == nil && pin != nil && pin.kind == trustedCachePathInRepo
+}
+
+type trustedRepoPaths struct {
+	requestedPath string
+	canonicalPath string
+	canonicalInfo fs.FileInfo
+}
+
+func resolveTrustedRepoPaths(repoPath string) (trustedRepoPaths, error) {
+	requestedPath, err := normalizeTrustedRepoPath(repoPath)
 	if err != nil {
-		return false
+		return trustedRepoPaths{}, err
 	}
-	return pathWithinDir(resolvedRepoPath, resolvedCandidatePath)
+	canonicalPath, err := resolvePathWithinExistingTree(requestedPath)
+	if err != nil {
+		return trustedRepoPaths{}, err
+	}
+	canonicalPath = filepath.Clean(canonicalPath)
+	canonicalInfo, err := os.Lstat(canonicalPath)
+	if err != nil {
+		return trustedRepoPaths{}, fmt.Errorf("stat canonical repoPath: %w", err)
+	}
+	if canonicalInfo.Mode()&os.ModeSymlink != 0 || !canonicalInfo.IsDir() {
+		return trustedRepoPaths{}, errors.New("repoPath must resolve to a directory")
+	}
+	return trustedRepoPaths{
+		requestedPath: filepath.Clean(requestedPath),
+		canonicalPath: canonicalPath,
+		canonicalInfo: canonicalInfo,
+	}, nil
+}
+
+func normalizeTrustedCacheCandidate(requestedRepoPath, candidatePath string) string {
+	candidatePath = strings.TrimSpace(candidatePath)
+	if !filepath.IsAbs(candidatePath) {
+		candidatePath = filepath.Join(requestedRepoPath, candidatePath)
+	}
+	return filepath.Clean(candidatePath)
+}
+
+func validTrustedCacheCandidate(candidatePath string) bool {
+	return !strings.ContainsRune(candidatePath, '\x00')
+}
+
+func pathWithinTrustedRepresentations(repoPaths trustedRepoPaths, candidatePath string) bool {
+	return pathWithinDir(repoPaths.requestedPath, candidatePath) ||
+		pathWithinDir(repoPaths.canonicalPath, candidatePath)
 }
 
 func validateNoSymlinkEscape(repoPath, candidatePath, field string) error {
-	cleanRepoPath := filepath.Clean(repoPath)
-	cleanCandidatePath := filepath.Clean(candidatePath)
-	resolvedRepoPath, err := filepath.EvalSymlinks(cleanRepoPath)
-	if err != nil {
-		resolvedRepoPath = cleanRepoPath
-	}
-	walkRoot, walkTarget, err := resolveTrustedWalkPaths(cleanRepoPath, cleanCandidatePath, resolvedRepoPath, field)
-	if err != nil {
-		return err
-	}
-	return validateWalkedPathSegments(walkRoot, walkTarget, resolvedRepoPath, field)
+	return validateTrustedCachePath(repoPath, candidatePath, field)
 }
 
-func resolveTrustedWalkPaths(cleanRepoPath, cleanCandidatePath, resolvedRepoPath, field string) (string, string, error) {
-	if pathWithinDir(cleanRepoPath, cleanCandidatePath) {
-		return cleanRepoPath, cleanCandidatePath, nil
+func trustedCachePathError(field string, kind trustedCachePathValidationKind) error {
+	return &trustedCachePathValidationError{
+		field: field,
+		kind:  kind,
 	}
-
-	resolvedCandidatePath, err := resolvePathWithinExistingTree(cleanCandidatePath)
-	if err != nil || !pathWithinDir(resolvedRepoPath, resolvedCandidatePath) {
-		return "", "", fmt.Errorf("%s must stay within repoPath", field)
-	}
-	return resolvedRepoPath, resolvedCandidatePath, nil
 }
 
-func validateWalkedPathSegments(walkRoot, walkTarget, resolvedRepoPath, field string) error {
-	relativePath, err := filepath.Rel(walkRoot, walkTarget)
-	if err != nil {
-		return fmt.Errorf("%s must stay within repoPath", field)
+func trustedExternalCachePathError(field string, pin *trustedCachePin) error {
+	return &trustedCachePathValidationError{
+		field:      field,
+		kind:       trustedCachePathValidationExternal,
+		trustedPin: pin,
 	}
-	if relativePath == "." {
-		return nil
-	}
-
-	currentPath := walkRoot
-	for _, segment := range strings.Split(relativePath, string(filepath.Separator)) {
-		currentPath = filepath.Join(currentPath, segment)
-		done, err := validateWalkedPathSegment(currentPath, resolvedRepoPath, field)
-		if done || err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
-func validateWalkedPathSegment(currentPath, resolvedRepoPath, field string) (bool, error) {
-	info, err := os.Lstat(currentPath)
-	if errors.Is(err, os.ErrNotExist) {
-		return true, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("stat %s: %w", field, err)
-	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		return false, nil
-	}
+type trustedCachePathValidationError struct {
+	field      string
+	kind       trustedCachePathValidationKind
+	trustedPin *trustedCachePin
+}
 
-	resolvedPath, err := filepath.EvalSymlinks(currentPath)
-	if err != nil || !pathWithinDir(resolvedRepoPath, resolvedPath) {
-		return false, fmt.Errorf("%s must stay within repoPath", field)
-	}
-	return false, nil
+func (e *trustedCachePathValidationError) Error() string {
+	return fmt.Sprintf("%s must stay within repoPath", e.field)
+}
+
+func trustedCachePathErrorHasKind(err error, kind trustedCachePathValidationKind) bool {
+	var validationErr *trustedCachePathValidationError
+	return errors.As(err, &validationErr) && validationErr.kind == kind
 }
 
 func pathWithinDir(root, child string) bool {

--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -1,17 +1,28 @@
 package analysis
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 type resolvedCacheOptions struct {
-	Enabled  bool
-	Path     string
-	ReadOnly bool
+	Enabled   bool
+	Path      string
+	WritePath string
+	ReadOnly  bool
+}
+
+func (o *resolvedCacheOptions) writePath() string {
+	if o.WritePath != "" {
+		return o.WritePath
+	}
+	return o.Path
 }
 
 type analysisCache struct {
@@ -38,19 +49,20 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 		cache.cacheable = false
 		return cache
 	}
+	writePath := options.writePath()
 	if req.Cache == nil || strings.TrimSpace(req.Cache.Path) == "" {
-		if cachePathEscapesRepo(options.Path, repoPath) {
+		if cachePathEscapesRepo(writePath, repoPath) {
 			cache.cacheable = false
 			cache.warn("analysis cache unavailable: cache path escapes repository root")
 			return cache
 		}
 	}
-	if err := os.MkdirAll(filepath.Join(options.Path, "keys"), 0o750); err != nil {
+	if err := ensureConfinedDirectory(writePath, "keys", 0o750); err != nil {
 		cache.cacheable = false
 		cache.warn("analysis cache unavailable: " + err.Error())
 		return cache
 	}
-	if err := os.MkdirAll(filepath.Join(options.Path, "objects"), 0o750); err != nil {
+	if err := ensureConfinedDirectory(writePath, "objects", 0o750); err != nil {
 		cache.cacheable = false
 		cache.warn("analysis cache unavailable: " + err.Error())
 		return cache
@@ -80,9 +92,10 @@ func cachePathEscapesRepo(cachePath, repoPath string) bool {
 
 func resolveCacheOptions(req *CacheOptions, repoPath string) resolvedCacheOptions {
 	options := resolvedCacheOptions{
-		Enabled:  true,
-		Path:     filepath.Join(repoPath, ".lopper-cache"),
-		ReadOnly: false,
+		Enabled:   true,
+		Path:      filepath.Join(repoPath, ".lopper-cache"),
+		WritePath: filepath.Join(repoPath, ".lopper-cache"),
+		ReadOnly:  false,
 	}
 	if req == nil {
 		return options
@@ -90,9 +103,49 @@ func resolveCacheOptions(req *CacheOptions, repoPath string) resolvedCacheOption
 	options.Enabled = req.Enabled
 	if strings.TrimSpace(req.Path) != "" {
 		options.Path = strings.TrimSpace(req.Path)
+		switch {
+		case req.PinnedPath != "":
+			options.WritePath = req.PinnedPath
+		case filepath.IsAbs(options.Path):
+			options.WritePath = filepath.Clean(options.Path)
+		default:
+			options.WritePath = filepath.Join(repoPath, options.Path)
+		}
 	}
 	options.ReadOnly = req.ReadOnly
 	return options
+}
+
+// ResolveTrustedCacheOptions normalizes enabled cache options so writes stay
+// within the trusted repository root. Empty paths are left empty so callers can
+// preserve default cache-path behavior.
+func ResolveTrustedCacheOptions(repoPath string, req *CacheOptions) (*CacheOptions, error) {
+	if req == nil {
+		return nil, nil
+	}
+	options := *req
+	options.Path = strings.TrimSpace(options.Path)
+	if !options.Enabled || options.Path == "" {
+		return &options, nil
+	}
+	if strings.TrimSpace(options.PinnedPath) != "" {
+		options.PinnedPath = filepath.Clean(strings.TrimSpace(options.PinnedPath))
+		if err := validateTrustedCachePath(repoPath, options.PinnedPath, "cachePath"); err != nil {
+			return nil, err
+		}
+		return &options, nil
+	}
+	cachePath := options.Path
+	if !filepath.IsAbs(cachePath) {
+		cachePath = filepath.Join(repoPath, cachePath)
+	}
+	cachePath = filepath.Clean(cachePath)
+	pinnedPath, err := pinTrustedCachePath(repoPath, cachePath, "cachePath")
+	if err != nil {
+		return nil, err
+	}
+	options.PinnedPath = pinnedPath
+	return &options, nil
 }
 
 func (c *analysisCache) warn(message string) {
@@ -120,4 +173,155 @@ func (c *analysisCache) metadataSnapshot() *report.CacheMetadata {
 		snapshot.Invalidations = append([]report.CacheInvalidation(nil), c.metadata.Invalidations...)
 	}
 	return &snapshot
+}
+
+func ensureConfinedDirectory(rootPath, name string, perm os.FileMode) (returnErr error) {
+	targetPath := filepath.Join(rootPath, name)
+	root, rel, err := openConfinedWriteRootUnder(rootPath, targetPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+	return root.EnsureDir(rel, perm)
+}
+
+func pinTrustedCachePath(repoPath, cachePath, field string) (string, error) {
+	if err := validateTrustedCachePath(repoPath, cachePath, field); err != nil {
+		return "", err
+	}
+	return resolvePathWithinExistingTree(cachePath)
+}
+
+func openConfinedWriteRootUnder(rootPath, targetPath string) (*safeio.WriteRoot, string, error) {
+	rootPath = filepath.Clean(rootPath)
+	targetPath = filepath.Clean(targetPath)
+	targetRel, err := filepath.Rel(rootPath, targetPath)
+	if err != nil {
+		return nil, "", err
+	}
+	canonicalRootPath, err := resolvePathWithinExistingTree(rootPath)
+	if err != nil {
+		return nil, "", err
+	}
+	root, rootRel, err := safeio.OpenExistingCanonicalWriteRoot(canonicalRootPath, true)
+	if err != nil {
+		return nil, "", err
+	}
+	if rootRel == "." {
+		return root, targetRel, nil
+	}
+	return root, filepath.Join(rootRel, targetRel), nil
+}
+
+func resolvePathWithinExistingTree(path string) (string, error) {
+	cleanPath := filepath.Clean(path)
+	missingSegments := make([]string, 0, 4)
+	currentPath := cleanPath
+	for {
+		resolvedPath, err := filepath.EvalSymlinks(currentPath)
+		if err == nil {
+			if len(missingSegments) == 0 {
+				return resolvedPath, nil
+			}
+			parts := []string{resolvedPath}
+			for i := len(missingSegments) - 1; i >= 0; i-- {
+				parts = append(parts, missingSegments[i])
+			}
+			return filepath.Join(parts...), nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parentPath := filepath.Dir(currentPath)
+		if parentPath == currentPath {
+			return "", err
+		}
+		missingSegments = append(missingSegments, filepath.Base(currentPath))
+		currentPath = parentPath
+	}
+}
+
+func validateTrustedCachePath(repoPath, cachePath, field string) error {
+	cachePath = strings.TrimSpace(cachePath)
+	if cachePath == "" {
+		return nil
+	}
+	if !pathWithinTrustedRoot(repoPath, cachePath) {
+		return fmt.Errorf("%s must stay within repoPath", field)
+	}
+	return validateNoSymlinkEscape(repoPath, cachePath, field)
+}
+
+func pathWithinTrustedRoot(repoPath, candidatePath string) bool {
+	cleanRepoPath := filepath.Clean(repoPath)
+	cleanCandidatePath := filepath.Clean(candidatePath)
+	if pathWithinDir(cleanRepoPath, cleanCandidatePath) {
+		return true
+	}
+	resolvedRepoPath, err := filepath.EvalSymlinks(cleanRepoPath)
+	if err != nil {
+		return false
+	}
+	resolvedCandidatePath, err := resolvePathWithinExistingTree(cleanCandidatePath)
+	if err != nil {
+		return false
+	}
+	return pathWithinDir(resolvedRepoPath, resolvedCandidatePath)
+}
+
+func validateNoSymlinkEscape(repoPath, candidatePath, field string) error {
+	cleanRepoPath := filepath.Clean(repoPath)
+	cleanCandidatePath := filepath.Clean(candidatePath)
+	resolvedRepoPath, err := filepath.EvalSymlinks(cleanRepoPath)
+	if err != nil {
+		resolvedRepoPath = cleanRepoPath
+	}
+	walkRoot := cleanRepoPath
+	walkTarget := cleanCandidatePath
+	if !pathWithinDir(walkRoot, walkTarget) {
+		resolvedCandidatePath, resolveErr := resolvePathWithinExistingTree(cleanCandidatePath)
+		if resolveErr != nil || !pathWithinDir(resolvedRepoPath, resolvedCandidatePath) {
+			return fmt.Errorf("%s must stay within repoPath", field)
+		}
+		walkRoot = resolvedRepoPath
+		walkTarget = resolvedCandidatePath
+	}
+	relativePath, err := filepath.Rel(walkRoot, walkTarget)
+	if err != nil {
+		return fmt.Errorf("%s must stay within repoPath", field)
+	}
+	if relativePath == "." {
+		return nil
+	}
+	currentPath := walkRoot
+	for _, segment := range strings.Split(relativePath, string(filepath.Separator)) {
+		currentPath = filepath.Join(currentPath, segment)
+		info, statErr := os.Lstat(currentPath)
+		if errors.Is(statErr, os.ErrNotExist) {
+			return nil
+		}
+		if statErr != nil {
+			return fmt.Errorf("stat %s: %w", field, statErr)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		resolvedPath, resolveErr := filepath.EvalSymlinks(currentPath)
+		if resolveErr != nil || !pathWithinDir(resolvedRepoPath, resolvedPath) {
+			return fmt.Errorf("%s must stay within repoPath", field)
+		}
+	}
+	return nil
+}
+
+func pathWithinDir(root, child string) bool {
+	rel, err := filepath.Rel(root, child)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }

--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,6 +32,8 @@ type analysisCache struct {
 	warnings        []string
 	cacheable       bool
 	inputDigestMemo map[cacheInputDigestMemoKey]string
+	writeRootPath   string
+	writeRootInfo   fs.FileInfo
 }
 
 func newAnalysisCache(req Request, repoPath string) *analysisCache {
@@ -67,6 +70,14 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 		cache.warn("analysis cache unavailable: " + err.Error())
 		return cache
 	}
+	writeRootPath, writeRootInfo, err := pinWriteRoot(writePath)
+	if err != nil {
+		cache.cacheable = false
+		cache.warn("analysis cache unavailable: " + err.Error())
+		return cache
+	}
+	cache.writeRootPath = writeRootPath
+	cache.writeRootInfo = writeRootInfo
 	cache.cacheable = true
 	return cache
 }
@@ -189,6 +200,43 @@ func ensureConfinedDirectory(rootPath, name string, perm os.FileMode) (returnErr
 	return root.EnsureDir(rel, perm)
 }
 
+func pinWriteRoot(rootPath string) (string, fs.FileInfo, error) {
+	pinnedPath, err := resolvePathWithinExistingTree(rootPath)
+	if err != nil {
+		return "", nil, err
+	}
+	info, err := os.Lstat(pinnedPath)
+	if err != nil {
+		return "", nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", nil, fmt.Errorf("cache root is not pinned to existing directory: %s", rootPath)
+	}
+	return pinnedPath, info, nil
+}
+
+func (c *analysisCache) pinnedWritePath() string {
+	if strings.TrimSpace(c.writeRootPath) != "" {
+		return c.writeRootPath
+	}
+	return c.options.writePath()
+}
+
+func (c *analysisCache) validateWriteRoot() error {
+	if c == nil || c.writeRootInfo == nil {
+		return nil
+	}
+	writePath := c.pinnedWritePath()
+	info, err := os.Lstat(writePath)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !os.SameFile(c.writeRootInfo, info) {
+		return fmt.Errorf("cache root changed while pinned: %s", writePath)
+	}
+	return nil
+}
+
 func pinTrustedCachePath(repoPath, cachePath, field string) (string, error) {
 	if err := validateTrustedCachePath(repoPath, cachePath, field); err != nil {
 		return "", err
@@ -280,16 +328,26 @@ func validateNoSymlinkEscape(repoPath, candidatePath, field string) error {
 	if err != nil {
 		resolvedRepoPath = cleanRepoPath
 	}
-	walkRoot := cleanRepoPath
-	walkTarget := cleanCandidatePath
-	if !pathWithinDir(walkRoot, walkTarget) {
-		resolvedCandidatePath, resolveErr := resolvePathWithinExistingTree(cleanCandidatePath)
-		if resolveErr != nil || !pathWithinDir(resolvedRepoPath, resolvedCandidatePath) {
-			return fmt.Errorf("%s must stay within repoPath", field)
-		}
-		walkRoot = resolvedRepoPath
-		walkTarget = resolvedCandidatePath
+	walkRoot, walkTarget, err := resolveTrustedWalkPaths(cleanRepoPath, cleanCandidatePath, resolvedRepoPath, field)
+	if err != nil {
+		return err
 	}
+	return validateWalkedPathSegments(walkRoot, walkTarget, resolvedRepoPath, field)
+}
+
+func resolveTrustedWalkPaths(cleanRepoPath, cleanCandidatePath, resolvedRepoPath, field string) (string, string, error) {
+	if pathWithinDir(cleanRepoPath, cleanCandidatePath) {
+		return cleanRepoPath, cleanCandidatePath, nil
+	}
+
+	resolvedCandidatePath, err := resolvePathWithinExistingTree(cleanCandidatePath)
+	if err != nil || !pathWithinDir(resolvedRepoPath, resolvedCandidatePath) {
+		return "", "", fmt.Errorf("%s must stay within repoPath", field)
+	}
+	return resolvedRepoPath, resolvedCandidatePath, nil
+}
+
+func validateWalkedPathSegments(walkRoot, walkTarget, resolvedRepoPath, field string) error {
 	relativePath, err := filepath.Rel(walkRoot, walkTarget)
 	if err != nil {
 		return fmt.Errorf("%s must stay within repoPath", field)
@@ -297,25 +355,35 @@ func validateNoSymlinkEscape(repoPath, candidatePath, field string) error {
 	if relativePath == "." {
 		return nil
 	}
+
 	currentPath := walkRoot
 	for _, segment := range strings.Split(relativePath, string(filepath.Separator)) {
 		currentPath = filepath.Join(currentPath, segment)
-		info, statErr := os.Lstat(currentPath)
-		if errors.Is(statErr, os.ErrNotExist) {
-			return nil
-		}
-		if statErr != nil {
-			return fmt.Errorf("stat %s: %w", field, statErr)
-		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			continue
-		}
-		resolvedPath, resolveErr := filepath.EvalSymlinks(currentPath)
-		if resolveErr != nil || !pathWithinDir(resolvedRepoPath, resolvedPath) {
-			return fmt.Errorf("%s must stay within repoPath", field)
+		done, err := validateWalkedPathSegment(currentPath, resolvedRepoPath, field)
+		if done || err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func validateWalkedPathSegment(currentPath, resolvedRepoPath, field string) (bool, error) {
+	info, err := os.Lstat(currentPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat %s: %w", field, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return false, nil
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(currentPath)
+	if err != nil || !pathWithinDir(resolvedRepoPath, resolvedPath) {
+		return false, fmt.Errorf("%s must stay within repoPath", field)
+	}
+	return false, nil
 }
 
 func pathWithinDir(root, child string) bool {

--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -27,13 +27,15 @@ func (o *resolvedCacheOptions) writePath() string {
 }
 
 type analysisCache struct {
-	options         resolvedCacheOptions
-	metadata        report.CacheMetadata
-	warnings        []string
-	cacheable       bool
-	inputDigestMemo map[cacheInputDigestMemoKey]string
-	writeRootPath   string
-	writeRootInfo   fs.FileInfo
+	options           resolvedCacheOptions
+	metadata          report.CacheMetadata
+	warnings          []string
+	cacheable         bool
+	inputDigestMemo   map[cacheInputDigestMemoKey]string
+	analysisRootPath  string
+	stableKeyRepoPath string
+	writeRootPath     string
+	writeRootInfo     fs.FileInfo
 }
 
 const analysisCacheUnavailablePrefix = "analysis cache unavailable: "
@@ -41,6 +43,8 @@ const analysisCacheUnavailablePrefix = "analysis cache unavailable: "
 var (
 	cacheInitBeforeObjectsEnsureFn = func() error { return nil }
 )
+
+const defaultAnalysisCacheDirName = ".lopper-cache"
 
 func newAnalysisCache(req Request, repoPath string) *analysisCache {
 	options := resolveCacheOptions(req.Cache, repoPath)
@@ -50,16 +54,28 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 		ReadOnly: options.ReadOnly,
 	}
 	cache := &analysisCache{
-		options:  options,
-		metadata: metadata,
-		warnings: make([]string, 0),
+		options:          options,
+		metadata:         metadata,
+		warnings:         make([]string, 0),
+		analysisRootPath: filepath.Clean(repoPath),
 	}
 	if !options.Enabled {
 		cache.cacheable = false
 		return cache
 	}
+	if req.Cache != nil && strings.TrimSpace(req.Cache.PinnedPath) != "" {
+		if strings.TrimSpace(req.RepoPath) != "" {
+			repoRootPath := filepath.Clean(req.RepoPath)
+			if repoRootPath != cache.analysisRootPath {
+				cache.stableKeyRepoPath = repoRootPath
+			}
+		}
+		if strings.TrimSpace(req.Cache.Path) == "" {
+			cache.metadata.Path = options.WritePath
+		}
+	}
 	writePath := options.writePath()
-	if req.Cache == nil || strings.TrimSpace(req.Cache.Path) == "" {
+	if req.Cache == nil || (strings.TrimSpace(req.Cache.Path) == "" && strings.TrimSpace(req.Cache.PinnedPath) == "") {
 		if cachePathEscapesRepo(writePath, repoPath) {
 			cache.cacheable = false
 			cache.warn(analysisCacheUnavailablePrefix + "cache path escapes repository root")
@@ -76,6 +92,23 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 	cache.writeRootInfo = writeRootInfo
 	cache.cacheable = true
 	return cache
+}
+
+func (c *analysisCache) stableCacheRoot(normalizedRoot string) string {
+	if c == nil || c.stableKeyRepoPath == "" {
+		return normalizedRoot
+	}
+	rel, err := filepath.Rel(c.analysisRootPath, normalizedRoot)
+	if err != nil {
+		return normalizedRoot
+	}
+	if rel == "." {
+		return c.stableKeyRepoPath
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return normalizedRoot
+	}
+	return filepath.Join(c.stableKeyRepoPath, rel)
 }
 
 func cachePathEscapesRepo(cachePath, repoPath string) bool {
@@ -100,14 +133,19 @@ func cachePathEscapesRepo(cachePath, repoPath string) bool {
 func resolveCacheOptions(req *CacheOptions, repoPath string) resolvedCacheOptions {
 	options := resolvedCacheOptions{
 		Enabled:   true,
-		Path:      filepath.Join(repoPath, ".lopper-cache"),
-		WritePath: filepath.Join(repoPath, ".lopper-cache"),
+		Path:      filepath.Join(repoPath, defaultAnalysisCacheDirName),
+		WritePath: filepath.Join(repoPath, defaultAnalysisCacheDirName),
 		ReadOnly:  false,
 	}
 	if req == nil {
 		return options
 	}
 	options.Enabled = req.Enabled
+	if strings.TrimSpace(req.PinnedPath) != "" {
+		pinnedPath := filepath.Clean(strings.TrimSpace(req.PinnedPath))
+		options.Path = pinnedPath
+		options.WritePath = pinnedPath
+	}
 	if strings.TrimSpace(req.Path) != "" {
 		options.Path = strings.TrimSpace(req.Path)
 		switch {
@@ -123,6 +161,10 @@ func resolveCacheOptions(req *CacheOptions, repoPath string) resolvedCacheOption
 	return options
 }
 
+func ResolveTrustedDefaultCachePath(repoPath string) (string, error) {
+	return pinTrustedCachePath(repoPath, filepath.Join(repoPath, defaultAnalysisCacheDirName), "cachePath")
+}
+
 // ResolveTrustedCacheOptions normalizes enabled cache options so writes stay
 // within the trusted repository root. Empty paths are left empty so callers can
 // preserve default cache-path behavior.
@@ -132,14 +174,18 @@ func ResolveTrustedCacheOptions(repoPath string, req *CacheOptions) (*CacheOptio
 	}
 	options := *req
 	options.Path = strings.TrimSpace(options.Path)
-	if !options.Enabled || options.Path == "" {
+	options.PinnedPath = strings.TrimSpace(options.PinnedPath)
+	if !options.Enabled {
 		return &options, nil
 	}
-	if strings.TrimSpace(options.PinnedPath) != "" {
-		options.PinnedPath = filepath.Clean(strings.TrimSpace(options.PinnedPath))
+	if options.PinnedPath != "" {
+		options.PinnedPath = filepath.Clean(options.PinnedPath)
 		if err := validateTrustedCachePath(repoPath, options.PinnedPath, "cachePath"); err != nil {
 			return nil, err
 		}
+		return &options, nil
+	}
+	if options.Path == "" {
 		return &options, nil
 	}
 	cachePath := options.Path
@@ -219,25 +265,22 @@ func ensurePinnedCacheLayout(rootPath string) (_ string, _ fs.FileInfo, returnEr
 	if rootRel != "." {
 		pinnedPath = filepath.Join(pinnedPath, rootRel)
 	}
-	root, err := safeio.OpenCanonicalWriteRoot(pinnedPath)
-	if err != nil {
-		return "", nil, err
+	keysRel := filepath.Join(rootRel, "keys")
+	objectsRel := filepath.Join(rootRel, "objects")
+	if rootRel == "." {
+		keysRel = "keys"
+		objectsRel = "objects"
 	}
-	defer func() {
-		if closeErr := root.Close(); closeErr != nil {
-			returnErr = errors.Join(returnErr, closeErr)
-		}
-	}()
-	if err := root.EnsureDir("keys", 0o750); err != nil {
+	if err := ancestorRoot.EnsureDir(keysRel, 0o750); err != nil {
 		return "", nil, err
 	}
 	if err := cacheInitBeforeObjectsEnsureFn(); err != nil {
 		return "", nil, err
 	}
-	if err := root.EnsureDir("objects", 0o750); err != nil {
+	if err := ancestorRoot.EnsureDir(objectsRel, 0o750); err != nil {
 		return "", nil, err
 	}
-	info, err := root.Lstat(".")
+	info, err := ancestorRoot.Lstat(rootRel)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -36,6 +36,12 @@ type analysisCache struct {
 	writeRootInfo   fs.FileInfo
 }
 
+const analysisCacheUnavailablePrefix = "analysis cache unavailable: "
+
+var (
+	cacheInitBeforeObjectsEnsureFn = func() error { return nil }
+)
+
 func newAnalysisCache(req Request, repoPath string) *analysisCache {
 	options := resolveCacheOptions(req.Cache, repoPath)
 	metadata := report.CacheMetadata{
@@ -56,24 +62,14 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 	if req.Cache == nil || strings.TrimSpace(req.Cache.Path) == "" {
 		if cachePathEscapesRepo(writePath, repoPath) {
 			cache.cacheable = false
-			cache.warn("analysis cache unavailable: cache path escapes repository root")
+			cache.warn(analysisCacheUnavailablePrefix + "cache path escapes repository root")
 			return cache
 		}
 	}
-	if err := ensureConfinedDirectory(writePath, "keys", 0o750); err != nil {
-		cache.cacheable = false
-		cache.warn("analysis cache unavailable: " + err.Error())
-		return cache
-	}
-	if err := ensureConfinedDirectory(writePath, "objects", 0o750); err != nil {
-		cache.cacheable = false
-		cache.warn("analysis cache unavailable: " + err.Error())
-		return cache
-	}
-	writeRootPath, writeRootInfo, err := pinWriteRoot(writePath)
+	writeRootPath, writeRootInfo, err := ensurePinnedCacheLayout(writePath)
 	if err != nil {
 		cache.cacheable = false
-		cache.warn("analysis cache unavailable: " + err.Error())
+		cache.warn(analysisCacheUnavailablePrefix + err.Error())
 		return cache
 	}
 	cache.writeRootPath = writeRootPath
@@ -200,17 +196,50 @@ func ensureConfinedDirectory(rootPath, name string, perm os.FileMode) (returnErr
 	return root.EnsureDir(rel, perm)
 }
 
-func pinWriteRoot(rootPath string) (string, fs.FileInfo, error) {
-	pinnedPath, err := resolvePathWithinExistingTree(rootPath)
+func ensurePinnedCacheLayout(rootPath string) (_ string, _ fs.FileInfo, returnErr error) {
+	canonicalRootPath, err := resolvePathWithinExistingTree(rootPath)
 	if err != nil {
 		return "", nil, err
 	}
-	info, err := os.Lstat(pinnedPath)
+	ancestorRoot, rootRel, err := safeio.OpenExistingCanonicalWriteRoot(canonicalRootPath, true)
 	if err != nil {
 		return "", nil, err
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return "", nil, fmt.Errorf("cache root is not pinned to existing directory: %s", rootPath)
+	defer func() {
+		if closeErr := ancestorRoot.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+	if rootRel != "." {
+		if err := ancestorRoot.EnsureDir(rootRel, 0o750); err != nil {
+			return "", nil, err
+		}
+	}
+	pinnedPath := ancestorRoot.CanonicalPath()
+	if rootRel != "." {
+		pinnedPath = filepath.Join(pinnedPath, rootRel)
+	}
+	root, err := safeio.OpenCanonicalWriteRoot(pinnedPath)
+	if err != nil {
+		return "", nil, err
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+	if err := root.EnsureDir("keys", 0o750); err != nil {
+		return "", nil, err
+	}
+	if err := cacheInitBeforeObjectsEnsureFn(); err != nil {
+		return "", nil, err
+	}
+	if err := root.EnsureDir("objects", 0o750); err != nil {
+		return "", nil, err
+	}
+	info, err := root.Lstat(".")
+	if err != nil {
+		return "", nil, err
 	}
 	return pinnedPath, info, nil
 }

--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -68,6 +68,9 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 	if len(req.LicenseDenyList) > 0 {
 		baseKey["licenseDeny"] = req.LicenseDenyList
 	}
+	if scopeIdentity := normalizedScopeCacheIdentity(req); scopeIdentity != nil {
+		baseKey["pathScope"] = scopeIdentity
+	}
 	baseKey["includeRegistryProvenance"] = req.IncludeRegistryProvenance
 	baseDigest, err := hashJSON(baseKey)
 	if err != nil {
@@ -155,6 +158,22 @@ func cleanRuntimeTracePath(tracePath string) string {
 
 func normalizeCacheLanguage(languageID string) string {
 	return strings.ToLower(strings.TrimSpace(languageID))
+}
+
+type scopeCacheIdentity struct {
+	Include []string `json:"include,omitempty"`
+	Exclude []string `json:"exclude,omitempty"`
+}
+
+func normalizedScopeCacheIdentity(req Request) *scopeCacheIdentity {
+	identity := &scopeCacheIdentity{
+		Include: normalizePatterns(req.IncludePatterns),
+		Exclude: normalizePatterns(req.ExcludePatterns),
+	}
+	if len(identity.Include) == 0 && len(identity.Exclude) == 0 {
+		return nil
+	}
+	return identity
 }
 
 func writeInputDigestRecord(w io.Writer, input cacheDigestInput) error {

--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -24,8 +24,9 @@ type cacheDigestInput struct {
 }
 
 type cacheInputDigestMemoKey struct {
-	normalizedRoot  string
-	cleanConfigPath string
+	normalizedRoot          string
+	cleanConfigIdentityPath string
+	cleanConfigContentPath  string
 }
 
 func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot string) (cacheEntryDescriptor, error) {
@@ -44,12 +45,12 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 		"topN":           req.TopN,
 		"suggestOnly":    req.SuggestOnly,
 		"runtimeProfile": req.RuntimeProfile,
-		"configPath":     strings.TrimSpace(req.ConfigPath),
+		"configPath":     stableConfigCachePath(req),
 	}
 	if command := strings.TrimSpace(req.RuntimeTestCommand); command != "" {
 		baseKey["runtimeTestCommand"] = command
 		baseKey["runtimeTracePathExplicit"] = req.RuntimeTracePathExplicit
-		if tracePath := cleanRuntimeTracePath(req.RuntimeTracePath); tracePath != "" {
+		if tracePath := stableRuntimeTraceCachePath(req); tracePath != "" {
 			baseKey["runtimeTracePath"] = tracePath
 		}
 	}
@@ -76,7 +77,7 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 	if err != nil {
 		return cacheEntryDescriptor{}, err
 	}
-	inputDigest, err := c.memoizedInputDigest(normalizedRoot, req.ConfigPath)
+	inputDigest, err := c.memoizedInputDigest(normalizedRoot, stableConfigCachePath(req), req.ConfigPath)
 	if err != nil {
 		return cacheEntryDescriptor{}, err
 	}
@@ -87,18 +88,19 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 	}, nil
 }
 
-func (c *analysisCache) memoizedInputDigest(rootPath, configPath string) (string, error) {
+func (c *analysisCache) memoizedInputDigest(rootPath, configIdentityPath, configContentPath string) (string, error) {
 	if c.inputDigestMemo == nil {
 		c.inputDigestMemo = make(map[cacheInputDigestMemoKey]string)
 	}
 	memoKey := cacheInputDigestMemoKey{
-		normalizedRoot:  filepath.Clean(rootPath),
-		cleanConfigPath: cleanConfigPath(configPath),
+		normalizedRoot:          filepath.Clean(rootPath),
+		cleanConfigIdentityPath: cleanConfigPath(configIdentityPath),
+		cleanConfigContentPath:  cleanConfigPath(configContentPath),
 	}
 	if digest, ok := c.inputDigestMemo[memoKey]; ok {
 		return digest, nil
 	}
-	digest, err := c.computeInputDigest(memoKey.normalizedRoot, memoKey.cleanConfigPath)
+	digest, err := c.computeInputDigestWithConfigIdentity(memoKey.normalizedRoot, memoKey.cleanConfigIdentityPath, memoKey.cleanConfigContentPath)
 	if err != nil {
 		return "", err
 	}
@@ -107,6 +109,10 @@ func (c *analysisCache) memoizedInputDigest(rootPath, configPath string) (string
 }
 
 func (c *analysisCache) computeInputDigest(rootPath, configPath string) (string, error) {
+	return c.computeInputDigestWithConfigIdentity(rootPath, configPath, configPath)
+}
+
+func (c *analysisCache) computeInputDigestWithConfigIdentity(rootPath, configIdentityPath, configContentPath string) (string, error) {
 	rootPath = filepath.Clean(rootPath)
 	files, err := c.collectRelevantFiles(rootPath)
 	if err != nil {
@@ -121,11 +127,12 @@ func (c *analysisCache) computeInputDigest(rootPath, configPath string) (string,
 		})
 	}
 
-	cleanedConfigPath := cleanConfigPath(configPath)
-	if cleanedConfigPath != "" {
+	cleanedConfigIdentityPath := cleanConfigPath(configIdentityPath)
+	cleanedConfigContentPath := cleanConfigPath(configContentPath)
+	if cleanedConfigContentPath != "" {
 		inputs = append(inputs, cacheDigestInput{
-			sortKey:      "config\x00" + cleanedConfigPath,
-			path:         cleanedConfigPath,
+			sortKey:      "config\x00" + cleanedConfigIdentityPath,
+			path:         cleanedConfigContentPath,
 			allowMissing: true,
 		})
 	}
@@ -154,6 +161,20 @@ func cleanRuntimeTracePath(tracePath string) string {
 		return ""
 	}
 	return filepath.Clean(strings.TrimSpace(tracePath))
+}
+
+func stableConfigCachePath(req Request) string {
+	if strings.TrimSpace(req.ConfigCachePath) != "" {
+		return cleanConfigPath(req.ConfigCachePath)
+	}
+	return cleanConfigPath(req.ConfigPath)
+}
+
+func stableRuntimeTraceCachePath(req Request) string {
+	if strings.TrimSpace(req.RuntimeTraceCachePath) != "" {
+		return cleanRuntimeTracePath(req.RuntimeTraceCachePath)
+	}
+	return cleanRuntimeTracePath(req.RuntimeTracePath)
 }
 
 func normalizeCacheLanguage(languageID string) string {

--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -34,10 +34,11 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 	}
 	adapterID = strings.TrimSpace(adapterID)
 	normalizedRoot = filepath.Clean(normalizedRoot)
+	stableRoot := c.stableCacheRoot(normalizedRoot)
 	baseKey := map[string]any{
 		"schema":         analysisCacheSchemaVersion,
 		"adapter":        adapterID,
-		"root":           normalizedRoot,
+		"root":           stableRoot,
 		"dependency":     req.Dependency,
 		"language":       normalizeCacheLanguage(req.Language),
 		"topN":           req.TopN,
@@ -77,7 +78,7 @@ func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot stri
 		return cacheEntryDescriptor{}, err
 	}
 	return cacheEntryDescriptor{
-		KeyLabel:    adapterID + ":" + normalizedRoot,
+		KeyLabel:    adapterID + ":" + stableRoot,
 		KeyDigest:   baseDigest,
 		InputDigest: inputDigest,
 	}, nil

--- a/internal/analysis/cache_extra_test.go
+++ b/internal/analysis/cache_extra_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 const (
@@ -127,8 +129,8 @@ func TestResolveTrustedCacheOptionsRejectsPathOutsideRepo(t *testing.T) {
 		Enabled: true,
 		Path:    outside,
 	})
-	if options != nil {
-		t.Fatalf("expected rejected options to remain nil, got %#v", options)
+	if !AuthenticatedExternalCacheOptions(options, err) {
+		t.Fatalf("expected rejected options to carry an authenticated external pin, options=%#v err=%v", options, err)
 	}
 	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
 		t.Fatalf("expected outside path rejection, got %v", err)
@@ -152,6 +154,152 @@ func TestResolveTrustedCacheOptionsRejectsSymlinkAncestorEscape(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
 		t.Fatalf("expected symlink ancestor rejection, got %v", err)
 	}
+	if !CachePathSymlinkEscape(err) {
+		t.Fatalf("expected symlink escape sentinel, got %v", err)
+	}
+}
+
+func TestResolveTrustedCacheOptionsRejectsAbsoluteSymlinkAncestorEscape(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	options, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join(repo, "tmp", "cache"),
+	})
+	if options != nil {
+		t.Fatalf("expected rejected options to remain nil, got %#v", options)
+	}
+	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected absolute symlink ancestor rejection, got %v", err)
+	}
+	if !CachePathSymlinkEscape(err) {
+		t.Fatalf("expected absolute symlink escape sentinel, got %v", err)
+	}
+}
+
+func TestResolveTrustedCacheOptionsRejectsCanonicalSymlinkEscapeUnderRequestedRepoAlias(t *testing.T) {
+	requestedRepo, canonicalCache, outsideCache := canonicalAliasCacheEscapeFixture(t)
+
+	options, err := ResolveTrustedCacheOptions(requestedRepo, &CacheOptions{
+		Enabled: true,
+		Path:    canonicalCache,
+	})
+	if options != nil {
+		t.Fatalf("expected canonical-form symlink escape rejection, got %#v", options)
+	}
+	if !CachePathSymlinkEscape(err) {
+		t.Fatalf("expected symlink escape sentinel, got %v", err)
+	}
+	if CachePathExternal(err) {
+		t.Fatalf("expected in-repo canonical form not to be classified as external, got %v", err)
+	}
+	if _, statErr := os.Stat(outsideCache); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no external cache directory, stat err=%v", statErr)
+	}
+}
+
+func TestResolveTrustedCacheOptionsRejectsAlternateAbsoluteRepoAliasesThatLaterEscape(t *testing.T) {
+	for _, fixture := range alternateAbsoluteRepoAliasEscapeFixtures(t) {
+		t.Run(fixture.name, func(t *testing.T) {
+			options, err := ResolveTrustedCacheOptions(fixture.requestedRepo, &CacheOptions{
+				Enabled: true,
+				Path:    fixture.cachePath,
+			})
+			if options != nil {
+				t.Fatalf("expected alternate-alias escape rejection, got %#v", options)
+			}
+			if !CachePathSymlinkEscape(err) || CachePathExternal(err) {
+				t.Fatalf("expected authenticated symlink escape classification, got %v", err)
+			}
+			if _, statErr := os.Stat(fixture.outsideCache); !os.IsNotExist(statErr) {
+				t.Fatalf("expected no outside cache directory, stat err=%v", statErr)
+			}
+		})
+	}
+}
+
+func TestResolveTrustedCacheOptionsClassifiesExternalAliasesIntoRepoWithoutMutation(t *testing.T) {
+	repo := t.TempDir()
+	cacheSubdir := filepath.Join(repo, ".cache", "lopper")
+	if err := os.MkdirAll(cacheSubdir, 0o750); err != nil {
+		t.Fatalf("mkdir cache subdir: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name         string
+		target       string
+		wantRelative string
+	}{
+		{name: "repo root", target: repo, wantRelative: "."},
+		{name: "repo subdir", target: cacheSubdir, wantRelative: filepath.Join(".cache", "lopper")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			aliasPath := filepath.Join(t.TempDir(), "external-cache-alias")
+			if err := os.Symlink(tc.target, aliasPath); err != nil {
+				t.Skipf("symlink not supported: %v", err)
+			}
+
+			options, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+				Enabled: true,
+				Path:    aliasPath,
+			})
+			if err != nil {
+				t.Fatalf("resolve external alias into repo: %v", err)
+			}
+			if !InRepoCacheOptions(options) {
+				t.Fatalf("expected external alias to mint an in-repo pin, got %#v", options)
+			}
+			if options.trustedPin.repoRelativePath != tc.wantRelative {
+				t.Fatalf("expected repo-relative pin %q, got %q", tc.wantRelative, options.trustedPin.repoRelativePath)
+			}
+			assertCacheLayoutAbsent(t, tc.target)
+		})
+	}
+}
+
+func TestTrustedCacheClassificationRejectsForgedErrorsAndMutablePathRebinding(t *testing.T) {
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "cache")
+	options, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: true,
+		Path:    outside,
+	})
+	if !AuthenticatedExternalCacheOptions(options, err) {
+		t.Fatalf("expected genuine external classification, options=%#v err=%v", options, err)
+	}
+	wrappedErr := fmt.Errorf("wrapped external classification: %w", err)
+	if !CachePathExternal(wrappedErr) || !AuthenticatedExternalCacheOptions(options, wrappedErr) {
+		t.Fatalf("expected wrapped authenticated classification to remain recognizable, err=%v", wrappedErr)
+	}
+
+	lookalike := errors.New("trusted cache path is external to repoPath")
+	if CachePathExternal(lookalike) {
+		t.Fatalf("expected matching mutable error text not to authorize an external cache")
+	}
+	if AuthenticatedExternalCacheOptions(options, lookalike) {
+		t.Fatalf("expected a forged classification error not to authenticate options")
+	}
+
+	repoAlias := filepath.Join(t.TempDir(), "repo-alias")
+	if err := os.Symlink(repo, repoAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	options.Path = repoAlias
+	if InRepoCacheOptions(options) {
+		t.Fatalf("expected exported path mutation not to reclassify the opaque external pin")
+	}
+	canonicalOutside, resolveErr := resolvePathWithinExistingTree(outside)
+	if resolveErr != nil {
+		t.Fatalf("resolve expected external pin: %v", resolveErr)
+	}
+	if options.trustedPinnedPath() != canonicalOutside {
+		t.Fatalf("expected opaque pin to remain bound to %q, got %q", canonicalOutside, options.trustedPinnedPath())
+	}
+	assertCacheLayoutAbsent(t, repo)
 }
 
 func TestResolveTrustedCacheOptionsBypassesNilDisabledAndEmptyPath(t *testing.T) {
@@ -177,18 +325,288 @@ func TestResolveTrustedCacheOptionsBypassesNilDisabledAndEmptyPath(t *testing.T)
 	if err != nil {
 		t.Fatalf("resolve empty-path cache options: %v", err)
 	}
-	if emptyPath == nil || emptyPath.Path != "" || emptyPath.PinnedPath != "" {
+	if emptyPath == nil || emptyPath.Path != "" || emptyPath.hasTrustedPin() {
 		t.Fatalf("expected empty cache path to preserve default-path behavior, got %#v", emptyPath)
 	}
 }
 
+func TestTrustedCacheBoundaryGuardBranches(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	assertTrustedCacheNilAndInvalidGuards(t, repo, repository)
+	cacheOptions := assertTrustedCacheOptionReuse(t, repo, repository)
+	assertTrustedCacheRepositoryMismatch(t, repo, cacheOptions)
+	assertTrustedDefaultCacheSymlinkRejection(t, repo, repository)
+}
+
+func assertTrustedCacheNilAndInvalidGuards(t *testing.T, repo string, repository *RepositoryAuthorization) {
+	t.Helper()
+	if CachePathExternal(nil) || CachePathSymlinkEscape(nil) {
+		t.Fatal("nil errors must not carry trusted cache classifications")
+	}
+	if AuthenticatedExternalCacheOptions(nil, errors.New("external")) {
+		t.Fatal("nil cache options must not authenticate an external classification")
+	}
+	if (*RepositoryAuthorization)(nil).matchesPath(repo) {
+		t.Fatal("nil repository authorization must not match a path")
+	}
+	if _, err := ResolveTrustedDefaultCacheOptionsForRepository(nil, false); err == nil {
+		t.Fatal("expected missing repository authorization rejection")
+	}
+	if _, err := ResolveTrustedDefaultCacheOptions(filepath.Join(repo, "missing"), false); err == nil {
+		t.Fatal("expected missing repository rejection for default cache options")
+	}
+	if _, err := ResolveTrustedCacheOptions(filepath.Join(repo, "missing"), &CacheOptions{Enabled: true, Path: ".cache"}); err == nil {
+		t.Fatal("expected missing repository rejection for explicit cache options")
+	}
+	if options, err := ResolveTrustedCacheOptionsForRepository(repository, nil); err != nil || options != nil {
+		t.Fatalf("nil cache options = %#v, %v; want nil, nil", options, err)
+	}
+	if _, err := ResolveTrustedCacheOptionsForRepository(nil, &CacheOptions{Enabled: true}); err == nil {
+		t.Fatal("expected cache resolution without repository authorization to fail")
+	}
+	if _, err := useTrustedCacheOptions(repo, nil); err == nil {
+		t.Fatal("expected unauthenticated trusted-cache use to fail")
+	}
+	if _, err := pinTrustedCachePathForRepository(nil, filepath.Join(repo, "cache"), "cachePath"); !CachePathSymlinkEscape(err) {
+		t.Fatalf("expected nil repository pin attempt to be a symlink-escape rejection, got %v", err)
+	}
+	repoPaths := trustedRepoPaths{requestedPath: repo, canonicalPath: repo}
+	if _, err := resolveTrustedAbsolutePath(repo, repoPaths, maxTrustedCacheSymlinkExpansions+1); err == nil {
+		t.Fatal("expected excessive cache-path symlink expansion rejection")
+	}
+	if _, err := resolveTrustedAbsolutePath(string([]byte{0}), repoPaths, 0); err == nil {
+		t.Fatal("expected invalid absolute cache-path resolution to fail")
+	}
+}
+
+func assertTrustedCacheOptionReuse(t *testing.T, repo string, repository *RepositoryAuthorization) *CacheOptions {
+	t.Helper()
+	cacheOptions, err := ResolveTrustedCacheOptionsForRepository(repository, &CacheOptions{Enabled: true, Path: filepath.Join(".cache", "lopper")})
+	if err != nil {
+		t.Fatalf("resolve in-repository cache options: %v", err)
+	}
+	reused, err := ResolveTrustedCacheOptions(repo, cacheOptions)
+	if err != nil || reused.trustedPin != cacheOptions.trustedPin {
+		t.Fatalf("reuse trusted cache options: options=%#v err=%v", reused, err)
+	}
+	reused, err = ResolveTrustedCacheOptionsForRepository(repository, cacheOptions)
+	if err != nil || reused.trustedPin != cacheOptions.trustedPin {
+		t.Fatalf("reuse trusted cache options at repository boundary: options=%#v err=%v", reused, err)
+	}
+	return cacheOptions
+}
+
+func assertTrustedCacheRepositoryMismatch(t *testing.T, repo string, cacheOptions *CacheOptions) {
+	t.Helper()
+	otherRepository, err := ResolveTrustedRepository(t.TempDir())
+	if err != nil {
+		t.Fatalf("authorize second repository: %v", err)
+	}
+	if _, err := ResolveTrustedCacheOptionsForRepository(otherRepository, cacheOptions); err == nil {
+		t.Fatal("expected cache pin/repository authorization mismatch")
+	}
+	if _, err := ResolveTrustedCacheOptions(repo, cacheOptions); err != nil {
+		t.Fatalf("reuse trusted cache options for matching path: %v", err)
+	}
+	if _, err := ResolveTrustedCacheOptions(TrustedRepositoryPath(otherRepository), cacheOptions); err == nil {
+		t.Fatal("expected trusted cache options to reject a different repository path")
+	}
+}
+
+func assertTrustedDefaultCacheSymlinkRejection(t *testing.T, repo string, repository *RepositoryAuthorization) {
+	t.Helper()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repo, defaultAnalysisCacheDirName)); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if _, err := ResolveTrustedDefaultCacheOptionsForRepository(repository, false); !CachePathSymlinkEscape(err) {
+		t.Fatalf("expected symlinked default cache rejection, got %v", err)
+	}
+}
+
+func TestTrustedCacheIdentityNormalizesRelativeCandidatesAndRejectsInvalidRepositories(t *testing.T) {
+	repo := t.TempDir()
+	if got := normalizeTrustedCacheCandidate(repo, filepath.Join(".cache", "lopper")); got != filepath.Join(repo, ".cache", "lopper") {
+		t.Fatalf("normalized relative cache path = %q", got)
+	}
+	if _, err := resolveTrustedRepoPaths(string([]byte{0})); err == nil {
+		t.Fatal("expected invalid repository path rejection")
+	}
+
+	brokenLink := filepath.Join(t.TempDir(), "broken-repository")
+	if err := os.Symlink("missing-target", brokenLink); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if _, err := resolveTrustedRepoPaths(brokenLink); err == nil {
+		t.Fatal("expected broken repository symlink rejection")
+	}
+}
+
+func TestRepositoryBackedCacheLayoutUsesRetainedRootAndFailsClosed(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	cacheOptions, err := ResolveTrustedCacheOptionsForRepository(repository, &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join(".cache", "lopper"),
+	})
+	if err != nil {
+		t.Fatalf("resolve in-repository cache options: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, cacheOptions)
+	if err != nil {
+		t.Fatalf("open trusted repository: %v", err)
+	}
+
+	expectedHookErr := errors.New("objects init blocked")
+	previousHook := cacheInitBeforeObjectsEnsureFn
+	cacheInitBeforeObjectsEnsureFn = func() error { return expectedHookErr }
+	t.Cleanup(func() {
+		cacheInitBeforeObjectsEnsureFn = previousHook
+	})
+	cache := newAnalysisCache(Request{RepoPath: repo, Repository: repository, Cache: cacheOptions}, view.ExecutionPath(), view)
+	if cache.cacheable || len(cache.takeWarnings()) == 0 {
+		t.Fatal("expected retained-root cache initialization hook failure")
+	}
+	cacheRoot := filepath.Join(repo, ".cache", "lopper")
+	if _, err := os.Stat(filepath.Join(cacheRoot, cacheKeysDirName)); err != nil {
+		t.Fatalf("expected keys directory before hook failure: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheRoot, cacheObjectsDirName)); !os.IsNotExist(err) {
+		t.Fatalf("expected objects directory to remain absent, got %v", err)
+	}
+
+	cacheInitBeforeObjectsEnsureFn = previousHook
+	cache = newAnalysisCache(Request{RepoPath: repo, Repository: repository, Cache: cacheOptions}, view.ExecutionPath(), view)
+	if !cache.cacheable || cache.writeRootOpener == nil {
+		t.Fatalf("expected retained-root cache initialization success, warnings=%#v", cache.takeWarnings())
+	}
+	root, err := cache.openPinnedWriteRoot()
+	if err != nil {
+		t.Fatalf("open retained cache root: %v", err)
+	}
+	if err := root.Close(); err != nil {
+		t.Fatalf("close retained cache root: %v", err)
+	}
+
+	if err := view.Close(); err != nil {
+		t.Fatalf("close trusted repository: %v", err)
+	}
+	cache = newAnalysisCache(Request{RepoPath: repo, Repository: repository, Cache: cacheOptions}, repo, view)
+	if cache.cacheable {
+		t.Fatal("expected closed retained root to reject cache initialization")
+	}
+
+	var nilCache *analysisCache
+	nilCache.configureStablePaths(Request{})
+	if nilCache.validateDefaultWritePath(Request{}, repo) {
+		t.Fatal("nil cache must not validate a default write path")
+	}
+}
+
+func TestTrustedCanonicalCacheLayoutRejectsBlockingEntries(t *testing.T) {
+	for _, entry := range []string{cacheKeysDirName, cacheObjectsDirName} {
+		t.Run(entry, func(t *testing.T) {
+			root := mustEvalSymlinks(t, t.TempDir())
+			if entry == cacheObjectsDirName {
+				if err := os.Mkdir(filepath.Join(root, cacheKeysDirName), 0o750); err != nil {
+					t.Fatalf("create keys directory: %v", err)
+				}
+			}
+			writeFile(t, filepath.Join(root, entry), "blocking file\n")
+			if _, _, err := ensureTrustedPinnedCacheLayout(root); err == nil {
+				t.Fatalf("expected blocking %s entry rejection", entry)
+			}
+		})
+	}
+}
+
+func TestAnalysisCachePinnedWriteRootGuardBranches(t *testing.T) {
+	var nilCache *analysisCache
+	if _, err := nilCache.openPinnedWriteRoot(); err == nil {
+		t.Fatal("expected nil analysis cache rejection")
+	}
+
+	expectedOpenErr := errors.New("retained cache root unavailable")
+	cache := &analysisCache{
+		writeRootOpener: func() (*safeio.WriteRoot, error) {
+			return nil, expectedOpenErr
+		},
+	}
+	if _, err := cache.openPinnedWriteRoot(); !errors.Is(err, expectedOpenErr) {
+		t.Fatalf("expected retained cache-root opener error, got %v", err)
+	}
+
+	rootA := mustEvalSymlinks(t, t.TempDir())
+	rootB := mustEvalSymlinks(t, t.TempDir())
+	rootAInfo, err := os.Lstat(rootA)
+	if err != nil {
+		t.Fatalf("stat root A: %v", err)
+	}
+	cache = &analysisCache{
+		writeRootInfo: rootAInfo,
+		writeRootOpener: func() (*safeio.WriteRoot, error) {
+			return safeio.OpenCanonicalWriteRoot(rootB)
+		},
+	}
+	if _, err := cache.openPinnedWriteRoot(); err == nil || !strings.Contains(err.Error(), "cache root changed while pinned") {
+		t.Fatalf("expected retained cache-root identity mismatch, got %v", err)
+	}
+
+	closedRoot, err := safeio.OpenCanonicalWriteRoot(rootA)
+	if err != nil {
+		t.Fatalf("open root to close: %v", err)
+	}
+	if err := closedRoot.Close(); err != nil {
+		t.Fatalf("close root before validation: %v", err)
+	}
+	if err := cache.validateOpenedWriteRoot(closedRoot); err == nil {
+		t.Fatal("expected closed cache-root validation failure")
+	}
+}
+
+func TestAnalysisCacheStableRootAndDefaultValidationBranches(t *testing.T) {
+	repo := t.TempDir()
+	cache := &analysisCache{
+		options:           resolvedCacheOptions{WritePath: filepath.Join(repo, defaultAnalysisCacheDirName)},
+		analysisRootPath:  repo,
+		stableKeyRepoPath: filepath.Join(string(os.PathSeparator), "stable", "repository"),
+	}
+	if !cache.validateDefaultWritePath(Request{}, repo) {
+		t.Fatal("expected safe missing default cache path")
+	}
+	outside := t.TempDir()
+	if got := cache.stableCacheRoot(outside); got != outside {
+		t.Fatalf("outside stable cache root = %q, want %q", got, outside)
+	}
+}
+
 func TestResolveCacheOptionsUsesPinnedWritePath(t *testing.T) {
-	options := resolveCacheOptions(&CacheOptions{Enabled: true, Path: filepath.Join(".cache", "lopper"), PinnedPath: "/trusted/cache", ReadOnly: true}, "/repo")
+	cacheOptions := &CacheOptions{
+		Enabled:    true,
+		Path:       filepath.Join(".cache", "lopper"),
+		ReadOnly:   true,
+		trustedPin: &trustedCachePin{canonicalPath: "/trusted/cache"},
+	}
+	options := resolveCacheOptions(cacheOptions, "/repo")
 	if options.Path != filepath.Join(".cache", "lopper") {
 		t.Fatalf("expected display path to remain unchanged, got %#v", options)
 	}
 	if options.WritePath != "/trusted/cache" || !options.ReadOnly {
 		t.Fatalf("expected pinned write path to be preferred, got %#v", options)
+	}
+}
+
+func TestResolveCacheOptionsUsesRelativeWritePath(t *testing.T) {
+	options := resolveCacheOptions(&CacheOptions{Enabled: true, Path: filepath.Join(".cache", "lopper")}, "/repo")
+	if options.WritePath != filepath.Join("/repo", ".cache", "lopper") {
+		t.Fatalf("expected repository-relative cache write path, got %#v", options)
 	}
 }
 
@@ -227,13 +645,48 @@ func TestResolveTrustedCacheOptionsPinsRelativePathWithoutRewritingUserValue(t *
 	if err != nil {
 		t.Fatalf("resolve expected pinned path: %v", err)
 	}
-	if cacheOptions.PinnedPath != expectedPinnedPath {
-		t.Fatalf("expected pinned path inside repo, got %q", cacheOptions.PinnedPath)
+	if cacheOptions.trustedPinnedPath() != expectedPinnedPath {
+		t.Fatalf("expected pinned path inside repo, got %q", cacheOptions.trustedPinnedPath())
 	}
 }
 
-func TestResolveTrustedCacheOptionsPreservesSuppliedPinnedPathAcrossRepoAlias(t *testing.T) {
+func TestResolveTrustedCacheOptionsPinsRelativePathFromCanonicalDotRepoPath(t *testing.T) {
+	repo := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir repo: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	cacheOptions, err := ResolveTrustedCacheOptions(".", &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join(".cache", "lopper"),
+	})
+	if err != nil {
+		t.Fatalf("resolve trusted cache options from dot repo path: %v", err)
+	}
+	expectedPinnedPath, err := resolvePathWithinExistingTree(filepath.Join(repo, ".cache", "lopper"))
+	if err != nil {
+		t.Fatalf("resolve expected pinned path: %v", err)
+	}
+	if cacheOptions.trustedPinnedPath() != expectedPinnedPath {
+		t.Fatalf("expected canonical pinned path %q, got %q", expectedPinnedPath, cacheOptions.trustedPinnedPath())
+	}
+}
+
+func TestResolveTrustedCacheOptionsPinsCanonicalPathAcrossRepoAlias(t *testing.T) {
 	realRepo := t.TempDir()
+	canonicalRepo, err := filepath.EvalSymlinks(realRepo)
+	if err != nil {
+		t.Fatalf("resolve canonical repo: %v", err)
+	}
 	aliasRoot := t.TempDir()
 	repoAlias := filepath.Join(aliasRoot, "repo-alias")
 	if err := os.Symlink(realRepo, repoAlias); err != nil {
@@ -241,57 +694,71 @@ func TestResolveTrustedCacheOptionsPreservesSuppliedPinnedPathAcrossRepoAlias(t 
 	}
 
 	cachePath := filepath.Join(".cache", "lopper")
-	pinnedPath, err := resolvePathWithinExistingTree(filepath.Join(realRepo, cachePath))
+	pinnedPath, err := resolvePathWithinExistingTree(filepath.Join(canonicalRepo, cachePath))
 	if err != nil {
 		t.Fatalf("resolve pinned path: %v", err)
 	}
 	cacheOptions, err := ResolveTrustedCacheOptions(repoAlias, &CacheOptions{
-		Enabled:    true,
-		Path:       cachePath,
-		PinnedPath: pinnedPath,
+		Enabled: true,
+		Path:    filepath.Join(canonicalRepo, cachePath),
 	})
 	if err != nil {
 		t.Fatalf("resolve trusted cache options for alias repo: %v", err)
 	}
-	if cacheOptions.PinnedPath != pinnedPath {
-		t.Fatalf("expected supplied pinned path to be preserved, got %q", cacheOptions.PinnedPath)
+	if cacheOptions.trustedPinnedPath() != pinnedPath {
+		t.Fatalf("expected canonical pinned path to be preserved, got %q", cacheOptions.trustedPinnedPath())
 	}
 }
 
-func TestResolveTrustedCacheOptionsRejectsSuppliedPinnedPathOutsideRepo(t *testing.T) {
+func TestResolveTrustedCacheOptionsEstablishesOpaqueCanonicalPin(t *testing.T) {
 	repo := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "cache")
+	pinnedAlias := filepath.Join(repo, ".cache", "lopper")
 
 	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
-		Enabled:    true,
-		Path:       filepath.Join(".cache", "lopper"),
-		PinnedPath: outside,
+		Enabled: true,
+		Path:    pinnedAlias,
 	})
-	if cacheOptions != nil {
-		t.Fatalf("expected outside pinned path rejection, got %#v", cacheOptions)
+	if err != nil {
+		t.Fatalf("resolve trusted cache options: %v", err)
 	}
-	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
-		t.Fatalf("expected outside pinned path rejection, got %v", err)
+	expectedPinnedPath, err := resolvePathWithinExistingTree(pinnedAlias)
+	if err != nil {
+		t.Fatalf("resolve expected canonical pinned path: %v", err)
+	}
+	if cacheOptions.trustedPin == nil {
+		t.Fatal("expected an opaque trusted cache pin")
+	}
+	if cacheOptions.trustedPinnedPath() != expectedPinnedPath {
+		t.Fatalf("expected canonical pin %q, got %q", expectedPinnedPath, cacheOptions.trustedPinnedPath())
 	}
 }
 
-func TestResolveTrustedCacheOptionsRejectsPinnedOnlyPathOutsideRepoBeforeMutation(t *testing.T) {
+func TestResolveTrustedCacheOptionsRejectsOutsidePathBeforeMutation(t *testing.T) {
 	repo := t.TempDir()
 	outsideRoot := t.TempDir()
 	outside := filepath.Join(outsideRoot, "missing", "cache")
 
 	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
-		Enabled:    true,
-		PinnedPath: outside,
+		Enabled: true,
+		Path:    outside,
 	})
-	if cacheOptions != nil {
-		t.Fatalf("expected pinned-only outside path rejection, got %#v", cacheOptions)
+	if !AuthenticatedExternalCacheOptions(cacheOptions, err) {
+		t.Fatalf("expected authenticated external options, options=%#v err=%v", cacheOptions, err)
 	}
 	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
-		t.Fatalf("expected pinned-only outside path rejection, got %v", err)
+		t.Fatalf("expected outside path rejection, got %v", err)
 	}
 	if _, statErr := os.Stat(filepath.Join(outsideRoot, "missing")); !os.IsNotExist(statErr) {
 		t.Fatalf("expected no filesystem mutation for rejected pinned path, stat err=%v", statErr)
+	}
+}
+
+func assertCacheLayoutAbsent(t *testing.T, root string) {
+	t.Helper()
+	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
+		if _, err := os.Stat(filepath.Join(root, dir)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to remain absent under %s, stat err=%v", dir, root, err)
+		}
 	}
 }
 
@@ -311,26 +778,34 @@ func TestCachePathEscapesRepoFallsBackToCleanMissingRepoPath(t *testing.T) {
 
 func TestPathWithinTrustedRootAcceptsCanonicalRepoAlias(t *testing.T) {
 	realRepo := t.TempDir()
+	canonicalRepo, err := filepath.EvalSymlinks(realRepo)
+	if err != nil {
+		t.Fatalf("resolve canonical repo: %v", err)
+	}
 	aliasRoot := t.TempDir()
 	repoAlias := filepath.Join(aliasRoot, "repo-alias")
 	if err := os.Symlink(realRepo, repoAlias); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
 
-	if !pathWithinTrustedRoot(repoAlias, filepath.Join(realRepo, cacheDirName)) {
+	if !pathWithinTrustedRoot(repoAlias, filepath.Join(canonicalRepo, cacheDirName)) {
 		t.Fatalf("expected canonical repo alias path to stay within trusted root")
 	}
 }
 
 func TestValidateNoSymlinkEscapeAllowsMissingCanonicalDescendant(t *testing.T) {
 	realRepo := t.TempDir()
+	canonicalRepo, err := filepath.EvalSymlinks(realRepo)
+	if err != nil {
+		t.Fatalf("resolve canonical repo: %v", err)
+	}
 	aliasRoot := t.TempDir()
 	repoAlias := filepath.Join(aliasRoot, "repo-alias")
 	if err := os.Symlink(realRepo, repoAlias); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
 
-	err := validateNoSymlinkEscape(repoAlias, filepath.Join(realRepo, "missing", cacheDirName), "cachePath")
+	err = validateNoSymlinkEscape(repoAlias, filepath.Join(canonicalRepo, "missing", cacheDirName), "cachePath")
 	if err != nil {
 		t.Fatalf("expected missing canonical descendant to remain allowed, got %v", err)
 	}
@@ -481,6 +956,44 @@ func TestResolvePathWithinExistingTreeRejectsInvalidPath(t *testing.T) {
 	}
 }
 
+func TestResolveTrustedAbsolutePathFollowsInRepoSymlinkWithMissingSuffix(t *testing.T) {
+	repo := t.TempDir()
+	actual := filepath.Join(repo, "actual")
+	if err := os.MkdirAll(actual, 0o755); err != nil {
+		t.Fatalf("mkdir actual target: %v", err)
+	}
+	linkPath := filepath.Join(repo, "linked")
+	if err := os.Symlink(filepath.Base(actual), linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	repoPaths, err := resolveTrustedRepoPaths(repo)
+	if err != nil {
+		t.Fatalf("resolve trusted repo paths: %v", err)
+	}
+
+	resolved, err := resolveTrustedAbsolutePath(filepath.Join(repo, "linked", "missing", "cache"), repoPaths, 0)
+	if err != nil {
+		t.Fatalf("resolve trusted absolute path through in-repo symlink: %v", err)
+	}
+	if !resolved.enteredRepository {
+		t.Fatalf("expected symlinked path to stay inside repository, got %#v", resolved)
+	}
+	if !resolved.missingPath {
+		t.Fatalf("expected unresolved suffix to be reported missing, got %#v", resolved)
+	}
+	if resolved.symlinkExpansions < 1 {
+		t.Fatalf("expected at least one symlink expansion, got %#v", resolved)
+	}
+	expectedPath, err := resolvePathWithinExistingTree(filepath.Join(actual, "missing", "cache"))
+	if err != nil {
+		t.Fatalf("resolve expected path within existing tree: %v", err)
+	}
+	if resolved.path != expectedPath {
+		t.Fatalf("resolved path = %q, want %q", resolved.path, expectedPath)
+	}
+}
+
 func TestPathWithinTrustedRootRejectsMissingRepoAndInvalidCandidate(t *testing.T) {
 	if pathWithinTrustedRoot(filepath.Join(t.TempDir(), "missing-repo"), t.TempDir()) {
 		t.Fatalf("expected missing repo root to be rejected")
@@ -533,8 +1046,8 @@ func TestPinnedTrustedCachePathPreventsSymlinkRetargetRaceBeforeFirstWrite(t *te
 	if err != nil {
 		t.Fatalf("resolve expected pinned cache root: %v", err)
 	}
-	if cacheOptions.PinnedPath != expectedPinnedPath {
-		t.Fatalf("expected pinned cache root under original target, got %q", cacheOptions.PinnedPath)
+	if cacheOptions.trustedPinnedPath() != expectedPinnedPath {
+		t.Fatalf("expected pinned cache root under original target, got %q", cacheOptions.trustedPinnedPath())
 	}
 
 	if err := os.Remove(linkPath); err != nil {
@@ -556,6 +1069,49 @@ func TestPinnedTrustedCachePathPreventsSymlinkRetargetRaceBeforeFirstWrite(t *te
 	}
 	if _, err := os.Stat(filepath.Join(redirectedTarget, "cache")); !os.IsNotExist(err) {
 		t.Fatalf("expected retargeted outside cache root to remain absent, got err=%v", err)
+	}
+}
+
+func TestPinnedTrustedCachePathRejectsInsertedSymlinkForMissingSuffixBeforeFirstWrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics are covered on Unix")
+	}
+
+	repo := t.TempDir()
+	cacheParent := filepath.Join(repo, "cache-parent")
+	redirectedTarget := t.TempDir()
+	if err := os.MkdirAll(cacheParent, 0o755); err != nil {
+		t.Fatalf("mkdir cache parent: %v", err)
+	}
+
+	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join("cache-parent", "missing", "cache"),
+	})
+	if err != nil {
+		t.Fatalf("resolve trusted cache options: %v", err)
+	}
+	expectedPinnedPath, err := resolvePathWithinExistingTree(filepath.Join(cacheParent, "missing", "cache"))
+	if err != nil {
+		t.Fatalf("resolve expected pinned cache root: %v", err)
+	}
+	if cacheOptions.trustedPinnedPath() != expectedPinnedPath {
+		t.Fatalf("expected pinned cache root under original repo ancestor, got %q", cacheOptions.trustedPinnedPath())
+	}
+
+	if err := os.Symlink(redirectedTarget, filepath.Join(cacheParent, "missing")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cache := newAnalysisCache(Request{Cache: cacheOptions}, repo)
+	if cache.cacheable {
+		t.Fatalf("expected inserted missing-suffix symlink to fail cache init, warnings=%#v", cache.takeWarnings())
+	}
+	if _, err := os.Stat(filepath.Join(redirectedTarget, "cache")); !os.IsNotExist(err) {
+		t.Fatalf("expected redirected outside cache root to remain absent, got err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(cacheParent, "missing")); err != nil {
+		t.Fatalf("expected inserted symlink to remain in place for failure inspection: %v", err)
 	}
 }
 
@@ -649,6 +1205,93 @@ func withCacheInitBeforeObjectsEnsureHook(t *testing.T, hook func() error) {
 	t.Cleanup(func() {
 		cacheInitBeforeObjectsEnsureFn = previous
 	})
+}
+
+func canonicalAliasCacheEscapeFixture(t *testing.T) (requestedRepo, canonicalCache, outsideCache string) {
+	t.Helper()
+
+	canonicalParent := t.TempDir()
+	canonicalRepo := filepath.Join(canonicalParent, "repo")
+	if err := os.MkdirAll(canonicalRepo, 0o755); err != nil {
+		t.Fatalf("mkdir canonical repo: %v", err)
+	}
+	canonicalRepo, err := filepath.EvalSymlinks(canonicalRepo)
+	if err != nil {
+		t.Fatalf("resolve canonical repo: %v", err)
+	}
+	requestedParent := filepath.Join(t.TempDir(), "requested-parent")
+	if err := os.Symlink(canonicalParent, requestedParent); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(canonicalRepo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	return filepath.Join(requestedParent, "repo"),
+		filepath.Join(canonicalRepo, "tmp", "cache"),
+		filepath.Join(outside, "cache")
+}
+
+type alternateRepoAliasEscapeFixture struct {
+	name          string
+	requestedRepo string
+	cachePath     string
+	outsideCache  string
+}
+
+func alternateAbsoluteRepoAliasEscapeFixtures(t *testing.T) []alternateRepoAliasEscapeFixture {
+	t.Helper()
+	fixtures := []alternateRepoAliasEscapeFixture{arbitraryAbsoluteRepoAliasEscapeFixture(t)}
+	if systemAlias, ok := systemAbsoluteRepoAliasEscapeFixture(t); ok {
+		fixtures = append(fixtures, systemAlias)
+	}
+	return fixtures
+}
+
+func arbitraryAbsoluteRepoAliasEscapeFixture(t *testing.T) alternateRepoAliasEscapeFixture {
+	t.Helper()
+	repoParent := t.TempDir()
+	repo := filepath.Join(repoParent, "repo")
+	if err := os.Mkdir(repo, 0o750); err != nil {
+		t.Fatalf("mkdir arbitrary-alias repo: %v", err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	aliasParent := filepath.Join(t.TempDir(), "alternate-parent")
+	if err := os.Symlink(repoParent, aliasParent); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	return alternateRepoAliasEscapeFixture{
+		name:          "arbitrary alias",
+		requestedRepo: repo,
+		cachePath:     filepath.Join(aliasParent, "repo", "tmp", "cache"),
+		outsideCache:  filepath.Join(outside, "cache"),
+	}
+}
+
+func systemAbsoluteRepoAliasEscapeFixture(t *testing.T) (alternateRepoAliasEscapeFixture, bool) {
+	t.Helper()
+	requestedRepo := t.TempDir()
+	canonicalRepo, err := filepath.EvalSymlinks(requestedRepo)
+	if err != nil {
+		t.Fatalf("resolve system-alias repo: %v", err)
+	}
+	if filepath.Clean(requestedRepo) == filepath.Clean(canonicalRepo) {
+		return alternateRepoAliasEscapeFixture{}, false
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(requestedRepo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	return alternateRepoAliasEscapeFixture{
+		name:          "system absolute alias",
+		requestedRepo: canonicalRepo,
+		cachePath:     filepath.Join(requestedRepo, "tmp", "cache"),
+		outsideCache:  filepath.Join(outside, "cache"),
+	}, true
 }
 
 func runCacheLookupRootSwapCase(t *testing.T, tc cacheLookupRootSwapCase) {

--- a/internal/analysis/cache_extra_test.go
+++ b/internal/analysis/cache_extra_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -111,6 +112,331 @@ func TestNewAnalysisCacheRejectsBrokenSymlinkedDefaultPathOutsideRepo(t *testing
 	assertSymlinkedDefaultCachePathRejected(t, repo, outside, "broken symlinked")
 }
 
+func TestResolveTrustedCacheOptionsRejectsPathOutsideRepo(t *testing.T) {
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "cache")
+
+	options, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: true,
+		Path:    outside,
+	})
+	if options != nil {
+		t.Fatalf("expected rejected options to remain nil, got %#v", options)
+	}
+	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected outside path rejection, got %v", err)
+	}
+}
+
+func TestResolveTrustedCacheOptionsRejectsSymlinkAncestorEscape(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	options, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join("tmp", "cache"),
+	})
+	if options != nil {
+		t.Fatalf("expected rejected options to remain nil, got %#v", options)
+	}
+	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected symlink ancestor rejection, got %v", err)
+	}
+}
+
+func TestResolveTrustedCacheOptionsBypassesNilDisabledAndEmptyPath(t *testing.T) {
+	repo := t.TempDir()
+
+	options, err := ResolveTrustedCacheOptions(repo, nil)
+	if err != nil || options != nil {
+		t.Fatalf("expected nil cache options to bypass unchanged, got %#v err=%v", options, err)
+	}
+
+	disabled, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: false,
+		Path:    filepath.Join(t.TempDir(), "cache"),
+	})
+	if err != nil {
+		t.Fatalf("resolve disabled cache options: %v", err)
+	}
+	if disabled == nil || disabled.Enabled || disabled.Path == "" {
+		t.Fatalf("expected disabled cache options to round-trip, got %#v", disabled)
+	}
+
+	emptyPath, err := ResolveTrustedCacheOptions(repo, &CacheOptions{Enabled: true})
+	if err != nil {
+		t.Fatalf("resolve empty-path cache options: %v", err)
+	}
+	if emptyPath == nil || emptyPath.Path != "" || emptyPath.PinnedPath != "" {
+		t.Fatalf("expected empty cache path to preserve default-path behavior, got %#v", emptyPath)
+	}
+}
+
+func TestResolveCacheOptionsUsesPinnedWritePath(t *testing.T) {
+	options := resolveCacheOptions(&CacheOptions{Enabled: true, Path: filepath.Join(".cache", "lopper"), PinnedPath: "/trusted/cache", ReadOnly: true}, "/repo")
+	if options.Path != filepath.Join(".cache", "lopper") {
+		t.Fatalf("expected display path to remain unchanged, got %#v", options)
+	}
+	if options.WritePath != "/trusted/cache" || !options.ReadOnly {
+		t.Fatalf("expected pinned write path to be preferred, got %#v", options)
+	}
+}
+
+func TestResolveCacheOptionsUsesAbsolutePathAsWritePath(t *testing.T) {
+	options := resolveCacheOptions(&CacheOptions{Enabled: true, Path: "/trusted/cache"}, "/repo")
+	if options.WritePath != filepath.Clean("/trusted/cache") {
+		t.Fatalf("expected absolute cache path to be used as write path, got %#v", options)
+	}
+}
+
+func TestValidateTrustedCachePathAllowsEmptyPath(t *testing.T) {
+	if err := validateTrustedCachePath("/repo", "", "cachePath"); err != nil {
+		t.Fatalf("expected empty cache path to be allowed, got %v", err)
+	}
+}
+
+func TestPathWithinDirRejectsTraversal(t *testing.T) {
+	if pathWithinDir("/repo", "/outside") {
+		t.Fatalf("expected outside path to be rejected")
+	}
+}
+
+func TestResolveTrustedCacheOptionsPinsRelativePathWithoutRewritingUserValue(t *testing.T) {
+	repo := t.TempDir()
+	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join(".cache", "lopper"),
+	})
+	if err != nil {
+		t.Fatalf("resolve trusted cache options: %v", err)
+	}
+	if cacheOptions.Path != filepath.Join(".cache", "lopper") {
+		t.Fatalf("expected user path to remain relative, got %q", cacheOptions.Path)
+	}
+	expectedPinnedPath, err := resolvePathWithinExistingTree(filepath.Join(repo, ".cache", "lopper"))
+	if err != nil {
+		t.Fatalf("resolve expected pinned path: %v", err)
+	}
+	if cacheOptions.PinnedPath != expectedPinnedPath {
+		t.Fatalf("expected pinned path inside repo, got %q", cacheOptions.PinnedPath)
+	}
+}
+
+func TestResolveTrustedCacheOptionsPreservesSuppliedPinnedPathAcrossRepoAlias(t *testing.T) {
+	realRepo := t.TempDir()
+	aliasRoot := t.TempDir()
+	repoAlias := filepath.Join(aliasRoot, "repo-alias")
+	if err := os.Symlink(realRepo, repoAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cachePath := filepath.Join(".cache", "lopper")
+	pinnedPath, err := resolvePathWithinExistingTree(filepath.Join(realRepo, cachePath))
+	if err != nil {
+		t.Fatalf("resolve pinned path: %v", err)
+	}
+	cacheOptions, err := ResolveTrustedCacheOptions(repoAlias, &CacheOptions{
+		Enabled:    true,
+		Path:       cachePath,
+		PinnedPath: pinnedPath,
+	})
+	if err != nil {
+		t.Fatalf("resolve trusted cache options for alias repo: %v", err)
+	}
+	if cacheOptions.PinnedPath != pinnedPath {
+		t.Fatalf("expected supplied pinned path to be preserved, got %q", cacheOptions.PinnedPath)
+	}
+}
+
+func TestResolveTrustedCacheOptionsRejectsSuppliedPinnedPathOutsideRepo(t *testing.T) {
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "cache")
+
+	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled:    true,
+		Path:       filepath.Join(".cache", "lopper"),
+		PinnedPath: outside,
+	})
+	if cacheOptions != nil {
+		t.Fatalf("expected outside pinned path rejection, got %#v", cacheOptions)
+	}
+	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected outside pinned path rejection, got %v", err)
+	}
+}
+
+func TestCachePathEscapesRepoReturnsFalseForMissingPath(t *testing.T) {
+	repo := t.TempDir()
+	if cachePathEscapesRepo(filepath.Join(repo, cacheDirName), repo) {
+		t.Fatalf("expected missing in-repo cache path to remain allowed")
+	}
+}
+
+func TestCachePathEscapesRepoFallsBackToCleanMissingRepoPath(t *testing.T) {
+	cachePath := t.TempDir()
+	if !cachePathEscapesRepo(cachePath, filepath.Join(t.TempDir(), "missing-repo")) {
+		t.Fatalf("expected cache path outside missing repo root to be rejected")
+	}
+}
+
+func TestPathWithinTrustedRootAcceptsCanonicalRepoAlias(t *testing.T) {
+	realRepo := t.TempDir()
+	aliasRoot := t.TempDir()
+	repoAlias := filepath.Join(aliasRoot, "repo-alias")
+	if err := os.Symlink(realRepo, repoAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if !pathWithinTrustedRoot(repoAlias, filepath.Join(realRepo, cacheDirName)) {
+		t.Fatalf("expected canonical repo alias path to stay within trusted root")
+	}
+}
+
+func TestValidateNoSymlinkEscapeAllowsMissingCanonicalDescendant(t *testing.T) {
+	realRepo := t.TempDir()
+	aliasRoot := t.TempDir()
+	repoAlias := filepath.Join(aliasRoot, "repo-alias")
+	if err := os.Symlink(realRepo, repoAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	err := validateNoSymlinkEscape(repoAlias, filepath.Join(realRepo, "missing", cacheDirName), "cachePath")
+	if err != nil {
+		t.Fatalf("expected missing canonical descendant to remain allowed, got %v", err)
+	}
+}
+
+func TestValidateNoSymlinkEscapeRejectsBrokenSymlinkDescendant(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Symlink(filepath.Join(repo, "missing-target"), filepath.Join(repo, "cache-link")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	err := validateNoSymlinkEscape(repo, filepath.Join(repo, "cache-link", cacheDirName), "cachePath")
+	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected broken symlink descendant rejection, got %v", err)
+	}
+}
+
+func TestOpenConfinedWriteRootUnderReturnsCanonicalRelativeSuffix(t *testing.T) {
+	repo := t.TempDir()
+	rootPath := filepath.Join(repo, "nested", "cache")
+	targetPath := filepath.Join(rootPath, cacheKeysDirName)
+
+	root, rel, err := openConfinedWriteRootUnder(rootPath, targetPath)
+	if err != nil {
+		t.Fatalf("open confined write root: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Errorf("close confined write root: %v", closeErr)
+		}
+	})
+
+	if rel != filepath.Join("nested", "cache", cacheKeysDirName) {
+		t.Fatalf("expected canonical relative suffix, got %q", rel)
+	}
+}
+
+func TestOpenConfinedWriteRootUnderRejectsInvalidTargetPath(t *testing.T) {
+	if _, _, err := openConfinedWriteRootUnder(t.TempDir(), string([]byte{0})); err == nil {
+		t.Fatalf("expected invalid target path to be rejected")
+	}
+}
+
+func TestOpenConfinedWriteRootUnderRejectsInvalidRootPath(t *testing.T) {
+	if _, _, err := openConfinedWriteRootUnder(string([]byte{0}), filepath.Join(t.TempDir(), cacheKeysDirName)); err == nil {
+		t.Fatalf("expected invalid root path to be rejected")
+	}
+}
+
+func TestResolvePathWithinExistingTreeRejectsInvalidPath(t *testing.T) {
+	if _, err := resolvePathWithinExistingTree(string([]byte{0})); err == nil {
+		t.Fatalf("expected invalid path to be rejected")
+	}
+}
+
+func TestPathWithinTrustedRootRejectsMissingRepoAndInvalidCandidate(t *testing.T) {
+	if pathWithinTrustedRoot(filepath.Join(t.TempDir(), "missing-repo"), t.TempDir()) {
+		t.Fatalf("expected missing repo root to be rejected")
+	}
+	if pathWithinTrustedRoot(t.TempDir(), string([]byte{0})) {
+		t.Fatalf("expected invalid candidate path to be rejected")
+	}
+}
+
+func TestValidateNoSymlinkEscapeAllowsRepoRootAndRejectsInvalidCandidate(t *testing.T) {
+	repo := t.TempDir()
+	if err := validateNoSymlinkEscape(repo, repo, "cachePath"); err != nil {
+		t.Fatalf("expected repo root to be allowed, got %v", err)
+	}
+	if err := validateNoSymlinkEscape(repo, string([]byte{0}), "cachePath"); err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected invalid candidate path rejection, got %v", err)
+	}
+}
+
+func TestPathWithinDirRejectsInvalidChildPath(t *testing.T) {
+	if pathWithinDir(t.TempDir(), string([]byte{0})) {
+		t.Fatalf("expected invalid child path to be rejected")
+	}
+}
+
+func TestPinnedTrustedCachePathPreventsSymlinkRetargetRaceBeforeFirstWrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics are covered on Unix")
+	}
+
+	repo := t.TempDir()
+	allowedTarget := filepath.Join(repo, "allowed-target")
+	redirectedTarget := t.TempDir()
+	if err := os.MkdirAll(allowedTarget, 0o755); err != nil {
+		t.Fatalf("mkdir allowed target: %v", err)
+	}
+	linkPath := filepath.Join(repo, "allowed-link")
+	if err := os.Symlink(filepath.Base(allowedTarget), linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join("allowed-link", "cache"),
+	})
+	if err != nil {
+		t.Fatalf("resolve trusted cache options: %v", err)
+	}
+	expectedPinnedPath, err := resolvePathWithinExistingTree(filepath.Join(allowedTarget, "cache"))
+	if err != nil {
+		t.Fatalf("resolve expected pinned cache root: %v", err)
+	}
+	if cacheOptions.PinnedPath != expectedPinnedPath {
+		t.Fatalf("expected pinned cache root under original target, got %q", cacheOptions.PinnedPath)
+	}
+
+	if err := os.Remove(linkPath); err != nil {
+		t.Fatalf("remove original symlink: %v", err)
+	}
+	if err := os.Symlink(redirectedTarget, linkPath); err != nil {
+		t.Fatalf("retarget allowed symlink: %v", err)
+	}
+
+	cache := newAnalysisCache(Request{Cache: cacheOptions}, repo)
+	if !cache.cacheable {
+		t.Fatalf("expected pinned cache to remain usable, warnings=%#v", cache.takeWarnings())
+	}
+	if _, err := os.Stat(filepath.Join(allowedTarget, "cache", cacheKeysDirName)); err != nil {
+		t.Fatalf("expected pinned keys dir to be created in original target: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(allowedTarget, "cache", cacheObjectsDirName)); err != nil {
+		t.Fatalf("expected pinned objects dir to be created in original target: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(redirectedTarget, "cache")); !os.IsNotExist(err) {
+		t.Fatalf("expected retargeted outside cache root to remain absent, got err=%v", err)
+	}
+}
+
 func assertSymlinkedDefaultCachePathRejected(t *testing.T, repo, outside, description string) {
 	t.Helper()
 
@@ -165,7 +491,7 @@ func TestHashFileOrMissingAndWriteFileAtomic(t *testing.T) {
 	if err := os.Chmod(targetPath, 0o644); err != nil {
 		t.Fatalf("chmod target file: %v", err)
 	}
-	if err := writeFileAtomic(targetPath, []byte("hello")); err != nil {
+	if err := writeFileAtomic(dir, targetPath, []byte("hello")); err != nil {
 		t.Fatalf("write file atomic: %v", err)
 	}
 	digest, err = hashFileOrMissing(targetPath)
@@ -181,6 +507,97 @@ func TestHashFileOrMissingAndWriteFileAtomic(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o644 {
 		t.Fatalf("expected existing file mode 0644 to be preserved, got %#o", info.Mode().Perm())
+	}
+}
+
+func TestWriteFileAtomicRewritesReadOnlyExistingCacheFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only replacement semantics are covered by safeio platform tests")
+	}
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "keys", "pointer.json")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o750); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("before"), 0o444); err != nil {
+		t.Fatalf("seed target file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(targetPath, 0o600); err != nil && !os.IsNotExist(err) {
+			t.Errorf("restore target file permissions: %v", err)
+		}
+	})
+
+	probe, probeErr := os.OpenFile(targetPath, os.O_WRONLY, 0)
+	if probeErr == nil {
+		if err := probe.Close(); err != nil {
+			t.Fatalf("close writability probe: %v", err)
+		}
+		t.Skip("effective privileges bypass read-only file permissions")
+	}
+	if !os.IsPermission(probeErr) {
+		t.Skipf("read-only file semantics are not testable: %v", probeErr)
+	}
+
+	if err := writeFileAtomic(dir, targetPath, []byte("after")); err != nil {
+		t.Fatalf("rewrite readonly cache file: %v", err)
+	}
+	if got, err := os.ReadFile(targetPath); err != nil {
+		t.Fatalf("read rewritten cache file: %v", err)
+	} else if string(got) != "after" {
+		t.Fatalf("unexpected rewritten content: %q", string(got))
+	}
+	if info, err := os.Stat(targetPath); err != nil {
+		t.Fatalf("stat rewritten cache file: %v", err)
+	} else if info.Mode().Perm() != 0o444 {
+		t.Fatalf("expected rewritten read-only mode 0444 to be preserved, got %#o", info.Mode().Perm())
+	}
+}
+
+func TestWriteFileAtomicRejectsSymlinkedParentEscape(t *testing.T) {
+	rootDir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(rootDir, "keys")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	targetPath := filepath.Join(rootDir, "keys", "pointer.json")
+	err := writeFileAtomic(rootDir, targetPath, []byte("after"))
+	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
+		t.Fatalf("expected symlinked parent rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "pointer.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside cache file to remain absent, got err=%v", statErr)
+	}
+}
+
+func TestWriteFileAtomicRejectsRootSwapBeforeParentCreation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics are covered on Unix")
+	}
+
+	rootDir := t.TempDir()
+	originalParent := filepath.Join(rootDir, "keys")
+	if err := os.MkdirAll(originalParent, 0o755); err != nil {
+		t.Fatalf("mkdir original parent: %v", err)
+	}
+	outside := t.TempDir()
+	outsideTarget := filepath.Join(outside, "pointer.json")
+	if err := os.Remove(originalParent); err != nil {
+		t.Fatalf("remove original parent: %v", err)
+	}
+	if err := os.Symlink(outside, originalParent); err != nil {
+		t.Fatalf("retarget parent symlink: %v", err)
+	}
+
+	targetPath := filepath.Join(rootDir, "keys", "pointer.json")
+	err := writeFileAtomic(rootDir, targetPath, []byte("after"))
+	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
+		t.Fatalf("expected swapped parent symlink rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(outsideTarget); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside cache file to remain absent, got err=%v", statErr)
 	}
 }
 
@@ -420,7 +837,7 @@ func testAnalysisCacheWriteAtomicAndHashFileErrors(t *testing.T) {
 	if err := os.MkdirAll(targetDir, 0o750); err != nil {
 		t.Fatalf("mkdir target: %v", err)
 	}
-	if writeFileAtomic(targetDir, []byte("x")) == nil {
+	if writeFileAtomic(dir, targetDir, []byte("x")) == nil {
 		t.Fatalf("expected writeFileAtomic to fail when target is directory")
 	}
 	if _, err := hashFile(targetDir); err == nil {

--- a/internal/analysis/cache_extra_test.go
+++ b/internal/analysis/cache_extra_test.go
@@ -275,6 +275,26 @@ func TestResolveTrustedCacheOptionsRejectsSuppliedPinnedPathOutsideRepo(t *testi
 	}
 }
 
+func TestResolveTrustedCacheOptionsRejectsPinnedOnlyPathOutsideRepoBeforeMutation(t *testing.T) {
+	repo := t.TempDir()
+	outsideRoot := t.TempDir()
+	outside := filepath.Join(outsideRoot, "missing", "cache")
+
+	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled:    true,
+		PinnedPath: outside,
+	})
+	if cacheOptions != nil {
+		t.Fatalf("expected pinned-only outside path rejection, got %#v", cacheOptions)
+	}
+	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected pinned-only outside path rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outsideRoot, "missing")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no filesystem mutation for rejected pinned path, stat err=%v", statErr)
+	}
+}
+
 func TestCachePathEscapesRepoReturnsFalseForMissingPath(t *testing.T) {
 	repo := t.TempDir()
 	if cachePathEscapesRepo(filepath.Join(repo, cacheDirName), repo) {
@@ -539,7 +559,7 @@ func TestPinnedTrustedCachePathPreventsSymlinkRetargetRaceBeforeFirstWrite(t *te
 	}
 }
 
-func TestAnalysisCachePinnedRootPreventsSwapBetweenInitOperations(t *testing.T) {
+func TestEnsurePinnedCacheLayoutRejectsCacheRootSwapBetweenInitOperations(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("directory replacement semantics are covered on Unix")
 	}
@@ -556,14 +576,14 @@ func TestAnalysisCachePinnedRootPreventsSwapBetweenInitOperations(t *testing.T) 
 		return os.Symlink(redirectedCachePath, cachePath)
 	})
 
-	cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
-	if !cache.cacheable {
-		t.Fatalf("expected cache to remain usable during init swap, warnings=%#v", cache.takeWarnings())
+	if _, _, err := ensurePinnedCacheLayout(cachePath); err == nil {
+		t.Fatalf("expected cache root replacement during init to fail closed")
 	}
-	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
-		if _, err := os.Stat(filepath.Join(renamedCachePath, dir)); err != nil {
-			t.Fatalf("expected %s dir in original pinned cache root: %v", dir, err)
-		}
+	if _, err := os.Stat(filepath.Join(renamedCachePath, cacheKeysDirName)); err != nil {
+		t.Fatalf("expected keys dir created before replacement to remain in original root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(renamedCachePath, cacheObjectsDirName)); !os.IsNotExist(err) {
+		t.Fatalf("expected objects dir creation to stop after replacement, got err=%v", err)
 	}
 	if _, err := os.Stat(filepath.Join(redirectedCachePath, cacheKeysDirName)); !os.IsNotExist(err) {
 		t.Fatalf("expected redirected keys dir to remain absent, got err=%v", err)

--- a/internal/analysis/cache_extra_test.go
+++ b/internal/analysis/cache_extra_test.go
@@ -32,6 +32,13 @@ type analysisCacheLookupCase struct {
 	wantRepoPath string
 }
 
+type cacheLookupRootSwapCase struct {
+	name         string
+	swapOnRead   int
+	outsideRepo  string
+	outsideObjID string
+}
+
 func TestAnalysisCacheWarningLifecycleAndSnapshot(t *testing.T) {
 	cache := &analysisCache{
 		metadata: report.CacheMetadata{Invalidations: []report.CacheInvalidation{{Key: "k", Reason: "reason"}}},
@@ -353,6 +360,101 @@ func TestOpenConfinedWriteRootUnderRejectsInvalidRootPath(t *testing.T) {
 	}
 }
 
+func TestEnsureConfinedDirectoryCreatesChildWithinRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := ensureConfinedDirectory(root, cacheKeysDirName, 0o750); err != nil {
+		t.Fatalf("ensure confined directory: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, cacheKeysDirName)); err != nil {
+		t.Fatalf("expected confined directory to be created: %v", err)
+	}
+}
+
+func TestEnsureConfinedDirectoryRejectsSymlinkTarget(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Symlink(t.TempDir(), filepath.Join(root, cacheKeysDirName)); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if err := ensureConfinedDirectory(root, cacheKeysDirName, 0o750); err == nil {
+		t.Fatalf("expected symlinked confined directory target to be rejected")
+	}
+}
+
+func TestEnsureConfinedDirectoryRejectsInvalidRoot(t *testing.T) {
+	if err := ensureConfinedDirectory(string([]byte{0}), cacheKeysDirName, 0o750); err == nil {
+		t.Fatalf("expected invalid root path to be rejected")
+	}
+}
+
+func TestEnsurePinnedCacheLayoutPinsExistingRoot(t *testing.T) {
+	root := mustEvalSymlinks(t, t.TempDir())
+	pinnedPath, info, err := ensurePinnedCacheLayout(root)
+	if err != nil {
+		t.Fatalf("ensure pinned cache layout: %v", err)
+	}
+	if pinnedPath != root {
+		t.Fatalf("expected existing cache root to remain pinned, got %q want %q", pinnedPath, root)
+	}
+	if info == nil || !info.IsDir() {
+		t.Fatalf("expected pinned cache root info for directory, got %#v", info)
+	}
+	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
+		if _, err := os.Stat(filepath.Join(root, dir)); err != nil {
+			t.Fatalf("expected %s dir under pinned root: %v", dir, err)
+		}
+	}
+}
+
+func TestEnsurePinnedCacheLayoutCreatesMissingRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "cache-root")
+	pinnedPath, info, err := ensurePinnedCacheLayout(root)
+	if err != nil {
+		t.Fatalf("ensure pinned cache layout: %v", err)
+	}
+	expectedRoot := mustEvalSymlinks(t, root)
+	if pinnedPath != expectedRoot {
+		t.Fatalf("expected missing cache root to be created at %q, got %q", expectedRoot, pinnedPath)
+	}
+	if info == nil || !info.IsDir() {
+		t.Fatalf("expected created cache root info for directory, got %#v", info)
+	}
+	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
+		if _, err := os.Stat(filepath.Join(root, dir)); err != nil {
+			t.Fatalf("expected %s dir under created root: %v", dir, err)
+		}
+	}
+}
+
+func TestEnsurePinnedCacheLayoutPropagatesObjectsHookError(t *testing.T) {
+	expectedErr := errors.New("objects init blocked")
+	root := filepath.Join(t.TempDir(), "cache-root")
+	withCacheInitBeforeObjectsEnsureHook(t, func() error { return expectedErr })
+
+	pinnedPath, info, err := ensurePinnedCacheLayout(root)
+	if pinnedPath != "" || info != nil {
+		t.Fatalf("expected no pinned cache root on hook error, got path=%q info=%#v", pinnedPath, info)
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected objects hook error, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, cacheKeysDirName)); statErr != nil {
+		t.Fatalf("expected keys dir to be created before hook failure: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, cacheObjectsDirName)); !os.IsNotExist(statErr) {
+		t.Fatalf("expected objects dir to remain absent after hook failure, got err=%v", statErr)
+	}
+}
+
+func TestEnsurePinnedCacheLayoutRejectsInvalidRoot(t *testing.T) {
+	pinnedPath, info, err := ensurePinnedCacheLayout(string([]byte{0}))
+	if pinnedPath != "" || info != nil {
+		t.Fatalf("expected invalid root path to return no pinned cache root, got path=%q info=%#v", pinnedPath, info)
+	}
+	if err == nil {
+		t.Fatalf("expected invalid root path to be rejected")
+	}
+}
+
 func TestResolvePathWithinExistingTreeRejectsInvalidPath(t *testing.T) {
 	if _, err := resolvePathWithinExistingTree(string([]byte{0})); err == nil {
 		t.Fatalf("expected invalid path to be rejected")
@@ -437,6 +539,40 @@ func TestPinnedTrustedCachePathPreventsSymlinkRetargetRaceBeforeFirstWrite(t *te
 	}
 }
 
+func TestAnalysisCachePinnedRootPreventsSwapBetweenInitOperations(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics are covered on Unix")
+	}
+
+	repo := t.TempDir()
+	cachePath := filepath.Join(repo, "cache-root")
+	renamedCachePath := filepath.Join(repo, "cache-root-renamed")
+	redirectedCachePath := t.TempDir()
+
+	withCacheInitBeforeObjectsEnsureHook(t, func() error {
+		if err := os.Rename(cachePath, renamedCachePath); err != nil {
+			return err
+		}
+		return os.Symlink(redirectedCachePath, cachePath)
+	})
+
+	cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
+	if !cache.cacheable {
+		t.Fatalf("expected cache to remain usable during init swap, warnings=%#v", cache.takeWarnings())
+	}
+	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
+		if _, err := os.Stat(filepath.Join(renamedCachePath, dir)); err != nil {
+			t.Fatalf("expected %s dir in original pinned cache root: %v", dir, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(redirectedCachePath, cacheKeysDirName)); !os.IsNotExist(err) {
+		t.Fatalf("expected redirected keys dir to remain absent, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(redirectedCachePath, cacheObjectsDirName)); !os.IsNotExist(err) {
+		t.Fatalf("expected redirected objects dir to remain absent, got err=%v", err)
+	}
+}
+
 func TestAnalysisCacheRejectsCacheRootSwapBeforeStoreWrite(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("directory replacement semantics are covered on Unix")
@@ -476,58 +612,77 @@ func TestAnalysisCacheLookupRejectsCacheRootSwapBeforeReads(t *testing.T) {
 		t.Skip("directory replacement semantics are covered on Unix")
 	}
 
-	for _, tc := range []struct {
-		name         string
-		swapOnRead   int
-		outsideRepo  string
-		outsideObjID string
-	}{
+	for _, tc := range []cacheLookupRootSwapCase{
 		{name: "before pointer read", swapOnRead: 1, outsideRepo: "outside-pointer", outsideObjID: "outside-pointer"},
 		{name: "before object read", swapOnRead: 2, outsideRepo: "outside-object", outsideObjID: "outside-object"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			repo := t.TempDir()
-			cachePath := filepath.Join(repo, "cache-root")
-			cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
-			if !cache.cacheable {
-				t.Fatalf("expected cache to be usable before root swap, warnings=%#v", cache.takeWarnings())
-			}
-
-			entry := cacheEntryDescriptor{KeyLabel: "k", KeyDigest: "key", InputDigest: "input"}
-			mustWriteCachedObject(t, cachePath, "inside-object", report.Report{RepoPath: "inside"})
-			mustWritePointer(t, filepath.Join(cachePath, cacheKeysDirName, entry.KeyDigest+".json"), cachePointer{
-				InputDigest:  entry.InputDigest,
-				ObjectDigest: "inside-object",
-			})
-
-			redirectedCachePath := t.TempDir()
-			mustWriteCachedObject(t, redirectedCachePath, tc.outsideObjID, report.Report{RepoPath: tc.outsideRepo})
-			mustWritePointer(t, filepath.Join(redirectedCachePath, cacheKeysDirName, entry.KeyDigest+".json"), cachePointer{
-				InputDigest:  entry.InputDigest,
-				ObjectDigest: tc.outsideObjID,
-			})
-
-			originalCachePath := filepath.Join(repo, "cache-root-original")
-			readCount := 0
-			withCacheLookupBeforeReadHook(t, func() error {
-				readCount++
-				if readCount != tc.swapOnRead {
-					return nil
-				}
-				if err := os.Rename(cachePath, originalCachePath); err != nil {
-					return err
-				}
-				return os.Symlink(redirectedCachePath, cachePath)
-			})
-
-			got, hit, err := cache.lookup(entry)
-			if hit || got.RepoPath != "" {
-				t.Fatalf("expected swapped lookup to return no cached report, got report=%#v hit=%v", got, hit)
-			}
-			if err != nil && !strings.Contains(err.Error(), "cache root changed while pinned") {
-				t.Fatalf("expected lookup to fail closed without outside read, got err=%v", err)
-			}
+			runCacheLookupRootSwapCase(t, tc)
 		})
+	}
+}
+
+func withCacheInitBeforeObjectsEnsureHook(t *testing.T, hook func() error) {
+	t.Helper()
+	previous := cacheInitBeforeObjectsEnsureFn
+	cacheInitBeforeObjectsEnsureFn = hook
+	t.Cleanup(func() {
+		cacheInitBeforeObjectsEnsureFn = previous
+	})
+}
+
+func runCacheLookupRootSwapCase(t *testing.T, tc cacheLookupRootSwapCase) {
+	t.Helper()
+
+	repo := t.TempDir()
+	cachePath := filepath.Join(repo, "cache-root")
+	cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
+	if !cache.cacheable {
+		t.Fatalf("expected cache to be usable before root swap, warnings=%#v", cache.takeWarnings())
+	}
+
+	entry := cacheEntryDescriptor{KeyLabel: "k", KeyDigest: "key", InputDigest: "input"}
+	seedLookupCachePaths(t, cachePath, entry, "inside-object", report.Report{RepoPath: "inside"})
+
+	redirectedCachePath := t.TempDir()
+	seedLookupCachePaths(t, redirectedCachePath, entry, tc.outsideObjID, report.Report{RepoPath: tc.outsideRepo})
+
+	installLookupSwapHook(t, cachePath, filepath.Join(repo, "cache-root-original"), redirectedCachePath, tc.swapOnRead)
+	got, hit, err := cache.lookup(entry)
+	assertLookupRootSwapResult(t, got, hit, err)
+}
+
+func seedLookupCachePaths(t *testing.T, cachePath string, entry cacheEntryDescriptor, objectID string, rep report.Report) {
+	t.Helper()
+	mustWriteCachedObject(t, cachePath, objectID, rep)
+	mustWritePointer(t, filepath.Join(cachePath, cacheKeysDirName, entry.KeyDigest+".json"), cachePointer{
+		InputDigest:  entry.InputDigest,
+		ObjectDigest: objectID,
+	})
+}
+
+func installLookupSwapHook(t *testing.T, cachePath, originalCachePath, redirectedCachePath string, swapOnRead int) {
+	t.Helper()
+	readCount := 0
+	withCacheLookupBeforeReadHook(t, func() error {
+		readCount++
+		if readCount != swapOnRead {
+			return nil
+		}
+		if err := os.Rename(cachePath, originalCachePath); err != nil {
+			return err
+		}
+		return os.Symlink(redirectedCachePath, cachePath)
+	})
+}
+
+func assertLookupRootSwapResult(t *testing.T, got report.Report, hit bool, err error) {
+	t.Helper()
+	if hit || got.RepoPath != "" {
+		t.Fatalf("expected swapped lookup to return no cached report, got report=%#v hit=%v", got, hit)
+	}
+	if err != nil && !strings.Contains(err.Error(), "cache root changed while pinned") {
+		t.Fatalf("expected lookup to fail closed without outside read, got err=%v", err)
 	}
 }
 

--- a/internal/analysis/cache_extra_test.go
+++ b/internal/analysis/cache_extra_test.go
@@ -437,6 +437,100 @@ func TestPinnedTrustedCachePathPreventsSymlinkRetargetRaceBeforeFirstWrite(t *te
 	}
 }
 
+func TestAnalysisCacheRejectsCacheRootSwapBeforeStoreWrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics are covered on Unix")
+	}
+
+	repo := t.TempDir()
+	cachePath := filepath.Join(repo, "cache-root")
+	cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
+	if !cache.cacheable {
+		t.Fatalf("expected cache to be usable before root swap, warnings=%#v", cache.takeWarnings())
+	}
+
+	redirectedCachePath := t.TempDir()
+	originalCachePath := filepath.Join(repo, "cache-root-original")
+	withCacheStoreBeforeRootOpenHook(t, func() error {
+		if err := os.Rename(cachePath, originalCachePath); err != nil {
+			return err
+		}
+		return os.Symlink(redirectedCachePath, cachePath)
+	})
+
+	entry := cacheEntryDescriptor{KeyDigest: "swapped-root", InputDigest: "input"}
+	storeErr := cache.store(entry, report.Report{RepoPath: repo})
+	if storeErr == nil || !containsAny(storeErr.Error(), "cache root changed while pinned", "open canonical root") {
+		t.Fatalf("expected swapped cache root rejection, got %v", storeErr)
+	}
+	if _, err := os.Stat(filepath.Join(redirectedCachePath, "objects")); !os.IsNotExist(err) {
+		t.Fatalf("expected redirected cache root to remain untouched, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(originalCachePath, "objects")); err != nil {
+		t.Fatalf("expected original cache root contents to remain present, got %v", err)
+	}
+}
+
+func TestAnalysisCacheLookupRejectsCacheRootSwapBeforeReads(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics are covered on Unix")
+	}
+
+	for _, tc := range []struct {
+		name         string
+		swapOnRead   int
+		outsideRepo  string
+		outsideObjID string
+	}{
+		{name: "before pointer read", swapOnRead: 1, outsideRepo: "outside-pointer", outsideObjID: "outside-pointer"},
+		{name: "before object read", swapOnRead: 2, outsideRepo: "outside-object", outsideObjID: "outside-object"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			cachePath := filepath.Join(repo, "cache-root")
+			cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
+			if !cache.cacheable {
+				t.Fatalf("expected cache to be usable before root swap, warnings=%#v", cache.takeWarnings())
+			}
+
+			entry := cacheEntryDescriptor{KeyLabel: "k", KeyDigest: "key", InputDigest: "input"}
+			mustWriteCachedObject(t, cachePath, "inside-object", report.Report{RepoPath: "inside"})
+			mustWritePointer(t, filepath.Join(cachePath, cacheKeysDirName, entry.KeyDigest+".json"), cachePointer{
+				InputDigest:  entry.InputDigest,
+				ObjectDigest: "inside-object",
+			})
+
+			redirectedCachePath := t.TempDir()
+			mustWriteCachedObject(t, redirectedCachePath, tc.outsideObjID, report.Report{RepoPath: tc.outsideRepo})
+			mustWritePointer(t, filepath.Join(redirectedCachePath, cacheKeysDirName, entry.KeyDigest+".json"), cachePointer{
+				InputDigest:  entry.InputDigest,
+				ObjectDigest: tc.outsideObjID,
+			})
+
+			originalCachePath := filepath.Join(repo, "cache-root-original")
+			readCount := 0
+			withCacheLookupBeforeReadHook(t, func() error {
+				readCount++
+				if readCount != tc.swapOnRead {
+					return nil
+				}
+				if err := os.Rename(cachePath, originalCachePath); err != nil {
+					return err
+				}
+				return os.Symlink(redirectedCachePath, cachePath)
+			})
+
+			got, hit, err := cache.lookup(entry)
+			if hit || got.RepoPath != "" {
+				t.Fatalf("expected swapped lookup to return no cached report, got report=%#v hit=%v", got, hit)
+			}
+			if err != nil && !strings.Contains(err.Error(), "cache root changed while pinned") {
+				t.Fatalf("expected lookup to fail closed without outside read, got err=%v", err)
+			}
+		})
+	}
+}
+
 func assertSymlinkedDefaultCachePathRejected(t *testing.T, repo, outside, description string) {
 	t.Helper()
 
@@ -459,6 +553,33 @@ func assertSymlinkedDefaultCachePathRejected(t *testing.T, repo, outside, descri
 	if _, err := os.Stat(filepath.Join(outside, cacheObjectsDirName)); !os.IsNotExist(err) {
 		t.Fatalf("expected no objects dir to be created outside repo, stat err=%v", err)
 	}
+}
+
+func withCacheStoreBeforeRootOpenHook(t *testing.T, hook func() error) {
+	t.Helper()
+	previous := cacheStoreBeforeRootOpenFn
+	cacheStoreBeforeRootOpenFn = hook
+	t.Cleanup(func() {
+		cacheStoreBeforeRootOpenFn = previous
+	})
+}
+
+func withCacheLookupBeforeReadHook(t *testing.T, hook func() error) {
+	t.Helper()
+	previous := cacheLookupBeforeReadFn
+	cacheLookupBeforeReadFn = hook
+	t.Cleanup(func() {
+		cacheLookupBeforeReadFn = previous
+	})
+}
+
+func containsAny(got string, parts ...string) bool {
+	for _, part := range parts {
+		if strings.Contains(got, part) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestLockOrConfigFileRecognizesGradleVersionCatalogs(t *testing.T) {

--- a/internal/analysis/cache_fs.go
+++ b/internal/analysis/cache_fs.go
@@ -12,6 +12,11 @@ import (
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
+type cacheAtomicWriteRoot interface {
+	WriteFileReplacingParents(targetPath string, data []byte, perm, parentPerm os.FileMode) error
+	Close() error
+}
+
 func writeFileDigest(w io.Writer, path string) error {
 	digest, err := hashFileDigest(path)
 	if err != nil {
@@ -95,18 +100,19 @@ func writeHexDigest(w io.Writer, digest [sha256.Size]byte) error {
 	return err
 }
 
-func writeFileAtomic(rootPath, targetPath string, data []byte) error {
+func writeFileAtomic(rootPath, targetPath string, data []byte) (err error) {
 	rootPath = filepath.Clean(rootPath)
 	targetPath = filepath.Clean(targetPath)
 	root, rel, err := openConfinedWriteRootUnder(rootPath, targetPath)
 	if err != nil {
 		return err
 	}
+	return writeFileAtomicWithRoot(root, rel, data)
+}
+
+func writeFileAtomicWithRoot(root cacheAtomicWriteRoot, rel string, data []byte) (err error) {
 	defer func() {
 		err = errors.Join(err, root.Close())
 	}()
-	if writeErr := root.WriteFileReplacingParents(rel, data, 0o600, 0o750); writeErr != nil {
-		err = writeErr
-	}
-	return err
+	return root.WriteFileReplacingParents(rel, data, 0o600, 0o750)
 }

--- a/internal/analysis/cache_fs.go
+++ b/internal/analysis/cache_fs.go
@@ -95,10 +95,18 @@ func writeHexDigest(w io.Writer, digest [sha256.Size]byte) error {
 	return err
 }
 
-func writeFileAtomic(path string, data []byte) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o750); err != nil {
+func writeFileAtomic(rootPath, targetPath string, data []byte) error {
+	rootPath = filepath.Clean(rootPath)
+	targetPath = filepath.Clean(targetPath)
+	root, rel, err := openConfinedWriteRootUnder(rootPath, targetPath)
+	if err != nil {
 		return err
 	}
-	return safeio.WriteFileReplacingUnder(dir, path, data, 0o600)
+	defer func() {
+		err = errors.Join(err, root.Close())
+	}()
+	if writeErr := root.WriteFileReplacingParents(rel, data, 0o600, 0o750); writeErr != nil {
+		err = writeErr
+	}
+	return err
 }

--- a/internal/analysis/cache_storage.go
+++ b/internal/analysis/cache_storage.go
@@ -22,8 +22,9 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 	if c == nil || !c.options.Enabled || !c.cacheable {
 		return report.Report{}, false, nil
 	}
-	pointerPath := filepath.Join(c.options.Path, "keys", entry.KeyDigest+".json")
-	pointerData, err := safeio.ReadFileUnder(c.options.Path, pointerPath)
+	writePath := c.options.writePath()
+	pointerPath := filepath.Join(writePath, "keys", entry.KeyDigest+".json")
+	pointerData, err := safeio.ReadFileUnder(writePath, pointerPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			c.metadata.Misses++
@@ -43,8 +44,8 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 		return report.Report{}, false, nil
 	}
 
-	objectPath := filepath.Join(c.options.Path, "objects", pointer.ObjectDigest+".json")
-	objectData, err := safeio.ReadFileUnder(c.options.Path, objectPath)
+	objectPath := filepath.Join(writePath, "objects", pointer.ObjectDigest+".json")
+	objectData, err := safeio.ReadFileUnder(writePath, objectPath)
 	if err != nil {
 		c.metadata.Misses++
 		reason := "object-read-error"
@@ -75,12 +76,13 @@ func (c *analysisCache) store(entry cacheEntryDescriptor, data report.Report) er
 		return err
 	}
 	objectDigest := sha256Hex(serializedPayload)
-	objectPath := filepath.Join(c.options.Path, "objects", objectDigest+".json")
+	writePath := c.options.writePath()
+	objectPath := filepath.Join(writePath, "objects", objectDigest+".json")
 	if _, err := os.Stat(objectPath); err != nil {
 		if !os.IsNotExist(err) {
 			return err
 		}
-		if err := writeFileAtomic(objectPath, serializedPayload); err != nil {
+		if err := writeFileAtomic(writePath, objectPath, serializedPayload); err != nil {
 			return err
 		}
 	}
@@ -90,8 +92,8 @@ func (c *analysisCache) store(entry cacheEntryDescriptor, data report.Report) er
 	if err != nil {
 		return err
 	}
-	pointerPath := filepath.Join(c.options.Path, "keys", entry.KeyDigest+".json")
-	if err := writeFileAtomic(pointerPath, serializedPointer); err != nil {
+	pointerPath := filepath.Join(writePath, "keys", entry.KeyDigest+".json")
+	if err := writeFileAtomic(writePath, pointerPath, serializedPointer); err != nil {
 		return err
 	}
 	c.metadata.Writes++

--- a/internal/analysis/cache_storage.go
+++ b/internal/analysis/cache_storage.go
@@ -131,8 +131,21 @@ func (c *analysisCache) openStoreWriteRoot() (*safeio.WriteRoot, error) {
 }
 
 func (c *analysisCache) openPinnedWriteRoot() (_ *safeio.WriteRoot, err error) {
+	if c == nil {
+		return nil, errors.New("analysis cache is required")
+	}
+	if c.writeRootOpener != nil {
+		root, err := c.writeRootOpener()
+		if err != nil {
+			return nil, err
+		}
+		if err := c.validateOpenedWriteRoot(root); err != nil {
+			return nil, errors.Join(err, root.Close())
+		}
+		return root, nil
+	}
 	rootPath := c.pinnedWritePath()
-	if c == nil || c.writeRootInfo == nil {
+	if c.writeRootInfo == nil {
 		rootPath, err = resolvePathWithinExistingTree(rootPath)
 		if err != nil {
 			return nil, err

--- a/internal/analysis/cache_storage.go
+++ b/internal/analysis/cache_storage.go
@@ -2,11 +2,17 @@ package analysis
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+var (
+	cacheStoreBeforeRootOpenFn = func() error { return nil }
+	cacheLookupBeforeReadFn    = func() error { return nil }
 )
 
 type cachePointer struct {
@@ -18,13 +24,20 @@ type cachedPayload struct {
 	Report report.Report `json:"report"`
 }
 
-func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool, error) {
+func (c *analysisCache) lookup(entry cacheEntryDescriptor) (_ report.Report, hit bool, err error) {
 	if c == nil || !c.options.Enabled || !c.cacheable {
 		return report.Report{}, false, nil
 	}
-	writePath := c.options.writePath()
-	pointerPath := filepath.Join(writePath, "keys", entry.KeyDigest+".json")
-	pointerData, err := safeio.ReadFileUnder(writePath, pointerPath)
+	root, err := c.openPinnedWriteRoot()
+	if err != nil {
+		return report.Report{}, false, err
+	}
+	defer func() {
+		err = errors.Join(err, root.Close())
+	}()
+
+	pointerPath := filepath.Join("keys", entry.KeyDigest+".json")
+	pointerData, err := c.readCacheFile(root, pointerPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			c.metadata.Misses++
@@ -44,8 +57,8 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 		return report.Report{}, false, nil
 	}
 
-	objectPath := filepath.Join(writePath, "objects", pointer.ObjectDigest+".json")
-	objectData, err := safeio.ReadFileUnder(writePath, objectPath)
+	objectPath := filepath.Join("objects", pointer.ObjectDigest+".json")
+	objectData, err := c.readCacheFile(root, objectPath)
 	if err != nil {
 		c.metadata.Misses++
 		reason := "object-read-error"
@@ -66,7 +79,7 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 	return payload.Report, true, nil
 }
 
-func (c *analysisCache) store(entry cacheEntryDescriptor, data report.Report) error {
+func (c *analysisCache) store(entry cacheEntryDescriptor, data report.Report) (err error) {
 	if c == nil || !c.options.Enabled || !c.cacheable || c.options.ReadOnly {
 		return nil
 	}
@@ -76,13 +89,20 @@ func (c *analysisCache) store(entry cacheEntryDescriptor, data report.Report) er
 		return err
 	}
 	objectDigest := sha256Hex(serializedPayload)
-	writePath := c.options.writePath()
-	objectPath := filepath.Join(writePath, "objects", objectDigest+".json")
-	if _, err := os.Stat(objectPath); err != nil {
+	root, err := c.openStoreWriteRoot()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, root.Close())
+	}()
+
+	objectPath := filepath.Join("objects", objectDigest+".json")
+	if _, err := root.Lstat(objectPath); err != nil {
 		if !os.IsNotExist(err) {
 			return err
 		}
-		if err := writeFileAtomic(writePath, objectPath, serializedPayload); err != nil {
+		if err := root.WriteFileReplacingParents(objectPath, serializedPayload, 0o600, 0o750); err != nil {
 			return err
 		}
 	}
@@ -92,10 +112,68 @@ func (c *analysisCache) store(entry cacheEntryDescriptor, data report.Report) er
 	if err != nil {
 		return err
 	}
-	pointerPath := filepath.Join(writePath, "keys", entry.KeyDigest+".json")
-	if err := writeFileAtomic(writePath, pointerPath, serializedPointer); err != nil {
+	pointerPath := filepath.Join("keys", entry.KeyDigest+".json")
+	if err := root.WriteFileReplacingParents(pointerPath, serializedPointer, 0o600, 0o750); err != nil {
 		return err
 	}
 	c.metadata.Writes++
 	return nil
+}
+
+func (c *analysisCache) openStoreWriteRoot() (*safeio.WriteRoot, error) {
+	if err := c.validateWriteRoot(); err != nil {
+		return nil, err
+	}
+	if err := cacheStoreBeforeRootOpenFn(); err != nil {
+		return nil, err
+	}
+	return c.openPinnedWriteRoot()
+}
+
+func (c *analysisCache) openPinnedWriteRoot() (_ *safeio.WriteRoot, err error) {
+	rootPath := c.pinnedWritePath()
+	if c == nil || c.writeRootInfo == nil {
+		rootPath, err = resolvePathWithinExistingTree(rootPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	root, err := safeio.OpenCanonicalWriteRoot(rootPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.validateOpenedWriteRoot(root); err != nil {
+		if closeErr := root.Close(); closeErr != nil {
+			return nil, errors.Join(err, closeErr)
+		}
+		return nil, err
+	}
+	return root, nil
+}
+
+func (c *analysisCache) validateOpenedWriteRoot(root *safeio.WriteRoot) error {
+	if c == nil || c.writeRootInfo == nil {
+		return nil
+	}
+	info, err := root.Lstat(".")
+	if err != nil {
+		return err
+	}
+	if !os.SameFile(c.writeRootInfo, info) {
+		return errors.New("cache root changed while pinned")
+	}
+	return nil
+}
+
+func (c *analysisCache) readCacheFile(root *safeio.WriteRoot, path string) ([]byte, error) {
+	if err := cacheLookupBeforeReadFn(); err != nil {
+		return nil, err
+	}
+	if err := c.validateWriteRoot(); err != nil {
+		return nil, err
+	}
+	if err := c.validateOpenedWriteRoot(root); err != nil {
+		return nil, err
+	}
+	return root.ReadFile(path)
 }

--- a/internal/analysis/cache_store_error_paths_test.go
+++ b/internal/analysis/cache_store_error_paths_test.go
@@ -29,6 +29,16 @@ type cacheAtomicWriteRootStub struct {
 	closeErr error
 }
 
+type cachePinnedRootValidationCase struct {
+	name string
+	run  func(*testing.T)
+}
+
+type cacheReadCacheFileValidationCase struct {
+	name string
+	run  func(*testing.T, *safeio.WriteRoot, string)
+}
+
 func (r *cacheAtomicWriteRootStub) WriteFileReplacingParents(string, []byte, os.FileMode, os.FileMode) error {
 	return r.writeErr
 }
@@ -186,121 +196,20 @@ func TestAnalysisCacheAdditionalStoreBranches(t *testing.T) {
 }
 
 func TestAnalysisCachePinnedWriteRootValidationBranches(t *testing.T) {
-	t.Run("validateOpenedWriteRoot rejects changed pinned root", func(t *testing.T) {
-		expectedRoot := mustEvalSymlinks(t, t.TempDir())
-		openedRoot := mustEvalSymlinks(t, t.TempDir())
-
-		info, err := os.Lstat(expectedRoot)
-		if err != nil {
-			t.Fatalf("lstat expected root: %v", err)
-		}
-		root, err := safeio.OpenCanonicalWriteRoot(openedRoot)
-		if err != nil {
-			t.Fatalf("open canonical write root: %v", err)
-		}
-		t.Cleanup(func() {
-			if closeErr := root.Close(); closeErr != nil {
-				t.Errorf("close canonical write root: %v", closeErr)
-			}
+	for _, tc := range cachePinnedRootValidationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.run(t)
 		})
-
-		cache := &analysisCache{writeRootInfo: info}
-		err = cache.validateOpenedWriteRoot(root)
-		if err == nil || !strings.Contains(err.Error(), "cache root changed while pinned") {
-			t.Fatalf("expected changed pinned root error, got %v", err)
-		}
-	})
-
-	t.Run("validateOpenedWriteRoot propagates pinned root lstat errors", func(t *testing.T) {
-		rootPath := mustEvalSymlinks(t, t.TempDir())
-		info, err := os.Lstat(rootPath)
-		if err != nil {
-			t.Fatalf("lstat root path: %v", err)
-		}
-		root, err := safeio.OpenCanonicalWriteRoot(rootPath)
-		if err != nil {
-			t.Fatalf("open canonical write root: %v", err)
-		}
-		if err := root.Close(); err != nil {
-			t.Fatalf("close canonical write root: %v", err)
-		}
-
-		cache := &analysisCache{writeRootInfo: info}
-		if err := cache.validateOpenedWriteRoot(root); err == nil {
-			t.Fatal("expected closed pinned root lstat error")
-		}
-	})
+	}
 }
 
 func TestAnalysisCacheReadCacheFileValidationBranches(t *testing.T) {
 	cachePath := mustEvalSymlinks(t, t.TempDir())
-	root, err := safeio.OpenCanonicalWriteRoot(cachePath)
-	if err != nil {
-		t.Fatalf("open canonical write root: %v", err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil {
-			t.Errorf("close canonical write root: %v", closeErr)
-		}
-	})
-
-	t.Run("readCacheFile returns lookup hook error", func(t *testing.T) {
-		expectedErr := errors.New("lookup hook failure")
-		withCacheLookupBeforeReadHook(t, func() error { return expectedErr })
-
-		cache := &analysisCache{}
-		_, err := cache.readCacheFile(root, "keys/missing.json")
-		if !errors.Is(err, expectedErr) {
-			t.Fatalf("expected lookup hook error, got %v", err)
-		}
-	})
-
-	t.Run("readCacheFile returns validateWriteRoot error before read", func(t *testing.T) {
-		pinnedRoot := t.TempDir()
-		pinnedInfo, err := os.Lstat(pinnedRoot)
-		if err != nil {
-			t.Fatalf("lstat pinned root: %v", err)
-		}
-
-		cache := &analysisCache{
-			options:       resolvedCacheOptions{Path: filepath.Join(cachePath, "cache")},
-			writeRootPath: filepath.Join(cachePath, "missing-root"),
-			writeRootInfo: pinnedInfo,
-		}
-		_, err = cache.readCacheFile(root, "keys/missing.json")
-		if err == nil || !errors.Is(err, os.ErrNotExist) {
-			t.Fatalf("expected validateWriteRoot lstat error, got %v", err)
-		}
-	})
-
-	t.Run("readCacheFile returns validateOpenedWriteRoot error before read", func(t *testing.T) {
-		pinnedRoot := mustEvalSymlinks(t, t.TempDir())
-		openedRootPath := mustEvalSymlinks(t, t.TempDir())
-		pinnedInfo, err := os.Lstat(pinnedRoot)
-		if err != nil {
-			t.Fatalf("lstat pinned root: %v", err)
-		}
-
-		openedRoot, err := safeio.OpenCanonicalWriteRoot(openedRootPath)
-		if err != nil {
-			t.Fatalf("open canonical opened root: %v", err)
-		}
-		t.Cleanup(func() {
-			if closeErr := openedRoot.Close(); closeErr != nil {
-				t.Errorf("close canonical opened root: %v", closeErr)
-			}
+	for _, tc := range cacheReadCacheFileValidationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.run(t, openCanonicalWriteRootForTest(t, cachePath), cachePath)
 		})
-
-		cache := &analysisCache{
-			options:       resolvedCacheOptions{Path: pinnedRoot},
-			writeRootPath: pinnedRoot,
-			writeRootInfo: pinnedInfo,
-		}
-		_, err = cache.readCacheFile(openedRoot, "keys/missing.json")
-		if err == nil || !strings.Contains(err.Error(), "cache root changed while pinned") {
-			t.Fatalf("expected changed pinned root error before read, got %v", err)
-		}
-	})
+	}
 }
 
 func TestAnalysisCacheOpenStoreWriteRootPropagatesHookError(t *testing.T) {
@@ -456,6 +365,115 @@ func storeTestAnalysisCache(cachePath, keyDigest string) error {
 	entry := cacheEntryDescriptor{KeyDigest: keyDigest, InputDigest: "input"}
 	rep := report.Report{RepoPath: "repo"}
 	return newTestAnalysisCache(cachePath).store(entry, rep)
+}
+
+func cachePinnedRootValidationCases() []cachePinnedRootValidationCase {
+	return []cachePinnedRootValidationCase{
+		{
+			name: "validateOpenedWriteRoot rejects changed pinned root",
+			run: func(t *testing.T) {
+				expectedRoot := mustEvalSymlinks(t, t.TempDir())
+				info := lstatForTest(t, expectedRoot, "expected root")
+				root := openCanonicalWriteRootForTest(t, mustEvalSymlinks(t, t.TempDir()))
+
+				cache := &analysisCache{writeRootInfo: info}
+				err := cache.validateOpenedWriteRoot(root)
+				if err == nil || !strings.Contains(err.Error(), "cache root changed while pinned") {
+					t.Fatalf("expected changed pinned root error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "validateOpenedWriteRoot propagates pinned root lstat errors",
+			run: func(t *testing.T) {
+				rootPath := mustEvalSymlinks(t, t.TempDir())
+				info := lstatForTest(t, rootPath, "root path")
+				root, err := safeio.OpenCanonicalWriteRoot(rootPath)
+				if err != nil {
+					t.Fatalf("open canonical write root: %v", err)
+				}
+				if err := root.Close(); err != nil {
+					t.Fatalf("close canonical write root: %v", err)
+				}
+
+				cache := &analysisCache{writeRootInfo: info}
+				if err := cache.validateOpenedWriteRoot(root); err == nil {
+					t.Fatal("expected closed pinned root lstat error")
+				}
+			},
+		},
+	}
+}
+
+func cacheReadCacheFileValidationCases() []cacheReadCacheFileValidationCase {
+	return []cacheReadCacheFileValidationCase{
+		{
+			name: "readCacheFile returns lookup hook error",
+			run: func(t *testing.T, root *safeio.WriteRoot, _ string) {
+				expectedErr := errors.New("lookup hook failure")
+				withCacheLookupBeforeReadHook(t, func() error { return expectedErr })
+
+				cache := &analysisCache{}
+				_, err := cache.readCacheFile(root, "keys/missing.json")
+				if !errors.Is(err, expectedErr) {
+					t.Fatalf("expected lookup hook error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "readCacheFile returns validateWriteRoot error before read",
+			run: func(t *testing.T, root *safeio.WriteRoot, cachePath string) {
+				pinnedRoot := t.TempDir()
+				cache := &analysisCache{
+					options:       resolvedCacheOptions{Path: filepath.Join(cachePath, "cache")},
+					writeRootPath: filepath.Join(cachePath, "missing-root"),
+					writeRootInfo: lstatForTest(t, pinnedRoot, "pinned root"),
+				}
+				_, err := cache.readCacheFile(root, "keys/missing.json")
+				if err == nil || !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("expected validateWriteRoot lstat error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "readCacheFile returns validateOpenedWriteRoot error before read",
+			run: func(t *testing.T, _ *safeio.WriteRoot, _ string) {
+				pinnedRoot := mustEvalSymlinks(t, t.TempDir())
+				cache := &analysisCache{
+					options:       resolvedCacheOptions{Path: pinnedRoot},
+					writeRootPath: pinnedRoot,
+					writeRootInfo: lstatForTest(t, pinnedRoot, "pinned root"),
+				}
+				_, err := cache.readCacheFile(openCanonicalWriteRootForTest(t, mustEvalSymlinks(t, t.TempDir())), "keys/missing.json")
+				if err == nil || !strings.Contains(err.Error(), "cache root changed while pinned") {
+					t.Fatalf("expected changed pinned root error before read, got %v", err)
+				}
+			},
+		},
+	}
+}
+
+func openCanonicalWriteRootForTest(t *testing.T, path string) *safeio.WriteRoot {
+	t.Helper()
+	root, err := safeio.OpenCanonicalWriteRoot(path)
+	if err != nil {
+		t.Fatalf("open canonical write root: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Errorf("close canonical write root: %v", closeErr)
+		}
+	})
+	return root
+}
+
+func lstatForTest(t *testing.T, path, label string) os.FileInfo {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", label, err)
+	}
+	return info
 }
 
 func newTestAnalysisCache(cachePath string) *analysisCache {

--- a/internal/analysis/cache_store_error_paths_test.go
+++ b/internal/analysis/cache_store_error_paths_test.go
@@ -72,7 +72,7 @@ func TestAnalysisCacheAdditionalAtomicWriteErrors(t *testing.T) {
 	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
 		t.Fatalf("write blocker: %v", err)
 	}
-	if writeFileAtomic(filepath.Join(blocker, "child.json"), []byte("x")) == nil {
+	if writeFileAtomic(blocker, filepath.Join(blocker, "child.json"), []byte("x")) == nil {
 		t.Fatalf("expected atomic write to fail when parent path is a file")
 	}
 	if entries, err := os.ReadDir(dir); err != nil {
@@ -94,7 +94,7 @@ func TestAnalysisCacheAdditionalAtomicWriteErrors(t *testing.T) {
 			t.Fatalf("restore readonly dir perms: %v", err)
 		}
 	})
-	if writeFileAtomic(filepath.Join(readOnlyDir, "child.json"), []byte("x")) == nil {
+	if writeFileAtomic(readOnlyDir, filepath.Join(readOnlyDir, "child.json"), []byte("x")) == nil {
 		t.Fatalf("expected atomic write to fail when temp file cannot be created")
 	}
 }

--- a/internal/analysis/cache_store_error_paths_test.go
+++ b/internal/analysis/cache_store_error_paths_test.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 type cacheFailAfterWriter struct {
@@ -20,6 +22,19 @@ type cacheStoreFailureCase struct {
 	name       string
 	blockedDir string
 	keyDigest  string
+}
+
+type cacheAtomicWriteRootStub struct {
+	writeErr error
+	closeErr error
+}
+
+func (r *cacheAtomicWriteRootStub) WriteFileReplacingParents(string, []byte, os.FileMode, os.FileMode) error {
+	return r.writeErr
+}
+
+func (r *cacheAtomicWriteRootStub) Close() error {
+	return r.closeErr
 }
 
 func (w *cacheFailAfterWriter) Write(p []byte) (int, error) {
@@ -97,6 +112,23 @@ func TestAnalysisCacheAdditionalAtomicWriteErrors(t *testing.T) {
 	if writeFileAtomic(readOnlyDir, filepath.Join(readOnlyDir, "child.json"), []byte("x")) == nil {
 		t.Fatalf("expected atomic write to fail when temp file cannot be created")
 	}
+
+	t.Run("writeFileAtomicWithRoot returns close error", func(t *testing.T) {
+		closeErr := errors.New("close root failure")
+		err := writeFileAtomicWithRoot(&cacheAtomicWriteRootStub{closeErr: closeErr}, "child.json", []byte("x"))
+		if !errors.Is(err, closeErr) {
+			t.Fatalf("expected close error, got %v", err)
+		}
+	})
+
+	t.Run("writeFileAtomicWithRoot joins write and close errors", func(t *testing.T) {
+		writeErr := errors.New("write failure")
+		closeErr := errors.New("close root failure")
+		err := writeFileAtomicWithRoot(&cacheAtomicWriteRootStub{writeErr: writeErr, closeErr: closeErr}, "child.json", []byte("x"))
+		if !errors.Is(err, writeErr) || !errors.Is(err, closeErr) {
+			t.Fatalf("expected joined write and close errors, got %v", err)
+		}
+	})
 }
 
 func TestAnalysisCacheAdditionalWriteBranches(t *testing.T) {
@@ -153,6 +185,246 @@ func TestAnalysisCacheAdditionalStoreBranches(t *testing.T) {
 	}
 }
 
+func TestAnalysisCachePinnedWriteRootValidationBranches(t *testing.T) {
+	t.Run("validateOpenedWriteRoot rejects changed pinned root", func(t *testing.T) {
+		expectedRoot := mustEvalSymlinks(t, t.TempDir())
+		openedRoot := mustEvalSymlinks(t, t.TempDir())
+
+		info, err := os.Lstat(expectedRoot)
+		if err != nil {
+			t.Fatalf("lstat expected root: %v", err)
+		}
+		root, err := safeio.OpenCanonicalWriteRoot(openedRoot)
+		if err != nil {
+			t.Fatalf("open canonical write root: %v", err)
+		}
+		t.Cleanup(func() {
+			if closeErr := root.Close(); closeErr != nil {
+				t.Errorf("close canonical write root: %v", closeErr)
+			}
+		})
+
+		cache := &analysisCache{writeRootInfo: info}
+		err = cache.validateOpenedWriteRoot(root)
+		if err == nil || !strings.Contains(err.Error(), "cache root changed while pinned") {
+			t.Fatalf("expected changed pinned root error, got %v", err)
+		}
+	})
+
+	t.Run("validateOpenedWriteRoot propagates pinned root lstat errors", func(t *testing.T) {
+		rootPath := mustEvalSymlinks(t, t.TempDir())
+		info, err := os.Lstat(rootPath)
+		if err != nil {
+			t.Fatalf("lstat root path: %v", err)
+		}
+		root, err := safeio.OpenCanonicalWriteRoot(rootPath)
+		if err != nil {
+			t.Fatalf("open canonical write root: %v", err)
+		}
+		if err := root.Close(); err != nil {
+			t.Fatalf("close canonical write root: %v", err)
+		}
+
+		cache := &analysisCache{writeRootInfo: info}
+		if err := cache.validateOpenedWriteRoot(root); err == nil {
+			t.Fatal("expected closed pinned root lstat error")
+		}
+	})
+}
+
+func TestAnalysisCacheReadCacheFileValidationBranches(t *testing.T) {
+	cachePath := mustEvalSymlinks(t, t.TempDir())
+	root, err := safeio.OpenCanonicalWriteRoot(cachePath)
+	if err != nil {
+		t.Fatalf("open canonical write root: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Errorf("close canonical write root: %v", closeErr)
+		}
+	})
+
+	t.Run("readCacheFile returns lookup hook error", func(t *testing.T) {
+		expectedErr := errors.New("lookup hook failure")
+		withCacheLookupBeforeReadHook(t, func() error { return expectedErr })
+
+		cache := &analysisCache{}
+		_, err := cache.readCacheFile(root, "keys/missing.json")
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("expected lookup hook error, got %v", err)
+		}
+	})
+
+	t.Run("readCacheFile returns validateWriteRoot error before read", func(t *testing.T) {
+		pinnedRoot := t.TempDir()
+		pinnedInfo, err := os.Lstat(pinnedRoot)
+		if err != nil {
+			t.Fatalf("lstat pinned root: %v", err)
+		}
+
+		cache := &analysisCache{
+			options:       resolvedCacheOptions{Path: filepath.Join(cachePath, "cache")},
+			writeRootPath: filepath.Join(cachePath, "missing-root"),
+			writeRootInfo: pinnedInfo,
+		}
+		_, err = cache.readCacheFile(root, "keys/missing.json")
+		if err == nil || !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected validateWriteRoot lstat error, got %v", err)
+		}
+	})
+
+	t.Run("readCacheFile returns validateOpenedWriteRoot error before read", func(t *testing.T) {
+		pinnedRoot := mustEvalSymlinks(t, t.TempDir())
+		openedRootPath := mustEvalSymlinks(t, t.TempDir())
+		pinnedInfo, err := os.Lstat(pinnedRoot)
+		if err != nil {
+			t.Fatalf("lstat pinned root: %v", err)
+		}
+
+		openedRoot, err := safeio.OpenCanonicalWriteRoot(openedRootPath)
+		if err != nil {
+			t.Fatalf("open canonical opened root: %v", err)
+		}
+		t.Cleanup(func() {
+			if closeErr := openedRoot.Close(); closeErr != nil {
+				t.Errorf("close canonical opened root: %v", closeErr)
+			}
+		})
+
+		cache := &analysisCache{
+			options:       resolvedCacheOptions{Path: pinnedRoot},
+			writeRootPath: pinnedRoot,
+			writeRootInfo: pinnedInfo,
+		}
+		_, err = cache.readCacheFile(openedRoot, "keys/missing.json")
+		if err == nil || !strings.Contains(err.Error(), "cache root changed while pinned") {
+			t.Fatalf("expected changed pinned root error before read, got %v", err)
+		}
+	})
+}
+
+func TestAnalysisCacheOpenStoreWriteRootPropagatesHookError(t *testing.T) {
+	cachePath := t.TempDir()
+	cache := &analysisCache{
+		options:       resolvedCacheOptions{Enabled: true, Path: cachePath},
+		cacheable:     true,
+		writeRootPath: cachePath,
+	}
+
+	expectedErr := errors.New("store hook failure")
+	withCacheStoreBeforeRootOpenHook(t, func() error { return expectedErr })
+
+	root, err := cache.openStoreWriteRoot()
+	if root != nil {
+		t.Fatalf("expected no write root on hook failure, got %v", root)
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected hook failure, got %v", err)
+	}
+}
+
+func TestAnalysisCacheOpenStoreWriteRootReturnsValidateWriteRootError(t *testing.T) {
+	pinnedRoot := t.TempDir()
+	pinnedInfo, err := os.Lstat(pinnedRoot)
+	if err != nil {
+		t.Fatalf("lstat pinned root: %v", err)
+	}
+
+	cache := &analysisCache{
+		options:       resolvedCacheOptions{Enabled: true, Path: filepath.Join(pinnedRoot, "cache")},
+		writeRootPath: filepath.Join(pinnedRoot, "missing-root"),
+		writeRootInfo: pinnedInfo,
+	}
+
+	root, err := cache.openStoreWriteRoot()
+	if root != nil {
+		t.Fatalf("expected no write root on validation failure, got %v", root)
+	}
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected validateWriteRoot error, got %v", err)
+	}
+}
+
+func TestAnalysisCacheOpenPinnedWriteRootBranches(t *testing.T) {
+	t.Run("openPinnedWriteRoot returns resolve existing tree error", func(t *testing.T) {
+		cache := &analysisCache{
+			options: resolvedCacheOptions{
+				Enabled: true,
+				Path:    string([]byte{0}),
+			},
+		}
+
+		root, err := cache.openPinnedWriteRoot()
+		if root != nil {
+			t.Fatalf("expected no write root for invalid path, got %v", root)
+		}
+		if err == nil {
+			t.Fatal("expected resolvePathWithinExistingTree error")
+		}
+	})
+
+	t.Run("openPinnedWriteRoot returns validation error after open", func(t *testing.T) {
+		rootPath := mustEvalSymlinks(t, t.TempDir())
+		expectedRoot := mustEvalSymlinks(t, t.TempDir())
+		expectedInfo, err := os.Lstat(expectedRoot)
+		if err != nil {
+			t.Fatalf("lstat expected root: %v", err)
+		}
+
+		cache := &analysisCache{
+			options:       resolvedCacheOptions{Enabled: true, Path: rootPath},
+			writeRootPath: rootPath,
+			writeRootInfo: expectedInfo,
+		}
+
+		root, err := cache.openPinnedWriteRoot()
+		if root != nil {
+			t.Fatalf("expected no write root on validation failure, got %v", root)
+		}
+		if err == nil || !strings.Contains(err.Error(), "cache root changed while pinned") {
+			t.Fatalf("expected changed pinned root error, got %v", err)
+		}
+	})
+}
+
+func TestAnalysisCacheLookupReturnsOpenPinnedWriteRootError(t *testing.T) {
+	cache := &analysisCache{
+		options: resolvedCacheOptions{
+			Enabled: true,
+			Path:    string([]byte{0}),
+		},
+		cacheable: true,
+	}
+
+	got, hit, err := cache.lookup(cacheEntryDescriptor{KeyDigest: "key"})
+	if hit || got.RepoPath != "" || len(got.Dependencies) != 0 {
+		t.Fatalf("expected lookup miss on pinned root error, got report=%#v hit=%v", got, hit)
+	}
+	if err == nil {
+		t.Fatal("expected pinned root open error")
+	}
+}
+
+func TestAnalysisCacheStoreReturnsOpenStoreWriteRootError(t *testing.T) {
+	pinnedRoot := t.TempDir()
+	pinnedInfo, err := os.Lstat(pinnedRoot)
+	if err != nil {
+		t.Fatalf("lstat pinned root: %v", err)
+	}
+
+	cache := &analysisCache{
+		options:       resolvedCacheOptions{Enabled: true, Path: filepath.Join(pinnedRoot, "cache")},
+		cacheable:     true,
+		writeRootPath: filepath.Join(pinnedRoot, "missing-root"),
+		writeRootInfo: pinnedInfo,
+	}
+
+	err = cache.store(cacheEntryDescriptor{KeyDigest: "key", InputDigest: "input"}, report.Report{RepoPath: "repo"})
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected openStoreWriteRoot error, got %v", err)
+	}
+}
+
 func testAnalysisCacheStoreWriteFailure(t *testing.T, tc cacheStoreFailureCase) {
 	t.Helper()
 
@@ -191,4 +463,14 @@ func newTestAnalysisCache(cachePath string) *analysisCache {
 		options:   resolvedCacheOptions{Enabled: true, Path: cachePath},
 		cacheable: true,
 	}
+}
+
+func mustEvalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("eval symlinks for %s: %v", path, err)
+	}
+	return resolved
 }

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -517,7 +517,7 @@ func TestHashFileOrMissingScenarios(t *testing.T) {
 func TestWriteFileAtomicSuccessAndFallbackError(t *testing.T) {
 	repo := t.TempDir()
 	target := filepath.Join(repo, "dir", "file.json")
-	if err := writeFileAtomic(target, []byte(`{"x":1}`)); err != nil {
+	if err := writeFileAtomic(repo, target, []byte(`{"x":1}`)); err != nil {
 		t.Fatalf("write file atomic success: %v", err)
 	}
 	content, err := os.ReadFile(target)
@@ -532,7 +532,7 @@ func TestWriteFileAtomicSuccessAndFallbackError(t *testing.T) {
 	if err := os.MkdirAll(dirTarget, 0o755); err != nil {
 		t.Fatalf("mkdir dirTarget: %v", err)
 	}
-	if writeFileAtomic(dirTarget, []byte("x")) == nil {
+	if writeFileAtomic(repo, dirTarget, []byte("x")) == nil {
 		t.Fatalf("expected error when target path is an existing directory")
 	}
 }
@@ -544,7 +544,7 @@ func TestWriteFileAtomicOverwritesExistingFilePreservingMode(t *testing.T) {
 		t.Fatalf("seed target file: %v", err)
 	}
 
-	if err := writeFileAtomic(target, []byte("after")); err != nil {
+	if err := writeFileAtomic(repo, target, []byte("after")); err != nil {
 		t.Fatalf("overwrite existing cache file: %v", err)
 	}
 

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -93,37 +93,10 @@ func TestAnalysisCacheHitAndInvalidation(t *testing.T) {
 	svc, adapter := newCacheTestService(t)
 	cacheDir := filepath.Join(repo, cacheTestDirectoryName)
 	req := newCacheRequest(repo, cacheDir, false)
-
-	first, err := svc.Analyse(context.Background(), req)
-	if err != nil {
-		t.Fatalf("first analyse: %v", err)
-	}
-	if adapter.calls != 1 {
-		t.Fatalf("expected first run to call adapter once, got %d", adapter.calls)
-	}
-	if first.Cache == nil || first.Cache.Misses != 1 || first.Cache.Writes != 1 || first.Cache.Hits != 0 {
-		t.Fatalf("unexpected first cache metadata: %#v", first.Cache)
-	}
-
-	second, err := svc.Analyse(context.Background(), req)
-	if err != nil {
-		t.Fatalf("second analyse: %v", err)
-	}
-	if adapter.calls != 1 {
-		t.Fatalf("expected second run to be cache hit, adapter calls=%d", adapter.calls)
-	}
-	if second.Cache == nil || second.Cache.Hits != 1 || second.Cache.Misses != 0 {
-		t.Fatalf("unexpected second cache metadata: %#v", second.Cache)
-	}
-
+	assertCacheTestRun(t, svc, req, adapter, 1, 1, 1, 0)
+	assertCacheTestRun(t, svc, req, adapter, 1, 0, 0, 1)
 	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "import { filter } from \"lodash\"\nfilter([1], (x) => x)\n")
-	third, err := svc.Analyse(context.Background(), req)
-	if err != nil {
-		t.Fatalf("third analyse: %v", err)
-	}
-	if adapter.calls != 2 {
-		t.Fatalf("expected cache invalidation after source change, adapter calls=%d", adapter.calls)
-	}
+	third := assertCacheTestRun(t, svc, req, adapter, 2, 1, 1, 0)
 	if third.Cache == nil || third.Cache.Misses != 1 {
 		t.Fatalf("expected miss after source change, got %#v", third.Cache)
 	}
@@ -142,13 +115,7 @@ func TestAnalysisCacheSeparatesSuggestOnlyEntries(t *testing.T) {
 	baseReq := newCacheRequest(repo, cacheDir, false)
 	baseReq.Dependency = "dep"
 
-	first, err := svc.Analyse(context.Background(), baseReq)
-	if err != nil {
-		t.Fatalf("first analyse: %v", err)
-	}
-	if adapter.calls != 1 {
-		t.Fatalf("expected first run to call adapter once, got %d", adapter.calls)
-	}
+	first := assertCacheTestRun(t, svc, baseReq, adapter, 1, 1, 1, 0)
 	if first.Dependencies[0].Codemod != nil {
 		t.Fatalf("expected non-suggest run to skip codemod, got %#v", first.Dependencies[0].Codemod)
 	}
@@ -156,16 +123,7 @@ func TestAnalysisCacheSeparatesSuggestOnlyEntries(t *testing.T) {
 	suggestReq := baseReq
 	suggestReq.SuggestOnly = true
 
-	second, err := svc.Analyse(context.Background(), suggestReq)
-	if err != nil {
-		t.Fatalf("suggest-only analyse: %v", err)
-	}
-	if adapter.calls != 2 {
-		t.Fatalf("expected suggest-only mode to use a distinct cache key, adapter calls=%d", adapter.calls)
-	}
-	if second.Cache == nil || second.Cache.Hits != 0 || second.Cache.Misses != 1 {
-		t.Fatalf("expected suggest-only run cache miss on first invocation, got %#v", second.Cache)
-	}
+	second := assertCacheTestRun(t, svc, suggestReq, adapter, 2, 1, 1, 0)
 	if second.Dependencies[0].Codemod == nil || second.Dependencies[0].Codemod.Mode != "suggest-only" {
 		t.Fatalf("expected suggest-only codemod output, got %#v", second.Dependencies[0].Codemod)
 	}
@@ -183,6 +141,21 @@ func TestAnalysisCacheSeparatesSuggestOnlyEntries(t *testing.T) {
 	if third.Dependencies[0].Codemod == nil || third.Dependencies[0].Codemod.Mode != "suggest-only" {
 		t.Fatalf("expected cached suggest-only codemod output, got %#v", third.Dependencies[0].Codemod)
 	}
+}
+
+func assertCacheTestRun(t *testing.T, svc *Service, req Request, adapter *countingAdapter, wantCalls, wantMisses, wantWrites, wantHits int) report.Report {
+	t.Helper()
+	result, err := svc.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("analyse: %v", err)
+	}
+	if adapter.calls != wantCalls {
+		t.Fatalf("unexpected adapter calls: got %d want %d", adapter.calls, wantCalls)
+	}
+	if result.Cache == nil || result.Cache.Misses != wantMisses || result.Cache.Writes != wantWrites || result.Cache.Hits != wantHits {
+		t.Fatalf("unexpected cache metadata: %#v", result.Cache)
+	}
+	return result
 }
 
 func TestAnalysisCacheReadOnlySkipsWrites(t *testing.T) {
@@ -333,11 +306,15 @@ func TestAnalysisCachePrepareEntryIncludesNormalizedPathScopeIdentity(t *testing
 	req := Request{
 		RepoPath: repo,
 		TopN:     1,
-		Cache: &CacheOptions{
-			Enabled:    true,
-			PinnedPath: filepath.Join(repo, cacheTestDirectoryName),
-		},
 	}
+	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join(repo, cacheTestDirectoryName),
+	})
+	if err != nil {
+		t.Fatalf("resolve trusted pinned cache path: %v", err)
+	}
+	req.Cache = cacheOptions
 	cache := newAnalysisCache(req, repo)
 
 	unscopedEntry, err := cache.prepareEntry(req, "cachelang", repo)
@@ -435,6 +412,21 @@ func TestAnalysisCachePrepareEntryDoesNotReuseInputDigestForDifferentConfigPath(
 	reqB.ConfigPath = configPathB
 	if _, err := cache.prepareEntry(reqB, "adapter-b", root); err == nil {
 		t.Fatalf("expected digest recomputation for different config path to fail after root removal")
+	}
+}
+
+func TestStableRuntimeAndConfigCachePathsPreferStableFields(t *testing.T) {
+	req := Request{
+		ConfigPath:            filepath.Join("/tmp", "snapshot", "config.yml"),
+		ConfigCachePath:       "config.yml",
+		RuntimeTracePath:      filepath.Join("/tmp", "snapshot", "trace.ndjson"),
+		RuntimeTraceCachePath: "trace.ndjson",
+	}
+	if got := stableConfigCachePath(req); got != "config.yml" {
+		t.Fatalf("expected stable config cache path, got %q", got)
+	}
+	if got := stableRuntimeTraceCachePath(req); got != "trace.ndjson" {
+		t.Fatalf("expected stable runtime trace cache path, got %q", got)
 	}
 }
 

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -327,6 +327,47 @@ func TestAnalysisCachePrepareEntryIncludesRuntimeCaptureRequestScope(t *testing.
 	}
 }
 
+func TestAnalysisCachePrepareEntryIncludesNormalizedPathScopeIdentity(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "console.log('hello')\n")
+	req := Request{
+		RepoPath: repo,
+		TopN:     1,
+		Cache: &CacheOptions{
+			Enabled:    true,
+			PinnedPath: filepath.Join(repo, cacheTestDirectoryName),
+		},
+	}
+	cache := newAnalysisCache(req, repo)
+
+	unscopedEntry, err := cache.prepareEntry(req, "cachelang", repo)
+	if err != nil {
+		t.Fatalf("prepare unscoped entry: %v", err)
+	}
+
+	scopedReq := req
+	scopedReq.IncludePatterns = []string{" src/** ", "src/**"}
+	scopedReq.ExcludePatterns = []string{"vendor/**", "vendor/**"}
+	scopedEntry, err := cache.prepareEntry(scopedReq, "cachelang", repo)
+	if err != nil {
+		t.Fatalf("prepare scoped entry: %v", err)
+	}
+	if unscopedEntry.KeyDigest == scopedEntry.KeyDigest {
+		t.Fatalf("expected scoped cache entry key to differ from unscoped key")
+	}
+
+	normalizedReq := req
+	normalizedReq.IncludePatterns = []string{"src/**"}
+	normalizedReq.ExcludePatterns = []string{"vendor/**"}
+	normalizedEntry, err := cache.prepareEntry(normalizedReq, "cachelang", repo)
+	if err != nil {
+		t.Fatalf("prepare normalized scoped entry: %v", err)
+	}
+	if scopedEntry.KeyDigest != normalizedEntry.KeyDigest {
+		t.Fatalf("expected normalized scope patterns to produce a stable cache key")
+	}
+}
+
 func TestAnalysisCachePrepareEntryMemoizesInputDigestForSameRootAndConfig(t *testing.T) {
 	repo := t.TempDir()
 	root := filepath.Join(repo, "root")

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -39,10 +39,13 @@ func (s *Service) newAnalysisPipeline(ctx context.Context, req Request) (*analys
 	if err != nil {
 		return nil, err
 	}
-	req.Cache, err = ResolveTrustedCacheOptions(repoPath, req.Cache)
-	if err != nil {
-		return nil, err
+	if req.Cache != nil && strings.TrimSpace(req.Cache.PinnedPath) != "" {
+		req.Cache, err = ResolveTrustedCacheOptions(repoPath, req.Cache)
+		if err != nil {
+			return nil, err
+		}
 	}
+	req.RepoPath = repoPath
 
 	req.ScopeMode = normalizeScopeMode(req.ScopeMode)
 	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScope(repoPath, req.IncludePatterns, req.ExcludePatterns)

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -21,17 +22,20 @@ const (
 )
 
 type analysisPipeline struct {
-	service          *Service
-	request          Request
-	repoPath         string
-	analysisRepoPath string
-	scopeWarnings    []string
-	cleanupFn        func()
-	candidates       []language.Candidate
-	cache            *analysisCache
-	reports          []report.Report
-	warnings         []string
-	analyzedRoots    []string
+	service           *Service
+	request           Request
+	repoPath          string
+	executionRepoPath string
+	analysisRepoPath  string
+	repositoryView    *RepositoryView
+	ownsRepository    bool
+	scopeWarnings     []string
+	cleanupFn         func()
+	candidates        []language.Candidate
+	cache             *analysisCache
+	reports           []report.Report
+	warnings          []string
+	analyzedRoots     []string
 }
 
 func (s *Service) newAnalysisPipeline(ctx context.Context, req Request) (*analysisPipeline, error) {
@@ -39,41 +43,193 @@ func (s *Service) newAnalysisPipeline(ctx context.Context, req Request) (*analys
 	if err != nil {
 		return nil, err
 	}
-	if req.Cache != nil && strings.TrimSpace(req.Cache.PinnedPath) != "" {
-		req.Cache, err = ResolveTrustedCacheOptions(repoPath, req.Cache)
+	repository, err := resolvePipelineRepository(repoPath, req)
+	if err != nil {
+		return nil, err
+	}
+	req.Repository = repository
+	req.Cache, err = normalizePipelineCacheOptions(repoPath, req)
+	if err != nil {
+		return nil, err
+	}
+	repositoryView, ownsRepository, err := resolvePipelineRepositoryView(ctx, repoPath, req)
+	if err != nil {
+		return nil, err
+	}
+	executionRepoPath := repositoryView.ExecutionPath()
+	req.RepositoryView = repositoryView
+	req.RepoPath = repositoryView.StablePath(executionRepoPath)
+	req.ConfigCachePath = repositoryView.StablePath(req.ConfigPath)
+	req.RuntimeTraceCachePath = repositoryView.StablePath(req.RuntimeTracePath)
+	req.ConfigPath, err = repositoryView.SnapshotPath(req.ConfigPath)
+	if err != nil {
+		if ownsRepository {
+			err = errors.Join(err, repositoryView.Close())
+		}
+		return nil, err
+	}
+	if req.RuntimeTracePathExplicit {
+		req.RuntimeTracePath, err = repositoryView.SnapshotPath(req.RuntimeTracePath)
 		if err != nil {
+			if ownsRepository {
+				err = errors.Join(err, repositoryView.Close())
+			}
 			return nil, err
 		}
 	}
-	req.RepoPath = repoPath
 
 	req.ScopeMode = normalizeScopeMode(req.ScopeMode)
-	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScope(repoPath, req.IncludePatterns, req.ExcludePatterns)
+	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScope(executionRepoPath, req.IncludePatterns, req.ExcludePatterns, pinnedScopedCacheRoot(req.Cache))
 	if err != nil {
+		if ownsRepository {
+			err = errors.Join(err, repositoryView.Close())
+		}
 		return nil, err
 	}
 	candidates, err := s.resolveCandidates(ctx, analysisRepoPath, req)
 	if err != nil {
 		cleanupFn()
+		if ownsRepository {
+			err = errors.Join(err, repositoryView.Close())
+		}
 		return nil, err
 	}
 
 	return &analysisPipeline{
-		service:          s,
-		request:          req,
-		repoPath:         repoPath,
-		analysisRepoPath: analysisRepoPath,
-		scopeWarnings:    scopeWarnings,
-		cleanupFn:        cleanupFn,
-		candidates:       candidates,
-		cache:            newAnalysisCache(req, analysisRepoPath),
+		service:           s,
+		request:           req,
+		repoPath:          repoPath,
+		executionRepoPath: executionRepoPath,
+		analysisRepoPath:  analysisRepoPath,
+		repositoryView:    repositoryView,
+		ownsRepository:    ownsRepository,
+		scopeWarnings:     scopeWarnings,
+		cleanupFn:         cleanupFn,
+		candidates:        candidates,
+		cache:             newAnalysisCache(req, analysisRepoPath, repositoryView),
 	}, nil
 }
 
-func (p *analysisPipeline) cleanup() {
+func (p *analysisPipeline) cleanup() error {
 	if p.cleanupFn != nil {
 		p.cleanupFn()
 	}
+	if p.ownsRepository && p.repositoryView != nil {
+		return p.repositoryView.Close()
+	}
+	return nil
+}
+
+func normalizePipelineCacheOptions(repoPath string, req Request) (*CacheOptions, error) {
+	if req.Cache == nil {
+		return ResolveTrustedDefaultCacheOptionsForRepository(req.Repository, false)
+	}
+	if !req.Cache.Enabled {
+		return req.Cache, nil
+	}
+	if strings.TrimSpace(req.Cache.Path) == "" && !req.Cache.hasTrustedPin() {
+		return ResolveTrustedDefaultCacheOptionsForRepository(req.Repository, req.Cache.ReadOnly)
+	}
+	cacheOptions, err := resolvePipelineCacheOptions(repoPath, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateTrustedScopedCacheOptions(cacheOptions, req.IncludePatterns, req.ExcludePatterns); err != nil {
+		return nil, err
+	}
+	return cacheOptions, nil
+}
+
+func resolvePipelineCacheOptions(repoPath string, req Request) (*CacheOptions, error) {
+	if req.Repository == nil {
+		repository, err := resolvePipelineRepository(repoPath, req)
+		if err != nil {
+			return nil, err
+		}
+		req.Repository = repository
+	} else if err := useTrustedRepository(repoPath, req.Repository); err != nil {
+		return nil, err
+	}
+	if req.Cache.hasTrustedPin() {
+		if req.Cache.trustedPin.repositoryState != req.Repository.authorizationState() {
+			return nil, errors.New("trusted cache pin does not match repository authorization")
+		}
+		return useTrustedCacheOptions(repoPath, req.Cache)
+	}
+	cacheOptions, err := ResolveTrustedCacheOptionsForRepository(req.Repository, req.Cache)
+	if err == nil {
+		return cacheOptions, nil
+	}
+	if AuthenticatedExternalCacheOptions(cacheOptions, err) {
+		return cacheOptions, nil
+	}
+	return nil, err
+}
+
+func resolvePipelineRepository(repoPath string, req Request) (*RepositoryAuthorization, error) {
+	if req.Repository != nil {
+		if err := useTrustedRepository(repoPath, req.Repository); err != nil {
+			return nil, err
+		}
+		return req.Repository, nil
+	}
+	if req.Cache.hasTrustedPin() {
+		repository := newRepositoryAuthorization(req.Cache.trustedPin.repositoryState)
+		if err := useTrustedRepository(repoPath, repository); err != nil {
+			return nil, err
+		}
+		return repository, nil
+	}
+	return ResolveTrustedRepository(repoPath)
+}
+
+func resolvePipelineRepositoryView(ctx context.Context, repoPath string, req Request) (*RepositoryView, bool, error) {
+	if req.RepositoryView != nil {
+		if !req.RepositoryView.matches(req.Repository) {
+			return nil, false, errors.New("trusted repository view does not match repository authorization")
+		}
+		return req.RepositoryView, false, nil
+	}
+	view, err := OpenTrustedRepository(ctx, req.Repository, repoPath, req.Cache)
+	if err != nil {
+		return nil, false, err
+	}
+	return view, true, nil
+}
+
+// ValidateTrustedScopedCacheOptions rejects authenticated in-repository cache
+// roots that would otherwise be copied into a scoped workspace.
+func ValidateTrustedScopedCacheOptions(cacheOptions *CacheOptions, includePatterns, excludePatterns []string) error {
+	if !patternsUseScopedWorkspace(includePatterns, excludePatterns) || cacheOptions == nil || !cacheOptions.Enabled {
+		return nil
+	}
+	if !scopedCacheTargetsRepositoryRoot(cacheOptions) {
+		return nil
+	}
+	return fmt.Errorf("scoped analysis does not allow cachePath at the repository root because cache keys/objects would be copied into the scoped workspace")
+}
+
+func scopedCacheTargetsRepositoryRoot(cacheOptions *CacheOptions) bool {
+	return InRepoCacheOptions(cacheOptions) && cacheOptions.trustedPin.repoRelativePath == "."
+}
+
+func requestUsesScopedWorkspace(req Request) bool {
+	return patternsUseScopedWorkspace(req.IncludePatterns, req.ExcludePatterns)
+}
+
+func patternsUseScopedWorkspace(includePatterns, excludePatterns []string) bool {
+	return len(normalizePatterns(includePatterns)) > 0 || len(normalizePatterns(excludePatterns)) > 0
+}
+
+func pinnedScopedCacheRoot(cache *CacheOptions) string {
+	if cache == nil || !cache.Enabled || !InRepoCacheOptions(cache) {
+		return ""
+	}
+	relativePath := cache.trustedPin.repoRelativePath
+	if relativePath == "." {
+		return ""
+	}
+	return filepath.Clean(relativePath)
 }
 
 func (p *analysisPipeline) execute(ctx context.Context) error {
@@ -81,14 +237,57 @@ func (p *analysisPipeline) execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	runtimeWarnings, runtimeTracePath, pythonRuntimeTraceCaptured := captureRuntimeTraceIfNeeded(ctx, p.request, p.repoPath, p.cache, p.candidates)
+	runtimeWarnings, runtimeTracePath, pythonRuntimeTraceCaptured := captureRuntimeTraceIfNeeded(ctx, p.request, p.executionRepoPath, p.cache, p.candidates)
+	persistWarnings, err := p.persistRuntimeTrace(runtimeTracePath)
+	if err != nil {
+		return err
+	}
 	p.reports = reports
 	warnings = append(warnings, runtimeWarnings...)
+	warnings = append(warnings, persistWarnings...)
 	p.warnings = warnings
 	p.analyzedRoots = analyzedRoots
 	p.request.RuntimeTracePath = runtimeTracePath
 	p.request.PythonRuntimeTraceCaptured = pythonRuntimeTraceCaptured
 	return nil
+}
+
+func (p *analysisPipeline) persistRuntimeTrace(runtimeTracePath string) ([]string, error) {
+	if p == nil || p.repositoryView == nil || strings.TrimSpace(runtimeTracePath) == "" || strings.TrimSpace(p.request.RuntimeTestCommand) == "" {
+		return nil, nil
+	}
+	relativePath, inRepository := p.repositoryView.RepositoryRelativePath(runtimeTracePath)
+	if !inRepository || !isSafeRepositoryRelativePath(relativePath, false) {
+		return nil, nil
+	}
+	data, err := p.repositoryView.ReadExecutionFile(relativePath)
+	if err != nil {
+		if p.request.RuntimeTracePathExplicit {
+			return nil, fmt.Errorf("persist requested runtime trace %s: %w", p.repositoryView.DisplayPath(relativePath), err)
+		}
+		return nil, nil
+	}
+	if err := p.repositoryView.WriteFile(relativePath, data, 0o600); err != nil {
+		if p.request.RuntimeTracePathExplicit {
+			return nil, fmt.Errorf("persist requested runtime trace %s: %w", p.repositoryView.DisplayPath(relativePath), err)
+		}
+		return nil, nil
+	}
+	stateRelativePath := relativePath + ".state.json"
+	stateData, err := p.repositoryView.ReadExecutionFile(stateRelativePath)
+	if err == nil {
+		if err := p.repositoryView.WriteFile(stateRelativePath, stateData, 0o600); err != nil {
+			if !p.request.RuntimeTracePathExplicit {
+				return nil, nil
+			}
+			return []string{fmt.Sprintf("runtime trace state was not persisted to %s: %v", p.repositoryView.DisplayPath(stateRelativePath), err)}, nil
+		}
+		return nil, nil
+	}
+	if errors.Is(err, os.ErrNotExist) || !p.request.RuntimeTracePathExplicit {
+		return nil, nil
+	}
+	return []string{fmt.Sprintf("runtime trace state was not persisted to %s: %v", p.repositoryView.DisplayPath(stateRelativePath), err)}, nil
 }
 
 func (p *analysisPipeline) finalReport() (report.Report, error) {
@@ -110,6 +309,9 @@ func (p *analysisPipeline) finalReport() (report.Report, error) {
 
 func (p *analysisPipeline) collectWarnings() []string {
 	warnings := append([]string(nil), p.scopeWarnings...)
+	if p.repositoryView != nil {
+		warnings = append(warnings, p.repositoryView.snapshotWarnings()...)
+	}
 	warnings = append(warnings, p.warnings...)
 	if p.cache != nil {
 		warnings = append(warnings, p.cache.takeWarnings()...)
@@ -326,8 +528,12 @@ func remapAnalyzedRoots(roots []string, fromRepoPath, toRepoPath string) []strin
 	remapped := make([]string, 0, len(roots))
 	for _, root := range roots {
 		rel, err := filepath.Rel(fromRepoPath, root)
-		if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
 			remapped = append(remapped, root)
+			continue
+		}
+		if rel == "." {
+			remapped = append(remapped, toRepoPath)
 			continue
 		}
 		remapped = append(remapped, filepath.Join(toRepoPath, rel))

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -39,6 +39,10 @@ func (s *Service) newAnalysisPipeline(ctx context.Context, req Request) (*analys
 	if err != nil {
 		return nil, err
 	}
+	req.Cache, err = ResolveTrustedCacheOptions(repoPath, req.Cache)
+	if err != nil {
+		return nil, err
+	}
 
 	req.ScopeMode = normalizeScopeMode(req.ScopeMode)
 	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScope(repoPath, req.IncludePatterns, req.ExcludePatterns)

--- a/internal/analysis/pipeline_setup_paths_test.go
+++ b/internal/analysis/pipeline_setup_paths_test.go
@@ -2,10 +2,14 @@ package analysis
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
@@ -19,6 +23,488 @@ func TestAnalysisPipelineAdditionalSetupBranches(t *testing.T) {
 	}); err == nil {
 		t.Fatalf("expected newAnalysisPipeline to surface applyPathScope failures")
 	}
+	if _, err := service.newAnalysisPipeline(context.Background(), Request{
+		RepoPath: filepath.Join(t.TempDir(), "missing"),
+	}); err == nil {
+		t.Fatal("expected newAnalysisPipeline to reject a missing repository")
+	}
+	for _, tc := range []struct {
+		name string
+		req  Request
+	}{
+		{
+			name: "unsafe relative config path",
+			req: Request{
+				RepoPath:   t.TempDir(),
+				ConfigPath: filepath.Join("..", "outside.yml"),
+				Cache:      &CacheOptions{Enabled: false},
+				Repository: mustResolveTrustedRepositoryForPipelineTest(t, t.TempDir()),
+			},
+		},
+		{
+			name: "unsafe explicit runtime trace path",
+			req: Request{
+				RepoPath:                 t.TempDir(),
+				RuntimeTracePath:         filepath.Join("..", "runtime.ndjson"),
+				RuntimeTracePathExplicit: true,
+				Cache:                    &CacheOptions{Enabled: false},
+				Repository:               mustResolveTrustedRepositoryForPipelineTest(t, t.TempDir()),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := tc.req.RepoPath
+			tc.req.Repository = mustResolveTrustedRepositoryForPipelineTest(t, repo)
+			if _, err := service.newAnalysisPipeline(context.Background(), tc.req); err == nil || !strings.Contains(err.Error(), "repository root") {
+				t.Fatalf("expected traversal rejection, got %v", err)
+			}
+		})
+	}
+}
+
+func mustResolveTrustedRepositoryForPipelineTest(t *testing.T, repo string) *RepositoryAuthorization {
+	t.Helper()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	return repository
+}
+
+func TestPipelineRepositoryAuthorizationGuardBranches(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+	repositoryA, repositoryB, cacheA := mustPipelineRepoAuth(t, repoA, repoB)
+	assertPipelineRepositoryResolution(t, repoA, repoB, repositoryA, repositoryB, cacheA)
+	assertPipelineRepositoryViewResolution(t, repoA, repositoryA, repositoryB, cacheA)
+	assertPipelineRemovedRepositoryViewFails(t)
+	assertPipelineCacheOptionGuards(t, repoA, repoB, repositoryA, repositoryB, cacheA)
+}
+
+func TestNormalizePipelineCacheOptionBranches(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+
+	defaultOptions, err := normalizePipelineCacheOptions(repo, Request{Repository: repository})
+	if err != nil || !InRepoCacheOptions(defaultOptions) {
+		t.Fatalf("normalize default cache options: options=%#v err=%v", defaultOptions, err)
+	}
+	disabled := &CacheOptions{Enabled: false, Path: filepath.Join(t.TempDir(), "unused")}
+	if got, err := normalizePipelineCacheOptions(repo, Request{Repository: repository, Cache: disabled}); err != nil || got != disabled {
+		t.Fatalf("normalize disabled cache options: got=%#v err=%v", got, err)
+	}
+	blankOptions, err := normalizePipelineCacheOptions(repo, Request{
+		Repository: repository,
+		Cache:      &CacheOptions{Enabled: true, ReadOnly: true},
+	})
+	if err != nil || !blankOptions.ReadOnly || !InRepoCacheOptions(blankOptions) {
+		t.Fatalf("normalize blank-path cache options: options=%#v err=%v", blankOptions, err)
+	}
+	if got := pinnedScopedCacheRoot(&CacheOptions{Enabled: false}); got != "" {
+		t.Fatalf("disabled scoped cache root = %q, want empty", got)
+	}
+	rootCache, err := ResolveTrustedCacheOptionsForRepository(repository, &CacheOptions{
+		Enabled: true,
+		Path:    repo,
+	})
+	if err != nil {
+		t.Fatalf("resolve repository-root cache: %v", err)
+	}
+	if got := pinnedScopedCacheRoot(rootCache); got != "" {
+		t.Fatalf("repository-root scoped cache = %q, want empty", got)
+	}
+}
+
+func TestNormalizePipelineCacheOptionsRejectsScopedRepoRootCachePath(t *testing.T) {
+	repoRoot := t.TempDir()
+	req := Request{
+		RepoPath:        repoRoot,
+		IncludePatterns: []string{"src/**"},
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    repoRoot,
+		},
+	}
+	if !requestUsesScopedWorkspace(req) {
+		t.Fatalf("expected scoped workspace request for %#v", req.IncludePatterns)
+	}
+	cacheOptions, err := resolvePipelineCacheOptions(repoRoot, req)
+	if err != nil {
+		t.Fatalf("resolve pipeline cache options: %v", err)
+	}
+	if !scopedCacheTargetsRepositoryRoot(cacheOptions) {
+		t.Fatalf("expected repo-root cache detection, repo=%q cache=%#v", repoRoot, cacheOptions)
+	}
+
+	_, err = normalizePipelineCacheOptions(repoRoot, req)
+	if err == nil || !strings.Contains(err.Error(), "scoped analysis does not allow cachePath at the repository root") {
+		t.Fatalf("expected scoped repo-root cache rejection, got %v", err)
+	}
+}
+
+func TestResolveTrustedCacheOptionsRejectsRelativeExternalTraversal(t *testing.T) {
+	repoRoot := t.TempDir()
+	outsideCache := filepath.Join(t.TempDir(), "outside-cache")
+	options, err := ResolveTrustedCacheOptions(repoRoot, &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join("..", filepath.Base(outsideCache)),
+	})
+	if options != nil {
+		t.Fatalf("expected relative external traversal rejection, got %#v", options)
+	}
+	if err == nil || !CachePathExternal(err) {
+		t.Fatalf("expected authenticated external-path rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(outsideCache); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no outside cache directory, stat err=%v", statErr)
+	}
+}
+
+func TestPinnedScopedCacheRootUsesCanonicalRepoAndPinnedPaths(t *testing.T) {
+	repoRoot := t.TempDir()
+	aliasRoot := t.TempDir()
+	repoAlias := filepath.Join(aliasRoot, "repo")
+	if err := os.Symlink(repoRoot, repoAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cacheRoot := filepath.Join(repoRoot, ".cache", "lopper")
+	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
+		t.Fatalf("mkdir cache root: %v", err)
+	}
+	cacheRoot, err := filepath.EvalSymlinks(cacheRoot)
+	if err != nil {
+		t.Fatalf("resolve canonical cache root: %v", err)
+	}
+	cacheOptions, err := ResolveTrustedCacheOptions(repoAlias, &CacheOptions{
+		Enabled: true,
+		Path:    cacheRoot,
+	})
+	if err != nil {
+		t.Fatalf("resolve trusted cache options: %v", err)
+	}
+
+	relativeRoot := pinnedScopedCacheRoot(cacheOptions)
+	if relativeRoot != filepath.Join(".cache", "lopper") {
+		t.Fatalf("expected canonical relative scoped cache root, got %q", relativeRoot)
+	}
+}
+
+func TestServiceTrustedCachePinKeepsExecutionBoundAfterRequestedRepoParentAliasSwap(t *testing.T) {
+	requestedRepo, canonicalRepo, redirectedRepo, requestedParent, cacheOptions, expectedCanonicalPath := setupTrustedCacheAliasSwapFixture(t)
+	service, adapter := newRecordingPipelineService(t, "bound-repo")
+	req := Request{RepoPath: requestedRepo, Language: adapter.id, Cache: cacheOptions}
+	assertPipelineServiceCacheMiss(t, service, req, 0, "repo-a-original")
+	writeFile(t, filepath.Join(canonicalRepo, "identity.js"), "repo-a-updated\n")
+	if err := os.Remove(requestedParent); err != nil {
+		t.Fatalf("remove requested parent alias: %v", err)
+	}
+	if err := os.Symlink(filepath.Dir(redirectedRepo), requestedParent); err != nil {
+		t.Fatalf("retarget requested parent alias: %v", err)
+	}
+	assertPipelineServiceCacheMiss(t, service, req, 0, "repo-a-updated")
+	if len(adapter.detectPaths) != 2 || adapter.detectPaths[0] == canonicalRepo || adapter.detectPaths[1] == canonicalRepo {
+		t.Fatalf("expected both detections to use handle-derived snapshots, got %#v", adapter.detectPaths)
+	}
+	if len(adapter.analysePaths) != 2 || adapter.analysePaths[0] != adapter.detectPaths[0] || adapter.analysePaths[1] != adapter.detectPaths[1] {
+		t.Fatalf("expected each adapter invocation to use its detected snapshot, detect=%#v analyse=%#v", adapter.detectPaths, adapter.analysePaths)
+	}
+	assertCacheDirsExist(t, expectedCanonicalPath)
+	if _, statErr := os.Stat(filepath.Join(redirectedRepo, ".cache")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected redirected repo cache to remain absent, stat err=%v", statErr)
+	}
+}
+
+func mustPipelineRepoAuth(t *testing.T, repoA, repoB string) (*RepositoryAuthorization, *RepositoryAuthorization, *CacheOptions) {
+	t.Helper()
+	repositoryA, err := ResolveTrustedRepository(repoA)
+	if err != nil {
+		t.Fatalf("authorize repo A: %v", err)
+	}
+	repositoryB, err := ResolveTrustedRepository(repoB)
+	if err != nil {
+		t.Fatalf("authorize repo B: %v", err)
+	}
+	cacheA, err := ResolveTrustedCacheOptionsForRepository(repositoryA, &CacheOptions{Enabled: true, Path: filepath.Join(".cache", "lopper")})
+	if err != nil {
+		t.Fatalf("resolve repo A cache: %v", err)
+	}
+	return repositoryA, repositoryB, cacheA
+}
+
+func assertPipelineRepositoryResolution(t *testing.T, repoA, repoB string, repositoryA, repositoryB *RepositoryAuthorization, cacheA *CacheOptions) {
+	t.Helper()
+	if got, err := resolvePipelineRepository(repoA, Request{Repository: repositoryA}); err != nil || got != repositoryA {
+		t.Fatalf("resolve supplied repository authorization: got=%p err=%v", got, err)
+	}
+	if _, err := resolvePipelineRepository(repoB, Request{Repository: repositoryA}); err == nil {
+		t.Fatal("expected supplied repository authorization mismatch")
+	}
+	if got, err := resolvePipelineRepository(repoA, Request{Cache: cacheA}); err != nil || got.authorizationState() != repositoryA.authorizationState() {
+		t.Fatalf("resolve repository from cache pin: got=%p err=%v", got, err)
+	}
+	if _, err := resolvePipelineRepository(repoB, Request{Cache: cacheA}); err == nil {
+		t.Fatal("expected cache-derived repository authorization mismatch")
+	}
+}
+
+func assertPipelineRepositoryViewResolution(t *testing.T, repoA string, repositoryA, repositoryB *RepositoryAuthorization, cacheA *CacheOptions) {
+	t.Helper()
+	borrowedView := &RepositoryView{state: repositoryA.authorizationState()}
+	if got, owns, err := resolvePipelineRepositoryView(context.Background(), repoA, Request{Repository: repositoryA, RepositoryView: borrowedView}); err != nil || owns || got != borrowedView {
+		t.Fatalf("resolve borrowed repository view: got=%p owns=%t err=%v", got, owns, err)
+	}
+	if _, _, err := resolvePipelineRepositoryView(context.Background(), repoA, Request{Repository: repositoryB, RepositoryView: borrowedView}); err == nil {
+		t.Fatal("expected borrowed repository view mismatch")
+	}
+	openedView, owns, err := resolvePipelineRepositoryView(context.Background(), repoA, Request{Repository: repositoryA, Cache: cacheA})
+	if err != nil || !owns {
+		t.Fatalf("open owned repository view: owns=%t err=%v", owns, err)
+	}
+	if err := openedView.Close(); err != nil {
+		t.Fatalf("close owned repository view: %v", err)
+	}
+}
+
+func assertPipelineRemovedRepositoryViewFails(t *testing.T) {
+	t.Helper()
+	removedRepo := filepath.Join(t.TempDir(), "removed-repo")
+	if err := os.Mkdir(removedRepo, 0o750); err != nil {
+		t.Fatalf("create removable repository: %v", err)
+	}
+	removedAuthorization, err := ResolveTrustedRepository(removedRepo)
+	if err != nil {
+		t.Fatalf("authorize removable repository: %v", err)
+	}
+	if err := os.Remove(removedRepo); err != nil {
+		t.Fatalf("remove authorized repository: %v", err)
+	}
+	if _, _, err := resolvePipelineRepositoryView(context.Background(), removedRepo, Request{Repository: removedAuthorization}); err == nil {
+		t.Fatal("expected removed authorized repository to fail opening")
+	}
+}
+
+func assertPipelineCacheOptionGuards(t *testing.T, repoA, repoB string, repositoryA, repositoryB *RepositoryAuthorization, cacheA *CacheOptions) {
+	t.Helper()
+	if _, err := resolvePipelineCacheOptions(repoA, Request{Repository: repositoryB, Cache: cacheA}); err == nil {
+		t.Fatal("expected cache/repository pin mismatch")
+	}
+	repositoryAClone, err := ResolveTrustedRepository(repoA)
+	if err != nil {
+		t.Fatalf("authorize repo A clone: %v", err)
+	}
+	if _, err := resolvePipelineCacheOptions(repoA, Request{Repository: repositoryAClone, Cache: cacheA}); err == nil {
+		t.Fatal("expected independently minted repository authorization to reject repo A cache pin")
+	}
+	if _, err := resolvePipelineCacheOptions(repoB, Request{Repository: repositoryA, Cache: &CacheOptions{Enabled: true, Path: ".cache"}}); err == nil {
+		t.Fatal("expected pipeline repository path mismatch")
+	}
+	if _, err := resolvePipelineCacheOptions(filepath.Join(repoA, "missing"), Request{Cache: &CacheOptions{Enabled: true, Path: ".cache"}}); err == nil {
+		t.Fatal("expected pipeline cache resolution for missing repository to fail")
+	}
+	resolved, err := resolvePipelineCacheOptions(repoA, Request{Cache: &CacheOptions{Enabled: true, Path: ".cache"}})
+	if err != nil || !InRepoCacheOptions(resolved) {
+		t.Fatalf("resolve cache with pipeline-created authorization: options=%#v err=%v", resolved, err)
+	}
+}
+
+func setupTrustedCacheAliasSwapFixture(t *testing.T) (string, string, string, string, *CacheOptions, string) {
+	t.Helper()
+	canonicalParent := t.TempDir()
+	canonicalRepo := filepath.Join(canonicalParent, "repo")
+	if err := os.MkdirAll(canonicalRepo, 0o755); err != nil {
+		t.Fatalf("mkdir canonical repo: %v", err)
+	}
+	writeFile(t, filepath.Join(canonicalRepo, "identity.js"), "repo-a-original\n")
+	redirectedParent := t.TempDir()
+	redirectedRepo := filepath.Join(redirectedParent, "repo")
+	if err := os.MkdirAll(redirectedRepo, 0o755); err != nil {
+		t.Fatalf("mkdir redirected repo: %v", err)
+	}
+	writeFile(t, filepath.Join(redirectedRepo, "identity.js"), "repo-a-original\n")
+	requestedParent := filepath.Join(t.TempDir(), "requested-parent")
+	if err := os.Symlink(canonicalParent, requestedParent); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	requestedRepo := filepath.Join(requestedParent, "repo")
+	canonicalRepoResolved, err := filepath.EvalSymlinks(canonicalRepo)
+	if err != nil {
+		t.Fatalf("resolve canonical repo: %v", err)
+	}
+	cacheOptions, err := ResolveTrustedCacheOptions(requestedRepo, &CacheOptions{Enabled: true, Path: filepath.Join(".cache", "lopper")})
+	if err != nil {
+		t.Fatalf("resolve trusted cache options: %v", err)
+	}
+	expectedCanonicalPath, err := resolvePathWithinExistingTree(filepath.Join(canonicalRepoResolved, ".cache", "lopper"))
+	if err != nil {
+		t.Fatalf("resolve expected canonical cache path: %v", err)
+	}
+	if cacheOptions.trustedPinnedPath() != expectedCanonicalPath {
+		t.Fatalf("expected original canonical pin %q, got %q", expectedCanonicalPath, cacheOptions.trustedPinnedPath())
+	}
+	return requestedRepo, canonicalRepoResolved, redirectedRepo, requestedParent, cacheOptions, expectedCanonicalPath
+}
+
+func newRecordingPipelineService(t *testing.T, id string) (*Service, *recordingRepoAdapter) {
+	t.Helper()
+	adapter := &recordingRepoAdapter{id: id}
+	registry := language.NewRegistry()
+	if err := registry.Register(adapter); err != nil {
+		t.Fatalf("register recording adapter: %v", err)
+	}
+	return &Service{Registry: registry}, adapter
+}
+
+func assertPipelineServiceCacheMiss(t *testing.T, service *Service, req Request, expectedHits int, expectedName string) {
+	t.Helper()
+	result, err := service.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("analyse through requested repo alias: %v", err)
+	}
+	if result.Cache == nil || result.Cache.Hits != expectedHits || result.Cache.Misses != 1 || result.Cache.Writes != 1 {
+		t.Fatalf("unexpected cache metadata: %#v", result.Cache)
+	}
+	if len(result.Dependencies) != 1 || result.Dependencies[0].Name != expectedName {
+		t.Fatalf("unexpected adapter result: %#v", result.Dependencies)
+	}
+}
+
+func TestServiceTrustedCachePinRejectsCanonicalRepositoryReplacement(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join(".cache", "lopper"),
+	})
+	if err != nil {
+		t.Fatalf("resolve trusted cache options: %v", err)
+	}
+
+	originalRepo := filepath.Join(parent, "repo-original")
+	if err := os.Rename(repo, originalRepo); err != nil {
+		t.Fatalf("move original repo: %v", err)
+	}
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("create replacement repo: %v", err)
+	}
+
+	adapter := &recordingRepoAdapter{id: "bound-repo"}
+	registry := language.NewRegistry()
+	if err := registry.Register(adapter); err != nil {
+		t.Fatalf("register recording adapter: %v", err)
+	}
+	_, err = (&Service{Registry: registry}).Analyse(context.Background(), Request{
+		RepoPath: repo,
+		Language: adapter.id,
+		Cache:    cacheOptions,
+	})
+	if err == nil || !strings.Contains(err.Error(), "trusted cache repository changed after validation") {
+		t.Fatalf("expected canonical repository identity rejection, got %v", err)
+	}
+	if len(adapter.detectPaths) != 0 || len(adapter.analysePaths) != 0 {
+		t.Fatalf("expected repository replacement rejection before adapter invocation, detect=%#v analyse=%#v", adapter.detectPaths, adapter.analysePaths)
+	}
+	if _, statErr := os.Stat(filepath.Join(repo, ".cache")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected replacement repo cache to remain absent, stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(originalRepo, ".cache")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected original repo cache to remain absent, stat err=%v", statErr)
+	}
+}
+
+func TestServiceRepositoryHandleRemainsBoundAcrossCanonicalReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	repo, repoB, movedRepoA, cacheOptions := setupPipelineCanonicalReplacementFixture(t)
+	previousHook := repositoryViewHandleOpenedFn
+	repositoryViewHandleOpenedFn = func() error {
+		if err := os.Rename(repo, movedRepoA); err != nil {
+			return err
+		}
+		return os.Rename(repoB, repo)
+	}
+	t.Cleanup(func() {
+		repositoryViewHandleOpenedFn = previousHook
+	})
+	service, adapter := newRecordingPipelineService(t, "bound-handle")
+	request := Request{RepoPath: repo, Language: adapter.id, Cache: cacheOptions}
+	assertPipelineServiceCacheMiss(t, service, request, 0, "repo-a")
+	assertCacheDirsExist(t, filepath.Join(movedRepoA, ".cache", "lopper"))
+	if _, statErr := os.Stat(filepath.Join(repo, ".cache")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected replacement repo B to receive no cache directories, stat err=%v", statErr)
+	}
+	repositoryViewHandleOpenedFn = previousHook
+	if _, err := service.Analyse(context.Background(), request); err == nil || !strings.Contains(err.Error(), "trusted cache repository changed after validation") {
+		t.Fatalf("expected second run to reject replacement repo B, got %v", err)
+	}
+	if len(adapter.detectPaths) != 1 || len(adapter.analysePaths) != 1 {
+		t.Fatalf("expected replacement repo B to receive no adapter reads, detect=%#v analyse=%#v", adapter.detectPaths, adapter.analysePaths)
+	}
+	if _, statErr := os.Stat(filepath.Join(repo, ".cache")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected replacement repo B to receive no cache directories after second run, stat err=%v", statErr)
+	}
+}
+
+func setupPipelineCanonicalReplacementFixture(t *testing.T) (string, string, string, *CacheOptions) {
+	t.Helper()
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	if err := os.Mkdir(repo, 0o750); err != nil {
+		t.Fatalf("mkdir repo A: %v", err)
+	}
+	writeFile(t, filepath.Join(repo, "identity.js"), "repo-a\n")
+	repoB := filepath.Join(parent, "repo-b")
+	if err := os.Mkdir(repoB, 0o750); err != nil {
+		t.Fatalf("mkdir repo B: %v", err)
+	}
+	writeFile(t, filepath.Join(repoB, "identity.js"), "repo-b\n")
+	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{Enabled: true, Path: filepath.Join(".cache", "lopper")})
+	if err != nil {
+		t.Fatalf("resolve trusted cache options: %v", err)
+	}
+	return repo, repoB, filepath.Join(parent, "repo-a-original"), cacheOptions
+}
+
+type recordingRepoAdapter struct {
+	id           string
+	detectPaths  []string
+	analysePaths []string
+}
+
+func (a *recordingRepoAdapter) ID() string {
+	return a.id
+}
+
+func (a *recordingRepoAdapter) Aliases() []string {
+	return nil
+}
+
+func (a *recordingRepoAdapter) Detect(_ context.Context, repoPath string) (bool, error) {
+	a.detectPaths = append(a.detectPaths, repoPath)
+	return true, nil
+}
+
+func (a *recordingRepoAdapter) Analyse(_ context.Context, req language.Request) (report.Report, error) {
+	a.analysePaths = append(a.analysePaths, req.RepoPath)
+	identity, err := os.ReadFile(filepath.Join(req.RepoPath, "identity.js"))
+	if err != nil {
+		return report.Report{}, err
+	}
+	return report.Report{
+		Dependencies: []report.DependencyReport{{
+			Name:              strings.TrimSpace(string(identity)),
+			UsedExportsCount:  1,
+			TotalExportsCount: 1,
+			UsedPercent:       100,
+		}},
+	}, nil
 }
 
 func TestScopedCandidateRootsChangedPackagesSuccessBranch(t *testing.T) {

--- a/internal/analysis/pipeline_setup_paths_test.go
+++ b/internal/analysis/pipeline_setup_paths_test.go
@@ -85,3 +85,13 @@ func TestScopeMetadataIncludesRepoRootAsDot(t *testing.T) {
 		t.Fatalf("expected repo root package to map to dot, got %#v", metadata.Packages)
 	}
 }
+
+func TestScopeMetadataDropsInvalidRepoPaths(t *testing.T) {
+	metadata := scopeMetadata(ScopeModePackage, string([]byte{0}), []string{"/repo/pkg"})
+	if metadata == nil {
+		t.Fatalf("expected scope metadata")
+	}
+	if len(metadata.Packages) != 0 {
+		t.Fatalf("expected invalid repo path to drop package entries, got %#v", metadata.Packages)
+	}
+}

--- a/internal/analysis/pipeline_setup_paths_test.go
+++ b/internal/analysis/pipeline_setup_paths_test.go
@@ -68,3 +68,20 @@ func TestScopedCandidateRootsUsesExplicitChangedFilesWithoutWorkspaceFallback(t 
 		t.Fatalf("expected explicit changed files to select package b only, got %#v", roots)
 	}
 }
+
+func TestScopeMetadataIncludesRepoRootAsDot(t *testing.T) {
+	repoRoot := t.TempDir()
+	metadata := scopeMetadata("unexpected", repoRoot, []string{
+		filepath.Join(repoRoot, "packages", "b"),
+		repoRoot,
+	})
+	if metadata == nil {
+		t.Fatalf("expected scope metadata")
+	}
+	if metadata.Mode != ScopeModePackage {
+		t.Fatalf("expected scope mode normalization to package, got %q", metadata.Mode)
+	}
+	if len(metadata.Packages) != 2 || metadata.Packages[0] != "." || metadata.Packages[1] != "packages/b" {
+		t.Fatalf("expected repo root package to map to dot, got %#v", metadata.Packages)
+	}
+}

--- a/internal/analysis/pipeline_test.go
+++ b/internal/analysis/pipeline_test.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -148,6 +149,472 @@ func TestAnalysisPipelineCacheMetadataNil(t *testing.T) {
 	pipeline := &analysisPipeline{}
 	if got := pipeline.cacheMetadata(); got != nil {
 		t.Fatalf("expected nil cache metadata, got %#v", got)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceAndCleanupWithOwnedRepositoryView(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+
+	runtimeTracePath := filepath.Join(view.ExecutionPath(), "trace", "runtime.ndjson")
+	runtimeStatePath := runtimeTracePath + ".state.json"
+	writeFile(t, runtimeTracePath, "{\"module\":\"lodash/map\"}\n")
+	writeFile(t, runtimeStatePath, "{\"captured\":true}\n")
+
+	cleanupCalled := 0
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		ownsRepository:    true,
+		request:           Request{RuntimeTestCommand: "npm test", RuntimeTracePathExplicit: true},
+		cleanupFn: func() {
+			cleanupCalled++
+		},
+	}
+
+	warnings, err := pipeline.persistRuntimeTrace(runtimeTracePath)
+	if err != nil {
+		t.Fatalf("persist runtime trace: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no runtime trace persistence warnings, got %#v", warnings)
+	}
+
+	if data, err := os.ReadFile(filepath.Join(repo, "trace", "runtime.ndjson")); err != nil || string(data) != "{\"module\":\"lodash/map\"}\n" {
+		t.Fatalf("persist runtime trace report: data=%q err=%v", data, err)
+	}
+	if data, err := os.ReadFile(filepath.Join(repo, "trace", "runtime.ndjson.state.json")); err != nil || string(data) != "{\"captured\":true}\n" {
+		t.Fatalf("persist runtime trace state: data=%q err=%v", data, err)
+	}
+
+	snapshotPath := view.ExecutionPath()
+	if err := pipeline.cleanup(); err != nil {
+		t.Fatalf("pipeline cleanup: %v", err)
+	}
+	if cleanupCalled != 1 {
+		t.Fatalf("expected cleanupFn once, got %d", cleanupCalled)
+	}
+	if _, err := os.Stat(snapshotPath); !os.IsNotExist(err) {
+		t.Fatalf("expected owned repository view cleanup to remove snapshot, stat err=%v", err)
+	}
+}
+
+func TestAnalysisPipelineCleanupWithoutOwnedRepositoryViewAndRuntimeTraceSkip(t *testing.T) {
+	cleanupCalled := 0
+	pipeline := &analysisPipeline{
+		executionRepoPath: t.TempDir(),
+		cleanupFn: func() {
+			cleanupCalled++
+		},
+	}
+
+	warnings, err := pipeline.persistRuntimeTrace(filepath.Join(t.TempDir(), "outside", "runtime.ndjson"))
+	if err != nil {
+		t.Fatalf("unexpected external runtime trace persistence error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no external runtime trace persistence warnings, got %#v", warnings)
+	}
+
+	if err := pipeline.cleanup(); err != nil {
+		t.Fatalf("pipeline cleanup without owned repository view: %v", err)
+	}
+	if cleanupCalled != 1 {
+		t.Fatalf("expected cleanupFn once without owned repository view, got %d", cleanupCalled)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceRefusesSymlinkedRepositoryTarget(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, "trace-target"), 0o750); err != nil {
+		t.Fatalf("mkdir trace target: %v", err)
+	}
+	if err := os.Symlink("trace-target", filepath.Join(repo, "trace")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	runtimeTracePath := filepath.Join(view.ExecutionPath(), "trace-target", "runtime.ndjson")
+	writeFile(t, runtimeTracePath, "{\"module\":\"lodash/map\"}\n")
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		request:           Request{RuntimeTestCommand: "npm test", RuntimeTracePathExplicit: true},
+	}
+	_, err = pipeline.persistRuntimeTrace(filepath.Join(view.ExecutionPath(), "trace", "runtime.ndjson"))
+	if err == nil || !strings.Contains(err.Error(), "persist requested runtime trace") {
+		t.Fatalf("expected symlinked repository target persistence error, got %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(repo, "trace-target", "runtime.ndjson")); !os.IsNotExist(err) {
+		t.Fatalf("symlinked repository trace target was written: %v", err)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceSurfacesMissingExplicitTrace(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		request:           Request{RuntimeTestCommand: "npm test", RuntimeTracePathExplicit: true},
+	}
+	_, err = pipeline.persistRuntimeTrace(filepath.Join(view.ExecutionPath(), "trace", "missing.ndjson"))
+	if err == nil || !strings.Contains(err.Error(), "persist requested runtime trace") {
+		t.Fatalf("expected missing trace persistence error, got %v", err)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceAllowsMissingDefaultTrace(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		request:           Request{RuntimeTestCommand: "npm test"},
+	}
+	warnings, err := pipeline.persistRuntimeTrace(filepath.Join(view.ExecutionPath(), "trace", "missing.ndjson"))
+	if err != nil {
+		t.Fatalf("expected missing default trace persistence to stay best-effort, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for missing default trace persistence, got %#v", warnings)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceAllowsDefaultWriteFailure(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	runtimeTracePath := filepath.Join(view.ExecutionPath(), "trace", "runtime.ndjson")
+	writeFile(t, runtimeTracePath, "{\"module\":\"lodash/map\"}\n")
+	if err := os.MkdirAll(filepath.Join(repo, "trace", "runtime.ndjson"), 0o750); err != nil {
+		t.Fatalf("mkdir blocking runtime trace path: %v", err)
+	}
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		request:           Request{RuntimeTestCommand: "npm test"},
+	}
+	warnings, err := pipeline.persistRuntimeTrace(runtimeTracePath)
+	if err != nil {
+		t.Fatalf("expected default trace write failure to stay best-effort, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for default trace write failure, got %#v", warnings)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceSurfacesExplicitWriteFailure(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	runtimeTracePath := filepath.Join(view.ExecutionPath(), "trace", "runtime.ndjson")
+	writeFile(t, runtimeTracePath, "{\"module\":\"lodash/map\"}\n")
+	if err := os.MkdirAll(filepath.Join(repo, "trace", "runtime.ndjson"), 0o750); err != nil {
+		t.Fatalf("mkdir blocking runtime trace path: %v", err)
+	}
+
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		request:           Request{RuntimeTestCommand: "npm test", RuntimeTracePathExplicit: true},
+	}
+	_, err = pipeline.persistRuntimeTrace(runtimeTracePath)
+	if err == nil || !strings.Contains(err.Error(), "persist requested runtime trace") {
+		t.Fatalf("expected explicit runtime trace write failure, got %v", err)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceExplicitlyAllowsMissingState(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	runtimeTracePath := filepath.Join(view.ExecutionPath(), "trace", "runtime.ndjson")
+	writeFile(t, runtimeTracePath, "{\"module\":\"lodash/map\"}\n")
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		request:           Request{RuntimeTestCommand: "npm test", RuntimeTracePathExplicit: true},
+	}
+	warnings, err := pipeline.persistRuntimeTrace(runtimeTracePath)
+	if err != nil {
+		t.Fatalf("persist explicit runtime trace without state: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for missing explicit state file, got %#v", warnings)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceWarnsWhenExplicitStateWriteFails(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	runtimeTracePath := filepath.Join(view.ExecutionPath(), "trace", "runtime.ndjson")
+	writeFile(t, runtimeTracePath, "{\"module\":\"lodash/map\"}\n")
+	writeFile(t, runtimeTracePath+".state.json", "{\"captured\":true}\n")
+	if err := os.MkdirAll(filepath.Join(repo, "trace", "runtime.ndjson.state.json"), 0o750); err != nil {
+		t.Fatalf("mkdir blocking state path: %v", err)
+	}
+
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		request:           Request{RuntimeTestCommand: "npm test", RuntimeTracePathExplicit: true},
+	}
+	warnings, err := pipeline.persistRuntimeTrace(runtimeTracePath)
+	if err != nil {
+		t.Fatalf("persist explicit runtime trace with blocked state path: %v", err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "runtime trace state was not persisted") {
+		t.Fatalf("expected explicit state write warning, got %#v", warnings)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceWarnsWhenExplicitStateReadFails(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	runtimeTracePath := filepath.Join(view.ExecutionPath(), "trace", "runtime.ndjson")
+	writeFile(t, runtimeTracePath, "{\"module\":\"lodash/map\"}\n")
+	if err := os.MkdirAll(runtimeTracePath+".state.json", 0o750); err != nil {
+		t.Fatalf("mkdir state directory in execution snapshot: %v", err)
+	}
+
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		request:           Request{RuntimeTestCommand: "npm test", RuntimeTracePathExplicit: true},
+	}
+	warnings, err := pipeline.persistRuntimeTrace(runtimeTracePath)
+	if err != nil {
+		t.Fatalf("persist explicit runtime trace with unreadable state path: %v", err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "runtime trace state was not persisted") {
+		t.Fatalf("expected explicit state read warning, got %#v", warnings)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceAllowsDefaultStateWriteFailure(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	runtimeTracePath := filepath.Join(view.ExecutionPath(), "trace", "runtime.ndjson")
+	writeFile(t, runtimeTracePath, "{\"module\":\"lodash/map\"}\n")
+	writeFile(t, runtimeTracePath+".state.json", "{\"captured\":true}\n")
+	if err := os.MkdirAll(filepath.Join(repo, "trace", "runtime.ndjson.state.json"), 0o750); err != nil {
+		t.Fatalf("mkdir blocking state path: %v", err)
+	}
+
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		request:           Request{RuntimeTestCommand: "npm test"},
+	}
+	warnings, err := pipeline.persistRuntimeTrace(runtimeTracePath)
+	if err != nil {
+		t.Fatalf("expected default state write failure to stay best-effort, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for default state write failure, got %#v", warnings)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceAllowsDefaultStateReadFailure(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	runtimeTracePath := filepath.Join(view.ExecutionPath(), "trace", "runtime.ndjson")
+	writeFile(t, runtimeTracePath, "{\"module\":\"lodash/map\"}\n")
+	if err := os.MkdirAll(runtimeTracePath+".state.json", 0o750); err != nil {
+		t.Fatalf("mkdir state directory in execution snapshot: %v", err)
+	}
+
+	pipeline := &analysisPipeline{
+		executionRepoPath: view.ExecutionPath(),
+		repositoryView:    view,
+		request:           Request{RuntimeTestCommand: "npm test"},
+	}
+	warnings, err := pipeline.persistRuntimeTrace(runtimeTracePath)
+	if err != nil {
+		t.Fatalf("expected default state read failure to stay best-effort, got %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for default state read failure, got %#v", warnings)
+	}
+}
+
+func TestAnalysisPipelinePersistRuntimeTraceNoopsWithoutCaptureContext(t *testing.T) {
+	if warnings, err := (*analysisPipeline)(nil).persistRuntimeTrace("trace.ndjson"); err != nil || len(warnings) != 0 {
+		t.Fatalf("expected nil pipeline runtime trace noop, warnings=%#v err=%v", warnings, err)
+	}
+	pipeline := &analysisPipeline{}
+	if warnings, err := pipeline.persistRuntimeTrace("trace.ndjson"); err != nil || len(warnings) != 0 {
+		t.Fatalf("expected missing repository view runtime trace noop, warnings=%#v err=%v", warnings, err)
+	}
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+	pipeline = &analysisPipeline{repositoryView: view}
+	if warnings, err := pipeline.persistRuntimeTrace(""); err != nil || len(warnings) != 0 {
+		t.Fatalf("expected blank runtime trace noop, warnings=%#v err=%v", warnings, err)
+	}
+	if warnings, err := pipeline.persistRuntimeTrace(filepath.Join(view.ExecutionPath(), "trace", "runtime.ndjson")); err != nil || len(warnings) != 0 {
+		t.Fatalf("expected missing runtime command noop, warnings=%#v err=%v", warnings, err)
+	}
+	pipeline.request.RuntimeTestCommand = "npm test"
+	if warnings, err := pipeline.persistRuntimeTrace(view.ExecutionPath()); err != nil || len(warnings) != 0 {
+		t.Fatalf("expected repository-root runtime trace noop, warnings=%#v err=%v", warnings, err)
+	}
+	if warnings, err := pipeline.persistRuntimeTrace(filepath.Join(t.TempDir(), "outside", "runtime.ndjson")); err != nil || len(warnings) != 0 {
+		t.Fatalf("expected external runtime trace noop, warnings=%#v err=%v", warnings, err)
+	}
+}
+
+func TestRemapAnalyzedRootsMapsExecutionRootToAuthorizedRepository(t *testing.T) {
+	got := remapAnalyzedRoots([]string{"/execution-snapshot"}, "/execution-snapshot", "/authorized-repo")
+	if len(got) != 1 || got[0] != "/authorized-repo" {
+		t.Fatalf("remapped execution root = %#v, want authorized repository root", got)
 	}
 }
 

--- a/internal/analysis/registry_test.go
+++ b/internal/analysis/registry_test.go
@@ -46,6 +46,22 @@ func TestRegisterAdaptersRejectsNilRegistry(t *testing.T) {
 	}
 }
 
+func TestRegisterAdaptersPropagatesRegistryErrors(t *testing.T) {
+	registry := language.NewRegistry()
+	factories := []adapterFactory{
+		func() language.Adapter {
+			return &testServiceAdapter{id: "dup", detect: language.Detection{Matched: true}}
+		},
+		func() language.Adapter {
+			return &testServiceAdapter{id: "dup", detect: language.Detection{Matched: true}}
+		},
+	}
+
+	if err := registerAdapters(registry, factories); err == nil {
+		t.Fatalf("expected duplicate adapter registration error")
+	}
+}
+
 func TestNewServiceRegistersPowerShellAdapter(t *testing.T) {
 	service := NewService()
 	if service.InitErr != nil {

--- a/internal/analysis/repository.go
+++ b/internal/analysis/repository.go
@@ -1,0 +1,507 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+// RepositoryAuthorization is an opaque repository identity established at the
+// path-validation boundary.
+type RepositoryAuthorization struct {
+	self  *RepositoryAuthorization
+	state *repositoryAuthState
+	nonce uint64
+}
+
+// RepositoryView retains a no-follow repository handle and a stable execution
+// snapshot derived from that handle.
+type RepositoryView struct {
+	state         *repositoryAuthState
+	root          safeio.Root
+	executionRoot safeio.Root
+	executionPath string
+	warnings      []string
+	gitMetadata   RepositoryGitMetadata
+	closeOnce     sync.Once
+	closeErr      error
+}
+
+var repositoryViewHandleOpenedFn = func() error { return nil }
+var repositoryViewCloseFn = func() error { return nil }
+var repositoryAuthorizationNonce uint64
+
+// SetRepositoryViewHandleOpenedHookForTest replaces the retained-handle hook
+// used by repository-opening tests and returns a restore function.
+func SetRepositoryViewHandleOpenedHookForTest(hook func() error) func() {
+	previous := repositoryViewHandleOpenedFn
+	if hook == nil {
+		hook = func() error { return nil }
+	}
+	repositoryViewHandleOpenedFn = hook
+	return func() {
+		repositoryViewHandleOpenedFn = previous
+	}
+}
+
+// SetRepositoryViewCloseHookForTest replaces the retained-view close hook used
+// by ownership and error-propagation tests and returns a restore function.
+func SetRepositoryViewCloseHookForTest(hook func() error) func() {
+	previous := repositoryViewCloseFn
+	if hook == nil {
+		hook = func() error { return nil }
+	}
+	repositoryViewCloseFn = hook
+	return func() {
+		repositoryViewCloseFn = previous
+	}
+}
+
+// ResolveTrustedRepository establishes an immutable canonical repository
+// identity. Filesystem canonicalization happens only in this function.
+func ResolveTrustedRepository(repoPath string) (*RepositoryAuthorization, error) {
+	paths, err := resolveTrustedRepoPaths(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	return newRepositoryAuthorization(&repositoryAuthState{
+		paths: paths,
+		nonce: atomic.AddUint64(&repositoryAuthorizationNonce, 1),
+	}), nil
+}
+
+// ResolveAuthorizedRepository reuses an existing repository authorization or a
+// trusted cache-bound repository identity when available before falling back to
+// a fresh authorization for repoPath.
+func ResolveAuthorizedRepository(repoPath string, repository *RepositoryAuthorization, cache *CacheOptions) (*RepositoryAuthorization, error) {
+	if repository != nil {
+		if err := useTrustedRepository(repoPath, repository); err != nil {
+			return nil, err
+		}
+		return repository, nil
+	}
+	if cache != nil && cache.hasTrustedPin() {
+		repository = newRepositoryAuthorization(cache.trustedPin.repositoryState)
+		if err := useTrustedRepository(repoPath, repository); err != nil {
+			return nil, err
+		}
+		return repository, nil
+	}
+	return ResolveTrustedRepository(repoPath)
+}
+
+// TrustedRepositoryPath returns the normalized path supplied at authorization.
+func TrustedRepositoryPath(repository *RepositoryAuthorization) string {
+	if repository == nil {
+		return ""
+	}
+	if state := repository.authorizationState(); state != nil {
+		return state.paths.requestedPath
+	}
+	return ""
+}
+
+func useTrustedRepository(repoPath string, repository *RepositoryAuthorization) error {
+	state := repository.authorizationState()
+	if state == nil || state.paths.canonicalInfo == nil {
+		return errors.New("trusted repository authorization is required")
+	}
+	normalizedRepoPath, err := normalizeTrustedRepoPath(repoPath)
+	if err != nil {
+		return err
+	}
+	if !repository.matchesPath(normalizedRepoPath) {
+		return errors.New("trusted repository authorization does not match repoPath")
+	}
+	return nil
+}
+
+func (r *RepositoryAuthorization) matchesPath(repoPath string) bool {
+	state := r.authorizationState()
+	if state == nil {
+		return false
+	}
+	cleanRepoPath := filepath.Clean(repoPath)
+	if cleanRepoPath == state.paths.requestedPath || cleanRepoPath == state.paths.canonicalPath {
+		return true
+	}
+	info, err := os.Lstat(cleanRepoPath)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	return os.SameFile(state.paths.canonicalInfo, info)
+}
+
+// OpenTrustedRepository verifies a no-follow root handle against the authorized
+// identity and snapshots repository contents through that retained handle.
+func OpenTrustedRepository(ctx context.Context, repository *RepositoryAuthorization, repoPath string, cache *CacheOptions) (_ *RepositoryView, returnErr error) {
+	return openTrustedRepository(ctx, repository, repoPath, cache, false)
+}
+
+// OpenTrustedRepositoryWithGitMetadata additionally seals Git-sensitive state
+// into the retained view before the completed-view test hook can run.
+func OpenTrustedRepositoryWithGitMetadata(ctx context.Context, repository *RepositoryAuthorization, repoPath string, cache *CacheOptions) (_ *RepositoryView, returnErr error) {
+	return openTrustedRepository(ctx, repository, repoPath, cache, true)
+}
+
+func openTrustedRepository(ctx context.Context, repository *RepositoryAuthorization, repoPath string, cache *CacheOptions, captureGitMetadata bool) (_ *RepositoryView, returnErr error) {
+	if err := useTrustedRepository(repoPath, repository); err != nil {
+		return nil, err
+	}
+	state := repository.authorizationState()
+	if cache != nil && cache.hasTrustedPin() && cache.trustedPin.repositoryState != state {
+		return nil, errors.New("trusted cache pin does not match repository authorization")
+	}
+
+	root, err := safeio.OpenRootNoFollow(state.paths.canonicalPath)
+	if err != nil {
+		return nil, fmt.Errorf("open trusted repository: %w", err)
+	}
+	var executionPath string
+	var executionRoot safeio.Root
+	defer func() {
+		returnErr = cleanupFailedRepositoryOpen(returnErr, root, executionRoot, executionPath)
+	}()
+
+	openedInfo, err := inspectTrustedRepositoryRoot(root, state)
+	if err != nil {
+		return nil, err
+	}
+
+	var gitMetadata RepositoryGitMetadata
+	if captureGitMetadata {
+		gitMetadata = captureRepositoryGitMetadata(ctx, state.paths.canonicalPath)
+	}
+
+	var snapshotWarnings []string
+	executionPath, executionRoot, snapshotWarnings, err = openRepositoryExecutionSnapshot(ctx, root, cache)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyRepositoryAfterSnapshot(ctx, state, openedInfo, captureGitMetadata, gitMetadata); err != nil {
+		return nil, err
+	}
+
+	view := &RepositoryView{
+		state:         state,
+		root:          root,
+		executionRoot: executionRoot,
+		executionPath: executionPath,
+		warnings:      snapshotWarnings,
+		gitMetadata:   gitMetadata,
+	}
+	if err := repositoryViewHandleOpenedFn(); err != nil {
+		return nil, err
+	}
+	return view, nil
+}
+
+func cleanupFailedRepositoryOpen(openErr error, root, executionRoot safeio.Root, executionPath string) error {
+	if openErr == nil {
+		return nil
+	}
+	if executionRoot != nil {
+		openErr = errors.Join(openErr, executionRoot.Close())
+	}
+	if executionPath != "" {
+		openErr = errors.Join(openErr, os.RemoveAll(executionPath))
+	}
+	return errors.Join(openErr, root.Close())
+}
+
+func inspectTrustedRepositoryRoot(root safeio.Root, state *repositoryAuthState) (fs.FileInfo, error) {
+	openedInfo, err := root.Lstat(".")
+	if err != nil {
+		return nil, fmt.Errorf("inspect trusted repository handle: %w", err)
+	}
+	if !openedInfo.IsDir() || !os.SameFile(state.paths.canonicalInfo, openedInfo) {
+		return nil, errors.New("trusted cache repository changed after validation")
+	}
+	return openedInfo, nil
+}
+
+func openRepositoryExecutionSnapshot(ctx context.Context, root safeio.Root, cache *CacheOptions) (string, safeio.Root, []string, error) {
+	snapshot, err := snapshotRepositoryRoot(ctx, root, repositorySnapshotSkip(cache))
+	if err != nil {
+		return "", nil, nil, err
+	}
+	executionPath := snapshot.path
+	executionRoot, err := safeio.OpenRoot(executionPath)
+	if err != nil {
+		return executionPath, nil, nil, fmt.Errorf("open repository execution snapshot: %w", err)
+	}
+	return executionPath, executionRoot, snapshot.diagnostics.warnings(), nil
+}
+
+func (r *RepositoryView) snapshotWarnings() []string {
+	if r == nil || len(r.warnings) == 0 {
+		return nil
+	}
+	return append([]string(nil), r.warnings...)
+}
+
+func verifyRepositoryAfterSnapshot(ctx context.Context, state *repositoryAuthState, openedInfo fs.FileInfo, captureGitMetadata bool, expectedMetadata RepositoryGitMetadata) error {
+	if captureGitMetadata {
+		verifiedMetadata := captureRepositoryGitMetadata(ctx, state.paths.canonicalPath)
+		if !expectedMetadata.equal(verifiedMetadata) {
+			return errors.New("trusted repository Git state changed while opening repository view")
+		}
+	}
+	currentInfo, err := os.Lstat(state.paths.canonicalPath)
+	if err != nil {
+		return errors.New("trusted repository changed while opening repository view")
+	}
+	if !currentInfo.IsDir() || !os.SameFile(openedInfo, currentInfo) {
+		return errors.New("trusted repository changed while opening repository view")
+	}
+	return nil
+}
+
+func repositorySnapshotSkip(cache *CacheOptions) string {
+	if !InRepoCacheOptions(cache) {
+		return ""
+	}
+	return filepath.Clean(cache.trustedPin.repoRelativePath)
+}
+
+// ExecutionPath returns the stable snapshot used for path-based adapters and
+// subprocesses.
+func (r *RepositoryView) ExecutionPath() string {
+	if r == nil {
+		return ""
+	}
+	return r.executionPath
+}
+
+// GitMetadata returns a defensive copy of Git-sensitive state sealed while the
+// retained repository view was opened.
+func (r *RepositoryView) GitMetadata() RepositoryGitMetadata {
+	if r == nil {
+		return RepositoryGitMetadata{}
+	}
+	return r.gitMetadata.clone()
+}
+
+func (r *RepositoryView) canonicalPath() string {
+	if r == nil || r.state == nil {
+		return ""
+	}
+	return r.state.paths.canonicalPath
+}
+
+func (r *RepositoryView) matches(repository *RepositoryAuthorization) bool {
+	return r != nil && repository != nil && r.state != nil && r.state == repository.authorizationState()
+}
+
+// ValidateRepositoryView verifies that a retained view belongs to the supplied
+// repository authorization without reopening either repository pathname.
+func ValidateRepositoryView(repository *RepositoryAuthorization, view *RepositoryView) error {
+	if !view.matches(repository) {
+		return errors.New("trusted repository view does not match repository authorization")
+	}
+	return nil
+}
+
+var errUnsafeRepositoryRelativePath = errors.New("repository path must stay within the repository root")
+
+// SnapshotPath remaps a repository-relative or authorized absolute path into
+// the stable execution snapshot. External absolute paths are left unchanged.
+func (r *RepositoryView) SnapshotPath(path string) (string, error) {
+	if r == nil || strings.TrimSpace(path) == "" {
+		return path, nil
+	}
+	cleanPath := filepath.Clean(strings.TrimSpace(path))
+	if !filepath.IsAbs(cleanPath) {
+		if !isSafeRepositoryRelativePath(cleanPath, true) {
+			return "", fmt.Errorf("%w: %s", errUnsafeRepositoryRelativePath, path)
+		}
+		return filepath.Join(r.executionPath, cleanPath), nil
+	}
+	for _, root := range r.repositoryRoots() {
+		if !pathWithinDir(root, cleanPath) {
+			continue
+		}
+		relativePath, err := filepath.Rel(root, cleanPath)
+		if err == nil {
+			return filepath.Join(r.executionPath, relativePath), nil
+		}
+	}
+	return cleanPath, nil
+}
+
+// RepositoryRelativePath returns a safe repository-relative representation for
+// paths expressed relative to, or absolutely beneath, either authorized path.
+func (r *RepositoryView) RepositoryRelativePath(path string) (string, bool) {
+	if r == nil || r.state == nil || strings.TrimSpace(path) == "" {
+		return "", false
+	}
+	cleanPath := filepath.Clean(strings.TrimSpace(path))
+	if !filepath.IsAbs(cleanPath) {
+		return cleanPath, isSafeRepositoryRelativePath(cleanPath, true)
+	}
+	for _, root := range r.repositoryRoots() {
+		if !pathWithinDir(root, cleanPath) {
+			continue
+		}
+		relativePath, err := filepath.Rel(root, cleanPath)
+		if err == nil && isSafeRepositoryRelativePath(relativePath, true) {
+			return filepath.Clean(relativePath), true
+		}
+	}
+	return "", false
+}
+
+func (r *RepositoryView) repositoryRoots() []string {
+	if r == nil || r.state == nil {
+		return nil
+	}
+	return []string{
+		r.state.paths.requestedPath,
+		r.state.paths.canonicalPath,
+		r.executionPath,
+	}
+}
+
+// DisplayPath returns the authorized requested-path representation of a
+// repository-relative path.
+func (r *RepositoryView) DisplayPath(relativePath string) string {
+	if r == nil || r.state == nil {
+		return ""
+	}
+	return filepath.Join(r.state.paths.requestedPath, filepath.Clean(relativePath))
+}
+
+// StablePath maps a repository path, including an execution-snapshot path,
+// back to the authorized requested-path identity. External paths are unchanged.
+func (r *RepositoryView) StablePath(path string) string {
+	if r == nil || strings.TrimSpace(path) == "" {
+		return strings.TrimSpace(path)
+	}
+	if relativePath, ok := r.RepositoryRelativePath(path); ok {
+		return r.DisplayPath(relativePath)
+	}
+	return filepath.Clean(strings.TrimSpace(path))
+}
+
+// OpenWriteRoot opens a repository-relative write root from the retained
+// repository handle.
+func (r *RepositoryView) OpenWriteRoot(relativePath string, create bool) (*safeio.WriteRoot, error) {
+	if r == nil || r.root == nil {
+		return nil, errors.New("trusted repository view is required")
+	}
+	return safeio.OpenRelativeWriteRoot(r.root, relativePath, create, 0o750)
+}
+
+// ReadFile reads a repository-relative file through the retained handle.
+func (r *RepositoryView) ReadFile(relativePath string) ([]byte, error) {
+	if r == nil || r.root == nil {
+		return nil, errors.New("trusted repository view is required")
+	}
+	return safeio.ReadFileWithinRoot(r.root, relativePath)
+}
+
+// ReadExecutionFile reads a repository-relative file from the retained
+// execution snapshot.
+func (r *RepositoryView) ReadExecutionFile(relativePath string) ([]byte, error) {
+	if r == nil || r.executionRoot == nil {
+		return nil, errors.New("trusted repository execution view is required")
+	}
+	return safeio.ReadFileWithinRoot(r.executionRoot, relativePath)
+}
+
+// Lstat inspects a repository-relative path through the retained handle.
+func (r *RepositoryView) Lstat(relativePath string) (fs.FileInfo, error) {
+	if r == nil || r.root == nil {
+		return nil, errors.New("trusted repository view is required")
+	}
+	if !isSafeRepositoryRelativePath(relativePath, true) {
+		return nil, fmt.Errorf("repository path must be relative: %s", relativePath)
+	}
+	return r.root.Lstat(filepath.Clean(relativePath))
+}
+
+// WriteFile atomically writes a repository-relative file through the retained
+// handle, creating missing parents.
+func (r *RepositoryView) WriteFile(relativePath string, data []byte, perm os.FileMode) (returnErr error) {
+	root, err := r.OpenWriteRoot(".", false)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, root.Close())
+	}()
+	return root.WriteFileReplacingParents(relativePath, data, perm, 0o750)
+}
+
+// EnsureDir creates a repository-relative directory through the retained
+// handle.
+func (r *RepositoryView) EnsureDir(relativePath string, perm os.FileMode) (returnErr error) {
+	root, err := r.OpenWriteRoot(".", false)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, root.Close())
+	}()
+	return root.EnsureDir(relativePath, perm)
+}
+
+func isSafeRepositoryRelativePath(path string, allowRoot bool) bool {
+	if filepath.IsAbs(path) {
+		return false
+	}
+	cleanPath := filepath.Clean(path)
+	if cleanPath == "." {
+		return allowRoot
+	}
+	return cleanPath != ".." && !strings.HasPrefix(cleanPath, ".."+string(filepath.Separator))
+}
+
+// Close removes the execution snapshot and releases the retained handle.
+func (r *RepositoryView) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		var cleanupErr error
+		if r.executionRoot != nil {
+			cleanupErr = r.executionRoot.Close()
+		}
+		if r.executionPath != "" {
+			cleanupErr = errors.Join(cleanupErr, os.RemoveAll(r.executionPath))
+		}
+		if r.root != nil {
+			cleanupErr = errors.Join(cleanupErr, r.root.Close())
+		}
+		cleanupErr = errors.Join(cleanupErr, repositoryViewCloseFn())
+		r.closeErr = cleanupErr
+	})
+	return r.closeErr
+}
+
+func newRepositoryAuthorization(state *repositoryAuthState) *RepositoryAuthorization {
+	if state == nil {
+		return nil
+	}
+	authorization := &RepositoryAuthorization{
+		state: state,
+		nonce: state.nonce,
+	}
+	authorization.self = authorization
+	return authorization
+}
+
+func (r *RepositoryAuthorization) authorizationState() *repositoryAuthState {
+	if r == nil || r.self != r || r.state == nil || r.state.nonce == 0 || r.state.nonce != r.nonce {
+		return nil
+	}
+	return r.state
+}

--- a/internal/analysis/repository_git.go
+++ b/internal/analysis/repository_git.go
@@ -1,0 +1,403 @@
+package analysis
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/gitexec"
+)
+
+const repositoryGitFilterProbeMarker = "__LOPPER_REPOSITORY_FILTER_PROBE__"
+
+var resolveRepositoryGitBinaryPathFn = gitexec.ResolveBinaryPath
+var repositoryGitWorktreeFn = repositoryIsGitWorktree
+var repositoryExecutableFiltersFn = repositoryExecutableFilterDrivers
+var repositoryActiveFiltersFn = repositoryActiveFilterDrivers
+var repositoryCurrentCommitFn = repositoryCurrentCommit
+var repositoryChangedFilesFn = repositoryChangedFiles
+
+// RepositoryGitFilter identifies a tracked path whose configured clean or
+// process filter makes raw lockfile comparisons unsafe.
+type RepositoryGitFilter struct {
+	Path   string
+	Driver string
+}
+
+// RepositoryGitMetadata is the Git-sensitive state sealed into a
+// RepositoryView. Captured distinguishes a clean/non-Git repository from a
+// view opened without metadata capture.
+type RepositoryGitMetadata struct {
+	Captured            bool
+	IsWorktree          bool
+	CurrentCommit       string
+	ChangedFiles        []string
+	ActiveFilterDrivers []RepositoryGitFilter
+	CaptureError        error
+}
+
+func (m *RepositoryGitMetadata) clone() RepositoryGitMetadata {
+	if m == nil {
+		return RepositoryGitMetadata{}
+	}
+	cloned := *m
+	cloned.ChangedFiles = append([]string{}, m.ChangedFiles...)
+	cloned.ActiveFilterDrivers = append([]RepositoryGitFilter{}, m.ActiveFilterDrivers...)
+	return cloned
+}
+
+func (m *RepositoryGitMetadata) equal(other RepositoryGitMetadata) bool {
+	return m.Captured == other.Captured &&
+		m.IsWorktree == other.IsWorktree &&
+		m.CurrentCommit == other.CurrentCommit &&
+		slices.Equal(m.ChangedFiles, other.ChangedFiles) &&
+		slices.Equal(m.ActiveFilterDrivers, other.ActiveFilterDrivers) &&
+		errorText(m.CaptureError) == errorText(other.CaptureError)
+}
+
+func errorText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func captureRepositoryGitMetadata(ctx context.Context, repoPath string) RepositoryGitMetadata {
+	metadata := RepositoryGitMetadata{Captured: true}
+	gitPath, err := resolveRepositoryGitBinaryPathFn()
+	if err != nil {
+		metadata.CaptureError = fmt.Errorf("resolve git binary: %w", err)
+		return metadata
+	}
+
+	metadata.IsWorktree, err = repositoryGitWorktreeFn(ctx, gitPath, repoPath)
+	if err != nil || !metadata.IsWorktree {
+		metadata.CaptureError = err
+		return metadata
+	}
+
+	configuredDrivers, err := repositoryExecutableFiltersFn(ctx, gitPath, repoPath)
+	if err != nil {
+		metadata.CaptureError = err
+		return metadata
+	}
+	metadata.ActiveFilterDrivers, err = repositoryActiveFiltersFn(ctx, gitPath, repoPath, configuredDrivers)
+	if err != nil {
+		metadata.CaptureError = err
+		return metadata
+	}
+
+	var hasHead bool
+	metadata.CurrentCommit, hasHead, err = repositoryCurrentCommitFn(ctx, gitPath, repoPath)
+	if err != nil {
+		metadata.CaptureError = err
+		return metadata
+	}
+	metadata.ChangedFiles, err = repositoryChangedFilesFn(ctx, gitPath, repoPath, configuredDrivers, hasHead)
+	if err != nil {
+		metadata.CaptureError = err
+	}
+	return metadata
+}
+
+func repositoryIsGitWorktree(ctx context.Context, gitPath, repoPath string) (bool, error) {
+	command, err := repositoryGitCommand(ctx, gitPath, repoPath, nil, "rev-parse", "--is-inside-work-tree")
+	if err != nil {
+		return false, err
+	}
+	output, err := command.CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 128 && bytes.Contains(output, []byte("not a git repository")) {
+			return false, nil
+		}
+		return false, fmt.Errorf("run git rev-parse --is-inside-work-tree: %w", err)
+	}
+	return strings.TrimSpace(string(output)) == "true", nil
+}
+
+func repositoryCurrentCommit(ctx context.Context, gitPath, repoPath string) (string, bool, error) {
+	command, err := repositoryGitCommand(ctx, gitPath, repoPath, nil, "rev-parse", "--verify", "--quiet", "HEAD")
+	if err != nil {
+		return "", false, err
+	}
+	output, err := command.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("run git rev-parse --verify --quiet HEAD: %w", err)
+	}
+	return strings.TrimSpace(string(output)), true, nil
+}
+
+func repositoryChangedFiles(ctx context.Context, gitPath, repoPath string, configuredDrivers []string, hasHead bool) ([]string, error) {
+	filterArgs := repositoryFilterOverrides(configuredDrivers)
+	groups := make([][]string, 0, 3)
+	if hasHead {
+		changed, err := repositoryGitPaths(ctx, gitPath, repoPath, filterArgs, "diff", "--no-ext-diff", "--no-textconv", "HEAD", "--name-only", "-z", "--")
+		if err != nil {
+			return nil, err
+		}
+		groups = append(groups, changed)
+	} else {
+		for _, args := range [][]string{
+			{"diff", "--no-ext-diff", "--no-textconv", "--cached", "--name-only", "-z", "--"},
+			{"diff", "--no-ext-diff", "--no-textconv", "--name-only", "-z", "--"},
+		} {
+			changed, err := repositoryGitPaths(ctx, gitPath, repoPath, filterArgs, args...)
+			if err != nil {
+				return nil, err
+			}
+			groups = append(groups, changed)
+		}
+	}
+	untracked, err := repositoryGitPaths(ctx, gitPath, repoPath, nil, "ls-files", "--others", "--exclude-standard", "-z")
+	if err != nil {
+		return nil, err
+	}
+	return mergeRepositoryGitPaths(append(groups, untracked)...), nil
+}
+
+func repositoryActiveFilterDrivers(ctx context.Context, gitPath, repoPath string, configuredDrivers []string) ([]RepositoryGitFilter, error) {
+	if len(configuredDrivers) == 0 {
+		return nil, nil
+	}
+	output, err := repositoryGitCheckAttrOutput(ctx, gitPath, repoPath)
+	if err != nil {
+		return nil, err
+	}
+	configured := repositoryConfiguredDriverSet(configuredDrivers)
+	filters, err := parseRepositoryGitFilters(output, configured)
+	if err != nil {
+		return nil, err
+	}
+	active, err := repositoryResolveActiveFilters(ctx, gitPath, repoPath, filters)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(active, func(i, j int) bool {
+		if active[i].Path == active[j].Path {
+			return active[i].Driver < active[j].Driver
+		}
+		return active[i].Path < active[j].Path
+	})
+	return active, nil
+}
+
+func repositoryGitCheckAttrOutput(ctx context.Context, gitPath, repoPath string) ([]byte, error) {
+	trackedPaths, err := repositoryGitPaths(ctx, gitPath, repoPath, nil, "ls-files", "--cached", "-z")
+	if err != nil || len(trackedPaths) == 0 {
+		return nil, err
+	}
+	command, err := repositoryGitCommand(ctx, gitPath, repoPath, nil, "check-attr", "--stdin", "-z", "--all")
+	if err != nil {
+		return nil, err
+	}
+	command.Stdin = strings.NewReader(strings.Join(trackedPaths, "\x00") + "\x00")
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("run git check-attr --stdin -z --all: %w", err)
+	}
+	return output, nil
+}
+
+func repositoryConfiguredDriverSet(configuredDrivers []string) map[string]struct{} {
+	configured := make(map[string]struct{}, len(configuredDrivers))
+	for _, driver := range configuredDrivers {
+		configured[driver] = struct{}{}
+	}
+	return configured
+}
+
+func repositoryResolveActiveFilters(ctx context.Context, gitPath, repoPath string, filters []RepositoryGitFilter) ([]RepositoryGitFilter, error) {
+	active := filters[:0]
+	for _, filter := range filters {
+		if !repositoryGitAttributeStateDriver(filter.Driver) {
+			active = append(active, filter)
+			continue
+		}
+		usesDriver, err := repositoryPathUsesNamedFilterDriver(ctx, gitPath, repoPath, filter)
+		if err != nil {
+			return nil, err
+		}
+		if usesDriver {
+			active = append(active, filter)
+		}
+	}
+	return active, nil
+}
+
+func repositoryExecutableFilterDrivers(ctx context.Context, gitPath, repoPath string) ([]string, error) {
+	command, err := repositoryGitCommand(ctx, gitPath, repoPath, nil, "config", "--null", "--includes", "--get-regexp", `^filter\..*\.(clean|process)$`)
+	if err != nil {
+		return nil, err
+	}
+	output, err := command.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read executable git filter configuration: %w", err)
+	}
+
+	effective := make(map[string]string)
+	for _, record := range parseRepositoryNULFields(output) {
+		key, value, ok := strings.Cut(record, "\n")
+		_, validKey := repositoryGitFilterDriverFromConfigKey(key)
+		if !ok || !validKey {
+			return nil, fmt.Errorf("parse executable git filter configuration: unexpected record %q", record)
+		}
+		effective[key] = strings.TrimSpace(value)
+	}
+	configured := make(map[string]struct{}, len(effective))
+	for key, command := range effective {
+		if command != "" {
+			driver, _ := repositoryGitFilterDriverFromConfigKey(key)
+			configured[driver] = struct{}{}
+		}
+	}
+	drivers := make([]string, 0, len(configured))
+	for driver := range configured {
+		drivers = append(drivers, driver)
+	}
+	sort.Strings(drivers)
+	return drivers, nil
+}
+
+func parseRepositoryGitFilters(output []byte, configured map[string]struct{}) ([]RepositoryGitFilter, error) {
+	if len(output) == 0 {
+		return nil, nil
+	}
+	if output[len(output)-1] != 0 {
+		return nil, errors.New("parse git attributes: missing trailing NUL terminator")
+	}
+	fields := parseRepositoryNULFields(output)
+	if len(fields)%3 != 0 {
+		return nil, fmt.Errorf("parse git attributes: incomplete attribute triplet")
+	}
+	filters := make([]RepositoryGitFilter, 0, len(fields)/3)
+	for index := 0; index < len(fields); index += 3 {
+		driver := strings.TrimSpace(fields[index+2])
+		if fields[index+1] != "filter" {
+			continue
+		}
+		if _, ok := configured[driver]; ok {
+			filters = append(filters, RepositoryGitFilter{Path: fields[index], Driver: driver})
+		}
+	}
+	return filters, nil
+}
+
+func repositoryPathUsesNamedFilterDriver(ctx context.Context, gitPath, repoPath string, filter RepositoryGitFilter) (bool, error) {
+	probeCommand := "git hash-object --stdin --" + repositoryGitFilterProbeMarker
+	configArgs := []string{
+		"-c", fmt.Sprintf("filter.%s.clean=%s", filter.Driver, probeCommand),
+		"-c", fmt.Sprintf("filter.%s.process=%s", filter.Driver, probeCommand),
+		"-c", fmt.Sprintf("filter.%s.required=true", filter.Driver),
+	}
+	command, err := repositoryGitCommand(ctx, gitPath, repoPath, configArgs, "hash-object", "--path="+filter.Path, "--stdin")
+	if err != nil {
+		return false, err
+	}
+	command.Stdin = strings.NewReader("lopper-repository-filter-probe\n")
+	output, probeErr := command.CombinedOutput()
+	if bytes.Contains(output, []byte(repositoryGitFilterProbeMarker)) {
+		return true, nil
+	}
+	if probeErr != nil {
+		return false, fmt.Errorf("probe git filter driver %q for %q: %w", filter.Driver, filter.Path, probeErr)
+	}
+	return false, nil
+}
+
+func repositoryGitAttributeStateDriver(driver string) bool {
+	return driver == "set" || driver == "unset" || driver == "unspecified"
+}
+
+func repositoryGitFilterDriverFromConfigKey(key string) (string, bool) {
+	lowerKey := strings.ToLower(key)
+	if !strings.HasPrefix(lowerKey, "filter.") {
+		return "", false
+	}
+	for _, suffix := range []string{".clean", ".process"} {
+		if strings.HasSuffix(lowerKey, suffix) && len(key) > len("filter.")+len(suffix) {
+			return key[len("filter.") : len(key)-len(suffix)], true
+		}
+	}
+	return "", false
+}
+
+func repositoryFilterOverrides(drivers []string) []string {
+	overrides := make([]string, 0, len(drivers)*6)
+	for _, driver := range drivers {
+		overrides = append(overrides, "-c", fmt.Sprintf("filter.%s.clean=", driver), "-c", fmt.Sprintf("filter.%s.process=", driver), "-c", fmt.Sprintf("filter.%s.required=false", driver))
+	}
+	return overrides
+}
+
+func repositoryGitPaths(ctx context.Context, gitPath, repoPath string, configArgs []string, args ...string) ([]string, error) {
+	command, err := repositoryGitCommand(ctx, gitPath, repoPath, configArgs, args...)
+	if err != nil {
+		return nil, err
+	}
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+	}
+	return parseRepositoryNULFields(output), nil
+}
+
+func repositoryGitCommand(ctx context.Context, gitPath, repoPath string, configArgs []string, args ...string) (*exec.Cmd, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	commandArgs := append(gitexec.SafeConfigArgs(), configArgs...)
+	commandArgs = append(commandArgs, "-C", repoPath)
+	commandArgs = append(commandArgs, args...)
+	command, err := gitexec.CommandContext(ctx, gitPath, commandArgs...)
+	if err != nil {
+		return nil, err
+	}
+	command.Env = append(gitexec.SanitizedEnv(), "LC_ALL=C")
+	return command, nil
+}
+
+func parseRepositoryNULFields(output []byte) []string {
+	if len(output) == 0 {
+		return nil
+	}
+	fields := bytes.Split(output, []byte{0})
+	if len(fields[len(fields)-1]) == 0 {
+		fields = fields[:len(fields)-1]
+	}
+	parsed := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if len(field) > 0 {
+			parsed = append(parsed, string(field))
+		}
+	}
+	return parsed
+}
+
+func mergeRepositoryGitPaths(groups ...[]string) []string {
+	paths := make(map[string]struct{})
+	for _, group := range groups {
+		for _, path := range group {
+			paths[path] = struct{}{}
+		}
+	}
+	merged := make([]string, 0, len(paths))
+	for path := range paths {
+		merged = append(merged, path)
+	}
+	sort.Strings(merged)
+	return merged
+}

--- a/internal/analysis/repository_git_test.go
+++ b/internal/analysis/repository_git_test.go
@@ -1,0 +1,473 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/gitexec"
+	"github.com/ben-ranford/lopper/internal/testutil"
+	"github.com/ben-ranford/lopper/internal/workspace"
+)
+
+func TestOpenTrustedRepositoryWithGitMetadataSealsSamePathHeadAndConfig(t *testing.T) {
+	repo := t.TempDir()
+	const configA = "thresholds:\n  low_confidence_warning_percent: 11\n"
+	const configB = "thresholds:\n  low_confidence_warning_percent: 77\n"
+	writeFile(t, filepath.Join(repo, ".lopper.yml"), configA)
+	initRepositoryGitFixture(t, repo)
+	commitA, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("resolve commit A: %v", err)
+	}
+
+	writeFile(t, filepath.Join(repo, ".lopper.yml"), configB)
+	testutil.RunGit(t, repo, "add", ".lopper.yml")
+	testutil.RunGit(t, repo, "commit", "-m", "config B")
+	commitB, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("resolve commit B: %v", err)
+	}
+	testutil.RunGit(t, repo, "checkout", "--detach", commitA)
+
+	hookCalls := 0
+	restore := SetRepositoryViewHandleOpenedHookForTest(func() error {
+		hookCalls++
+		testutil.RunGit(t, repo, "checkout", "--detach", commitB)
+		return nil
+	})
+	t.Cleanup(restore)
+
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepositoryWithGitMetadata(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open metadata repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	metadata := view.GitMetadata()
+	if !metadata.Captured || !metadata.IsWorktree || metadata.CaptureError != nil {
+		t.Fatalf("unexpected Git metadata: %#v", metadata)
+	}
+	if metadata.CurrentCommit != commitA {
+		t.Fatalf("captured commit = %q, want commit A %q", metadata.CurrentCommit, commitA)
+	}
+	if len(metadata.ChangedFiles) != 0 {
+		t.Fatalf("captured clean repository as dirty: %#v", metadata.ChangedFiles)
+	}
+	if hookCalls != 1 {
+		t.Fatalf("completed-view hook calls = %d, want 1", hookCalls)
+	}
+	assertRepositoryConfigContents(t, filepath.Join(view.ExecutionPath(), ".lopper.yml"), configA, "snapshot config retargeted after checkout")
+	assertRepositoryConfigContents(t, filepath.Join(repo, ".lopper.yml"), configB, "same-path checkout hook did not install config B")
+
+	metadata.ChangedFiles = append(metadata.ChangedFiles, "mutated")
+	if slices.Contains(view.GitMetadata().ChangedFiles, "mutated") {
+		t.Fatal("Git metadata accessor exposed mutable view state")
+	}
+}
+
+func assertRepositoryConfigContents(t *testing.T, path, want, failure string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("%s: %q", failure, got)
+	}
+}
+
+func TestOpenTrustedRepositoryWithGitMetadataCapturesDirtyFiltersAndNonGit(t *testing.T) {
+	t.Run("dirty filtered worktree", testRepositoryGitDirtyFilteredWorktree)
+	t.Run("non Git directory is explicitly captured", testRepositoryGitNonGitDirectoryCaptured)
+	var nilView *RepositoryView
+	if metadata := nilView.GitMetadata(); metadata.Captured {
+		t.Fatalf("nil view returned captured metadata: %#v", metadata)
+	}
+}
+
+func TestRepositoryGitMetadataCapturesUnbornAndStateNamedFilters(t *testing.T) {
+	t.Run("unborn head", func(t *testing.T) {
+		repo := t.TempDir()
+		testutil.RunGit(t, repo, "init")
+		writeFile(t, filepath.Join(repo, "staged.txt"), "staged\n")
+		writeFile(t, filepath.Join(repo, "untracked.txt"), "untracked\n")
+		testutil.RunGit(t, repo, "add", "staged.txt")
+
+		metadata := captureRepositoryGitMetadata(context.Background(), repo)
+		if metadata.CaptureError != nil || !metadata.IsWorktree || metadata.CurrentCommit != "" {
+			t.Fatalf("unborn metadata = %#v", metadata)
+		}
+		if !slices.Contains(metadata.ChangedFiles, "staged.txt") || !slices.Contains(metadata.ChangedFiles, "untracked.txt") {
+			t.Fatalf("unborn changed files = %#v", metadata.ChangedFiles)
+		}
+	})
+
+	for _, tc := range []struct {
+		name       string
+		attribute  string
+		wantActive bool
+	}{
+		{name: "named state driver", attribute: "*.json filter=set", wantActive: true},
+		{name: "boolean attribute state", attribute: "*.json filter"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, ".gitattributes"), tc.attribute+"\n")
+			writeFile(t, filepath.Join(repo, "package.json"), "{}\n")
+			initRepositoryGitFixture(t, repo)
+			testutil.RunGit(t, repo, "config", "filter.set.clean", "cat")
+
+			metadata := captureRepositoryGitMetadata(context.Background(), repo)
+			if metadata.CaptureError != nil {
+				t.Fatalf("capture state-named filter metadata: %v", metadata.CaptureError)
+			}
+			active := slices.Contains(metadata.ActiveFilterDrivers, RepositoryGitFilter{Path: "package.json", Driver: "set"})
+			if active != tc.wantActive {
+				t.Fatalf("state-named filter active = %t, want %t: %#v", active, tc.wantActive, metadata.ActiveFilterDrivers)
+			}
+		})
+	}
+}
+
+func TestRepositoryGitMetadataCaptureStageErrors(t *testing.T) {
+	sentinel := errors.New("git metadata sentinel")
+	originalBinary := resolveRepositoryGitBinaryPathFn
+	originalWorktree := repositoryGitWorktreeFn
+	originalExecutableFilters := repositoryExecutableFiltersFn
+	originalActiveFilters := repositoryActiveFiltersFn
+	originalCurrentCommit := repositoryCurrentCommitFn
+	originalChangedFiles := repositoryChangedFilesFn
+	t.Cleanup(func() {
+		resolveRepositoryGitBinaryPathFn = originalBinary
+		repositoryGitWorktreeFn = originalWorktree
+		repositoryExecutableFiltersFn = originalExecutableFilters
+		repositoryActiveFiltersFn = originalActiveFilters
+		repositoryCurrentCommitFn = originalCurrentCommit
+		repositoryChangedFilesFn = originalChangedFiles
+	})
+
+	reset := func() {
+		resolveRepositoryGitBinaryPathFn = func() (string, error) { return gitexec.ExecutablePrimary, nil }
+		repositoryGitWorktreeFn = func(context.Context, string, string) (bool, error) { return true, nil }
+		repositoryExecutableFiltersFn = func(context.Context, string, string) ([]string, error) { return []string{"demo"}, nil }
+		repositoryActiveFiltersFn = func(context.Context, string, string, []string) ([]RepositoryGitFilter, error) {
+			return []RepositoryGitFilter{{Path: "package.json", Driver: "demo"}}, nil
+		}
+		repositoryCurrentCommitFn = func(context.Context, string, string) (string, bool, error) { return "abc", true, nil }
+		repositoryChangedFilesFn = func(context.Context, string, string, []string, bool) ([]string, error) {
+			return []string{"package.json"}, nil
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		fail func()
+	}{
+		{name: "binary", fail: func() {
+			resolveRepositoryGitBinaryPathFn = func() (string, error) { return "", sentinel }
+		}},
+		{name: "worktree", fail: func() {
+			repositoryGitWorktreeFn = func(context.Context, string, string) (bool, error) { return false, sentinel }
+		}},
+		{name: "filters config", fail: func() {
+			repositoryExecutableFiltersFn = func(context.Context, string, string) ([]string, error) { return nil, sentinel }
+		}},
+		{name: "active filters", fail: func() {
+			repositoryActiveFiltersFn = func(context.Context, string, string, []string) ([]RepositoryGitFilter, error) { return nil, sentinel }
+		}},
+		{name: "current commit", fail: func() {
+			repositoryCurrentCommitFn = func(context.Context, string, string) (string, bool, error) { return "", false, sentinel }
+		}},
+		{name: "changed files", fail: func() {
+			repositoryChangedFilesFn = func(context.Context, string, string, []string, bool) ([]string, error) { return nil, sentinel }
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reset()
+			tc.fail()
+			metadata := captureRepositoryGitMetadata(context.Background(), t.TempDir())
+			if !errors.Is(metadata.CaptureError, sentinel) {
+				t.Fatalf("capture error = %v, want sentinel", metadata.CaptureError)
+			}
+		})
+	}
+}
+
+func TestRepositoryGitMetadataParserAndCommandErrors(t *testing.T) {
+	t.Run("parser helpers", testRepositoryGitParserHelpers)
+	t.Run("missing and unsupported commands", testRepositoryGitMissingAndUnsupportedCommands)
+	t.Run("empty repository and invalid path", testRepositoryGitEmptyRepositoryAndInvalidPath)
+}
+
+func TestOpenTrustedRepositoryWithGitMetadataRejectsCaptureAndIdentityDrift(t *testing.T) {
+	originalWorktree := repositoryGitWorktreeFn
+	originalExecutableFilters := repositoryExecutableFiltersFn
+	originalActiveFilters := repositoryActiveFiltersFn
+	originalCurrentCommit := repositoryCurrentCommitFn
+	originalChangedFiles := repositoryChangedFilesFn
+	t.Cleanup(func() {
+		repositoryGitWorktreeFn = originalWorktree
+		repositoryExecutableFiltersFn = originalExecutableFilters
+		repositoryActiveFiltersFn = originalActiveFilters
+		repositoryCurrentCommitFn = originalCurrentCommit
+		repositoryChangedFilesFn = originalChangedFiles
+	})
+	reset := func() {
+		repositoryGitWorktreeFn = func(context.Context, string, string) (bool, error) { return true, nil }
+		repositoryExecutableFiltersFn = func(context.Context, string, string) ([]string, error) { return nil, nil }
+		repositoryActiveFiltersFn = func(context.Context, string, string, []string) ([]RepositoryGitFilter, error) { return nil, nil }
+		repositoryCurrentCommitFn = func(context.Context, string, string) (string, bool, error) { return "commit-a", true, nil }
+	}
+
+	t.Run("Git state", func(t *testing.T) {
+		reset()
+		repositoryChangedFilesFn = sequenceRepositoryChangedFiles(nil, []string{"state-1"}, []string{"state-2"})
+		assertOpenTrustedRepositoryWithGitMetadataError(t, t.TempDir(), "Git state changed")
+	})
+
+	t.Run("directory identity", func(t *testing.T) {
+		reset()
+		parent := t.TempDir()
+		repo := filepath.Join(parent, "repo")
+		moved := filepath.Join(parent, "moved")
+		if err := os.Mkdir(repo, 0o750); err != nil {
+			t.Fatalf("mkdir repository: %v", err)
+		}
+		renameOnSecondCall := renameRepositoryOnSecondCall(repo, moved)
+		repositoryChangedFilesFn = func(context.Context, string, string, []string, bool) ([]string, error) {
+			if err := renameOnSecondCall(); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		}
+		assertOpenTrustedRepositoryWithGitMetadataError(t, repo, "repository changed while opening")
+	})
+}
+
+func testRepositoryGitDirtyFilteredWorktree(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, ".gitattributes"), "*.json filter=demo\n")
+	writeFile(t, filepath.Join(repo, "package.json"), "{}\n")
+	writeFile(t, filepath.Join(repo, "second.json"), "{}\n")
+	initRepositoryGitFixture(t, repo)
+	testutil.RunGit(t, repo, "config", "filter.demo.clean", "cat")
+	testutil.RunGit(t, repo, "config", "filter.demo.process", "")
+	writeFile(t, filepath.Join(repo, "package.json"), "{\"changed\":true}\n")
+	writeFile(t, filepath.Join(repo, "untracked.txt"), "new\n")
+	view := openRepositoryGitMetadataView(t, repo)
+	metadata := view.GitMetadata()
+	if metadata.CaptureError != nil {
+		t.Fatalf("capture Git metadata: %v", metadata.CaptureError)
+	}
+	if !slices.Contains(metadata.ChangedFiles, "package.json") || !slices.Contains(metadata.ChangedFiles, "untracked.txt") {
+		t.Fatalf("changed files = %#v", metadata.ChangedFiles)
+	}
+	if !slices.Contains(metadata.ActiveFilterDrivers, RepositoryGitFilter{Path: "package.json", Driver: "demo"}) {
+		t.Fatalf("active filters = %#v", metadata.ActiveFilterDrivers)
+	}
+}
+
+func testRepositoryGitNonGitDirectoryCaptured(t *testing.T) {
+	metadata := openRepositoryGitMetadataView(t, t.TempDir()).GitMetadata()
+	if !metadata.Captured || metadata.IsWorktree || metadata.CaptureError != nil {
+		t.Fatalf("non-Git metadata = %#v", metadata)
+	}
+}
+
+func openRepositoryGitMetadataView(t *testing.T, repo string) *RepositoryView {
+	t.Helper()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := OpenTrustedRepositoryWithGitMetadata(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open metadata repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+	return view
+}
+
+func testRepositoryGitParserHelpers(t *testing.T) {
+	if isAbsoluteLocationPath("") {
+		t.Fatal("empty location path reported absolute")
+	}
+	if cloned := (*RepositoryGitMetadata)(nil).clone(); cloned.Captured {
+		t.Fatalf("nil metadata clone = %#v", cloned)
+	}
+	if errorText(errors.New("sentinel")) != "sentinel" {
+		t.Fatal("errorText did not preserve error text")
+	}
+	if filters, err := parseRepositoryGitFilters(nil, nil); err != nil || len(filters) != 0 {
+		t.Fatalf("empty attributes = %#v, %v", filters, err)
+	}
+	for _, output := range [][]byte{[]byte("path\x00filter\x00demo"), []byte("path\x00filter\x00")} {
+		if _, err := parseRepositoryGitFilters(output, map[string]struct{}{"demo": {}}); err == nil {
+			t.Fatalf("expected malformed attributes error for %q", output)
+		}
+	}
+	filters, err := parseRepositoryGitFilters([]byte("path\x00diff\x00demo\x00path\x00filter\x00missing\x00"), map[string]struct{}{"demo": {}})
+	if err != nil || len(filters) != 0 {
+		t.Fatalf("unexpected inert filters: %#v, %v", filters, err)
+	}
+	for _, key := range []string{"other.demo.clean", "filter.demo.other", "filter..clean"} {
+		if driver, ok := repositoryGitFilterDriverFromConfigKey(key); ok || driver != "" {
+			t.Fatalf("accepted invalid filter config key %q", key)
+		}
+	}
+}
+
+func testRepositoryGitMissingAndUnsupportedCommands(t *testing.T) {
+	repo := t.TempDir()
+	gitPath, err := gitexec.ResolveBinaryPath()
+	if err != nil {
+		t.Fatalf("resolve git binary: %v", err)
+	}
+	missingRepo := filepath.Join(repo, "missing")
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{name: "missing worktree", run: func() error {
+			_, err := repositoryIsGitWorktree(context.Background(), gitPath, missingRepo)
+			return err
+		}},
+		{name: "missing current commit", run: func() error {
+			_, _, err := repositoryCurrentCommit(context.Background(), gitPath, missingRepo)
+			return err
+		}},
+		{name: "missing changed files", run: func() error {
+			_, err := repositoryChangedFiles(context.Background(), gitPath, missingRepo, nil, true)
+			return err
+		}},
+		{name: "missing unborn changed files", run: func() error {
+			_, err := repositoryChangedFiles(context.Background(), gitPath, missingRepo, nil, false)
+			return err
+		}},
+		{name: "missing active filters", run: func() error {
+			_, err := repositoryActiveFilterDrivers(context.Background(), gitPath, missingRepo, []string{"demo"})
+			return err
+		}},
+		{name: "missing filter config", run: func() error {
+			_, err := repositoryExecutableFilterDrivers(context.Background(), gitPath, missingRepo)
+			return err
+		}},
+		{name: "unsupported git paths", run: func() error {
+			_, err := repositoryGitPaths(context.Background(), "unsupported", repo, nil, "status")
+			return err
+		}},
+		{name: "unsupported worktree", run: func() error { _, err := repositoryIsGitWorktree(context.Background(), "unsupported", repo); return err }},
+		{name: "unsupported current commit", run: func() error {
+			_, _, err := repositoryCurrentCommit(context.Background(), "unsupported", repo)
+			return err
+		}},
+		{name: "unsupported active filters", run: func() error {
+			_, err := repositoryActiveFilterDrivers(context.Background(), "unsupported", repo, []string{"demo"})
+			return err
+		}},
+		{name: "unsupported filter config", run: func() error {
+			_, err := repositoryExecutableFilterDrivers(context.Background(), "unsupported", repo)
+			return err
+		}},
+		{name: "unsupported filter probe", run: func() error {
+			_, err := repositoryPathUsesNamedFilterDriver(context.Background(), "unsupported", repo, RepositoryGitFilter{Path: "package.json", Driver: "set"})
+			return err
+		}},
+	} {
+		if err := tc.run(); err == nil {
+			t.Fatalf("expected %s error", tc.name)
+		}
+	}
+	var nilContext context.Context
+	if _, err := repositoryGitCommand(nilContext, "unsupported", repo, nil, "status"); err == nil {
+		t.Fatal("expected unsupported nil-context Git command error")
+	}
+	if _, err := repositoryPathUsesNamedFilterDriver(context.Background(), gitPath, repo, RepositoryGitFilter{Path: "\x00", Driver: "set"}); err == nil || !strings.Contains(err.Error(), "probe git filter") {
+		t.Fatalf("expected filter probe error, got %v", err)
+	}
+}
+
+func testRepositoryGitEmptyRepositoryAndInvalidPath(t *testing.T) {
+	gitPath, err := gitexec.ResolveBinaryPath()
+	if err != nil {
+		t.Fatalf("resolve git binary: %v", err)
+	}
+	emptyRepo := t.TempDir()
+	testutil.RunGit(t, emptyRepo, "init")
+	testutil.RunGit(t, emptyRepo, "config", "filter.demo.clean", "cat")
+	if filters, err := repositoryActiveFilterDrivers(context.Background(), gitPath, emptyRepo, []string{"demo"}); err != nil || len(filters) != 0 {
+		t.Fatalf("empty repository active filters = %#v, %v", filters, err)
+	}
+	repository, err := ResolveTrustedRepository(emptyRepo)
+	if err != nil {
+		t.Fatalf("authorize empty repository: %v", err)
+	}
+	if err := useTrustedRepository("\x00", repository); err == nil {
+		t.Fatal("expected invalid repository path rejection")
+	}
+}
+
+func sequenceRepositoryChangedFiles(callErr error, states ...[]string) func(context.Context, string, string, []string, bool) ([]string, error) {
+	call := 0
+	return func(context.Context, string, string, []string, bool) ([]string, error) {
+		call++
+		if callErr != nil {
+			return nil, callErr
+		}
+		if call-1 < len(states) {
+			return states[call-1], nil
+		}
+		return nil, nil
+	}
+}
+
+func renameRepositoryOnSecondCall(repo, moved string) func() error {
+	call := 0
+	return func() error {
+		call++
+		if call != 2 {
+			return nil
+		}
+		if err := os.Rename(repo, moved); err != nil {
+			return err
+		}
+		return os.Mkdir(repo, 0o750)
+	}
+}
+
+func assertOpenTrustedRepositoryWithGitMetadataError(t *testing.T, repo, wantSubstring string) {
+	t.Helper()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	if _, err := OpenTrustedRepositoryWithGitMetadata(context.Background(), repository, repo, nil); err == nil || !strings.Contains(err.Error(), wantSubstring) {
+		t.Fatalf("expected %s rejection, got %v", wantSubstring, err)
+	}
+}
+
+func initRepositoryGitFixture(t *testing.T, repo string) {
+	t.Helper()
+	testutil.RunGit(t, repo, "init")
+	testutil.RunGit(t, repo, "config", "user.email", "analysis-test@example.com")
+	testutil.RunGit(t, repo, "config", "user.name", "Analysis Test")
+	testutil.RunGit(t, repo, "add", ".")
+	testutil.RunGit(t, repo, "commit", "-m", "fixture A")
+}

--- a/internal/analysis/repository_snapshot.go
+++ b/internal/analysis/repository_snapshot.go
@@ -1,0 +1,282 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+const (
+	maxRepositorySnapshotFiles = 20000
+	maxRepositorySnapshotBytes = 128 << 20
+)
+
+type repositorySnapshotBudget struct {
+	files int
+	bytes int64
+}
+
+type repositorySnapshotResult struct {
+	path        string
+	diagnostics repositorySnapshotDiagnostics
+}
+
+type repositorySnapshotDiagnostics struct {
+	unsafeSymlinks []repositorySnapshotUnsafeSymlink
+}
+
+type repositorySnapshotUnsafeSymlink struct {
+	relativePath string
+	reason       repositorySnapshotUnsafeSymlinkReason
+}
+
+type repositorySnapshotUnsafeSymlinkReason int
+
+const (
+	repositorySnapshotUnsafeSymlinkUntrusted repositorySnapshotUnsafeSymlinkReason = iota
+	repositorySnapshotUnsafeSymlinkEscapesRoot
+)
+
+func snapshotRepositoryRoot(ctx context.Context, source safeio.Root, skipDir string) (_ repositorySnapshotResult, returnErr error) {
+	targetPath, err := os.MkdirTemp("", "lopper-repository-*")
+	if err != nil {
+		return repositorySnapshotResult{}, fmt.Errorf("create repository execution snapshot: %w", err)
+	}
+	defer func() {
+		if returnErr != nil {
+			returnErr = errors.Join(returnErr, os.RemoveAll(targetPath))
+		}
+	}()
+
+	target, err := safeio.OpenRoot(targetPath)
+	if err != nil {
+		return repositorySnapshotResult{}, fmt.Errorf("open repository execution snapshot: %w", err)
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, target.Close())
+	}()
+	result := repositorySnapshotResult{path: targetPath}
+	if err := copyRepositoryDirectory(ctx, source, target, ".", filepath.Clean(skipDir), &repositorySnapshotBudget{}, &result.diagnostics); err != nil {
+		return repositorySnapshotResult{}, fmt.Errorf("snapshot repository: %w", err)
+	}
+	return result, nil
+}
+
+func copyRepositoryDirectory(ctx context.Context, source, target safeio.Root, relativeDir, skipDir string, budget *repositorySnapshotBudget, diagnostics *repositorySnapshotDiagnostics) (returnErr error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	entries, err := safeio.ReadDirWithinRoot(source, relativeDir)
+	if err != nil {
+		return err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := copyRepositoryEntry(ctx, source, target, relativeDir, skipDir, entry, budget, diagnostics); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyRepositoryEntry(ctx context.Context, source, target safeio.Root, relativeDir, skipDir string, entry fs.DirEntry, budget *repositorySnapshotBudget, diagnostics *repositorySnapshotDiagnostics) error {
+	relativePath := repositorySnapshotEntryPath(relativeDir, entry.Name())
+	if shouldSkipRepositorySnapshotPath(relativePath, skipDir) {
+		return nil
+	}
+	info, err := source.Lstat(relativePath)
+	if err != nil {
+		return err
+	}
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		return copyRepositorySymlink(source, target, relativePath, diagnostics)
+	case info.IsDir():
+		return copyRepositorySubdirectory(ctx, source, target, relativePath, skipDir, info, budget, diagnostics)
+	case info.Mode().IsRegular():
+		return copyRepositorySnapshotFile(ctx, source, target, relativePath, info, budget)
+	default:
+		return nil
+	}
+}
+
+func repositorySnapshotEntryPath(relativeDir, entryName string) string {
+	if relativeDir == "." {
+		return entryName
+	}
+	return filepath.Join(relativeDir, entryName)
+}
+
+func copyRepositorySubdirectory(ctx context.Context, source, target safeio.Root, relativePath, skipDir string, info fs.FileInfo, budget *repositorySnapshotBudget, diagnostics *repositorySnapshotDiagnostics) error {
+	if err := target.Mkdir(relativePath, info.Mode().Perm()|0o700); err != nil && !errors.Is(err, fs.ErrExist) {
+		return err
+	}
+	if err := copyRepositoryDirectory(ctx, source, target, relativePath, skipDir, budget, diagnostics); err != nil {
+		return err
+	}
+	return target.Chmod(relativePath, info.Mode().Perm())
+}
+
+func copyRepositorySnapshotFile(ctx context.Context, source, target safeio.Root, relativePath string, info fs.FileInfo, budget *repositorySnapshotBudget) error {
+	if err := budget.noteFile(info.Size()); err != nil {
+		return err
+	}
+	return copyRepositoryRegularFile(ctx, source, target, relativePath, info.Mode().Perm())
+}
+
+func shouldSkipRepositorySnapshotPath(relativePath, skipDir string) bool {
+	cleanPath := filepath.Clean(relativePath)
+	if cleanPath == ".git" || cleanPath == defaultAnalysisCacheDirName {
+		return true
+	}
+	return skipDir != "" && skipDir != "." && cleanPath == skipDir
+}
+
+func copyRepositorySymlink(source, target safeio.Root, relativePath string, diagnostics *repositorySnapshotDiagnostics) error {
+	linkTarget, err := safeio.ReadlinkWithinRoot(source, relativePath)
+	if err != nil {
+		return err
+	}
+	if filepath.IsAbs(linkTarget) {
+		diagnostics.recordUnsafeSymlink(relativePath, repositorySnapshotUnsafeSymlinkUntrusted)
+		return nil
+	}
+	resolvedRelative := filepath.Clean(filepath.Join(filepath.Dir(relativePath), linkTarget))
+	if resolvedRelative == ".." || strings.HasPrefix(resolvedRelative, ".."+string(filepath.Separator)) {
+		diagnostics.recordUnsafeSymlink(relativePath, repositorySnapshotUnsafeSymlinkEscapesRoot)
+		return nil
+	}
+	return safeio.SymlinkWithinRoot(target, linkTarget, relativePath)
+}
+
+func copyRepositoryRegularFile(ctx context.Context, source, target safeio.Root, relativePath string, perm os.FileMode) (returnErr error) {
+	sourceFile, err := source.Open(relativePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, sourceFile.Close())
+	}()
+
+	targetFile, err := target.OpenFile(relativePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, targetFile.Close())
+	}()
+	buffer := make([]byte, 32*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		n, readErr := sourceFile.Read(buffer)
+		if n > 0 {
+			if _, err := targetFile.Write(buffer[:n]); err != nil {
+				return err
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}
+
+func (b *repositorySnapshotBudget) noteFile(size int64) error {
+	if b == nil {
+		return nil
+	}
+	b.files++
+	if b.files > maxRepositorySnapshotFiles {
+		return fmt.Errorf("repository snapshot exceeds file limit (%d)", maxRepositorySnapshotFiles)
+	}
+	b.bytes += size
+	if b.bytes > maxRepositorySnapshotBytes {
+		return fmt.Errorf("repository snapshot exceeds byte limit (%d)", maxRepositorySnapshotBytes)
+	}
+	return nil
+}
+
+func (d *repositorySnapshotDiagnostics) recordUnsafeSymlink(relativePath string, reason repositorySnapshotUnsafeSymlinkReason) {
+	if d == nil {
+		return
+	}
+	d.unsafeSymlinks = append(d.unsafeSymlinks, repositorySnapshotUnsafeSymlink{
+		relativePath: relativePath,
+		reason:       reason,
+	})
+}
+
+func (d *repositorySnapshotDiagnostics) warnings() []string {
+	if d == nil || len(d.unsafeSymlinks) == 0 {
+		return nil
+	}
+	warnings := make([]string, 0, len(d.unsafeSymlinks)+1)
+	skippedJVMSourceSymlinks := 0
+	for _, item := range d.unsafeSymlinks {
+		if repositorySnapshotJVMSourcePath(item.relativePath) {
+			skippedJVMSourceSymlinks++
+			warnings = append(warnings, fmt.Sprintf("skipped JVM source symlink %s: %s", item.relativePath, item.warningDescription()))
+		}
+		if repositorySnapshotJVMBuildPath(item.relativePath) {
+			warnings = append(warnings, fmt.Sprintf("unable to read %s: %s", filepath.ToSlash(item.relativePath), item.buildWarningError()))
+		}
+	}
+	if skippedJVMSourceSymlinks > 0 {
+		warnings = append(warnings, fmt.Sprintf("skipped %d unreadable or untrusted JVM source symlink(s)", skippedJVMSourceSymlinks))
+	}
+	return warnings
+}
+
+func repositorySnapshotJVMSourcePath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".java", ".kt", ".kts":
+		return true
+	default:
+		return false
+	}
+}
+
+func repositorySnapshotJVMBuildPath(path string) bool {
+	switch strings.ToLower(filepath.Base(path)) {
+	case "build.gradle", "build.gradle.kts", "pom.xml":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *repositorySnapshotUnsafeSymlink) warningDescription() string {
+	switch s.reason {
+	case repositorySnapshotUnsafeSymlinkEscapesRoot:
+		return "target escapes repo root"
+	default:
+		return "target is an untrusted symlink"
+	}
+}
+
+func (s *repositorySnapshotUnsafeSymlink) buildWarningError() string {
+	switch s.reason {
+	case repositorySnapshotUnsafeSymlinkEscapesRoot:
+		return safeio.ErrPathEscapesRoot.Error()
+	default:
+		return safeio.ErrTargetPathSymlink.Error()
+	}
+}

--- a/internal/analysis/repository_snapshot_test.go
+++ b/internal/analysis/repository_snapshot_test.go
@@ -1,0 +1,511 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+func TestSnapshotRepositoryRootReportsCreationAndCopyErrors(t *testing.T) {
+	t.Run("temporary directory", func(t *testing.T) {
+		blockingPath := filepath.Join(t.TempDir(), "not-a-directory")
+		if err := os.WriteFile(blockingPath, []byte("file"), 0o600); err != nil {
+			t.Fatalf("write blocking temporary path: %v", err)
+		}
+		t.Setenv("TMPDIR", blockingPath)
+		if _, err := snapshotRepositoryRoot(context.Background(), &snapshotRootStub{}, ""); err == nil {
+			t.Fatal("expected repository snapshot temporary-directory failure")
+		}
+	})
+
+	t.Run("source directory read", func(t *testing.T) {
+		expectedErr := errors.New("source directory unavailable")
+		source := &snapshotRootStub{
+			directories: map[string]snapshotReadDirResult{
+				".": {err: expectedErr},
+			},
+		}
+		if _, err := snapshotRepositoryRoot(context.Background(), source, ""); !errors.Is(err, expectedErr) {
+			t.Fatalf("expected repository snapshot copy error, got %v", err)
+		}
+	})
+}
+
+func TestCopyRepositoryDirectoryPropagatesRootedOperationErrors(t *testing.T) {
+	for _, tc := range repositorySnapshotCopyErrorTests() {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, source, target, wantErr := tc.build()
+			if err := copyRepositoryDirectory(ctx, source, target, ".", "", &repositorySnapshotBudget{}, nil); !errors.Is(err, wantErr) {
+				t.Fatalf("expected %s error, got %v", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestCopyRepositoryDirectoryHonorsCancellationAndBounds(t *testing.T) {
+	t.Run("cancellation", testCopyRepositoryDirectoryCancellation)
+	t.Run("cancellation after directory read", testCopyRepositoryDirectoryPostReadCancellation)
+	t.Run("unsupported special file", testCopyRepositoryDirectorySkipsSpecialFiles)
+	t.Run("byte budget", testCopyRepositoryDirectoryByteBudget)
+	t.Run("file budget", testRepositorySnapshotFileBudget)
+	t.Run("budget no-op and success", testRepositorySnapshotBudgetNoOpAndSuccess)
+}
+
+func testCopyRepositoryDirectoryCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	source := snapshotSourceWithEntry("file", snapshotLstat(0o600))
+	if err := copyRepositoryDirectory(ctx, source, &snapshotRootStub{}, ".", "", &repositorySnapshotBudget{}, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}
+
+func testCopyRepositoryDirectoryPostReadCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	source := &snapshotRootStub{
+		open: func(string) (safeio.File, error) {
+			return &snapshotFileStub{readDir: func(int) ([]fs.DirEntry, error) {
+				cancel()
+				return []fs.DirEntry{&snapshotDirEntry{name: "file"}}, nil
+			}}, nil
+		},
+	}
+	if err := copyRepositoryDirectory(ctx, source, &snapshotRootStub{}, ".", "", &repositorySnapshotBudget{}, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected post-read cancellation, got %v", err)
+	}
+}
+
+func testCopyRepositoryDirectorySkipsSpecialFiles(t *testing.T) {
+	source := snapshotSourceWithEntry("socket", snapshotLstat(fs.ModeSocket|0o600))
+	if err := copyRepositoryDirectory(context.Background(), source, &snapshotRootStub{}, ".", "", &repositorySnapshotBudget{}, nil); err != nil {
+		t.Fatalf("expected unsupported special file to be omitted, got %v", err)
+	}
+}
+
+func testCopyRepositoryDirectoryByteBudget(t *testing.T) {
+	source := snapshotSourceWithEntry("file", func(name string) (fs.FileInfo, error) {
+		return &snapshotFileInfo{name: name, mode: 0o600, size: maxRepositorySnapshotBytes + 1}, nil
+	})
+	err := copyRepositoryDirectory(context.Background(), source, &snapshotRootStub{}, ".", "", &repositorySnapshotBudget{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("expected byte-limit rejection, got %v", err)
+	}
+}
+
+func testRepositorySnapshotFileBudget(t *testing.T) {
+	budget := &repositorySnapshotBudget{files: maxRepositorySnapshotFiles}
+	if err := budget.noteFile(1); err == nil || !strings.Contains(err.Error(), "file limit") {
+		t.Fatalf("expected file-limit rejection, got %v", err)
+	}
+}
+
+func testRepositorySnapshotBudgetNoOpAndSuccess(t *testing.T) {
+	var nilBudget *repositorySnapshotBudget
+	if err := nilBudget.noteFile(1); err != nil {
+		t.Fatalf("expected nil budget to allow noteFile, got %v", err)
+	}
+	budget := &repositorySnapshotBudget{}
+	if err := budget.noteFile(1); err != nil {
+		t.Fatalf("expected in-budget file to succeed, got %v", err)
+	}
+	if budget.files != 1 || budget.bytes != 1 {
+		t.Fatalf("unexpected budget accounting after noteFile: %#v", budget)
+	}
+}
+
+type repositorySnapshotCopyErrorTest struct {
+	name  string
+	build func() (context.Context, *snapshotRootStub, *snapshotRootStub, error)
+}
+
+func repositorySnapshotCopyErrorTests() []repositorySnapshotCopyErrorTest {
+	return []repositorySnapshotCopyErrorTest{
+		{
+			name: "lstat",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("lstat failed")
+				return context.Background(), snapshotSourceWithEntry("entry", func(string) (fs.FileInfo, error) {
+					return nil, expectedErr
+				}), &snapshotRootStub{}, expectedErr
+			},
+		},
+		{
+			name: "readlink",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("readlink failed")
+				source := snapshotSourceWithEntry("link", snapshotLstat(fs.ModeSymlink|0o777))
+				source.readlink = func(string) (string, error) { return "", expectedErr }
+				return context.Background(), source, &snapshotRootStub{}, expectedErr
+			},
+		},
+		{
+			name: "mkdir",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("mkdir failed")
+				source := snapshotSourceWithEntry("dir", snapshotLstat(fs.ModeDir|0o750))
+				target := &snapshotRootStub{mkdir: func(string, os.FileMode) error { return expectedErr }}
+				return context.Background(), source, target, expectedErr
+			},
+		},
+		{
+			name: "recursive read",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("recursive read failed")
+				source := snapshotSourceWithEntry("dir", snapshotLstat(fs.ModeDir|0o750))
+				source.directories["dir"] = snapshotReadDirResult{err: expectedErr}
+				return context.Background(), source, &snapshotRootStub{}, expectedErr
+			},
+		},
+		{
+			name: "chmod",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("chmod failed")
+				source := snapshotSourceWithEntry("dir", snapshotLstat(fs.ModeDir|0o750))
+				source.directories["dir"] = snapshotReadDirResult{}
+				target := &snapshotRootStub{chmod: func(string, os.FileMode) error { return expectedErr }}
+				return context.Background(), source, target, expectedErr
+			},
+		},
+		{
+			name: "source file open",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("source open failed")
+				source := snapshotSourceWithEntry("file", snapshotLstat(0o600))
+				source.open = func(string) (safeio.File, error) { return nil, expectedErr }
+				return context.Background(), source, &snapshotRootStub{}, expectedErr
+			},
+		},
+		{
+			name: "target file open",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("target open failed")
+				source := repositorySnapshotOpenSource(strings.NewReader("content"), nil)
+				target := &snapshotRootStub{openFile: func(string, int, os.FileMode) (safeio.File, error) { return nil, expectedErr }}
+				return context.Background(), source, target, expectedErr
+			},
+		},
+		{
+			name: "copy",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("copy failed")
+				source := repositorySnapshotOpenSource(&snapshotErrorReader{err: expectedErr}, nil)
+				target := &snapshotRootStub{openFile: func(string, int, os.FileMode) (safeio.File, error) { return &snapshotFileStub{}, nil }}
+				return context.Background(), source, target, expectedErr
+			},
+		},
+		{
+			name: "write",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("write failed")
+				return repositorySnapshotFileTransferErrorTest(expectedErr, &snapshotFileStub{writeErr: expectedErr})
+			},
+		},
+		{
+			name: "close",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("close failed")
+				source := repositorySnapshotOpenSource(strings.NewReader("content"), expectedErr)
+				target := &snapshotRootStub{openFile: func(string, int, os.FileMode) (safeio.File, error) { return &snapshotFileStub{}, nil }}
+				return context.Background(), source, target, expectedErr
+			},
+		},
+		{
+			name: "target close",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				expectedErr := errors.New("target close failed")
+				return repositorySnapshotFileTransferErrorTest(expectedErr, &snapshotFileStub{closeErr: expectedErr})
+			},
+		},
+		{
+			name: "copy cancellation",
+			build: func() (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+				ctx, cancel := context.WithCancel(context.Background())
+				source := snapshotSourceWithEntry("file", snapshotLstat(0o600))
+				source.open = func(string) (safeio.File, error) {
+					return &snapshotFileStub{reader: &snapshotCancelReader{cancel: cancel, data: []byte("content")}}, nil
+				}
+				target := &snapshotRootStub{openFile: func(string, int, os.FileMode) (safeio.File, error) { return &snapshotFileStub{}, nil }}
+				return ctx, source, target, context.Canceled
+			},
+		},
+	}
+}
+
+func repositorySnapshotOpenSource(reader io.Reader, closeErr error) *snapshotRootStub {
+	source := snapshotSourceWithEntry("file", snapshotLstat(0o600))
+	source.open = func(string) (safeio.File, error) {
+		return &snapshotFileStub{reader: reader, closeErr: closeErr}, nil
+	}
+	return source
+}
+
+func repositorySnapshotFileTransferErrorTest(expectedErr error, targetFile *snapshotFileStub) (context.Context, *snapshotRootStub, *snapshotRootStub, error) {
+	return context.Background(), repositorySnapshotOpenSource(strings.NewReader("content"), nil), repositorySnapshotTargetWithStubFile(targetFile), expectedErr
+}
+
+func repositorySnapshotTargetWithStubFile(file *snapshotFileStub) *snapshotRootStub {
+	return &snapshotRootStub{
+		openFile: func(string, int, os.FileMode) (safeio.File, error) {
+			return file, nil
+		},
+	}
+}
+
+func TestSnapshotRepositoryRootSkipsGitDirectory(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, ".git", "config"), "[core]\n")
+	writeFile(t, filepath.Join(repo, "tracked.txt"), "tracked\n")
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open repo root: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close repo root: %v", err)
+		}
+	})
+
+	snapshot, err := snapshotRepositoryRoot(context.Background(), root, "")
+	if err != nil {
+		t.Fatalf("snapshot repository root: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(snapshot.path); err != nil {
+			t.Errorf("remove snapshot: %v", err)
+		}
+	}()
+
+	if _, err := os.Stat(filepath.Join(snapshot.path, ".git")); !os.IsNotExist(err) {
+		t.Fatalf("expected .git omission, stat err=%v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(snapshot.path, "tracked.txt")); err != nil || string(data) != "tracked\n" {
+		t.Fatalf("expected tracked file in snapshot, data=%q err=%v", data, err)
+	}
+}
+
+func TestRepositorySnapshotDiagnosticsReportUnsafeJVMSymlinks(t *testing.T) {
+	diagnostics := repositorySnapshotDiagnostics{}
+	diagnostics.recordUnsafeSymlink(filepath.Join("src", "main", "java", "Outside.java"), repositorySnapshotUnsafeSymlinkEscapesRoot)
+	diagnostics.recordUnsafeSymlink("build.gradle", repositorySnapshotUnsafeSymlinkUntrusted)
+	diagnostics.recordUnsafeSymlink(filepath.Join("docs", "ignored.md"), repositorySnapshotUnsafeSymlinkUntrusted)
+
+	got := diagnostics.warnings()
+	want := []string{
+		"skipped JVM source symlink " + filepath.Join("src", "main", "java", "Outside.java") + ": target escapes repo root",
+		"unable to read build.gradle: " + safeio.ErrTargetPathSymlink.Error(),
+		"skipped 1 unreadable or untrusted JVM source symlink(s)",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected warning count: got %#v want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("warning[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func snapshotSourceWithEntry(name string, lstat func(string) (fs.FileInfo, error)) *snapshotRootStub {
+	return &snapshotRootStub{
+		directories: map[string]snapshotReadDirResult{
+			".": {entries: []fs.DirEntry{&snapshotDirEntry{name: name}}},
+		},
+		lstat: lstat,
+	}
+}
+
+func snapshotLstat(mode fs.FileMode) func(string) (fs.FileInfo, error) {
+	return func(name string) (fs.FileInfo, error) {
+		return &snapshotFileInfo{name: name, mode: mode}, nil
+	}
+}
+
+type snapshotReadDirResult struct {
+	entries []fs.DirEntry
+	err     error
+}
+
+type snapshotRootStub struct {
+	directories map[string]snapshotReadDirResult
+	open        func(string) (safeio.File, error)
+	openFile    func(string, int, os.FileMode) (safeio.File, error)
+	lstat       func(string) (fs.FileInfo, error)
+	readlink    func(string) (string, error)
+	symlink     func(string, string) error
+	mkdir       func(string, os.FileMode) error
+	chmod       func(string, os.FileMode) error
+}
+
+func (r *snapshotRootStub) Open(name string) (safeio.File, error) {
+	if result, ok := r.directories[name]; ok {
+		return &snapshotFileStub{
+			readDir: func(int) ([]fs.DirEntry, error) {
+				return result.entries, result.err
+			},
+		}, nil
+	}
+	if r.open != nil {
+		return r.open(name)
+	}
+	return nil, fs.ErrNotExist
+}
+
+func (r *snapshotRootStub) OpenFile(name string, flag int, perm os.FileMode) (safeio.File, error) {
+	if r.openFile != nil {
+		return r.openFile(name, flag, perm)
+	}
+	return &snapshotFileStub{}, nil
+}
+
+func (r *snapshotRootStub) OpenRoot(string) (safeio.Root, error) {
+	return r, nil
+}
+
+func (r *snapshotRootStub) Lstat(name string) (fs.FileInfo, error) {
+	if r.lstat != nil {
+		return r.lstat(name)
+	}
+	return &snapshotFileInfo{name: name, mode: fs.ModeDir | 0o750}, nil
+}
+
+func (r *snapshotRootStub) Readlink(name string) (string, error) {
+	if r.readlink != nil {
+		return r.readlink(name)
+	}
+	return "", fs.ErrInvalid
+}
+
+func (r *snapshotRootStub) Symlink(oldName, newName string) error {
+	if r.symlink != nil {
+		return r.symlink(oldName, newName)
+	}
+	return nil
+}
+
+func (r *snapshotRootStub) Mkdir(name string, perm os.FileMode) error {
+	if r.mkdir != nil {
+		return r.mkdir(name, perm)
+	}
+	return nil
+}
+
+func (r *snapshotRootStub) Chmod(name string, perm os.FileMode) error {
+	if r.chmod != nil {
+		return r.chmod(name, perm)
+	}
+	return nil
+}
+
+func (*snapshotRootStub) MkdirAll(string, os.FileMode) error {
+	return nil
+}
+
+func (*snapshotRootStub) Link(string, string) error {
+	return nil
+}
+
+func (*snapshotRootStub) Rename(string, string) error {
+	return nil
+}
+
+func (*snapshotRootStub) Remove(string) error {
+	return nil
+}
+
+func (*snapshotRootStub) Close() error {
+	return nil
+}
+
+type snapshotFileStub struct {
+	reader   io.Reader
+	readDir  func(int) ([]fs.DirEntry, error)
+	writeErr error
+	closeErr error
+}
+
+func (f *snapshotFileStub) Read(data []byte) (int, error) {
+	if f.reader == nil {
+		return 0, io.EOF
+	}
+	return f.reader.Read(data)
+}
+
+func (f *snapshotFileStub) Write(data []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return len(data), nil
+}
+
+func (f *snapshotFileStub) Close() error {
+	return f.closeErr
+}
+
+func (*snapshotFileStub) Stat() (fs.FileInfo, error) {
+	return &snapshotFileInfo{mode: 0o600}, nil
+}
+
+func (*snapshotFileStub) Chmod(os.FileMode) error {
+	return nil
+}
+
+func (f *snapshotFileStub) ReadDir(count int) ([]fs.DirEntry, error) {
+	if f.readDir == nil {
+		return nil, fs.ErrInvalid
+	}
+	return f.readDir(count)
+}
+
+type snapshotErrorReader struct {
+	err error
+}
+
+func (r *snapshotErrorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+type snapshotCancelReader struct {
+	cancel func()
+	data   []byte
+	read   bool
+}
+
+func (r *snapshotCancelReader) Read(buffer []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+	r.read = true
+	copy(buffer, r.data)
+	r.cancel()
+	return len(r.data), nil
+}
+
+type snapshotDirEntry struct {
+	name string
+}
+
+func (e *snapshotDirEntry) Name() string               { return e.name }
+func (*snapshotDirEntry) IsDir() bool                  { return false }
+func (*snapshotDirEntry) Type() fs.FileMode            { return 0 }
+func (e *snapshotDirEntry) Info() (fs.FileInfo, error) { return &snapshotFileInfo{name: e.name}, nil }
+
+type snapshotFileInfo struct {
+	name string
+	mode fs.FileMode
+	size int64
+}
+
+func (i *snapshotFileInfo) Name() string      { return i.name }
+func (i *snapshotFileInfo) Size() int64       { return i.size }
+func (i *snapshotFileInfo) Mode() fs.FileMode { return i.mode }
+func (*snapshotFileInfo) ModTime() time.Time  { return time.Time{} }
+func (i *snapshotFileInfo) IsDir() bool       { return i.mode.IsDir() }
+func (*snapshotFileInfo) Sys() any            { return nil }

--- a/internal/analysis/repository_test.go
+++ b/internal/analysis/repository_test.go
@@ -1,0 +1,574 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
+)
+
+func TestRepositoryViewRetainsRootAndProvidesRootedOperations(t *testing.T) {
+	repo, outside, customCache := setupRepositoryViewFixture(t)
+	view, snapshotPath := openRepositoryViewFixture(t, repo, customCache)
+	assertRepositoryViewPaths(t, view, repo, outside, snapshotPath)
+	assertRepositoryViewOperations(t, view, repo)
+	assertRepositorySnapshotContents(t, snapshotPath, customCache)
+	assertRepositoryViewClose(t, view, snapshotPath)
+}
+
+func TestRepositoryAuthorizationAndViewGuardBranches(t *testing.T) {
+	t.Run("nil view helpers", testRepositoryNilViewGuards)
+	t.Run("authorization mismatches", testRepositoryAuthorizationMismatches)
+	t.Run("open hook and repository validation", testRepositoryOpenHookAndPathValidation)
+}
+
+func setupRepositoryViewFixture(t *testing.T) (repo string, outside string, customCache string) {
+	t.Helper()
+	parent := t.TempDir()
+	repo = filepath.Join(parent, "repo")
+	if err := os.MkdirAll(filepath.Join(repo, "nested"), 0o750); err != nil {
+		t.Fatalf("mkdir repository: %v", err)
+	}
+	writeFile(t, filepath.Join(repo, "nested", "source.txt"), "repo-a\n")
+	writeFile(t, filepath.Join(repo, defaultAnalysisCacheDirName, "keys", "default.json"), "{}\n")
+	customCache = filepath.Join(".cache", "lopper")
+	writeFile(t, filepath.Join(repo, customCache, "objects", "custom.json"), "{}\n")
+	if err := os.Symlink(filepath.Join("nested", "source.txt"), filepath.Join(repo, "source-link")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	outside = t.TempDir()
+	writeFile(t, filepath.Join(outside, "outside.txt"), "outside\n")
+	if err := os.Symlink(filepath.Join(outside, "outside.txt"), filepath.Join(repo, "absolute-link")); err != nil {
+		t.Fatalf("create absolute symlink: %v", err)
+	}
+	if err := os.Symlink(filepath.Join("..", filepath.Base(outside), "outside.txt"), filepath.Join(repo, "upward-link")); err != nil {
+		t.Fatalf("create upward symlink: %v", err)
+	}
+	return repo, outside, customCache
+}
+
+func openRepositoryViewFixture(t *testing.T, repo, customCache string) (*RepositoryView, string) {
+	t.Helper()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	if got := TrustedRepositoryPath(repository); got != filepath.Clean(repo) {
+		t.Fatalf("unexpected requested repository path: %q", got)
+	}
+	cacheOptions, err := ResolveTrustedCacheOptionsForRepository(repository, &CacheOptions{Enabled: true, Path: customCache})
+	if err != nil {
+		t.Fatalf("resolve cache options: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, cacheOptions)
+	if err != nil {
+		t.Fatalf("open trusted repository: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+	return view, view.ExecutionPath()
+}
+
+func assertRepositoryViewPaths(t *testing.T, view *RepositoryView, repo, outside, snapshotPath string) {
+	t.Helper()
+	if snapshotPath == "" || snapshotPath == repo {
+		t.Fatalf("expected independent execution snapshot, got %q", snapshotPath)
+	}
+	wantSnapshotFile := filepath.Join(snapshotPath, "nested", "source.txt")
+	for _, tc := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "relative snapshot path", path: filepath.Join("nested", "source.txt"), want: wantSnapshotFile},
+		{name: "absolute snapshot path", path: filepath.Join(repo, "nested", "source.txt"), want: wantSnapshotFile},
+		{name: "external path preserved", path: filepath.Join(outside, "outside.txt"), want: filepath.Join(outside, "outside.txt")},
+		{name: "empty path preserved", path: "", want: ""},
+	} {
+		if got, err := view.SnapshotPath(tc.path); err != nil || got != tc.want {
+			t.Fatalf("%s: got %q err=%v want %q", tc.name, got, err, tc.want)
+		}
+	}
+	if _, err := view.SnapshotPath(filepath.Join("..", "outside.txt")); err == nil || !strings.Contains(err.Error(), "repository root") {
+		t.Fatalf("expected unsafe relative snapshot rejection, got %v", err)
+	}
+	for _, path := range []string{"nested/source.txt", filepath.Join(repo, "nested", "source.txt")} {
+		relativePath, ok := view.RepositoryRelativePath(path)
+		if !ok || relativePath != filepath.Join("nested", "source.txt") {
+			t.Fatalf("expected repository-relative path for %q, got %q ok=%t", path, relativePath, ok)
+		}
+	}
+	for _, path := range []string{"../outside", filepath.Join(outside, "outside.txt"), ""} {
+		if relativePath, ok := view.RepositoryRelativePath(path); ok {
+			t.Fatalf("expected %q to remain outside repository, got %q", path, relativePath)
+		}
+	}
+	if got := view.DisplayPath(filepath.Join("nested", "source.txt")); got != filepath.Join(repo, "nested", "source.txt") {
+		t.Fatalf("unexpected display path: %q", got)
+	}
+}
+
+func assertRepositoryViewOperations(t *testing.T, view *RepositoryView, repo string) {
+	t.Helper()
+	data, err := view.ReadFile(filepath.Join("nested", "source.txt"))
+	if err != nil || string(data) != "repo-a\n" {
+		t.Fatalf("read retained repository file: data=%q err=%v", data, err)
+	}
+	snapshotData, err := view.ReadExecutionFile(filepath.Join("nested", "source.txt"))
+	if err != nil || string(snapshotData) != "repo-a\n" {
+		t.Fatalf("read retained execution file: data=%q err=%v", snapshotData, err)
+	}
+	if _, err := view.ReadExecutionFile("../outside"); err == nil {
+		t.Fatal("expected execution snapshot traversal rejection")
+	}
+	if info, err := view.Lstat("nested"); err != nil || !info.IsDir() {
+		t.Fatalf("lstat retained repository directory: info=%#v err=%v", info, err)
+	}
+	if _, err := view.Lstat("../outside"); err == nil {
+		t.Fatal("expected repository traversal lstat rejection")
+	}
+	if err := view.EnsureDir(filepath.Join(".artifacts", "nested"), 0o750); err != nil {
+		t.Fatalf("create rooted repository directory: %v", err)
+	}
+	if err := view.WriteFile(filepath.Join(".artifacts", "nested", "result.txt"), []byte("bound\n"), 0o600); err != nil {
+		t.Fatalf("write rooted repository file: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(repo, ".artifacts", "nested", "result.txt")); err != nil || string(got) != "bound\n" {
+		t.Fatalf("inspect rooted repository write: data=%q err=%v", got, err)
+	}
+	writeRoot, err := view.OpenWriteRoot(".artifacts", false)
+	if err != nil {
+		t.Fatalf("open retained write root: %v", err)
+	}
+	if err := writeRoot.Close(); err != nil {
+		t.Fatalf("close retained write root: %v", err)
+	}
+}
+
+func assertRepositorySnapshotContents(t *testing.T, snapshotPath, customCache string) {
+	t.Helper()
+	if linkInfo, err := os.Lstat(filepath.Join(snapshotPath, "source-link")); err != nil || linkInfo.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected safe relative symlink in snapshot: info=%#v err=%v", linkInfo, err)
+	}
+	for _, omitted := range []string{"absolute-link", "upward-link", defaultAnalysisCacheDirName, customCache} {
+		if _, err := os.Lstat(filepath.Join(snapshotPath, omitted)); !os.IsNotExist(err) {
+			t.Fatalf("expected %q omitted from repository snapshot, stat err=%v", omitted, err)
+		}
+	}
+}
+
+func assertRepositoryViewClose(t *testing.T, view *RepositoryView, snapshotPath string) {
+	t.Helper()
+	if err := view.Close(); err != nil {
+		t.Fatalf("close repository view: %v", err)
+	}
+	if err := view.Close(); err != nil {
+		t.Fatalf("close repository view twice: %v", err)
+	}
+	if _, err := os.Stat(snapshotPath); !os.IsNotExist(err) {
+		t.Fatalf("expected execution snapshot cleanup, stat err=%v", err)
+	}
+}
+
+func testRepositoryNilViewGuards(t *testing.T) {
+	if TrustedRepositoryPath(nil) != "" {
+		t.Fatal("expected nil repository authorization to have no path")
+	}
+	var nilView *RepositoryView
+	if nilView.ExecutionPath() != "" || nilView.canonicalPath() != "" || nilView.DisplayPath(".") != "" {
+		t.Fatal("expected nil repository view path helpers to return empty paths")
+	}
+	if roots := nilView.repositoryRoots(); len(roots) != 0 {
+		t.Fatalf("expected nil repository roots, got %#v", roots)
+	}
+	if got, err := nilView.SnapshotPath("path"); err != nil || got != "path" {
+		t.Fatalf("expected nil snapshot mapping to preserve path, got %q err=%v", got, err)
+	}
+	if _, ok := nilView.RepositoryRelativePath("path"); ok {
+		t.Fatal("expected nil repository view not to authorize paths")
+	}
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{name: "write root", run: func() error { _, err := nilView.OpenWriteRoot(".", false); return err }},
+		{name: "read file", run: func() error { _, err := nilView.ReadFile("file"); return err }},
+		{name: "read execution file", run: func() error { _, err := nilView.ReadExecutionFile("file"); return err }},
+		{name: "lstat", run: func() error { _, err := nilView.Lstat("file"); return err }},
+		{name: "write file", run: func() error { return nilView.WriteFile("file", nil, 0o600) }},
+		{name: "ensure dir", run: func() error { return nilView.EnsureDir("dir", 0o750) }},
+	} {
+		if err := tc.run(); err == nil {
+			t.Fatalf("expected nil repository %s rejection", tc.name)
+		}
+	}
+	if err := nilView.Close(); err != nil {
+		t.Fatalf("close nil repository view: %v", err)
+	}
+	if isSafeRepositoryRelativePath(filepath.Join(string(os.PathSeparator), "absolute"), true) {
+		t.Fatal("expected absolute repository-relative path rejection")
+	}
+	if isSafeRepositoryRelativePath(".", false) {
+		t.Fatal("expected repository root rejection when root is disallowed")
+	}
+}
+
+func testRepositoryAuthorizationMismatches(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+	repositoryA, err := ResolveTrustedRepository(repoA)
+	if err != nil {
+		t.Fatalf("authorize repo A: %v", err)
+	}
+	repositoryB, err := ResolveTrustedRepository(repoB)
+	if err != nil {
+		t.Fatalf("authorize repo B: %v", err)
+	}
+	if err := useTrustedRepository(repoB, repositoryA); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected repository authorization mismatch, got %v", err)
+	}
+	if err := useTrustedRepository(repoA, nil); err == nil {
+		t.Fatal("expected missing repository authorization rejection")
+	}
+	if _, err := OpenTrustedRepository(context.Background(), repositoryA, repoB, nil); err == nil {
+		t.Fatal("expected mismatched repository path rejection")
+	}
+	cacheB, err := ResolveTrustedDefaultCacheOptionsForRepository(repositoryB, false)
+	if err != nil {
+		t.Fatalf("resolve repo B cache options: %v", err)
+	}
+	if _, err := OpenTrustedRepository(context.Background(), repositoryA, repoA, cacheB); err == nil || !strings.Contains(err.Error(), "cache pin does not match") {
+		t.Fatalf("expected cache authorization mismatch, got %v", err)
+	}
+}
+
+func testRepositoryOpenHookAndPathValidation(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	expectedHookErr := errors.New("stop after retained handle")
+	previousHook := repositoryViewHandleOpenedFn
+	repositoryViewHandleOpenedFn = func() error { return expectedHookErr }
+	t.Cleanup(func() {
+		repositoryViewHandleOpenedFn = previousHook
+	})
+	if _, err := OpenTrustedRepository(context.Background(), repository, repo, nil); !errors.Is(err, expectedHookErr) {
+		t.Fatalf("expected retained-handle hook error, got %v", err)
+	}
+	repositoryViewHandleOpenedFn = previousHook
+
+	filePath := filepath.Join(t.TempDir(), "repo-file")
+	writeFile(t, filePath, "not a directory\n")
+	if _, err := ResolveTrustedRepository(filePath); err == nil {
+		t.Fatal("expected file repository rejection")
+	}
+	if _, err := ResolveTrustedRepository(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("expected missing repository rejection")
+	}
+}
+
+func TestRepositoryAuthorizationRejectsCopiedOrReassignedWrappers(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+	authorizationA, err := ResolveTrustedRepository(repoA)
+	if err != nil {
+		t.Fatalf("authorize repo A: %v", err)
+	}
+	authorizationB, err := ResolveTrustedRepository(repoB)
+	if err != nil {
+		t.Fatalf("authorize repo B: %v", err)
+	}
+	copiedValue := *authorizationA
+	copiedAuthorization := &copiedValue
+	if err := useTrustedRepository(repoA, copiedAuthorization); err == nil {
+		t.Fatal("expected copied authorization wrapper rejection")
+	}
+
+	*authorizationA, *authorizationB = *authorizationB, *authorizationA
+	if err := useTrustedRepository(repoA, authorizationA); err == nil {
+		t.Fatal("expected reassigned authorization wrapper rejection")
+	}
+}
+
+func TestRepositoryAuthorizationMatchesFilesystemEquivalentAliasOnCaseInsensitiveSystems(t *testing.T) {
+	repoParent := t.TempDir()
+	repoBase := "Repo"
+	repoPath := filepath.Join(repoParent, repoBase)
+	if err := os.Mkdir(repoPath, 0o750); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	aliasPath := filepath.Join(repoParent, strings.ToLower(repoBase))
+	if aliasPath == repoPath {
+		t.Skip("filesystem preserves identical casing only")
+	}
+	aliasInfo, err := os.Stat(aliasPath)
+	if err != nil {
+		t.Skipf("alternate-case alias unavailable: %v", err)
+	}
+	repoInfo, err := os.Stat(repoPath)
+	if err != nil {
+		t.Fatalf("stat canonical repo: %v", err)
+	}
+	if !os.SameFile(repoInfo, aliasInfo) {
+		t.Skip("filesystem is case-sensitive")
+	}
+
+	authorization, err := ResolveTrustedRepository(repoPath)
+	if err != nil {
+		t.Fatalf("authorize repo: %v", err)
+	}
+	if err := useTrustedRepository(aliasPath, authorization); err != nil {
+		t.Fatalf("expected alternate-case alias acceptance, got %v", err)
+	}
+}
+
+func TestResolveAuthorizedRepositoryReusesProvidedOrCacheBoundIdentity(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	authorizationA, err := ResolveTrustedRepository(repoA)
+	if err != nil {
+		t.Fatalf("authorize repo A: %v", err)
+	}
+	if got, err := ResolveAuthorizedRepository(repoA, authorizationA, nil); err != nil || got != authorizationA {
+		t.Fatalf("expected provided authorization reuse, got auth=%#v err=%v", got, err)
+	}
+	if _, err := ResolveAuthorizedRepository(repoB, authorizationA, nil); err == nil {
+		t.Fatal("expected provided authorization mismatch rejection")
+	}
+
+	cacheA, err := ResolveTrustedDefaultCacheOptionsForRepository(authorizationA, false)
+	if err != nil {
+		t.Fatalf("resolve repo A cache options: %v", err)
+	}
+	cacheBound, err := ResolveAuthorizedRepository(repoA, nil, cacheA)
+	if err != nil {
+		t.Fatalf("resolve cache-bound authorization: %v", err)
+	}
+	if cacheBound == nil || cacheBound.authorizationState() != authorizationA.authorizationState() {
+		t.Fatalf("expected cache-bound authorization to reuse repo A identity, got %#v", cacheBound)
+	}
+	if _, err := ResolveAuthorizedRepository(repoB, nil, cacheA); err == nil {
+		t.Fatal("expected cache-bound authorization mismatch rejection")
+	}
+	if fresh, err := ResolveAuthorizedRepository(repoA, nil, nil); err != nil || fresh == nil {
+		t.Fatalf("expected fresh authorization when no prior identity exists, auth=%#v err=%v", fresh, err)
+	}
+}
+
+func TestSetRepositoryViewHandleOpenedHookForTestRestoresPreviousHook(t *testing.T) {
+	restore := SetRepositoryViewHandleOpenedHookForTest(func() error {
+		return errors.New("hooked")
+	})
+	restore()
+	repository, err := ResolveTrustedRepository(t.TempDir())
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	if view, err := OpenTrustedRepository(context.Background(), repository, TrustedRepositoryPath(repository), nil); err != nil {
+		t.Fatalf("open trusted repository after restore: %v", err)
+	} else if err := view.Close(); err != nil {
+		t.Fatalf("close trusted repository after restore: %v", err)
+	}
+
+	restore = SetRepositoryViewHandleOpenedHookForTest(nil)
+	if view, err := OpenTrustedRepository(context.Background(), repository, TrustedRepositoryPath(repository), nil); err != nil {
+		t.Fatalf("open trusted repository with nil hook replacement: %v", err)
+	} else if err := view.Close(); err != nil {
+		t.Fatalf("close trusted repository with nil hook replacement: %v", err)
+	}
+	restore()
+}
+
+func TestRepositoryAuthorizationHelperRejectsNilState(t *testing.T) {
+	if newRepositoryAuthorization(nil) != nil {
+		t.Fatal("expected nil repository state to produce no authorization wrapper")
+	}
+
+	malformed := &RepositoryAuthorization{}
+	if TrustedRepositoryPath(malformed) != "" {
+		t.Fatalf("expected malformed repository authorization to expose no trusted path")
+	}
+	if malformed.matchesPath(t.TempDir()) {
+		t.Fatalf("expected malformed repository authorization not to match paths")
+	}
+	if err := useTrustedRepository(t.TempDir(), malformed); err == nil {
+		t.Fatalf("expected malformed repository authorization rejection")
+	}
+	validRepo := t.TempDir()
+	validAuthorization := newRepositoryAuthorization(&repositoryAuthState{
+		paths: trustedRepoPaths{
+			requestedPath: validRepo,
+			canonicalPath: validRepo,
+			canonicalInfo: mustRepositoryDirInfo(t, validRepo),
+		},
+		nonce: 1,
+	})
+	if err := useTrustedRepository(string([]byte{0}), validAuthorization); err == nil {
+		t.Fatalf("expected invalid repository path normalization failure")
+	}
+	filePath := filepath.Join(t.TempDir(), "repo-file")
+	writeFile(t, filePath, "not a directory\n")
+	if malformed := newRepositoryAuthorization(&repositoryAuthState{
+		paths: trustedRepoPaths{
+			requestedPath: filepath.Dir(filePath),
+			canonicalPath: filepath.Dir(filePath),
+			canonicalInfo: mustRepositoryDirInfo(t, filepath.Dir(filePath)),
+		},
+	}); malformed.matchesPath(filePath) {
+		t.Fatalf("expected repository authorization not to match non-directory file path")
+	}
+}
+
+func TestRepositoryOpenHelpersFailClosed(t *testing.T) {
+	expectedErr := errors.New("inspect failed")
+	failingRoot := &snapshotRootStub{
+		lstat: func(string) (os.FileInfo, error) {
+			return nil, expectedErr
+		},
+	}
+	if _, err := inspectTrustedRepositoryRoot(failingRoot, &repositoryAuthState{}); !errors.Is(err, expectedErr) {
+		t.Fatalf("expected retained-root inspection error, got %v", err)
+	}
+
+	repo := t.TempDir()
+	root, err := safeio.OpenRoot(repo)
+	if err != nil {
+		t.Fatalf("open snapshot source root: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close snapshot source root: %v", err)
+		}
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	executionPath, executionRoot, warnings, err := openRepositoryExecutionSnapshot(ctx, root, nil)
+	if err == nil || executionPath != "" || executionRoot != nil || len(warnings) != 0 {
+		t.Fatalf("expected cancelled execution snapshot open, path=%q root=%#v warnings=%#v err=%v", executionPath, executionRoot, warnings, err)
+	}
+
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	state := repository.authorizationState()
+	openedInfo := state.paths.canonicalInfo
+	if err := os.RemoveAll(repo); err != nil {
+		t.Fatalf("remove repository before verification: %v", err)
+	}
+	if err := verifyRepositoryAfterSnapshot(context.Background(), state, openedInfo, false, RepositoryGitMetadata{}); err == nil {
+		t.Fatal("expected missing repository verification failure")
+	}
+}
+
+func TestRepositoryViewMapsExecutionPathsToAuthorizedDisplayIdentity(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "nested", "config.yml"), "thresholds: {}\n")
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("resolve trusted repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close trusted repository: %v", err)
+		}
+	})
+	if err := ValidateRepositoryView(repository, view); err != nil {
+		t.Fatalf("validate matching repository view: %v", err)
+	}
+	otherRepository, err := ResolveTrustedRepository(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve other trusted repository: %v", err)
+	}
+	if err := ValidateRepositoryView(otherRepository, view); err == nil {
+		t.Fatal("expected mismatched repository view rejection")
+	}
+	if err := ValidateRepositoryView(repository, nil); err == nil {
+		t.Fatal("expected nil repository view rejection")
+	}
+	if got := view.canonicalPath(); got == "" {
+		t.Fatal("expected retained view canonical path")
+	}
+
+	snapshotPath := filepath.Join(view.ExecutionPath(), "nested", "config.yml")
+	relativePath, ok := view.RepositoryRelativePath(snapshotPath)
+	if !ok || relativePath != filepath.Join("nested", "config.yml") {
+		t.Fatalf("execution path did not map to repository relative identity: %q, %t", relativePath, ok)
+	}
+	if got := view.StablePath(snapshotPath); got != filepath.Join(repo, "nested", "config.yml") {
+		t.Fatalf("stable execution path = %q", got)
+	}
+	if got, err := view.SnapshotPath(snapshotPath); err != nil || got != snapshotPath {
+		t.Fatalf("snapshot path remap = %q err=%v, want %q", got, err, snapshotPath)
+	}
+}
+
+func TestRepositoryViewCloseHookRunsOnceAndPropagatesError(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("resolve trusted repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository: %v", err)
+	}
+	closeErr := errors.New("repository view close sentinel")
+	closeCalls := 0
+	restore := SetRepositoryViewCloseHookForTest(func() error {
+		closeCalls++
+		return closeErr
+	})
+	t.Cleanup(restore)
+
+	if err := view.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("first close error = %v", err)
+	}
+	if err := view.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("second close error = %v", err)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("close hook calls = %d, want 1", closeCalls)
+	}
+}
+
+func TestRepositoryViewCloseHookAcceptsNilReplacement(t *testing.T) {
+	restore := SetRepositoryViewCloseHookForTest(nil)
+	t.Cleanup(restore)
+
+	repo := t.TempDir()
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("resolve trusted repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository: %v", err)
+	}
+	if err := view.Close(); err != nil {
+		t.Fatalf("close repository view with nil hook replacement: %v", err)
+	}
+}
+
+func mustRepositoryDirInfo(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("stat repository directory %s: %v", path, err)
+	}
+	return info
+}

--- a/internal/analysis/request.go
+++ b/internal/analysis/request.go
@@ -12,9 +12,10 @@ const (
 )
 
 type CacheOptions struct {
-	Enabled  bool
-	Path     string
-	ReadOnly bool
+	Enabled    bool
+	Path       string
+	ReadOnly   bool
+	PinnedPath string
 }
 
 type Request struct {

--- a/internal/analysis/request.go
+++ b/internal/analysis/request.go
@@ -12,14 +12,38 @@ const (
 )
 
 type CacheOptions struct {
-	Enabled    bool
-	Path       string
-	ReadOnly   bool
-	PinnedPath string
+	Enabled  bool
+	Path     string
+	ReadOnly bool
+
+	trustedPin *trustedCachePin
 }
+
+type repositoryAuthState struct {
+	paths trustedRepoPaths
+	nonce uint64
+}
+
+// trustedCachePin is created only at the repository validation boundary.
+// Downstream code consumes these immutable identities without resolving again.
+type trustedCachePin struct {
+	kind             trustedCachePathKind
+	repositoryState  *repositoryAuthState
+	canonicalPath    string
+	repoRelativePath string
+}
+
+type trustedCachePathKind uint8
+
+const (
+	trustedCachePathInRepo trustedCachePathKind = iota + 1
+	trustedCachePathExternal
+)
 
 type Request struct {
 	RepoPath                          string
+	Repository                        *RepositoryAuthorization
+	RepositoryView                    *RepositoryView
 	ChangedFiles                      []string
 	ChangedFilesExplicit              bool
 	Dependency                        string
@@ -28,8 +52,10 @@ type Request struct {
 	SuggestOnly                       bool
 	Language                          string
 	ConfigPath                        string
+	ConfigCachePath                   string
 	RuntimeProfile                    string
 	RuntimeTracePath                  string
+	RuntimeTraceCachePath             string
 	RuntimeTracePathExplicit          bool
 	PythonRuntimeTraceCaptured        bool
 	RuntimeTestCommand                string

--- a/internal/analysis/runtime_capture_test.go
+++ b/internal/analysis/runtime_capture_test.go
@@ -168,6 +168,36 @@ func TestCaptureRuntimeTraceIfNeededWarningAndReuseBranches(t *testing.T) {
 	}
 }
 
+func TestCaptureRuntimeTraceIfNeededSuccessUsesDefaultTracePath(t *testing.T) {
+	repo := t.TempDir()
+	counterPath := filepath.Join(repo, "runtime-counter.txt")
+	cache := &analysisCache{metadata: report.CacheMetadata{Enabled: true, Hits: 1}}
+	req := Request{
+		RuntimeTestCommand: "npm test",
+		Features:           mustResolvePythonRuntimeCaptureFeatureSet(t, true),
+	}
+
+	t.Setenv("LOPPER_RUNTIME_COUNTER", counterPath)
+	t.Setenv("LOPPER_RUNTIME_BIN_DIRS", setupFakeAnalysisRuntimeTool(t))
+
+	warnings, tracePath, captured := captureRuntimeTraceIfNeeded(context.Background(), req, repo, cache, nil)
+	if len(warnings) != 0 {
+		t.Fatalf("expected successful runtime capture without warnings, got %#v", warnings)
+	}
+	if tracePath != runtime.DefaultTracePath(repo) {
+		t.Fatalf("expected default runtime trace path, got %q", tracePath)
+	}
+	if captured {
+		t.Fatal("expected node capture provider to report captured=false")
+	}
+	if got := readRuntimeCounter(t, counterPath); got != 1 {
+		t.Fatalf("expected runtime capture invocation count 1, got %d", got)
+	}
+	if _, err := os.Stat(tracePath); err != nil {
+		t.Fatalf("expected runtime trace output to be written: %v", err)
+	}
+}
+
 func TestCaptureProviderForPythonRuntimeRequests(t *testing.T) {
 	features := mustResolvePythonRuntimeCaptureFeatureSet(t, true)
 	runnerProfilesDisabled := mustResolvePythonRuntimeCaptureWithRunnerProfilesDisabled(t)

--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -12,9 +12,7 @@ const maxScopeDiagnostics = 5
 
 var scopeWorkspaceCreatedFn = func(string) {}
 
-func noOpCleanup() {
-	// Intentionally empty: when no scope patterns are configured, there is no temporary workspace to clean up.
-}
+func noOpCleanup() { /* Intentionally empty: no scoped workspace was created. */ }
 
 type scopeStats struct {
 	includeMatches     map[string]int
@@ -110,7 +108,7 @@ func (w *scopeWalker) walk(currentPath string, entry fs.DirEntry, walkErr error)
 		return walkErr
 	}
 	if entry.IsDir() {
-		if entry.Name() == ".git" {
+		if shouldSkipScopeDir(w.repoPath, currentPath, entry.Name()) {
 			return filepath.SkipDir
 		}
 		return nil
@@ -161,4 +159,11 @@ func recordScopeSkipReason(stats *scopeStats, slashed string, reason string) {
 		return
 	}
 	stats.skippedDiagnostics = append(stats.skippedDiagnostics, slashed+" ("+reason+")")
+}
+
+func shouldSkipScopeDir(repoPath, currentPath, name string) bool {
+	if name == ".git" {
+		return true
+	}
+	return filepath.Clean(currentPath) == filepath.Join(filepath.Clean(repoPath), defaultAnalysisCacheDirName)
 }

--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 const maxScopeDiagnostics = 5
@@ -37,6 +38,7 @@ func newScopeStats(includePatterns, excludePatterns []string) *scopeStats {
 type scopeWalker struct {
 	repoPath        string
 	scopedRoot      string
+	skipDir         string
 	includePatterns []string
 	excludePatterns []string
 	includeCompiled []compiledPattern
@@ -49,7 +51,7 @@ type compiledPattern struct {
 	regex   *regexp.Regexp
 }
 
-func applyPathScope(repoPath string, includePatterns []string, excludePatterns []string) (string, []string, func(), error) {
+func applyPathScope(repoPath string, includePatterns []string, excludePatterns []string, skipDir string) (string, []string, func(), error) {
 	includePatterns = normalizePatterns(includePatterns)
 	excludePatterns = normalizePatterns(excludePatterns)
 	if len(includePatterns) == 0 && len(excludePatterns) == 0 {
@@ -79,6 +81,7 @@ func applyPathScope(repoPath string, includePatterns []string, excludePatterns [
 	walker := &scopeWalker{
 		repoPath:        repoPath,
 		scopedRoot:      scopedRoot,
+		skipDir:         strings.TrimSpace(skipDir),
 		includePatterns: includePatterns,
 		excludePatterns: excludePatterns,
 		includeCompiled: includeCompiled,
@@ -112,7 +115,7 @@ func (w *scopeWalker) walk(currentPath string, entry fs.DirEntry, walkErr error)
 		return walkErr
 	}
 	if entry.IsDir() {
-		if shouldSkipScopeDir(w.repoPath, currentPath, entry.Name()) {
+		if shouldSkipScopeDir(w.repoPath, currentPath, entry.Name(), w.skipDir) {
 			return filepath.SkipDir
 		}
 		return nil
@@ -165,9 +168,17 @@ func recordScopeSkipReason(stats *scopeStats, slashed string, reason string) {
 	stats.skippedDiagnostics = append(stats.skippedDiagnostics, slashed+" ("+reason+")")
 }
 
-func shouldSkipScopeDir(repoPath, currentPath, name string) bool {
+func shouldSkipScopeDir(repoPath, currentPath, name, skipDir string) bool {
 	if name == ".git" {
 		return true
 	}
-	return filepath.Clean(currentPath) == filepath.Join(filepath.Clean(repoPath), defaultAnalysisCacheDirName)
+	repoRoot := filepath.Clean(repoPath)
+	cleanCurrentPath := filepath.Clean(currentPath)
+	if cleanCurrentPath == filepath.Join(repoRoot, defaultAnalysisCacheDirName) {
+		return true
+	}
+	if strings.TrimSpace(skipDir) == "" {
+		return false
+	}
+	return cleanCurrentPath == filepath.Join(repoRoot, filepath.Clean(skipDir))
 }

--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -10,9 +10,13 @@ import (
 
 const maxScopeDiagnostics = 5
 
-var scopeWorkspaceCreatedFn = func(string) {}
+var scopeWorkspaceCreatedFn = func(path string) {
+	_ = path // Default hook is intentionally inert outside tests.
+}
 
-func noOpCleanup() { /* Intentionally empty: no scoped workspace was created. */ }
+func noOpCleanup() {
+	// Intentionally empty: no scoped workspace was created.
+}
 
 type scopeStats struct {
 	includeMatches     map[string]int

--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -10,6 +10,8 @@ import (
 
 const maxScopeDiagnostics = 5
 
+var scopeWorkspaceCreatedFn = func(string) {}
+
 func noOpCleanup() {
 	// Intentionally empty: when no scope patterns are configured, there is no temporary workspace to clean up.
 }
@@ -64,6 +66,7 @@ func applyPathScope(repoPath string, includePatterns []string, excludePatterns [
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("create analysis scope workspace: %w", err)
 	}
+	scopeWorkspaceCreatedFn(scopedRoot)
 	cleanup := func() {
 		if err := os.RemoveAll(scopedRoot); err != nil {
 			fmt.Fprintf(os.Stderr, "cleanup scoped workspace %s: %v\n", scopedRoot, err)

--- a/internal/analysis/scope_copy_errors_test.go
+++ b/internal/analysis/scope_copy_errors_test.go
@@ -32,6 +32,14 @@ func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 		t.Fatalf("expected copyFile to fail when source path is a directory")
 	}
 
+	repoRootFile := filepath.Join(t.TempDir(), "repo-root-file")
+	if err := os.WriteFile(repoRootFile, []byte("file"), 0o600); err != nil {
+		t.Fatalf("write repo-root file: %v", err)
+	}
+	if err := copyFile(repoRootFile, scopedRoot, filepath.Join("src", scopeKeepJS)); err == nil || !strings.Contains(err.Error(), "open source root") {
+		t.Fatalf("expected copyFile source-root open error, got %v", err)
+	}
+
 	var err error
 	joinCloseError(&err, func() error { return errors.New("close failed") })
 	if err == nil || !strings.Contains(err.Error(), "close failed") {

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -18,7 +18,7 @@ func TestApplyPathScopeFiltersFilesAndReportsDiagnostics(t *testing.T) {
 	writeScopeFile(t, filepath.Join(repo, "src", "skip.test.js"), "export const skip = true\n")
 	writeScopeFile(t, filepath.Join(repo, "README.md"), "doc\n")
 
-	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, []string{"**/*.test.js"})
+	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, []string{"**/*.test.js"}, "")
 	if err != nil {
 		t.Fatalf("apply path scope: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestGlobMatchSupportsDoubleStar(t *testing.T) {
 
 func TestApplyPathScopeNoPatternsReturnsOriginalPath(t *testing.T) {
 	repo := t.TempDir()
-	scopedPath, warnings, cleanup, err := applyPathScope(repo, nil, nil)
+	scopedPath, warnings, cleanup, err := applyPathScope(repo, nil, nil, "")
 	if err != nil {
 		t.Fatalf("apply path scope without patterns: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestApplyPathScopeSkipsSymlinkedFiles(t *testing.T) {
 		t.Skipf("symlink unsupported in test environment: %v", err)
 	}
 
-	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil)
+	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil, "")
 	if err != nil {
 		t.Fatalf("apply path scope: %v", err)
 	}
@@ -133,42 +133,13 @@ func TestApplyPathScopeSkipsPinnedCacheDirAndToleratesConcurrentCacheWrites(t *t
 	repo := t.TempDir()
 	writeScopeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
 	writeScopeFile(t, filepath.Join(repo, defaultAnalysisCacheDirName, "objects", "seed.json"), "{\"cached\":true}\n")
-
-	stopWrites := make(chan struct{})
-	writeErrs := make(chan error, 1)
-	var writer sync.WaitGroup
-	writer.Add(1)
-	go func() {
-		defer writer.Done()
-		for i := 0; i < 64; i++ {
-			select {
-			case <-stopWrites:
-				return
-			default:
-			}
-			path := filepath.Join(repo, defaultAnalysisCacheDirName, "objects", "concurrent", strings.Repeat("x", i%4+1)+".json")
-			if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-				select {
-				case writeErrs <- err:
-				default:
-				}
-				return
-			}
-			if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
-				select {
-				case writeErrs <- err:
-				default:
-				}
-				return
-			}
-		}
-	}()
+	stopWrites, writeErrs, waitWrites := startConcurrentScopeCacheWrites(repo)
 	defer func() {
 		close(stopWrites)
-		writer.Wait()
+		waitWrites()
 	}()
 
-	scopedPath, _, cleanup, err := applyPathScope(repo, []string{"**"}, nil)
+	scopedPath, _, cleanup, err := applyPathScope(repo, []string{"**"}, nil, "")
 	if err != nil {
 		t.Fatalf("apply path scope with pinned cache dir present: %v", err)
 	}
@@ -184,6 +155,60 @@ func TestApplyPathScopeSkipsPinnedCacheDirAndToleratesConcurrentCacheWrites(t *t
 	case err := <-writeErrs:
 		t.Fatalf("concurrent cache write failed: %v", err)
 	default:
+	}
+}
+
+func startConcurrentScopeCacheWrites(repo string) (chan struct{}, chan error, func()) {
+	stopWrites := make(chan struct{})
+	writeErrs := make(chan error, 1)
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		for i := 0; i < 64; i++ {
+			select {
+			case <-stopWrites:
+				return
+			default:
+			}
+			path := filepath.Join(repo, defaultAnalysisCacheDirName, "objects", "concurrent", strings.Repeat("x", i%4+1)+".json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+				reportScopeWriteError(writeErrs, err)
+				return
+			}
+			if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+				reportScopeWriteError(writeErrs, err)
+				return
+			}
+		}
+	}()
+	return stopWrites, writeErrs, writer.Wait
+}
+
+func reportScopeWriteError(writeErrs chan error, err error) {
+	select {
+	case writeErrs <- err:
+	default:
+	}
+}
+
+func TestApplyPathScopeSkipsConfiguredPinnedCacheDir(t *testing.T) {
+	repo := t.TempDir()
+	cacheRoot := filepath.Join(".cache", "lopper")
+	writeScopeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
+	writeScopeFile(t, filepath.Join(repo, cacheRoot, "objects", "seed.json"), "{\"cached\":true}\n")
+
+	scopedPath, _, cleanup, err := applyPathScope(repo, []string{"**"}, nil, cacheRoot)
+	if err != nil {
+		t.Fatalf("apply path scope with configured cache dir present: %v", err)
+	}
+	defer cleanup()
+
+	if _, err := os.Stat(filepath.Join(scopedPath, scopeKeepJSPath)); err != nil {
+		t.Fatalf("expected in-scope file copied into scoped workspace: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(scopedPath, cacheRoot)); !os.IsNotExist(err) {
+		t.Fatalf("expected configured pinned cache dir to be excluded from scoped workspace, got err=%v", err)
 	}
 }
 
@@ -269,4 +294,8 @@ func writeScopeFile(t *testing.T, path string, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func TestNoOpCleanupReturnsSafely(t *testing.T) {
+	noOpCleanup()
 }

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -125,6 +126,64 @@ func TestApplyPathScopeSkipsSymlinkedFiles(t *testing.T) {
 	}
 	if !containsWarning(warnings, "analysis scope skipped file: src/linked.js (is symlink (not copied))") {
 		t.Fatalf("expected symlink skip diagnostic, got %#v", warnings)
+	}
+}
+
+func TestApplyPathScopeSkipsPinnedCacheDirAndToleratesConcurrentCacheWrites(t *testing.T) {
+	repo := t.TempDir()
+	writeScopeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
+	writeScopeFile(t, filepath.Join(repo, defaultAnalysisCacheDirName, "objects", "seed.json"), "{\"cached\":true}\n")
+
+	stopWrites := make(chan struct{})
+	writeErrs := make(chan error, 1)
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		for i := 0; i < 64; i++ {
+			select {
+			case <-stopWrites:
+				return
+			default:
+			}
+			path := filepath.Join(repo, defaultAnalysisCacheDirName, "objects", "concurrent", strings.Repeat("x", i%4+1)+".json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+				select {
+				case writeErrs <- err:
+				default:
+				}
+				return
+			}
+			if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+				select {
+				case writeErrs <- err:
+				default:
+				}
+				return
+			}
+		}
+	}()
+	defer func() {
+		close(stopWrites)
+		writer.Wait()
+	}()
+
+	scopedPath, _, cleanup, err := applyPathScope(repo, []string{"**"}, nil)
+	if err != nil {
+		t.Fatalf("apply path scope with pinned cache dir present: %v", err)
+	}
+	defer cleanup()
+
+	if _, err := os.Stat(filepath.Join(scopedPath, scopeKeepJSPath)); err != nil {
+		t.Fatalf("expected in-scope file copied into scoped workspace: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(scopedPath, defaultAnalysisCacheDirName)); !os.IsNotExist(err) {
+		t.Fatalf("expected pinned cache dir to be excluded from scoped workspace, got err=%v", err)
+	}
+	select {
+	case err := <-writeErrs:
+		t.Fatalf("concurrent cache write failed: %v", err)
+	default:
 	}
 }
 

--- a/internal/analysis/scope_workspace_guards_test.go
+++ b/internal/analysis/scope_workspace_guards_test.go
@@ -17,7 +17,7 @@ func TestScopeNoOpCleanupIsCallable(t *testing.T) {
 }
 
 func TestScopeApplyPathScopeReturnsWalkErrorForMissingRepo(t *testing.T) {
-	_, _, _, err := applyPathScope(filepath.Join(t.TempDir(), "missing"), []string{scopeJSGlob}, nil)
+	_, _, _, err := applyPathScope(filepath.Join(t.TempDir(), "missing"), []string{scopeJSGlob}, nil, "")
 	if err == nil {
 		t.Fatalf("expected missing repo to fail applyPathScope")
 	}
@@ -68,10 +68,10 @@ func TestScopePatternCompileAndTempWorkspaceFailures(t *testing.T) {
 	if _, err := compileGlobPatterns([]string{invalidPattern}); err == nil {
 		t.Fatalf("expected invalid utf-8 pattern to fail compilation")
 	}
-	if _, _, _, err := applyPathScope(t.TempDir(), []string{invalidPattern}, nil); err == nil {
+	if _, _, _, err := applyPathScope(t.TempDir(), []string{invalidPattern}, nil, ""); err == nil {
 		t.Fatalf("expected include pattern compile error")
 	}
-	if _, _, _, err := applyPathScope(t.TempDir(), nil, []string{invalidPattern}); err == nil {
+	if _, _, _, err := applyPathScope(t.TempDir(), nil, []string{invalidPattern}, ""); err == nil {
 		t.Fatalf("expected exclude pattern compile error")
 	}
 
@@ -81,7 +81,7 @@ func TestScopePatternCompileAndTempWorkspaceFailures(t *testing.T) {
 		t.Fatalf("write tmp file: %v", err)
 	}
 	t.Setenv("TMPDIR", tmpFile)
-	if _, _, _, err := applyPathScope(t.TempDir(), []string{scopeJSGlob}, nil); err == nil {
+	if _, _, _, err := applyPathScope(t.TempDir(), []string{scopeJSGlob}, nil, ""); err == nil {
 		t.Fatalf("expected temp workspace creation to fail")
 	}
 }

--- a/internal/analysis/service.go
+++ b/internal/analysis/service.go
@@ -18,12 +18,14 @@ type Service struct {
 	InitErr  error
 }
 
-func (s *Service) Analyse(ctx context.Context, req Request) (report.Report, error) {
+func (s *Service) Analyse(ctx context.Context, req Request) (_ report.Report, returnErr error) {
 	pipeline, err := s.newAnalysisPipeline(ctx, req)
 	if err != nil {
 		return report.Report{}, err
 	}
-	defer pipeline.cleanup()
+	defer func() {
+		returnErr = errors.Join(returnErr, pipeline.cleanup())
+	}()
 
 	if err := pipeline.execute(ctx); err != nil {
 		return report.Report{}, err

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -693,6 +693,178 @@ func TestServiceAnalyseMissingRuntimeTraceFallsBack(t *testing.T) {
 	}
 }
 
+func TestServiceAnalyseAllowsAbsoluteCachePathOutsideRepo(t *testing.T) {
+	repo := t.TempDir()
+	writeJSFixture(t, repo)
+	outsideCache := filepath.Join(t.TempDir(), "lopper-cache")
+
+	reportData, err := NewService().Analyse(context.Background(), Request{
+		RepoPath:   repo,
+		Dependency: "lodash",
+		Language:   "js-ts",
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    outsideCache,
+		},
+	})
+	if err != nil {
+		t.Fatalf("analyse with absolute cache path outside repo: %v", err)
+	}
+	if len(reportData.Dependencies) != 1 {
+		t.Fatalf("expected one dependency report, got %#v", reportData.Dependencies)
+	}
+	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
+		if _, err := os.Stat(filepath.Join(outsideCache, dir)); err != nil {
+			t.Fatalf("expected %s dir in external cache root: %v", dir, err)
+		}
+	}
+}
+
+func TestServiceAnalyseScopedPinnedDefaultCacheWritesStayUnderRepoRoot(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
+	writeFile(t, filepath.Join(repo, "src", indexJSFileName), lodashMapUsageJS)
+	writeFile(t, filepath.Join(repo, "node_modules", "lodash", packageJSONFileName), nodeMainPackageJSON)
+	writeFile(t, filepath.Join(repo, "node_modules", "lodash", indexJSFileName), mapExportJSContent)
+
+	pinnedCachePath, err := ResolveTrustedDefaultCachePath(repo)
+	if err != nil {
+		t.Fatalf("resolve trusted default cache path: %v", err)
+	}
+
+	var scopedRoot string
+	previousScopeWorkspaceCreatedFn := scopeWorkspaceCreatedFn
+	scopeWorkspaceCreatedFn = func(path string) {
+		scopedRoot = path
+	}
+	t.Cleanup(func() {
+		scopeWorkspaceCreatedFn = previousScopeWorkspaceCreatedFn
+	})
+
+	previousCacheInitHook := cacheInitBeforeObjectsEnsureFn
+	cacheInitBeforeObjectsEnsureFn = func() error {
+		if scopedRoot == "" {
+			t.Fatalf("expected scoped workspace path before cache initialization")
+		}
+		if _, err := os.Stat(filepath.Join(scopedRoot, defaultAnalysisCacheDirName)); !os.IsNotExist(err) {
+			t.Fatalf("expected scoped workspace cache root to remain absent during cache init, stat err=%v", err)
+		}
+		if _, err := os.Stat(filepath.Join(repo, defaultAnalysisCacheDirName, cacheKeysDirName)); err != nil {
+			t.Fatalf("expected repo-root cache keys dir during cache init: %v", err)
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		cacheInitBeforeObjectsEnsureFn = previousCacheInitHook
+	})
+
+	req := Request{
+		RepoPath:        repo,
+		Dependency:      "lodash",
+		Language:        "js-ts",
+		IncludePatterns: []string{"src/**"},
+		ExcludePatterns: []string{"vendor/**"},
+		Cache: &CacheOptions{
+			Enabled:    true,
+			PinnedPath: pinnedCachePath,
+		},
+	}
+
+	reportData, err := NewService().Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("analyse with scoped pinned default cache path: %v", err)
+	}
+	if len(reportData.Dependencies) != 1 {
+		t.Fatalf("expected one dependency report, got %#v", reportData.Dependencies)
+	}
+	if reportData.Cache == nil || reportData.Cache.Path != pinnedCachePath || reportData.Cache.Misses != 1 || reportData.Cache.Writes != 1 {
+		t.Fatalf("expected scoped cache metadata to report pinned repo-root path and first-run miss/write, got %#v", reportData.Cache)
+	}
+	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
+		if _, err := os.Stat(filepath.Join(repo, defaultAnalysisCacheDirName, dir)); err != nil {
+			t.Fatalf("expected %s dir in repo-root default cache: %v", dir, err)
+		}
+	}
+	if scopedRoot == "" {
+		t.Fatalf("expected scoped workspace to be created")
+	}
+	if _, err := os.Stat(filepath.Join(scopedRoot, defaultAnalysisCacheDirName)); !os.IsNotExist(err) {
+		t.Fatalf("expected scoped workspace cache root to remain absent after analysis, stat err=%v", err)
+	}
+
+	secondReport, err := NewService().Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("repeat analyse with scoped pinned default cache path: %v", err)
+	}
+	if secondReport.Cache == nil || secondReport.Cache.Path != pinnedCachePath || secondReport.Cache.Hits != 1 || secondReport.Cache.Misses != 0 {
+		t.Fatalf("expected second scoped run to reuse pinned repo-root cache, got %#v", secondReport.Cache)
+	}
+}
+
+func TestServiceAnalyseScopedExplicitRelativeCachePathUsesPinnedRepoKeyAcrossRuns(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
+	writeFile(t, filepath.Join(repo, "src", indexJSFileName), lodashMapUsageJS)
+	writeFile(t, filepath.Join(repo, "node_modules", "lodash", packageJSONFileName), nodeMainPackageJSON)
+	writeFile(t, filepath.Join(repo, "node_modules", "lodash", indexJSFileName), mapExportJSContent)
+
+	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join(".cache", "lopper"),
+	})
+	if err != nil {
+		t.Fatalf("resolve trusted explicit relative cache path: %v", err)
+	}
+	if cacheOptions.PinnedPath == "" {
+		t.Fatalf("expected trusted cache options to pin explicit relative cache path")
+	}
+
+	var scopedRoot string
+	previousScopeWorkspaceCreatedFn := scopeWorkspaceCreatedFn
+	scopeWorkspaceCreatedFn = func(path string) {
+		scopedRoot = path
+	}
+	t.Cleanup(func() {
+		scopeWorkspaceCreatedFn = previousScopeWorkspaceCreatedFn
+	})
+
+	req := Request{
+		RepoPath:        repo,
+		Dependency:      "lodash",
+		Language:        "js-ts",
+		IncludePatterns: []string{"src/**"},
+		ExcludePatterns: []string{"vendor/**"},
+		Cache:           cacheOptions,
+	}
+
+	firstReport, err := NewService().Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first analyse with scoped explicit relative cache path: %v", err)
+	}
+	if firstReport.Cache == nil || firstReport.Cache.Path != filepath.Join(".cache", "lopper") || firstReport.Cache.Misses != 1 || firstReport.Cache.Writes != 1 {
+		t.Fatalf("expected first scoped run to report explicit relative cache path with miss/write metadata, got %#v", firstReport.Cache)
+	}
+	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
+		if _, err := os.Stat(filepath.Join(repo, ".cache", "lopper", dir)); err != nil {
+			t.Fatalf("expected %s dir in repo-root explicit cache path: %v", dir, err)
+		}
+	}
+	if scopedRoot == "" {
+		t.Fatalf("expected scoped workspace to be created")
+	}
+	if _, err := os.Stat(filepath.Join(scopedRoot, ".cache", "lopper")); !os.IsNotExist(err) {
+		t.Fatalf("expected scoped workspace explicit cache root to remain absent after first run, stat err=%v", err)
+	}
+
+	secondReport, err := NewService().Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second analyse with scoped explicit relative cache path: %v", err)
+	}
+	if secondReport.Cache == nil || secondReport.Cache.Path != filepath.Join(".cache", "lopper") || secondReport.Cache.Hits != 1 || secondReport.Cache.Misses != 0 {
+		t.Fatalf("expected second scoped run to hit repo-root explicit cache with truthful metadata, got %#v", secondReport.Cache)
+	}
+}
+
 func dependencyByLanguageName(t *testing.T, dependencies []report.DependencyReport, languageID, name string) report.DependencyReport {
 	t.Helper()
 	for _, dependency := range dependencies {

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -721,42 +721,15 @@ func TestServiceAnalyseAllowsAbsoluteCachePathOutsideRepo(t *testing.T) {
 }
 
 func TestServiceAnalyseScopedPinnedDefaultCacheWritesStayUnderRepoRoot(t *testing.T) {
-	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
-	writeFile(t, filepath.Join(repo, "src", indexJSFileName), lodashMapUsageJS)
-	writeFile(t, filepath.Join(repo, "node_modules", "lodash", packageJSONFileName), nodeMainPackageJSON)
-	writeFile(t, filepath.Join(repo, "node_modules", "lodash", indexJSFileName), mapExportJSContent)
+	repo := writeScopedCacheFixture(t)
 
 	pinnedCachePath, err := ResolveTrustedDefaultCachePath(repo)
 	if err != nil {
 		t.Fatalf("resolve trusted default cache path: %v", err)
 	}
 
-	var scopedRoot string
-	previousScopeWorkspaceCreatedFn := scopeWorkspaceCreatedFn
-	scopeWorkspaceCreatedFn = func(path string) {
-		scopedRoot = path
-	}
-	t.Cleanup(func() {
-		scopeWorkspaceCreatedFn = previousScopeWorkspaceCreatedFn
-	})
-
-	previousCacheInitHook := cacheInitBeforeObjectsEnsureFn
-	cacheInitBeforeObjectsEnsureFn = func() error {
-		if scopedRoot == "" {
-			t.Fatalf("expected scoped workspace path before cache initialization")
-		}
-		if _, err := os.Stat(filepath.Join(scopedRoot, defaultAnalysisCacheDirName)); !os.IsNotExist(err) {
-			t.Fatalf("expected scoped workspace cache root to remain absent during cache init, stat err=%v", err)
-		}
-		if _, err := os.Stat(filepath.Join(repo, defaultAnalysisCacheDirName, cacheKeysDirName)); err != nil {
-			t.Fatalf("expected repo-root cache keys dir during cache init: %v", err)
-		}
-		return nil
-	}
-	t.Cleanup(func() {
-		cacheInitBeforeObjectsEnsureFn = previousCacheInitHook
-	})
+	scopedRoot := captureScopedWorkspacePath(t)
+	assertScopedCacheInitUsesRepoRoot(t, repo, scopedRoot)
 
 	req := Request{
 		RepoPath:        repo,
@@ -780,17 +753,8 @@ func TestServiceAnalyseScopedPinnedDefaultCacheWritesStayUnderRepoRoot(t *testin
 	if reportData.Cache == nil || reportData.Cache.Path != pinnedCachePath || reportData.Cache.Misses != 1 || reportData.Cache.Writes != 1 {
 		t.Fatalf("expected scoped cache metadata to report pinned repo-root path and first-run miss/write, got %#v", reportData.Cache)
 	}
-	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
-		if _, err := os.Stat(filepath.Join(repo, defaultAnalysisCacheDirName, dir)); err != nil {
-			t.Fatalf("expected %s dir in repo-root default cache: %v", dir, err)
-		}
-	}
-	if scopedRoot == "" {
-		t.Fatalf("expected scoped workspace to be created")
-	}
-	if _, err := os.Stat(filepath.Join(scopedRoot, defaultAnalysisCacheDirName)); !os.IsNotExist(err) {
-		t.Fatalf("expected scoped workspace cache root to remain absent after analysis, stat err=%v", err)
-	}
+	assertCacheDirsExist(t, filepath.Join(repo, defaultAnalysisCacheDirName))
+	assertScopedRootExcludesCacheDir(t, *scopedRoot, defaultAnalysisCacheDirName)
 
 	secondReport, err := NewService().Analyse(context.Background(), req)
 	if err != nil {
@@ -802,11 +766,7 @@ func TestServiceAnalyseScopedPinnedDefaultCacheWritesStayUnderRepoRoot(t *testin
 }
 
 func TestServiceAnalyseScopedExplicitRelativeCachePathUsesPinnedRepoKeyAcrossRuns(t *testing.T) {
-	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
-	writeFile(t, filepath.Join(repo, "src", indexJSFileName), lodashMapUsageJS)
-	writeFile(t, filepath.Join(repo, "node_modules", "lodash", packageJSONFileName), nodeMainPackageJSON)
-	writeFile(t, filepath.Join(repo, "node_modules", "lodash", indexJSFileName), mapExportJSContent)
+	repo := writeScopedCacheFixture(t)
 
 	cacheOptions, err := ResolveTrustedCacheOptions(repo, &CacheOptions{
 		Enabled: true,
@@ -819,14 +779,7 @@ func TestServiceAnalyseScopedExplicitRelativeCachePathUsesPinnedRepoKeyAcrossRun
 		t.Fatalf("expected trusted cache options to pin explicit relative cache path")
 	}
 
-	var scopedRoot string
-	previousScopeWorkspaceCreatedFn := scopeWorkspaceCreatedFn
-	scopeWorkspaceCreatedFn = func(path string) {
-		scopedRoot = path
-	}
-	t.Cleanup(func() {
-		scopeWorkspaceCreatedFn = previousScopeWorkspaceCreatedFn
-	})
+	scopedRoot := captureScopedWorkspacePath(t)
 
 	req := Request{
 		RepoPath:        repo,
@@ -844,17 +797,8 @@ func TestServiceAnalyseScopedExplicitRelativeCachePathUsesPinnedRepoKeyAcrossRun
 	if firstReport.Cache == nil || firstReport.Cache.Path != filepath.Join(".cache", "lopper") || firstReport.Cache.Misses != 1 || firstReport.Cache.Writes != 1 {
 		t.Fatalf("expected first scoped run to report explicit relative cache path with miss/write metadata, got %#v", firstReport.Cache)
 	}
-	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
-		if _, err := os.Stat(filepath.Join(repo, ".cache", "lopper", dir)); err != nil {
-			t.Fatalf("expected %s dir in repo-root explicit cache path: %v", dir, err)
-		}
-	}
-	if scopedRoot == "" {
-		t.Fatalf("expected scoped workspace to be created")
-	}
-	if _, err := os.Stat(filepath.Join(scopedRoot, ".cache", "lopper")); !os.IsNotExist(err) {
-		t.Fatalf("expected scoped workspace explicit cache root to remain absent after first run, stat err=%v", err)
-	}
+	assertCacheDirsExist(t, filepath.Join(repo, ".cache", "lopper"))
+	assertScopedRootExcludesCacheDir(t, *scopedRoot, filepath.Join(".cache", "lopper"))
 
 	secondReport, err := NewService().Analyse(context.Background(), req)
 	if err != nil {
@@ -862,6 +806,118 @@ func TestServiceAnalyseScopedExplicitRelativeCachePathUsesPinnedRepoKeyAcrossRun
 	}
 	if secondReport.Cache == nil || secondReport.Cache.Path != filepath.Join(".cache", "lopper") || secondReport.Cache.Hits != 1 || secondReport.Cache.Misses != 0 {
 		t.Fatalf("expected second scoped run to hit repo-root explicit cache with truthful metadata, got %#v", secondReport.Cache)
+	}
+}
+
+func TestServiceAnalyseScopedAndUnscopedPinnedCacheEntriesDoNotCollide(t *testing.T) {
+	repo := writeScopedCacheFixture(t)
+	pinnedCachePath, err := ResolveTrustedDefaultCachePath(repo)
+	if err != nil {
+		t.Fatalf("resolve trusted default cache path: %v", err)
+	}
+
+	baseReq := Request{
+		RepoPath:   repo,
+		Dependency: "lodash",
+		Language:   "js-ts",
+		Cache: &CacheOptions{
+			Enabled:    true,
+			PinnedPath: pinnedCachePath,
+		},
+	}
+	scopedReq := baseReq
+	scopedReq.IncludePatterns = []string{"src/**"}
+
+	unscopedFirst, err := NewService().Analyse(context.Background(), baseReq)
+	if err != nil {
+		t.Fatalf("first unscoped analyse: %v", err)
+	}
+	if unscopedFirst.Cache == nil || unscopedFirst.Cache.Misses != 1 || unscopedFirst.Cache.Writes != 1 {
+		t.Fatalf("expected first unscoped run to miss and write, got %#v", unscopedFirst.Cache)
+	}
+
+	scopedFirst, err := NewService().Analyse(context.Background(), scopedReq)
+	if err != nil {
+		t.Fatalf("first scoped analyse: %v", err)
+	}
+	if scopedFirst.Cache == nil || scopedFirst.Cache.Misses != 1 || scopedFirst.Cache.Writes != 1 {
+		t.Fatalf("expected first scoped run to miss and write its own entry, got %#v", scopedFirst.Cache)
+	}
+
+	unscopedSecond, err := NewService().Analyse(context.Background(), baseReq)
+	if err != nil {
+		t.Fatalf("second unscoped analyse: %v", err)
+	}
+	if unscopedSecond.Cache == nil || unscopedSecond.Cache.Hits != 1 || unscopedSecond.Cache.Misses != 0 {
+		t.Fatalf("expected second unscoped run to hit its original entry, got %#v", unscopedSecond.Cache)
+	}
+
+	scopedSecond, err := NewService().Analyse(context.Background(), scopedReq)
+	if err != nil {
+		t.Fatalf("second scoped analyse: %v", err)
+	}
+	if scopedSecond.Cache == nil || scopedSecond.Cache.Hits != 1 || scopedSecond.Cache.Misses != 0 {
+		t.Fatalf("expected second scoped run to hit its scoped entry, got %#v", scopedSecond.Cache)
+	}
+}
+
+func writeScopedCacheFixture(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, packageJSONFileName), demoPackageJSONContent)
+	writeFile(t, filepath.Join(repo, "src", indexJSFileName), lodashMapUsageJS)
+	writeFile(t, filepath.Join(repo, "node_modules", "lodash", packageJSONFileName), nodeMainPackageJSON)
+	writeFile(t, filepath.Join(repo, "node_modules", "lodash", indexJSFileName), mapExportJSContent)
+	return repo
+}
+
+func captureScopedWorkspacePath(t *testing.T) *string {
+	t.Helper()
+	scopedRoot := new(string)
+	previous := scopeWorkspaceCreatedFn
+	scopeWorkspaceCreatedFn = func(path string) {
+		*scopedRoot = path
+	}
+	t.Cleanup(func() {
+		scopeWorkspaceCreatedFn = previous
+	})
+	return scopedRoot
+}
+
+func assertScopedCacheInitUsesRepoRoot(t *testing.T, repo string, scopedRoot *string) {
+	t.Helper()
+	previous := cacheInitBeforeObjectsEnsureFn
+	cacheInitBeforeObjectsEnsureFn = func() error {
+		if *scopedRoot == "" {
+			t.Fatalf("expected scoped workspace path before cache initialization")
+		}
+		assertScopedRootExcludesCacheDir(t, *scopedRoot, defaultAnalysisCacheDirName)
+		if _, err := os.Stat(filepath.Join(repo, defaultAnalysisCacheDirName, cacheKeysDirName)); err != nil {
+			t.Fatalf("expected repo-root cache keys dir during cache init: %v", err)
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		cacheInitBeforeObjectsEnsureFn = previous
+	})
+}
+
+func assertCacheDirsExist(t *testing.T, root string) {
+	t.Helper()
+	for _, dir := range []string{cacheKeysDirName, cacheObjectsDirName} {
+		if _, err := os.Stat(filepath.Join(root, dir)); err != nil {
+			t.Fatalf("expected %s dir in %s: %v", dir, root, err)
+		}
+	}
+}
+
+func assertScopedRootExcludesCacheDir(t *testing.T, scopedRoot string, relativeCachePath string) {
+	t.Helper()
+	if scopedRoot == "" {
+		t.Fatalf("expected scoped workspace to be created")
+	}
+	if _, err := os.Stat(filepath.Join(scopedRoot, relativeCachePath)); !os.IsNotExist(err) {
+		t.Fatalf("expected scoped workspace cache root %q to remain absent, stat err=%v", relativeCachePath, err)
 	}
 }
 

--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -11,6 +12,7 @@ import (
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 const (
@@ -580,45 +582,45 @@ func TestServiceAnalysePythonRuntimeTraceIntegration(t *testing.T) {
 	writeFile(t, tracePath, "{\"language\":\"python\",\"module\":\"requests.sessions\",\"parent\":\"/repo/main.py\",\"entrypoint\":\"/repo/main.py\"}\n{\"language\":\"python\",\"module\":\"httpx._client\",\"parent\":\"/repo/main.py\",\"entrypoint\":\"/repo/main.py\"}\n")
 
 	service := NewService()
-	disabledFeature, err := service.Analyse(context.Background(), Request{
+	assertPythonRuntimeFeatureDisabled(t, service, repo, tracePath)
+	assertPythonRuntimeTraceDisabled(t, service, repo, tracePath)
+	assertPythonRuntimeStableDefaults(t, service, repo, tracePath)
+}
+
+func analysePythonRuntimeReport(t *testing.T, service *Service, repo, tracePath string, features featureflags.Set) report.Report {
+	t.Helper()
+	reportData, err := service.Analyse(context.Background(), Request{
 		RepoPath:         repo,
 		TopN:             10,
 		Language:         "python",
 		RuntimeTracePath: tracePath,
-		Features:         mustResolvePythonRuntimeTraceFeatureSet(t, false),
+		Features:         features,
 	})
 	if err != nil {
-		t.Fatalf("analyse python runtime with feature disabled: %v", err)
+		t.Fatalf("analyse python runtime: %v", err)
 	}
-	if dep := dependencyByLanguageName(t, disabledFeature.Dependencies, "python", "requests"); dep.RuntimeUsage != nil {
+	return reportData
+}
+
+func assertPythonRuntimeFeatureDisabled(t *testing.T, service *Service, repo, tracePath string) {
+	t.Helper()
+	reportData := analysePythonRuntimeReport(t, service, repo, tracePath, mustResolvePythonRuntimeTraceFeatureSet(t, false))
+	if dep := dependencyByLanguageName(t, reportData.Dependencies, "python", "requests"); dep.RuntimeUsage != nil {
 		t.Fatalf("did not expect Python runtime usage with feature disabled, got %#v", dep.RuntimeUsage)
 	}
+}
 
-	captureWithTraceDisabled, err := service.Analyse(context.Background(), Request{
-		RepoPath:         repo,
-		TopN:             10,
-		Language:         "python",
-		RuntimeTracePath: tracePath,
-		Features:         mustResolvePythonRuntimeCaptureWithTraceDisabled(t),
-	})
-	if err != nil {
-		t.Fatalf("analyse Python runtime with trace disabled: %v", err)
-	}
-	if requests := dependencyByLanguageName(t, captureWithTraceDisabled.Dependencies, "python", "requests"); requests.RuntimeUsage != nil {
+func assertPythonRuntimeTraceDisabled(t *testing.T, service *Service, repo, tracePath string) {
+	t.Helper()
+	reportData := analysePythonRuntimeReport(t, service, repo, tracePath, mustResolvePythonRuntimeCaptureWithTraceDisabled(t))
+	if requests := dependencyByLanguageName(t, reportData.Dependencies, "python", "requests"); requests.RuntimeUsage != nil {
 		t.Fatalf("did not expect an explicit Python trace to bypass the disabled trace feature, got %#v", requests.RuntimeUsage)
 	}
+}
 
-	stableDefault, err := service.Analyse(context.Background(), Request{
-		RepoPath:         repo,
-		TopN:             10,
-		Language:         "python",
-		RuntimeTracePath: tracePath,
-		Features:         mustResolveStableDefaultsFeatureSet(t),
-	})
-	if err != nil {
-		t.Fatalf("analyse python runtime with stable defaults: %v", err)
-	}
-
+func assertPythonRuntimeStableDefaults(t *testing.T, service *Service, repo, tracePath string) {
+	t.Helper()
+	stableDefault := analysePythonRuntimeReport(t, service, repo, tracePath, mustResolveStableDefaultsFeatureSet(t))
 	requests := dependencyByLanguageName(t, stableDefault.Dependencies, "python", "requests")
 	if requests.RuntimeUsage == nil || requests.RuntimeUsage.Correlation != report.RuntimeCorrelationOverlap {
 		t.Fatalf("expected Python requests overlap correlation, got %#v", requests.RuntimeUsage)
@@ -632,7 +634,6 @@ func TestServiceAnalysePythonRuntimeTraceIntegration(t *testing.T) {
 	if len(requests.RuntimeUsage.ParentModules) != 1 || requests.RuntimeUsage.ParentModules[0].Module != "/repo/main.py" {
 		t.Fatalf("expected Python runtime parent detail, got %#v", requests.RuntimeUsage.ParentModules)
 	}
-
 	httpx := dependencyByLanguageName(t, stableDefault.Dependencies, "python", "httpx")
 	if httpx.RuntimeUsage == nil || httpx.RuntimeUsage.Correlation != report.RuntimeCorrelationRuntimeOnly || !httpx.RuntimeUsage.RuntimeOnly {
 		t.Fatalf("expected Python httpx runtime-only row, got %#v", httpx.RuntimeUsage)
@@ -720,13 +721,127 @@ func TestServiceAnalyseAllowsAbsoluteCachePathOutsideRepo(t *testing.T) {
 	}
 }
 
+func TestServiceAnalyseRejectsAbsoluteSymlinkEscapeCachePath(t *testing.T) {
+	repo := writeScopedCacheFixture(t)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := NewService().Analyse(context.Background(), Request{
+		RepoPath:   repo,
+		Dependency: "lodash",
+		Language:   "js-ts",
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    filepath.Join(repo, "tmp", "cache"),
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected absolute symlink cache rejection, got %v", err)
+	}
+}
+
+func TestServiceAnalyseRejectsCanonicalSymlinkEscapeUnderRequestedRepoAlias(t *testing.T) {
+	requestedRepo, canonicalCache, outsideCache := canonicalAliasCacheEscapeFixture(t)
+	writeJSFixture(t, requestedRepo)
+
+	_, err := NewService().Analyse(context.Background(), Request{
+		RepoPath:   requestedRepo,
+		Dependency: "lodash",
+		Language:   "js-ts",
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    canonicalCache,
+		},
+	})
+	if !CachePathSymlinkEscape(err) {
+		t.Fatalf("expected service symlink escape rejection, got %v", err)
+	}
+	if CachePathExternal(err) {
+		t.Fatalf("expected service not to classify canonical in-repo form as external, got %v", err)
+	}
+	if _, statErr := os.Stat(outsideCache); !os.IsNotExist(statErr) {
+		t.Fatalf("expected service not to create external cache directory, stat err=%v", statErr)
+	}
+}
+
+func TestServiceAnalyseRejectsAlternateAbsoluteRepoAliasesThatLaterEscape(t *testing.T) {
+	for _, fixture := range alternateAbsoluteRepoAliasEscapeFixtures(t) {
+		t.Run(fixture.name, func(t *testing.T) {
+			writeJSFixture(t, fixture.requestedRepo)
+			_, err := NewService().Analyse(context.Background(), Request{
+				RepoPath:   fixture.requestedRepo,
+				Dependency: "lodash",
+				Language:   "js-ts",
+				Cache: &CacheOptions{
+					Enabled: true,
+					Path:    fixture.cachePath,
+				},
+			})
+			if !CachePathSymlinkEscape(err) || CachePathExternal(err) {
+				t.Fatalf("expected service symlink escape rejection, got %v", err)
+			}
+			if _, statErr := os.Stat(fixture.outsideCache); !os.IsNotExist(statErr) {
+				t.Fatalf("expected service not to create outside cache, stat err=%v", statErr)
+			}
+		})
+	}
+}
+
+func TestServiceAnalyseConfiguredRepoCacheIgnoresWorkingDirectory(t *testing.T) {
+	repo := t.TempDir()
+	writeJSFixture(t, repo)
+	configuredCache := filepath.Join(repo, ".cache", "lopper")
+	workingDir := t.TempDir()
+
+	originalWorkingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(workingDir); err != nil {
+		t.Fatalf("change working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWorkingDir); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
+
+	reportData, err := NewService().Analyse(context.Background(), Request{
+		RepoPath:   repo,
+		Dependency: "lodash",
+		Language:   "js-ts",
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    configuredCache,
+		},
+	})
+	if err != nil {
+		t.Fatalf("analyse with configured repo cache path: %v", err)
+	}
+	if reportData.Cache == nil || reportData.Cache.Path != configuredCache || reportData.Cache.Misses != 1 || reportData.Cache.Writes != 1 {
+		t.Fatalf("expected configured repo cache miss/write metadata, got %#v", reportData.Cache)
+	}
+	assertCacheDirsExist(t, configuredCache)
+
+	entries, err := os.ReadDir(workingDir)
+	if err != nil {
+		t.Fatalf("read working directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no cache writes in working directory, got %#v", entries)
+	}
+}
+
 func TestServiceAnalyseScopedPinnedDefaultCacheWritesStayUnderRepoRoot(t *testing.T) {
 	repo := writeScopedCacheFixture(t)
 
-	pinnedCachePath, err := ResolveTrustedDefaultCachePath(repo)
+	cacheOptions, err := ResolveTrustedDefaultCacheOptions(repo, false)
 	if err != nil {
-		t.Fatalf("resolve trusted default cache path: %v", err)
+		t.Fatalf("resolve trusted default cache options: %v", err)
 	}
+	pinnedCachePath := cacheOptions.trustedPinnedPath()
 
 	scopedRoot := captureScopedWorkspacePath(t)
 	assertScopedCacheInitUsesRepoRoot(t, repo, scopedRoot)
@@ -737,10 +852,7 @@ func TestServiceAnalyseScopedPinnedDefaultCacheWritesStayUnderRepoRoot(t *testin
 		Language:        "js-ts",
 		IncludePatterns: []string{"src/**"},
 		ExcludePatterns: []string{"vendor/**"},
-		Cache: &CacheOptions{
-			Enabled:    true,
-			PinnedPath: pinnedCachePath,
-		},
+		Cache:           cacheOptions,
 	}
 
 	reportData, err := NewService().Analyse(context.Background(), req)
@@ -754,7 +866,6 @@ func TestServiceAnalyseScopedPinnedDefaultCacheWritesStayUnderRepoRoot(t *testin
 		t.Fatalf("expected scoped cache metadata to report pinned repo-root path and first-run miss/write, got %#v", reportData.Cache)
 	}
 	assertCacheDirsExist(t, filepath.Join(repo, defaultAnalysisCacheDirName))
-	assertScopedRootExcludesCacheDir(t, *scopedRoot, defaultAnalysisCacheDirName)
 
 	secondReport, err := NewService().Analyse(context.Background(), req)
 	if err != nil {
@@ -775,11 +886,12 @@ func TestServiceAnalyseScopedExplicitRelativeCachePathUsesPinnedRepoKeyAcrossRun
 	if err != nil {
 		t.Fatalf("resolve trusted explicit relative cache path: %v", err)
 	}
-	if cacheOptions.PinnedPath == "" {
+	if !cacheOptions.hasTrustedPin() {
 		t.Fatalf("expected trusted cache options to pin explicit relative cache path")
 	}
 
 	scopedRoot := captureScopedWorkspacePath(t)
+	assertScopedCacheInitExcludesCacheDir(t, scopedRoot, filepath.Join(".cache", "lopper"))
 
 	req := Request{
 		RepoPath:        repo,
@@ -798,7 +910,6 @@ func TestServiceAnalyseScopedExplicitRelativeCachePathUsesPinnedRepoKeyAcrossRun
 		t.Fatalf("expected first scoped run to report explicit relative cache path with miss/write metadata, got %#v", firstReport.Cache)
 	}
 	assertCacheDirsExist(t, filepath.Join(repo, ".cache", "lopper"))
-	assertScopedRootExcludesCacheDir(t, *scopedRoot, filepath.Join(".cache", "lopper"))
 
 	secondReport, err := NewService().Analyse(context.Background(), req)
 	if err != nil {
@@ -809,55 +920,244 @@ func TestServiceAnalyseScopedExplicitRelativeCachePathUsesPinnedRepoKeyAcrossRun
 	}
 }
 
+func TestServiceAnalyseScopedAbsoluteInRepoCachePathPinsAndHitsAcrossRuns(t *testing.T) {
+	repo := writeScopedCacheFixture(t)
+	absoluteCachePath := filepath.Join(repo, ".cache", "lopper-absolute")
+	if err := os.MkdirAll(absoluteCachePath, 0o750); err != nil {
+		t.Fatalf("create pre-seeded absolute cache root: %v", err)
+	}
+
+	scopedRoot := captureScopedWorkspacePath(t)
+	assertScopedCacheInitExcludesCacheDir(t, scopedRoot, filepath.Join(".cache", "lopper-absolute"))
+	req := Request{
+		RepoPath:        repo,
+		Dependency:      "lodash",
+		Language:        "js-ts",
+		IncludePatterns: []string{"**"},
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    absoluteCachePath,
+		},
+	}
+
+	firstReport, err := NewService().Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first analyse with scoped absolute in-repo cache path: %v", err)
+	}
+	if firstReport.Cache == nil || firstReport.Cache.Path != absoluteCachePath || firstReport.Cache.Misses != 1 || firstReport.Cache.Writes != 1 {
+		t.Fatalf("expected first scoped run to report absolute in-repo cache miss/write metadata, got %#v", firstReport.Cache)
+	}
+	assertCacheDirsExist(t, absoluteCachePath)
+
+	secondReport, err := NewService().Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second analyse with scoped absolute in-repo cache path: %v", err)
+	}
+	if secondReport.Cache == nil || secondReport.Cache.Path != absoluteCachePath || secondReport.Cache.Hits != 1 || secondReport.Cache.Misses != 0 {
+		t.Fatalf("expected second scoped run to hit absolute in-repo cache with truthful metadata, got %#v", secondReport.Cache)
+	}
+}
+
+func TestServiceAnalyseConfigPathUsesStableCacheIdentityAcrossSnapshotRuns(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestPackageJSONFileName), "{\n  \"name\": \"demo\"\n}\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "console.log('hello')\n")
+	configPath := filepath.Join(repo, ".lopper.yml")
+	testutil.MustWriteFile(t, configPath, "thresholds:\n  low_confidence_warning_percent: 10\n")
+
+	service, adapter := newCacheTestService(t)
+	req := newCacheRequest(repo, filepath.Join(repo, cacheTestDirectoryName), false)
+	req.ConfigPath = configPath
+
+	first, err := service.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first analyse with explicit config path: %v", err)
+	}
+	if first.Cache == nil || first.Cache.Misses != 1 || first.Cache.Writes != 1 {
+		t.Fatalf("expected first config-path run cache miss/write, got %#v", first.Cache)
+	}
+
+	second, err := service.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second analyse with explicit config path: %v", err)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("expected explicit config path to preserve cache hit across snapshot runs, adapter calls=%d", adapter.calls)
+	}
+	if second.Cache == nil || second.Cache.Hits != 1 || second.Cache.Misses != 0 {
+		t.Fatalf("expected second config-path run cache hit, got %#v", second.Cache)
+	}
+}
+
+func TestServiceAnalyseScopedAbsoluteInRepoCachePathSkipsCacheDirAcrossRepoAliasOnSecondRun(t *testing.T) {
+	repo := writeScopedCacheFixture(t)
+	aliasRoot := t.TempDir()
+	repoAlias := filepath.Join(aliasRoot, "repo")
+	if err := os.Symlink(repo, repoAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cachePath := filepath.Join(repoAlias, ".cache", "lopper-alias")
+	scopedRoots := captureScopedWorkspacePaths(t)
+	req := Request{
+		RepoPath:        repoAlias,
+		Dependency:      "lodash",
+		Language:        "js-ts",
+		IncludePatterns: []string{"**"},
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    cachePath,
+		},
+	}
+
+	firstReport, err := NewService().Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first analyse with aliased absolute in-repo cache path: %v", err)
+	}
+	if firstReport.Cache == nil || firstReport.Cache.Path != cachePath || firstReport.Cache.Misses != 1 || firstReport.Cache.Writes != 1 {
+		t.Fatalf("expected first aliased scoped run to miss and write, got %#v", firstReport.Cache)
+	}
+	assertCacheDirsExist(t, filepath.Join(repo, ".cache", "lopper-alias"))
+
+	previous := cacheInitBeforeObjectsEnsureFn
+	cacheInitBeforeObjectsEnsureFn = func() error {
+		if len(*scopedRoots) < 2 {
+			t.Fatalf("expected second scoped workspace before cache init, roots=%#v", *scopedRoots)
+		}
+		assertScopedRootExcludesCacheDir(t, (*scopedRoots)[len(*scopedRoots)-1], filepath.Join(".cache", "lopper-alias"))
+		return nil
+	}
+	t.Cleanup(func() {
+		cacheInitBeforeObjectsEnsureFn = previous
+	})
+
+	secondReport, err := NewService().Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second analyse with aliased absolute in-repo cache path: %v", err)
+	}
+	if secondReport.Cache == nil || secondReport.Cache.Path != cachePath || secondReport.Cache.Hits != 1 || secondReport.Cache.Misses != 0 {
+		t.Fatalf("expected second aliased scoped run to hit cached entry, got %#v", secondReport.Cache)
+	}
+}
+
+func TestServiceAnalyseScopedRepoRootCachePathIsRejected(t *testing.T) {
+	repo := writeScopedCacheFixture(t)
+
+	_, err := NewService().Analyse(context.Background(), Request{
+		RepoPath:        repo,
+		Dependency:      "lodash",
+		Language:        "js-ts",
+		IncludePatterns: []string{"src/**"},
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    repo,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "scoped analysis does not allow cachePath at the repository root") {
+		t.Fatalf("expected scoped repo-root cache rejection, got %v", err)
+	}
+}
+
+func TestServiceAnalyseScopedExternalCacheAliasToRepoRootIsRejectedBeforeCacheInit(t *testing.T) {
+	repo := writeScopedCacheFixture(t)
+	cacheAlias := filepath.Join(t.TempDir(), "external-cache-alias")
+	if err := os.Symlink(repo, cacheAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := NewService().Analyse(context.Background(), Request{
+		RepoPath:        repo,
+		Dependency:      "lodash",
+		Language:        "js-ts",
+		IncludePatterns: []string{"src/**"},
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    cacheAlias,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "scoped analysis does not allow cachePath at the repository root") {
+		t.Fatalf("expected external alias to receive in-repo root rejection, got %v", err)
+	}
+	assertCacheLayoutAbsent(t, repo)
+}
+
+func TestServicePipelineScopedExternalCacheAliasToRepoSubdirUsesInRepoExclusionWithoutMutation(t *testing.T) {
+	repo := writeScopedCacheFixture(t)
+	cacheRoot := filepath.Join(repo, ".cache", "external-alias")
+	if err := os.MkdirAll(cacheRoot, 0o750); err != nil {
+		t.Fatalf("mkdir cache root: %v", err)
+	}
+	cacheAlias := filepath.Join(t.TempDir(), "external-cache-alias")
+	if err := os.Symlink(cacheRoot, cacheAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	req := Request{
+		RepoPath:        repo,
+		Dependency:      "lodash",
+		Language:        "js-ts",
+		IncludePatterns: []string{"**"},
+		Cache: &CacheOptions{
+			Enabled: true,
+			Path:    cacheAlias,
+		},
+	}
+	cacheOptions, err := normalizePipelineCacheOptions(repo, req)
+	if err != nil {
+		t.Fatalf("normalize external alias to repo subdir: %v", err)
+	}
+	if !InRepoCacheOptions(cacheOptions) {
+		t.Fatalf("expected external alias to mint an in-repo pin, got %#v", cacheOptions)
+	}
+	if relativeRoot := pinnedScopedCacheRoot(cacheOptions); relativeRoot != filepath.Join(".cache", "external-alias") {
+		t.Fatalf("expected scoped copy exclusion for aliased cache subdir, got %q", relativeRoot)
+	}
+	req.Cache = cacheOptions
+	req.Language = language.Auto
+	scopedRoots := captureScopedWorkspacePaths(t)
+	_, err = (&Service{Registry: language.NewRegistry()}).newAnalysisPipeline(context.Background(), req)
+	if !errors.Is(err, language.ErrNoMatch) {
+		t.Fatalf("expected empty registry to stop before cache initialization, got %v", err)
+	}
+	if len(*scopedRoots) != 1 {
+		t.Fatalf("expected one scoped workspace, got %#v", *scopedRoots)
+	}
+	if _, statErr := os.Stat((*scopedRoots)[0]); !os.IsNotExist(statErr) {
+		t.Fatalf("expected failed pipeline setup to clean scoped workspace, stat err=%v", statErr)
+	}
+	assertCacheLayoutAbsent(t, cacheRoot)
+	assertCacheLayoutAbsent(t, repo)
+}
+
 func TestServiceAnalyseScopedAndUnscopedPinnedCacheEntriesDoNotCollide(t *testing.T) {
 	repo := writeScopedCacheFixture(t)
-	pinnedCachePath, err := ResolveTrustedDefaultCachePath(repo)
+	cacheOptions, err := ResolveTrustedDefaultCacheOptions(repo, false)
 	if err != nil {
-		t.Fatalf("resolve trusted default cache path: %v", err)
+		t.Fatalf("resolve trusted default cache options: %v", err)
 	}
 
 	baseReq := Request{
 		RepoPath:   repo,
 		Dependency: "lodash",
 		Language:   "js-ts",
-		Cache: &CacheOptions{
-			Enabled:    true,
-			PinnedPath: pinnedCachePath,
-		},
+		Cache:      cacheOptions,
 	}
 	scopedReq := baseReq
 	scopedReq.IncludePatterns = []string{"src/**"}
+	assertScopedCacheRun(t, baseReq, 1, 1, 1, 0)
+	assertScopedCacheRun(t, scopedReq, 1, 1, 1, 0)
+	assertScopedCacheRun(t, baseReq, 0, 0, 0, 1)
+	assertScopedCacheRun(t, scopedReq, 0, 0, 0, 1)
+}
 
-	unscopedFirst, err := NewService().Analyse(context.Background(), baseReq)
+func assertScopedCacheRun(t *testing.T, req Request, wantMisses, wantWrites, wantCallsDelta, wantHits int) {
+	t.Helper()
+	result, err := NewService().Analyse(context.Background(), req)
 	if err != nil {
-		t.Fatalf("first unscoped analyse: %v", err)
+		t.Fatalf("analyse: %v", err)
 	}
-	if unscopedFirst.Cache == nil || unscopedFirst.Cache.Misses != 1 || unscopedFirst.Cache.Writes != 1 {
-		t.Fatalf("expected first unscoped run to miss and write, got %#v", unscopedFirst.Cache)
-	}
-
-	scopedFirst, err := NewService().Analyse(context.Background(), scopedReq)
-	if err != nil {
-		t.Fatalf("first scoped analyse: %v", err)
-	}
-	if scopedFirst.Cache == nil || scopedFirst.Cache.Misses != 1 || scopedFirst.Cache.Writes != 1 {
-		t.Fatalf("expected first scoped run to miss and write its own entry, got %#v", scopedFirst.Cache)
-	}
-
-	unscopedSecond, err := NewService().Analyse(context.Background(), baseReq)
-	if err != nil {
-		t.Fatalf("second unscoped analyse: %v", err)
-	}
-	if unscopedSecond.Cache == nil || unscopedSecond.Cache.Hits != 1 || unscopedSecond.Cache.Misses != 0 {
-		t.Fatalf("expected second unscoped run to hit its original entry, got %#v", unscopedSecond.Cache)
-	}
-
-	scopedSecond, err := NewService().Analyse(context.Background(), scopedReq)
-	if err != nil {
-		t.Fatalf("second scoped analyse: %v", err)
-	}
-	if scopedSecond.Cache == nil || scopedSecond.Cache.Hits != 1 || scopedSecond.Cache.Misses != 0 {
-		t.Fatalf("expected second scoped run to hit its scoped entry, got %#v", scopedSecond.Cache)
+	if result.Cache == nil || result.Cache.Misses != wantMisses || result.Cache.Writes != wantWrites || result.Cache.Hits != wantHits {
+		t.Fatalf("unexpected scoped cache metadata: %#v", result.Cache)
 	}
 }
 
@@ -884,17 +1184,39 @@ func captureScopedWorkspacePath(t *testing.T) *string {
 	return scopedRoot
 }
 
+func captureScopedWorkspacePaths(t *testing.T) *[]string {
+	t.Helper()
+	scopedRoots := &[]string{}
+	previous := scopeWorkspaceCreatedFn
+	scopeWorkspaceCreatedFn = func(path string) {
+		*scopedRoots = append(*scopedRoots, path)
+	}
+	t.Cleanup(func() {
+		scopeWorkspaceCreatedFn = previous
+	})
+	return scopedRoots
+}
+
 func assertScopedCacheInitUsesRepoRoot(t *testing.T, repo string, scopedRoot *string) {
 	t.Helper()
 	previous := cacheInitBeforeObjectsEnsureFn
 	cacheInitBeforeObjectsEnsureFn = func() error {
-		if *scopedRoot == "" {
-			t.Fatalf("expected scoped workspace path before cache initialization")
-		}
 		assertScopedRootExcludesCacheDir(t, *scopedRoot, defaultAnalysisCacheDirName)
 		if _, err := os.Stat(filepath.Join(repo, defaultAnalysisCacheDirName, cacheKeysDirName)); err != nil {
 			t.Fatalf("expected repo-root cache keys dir during cache init: %v", err)
 		}
+		return nil
+	}
+	t.Cleanup(func() {
+		cacheInitBeforeObjectsEnsureFn = previous
+	})
+}
+
+func assertScopedCacheInitExcludesCacheDir(t *testing.T, scopedRoot *string, relativeCachePath string) {
+	t.Helper()
+	previous := cacheInitBeforeObjectsEnsureFn
+	cacheInitBeforeObjectsEnsureFn = func() error {
+		assertScopedRootExcludesCacheDir(t, *scopedRoot, relativeCachePath)
 		return nil
 	}
 	t.Cleanup(func() {
@@ -915,6 +1237,13 @@ func assertScopedRootExcludesCacheDir(t *testing.T, scopedRoot string, relativeC
 	t.Helper()
 	if scopedRoot == "" {
 		t.Fatalf("expected scoped workspace to be created")
+	}
+	info, err := os.Stat(scopedRoot)
+	if err != nil {
+		t.Fatalf("expected scoped workspace %q to exist before cache initialization: %v", scopedRoot, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected scoped workspace %q to be a directory", scopedRoot)
 	}
 	if _, err := os.Stat(filepath.Join(scopedRoot, relativeCachePath)); !os.IsNotExist(err) {
 		t.Fatalf("expected scoped workspace cache root %q to remain absent, stat err=%v", relativeCachePath, err)
@@ -1234,6 +1563,90 @@ func TestServiceAppliesScopeBeforeResolve(t *testing.T) {
 	}
 }
 
+func TestServiceAnalyseRepositoryViewPreservesUnsafeJVMSymlinkWarningsWithoutOutsideReads(t *testing.T) {
+	repo := t.TempDir()
+	outsideDir := t.TempDir()
+	writeFile(t, filepath.Join(repo, buildGradleFileName), `
+dependencies {
+  implementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
+  implementation("com.outside:secret:1.0.0")
+}
+`)
+	writeFile(t, filepath.Join(repo, "src", "main", "java", "App.java"), `
+import org.junit.jupiter.api.Assertions;
+class App { void run() { Assertions.assertTrue(true); } }
+`)
+	writeFile(t, filepath.Join(outsideDir, "Outside.java"), `
+import com.outside.SecretApi;
+class Outside { void use() { SecretApi.call(); } }
+`)
+	if err := os.Symlink(filepath.Join("..", "..", "..", "..", filepath.Base(outsideDir), "Outside.java"), filepath.Join(repo, "src", "main", "java", "Outside.java")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	service := NewService()
+	direct, err := service.Analyse(context.Background(), Request{
+		RepoPath:   repo,
+		Language:   "jvm",
+		Dependency: "secret",
+		TopN:       10,
+	})
+	if err != nil {
+		t.Fatalf("analyse direct repo: %v", err)
+	}
+
+	repository, err := ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("resolve trusted repository: %v", err)
+	}
+	view, err := OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	defer func() {
+		if closeErr := view.Close(); closeErr != nil {
+			t.Errorf("close repository view: %v", closeErr)
+		}
+	}()
+
+	withView, err := service.Analyse(context.Background(), Request{
+		RepoPath:       repo,
+		Repository:     repository,
+		RepositoryView: view,
+		Language:       "jvm",
+		Dependency:     "secret",
+		TopN:           10,
+	})
+	if err != nil {
+		t.Fatalf("analyse through repository view: %v", err)
+	}
+
+	const sourceWarning = "skipped JVM source symlink src/main/java/Outside.java: target escapes repo root"
+	const summaryWarning = "skipped 1 unreadable or untrusted JVM source symlink(s)"
+	assertContainsWarning(t, direct.Warnings, sourceWarning)
+	assertContainsWarning(t, direct.Warnings, summaryWarning)
+	assertContainsWarning(t, withView.Warnings, sourceWarning)
+	assertContainsWarning(t, withView.Warnings, summaryWarning)
+	if countWarningsMatching(direct.Warnings, sourceWarning) != 1 {
+		t.Fatalf("expected one direct symlink warning, got %#v", direct.Warnings)
+	}
+	if countWarningsMatching(withView.Warnings, sourceWarning) != 1 {
+		t.Fatalf("expected one repository-view symlink warning, got %#v", withView.Warnings)
+	}
+	if hasDependencyByLanguageAndName(direct, "jvm", "secret") {
+		t.Fatalf("expected direct analysis to ignore outside source content, got %#v", direct.Dependencies)
+	}
+	if hasDependencyByLanguageAndName(withView, "jvm", "secret") {
+		t.Fatalf("expected repository-view analysis to ignore outside source content, got %#v", withView.Dependencies)
+	}
+	if findDependencyByLanguageAndName(t, direct, "jvm", "junit-jupiter-api").UsedExportsCount == 0 {
+		t.Fatalf("expected direct in-repo dependency usage, got %#v", direct.Dependencies)
+	}
+	if findDependencyByLanguageAndName(t, withView, "jvm", "junit-jupiter-api").UsedExportsCount == 0 {
+		t.Fatalf("expected repository-view in-repo dependency usage, got %#v", withView.Dependencies)
+	}
+}
+
 func hasRecommendationCode(dep report.DependencyReport, code string) bool {
 	for _, rec := range dep.Recommendations {
 		if rec.Code == code {
@@ -1317,4 +1730,44 @@ func (f *findingsAdapter) Analyse(context.Context, language.Request) (report.Rep
 			},
 		},
 	}, nil
+}
+
+func assertContainsWarning(t *testing.T, warnings []string, want string) {
+	t.Helper()
+	for _, warning := range warnings {
+		if warning == want {
+			return
+		}
+	}
+	t.Fatalf("expected warning %q in %#v", want, warnings)
+}
+
+func countWarningsMatching(warnings []string, want string) int {
+	count := 0
+	for _, warning := range warnings {
+		if warning == want {
+			count++
+		}
+	}
+	return count
+}
+
+func findDependencyByLanguageAndName(t *testing.T, reportData report.Report, languageID, name string) report.DependencyReport {
+	t.Helper()
+	for _, dependency := range reportData.Dependencies {
+		if dependency.Language == languageID && dependency.Name == name {
+			return dependency
+		}
+	}
+	t.Fatalf("expected dependency %s/%s in %#v", languageID, name, reportData.Dependencies)
+	return report.DependencyReport{}
+}
+
+func hasDependencyByLanguageAndName(reportData report.Report, languageID, name string) bool {
+	for _, dependency := range reportData.Dependencies {
+		if dependency.Language == languageID && dependency.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/app/analyse_pipeline.go
+++ b/internal/app/analyse_pipeline.go
@@ -2,16 +2,44 @@ package app
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/report"
 )
 
 type analyseReportStage func(context.Context, report.Report) (report.Report, error)
 
-func (a *App) executeAnalyse(ctx context.Context, req Request) (string, error) {
+func (a *App) executeAnalyse(ctx context.Context, req Request) (_ string, returnErr error) {
 	if err := validateAnalyseFeatures(req.Analyse); err != nil {
 		return "", err
+	}
+	repository, err := analysis.ResolveAuthorizedRepository(req.RepoPath, req.Analyse.repository, req.Analyse.cacheOptions)
+	if err != nil {
+		return "", err
+	}
+	req.Analyse.repository = repository
+	repositoryView, ownsRepositoryView, err := openAnalyseRepositoryView(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	if repositoryView != nil {
+		if ownsRepositoryView {
+			defer func() {
+				returnErr = errors.Join(returnErr, repositoryView.Close())
+			}()
+		}
+		req.Analyse.repositoryView = repositoryView
+		captureAnalyseGitSensitiveState(ctx, repositoryView, &req.Analyse)
+		req.Analyse.advisoryLoadPath, err = repositoryView.SnapshotPath(req.Analyse.AdvisorySourcePath)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	prepared, err := prepareAnalyseExecution(ctx, req)
@@ -30,6 +58,43 @@ func (a *App) executeAnalyse(ctx context.Context, req Request) (string, error) {
 	return a.completeAnalyseExecution(ctx, req.RepoPath, req.Analyse, reportData, err)
 }
 
+func captureAnalyseGitSensitiveState(ctx context.Context, repositoryView *analysis.RepositoryView, req *AnalyseRequest) {
+	if req == nil {
+		return
+	}
+	metadata := repositoryView.GitMetadata()
+	if !req.currentBaselineKeyCaptured {
+		if currentCommit := strings.TrimSpace(metadata.CurrentCommit); currentCommit != "" {
+			req.currentBaselineKey = "commit:" + currentCommit
+		}
+		req.currentBaselineKeyCaptured = true
+	}
+	if !req.codemodPreconditionCaptured {
+		if req.ApplyCodemod && !req.AllowDirty {
+			req.codemodPrecondition = ensureCleanRepositoryViewForCodemod(repositoryView, false)
+		}
+		req.codemodPreconditionCaptured = true
+	}
+	if !req.lockfileDriftCaptured {
+		req.lockfileWarnings, req.lockfileDriftErr = evaluateLockfileDriftPolicyWithRepositoryView(ctx, repositoryView, req.Thresholds.LockfileDriftPolicy, req.Features)
+		req.lockfileDriftCaptured = true
+	}
+}
+
+func openAnalyseRepositoryView(ctx context.Context, req Request) (*analysis.RepositoryView, bool, error) {
+	if req.Analyse.repositoryView != nil {
+		if err := analysis.ValidateRepositoryView(req.Analyse.repository, req.Analyse.repositoryView); err != nil {
+			return nil, false, err
+		}
+		return req.Analyse.repositoryView, false, nil
+	}
+	view, err := analysis.OpenTrustedRepositoryWithGitMetadata(ctx, req.Analyse.repository, req.RepoPath, req.Analyse.cacheOptions)
+	if err != nil {
+		return nil, false, err
+	}
+	return view, true, nil
+}
+
 func (a *App) invokeAnalyse(ctx context.Context, prepared preparedAnalyseExecution) (report.Report, error) {
 	return a.Analyzer.Analyse(ctx, prepared.request)
 }
@@ -45,7 +110,7 @@ func (a *App) runAnalysePostStages(ctx context.Context, repoPath string, req Ana
 			return applyVulnerabilityExceptionsIfNeeded(reportData, req, now)
 		},
 		func(_ context.Context, reportData report.Report) (report.Report, error) {
-			return a.applyBaselineIfNeeded(reportData, repoPath, req)
+			return a.applyBaselineIfNeededWithRepository(reportData, repoPath, req, req.repositoryView)
 		},
 		analyseValidationStage(func(reportData report.Report) error {
 			return validateFailOnIncrease(reportData, req.Thresholds.FailOnIncreasePercent)
@@ -60,10 +125,10 @@ func (a *App) runAnalysePostStages(ctx context.Context, repoPath string, req Ana
 			return validateReachableVulnerabilityThreshold(reportData, req.Thresholds.ReachableVulnerabilityPriority)
 		}),
 		func(ctx context.Context, reportData report.Report) (report.Report, error) {
-			return applyCodemodIfNeeded(ctx, reportData, repoPath, req, now)
+			return applyCodemodIfNeededWithRepository(ctx, reportData, repoPath, req, now, req.repositoryView)
 		},
 		func(_ context.Context, reportData report.Report) (report.Report, error) {
-			return a.saveBaselineIfNeeded(reportData, repoPath, req, now)
+			return a.saveBaselineIfNeededWithRepository(reportData, repoPath, req, now, req.repositoryView)
 		},
 	})
 }
@@ -102,10 +167,53 @@ func (a *App) completeAnalyseExecution(ctx context.Context, repoPath string, req
 		return "", err
 	}
 
-	output, err := persistCommandOutput(formatted, req.OutputPath, "analyse report", repoPath)
+	output, err := persistAnalyseOutput(formatted, req.OutputPath, repoPath, req.repositoryView)
 	if err != nil {
 		return "", err
 	}
 
 	return output, runErr
+}
+
+func persistAnalyseOutput(formatted, outputPath, repoPath string, repositoryView *analysis.RepositoryView) (string, error) {
+	trimmedOutputPath := strings.TrimSpace(outputPath)
+	if repositoryView == nil || trimmedOutputPath == "" || trimmedOutputPath == "-" || !filepath.IsAbs(trimmedOutputPath) {
+		return persistCommandOutput(formatted, outputPath, "analyse report", repoPath)
+	}
+	relativePath, inRepository := repositoryView.RepositoryRelativePath(trimmedOutputPath)
+	if !inRepository {
+		return persistCommandOutput(formatted, outputPath, "analyse report", repoPath)
+	}
+	if hasDirectoryStyleOutputPath(trimmedOutputPath) {
+		return "", fmt.Errorf("output path must name a file: %s", trimmedOutputPath)
+	}
+	if err := rejectRepositoryOutputSymlink(repositoryView, relativePath); err != nil {
+		return "", err
+	}
+	if err := repositoryView.WriteFile(relativePath, []byte(formatted), 0o600); err != nil {
+		return "", err
+	}
+	return "analyse report written to " + trimmedOutputPath, nil
+}
+
+func rejectRepositoryOutputSymlink(repositoryView *analysis.RepositoryView, relativePath string) error {
+	parent := filepath.Dir(filepath.Clean(relativePath))
+	if parent == "." {
+		return nil
+	}
+	current := ""
+	for _, component := range strings.Split(parent, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := repositoryView.Lstat(current)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("output root contains symlink: %s", current)
+		}
+	}
+	return nil
 }

--- a/internal/app/analyse_postprocess.go
+++ b/internal/app/analyse_postprocess.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ben-ranford/lopper/internal/advisory"
+	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/workspace"
 )
@@ -45,6 +46,23 @@ func (a *App) applyBaselineIfNeeded(reportData report.Report, repoPath string, r
 	return reportData, nil
 }
 
+func (a *App) applyBaselineIfNeededWithRepository(reportData report.Report, repoPath string, req AnalyseRequest, repository *analysis.RepositoryView) (report.Report, error) {
+	if repository == nil {
+		return a.applyBaselineIfNeeded(reportData, repoPath, req)
+	}
+	boundRequest := req
+	var err error
+	boundRequest.BaselinePath, err = repository.SnapshotPath(req.BaselinePath)
+	if err != nil {
+		return reportData, err
+	}
+	boundRequest.BaselineStorePath, err = repository.SnapshotPath(req.BaselineStorePath)
+	if err != nil {
+		return reportData, err
+	}
+	return a.applyBaselineIfNeeded(reportData, repoPath, boundRequest)
+}
+
 func isBootstrapableMissingBaseline(req AnalyseRequest, err error) bool {
 	if !req.SaveBaseline {
 		return false
@@ -61,28 +79,75 @@ func isBootstrapableMissingBaseline(req AnalyseRequest, err error) bool {
 	return true
 }
 
+func currentBaselineKeyForAnalyse(repoPath string, req AnalyseRequest) string {
+	if req.currentBaselineKeyCaptured {
+		return strings.TrimSpace(req.currentBaselineKey)
+	}
+	if req.repositoryView != nil {
+		return ""
+	}
+	return resolveCurrentBaselineKey(repoPath)
+}
+
 func resolveBaselineComparisonPaths(repoPath string, req AnalyseRequest) (string, string, string, bool, error) {
+	currentKey := currentBaselineKeyForAnalyse(repoPath, req)
 	if strings.TrimSpace(req.BaselinePath) != "" {
-		return strings.TrimSpace(req.BaselinePath), "", resolveCurrentBaselineKey(repoPath), true, nil
+		return strings.TrimSpace(req.BaselinePath), "", currentKey, true, nil
 	}
 
-	return resolveBaselineStoreComparisonPaths(repoPath, baselineKeyRequestFromAnalyse(req), report.ResolveBaselineSnapshotPath)
+	return resolveBaselineStoreComparisonPaths(currentKey, baselineKeyRequestFromAnalyse(req), report.ResolveBaselineSnapshotPath)
 }
 
 func (a *App) saveBaselineIfNeeded(reportData report.Report, repoPath string, req AnalyseRequest, now time.Time) (report.Report, error) {
-	return saveImmutableBaselineSnapshot(reportData, immutableBaselineSaveConfig[report.Report]{
-		enabled:       req.SaveBaseline,
-		repoPath:      repoPath,
-		req:           baselineKeyRequestFromAnalyse(req),
-		keyName:       "baseline",
-		now:           now,
-		save:          report.SaveSnapshot,
-		appendWarning: appendBaselineSaveWarning,
-	})
+	return a.saveBaselineIfNeededWithRepository(reportData, repoPath, req, now, nil)
+}
+
+func (a *App) saveBaselineIfNeededWithRepository(reportData report.Report, repoPath string, req AnalyseRequest, now time.Time, repository *analysis.RepositoryView) (report.Report, error) {
+	if repository == nil || !req.SaveBaseline {
+		return saveImmutableBaselineSnapshot(reportData, immutableBaselineSaveConfig[report.Report]{
+			enabled:       req.SaveBaseline,
+			repoPath:      repoPath,
+			currentKey:    currentBaselineKeyForAnalyse(repoPath, req),
+			req:           baselineKeyRequestFromAnalyse(req),
+			keyName:       "baseline",
+			now:           now,
+			save:          report.SaveSnapshot,
+			appendWarning: appendBaselineSaveWarning,
+		})
+	}
+	relativeStore, inRepository := repository.RepositoryRelativePath(req.BaselineStorePath)
+	if !inRepository {
+		return saveImmutableBaselineSnapshot(reportData, immutableBaselineSaveConfig[report.Report]{
+			enabled:       true,
+			repoPath:      repoPath,
+			currentKey:    currentBaselineKeyForAnalyse(repoPath, req),
+			req:           baselineKeyRequestFromAnalyse(req),
+			keyName:       "baseline",
+			now:           now,
+			save:          report.SaveSnapshot,
+			appendWarning: appendBaselineSaveWarning,
+		})
+	}
+	saveKey, err := resolveBaselineSaveKey(currentBaselineKeyForAnalyse(repoPath, req), baselineKeyRequestFromAnalyse(req), "baseline")
+	if err != nil {
+		return reportData, err
+	}
+	root, err := repository.OpenWriteRoot(".", false)
+	if err != nil {
+		return reportData, err
+	}
+	savedPath, saveErr := report.SaveSnapshotWithinRoot(root, relativeStore, repository.DisplayPath(relativeStore), saveKey, reportData, now)
+	if closeErr := root.Close(); closeErr != nil {
+		saveErr = errors.Join(saveErr, closeErr)
+	}
+	if saveErr != nil {
+		return reportData, saveErr
+	}
+	return appendBaselineSaveWarning(reportData, savedPath), nil
 }
 
 func resolveSaveBaselineKey(repoPath string, req AnalyseRequest) (string, error) {
-	return resolveBaselineSaveKey(repoPath, baselineKeyRequestFromAnalyse(req), "baseline")
+	return resolveBaselineSaveKey(currentBaselineKeyForAnalyse(repoPath, req), baselineKeyRequestFromAnalyse(req), "baseline")
 }
 
 type baselineKeyRequest struct {
@@ -107,7 +172,7 @@ func baselineKeyRequestFromDashboard(resolved resolvedDashboardRequest) baseline
 	}
 }
 
-func resolveBaselineStoreComparisonPaths(repoPath string, req baselineKeyRequest, snapshotPath func(string, string) string) (string, string, string, bool, error) {
+func resolveBaselineStoreComparisonPaths(currentKey string, req baselineKeyRequest, snapshotPath func(string, string) string) (string, string, string, bool, error) {
 	storePath := strings.TrimSpace(req.storePath)
 	if storePath == "" {
 		return "", "", "", false, nil
@@ -115,28 +180,28 @@ func resolveBaselineStoreComparisonPaths(repoPath string, req baselineKeyRequest
 
 	baselineKey := strings.TrimSpace(req.key)
 	if baselineKey == "" {
-		baselineKey = resolveCurrentBaselineKey(repoPath)
+		baselineKey = strings.TrimSpace(currentKey)
 	}
 	if baselineKey == "" {
 		return "", "", "", false, fmt.Errorf("baseline key is required when using --baseline-store")
 	}
 
-	return snapshotPath(storePath, baselineKey), baselineKey, resolveCurrentBaselineKey(repoPath), true, nil
+	return snapshotPath(storePath, baselineKey), baselineKey, strings.TrimSpace(currentKey), true, nil
 }
 
-func resolveBaselineSaveTarget(repoPath string, req baselineKeyRequest, keyName string) (string, string, error) {
+func resolveBaselineSaveTarget(currentKey string, req baselineKeyRequest, keyName string) (string, string, error) {
 	storePath := strings.TrimSpace(req.storePath)
 	if storePath == "" {
 		return "", "", fmt.Errorf("--save-baseline requires --baseline-store")
 	}
-	saveKey, err := resolveBaselineSaveKey(repoPath, req, keyName)
+	saveKey, err := resolveBaselineSaveKey(currentKey, req, keyName)
 	if err != nil {
 		return "", "", err
 	}
 	return storePath, saveKey, nil
 }
 
-func resolveBaselineSaveKey(repoPath string, req baselineKeyRequest, keyName string) (string, error) {
+func resolveBaselineSaveKey(currentKey string, req baselineKeyRequest, keyName string) (string, error) {
 	if label := strings.TrimSpace(req.label); label != "" {
 		return "label:" + label, nil
 	}
@@ -144,16 +209,16 @@ func resolveBaselineSaveKey(repoPath string, req baselineKeyRequest, keyName str
 		return key, nil
 	}
 
-	key := resolveCurrentBaselineKey(repoPath)
-	if key == "" {
+	if strings.TrimSpace(currentKey) == "" {
 		return "", fmt.Errorf("unable to resolve git commit for %s key; pass --baseline-label or --baseline-key", keyName)
 	}
-	return key, nil
+	return strings.TrimSpace(currentKey), nil
 }
 
 type immutableBaselineSaveConfig[T any] struct {
 	enabled       bool
 	repoPath      string
+	currentKey    string
 	req           baselineKeyRequest
 	keyName       string
 	now           time.Time
@@ -166,7 +231,7 @@ func saveImmutableBaselineSnapshot[T any](reportData T, cfg immutableBaselineSav
 		return reportData, nil
 	}
 
-	storePath, saveKey, err := resolveBaselineSaveTarget(cfg.repoPath, cfg.req, cfg.keyName)
+	storePath, saveKey, err := resolveBaselineSaveTarget(cfg.currentKey, cfg.req, cfg.keyName)
 	if err != nil {
 		return reportData, err
 	}
@@ -186,7 +251,11 @@ func applyAdvisoriesIfNeeded(reportData report.Report, req AnalyseRequest) (repo
 	if strings.TrimSpace(req.AdvisorySourcePath) == "" {
 		return reportData, nil
 	}
-	advisories, err := advisory.Load(req.AdvisorySourcePath)
+	loadPath := strings.TrimSpace(req.advisoryLoadPath)
+	if loadPath == "" {
+		loadPath = req.AdvisorySourcePath
+	}
+	advisories, err := advisory.Load(loadPath)
 	if err != nil {
 		return reportData, err
 	}

--- a/internal/app/analyse_postprocess_test.go
+++ b/internal/app/analyse_postprocess_test.go
@@ -1,0 +1,206 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ben-ranford/lopper/internal/analysis"
+	"github.com/ben-ranford/lopper/internal/report"
+)
+
+func TestApplyAdvisoriesIfNeededBranches(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{name: "skips blank advisory source path", run: testApplyAdvisoriesSkipsBlankSourcePath},
+		{name: "uses advisory load path and recomputes summary", run: testApplyAdvisoriesUsesLoadPath},
+		{name: "propagates advisory load errors", run: testApplyAdvisoriesPropagatesLoadErrors},
+	} {
+		t.Run(tc.name, tc.run)
+	}
+}
+
+func testApplyAdvisoriesSkipsBlankSourcePath(t *testing.T) {
+	t.Helper()
+
+	input := report.Report{
+		Summary: &report.Summary{DependencyCount: 1},
+	}
+	got, err := applyAdvisoriesIfNeeded(input, AnalyseRequest{AdvisorySourcePath: "   "})
+	if err != nil {
+		t.Fatalf("apply advisories with blank source path: %v", err)
+	}
+	if got.Summary.DependencyCount != input.Summary.DependencyCount {
+		t.Fatalf("expected summary to remain unchanged, got %#v", got.Summary)
+	}
+}
+
+func testApplyAdvisoriesUsesLoadPath(t *testing.T) {
+	t.Helper()
+
+	advisoryPath := filepath.Join(t.TempDir(), "advisories.json")
+	if err := os.WriteFile(advisoryPath, []byte(`{"advisories":[{"id":"GHSA-lib","package":"lib","ecosystem":"npm","severity":"high","source":"fixture"}]}`), 0o600); err != nil {
+		t.Fatalf("write advisory source: %v", err)
+	}
+
+	input := report.Report{
+		Dependencies: []report.DependencyReport{{
+			Name:     "lib",
+			Language: "js-ts",
+			Identity: &report.DependencyIdentity{Version: "1.0.0"},
+		}},
+	}
+	got, err := applyAdvisoriesIfNeeded(input, AnalyseRequest{
+		AdvisorySourcePath: "ignored.json",
+		advisoryLoadPath:   advisoryPath,
+	})
+	if err != nil {
+		t.Fatalf("apply advisories: %v", err)
+	}
+	if len(got.Dependencies) != 1 || len(got.Dependencies[0].Vulnerabilities) != 1 {
+		t.Fatalf("expected advisory annotation to add one vulnerability, got %#v", got.Dependencies)
+	}
+	finding := got.Dependencies[0].Vulnerabilities[0]
+	if finding.AdvisoryID != "GHSA-lib" || finding.Source != "fixture" {
+		t.Fatalf("unexpected advisory finding: %#v", finding)
+	}
+	if got.Summary == nil || got.Summary.Vulnerabilities == nil || got.Summary.Vulnerabilities.TotalFindings != 1 {
+		t.Fatalf("expected summary recomputation to include one vulnerability, got %#v", got.Summary)
+	}
+}
+
+func testApplyAdvisoriesPropagatesLoadErrors(t *testing.T) {
+	t.Helper()
+
+	_, err := applyAdvisoriesIfNeeded(report.Report{}, AnalyseRequest{
+		AdvisorySourcePath: "advisories.json",
+		advisoryLoadPath:   filepath.Join(t.TempDir(), "missing.json"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "read advisory source") {
+		t.Fatalf("expected advisory load error, got %v", err)
+	}
+}
+
+func TestApplyBaselineIfNeededWithRepositoryRejectsUnsafeRelativeStorePath(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := analysis.OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	req := AnalyseRequest{
+		BaselineStorePath: filepath.Join("..", "outside"),
+		BaselineKey:       "label:nightly",
+	}
+	application := &App{}
+	_, err = application.applyBaselineIfNeededWithRepository(report.Report{}, repo, req, view)
+	if err == nil || !strings.Contains(err.Error(), "repository root") {
+		t.Fatalf("expected unsafe relative baseline store rejection, got %v", err)
+	}
+}
+
+func TestApplyBaselineIfNeededWithRepositoryRejectsUnsafeRelativeBaselinePath(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := analysis.OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	req := AnalyseRequest{
+		BaselinePath: filepath.Join("..", "outside.json"),
+	}
+	application := &App{}
+	_, err = application.applyBaselineIfNeededWithRepository(report.Report{}, repo, req, view)
+	if err == nil || !strings.Contains(err.Error(), "repository root") {
+		t.Fatalf("expected unsafe relative baseline path rejection, got %v", err)
+	}
+}
+
+func TestApplyBaselineIfNeededWithRepositoryFallsBackWithoutView(t *testing.T) {
+	application := &App{}
+	input := report.Report{Summary: &report.Summary{DependencyCount: 1}}
+	got, err := application.applyBaselineIfNeededWithRepository(input, ".", AnalyseRequest{}, nil)
+	if err != nil {
+		t.Fatalf("apply baseline without repository view: %v", err)
+	}
+	if got.Summary == nil || got.Summary.DependencyCount != 1 {
+		t.Fatalf("expected report to remain unchanged without repository view, got %#v", got)
+	}
+}
+
+func TestApplyAdvisoriesIfNeededFallsBackToAdvisorySourcePath(t *testing.T) {
+	repo := t.TempDir()
+	advisoryPath := filepath.Join(repo, "advisories.json")
+	if err := os.WriteFile(advisoryPath, []byte(`{"advisories":[{"id":"GHSA-lib","package":"lib","ecosystem":"npm","severity":"high","source":"fixture"}]}`), 0o600); err != nil {
+		t.Fatalf("write advisory source: %v", err)
+	}
+
+	input := report.Report{
+		Dependencies: []report.DependencyReport{{
+			Name:     "lib",
+			Language: "js-ts",
+			Identity: &report.DependencyIdentity{Version: "1.0.0"},
+		}},
+	}
+	got, err := applyAdvisoriesIfNeeded(input, AnalyseRequest{
+		AdvisorySourcePath: advisoryPath,
+	})
+	if err != nil {
+		t.Fatalf("apply advisories without fallback path: %v", err)
+	}
+	if len(got.Dependencies) != 1 || len(got.Dependencies[0].Vulnerabilities) != 1 {
+		t.Fatalf("expected advisory annotation through retained-view fallback path, got %#v", got.Dependencies)
+	}
+}
+
+func TestReachableVulnerabilityThresholdHelpers(t *testing.T) {
+	if hasReachableVulnerabilityAtOrAbove(report.Report{}, "   ") {
+		t.Fatalf("expected blank threshold to be ignored")
+	}
+	if hasReachableVulnerabilityAtOrAbove(report.Report{}, report.VulnerabilityPriorityOff) {
+		t.Fatalf("expected off threshold to be ignored")
+	}
+
+	deps := []report.DependencyReport{{
+		Name: "lib",
+		Vulnerabilities: []report.VulnerabilityFinding{
+			{
+				AdvisoryID: "GHSA-suppressed",
+				Reachable:  true,
+				Priority:   report.VulnerabilityPriorityCritical,
+				Decision:   &report.VulnerabilityExceptionDecision{Status: "not-affected"},
+			},
+			{
+				AdvisoryID:    "GHSA-unevaluable",
+				Reachable:     true,
+				VersionStatus: "unevaluable",
+				Priority:      report.VulnerabilityPriorityLow,
+			},
+		},
+	}}
+	if !dependencyHasReachableVulnerabilityAtOrAbove(deps, report.VulnerabilityPriorityCritical) {
+		t.Fatalf("expected unevaluable reachable vulnerability to satisfy threshold")
+	}
+}

--- a/internal/app/analyse_prepare.go
+++ b/internal/app/analyse_prepare.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/analysis"
@@ -29,11 +30,9 @@ func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseE
 	}
 
 	runtimeTracePath, runtimeTracePathExplicit := prepareRuntimeTracePlan(req)
-	cacheOptions := &analysis.CacheOptions{
-		Enabled:    req.Analyse.CacheEnabled,
-		Path:       req.Analyse.CachePath,
-		ReadOnly:   req.Analyse.CacheReadOnly,
-		PinnedPath: req.Analyse.CachePinnedPath,
+	cacheOptions, err := prepareAnalyseCacheOptions(req.RepoPath, req.Analyse)
+	if err != nil {
+		return preparedAnalyseExecution{}, err
 	}
 	baseRequest := analysis.Request{
 		RepoPath:                 req.RepoPath,
@@ -112,4 +111,29 @@ func prepareRuntimeTrace(_ context.Context, req Request) ([]string, string) {
 func prepareRuntimeTracePlan(req Request) (string, bool) {
 	path := strings.TrimSpace(req.Analyse.RuntimeTracePath)
 	return path, path != ""
+}
+
+func prepareAnalyseCacheOptions(repoPath string, req AnalyseRequest) (*analysis.CacheOptions, error) {
+	cacheOptions := &analysis.CacheOptions{
+		Enabled:    req.CacheEnabled,
+		Path:       req.CachePath,
+		ReadOnly:   req.CacheReadOnly,
+		PinnedPath: req.CachePinnedPath,
+	}
+	if !cacheOptions.Enabled || strings.TrimSpace(cacheOptions.PinnedPath) != "" {
+		return cacheOptions, nil
+	}
+	cachePath := strings.TrimSpace(cacheOptions.Path)
+	if cachePath == "" || strings.TrimSpace(repoPath) == "" {
+		return cacheOptions, nil
+	}
+
+	trustedOptions, err := analysis.ResolveTrustedCacheOptions(repoPath, cacheOptions)
+	if err == nil {
+		return trustedOptions, nil
+	}
+	if filepath.IsAbs(cachePath) {
+		return cacheOptions, nil
+	}
+	return nil, err
 }

--- a/internal/app/analyse_prepare.go
+++ b/internal/app/analyse_prepare.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 
@@ -21,7 +22,7 @@ type preparedAnalyseExecution struct {
 }
 
 func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseExecution, error) {
-	lockfileWarnings, err := evaluateLockfileDriftPolicyWithFeatures(ctx, req.RepoPath, req.Analyse.Thresholds.LockfileDriftPolicy, req.Analyse.Features)
+	lockfileWarnings, err := resolvePreparedLockfileDrift(ctx, req.RepoPath, req.Analyse)
 	if err != nil {
 		return preparedAnalyseExecution{}, err
 	}
@@ -34,8 +35,13 @@ func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseE
 	if err != nil {
 		return preparedAnalyseExecution{}, err
 	}
+	if err := analysis.ValidateTrustedScopedCacheOptions(cacheOptions, req.Analyse.IncludePatterns, req.Analyse.ExcludePatterns); err != nil {
+		return preparedAnalyseExecution{}, err
+	}
 	baseRequest := analysis.Request{
 		RepoPath:                 req.RepoPath,
+		Repository:               req.Analyse.repository,
+		RepositoryView:           req.Analyse.repositoryView,
 		Dependency:               req.Analyse.Dependency,
 		TopN:                     req.Analyse.TopN,
 		ScopeMode:                req.Analyse.ScopeMode,
@@ -72,15 +78,31 @@ func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseE
 	}, nil
 }
 
+func resolvePreparedLockfileDrift(ctx context.Context, repoPath string, req AnalyseRequest) ([]string, error) {
+	if req.lockfileDriftCaptured {
+		return append([]string{}, req.lockfileWarnings...), req.lockfileDriftErr
+	}
+	if req.repositoryView != nil {
+		return nil, errors.New("lockfile drift state was not captured before opening the repository view")
+	}
+	return evaluateLockfileDriftPolicyWithFeatures(ctx, repoPath, req.Thresholds.LockfileDriftPolicy, req.Features)
+}
+
 func validateCodemodApplyPreconditions(ctx context.Context, repoPath string, req AnalyseRequest) error {
-	if !req.ApplyCodemod {
+	if !req.ApplyCodemod || req.AllowDirty {
 		return nil
+	}
+	if req.codemodPreconditionCaptured {
+		return req.codemodPrecondition
+	}
+	if req.repositoryView != nil {
+		return errors.New("codemod cleanliness state was not captured before opening the repository view")
 	}
 	normalizedRepoPath, err := normalizeRepoPathForCodemod(repoPath)
 	if err != nil {
 		return err
 	}
-	return ensureCleanWorktreeForCodemod(ctx, normalizedRepoPath, req.AllowDirty)
+	return ensureCleanWorktreeForCodemod(ctx, normalizedRepoPath, false)
 }
 
 func decorateAnalyseReport(reportData *report.Report, prepared preparedAnalyseExecution) {
@@ -114,13 +136,15 @@ func prepareRuntimeTracePlan(req Request) (string, bool) {
 }
 
 func prepareAnalyseCacheOptions(repoPath string, req AnalyseRequest) (*analysis.CacheOptions, error) {
-	cacheOptions := &analysis.CacheOptions{
-		Enabled:    req.CacheEnabled,
-		Path:       req.CachePath,
-		ReadOnly:   req.CacheReadOnly,
-		PinnedPath: req.CachePinnedPath,
+	if req.cacheOptions != nil {
+		return req.cacheOptions, nil
 	}
-	if !cacheOptions.Enabled || strings.TrimSpace(cacheOptions.PinnedPath) != "" {
+	cacheOptions := &analysis.CacheOptions{
+		Enabled:  req.CacheEnabled,
+		Path:     req.CachePath,
+		ReadOnly: req.CacheReadOnly,
+	}
+	if !cacheOptions.Enabled {
 		return cacheOptions, nil
 	}
 	cachePath := strings.TrimSpace(cacheOptions.Path)
@@ -128,12 +152,20 @@ func prepareAnalyseCacheOptions(repoPath string, req AnalyseRequest) (*analysis.
 		return cacheOptions, nil
 	}
 
-	trustedOptions, err := analysis.ResolveTrustedCacheOptions(repoPath, cacheOptions)
+	var (
+		trustedOptions *analysis.CacheOptions
+		err            error
+	)
+	if req.repository != nil {
+		trustedOptions, err = analysis.ResolveTrustedCacheOptionsForRepository(req.repository, cacheOptions)
+	} else {
+		trustedOptions, err = analysis.ResolveTrustedCacheOptions(repoPath, cacheOptions)
+	}
 	if err == nil {
 		return trustedOptions, nil
 	}
-	if filepath.IsAbs(cachePath) {
-		return cacheOptions, nil
+	if filepath.IsAbs(cachePath) && analysis.AuthenticatedExternalCacheOptions(trustedOptions, err) {
+		return trustedOptions, nil
 	}
 	return nil, err
 }

--- a/internal/app/analyse_prepare.go
+++ b/internal/app/analyse_prepare.go
@@ -29,6 +29,15 @@ func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseE
 	}
 
 	runtimeTracePath, runtimeTracePathExplicit := prepareRuntimeTracePlan(req)
+	cacheOptions, err := analysis.ResolveTrustedCacheOptions(req.RepoPath, &analysis.CacheOptions{
+		Enabled:    req.Analyse.CacheEnabled,
+		Path:       req.Analyse.CachePath,
+		ReadOnly:   req.Analyse.CacheReadOnly,
+		PinnedPath: req.Analyse.CachePinnedPath,
+	})
+	if err != nil {
+		return preparedAnalyseExecution{}, err
+	}
 	baseRequest := analysis.Request{
 		RepoPath:                 req.RepoPath,
 		Dependency:               req.Analyse.Dependency,
@@ -44,11 +53,7 @@ func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseE
 		IncludePatterns:          req.Analyse.IncludePatterns,
 		ExcludePatterns:          req.Analyse.ExcludePatterns,
 		Features:                 req.Analyse.Features,
-		Cache: &analysis.CacheOptions{
-			Enabled:  req.Analyse.CacheEnabled,
-			Path:     req.Analyse.CachePath,
-			ReadOnly: req.Analyse.CacheReadOnly,
-		},
+		Cache:                    cacheOptions,
 	}
 	policy := analysisRequestPolicy{
 		thresholds:              req.Analyse.Thresholds,

--- a/internal/app/analyse_prepare.go
+++ b/internal/app/analyse_prepare.go
@@ -29,14 +29,11 @@ func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseE
 	}
 
 	runtimeTracePath, runtimeTracePathExplicit := prepareRuntimeTracePlan(req)
-	cacheOptions, err := analysis.ResolveTrustedCacheOptions(req.RepoPath, &analysis.CacheOptions{
+	cacheOptions := &analysis.CacheOptions{
 		Enabled:    req.Analyse.CacheEnabled,
 		Path:       req.Analyse.CachePath,
 		ReadOnly:   req.Analyse.CacheReadOnly,
 		PinnedPath: req.Analyse.CachePinnedPath,
-	})
-	if err != nil {
-		return preparedAnalyseExecution{}, err
 	}
 	baseRequest := analysis.Request{
 		RepoPath:                 req.RepoPath,

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -89,7 +89,7 @@ func TestExecuteAnalyseAnalyzerError(t *testing.T) {
 	}
 }
 
-func TestExecuteAnalyseRejectsCachePathOutsideRepoWithoutWrites(t *testing.T) {
+func TestExecuteAnalysePreservesAbsoluteCachePathOutsideRepoForCLIRequests(t *testing.T) {
 	repo := t.TempDir()
 	outsideCache := filepath.Join(t.TempDir(), "cache")
 	analyzer := &fakeAnalyzer{}
@@ -102,15 +102,17 @@ func TestExecuteAnalyseRejectsCachePathOutsideRepoWithoutWrites(t *testing.T) {
 	req.Analyse.CacheEnabled = true
 	req.Analyse.CachePath = outsideCache
 
-	_, err := application.Execute(context.Background(), req)
-	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
-		t.Fatalf("expected outside cache rejection, got %v", err)
+	if _, err := application.Execute(context.Background(), req); err != nil {
+		t.Fatalf("expected CLI cache path compatibility, got %v", err)
 	}
-	if analyzer.called {
-		t.Fatalf("expected analyzer to remain uncalled")
+	if !analyzer.called {
+		t.Fatalf("expected analyzer to be called")
 	}
-	if _, statErr := os.Stat(outsideCache); !os.IsNotExist(statErr) {
-		t.Fatalf("expected no outside cache writes, stat err=%v", statErr)
+	if analyzer.lastReq.Cache == nil {
+		t.Fatalf("expected cache options to be forwarded")
+	}
+	if analyzer.lastReq.Cache.Path != outsideCache || analyzer.lastReq.Cache.PinnedPath != "" {
+		t.Fatalf("expected absolute CLI cache path to remain unchanged, got %#v", analyzer.lastReq.Cache)
 	}
 }
 

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -2,12 +2,14 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/safeio"
@@ -116,6 +118,67 @@ func TestExecuteAnalysePreservesAbsoluteCachePathOutsideRepoForCLIRequests(t *te
 	}
 }
 
+func TestExecuteAnalysePinsScopedRelativeCachePathAndReusesRepoRoot(t *testing.T) {
+	repo := writeScopedCacheFixtureRepo(t)
+	application := &App{Analyzer: analysis.NewService(), Formatter: report.NewFormatter()}
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.CacheEnabled = true
+	req.Analyse.CachePath = filepath.Join(".cache", "lopper")
+	req.Analyse.IncludePatterns = []string{"src/**"}
+	req.Analyse.ExcludePatterns = []string{"vendor/**"}
+
+	first := executeAnalyseReport(t, application, req)
+	if first.Cache == nil || first.Cache.Path != filepath.Join(".cache", "lopper") || first.Cache.Misses != 1 || first.Cache.Writes != 1 {
+		t.Fatalf("expected first scoped CLI run to write through the repo-root relative cache path, got %#v", first.Cache)
+	}
+	for _, dir := range []string{"keys", "objects"} {
+		if _, err := os.Stat(filepath.Join(repo, ".cache", "lopper", dir)); err != nil {
+			t.Fatalf("expected %s dir in repo-root scoped cache path: %v", dir, err)
+		}
+	}
+
+	second := executeAnalyseReport(t, application, req)
+	if second.Cache == nil || second.Cache.Path != filepath.Join(".cache", "lopper") || second.Cache.Hits != 1 || second.Cache.Misses != 0 {
+		t.Fatalf("expected second scoped CLI run to reuse the repo-root relative cache path, got %#v", second.Cache)
+	}
+}
+
+func TestExecuteAnalyseScopedAbsoluteCachePathOutsideRepoReusesExternalPath(t *testing.T) {
+	repo := writeScopedCacheFixtureRepo(t)
+	outsideCache := filepath.Join(t.TempDir(), "cache")
+	application := &App{Analyzer: analysis.NewService(), Formatter: report.NewFormatter()}
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.CacheEnabled = true
+	req.Analyse.CachePath = outsideCache
+	req.Analyse.IncludePatterns = []string{"src/**"}
+	req.Analyse.ExcludePatterns = []string{"vendor/**"}
+
+	first := executeAnalyseReport(t, application, req)
+	if first.Cache == nil || first.Cache.Path != outsideCache || first.Cache.Misses != 1 || first.Cache.Writes != 1 {
+		t.Fatalf("expected first scoped CLI run to use the external absolute cache path, got %#v", first.Cache)
+	}
+	for _, dir := range []string{"keys", "objects"} {
+		if _, err := os.Stat(filepath.Join(outsideCache, dir)); err != nil {
+			t.Fatalf("expected %s dir in external scoped cache path: %v", dir, err)
+		}
+	}
+
+	second := executeAnalyseReport(t, application, req)
+	if second.Cache == nil || second.Cache.Path != outsideCache || second.Cache.Hits != 1 || second.Cache.Misses != 0 {
+		t.Fatalf("expected second scoped CLI run to reuse the external absolute cache path, got %#v", second.Cache)
+	}
+}
+
 func TestExecuteAnalyseOutputFile(t *testing.T) {
 	analyzer := &fakeAnalyzer{
 		report: report.Report{
@@ -148,6 +211,38 @@ func TestExecuteAnalyseOutputFile(t *testing.T) {
 	if !strings.Contains(string(data), `"name": "lodash"`) {
 		t.Fatalf("expected analyse JSON content, got %q", string(data))
 	}
+}
+
+func executeAnalyseReport(t *testing.T, application *App, req Request) report.Report {
+	t.Helper()
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf(executeAnalyseErrFmt, err)
+	}
+	var reportData report.Report
+	if err := json.Unmarshal([]byte(output), &reportData); err != nil {
+		t.Fatalf("decode analyse report: %v", err)
+	}
+	return reportData
+}
+
+func writeScopedCacheFixtureRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	writeFixture := func(relPath string, content string) {
+		path := filepath.Join(repo, relPath)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", relPath, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", relPath, err)
+		}
+	}
+	writeFixture("package.json", "{\n  \"name\": \"demo\"\n}\n")
+	writeFixture(filepath.Join("src", "index.js"), "import { map } from \"lodash\"\nmap([1], (x) => x)\n")
+	writeFixture(filepath.Join("node_modules", "lodash", "package.json"), "{\n  \"main\": \"index.js\"\n}\n")
+	writeFixture(filepath.Join("node_modules", "lodash", "index.js"), "export function map() {}\n")
+	return repo
 }
 
 func TestExecuteAnalyseRejectsAbsoluteOutputUnderRequestedRepoSymlinkOutsideWorkingDirectory(t *testing.T) {

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -89,6 +89,31 @@ func TestExecuteAnalyseAnalyzerError(t *testing.T) {
 	}
 }
 
+func TestExecuteAnalyseRejectsCachePathOutsideRepoWithoutWrites(t *testing.T) {
+	repo := t.TempDir()
+	outsideCache := filepath.Join(t.TempDir(), "cache")
+	analyzer := &fakeAnalyzer{}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.CacheEnabled = true
+	req.Analyse.CachePath = outsideCache
+
+	_, err := application.Execute(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected outside cache rejection, got %v", err)
+	}
+	if analyzer.called {
+		t.Fatalf("expected analyzer to remain uncalled")
+	}
+	if _, statErr := os.Stat(outsideCache); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no outside cache writes, stat err=%v", statErr)
+	}
+}
+
 func TestExecuteAnalyseOutputFile(t *testing.T) {
 	analyzer := &fakeAnalyzer{
 		report: report.Report{

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -13,7 +14,9 @@ import (
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/safeio"
+	"github.com/ben-ranford/lopper/internal/testutil"
 	"github.com/ben-ranford/lopper/internal/thresholds"
+	"github.com/ben-ranford/lopper/internal/workspace"
 )
 
 func TestExecuteAnalyseEmitsEffectiveThresholds(t *testing.T) {
@@ -37,7 +40,7 @@ func TestExecuteAnalyseEmitsEffectiveThresholds(t *testing.T) {
 	req.Analyse.CacheEnabled = false
 	req.Analyse.CachePath = "/tmp/lopper-cache"
 	req.Analyse.CacheReadOnly = true
-	req.Analyse.Features = mustEnabledPreviewFeatureSet(t)
+	req.Analyse.Features = mustResolveAppTestFeatures(t, report.ReachabilityVulnerabilityPrioritizationPreviewFeature)
 	req.Analyse.PolicySources = []string{"cli", "defaults"}
 	req.Analyse.Thresholds = thresholds.Values{
 		FailOnIncreasePercent:             -1,
@@ -113,8 +116,156 @@ func TestExecuteAnalysePreservesAbsoluteCachePathOutsideRepoForCLIRequests(t *te
 	if analyzer.lastReq.Cache == nil {
 		t.Fatalf("expected cache options to be forwarded")
 	}
-	if analyzer.lastReq.Cache.Path != outsideCache || analyzer.lastReq.Cache.PinnedPath != "" {
+	if analyzer.lastReq.Cache.Path != outsideCache {
 		t.Fatalf("expected absolute CLI cache path to remain unchanged, got %#v", analyzer.lastReq.Cache)
+	}
+}
+
+func TestExecuteAnalyseRejectsAbsoluteSymlinkEscapeCachePathForCLIRequests(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	analyzer := &fakeAnalyzer{}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.CacheEnabled = true
+	req.Analyse.CachePath = filepath.Join(repo, "tmp", "cache")
+
+	_, err := application.Execute(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected absolute symlink cache rejection, got %v", err)
+	}
+	if analyzer.called {
+		t.Fatalf("expected analyzer to remain uncalled")
+	}
+}
+
+func TestExecuteAnalyseRejectsCanonicalSymlinkEscapeUnderRequestedRepoAlias(t *testing.T) {
+	requestedRepo, canonicalCache, outsideCache := analyseCanonicalAliasCacheEscapeFixture(t)
+	analyzer := &fakeAnalyzer{}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = requestedRepo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.CacheEnabled = true
+	req.Analyse.CachePath = canonicalCache
+
+	_, err := application.Execute(context.Background(), req)
+	if !analysis.CachePathSymlinkEscape(err) {
+		t.Fatalf("expected CLI symlink escape rejection, got %v", err)
+	}
+	if analysis.CachePathExternal(err) {
+		t.Fatalf("expected CLI not to classify canonical in-repo form as external, got %v", err)
+	}
+	if analyzer.called {
+		t.Fatalf("expected analyzer to remain uncalled")
+	}
+	if _, statErr := os.Stat(outsideCache); !os.IsNotExist(statErr) {
+		t.Fatalf("expected CLI not to create external cache directory, stat err=%v", statErr)
+	}
+}
+
+func TestExecuteAnalyseRejectsAlternateAbsoluteRepoAliasesThatLaterEscape(t *testing.T) {
+	for _, fixture := range appAlternateAbsoluteRepoAliasEscapeFixtures(t) {
+		t.Run(fixture.name, func(t *testing.T) {
+			analyzer := &fakeAnalyzer{}
+			application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+			req := DefaultRequest()
+			req.Mode = ModeAnalyse
+			req.RepoPath = fixture.requestedRepo
+			req.Analyse.Dependency = "lodash"
+			req.Analyse.CacheEnabled = true
+			req.Analyse.CachePath = fixture.cachePath
+
+			_, err := application.Execute(context.Background(), req)
+			if !analysis.CachePathSymlinkEscape(err) || analysis.CachePathExternal(err) {
+				t.Fatalf("expected CLI alternate-alias escape rejection, got %v", err)
+			}
+			if analyzer.called {
+				t.Fatalf("expected analyzer to remain uncalled")
+			}
+			if _, statErr := os.Stat(fixture.outsideCache); !os.IsNotExist(statErr) {
+				t.Fatalf("expected CLI not to create outside cache, stat err=%v", statErr)
+			}
+		})
+	}
+}
+
+func TestExecuteAnalyseRejectsUnsafeRelativeAdvisorySourcePathWithRepositoryView(t *testing.T) {
+	repo := t.TempDir()
+	analyzer := &fakeAnalyzer{}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.CacheEnabled = false
+	req.Analyse.AdvisorySourcePath = filepath.Join("..", "outside-advisories.json")
+	req.Analyse.Features = mustResolveAppTestFeatures(t, report.ReachabilityVulnerabilityPrioritizationPreviewFeature)
+
+	_, err := application.Execute(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "repository root") {
+		t.Fatalf("expected advisory traversal rejection, got %v", err)
+	}
+	if analyzer.called {
+		t.Fatalf("expected analyzer to remain uncalled")
+	}
+}
+
+func TestExecuteAnalyseRejectsUnsafeRelativeBaselineStorePathWithRepositoryView(t *testing.T) {
+	repo := t.TempDir()
+	analyzer := &fakeAnalyzer{report: report.Report{}}
+	application := &App{Analyzer: analyzer, Formatter: report.NewFormatter()}
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.CacheEnabled = false
+	req.Analyse.SaveBaseline = true
+	req.Analyse.BaselineStorePath = filepath.Join("..", "outside-baselines")
+	req.Analyse.BaselineLabel = "nightly"
+
+	_, err := application.Execute(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "repository root") {
+		t.Fatalf("expected baseline store traversal rejection, got %v", err)
+	}
+	if !analyzer.called {
+		t.Fatalf("expected analyzer to run before postprocess baseline rejection")
+	}
+}
+
+func TestExecuteAnalyseClassifiesExternalCacheAliasesIntoRepoBeforeAnalyzerInvocation(t *testing.T) {
+	repo := t.TempDir()
+	cacheSubdir := filepath.Join(repo, ".cache", "lopper")
+	if err := os.MkdirAll(cacheSubdir, 0o750); err != nil {
+		t.Fatalf("mkdir cache subdir: %v", err)
+	}
+	for _, tc := range repoCacheAliasFixtures(repo, cacheSubdir) {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheAlias := mustSymlinkCacheAlias(t, tc.target)
+			analyzer := &fakeAnalyzer{}
+			req := DefaultRequest()
+			req.Mode = ModeAnalyse
+			req.RepoPath = repo
+			req.Analyse.Dependency = "lodash"
+			req.Analyse.CacheEnabled = true
+			req.Analyse.CachePath = cacheAlias
+			req.Analyse.IncludePatterns = []string{"**"}
+
+			_, err := (&App{Analyzer: analyzer, Formatter: report.NewFormatter()}).Execute(context.Background(), req)
+			assertCLIRepoCacheAliasOutcome(t, err, analyzer, tc.wantReject)
+			assertRepoCachePreparationSkipped(t, tc.target, "cache preparation")
+		})
 	}
 }
 
@@ -148,6 +299,140 @@ func TestExecuteAnalysePinsScopedRelativeCachePathAndReusesRepoRoot(t *testing.T
 	}
 }
 
+func analyseCanonicalAliasCacheEscapeFixture(t *testing.T) (requestedRepo, canonicalCache, outsideCache string) {
+	t.Helper()
+
+	canonicalParent := t.TempDir()
+	canonicalRepo := filepath.Join(canonicalParent, "repo")
+	if err := os.MkdirAll(canonicalRepo, 0o755); err != nil {
+		t.Fatalf("mkdir canonical repo: %v", err)
+	}
+	canonicalRepo, err := filepath.EvalSymlinks(canonicalRepo)
+	if err != nil {
+		t.Fatalf("resolve canonical repo: %v", err)
+	}
+	requestedParent := filepath.Join(t.TempDir(), "requested-parent")
+	if err := os.Symlink(canonicalParent, requestedParent); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(canonicalRepo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	return filepath.Join(requestedParent, "repo"),
+		filepath.Join(canonicalRepo, "tmp", "cache"),
+		filepath.Join(outside, "cache")
+}
+
+type appAlternateRepoAliasEscapeFixture struct {
+	name          string
+	requestedRepo string
+	cachePath     string
+	outsideCache  string
+}
+
+func appAlternateAbsoluteRepoAliasEscapeFixtures(t *testing.T) []appAlternateRepoAliasEscapeFixture {
+	t.Helper()
+	repoParent := t.TempDir()
+	repo := filepath.Join(repoParent, "repo")
+	if err := os.Mkdir(repo, 0o750); err != nil {
+		t.Fatalf("mkdir arbitrary-alias repo: %v", err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	aliasParent := filepath.Join(t.TempDir(), "alternate-parent")
+	if err := os.Symlink(repoParent, aliasParent); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	fixtures := []appAlternateRepoAliasEscapeFixture{{
+		name:          "arbitrary alias",
+		requestedRepo: repo,
+		cachePath:     filepath.Join(aliasParent, "repo", "tmp", "cache"),
+		outsideCache:  filepath.Join(outside, "cache"),
+	}}
+
+	systemRequestedRepo := t.TempDir()
+	systemCanonicalRepo, err := filepath.EvalSymlinks(systemRequestedRepo)
+	if err != nil {
+		t.Fatalf("resolve system-alias repo: %v", err)
+	}
+	if filepath.Clean(systemRequestedRepo) == filepath.Clean(systemCanonicalRepo) {
+		return fixtures
+	}
+	systemOutside := t.TempDir()
+	if err := os.Symlink(systemOutside, filepath.Join(systemRequestedRepo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	return append(fixtures, appAlternateRepoAliasEscapeFixture{
+		name:          "system absolute alias",
+		requestedRepo: systemCanonicalRepo,
+		cachePath:     filepath.Join(systemRequestedRepo, "tmp", "cache"),
+		outsideCache:  filepath.Join(systemOutside, "cache"),
+	})
+}
+
+func TestExecuteAnalysePinsScopedDefaultCachePathAndReusesRepoRoot(t *testing.T) {
+	repo := writeScopedCacheFixtureRepo(t)
+	application := &App{Analyzer: analysis.NewService(), Formatter: report.NewFormatter()}
+	canonicalRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("resolve canonical repo path: %v", err)
+	}
+	expectedPinnedPath := filepath.Join(canonicalRepo, ".lopper-cache")
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.CacheEnabled = true
+	req.Analyse.IncludePatterns = []string{"src/**"}
+	req.Analyse.ExcludePatterns = []string{"vendor/**"}
+
+	first := executeAnalyseReport(t, application, req)
+	if first.Cache == nil || first.Cache.Path != expectedPinnedPath || first.Cache.Misses != 1 || first.Cache.Writes != 1 {
+		t.Fatalf("expected first scoped CLI run to pin and write the repo-root default cache path, got %#v", first.Cache)
+	}
+	for _, dir := range []string{"keys", "objects"} {
+		if _, err := os.Stat(filepath.Join(repo, ".lopper-cache", dir)); err != nil {
+			t.Fatalf("expected %s dir in repo-root default cache path: %v", dir, err)
+		}
+	}
+
+	second := executeAnalyseReport(t, application, req)
+	if second.Cache == nil || second.Cache.Path != expectedPinnedPath || second.Cache.Hits != 1 || second.Cache.Misses != 0 {
+		t.Fatalf("expected second scoped CLI run to reuse the repo-root default cache path, got %#v", second.Cache)
+	}
+}
+
+func TestExecuteAnalysePinsRelativeCachePathFromCanonicalDotRepoPath(t *testing.T) {
+	repo := writeScopedCacheFixtureRepo(t)
+	canonicalRepo := chdirCanonicalWorkspace(t, repo)
+	application := &App{Analyzer: analysis.NewService(), Formatter: report.NewFormatter()}
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = "."
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.CacheEnabled = true
+	req.Analyse.CachePath = filepath.Join(".cache", "lopper")
+	req.Analyse.IncludePatterns = []string{"src/**"}
+
+	reportData := executeAnalyseReport(t, application, req)
+	if reportData.Cache == nil || reportData.Cache.Path != filepath.Join(".cache", "lopper") || reportData.Cache.Misses != 1 || reportData.Cache.Writes != 1 {
+		t.Fatalf("expected scoped CLI run to pin relative cache path from repo dot, got %#v", reportData.Cache)
+	}
+	for _, dir := range []string{"keys", "objects"} {
+		if _, err := os.Stat(filepath.Join(canonicalRepo, ".cache", "lopper", dir)); err != nil {
+			t.Fatalf("expected %s dir in canonical repo-root relative cache path: %v", dir, err)
+		}
+	}
+}
+
 func TestExecuteAnalyseScopedAbsoluteCachePathOutsideRepoReusesExternalPath(t *testing.T) {
 	repo := writeScopedCacheFixtureRepo(t)
 	outsideCache := filepath.Join(t.TempDir(), "cache")
@@ -176,6 +461,29 @@ func TestExecuteAnalyseScopedAbsoluteCachePathOutsideRepoReusesExternalPath(t *t
 	second := executeAnalyseReport(t, application, req)
 	if second.Cache == nil || second.Cache.Path != outsideCache || second.Cache.Hits != 1 || second.Cache.Misses != 0 {
 		t.Fatalf("expected second scoped CLI run to reuse the external absolute cache path, got %#v", second.Cache)
+	}
+}
+
+func TestPrepareAnalyseCacheOptionsAcceptsAuthenticatedExternalCacheForRepository(t *testing.T) {
+	repo := writeScopedCacheFixtureRepo(t)
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	outsideCache := filepath.Join(t.TempDir(), "cache")
+	options, err := prepareAnalyseCacheOptions(repo, AnalyseRequest{
+		CacheEnabled: true,
+		CachePath:    outsideCache,
+		repository:   repository,
+	})
+	if err != nil {
+		t.Fatalf("expected authenticated external cache path to be accepted, got %v", err)
+	}
+	if options == nil || options.Path != outsideCache {
+		t.Fatalf("expected authenticated external cache options, got %#v", options)
+	}
+	if analysis.InRepoCacheOptions(options) {
+		t.Fatalf("expected external cache options, got in-repository pin %#v", options)
 	}
 }
 
@@ -681,6 +989,448 @@ func TestExecuteAnalyseBootstrapBaselineStoreOnFirstSave(t *testing.T) {
 	}
 	if _, err := os.Stat(report.BaselineSnapshotPath(baselineStore, resolveCurrentBaselineKey("."))); err != nil {
 		t.Fatalf("expected initial baseline snapshot to be written: %v", err)
+	}
+}
+
+func TestExecuteAnalyseRetainsAuthorizedRepositoryAcrossPostprocess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	t.Run("advisory load", testExecuteAnalyseRetainsAuthorizedRepositoryAcrossAdvisoryLoad)
+	t.Run("baseline save uses repo a commit", testExecuteAnalyseRetainsAuthorizedRepositoryAcrossBaselineSave)
+	t.Run("codemod writes and rollback stay on repo a", testExecuteAnalyseRetainsAuthorizedRepositoryAcrossCodemod)
+}
+
+func testExecuteAnalyseRetainsAuthorizedRepositoryAcrossAdvisoryLoad(t *testing.T) {
+	repo, repoB, movedRepoA := setupRetargetedRepoPair(t)
+	mustMkdirAll(t, filepath.Join(repo, "security"))
+	mustMkdirAll(t, filepath.Join(repoB, "security"))
+	writeTextFile(t, filepath.Join(repoB, indexJSFile), "repo-b must remain unchanged\n", 0o644)
+	advisoryRelPath := filepath.Join("security", "advisories.yml")
+	writeTextFile(t, filepath.Join(repo, advisoryRelPath), "advisories:\n  - id: GHSA-repo-a\n    package: lodash\n    ecosystem: npm\n    severity: high\n", 0o600)
+	writeTextFile(t, filepath.Join(repoB, advisoryRelPath), "{malformed repo-b advisories", 0o600)
+	analyzer := newRetargetingMutationAnalyzer(repo, movedRepoA, repoB, report.Report{
+		SchemaVersion: report.SchemaVersion,
+		RepoPath:      repo,
+		Dependencies:  []report.DependencyReport{{Name: "lodash", Language: "js-ts", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+	})
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.CacheEnabled = false
+	req.Analyse.AdvisorySourcePath = advisoryRelPath
+	req.Analyse.Features = mustResolveAppTestFeatures(t, report.ReachabilityVulnerabilityPrioritizationPreviewFeature)
+	output, err := (&App{Analyzer: analyzer, Formatter: report.NewFormatter()}).executeAnalyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute analyse with advisory swap: %v", err)
+	}
+	if !strings.Contains(output, "GHSA-repo-a") {
+		t.Fatalf("expected advisory annotation from moved repo A, got %q", output)
+	}
+}
+
+func testExecuteAnalyseRetainsAuthorizedRepositoryAcrossBaselineSave(t *testing.T) {
+	repo, repoB, movedRepoA := setupRetargetedRepoPair(t)
+	writeTextFile(t, filepath.Join(repoB, indexJSFile), "repo-b must remain unchanged\n", 0o644)
+	writeTextFile(t, filepath.Join(repoB, "identity.txt"), "repo-b\n", 0o644)
+	testutil.RunGit(t, repoB, "init")
+	testutil.RunGit(t, repoB, "config", "user.email", "test@example.com")
+	testutil.RunGit(t, repoB, "config", "user.name", "Test User")
+	testutil.RunGit(t, repoB, "add", ".")
+	testutil.RunGit(t, repoB, "commit", "-m", "repo-b fixture")
+	repoBCommit, err := workspace.CurrentCommitSHA(repoB)
+	if err != nil {
+		t.Fatalf("repo B commit: %v", err)
+	}
+	repoACommit, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("repo A commit: %v", err)
+	}
+	if repoACommit == repoBCommit {
+		t.Fatal("expected distinct repo A and repo B commits")
+	}
+	analyzer := newRetargetingMutationAnalyzer(repo, movedRepoA, repoB, report.Report{
+		SchemaVersion: report.SchemaVersion,
+		GeneratedAt:   testTime(),
+		RepoPath:      repo,
+		Dependencies:  []report.DependencyReport{{Name: "lodash", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+	})
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.TopN = 1
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.CacheEnabled = false
+	req.Analyse.SaveBaseline = true
+	req.Analyse.BaselineStorePath = filepath.Join(".artifacts", "baselines")
+	if _, err := (&App{Analyzer: analyzer, Formatter: report.NewFormatter()}).executeAnalyse(context.Background(), req); err != nil {
+		t.Fatalf("execute analyse with baseline save swap: %v", err)
+	}
+	catalog, err := report.ListBaselineSnapshots(filepath.Join(movedRepoA, ".artifacts", "baselines"), 10)
+	if err != nil {
+		t.Fatalf("list moved repo A snapshots: %v", err)
+	}
+	if len(catalog.Snapshots) != 1 || catalog.Snapshots[0].Key != "commit:"+repoACommit {
+		t.Fatalf("expected moved repo A snapshot keyed by repo A commit, got %#v", catalog.Snapshots)
+	}
+	unexpectedSnapshot := report.BaselineSnapshotPath(filepath.Join(repo, ".artifacts", "baselines"), "commit:"+repoBCommit)
+	if _, err := os.Stat(unexpectedSnapshot); !os.IsNotExist(err) {
+		t.Fatalf("expected replacement repo B snapshot to remain absent, stat err=%v", err)
+	}
+}
+
+func testExecuteAnalyseRetainsAuthorizedRepositoryAcrossCodemod(t *testing.T) {
+	repo, repoB, movedRepoA := setupRetargetedRepoPair(t)
+	writeTextFile(t, filepath.Join(repo, indexJSFile), importLodashLineWithLF, 0o644)
+	writeTextFile(t, filepath.Join(repoB, indexJSFile), "repo-b must remain unchanged\n", 0o644)
+	analyzer := newRetargetingMutationAnalyzer(repo, movedRepoA, repoB, singleLodashSuggestionReport(indexJSFile))
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.ApplyCodemod = true
+	req.Analyse.AllowDirty = true
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.CacheEnabled = false
+	output, err := (&App{Analyzer: analyzer, Formatter: report.NewFormatter()}).executeAnalyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute analyse with codemod swap: %v", err)
+	}
+	if !strings.Contains(readTextFile(t, filepath.Join(movedRepoA, indexJSFile)), "lodash/map") {
+		t.Fatalf("expected codemod write in moved repo A")
+	}
+	if got := readTextFile(t, filepath.Join(repo, indexJSFile)); got != "repo-b must remain unchanged\n" {
+		t.Fatalf("expected repo B source to remain untouched, got %q", got)
+	}
+	if !strings.Contains(output, ".artifacts/lopper-codemod-backups/") {
+		t.Fatalf("expected rollback artifact path in output, got %q", output)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".artifacts")); !os.IsNotExist(err) {
+		t.Fatalf("expected replacement repo B to receive no rollback artifacts, stat err=%v", err)
+	}
+}
+
+func setupRetargetedRepoPair(t *testing.T) (repo string, repoB string, movedRepoA string) {
+	t.Helper()
+	repo, _ = setupMCPGitLodashFixture(t)
+	parent := filepath.Dir(repo)
+	repoB = filepath.Join(parent, filepath.Base(repo)+"-repo-b")
+	if err := os.Mkdir(repoB, 0o750); err != nil {
+		t.Fatalf("mkdir repo B: %v", err)
+	}
+	movedRepoA = filepath.Join(parent, filepath.Base(repo)+"-repo-a-original")
+	return repo, repoB, movedRepoA
+}
+
+func newRetargetingMutationAnalyzer(repo, movedRepoA, repoB string, rep report.Report) *retargetingMutationAnalyzer {
+	return &retargetingMutationAnalyzer{
+		repo:      repo,
+		movedRepo: movedRepoA,
+		repoB:     repoB,
+		report:    rep,
+	}
+}
+
+func TestExecuteAnalyseCapturesGitSensitiveStateBeforeEarliestViewHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	t.Run("dirty repo a is not replaced by clean repo b", testExecuteAnalyseCapturesDirtyRepoStateBeforeSwap)
+	t.Run("empty repo a commit is captured and never replaced by repo b head", testExecuteAnalyseCapturesEmptyRepoCommitBeforeSwap)
+	t.Run("repo a lockfile drift is not replaced by repo b state", testExecuteAnalyseCapturesLockfileDriftBeforeSwap)
+}
+
+type repoCacheAliasFixture struct {
+	name       string
+	target     string
+	wantReject bool
+}
+
+func repoCacheAliasFixtures(repo, cacheSubdir string) []repoCacheAliasFixture {
+	return []repoCacheAliasFixture{
+		{name: "repo root", target: repo, wantReject: true},
+		{name: "repo subdir", target: cacheSubdir},
+	}
+}
+
+func mustSymlinkCacheAlias(t *testing.T, target string) string {
+	t.Helper()
+	cacheAlias := filepath.Join(t.TempDir(), "external-cache-alias")
+	if err := os.Symlink(target, cacheAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	return cacheAlias
+}
+
+func assertCLIRepoCacheAliasOutcome(t *testing.T, err error, analyzer *fakeAnalyzer, wantReject bool) {
+	t.Helper()
+	if wantReject {
+		if err == nil || !strings.Contains(err.Error(), "scoped analysis does not allow cachePath at the repository root") {
+			t.Fatalf("expected external repo-root alias rejection, got %v", err)
+		}
+		if analyzer.called {
+			t.Fatalf("expected analyzer to remain uncalled")
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("execute with external alias to repo subdir: %v", err)
+	}
+	if !analyzer.called || !analysis.InRepoCacheOptions(analyzer.lastReq.Cache) {
+		t.Fatalf("expected analyzer to receive an opaque in-repo cache pin, request=%#v", analyzer.lastReq)
+	}
+}
+
+func assertRepoCachePreparationSkipped(t *testing.T, target, label string) {
+	t.Helper()
+	for _, dir := range []string{"keys", "objects"} {
+		if _, statErr := os.Stat(filepath.Join(target, dir)); !os.IsNotExist(statErr) {
+			t.Fatalf("expected %s not to create %s under %s, stat err=%v", label, dir, target, statErr)
+		}
+	}
+}
+
+func testExecuteAnalyseCapturesDirtyRepoStateBeforeSwap(t *testing.T) {
+	repo, _ := setupMCPGitLodashFixture(t)
+	writeTextFile(t, filepath.Join(repo, "README.md"), "dirty repo a\n", 0o600)
+	repoB := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-repo-b")
+	if err := os.Mkdir(repoB, 0o750); err != nil {
+		t.Fatalf("mkdir repo B: %v", err)
+	}
+	writeTextFile(t, filepath.Join(repoB, "identity.txt"), "clean repo b\n", 0o600)
+	initGitRepo(t, repoB)
+	restoreSwap := installRepositorySwap(t, repo, repoB)
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Dependency = "lodash"
+	req.Analyse.ApplyCodemod = true
+	req.Analyse.CacheEnabled = false
+	_, err := (&App{Analyzer: &fakeAnalyzer{}, Formatter: report.NewFormatter()}).executeAnalyse(context.Background(), req)
+	restoreSwap()
+	if !errors.Is(err, ErrDirtyWorktree) {
+		t.Fatalf("expected repo A dirty-worktree rejection, got %v", err)
+	}
+}
+
+func testExecuteAnalyseCapturesEmptyRepoCommitBeforeSwap(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	repoB := filepath.Join(parent, "repo-b")
+	createRepos(t, repo, repoB)
+	writeTextFile(t, filepath.Join(repo, "identity.txt"), "non-git repo a\n", 0o600)
+	writeTextFile(t, filepath.Join(repoB, "identity.txt"), "git repo b\n", 0o600)
+	initGitRepo(t, repoB)
+	repoBCommit := resolveCurrentBaselineKey(repoB)
+	restoreSwap := installRepositorySwap(t, repo, repoB)
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.TopN = 1
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.CacheEnabled = false
+	req.Analyse.SaveBaseline = true
+	req.Analyse.BaselineStorePath = filepath.Join(repo, ".artifacts", "baselines")
+	analyzer := &fakeAnalyzer{report: report.Report{SchemaVersion: report.SchemaVersion, RepoPath: repo}}
+	_, err := (&App{Analyzer: analyzer, Formatter: report.NewFormatter()}).executeAnalyse(context.Background(), req)
+	restoreSwap()
+	if err == nil || !strings.Contains(err.Error(), "baseline key is required") {
+		t.Fatalf("expected captured empty repo A commit, got %v", err)
+	}
+	if _, statErr := os.Stat(report.BaselineSnapshotPath(filepath.Join(repo, ".artifacts", "baselines"), repoBCommit)); !os.IsNotExist(statErr) {
+		t.Fatalf("replacement repo B received a commit-keyed baseline: %v", statErr)
+	}
+}
+
+func testExecuteAnalyseCapturesLockfileDriftBeforeSwap(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	repoB := filepath.Join(parent, "repo-b")
+	createRepos(t, repo, repoB)
+	writeTextFile(t, filepath.Join(repo, "package.json"), "{\"dependencies\":{\"lodash\":\"1.0.0\"}}\n", 0o600)
+	writeTextFile(t, filepath.Join(repoB, "identity.txt"), "clean repo b\n", 0o600)
+	restoreSwap := installRepositorySwap(t, repo, repoB)
+
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.CacheEnabled = false
+	req.Analyse.Thresholds.LockfileDriftPolicy = "fail"
+	_, err := (&App{Analyzer: &fakeAnalyzer{}, Formatter: report.NewFormatter()}).executeAnalyse(context.Background(), req)
+	restoreSwap()
+	if !errors.Is(err, ErrLockfileDrift) {
+		t.Fatalf("expected captured repo A lockfile drift, got %v", err)
+	}
+}
+
+func createRepos(t *testing.T, paths ...string) {
+	t.Helper()
+	for _, path := range paths {
+		if err := os.Mkdir(path, 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+}
+
+func installRepositorySwap(t *testing.T, repo, repoB string) func() {
+	t.Helper()
+	movedRepoA := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-repo-a-original")
+	restore := analysis.SetRepositoryViewHandleOpenedHookForTest(repositorySwapHook(repo, movedRepoA, repoB))
+	t.Cleanup(restore)
+	return restore
+}
+
+func TestExecuteAnalysePersistsAbsoluteInRepoOutputThroughRetainedView(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	repoB := filepath.Join(parent, "repo-b")
+	for _, path := range []string{repo, repoB} {
+		if err := os.Mkdir(path, 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	writeTextFile(t, filepath.Join(repo, "identity.txt"), "repo a\n", 0o600)
+	writeTextFile(t, filepath.Join(repoB, "identity.txt"), "repo b\n", 0o600)
+	movedRepoA := filepath.Join(parent, "repo-a-original")
+	analyzer := &retargetingMutationAnalyzer{
+		repo:      repo,
+		movedRepo: movedRepoA,
+		repoB:     repoB,
+		report:    report.Report{SchemaVersion: report.SchemaVersion, RepoPath: repo},
+	}
+	outputPath := filepath.Join(repo, "reports", "analyse.json")
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.OutputPath = outputPath
+	req.Analyse.CacheEnabled = false
+
+	status, err := (&App{Analyzer: analyzer, Formatter: report.NewFormatter()}).executeAnalyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute analyse with output swap: %v", err)
+	}
+	if status != "analyse report written to "+outputPath {
+		t.Fatalf("unexpected output status %q", status)
+	}
+	if _, err := os.Stat(filepath.Join(movedRepoA, "reports", "analyse.json")); err != nil {
+		t.Fatalf("expected output in moved repo A: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "reports", "analyse.json")); !os.IsNotExist(err) {
+		t.Fatalf("replacement repo B received analyse output: %v", err)
+	}
+}
+
+func TestExecuteAnalyseRetainsSamePathHeadAndConfigFromOpenedView(t *testing.T) {
+	repo, _ := setupMCPGitLodashFixture(t)
+	configPath := filepath.Join(repo, ".lopper.yml")
+	writeTextFile(t, configPath, "thresholds:\n  low_confidence_warning_percent: 13\n", 0o600)
+	testutil.RunGit(t, repo, "add", ".lopper.yml")
+	testutil.RunGit(t, repo, "commit", "-m", "config A")
+	commitA, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("resolve commit A: %v", err)
+	}
+
+	writeTextFile(t, configPath, "thresholds:\n  low_confidence_warning_percent: 91\n", 0o600)
+	testutil.RunGit(t, repo, "add", ".lopper.yml")
+	testutil.RunGit(t, repo, "commit", "-m", "config B")
+	commitB, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("resolve commit B: %v", err)
+	}
+	testutil.RunGit(t, repo, "checkout", "--detach", commitA)
+
+	viewOpens := 0
+	restoreOpen := analysis.SetRepositoryViewHandleOpenedHookForTest(func() error {
+		viewOpens++
+		testutil.RunGit(t, repo, "checkout", "--detach", commitB)
+		return nil
+	})
+	t.Cleanup(restoreOpen)
+	viewCloses := 0
+	restoreClose := analysis.SetRepositoryViewCloseHookForTest(func() error {
+		viewCloses++
+		return nil
+	})
+	t.Cleanup(restoreClose)
+
+	analyzer := &snapshotConfigAnalyzer{
+		report: report.Report{
+			SchemaVersion: report.SchemaVersion,
+			GeneratedAt:   testTime(),
+			RepoPath:      repo,
+			Dependencies:  []report.DependencyReport{{Name: "lodash", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+		},
+	}
+	baselineStore := filepath.Join(repo, ".artifacts", "baselines")
+	req := DefaultRequest()
+	req.Mode = ModeAnalyse
+	req.RepoPath = repo
+	req.Analyse.TopN = 1
+	req.Analyse.ConfigPath = configPath
+	req.Analyse.Format = report.FormatJSON
+	req.Analyse.CacheEnabled = false
+	req.Analyse.SaveBaseline = true
+	req.Analyse.BaselineStorePath = baselineStore
+	req.Analyse.Thresholds.LockfileDriftPolicy = "off"
+
+	if _, err := (&App{Analyzer: analyzer, Formatter: report.NewFormatter()}).executeAnalyse(context.Background(), req); err != nil {
+		t.Fatalf("execute same-path drift analysis: %v", err)
+	}
+	if analyzer.config != "thresholds:\n  low_confidence_warning_percent: 13\n" {
+		t.Fatalf("analyzer config = %q, want config A", analyzer.config)
+	}
+	if liveConfig := readTextFile(t, configPath); liveConfig != "thresholds:\n  low_confidence_warning_percent: 91\n" {
+		t.Fatalf("live config = %q, want config B after hook", liveConfig)
+	}
+	catalog, err := report.ListBaselineSnapshots(baselineStore, 10)
+	if err != nil {
+		t.Fatalf("list saved baselines: %v", err)
+	}
+	snapshots := catalog.Snapshots
+	if len(snapshots) != 1 || snapshots[0].Key != "commit:"+commitA {
+		t.Fatalf("saved baselines = %#v, want commit A", snapshots)
+	}
+	if snapshots[0].Key == "commit:"+commitB {
+		t.Fatal("same-path commit B retargeted baseline key")
+	}
+	if viewOpens != 1 || viewCloses != 1 {
+		t.Fatalf("repository view opens/closes = %d/%d, want 1/1", viewOpens, viewCloses)
+	}
+}
+
+type snapshotConfigAnalyzer struct {
+	report report.Report
+	config string
+}
+
+func (a *snapshotConfigAnalyzer) Analyse(_ context.Context, req analysis.Request) (report.Report, error) {
+	snapshotConfigPath, err := req.RepositoryView.SnapshotPath(req.ConfigPath)
+	if err != nil {
+		return report.Report{}, err
+	}
+	config, err := os.ReadFile(snapshotConfigPath)
+	if err != nil {
+		return report.Report{}, err
+	}
+	a.config = string(config)
+	return a.report, nil
+}
+
+func repositorySwapHook(repo, movedRepo, replacementRepo string) func() error {
+	return func() error {
+		if err := os.Rename(repo, movedRepo); err != nil {
+			return err
+		}
+		return os.Rename(replacementRepo, repo)
 	}
 }
 

--- a/internal/app/app_execute_analyse_test.go
+++ b/internal/app/app_execute_analyse_test.go
@@ -229,7 +229,7 @@ func executeAnalyseReport(t *testing.T, application *App, req Request) report.Re
 func writeScopedCacheFixtureRepo(t *testing.T) string {
 	t.Helper()
 	repo := t.TempDir()
-	writeFixture := func(relPath string, content string) {
+	writeFixture := func(relPath, content string) {
 		path := filepath.Join(repo, relPath)
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", relPath, err)

--- a/internal/app/app_mcp_mutations_test.go
+++ b/internal/app/app_mcp_mutations_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/mcp"
@@ -244,6 +246,124 @@ func TestExecuteMCPMutationRejectsDirtyWorktree(t *testing.T) {
 	}
 }
 
+func TestExecuteMCPMutationUsesCapturedRepoACleanlinessAfterSwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	repo, _ := setupMCPGitLodashFixture(t)
+	writeTextFile(t, filepath.Join(repo, "README.md"), "dirty repo a\n", 0o600)
+	repoB := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-repo-b")
+	if err := os.Mkdir(repoB, 0o750); err != nil {
+		t.Fatalf("mkdir repo B: %v", err)
+	}
+	writeTextFile(t, filepath.Join(repoB, "identity.txt"), "clean repo b\n", 0o600)
+	initGitRepo(t, repoB)
+	movedRepoA := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-repo-a-original")
+	viewOpens := 0
+	restore := analysis.SetRepositoryViewHandleOpenedHookForTest(func() error {
+		viewOpens++
+		return repositorySwapHook(repo, movedRepoA, repoB)()
+	})
+	t.Cleanup(restore)
+	viewCloses := 0
+	restoreClose := analysis.SetRepositoryViewCloseHookForTest(func() error {
+		viewCloses++
+		return nil
+	})
+	t.Cleanup(restoreClose)
+
+	response := executeMCPTool(t, "lopper_apply_codemod", map[string]any{
+		"repoPath":     repo,
+		"dependency":   "lodash",
+		"confirmApply": true,
+		"cacheEnabled": false,
+	})
+	if response.Result == nil || !response.Result.IsError {
+		t.Fatalf("expected captured dirty repo A rejection, got %#v", response)
+	}
+	if !strings.Contains(response.Result.Content[0].Text, "clean git worktree") {
+		t.Fatalf("expected dirty-worktree error, got %#v", response.Result.Content)
+	}
+	if viewOpens != 1 {
+		t.Fatalf("repository view opens = %d, want 1", viewOpens)
+	}
+	if viewCloses != 1 {
+		t.Fatalf("repository view closes = %d, want 1", viewCloses)
+	}
+}
+
+func TestExecuteMCPMutationTransfersSinglePolicyViewAcrossRepositorySwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	repo, _ := setupMCPGitLodashFixture(t)
+	writeTextFile(t, filepath.Join(repo, ".lopper.yml"), "thresholds:\n  low_confidence_warning_percent: 17\n", 0o600)
+	testutil.RunGit(t, repo, "add", ".lopper.yml")
+	testutil.RunGit(t, repo, "commit", "-m", "add policy")
+
+	parent := filepath.Dir(repo)
+	repoB := filepath.Join(parent, filepath.Base(repo)+"-repo-b")
+	if err := os.Mkdir(repoB, 0o750); err != nil {
+		t.Fatalf("mkdir repo B: %v", err)
+	}
+	writeTextFile(t, filepath.Join(repoB, indexJSFile), "repo-b must remain unchanged\n", 0o644)
+	movedRepoA := filepath.Join(parent, filepath.Base(repo)+"-repo-a-original")
+	viewOpens := 0
+	restore := analysis.SetRepositoryViewHandleOpenedHookForTest(func() error {
+		viewOpens++
+		if viewOpens != 1 {
+			return nil
+		}
+		if err := os.Rename(repo, movedRepoA); err != nil {
+			return err
+		}
+		return os.Rename(repoB, repo)
+	})
+	t.Cleanup(restore)
+	viewCloses := 0
+	restoreClose := analysis.SetRepositoryViewCloseHookForTest(func() error {
+		viewCloses++
+		return nil
+	})
+	t.Cleanup(restoreClose)
+
+	response := executeMCPTool(t, "lopper_apply_codemod", map[string]any{
+		"repoPath":      repo,
+		"dependency":    "lodash",
+		"confirmApply":  true,
+		"cacheEnabled":  false,
+		"timeoutMillis": 10000,
+	})
+	if response.Result == nil || response.Result.IsError {
+		t.Fatalf("expected successful retained-view mutation, got %#v", response)
+	}
+	if viewOpens != 1 {
+		t.Fatalf("repository view opens = %d, want 1", viewOpens)
+	}
+	if viewCloses != 1 {
+		t.Fatalf("repository view closes = %d, want 1", viewCloses)
+	}
+	var payload struct {
+		BackupPath string `json:"backupPath"`
+	}
+	decodeMCPStructuredContent(t, response, &payload)
+	if !strings.Contains(readTextFile(t, filepath.Join(movedRepoA, indexJSFile)), "lodash/map") {
+		t.Fatal("expected codemod write in moved repo A")
+	}
+	if got := readTextFile(t, filepath.Join(repo, indexJSFile)); got != "repo-b must remain unchanged\n" {
+		t.Fatalf("replacement repo B source changed: %q", got)
+	}
+	if payload.BackupPath == "" {
+		t.Fatal("expected rollback artifact path")
+	}
+	if _, err := os.Stat(filepath.Join(movedRepoA, filepath.FromSlash(payload.BackupPath))); err != nil {
+		t.Fatalf("expected rollback artifact in moved repo A: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".artifacts")); !os.IsNotExist(err) {
+		t.Fatalf("replacement repo B received artifacts: %v", err)
+	}
+}
+
 func TestMCPMutationPinnedCachePathSurvivesSymlinkRetargetBeforeFirstWrite(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("directory replacement semantics are covered on Unix")
@@ -268,13 +388,10 @@ func TestMCPMutationPinnedCachePathSurvivesSymlinkRetargetBeforeFirstWrite(t *te
 		t.Fatalf("resolve trusted cache options: %v", err)
 	}
 	req := newMCPAnalyseRequest(mcp.AnalysisMutationRequest{
-		RepoPath:        repo,
-		Dependency:      "lodash",
-		Language:        "js-ts",
-		CacheEnabled:    cacheOptions.Enabled,
-		CachePath:       cacheOptions.Path,
-		CachePinnedPath: cacheOptions.PinnedPath,
-		CacheReadOnly:   cacheOptions.ReadOnly,
+		RepoPath:   repo,
+		Dependency: "lodash",
+		Language:   "js-ts",
+		Cache:      cacheOptions,
 	})
 	req.Analyse.Thresholds = thresholds.Defaults()
 
@@ -298,6 +415,224 @@ func TestMCPMutationPinnedCachePathSurvivesSymlinkRetargetBeforeFirstWrite(t *te
 	if _, err := os.Stat(filepath.Join(redirectedTarget, "cache")); !os.IsNotExist(err) {
 		t.Fatalf("expected retargeted outside cache root to remain absent, got err=%v", err)
 	}
+}
+
+func TestMCPMutationStagesRemainBoundAfterRepositoryReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	t.Run("codemod and rollback", testMCPMutationCodemodAndRollbackRemainBound)
+	t.Run("baseline write", testMCPMutationBaselineWriteRemainsBound)
+}
+
+func testMCPMutationCodemodAndRollbackRemainBound(t *testing.T) {
+	repo, _ := setupMCPGitLodashFixture(t)
+	parent := filepath.Dir(repo)
+	repoB := filepath.Join(parent, filepath.Base(repo)+"-repo-b")
+	if err := os.Mkdir(repoB, 0o750); err != nil {
+		t.Fatalf("mkdir repo B: %v", err)
+	}
+	writeTextFile(t, filepath.Join(repoB, indexJSFile), "repo-b must remain unchanged\n", 0o644)
+	movedRepoA := filepath.Join(parent, filepath.Base(repo)+"-repo-a-original")
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repo A: %v", err)
+	}
+	cacheOptions, err := analysis.ResolveTrustedCacheOptionsForRepository(repository, &analysis.CacheOptions{Enabled: false})
+	if err != nil {
+		t.Fatalf("resolve disabled cache options: %v", err)
+	}
+	analyzer := &retargetingMutationAnalyzer{
+		repo:      repo,
+		movedRepo: movedRepoA,
+		repoB:     repoB,
+		report:    singleLodashSuggestionReport(indexJSFile),
+	}
+	runner := &appMCPMutationRunner{app: &App{Analyzer: analyzer, Formatter: report.NewFormatter()}}
+	reportData, err := runner.ApplyCodemod(context.Background(), mcp.AnalysisMutationRequest{
+		RepoPath:   repo,
+		Repository: repository,
+		Dependency: "lodash",
+		Language:   "js-ts",
+		Cache:      cacheOptions,
+		Thresholds: thresholds.Defaults(),
+		AllowDirty: false,
+	})
+	if err != nil {
+		t.Fatalf("apply codemod after repository replacement: %v", err)
+	}
+	if analyzer.lastRequest.RepositoryView == nil {
+		t.Fatalf("expected analyzer request to retain repository view")
+	}
+	if got := readTextFile(t, filepath.Join(movedRepoA, indexJSFile)); !strings.Contains(got, "lodash/map") {
+		t.Fatalf("expected codemod write in moved repo A, got %q", got)
+	}
+	if got := readTextFile(t, filepath.Join(repo, indexJSFile)); got != "repo-b must remain unchanged\n" {
+		t.Fatalf("expected repo B source to remain untouched, got %q", got)
+	}
+	apply := requireCodemodApplyReport(t, reportData)
+	if apply.BackupPath == "" {
+		t.Fatalf("expected rooted rollback artifact, report=%#v", reportData)
+	}
+	if _, err := os.Stat(filepath.Join(movedRepoA, filepath.FromSlash(apply.BackupPath))); err != nil {
+		t.Fatalf("expected rollback artifact in moved repo A: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".artifacts")); !os.IsNotExist(err) {
+		t.Fatalf("expected replacement repo B to receive no artifacts, stat err=%v", err)
+	}
+}
+
+func testMCPMutationBaselineWriteRemainsBound(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	if err := os.Mkdir(repo, 0o750); err != nil {
+		t.Fatalf("mkdir repo A: %v", err)
+	}
+	writeTextFile(t, filepath.Join(repo, "identity.txt"), "repo-a\n", 0o644)
+	repoB := filepath.Join(parent, "repo-b")
+	if err := os.Mkdir(repoB, 0o750); err != nil {
+		t.Fatalf("mkdir repo B: %v", err)
+	}
+	writeTextFile(t, filepath.Join(repoB, "identity.txt"), "repo-b\n", 0o644)
+	repoBBaseline := report.BaselineSnapshotPath(filepath.Join(repoB, ".artifacts", "baselines"), "manual-retarget")
+	if err := os.MkdirAll(filepath.Dir(repoBBaseline), 0o750); err != nil {
+		t.Fatalf("mkdir repo B baseline trap: %v", err)
+	}
+	writeTextFile(t, repoBBaseline, "{malformed repo-b baseline", 0o600)
+	movedRepoA := filepath.Join(parent, "repo-a-original")
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repo A: %v", err)
+	}
+	cacheOptions, err := analysis.ResolveTrustedCacheOptionsForRepository(repository, &analysis.CacheOptions{Enabled: false})
+	if err != nil {
+		t.Fatalf("resolve disabled cache options: %v", err)
+	}
+	analyzer := &retargetingMutationAnalyzer{
+		repo:      repo,
+		movedRepo: movedRepoA,
+		repoB:     repoB,
+		report: report.Report{
+			SchemaVersion: report.SchemaVersion,
+			RepoPath:      repo,
+			Dependencies:  []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 1, UsedPercent: 100}},
+		},
+	}
+	runner := &appMCPMutationRunner{app: &App{Analyzer: analyzer, Formatter: report.NewFormatter()}}
+	storePath := filepath.Join(repo, ".artifacts", "baselines")
+	_, _, err = runner.SaveBaseline(context.Background(), mcp.AnalysisMutationRequest{
+		RepoPath:          repo,
+		Repository:        repository,
+		TopN:              1,
+		Language:          "js-ts",
+		Cache:             cacheOptions,
+		Thresholds:        thresholds.Defaults(),
+		BaselineStorePath: storePath,
+		BaselineKey:       "manual-retarget",
+	})
+	if err != nil {
+		t.Fatalf("save baseline after repository replacement: %v", err)
+	}
+	expectedSnapshot := report.BaselineSnapshotPath(filepath.Join(movedRepoA, ".artifacts", "baselines"), "manual-retarget")
+	if _, err := os.Stat(expectedSnapshot); err != nil {
+		t.Fatalf("expected baseline in moved repo A: %v", err)
+	}
+	if got := readTextFile(t, filepath.Join(repo, ".artifacts", "baselines", filepath.Base(repoBBaseline))); got != "{malformed repo-b baseline" {
+		t.Fatalf("expected replacement repo B baseline trap to remain untouched, got %q", got)
+	}
+}
+
+func TestRepositoryAwareAnalysisAndBaselineGuardBranches(t *testing.T) {
+	removedRepo := filepath.Join(t.TempDir(), "removed-repo")
+	if err := os.Mkdir(removedRepo, 0o750); err != nil {
+		t.Fatalf("mkdir removable repository: %v", err)
+	}
+	removedAuthorization, err := analysis.ResolveTrustedRepository(removedRepo)
+	if err != nil {
+		t.Fatalf("authorize removable repository: %v", err)
+	}
+	if err := os.Remove(removedRepo); err != nil {
+		t.Fatalf("remove authorized repository: %v", err)
+	}
+	executeRequest := DefaultRequest()
+	executeRequest.RepoPath = removedRepo
+	executeRequest.Analyse.repository = removedAuthorization
+	if _, err := (&App{}).executeAnalyse(context.Background(), executeRequest); err == nil {
+		t.Fatal("expected removed authorized repository rejection before analysis")
+	}
+
+	repo := t.TempDir()
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := analysis.OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close trusted repository: %v", err)
+		}
+	})
+	now := time.Date(2026, time.July, 26, 0, 0, 0, 0, time.UTC)
+	reportData := report.Report{SchemaVersion: report.SchemaVersion, RepoPath: repo}
+	application := &App{}
+
+	externalStore := filepath.Join(t.TempDir(), "baselines")
+	externalRequest := AnalyseRequest{
+		SaveBaseline:      true,
+		BaselineStorePath: externalStore,
+		BaselineKey:       "external",
+	}
+	if _, err := application.saveBaselineIfNeededWithRepository(reportData, repo, externalRequest, now, view); err != nil {
+		t.Fatalf("save genuine external baseline with repository view: %v", err)
+	}
+	if _, err := os.Stat(report.BaselineSnapshotPath(externalStore, "external")); err != nil {
+		t.Fatalf("inspect genuine external baseline: %v", err)
+	}
+
+	inRepoRequest := AnalyseRequest{
+		SaveBaseline:      true,
+		BaselineStorePath: filepath.Join(repo, ".artifacts", "baselines"),
+	}
+	if _, err := application.saveBaselineIfNeededWithRepository(reportData, repo, inRepoRequest, now, view); err == nil {
+		t.Fatal("expected missing rooted baseline key rejection")
+	}
+	inRepoRequest.BaselineKey = "rooted"
+	if _, err := application.saveBaselineIfNeededWithRepository(reportData, repo, inRepoRequest, now, view); err != nil {
+		t.Fatalf("save rooted baseline: %v", err)
+	}
+	if _, err := application.saveBaselineIfNeededWithRepository(reportData, repo, inRepoRequest, now, view); err == nil {
+		t.Fatal("expected immutable rooted baseline duplicate rejection")
+	}
+
+	if err := view.Close(); err != nil {
+		t.Fatalf("close trusted repository before write: %v", err)
+	}
+	inRepoRequest.BaselineKey = "closed"
+	if _, err := application.saveBaselineIfNeededWithRepository(reportData, repo, inRepoRequest, now, view); err == nil {
+		t.Fatal("expected rooted baseline write through closed repository view to fail")
+	}
+}
+
+type retargetingMutationAnalyzer struct {
+	repo        string
+	movedRepo   string
+	repoB       string
+	report      report.Report
+	lastRequest analysis.Request
+}
+
+func (a *retargetingMutationAnalyzer) Analyse(_ context.Context, req analysis.Request) (report.Report, error) {
+	a.lastRequest = req
+	if err := os.Rename(a.repo, a.movedRepo); err != nil {
+		return report.Report{}, err
+	}
+	if err := os.Rename(a.repoB, a.repo); err != nil {
+		return report.Report{}, err
+	}
+	return a.report, nil
 }
 
 func TestExecuteMCPReadOnlyToolRejectsMutationArguments(t *testing.T) {
@@ -331,6 +666,37 @@ func TestMCPMutationRunnerHelperBranches(t *testing.T) {
 	}
 	if got := savedSnapshotPath([]string{"unrelated warning"}, baselineSaveWarningPrefix); got != "" {
 		t.Fatalf("expected no saved snapshot path, got %q", got)
+	}
+}
+
+func TestMCPMutationCaptureDoesNotOverwriteAuthorizedCapturedState(t *testing.T) {
+	codemodErr := errors.New("captured codemod sentinel")
+	lockfileErr := errors.New("captured lockfile sentinel")
+	request := mcp.AnalysisMutationRequest{
+		RepoPath:                    t.TempDir(),
+		CurrentBaselineKey:          "commit:authorized",
+		CurrentBaselineKeyCaptured:  true,
+		ApplyCodemod:                true,
+		CodemodPrecondition:         codemodErr,
+		CodemodPreconditionCaptured: true,
+		LockfileWarnings:            []string{"captured warning"},
+		LockfileDriftErr:            lockfileErr,
+		LockfileDriftCaptured:       true,
+		Thresholds:                  thresholds.Defaults(),
+	}
+	captured, err := (&appMCPMutationRunner{}).CaptureAnalysisState(context.Background(), request)
+	if err != nil {
+		t.Fatalf("capture analysis state: %v", err)
+	}
+	if captured.CurrentBaselineKey != request.CurrentBaselineKey || !captured.CurrentBaselineKeyCaptured {
+		t.Fatalf("current commit capture was overwritten: %#v", captured)
+	}
+	if !errors.Is(captured.CodemodPrecondition, codemodErr) || !captured.CodemodPreconditionCaptured {
+		t.Fatalf("codemod capture was overwritten: %#v", captured.CodemodPrecondition)
+	}
+	if !errors.Is(captured.LockfileDriftErr, lockfileErr) || !captured.LockfileDriftCaptured ||
+		len(captured.LockfileWarnings) != 1 || captured.LockfileWarnings[0] != request.LockfileWarnings[0] {
+		t.Fatalf("lockfile capture was overwritten: %#v", captured)
 	}
 }
 

--- a/internal/app/app_mcp_mutations_test.go
+++ b/internal/app/app_mcp_mutations_test.go
@@ -9,12 +9,16 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/analysis"
+	"github.com/ben-ranford/lopper/internal/mcp"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
+	"github.com/ben-ranford/lopper/internal/thresholds"
 )
 
 const (
@@ -237,6 +241,62 @@ func TestExecuteMCPMutationRejectsDirtyWorktree(t *testing.T) {
 	}
 	if got := readTextFile(t, sourcePath); got != mcpMapSource {
 		t.Fatalf("expected source to remain unchanged, got %q", got)
+	}
+}
+
+func TestMCPMutationPinnedCachePathSurvivesSymlinkRetargetBeforeFirstWrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics are covered on Unix")
+	}
+
+	repo, _ := setupMCPGitLodashFixture(t)
+	allowedTarget := filepath.Join(repo, "allowed-target")
+	redirectedTarget := t.TempDir()
+	if err := os.MkdirAll(allowedTarget, 0o755); err != nil {
+		t.Fatalf("mkdir allowed target: %v", err)
+	}
+	linkPath := filepath.Join(repo, "allowed-link")
+	if err := os.Symlink(filepath.Base(allowedTarget), linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	cacheOptions, err := analysis.ResolveTrustedCacheOptions(repo, &analysis.CacheOptions{
+		Enabled: true,
+		Path:    filepath.Join("allowed-link", "cache"),
+	})
+	if err != nil {
+		t.Fatalf("resolve trusted cache options: %v", err)
+	}
+	req := newMCPAnalyseRequest(mcp.AnalysisMutationRequest{
+		RepoPath:        repo,
+		Dependency:      "lodash",
+		Language:        "js-ts",
+		CacheEnabled:    cacheOptions.Enabled,
+		CachePath:       cacheOptions.Path,
+		CachePinnedPath: cacheOptions.PinnedPath,
+		CacheReadOnly:   cacheOptions.ReadOnly,
+	})
+	req.Analyse.Thresholds = thresholds.Defaults()
+
+	if err := os.Remove(linkPath); err != nil {
+		t.Fatalf("remove original symlink: %v", err)
+	}
+	if err := os.Symlink(redirectedTarget, linkPath); err != nil {
+		t.Fatalf("retarget cache symlink: %v", err)
+	}
+
+	application := &App{Analyzer: analysis.NewService(), Formatter: report.NewFormatter()}
+	if _, err := application.executeAnalyse(context.Background(), req); err != nil {
+		t.Fatalf("execute analyse with pinned cache path: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(allowedTarget, "cache", "keys")); err != nil {
+		t.Fatalf("expected pinned keys dir in original target: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(allowedTarget, "cache", "objects")); err != nil {
+		t.Fatalf("expected pinned objects dir in original target: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(redirectedTarget, "cache")); !os.IsNotExist(err) {
+		t.Fatalf("expected retargeted outside cache root to remain absent, got err=%v", err)
 	}
 }
 

--- a/internal/app/app_save_baseline_test.go
+++ b/internal/app/app_save_baseline_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/dashboard"
 	"github.com/ben-ranford/lopper/internal/report"
 )
@@ -143,6 +144,78 @@ func TestSaveBaselineIfNeededDisabledNoop(t *testing.T) {
 	}
 	if len(updated.Warnings) != 1 || updated.Warnings[0] != "keep" {
 		t.Fatalf("expected unchanged report on noop save baseline, got %#v", updated)
+	}
+}
+
+func TestSaveBaselineIfNeededWithRepositoryKeepsExternalStoreOnFilesystem(t *testing.T) {
+	repo := t.TempDir()
+	externalStore := t.TempDir()
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := analysis.OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	application := &App{Formatter: report.NewFormatter()}
+	base := report.Report{SchemaVersion: "0.1.0", RepoPath: repo}
+	req := AnalyseRequest{
+		SaveBaseline:      true,
+		BaselineStorePath: externalStore,
+		BaselineLabel:     "nightly",
+	}
+	updated, err := application.saveBaselineIfNeededWithRepository(base, repo, req, testTime(), view)
+	if err != nil {
+		t.Fatalf("save baseline with external store: %v", err)
+	}
+	if len(updated.Warnings) == 0 || !strings.Contains(updated.Warnings[0], externalStore) {
+		t.Fatalf("expected external baseline save warning, got %#v", updated.Warnings)
+	}
+}
+
+func TestSaveBaselineIfNeededWithRepositoryWritesInRepoStoreThroughRetainedView(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := analysis.OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	application := &App{Formatter: report.NewFormatter()}
+	base := report.Report{SchemaVersion: "0.1.0", RepoPath: repo}
+	req := AnalyseRequest{
+		SaveBaseline:      true,
+		BaselineStorePath: filepath.Join(repo, "baselines"),
+		BaselineLabel:     "nightly",
+	}
+	updated, err := application.saveBaselineIfNeededWithRepository(base, repo, req, testTime(), view)
+	if err != nil {
+		t.Fatalf("save baseline with in-repo store: %v", err)
+	}
+	if len(updated.Warnings) == 0 {
+		t.Fatalf("expected in-repo save warning, got %#v", updated.Warnings)
+	}
+	savedPath := strings.TrimPrefix(updated.Warnings[0], "saved immutable baseline snapshot: ")
+	if _, err := os.Stat(savedPath); err != nil {
+		t.Fatalf("expected retained-view baseline snapshot to exist: %v", err)
+	}
+	if !strings.Contains(savedPath, filepath.Join(repo, "baselines")) {
+		t.Fatalf("expected in-repo baseline snapshot path, got %q", savedPath)
 	}
 }
 

--- a/internal/app/app_test_helpers_test.go
+++ b/internal/app/app_test_helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/ben-ranford/lopper/internal/analysis"
-	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/notify"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/ui"
@@ -137,24 +136,4 @@ func writeBlockedFile(t *testing.T, path string) {
 	if err := os.WriteFile(path, []byte("blocked"), 0o600); err != nil {
 		t.Fatalf("write blocker: %v", err)
 	}
-}
-
-func mustEnabledPreviewFeatureSet(t *testing.T) featureflags.Set {
-	t.Helper()
-	registry, err := featureflags.NewRegistry([]featureflags.Flag{{
-		Code:      "LOP-FEAT-0001",
-		Name:      "dart-source-attribution",
-		Lifecycle: featureflags.LifecyclePreview,
-	}})
-	if err != nil {
-		t.Fatalf("new feature registry: %v", err)
-	}
-	features, err := registry.Resolve(featureflags.ResolveOptions{
-		Channel: featureflags.ChannelDev,
-		Enable:  []string{"dart-source-attribution"},
-	})
-	if err != nil {
-		t.Fatalf("resolve feature set: %v", err)
-	}
-	return features
 }

--- a/internal/app/codemod_apply.go
+++ b/internal/app/codemod_apply.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/safeio"
 	"github.com/ben-ranford/lopper/internal/workspace"
@@ -64,6 +65,10 @@ type codemodContentLine struct {
 }
 
 func applyCodemodIfNeeded(ctx context.Context, reportData report.Report, repoPath string, req AnalyseRequest, now time.Time) (report.Report, error) {
+	return applyCodemodIfNeededWithRepository(ctx, reportData, repoPath, req, now, nil)
+}
+
+func applyCodemodIfNeededWithRepository(ctx context.Context, reportData report.Report, repoPath string, req AnalyseRequest, now time.Time, repository *analysis.RepositoryView) (report.Report, error) {
 	if !req.ApplyCodemod {
 		return reportData, nil
 	}
@@ -76,7 +81,7 @@ func applyCodemodIfNeeded(ctx context.Context, reportData report.Report, repoPat
 		return reportData, nil
 	}
 
-	mutation, err := executeCodemodApplyMutation(target, now)
+	mutation, err := executeCodemodApplyMutationWithRepository(target, now, repository)
 	if err != nil {
 		return reportData, err
 	}
@@ -108,8 +113,12 @@ func resolveCodemodApplyTarget(reportData *report.Report, repoPath, dependency s
 	}, true, nil
 }
 
-func executeCodemodApplyMutation(target codemodApplyTarget, now time.Time) (codemodApplyMutation, error) {
-	preparedFiles, failedResults := prepareCodemodFiles(target.repoPath, target.codemod.Suggestions)
+func executeCodemodApplyMutationWithRepository(target codemodApplyTarget, now time.Time, repository *analysis.RepositoryView) (codemodApplyMutation, error) {
+	preparationPath := target.repoPath
+	if repository != nil {
+		preparationPath = repository.ExecutionPath()
+	}
+	preparedFiles, failedResults := prepareCodemodFiles(preparationPath, target.codemod.Suggestions)
 	mutation := codemodApplyMutation{
 		skipResults:   buildCodemodSkipResults(target.codemod.Skips),
 		failedResults: failedResults,
@@ -118,13 +127,13 @@ func executeCodemodApplyMutation(target codemodApplyTarget, now time.Time) (code
 		return mutation, nil
 	}
 
-	backupPath, err := writeCodemodRollbackArtifact(target.repoPath, target.dependency, preparedFiles, now)
+	backupPath, err := writeCodemodRollbackArtifactWithRepository(target.repoPath, target.dependency, preparedFiles, now, repository)
 	if err != nil {
 		return codemodApplyMutation{}, fmt.Errorf("write codemod rollback artifact: %w", err)
 	}
 
 	mutation.backupPath = backupPath
-	mutation.appliedResults, mutation.failedResults = applyPreparedCodemodFiles(target.repoPath, preparedFiles, mutation.failedResults)
+	mutation.appliedResults, mutation.failedResults = applyPreparedCodemodFilesWithRepository(target.repoPath, preparedFiles, mutation.failedResults, repository)
 	return mutation, nil
 }
 
@@ -165,7 +174,31 @@ func ensureCleanWorktreeForCodemod(ctx context.Context, repoPath string, allowDi
 	if !hasGitContext || len(changed) == 0 {
 		return nil
 	}
+	return dirtyWorktreeError(changed)
+}
 
+func ensureCleanRepositoryViewForCodemod(repositoryView *analysis.RepositoryView, allowDirty bool) error {
+	if allowDirty {
+		return nil
+	}
+	metadata := repositoryView.GitMetadata()
+	if !metadata.Captured {
+		return errors.New("repository view Git metadata was not captured")
+	}
+	if metadata.CaptureError != nil {
+		return metadata.CaptureError
+	}
+	if !metadata.IsWorktree || len(metadata.ChangedFiles) == 0 {
+		return nil
+	}
+	changed := make(map[string]struct{}, len(metadata.ChangedFiles))
+	for _, path := range metadata.ChangedFiles {
+		changed[filepath.Clean(filepath.FromSlash(path))] = struct{}{}
+	}
+	return dirtyWorktreeError(changed)
+}
+
+func dirtyWorktreeError(changed map[string]struct{}) error {
 	files := make([]string, 0, len(changed))
 	for file := range changed {
 		files = append(files, file)
@@ -400,9 +433,19 @@ func joinCodemodContentLines(lines []codemodContentLine) string {
 }
 
 func applyPreparedCodemodFiles(repoPath string, prepared []preparedCodemodFile, failures []report.CodemodApplyResult) ([]report.CodemodApplyResult, []report.CodemodApplyResult) {
+	return applyPreparedCodemodFilesWithRepository(repoPath, prepared, failures, nil)
+}
+
+func applyPreparedCodemodFilesWithRepository(repoPath string, prepared []preparedCodemodFile, failures []report.CodemodApplyResult, repository *analysis.RepositoryView) ([]report.CodemodApplyResult, []report.CodemodApplyResult) {
 	applied := make([]report.CodemodApplyResult, 0, len(prepared))
 	for _, item := range prepared {
-		if err := writeFileAtomically(repoPath, item.absPath, item.updated, item.mode); err != nil {
+		var err error
+		if repository != nil {
+			err = repository.WriteFile(item.file, []byte(item.updated), item.mode)
+		} else {
+			err = writeFileAtomically(repoPath, item.absPath, item.updated, item.mode)
+		}
+		if err != nil {
 			failures = append(failures, report.CodemodApplyResult{
 				File:       item.file,
 				Status:     codemodApplyStatusFailed,
@@ -421,8 +464,20 @@ func applyPreparedCodemodFiles(repoPath string, prepared []preparedCodemodFile, 
 }
 
 func writeCodemodRollbackArtifact(repoPath, dependency string, prepared []preparedCodemodFile, now time.Time) (relativePath string, err error) {
+	return writeCodemodRollbackArtifactWithRepository(repoPath, dependency, prepared, now, nil)
+}
+
+func writeCodemodRollbackArtifactWithRepository(repoPath, dependency string, prepared []preparedCodemodFile, now time.Time, repository *analysis.RepositoryView) (relativePath string, err error) {
 	if len(prepared) == 0 {
 		return "", nil
+	}
+	if repository != nil {
+		if err := repository.EnsureDir(codemodRollbackDir, 0o750); err != nil {
+			return "", err
+		}
+		return writeCodemodRollbackPayload(dependency, prepared, now, func(relativePath string, data []byte) error {
+			return repository.WriteFile(relativePath, data, 0o600)
+		})
 	}
 	root, err := os.OpenRoot(repoPath)
 	if err != nil {
@@ -437,10 +492,12 @@ func writeCodemodRollbackArtifact(repoPath, dependency string, prepared []prepar
 		return "", err
 	}
 
-	fileName := fmt.Sprintf("%s-%d.json", sanitizeArtifactName(dependency), now.UTC().UnixNano())
-	relativePath = filepath.Join(codemodRollbackDir, fileName)
-	absPath := filepath.Join(repoPath, relativePath)
+	return writeCodemodRollbackPayload(dependency, prepared, now, func(relativePath string, data []byte) error {
+		return writeFileAtomically(repoPath, filepath.Join(repoPath, relativePath), string(data), 0o600)
+	})
+}
 
+func writeCodemodRollbackPayload(dependency string, prepared []preparedCodemodFile, now time.Time, write func(string, []byte) error) (string, error) {
 	payload := codemodRollbackArtifact{
 		GeneratedAt: now.UTC(),
 		Dependency:  dependency,
@@ -458,7 +515,9 @@ func writeCodemodRollbackArtifact(repoPath, dependency string, prepared []prepar
 	if err != nil {
 		return "", err
 	}
-	if err := writeFileAtomically(repoPath, absPath, string(data)+"\n", 0o600); err != nil {
+	fileName := fmt.Sprintf("%s-%d.json", sanitizeArtifactName(dependency), now.UTC().UnixNano())
+	relativePath := filepath.Join(codemodRollbackDir, fileName)
+	if err := write(relativePath, append(data, '\n')); err != nil {
 		return "", err
 	}
 	return filepath.ToSlash(relativePath), nil

--- a/internal/app/coverage_thresholds_test.go
+++ b/internal/app/coverage_thresholds_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 const (
@@ -116,6 +118,191 @@ func TestAnalyseFormatterReturnsFormatterErrorWithoutOriginalError(t *testing.T)
 	}
 	if err == nil || !strings.Contains(err.Error(), "unknown format") {
 		t.Fatalf("expected formatter error, got %v", err)
+	}
+}
+
+func TestRetainedAnalyseViewRejectsMismatchedAndUncapturedState(t *testing.T) {
+	repo := t.TempDir()
+	view := openAnalysisViewWithoutMetadata(t, repo)
+	uncaptured := AnalyseRequest{repositoryView: view}
+	assertUncapturedRetainedAnalyseViewErrors(t, repo, view, uncaptured)
+	assertMetadataRetainedAnalyseViewErrors(t, uncaptured)
+	assertFilteredRetainedAnalyseViewErrors(t, uncaptured)
+	assertBorrowedRetainedViewMismatch(t, repo, view)
+}
+
+func openAnalysisViewWithoutMetadata(t *testing.T, repo string) *analysis.RepositoryView {
+	t.Helper()
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := analysis.OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+	return view
+}
+
+func openAnalysisViewWithMetadata(t *testing.T, repo string) *analysis.RepositoryView {
+	t.Helper()
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := analysis.OpenTrustedRepositoryWithGitMetadata(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open metadata repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close metadata repository view: %v", err)
+		}
+	})
+	return view
+}
+
+func assertUncapturedRetainedAnalyseViewErrors(t *testing.T, repo string, view *analysis.RepositoryView, uncaptured AnalyseRequest) {
+	t.Helper()
+	if _, err := resolvePreparedLockfileDrift(context.Background(), repo, uncaptured); err == nil || !strings.Contains(err.Error(), "was not captured") {
+		t.Fatalf("expected uncaptured lockfile state rejection, got %v", err)
+	}
+	uncaptured.ApplyCodemod = true
+	if err := validateCodemodApplyPreconditions(context.Background(), repo, uncaptured); err == nil || !strings.Contains(err.Error(), "was not captured") {
+		t.Fatalf("expected uncaptured codemod state rejection, got %v", err)
+	}
+	if key := currentBaselineKeyForAnalyse(repo, uncaptured); key != "" {
+		t.Fatalf("uncaptured retained-view baseline key = %q, want empty", key)
+	}
+	if err := ensureCleanRepositoryViewForCodemod(view, true); err != nil {
+		t.Fatalf("allow-dirty retained view returned error: %v", err)
+	}
+	if err := ensureCleanRepositoryViewForCodemod(view, false); err == nil || !strings.Contains(err.Error(), "metadata was not captured") {
+		t.Fatalf("expected uncaptured retained-view cleanliness rejection, got %v", err)
+	}
+	if _, err := evaluateLockfileDriftPolicyWithRepositoryView(context.Background(), view, "warn", uncaptured.Features); err == nil || !strings.Contains(err.Error(), "metadata was not captured") {
+		t.Fatalf("expected uncaptured retained-view lockfile rejection, got %v", err)
+	}
+	filterErr := repositoryViewLockfileFilterError([]analysis.RepositoryGitFilter{{Path: "package.json", Driver: "demo"}}, []string{"package.json"})
+	if filterErr == nil || !strings.Contains(filterErr.Error(), "package.json (demo)") {
+		t.Fatalf("expected captured filter ambiguity, got %v", filterErr)
+	}
+	if err := ensureCleanWorktreeForCodemod(context.Background(), repo, true); err != nil {
+		t.Fatalf("allow-dirty live precondition returned error: %v", err)
+	}
+}
+
+func assertMetadataRetainedAnalyseViewErrors(t *testing.T, uncaptured AnalyseRequest) {
+	t.Helper()
+	metadataRepo := t.TempDir()
+	writeFile(t, filepath.Join(metadataRepo, goModManifestName), oversizedGoModManifestBody())
+	metadataView := openAnalysisViewWithMetadata(t, metadataRepo)
+	if err := ensureCleanRepositoryViewForCodemod(metadataView, false); err != nil {
+		t.Fatalf("clean non-Git metadata view returned error: %v", err)
+	}
+	if _, err := evaluateLockfileDriftPolicyWithRepositoryView(context.Background(), metadataView, "fail", uncaptured.Features); !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected retained-view oversized manifest failure, got %v", err)
+	}
+	if _, err := applyCodemodIfNeededWithRepository(context.Background(), report.Report{}, "", AnalyseRequest{ApplyCodemod: true}, time.Now(), nil); err == nil {
+		t.Fatal("expected invalid retained codemod target rejection")
+	}
+}
+
+func assertFilteredRetainedAnalyseViewErrors(t *testing.T, uncaptured AnalyseRequest) {
+	t.Helper()
+	filteredRepo := t.TempDir()
+	writeFile(t, filepath.Join(filteredRepo, ".gitattributes"), "*.json filter=demo\n")
+	writeFile(t, filepath.Join(filteredRepo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(filteredRepo, lockfileName), demoPackageJSON)
+	initGitRepo(t, filteredRepo)
+	runGit(t, filteredRepo, "config", "filter.demo.clean", "cat")
+	filteredView := openAnalysisViewWithMetadata(t, filteredRepo)
+	if _, err := evaluateLockfileDriftPolicyWithRepositoryView(context.Background(), filteredView, "warn", uncaptured.Features); err == nil || !strings.Contains(err.Error(), "active custom git filter") {
+		t.Fatalf("expected retained-view filter rejection, got %v", err)
+	}
+}
+
+func assertBorrowedRetainedViewMismatch(t *testing.T, repo string, view *analysis.RepositoryView) {
+	t.Helper()
+	otherRepository, err := analysis.ResolveTrustedRepository(t.TempDir())
+	if err != nil {
+		t.Fatalf("authorize other repository: %v", err)
+	}
+	req := DefaultRequest()
+	req.RepoPath = repo
+	req.Analyse.repository = otherRepository
+	req.Analyse.repositoryView = view
+	if _, _, err := openAnalyseRepositoryView(context.Background(), req); err == nil {
+		t.Fatal("expected mismatched borrowed repository view rejection")
+	}
+}
+
+func TestPersistAnalyseOutputRetainedViewGuards(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, "reports"), 0o750); err != nil {
+		t.Fatalf("mkdir reports: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(repo, "directory-target"), 0o750); err != nil {
+		t.Fatalf("mkdir directory target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "blocked"), []byte("not a directory\n"), 0o600); err != nil {
+		t.Fatalf("write blocked parent: %v", err)
+	}
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	view, err := analysis.OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := view.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+
+	directoryStylePath := filepath.Join(repo, "reports") + string(os.PathSeparator)
+	if _, err := persistAnalyseOutput("{}", directoryStylePath, repo, view); err == nil || !strings.Contains(err.Error(), "must name a file") {
+		t.Fatalf("expected directory-style output rejection, got %v", err)
+	}
+	rootOutput := filepath.Join(repo, "report.json")
+	if _, err := persistAnalyseOutput("root\n", rootOutput, repo, view); err != nil {
+		t.Fatalf("write repository-root output: %v", err)
+	}
+	nestedOutput := filepath.Join(repo, "reports", "analyse.json")
+	if _, err := persistAnalyseOutput("nested\n", nestedOutput, repo, view); err != nil {
+		t.Fatalf("write output through existing repository directory: %v", err)
+	}
+	if _, err := persistAnalyseOutput("{}", filepath.Join(repo, "directory-target"), repo, view); err == nil {
+		t.Fatal("expected retained-view write to reject a directory target")
+	}
+	if _, err := persistAnalyseOutput("{}", filepath.Join(repo, "blocked", "nested", "analyse.json"), repo, view); err == nil {
+		t.Fatal("expected retained-view output inspection error below a file")
+	}
+}
+
+func TestAnalyseRepositoryBoundaryErrorBranches(t *testing.T) {
+	captureAnalyseGitSensitiveState(context.Background(), nil, nil)
+
+	req := DefaultRequest()
+	req.RepoPath = filepath.Join(t.TempDir(), "missing")
+	if _, err := (&App{Analyzer: &fakeAnalyzer{}, Formatter: report.NewFormatter()}).executeAnalyse(context.Background(), req); err == nil {
+		t.Fatal("expected missing repository authorization failure")
+	}
+
+	repo := t.TempDir()
+	current, err := (&App{}).applyBaselineIfNeededWithRepository(report.Report{}, repo, AnalyseRequest{}, nil)
+	if err != nil {
+		t.Fatalf("apply disabled baseline without repository view: %v", err)
+	}
+	if len(current.Dependencies) != 0 {
+		t.Fatalf("disabled baseline changed report: %#v", current)
 	}
 }
 

--- a/internal/app/dashboard.go
+++ b/internal/app/dashboard.go
@@ -111,6 +111,7 @@ func (a *App) saveDashboardBaselineIfNeeded(reportData dashboard.Report, repoPat
 	return saveImmutableBaselineSnapshot(reportData, immutableBaselineSaveConfig[dashboard.Report]{
 		enabled:       resolved.saveBaseline,
 		repoPath:      repoPath,
+		currentKey:    resolveCurrentBaselineKey(repoPath),
 		req:           baselineKeyRequestFromDashboard(resolved),
 		keyName:       "dashboard baseline",
 		now:           now,
@@ -120,7 +121,7 @@ func (a *App) saveDashboardBaselineIfNeeded(reportData dashboard.Report, repoPat
 }
 
 func resolveDashboardBaselinePaths(repoPath string, resolved resolvedDashboardRequest) (string, string, string, bool, error) {
-	return resolveBaselineStoreComparisonPaths(repoPath, baselineKeyRequestFromDashboard(resolved), dashboard.ResolveBaselineSnapshotPath)
+	return resolveBaselineStoreComparisonPaths(resolveCurrentBaselineKey(repoPath), baselineKeyRequestFromDashboard(resolved), dashboard.ResolveBaselineSnapshotPath)
 }
 
 func appendDashboardBaselineSaveWarning(reportData dashboard.Report, savedPath string) dashboard.Report {

--- a/internal/app/dashboard_request_options_test.go
+++ b/internal/app/dashboard_request_options_test.go
@@ -186,3 +186,34 @@ func TestLoadDashboardConfigEmptyPath(t *testing.T) {
 		t.Fatalf("expected empty loaded config, got %#v", loaded)
 	}
 }
+
+func TestDashboardRoutingOptionsCopiesOwnershipConfig(t *testing.T) {
+	config := dashboard.ConfigOwnership{
+		DefaultOwner:  "security",
+		DefaultTeam:   "platform",
+		DefaultDue:    "2026-08-15",
+		DefaultStatus: "triage",
+		Rules: []dashboard.ConfigOwnershipRule{{
+			Repo:       "api",
+			PathPrefix: "services/api",
+			Category:   "vulnerability",
+			Dependency: "lib",
+			Owner:      "owner",
+			Team:       "team",
+			Due:        "2026-08-01",
+			Status:     "assigned",
+		}},
+	}
+
+	got := dashboardRoutingOptions(config)
+	if got.DefaultOwner != config.DefaultOwner || got.DefaultTeam != config.DefaultTeam || got.DefaultDue != config.DefaultDue || got.DefaultStatus != config.DefaultStatus {
+		t.Fatalf("expected defaults to be copied, got %#v", got)
+	}
+	if len(got.Rules) != 1 {
+		t.Fatalf("expected one routing rule, got %#v", got.Rules)
+	}
+	rule := got.Rules[0]
+	if rule.Repo != "api" || rule.PathPrefix != "services/api" || rule.Category != "vulnerability" || rule.Dependency != "lib" || rule.Owner != "owner" || rule.Team != "team" || rule.Due != "2026-08-01" || rule.Status != "assigned" {
+		t.Fatalf("unexpected routing rule conversion: %#v", rule)
+	}
+}

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -99,6 +99,26 @@ func TestExecuteFeaturesOutputFile(t *testing.T) {
 	}
 }
 
+func TestExecuteFeaturesOutputPathError(t *testing.T) {
+	registry := mustFeatureRegistry(t)
+	application := &App{Features: registry}
+	root := t.TempDir()
+	blocker := filepath.Join(root, "blocked")
+	if err := os.WriteFile(blocker, []byte("block"), 0o600); err != nil {
+		t.Fatalf("write blocker file: %v", err)
+	}
+
+	req := DefaultRequest()
+	req.Mode = ModeFeatures
+	req.Features.Format = "json"
+	req.Features.Channel = "dev"
+	req.Features.OutputPath = filepath.Join(blocker, "features.json")
+
+	if _, err := application.Execute(context.Background(), req); err == nil {
+		t.Fatalf("expected feature output path error")
+	}
+}
+
 func TestExecuteFeaturesRollingChannel(t *testing.T) {
 	application := &App{Features: mustFeatureRegistry(t)}
 	req := DefaultRequest()
@@ -116,43 +136,8 @@ func TestExecuteFeaturesRollingChannel(t *testing.T) {
 }
 
 func TestExecuteFeaturesReleaseChannelAndEmptyRegistry(t *testing.T) {
-	application := &App{Features: mustFeatureRegistry(t)}
-	req := DefaultRequest()
-	req.Mode = ModeFeatures
-	req.Features.Format = "json"
-	req.Features.Channel = "release"
-	req.Features.Release = "v1.4.2"
-
-	output, err := application.Execute(context.Background(), req)
-	if err != nil {
-		t.Fatalf("execute release features: %v", err)
-	}
-	if !strings.Contains(output, `"code": "LOP-FEAT-0002"`) || !strings.Contains(output, `"enabledByDefault": true`) {
-		t.Fatalf("expected release manifest to enable stable flag: %s", output)
-	}
-
-	emptyReq := DefaultRequest()
-	emptyReq.Mode = ModeFeatures
-	// Keep this assertion stable across CI lanes that set BUILD_CHANNEL=rolling.
-	emptyReq.Features.Channel = "dev"
-	emptyOutput, err := (&App{}).Execute(context.Background(), emptyReq)
-	if err != nil {
-		t.Fatalf("execute empty features: %v", err)
-	}
-	if !strings.Contains(emptyOutput, "dart-source-attribution") ||
-		!strings.Contains(emptyOutput, "lockfile-drift-ecosystem-expansion") ||
-		!strings.Contains(emptyOutput, "swift-carthage") ||
-		!strings.Contains(emptyOutput, "powershell-adapter") ||
-		!strings.Contains(emptyOutput, "go-vendored-provenance") ||
-		!strings.Contains(emptyOutput, "baseline-provenance-runtime-context") ||
-		!strings.Contains(emptyOutput, "vscode-multi-root-workflows") ||
-		!strings.Contains(emptyOutput, "mcp-server") ||
-		!strings.Contains(emptyOutput, "true") {
-		t.Fatalf("expected default feature table to include embedded graduated flags enabled by default, got %q", emptyOutput)
-	}
-	if strings.Contains(emptyOutput, "dart-source-attribution-preview") || strings.Contains(emptyOutput, "mcp-server-preview") {
-		t.Fatalf("expected default feature table to use stable aliases, got %q", emptyOutput)
-	}
+	t.Run("release manifest enables stable flag", testExecuteFeaturesReleaseChannel)
+	t.Run("empty registry output uses stable aliases", testExecuteFeaturesEmptyRegistryOutput)
 }
 
 func TestExecuteFeaturesDefaultReleaseAndStdoutOutputPath(t *testing.T) {
@@ -287,4 +272,50 @@ func mustFeatureRegistry(t *testing.T) *featureflags.Registry {
 		t.Fatalf("new feature registry: %v", err)
 	}
 	return registry
+}
+
+func testExecuteFeaturesReleaseChannel(t *testing.T) {
+	t.Helper()
+
+	application := &App{Features: mustFeatureRegistry(t)}
+	req := DefaultRequest()
+	req.Mode = ModeFeatures
+	req.Features.Format = "json"
+	req.Features.Channel = "release"
+	req.Features.Release = "v1.4.2"
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute release features: %v", err)
+	}
+	if !strings.Contains(output, `"code": "LOP-FEAT-0002"`) || !strings.Contains(output, `"enabledByDefault": true`) {
+		t.Fatalf("expected release manifest to enable stable flag: %s", output)
+	}
+}
+
+func testExecuteFeaturesEmptyRegistryOutput(t *testing.T) {
+	t.Helper()
+
+	req := DefaultRequest()
+	req.Mode = ModeFeatures
+	req.Features.Channel = "dev"
+
+	output, err := (&App{}).Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute empty features: %v", err)
+	}
+	assertContainsAll(t, output, []string{
+		"dart-source-attribution",
+		"lockfile-drift-ecosystem-expansion",
+		"swift-carthage",
+		"powershell-adapter",
+		"go-vendored-provenance",
+		"baseline-provenance-runtime-context",
+		"vscode-multi-root-workflows",
+		"mcp-server",
+		"true",
+	})
+	if strings.Contains(output, "dart-source-attribution-preview") || strings.Contains(output, "mcp-server-preview") {
+		t.Fatalf("expected default feature table to use stable aliases, got %q", output)
+	}
 }

--- a/internal/app/lockfile_drift.go
+++ b/internal/app/lockfile_drift.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
+	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/workspace"
 )
@@ -29,6 +31,42 @@ func evaluateLockfileDriftPolicyWithFeatures(ctx context.Context, repoPath, poli
 	}
 	failMode := normalizedPolicy == "fail"
 	result := detectLockfileDriftDetailed(ctx, repoPath, failMode, features)
+	return resolveLockfileDriftPolicyResult(result, failMode)
+}
+
+func evaluateLockfileDriftPolicyWithRepositoryView(ctx context.Context, repositoryView *analysis.RepositoryView, policy string, features featureflags.Set) ([]string, error) {
+	normalizedPolicy := strings.TrimSpace(policy)
+	if normalizedPolicy == "off" {
+		return nil, nil
+	}
+	metadata := repositoryView.GitMetadata()
+	if !metadata.Captured {
+		return nil, errors.New("repository view Git metadata was not captured")
+	}
+	if metadata.CaptureError != nil {
+		return nil, metadata.CaptureError
+	}
+
+	failMode := normalizedPolicy == "fail"
+	rules := activeLockfileRules(features)
+	prepared, candidatePaths, candidateErr := prepareLockfileManifestChangeCandidates(ctx, repositoryView.ExecutionPath(), rules)
+	if candidateErr != nil && (failMode || !isRecoverableLockfileManifestReadError(candidateErr)) {
+		return nil, candidateErr
+	}
+	if filterErr := repositoryViewLockfileFilterError(metadata.ActiveFilterDrivers, candidatePaths); filterErr != nil {
+		return nil, errors.Join(candidateErr, filterErr)
+	}
+
+	gitContext := lockfileGitContext{
+		changedFiles:  repositoryViewChangedFiles(metadata.ChangedFiles),
+		hasGitContext: metadata.IsWorktree,
+		preparedScan:  prepared,
+	}
+	result := scanLockfileDriftDetailed(ctx, repositoryView.ExecutionPath(), gitContext, failMode, rules)
+	return resolveLockfileDriftPolicyResult(result, failMode)
+}
+
+func resolveLockfileDriftPolicyResult(result lockfileDriftResult, failMode bool) ([]string, error) {
 	if result.err != nil && !failMode && isPureLockfileManifestReadSizeError(result.err) {
 		return result.orderedWarnings, nil
 	}
@@ -39,6 +77,32 @@ func evaluateLockfileDriftPolicyWithFeatures(ctx context.Context, repoPath, poli
 		return result.findings, formatLockfileDriftError(result.findings)
 	}
 	return result.findings, nil
+}
+
+func repositoryViewChangedFiles(paths []string) map[string]struct{} {
+	changed := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		changed[filepath.Clean(filepath.FromSlash(path))] = struct{}{}
+	}
+	return changed
+}
+
+func repositoryViewLockfileFilterError(filters []analysis.RepositoryGitFilter, candidatePaths []string) error {
+	candidates := make(map[string]struct{}, len(candidatePaths))
+	for _, path := range candidatePaths {
+		candidates[filepath.Clean(path)] = struct{}{}
+	}
+	active := make([]gitFilterPathDriver, 0)
+	for _, filter := range filters {
+		path := filepath.Clean(filepath.FromSlash(filter.Path))
+		if _, ok := candidates[path]; ok {
+			active = append(active, gitFilterPathDriver{path: path, driver: filter.Driver})
+		}
+	}
+	if len(active) == 0 {
+		return nil
+	}
+	return newLockfileDriftFilterAmbiguityError(active)
 }
 
 func oversizedLockfileDriftWarning(err error) string {

--- a/internal/app/lockfile_drift_head_test.go
+++ b/internal/app/lockfile_drift_head_test.go
@@ -39,6 +39,20 @@ func TestLockfileManifestIOFromContextUsesDefaults(t *testing.T) {
 	}
 }
 
+func TestLockfileManifestIOFromNilContextUsesDefaults(t *testing.T) {
+	fromContext := lockfileManifestIOFromContext(nil)
+	if fromContext.readFileUnder == nil || fromContext.readFileUnderLimit == nil {
+		t.Fatalf("expected default manifest readers from nil context, got %#v", fromContext)
+	}
+}
+
+func TestLockfileManifestIOFromBackgroundContextUsesDefaults(t *testing.T) {
+	fromContext := lockfileManifestIOFromContext(context.Background())
+	if fromContext.readFileUnder == nil || fromContext.readFileUnderLimit == nil {
+		t.Fatalf("expected default manifest readers from background context, got %#v", fromContext)
+	}
+}
+
 func TestLockfileManifestChangeCandidatePathsWithReadErrorsSkipsRecoverableManifestErrors(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, pyprojectManifestName), oversizedManifestBody("[tool.poetry]\nname = \"demo\"\n", "# filler\n", 8))
@@ -254,6 +268,157 @@ func TestEvaluatePreparedReplayRuleReturnsNoFindingWithoutReplayInputs(t *testin
 	}
 	if finding.kind != 0 || finding.manifest != "" || finding.relDir != "" || len(finding.lockfiles) != 0 {
 		t.Fatalf("expected no finding without replay inputs, got found=%v finding=%#v", found, finding)
+	}
+}
+
+func TestEvaluatePreparedReplayRuleDetectsMissingLockfile(t *testing.T) {
+	repo := t.TempDir()
+	snapshot := lockfileDirSnapshot{repoPath: repo, path: repo, relDir: "."}
+	cache := newLockfileManifestCache(snapshot)
+	dir := lockfilePreparedDir{repoPath: repo, path: repo, relDir: "."}
+	prepared := lockfilePreparedRule{
+		replay: &lockfilePreparedRuleReplay{
+			rule:      mustLockfileRule(t, "npm", manifestFileName),
+			manifests: []string{manifestFileName},
+		},
+	}
+
+	finding, found, err := evaluatePreparedReplayRule(dir, prepared, lockfileGitContext{}, cache)
+	if err != nil {
+		t.Fatalf("evaluate replay missing lockfile: %v", err)
+	}
+	if !found {
+		t.Fatal("expected missing lockfile finding")
+	}
+	if finding.kind != lockfileDriftMissingLockfile || finding.manifest != manifestFileName || finding.relDir != "." {
+		t.Fatalf("unexpected missing lockfile finding: %#v", finding)
+	}
+}
+
+func TestPreparedLockfileNameConversions(t *testing.T) {
+	lockfiles := []presentLockfile{{name: "package-lock.json"}, {name: "pnpm-lock.yaml"}}
+
+	names := preparedLockfileNames(lockfiles)
+	if !reflect.DeepEqual(names, []string{"package-lock.json", "pnpm-lock.yaml"}) {
+		t.Fatalf("unexpected prepared lockfile names: %#v", names)
+	}
+
+	roundTrip := preparedPresentLockfiles(names)
+	if !reflect.DeepEqual(roundTrip, lockfiles) {
+		t.Fatalf("unexpected prepared present lockfiles: %#v", roundTrip)
+	}
+
+	if names := preparedLockfileNames(nil); len(names) != 0 {
+		t.Fatalf("expected nil lockfile names to stay empty, got %#v", names)
+	}
+	if lockfiles := preparedPresentLockfiles(nil); len(lockfiles) != 0 {
+		t.Fatalf("expected nil prepared lockfiles to stay empty, got %#v", lockfiles)
+	}
+}
+
+func TestEvaluatePreparedReplayRuleReturnsNoFindingForMatchingManifest(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+
+	snapshot, err := readLockfileDirSnapshot(repo, repo)
+	if err != nil {
+		t.Fatalf("read lockfile snapshot: %v", err)
+	}
+	dir := lockfilePreparedDir{repoPath: repo, path: repo, relDir: "."}
+	prepared := lockfilePreparedRule{
+		replay: &lockfilePreparedRuleReplay{
+			rule:      mustLockfileRule(t, "npm", manifestFileName),
+			manifests: []string{manifestFileName},
+			lockfiles: []string{lockfileName},
+		},
+	}
+
+	finding, found, err := evaluatePreparedReplayRule(dir, prepared, lockfileGitContext{}, newLockfileManifestCache(snapshot))
+	if err != nil {
+		t.Fatalf("evaluate replay with matching manifest: %v", err)
+	}
+	if found || finding.kind != 0 {
+		t.Fatalf("expected no finding for matching manifest replay, got found=%v finding=%#v", found, finding)
+	}
+}
+
+func TestAppendPreparedReplayRuleHandlesRecoverableAndFatalErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{name: "recoverable manifest read error is downgraded to warning", run: testAppendPreparedReplayRuleRecoverableError},
+		{name: "fatal matcher error stops replay processing", run: testAppendPreparedReplayRuleFatalError},
+	} {
+		t.Run(tc.name, tc.run)
+	}
+}
+
+func testAppendPreparedReplayRuleRecoverableError(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, pyprojectManifestName), oversizedManifestBody("[tool.poetry]\nname = \"demo\"\n", "# filler\n", 8))
+	writeFile(t, filepath.Join(repo, poetryLockName), "# lock\n")
+
+	snapshot, err := readLockfileDirSnapshot(repo, repo)
+	if err != nil {
+		t.Fatalf("read lockfile snapshot: %v", err)
+	}
+	dir := lockfilePreparedDir{repoPath: repo, path: repo, relDir: "."}
+	prepared := lockfilePreparedRule{
+		replay: &lockfilePreparedRuleReplay{
+			rule:      mustLockfileRule(t, "Poetry", pyprojectManifestName),
+			manifests: []string{pyprojectManifestName},
+			lockfiles: []string{poetryLockName},
+		},
+	}
+
+	var result lockfileDriftResult
+	if ok := result.appendPreparedReplayRule(dir, prepared, lockfileGitContext{}, newLockfileManifestCache(snapshot)); !ok {
+		t.Fatal("expected recoverable replay error to continue")
+	}
+	if !errors.Is(result.err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected recoverable file size error, got %v", result.err)
+	}
+	if len(result.findings) != 0 || len(result.orderedWarnings) != 1 {
+		t.Fatalf("expected one ordered warning and no findings, got %#v %#v", result.findings, result.orderedWarnings)
+	}
+}
+
+func testAppendPreparedReplayRuleFatalError(t *testing.T) {
+	t.Helper()
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, manifestFileName), demoPackageJSON)
+	writeFile(t, filepath.Join(repo, lockfileName), "{}\n")
+
+	snapshot, err := readLockfileDirSnapshot(repo, repo)
+	if err != nil {
+		t.Fatalf("read lockfile snapshot: %v", err)
+	}
+	dir := lockfilePreparedDir{repoPath: repo, path: repo, relDir: "."}
+	prepared := lockfilePreparedRule{
+		replay: &lockfilePreparedRuleReplay{
+			rule: lockfileRule{
+				manager:  "custom",
+				manifest: manifestFileName,
+				manifestMatcher: func(string, string) (bool, error) {
+					return false, errors.New("matcher failed")
+				},
+			},
+			manifests: []string{manifestFileName},
+			lockfiles: []string{lockfileName},
+		},
+	}
+
+	var result lockfileDriftResult
+	if ok := result.appendPreparedReplayRule(dir, prepared, lockfileGitContext{}, newLockfileManifestCache(snapshot)); ok {
+		t.Fatal("expected fatal replay error to stop processing")
+	}
+	if result.err == nil || !strings.Contains(result.err.Error(), "matcher failed") {
+		t.Fatalf("expected matcher failure to be recorded, got %v", result.err)
 	}
 }
 

--- a/internal/app/lockfile_drift_warning_test.go
+++ b/internal/app/lockfile_drift_warning_test.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestLockfileDriftWarningHelpers(t *testing.T) {
+	findings := []lockfileDriftFinding{
+		{
+			kind:      lockfileDriftMissingLockfile,
+			manifest:  "package.json",
+			relDir:    "services/api",
+			rule:      lockfileRule{manager: "npm", lockfiles: []string{"package-lock.json"}, remedy: "run npm install"},
+			lockfiles: nil,
+		},
+		{
+			kind:      lockfileDriftStaleLockfile,
+			manifest:  "package.json",
+			relDir:    ".",
+			rule:      lockfileRule{manager: "npm", manifest: "package.json"},
+			lockfiles: []presentLockfile{{name: "package-lock.json"}},
+		},
+	}
+
+	warnings := buildLockfileDriftWarnings(findings)
+	if len(warnings) != len(findings) {
+		t.Fatalf("expected %d warnings, got %#v", len(findings), warnings)
+	}
+	if !strings.Contains(warnings[0], "package.json exists but no matching lockfile (package-lock.json) was found") {
+		t.Fatalf("unexpected missing lockfile warning: %q", warnings[0])
+	}
+	if !strings.Contains(warnings[1], "package-lock.json exists without package.json") {
+		t.Fatalf("unexpected stale lockfile warning: %q", warnings[1])
+	}
+
+	err := formatLockfileDriftError(warnings)
+	if !errors.Is(err, ErrLockfileDrift) {
+		t.Fatalf("expected lockfile drift sentinel error, got %v", err)
+	}
+	if strings.Count(err.Error(), lockfileDriftWarningPrefix) != 1 {
+		t.Fatalf("expected formatted error to keep only the sentinel prefix, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "npm in services/api") || !strings.Contains(err.Error(), "npm in .") {
+		t.Fatalf("expected both warnings in formatted error, got %q", err)
+	}
+}

--- a/internal/app/mcp_mutations.go
+++ b/internal/app/mcp_mutations.go
@@ -97,6 +97,7 @@ func newMCPAnalyseRequest(req mcp.AnalysisMutationRequest) Request {
 	appReq.Analyse.Language = req.Language
 	appReq.Analyse.CacheEnabled = req.CacheEnabled
 	appReq.Analyse.CachePath = req.CachePath
+	appReq.Analyse.CachePinnedPath = req.CachePinnedPath
 	appReq.Analyse.CacheReadOnly = req.CacheReadOnly
 	appReq.Analyse.RuntimeProfile = req.RuntimeProfile
 	appReq.Analyse.RuntimeTracePath = req.RuntimeTracePath

--- a/internal/app/mcp_mutations.go
+++ b/internal/app/mcp_mutations.go
@@ -45,6 +45,20 @@ func (a *App) ensureMCPMutationDefaults() {
 	}
 }
 
+func (*appMCPMutationRunner) CaptureAnalysisState(ctx context.Context, req mcp.AnalysisMutationRequest) (mcp.AnalysisMutationRequest, error) {
+	appReq := newMCPAnalyseRequest(req)
+	appReq.Analyse.ApplyCodemod = req.ApplyCodemod
+	captureAnalyseGitSensitiveState(ctx, req.RepositoryView, &appReq.Analyse)
+	req.CurrentBaselineKey = appReq.Analyse.currentBaselineKey
+	req.CurrentBaselineKeyCaptured = appReq.Analyse.currentBaselineKeyCaptured
+	req.CodemodPrecondition = appReq.Analyse.codemodPrecondition
+	req.CodemodPreconditionCaptured = appReq.Analyse.codemodPreconditionCaptured
+	req.LockfileWarnings = append([]string{}, appReq.Analyse.lockfileWarnings...)
+	req.LockfileDriftErr = appReq.Analyse.lockfileDriftErr
+	req.LockfileDriftCaptured = appReq.Analyse.lockfileDriftCaptured
+	return req, nil
+}
+
 func (r *appMCPMutationRunner) ApplyCodemod(ctx context.Context, req mcp.AnalysisMutationRequest) (report.Report, error) {
 	appReq := newMCPAnalyseRequest(req)
 	appReq.Analyse.ApplyCodemod = true
@@ -95,15 +109,26 @@ func newMCPAnalyseRequest(req mcp.AnalysisMutationRequest) Request {
 	appReq.Analyse.ScopeMode = req.ScopeMode
 	appReq.Analyse.Format = report.FormatJSON
 	appReq.Analyse.Language = req.Language
-	appReq.Analyse.CacheEnabled = req.CacheEnabled
-	appReq.Analyse.CachePath = req.CachePath
-	appReq.Analyse.CachePinnedPath = req.CachePinnedPath
-	appReq.Analyse.CacheReadOnly = req.CacheReadOnly
+	appReq.Analyse.cacheOptions = req.Cache
+	appReq.Analyse.repository = req.Repository
+	appReq.Analyse.repositoryView = req.RepositoryView
+	if req.Cache != nil {
+		appReq.Analyse.CacheEnabled = req.Cache.Enabled
+		appReq.Analyse.CachePath = req.Cache.Path
+		appReq.Analyse.CacheReadOnly = req.Cache.ReadOnly
+	}
 	appReq.Analyse.RuntimeProfile = req.RuntimeProfile
 	appReq.Analyse.RuntimeTracePath = req.RuntimeTracePath
 	appReq.Analyse.IncludePatterns = append([]string{}, req.IncludePatterns...)
 	appReq.Analyse.ExcludePatterns = append([]string{}, req.ExcludePatterns...)
 	appReq.Analyse.ConfigPath = req.ConfigPath
+	appReq.Analyse.currentBaselineKey = req.CurrentBaselineKey
+	appReq.Analyse.currentBaselineKeyCaptured = req.CurrentBaselineKeyCaptured
+	appReq.Analyse.codemodPrecondition = req.CodemodPrecondition
+	appReq.Analyse.codemodPreconditionCaptured = req.CodemodPreconditionCaptured
+	appReq.Analyse.lockfileWarnings = append([]string{}, req.LockfileWarnings...)
+	appReq.Analyse.lockfileDriftErr = req.LockfileDriftErr
+	appReq.Analyse.lockfileDriftCaptured = req.LockfileDriftCaptured
 	appReq.Analyse.PolicySources = append([]string{}, req.PolicySources...)
 	appReq.Analyse.PolicyTrace = append([]report.PolicyMergeTrace{}, req.PolicyTrace...)
 	appReq.Analyse.Features = req.Features

--- a/internal/app/pr_review_test.go
+++ b/internal/app/pr_review_test.go
@@ -163,6 +163,15 @@ func TestBuildPRReviewArtifactAppliesReachableVulnerabilityPriorityThreshold(t *
 	}
 }
 
+func TestPRReviewRevisionHelpers(t *testing.T) {
+	if got := shortPRReviewRevision("  abcdef1234567890  "); got != "abcdef123456" {
+		t.Fatalf("expected trimmed short revision, got %q", got)
+	}
+	if got := shortPRReviewRevision("short"); got != "short" {
+		t.Fatalf("expected short revision to pass through, got %q", got)
+	}
+}
+
 func TestBuildPRReviewArtifactTreatsUnevaluableReachableFindingsAsRegressionsUnlessOff(t *testing.T) {
 	baseDependency := prReviewTestDependency("lib", "npm", "1.0.0", 100, 90, false)
 	headDependency := baseDependency
@@ -1255,18 +1264,14 @@ func TestBuildPRReviewArtifactPreservesDuplicateVersionlessInstancesDeterministi
 	first := build([]report.DependencyReport{baseChanged, baseStable}, []report.DependencyReport{headAdded, headStable, headChanged})
 	second := build([]report.DependencyReport{baseStable, baseChanged}, []report.DependencyReport{headChanged, headAdded, headStable})
 
-	if first.Summary.Added != 1 || first.Summary.Upgraded != 1 || first.Summary.PolicyChanged != 1 {
-		t.Fatalf("expected duplicate versionless instances to retain one add, one upgrade, and one policy change, got %#v", first.Summary)
-	}
+	assertPRReviewDuplicateVersionlessSummary(t, first.Summary)
 	if first.Summary != second.Summary {
 		t.Fatalf("expected duplicate pairing summary to be order-independent, got %#v vs %#v", first.Summary, second.Summary)
 	}
 
 	firstAdded := prReviewTestSectionRows(t, first, prReviewCategoryAdded)
 	secondAdded := prReviewTestSectionRows(t, second, prReviewCategoryAdded)
-	if len(firstAdded) != 1 || firstAdded[0].HeadVersion != "3.0.0" || len(secondAdded) != 1 || secondAdded[0].HeadVersion != "3.0.0" {
-		t.Fatalf("expected added duplicate instance to survive pairing, got %#v and %#v", firstAdded, secondAdded)
-	}
+	assertPRReviewDuplicateVersionlessAddedRows(t, firstAdded, secondAdded)
 
 	firstUpgraded := prReviewTestSectionRows(t, first, prReviewCategoryUpgraded)
 	secondUpgraded := prReviewTestSectionRows(t, second, prReviewCategoryUpgraded)
@@ -1284,6 +1289,22 @@ func TestBuildPRReviewArtifactPreservesDuplicateVersionlessInstancesDeterministi
 	}
 	if len(secondPolicy) != 1 || secondPolicy[0].PolicyChange != firstPolicy[0].PolicyChange || secondPolicy[0].BaseVersion != firstPolicy[0].BaseVersion || secondPolicy[0].HeadVersion != firstPolicy[0].HeadVersion {
 		t.Fatalf("expected policy row to be order-independent, got %#v vs %#v", firstPolicy, secondPolicy)
+	}
+}
+
+func assertPRReviewDuplicateVersionlessSummary(t *testing.T, summary prReviewSummary) {
+	t.Helper()
+
+	if summary.Added != 1 || summary.Upgraded != 1 || summary.PolicyChanged != 1 {
+		t.Fatalf("expected duplicate versionless instances to retain one add, one upgrade, and one policy change, got %#v", summary)
+	}
+}
+
+func assertPRReviewDuplicateVersionlessAddedRows(t *testing.T, firstAdded, secondAdded []prReviewRow) {
+	t.Helper()
+
+	if len(firstAdded) != 1 || firstAdded[0].HeadVersion != "3.0.0" || len(secondAdded) != 1 || secondAdded[0].HeadVersion != "3.0.0" {
+		t.Fatalf("expected added duplicate instance to survive pairing, got %#v and %#v", firstAdded, secondAdded)
 	}
 }
 
@@ -1534,14 +1555,33 @@ func assertPRReviewAnalysisCalls(t *testing.T, calls []analysis.Request) {
 func assertPRReviewAnalysisCall(t *testing.T, call analysis.Request) {
 	t.Helper()
 
+	assertPRReviewAnalysisCache(t, call)
+	assertPRReviewAnalysisOptions(t, call)
+	assertPRReviewAnalysisPolicies(t, call)
+	assertPRReviewAnalysisWeightsAndFiles(t, call)
+}
+
+func assertPRReviewAnalysisCache(t *testing.T, call analysis.Request) {
+	t.Helper()
+
 	if call.Cache == nil || call.Cache.Enabled || !call.Cache.ReadOnly {
 		t.Fatalf("expected pr-review analysis cache to be disabled/read-only, got %#v", call.Cache)
 	}
+}
+
+func assertPRReviewAnalysisOptions(t *testing.T, call analysis.Request) {
+	t.Helper()
+
 	if call.TopN != 7 || call.ScopeMode != ScopeModeChangedPackages ||
 		strings.Join(call.IncludePatterns, ",") != "src/**" ||
 		strings.Join(call.ExcludePatterns, ",") != "vendor/**" {
 		t.Fatalf("expected analysis request options to be forwarded, got %#v", call)
 	}
+}
+
+func assertPRReviewAnalysisPolicies(t *testing.T, call analysis.Request) {
+	t.Helper()
+
 	if strings.Join(call.LicenseDenyList, ",") != "GPL-3.0-only" || !call.IncludeRegistryProvenance {
 		t.Fatalf("expected license policy to be forwarded, got %#v", call)
 	}
@@ -1549,6 +1589,11 @@ func assertPRReviewAnalysisCall(t *testing.T, call analysis.Request) {
 		call.MinUsagePercentForRecommendations == nil || *call.MinUsagePercentForRecommendations != 62 {
 		t.Fatalf("expected threshold policy to be forwarded, got %#v", call)
 	}
+}
+
+func assertPRReviewAnalysisWeightsAndFiles(t *testing.T, call analysis.Request) {
+	t.Helper()
+
 	if call.RemovalCandidateWeights == nil ||
 		call.RemovalCandidateWeights.Usage != 0.1 ||
 		call.RemovalCandidateWeights.Impact != 0.2 ||

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -52,6 +52,7 @@ type AnalyseRequest struct {
 	Language                string
 	CacheEnabled            bool
 	CachePath               string
+	CachePinnedPath         string
 	CacheReadOnly           bool
 	RuntimeProfile          string
 	BaselinePath            string

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -52,7 +52,6 @@ type AnalyseRequest struct {
 	Language                string
 	CacheEnabled            bool
 	CachePath               string
-	CachePinnedPath         string
 	CacheReadOnly           bool
 	RuntimeProfile          string
 	BaselinePath            string
@@ -72,6 +71,18 @@ type AnalyseRequest struct {
 	Features                featureflags.Set
 	Thresholds              thresholds.Values
 	Notifications           notify.Config
+
+	cacheOptions                *analysis.CacheOptions
+	repository                  *analysis.RepositoryAuthorization
+	repositoryView              *analysis.RepositoryView
+	advisoryLoadPath            string
+	currentBaselineKey          string
+	currentBaselineKeyCaptured  bool
+	codemodPrecondition         error
+	codemodPreconditionCaptured bool
+	lockfileWarnings            []string
+	lockfileDriftErr            error
+	lockfileDriftCaptured       bool
 }
 
 type TUIRequest struct {

--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -2,7 +2,9 @@ package baseline
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -115,6 +117,72 @@ func LoadConfiguredStoreSnapshot[T any](dir, key string, maxBytes int64, store S
 
 func SaveConfiguredSnapshot[T any](dir, key string, now time.Time, report T, store SnapshotStore[T]) (string, error) {
 	return SaveSnapshot(dir, key, now, report, store.ExistsErr, store.Normalize)
+}
+
+// SaveConfiguredSnapshotWithinRoot saves an immutable snapshot beneath an
+// already-open write root.
+func SaveConfiguredSnapshotWithinRoot[T any](root *safeio.WriteRoot, dir, displayDir, key string, now time.Time, report T, store SnapshotStore[T]) (string, error) {
+	trimmedKey := strings.TrimSpace(key)
+	if root == nil {
+		return "", errors.New("baseline store root is required")
+	}
+	if trimmedKey == "" {
+		return "", errors.New("baseline key is required")
+	}
+	cleanDir := filepath.Clean(strings.TrimSpace(dir))
+	if filepath.IsAbs(cleanDir) || cleanDir == ".." || strings.HasPrefix(cleanDir, ".."+string(filepath.Separator)) {
+		return "", errors.New("baseline store directory must be relative to repository root")
+	}
+	if cleanDir != "." {
+		if err := root.EnsureDir(cleanDir, 0o750); err != nil {
+			return "", err
+		}
+	}
+
+	if err := rejectMatchingLegacySnapshotWithinRoot(root, cleanDir, displayDir, trimmedKey, store.ExistsErr); err != nil {
+		return "", err
+	}
+	payload, err := json.MarshalIndent(NewConfiguredSnapshot(trimmedKey, report, now, store), "", "  ")
+	if err != nil {
+		return "", err
+	}
+	payload = append(payload, '\n')
+	fileName := SnapshotFileName(trimmedKey)
+	targetPath := filepath.Join(cleanDir, fileName)
+	if err := root.WriteFileExclusiveCreatingParents(targetPath, payload, 0o600, 0o750); err != nil {
+		if errors.Is(err, os.ErrExist) && store.ExistsErr != nil {
+			return "", store.ExistsErr
+		}
+		return "", err
+	}
+	return filepath.Join(displayDir, fileName), nil
+}
+
+func rejectMatchingLegacySnapshotWithinRoot(root *safeio.WriteRoot, dir, displayDir, key string, existsErr error) error {
+	legacyName := LegacySnapshotFileName(key)
+	legacyPath := filepath.Join(dir, legacyName)
+	info, err := root.Lstat(legacyPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	displayPath := filepath.Join(displayDir, legacyName)
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("baseline snapshot must not be a symlink: %s", displayPath)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("baseline snapshot must be a regular file: %s", displayPath)
+	}
+	if info.Size() > MaxSnapshotBytes {
+		return fmt.Errorf("%w: %s", ErrSnapshotTooLarge, displayPath)
+	}
+	data, err := root.ReadFile(legacyPath)
+	if err != nil {
+		return err
+	}
+	return matchingLegacySnapshotError(data, key, existsErr, displayPath)
 }
 
 func NewConfiguredSnapshot[T any](key string, report T, now time.Time, store SnapshotStore[T]) Snapshot[T] {

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 type testSnapshotReport struct {
@@ -309,45 +312,20 @@ func TestLoadStoreSnapshotReturnsReadDecodeAndValidationErrors(t *testing.T) {
 		decodeCalled = true
 		return testSnapshotReport{}, "", nil
 	}
-	got, key, path, err := LoadStoreSnapshot(dir, "label:missing", MaxSnapshotBytes, unexpectedDecode, nil)
-	if !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("LoadStoreSnapshot() read error = %v, want os.ErrNotExist", err)
-	}
-	if decodeCalled || got != (testSnapshotReport{}) || key != "" || path != ResolveSnapshotPath(dir, "label:missing") {
-		t.Fatalf("LoadStoreSnapshot() read failure = %#v, %q, %q, decodeCalled=%t", got, key, path, decodeCalled)
-	}
+	assertLoadStoreSnapshotReadError(t, dir, decodeCalled, unexpectedDecode)
 
 	decodeErr := errors.New("decode snapshot")
 	failDecode := func([]byte) (testSnapshotReport, string, error) {
 		return testSnapshotReport{}, "", decodeErr
 	}
-	got, key, path, err = LoadStoreSnapshot(dir, "label:weekly", MaxSnapshotBytes, failDecode, nil)
-	if !errors.Is(err, decodeErr) {
-		t.Fatalf("LoadStoreSnapshot() decode error = %v, want %v", err, decodeErr)
-	}
-	if got != (testSnapshotReport{}) || key != "" || path != savedPath {
-		t.Fatalf("LoadStoreSnapshot() decode failure = %#v, %q, %q", got, key, path)
-	}
+	assertLoadStoreSnapshotDecodeError(t, dir, savedPath, decodeErr, failDecode)
 
 	decode := func([]byte) (testSnapshotReport, string, error) {
 		return testSnapshotReport{Value: "decoded"}, "label:stored", nil
 	}
-	got, key, path, err = LoadStoreSnapshot(dir, "label:weekly", MaxSnapshotBytes, decode, nil)
-	if err != nil || got.Value != "decoded" || key != "label:stored" || path != savedPath {
-		t.Fatalf("LoadStoreSnapshot() without validation = %#v, %q, %q, %v", got, key, path, err)
-	}
-
 	validateErr := errors.New("validate snapshot key")
-	rejectKey := func(string, string) error {
-		return validateErr
-	}
-	got, key, path, err = LoadStoreSnapshot(dir, "label:weekly", MaxSnapshotBytes, decode, rejectKey)
-	if !errors.Is(err, validateErr) {
-		t.Fatalf("LoadStoreSnapshot() validation error = %v, want %v", err, validateErr)
-	}
-	if got != (testSnapshotReport{}) || key != "label:stored" || path != savedPath {
-		t.Fatalf("LoadStoreSnapshot() validation failure = %#v, %q, %q", got, key, path)
-	}
+	assertLoadStoreSnapshotSuccess(t, dir, savedPath, decode)
+	assertLoadStoreSnapshotValidationError(t, dir, savedPath, decode, validateErr)
 }
 
 func TestValidateSnapshotKeyWrapsCustomMismatchError(t *testing.T) {
@@ -365,20 +343,7 @@ func TestValidateSnapshotKeyWrapsCustomMismatchError(t *testing.T) {
 
 func TestConfiguredSnapshotHelpersRoundTrip(t *testing.T) {
 	t.Parallel()
-
-	repair := func(report testSnapshotReport) testSnapshotReport {
-		report.Value = "repaired:" + report.Value
-		return report
-	}
-	store := SnapshotStore[testSnapshotReport]{
-		Repair:            repair,
-		Normalize:         normalizeTestSnapshotReport,
-		UnsupportedSchema: func(version string) error { return fmt.Errorf("unsupported configured schema version: %s", version) },
-		ValidateKey: func(requestedKey, storedKey string) error {
-			return ValidateSnapshotKey(requestedKey, storedKey, errors.New("configured key mismatch"))
-		},
-		ExistsErr: errors.New("configured snapshot already exists"),
-	}
+	store := configuredSnapshotRoundTripStore()
 	dir := t.TempDir()
 	now := time.Date(2026, time.July, 12, 11, 15, 0, 0, time.FixedZone("AEST", 10*60*60))
 
@@ -391,7 +356,71 @@ func TestConfiguredSnapshotHelpersRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SaveConfiguredSnapshot() error = %v", err)
 	}
+	assertConfiguredSnapshotLoadRoundTrip(t, path, store)
+	assertConfiguredSnapshotDecodeRoundTrip(t, path, store)
+	assertConfiguredStoreSnapshotRoundTrip(t, dir, path, store)
+}
 
+func assertLoadStoreSnapshotReadError(t *testing.T, dir string, decodeCalled bool, unexpectedDecode func([]byte) (testSnapshotReport, string, error)) {
+	t.Helper()
+	got, key, path, err := LoadStoreSnapshot(dir, "label:missing", MaxSnapshotBytes, unexpectedDecode, nil)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("LoadStoreSnapshot() read error = %v, want os.ErrNotExist", err)
+	}
+	if decodeCalled || got != (testSnapshotReport{}) || key != "" || path != ResolveSnapshotPath(dir, "label:missing") {
+		t.Fatalf("LoadStoreSnapshot() read failure = %#v, %q, %q, decodeCalled=%t", got, key, path, decodeCalled)
+	}
+}
+
+func assertLoadStoreSnapshotDecodeError(t *testing.T, dir, savedPath string, decodeErr error, failDecode func([]byte) (testSnapshotReport, string, error)) {
+	t.Helper()
+	got, key, path, err := LoadStoreSnapshot(dir, "label:weekly", MaxSnapshotBytes, failDecode, nil)
+	if !errors.Is(err, decodeErr) {
+		t.Fatalf("LoadStoreSnapshot() decode error = %v, want %v", err, decodeErr)
+	}
+	if got != (testSnapshotReport{}) || key != "" || path != savedPath {
+		t.Fatalf("LoadStoreSnapshot() decode failure = %#v, %q, %q", got, key, path)
+	}
+}
+
+func assertLoadStoreSnapshotSuccess(t *testing.T, dir, savedPath string, decode func([]byte) (testSnapshotReport, string, error)) {
+	t.Helper()
+	got, key, path, err := LoadStoreSnapshot(dir, "label:weekly", MaxSnapshotBytes, decode, nil)
+	if err != nil || got.Value != "decoded" || key != "label:stored" || path != savedPath {
+		t.Fatalf("LoadStoreSnapshot() without validation = %#v, %q, %q, %v", got, key, path, err)
+	}
+}
+
+func assertLoadStoreSnapshotValidationError(t *testing.T, dir, savedPath string, decode func([]byte) (testSnapshotReport, string, error), validateErr error) {
+	t.Helper()
+	rejectKey := func(string, string) error { return validateErr }
+	got, key, path, err := LoadStoreSnapshot(dir, "label:weekly", MaxSnapshotBytes, decode, rejectKey)
+	if !errors.Is(err, validateErr) {
+		t.Fatalf("LoadStoreSnapshot() validation error = %v, want %v", err, validateErr)
+	}
+	if got != (testSnapshotReport{}) || key != "label:stored" || path != savedPath {
+		t.Fatalf("LoadStoreSnapshot() validation failure = %#v, %q, %q", got, key, path)
+	}
+}
+
+func configuredSnapshotRoundTripStore() SnapshotStore[testSnapshotReport] {
+	repair := func(report testSnapshotReport) testSnapshotReport {
+		report.Value = "repaired:" + report.Value
+		return report
+	}
+	return SnapshotStore[testSnapshotReport]{
+		Repair:            repair,
+		Normalize:         normalizeTestSnapshotReport,
+		UnsupportedSchema: func(version string) error { return fmt.Errorf("unsupported configured schema version: %s", version) },
+		ValidateKey: func(requestedKey, storedKey string) error {
+			return ValidateSnapshotKey(requestedKey, storedKey, errors.New("configured key mismatch"))
+		},
+		ExistsErr: errors.New("configured snapshot already exists"),
+	}
+}
+
+func assertConfiguredSnapshotLoadRoundTrip(t *testing.T, path string, store SnapshotStore[testSnapshotReport]) {
+	t.Helper()
 	got, key, err := LoadConfiguredSnapshot(path, store)
 	if err != nil {
 		t.Fatalf("LoadConfiguredSnapshot() error = %v", err)
@@ -399,12 +428,14 @@ func TestConfiguredSnapshotHelpersRoundTrip(t *testing.T) {
 	if key != "label:configured" || got.Value != "repaired:OK" {
 		t.Fatalf("LoadConfiguredSnapshot() = key=%q report=%#v", key, got)
 	}
+}
 
+func assertConfiguredSnapshotDecodeRoundTrip(t *testing.T, path string, store SnapshotStore[testSnapshotReport]) {
+	t.Helper()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read configured snapshot: %v", err)
 	}
-
 	decoded, decodedKey, err := DecodeConfiguredSnapshot(data, store)
 	if err != nil {
 		t.Fatalf("DecodeConfiguredSnapshot() error = %v", err)
@@ -412,7 +443,10 @@ func TestConfiguredSnapshotHelpersRoundTrip(t *testing.T) {
 	if decodedKey != "label:configured" || decoded.Value != "repaired:OK" {
 		t.Fatalf("DecodeConfiguredSnapshot() = key=%q report=%#v", decodedKey, decoded)
 	}
+}
 
+func assertConfiguredStoreSnapshotRoundTrip(t *testing.T, dir, path string, store SnapshotStore[testSnapshotReport]) {
+	t.Helper()
 	loaded, loadedKey, resolvedPath, err := LoadConfiguredStoreSnapshot(dir, " label:configured ", MaxSnapshotBytes, store)
 	if err != nil {
 		t.Fatalf("LoadConfiguredStoreSnapshot() error = %v", err)
@@ -460,6 +494,237 @@ func TestConfiguredSnapshotHelpersReturnCustomErrors(t *testing.T) {
 	}
 	if loadedKey != "label:configured" || resolvedPath != path {
 		t.Fatalf("LoadConfiguredStoreSnapshot() validation result = key=%q path=%q", loadedKey, resolvedPath)
+	}
+}
+
+func TestSaveConfiguredSnapshotWithinRoot(t *testing.T) {
+	rootDir := t.TempDir()
+	root, err := safeio.OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open rooted baseline store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close rooted baseline store: %v", err)
+		}
+	})
+
+	existsMarker := errors.New("configured snapshot already exists")
+	store := SnapshotStore[testSnapshotReport]{
+		Normalize: normalizeTestSnapshotReport,
+		ExistsErr: existsMarker,
+	}
+	now := time.Date(2026, time.July, 25, 23, 15, 0, 0, time.FixedZone("AEST", 10*60*60))
+	dir := filepath.Join("state", "baselines")
+	displayDir := filepath.Join("/display", "state", "baselines")
+
+	path, err := SaveConfiguredSnapshotWithinRoot(root, dir, displayDir, " label:rooted ", now, testSnapshotReport{Value: "ok"}, store)
+	if err != nil {
+		t.Fatalf("save rooted baseline: %v", err)
+	}
+	wantPath := filepath.Join(displayDir, SnapshotFileName("label:rooted"))
+	if path != wantPath {
+		t.Fatalf("rooted baseline path = %q, want %q", path, wantPath)
+	}
+	data, err := os.ReadFile(filepath.Join(rootDir, dir, SnapshotFileName("label:rooted")))
+	if err != nil {
+		t.Fatalf("read rooted baseline: %v", err)
+	}
+	var snapshot Snapshot[testSnapshotReport]
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		t.Fatalf("decode rooted baseline: %v", err)
+	}
+	if snapshot.Key != "label:rooted" || snapshot.Report.Value != "OK" || !snapshot.SavedAt.Equal(now.UTC()) {
+		t.Fatalf("unexpected rooted baseline: %#v", snapshot)
+	}
+	if _, err := SaveConfiguredSnapshotWithinRoot(root, dir, displayDir, "label:rooted", now, testSnapshotReport{}, store); !errors.Is(err, existsMarker) {
+		t.Fatalf("duplicate rooted baseline error = %v, want %v", err, existsMarker)
+	}
+	if _, err := SaveConfiguredSnapshotWithinRoot(root, dir, displayDir, "label:rooted", now, testSnapshotReport{}, SnapshotStore[testSnapshotReport]{}); !errors.Is(err, os.ErrExist) {
+		t.Fatalf("raw duplicate rooted baseline error = %v, want os.ErrExist", err)
+	}
+}
+
+func TestSaveConfiguredSnapshotWithinRootAllowsRepositoryRootStore(t *testing.T) {
+	rootDir := t.TempDir()
+	root, err := safeio.OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open rooted baseline store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close rooted baseline store: %v", err)
+		}
+	})
+
+	now := time.Date(2026, time.July, 26, 9, 0, 0, 0, time.UTC)
+	path, err := SaveConfiguredSnapshotWithinRoot(root, ".", rootDir, "label:root", now, testSnapshotReport{Value: "ok"}, SnapshotStore[testSnapshotReport]{})
+	if err != nil {
+		t.Fatalf("save rooted baseline at repository root: %v", err)
+	}
+	if path != filepath.Join(rootDir, SnapshotFileName("label:root")) {
+		t.Fatalf("unexpected rooted baseline path: %q", path)
+	}
+	if _, err := os.Stat(filepath.Join(rootDir, SnapshotFileName("label:root"))); err != nil {
+		t.Fatalf("expected rooted baseline file: %v", err)
+	}
+}
+
+func TestSaveConfiguredSnapshotWithinRootLegacyCompatibility(t *testing.T) {
+	rootDir := t.TempDir()
+	root, err := safeio.OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open rooted baseline store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close rooted baseline store: %v", err)
+		}
+	})
+
+	dir := "baselines"
+	if err := os.Mkdir(filepath.Join(rootDir, dir), 0o750); err != nil {
+		t.Fatalf("create baseline directory: %v", err)
+	}
+	key := "label:a/b"
+	legacyPath := filepath.Join(rootDir, dir, LegacySnapshotFileName(key))
+	if err := os.WriteFile(legacyPath, []byte(`{"key":"label:a_b"}`), 0o600); err != nil {
+		t.Fatalf("write non-matching legacy baseline: %v", err)
+	}
+	store := SnapshotStore[testSnapshotReport]{ExistsErr: errors.New("baseline exists")}
+	if _, err := SaveConfiguredSnapshotWithinRoot(root, dir, dir, key, time.Now(), testSnapshotReport{}, store); err != nil {
+		t.Fatalf("non-matching legacy key should not block rooted save: %v", err)
+	}
+
+	matchingKey := "label:matching"
+	matchingPath := filepath.Join(rootDir, dir, LegacySnapshotFileName(matchingKey))
+	if err := os.WriteFile(matchingPath, []byte(`{"key":"label:matching"}`), 0o600); err != nil {
+		t.Fatalf("write matching legacy baseline: %v", err)
+	}
+	if _, err := SaveConfiguredSnapshotWithinRoot(root, dir, dir, matchingKey, time.Now(), testSnapshotReport{}, store); !errors.Is(err, store.ExistsErr) {
+		t.Fatalf("matching legacy baseline error = %v, want %v", err, store.ExistsErr)
+	}
+
+	matchingWithoutMarker := "label:no-marker"
+	if err := os.WriteFile(filepath.Join(rootDir, dir, LegacySnapshotFileName(matchingWithoutMarker)), []byte(`{"key":"label:no-marker"}`), 0o600); err != nil {
+		t.Fatalf("write marker-free legacy baseline: %v", err)
+	}
+	if _, err := SaveConfiguredSnapshotWithinRoot(root, dir, dir, matchingWithoutMarker, time.Now(), testSnapshotReport{}, SnapshotStore[testSnapshotReport]{}); err == nil || !strings.Contains(err.Error(), "baseline snapshot already exists") {
+		t.Fatalf("marker-free matching legacy baseline error = %v", err)
+	}
+}
+
+func TestSaveConfiguredSnapshotWithinRootRejectsUnsafeLegacyEntries(t *testing.T) {
+	rootDir := t.TempDir()
+	root, err := safeio.OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open rooted baseline store: %v", err)
+	}
+	dir := "baselines"
+	if err := os.Mkdir(filepath.Join(rootDir, dir), 0o750); err != nil {
+		t.Fatalf("create baseline directory: %v", err)
+	}
+	store := SnapshotStore[testSnapshotReport]{}
+	assertRejected := func(key string, create func(string) error, want error) {
+		t.Helper()
+		assertUnsafeLegacySnapshotRejected(t, rootDir, root, dir, key, create, want, store)
+	}
+	assertRejected("label:directory", func(path string) error { return os.Mkdir(path, 0o750) }, nil)
+	assertRejected("label:oversized", createOversizedLegacySnapshot, ErrSnapshotTooLarge)
+	assertSymlinkedLegacySnapshotRejected(t, rootDir, root, dir, store)
+
+	if err := root.Close(); err != nil {
+		t.Fatalf("close rooted baseline store: %v", err)
+	}
+	if _, err := SaveConfiguredSnapshotWithinRoot(root, dir, dir, "label:closed", time.Now(), testSnapshotReport{}, store); err == nil {
+		t.Fatal("expected closed rooted baseline store rejection")
+	}
+}
+
+func assertUnsafeLegacySnapshotRejected(t *testing.T, rootDir string, root *safeio.WriteRoot, dir, key string, create func(string) error, want error, store SnapshotStore[testSnapshotReport]) {
+	t.Helper()
+	path := filepath.Join(rootDir, dir, LegacySnapshotFileName(key))
+	if err := create(path); err != nil {
+		t.Fatalf("create unsafe legacy entry: %v", err)
+	}
+	_, err := SaveConfiguredSnapshotWithinRoot(root, dir, dir, key, time.Now(), testSnapshotReport{}, store)
+	if want != nil && !errors.Is(err, want) {
+		t.Fatalf("legacy entry error = %v, want %v", err, want)
+	}
+	if want == nil && err == nil {
+		t.Fatal("expected unsafe legacy entry rejection")
+	}
+}
+
+func createOversizedLegacySnapshot(path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if err := file.Truncate(MaxSnapshotBytes + 1); err != nil {
+		return errors.Join(err, file.Close())
+	}
+	return file.Close()
+}
+
+func assertSymlinkedLegacySnapshotRejected(t *testing.T, rootDir string, root *safeio.WriteRoot, dir string, store SnapshotStore[testSnapshotReport]) {
+	t.Helper()
+	symlinkKey := "label:symlink"
+	symlinkTarget := filepath.Join(rootDir, dir, "target.json")
+	if err := os.WriteFile(symlinkTarget, []byte(`{"key":"target"}`), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	symlinkPath := filepath.Join(rootDir, dir, LegacySnapshotFileName(symlinkKey))
+	if err := os.Symlink(filepath.Base(symlinkTarget), symlinkPath); err != nil {
+		t.Logf("symlink creation unsupported: %v", err)
+		return
+	}
+	if _, err := SaveConfiguredSnapshotWithinRoot(root, dir, dir, symlinkKey, time.Now(), testSnapshotReport{}, store); err == nil {
+		t.Fatal("expected symlinked legacy entry rejection")
+	}
+}
+
+func TestSaveConfiguredSnapshotWithinRootRejectsUnsafeInputsAndWriteFailures(t *testing.T) {
+	rootDir := t.TempDir()
+	root, err := safeio.OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("open rooted baseline store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close rooted baseline store: %v", err)
+		}
+	})
+	now := time.Date(2026, time.July, 25, 0, 0, 0, 0, time.UTC)
+	store := SnapshotStore[any]{ExistsErr: errors.New("baseline exists")}
+
+	testCases := []struct {
+		name string
+		root *safeio.WriteRoot
+		dir  string
+		key  string
+	}{
+		{name: "missing root", root: nil, dir: "baselines", key: "label:test"},
+		{name: "missing key", root: root, dir: "baselines", key: "  "},
+		{name: "absolute directory", root: root, dir: filepath.Join(string(os.PathSeparator), "outside"), key: "label:test"},
+		{name: "escaping directory", root: root, dir: filepath.Join("..", "outside"), key: "label:test"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, err := SaveConfiguredSnapshotWithinRoot(testCase.root, testCase.dir, testCase.dir, testCase.key, now, "report", store); err == nil {
+				t.Fatal("expected rooted baseline input rejection")
+			}
+		})
+	}
+
+	if err := os.WriteFile(filepath.Join(rootDir, "blocking"), []byte("file"), 0o600); err != nil {
+		t.Fatalf("write blocking parent: %v", err)
+	}
+	if _, err := SaveConfiguredSnapshotWithinRoot(root, filepath.Join("blocking", "child"), "display", "label:test", now, "report", store); err == nil {
+		t.Fatal("expected rooted baseline parent creation failure")
+	}
+	if _, err := SaveConfiguredSnapshotWithinRoot[any](root, "marshal", "display", "label:test", now, make(chan int), store); err == nil {
+		t.Fatal("expected rooted baseline marshal failure")
 	}
 }
 

--- a/internal/baseline/store.go
+++ b/internal/baseline/store.go
@@ -203,6 +203,10 @@ func rejectMatchingLegacySnapshot(dir, key string, existsErr error) error {
 	if err != nil {
 		return err
 	}
+	return matchingLegacySnapshotError(data, key, existsErr, filepath.Join(dir, legacyName))
+}
+
+func matchingLegacySnapshotError(data []byte, key string, existsErr error, path string) error {
 	var identity struct {
 		Key string `json:"key"`
 	}
@@ -210,9 +214,9 @@ func rejectMatchingLegacySnapshot(dir, key string, existsErr error) error {
 		return nil
 	}
 	if existsErr == nil {
-		return fmt.Errorf("baseline snapshot already exists: key %q (%s)", key, filepath.Join(dir, legacyName))
+		return fmt.Errorf("baseline snapshot already exists: key %q (%s)", key, path)
 	}
-	return fmt.Errorf("%w: key %q (%s)", existsErr, key, filepath.Join(dir, legacyName))
+	return fmt.Errorf("%w: key %q (%s)", existsErr, key, path)
 }
 
 func ListStoreEntries(dir string) ([]string, error) {

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -6,17 +6,21 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/testutil"
 	"github.com/ben-ranford/lopper/internal/thresholds"
 	"github.com/ben-ranford/lopper/internal/version"
+	"github.com/ben-ranford/lopper/internal/workspace"
 )
 
 type failWriteCloser struct{}
@@ -138,6 +142,231 @@ func TestHandlePayloadBranches(t *testing.T) {
 	}))
 	if badCall.Error == nil || badCall.Error.Code != codeInvalidParams {
 		t.Fatalf("expected invalid params error, got %#v", badCall)
+	}
+}
+
+func TestRunAnalysisToolRetainsAuthorizedPolicyInputsAcrossRepositorySwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	repoB := filepath.Join(parent, "repo-b")
+	for _, root := range []string{repo, repoB} {
+		if err := os.Mkdir(root, 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", root, err)
+		}
+	}
+	writeMCPRepoConfigFixture(t, repo, 11, "GHSA-repo-a")
+	writeMCPRepoConfigFixture(t, repoB, 77, "GHSA-repo-b")
+	movedRepoA := filepath.Join(parent, "repo-a-original")
+
+	restore := analysis.SetRepositoryViewHandleOpenedHookForTest(func() error {
+		if err := os.Rename(repo, movedRepoA); err != nil {
+			return err
+		}
+		return os.Rename(repoB, repo)
+	})
+	t.Cleanup(restore)
+
+	server := NewServer(Options{Analyzer: &fakeAnalyser{report: sampleReport(repo)}})
+	result := server.runAnalysisTool(context.Background(), mustJSON(t, analysisToolArguments{RepoPath: repo, Dependency: "lodash", EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}, CacheEnabled: boolPtr(false)}), analysisToolKindDependency)
+	if result.IsError {
+		t.Fatalf("unexpected retained-view analysis error: %#v", result)
+	}
+	payload := result.StructuredContent.(analysisPayload)
+	if payload.Report.EffectiveThresholds == nil || payload.Report.EffectiveThresholds.LowConfidenceWarningPercent != 11 {
+		t.Fatalf("expected repo A thresholds after swap, got %#v", payload.Report.EffectiveThresholds)
+	}
+	if len(payload.Report.Dependencies) == 0 || len(payload.Report.Dependencies[0].Vulnerabilities) == 0 || payload.Report.Dependencies[0].Vulnerabilities[0].AdvisoryID != "GHSA-repo-a" {
+		t.Fatalf("expected repo A advisory annotation after swap, got %#v", payload.Report.Dependencies)
+	}
+}
+
+func TestRunCompareBaselineRetainsAuthorizedCurrentCommitAcrossRepositorySwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	repoB := filepath.Join(parent, "repo-b")
+	if err := os.Mkdir(repo, 0o750); err != nil {
+		t.Fatalf("mkdir repo A: %v", err)
+	}
+	if err := os.Mkdir(repoB, 0o750); err != nil {
+		t.Fatalf("mkdir repo B: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte("{\n  \"name\": \"repo-a\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write repo A package.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoB, "package.json"), []byte("{\n  \"name\": \"repo-b\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write repo B package.json: %v", err)
+	}
+	initMCPGitRepo(t, repo, "repo-a")
+	initMCPGitRepo(t, repoB, "repo-b")
+	repoACommit, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("repo A commit: %v", err)
+	}
+	repoBCommit, err := workspace.CurrentCommitSHA(repoB)
+	if err != nil {
+		t.Fatalf("repo B commit: %v", err)
+	}
+	baselinePath := filepath.Join(parent, "baseline.json")
+	writeJSONFile(t, baselinePath, report.Report{
+		SchemaVersion: report.SchemaVersion,
+		RepoPath:      repo,
+		Dependencies: []report.DependencyReport{{
+			Name:              "lodash",
+			Language:          "js-ts",
+			UsedExportsCount:  8,
+			TotalExportsCount: 10,
+			UsedPercent:       80,
+		}},
+	})
+	movedRepoA := filepath.Join(parent, "repo-a-original")
+
+	restore := analysis.SetRepositoryViewHandleOpenedHookForTest(func() error {
+		if err := os.Rename(repo, movedRepoA); err != nil {
+			return err
+		}
+		return os.Rename(repoB, repo)
+	})
+	t.Cleanup(restore)
+
+	server := NewServer(Options{Analyzer: &fakeAnalyser{report: sampleReport(repo)}})
+	result := server.runAnalysisTool(context.Background(), mustJSON(t, analysisToolArguments{RepoPath: repo, Dependency: "lodash", BaselinePath: baselinePath, CacheEnabled: boolPtr(false)}), analysisToolKindCompare)
+	if result.IsError {
+		t.Fatalf("unexpected compare error: %#v", result)
+	}
+	payload := result.StructuredContent.(analysisPayload)
+	if payload.Report.BaselineComparison == nil || payload.Report.BaselineComparison.CurrentKey != "commit:"+repoACommit {
+		t.Fatalf("expected repo A current key after swap, got %#v", payload.Report.BaselineComparison)
+	}
+	if payload.Report.BaselineComparison.CurrentKey == "commit:"+repoBCommit {
+		t.Fatalf("expected repo B commit not to leak into compare current key")
+	}
+}
+
+func TestRunCompareBaselineSealsSamePathHeadAndConfigAfterViewOpen(t *testing.T) {
+	repo := t.TempDir()
+	writeMCPRepoConfigFixture(t, repo, 29, "GHSA-config-a")
+	initMCPGitRepo(t, repo, "config-a")
+	commitA, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("resolve commit A: %v", err)
+	}
+
+	writeMCPRepoConfigFixture(t, repo, 93, "GHSA-config-b")
+	if err := os.WriteFile(filepath.Join(repo, "identity.txt"), []byte("config-b\n"), 0o600); err != nil {
+		t.Fatalf("write identity B: %v", err)
+	}
+	testutil.RunGit(t, repo, "add", ".")
+	testutil.RunGit(t, repo, "commit", "-m", "config-b")
+	commitB, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("resolve commit B: %v", err)
+	}
+	testutil.RunGit(t, repo, "checkout", "--detach", commitA)
+
+	baselinePath := filepath.Join(t.TempDir(), "baseline.json")
+	writeJSONFile(t, baselinePath, report.Report{
+		SchemaVersion: report.SchemaVersion,
+		RepoPath:      repo,
+		Dependencies: []report.DependencyReport{{
+			Name:              "lodash",
+			Language:          "js-ts",
+			UsedExportsCount:  8,
+			TotalExportsCount: 10,
+			UsedPercent:       80,
+		}},
+	})
+	viewOpens := 0
+	restoreOpen := analysis.SetRepositoryViewHandleOpenedHookForTest(func() error {
+		viewOpens++
+		testutil.RunGit(t, repo, "checkout", "--detach", commitB)
+		return nil
+	})
+	t.Cleanup(restoreOpen)
+	viewCloses := 0
+	restoreClose := analysis.SetRepositoryViewCloseHookForTest(func() error {
+		viewCloses++
+		return nil
+	})
+	t.Cleanup(restoreClose)
+
+	server := NewServer(Options{Analyzer: &fakeAnalyser{report: sampleReport(repo)}})
+	args := analysisToolArguments{
+		RepoPath:       repo,
+		Dependency:     "lodash",
+		BaselinePath:   baselinePath,
+		CacheEnabled:   boolPtr(false),
+		EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature},
+	}
+	result := server.runAnalysisTool(context.Background(), mustJSON(t, args), analysisToolKindCompare)
+	if result.IsError {
+		t.Fatalf("unexpected same-path compare error: %#v", result)
+	}
+	payload := result.StructuredContent.(analysisPayload)
+	if payload.Report.BaselineComparison == nil ||
+		payload.Report.BaselineComparison.CurrentKey != "commit:"+commitA {
+		t.Fatalf("compare current key = %#v, want commit A", payload.Report.BaselineComparison)
+	}
+	if payload.Report.EffectiveThresholds == nil ||
+		payload.Report.EffectiveThresholds.LowConfidenceWarningPercent != 29 {
+		t.Fatalf("compare thresholds = %#v, want config A", payload.Report.EffectiveThresholds)
+	}
+	if payload.Report.BaselineComparison.CurrentKey == "commit:"+commitB {
+		t.Fatal("same-path commit B retargeted compare current key")
+	}
+	if viewOpens != 1 || viewCloses != 1 {
+		t.Fatalf("repository view opens/closes = %d/%d, want 1/1", viewOpens, viewCloses)
+	}
+}
+
+func TestRunAnalysisToolPropagatesRepositoryViewCloseFailure(t *testing.T) {
+	repo := t.TempDir()
+	closeErr := errors.New("read-only repository close sentinel")
+	closeCalls := 0
+	restore := analysis.SetRepositoryViewCloseHookForTest(func() error {
+		closeCalls++
+		return closeErr
+	})
+	t.Cleanup(restore)
+
+	server := NewServer(Options{Analyzer: &fakeAnalyser{report: sampleReport(repo)}})
+	result := server.runAnalysisTool(context.Background(), mustJSON(t, analysisToolArguments{RepoPath: repo, Dependency: "lodash", CacheEnabled: boolPtr(false)}), analysisToolKindDependency)
+	if !result.IsError || len(result.Content) == 0 || !strings.Contains(result.Content[0].Text, closeErr.Error()) {
+		t.Fatalf("expected close failure in analysis result, got %#v", result)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("repository close calls = %d, want 1", closeCalls)
+	}
+}
+
+func TestRunAnalysisToolJoinsPolicyLoadAndRepositoryViewCloseFailures(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("thresholds:\n  low_confidence_warning_percent: 101\n"), 0o600); err != nil {
+		t.Fatalf("write invalid policy: %v", err)
+	}
+	closeErr := errors.New("read-only policy close sentinel")
+	closeCalls := 0
+	restore := analysis.SetRepositoryViewCloseHookForTest(func() error {
+		closeCalls++
+		return closeErr
+	})
+	t.Cleanup(restore)
+
+	server := NewServer(Options{Analyzer: &fakeAnalyser{report: sampleReport(repo)}})
+	result := server.runAnalysisTool(context.Background(), mustJSON(t, analysisToolArguments{RepoPath: repo, CacheEnabled: boolPtr(false)}), analysisToolKindTop)
+	if !result.IsError || len(result.Content) == 0 {
+		t.Fatalf("expected joined policy-load failure, got %#v", result)
+	}
+	if !strings.Contains(result.Content[0].Text, "low_confidence_warning_percent") || !strings.Contains(result.Content[0].Text, closeErr.Error()) {
+		t.Fatalf("expected policy and close errors, got %q", result.Content[0].Text)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("repository close calls = %d, want 1", closeCalls)
 	}
 }
 
@@ -275,6 +504,8 @@ func TestResolveAnalysisRequestValidationBranches(t *testing.T) {
 		{"baseline conflict", analysisToolArguments{RepoPath: repo, BaselinePath: "a.json", BaselineStorePath: "store", BaselineKey: "key"}, analysisToolKindCompare, "baselinePath and baselineStorePath"},
 		{"store missing key", analysisToolArguments{RepoPath: repo, BaselineStorePath: "store"}, analysisToolKindCompare, "baselineKey"},
 		{"feature error", analysisToolArguments{RepoPath: repo, EnableFeatures: []string{"missing"}}, analysisToolKindTop, "unknown feature"},
+		{"unsafe relative advisory path", analysisToolArguments{RepoPath: repo, AdvisorySourcePath: filepath.Join("..", "outside.yml")}, analysisToolKindTop, "repository root"},
+		{"unsafe relative baseline path", analysisToolArguments{RepoPath: repo, BaselinePath: filepath.Join("..", "outside.json")}, analysisToolKindCompare, "repository root"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -318,6 +549,9 @@ func TestListLanguagesBranches(t *testing.T) {
 	if result := server.runListLanguagesTool(context.Background(), mustJSON(t, listLanguagesArguments{RepoPath: repo, ConfigPath: configPath})); result.IsError {
 		t.Fatalf("expected config metadata success, got %#v", result)
 	}
+	if result := server.runListLanguagesTool(context.Background(), mustJSON(t, listLanguagesArguments{RepoPath: repo, ConfigPath: filepath.Join("..", "outside.yml")})); !result.IsError {
+		t.Fatalf("expected unsafe relative config path rejection")
+	}
 	if result := server.runListLanguagesTool(context.Background(), mustJSON(t, listLanguagesArguments{RepoPath: repo, ConfigPath: "missing.yml"})); !result.IsError {
 		t.Fatalf("expected missing config error")
 	}
@@ -331,6 +565,26 @@ func TestListLanguagesBranches(t *testing.T) {
 	cancel()
 	if result := server.runListLanguagesTool(ctx, mustJSON(t, listLanguagesArguments{})); !result.IsError {
 		t.Fatalf("expected context error")
+	}
+}
+
+func TestLoadThresholdsThroughRepositoryViewRejectsUnsafeRelativePath(t *testing.T) {
+	repo := t.TempDir()
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	repositoryView, err := analysis.OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := repositoryView.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+	if _, err := loadThresholdsThroughRepositoryView(repositoryView, filepath.Join("..", "outside.yml")); err == nil || !strings.Contains(err.Error(), "repository root") {
+		t.Fatalf("expected unsafe config path rejection, got %v", err)
 	}
 }
 
@@ -409,14 +663,23 @@ func TestDefaultServerFeatureBranches(t *testing.T) {
 
 func TestThresholdAndPolicyHelpers(t *testing.T) {
 	repo := t.TempDir()
-	bad := analysisToolArguments{LowConfidenceWarningPercent: intPtr(101)}
-	if _, _, _, _, err := resolveThresholds(repo, bad); err == nil {
+	assertThresholdResolutionErrors(t, repo)
+	assertThresholdResolutionValues(t, repo)
+	assertThresholdPolicyHelpers(t)
+}
+
+func assertThresholdResolutionErrors(t *testing.T, repo string) {
+	t.Helper()
+	if _, _, _, _, err := resolveThresholds(repo, analysisToolArguments{LowConfidenceWarningPercent: intPtr(101)}); err == nil {
 		t.Fatalf("expected threshold override validation error")
 	}
 	if _, _, _, _, err := resolveThresholds(repo, analysisToolArguments{ConfigPath: "missing.yml"}); err == nil {
 		t.Fatalf("expected missing config error")
 	}
+}
 
+func assertThresholdResolutionValues(t *testing.T, repo string) {
+	t.Helper()
 	args := analysisToolArguments{
 		LowConfidenceWarningPercent:       intPtr(35),
 		MinUsagePercentForRecommendations: intPtr(45),
@@ -440,6 +703,10 @@ func TestThresholdAndPolicyHelpers(t *testing.T) {
 	if !values.LicenseFailOnDeny || !values.LicenseIncludeRegistryProvenance || values.ReachableVulnerabilityPriority != report.VulnerabilityPriorityHigh {
 		t.Fatalf("expected license policy values, got %#v", values)
 	}
+}
+
+func assertThresholdPolicyHelpers(t *testing.T) {
+	t.Helper()
 	if got := resolveAdvisorySourcePath(thresholds.LoadResult{AdvisorySourcePath: "config.yml"}, analysisToolArguments{}); got != "config.yml" {
 		t.Fatalf("expected config advisory source, got %q", got)
 	}
@@ -492,6 +759,25 @@ func TestBaselineHelpers(t *testing.T) {
 	}
 	if _, err := applyBaseline(currentReport, filepath.Join(repo, "missing.json"), "", "current"); err == nil {
 		t.Fatalf("expected missing baseline error")
+	}
+	repository, err := analysis.ResolveTrustedRepository(repo)
+	if err != nil {
+		t.Fatalf("authorize repository: %v", err)
+	}
+	repositoryView, err := analysis.OpenTrustedRepository(context.Background(), repository, repo, nil)
+	if err != nil {
+		t.Fatalf("open trusted repository view: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := repositoryView.Close(); err != nil {
+			t.Errorf("close repository view: %v", err)
+		}
+	})
+	if _, err := snapshotRepositoryPath(repositoryView, filepath.Join("..", "outside.json")); err == nil || !strings.Contains(err.Error(), "repository root") {
+		t.Fatalf("expected snapshot traversal rejection, got %v", err)
+	}
+	if got, err := snapshotRepositoryPath(nil, "  config.yml  "); err != nil || got != "config.yml" {
+		t.Fatalf("expected nil repository view snapshot helper to trim path, got %q err=%v", got, err)
 	}
 }
 
@@ -587,6 +873,31 @@ func stringPtr(value string) *string {
 
 func boolPtr(value bool) *bool {
 	return &value
+}
+
+func writeMCPRepoConfigFixture(t *testing.T, repo string, lowConfidence int, advisoryID string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(repo, "security"), 0o750); err != nil {
+		t.Fatalf("mkdir security: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte(fmt.Sprintf("thresholds:\n  low_confidence_warning_percent: %d\nadvisories:\n  source: security/advisories.yml\n", lowConfidence)), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "security", "advisories.yml"), []byte("advisories:\n  - id: "+advisoryID+"\n    package: lodash\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
+		t.Fatalf("write advisories: %v", err)
+	}
+}
+
+func initMCPGitRepo(t *testing.T, repo, identity string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, "identity.txt"), []byte(identity+"\n"), 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+	testutil.RunGit(t, repo, "init")
+	testutil.RunGit(t, repo, "config", "user.email", "mcp-test@example.com")
+	testutil.RunGit(t, repo, "config", "user.name", "MCP Test")
+	testutil.RunGit(t, repo, "add", ".")
+	testutil.RunGit(t, repo, "commit", "-m", identity)
 }
 
 func slicesEqual(left, right []string) bool {

--- a/internal/mcp/mutations.go
+++ b/internal/mcp/mutations.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/dashboard"
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/report"
@@ -20,34 +21,44 @@ import (
 const MutationToolsFeature = "mcp-mutation-tools"
 
 type MutationRunner interface {
+	CaptureAnalysisState(context.Context, AnalysisMutationRequest) (AnalysisMutationRequest, error)
 	ApplyCodemod(context.Context, AnalysisMutationRequest) (report.Report, error)
 	SaveBaseline(context.Context, AnalysisMutationRequest) (report.Report, string, error)
 	SaveDashboardBaseline(context.Context, DashboardMutationRequest) (dashboard.Report, string, error)
 }
 
 type AnalysisMutationRequest struct {
-	RepoPath          string
-	Dependency        string
-	TopN              int
-	ScopeMode         string
-	Language          string
-	ConfigPath        string
-	IncludePatterns   []string
-	ExcludePatterns   []string
-	CacheEnabled      bool
-	CachePath         string
-	CachePinnedPath   string
-	CacheReadOnly     bool
-	RuntimeProfile    string
-	RuntimeTracePath  string
-	Features          featureflags.Set
-	Thresholds        thresholds.Values
-	PolicySources     []string
-	PolicyTrace       []report.PolicyMergeTrace
-	AllowDirty        bool
-	BaselineStorePath string
-	BaselineKey       string
-	BaselineLabel     string
+	RepoPath   string
+	Repository *analysis.RepositoryAuthorization
+	// RepositoryView is borrowed by MutationRunner. The MCP tool boundary owns
+	// the view and closes it exactly once after runner execution.
+	RepositoryView              *analysis.RepositoryView
+	CurrentBaselineKey          string
+	CurrentBaselineKeyCaptured  bool
+	ApplyCodemod                bool
+	CodemodPrecondition         error
+	CodemodPreconditionCaptured bool
+	LockfileWarnings            []string
+	LockfileDriftErr            error
+	LockfileDriftCaptured       bool
+	Dependency                  string
+	TopN                        int
+	ScopeMode                   string
+	Language                    string
+	ConfigPath                  string
+	IncludePatterns             []string
+	ExcludePatterns             []string
+	Cache                       *analysis.CacheOptions
+	RuntimeProfile              string
+	RuntimeTracePath            string
+	Features                    featureflags.Set
+	Thresholds                  thresholds.Values
+	PolicySources               []string
+	PolicyTrace                 []report.PolicyMergeTrace
+	AllowDirty                  bool
+	BaselineStorePath           string
+	BaselineKey                 string
+	BaselineLabel               string
 }
 
 type DashboardMutationRequest struct {
@@ -207,6 +218,7 @@ func (s *Server) runCodemodApplyTool(ctx context.Context, rawArgs json.RawMessag
 	request.AllowDirty = args.AllowDirty
 
 	reportData, runErr := s.mutationRunner.ApplyCodemod(reqCtx, request)
+	runErr = errors.Join(runErr, request.RepositoryView.Close())
 	payload := shapeCodemodApplyPayload(request, reportData, runErr)
 	if runErr != nil {
 		return mutationToolError(runErr, payload)
@@ -237,15 +249,16 @@ func (s *Server) runBaselineSaveTool(ctx context.Context, rawArgs json.RawMessag
 	if err != nil {
 		return toolError(errorCodeInvalidInput, err)
 	}
-	storePath, key, err := resolveBaselineMutationTarget(request.RepoPath, args.BaselineStorePath, args.BaselineKey, args.BaselineLabel, "baseline")
+	storePath, key, err := resolveBaselineMutationTargetWithCurrentKey(request.RepoPath, args.BaselineStorePath, args.BaselineKey, args.BaselineLabel, "baseline", request.CurrentBaselineKey)
 	if err != nil {
-		return toolError(errorCodeInvalidInput, err)
+		return toolError(errorCodeInvalidInput, errors.Join(err, request.RepositoryView.Close()))
 	}
 	request.BaselineStorePath = storePath
 	request.BaselineKey = key
 	request.BaselineLabel = strings.TrimSpace(args.BaselineLabel)
 
 	reportData, savedPath, runErr := s.mutationRunner.SaveBaseline(reqCtx, request)
+	runErr = errors.Join(runErr, request.RepositoryView.Close())
 	if savedPath == "" {
 		savedPath = report.BaselineSnapshotPath(storePath, key)
 	}
@@ -307,8 +320,8 @@ const (
 	mutationAnalysisKindTopOrDependency mutationAnalysisKind = "top-or-dependency"
 )
 
-func (s *Server) resolveAnalysisMutationRequest(ctx context.Context, args mutationAnalysisArguments, kind mutationAnalysisKind) (AnalysisMutationRequest, error) {
-	repoPath, err := validateRepoPath(args.RepoPath)
+func (s *Server) resolveAnalysisMutationRequest(ctx context.Context, args mutationAnalysisArguments, kind mutationAnalysisKind) (_ AnalysisMutationRequest, returnErr error) {
+	repoPath, repository, err := validateTrustedRepoPath(args.RepoPath)
 	if err != nil {
 		return AnalysisMutationRequest{}, err
 	}
@@ -320,8 +333,21 @@ func (s *Server) resolveAnalysisMutationRequest(ctx context.Context, args mutati
 	if err != nil {
 		return AnalysisMutationRequest{}, err
 	}
-	analysisArgs := analysisArgsFromMutation(args)
-	loadResult, thresholdsValue, policySources, policyTrace, err := resolveThresholds(repoPath, analysisArgs)
+	cacheOptions, err := resolveMCPAnalysisCacheOptionsForRepository(repository, cacheEnabled(args.CacheEnabled), args.CachePath, args.CacheReadOnly)
+	if err != nil {
+		return AnalysisMutationRequest{}, err
+	}
+
+	repositoryView, err := analysis.OpenTrustedRepositoryWithGitMetadata(ctx, repository, repoPath, cacheOptions)
+	if err != nil {
+		return AnalysisMutationRequest{}, err
+	}
+	defer func() {
+		if repositoryView != nil {
+			returnErr = errors.Join(returnErr, repositoryView.Close())
+		}
+	}()
+	loadResult, thresholdsValue, policySources, policyTrace, err := resolveMutationThresholds(repositoryView, args)
 	if err != nil {
 		return AnalysisMutationRequest{}, err
 	}
@@ -329,34 +355,81 @@ func (s *Server) resolveAnalysisMutationRequest(ctx context.Context, args mutati
 	if err != nil {
 		return AnalysisMutationRequest{}, err
 	}
-	cacheOptions, err := resolveMCPAnalysisCacheOptions(repoPath, cacheEnabled(args.CacheEnabled), args.CachePath, args.CacheReadOnly)
-	if err != nil {
-		return AnalysisMutationRequest{}, err
-	}
 	if err := ctx.Err(); err != nil {
 		return AnalysisMutationRequest{}, err
 	}
+	includePatterns := mergeStringOptions(loadResult.Scope.Include, args.Include)
+	excludePatterns := mergeStringOptions(loadResult.Scope.Exclude, args.Exclude)
+	if err := analysis.ValidateTrustedScopedCacheOptions(cacheOptions, includePatterns, excludePatterns); err != nil {
+		return AnalysisMutationRequest{}, err
+	}
 
+	request := newAnalysisMutationRequest(args, analysisMutationRequestContext{
+		repoPath:      repoPath,
+		repository:    repository,
+		kind:          kind,
+		dependency:    dependency,
+		topN:          topN,
+		scopeMode:     scopeMode,
+		cache:         cacheOptions,
+		loadResult:    loadResult,
+		thresholds:    thresholdsValue,
+		features:      features,
+		policySources: policySources,
+		policyTrace:   policyTrace,
+	})
+	request.RepositoryView = repositoryView
+	request.CurrentBaselineKey, request.CurrentBaselineKeyCaptured = repositoryViewCurrentBaselineKey(repositoryView)
+	capturedRequest, err := s.mutationRunner.CaptureAnalysisState(ctx, request)
+	if err != nil {
+		return AnalysisMutationRequest{}, err
+	}
+	request.CodemodPrecondition = capturedRequest.CodemodPrecondition
+	request.CodemodPreconditionCaptured = capturedRequest.CodemodPreconditionCaptured
+	request.LockfileWarnings = append([]string{}, capturedRequest.LockfileWarnings...)
+	request.LockfileDriftErr = capturedRequest.LockfileDriftErr
+	request.LockfileDriftCaptured = capturedRequest.LockfileDriftCaptured
+	request.IncludePatterns = includePatterns
+	request.ExcludePatterns = excludePatterns
+	repositoryView = nil
+	return request, nil
+}
+
+type analysisMutationRequestContext struct {
+	repoPath      string
+	repository    *analysis.RepositoryAuthorization
+	kind          mutationAnalysisKind
+	dependency    string
+	topN          int
+	scopeMode     string
+	cache         *analysis.CacheOptions
+	loadResult    thresholds.LoadResult
+	thresholds    thresholds.Values
+	features      featureflags.Set
+	policySources []string
+	policyTrace   []report.PolicyMergeTrace
+}
+
+func newAnalysisMutationRequest(args mutationAnalysisArguments, req analysisMutationRequestContext) AnalysisMutationRequest {
 	return AnalysisMutationRequest{
-		RepoPath:         repoPath,
-		Dependency:       dependency,
-		TopN:             topN,
-		ScopeMode:        scopeMode,
+		RepoPath:         req.repoPath,
+		Repository:       req.repository,
+		ApplyCodemod:     req.kind == mutationAnalysisKindDependency,
+		Dependency:       req.dependency,
+		TopN:             req.topN,
+		ScopeMode:        req.scopeMode,
 		Language:         languageOrDefault(args.Language),
-		ConfigPath:       strings.TrimSpace(loadResult.ConfigPath),
-		IncludePatterns:  mergeStringOptions(loadResult.Scope.Include, args.Include),
-		ExcludePatterns:  mergeStringOptions(loadResult.Scope.Exclude, args.Exclude),
-		CacheEnabled:     cacheOptions.Enabled,
-		CachePath:        cacheOptions.Path,
-		CachePinnedPath:  cacheOptions.PinnedPath,
-		CacheReadOnly:    cacheOptions.ReadOnly,
+		ConfigPath:       strings.TrimSpace(req.loadResult.ConfigPath),
+		IncludePatterns:  mergeStringOptions(req.loadResult.Scope.Include, args.Include),
+		ExcludePatterns:  mergeStringOptions(req.loadResult.Scope.Exclude, args.Exclude),
+		Cache:            req.cache,
 		RuntimeProfile:   runtimeProfileOrDefault(args.RuntimeProfile),
 		RuntimeTracePath: strings.TrimSpace(args.RuntimeTracePath),
-		Features:         features,
-		Thresholds:       thresholdsValue,
-		PolicySources:    policySources,
-		PolicyTrace:      policyTrace,
-	}, nil
+		Features:         req.features,
+		Thresholds:       req.thresholds,
+		PolicySources:    append([]string{}, req.policySources...),
+		PolicyTrace:      append([]report.PolicyMergeTrace{}, req.policyTrace...),
+	}
 }
 
 func resolveMutationAnalysisTarget(args mutationAnalysisArguments, kind mutationAnalysisKind) (string, int, error) {
@@ -384,34 +457,71 @@ func resolveMutationAnalysisTarget(args mutationAnalysisArguments, kind mutation
 	}
 }
 
-func analysisArgsFromMutation(args mutationAnalysisArguments) analysisToolArguments {
-	return analysisToolArguments{
-		RepoPath:                          args.RepoPath,
-		Dependency:                        args.Dependency,
-		TopN:                              args.TopN,
-		Language:                          args.Language,
-		ScopeMode:                         args.ScopeMode,
-		ConfigPath:                        args.ConfigPath,
-		Include:                           append([]string{}, args.Include...),
-		Exclude:                           append([]string{}, args.Exclude...),
-		EnableFeatures:                    append([]string{}, args.EnableFeatures...),
-		DisableFeatures:                   append([]string{}, args.DisableFeatures...),
-		CacheEnabled:                      args.CacheEnabled,
-		CachePath:                         args.CachePath,
-		CacheReadOnly:                     args.CacheReadOnly,
-		RuntimeProfile:                    args.RuntimeProfile,
-		RuntimeTracePath:                  args.RuntimeTracePath,
+func resolveMutationThresholds(repositoryView *analysis.RepositoryView, args mutationAnalysisArguments) (thresholds.LoadResult, thresholds.Values, []string, []report.PolicyMergeTrace, error) {
+	loadResult, err := loadThresholdsThroughRepositoryView(repositoryView, strings.TrimSpace(args.ConfigPath))
+	if err != nil {
+		return thresholds.LoadResult{}, thresholds.Values{}, nil, nil, err
+	}
+	return resolveMutationThresholdsFromLoadResult(loadResult, args)
+}
+
+func resolveMutationThresholdsFromLoadResult(loadResult thresholds.LoadResult, args mutationAnalysisArguments) (thresholds.LoadResult, thresholds.Values, []string, []report.PolicyMergeTrace, error) {
+	overrides := thresholds.Overrides{
 		LowConfidenceWarningPercent:       args.LowConfidenceWarningPercent,
 		MinUsagePercentForRecommendations: args.MinUsagePercentForRecommendations,
 		MaxUncertainImportCount:           args.MaxUncertainImportCount,
-		ScoreWeightUsage:                  args.ScoreWeightUsage,
-		ScoreWeightImpact:                 args.ScoreWeightImpact,
-		ScoreWeightConfidence:             args.ScoreWeightConfidence,
-		LicenseDeny:                       append([]string{}, args.LicenseDeny...),
+		RemovalCandidateWeightUsage:       args.ScoreWeightUsage,
+		RemovalCandidateWeightImpact:      args.ScoreWeightImpact,
+		RemovalCandidateWeightConfidence:  args.ScoreWeightConfidence,
+		LicenseDenyList:                   append([]string{}, args.LicenseDeny...),
 		LicenseFailOnDeny:                 args.LicenseFailOnDeny,
-		LicenseProvenanceRegistry:         args.LicenseProvenanceRegistry,
-		TimeoutMillis:                     args.TimeoutMillis,
+		LicenseIncludeRegistryProvenance:  args.LicenseProvenanceRegistry,
 	}
+	return resolveThresholdsFromLoadResult(loadResult, overrides, hasMutationPolicyOverrides(args), mutationPolicyTrace(args))
+}
+
+func hasMutationPolicyOverrides(args mutationAnalysisArguments) bool {
+	return args.LowConfidenceWarningPercent != nil ||
+		args.MinUsagePercentForRecommendations != nil ||
+		args.MaxUncertainImportCount != nil ||
+		args.ScoreWeightUsage != nil ||
+		args.ScoreWeightImpact != nil ||
+		args.ScoreWeightConfidence != nil ||
+		len(args.LicenseDeny) > 0 ||
+		args.LicenseFailOnDeny != nil ||
+		args.LicenseProvenanceRegistry != nil
+}
+
+func mutationPolicyTrace(args mutationAnalysisArguments) []report.PolicyMergeTrace {
+	trace := make([]report.PolicyMergeTrace, 0, 8)
+	if args.LowConfidenceWarningPercent != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "thresholds.low_confidence_warning_percent", Source: "mcp"})
+	}
+	if args.MinUsagePercentForRecommendations != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "thresholds.min_usage_percent_for_recommendations", Source: "mcp"})
+	}
+	if args.MaxUncertainImportCount != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "thresholds.max_uncertain_import_count", Source: "mcp"})
+	}
+	if args.ScoreWeightUsage != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "removal_candidate_weights.usage", Source: "mcp"})
+	}
+	if args.ScoreWeightImpact != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "removal_candidate_weights.impact", Source: "mcp"})
+	}
+	if args.ScoreWeightConfidence != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "removal_candidate_weights.confidence", Source: "mcp"})
+	}
+	if len(args.LicenseDeny) > 0 {
+		trace = append(trace, report.PolicyMergeTrace{Field: "license.deny", Source: "mcp"})
+	}
+	if args.LicenseFailOnDeny != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "license.fail_on_deny", Source: "mcp"})
+	}
+	if args.LicenseProvenanceRegistry != nil {
+		trace = append(trace, report.PolicyMergeTrace{Field: "license.include_registry_provenance", Source: "mcp"})
+	}
+	return trace
 }
 
 func (s *Server) resolveDashboardMutationRequest(ctx context.Context, args dashboardBaselineSaveArguments) (DashboardMutationRequest, error) {
@@ -470,6 +580,10 @@ func validateDashboardMutationRepos(repos []DashboardRepoInput) error {
 }
 
 func resolveBaselineMutationTarget(repoPath, storePath, key, label, keyName string) (string, string, error) {
+	return resolveBaselineMutationTargetWithCurrentKey(repoPath, storePath, key, label, keyName, resolveAuthorizedCurrentBaselineKey(repoPath))
+}
+
+func resolveBaselineMutationTargetWithCurrentKey(repoPath, storePath, key, label, keyName, currentKey string) (string, string, error) {
 	resolvedStorePath, err := resolveLocalMutationPath(repoPath, storePath, "baselineStorePath")
 	if err != nil {
 		return "", "", err
@@ -485,11 +599,10 @@ func resolveBaselineMutationTarget(repoPath, storePath, key, label, keyName stri
 	case trimmedKey != "":
 		return resolvedStorePath, trimmedKey, nil
 	default:
-		currentKey := resolveMutationCurrentBaselineKey(repoPath)
-		if currentKey == "" {
+		if strings.TrimSpace(currentKey) == "" {
 			return "", "", fmt.Errorf("unable to resolve git commit for %s key; pass baselineLabel or baselineKey", keyName)
 		}
-		return resolvedStorePath, currentKey, nil
+		return resolvedStorePath, strings.TrimSpace(currentKey), nil
 	}
 }
 
@@ -510,12 +623,17 @@ func resolveLocalMutationPath(repoPath, rawPath, field string) (string, error) {
 	return filepath.Join(repoPath, trimmed), nil
 }
 
-func resolveMutationCurrentBaselineKey(repoPath string) string {
+func resolveAuthorizedCurrentBaselineKey(repoPath string) string {
+	currentKey, _ := captureAuthorizedCurrentBaselineKey(repoPath)
+	return currentKey
+}
+
+func captureAuthorizedCurrentBaselineKey(repoPath string) (string, bool) {
 	sha, err := workspace.CurrentCommitSHA(repoPath)
 	if err != nil || strings.TrimSpace(sha) == "" {
-		return ""
+		return "", true
 	}
-	return "commit:" + sha
+	return "commit:" + sha, true
 }
 
 func shapeCodemodApplyPayload(req AnalysisMutationRequest, reportData report.Report, err error) codemodApplyPayload {

--- a/internal/mcp/mutations.go
+++ b/internal/mcp/mutations.go
@@ -36,6 +36,7 @@ type AnalysisMutationRequest struct {
 	ExcludePatterns   []string
 	CacheEnabled      bool
 	CachePath         string
+	CachePinnedPath   string
 	CacheReadOnly     bool
 	RuntimeProfile    string
 	RuntimeTracePath  string
@@ -328,6 +329,10 @@ func (s *Server) resolveAnalysisMutationRequest(ctx context.Context, args mutati
 	if err != nil {
 		return AnalysisMutationRequest{}, err
 	}
+	cacheOptions, err := resolveMCPAnalysisCacheOptions(repoPath, cacheEnabled(args.CacheEnabled), args.CachePath, args.CacheReadOnly)
+	if err != nil {
+		return AnalysisMutationRequest{}, err
+	}
 	if err := ctx.Err(); err != nil {
 		return AnalysisMutationRequest{}, err
 	}
@@ -341,9 +346,10 @@ func (s *Server) resolveAnalysisMutationRequest(ctx context.Context, args mutati
 		ConfigPath:       strings.TrimSpace(loadResult.ConfigPath),
 		IncludePatterns:  mergeStringOptions(loadResult.Scope.Include, args.Include),
 		ExcludePatterns:  mergeStringOptions(loadResult.Scope.Exclude, args.Exclude),
-		CacheEnabled:     cacheEnabled(args.CacheEnabled),
-		CachePath:        strings.TrimSpace(args.CachePath),
-		CacheReadOnly:    args.CacheReadOnly,
+		CacheEnabled:     cacheOptions.Enabled,
+		CachePath:        cacheOptions.Path,
+		CachePinnedPath:  cacheOptions.PinnedPath,
+		CacheReadOnly:    cacheOptions.ReadOnly,
 		RuntimeProfile:   runtimeProfileOrDefault(args.RuntimeProfile),
 		RuntimeTracePath: strings.TrimSpace(args.RuntimeTracePath),
 		Features:         features,

--- a/internal/mcp/mutations_test.go
+++ b/internal/mcp/mutations_test.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/dashboard"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
+	"github.com/ben-ranford/lopper/internal/workspace"
 )
 
 func TestRunCodemodApplyToolReturnsStructuredPayload(t *testing.T) {
@@ -117,6 +120,271 @@ func TestRunBaselineSaveToolReturnsStructuredPayload(t *testing.T) {
 	}
 	if payload.ReportSummary == nil || payload.ReportSummary.DependencyCount != 1 {
 		t.Fatalf("expected report summary in structured content, got %#v", payload.ReportSummary)
+	}
+}
+
+func TestRunBaselineSaveToolUsesAuthorizedCommitAndConfigAfterRepositorySwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	repoB := filepath.Join(parent, "repo-b")
+	for _, root := range []string{repo, repoB} {
+		if err := os.Mkdir(root, 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", root, err)
+		}
+	}
+	writeMCPRepoConfigFixture(t, repo, 21, "GHSA-repo-a")
+	writeMCPRepoConfigFixture(t, repoB, 88, "GHSA-repo-b")
+	initMCPGitRepo(t, repo, "repo-a")
+	initMCPGitRepo(t, repoB, "repo-b")
+	repoACommit, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("repo A commit: %v", err)
+	}
+	repoBCommit, err := workspace.CurrentCommitSHA(repoB)
+	if err != nil {
+		t.Fatalf("repo B commit: %v", err)
+	}
+	movedRepoA := filepath.Join(parent, "repo-a-original")
+	restore := analysis.SetRepositoryViewHandleOpenedHookForTest(func() error {
+		if err := os.Rename(repo, movedRepoA); err != nil {
+			return err
+		}
+		return os.Rename(repoB, repo)
+	})
+	t.Cleanup(restore)
+
+	runner := &fakeMutationRunner{baselineReport: sampleReport(repo)}
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
+	result := callToolResult(t, server, toolSaveBaseline, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": ".artifacts/baselines",
+		"topN":              1,
+		"confirmSave":       true,
+		"cacheEnabled":      false,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected baseline save after swap: %#v", result)
+	}
+	if runner.lastBaseline.BaselineKey != "commit:"+repoACommit || runner.lastBaseline.CurrentBaselineKey != "commit:"+repoACommit {
+		t.Fatalf("expected repo A commit-bound baseline request, got %#v", runner.lastBaseline)
+	}
+	if runner.lastBaseline.Thresholds.LowConfidenceWarningPercent != 21 {
+		t.Fatalf("expected repo A thresholds after swap, got %#v", runner.lastBaseline.Thresholds)
+	}
+	if runner.lastBaseline.BaselineKey == "commit:"+repoBCommit {
+		t.Fatalf("expected repo B commit not to leak into baseline key")
+	}
+}
+
+func TestRunBaselineSaveToolSealsSamePathHeadAndConfigBeforeMutationCapture(t *testing.T) {
+	repo := t.TempDir()
+	writeMCPRepoConfigFixture(t, repo, 23, "GHSA-config-a")
+	initMCPGitRepo(t, repo, "repo-a")
+	commitA, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("resolve commit A: %v", err)
+	}
+
+	writeMCPRepoConfigFixture(t, repo, 89, "GHSA-config-b")
+	if err := os.WriteFile(filepath.Join(repo, "identity.txt"), []byte("repo-b\n"), 0o600); err != nil {
+		t.Fatalf("write identity B: %v", err)
+	}
+	testutil.RunGit(t, repo, "add", ".")
+	testutil.RunGit(t, repo, "commit", "-m", "repo-b")
+	commitB, err := workspace.CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("resolve commit B: %v", err)
+	}
+	testutil.RunGit(t, repo, "checkout", "--detach", commitA)
+
+	viewOpens := 0
+	restoreOpen := analysis.SetRepositoryViewHandleOpenedHookForTest(func() error {
+		viewOpens++
+		testutil.RunGit(t, repo, "checkout", "--detach", commitB)
+		return nil
+	})
+	t.Cleanup(restoreOpen)
+	viewCloses := 0
+	restoreClose := analysis.SetRepositoryViewCloseHookForTest(func() error {
+		viewCloses++
+		return nil
+	})
+	t.Cleanup(restoreClose)
+
+	runner := &fakeMutationRunner{baselineReport: sampleReport(repo)}
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
+	result := callToolResult(t, server, toolSaveBaseline, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": ".artifacts/baselines",
+		"topN":              1,
+		"confirmSave":       true,
+		"cacheEnabled":      false,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected same-path baseline mutation error: %#v", result)
+	}
+	if !runner.baselineCalled || runner.lastBaseline.RepositoryView == nil {
+		t.Fatalf("mutation did not receive the authoritative borrowed view: %#v", runner.lastBaseline)
+	}
+	if runner.lastBaseline.Thresholds.LowConfidenceWarningPercent != 23 {
+		t.Fatalf("mutation thresholds = %#v, want config A", runner.lastBaseline.Thresholds)
+	}
+	if runner.lastBaseline.CurrentBaselineKey != "commit:"+commitA ||
+		runner.lastBaseline.BaselineKey != "commit:"+commitA ||
+		!runner.lastBaseline.CurrentBaselineKeyCaptured {
+		t.Fatalf("mutation baseline identity = %#v, want commit A", runner.lastBaseline)
+	}
+	if runner.lastBaseline.CurrentBaselineKey == "commit:"+commitB {
+		t.Fatal("same-path commit B retargeted mutation state")
+	}
+	if viewOpens != 1 || viewCloses != 1 {
+		t.Fatalf("repository view opens/closes = %d/%d, want 1/1", viewOpens, viewCloses)
+	}
+}
+
+func TestRunBaselineSaveToolJoinsRunnerAndRepositoryViewCloseFailures(t *testing.T) {
+	repo := t.TempDir()
+	runErr := errors.New("baseline runner sentinel")
+	closeErr := errors.New("mutation repository close sentinel")
+	closeCalls := 0
+	restore := analysis.SetRepositoryViewCloseHookForTest(func() error {
+		closeCalls++
+		return closeErr
+	})
+	t.Cleanup(restore)
+
+	runner := &fakeMutationRunner{baselineErr: runErr}
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
+	result := callToolResult(t, server, toolSaveBaseline, map[string]any{
+		"repoPath":          repo,
+		"baselineStorePath": "baselines",
+		"baselineLabel":     "close-error",
+		"confirmSave":       true,
+		"cacheEnabled":      false,
+	})
+	if !result.IsError || len(result.Content) == 0 {
+		t.Fatalf("expected joined mutation failure, got %#v", result)
+	}
+	if !strings.Contains(result.Content[0].Text, runErr.Error()) || !strings.Contains(result.Content[0].Text, closeErr.Error()) {
+		t.Fatalf("expected runner and close errors, got %q", result.Content[0].Text)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("repository close calls = %d, want 1", closeCalls)
+	}
+}
+
+func TestRunCodemodApplyToolKeepsPinnedPolicyAndPropagatesRepositoryViewCloseFailure(t *testing.T) {
+	repo := t.TempDir()
+	configPath := filepath.Join(repo, ".lopper.yml")
+	if err := os.WriteFile(configPath, []byte("thresholds:\n  lockfile_drift_policy: off\n"), 0o600); err != nil {
+		t.Fatalf("write initial policy: %v", err)
+	}
+	closeErr := errors.New("policy drift close sentinel")
+	closeCalls := 0
+	restore := analysis.SetRepositoryViewCloseHookForTest(func() error {
+		closeCalls++
+		return closeErr
+	})
+	t.Cleanup(restore)
+
+	runner := &fakeMutationRunner{
+		captureFn: func(req AnalysisMutationRequest) (AnalysisMutationRequest, error) {
+			err := os.WriteFile(configPath, []byte("thresholds:\n  lockfile_drift_policy: warn\n"), 0o600)
+			return req, err
+		},
+	}
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
+	result := callToolResult(t, server, toolApplyCodemod, map[string]any{
+		"repoPath":     repo,
+		"dependency":   "lodash",
+		"confirmApply": true,
+		"cacheEnabled": false,
+	})
+	if !result.IsError || len(result.Content) == 0 {
+		t.Fatalf("expected repository-view close failure, got %#v", result)
+	}
+	if strings.Contains(result.Content[0].Text, "policy changed while capturing mutation preconditions") ||
+		!strings.Contains(result.Content[0].Text, closeErr.Error()) {
+		t.Fatalf("expected only the close failure after pinned-policy execution, got %q", result.Content[0].Text)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("repository close calls = %d, want 1", closeCalls)
+	}
+	if !runner.applyCalled {
+		t.Fatal("expected mutation runner to execute with pinned policy")
+	}
+	if runner.lastApply.Thresholds.LockfileDriftPolicy != "off" {
+		t.Fatalf("mutation policy = %q, want pinned off policy", runner.lastApply.Thresholds.LockfileDriftPolicy)
+	}
+}
+
+func TestAnalysisMutationCaptureFailureClosesAuthoritativeRepositoryView(t *testing.T) {
+	repo := t.TempDir()
+	captureErr := errors.New("capture precondition sentinel")
+	viewOpens := 0
+	restore := analysis.SetRepositoryViewHandleOpenedHookForTest(func() error {
+		viewOpens++
+		return nil
+	})
+	t.Cleanup(restore)
+	viewCloses := 0
+	restoreClose := analysis.SetRepositoryViewCloseHookForTest(func() error {
+		viewCloses++
+		return nil
+	})
+	t.Cleanup(restoreClose)
+
+	runner := &fakeMutationRunner{captureErr: captureErr}
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
+	result := callToolResult(t, server, toolApplyCodemod, map[string]any{
+		"repoPath":     repo,
+		"dependency":   "lodash",
+		"confirmApply": true,
+		"cacheEnabled": false,
+	})
+	assertMutationToolErrorContains(t, result, captureErr.Error())
+	if viewOpens != 1 {
+		t.Fatalf("repository view opens = %d, want 1", viewOpens)
+	}
+	if viewCloses != 1 {
+		t.Fatalf("repository view closes = %d, want 1", viewCloses)
+	}
+}
+
+func TestMutationPolicyTraceRecordsEveryOverrideWithStableSource(t *testing.T) {
+	args := mutationAnalysisArguments{
+		LowConfidenceWarningPercent:       intPtr(11),
+		MinUsagePercentForRecommendations: intPtr(22),
+		MaxUncertainImportCount:           intPtr(3),
+		ScoreWeightUsage:                  floatPtr(0.5),
+		ScoreWeightImpact:                 floatPtr(0.3),
+		ScoreWeightConfidence:             floatPtr(0.2),
+		LicenseDeny:                       []string{"GPL-3.0-only"},
+		LicenseFailOnDeny:                 boolPtr(true),
+		LicenseProvenanceRegistry:         boolPtr(true),
+	}
+	trace := mutationPolicyTrace(args)
+	wantFields := []string{
+		"thresholds.low_confidence_warning_percent",
+		"thresholds.min_usage_percent_for_recommendations",
+		"thresholds.max_uncertain_import_count",
+		"removal_candidate_weights.usage",
+		"removal_candidate_weights.impact",
+		"removal_candidate_weights.confidence",
+		"license.deny",
+		"license.fail_on_deny",
+		"license.include_registry_provenance",
+	}
+	if len(trace) != len(wantFields) {
+		t.Fatalf("policy trace length = %d, want %d: %#v", len(trace), len(wantFields), trace)
+	}
+	for index, field := range wantFields {
+		if trace[index].Field != field || trace[index].Source != "mcp" {
+			t.Fatalf("policy trace[%d] = %#v, want field %q from mcp", index, trace[index], field)
+		}
 	}
 }
 
@@ -434,20 +702,24 @@ func TestResolveMutationAnalysisTargetBranches(t *testing.T) {
 func TestResolveMutationRequestValidationBranches(t *testing.T) {
 	repo := t.TempDir()
 	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: &fakeMutationRunner{}})
+	assertMutationAnalysisValidationErrors(t, server, repo)
+	assertMutationExternalCacheCompatibility(t, server, repo)
+	assertMutationDashboardValidationErrors(t, server, repo)
+}
 
-	analysisCases := []struct {
+func assertMutationAnalysisValidationErrors(t *testing.T, server *Server, repo string) {
+	t.Helper()
+	for _, tc := range []struct {
 		name string
 		args mutationAnalysisArguments
 		want string
 	}{
 		{"bad repo", mutationAnalysisArguments{RepoPath: filepath.Join(repo, "missing"), Dependency: "dep"}, "stat repoPath"},
 		{"missing dependency", mutationAnalysisArguments{RepoPath: repo}, "dependency"},
-		{"cache path escape", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", CacheEnabled: boolPtr(true), CachePath: filepath.Join(t.TempDir(), "cache")}, "cachePath must stay within repoPath"},
 		{"bad scope", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", ScopeMode: "bad"}, "scopeMode"},
 		{"bad threshold", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", LowConfidenceWarningPercent: intPtr(101)}, "low_confidence"},
 		{"unknown feature", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", EnableFeatures: []string{"missing"}}, "unknown feature"},
-	}
-	for _, tc := range analysisCases {
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := server.resolveAnalysisMutationRequest(context.Background(), tc.args, mutationAnalysisKindDependency)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
@@ -455,15 +727,36 @@ func TestResolveMutationRequestValidationBranches(t *testing.T) {
 			}
 		})
 	}
-
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := server.resolveAnalysisMutationRequest(cancelled, mutationAnalysisArguments{RepoPath: repo, Dependency: "dep"}, mutationAnalysisKindDependency)
-	if !errors.Is(err, context.Canceled) {
+	if _, err := server.resolveAnalysisMutationRequest(cancelled, mutationAnalysisArguments{RepoPath: repo, Dependency: "dep"}, mutationAnalysisKindDependency); !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected canceled analysis request, got %v", err)
 	}
+}
 
-	dashboardCases := []struct {
+func assertMutationExternalCacheCompatibility(t *testing.T, server *Server, repo string) {
+	t.Helper()
+	outsideCache := filepath.Join(t.TempDir(), "cache")
+	request, err := server.resolveAnalysisMutationRequest(context.Background(), mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", CacheEnabled: boolPtr(true), CachePath: outsideCache, CacheReadOnly: true}, mutationAnalysisKindDependency)
+	if err != nil {
+		t.Fatalf("resolve mutation request with external cache path: %v", err)
+	}
+	if request.Cache == nil || !request.Cache.Enabled || request.Cache.Path != outsideCache || !request.Cache.ReadOnly {
+		t.Fatalf("expected external absolute cache path to be preserved for mutations, got %#v", request)
+	}
+	symlinkOutside := t.TempDir()
+	if err := os.Symlink(symlinkOutside, filepath.Join(repo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	_, err = server.resolveAnalysisMutationRequest(context.Background(), mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", CacheEnabled: boolPtr(true), CachePath: filepath.Join(repo, "tmp", "cache")}, mutationAnalysisKindDependency)
+	if err == nil || !strings.Contains(err.Error(), "cachePath must stay within repoPath") {
+		t.Fatalf("expected symlinked cache escape rejection, got %v", err)
+	}
+}
+
+func assertMutationDashboardValidationErrors(t *testing.T, server *Server, repo string) {
+	t.Helper()
+	for _, tc := range []struct {
 		name string
 		args dashboardBaselineSaveArguments
 		want string
@@ -473,8 +766,7 @@ func TestResolveMutationRequestValidationBranches(t *testing.T) {
 		{"bad topN", dashboardBaselineSaveArguments{RepoPath: repo, Repos: []DashboardRepoInput{{Path: repo}}, BaselineStorePath: "store", BaselineKey: "key", TopN: intPtr(0)}, "topN"},
 		{"bad store", dashboardBaselineSaveArguments{RepoPath: repo, Repos: []DashboardRepoInput{{Path: repo}}, BaselineStorePath: "https://example.com/store", BaselineKey: "key"}, "local filesystem"},
 		{"unknown feature", dashboardBaselineSaveArguments{RepoPath: repo, Repos: []DashboardRepoInput{{Path: repo}}, BaselineStorePath: "store", BaselineKey: "key", EnableFeatures: []string{"missing"}}, "unknown feature"},
-	}
-	for _, tc := range dashboardCases {
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := server.resolveDashboardMutationRequest(context.Background(), tc.args)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
@@ -482,10 +774,9 @@ func TestResolveMutationRequestValidationBranches(t *testing.T) {
 			}
 		})
 	}
-
-	cancelled, cancel = context.WithCancel(context.Background())
+	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err = server.resolveDashboardMutationRequest(cancelled, dashboardBaselineSaveArguments{
+	_, err := server.resolveDashboardMutationRequest(cancelled, dashboardBaselineSaveArguments{
 		RepoPath:          repo,
 		Repos:             []DashboardRepoInput{{Path: repo}},
 		BaselineStorePath: "store",
@@ -493,6 +784,87 @@ func TestResolveMutationRequestValidationBranches(t *testing.T) {
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected canceled dashboard request, got %v", err)
+	}
+}
+
+func TestResolveAnalysisMutationRequestRejectsCanonicalSymlinkEscapeUnderRequestedRepoAlias(t *testing.T) {
+	requestedRepo, canonicalCache, outsideCache := mcpCanonicalAliasCacheEscapeFixture(t)
+	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: &fakeMutationRunner{}})
+
+	args := mutationAnalysisArguments{
+		RepoPath:     requestedRepo,
+		Dependency:   "dep",
+		CacheEnabled: boolPtr(true),
+		CachePath:    canonicalCache,
+	}
+	_, err := server.resolveAnalysisMutationRequest(context.Background(), args, mutationAnalysisKindDependency)
+	if !analysis.CachePathSymlinkEscape(err) {
+		t.Fatalf("expected canonical-form mutation symlink escape rejection, got %v", err)
+	}
+	if analysis.CachePathExternal(err) {
+		t.Fatalf("expected mutation not to classify canonical in-repo form as external, got %v", err)
+	}
+	if _, statErr := os.Stat(outsideCache); !os.IsNotExist(statErr) {
+		t.Fatalf("expected MCP mutation not to create external cache directory, stat err=%v", statErr)
+	}
+}
+
+func TestResolveAnalysisMutationRequestRejectsAlternateAbsoluteRepoAliasesThatLaterEscape(t *testing.T) {
+	for _, fixture := range mcpAlternateAbsoluteRepoAliasEscapeFixtures(t) {
+		t.Run(fixture.name, func(t *testing.T) {
+			server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: &fakeMutationRunner{}})
+			args := mutationAnalysisArguments{
+				RepoPath:     fixture.requestedRepo,
+				Dependency:   "dep",
+				CacheEnabled: boolPtr(true),
+				CachePath:    fixture.cachePath,
+			}
+			_, err := server.resolveAnalysisMutationRequest(context.Background(), args, mutationAnalysisKindDependency)
+			if !analysis.CachePathSymlinkEscape(err) || analysis.CachePathExternal(err) {
+				t.Fatalf("expected MCP mutation alternate-alias escape rejection, got %v", err)
+			}
+			if _, statErr := os.Stat(fixture.outsideCache); !os.IsNotExist(statErr) {
+				t.Fatalf("expected MCP mutation not to create outside cache, stat err=%v", statErr)
+			}
+		})
+	}
+}
+
+func TestCodemodMutationClassifiesExternalCacheAliasesIntoRepoBeforeRunnerInvocation(t *testing.T) {
+	repo := t.TempDir()
+	cacheSubdir := filepath.Join(repo, ".cache", "lopper")
+	if err := os.MkdirAll(cacheSubdir, 0o750); err != nil {
+		t.Fatalf("mkdir cache subdir: %v", err)
+	}
+	for _, tc := range mcpRepoCacheAliasFixtures(repo, cacheSubdir) {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheAlias := mustMCPCacheAlias(t, tc.target)
+			runner := &fakeMutationRunner{applyReport: sampleReport(repo)}
+			server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
+			result := callToolResult(t, server, toolApplyCodemod, map[string]any{
+				"repoPath":     repo,
+				"dependency":   "lodash",
+				"cachePath":    cacheAlias,
+				"cacheEnabled": true,
+				"include":      []string{"**"},
+				"confirmApply": true,
+			})
+			assertMCPMutationRepoCacheAliasOutcome(t, result, runner.applyCalled, analysis.InRepoCacheOptions(runner.lastApply.Cache), tc.wantReject)
+			assertMCPCacheLayoutAbsent(t, tc.target)
+		})
+	}
+}
+
+func assertMCPMutationRepoCacheAliasOutcome(t *testing.T, result toolCallResult, called, inRepo bool, wantReject bool) {
+	t.Helper()
+	if wantReject {
+		if !result.IsError || !strings.Contains(result.Content[0].Text, "scoped analysis does not allow cachePath at the repository root") || called {
+			t.Fatalf("expected external repo-root alias rejection, got %#v called=%t", result, called)
+		}
+		return
+	}
+	if result.IsError || !called || !inRepo {
+		t.Fatalf("expected in-repo cache pin for mutation alias, result=%#v called=%t inRepo=%t", result, called, inRepo)
 	}
 }
 

--- a/internal/mcp/mutations_test.go
+++ b/internal/mcp/mutations_test.go
@@ -442,6 +442,7 @@ func TestResolveMutationRequestValidationBranches(t *testing.T) {
 	}{
 		{"bad repo", mutationAnalysisArguments{RepoPath: filepath.Join(repo, "missing"), Dependency: "dep"}, "stat repoPath"},
 		{"missing dependency", mutationAnalysisArguments{RepoPath: repo}, "dependency"},
+		{"cache path escape", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", CacheEnabled: boolPtr(true), CachePath: filepath.Join(t.TempDir(), "cache")}, "cachePath must stay within repoPath"},
 		{"bad scope", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", ScopeMode: "bad"}, "scopeMode"},
 		{"bad threshold", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", LowConfidenceWarningPercent: intPtr(101)}, "low_confidence"},
 		{"unknown feature", mutationAnalysisArguments{RepoPath: repo, Dependency: "dep", EnableFeatures: []string{"missing"}}, "unknown feature"},

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -397,6 +397,55 @@ func TestCallToolTimeoutCancelsAnalysis(t *testing.T) {
 	}
 }
 
+func TestCallAnalyseDependencyRejectsCachePathOutsideRepo(t *testing.T) {
+	repo := t.TempDir()
+	outsideCache := filepath.Join(t.TempDir(), "cache")
+	fake := &fakeAnalyser{report: sampleReport(repo)}
+	server := NewServer(Options{Analyzer: fake})
+
+	result := callToolResult(t, server, toolAnalyseDependency, map[string]any{
+		"repoPath":     repo,
+		"dependency":   "lodash",
+		"cachePath":    outsideCache,
+		"cacheEnabled": true,
+	})
+	if !result.IsError || !strings.Contains(result.Content[0].Text, "cachePath must stay within repoPath") {
+		t.Fatalf("expected outside cache rejection, got %#v", result)
+	}
+	if fake.called {
+		t.Fatalf("expected analyser to remain uncalled")
+	}
+	if _, err := os.Stat(outsideCache); !os.IsNotExist(err) {
+		t.Fatalf("expected no outside cache writes, stat err=%v", err)
+	}
+}
+
+func TestCallAnalyseDependencyRejectsSymlinkedCachePathEscape(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	fake := &fakeAnalyser{report: sampleReport(repo)}
+	server := NewServer(Options{Analyzer: fake})
+	result := callToolResult(t, server, toolAnalyseDependency, map[string]any{
+		"repoPath":     repo,
+		"dependency":   "lodash",
+		"cachePath":    filepath.Join("tmp", "cache"),
+		"cacheEnabled": true,
+	})
+	if !result.IsError || !strings.Contains(result.Content[0].Text, "cachePath must stay within repoPath") {
+		t.Fatalf("expected symlink escape rejection, got %#v", result)
+	}
+	if fake.called {
+		t.Fatalf("expected analyser to remain uncalled")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "cache")); !os.IsNotExist(err) {
+		t.Fatalf("expected no outside cache writes, stat err=%v", err)
+	}
+}
+
 func TestListLanguagesReturnsAdapterAndConfigMetadata(t *testing.T) {
 	registry := language.NewRegistry()
 	if err := registry.Register(newTestAdapter("js-ts", "javascript", "typescript")); err != nil {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -463,17 +464,14 @@ func TestCallAnalyseDependencyPinsDefaultCachePathForScopedRequest(t *testing.T)
 	if !fake.called {
 		t.Fatalf("expected analyser to be called")
 	}
-	expectedPinnedPath, err := analysis.ResolveTrustedDefaultCachePath(repo)
-	if err != nil {
-		t.Fatalf("resolve trusted default cache path: %v", err)
-	}
+	expectedPinnedPath := mustResolveDefaultPinnedCachePath(t, repo)
 	if fake.lastReq.Cache == nil || !fake.lastReq.Cache.Enabled {
 		t.Fatalf("expected enabled default cache options, got %#v", fake.lastReq.Cache)
 	}
 	if fake.lastReq.Cache.Path != "" {
 		t.Fatalf("expected default MCP cache path to remain implicit, got %#v", fake.lastReq.Cache)
 	}
-	if fake.lastReq.Cache.PinnedPath != expectedPinnedPath {
+	if pinnedPath := cachePinnedPathValue(fake.lastReq.Cache); pinnedPath != expectedPinnedPath {
 		t.Fatalf("expected pinned default cache path %q, got %#v", expectedPinnedPath, fake.lastReq.Cache)
 	}
 }
@@ -500,10 +498,7 @@ func TestCallAnalyseDependencyScopedRequestReusesPinnedDefaultCacheAndReportsCan
 	}
 
 	server := NewServer(Options{Analyzer: analysis.NewService()})
-	expectedPinnedPath, err := analysis.ResolveTrustedDefaultCachePath(repo)
-	if err != nil {
-		t.Fatalf("resolve trusted default cache path: %v", err)
-	}
+	expectedPinnedPath := mustResolveDefaultPinnedCachePath(t, repo)
 
 	first := callToolResult(t, server, toolAnalyseDependency, map[string]any{
 		"repoPath":   repo,
@@ -565,6 +560,31 @@ func TestListLanguagesReturnsAdapterAndConfigMetadata(t *testing.T) {
 	if payload.EffectiveThresholds.LowConfidenceWarningPercent == 0 {
 		t.Fatalf("expected threshold defaults in metadata")
 	}
+}
+
+func cachePinnedPathValue(cache any) string {
+	value := reflect.ValueOf(cache)
+	if !value.IsValid() || value.Kind() != reflect.Pointer || value.IsNil() {
+		return ""
+	}
+	field := value.Elem().FieldByName("PinnedPath")
+	if !field.IsValid() || field.Kind() != reflect.String {
+		return ""
+	}
+	return field.String()
+}
+
+func mustResolveDefaultPinnedCachePath(t *testing.T, repo string) string {
+	t.Helper()
+	cachePath := filepath.Join(repo, ".lopper-cache")
+	if err := os.MkdirAll(cachePath, 0o755); err != nil {
+		t.Fatalf("mkdir default pinned cache path: %v", err)
+	}
+	resolvedPath, err := filepath.EvalSymlinks(cachePath)
+	if err != nil {
+		t.Fatalf("resolve default pinned cache path: %v", err)
+	}
+	return resolvedPath
 }
 
 func TestServeProcessesFramedInitialize(t *testing.T) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -446,6 +446,100 @@ func TestCallAnalyseDependencyRejectsSymlinkedCachePathEscape(t *testing.T) {
 	}
 }
 
+func TestCallAnalyseDependencyPinsDefaultCachePathForScopedRequest(t *testing.T) {
+	repo := t.TempDir()
+	fake := &fakeAnalyser{report: sampleReport(repo)}
+	server := NewServer(Options{Analyzer: fake})
+
+	result := callToolResult(t, server, toolAnalyseDependency, map[string]any{
+		"repoPath":   repo,
+		"dependency": "lodash",
+		"include":    []string{"src/**"},
+		"exclude":    []string{"vendor/**"},
+	})
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %#v", result)
+	}
+	if !fake.called {
+		t.Fatalf("expected analyser to be called")
+	}
+	expectedPinnedPath, err := analysis.ResolveTrustedDefaultCachePath(repo)
+	if err != nil {
+		t.Fatalf("resolve trusted default cache path: %v", err)
+	}
+	if fake.lastReq.Cache == nil || !fake.lastReq.Cache.Enabled {
+		t.Fatalf("expected enabled default cache options, got %#v", fake.lastReq.Cache)
+	}
+	if fake.lastReq.Cache.Path != "" {
+		t.Fatalf("expected default MCP cache path to remain implicit, got %#v", fake.lastReq.Cache)
+	}
+	if fake.lastReq.Cache.PinnedPath != expectedPinnedPath {
+		t.Fatalf("expected pinned default cache path %q, got %#v", expectedPinnedPath, fake.lastReq.Cache)
+	}
+}
+
+func TestCallAnalyseDependencyScopedRequestReusesPinnedDefaultCacheAndReportsCanonicalPath(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o750); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "node_modules", "lodash"), 0o750); err != nil {
+		t.Fatalf("mkdir lodash fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte("{\n  \"name\": \"demo\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "src", "index.js"), []byte("import { map } from \"lodash\"\nmap([1], (x) => x)\n"), 0o600); err != nil {
+		t.Fatalf("write source fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "node_modules", "lodash", "package.json"), []byte("{\n  \"main\": \"index.js\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write lodash package.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "node_modules", "lodash", "index.js"), []byte("export function map() {}\n"), 0o600); err != nil {
+		t.Fatalf("write lodash index.js: %v", err)
+	}
+
+	server := NewServer(Options{Analyzer: analysis.NewService()})
+	expectedPinnedPath, err := analysis.ResolveTrustedDefaultCachePath(repo)
+	if err != nil {
+		t.Fatalf("resolve trusted default cache path: %v", err)
+	}
+
+	first := callToolResult(t, server, toolAnalyseDependency, map[string]any{
+		"repoPath":   repo,
+		"dependency": "lodash",
+		"include":    []string{"src/**"},
+		"exclude":    []string{"vendor/**"},
+	})
+	if first.IsError {
+		t.Fatalf("unexpected first tool error: %#v", first)
+	}
+	firstPayload, ok := first.StructuredContent.(analysisPayload)
+	if !ok {
+		t.Fatalf("expected first analysis payload, got %#v", first.StructuredContent)
+	}
+	if firstPayload.Report.Cache == nil || firstPayload.Report.Cache.Path != expectedPinnedPath || firstPayload.Report.Cache.Misses != 1 || firstPayload.Report.Cache.Writes != 1 {
+		t.Fatalf("expected first scoped MCP run to report canonical pinned cache path and miss/write metadata, got %#v", firstPayload.Report.Cache)
+	}
+
+	second := callToolResult(t, server, toolAnalyseDependency, map[string]any{
+		"repoPath":   repo,
+		"dependency": "lodash",
+		"include":    []string{"src/**"},
+		"exclude":    []string{"vendor/**"},
+	})
+	if second.IsError {
+		t.Fatalf("unexpected second tool error: %#v", second)
+	}
+	secondPayload, ok := second.StructuredContent.(analysisPayload)
+	if !ok {
+		t.Fatalf("expected second analysis payload, got %#v", second.StructuredContent)
+	}
+	if secondPayload.Report.Cache == nil || secondPayload.Report.Cache.Path != expectedPinnedPath || secondPayload.Report.Cache.Hits != 1 || secondPayload.Report.Cache.Misses != 0 {
+		t.Fatalf("expected second scoped MCP run to reuse canonical pinned cache path, got %#v", secondPayload.Report.Cache)
+	}
+}
+
 func TestListLanguagesReturnsAdapterAndConfigMetadata(t *testing.T) {
 	registry := language.NewRegistry()
 	if err := registry.Register(newTestAdapter("js-ts", "javascript", "typescript")); err != nil {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -6,9 +6,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -43,6 +44,8 @@ type testAdapter struct {
 }
 
 type fakeMutationRunner struct {
+	captureFn       func(AnalysisMutationRequest) (AnalysisMutationRequest, error)
+	captureErr      error
 	applyReport     report.Report
 	applyErr        error
 	baselineReport  report.Report
@@ -57,6 +60,13 @@ type fakeMutationRunner struct {
 	lastApply       AnalysisMutationRequest
 	lastBaseline    AnalysisMutationRequest
 	lastDashboard   DashboardMutationRequest
+}
+
+func (f *fakeMutationRunner) CaptureAnalysisState(_ context.Context, req AnalysisMutationRequest) (AnalysisMutationRequest, error) {
+	if f.captureFn != nil {
+		return f.captureFn(req)
+	}
+	return req, f.captureErr
 }
 
 func (f *fakeMutationRunner) ApplyCodemod(_ context.Context, req AnalysisMutationRequest) (report.Report, error) {
@@ -398,27 +408,15 @@ func TestCallToolTimeoutCancelsAnalysis(t *testing.T) {
 	}
 }
 
-func TestCallAnalyseDependencyRejectsCachePathOutsideRepo(t *testing.T) {
-	repo := t.TempDir()
+func TestCallAnalyseDependencySupportsAbsoluteCachePathOutsideRepo(t *testing.T) {
+	repo := writeMCPDependencyFixture(t)
 	outsideCache := filepath.Join(t.TempDir(), "cache")
-	fake := &fakeAnalyser{report: sampleReport(repo)}
-	server := NewServer(Options{Analyzer: fake})
-
-	result := callToolResult(t, server, toolAnalyseDependency, map[string]any{
-		"repoPath":     repo,
-		"dependency":   "lodash",
-		"cachePath":    outsideCache,
-		"cacheEnabled": true,
-	})
-	if !result.IsError || !strings.Contains(result.Content[0].Text, "cachePath must stay within repoPath") {
-		t.Fatalf("expected outside cache rejection, got %#v", result)
-	}
-	if fake.called {
-		t.Fatalf("expected analyser to remain uncalled")
-	}
-	if _, err := os.Stat(outsideCache); !os.IsNotExist(err) {
-		t.Fatalf("expected no outside cache writes, stat err=%v", err)
-	}
+	server := NewServer(Options{Analyzer: analysis.NewService()})
+	firstPayload := runScopedMCPDependencyAnalysis(t, server, repo, map[string]any{"cachePath": outsideCache, "cacheEnabled": true})
+	assertMCPCacheMetrics(t, firstPayload.Report.Cache, outsideCache, 1, 1, 0)
+	assertMCPCacheLayoutPresent(t, outsideCache)
+	secondPayload := runScopedMCPDependencyAnalysis(t, server, repo, map[string]any{"cachePath": outsideCache, "cacheEnabled": true})
+	assertMCPCacheMetrics(t, secondPayload.Report.Cache, outsideCache, 0, 0, 1)
 }
 
 func TestCallAnalyseDependencyRejectsSymlinkedCachePathEscape(t *testing.T) {
@@ -433,7 +431,7 @@ func TestCallAnalyseDependencyRejectsSymlinkedCachePathEscape(t *testing.T) {
 	result := callToolResult(t, server, toolAnalyseDependency, map[string]any{
 		"repoPath":     repo,
 		"dependency":   "lodash",
-		"cachePath":    filepath.Join("tmp", "cache"),
+		"cachePath":    filepath.Join(repo, "tmp", "cache"),
 		"cacheEnabled": true,
 	})
 	if !result.IsError || !strings.Contains(result.Content[0].Text, "cachePath must stay within repoPath") {
@@ -447,36 +445,77 @@ func TestCallAnalyseDependencyRejectsSymlinkedCachePathEscape(t *testing.T) {
 	}
 }
 
-func TestCallAnalyseDependencyPinsDefaultCachePathForScopedRequest(t *testing.T) {
-	repo := t.TempDir()
-	fake := &fakeAnalyser{report: sampleReport(repo)}
+func TestCallAnalyseDependencyRejectsCanonicalSymlinkEscapeUnderRequestedRepoAlias(t *testing.T) {
+	requestedRepo, canonicalCache, outsideCache := mcpCanonicalAliasCacheEscapeFixture(t)
+	fake := &fakeAnalyser{report: sampleReport(requestedRepo)}
 	server := NewServer(Options{Analyzer: fake})
 
 	result := callToolResult(t, server, toolAnalyseDependency, map[string]any{
-		"repoPath":   repo,
-		"dependency": "lodash",
-		"include":    []string{"src/**"},
-		"exclude":    []string{"vendor/**"},
+		"repoPath":     requestedRepo,
+		"dependency":   "lodash",
+		"cachePath":    canonicalCache,
+		"cacheEnabled": true,
 	})
-	if result.IsError {
-		t.Fatalf("unexpected tool error: %#v", result)
+	if !result.IsError || !strings.Contains(result.Content[0].Text, "cachePath must stay within repoPath") {
+		t.Fatalf("expected canonical-form symlink escape rejection, got %#v", result)
 	}
-	if !fake.called {
-		t.Fatalf("expected analyser to be called")
+	if fake.called {
+		t.Fatalf("expected analyser to remain uncalled")
 	}
-	expectedPinnedPath := mustResolveDefaultPinnedCachePath(t, repo)
-	if fake.lastReq.Cache == nil || !fake.lastReq.Cache.Enabled {
-		t.Fatalf("expected enabled default cache options, got %#v", fake.lastReq.Cache)
-	}
-	if fake.lastReq.Cache.Path != "" {
-		t.Fatalf("expected default MCP cache path to remain implicit, got %#v", fake.lastReq.Cache)
-	}
-	if cachePinnedPathValue(fake.lastReq.Cache) != expectedPinnedPath {
-		t.Fatalf("expected pinned default cache path %q, got %#v", expectedPinnedPath, fake.lastReq.Cache)
+	if _, err := os.Stat(outsideCache); !os.IsNotExist(err) {
+		t.Fatalf("expected MCP analysis not to create external cache directory, stat err=%v", err)
 	}
 }
 
-func TestCallAnalyseDependencyScopedRequestReusesPinnedDefaultCacheAndReportsCanonicalPath(t *testing.T) {
+func TestCallAnalyseDependencyRejectsAlternateAbsoluteRepoAliasesThatLaterEscape(t *testing.T) {
+	for _, fixture := range mcpAlternateAbsoluteRepoAliasEscapeFixtures(t) {
+		t.Run(fixture.name, func(t *testing.T) {
+			fake := &fakeAnalyser{report: sampleReport(fixture.requestedRepo)}
+			server := NewServer(Options{Analyzer: fake})
+			result := callToolResult(t, server, toolAnalyseDependency, map[string]any{
+				"repoPath":     fixture.requestedRepo,
+				"dependency":   "lodash",
+				"cachePath":    fixture.cachePath,
+				"cacheEnabled": true,
+			})
+			if !result.IsError || !strings.Contains(result.Content[0].Text, "cachePath must stay within repoPath") {
+				t.Fatalf("expected alternate-alias symlink escape rejection, got %#v", result)
+			}
+			if fake.called {
+				t.Fatalf("expected analyser to remain uncalled")
+			}
+			if _, statErr := os.Stat(fixture.outsideCache); !os.IsNotExist(statErr) {
+				t.Fatalf("expected MCP analysis not to create outside cache, stat err=%v", statErr)
+			}
+		})
+	}
+}
+
+func TestCallAnalyseDependencyClassifiesExternalCacheAliasesIntoRepoBeforeAnalyzerInvocation(t *testing.T) {
+	repo := t.TempDir()
+	cacheSubdir := filepath.Join(repo, ".cache", "lopper")
+	if err := os.MkdirAll(cacheSubdir, 0o750); err != nil {
+		t.Fatalf("mkdir cache subdir: %v", err)
+	}
+	for _, tc := range mcpRepoCacheAliasFixtures(repo, cacheSubdir) {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheAlias := mustMCPCacheAlias(t, tc.target)
+			fake := &fakeAnalyser{report: sampleReport(repo)}
+			server := NewServer(Options{Analyzer: fake})
+			result := callToolResult(t, server, toolAnalyseDependency, map[string]any{
+				"repoPath":     repo,
+				"dependency":   "lodash",
+				"cachePath":    cacheAlias,
+				"cacheEnabled": true,
+				"include":      []string{"**"},
+			})
+			assertMCPRepoCacheAliasOutcome(t, result, fake.called, analysis.InRepoCacheOptions(fake.lastReq.Cache), tc.wantReject)
+			assertMCPCacheLayoutAbsent(t, tc.target)
+		})
+	}
+}
+
+func TestCallAnalyseDependencyScopedRequestRejectsRepoRootCachePath(t *testing.T) {
 	repo := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o750); err != nil {
 		t.Fatalf("mkdir src: %v", err)
@@ -496,42 +535,268 @@ func TestCallAnalyseDependencyScopedRequestReusesPinnedDefaultCacheAndReportsCan
 	if err := os.WriteFile(filepath.Join(repo, "node_modules", "lodash", "index.js"), []byte("export function map() {}\n"), 0o600); err != nil {
 		t.Fatalf("write lodash index.js: %v", err)
 	}
+	server := NewServer(Options{Analyzer: analysis.NewService()})
 
+	result := callToolResult(t, server, toolAnalyseDependency, map[string]any{
+		"repoPath":     repo,
+		"dependency":   "lodash",
+		"cachePath":    repo,
+		"cacheEnabled": true,
+		"include":      []string{"src/**"},
+	})
+	if !result.IsError || !strings.Contains(result.Content[0].Text, "scoped analysis does not allow cachePath at the repository root") {
+		t.Fatalf("expected scoped repo-root cache rejection, got %#v", result)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "keys")); !os.IsNotExist(err) {
+		t.Fatalf("expected no repo-root cache writes, stat err=%v", err)
+	}
+}
+
+func TestCallAnalyseDependencyProvidesDefaultCacheOptionsForScopedRequest(t *testing.T) {
+	repo := t.TempDir()
+	fake := &fakeAnalyser{report: sampleReport(repo)}
+	server := NewServer(Options{Analyzer: fake})
+
+	result := callToolResult(t, server, toolAnalyseDependency, map[string]any{
+		"repoPath":   repo,
+		"dependency": "lodash",
+		"include":    []string{"src/**"},
+		"exclude":    []string{"vendor/**"},
+	})
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %#v", result)
+	}
+	if !fake.called {
+		t.Fatalf("expected analyser to be called")
+	}
+	if fake.lastReq.Cache == nil || !fake.lastReq.Cache.Enabled {
+		t.Fatalf("expected enabled default cache options, got %#v", fake.lastReq.Cache)
+	}
+	if fake.lastReq.Cache.Path != "" {
+		t.Fatalf("expected default MCP cache path to remain implicit, got %#v", fake.lastReq.Cache)
+	}
+}
+
+func TestCallAnalyseDependencyScopedRequestReusesPinnedDefaultCacheAndReportsCanonicalPath(t *testing.T) {
+	repo := writeMCPDependencyFixture(t)
 	server := NewServer(Options{Analyzer: analysis.NewService()})
 	expectedPinnedPath := mustResolveDefaultPinnedCachePath(t, repo)
+	firstPayload := runScopedMCPDependencyAnalysis(t, server, repo, nil)
+	assertMCPCacheMetrics(t, firstPayload.Report.Cache, expectedPinnedPath, 1, 1, 0)
+	secondPayload := runScopedMCPDependencyAnalysis(t, server, repo, nil)
+	assertMCPCacheMetrics(t, secondPayload.Report.Cache, expectedPinnedPath, 0, 0, 1)
+}
 
-	first := callToolResult(t, server, toolAnalyseDependency, map[string]any{
-		"repoPath":   repo,
-		"dependency": "lodash",
-		"include":    []string{"src/**"},
-		"exclude":    []string{"vendor/**"},
-	})
-	if first.IsError {
-		t.Fatalf("unexpected first tool error: %#v", first)
+type mcpRepoCacheAliasFixture struct {
+	name       string
+	target     string
+	wantReject bool
+}
+
+func writeMCPDependencyFixture(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	for _, dir := range []string{filepath.Join(repo, "src"), filepath.Join(repo, "node_modules", "lodash")} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("mkdir fixture dir %s: %v", dir, err)
+		}
 	}
-	firstPayload, ok := first.StructuredContent.(analysisPayload)
+	files := map[string]string{
+		"package.json":                   "{\n  \"name\": \"demo\"\n}\n",
+		filepath.Join("src", "index.js"): "import { map } from \"lodash\"\nmap([1], (x) => x)\n",
+		filepath.Join("node_modules", "lodash", "package.json"): "{\n  \"main\": \"index.js\"\n}\n",
+		filepath.Join("node_modules", "lodash", "index.js"):     "export function map() {}\n",
+	}
+	for rel, content := range files {
+		if err := os.WriteFile(filepath.Join(repo, rel), []byte(content), 0o600); err != nil {
+			t.Fatalf("write fixture %s: %v", rel, err)
+		}
+	}
+	return repo
+}
+
+func runScopedMCPDependencyAnalysis(t *testing.T, server *Server, repo string, extra map[string]any) analysisPayload {
+	t.Helper()
+	args := map[string]any{"repoPath": repo, "dependency": "lodash", "include": []string{"src/**"}, "exclude": []string{"vendor/**"}}
+	for key, value := range extra {
+		args[key] = value
+	}
+	result := callToolResult(t, server, toolAnalyseDependency, args)
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %#v", result)
+	}
+	payload, ok := result.StructuredContent.(analysisPayload)
 	if !ok {
-		t.Fatalf("expected first analysis payload, got %#v", first.StructuredContent)
+		t.Fatalf("expected analysis payload, got %#v", result.StructuredContent)
 	}
-	if firstPayload.Report.Cache == nil || firstPayload.Report.Cache.Path != expectedPinnedPath || firstPayload.Report.Cache.Misses != 1 || firstPayload.Report.Cache.Writes != 1 {
-		t.Fatalf("expected first scoped MCP run to report canonical pinned cache path and miss/write metadata, got %#v", firstPayload.Report.Cache)
+	return payload
+}
+
+func assertMCPCacheMetrics(t *testing.T, cache *report.CacheMetadata, path string, misses, writes, hits int) {
+	t.Helper()
+	if cache == nil || cache.Path != path || cache.Misses != misses || cache.Writes != writes || cache.Hits != hits {
+		t.Fatalf("unexpected cache metrics: %#v", cache)
+	}
+}
+
+func assertMCPCacheLayoutPresent(t *testing.T, root string) {
+	t.Helper()
+	for _, dir := range []string{"keys", "objects"} {
+		if _, err := os.Stat(filepath.Join(root, dir)); err != nil {
+			t.Fatalf("expected %s dir in external cache root: %v", dir, err)
+		}
+	}
+}
+
+func mcpRepoCacheAliasFixtures(repo, cacheSubdir string) []mcpRepoCacheAliasFixture {
+	return []mcpRepoCacheAliasFixture{{name: "repo root", target: repo, wantReject: true}, {name: "repo subdir", target: cacheSubdir}}
+}
+
+func mustMCPCacheAlias(t *testing.T, target string) string {
+	t.Helper()
+	cacheAlias := filepath.Join(t.TempDir(), "external-cache-alias")
+	if err := os.Symlink(target, cacheAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	return cacheAlias
+}
+
+func assertMCPRepoCacheAliasOutcome(t *testing.T, result toolCallResult, called, inRepo bool, wantReject bool) {
+	t.Helper()
+	if wantReject {
+		if !result.IsError || !strings.Contains(result.Content[0].Text, "scoped analysis does not allow cachePath at the repository root") || called {
+			t.Fatalf("expected external repo-root alias rejection, got %#v called=%t", result, called)
+		}
+		return
+	}
+	if result.IsError || !called || !inRepo {
+		t.Fatalf("expected in-repo cache pin for alias, result=%#v called=%t inRepo=%t", result, called, inRepo)
+	}
+}
+
+func assertMCPCacheLayoutAbsent(t *testing.T, root string) {
+	t.Helper()
+	for _, dir := range []string{"keys", "objects"} {
+		if _, statErr := os.Stat(filepath.Join(root, dir)); !os.IsNotExist(statErr) {
+			t.Fatalf("expected no cache creation under %s/%s, stat err=%v", root, dir, statErr)
+		}
+	}
+}
+
+func TestConfiguredMCPAnalysisUsesStableCacheIdentityAcrossRepositorySnapshots(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory replacement semantics are not available on Windows")
+	}
+	repo, repoB, movedRepoA := setupConfiguredMCPAnalysisRepos(t)
+	viewOpens := 0
+	restoreHook := analysis.SetRepositoryViewHandleOpenedHookForTest(func() error {
+		viewOpens++
+		if err := os.Rename(repo, movedRepoA); err != nil {
+			return err
+		}
+		return os.Rename(repoB, repo)
+	})
+	t.Cleanup(restoreHook)
+
+	server := NewServer(Options{Analyzer: analysis.NewService()})
+	args := analysisToolArguments{RepoPath: repo, Dependency: "lodash", ConfigPath: filepath.Join(repo, ".lopper.yml")}
+	firstPayload := runConfiguredMCPAnalysis(t, server, args)
+	assertConfiguredMCPAnalysisCache(t, firstPayload.Report.Cache, 1, 1, 0)
+	assertStableMCPPolicyMetadata(t, firstPayload.Report, repo)
+	assertMCPAnalysisCacheAbsent(t, repo, "replacement repo B received cache data")
+
+	restoreConfiguredMCPRepoPair(t, repo, repoB, movedRepoA)
+	if err := os.WriteFile(filepath.Join(repoB, ".lopper.yml"), []byte("thresholds:\n  low_confidence_warning_percent: 88\n"), 0o600); err != nil {
+		t.Fatalf("change repo B config trap: %v", err)
 	}
 
-	second := callToolResult(t, server, toolAnalyseDependency, map[string]any{
-		"repoPath":   repo,
-		"dependency": "lodash",
-		"include":    []string{"src/**"},
-		"exclude":    []string{"vendor/**"},
-	})
-	if second.IsError {
-		t.Fatalf("unexpected second tool error: %#v", second)
+	secondPayload := runConfiguredMCPAnalysis(t, server, args)
+	assertConfiguredMCPAnalysisCache(t, secondPayload.Report.Cache, 0, 0, 1)
+	assertStableMCPPolicyMetadata(t, secondPayload.Report, repo)
+	if viewOpens != 2 {
+		t.Fatalf("repository view opens = %d, want one per MCP call", viewOpens)
 	}
-	secondPayload, ok := second.StructuredContent.(analysisPayload)
-	if !ok {
-		t.Fatalf("expected second analysis payload, got %#v", second.StructuredContent)
+	assertMCPAnalysisCacheAbsent(t, repo, "replacement repo B received cache data after second call")
+}
+
+func setupConfiguredMCPAnalysisRepos(t *testing.T) (string, string, string) {
+	t.Helper()
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	repoB := filepath.Join(parent, "repo-b")
+	writeMCPAnalysisCacheFixture(t, repo, 11)
+	writeMCPAnalysisCacheFixture(t, repoB, 77)
+	return repo, repoB, filepath.Join(parent, "repo-a-original")
+}
+
+func runConfiguredMCPAnalysis(t *testing.T, server *Server, args analysisToolArguments) analysisPayload {
+	t.Helper()
+	result := server.runAnalysisTool(context.Background(), mustJSON(t, args), analysisToolKindDependency)
+	if result.IsError {
+		t.Fatalf("unexpected configured analysis error: %#v", result)
 	}
-	if secondPayload.Report.Cache == nil || secondPayload.Report.Cache.Path != expectedPinnedPath || secondPayload.Report.Cache.Hits != 1 || secondPayload.Report.Cache.Misses != 0 {
-		t.Fatalf("expected second scoped MCP run to reuse canonical pinned cache path, got %#v", secondPayload.Report.Cache)
+	return result.StructuredContent.(analysisPayload)
+}
+
+func assertConfiguredMCPAnalysisCache(t *testing.T, cache *report.CacheMetadata, wantMisses, wantWrites, wantHits int) {
+	t.Helper()
+	if cache == nil || cache.Misses != wantMisses || cache.Writes != wantWrites || cache.Hits != wantHits {
+		t.Fatalf("unexpected configured cache metadata: %#v", cache)
+	}
+}
+
+func restoreConfiguredMCPRepoPair(t *testing.T, repo, repoB, movedRepoA string) {
+	t.Helper()
+	if err := os.Rename(repo, repoB); err != nil {
+		t.Fatalf("restore repo B location: %v", err)
+	}
+	if err := os.Rename(movedRepoA, repo); err != nil {
+		t.Fatalf("restore repo A location: %v", err)
+	}
+}
+
+func assertMCPAnalysisCacheAbsent(t *testing.T, repo, failure string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(repo, ".lopper-cache")); !os.IsNotExist(err) {
+		t.Fatalf("%s: %v", failure, err)
+	}
+}
+
+func writeMCPAnalysisCacheFixture(t *testing.T, repo string, lowConfidence int) {
+	t.Helper()
+	for _, dir := range []string{filepath.Join(repo, "src"), filepath.Join(repo, "node_modules", "lodash")} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("mkdir fixture directory %s: %v", dir, err)
+		}
+	}
+	files := map[string]string{
+		".lopper.yml":                    fmt.Sprintf("thresholds:\n  low_confidence_warning_percent: %d\n", lowConfidence),
+		"package.json":                   "{\n  \"name\": \"demo\"\n}\n",
+		filepath.Join("src", "index.js"): "import { map } from \"lodash\"\nmap([1], (x) => x)\n",
+		filepath.Join("node_modules", "lodash", "package.json"): "{\n  \"main\": \"index.js\"\n}\n",
+		filepath.Join("node_modules", "lodash", "index.js"):     "export function map() {}\n",
+	}
+	for relativePath, content := range files {
+		if err := os.WriteFile(filepath.Join(repo, relativePath), []byte(content), 0o600); err != nil {
+			t.Fatalf("write fixture %s: %v", relativePath, err)
+		}
+	}
+}
+
+func assertStableMCPPolicyMetadata(t *testing.T, reportData report.Report, repo string) {
+	t.Helper()
+	if reportData.EffectivePolicy == nil {
+		t.Fatal("expected effective policy metadata")
+	}
+	serialized, err := json.Marshal(reportData.EffectivePolicy)
+	if err != nil {
+		t.Fatalf("marshal effective policy: %v", err)
+	}
+	if strings.Contains(string(serialized), "lopper-repository-snapshot-") {
+		t.Fatalf("snapshot path leaked into policy metadata: %s", serialized)
+	}
+	if !strings.Contains(string(serialized), filepath.Join(repo, ".lopper.yml")) {
+		t.Fatalf("authorized config identity missing from policy metadata: %s", serialized)
 	}
 }
 
@@ -562,18 +827,6 @@ func TestListLanguagesReturnsAdapterAndConfigMetadata(t *testing.T) {
 	}
 }
 
-func cachePinnedPathValue(cache any) string {
-	value := reflect.ValueOf(cache)
-	if !value.IsValid() || value.Kind() != reflect.Pointer || value.IsNil() {
-		return ""
-	}
-	field := value.Elem().FieldByName("PinnedPath")
-	if !field.IsValid() || field.Kind() != reflect.String {
-		return ""
-	}
-	return field.String()
-}
-
 func mustResolveDefaultPinnedCachePath(t *testing.T, repo string) string {
 	t.Helper()
 	cachePath := filepath.Join(repo, ".lopper-cache")
@@ -585,6 +838,81 @@ func mustResolveDefaultPinnedCachePath(t *testing.T, repo string) string {
 		t.Fatalf("resolve default pinned cache path: %v", err)
 	}
 	return resolvedPath
+}
+
+func mcpCanonicalAliasCacheEscapeFixture(t *testing.T) (requestedRepo, canonicalCache, outsideCache string) {
+	t.Helper()
+
+	canonicalParent := t.TempDir()
+	canonicalRepo := filepath.Join(canonicalParent, "repo")
+	if err := os.MkdirAll(canonicalRepo, 0o755); err != nil {
+		t.Fatalf("mkdir canonical repo: %v", err)
+	}
+	canonicalRepo, err := filepath.EvalSymlinks(canonicalRepo)
+	if err != nil {
+		t.Fatalf("resolve canonical repo: %v", err)
+	}
+	requestedParent := filepath.Join(t.TempDir(), "requested-parent")
+	if err := os.Symlink(canonicalParent, requestedParent); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(canonicalRepo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	return filepath.Join(requestedParent, "repo"),
+		filepath.Join(canonicalRepo, "tmp", "cache"),
+		filepath.Join(outside, "cache")
+}
+
+type mcpAlternateRepoAliasEscapeFixture struct {
+	name          string
+	requestedRepo string
+	cachePath     string
+	outsideCache  string
+}
+
+func mcpAlternateAbsoluteRepoAliasEscapeFixtures(t *testing.T) []mcpAlternateRepoAliasEscapeFixture {
+	t.Helper()
+	repoParent := t.TempDir()
+	repo := filepath.Join(repoParent, "repo")
+	if err := os.Mkdir(repo, 0o750); err != nil {
+		t.Fatalf("mkdir arbitrary-alias repo: %v", err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	aliasParent := filepath.Join(t.TempDir(), "alternate-parent")
+	if err := os.Symlink(repoParent, aliasParent); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	fixtures := []mcpAlternateRepoAliasEscapeFixture{{
+		name:          "arbitrary alias",
+		requestedRepo: repo,
+		cachePath:     filepath.Join(aliasParent, "repo", "tmp", "cache"),
+		outsideCache:  filepath.Join(outside, "cache"),
+	}}
+
+	systemRequestedRepo := t.TempDir()
+	systemCanonicalRepo, err := filepath.EvalSymlinks(systemRequestedRepo)
+	if err != nil {
+		t.Fatalf("resolve system-alias repo: %v", err)
+	}
+	if filepath.Clean(systemRequestedRepo) == filepath.Clean(systemCanonicalRepo) {
+		return fixtures
+	}
+	systemOutside := t.TempDir()
+	if err := os.Symlink(systemOutside, filepath.Join(systemRequestedRepo, "tmp")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	return append(fixtures, mcpAlternateRepoAliasEscapeFixture{
+		name:          "system absolute alias",
+		requestedRepo: systemCanonicalRepo,
+		cachePath:     filepath.Join(systemRequestedRepo, "tmp", "cache"),
+		outsideCache:  filepath.Join(systemOutside, "cache"),
+	})
 }
 
 func TestServeProcessesFramedInitialize(t *testing.T) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -471,7 +471,7 @@ func TestCallAnalyseDependencyPinsDefaultCachePathForScopedRequest(t *testing.T)
 	if fake.lastReq.Cache.Path != "" {
 		t.Fatalf("expected default MCP cache path to remain implicit, got %#v", fake.lastReq.Cache)
 	}
-	if pinnedPath := cachePinnedPathValue(fake.lastReq.Cache); pinnedPath != expectedPinnedPath {
+	if cachePinnedPathValue(fake.lastReq.Cache) != expectedPinnedPath {
 		t.Fatalf("expected pinned default cache path %q, got %#v", expectedPinnedPath, fake.lastReq.Cache)
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -294,6 +294,10 @@ func (s *Server) resolveAnalysisRequest(ctx context.Context, args analysisToolAr
 	if err != nil {
 		return resolvedToolRequest{}, err
 	}
+	cacheOptions, err := resolveMCPAnalysisCacheOptions(repoPath, cacheEnabled(args.CacheEnabled), args.CachePath, args.CacheReadOnly)
+	if err != nil {
+		return resolvedToolRequest{}, err
+	}
 	analysisReq := newAnalysisRequest(args, analysisRequestContext{
 		repoPath:   repoPath,
 		dependency: dependency,
@@ -302,6 +306,7 @@ func (s *Server) resolveAnalysisRequest(ctx context.Context, args analysisToolAr
 		loadResult: loadResult,
 		thresholds: thresholdsValue,
 		featureSet: features,
+		cache:      cacheOptions,
 	})
 
 	baselinePath, baselineKey, currentKey, err := resolveBaselineComparison(repoPath, args)
@@ -333,6 +338,7 @@ type analysisRequestContext struct {
 	loadResult thresholds.LoadResult
 	thresholds thresholds.Values
 	featureSet featureflags.Set
+	cache      *analysis.CacheOptions
 }
 
 func resolveAnalysisTarget(args analysisToolArguments, kind analysisToolKind) (string, int, error) {
@@ -391,11 +397,7 @@ func newAnalysisRequest(args analysisToolArguments, req analysisRequestContext) 
 		RemovalCandidateWeights:           &weights,
 		LicenseDenyList:                   append([]string{}, req.thresholds.LicenseDenyList...),
 		IncludeRegistryProvenance:         req.thresholds.LicenseIncludeRegistryProvenance,
-		Cache: &analysis.CacheOptions{
-			Enabled:  cacheEnabled(args.CacheEnabled),
-			Path:     strings.TrimSpace(args.CachePath),
-			ReadOnly: args.CacheReadOnly,
-		},
+		Cache:                             req.cache,
 	}
 }
 
@@ -823,6 +825,14 @@ func cacheEnabled(value *bool) bool {
 		return true
 	}
 	return *value
+}
+
+func resolveMCPAnalysisCacheOptions(repoPath string, enabled bool, rawPath string, readOnly bool) (*analysis.CacheOptions, error) {
+	return analysis.ResolveTrustedCacheOptions(repoPath, &analysis.CacheOptions{
+		Enabled:  enabled,
+		Path:     rawPath,
+		ReadOnly: readOnly,
+	})
 }
 
 func mergeStringOptions(configValues, argumentValues []string) []string {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -828,6 +828,18 @@ func cacheEnabled(value *bool) bool {
 }
 
 func resolveMCPAnalysisCacheOptions(repoPath string, enabled bool, rawPath string, readOnly bool) (*analysis.CacheOptions, error) {
+	if enabled && strings.TrimSpace(rawPath) == "" {
+		pinnedPath, err := analysis.ResolveTrustedDefaultCachePath(repoPath)
+		if err != nil {
+			return nil, err
+		}
+		return &analysis.CacheOptions{
+			Enabled:    true,
+			Path:       "",
+			ReadOnly:   readOnly,
+			PinnedPath: filepath.Clean(pinnedPath),
+		}, nil
+	}
 	return analysis.ResolveTrustedCacheOptions(repoPath, &analysis.CacheOptions{
 		Enabled:  enabled,
 		Path:     rawPath,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -124,11 +123,13 @@ type languagesPayload struct {
 
 type resolvedToolRequest struct {
 	analysisRequest    analysis.Request
+	repositoryView     *analysis.RepositoryView
 	repoPath           string
 	thresholds         thresholds.Values
 	policySources      []string
 	policyTrace        []report.PolicyMergeTrace
 	advisorySourcePath string
+	advisoryLoadPath   string
 	baselinePath       string
 	baselineKey        string
 	currentKey         string
@@ -238,18 +239,27 @@ func (s *Server) runAnalysisTool(ctx context.Context, rawArgs json.RawMessage, k
 		return toolError(errorCodeInvalidInput, err)
 	}
 
+	payload, summary, runErr := s.executeResolvedAnalysisTool(reqCtx, resolved, kind)
+	runErr = errors.Join(runErr, resolved.repositoryView.Close())
+	if runErr != nil {
+		return analysisErrorResult(runErr)
+	}
+	return toolSuccess(summary, payload)
+}
+
+func (s *Server) executeResolvedAnalysisTool(ctx context.Context, resolved resolvedToolRequest, kind analysisToolKind) (analysisPayload, string, error) {
 	analyzer := s.analyzer
 	if analyzer == nil {
 		analyzer = analysis.NewService()
 	}
-	reportData, err := analyzer.Analyse(reqCtx, resolved.analysisRequest)
+	reportData, err := analyzer.Analyse(ctx, resolved.analysisRequest)
 	if err != nil {
-		return analysisErrorResult(err)
+		return analysisPayload{}, "", err
 	}
-	if resolved.advisorySourcePath != "" {
-		advisories, err := advisory.Load(resolved.advisorySourcePath)
+	if resolved.advisoryLoadPath != "" {
+		advisories, err := advisory.Load(resolved.advisoryLoadPath)
 		if err != nil {
-			return analysisErrorResult(err)
+			return analysisPayload{}, "", err
 		}
 		report.AnnotateVulnerabilities(&reportData, advisories)
 		reportData.Summary = report.ComputeSummary(reportData.Dependencies)
@@ -258,7 +268,7 @@ func (s *Server) runAnalysisTool(ctx context.Context, rawArgs json.RawMessage, k
 	if resolved.baselinePath != "" {
 		reportData, err = applyBaseline(reportData, resolved.baselinePath, resolved.baselineKey, resolved.currentKey)
 		if err != nil {
-			return analysisErrorResult(err)
+			return analysisPayload{}, "", err
 		}
 	}
 
@@ -268,11 +278,11 @@ func (s *Server) runAnalysisTool(ctx context.Context, rawArgs json.RawMessage, k
 		Summary:       summary,
 		Report:        reportData,
 	}
-	return toolSuccess(summary, payload)
+	return payload, summary, nil
 }
 
-func (s *Server) resolveAnalysisRequest(ctx context.Context, args analysisToolArguments, kind analysisToolKind) (resolvedToolRequest, error) {
-	repoPath, err := validateRepoPath(args.RepoPath)
+func (s *Server) resolveAnalysisRequest(ctx context.Context, args analysisToolArguments, kind analysisToolKind) (_ resolvedToolRequest, returnErr error) {
+	repoPath, repository, err := validateTrustedRepoPath(args.RepoPath)
 	if err != nil {
 		return resolvedToolRequest{}, err
 	}
@@ -286,7 +296,21 @@ func (s *Server) resolveAnalysisRequest(ctx context.Context, args analysisToolAr
 	if err != nil {
 		return resolvedToolRequest{}, err
 	}
-	loadResult, thresholdsValue, policySources, policyTrace, err := resolveThresholds(repoPath, args)
+	cacheOptions, err := resolveMCPAnalysisCacheOptionsForRepository(repository, cacheEnabled(args.CacheEnabled), args.CachePath, args.CacheReadOnly)
+	if err != nil {
+		return resolvedToolRequest{}, err
+	}
+	repositoryView, err := analysis.OpenTrustedRepositoryWithGitMetadata(ctx, repository, repoPath, cacheOptions)
+	if err != nil {
+		return resolvedToolRequest{}, err
+	}
+	defer func() {
+		if repositoryView != nil {
+			returnErr = errors.Join(returnErr, repositoryView.Close())
+		}
+	}()
+	currentKey, currentKeyCaptured := repositoryViewCurrentBaselineKey(repositoryView)
+	loadResult, thresholdsValue, policySources, policyTrace, err := resolveThresholdsWithRepositoryView(repositoryView, args)
 	if err != nil {
 		return resolvedToolRequest{}, err
 	}
@@ -294,12 +318,9 @@ func (s *Server) resolveAnalysisRequest(ctx context.Context, args analysisToolAr
 	if err != nil {
 		return resolvedToolRequest{}, err
 	}
-	cacheOptions, err := resolveMCPAnalysisCacheOptions(repoPath, cacheEnabled(args.CacheEnabled), args.CachePath, args.CacheReadOnly)
-	if err != nil {
-		return resolvedToolRequest{}, err
-	}
 	analysisReq := newAnalysisRequest(args, analysisRequestContext{
 		repoPath:   repoPath,
+		repository: repository,
 		dependency: dependency,
 		topN:       topN,
 		scopeMode:  scopeMode,
@@ -308,30 +329,46 @@ func (s *Server) resolveAnalysisRequest(ctx context.Context, args analysisToolAr
 		featureSet: features,
 		cache:      cacheOptions,
 	})
+	analysisReq.RepositoryView = repositoryView
+	if err := analysis.ValidateTrustedScopedCacheOptions(analysisReq.Cache, analysisReq.IncludePatterns, analysisReq.ExcludePatterns); err != nil {
+		return resolvedToolRequest{}, err
+	}
 
-	baselinePath, baselineKey, currentKey, err := resolveBaselineComparison(repoPath, args)
+	baselinePath, baselineKey, baselineCurrentKey, err := resolveBaselineComparisonWithCapturedCurrentKey(repositoryView, args, currentKey, currentKeyCaptured)
 	if err != nil {
 		return resolvedToolRequest{}, err
 	}
-	advisorySourcePath := resolveAdvisorySourcePath(loadResult, args)
+	advisoryLoadPath, err := snapshotRepositoryPath(repositoryView, resolveAdvisorySourcePath(loadResult, args))
+	if err != nil {
+		return resolvedToolRequest{}, err
+	}
+	advisorySourcePath := displayRepositoryPath(repositoryView, advisoryLoadPath)
 	if err := validateAnalysisVulnerabilityFeature(features, thresholdsValue, advisorySourcePath); err != nil {
 		return resolvedToolRequest{}, err
 	}
+	if err := ctx.Err(); err != nil {
+		return resolvedToolRequest{}, err
+	}
+	retainedView := repositoryView
+	repositoryView = nil
 	return resolvedToolRequest{
 		analysisRequest:    analysisReq,
+		repositoryView:     retainedView,
 		repoPath:           repoPath,
 		thresholds:         thresholdsValue,
 		policySources:      policySources,
 		policyTrace:        policyTrace,
 		advisorySourcePath: advisorySourcePath,
+		advisoryLoadPath:   advisoryLoadPath,
 		baselinePath:       baselinePath,
 		baselineKey:        baselineKey,
-		currentKey:         currentKey,
-	}, ctx.Err()
+		currentKey:         baselineCurrentKey,
+	}, nil
 }
 
 type analysisRequestContext struct {
 	repoPath   string
+	repository *analysis.RepositoryAuthorization
 	dependency string
 	topN       int
 	scopeMode  string
@@ -381,6 +418,7 @@ func newAnalysisRequest(args analysisToolArguments, req analysisRequestContext) 
 	weights := thresholds.RemovalCandidateWeights(req.thresholds)
 	return analysis.Request{
 		RepoPath:                          req.repoPath,
+		Repository:                        req.repository,
 		Dependency:                        req.dependency,
 		TopN:                              req.topN,
 		ScopeMode:                         req.scopeMode,
@@ -552,6 +590,78 @@ func resolveThresholds(repoPath string, args analysisToolArguments) (thresholds.
 	return loadResult, resolved, policySources, policyTrace, nil
 }
 
+func resolveThresholdsWithRepositoryView(repositoryView *analysis.RepositoryView, args analysisToolArguments) (thresholds.LoadResult, thresholds.Values, []string, []report.PolicyMergeTrace, error) {
+	loadResult, err := loadThresholdsThroughRepositoryView(repositoryView, strings.TrimSpace(args.ConfigPath))
+	if err != nil {
+		return thresholds.LoadResult{}, thresholds.Values{}, nil, nil, err
+	}
+	overrides := thresholds.Overrides{
+		LowConfidenceWarningPercent:       args.LowConfidenceWarningPercent,
+		MinUsagePercentForRecommendations: args.MinUsagePercentForRecommendations,
+		MaxUncertainImportCount:           args.MaxUncertainImportCount,
+		RemovalCandidateWeightUsage:       args.ScoreWeightUsage,
+		RemovalCandidateWeightImpact:      args.ScoreWeightImpact,
+		RemovalCandidateWeightConfidence:  args.ScoreWeightConfidence,
+		LicenseDenyList:                   append([]string{}, args.LicenseDeny...),
+		LicenseFailOnDeny:                 args.LicenseFailOnDeny,
+		LicenseIncludeRegistryProvenance:  args.LicenseProvenanceRegistry,
+		ReachableVulnerabilityPriority:    args.ReachableVulnerabilityPriority,
+	}
+	return resolveThresholdsFromLoadResult(loadResult, overrides, hasMCPPolicyOverrides(args), mcpPolicyTrace(args))
+}
+
+func resolveThresholdsFromLoadResult(loadResult thresholds.LoadResult, overrides thresholds.Overrides, hasOverrides bool, overrideTrace []report.PolicyMergeTrace) (thresholds.LoadResult, thresholds.Values, []string, []report.PolicyMergeTrace, error) {
+	if err := overrides.Validate(); err != nil {
+		return thresholds.LoadResult{}, thresholds.Values{}, nil, nil, err
+	}
+	resolved := overrides.Apply(loadResult.Resolved)
+	if err := resolved.Validate(); err != nil {
+		return thresholds.LoadResult{}, thresholds.Values{}, nil, nil, err
+	}
+	policySources := append([]string{}, loadResult.PolicySources...)
+	policyTrace := append([]report.PolicyMergeTrace{}, loadResult.PolicyTrace...)
+	if hasOverrides {
+		policySources = prependPolicySource("mcp", policySources)
+		policyTrace = mergePolicyTraceUpdates(policyTrace, overrideTrace)
+	}
+	return loadResult, resolved, policySources, policyTrace, nil
+}
+
+func loadThresholdsThroughRepositoryView(repositoryView *analysis.RepositoryView, configPath string) (thresholds.LoadResult, error) {
+	snapshotPath, err := snapshotRepositoryPath(repositoryView, configPath)
+	if err != nil {
+		return thresholds.LoadResult{}, err
+	}
+	loadResult, err := thresholds.LoadWithPolicy(repositoryView.ExecutionPath(), snapshotPath)
+	if err != nil {
+		return thresholds.LoadResult{}, err
+	}
+	loadResult.ConfigPath = displayRepositoryPath(repositoryView, loadResult.ConfigPath)
+	loadResult.AdvisorySourcePath = displayRepositoryPath(repositoryView, loadResult.AdvisorySourcePath)
+	for index, source := range loadResult.PolicySources {
+		loadResult.PolicySources[index] = displayRepositoryPath(repositoryView, source)
+	}
+	for index, item := range loadResult.PolicyTrace {
+		loadResult.PolicyTrace[index].Source = displayRepositoryPath(repositoryView, item.Source)
+	}
+	return loadResult, nil
+}
+
+func snapshotRepositoryPath(repositoryView *analysis.RepositoryView, path string) (string, error) {
+	if repositoryView == nil {
+		return strings.TrimSpace(path), nil
+	}
+	return repositoryView.SnapshotPath(path)
+}
+
+func displayRepositoryPath(repositoryView *analysis.RepositoryView, path string) string {
+	trimmed := strings.TrimSpace(path)
+	if repositoryView == nil || trimmed == "" || !filepath.IsAbs(trimmed) {
+		return trimmed
+	}
+	return repositoryView.StablePath(trimmed)
+}
+
 func hasMCPPolicyOverrides(args analysisToolArguments) bool {
 	return args.LowConfidenceWarningPercent != nil ||
 		args.MinUsagePercentForRecommendations != nil ||
@@ -581,6 +691,10 @@ func prependPolicySource(source string, sources []string) []string {
 
 func mergeMCPPolicyTrace(trace []report.PolicyMergeTrace, args analysisToolArguments) []report.PolicyMergeTrace {
 	updates := mcpPolicyTrace(args)
+	return mergePolicyTraceUpdates(trace, updates)
+}
+
+func mergePolicyTraceUpdates(trace []report.PolicyMergeTrace, updates []report.PolicyMergeTrace) []report.PolicyMergeTrace {
 	if len(updates) == 0 {
 		return append([]report.PolicyMergeTrace{}, trace...)
 	}
@@ -659,6 +773,22 @@ func validateAnalysisVulnerabilityFeature(features featureflags.Set, values thre
 }
 
 func resolveBaselineComparison(repoPath string, args analysisToolArguments) (string, string, string, error) {
+	currentKey, captured := captureAuthorizedCurrentBaselineKey(repoPath)
+	return resolveBaselineComparisonWithCapturedCurrentKey(nil, args, currentKey, captured)
+}
+
+func repositoryViewCurrentBaselineKey(repositoryView *analysis.RepositoryView) (string, bool) {
+	metadata := repositoryView.GitMetadata()
+	if !metadata.Captured {
+		return "", false
+	}
+	if currentCommit := strings.TrimSpace(metadata.CurrentCommit); currentCommit != "" {
+		return "commit:" + currentCommit, true
+	}
+	return "", true
+}
+
+func resolveBaselineComparisonWithCapturedCurrentKey(repositoryView *analysis.RepositoryView, args analysisToolArguments, currentKey string, currentKeyCaptured bool) (string, string, string, error) {
 	baselinePath := strings.TrimSpace(args.BaselinePath)
 	baselineStorePath := strings.TrimSpace(args.BaselineStorePath)
 	baselineKey := strings.TrimSpace(args.BaselineKey)
@@ -674,9 +804,15 @@ func resolveBaselineComparison(repoPath string, args analysisToolArguments) (str
 	if baselinePath == "" {
 		return "", "", "", nil
 	}
-	currentKey := "current"
-	if sha, err := workspace.CurrentCommitSHA(repoPath); err == nil {
-		currentKey = "commit:" + sha
+	if repositoryView != nil {
+		var err error
+		baselinePath, err = snapshotRepositoryPath(repositoryView, baselinePath)
+		if err != nil {
+			return "", "", "", err
+		}
+	}
+	if currentKeyCaptured && strings.TrimSpace(currentKey) == "" {
+		currentKey = "current"
 	}
 	return baselinePath, baselineKey, currentKey, nil
 }
@@ -761,24 +897,26 @@ func contextForTimeout(ctx context.Context, timeoutMillis int) (context.Context,
 }
 
 func validateRepoPath(raw string) (string, error) {
+	repoPath, _, err := validateTrustedRepoPath(raw)
+	return repoPath, err
+}
+
+func validateTrustedRepoPath(raw string) (string, *analysis.RepositoryAuthorization, error) {
 	if strings.TrimSpace(raw) == "" {
-		return "", errors.New("repoPath is required")
+		return "", nil, errors.New("repoPath is required")
 	}
 	if strings.Contains(strings.ToLower(strings.TrimSpace(raw)), "://") {
-		return "", errors.New("repoPath must be a local filesystem path")
+		return "", nil, errors.New("repoPath must be a local filesystem path")
 	}
 	repoPath, err := workspace.NormalizeRepoPath(strings.TrimSpace(raw))
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	info, err := os.Stat(repoPath)
+	repository, err := analysis.ResolveTrustedRepository(repoPath)
 	if err != nil {
-		return "", fmt.Errorf("stat repoPath: %w", err)
+		return "", nil, fmt.Errorf("stat repoPath: %w", err)
 	}
-	if !info.IsDir() {
-		return "", fmt.Errorf("repoPath is not a directory: %s", repoPath)
-	}
-	return repoPath, nil
+	return repoPath, repository, nil
 }
 
 func topNOrDefault(topN *int) int {
@@ -827,24 +965,23 @@ func cacheEnabled(value *bool) bool {
 	return *value
 }
 
-func resolveMCPAnalysisCacheOptions(repoPath string, enabled bool, rawPath string, readOnly bool) (*analysis.CacheOptions, error) {
-	if enabled && strings.TrimSpace(rawPath) == "" {
-		pinnedPath, err := analysis.ResolveTrustedDefaultCachePath(repoPath)
-		if err != nil {
-			return nil, err
-		}
-		return &analysis.CacheOptions{
-			Enabled:    true,
-			Path:       "",
-			ReadOnly:   readOnly,
-			PinnedPath: filepath.Clean(pinnedPath),
-		}, nil
+func resolveMCPAnalysisCacheOptionsForRepository(repository *analysis.RepositoryAuthorization, enabled bool, rawPath string, readOnly bool) (*analysis.CacheOptions, error) {
+	cachePath := strings.TrimSpace(rawPath)
+	if enabled && cachePath == "" {
+		return analysis.ResolveTrustedDefaultCacheOptionsForRepository(repository, readOnly)
 	}
-	return analysis.ResolveTrustedCacheOptions(repoPath, &analysis.CacheOptions{
+	cacheOptions, err := analysis.ResolveTrustedCacheOptionsForRepository(repository, &analysis.CacheOptions{
 		Enabled:  enabled,
-		Path:     rawPath,
+		Path:     cachePath,
 		ReadOnly: readOnly,
 	})
+	if err == nil {
+		return cacheOptions, nil
+	}
+	if enabled && filepath.IsAbs(cachePath) && analysis.AuthenticatedExternalCacheOptions(cacheOptions, err) {
+		return cacheOptions, nil
+	}
+	return nil, err
 }
 
 func mergeStringOptions(configValues, argumentValues []string) []string {

--- a/internal/report/baseline_snapshot.go
+++ b/internal/report/baseline_snapshot.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	baselineutil "github.com/ben-ranford/lopper/internal/baseline"
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 const BaselineSnapshotSchemaVersion = baselineutil.SnapshotSchemaVersion
@@ -47,6 +48,10 @@ func ValidateBaselineSnapshotKey(requestedKey, storedKey string) error {
 
 func SaveSnapshot(dir string, key string, rep Report, now time.Time) (string, error) {
 	return baselineutil.SaveConfiguredSnapshot(dir, key, now, rep, baselineSnapshots)
+}
+
+func SaveSnapshotWithinRoot(root *safeio.WriteRoot, dir, displayDir, key string, rep Report, now time.Time) (string, error) {
+	return baselineutil.SaveConfiguredSnapshotWithinRoot(root, dir, displayDir, key, now, rep, baselineSnapshots)
 }
 
 func BaselineSnapshotPath(dir, key string) string {

--- a/internal/safeio/filesystem.go
+++ b/internal/safeio/filesystem.go
@@ -44,6 +44,21 @@ type File interface {
 	Chmod(perm os.FileMode) error
 }
 
+type directoryFile interface {
+	File
+	ReadDir(int) ([]fs.DirEntry, error)
+}
+
+type readlinkRoot interface {
+	Root
+	Readlink(string) (string, error)
+}
+
+type symlinkRoot interface {
+	Root
+	Symlink(string, string) error
+}
+
 type ReadDirFile interface {
 	File
 	ReadDir(count int) ([]fs.DirEntry, error)
@@ -52,6 +67,8 @@ type ReadDirFile interface {
 var ErrTargetPathSymlink = errors.New("target path is a symlink")
 
 var fileSystem FileSystem = &osFileSystem{}
+var sameDeviceFileInfoFn = sameDeviceRootPair
+var sameDeviceIdentitySupportedFn = sameDeviceIdentitySupported
 
 // OpenRoot opens a confined filesystem root.
 func OpenRoot(name string) (Root, error) {
@@ -71,6 +88,43 @@ func OpenRootExistingAncestorNoFollow(name string) (Root, string, []string, erro
 	return openRootExistingAncestorNoFollowWith(name, fileSystem.Abs, filepath.Rel, fileSystem.OpenRoot, func(root Root, childName, requestedPath string) (Root, string, error) {
 		return openRootChildPinnedWith(root, childName, requestedPath, fileSystem.OpenRootNoFollow, os.Stat, os.SameFile)
 	})
+}
+
+// ReadDirWithinRoot reads a directory without widening the public File
+// interface required by safeio callers.
+func ReadDirWithinRoot(root Root, name string) (_ []fs.DirEntry, returnErr error) {
+	file, err := root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, file.Close())
+	}()
+	reader, ok := file.(directoryFile)
+	if !ok {
+		return nil, errors.New("root file does not support directory reads")
+	}
+	return reader.ReadDir(-1)
+}
+
+// ReadlinkWithinRoot reads a symlink through a capability supported by the
+// concrete rooted filesystem implementation.
+func ReadlinkWithinRoot(root Root, name string) (string, error) {
+	reader, ok := root.(readlinkRoot)
+	if !ok {
+		return "", errors.New("root does not support symlink reads")
+	}
+	return reader.Readlink(name)
+}
+
+// SymlinkWithinRoot creates a symlink through a capability supported by the
+// concrete rooted filesystem implementation.
+func SymlinkWithinRoot(root Root, oldName, newName string) error {
+	writer, ok := root.(symlinkRoot)
+	if !ok {
+		return errors.New("root does not support symlink creation")
+	}
+	return writer.Symlink(oldName, newName)
 }
 
 type osFileSystem struct{}
@@ -189,7 +243,18 @@ func trustedRootAliasTarget(requestedPath string) (string, bool) {
 	}
 }
 
+func enforceSameDeviceBoundary(parent Root, child Root, left fs.FileInfo, right fs.FileInfo) bool {
+	if !sameDeviceIdentitySupportedFn() {
+		return true
+	}
+	return sameDeviceFileInfoFn(parent, child, left, right)
+}
+
 func openRootChildNoFollow(root Root, name, path string) (Root, error) {
+	parentInfo, err := root.Lstat(".")
+	if err != nil {
+		return nil, err
+	}
 	info, err := root.Lstat(name)
 	if err != nil {
 		return nil, err
@@ -211,6 +276,9 @@ func openRootChildNoFollow(root Root, name, path string) (Root, error) {
 	}
 	if !os.SameFile(info, openedInfo) {
 		return nil, closeRootWithError(next, fmt.Errorf("root changed while opening: %s", path))
+	}
+	if !enforceSameDeviceBoundary(root, next, parentInfo, openedInfo) {
+		return nil, closeRootWithError(next, fmt.Errorf("root crosses device boundary: %s", path))
 	}
 	return next, nil
 }
@@ -476,6 +544,14 @@ func (r *osRoot) OpenRoot(name string) (Root, error) {
 
 func (r *osRoot) Lstat(name string) (fs.FileInfo, error) {
 	return r.root.Lstat(name)
+}
+
+func (r *osRoot) Readlink(name string) (string, error) {
+	return r.root.Readlink(name)
+}
+
+func (r *osRoot) Symlink(oldName, newName string) error {
+	return r.root.Symlink(oldName, newName)
 }
 
 func (r *osRoot) Mkdir(name string, perm os.FileMode) error {

--- a/internal/safeio/filesystem_branches_test.go
+++ b/internal/safeio/filesystem_branches_test.go
@@ -56,7 +56,21 @@ func TestOpenPinnedDirectoryRejectsNonReadDirFileAndJoinsCloseErrors(t *testing.
 	}
 	fileCloseErr := errors.New("close opened file")
 	rootCloseErr := errors.New("close pinned ancestor")
-	childRoot := &fakeRoot{
+	childRoot := testPinnedDirectoryChildRoot(t, dirInfo, fileCloseErr, rootCloseErr)
+	root := testPinnedDirectoryParentRoot(t, dirInfo, childRoot)
+
+	dir, err := OpenPinnedDirectory(root, filepath.Join("nested", "leaf"))
+	if dir != nil {
+		t.Fatal("expected invalid pinned directory wrapper to return nil")
+	}
+	if !errors.Is(err, fs.ErrInvalid) || !errors.Is(err, fileCloseErr) || !errors.Is(err, rootCloseErr) {
+		t.Fatalf("expected invalid directory joined with file and root close errors, got %v", err)
+	}
+}
+
+func testPinnedDirectoryChildRoot(t *testing.T, dirInfo fs.FileInfo, fileCloseErr, rootCloseErr error) *fakeRoot {
+	t.Helper()
+	return &fakeRoot{
 		lstat: func(name string) (fs.FileInfo, error) {
 			if name == "." || name == "leaf" {
 				return dirInfo, nil
@@ -70,15 +84,19 @@ func TestOpenPinnedDirectoryRejectsNonReadDirFileAndJoinsCloseErrors(t *testing.
 			if name != "leaf" {
 				t.Fatalf("unexpected child open %q", name)
 			}
-			return &fakeFile{
-				stat:  func() (fs.FileInfo, error) { return dirInfo, nil },
-				close: func() error { return fileCloseErr },
-			}, nil
+			return &fakeFile{stat: func() (fs.FileInfo, error) { return dirInfo, nil }, close: func() error { return fileCloseErr }}, nil
 		},
 		close: func() error { return rootCloseErr },
 	}
-	root := &fakeRoot{
+}
+
+func testPinnedDirectoryParentRoot(t *testing.T, dirInfo fs.FileInfo, childRoot Root) *fakeRoot {
+	t.Helper()
+	return &fakeRoot{
 		lstat: func(name string) (fs.FileInfo, error) {
+			if name == "." {
+				return dirInfo, nil
+			}
 			if name != "nested" {
 				t.Fatalf("unexpected root lstat %q", name)
 			}
@@ -90,14 +108,6 @@ func TestOpenPinnedDirectoryRejectsNonReadDirFileAndJoinsCloseErrors(t *testing.
 			}
 			return childRoot, nil
 		},
-	}
-
-	dir, err := OpenPinnedDirectory(root, filepath.Join("nested", "leaf"))
-	if dir != nil {
-		t.Fatal("expected invalid pinned directory wrapper to return nil")
-	}
-	if !errors.Is(err, fs.ErrInvalid) || !errors.Is(err, fileCloseErr) || !errors.Is(err, rootCloseErr) {
-		t.Fatalf("expected invalid directory joined with file and root close errors, got %v", err)
 	}
 }
 

--- a/internal/safeio/filesystem_device_contract_test.go
+++ b/internal/safeio/filesystem_device_contract_test.go
@@ -1,0 +1,25 @@
+package safeio
+
+import (
+	"io/fs"
+	"testing"
+)
+
+type sysOverrideFileInfo struct {
+	fs.FileInfo
+	sys any
+}
+
+func (i *sysOverrideFileInfo) Sys() any {
+	return i.sys
+}
+
+func TestSameDeviceRootPairFailsClosedWithoutProvableIdentity(t *testing.T) {
+	info := &sysOverrideFileInfo{
+		FileInfo: statTestPath(t, t.TempDir()),
+		sys:      nil,
+	}
+	if sameDeviceRootPair(nil, nil, info, info) {
+		t.Fatal("expected same-device identity to fail closed when it cannot be proven")
+	}
+}

--- a/internal/safeio/filesystem_device_other.go
+++ b/internal/safeio/filesystem_device_other.go
@@ -1,0 +1,18 @@
+//go:build !unix && !windows
+
+package safeio
+
+import "io/fs"
+
+// Platforms selected by !unix && !windows do not currently expose a stable
+// device or volume identity contract in safeio. Generic rooted traversal must
+// preserve the preexisting nested read/write behavior there, while any feature
+// that explicitly requires device proof must fail closed by checking
+// sameDeviceIdentitySupported first.
+func sameDeviceIdentitySupported() bool {
+	return false
+}
+
+func sameDeviceRootPair(_ Root, _ Root, _, _ fs.FileInfo) bool {
+	return false
+}

--- a/internal/safeio/filesystem_device_other_test.go
+++ b/internal/safeio/filesystem_device_other_test.go
@@ -1,0 +1,31 @@
+//go:build !unix && !windows
+
+package safeio
+
+import (
+	"io/fs"
+	"testing"
+)
+
+func TestSameDeviceIdentityContractOnUnsupportedPlatforms(t *testing.T) {
+	if sameDeviceIdentitySupported() {
+		t.Fatal("unsupported platform unexpectedly reports stable device identity support")
+	}
+
+	info := &sysOverrideFileInfo{sys: nil}
+	if sameDeviceRootPair(nil, nil, info, info) {
+		t.Fatal("same-device proof must fail closed when unsupported platforms cannot prove identity")
+	}
+}
+
+func TestEnforceSameDeviceBoundaryAllowsTraversalWhenUnsupported(t *testing.T) {
+	previous := sameDeviceFileInfoFn
+	sameDeviceFileInfoFn = func(Root, Root, fs.FileInfo, fs.FileInfo) bool { return false }
+	t.Cleanup(func() {
+		sameDeviceFileInfoFn = previous
+	})
+
+	if !enforceSameDeviceBoundary(nil, nil, nil, nil) {
+		t.Fatal("generic traversal should stay enabled when stable device identity is unsupported")
+	}
+}

--- a/internal/safeio/filesystem_device_unix.go
+++ b/internal/safeio/filesystem_device_unix.go
@@ -1,0 +1,24 @@
+//go:build unix
+
+package safeio
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+// Unix builds enforce same-device traversal using st_dev from syscall.Stat_t.
+// Build-tag contract: callers may rely on stable device identity being
+// supported when this file is selected.
+func sameDeviceIdentitySupported() bool {
+	return true
+}
+
+func sameDeviceRootPair(_ Root, _ Root, left, right fs.FileInfo) bool {
+	leftStat, leftOK := left.Sys().(*syscall.Stat_t)
+	rightStat, rightOK := right.Sys().(*syscall.Stat_t)
+	if !leftOK || !rightOK {
+		return false
+	}
+	return leftStat.Dev == rightStat.Dev
+}

--- a/internal/safeio/filesystem_device_windows.go
+++ b/internal/safeio/filesystem_device_windows.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+package safeio
+
+import (
+	"errors"
+	"io/fs"
+	"syscall"
+)
+
+type windowsHandleFileIdentity struct {
+	volumeSerial uint32
+	fileIndexHi  uint32
+	fileIndexLo  uint32
+}
+
+type fdFile interface {
+	File
+	Fd() uintptr
+}
+
+var windowsHandleFileIdentityFn = windowsHandleFileIdentityFromFD
+
+// Windows builds enforce same-volume traversal using
+// GetFileInformationByHandle volume identity from pinned root handles.
+// Build-tag contract: callers may rely on stable device identity being
+// supported when this file is selected.
+func sameDeviceIdentitySupported() bool {
+	return true
+}
+
+func sameDeviceRootPair(parent Root, child Root, _, _ fs.FileInfo) bool {
+	parentIdentity, err := windowsRootIdentity(parent)
+	if err != nil {
+		return false
+	}
+	childIdentity, err := windowsRootIdentity(child)
+	if err != nil {
+		return false
+	}
+	return parentIdentity.volumeSerial == childIdentity.volumeSerial
+}
+
+func windowsRootIdentity(root Root) (windowsHandleFileIdentity, error) {
+	if root == nil {
+		return windowsHandleFileIdentity{}, errors.New("root is required")
+	}
+	file, err := root.Open(".")
+	if err != nil {
+		return windowsHandleFileIdentity{}, err
+	}
+	defer file.Close()
+	handleFile, ok := file.(fdFile)
+	if !ok {
+		return windowsHandleFileIdentity{}, errors.New("root handle does not expose a file descriptor")
+	}
+	return windowsHandleFileIdentityFn(handleFile.Fd())
+}
+
+func windowsHandleFileIdentityFromFD(fd uintptr) (windowsHandleFileIdentity, error) {
+	var info syscall.ByHandleFileInformation
+	if err := syscall.GetFileInformationByHandle(syscall.Handle(fd), &info); err != nil {
+		return windowsHandleFileIdentity{}, err
+	}
+	return windowsHandleFileIdentity{
+		volumeSerial: info.VolumeSerialNumber,
+		fileIndexHi:  info.FileIndexHigh,
+		fileIndexLo:  info.FileIndexLow,
+	}, nil
+}

--- a/internal/safeio/filesystem_device_windows_integration_test.go
+++ b/internal/safeio/filesystem_device_windows_integration_test.go
@@ -1,0 +1,122 @@
+//go:build windows
+
+package safeio
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWindowsOpenRootNoFollowTraversesNestedDirectoryWithRealHandles(t *testing.T) {
+	rootDir := t.TempDir()
+	nested := filepath.Join(rootDir, "nested", "child")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested path: %v", err)
+	}
+	targetPath := filepath.Join(nested, "result.txt")
+	if err := os.WriteFile(targetPath, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write nested file: %v", err)
+	}
+
+	root, err := OpenRootNoFollow(nested)
+	if err != nil {
+		t.Fatalf("open nested no-follow root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close nested no-follow root: %v", closeErr)
+		}
+	}()
+
+	openedInfo, err := root.Lstat(".")
+	if err != nil {
+		t.Fatalf("lstat nested no-follow root: %v", err)
+	}
+	if !os.SameFile(openedInfo, statTestPath(t, nested)) {
+		t.Fatal("expected nested no-follow root to retain directory identity")
+	}
+
+	data, err := ReadFileWithinRoot(root, "result.txt")
+	if err != nil {
+		t.Fatalf("read nested file through real root handle: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("unexpected nested file contents: %q", data)
+	}
+}
+
+func TestWindowsOpenRelativeWriteRootTraversesNestedDirectoryWithRealHandles(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rootDir, "existing"), 0o755); err != nil {
+		t.Fatalf("mkdir existing path: %v", err)
+	}
+
+	root, err := OpenRootNoFollow(rootDir)
+	if err != nil {
+		t.Fatalf("open parent root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close parent root: %v", closeErr)
+		}
+	}()
+
+	child, err := OpenRelativeWriteRoot(root, filepath.Join("existing", "created"), true, 0o750)
+	if err != nil {
+		t.Fatalf("open relative write root: %v", err)
+	}
+	defer func() {
+		if closeErr := child.Close(); closeErr != nil {
+			t.Fatalf("close relative write root: %v", closeErr)
+		}
+	}()
+
+	if err := child.WriteFileExclusiveCreatingParents(filepath.Join("nested", "result.txt"), []byte("bound\n"), 0o600, 0o750); err != nil {
+		t.Fatalf("write nested file through relative write root: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(rootDir, "existing", "created", "nested", "result.txt"))
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(data) != "bound\n" {
+		t.Fatalf("unexpected written file contents: %q", data)
+	}
+}
+
+func TestWindowsOpenRelativeWriteRootRejectsIdentityErrorsFromRealHandles(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rootDir, "existing"), 0o755); err != nil {
+		t.Fatalf("mkdir existing path: %v", err)
+	}
+
+	root, err := OpenRootNoFollow(rootDir)
+	if err != nil {
+		t.Fatalf("open parent root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatalf("close parent root: %v", closeErr)
+		}
+	}()
+
+	previous := windowsHandleFileIdentityFn
+	windowsHandleFileIdentityFn = func(uintptr) (windowsHandleFileIdentity, error) {
+		return windowsHandleFileIdentity{}, fs.ErrPermission
+	}
+	t.Cleanup(func() {
+		windowsHandleFileIdentityFn = previous
+	})
+
+	child, err := OpenRelativeWriteRoot(root, filepath.Join("existing", "created"), true, 0o750)
+	if child != nil {
+		_ = child.Close()
+		t.Fatal("expected identity lookup rejection to return no child root")
+	}
+	if err == nil || !strings.Contains(err.Error(), "device boundary") {
+		t.Fatalf("expected identity lookup rejection, got %v", err)
+	}
+}

--- a/internal/safeio/filesystem_device_windows_test.go
+++ b/internal/safeio/filesystem_device_windows_test.go
@@ -1,0 +1,105 @@
+//go:build windows
+
+package safeio
+
+import (
+	"errors"
+	"testing"
+)
+
+type windowsHandleTestFile struct {
+	fakeFile
+	fd uintptr
+}
+
+func (f *windowsHandleTestFile) Fd() uintptr {
+	return f.fd
+}
+
+func TestSameDeviceRootPairUsesPinnedRootHandlesOnWindows(t *testing.T) {
+	previous := windowsHandleFileIdentityFn
+	defer func() {
+		windowsHandleFileIdentityFn = previous
+	}()
+
+	var gotFDs []uintptr
+	windowsHandleFileIdentityFn = func(fd uintptr) (windowsHandleFileIdentity, error) {
+		gotFDs = append(gotFDs, fd)
+		switch fd {
+		case 11:
+			return windowsHandleFileIdentity{volumeSerial: 7, fileIndexHi: 1, fileIndexLo: 2}, nil
+		case 22:
+			return windowsHandleFileIdentity{volumeSerial: 7, fileIndexHi: 3, fileIndexLo: 4}, nil
+		default:
+			return windowsHandleFileIdentity{}, errors.New("unexpected handle")
+		}
+	}
+
+	parent := &fakeRoot{
+		open: func(string) (File, error) {
+			return &windowsHandleTestFile{fd: 11}, nil
+		},
+	}
+	child := &fakeRoot{
+		open: func(string) (File, error) {
+			return &windowsHandleTestFile{fd: 22}, nil
+		},
+	}
+
+	if !sameDeviceRootPair(parent, child, nil, nil) {
+		t.Fatal("expected same-device roots to be accepted when pinned handles share a volume")
+	}
+	if len(gotFDs) != 2 || gotFDs[0] != 11 || gotFDs[1] != 22 {
+		t.Fatalf("expected pinned root handles to be inspected, got %v", gotFDs)
+	}
+}
+
+func TestSameDeviceRootPairFailsClosedOnWindowsIdentityErrors(t *testing.T) {
+	previous := windowsHandleFileIdentityFn
+	defer func() {
+		windowsHandleFileIdentityFn = previous
+	}()
+
+	windowsHandleFileIdentityFn = func(uintptr) (windowsHandleFileIdentity, error) {
+		return windowsHandleFileIdentity{}, errors.New("identity unavailable")
+	}
+
+	withHandle := &fakeRoot{
+		open: func(string) (File, error) {
+			return &windowsHandleTestFile{fd: 11}, nil
+		},
+	}
+	if sameDeviceRootPair(withHandle, withHandle, nil, nil) {
+		t.Fatal("expected identity lookup failure to reject traversal")
+	}
+
+	withoutHandle := &fakeRoot{
+		open: func(string) (File, error) {
+			return &fakeFile{}, nil
+		},
+	}
+	if sameDeviceRootPair(withoutHandle, withHandle, nil, nil) {
+		t.Fatal("expected missing file-descriptor support to reject traversal")
+	}
+}
+
+func TestSameDeviceRootPairRejectsDifferentWindowsVolumes(t *testing.T) {
+	previous := windowsHandleFileIdentityFn
+	defer func() {
+		windowsHandleFileIdentityFn = previous
+	}()
+
+	windowsHandleFileIdentityFn = func(fd uintptr) (windowsHandleFileIdentity, error) {
+		if fd == 11 {
+			return windowsHandleFileIdentity{volumeSerial: 7, fileIndexHi: 1, fileIndexLo: 2}, nil
+		}
+		return windowsHandleFileIdentity{volumeSerial: 8, fileIndexHi: 1, fileIndexLo: 2}, nil
+	}
+
+	parent := &fakeRoot{open: func(string) (File, error) { return &windowsHandleTestFile{fd: 11}, nil }}
+	child := &fakeRoot{open: func(string) (File, error) { return &windowsHandleTestFile{fd: 22}, nil }}
+
+	if sameDeviceRootPair(parent, child, nil, nil) {
+		t.Fatal("expected different Windows volumes to be rejected")
+	}
+}

--- a/internal/safeio/read_test.go
+++ b/internal/safeio/read_test.go
@@ -681,8 +681,9 @@ func TestReadFileLimitRejectsSpecialFile(t *testing.T) {
 			continue
 		}
 
-		if _, err := ReadFileLimit(path, 1024); !errors.Is(err, ErrFileTooLarge) {
-			t.Fatalf("expected ErrFileTooLarge for %s, got %v", path, err)
+		_, err = ReadFileLimit(path, 1024)
+		if !errors.Is(err, ErrFileTooLarge) && !strings.Contains(err.Error(), "device boundary") {
+			t.Fatalf("expected special-file or device-boundary rejection for %s, got %v", path, err)
 		}
 		return
 	}

--- a/internal/safeio/read_test.go
+++ b/internal/safeio/read_test.go
@@ -389,7 +389,13 @@ func TestReadFileWithinRootLimitPreservesNestedMissingTargetAndAncestorCloseErro
 }
 
 func TestReadFileWithinRootLimitTranslatesMissingOpenError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), writeTestFileName)
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf(writeFileErrFmt, err)
+	}
+	info := statTestPath(t, path)
 	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return info, nil },
 		open: func(string) (File, error) {
 			return nil, os.ErrNotExist
 		},

--- a/internal/safeio/read_test.go
+++ b/internal/safeio/read_test.go
@@ -388,6 +388,19 @@ func TestReadFileWithinRootLimitPreservesNestedMissingTargetAndAncestorCloseErro
 	}
 }
 
+func TestReadFileWithinRootLimitTranslatesMissingOpenError(t *testing.T) {
+	root := &fakeRoot{
+		open: func(string) (File, error) {
+			return nil, os.ErrNotExist
+		},
+	}
+
+	_, err := ReadFileWithinRootLimit(root, writeTestFileName, 1)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing file error, got %v", err)
+	}
+}
+
 func TestReadFileWithinRootLimitRejectsFileReplacementBetweenLstatAndOpen(t *testing.T) {
 	rootDir := canonicalTempDir(t)
 	targetName := "swap.txt"

--- a/internal/safeio/root_capabilities_test.go
+++ b/internal/safeio/root_capabilities_test.go
@@ -1,0 +1,265 @@
+package safeio
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRootCapabilitiesAndRelativeWriteRoot(t *testing.T) {
+	rootDir, root := openRootCapabilitiesFixture(t)
+	assertRootDirectoryRead(t, root)
+	assertRootSymlinkCapabilities(t, root)
+	assertRelativeWriteRootCreation(t, rootDir, root)
+	assertRelativeWriteRootGuards(t, rootDir, root)
+}
+
+func openRootCapabilitiesFixture(t *testing.T) (string, Root) {
+	t.Helper()
+	rootDir := t.TempDir()
+	canonicalRootDir, err := filepath.EvalSymlinks(rootDir)
+	if err != nil {
+		t.Fatalf("canonicalize temporary root: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(rootDir, "existing"), 0o750); err != nil {
+		t.Fatalf("mkdir existing child: %v", err)
+	}
+	root, err := OpenRootNoFollow(canonicalRootDir)
+	if err != nil {
+		t.Fatalf("open no-follow root: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close no-follow root: %v", err)
+		}
+	})
+	return rootDir, root
+}
+
+func assertRootDirectoryRead(t *testing.T, root Root) {
+	t.Helper()
+	entries, err := ReadDirWithinRoot(root, ".")
+	if err != nil {
+		t.Fatalf("read rooted directory: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "existing" {
+		t.Fatalf("unexpected rooted directory entries: %#v", entries)
+	}
+}
+
+func assertRootSymlinkCapabilities(t *testing.T, root Root) {
+	t.Helper()
+	if err := SymlinkWithinRoot(root, "existing", "existing-link"); err != nil {
+		t.Logf("rooted symlink creation unsupported: %v", err)
+		return
+	}
+	linkTarget, err := ReadlinkWithinRoot(root, "existing-link")
+	if err != nil {
+		t.Fatalf("read rooted symlink: %v", err)
+	}
+	if linkTarget != "existing" {
+		t.Fatalf("unexpected rooted symlink target: %q", linkTarget)
+	}
+	if _, err := OpenRelativeWriteRoot(root, filepath.Join("existing-link", "child"), true, 0o750); err == nil {
+		t.Fatal("expected relative root traversal through symlink to fail")
+	}
+}
+
+func assertRelativeWriteRootCreation(t *testing.T, rootDir string, root Root) {
+	t.Helper()
+	child, err := OpenRelativeWriteRoot(root, filepath.Join("existing", "created"), true, 0o750)
+	if err != nil {
+		t.Fatalf("open created relative write root: %v", err)
+	}
+	if child.CanonicalPath() != filepath.Join("existing", "created") {
+		t.Fatalf("unexpected relative write-root identity: %q", child.CanonicalPath())
+	}
+	if err := child.WriteFileExclusiveCreatingParents(filepath.Join("nested", "result.txt"), []byte("bound\n"), 0o600, 0o750); err != nil {
+		t.Fatalf("write exclusive rooted file: %v", err)
+	}
+	if err := child.WriteFileExclusiveCreatingParents(filepath.Join("nested", "result.txt"), []byte("replace\n"), 0o600, 0o750); !errors.Is(err, os.ErrExist) {
+		t.Fatalf("expected duplicate exclusive write rejection, got %v", err)
+	}
+	if err := child.Close(); err != nil {
+		t.Fatalf("close relative write root: %v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(rootDir, "existing", "created", "nested", "result.txt")); err != nil || string(data) != "bound\n" {
+		t.Fatalf("inspect exclusive rooted write: data=%q err=%v", data, err)
+	}
+}
+
+func assertRelativeWriteRootGuards(t *testing.T, rootDir string, root Root) {
+	t.Helper()
+	rootCopy, err := OpenRelativeWriteRoot(root, ".", false, 0)
+	if err != nil {
+		t.Fatalf("open relative root copy: %v", err)
+	}
+	if err := rootCopy.Close(); err != nil {
+		t.Fatalf("close relative root copy: %v", err)
+	}
+	for _, target := range []string{filepath.Join(rootDir, "absolute"), ".."} {
+		if _, err := OpenRelativeWriteRoot(root, target, false, 0); err == nil {
+			t.Fatalf("expected unsafe relative root %q to fail", target)
+		}
+	}
+	if _, err := OpenRelativeWriteRoot(root, "missing", false, 0); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing relative root rejection, got %v", err)
+	}
+	if _, err := OpenRelativeWriteRoot(nil, ".", false, 0); err == nil {
+		t.Fatal("expected nil parent root rejection")
+	}
+}
+
+func TestRootCapabilityHelpersRejectUnsupportedImplementations(t *testing.T) {
+	expectedOpenErr := errors.New("open blocked")
+	openFailure := &fakeRoot{
+		Root: &fakeRoot{},
+		open: func(string) (File, error) {
+			return nil, expectedOpenErr
+		},
+	}
+	if _, err := ReadDirWithinRoot(openFailure, "."); !errors.Is(err, expectedOpenErr) {
+		t.Fatalf("expected directory open error, got %v", err)
+	}
+
+	unsupportedFile := &fakeFile{
+		close: func() error { return nil },
+	}
+	unsupportedRoot := &fakeRoot{
+		Root: &fakeRoot{},
+		open: func(string) (File, error) {
+			return unsupportedFile, nil
+		},
+	}
+	if _, err := ReadDirWithinRoot(unsupportedRoot, "."); err == nil || !strings.Contains(err.Error(), "does not support directory reads") {
+		t.Fatalf("expected unsupported directory reader error, got %v", err)
+	}
+	if _, err := ReadlinkWithinRoot(unsupportedRoot, "link"); err == nil || !strings.Contains(err.Error(), "does not support symlink reads") {
+		t.Fatalf("expected unsupported readlink error, got %v", err)
+	}
+	if err := SymlinkWithinRoot(unsupportedRoot, "target", "link"); err == nil || !strings.Contains(err.Error(), "does not support symlink creation") {
+		t.Fatalf("expected unsupported symlink error, got %v", err)
+	}
+}
+
+func TestOpenRootChildNoFollowRejectsDeviceBoundary(t *testing.T) {
+	previous := sameDeviceFileInfoFn
+	sameDeviceFileInfoFn = func(Root, Root, fs.FileInfo, fs.FileInfo) bool { return false }
+	t.Cleanup(func() {
+		sameDeviceFileInfoFn = previous
+	})
+
+	dirInfo := statTestPath(t, t.TempDir())
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			return dirInfo, nil
+		},
+		openRoot: func(string) (Root, error) {
+			return &fakeRoot{
+				lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+				close: func() error { return nil },
+			}, nil
+		},
+	}
+	opened, err := openRootChildNoFollow(root, "child", "/root/child")
+	if opened != nil {
+		t.Fatal("expected device-boundary child root rejection")
+	}
+	if err == nil || !strings.Contains(err.Error(), "device boundary") {
+		t.Fatalf("expected device-boundary error, got %v", err)
+	}
+}
+
+func TestOpenRootChildNoFollowAllowsTraversalWhenDeviceIdentityUnsupported(t *testing.T) {
+	withSameDeviceIdentitySupportedFn(t, func() bool { return false })
+	withSameDeviceFileInfoFn(t, func(Root, Root, fs.FileInfo, fs.FileInfo) bool { return false })
+
+	dirInfo := statTestPath(t, t.TempDir())
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			return dirInfo, nil
+		},
+		openRoot: func(string) (Root, error) {
+			return &fakeRoot{
+				lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+				close: func() error { return nil },
+			}, nil
+		},
+	}
+	opened, err := openRootChildNoFollow(root, "child", "/root/child")
+	if err != nil {
+		t.Fatalf("expected traversal without device proof support to remain usable, got %v", err)
+	}
+	if opened == nil {
+		t.Fatal("expected child root when device proof is unsupported")
+	}
+	if closeErr := opened.Close(); closeErr != nil {
+		t.Fatalf("close opened child root: %v", closeErr)
+	}
+}
+
+func TestWriteFileExclusiveCreatingParentsCleansUpWriteFailure(t *testing.T) {
+	expectedWriteErr := errors.New("write failed")
+	removed := false
+	root := &fakeRoot{
+		Root: &fakeRoot{},
+		openFile: func(string, int, os.FileMode) (File, error) {
+			return &fakeFile{
+				write: func([]byte) (int, error) {
+					return 0, expectedWriteErr
+				},
+				close: func() error { return nil },
+			}, nil
+		},
+		remove: func(string) error {
+			removed = true
+			return nil
+		},
+	}
+	writeRoot := &WriteRoot{root: root, rootAbs: "."}
+	err := writeRoot.WriteFileExclusiveCreatingParents("result.txt", []byte("payload"), 0o600, 0o750)
+	if !errors.Is(err, expectedWriteErr) {
+		t.Fatalf("expected write failure, got %v", err)
+	}
+	if !removed {
+		t.Fatal("expected failed exclusive write cleanup")
+	}
+
+	expectedRemoveErr := errors.New("remove failed")
+	root.remove = func(string) error {
+		return expectedRemoveErr
+	}
+	err = writeRoot.WriteFileExclusiveCreatingParents("remove-blocked.txt", []byte("payload"), 0o600, 0o750)
+	if !errors.Is(err, expectedWriteErr) || !errors.Is(err, expectedRemoveErr) {
+		t.Fatalf("expected joined write and cleanup errors, got %v", err)
+	}
+
+	expectedCloseErr := errors.New("close failed")
+	root.remove = func(string) error { return nil }
+	root.openFile = func(string, int, os.FileMode) (File, error) {
+		return &fakeFile{
+			write: func(data []byte) (int, error) { return len(data), nil },
+			close: func() error { return expectedCloseErr },
+		}, nil
+	}
+	if err := writeRoot.WriteFileExclusiveCreatingParents("close-blocked.txt", []byte("payload"), 0o600, 0o750); !errors.Is(err, expectedCloseErr) {
+		t.Fatalf("expected close failure, got %v", err)
+	}
+	if err := writeRoot.WriteFileExclusiveCreatingParents("close-blocked.txt", []byte("payload"), 0o600, 0o750); !errors.Is(err, expectedCloseErr) {
+		t.Fatalf("expected retry after close failure to reopen cleanly, got %v", err)
+	}
+
+	expectedOpenErr := errors.New("open failed")
+	root.openFile = func(string, int, os.FileMode) (File, error) {
+		return nil, expectedOpenErr
+	}
+	if err := writeRoot.WriteFileExclusiveCreatingParents("blocked.txt", []byte("payload"), 0o600, 0o750); !errors.Is(err, expectedOpenErr) {
+		t.Fatalf("expected open failure, got %v", err)
+	}
+	if err := writeRoot.WriteFileExclusiveCreatingParents(filepath.Join(string(os.PathSeparator), "absolute"), nil, 0o600, 0o750); err == nil {
+		t.Fatal("expected absolute exclusive write rejection")
+	}
+}

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -23,6 +23,11 @@ type WriteRoot struct {
 	rootAbs string
 }
 
+// CanonicalPath reports the canonical filesystem path pinned by this write root.
+func (r *WriteRoot) CanonicalPath() string {
+	return r.rootAbs
+}
+
 // OpenWriteRoot opens rootDir once for subsequent root-relative writes.
 func OpenWriteRoot(rootDir string) (*WriteRoot, error) {
 	rootAbs, err := resolveAbsolutePath("root", rootDir)

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -1,9 +1,11 @@
 package safeio
 
 import (
+	"bytes"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -71,6 +73,56 @@ func openWriteRoot(rootAbs string) (*WriteRoot, error) {
 	return &WriteRoot{root: root, rootAbs: rootAbs}, nil
 }
 
+// OpenRelativeWriteRoot opens a child write root from an already-open parent.
+// Existing path components must be real directories; missing components are
+// created only when create is true.
+func OpenRelativeWriteRoot(parent Root, targetPath string, create bool, perm os.FileMode) (*WriteRoot, error) {
+	if parent == nil {
+		return nil, errors.New("parent root is required")
+	}
+	targetRel, err := resolveRelativeTarget(targetPath, allowRootTarget)
+	if err != nil {
+		return nil, err
+	}
+	current, currentOwned, currentPath, err := openRelativeWriteRootDescendants(parent, targetRel, create, perm)
+	if err != nil {
+		return nil, err
+	}
+	if !currentOwned {
+		next, err := current.OpenRoot(".")
+		if err != nil {
+			return nil, err
+		}
+		current = next
+	}
+	return &WriteRoot{root: current, rootAbs: currentPath}, nil
+}
+
+func openRelativeWriteRootDescendants(parent Root, targetRel string, create bool, perm os.FileMode) (Root, bool, string, error) {
+	current := parent
+	currentOwned := false
+	currentPath := "."
+	for _, part := range strings.Split(targetRel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		partPath := filepath.Join(currentPath, part)
+		next, err := openTargetParentChild(current, part, partPath, create, perm)
+		if err != nil {
+			return nil, false, "", closeOwnedRootWithError(current, currentOwned, err)
+		}
+		if currentOwned {
+			if err := current.Close(); err != nil {
+				return nil, false, "", closeRootWithError(next, err)
+			}
+		}
+		current = next
+		currentOwned = true
+		currentPath = partPath
+	}
+	return current, currentOwned, currentPath, nil
+}
+
 // Close releases the pinned filesystem root.
 func (r *WriteRoot) Close() error {
 	return r.root.Close()
@@ -136,6 +188,50 @@ func (r *WriteRoot) WriteFileReplacingParents(targetPath string, data []byte, pe
 		return err
 	}
 	return r.writeFileAtTarget(target, data, perm, true, parentPerm, true)
+}
+
+// WriteFileExclusiveCreatingParents writes a new root-relative file and fails
+// if the target already exists.
+func (r *WriteRoot) WriteFileExclusiveCreatingParents(targetPath string, data []byte, perm, parentPerm os.FileMode) (returnErr error) {
+	target, err := r.resolveTarget(targetPath)
+	if err != nil {
+		return err
+	}
+	parent, closeParent, err := r.openTargetParent(target, true, parentPerm)
+	if err != nil {
+		return err
+	}
+	if closeParent {
+		defer func() {
+			returnErr = errors.Join(returnErr, parent.Close())
+		}()
+	}
+
+	targetName := filepath.Base(target.rel)
+	file, err := parent.OpenFile(targetName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		return err
+	}
+	removeOnError := true
+	writeSucceeded := false
+	defer func() {
+		closeErr := file.Close()
+		if closeErr == nil && writeSucceeded {
+			removeOnError = false
+		} else {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+		if removeOnError {
+			if removeErr := parent.Remove(targetName); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				returnErr = errors.Join(returnErr, removeErr)
+			}
+		}
+	}()
+	if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
+		return err
+	}
+	writeSucceeded = true
+	return nil
 }
 
 func (r *WriteRoot) resolveTarget(targetPath string) (rootedTarget, error) {
@@ -316,6 +412,10 @@ func (r *WriteRoot) openTargetParent(target rootedTarget, create bool, perm os.F
 }
 
 func openTargetParentChild(root Root, name, path string, create bool, perm os.FileMode) (Root, error) {
+	parentInfo, err := root.Lstat(".")
+	if err != nil {
+		return nil, err
+	}
 	info, err := lstatOrCreateDirectory(root, name, create, perm)
 	if err != nil {
 		return nil, err
@@ -337,6 +437,9 @@ func openTargetParentChild(root Root, name, path string, create bool, perm os.Fi
 	}
 	if !os.SameFile(info, openedInfo) {
 		return nil, closeRootWithError(next, fmt.Errorf("output parent changed while opening: %s", path))
+	}
+	if !enforceSameDeviceBoundary(root, next, parentInfo, openedInfo) {
+		return nil, closeRootWithError(next, fmt.Errorf("output parent crosses device boundary: %s", path))
 	}
 	return next, nil
 }

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -10,6 +10,13 @@ import (
 	"strings"
 )
 
+type canonicalTargetKind int
+
+const (
+	canonicalTargetDirectory canonicalTargetKind = iota
+	canonicalTargetFile
+)
+
 // WriteRoot pins a filesystem root for path-confined atomic writes.
 type WriteRoot struct {
 	root    Root
@@ -39,6 +46,18 @@ func OpenCanonicalWriteRoot(rootDir string) (*WriteRoot, error) {
 	return &WriteRoot{root: root, rootAbs: rootAbs}, nil
 }
 
+// OpenExistingCanonicalWriteRoot opens the deepest existing ancestor needed to
+// create or update targetPath without following symlinks during ancestor
+// discovery. It returns the pinned ancestor root and the remaining relative
+// suffix under that root.
+func OpenExistingCanonicalWriteRoot(targetPath string, isDir bool) (*WriteRoot, string, error) {
+	kind := canonicalTargetFile
+	if isDir {
+		kind = canonicalTargetDirectory
+	}
+	return openExistingCanonicalWriteRoot(targetPath, kind)
+}
+
 func openWriteRoot(rootAbs string) (*WriteRoot, error) {
 	root, err := fileSystem.OpenRoot(rootAbs)
 	if err != nil {
@@ -52,6 +71,32 @@ func (r *WriteRoot) Close() error {
 	return r.root.Close()
 }
 
+// EnsureDir creates targetPath as a directory under the pinned root, creating
+// missing parent directories without following symlinks.
+func (r *WriteRoot) EnsureDir(targetPath string, perm os.FileMode) (returnErr error) {
+	target, err := r.resolveTarget(targetPath)
+	if err != nil {
+		return err
+	}
+	parent, closeParent, err := r.openTargetParent(target, true, perm)
+	if err != nil {
+		return err
+	}
+	if closeParent {
+		defer func() {
+			if closeErr := parent.Close(); closeErr != nil {
+				returnErr = errors.Join(returnErr, closeErr)
+			}
+		}()
+	}
+	name := filepath.Base(target.rel)
+	child, err := openTargetParentChild(parent, name, target.abs, true, perm)
+	if err != nil {
+		return err
+	}
+	return child.Close()
+}
+
 // WriteFileCreatingParents atomically writes a root-relative file, creating
 // missing parent directories inside the pinned root.
 func (r *WriteRoot) WriteFileCreatingParents(targetPath string, data []byte, perm, parentPerm os.FileMode) error {
@@ -59,7 +104,19 @@ func (r *WriteRoot) WriteFileCreatingParents(targetPath string, data []byte, per
 	if err != nil {
 		return err
 	}
-	return r.writeFileAtTarget(target, data, perm, true, parentPerm)
+	return r.writeFileAtTarget(target, data, perm, true, parentPerm, false)
+}
+
+// WriteFileReplacingParents atomically writes a root-relative file, creating
+// missing parent directories inside the pinned root. Existing regular targets
+// retain their permission bits, and Windows keeps the established fallback
+// behavior for replace-existing failures on the final file.
+func (r *WriteRoot) WriteFileReplacingParents(targetPath string, data []byte, perm, parentPerm os.FileMode) error {
+	target, err := r.resolveTarget(targetPath)
+	if err != nil {
+		return err
+	}
+	return r.writeFileAtTarget(target, data, perm, true, parentPerm, true)
 }
 
 func (r *WriteRoot) resolveTarget(targetPath string) (rootedTarget, error) {
@@ -73,7 +130,92 @@ func (r *WriteRoot) resolveTarget(targetPath string) (rootedTarget, error) {
 	return rootedTarget{rootAbs: r.rootAbs, rel: rel, abs: filepath.Join(r.rootAbs, rel)}, nil
 }
 
-func (r *WriteRoot) writeFileAtTarget(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode) (returnErr error) {
+func openExistingCanonicalWriteRoot(targetPath string, kind canonicalTargetKind) (_ *WriteRoot, rel string, err error) {
+	targetAbs, err := resolveAbsolutePath("target", targetPath)
+	if err != nil {
+		return nil, "", err
+	}
+	searchAbs, targetRelParts := canonicalWriteTargetPlan(targetAbs, kind)
+
+	volumeRoot := filepath.VolumeName(searchAbs) + string(os.PathSeparator)
+	root, err := fileSystem.OpenRootNoFollow(volumeRoot)
+	if err != nil {
+		return nil, "", fmt.Errorf("open canonical root: %w", err)
+	}
+
+	current := root
+	currentAbs := volumeRoot
+	currentOwned := true
+	defer func() {
+		if err == nil {
+			return
+		}
+		if closeErr := closeOwnedRoot(current, currentOwned); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+
+	relToSearch, err := filepath.Rel(volumeRoot, searchAbs)
+	if err != nil {
+		return nil, "", err
+	}
+	if relToSearch == "." {
+		return &WriteRoot{root: current, rootAbs: currentAbs}, joinCanonicalRelative(targetRelParts), nil
+	}
+	searchParts := strings.Split(relToSearch, string(os.PathSeparator))
+	for i, part := range searchParts {
+		if part == "" || part == "." {
+			continue
+		}
+		partAbs := filepath.Join(currentAbs, part)
+		next, nextErr := openTargetParentChild(current, part, partAbs, false, 0)
+		if os.IsNotExist(nextErr) {
+			targetRelParts = append(searchParts[i:], targetRelParts...)
+			return &WriteRoot{root: current, rootAbs: currentAbs}, joinCanonicalRelative(targetRelParts), nil
+		}
+		if nextErr != nil {
+			return nil, "", nextErr
+		}
+		if currentOwned {
+			if closeErr := current.Close(); closeErr != nil {
+				if nextCloseErr := next.Close(); nextCloseErr != nil {
+					return nil, "", errors.Join(closeErr, nextCloseErr)
+				}
+				return nil, "", closeErr
+			}
+		}
+		current = next
+		currentAbs = partAbs
+		currentOwned = true
+	}
+	return &WriteRoot{root: current, rootAbs: currentAbs}, joinCanonicalRelative(targetRelParts), nil
+}
+
+func canonicalWriteTargetPlan(targetAbs string, kind canonicalTargetKind) (string, []string) {
+	searchAbs := filepath.Clean(targetAbs)
+	targetRelParts := make([]string, 0, 8)
+	if kind == canonicalTargetFile {
+		targetRelParts = append(targetRelParts, filepath.Base(searchAbs))
+		searchAbs = filepath.Dir(searchAbs)
+	}
+	return searchAbs, targetRelParts
+}
+
+func joinCanonicalRelative(parts []string) string {
+	if len(parts) == 0 {
+		return "."
+	}
+	return filepath.Join(parts...)
+}
+
+func closeOwnedRoot(root Root, owned bool) error {
+	if !owned {
+		return nil
+	}
+	return root.Close()
+}
+
+func (r *WriteRoot) writeFileAtTarget(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode, replacing bool) (returnErr error) {
 	parent, closeParent, err := r.openTargetParent(target, createParents, parentPerm)
 	if err != nil {
 		return err
@@ -88,8 +230,12 @@ func (r *WriteRoot) writeFileAtTarget(target rootedTarget, data []byte, perm os.
 	if err := writeFileParentReadyFn(); err != nil {
 		return err
 	}
+	parentTargetRel := filepath.Base(target.rel)
+	if replacing {
+		return WriteFileReplacingWithinRoot(parent, parentTargetRel, data, perm)
+	}
 	parentTarget := target
-	parentTarget.rel = filepath.Base(target.rel)
+	parentTarget.rel = parentTargetRel
 	return writeFileAtRoot(parent, parentTarget, data, perm)
 }
 
@@ -202,7 +348,7 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 			returnErr = errors.Join(returnErr, closeErr)
 		}
 	}()
-	return root.writeFileAtTarget(target, data, perm, false, 0)
+	return root.writeFileAtTarget(target, data, perm, false, 0, false)
 }
 
 func writeFileAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -71,6 +71,20 @@ func (r *WriteRoot) Close() error {
 	return r.root.Close()
 }
 
+// Lstat reports metadata for a root-relative path under the pinned root.
+func (r *WriteRoot) Lstat(targetPath string) (fs.FileInfo, error) {
+	targetRel, err := resolveRelativeTarget(targetPath, allowRootTarget)
+	if err != nil {
+		return nil, err
+	}
+	return r.root.Lstat(targetRel)
+}
+
+// ReadFile reads a root-relative file under the pinned root.
+func (r *WriteRoot) ReadFile(targetPath string) ([]byte, error) {
+	return ReadFileWithinRoot(r.root, targetPath)
+}
+
 // EnsureDir creates targetPath as a directory under the pinned root, creating
 // missing parent directories without following symlinks.
 func (r *WriteRoot) EnsureDir(targetPath string, perm os.FileMode) (returnErr error) {
@@ -143,14 +157,12 @@ func openExistingCanonicalWriteRoot(targetPath string, kind canonicalTargetKind)
 		return nil, "", fmt.Errorf("open canonical root: %w", err)
 	}
 
-	current := root
-	currentAbs := volumeRoot
-	currentOwned := true
+	cursor := canonicalWriteRootCursor{root: root, rootAbs: volumeRoot, owned: true}
 	defer func() {
 		if err == nil {
 			return
 		}
-		if closeErr := closeOwnedRoot(current, currentOwned); closeErr != nil {
+		if closeErr := cursor.closeIfOwned(); closeErr != nil {
 			err = errors.Join(err, closeErr)
 		}
 	}()
@@ -160,35 +172,13 @@ func openExistingCanonicalWriteRoot(targetPath string, kind canonicalTargetKind)
 		return nil, "", err
 	}
 	if relToSearch == "." {
-		return &WriteRoot{root: current, rootAbs: currentAbs}, joinCanonicalRelative(targetRelParts), nil
+		return cursor.writeRoot(), joinCanonicalRelative(targetRelParts), nil
 	}
-	searchParts := strings.Split(relToSearch, string(os.PathSeparator))
-	for i, part := range searchParts {
-		if part == "" || part == "." {
-			continue
-		}
-		partAbs := filepath.Join(currentAbs, part)
-		next, nextErr := openTargetParentChild(current, part, partAbs, false, 0)
-		if os.IsNotExist(nextErr) {
-			targetRelParts = append(searchParts[i:], targetRelParts...)
-			return &WriteRoot{root: current, rootAbs: currentAbs}, joinCanonicalRelative(targetRelParts), nil
-		}
-		if nextErr != nil {
-			return nil, "", nextErr
-		}
-		if currentOwned {
-			if closeErr := current.Close(); closeErr != nil {
-				if nextCloseErr := next.Close(); nextCloseErr != nil {
-					return nil, "", errors.Join(closeErr, nextCloseErr)
-				}
-				return nil, "", closeErr
-			}
-		}
-		current = next
-		currentAbs = partAbs
-		currentOwned = true
+	targetRelParts, err = cursor.descendSearchPath(strings.Split(relToSearch, string(os.PathSeparator)), targetRelParts)
+	if err != nil {
+		return nil, "", err
 	}
-	return &WriteRoot{root: current, rootAbs: currentAbs}, joinCanonicalRelative(targetRelParts), nil
+	return cursor.writeRoot(), joinCanonicalRelative(targetRelParts), nil
 }
 
 func canonicalWriteTargetPlan(targetAbs string, kind canonicalTargetKind) (string, []string) {
@@ -213,6 +203,57 @@ func closeOwnedRoot(root Root, owned bool) error {
 		return nil
 	}
 	return root.Close()
+}
+
+type canonicalWriteRootCursor struct {
+	root    Root
+	rootAbs string
+	owned   bool
+}
+
+func (c *canonicalWriteRootCursor) writeRoot() *WriteRoot {
+	return &WriteRoot{root: c.root, rootAbs: c.rootAbs}
+}
+
+func (c *canonicalWriteRootCursor) closeIfOwned() error {
+	return closeOwnedRoot(c.root, c.owned)
+}
+
+func (c *canonicalWriteRootCursor) descendSearchPath(searchParts, targetRelParts []string) ([]string, error) {
+	for i, part := range searchParts {
+		if part == "" || part == "." {
+			continue
+		}
+
+		partAbs := filepath.Join(c.rootAbs, part)
+		next, err := openTargetParentChild(c.root, part, partAbs, false, 0)
+		if os.IsNotExist(err) {
+			return append(searchParts[i:], targetRelParts...), nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := c.replace(next, partAbs); err != nil {
+			return nil, err
+		}
+	}
+	return targetRelParts, nil
+}
+
+func (c *canonicalWriteRootCursor) replace(next Root, nextAbs string) error {
+	if c.owned {
+		if closeErr := c.root.Close(); closeErr != nil {
+			if nextCloseErr := next.Close(); nextCloseErr != nil {
+				return errors.Join(closeErr, nextCloseErr)
+			}
+			return closeErr
+		}
+	}
+
+	c.root = next
+	c.rootAbs = nextAbs
+	c.owned = true
+	return nil
 }
 
 func (r *WriteRoot) writeFileAtTarget(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode, replacing bool) (returnErr error) {

--- a/internal/safeio/write_other_test.go
+++ b/internal/safeio/write_other_test.go
@@ -69,3 +69,45 @@ func TestWriteFileReplacingUnderReplacesReadOnlyExistingRegularFileOnNonWindows(
 		t.Fatalf("expected existing read-only mode 0444 to be preserved, got %#o", info.Mode().Perm())
 	}
 }
+
+func TestWriteRootReplacingParentsReplacesReadOnlyExistingRegularFileOnNonWindows(t *testing.T) {
+	rootDir := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+	targetPath := filepath.Join("nested", writeTestFileName)
+	targetAbs := filepath.Join(rootDir, targetPath)
+	if err := os.MkdirAll(filepath.Dir(targetAbs), 0o750); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	if err := os.WriteFile(targetAbs, []byte("before"), 0o444); err != nil {
+		t.Fatalf("seed target file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(targetAbs, 0o600); err != nil && !os.IsNotExist(err) {
+			t.Errorf("restore target file permissions: %v", err)
+		}
+	})
+
+	probe, probeErr := os.OpenFile(targetAbs, os.O_WRONLY, 0)
+	if probeErr == nil {
+		if err := probe.Close(); err != nil {
+			t.Fatalf("close writability probe: %v", err)
+		}
+		t.Skip("effective privileges bypass read-only file permissions")
+	}
+	if !os.IsPermission(probeErr) {
+		t.Skipf("read-only file semantics are not testable: %v", probeErr)
+	}
+
+	if err := root.WriteFileReplacingParents(targetPath, []byte("after"), 0o600, 0o750); err != nil {
+		t.Fatalf("WriteFileReplacingParents returned error: %v", err)
+	}
+
+	assertFileContent(t, targetAbs, "after")
+	info, err := os.Stat(targetAbs)
+	if err != nil {
+		t.Fatalf("stat replaced file: %v", err)
+	}
+	if info.Mode().Perm() != 0o444 {
+		t.Fatalf("expected existing read-only mode 0444 to be preserved, got %#o", info.Mode().Perm())
+	}
+}

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -119,6 +119,24 @@ func changedDirectoryTestRoot(t *testing.T) (*fakeRoot, *bool) {
 	return root, &childClosed
 }
 
+func withSameDeviceFileInfoFn(t *testing.T, fn func(Root, Root, fs.FileInfo, fs.FileInfo) bool) {
+	t.Helper()
+	previous := sameDeviceFileInfoFn
+	sameDeviceFileInfoFn = fn
+	t.Cleanup(func() {
+		sameDeviceFileInfoFn = previous
+	})
+}
+
+func withSameDeviceIdentitySupportedFn(t *testing.T, fn func() bool) {
+	t.Helper()
+	previous := sameDeviceIdentitySupportedFn
+	sameDeviceIdentitySupportedFn = fn
+	t.Cleanup(func() {
+		sameDeviceIdentitySupportedFn = previous
+	})
+}
+
 type writeRootFileFunc func(*WriteRoot, string, []byte, os.FileMode, os.FileMode) error
 
 func assertWriteRootRejectsParent(t *testing.T, root *WriteRoot, write writeRootFileFunc, wantError, failureMessage string) {
@@ -796,6 +814,35 @@ func TestOpenExistingCanonicalWriteRootRejectsSymlinkAncestor(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(outside, "nested", writeTestFileName)); !os.IsNotExist(statErr) {
 		t.Fatalf("expected no outside file writes, stat err=%v", statErr)
+	}
+}
+
+func TestOpenExistingCanonicalWriteRootRejectsDeviceBoundary(t *testing.T) {
+	withSameDeviceFileInfoFn(t, func(Root, Root, fs.FileInfo, fs.FileInfo) bool { return false })
+
+	dirInfo := statTestPath(t, t.TempDir())
+	withFileSystem(t, &fakeFileSystem{
+		abs: func(path string) (string, error) { return filepath.Clean(path), nil },
+		openRootNoFollow: func(string) (Root, error) {
+			return &fakeRoot{
+				lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+				openRoot: func(string) (Root, error) {
+					return &fakeRoot{
+						lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+						close: closeWithoutError,
+					}, nil
+				},
+				close: closeWithoutError,
+			}, nil
+		},
+	})
+
+	root, rel, err := OpenExistingCanonicalWriteRoot(filepath.Join(string(os.PathSeparator), "repo", writeTestFileName), false)
+	if root != nil || rel != "" {
+		t.Fatalf("expected rejected canonical write root, got root=%v rel=%q", root, rel)
+	}
+	if err == nil || !strings.Contains(err.Error(), "device boundary") {
+		t.Fatalf("expected device-boundary error, got %v", err)
 	}
 }
 
@@ -1507,6 +1554,29 @@ func TestWriteRootEnsureDirRejectsSymlinkTarget(t *testing.T) {
 	}
 }
 
+func TestWriteRootEnsureDirRejectsDeviceBoundary(t *testing.T) {
+	withSameDeviceFileInfoFn(t, func(Root, Root, fs.FileInfo, fs.FileInfo) bool { return false })
+
+	dirInfo := statTestPath(t, t.TempDir())
+	root := &WriteRoot{
+		root: &fakeRoot{
+			lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+			openRoot: func(string) (Root, error) {
+				return &fakeRoot{
+					lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+					close: closeWithoutError,
+				}, nil
+			},
+		},
+		rootAbs: ".",
+	}
+
+	err := root.EnsureDir(filepath.Join("reports", "nested"), 0o750)
+	if err == nil || !strings.Contains(err.Error(), "device boundary") {
+		t.Fatalf("expected device-boundary ensure-dir error, got %v", err)
+	}
+}
+
 func TestOpenTargetParentChildPropagatesOpenError(t *testing.T) {
 	dirInfo := statTestPath(t, t.TempDir())
 	expectedErr := errors.New("parent open failure")
@@ -1569,6 +1639,36 @@ func TestOpenTargetParentChildRejectsChangedDirectory(t *testing.T) {
 	}
 }
 
+func TestOpenTargetParentChildRejectsDeviceBoundary(t *testing.T) {
+	withSameDeviceFileInfoFn(t, func(Root, Root, fs.FileInfo, fs.FileInfo) bool { return false })
+
+	dirInfo := statTestPath(t, t.TempDir())
+	childClosed := false
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) {
+			return &fakeRoot{
+				lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+				close: func() error {
+					childClosed = true
+					return nil
+				},
+			}, nil
+		},
+	}
+
+	opened, err := openTargetParentChild(root, "parent", "/root/parent", false, 0)
+	if opened != nil {
+		t.Fatal("expected device-boundary parent root rejection")
+	}
+	if err == nil || !strings.Contains(err.Error(), "device boundary") {
+		t.Fatalf("expected device-boundary error, got %v", err)
+	}
+	if !childClosed {
+		t.Fatal("expected rejected device-boundary root to be closed")
+	}
+}
+
 func TestLstatOrCreateDirectoryPropagatesMkdirError(t *testing.T) {
 	expectedErr := errors.New("mkdir parent failure")
 	root := &fakeRoot{
@@ -1619,6 +1719,29 @@ func TestOpenTargetParentClosesOwnedParentAfterDescendantError(t *testing.T) {
 	}
 	if !ownedClosed {
 		t.Fatal("expected owned parent root to be closed")
+	}
+}
+
+func TestOpenRelativeWriteRootRejectsDeviceBoundary(t *testing.T) {
+	withSameDeviceFileInfoFn(t, func(Root, Root, fs.FileInfo, fs.FileInfo) bool { return false })
+
+	dirInfo := statTestPath(t, t.TempDir())
+	parent := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) {
+			return &fakeRoot{
+				lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+				close: closeWithoutError,
+			}, nil
+		},
+	}
+
+	opened, err := OpenRelativeWriteRoot(parent, "child", false, 0)
+	if opened != nil {
+		t.Fatal("expected device-boundary relative write root rejection")
+	}
+	if err == nil || !strings.Contains(err.Error(), "device boundary") {
+		t.Fatalf("expected device-boundary error, got %v", err)
 	}
 }
 

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -747,6 +747,36 @@ func TestOpenExistingCanonicalWriteRootJoinsOwnedAndNextCloseErrors(t *testing.T
 	}
 }
 
+func TestOpenExistingCanonicalWriteRootReturnsOwnedCloseError(t *testing.T) {
+	dirInfo := statTestPath(t, t.TempDir())
+	closeErr := errors.New("owned close failure")
+	next := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		close: closeWithoutError,
+	}
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) {
+			return next, nil
+		},
+		close: func() error { return closeErr },
+	}
+	withFileSystem(t, &fakeFileSystem{
+		abs: func(path string) (string, error) { return filepath.Clean(path), nil },
+		openRootNoFollow: func(string) (Root, error) {
+			return root, nil
+		},
+	})
+
+	opened, rel, err := OpenExistingCanonicalWriteRoot(filepath.Join(string(os.PathSeparator), "repo", "file.txt"), false)
+	if opened != nil || rel != "" {
+		t.Fatalf("expected nil root and empty rel on close failure, got root=%v rel=%q", opened, rel)
+	}
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("expected owned close error, got %v", err)
+	}
+}
+
 func TestOpenExistingCanonicalWriteRootRejectsSymlinkAncestor(t *testing.T) {
 	rootDir := t.TempDir()
 	outside := t.TempDir()
@@ -766,6 +796,70 @@ func TestOpenExistingCanonicalWriteRootRejectsSymlinkAncestor(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(outside, "nested", writeTestFileName)); !os.IsNotExist(statErr) {
 		t.Fatalf("expected no outside file writes, stat err=%v", statErr)
+	}
+}
+
+func TestOpenExistingCanonicalWriteRootReturnsVolumeRelativeFileAtRoot(t *testing.T) {
+	volumeRoot := filepath.VolumeName(t.TempDir()) + string(os.PathSeparator)
+	targetPath := filepath.Join(volumeRoot, writeTestFileName)
+
+	root, rel, err := OpenExistingCanonicalWriteRoot(targetPath, false)
+	if err != nil {
+		t.Fatalf("OpenExistingCanonicalWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close canonical write root: %v", closeErr)
+		}
+	})
+
+	if rel != writeTestFileName {
+		t.Fatalf("expected root-relative file name %q, got %q", writeTestFileName, rel)
+	}
+}
+
+func TestWriteRootLstatUsesRootRelativePath(t *testing.T) {
+	rootDir := t.TempDir()
+	targetPath := filepath.Join(rootDir, writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("before"), 0o600); err != nil {
+		t.Fatalf("seed target file: %v", err)
+	}
+
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+	info, err := root.Lstat(writeTestFileName)
+	if err != nil {
+		t.Fatalf("WriteRoot.Lstat returned error: %v", err)
+	}
+	if info.Name() != writeTestFileName {
+		t.Fatalf("expected file info for %q, got %q", writeTestFileName, info.Name())
+	}
+}
+
+func TestWriteRootLstatRejectsEscapingPath(t *testing.T) {
+	root := openTestWriteRoot(t, t.TempDir(), OpenWriteRoot)
+
+	info, err := root.Lstat(filepath.Join("..", writeTestFileName))
+	if info != nil {
+		t.Fatalf("expected no file info for escaping path, got %v", info)
+	}
+	if err == nil || !strings.Contains(err.Error(), "path escapes root") {
+		t.Fatalf("expected root escape rejection, got %v", err)
+	}
+}
+
+func TestWriteRootReadFileReadsRootRelativeFile(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootDir, writeTestFileName), []byte("root-relative"), 0o600); err != nil {
+		t.Fatalf("seed target file: %v", err)
+	}
+
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+	data, err := root.ReadFile(writeTestFileName)
+	if err != nil {
+		t.Fatalf("WriteRoot.ReadFile returned error: %v", err)
+	}
+	if string(data) != "root-relative" {
+		t.Fatalf("unexpected root-relative file contents: %q", string(data))
 	}
 }
 

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -119,12 +119,127 @@ func changedDirectoryTestRoot(t *testing.T) (*fakeRoot, *bool) {
 	return root, &childClosed
 }
 
-func assertWriteRootRejectsParent(t *testing.T, root *WriteRoot, wantError, failureMessage string) {
+type writeRootFileFunc func(*WriteRoot, string, []byte, os.FileMode, os.FileMode) error
+
+func assertWriteRootRejectsParent(t *testing.T, root *WriteRoot, write writeRootFileFunc, wantError, failureMessage string) {
 	t.Helper()
-	err := root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
+	err := write(root, filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
 	if err == nil || !strings.Contains(err.Error(), wantError) {
 		t.Fatalf("%s, got %v", failureMessage, err)
 	}
+}
+
+func writeRootCreatingParents(root *WriteRoot, targetPath string, data []byte, perm, parentPerm os.FileMode) error {
+	return root.WriteFileCreatingParents(targetPath, data, perm, parentPerm)
+}
+
+func writeRootReplacingParents(root *WriteRoot, targetPath string, data []byte, perm, parentPerm os.FileMode) error {
+	return root.WriteFileReplacingParents(targetPath, data, perm, parentPerm)
+}
+
+func assertWriteRootDoesNotCreateOutsideAfterMissingParentSwap(t *testing.T, write writeRootFileFunc, writeName string) {
+	t.Helper()
+	rootDir := t.TempDir()
+	outside := t.TempDir()
+	outsideSentinel := filepath.Join(outside, "sentinel.txt")
+	if err := os.WriteFile(outsideSentinel, []byte("outside-before"), 0o600); err != nil {
+		t.Fatalf("seed outside sentinel: %v", err)
+	}
+
+	withFileSystem(t, &fakeFileSystem{openRoot: func(name string) (Root, error) {
+		root, err := (&osFileSystem{}).OpenRoot(name)
+		if err != nil {
+			return nil, err
+		}
+		return &fakeRoot{
+			Root: root,
+			mkdir: func(path string, perm os.FileMode) error {
+				if err := os.Symlink(outside, filepath.Join(rootDir, "reports")); err != nil {
+					return err
+				}
+				return root.Mkdir(path, perm)
+			},
+		}, nil
+	}})
+
+	root, err := OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("OpenWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+
+	err = write(root, filepath.Join("reports", "nested", writeTestFileName), []byte("after"), 0o600, 0o750)
+	if err == nil {
+		t.Fatalf("%s: expected swapped parent symlink to be rejected", writeName)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "nested")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside nested directory to remain absent, got err=%v", statErr)
+	}
+	data, readErr := os.ReadFile(outsideSentinel)
+	if readErr != nil {
+		t.Fatalf("read outside sentinel: %v", readErr)
+	}
+	if string(data) != "outside-before" {
+		t.Fatalf("unexpected outside sentinel: %q", string(data))
+	}
+}
+
+func assertWriteRootPinsParentBeforeInRootSymlinkRetarget(t *testing.T, write writeRootFileFunc, writeName string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("directory replacement semantics are covered on Unix")
+	}
+
+	rootDir := t.TempDir()
+	originalParent := filepath.Join(rootDir, "reports")
+	relocatedParent := filepath.Join(rootDir, "reports-relocated")
+	redirectedParent := filepath.Join(rootDir, "redirected")
+	if err := os.MkdirAll(originalParent, 0o755); err != nil {
+		t.Fatalf("mkdir original parent: %v", err)
+	}
+	if err := os.MkdirAll(redirectedParent, 0o755); err != nil {
+		t.Fatalf("mkdir redirected parent: %v", err)
+	}
+	originalTarget := filepath.Join(originalParent, writeTestFileName)
+	redirectedTarget := filepath.Join(redirectedParent, writeTestFileName)
+	if err := os.WriteFile(originalTarget, []byte("original-before"), 0o600); err != nil {
+		t.Fatalf("seed original target: %v", err)
+	}
+	if err := os.WriteFile(redirectedTarget, []byte("redirected-before"), 0o600); err != nil {
+		t.Fatalf("seed redirected target: %v", err)
+	}
+
+	originalReady := writeFileParentReadyFn
+	writeFileParentReadyFn = func() error {
+		if err := os.Rename(originalParent, relocatedParent); err != nil {
+			return err
+		}
+		return os.Symlink(filepath.Base(redirectedParent), originalParent)
+	}
+	t.Cleanup(func() {
+		writeFileParentReadyFn = originalReady
+	})
+
+	root, err := OpenWriteRoot(rootDir)
+	if err != nil {
+		t.Fatalf("OpenWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+
+	err = write(root, filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
+	if err != nil {
+		t.Fatalf("%s returned error: %v", writeName, err)
+	}
+	assertFileContent(t, filepath.Join(relocatedParent, writeTestFileName), "after")
+	assertFileContent(t, redirectedTarget, "redirected-before")
 }
 
 func assertPreservedExistingRegularFileMode(t *testing.T, write func(rootDir, targetPath string, data []byte) error, writeName string) {
@@ -512,6 +627,145 @@ func TestOpenCanonicalWriteRootWrapsOpenError(t *testing.T) {
 	}
 	if !errors.Is(err, expectedErr) || !strings.Contains(err.Error(), "open canonical root") {
 		t.Fatalf("expected wrapped canonical open error, got %v", err)
+	}
+}
+
+func TestOpenExistingCanonicalWriteRootWritesBeneathDeepestExistingAncestor(t *testing.T) {
+	rootDir := filepath.Join(t.TempDir(), "repo")
+	existingDir := filepath.Join(rootDir, "existing")
+	if err := os.MkdirAll(existingDir, 0o755); err != nil {
+		t.Fatalf("mkdir existing ancestor: %v", err)
+	}
+	canonicalExistingDir, err := filepath.EvalSymlinks(existingDir)
+	if err != nil {
+		t.Fatalf("resolve existing ancestor: %v", err)
+	}
+
+	root, rel, err := OpenExistingCanonicalWriteRoot(filepath.Join(canonicalExistingDir, "nested", writeTestFileName), false)
+	if err != nil {
+		t.Fatalf("open existing canonical write root: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+	if rel != filepath.Join("nested", writeTestFileName) {
+		t.Fatalf("unexpected relative target: %q", rel)
+	}
+	if err := root.WriteFileCreatingParents(rel, []byte("hello"), 0o600, 0o750); err != nil {
+		t.Fatalf("write beneath existing ancestor: %v", err)
+	}
+	assertFileContent(t, filepath.Join(canonicalExistingDir, "nested", writeTestFileName), "hello")
+}
+
+func TestOpenExistingCanonicalWriteRootReturnsDotForExistingDirectoryTarget(t *testing.T) {
+	existingDir := filepath.Join(t.TempDir(), "existing")
+	if err := os.MkdirAll(existingDir, 0o755); err != nil {
+		t.Fatalf("mkdir existing target: %v", err)
+	}
+	canonicalExistingDir, err := filepath.EvalSymlinks(existingDir)
+	if err != nil {
+		t.Fatalf("resolve existing target: %v", err)
+	}
+
+	root, rel, err := OpenExistingCanonicalWriteRoot(canonicalExistingDir, true)
+	if err != nil {
+		t.Fatalf("open existing canonical directory root: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+	if rel != "." {
+		t.Fatalf("expected existing directory target to resolve to dot, got %q", rel)
+	}
+}
+
+func TestOpenExistingCanonicalWriteRootPropagatesResolutionError(t *testing.T) {
+	expectedErr := errors.New("existing canonical abs failure")
+	withFileSystem(t, &fakeFileSystem{abs: func(string) (string, error) {
+		return "", expectedErr
+	}})
+
+	root, rel, err := OpenExistingCanonicalWriteRoot("target", true)
+	if root != nil || rel != "" {
+		t.Fatalf("expected nil root and empty rel on resolution failure, got root=%v rel=%q", root, rel)
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected resolution error, got %v", err)
+	}
+}
+
+func TestOpenExistingCanonicalWriteRootWrapsCanonicalRootOpenError(t *testing.T) {
+	expectedErr := errors.New("existing canonical open failure")
+	withFileSystem(t, &fakeFileSystem{
+		abs: func(path string) (string, error) { return filepath.Clean(path), nil },
+		openRootNoFollow: func(string) (Root, error) {
+			return nil, expectedErr
+		},
+	})
+
+	root, rel, err := OpenExistingCanonicalWriteRoot(filepath.Join(string(os.PathSeparator), "target"), true)
+	if root != nil || rel != "" {
+		t.Fatalf("expected nil root and empty rel on canonical open failure, got root=%v rel=%q", root, rel)
+	}
+	if !errors.Is(err, expectedErr) || !strings.Contains(err.Error(), "open canonical root") {
+		t.Fatalf("expected wrapped canonical open error, got %v", err)
+	}
+}
+
+func TestOpenExistingCanonicalWriteRootJoinsOwnedAndNextCloseErrors(t *testing.T) {
+	dirInfo := statTestPath(t, t.TempDir())
+	closeErr := errors.New("owned close failure")
+	nextCloseErr := errors.New("next close failure")
+	next := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		close: func() error { return nextCloseErr },
+	}
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return dirInfo, nil },
+		openRoot: func(string) (Root, error) {
+			return next, nil
+		},
+		close: func() error { return closeErr },
+	}
+	withFileSystem(t, &fakeFileSystem{
+		abs: func(path string) (string, error) { return filepath.Clean(path), nil },
+		openRootNoFollow: func(string) (Root, error) {
+			return root, nil
+		},
+	})
+
+	opened, rel, err := OpenExistingCanonicalWriteRoot(filepath.Join(string(os.PathSeparator), "repo", "file.txt"), false)
+	if opened != nil || rel != "" {
+		t.Fatalf("expected nil root and empty rel on close failure, got root=%v rel=%q", opened, rel)
+	}
+	if !errors.Is(err, closeErr) || !errors.Is(err, nextCloseErr) {
+		t.Fatalf("expected joined close errors, got %v", err)
+	}
+}
+
+func TestOpenExistingCanonicalWriteRootRejectsSymlinkAncestor(t *testing.T) {
+	rootDir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(rootDir, "escape")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	root, rel, err := OpenExistingCanonicalWriteRoot(filepath.Join(rootDir, "escape", "nested", writeTestFileName), false)
+	if root != nil {
+		t.Fatal("expected rejected write root to remain nil")
+	}
+	if rel != "" {
+		t.Fatalf("expected empty relative path, got %q", rel)
+	}
+	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
+		t.Fatalf("expected symlink ancestor rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "nested", writeTestFileName)); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no outside file writes, stat err=%v", statErr)
 	}
 }
 
@@ -1091,7 +1345,7 @@ func TestWriteRootRejectsSymlinkedParent(t *testing.T) {
 		t.Fatalf("create reports symlink: %v", err)
 	}
 	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
-	assertWriteRootRejectsParent(t, root, "output parent contains symlink", "expected symlinked parent rejection")
+	assertWriteRootRejectsParent(t, root, writeRootCreatingParents, "output parent contains symlink", "expected symlinked parent rejection")
 	data, readErr := os.ReadFile(outsideTarget)
 	if readErr != nil {
 		t.Fatalf("read outside target: %v", readErr)
@@ -1107,7 +1361,56 @@ func TestWriteRootRejectsNonDirectoryParent(t *testing.T) {
 		t.Fatalf("write non-directory parent: %v", err)
 	}
 	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
-	assertWriteRootRejectsParent(t, root, "output parent is not a directory", "expected non-directory parent rejection")
+	assertWriteRootRejectsParent(t, root, writeRootCreatingParents, "output parent is not a directory", "expected non-directory parent rejection")
+}
+
+func TestWriteRootEnsureDirCreatesMissingNestedDirectory(t *testing.T) {
+	rootDir := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	if err := root.EnsureDir(filepath.Join("reports", "nested"), 0o750); err != nil {
+		t.Fatalf("EnsureDir returned error: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(rootDir, "reports", "nested"))
+	if err != nil {
+		t.Fatalf("stat ensured directory: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected ensured path to be a directory")
+	}
+}
+
+func TestWriteRootEnsureDirRejectsAbsoluteTarget(t *testing.T) {
+	root := openTestWriteRoot(t, t.TempDir(), OpenWriteRoot)
+	if err := root.EnsureDir(filepath.Join(string(os.PathSeparator), "absolute"), 0o750); err == nil {
+		t.Fatalf("expected absolute ensure target to be rejected")
+	}
+}
+
+func TestWriteRootEnsureDirPropagatesParentError(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rootDir, "reports"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write non-directory parent: %v", err)
+	}
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	err := root.EnsureDir(filepath.Join("reports", "nested"), 0o750)
+	if err == nil || !strings.Contains(err.Error(), "output parent is not a directory") {
+		t.Fatalf("expected parent error, got %v", err)
+	}
+}
+
+func TestWriteRootEnsureDirRejectsSymlinkTarget(t *testing.T) {
+	rootDir := t.TempDir()
+	if err := os.Symlink(t.TempDir(), filepath.Join(rootDir, "reports")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	err := root.EnsureDir("reports", 0o750)
+	if err == nil || !strings.Contains(err.Error(), "output parent contains symlink") {
+		t.Fatalf("expected symlink target rejection, got %v", err)
+	}
 }
 
 func TestOpenTargetParentChildPropagatesOpenError(t *testing.T) {
@@ -1225,20 +1528,35 @@ func TestOpenTargetParentClosesOwnedParentAfterDescendantError(t *testing.T) {
 	}
 }
 
-func TestOpenTargetParentReturnsExistingRootForTopLevelTarget(t *testing.T) {
+func TestWriteRootOpenTargetParentReturnsRootForTopLevelTarget(t *testing.T) {
 	root := &fakeRoot{}
 	writeRoot := &WriteRoot{root: root, rootAbs: "/root"}
 	target := rootedTarget{rootAbs: "/root", rel: writeTestFileName}
 
 	parent, closeParent, err := writeRoot.openTargetParent(target, false, 0)
 	if err != nil {
-		t.Fatalf("expected top-level target parent lookup to succeed, got %v", err)
+		t.Fatalf("openTargetParent returned error: %v", err)
 	}
 	if parent != root {
 		t.Fatalf("expected top-level target to reuse the write root, got %#v", parent)
 	}
 	if closeParent {
 		t.Fatal("expected top-level target parent to remain caller-owned")
+	}
+}
+
+func TestCloseOwnedRootSkipsUnownedRoot(t *testing.T) {
+	closed := false
+	root := &fakeRoot{close: func() error {
+		closed = true
+		return nil
+	}}
+
+	if err := closeOwnedRoot(root, false); err != nil {
+		t.Fatalf("closeOwnedRoot returned error: %v", err)
+	}
+	if closed {
+		t.Fatalf("expected unowned root close to be skipped")
 	}
 }
 
@@ -1308,7 +1626,7 @@ func TestWriteFileAtTargetJoinsReadyAndParentCloseErrors(t *testing.T) {
 		writeFileParentReadyFn = originalReady
 	})
 
-	err := writeRoot.writeFileAtTarget(target, []byte("data"), 0o600, false, 0)
+	err := writeRoot.writeFileAtTarget(target, []byte("data"), 0o600, false, 0, false)
 	if !errors.Is(err, readyErr) || !errors.Is(err, closeErr) {
 		t.Fatalf("expected joined ready and close errors, got %v", err)
 	}
@@ -1371,106 +1689,36 @@ func TestResolvedWriteFilePermPropagatesLookupError(t *testing.T) {
 }
 
 func TestWriteRootDoesNotCreateOutsideAfterMissingParentSwap(t *testing.T) {
+	assertWriteRootDoesNotCreateOutsideAfterMissingParentSwap(t, writeRootCreatingParents, "WriteFileCreatingParents")
+}
+
+func TestWriteRootReplacingParentsDoesNotCreateOutsideAfterMissingParentSwap(t *testing.T) {
+	assertWriteRootDoesNotCreateOutsideAfterMissingParentSwap(t, writeRootReplacingParents, "WriteFileReplacingParents")
+}
+
+func TestWriteRootReplacingParentsRejectsPathTraversalOutsideRoot(t *testing.T) {
 	rootDir := t.TempDir()
-	outside := t.TempDir()
-	outsideSentinel := filepath.Join(outside, "sentinel.txt")
-	if err := os.WriteFile(outsideSentinel, []byte("outside-before"), 0o600); err != nil {
-		t.Fatalf("seed outside sentinel: %v", err)
-	}
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+	outsidePath := filepath.Join(rootDir, "..", "outside.txt")
 
-	withFileSystem(t, &fakeFileSystem{openRoot: func(name string) (Root, error) {
-		root, err := (&osFileSystem{}).OpenRoot(name)
-		if err != nil {
-			return nil, err
-		}
-		return &fakeRoot{
-			Root: root,
-			mkdir: func(path string, perm os.FileMode) error {
-				if err := os.Symlink(outside, filepath.Join(rootDir, "reports")); err != nil {
-					return err
-				}
-				return root.Mkdir(path, perm)
-			},
-		}, nil
-	}})
-
-	root, err := OpenWriteRoot(rootDir)
-	if err != nil {
-		t.Fatalf("OpenWriteRoot returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
-			t.Errorf("close write root: %v", closeErr)
-		}
-	})
-
-	err = root.WriteFileCreatingParents(filepath.Join("reports", "nested", writeTestFileName), []byte("after"), 0o600, 0o750)
+	err := root.WriteFileReplacingParents(filepath.Join("..", "outside.txt"), []byte("secret"), 0o600, 0o750)
 	if err == nil {
-		t.Fatal("expected swapped parent symlink to be rejected")
+		t.Fatal("expected relative traversal rejection")
 	}
-	if _, statErr := os.Stat(filepath.Join(outside, "nested")); !os.IsNotExist(statErr) {
-		t.Fatalf("expected outside nested directory to remain absent, got err=%v", statErr)
+	if !strings.Contains(err.Error(), escapesRootErr) {
+		t.Fatalf(unexpectedErrFmt, err)
 	}
-	data, readErr := os.ReadFile(outsideSentinel)
-	if readErr != nil {
-		t.Fatalf("read outside sentinel: %v", readErr)
-	}
-	if string(data) != "outside-before" {
-		t.Fatalf("unexpected outside sentinel: %q", string(data))
+	if _, statErr := os.Stat(outsidePath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside file to remain absent, got err=%v", statErr)
 	}
 }
 
 func TestWriteRootPinsParentBeforeInRootSymlinkRetarget(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("directory replacement semantics are covered on Unix")
-	}
+	assertWriteRootPinsParentBeforeInRootSymlinkRetarget(t, writeRootCreatingParents, "WriteFileCreatingParents")
+}
 
-	rootDir := t.TempDir()
-	originalParent := filepath.Join(rootDir, "reports")
-	relocatedParent := filepath.Join(rootDir, "reports-relocated")
-	redirectedParent := filepath.Join(rootDir, "redirected")
-	if err := os.MkdirAll(originalParent, 0o755); err != nil {
-		t.Fatalf("mkdir original parent: %v", err)
-	}
-	if err := os.MkdirAll(redirectedParent, 0o755); err != nil {
-		t.Fatalf("mkdir redirected parent: %v", err)
-	}
-	originalTarget := filepath.Join(originalParent, writeTestFileName)
-	redirectedTarget := filepath.Join(redirectedParent, writeTestFileName)
-	if err := os.WriteFile(originalTarget, []byte("original-before"), 0o600); err != nil {
-		t.Fatalf("seed original target: %v", err)
-	}
-	if err := os.WriteFile(redirectedTarget, []byte("redirected-before"), 0o600); err != nil {
-		t.Fatalf("seed redirected target: %v", err)
-	}
-
-	originalReady := writeFileParentReadyFn
-	writeFileParentReadyFn = func() error {
-		if err := os.Rename(originalParent, relocatedParent); err != nil {
-			return err
-		}
-		return os.Symlink(filepath.Base(redirectedParent), originalParent)
-	}
-	t.Cleanup(func() {
-		writeFileParentReadyFn = originalReady
-	})
-
-	root, err := OpenWriteRoot(rootDir)
-	if err != nil {
-		t.Fatalf("OpenWriteRoot returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
-			t.Errorf("close write root: %v", closeErr)
-		}
-	})
-
-	err = root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
-	if err != nil {
-		t.Fatalf("WriteFileCreatingParents returned error: %v", err)
-	}
-	assertFileContent(t, filepath.Join(relocatedParent, writeTestFileName), "after")
-	assertFileContent(t, redirectedTarget, "redirected-before")
+func TestWriteRootReplacingParentsPinsParentBeforeInRootSymlinkRetarget(t *testing.T) {
+	assertWriteRootPinsParentBeforeInRootSymlinkRetarget(t, writeRootReplacingParents, "WriteFileReplacingParents")
 }
 
 func TestWriteFileUnderRejectsRootPathTarget(t *testing.T) {
@@ -1932,11 +2180,7 @@ func TestOpenPinnedReplacementTargetReturnsOpenError(t *testing.T) {
 }
 
 func TestOpenPinnedReplacementTargetReturnsOpenedFile(t *testing.T) {
-	targetPath := filepath.Join(t.TempDir(), "target")
-	if err := os.WriteFile(targetPath, []byte("target"), 0o600); err != nil {
-		t.Fatalf("seed pinned target: %v", err)
-	}
-	expectedInfo := statTestPath(t, targetPath)
+	expectedInfo, _ := writePinnedTargetInfoPair(t)
 	root := &fakeRoot{
 		openFile: func(string, int, os.FileMode) (File, error) {
 			return &fakeFile{
@@ -1948,13 +2192,13 @@ func TestOpenPinnedReplacementTargetReturnsOpenedFile(t *testing.T) {
 
 	file, err := openPinnedReplacementTarget(root, writeTestFileName, expectedInfo)
 	if err != nil {
-		t.Fatalf("expected pinned target open success, got %v", err)
+		t.Fatalf("expected opened file, got %v", err)
 	}
 	if file == nil {
-		t.Fatal("expected opened pinned target file")
+		t.Fatal("expected pinned replacement file")
 	}
 	if closeErr := file.Close(); closeErr != nil {
-		t.Fatalf("close opened pinned target: %v", closeErr)
+		t.Fatalf("close pinned replacement file: %v", closeErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

Confine caller-supplied MCP cache paths to the trusted repository root before any cache directory or artifact is written. The resolved cache location is pinned so symlink retargeting and parent replacement cannot redirect later writes.

## Changes

- Validate explicit MCP cache paths against the trusted repository root, including traversal and symlink ancestors.
- Carry the pinned cache root through analysis and MCP mutation flows.
- Preserve supported external cache paths for direct CLI analyses.
- Add confined atomic-write helpers that reject parent swaps, symlink targets, and path traversal.
- Add deterministic regression coverage for outside-root writes, scoped cache reuse, and symlink-retarget races.

## Validation

Commands and checks run:

```bash
make ci
go test -count=1 ./internal/analysis ./internal/app ./internal/mcp ./internal/safeio
go test -race -count=1 ./internal/analysis ./internal/mcp ./internal/safeio
```

Additional validation:

- Full CI and the commit hook both passed with 98.2% total coverage and every included package at or above 98%.
- Memory benchmark gate passed with no regression.
- New-code duplication was 0.00%.
- Post-rebase focused tests and race tests passed.

Regression-Test: ./internal/mcp::TestCallAnalyseDependencyRejectsCachePathOutsideRepo
Regression-Test: ./internal/mcp::TestCallAnalyseDependencyRejectsSymlinkedCachePathEscape

## Risk and compatibility

- Breaking changes: Caller-supplied MCP writable cache paths outside the trusted repository root are rejected.
- Migration required: Move an MCP cache path beneath the analysed repository root or disable MCP cache writes.
- Direct CLI analyses retain support for explicit external cache paths.
- Performance impact: Negligible path-validation work at cache setup.
- Memory benchmark impact: None observed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #1219
