### PR TITLE
fix(ci): fail closed without memory baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,24 +208,21 @@ bench-gate:
 	@set -eu; \
 	requested_base_ref="$(MEMORY_BENCH_BASE)"; \
 	base_ref="$$requested_base_ref"; \
-	used_fallback=0; \
-	if ! git rev-parse --verify -q "$$base_ref^{commit}" >/dev/null; then \
-		echo "Warning: memory benchmark base ref '$$base_ref' not found; falling back to 'HEAD~1'."; \
-		base_ref="HEAD~1"; \
-		used_fallback=1; \
-	fi; \
 	mkdir -p $$(dirname "$(BENCH_BASE_OUTPUT)"); \
+	write_invalid_memory_summary() { \
+		mkdir -p $$(dirname "$(MEMORY_BENCH_SUMMARY)") $$(dirname "$(MEMORY_BENCH_STATUS)"); \
+		printf "## Memory Benchmarks\n\nThresholds: bytes/op <= +%s%%, allocs/op <= +%s%%\n\nBase benchmarks: unavailable\nHead benchmarks: unavailable\n\nInput errors:\n- %s\n\nComparison status: invalid\nResult: benchmark input could not be read for a safe memory comparison.\n" "$(MEMORY_BENCH_MAX_BYTES_PCT)" "$(MEMORY_BENCH_MAX_ALLOCS_PCT)" "$$1" > "$(MEMORY_BENCH_SUMMARY)"; \
+		printf "2\n" > "$(MEMORY_BENCH_STATUS)"; \
+	}; \
 	if ! git rev-parse --verify -q "$$base_ref^{commit}" >/dev/null; then \
-		echo "No valid memory benchmark base ref found; skipping memory benchmark gate."; \
-		printf "## Memory Benchmarks\n\nNo valid base ref found; skipping memory benchmark gate.\n" > "$(MEMORY_BENCH_SUMMARY)"; \
-		printf "0\n" > "$(MEMORY_BENCH_STATUS)"; \
-		exit 0; \
+		echo "Memory benchmark base ref '$$base_ref' is missing or invalid; failing closed."; \
+		write_invalid_memory_summary "base benchmark input could not be read: requested base ref '$$base_ref' is missing or invalid."; \
+		exit 2; \
 	fi; \
 	if ! base_commit=$$(git merge-base "$$base_ref" HEAD 2>/dev/null); then \
-		echo "Base ref '$$base_ref' is not related to HEAD; skipping memory benchmark gate."; \
-		printf "## Memory Benchmarks\n\nBase ref '%s' is not related to HEAD; skipping memory benchmark gate.\n" "$$base_ref" > "$(MEMORY_BENCH_SUMMARY)"; \
-		printf "0\n" > "$(MEMORY_BENCH_STATUS)"; \
-		exit 0; \
+		echo "Memory benchmark base ref '$$base_ref' is not related to HEAD; failing closed."; \
+		write_invalid_memory_summary "base benchmark input could not be read: requested base ref '$$base_ref' is not related to HEAD."; \
+		exit 2; \
 	fi; \
 	bench_dir=$$(mktemp -d); \
 	base_tree="$$bench_dir/base"; \
@@ -233,11 +230,7 @@ bench-gate:
 	head_output_tmp=$$(mktemp); \
 	cleanup() { (unset GIT_INDEX_FILE; git worktree remove --force "$$base_tree" >/dev/null 2>&1 || true); rm -rf "$$bench_dir"; rm -f "$$base_output_tmp" "$$head_output_tmp"; }; \
 	trap cleanup EXIT INT TERM; \
-	if [ "$$used_fallback" -eq 1 ]; then \
-		echo "Running memory benchmark delta against fallback base $$base_ref (requested $$requested_base_ref)."; \
-	else \
-		echo "Running memory benchmark delta against $$base_ref."; \
-	fi; \
+	echo "Running memory benchmark delta against $$base_ref."; \
 	(unset GIT_INDEX_FILE; git worktree add --detach "$$base_tree" "$$base_commit" >/dev/null); \
 	if ! (cd "$$base_tree" && GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES)) > "$$base_output_tmp" 2>&1; then \
 		cat "$$base_output_tmp"; \

--- a/scripts/benchdelta_workflow_test.go
+++ b/scripts/benchdelta_workflow_test.go
@@ -54,6 +54,10 @@ func workflowInvalidCase(name, baseID, headID string, expected ...string) workfl
 		headID:       headID,
 		wantCode:     2,
 		wantContains: append([]string{"Comparison status: invalid"}, expected...),
+		wantOmit: []string{
+			"Result: memory benchmark gate passed.",
+			"Result: memory benchmark regression detected.",
+		},
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"maps"
 	"os"
 	"os/exec"
@@ -15,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/gitexec"
 	"gopkg.in/yaml.v3"
 )
 
@@ -3089,6 +3091,10 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		`write_invalid_memory_summary() { \`,
+		`printf "2\n" > "$(MEMORY_BENCH_STATUS)"`,
+		`requested base ref '$$base_ref' is missing or invalid`,
+		`requested base ref '$$base_ref' is not related to HEAD`,
 		`benchdelta_bin="$$bench_dir/benchdelta"`,
 		`$(GO_CMD) build -o "$$benchdelta_bin" ./tools/benchdelta`,
 		`"$$benchdelta_bin" -base "$(BENCH_BASE_OUTPUT)" -head "$(BENCH_HEAD_OUTPUT)"`,
@@ -3105,11 +3111,73 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 	for _, omit := range []string{
 		`$(GO_CMD) run ./tools/benchdelta`,
 		`if [ "$$status" -eq 2 ]; then`,
+		`falling back to 'HEAD~1'`,
+		`No valid memory benchmark base ref found; skipping memory benchmark gate.`,
+		`is not related to HEAD; skipping memory benchmark gate.`,
 	} {
 		if strings.Contains(target, omit) {
 			t.Fatalf("bench-gate target must not contain %q", omit)
 		}
 	}
+}
+
+func TestMakefileBenchGateFailsClosedForInvalidRequestedBase(t *testing.T) {
+	t.Parallel()
+
+	repo := newTempBenchGateRepo(t)
+	summaryPath := filepath.Join("nested", "summary", "memory-bench-summary.md")
+	statusPath := filepath.Join("nested", "status", "memory-bench-status.txt")
+	baseOutputPath := filepath.Join("nested", "base", "bench-base.out")
+	vars := map[string]string{
+		"MEMORY_BENCH_BASE":    "refs/heads/does-not-exist",
+		"MEMORY_BENCH_SUMMARY": summaryPath,
+		"MEMORY_BENCH_STATUS":  statusPath,
+		"BENCH_BASE_OUTPUT":    baseOutputPath,
+	}
+	output, _ := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", vars, 2)
+	if !strings.Contains(output, "missing or invalid; failing closed") {
+		t.Fatalf("expected invalid base failure output, got:\n%s", output)
+	}
+	wantContains := []string{
+		"Comparison status: invalid",
+		"base benchmark input could not be read: requested base ref 'refs/heads/does-not-exist' is missing or invalid.",
+	}
+	wantOmit := []string{
+		"Result: memory benchmark gate passed.",
+		"Result: memory benchmark regression detected.",
+	}
+	assertMemoryBenchArtifactsAtPaths(t, repo, summaryPath, statusPath, "2\n", wantContains, wantOmit)
+	assertFileExists(t, filepath.Join(repo, filepath.Dir(baseOutputPath)))
+}
+
+func TestMakefileBenchGateFailsClosedForUnrelatedRequestedBase(t *testing.T) {
+	t.Parallel()
+
+	repo := newTempBenchGateRepo(t)
+	runGitCommand(t, repo, "checkout", "--orphan", "unrelated-base")
+	writeFile(t, filepath.Join(repo, "unrelated.txt"), "unrelated\n")
+	runGitCommand(t, repo, "add", "unrelated.txt")
+	runGitCommand(t, repo, "commit", "-m", "unrelated history")
+	runGitCommand(t, repo, "checkout", "main")
+
+	vars := map[string]string{
+		"MEMORY_BENCH_BASE":    "unrelated-base",
+		"MEMORY_BENCH_SUMMARY": ".artifacts/memory-bench-summary.md",
+		"MEMORY_BENCH_STATUS":  ".artifacts/memory-bench-status.txt",
+	}
+	output, _ := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", vars, 2)
+	if !strings.Contains(output, "not related to HEAD; failing closed") {
+		t.Fatalf("expected unrelated base failure output, got:\n%s", output)
+	}
+	wantContains := []string{
+		"Comparison status: invalid",
+		"base benchmark input could not be read: requested base ref 'unrelated-base' is not related to HEAD.",
+	}
+	wantOmit := []string{
+		"Result: memory benchmark gate passed.",
+		"Result: memory benchmark regression detected.",
+	}
+	assertMemoryBenchArtifacts(t, repo, "2\n", wantContains, wantOmit)
 }
 
 func TestMakefileLockfiledriftHeadContract(t *testing.T) {
@@ -5002,6 +5070,34 @@ func runMakeTargetInDir(t *testing.T, dir, target string, vars map[string]string
 	return string(output)
 }
 
+func runMakeTargetInDirExpectExitCode(t *testing.T, dir, target string, vars map[string]string, wantExitCode int) (string, int) {
+	t.Helper()
+
+	args := []string{target}
+	for key, value := range vars {
+		args = append(args, key+"="+value)
+	}
+
+	cmd := exec.Command("make", args...)
+	cmd.Dir = dir
+	cmd.Env = gitexec.SanitizedEnv()
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		if wantExitCode != 0 {
+			t.Fatalf("make %s exited 0, want %d\n%s", target, wantExitCode, output)
+		}
+		return string(output), 0
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("make %s returned unexpected error: %v\n%s", target, err, output)
+	}
+	if exitErr.ExitCode() != wantExitCode {
+		t.Fatalf("make %s exit code = %d, want %d\n%s", target, exitErr.ExitCode(), wantExitCode, output)
+	}
+	return string(output), exitErr.ExitCode()
+}
+
 func newTempCoverageMakeRepo(t *testing.T) string {
 	t.Helper()
 
@@ -5010,6 +5106,19 @@ func newTempCoverageMakeRepo(t *testing.T) string {
 	if err := os.WriteFile(filepath.Join(root, "Makefile"), []byte(makefile), 0o644); err != nil {
 		t.Fatalf("write temp Makefile: %v", err)
 	}
+	return root
+}
+
+func newTempBenchGateRepo(t *testing.T) string {
+	t.Helper()
+
+	root := newTempCoverageMakeRepo(t)
+	runGitCommand(t, root, "init", "-b", "main")
+	runGitCommand(t, root, "config", "user.name", "Ben Ranford")
+	runGitCommand(t, root, "config", "user.email", "84072202+ben-ranford@users.noreply.github.com")
+	writeFile(t, filepath.Join(root, "README.md"), "baseline\n")
+	runGitCommand(t, root, "add", "README.md", "Makefile")
+	runGitCommand(t, root, "commit", "-m", "baseline")
 	return root
 }
 
@@ -5049,6 +5158,55 @@ func assertFileExists(t *testing.T, path string) {
 
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected %s to exist, err=%v", path, err)
+	}
+}
+
+func runGitCommand(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitexec.SanitizedEnv()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}
+
+func assertMemoryBenchArtifacts(t *testing.T, repo string, wantStatus string, wantContains []string, wantOmit []string) {
+	t.Helper()
+
+	assertMemoryBenchArtifactsAtPaths(t, repo, filepath.Join(".artifacts", "memory-bench-summary.md"), filepath.Join(".artifacts", "memory-bench-status.txt"), wantStatus, wantContains, wantOmit)
+}
+
+func assertMemoryBenchArtifactsAtPaths(t *testing.T, repo string, summaryRelPath string, statusRelPath string, wantStatus string, wantContains []string, wantOmit []string) {
+	t.Helper()
+
+	statusPath := filepath.Join(repo, statusRelPath)
+	statusBytes, err := os.ReadFile(statusPath)
+	if err != nil {
+		t.Fatalf("read memory bench status: %v", err)
+	}
+	if string(statusBytes) != wantStatus {
+		t.Fatalf("memory bench status = %q, want %q", statusBytes, wantStatus)
+	}
+
+	summaryPath := filepath.Join(repo, summaryRelPath)
+	summaryBytes, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read memory bench summary: %v", err)
+	}
+	summary := string(summaryBytes)
+	for _, want := range wantContains {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("expected memory bench summary to contain %q, got:\n%s", want, summary)
+		}
+	}
+	for _, omit := range wantOmit {
+		if strings.Contains(summary, omit) {
+			t.Fatalf("expected memory bench summary to omit %q, got:\n%s", omit, summary)
+		}
 	}
 }
 

--- a/tools/benchdelta/main.go
+++ b/tools/benchdelta/main.go
@@ -94,19 +94,20 @@ func main() {
 		exitErr(errors.New("both -base and -head are required"))
 	}
 
-	baseInput, err := parseBenchmarkFile(*basePath)
-	if err != nil {
-		exitErr(fmt.Errorf("parse base benchmarks: %w", err))
-	}
-	headInput, err := parseBenchmarkFile(*headPath)
-	if err != nil {
-		exitErr(fmt.Errorf("parse head benchmarks: %w", err))
-	}
-
 	limits := deltaThresholds{
 		bytesPct:  *maxBytesPct,
 		allocsPct: *maxAllocsPct,
 	}
+
+	baseInput, err := parseBenchmarkFile(*basePath)
+	if err != nil {
+		exitWithSummary(*summaryOut, invalidInputSummary(limits, "unavailable", "unavailable", fmt.Sprintf("base benchmark input could not be read: %v", err)))
+	}
+	headInput, err := parseBenchmarkFile(*headPath)
+	if err != nil {
+		exitWithSummary(*summaryOut, invalidInputSummary(limits, benchmarkCountLabel(len(baseInput.data)), "unavailable", fmt.Sprintf("head benchmark input could not be read: %v", err)))
+	}
+
 	summary, statusCode := compareBenchmarks(baseInput, headInput, limits)
 	fmt.Print(summary)
 	if *summaryOut != "" {
@@ -121,6 +122,16 @@ func main() {
 
 func exitErr(err error) {
 	fmt.Fprintln(os.Stderr, err)
+	os.Exit(exitCodeInvalid)
+}
+
+func exitWithSummary(summaryOut, summary string) {
+	fmt.Print(summary)
+	if strings.TrimSpace(summaryOut) != "" {
+		if err := os.WriteFile(summaryOut, []byte(summary), 0o600); err != nil {
+			exitErr(fmt.Errorf("write summary: %w", err))
+		}
+	}
 	os.Exit(exitCodeInvalid)
 }
 
@@ -349,6 +360,18 @@ func writeComparisonSummary(buf *bytes.Buffer, summary comparisonSummary) {
 	default:
 		buf.WriteString("Result: memory benchmark gate passed.\n")
 	}
+}
+
+func invalidInputSummary(limits deltaThresholds, baseCount, headCount, diagnostic string) string {
+	var buf bytes.Buffer
+	buf.WriteString("## Memory Benchmarks\n\n")
+	fmt.Fprintf(&buf, "Thresholds: bytes/op <= +%.1f%%, allocs/op <= +%.1f%%\n\n", limits.bytesPct, limits.allocsPct)
+	fmt.Fprintf(&buf, "Base benchmarks: %s\n", baseCount)
+	fmt.Fprintf(&buf, "Head benchmarks: %s\n\n", headCount)
+	writeList(&buf, "Input errors:", []string{diagnostic}, func(item string) string { return item })
+	buf.WriteString("Comparison status: invalid\n")
+	buf.WriteString("Result: benchmark input could not be read for a safe memory comparison.\n")
+	return buf.String()
 }
 
 func writeComparisonTable(buf *bytes.Buffer, rows []comparisonRow, showEmptyMessage bool) {

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -732,23 +732,28 @@ func TestMainInvalidComparisonsStillWriteDeterministicSummaryArtifacts(t *testin
 			args := append(append([]string{}, tc.args...), "-summary-out", summaryPath)
 			output, exitCode := runBenchdeltaHelper(t, "TestMainInvalidComparisonsStillWriteDeterministicSummaryArtifacts", args...)
 			assertBenchdeltaHelperExit(t, output, exitCode, exitCodeInvalid)
-
-			summaryBytes, err := os.ReadFile(summaryPath)
-			if err != nil {
-				t.Fatalf("read summary artifact: %v", err)
-			}
-			summary := string(summaryBytes)
-			for _, want := range tc.wantContains {
-				if !strings.Contains(summary, want) {
-					t.Fatalf("expected summary artifact to contain %q, got:\n%s", want, summary)
-				}
-			}
-			for _, omit := range tc.wantOmit {
-				if strings.Contains(summary, omit) {
-					t.Fatalf("expected summary artifact to omit %q, got:\n%s", omit, summary)
-				}
-			}
+			assertBenchdeltaSummaryArtifact(t, summaryPath, tc.wantContains, tc.wantOmit)
 		})
+	}
+}
+
+func assertBenchdeltaSummaryArtifact(t *testing.T, summaryPath string, wantContains, wantOmit []string) {
+	t.Helper()
+
+	summaryBytes, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read summary artifact: %v", err)
+	}
+	summary := string(summaryBytes)
+	for _, want := range wantContains {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("expected summary artifact to contain %q, got:\n%s", want, summary)
+		}
+	}
+	for _, omit := range wantOmit {
+		if strings.Contains(summary, omit) {
+			t.Fatalf("expected summary artifact to omit %q, got:\n%s", omit, summary)
+		}
 	}
 }
 

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -575,13 +575,13 @@ func TestMainExitCodesAndErrorPaths(t *testing.T) {
 			name:       "missing base file",
 			args:       []string{"-base", filepath.Join(dir, "missing.txt"), "-head", headPath},
 			wantCode:   exitCodeInvalid,
-			wantOutput: "parse base benchmarks",
+			wantOutput: "base benchmark input could not be read",
 		},
 		{
 			name:       "missing head file",
 			args:       []string{"-base", basePath, "-head", filepath.Join(dir, "missing-head.txt")},
 			wantCode:   exitCodeInvalid,
-			wantOutput: "parse head benchmarks",
+			wantOutput: "head benchmark input could not be read",
 		},
 	}
 
@@ -644,6 +644,111 @@ func TestMainSummaryWriteSuccess(t *testing.T) {
 	}
 	if !strings.Contains(string(summaryBytes), "Result: memory benchmark gate passed.") {
 		t.Fatalf("expected written summary to contain pass result, got:\n%s", summaryBytes)
+	}
+}
+
+func TestMainInvalidComparisonsStillWriteDeterministicSummaryArtifacts(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+
+	dir, _, headPath := writeMatchingBenchmarkFixtures(t)
+	malformedPath := filepath.Join(dir, "malformed.txt")
+	if err := os.WriteFile(malformedPath, []byte(strings.Repeat("x", 70*1024)+"\n"), 0o644); err != nil {
+		t.Fatalf("write malformed benchmark file: %v", err)
+	}
+	writeBenchmarkFixture(t, filepath.Join(dir, "zero-overlap-base.txt"), reportFixture(completeBenchmark("BaseOnly")))
+	writeBenchmarkFixture(t, filepath.Join(dir, "zero-overlap-head.txt"), reportFixture(completeBenchmark("HeadOnly")))
+
+	tests := []struct {
+		name         string
+		args         []string
+		wantContains []string
+		wantOmit     []string
+	}{
+		{
+			name: "missing base file",
+			args: []string{"-base", filepath.Join(dir, "missing.txt"), "-head", headPath},
+			wantContains: []string{
+				"Comparison status: invalid",
+				"Base benchmarks: unavailable",
+				"Head benchmarks: unavailable",
+				"base benchmark input could not be read",
+				"missing.txt",
+			},
+			wantOmit: []string{
+				"Result: memory benchmark gate passed.",
+				"Result: memory benchmark regression detected.",
+			},
+		},
+		{
+			name: "unreadable base path",
+			args: []string{"-base", dir, "-head", headPath},
+			wantContains: []string{
+				"Comparison status: invalid",
+				"Base benchmarks: unavailable",
+				"Head benchmarks: unavailable",
+				"base benchmark input could not be read",
+			},
+			wantOmit: []string{
+				"Result: memory benchmark gate passed.",
+				"Result: memory benchmark regression detected.",
+			},
+		},
+		{
+			name: "malformed base file",
+			args: []string{"-base", malformedPath, "-head", headPath},
+			wantContains: []string{
+				"Comparison status: invalid",
+				"Base benchmarks: unavailable",
+				"Head benchmarks: unavailable",
+				"base benchmark input could not be read",
+				"token too long",
+			},
+			wantOmit: []string{
+				"Result: memory benchmark gate passed.",
+				"Result: memory benchmark regression detected.",
+			},
+		},
+		{
+			name: "unrelated head comparison",
+			args: []string{"-base", filepath.Join(dir, "zero-overlap-base.txt"), "-head", filepath.Join(dir, "zero-overlap-head.txt")},
+			wantContains: []string{
+				"Comparison status: invalid",
+				"Base benchmarks: 1",
+				"Head benchmarks: 1",
+				"No overlapping benchmark names were found between base and head.",
+			},
+			wantOmit: []string{
+				"Result: memory benchmark gate passed.",
+				"Result: memory benchmark regression detected.",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			summaryPath := filepath.Join(dir, strings.ReplaceAll(tc.name, " ", "-")+".md")
+			args := append(append([]string{}, tc.args...), "-summary-out", summaryPath)
+			output, exitCode := runBenchdeltaHelper(t, "TestMainInvalidComparisonsStillWriteDeterministicSummaryArtifacts", args...)
+			assertBenchdeltaHelperExit(t, output, exitCode, exitCodeInvalid)
+
+			summaryBytes, err := os.ReadFile(summaryPath)
+			if err != nil {
+				t.Fatalf("read summary artifact: %v", err)
+			}
+			summary := string(summaryBytes)
+			for _, want := range tc.wantContains {
+				if !strings.Contains(summary, want) {
+					t.Fatalf("expected summary artifact to contain %q, got:\n%s", want, summary)
+				}
+			}
+			for _, omit := range tc.wantOmit {
+				if strings.Contains(summary, omit) {
+					t.Fatalf("expected summary artifact to omit %q, got:\n%s", omit, summary)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

The memory benchmark gate could report success when its requested base ref was missing or unrelated to `HEAD`. That made an invalid comparison look safe and could allow CI to pass without a usable memory baseline.

This replacement for superseded #1426 stays within #1401: invalid or unrelated baselines now fail closed with status 2 while still producing deterministic summary and status artifacts.

Closes #1401
Supersedes #1426

## Root cause

The Makefile fell back to `HEAD~1` when a requested base ref was invalid and skipped unrelated histories with exit status 0. Separately, `benchdelta` returned before writing its summary when benchmark input could not be read, so callers had no deterministic failure artifact.

## Changes

- Fail `bench-gate` with status 2 when the requested base ref is missing, invalid, or unrelated to `HEAD`.
- Write deterministic invalid-comparison summary and status artifacts before exiting.
- Make `benchdelta` emit an invalid summary for unreadable, malformed, or non-overlapping inputs without pass/regression wording.
- Isolate temporary Git repositories from inherited hook/worktree environment variables.
- Add focused Makefile and `benchdelta` regressions for missing, malformed, unreadable, and unrelated baselines.
- Keep invalid-summary assertions in a focused helper so the regression remains below Sonar's complexity limit.

## Validation

```bash
make ci
GIT_DIR=/Users/benranford/Projects/lopper/.git/worktrees/lopper-v184-1401-scoped \
GIT_WORK_TREE=/Users/benranford/Projects/lopper-v184-1401-scoped \
GIT_INDEX_FILE=/Users/benranford/Projects/lopper/.git/worktrees/lopper-v184-1401-scoped/index \
go test ./scripts -run 'TestMakefileBenchGateFailsClosedForInvalidRequestedBase|TestMakefileBenchGateFailsClosedForUnrelatedRequestedBase' -count=10
go test ./scripts ./tools/benchdelta -run 'TestMakefileBenchGateFailsClosedForInvalidRequestedBase|TestMakefileBenchGateFailsClosedForUnrelatedRequestedBase|TestMainInvalidComparisonsStillWriteDeterministicSummaryArtifacts' -count=1
```

- Scoped diff: 5 files, 315 additions, 27 deletions.
- New-code duplication: 0.00%.
- Aggregate coverage: 98.3%; every measured package met the 98% floor.
- Security scan: 0 issues.
- Vulnerability scan: 0 vulnerabilities.
- Memory benchmark gate: passed.

Regression-Test: ./scripts::TestMakefileBenchGateFailsClosedForInvalidRequestedBase
Regression-Test: ./scripts::TestMakefileBenchGateFailsClosedForUnrelatedRequestedBase
Regression-Test: ./tools/benchdelta::TestMainInvalidComparisonsStillWriteDeterministicSummaryArtifacts

## Risk and compatibility

- Breaking changes: CI now rejects an invalid memory benchmark baseline instead of silently passing.
- Migration required: none for valid benchmark configurations.
- Performance impact: none; valid benchmark comparisons use the existing execution path.
- Memory benchmark impact: none; the full memory benchmark gate passed.
- Runtime impact: none outside the CI benchmark tooling.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
