### PR TITLE
fix(mcp): force analysis cache read-only

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -432,7 +432,8 @@ func TestCallAnalyseTopRejectsInitializedTraversalShapedOutsideCachePath(t *test
 		t.Fatalf("mkdir objects: %v", err)
 	}
 	testutil.MustWriteFile(t, filepath.Join(outsideCache, "sentinel.txt"), "keep\n")
-	traversalPath := filepath.Join(repo, "..", "outside", "cache")
+	separator := string(os.PathSeparator)
+	traversalPath := repo + separator + ".." + separator + "outside" + separator + "cache"
 	server := NewServer(Options{Analyzer: analysis.NewService()})
 
 	result := callToolResult(t, server, toolAnalyseTop, map[string]any{

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -395,10 +395,13 @@ func TestCallCompareBaselineAppliesBaselineDiff(t *testing.T) {
 }
 
 func TestCallAnalyseTopForcesReadOnlyCacheAndLeavesOutsidePathAbsent(t *testing.T) {
-	repo := t.TempDir()
+	repoRoot, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp root: %v", err)
+	}
+	repo := filepath.Join(repoRoot, "repo")
 	writeMCPJSFixture(t, repo)
-	outsideRoot := t.TempDir()
-	outsideCache := filepath.Join(outsideRoot, "outside-cache")
+	outsideCache := filepath.Join(repoRoot, "outside-cache")
 	server := NewServer(Options{Analyzer: analysis.NewService()})
 
 	result := callToolResult(t, server, toolAnalyseTop, map[string]any{
@@ -417,6 +420,54 @@ func TestCallAnalyseTopForcesReadOnlyCacheAndLeavesOutsidePathAbsent(t *testing.
 	}
 	if _, err := os.Stat(outsideCache); !os.IsNotExist(err) {
 		t.Fatalf("expected outside cache path to remain absent, got err=%v", err)
+	}
+}
+
+func TestCallAnalyseTopUsesInitializedCacheReadOnly(t *testing.T) {
+	repoRoot, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp root: %v", err)
+	}
+	repo := filepath.Join(repoRoot, "repo")
+	writeMCPJSFixture(t, repo)
+	cachePath := filepath.Join(repoRoot, "cache")
+	for _, dirName := range []string{"keys", "objects"} {
+		if err := os.MkdirAll(filepath.Join(cachePath, dirName), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dirName, err)
+		}
+	}
+	testutil.MustWriteFile(t, filepath.Join(cachePath, "sentinel.txt"), "keep\n")
+	server := NewServer(Options{Analyzer: analysis.NewService()})
+
+	result := callToolResult(t, server, toolAnalyseTop, map[string]any{
+		"repoPath":      repo,
+		"topN":          1,
+		"language":      "js-ts",
+		"cachePath":     cachePath,
+		"cacheReadOnly": false,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected analyse error: %#v", result)
+	}
+	payload := result.StructuredContent.(analysisPayload)
+	if payload.Report.Cache == nil || !payload.Report.Cache.Enabled || !payload.Report.Cache.ReadOnly {
+		t.Fatalf("expected enabled readonly cache metadata, got %#v", payload.Report.Cache)
+	}
+	for _, dirName := range []string{"keys", "objects"} {
+		entries, err := os.ReadDir(filepath.Join(cachePath, dirName))
+		if err != nil {
+			t.Fatalf("read %s: %v", dirName, err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("expected initialized cache %s dir to remain untouched, got %#v", dirName, entries)
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(cachePath, "sentinel.txt"))
+	if err != nil {
+		t.Fatalf("read sentinel: %v", err)
+	}
+	if string(data) != "keep\n" {
+		t.Fatalf("expected sentinel file to remain unchanged, got %q", string(data))
 	}
 }
 
@@ -506,54 +557,6 @@ func TestCallAnalyseTopLeavesSymlinkedOutsideCachePathUnmodified(t *testing.T) {
 	}
 	if string(data) != "keep\n" {
 		t.Fatalf("expected sentinel file to remain unchanged, got %q", string(data))
-	}
-}
-
-func TestCachePathReadyForReadOnlyRequiresInitializedDirectories(t *testing.T) {
-	root, err := filepath.EvalSymlinks(t.TempDir())
-	if err != nil {
-		t.Fatalf("resolve temp root: %v", err)
-	}
-	cachePath := filepath.Join(root, "cache")
-	if cachePathReadyForReadOnly(cachePath) {
-		t.Fatalf("expected missing cache path to be unreadable")
-	}
-	if err := os.MkdirAll(filepath.Join(cachePath, "keys"), 0o755); err != nil {
-		t.Fatalf("mkdir keys: %v", err)
-	}
-	testutil.MustWriteFile(t, filepath.Join(cachePath, "objects"), "not-a-dir\n")
-	if cachePathReadyForReadOnly(cachePath) {
-		t.Fatalf("expected non-directory objects path to be unreadable")
-	}
-	if err := os.Remove(filepath.Join(cachePath, "objects")); err != nil {
-		t.Fatalf("remove objects file: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(cachePath, "objects"), 0o755); err != nil {
-		t.Fatalf("mkdir objects: %v", err)
-	}
-	if !cachePathReadyForReadOnly(cachePath) {
-		t.Fatalf("expected initialized cache path to be readable")
-	}
-}
-
-func TestPathContainsSymlinkDetectsAncestorLinks(t *testing.T) {
-	root, err := filepath.EvalSymlinks(t.TempDir())
-	if err != nil {
-		t.Fatalf("resolve temp root: %v", err)
-	}
-	target := filepath.Join(root, "target")
-	if err := os.MkdirAll(target, 0o755); err != nil {
-		t.Fatalf("mkdir target: %v", err)
-	}
-	linkRoot := filepath.Join(root, "link-root")
-	if err := os.Symlink(target, linkRoot); err != nil {
-		t.Skipf("symlink unsupported: %v", err)
-	}
-	if !pathContainsSymlink(filepath.Join(linkRoot, "cache")) {
-		t.Fatalf("expected symlinked ancestor to be detected")
-	}
-	if pathContainsSymlink(filepath.Join(root, "plain", "cache")) {
-		t.Fatalf("expected plain path without symlinks to be allowed")
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -133,6 +133,8 @@ func TestHandleToolsListRegistersMutationToolsWhenFeatureEnabled(t *testing.T) {
 	assertRequiredSchemaFields(t, byName[toolApplyCodemod], "repoPath", "dependency", "confirmApply")
 	assertRequiredSchemaFields(t, byName[toolSaveBaseline], "repoPath", "baselineStorePath", "confirmSave")
 	assertRequiredSchemaFields(t, byName[toolSaveDashboardBaseline], "repoPath", "baselineStorePath", "confirmSave")
+	assertMutationCacheSchema(t, byName[toolApplyCodemod])
+	assertMutationCacheSchema(t, byName[toolSaveBaseline])
 }
 
 func assertToolOrder(t *testing.T, tools []toolSpec) {
@@ -180,6 +182,21 @@ func assertDependencySchema(t *testing.T, tool toolSpec) {
 	}
 	if cacheReadOnly, ok := properties["cacheReadOnly"].(map[string]any); !ok || cacheReadOnly["default"] != true {
 		t.Fatalf("dependency schema should advertise read-only cache default, got %#v", properties["cacheReadOnly"])
+	}
+}
+
+func assertMutationCacheSchema(t *testing.T, tool toolSpec) {
+	t.Helper()
+	properties := tool.InputSchema["properties"].(map[string]any)
+	cacheReadOnly, ok := properties["cacheReadOnly"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s should advertise cacheReadOnly input", tool.Name)
+	}
+	if _, ok := cacheReadOnly["default"]; ok {
+		t.Fatalf("%s cacheReadOnly schema should not advertise a read-only default, got %#v", tool.Name, cacheReadOnly)
+	}
+	if description, ok := cacheReadOnly["description"].(string); ok && strings.Contains(description, "false is ignored") {
+		t.Fatalf("%s cacheReadOnly schema should not advertise ignored writes, got %#v", tool.Name, cacheReadOnly)
 	}
 }
 
@@ -403,11 +420,18 @@ func TestCallAnalyseTopForcesReadOnlyCacheAndLeavesOutsidePathAbsent(t *testing.
 	}
 }
 
-func TestCallAnalyseTopLeavesTraversalShapedOutsideCachePathAbsent(t *testing.T) {
+func TestCallAnalyseTopRejectsInitializedTraversalShapedOutsideCachePath(t *testing.T) {
 	repoRoot := t.TempDir()
 	repo := filepath.Join(repoRoot, "repo")
 	writeMCPJSFixture(t, repo)
 	outsideCache := filepath.Join(repoRoot, "outside", "cache")
+	if err := os.MkdirAll(filepath.Join(outsideCache, "keys"), 0o755); err != nil {
+		t.Fatalf("mkdir keys: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(outsideCache, "objects"), 0o755); err != nil {
+		t.Fatalf("mkdir objects: %v", err)
+	}
+	testutil.MustWriteFile(t, filepath.Join(outsideCache, "sentinel.txt"), "keep\n")
 	traversalPath := filepath.Join(repo, "..", "outside", "cache")
 	server := NewServer(Options{Analyzer: analysis.NewService()})
 
@@ -421,8 +445,25 @@ func TestCallAnalyseTopLeavesTraversalShapedOutsideCachePathAbsent(t *testing.T)
 	if result.IsError {
 		t.Fatalf("unexpected analyse error: %#v", result)
 	}
-	if _, err := os.Stat(outsideCache); !os.IsNotExist(err) {
-		t.Fatalf("expected traversal-shaped outside cache path to remain absent, got err=%v", err)
+	payload := result.StructuredContent.(analysisPayload)
+	if payload.Report.Cache == nil || payload.Report.Cache.Enabled || !payload.Report.Cache.ReadOnly {
+		t.Fatalf("expected disabled readonly cache metadata, got %#v", payload.Report.Cache)
+	}
+	for _, dirName := range []string{"keys", "objects"} {
+		entries, err := os.ReadDir(filepath.Join(outsideCache, dirName))
+		if err != nil {
+			t.Fatalf("read %s: %v", dirName, err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("expected traversal-shaped outside cache %s dir to remain untouched, got %#v", dirName, entries)
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(outsideCache, "sentinel.txt"))
+	if err != nil {
+		t.Fatalf("read sentinel: %v", err)
+	}
+	if string(data) != "keep\n" {
+		t.Fatalf("expected sentinel file to remain unchanged, got %q", string(data))
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 type fakeAnalyser struct {
@@ -176,6 +177,9 @@ func assertDependencySchema(t *testing.T, tool toolSpec) {
 	properties := tool.InputSchema["properties"].(map[string]any)
 	if _, ok := properties["topN"]; !ok {
 		t.Fatalf("dependency schema should advertise topN as accepted input")
+	}
+	if cacheReadOnly, ok := properties["cacheReadOnly"].(map[string]any); !ok || cacheReadOnly["default"] != true {
+		t.Fatalf("dependency schema should advertise read-only cache default, got %#v", properties["cacheReadOnly"])
 	}
 }
 
@@ -370,6 +374,144 @@ func TestCallCompareBaselineAppliesBaselineDiff(t *testing.T) {
 	}
 	if !strings.Contains(payload.Summary, "Waste delta") {
 		t.Fatalf("expected baseline summary with delta, got %q", payload.Summary)
+	}
+}
+
+func TestCallAnalyseTopForcesReadOnlyCacheAndLeavesOutsidePathAbsent(t *testing.T) {
+	repo := t.TempDir()
+	writeMCPJSFixture(t, repo)
+	outsideRoot := t.TempDir()
+	outsideCache := filepath.Join(outsideRoot, "outside-cache")
+	server := NewServer(Options{Analyzer: analysis.NewService()})
+
+	result := callToolResult(t, server, toolAnalyseTop, map[string]any{
+		"repoPath":      repo,
+		"topN":          1,
+		"language":      "js-ts",
+		"cachePath":     outsideCache,
+		"cacheReadOnly": false,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected analyse error: %#v", result)
+	}
+	payload := result.StructuredContent.(analysisPayload)
+	if payload.Report.Cache == nil || payload.Report.Cache.Enabled || !payload.Report.Cache.ReadOnly {
+		t.Fatalf("expected disabled readonly cache metadata, got %#v", payload.Report.Cache)
+	}
+	if _, err := os.Stat(outsideCache); !os.IsNotExist(err) {
+		t.Fatalf("expected outside cache path to remain absent, got err=%v", err)
+	}
+}
+
+func TestCallAnalyseTopLeavesTraversalShapedOutsideCachePathAbsent(t *testing.T) {
+	repoRoot := t.TempDir()
+	repo := filepath.Join(repoRoot, "repo")
+	writeMCPJSFixture(t, repo)
+	outsideCache := filepath.Join(repoRoot, "outside", "cache")
+	traversalPath := filepath.Join(repo, "..", "outside", "cache")
+	server := NewServer(Options{Analyzer: analysis.NewService()})
+
+	result := callToolResult(t, server, toolAnalyseTop, map[string]any{
+		"repoPath":      repo,
+		"topN":          1,
+		"language":      "js-ts",
+		"cachePath":     traversalPath,
+		"cacheReadOnly": false,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected analyse error: %#v", result)
+	}
+	if _, err := os.Stat(outsideCache); !os.IsNotExist(err) {
+		t.Fatalf("expected traversal-shaped outside cache path to remain absent, got err=%v", err)
+	}
+}
+
+func TestCallAnalyseTopLeavesSymlinkedOutsideCachePathUnmodified(t *testing.T) {
+	repo := t.TempDir()
+	writeMCPJSFixture(t, repo)
+	outsideRoot := t.TempDir()
+	outsideCache := filepath.Join(outsideRoot, "cache")
+	testutil.MustWriteFile(t, filepath.Join(outsideCache, "sentinel.txt"), "keep\n")
+	linkPath := filepath.Join(repo, "linked-cache")
+	if err := os.Symlink(outsideCache, linkPath); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	server := NewServer(Options{Analyzer: analysis.NewService()})
+
+	result := callToolResult(t, server, toolAnalyseTop, map[string]any{
+		"repoPath":      repo,
+		"topN":          1,
+		"language":      "js-ts",
+		"cachePath":     linkPath,
+		"cacheReadOnly": false,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected analyse error: %#v", result)
+	}
+	payload := result.StructuredContent.(analysisPayload)
+	if payload.Report.Cache == nil || payload.Report.Cache.Enabled || !payload.Report.Cache.ReadOnly {
+		t.Fatalf("expected disabled readonly cache metadata, got %#v", payload.Report.Cache)
+	}
+	if _, err := os.Stat(filepath.Join(outsideCache, "keys")); !os.IsNotExist(err) {
+		t.Fatalf("expected symlinked outside cache keys dir to remain absent, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outsideCache, "objects")); !os.IsNotExist(err) {
+		t.Fatalf("expected symlinked outside cache objects dir to remain absent, got err=%v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(outsideCache, "sentinel.txt"))
+	if err != nil {
+		t.Fatalf("read sentinel: %v", err)
+	}
+	if string(data) != "keep\n" {
+		t.Fatalf("expected sentinel file to remain unchanged, got %q", string(data))
+	}
+}
+
+func TestCachePathReadyForReadOnlyRequiresInitializedDirectories(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp root: %v", err)
+	}
+	cachePath := filepath.Join(root, "cache")
+	if cachePathReadyForReadOnly(cachePath) {
+		t.Fatalf("expected missing cache path to be unreadable")
+	}
+	if err := os.MkdirAll(filepath.Join(cachePath, "keys"), 0o755); err != nil {
+		t.Fatalf("mkdir keys: %v", err)
+	}
+	testutil.MustWriteFile(t, filepath.Join(cachePath, "objects"), "not-a-dir\n")
+	if cachePathReadyForReadOnly(cachePath) {
+		t.Fatalf("expected non-directory objects path to be unreadable")
+	}
+	if err := os.Remove(filepath.Join(cachePath, "objects")); err != nil {
+		t.Fatalf("remove objects file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cachePath, "objects"), 0o755); err != nil {
+		t.Fatalf("mkdir objects: %v", err)
+	}
+	if !cachePathReadyForReadOnly(cachePath) {
+		t.Fatalf("expected initialized cache path to be readable")
+	}
+}
+
+func TestPathContainsSymlinkDetectsAncestorLinks(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp root: %v", err)
+	}
+	target := filepath.Join(root, "target")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	linkRoot := filepath.Join(root, "link-root")
+	if err := os.Symlink(target, linkRoot); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if !pathContainsSymlink(filepath.Join(linkRoot, "cache")) {
+		t.Fatalf("expected symlinked ancestor to be detected")
+	}
+	if pathContainsSymlink(filepath.Join(root, "plain", "cache")) {
+		t.Fatalf("expected plain path without symlinks to be allowed")
 	}
 }
 
@@ -570,6 +712,14 @@ func sampleReport(repoPath string) report.Report {
 			UsedPercent:       50,
 		},
 	}
+}
+
+func writeMCPJSFixture(t *testing.T, repo string) {
+	t.Helper()
+	testutil.MustWriteFile(t, filepath.Join(repo, "package.json"), "{\n  \"name\": \"demo\"\n}\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "index.js"), "import { map } from \"lodash\"\nmap([1], (x) => x)\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "node_modules", "lodash", "package.json"), "{\n  \"main\": \"index.js\"\n}\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "node_modules", "lodash", "index.js"), "export function map() {}\n")
 }
 
 func mustJSON(t *testing.T, value any) json.RawMessage {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -430,7 +430,7 @@ func TestCallAnalyseTopUsesInitializedCacheReadOnly(t *testing.T) {
 	}
 	repo := filepath.Join(repoRoot, "repo")
 	writeMCPJSFixture(t, repo)
-	cachePath := filepath.Join(repoRoot, "cache")
+	cachePath := filepath.Join(repo, ".lopper-cache")
 	for _, dirName := range []string{"keys", "objects"} {
 		if err := os.MkdirAll(filepath.Join(cachePath, dirName), 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", dirName, err)
@@ -443,7 +443,7 @@ func TestCallAnalyseTopUsesInitializedCacheReadOnly(t *testing.T) {
 		"repoPath":      repo,
 		"topN":          1,
 		"language":      "js-ts",
-		"cachePath":     cachePath,
+		"include":       []string{"**/*.js"},
 		"cacheReadOnly": false,
 	})
 	if result.IsError {
@@ -452,6 +452,9 @@ func TestCallAnalyseTopUsesInitializedCacheReadOnly(t *testing.T) {
 	payload := result.StructuredContent.(analysisPayload)
 	if payload.Report.Cache == nil || !payload.Report.Cache.Enabled || !payload.Report.Cache.ReadOnly {
 		t.Fatalf("expected enabled readonly cache metadata, got %#v", payload.Report.Cache)
+	}
+	if payload.Report.Cache.Path != cachePath {
+		t.Fatalf("expected scoped analysis to preserve cache path %q, got %q", cachePath, payload.Report.Cache.Path)
 	}
 	for _, dirName := range []string{"keys", "objects"} {
 		entries, err := os.ReadDir(filepath.Join(cachePath, dirName))

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -415,6 +415,7 @@ func readOnlyMCPAnalysisCacheOptions(repoPath string, enabled *bool, cachePath s
 	if resolvedPath == "" {
 		resolvedPath = filepath.Join(repoPath, ".lopper-cache")
 	}
+	options.Path = resolvedPath
 	if !cachePathReadyForReadOnly(resolvedPath) {
 		options.Enabled = false
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -373,6 +373,7 @@ func newAnalysisRequest(args analysisToolArguments, req analysisRequestContext) 
 	lowConfidence := req.thresholds.LowConfidenceWarningPercent
 	minUsage := req.thresholds.MinUsagePercentForRecommendations
 	weights := thresholds.RemovalCandidateWeights(req.thresholds)
+	cacheOptions := readOnlyMCPAnalysisCacheOptions(req.repoPath, args.CacheEnabled, args.CachePath)
 	return analysis.Request{
 		RepoPath:                          req.repoPath,
 		Dependency:                        req.dependency,
@@ -391,11 +392,58 @@ func newAnalysisRequest(args analysisToolArguments, req analysisRequestContext) 
 		RemovalCandidateWeights:           &weights,
 		LicenseDenyList:                   append([]string{}, req.thresholds.LicenseDenyList...),
 		IncludeRegistryProvenance:         req.thresholds.LicenseIncludeRegistryProvenance,
-		Cache: &analysis.CacheOptions{
-			Enabled:  cacheEnabled(args.CacheEnabled),
-			Path:     strings.TrimSpace(args.CachePath),
-			ReadOnly: args.CacheReadOnly,
-		},
+		Cache:                             cacheOptions,
+	}
+}
+
+func readOnlyMCPAnalysisCacheOptions(repoPath string, enabled *bool, cachePath string) *analysis.CacheOptions {
+	trimmedPath := strings.TrimSpace(cachePath)
+	options := &analysis.CacheOptions{
+		Enabled:  cacheEnabled(enabled),
+		Path:     trimmedPath,
+		ReadOnly: true,
+	}
+	if !options.Enabled {
+		return options
+	}
+	resolvedPath := trimmedPath
+	if resolvedPath == "" {
+		resolvedPath = filepath.Join(repoPath, ".lopper-cache")
+	}
+	if !cachePathReadyForReadOnly(resolvedPath) {
+		options.Enabled = false
+	}
+	return options
+}
+
+func cachePathReadyForReadOnly(cachePath string) bool {
+	if pathContainsSymlink(cachePath) {
+		return false
+	}
+	for _, dirName := range []string{"keys", "objects"} {
+		info, err := os.Stat(filepath.Join(cachePath, dirName))
+		if err != nil || !info.IsDir() {
+			return false
+		}
+	}
+	return true
+}
+
+func pathContainsSymlink(path string) bool {
+	current := filepath.Clean(path)
+	for {
+		info, err := os.Lstat(current)
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return true
+		}
+		if err != nil && !os.IsNotExist(err) {
+			return true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return false
+		}
+		current = parent
 	}
 }
 
@@ -944,7 +992,7 @@ func commonAnalysisProperties() map[string]any {
 		"disableFeatures":                   stringArraySchema(),
 		"cacheEnabled":                      map[string]any{"type": "boolean", "default": true},
 		"cachePath":                         map[string]any{"type": "string"},
-		"cacheReadOnly":                     map[string]any{"type": "boolean", "default": false},
+		"cacheReadOnly":                     map[string]any{"type": "boolean", "default": true, "description": "Read-only MCP analysis never writes cache entries; false is ignored."},
 		"runtimeProfile":                    map[string]any{"type": "string", "enum": []string{"node-import", "node-require", "browser-import", "browser-require"}, "default": defaultRuntimeProfile},
 		"runtimeTracePath":                  map[string]any{"type": "string"},
 		"advisorySourcePath":                map[string]any{"type": "string", "description": "Local JSON or YAML advisory file used to attach vulnerability findings without network access."},

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -406,6 +407,10 @@ func readOnlyMCPAnalysisCacheOptions(repoPath string, enabled *bool, cachePath s
 	if !options.Enabled {
 		return options
 	}
+	if trimmedPath != "" && pathContainsTraversalComponent(trimmedPath) {
+		options.Enabled = false
+		return options
+	}
 	resolvedPath := trimmedPath
 	if resolvedPath == "" {
 		resolvedPath = filepath.Join(repoPath, ".lopper-cache")
@@ -445,6 +450,18 @@ func pathContainsSymlink(path string) bool {
 		}
 		current = parent
 	}
+}
+
+func pathContainsTraversalComponent(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	path = path[len(filepath.VolumeName(path)):]
+	parts := strings.FieldsFunc(path, func(r rune) bool {
+		return os.IsPathSeparator(uint8(r))
+	})
+	return slices.Contains(parts, "..")
 }
 
 func (s *Server) runListLanguagesTool(ctx context.Context, rawArgs json.RawMessage) toolCallResult {
@@ -950,6 +967,11 @@ func summarizeReport(kind analysisToolKind, reportData report.Report) string {
 
 func analysisInputSchema(requireDependency, allowDependency, allowTopN, requireBaseline bool) map[string]any {
 	properties := commonAnalysisProperties()
+	properties["cacheReadOnly"] = map[string]any{
+		"type":        "boolean",
+		"default":     true,
+		"description": "Read-only MCP analysis never writes cache entries; false is ignored.",
+	}
 	required := []string{"repoPath"}
 	if allowDependency {
 		properties["dependency"] = map[string]any{"type": "string"}
@@ -992,7 +1014,7 @@ func commonAnalysisProperties() map[string]any {
 		"disableFeatures":                   stringArraySchema(),
 		"cacheEnabled":                      map[string]any{"type": "boolean", "default": true},
 		"cachePath":                         map[string]any{"type": "string"},
-		"cacheReadOnly":                     map[string]any{"type": "boolean", "default": true, "description": "Read-only MCP analysis never writes cache entries; false is ignored."},
+		"cacheReadOnly":                     map[string]any{"type": "boolean"},
 		"runtimeProfile":                    map[string]any{"type": "string", "enum": []string{"node-import", "node-require", "browser-import", "browser-require"}, "default": defaultRuntimeProfile},
 		"runtimeTracePath":                  map[string]any{"type": "string"},
 		"advisorySourcePath":                map[string]any{"type": "string", "description": "Local JSON or YAML advisory file used to attach vulnerability findings without network access."},


### PR DESCRIPTION
## Summary

MCP analysis tools are read-only, but callers could omit or explicitly disable `cacheReadOnly` and supply an arbitrary `cachePath`. The analysis layer could then initialize and write cache state at that path.

This replacement for superseded #1424 fixes only the original #1219 boundary: MCP-generated analysis requests are always read-only, and unsafe or uninitialized cache paths are disabled before analysis. CLI and direct analysis cache behavior is unchanged.

Closes #1219
Supersedes #1424

Broader review work is tracked separately in #1428, #1429, and #1430.

## Changes

- Force MCP analysis cache options to `ReadOnly: true`, ignoring a caller-supplied false value.
- Disable MCP cache reuse when the requested path is missing, incomplete, traversal-shaped, or contains symlinked components.
- Make the MCP schema advertise the truthful read-only default without changing mutation-tool cache semantics.
- Preserve the validated default cache path when scoped analysis uses a temporary workspace.
- Add focused regressions proving outside, initialized traversal-shaped, and symlinked cache paths remain absent or unmodified.

## Validation

Commands and checks run:

```bash
make ci
go test -race ./internal/mcp
go vet ./internal/mcp
golangci-lint run ./internal/mcp/...
gosec ./internal/mcp/...
```

Additional manual validation:

- Fresh independent whole-delta review: PASS — zero findings before the first Codex pass.
- Scoped diff: 2 files, 275 additions, 6 deletions.
- Aggregate repository coverage: 98.3%; every measured package met the 98% floor.

Regression-Test: ./internal/mcp::TestCallAnalyseTopForcesReadOnlyCacheAndLeavesOutsidePathAbsent
Regression-Test: ./internal/mcp::TestCallAnalyseTopUsesInitializedCacheReadOnly
Regression-Test: ./internal/mcp::TestCallAnalyseTopRejectsInitializedTraversalShapedOutsideCachePath
Regression-Test: ./internal/mcp::TestCallAnalyseTopLeavesSymlinkedOutsideCachePathUnmodified
Regression-Test: ./internal/mcp::TestHandleToolsListRegistersMutationToolsWhenFeatureEnabled

## Risk and compatibility

- Breaking changes: MCP callers can no longer make analysis cache writes; this matches the read-only tool contract.
- Migration required: None.
- Performance impact: Unsafe or uninitialized MCP cache paths fall back to uncached analysis.
- Memory benchmark impact: None; the full memory benchmark gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review