### PR TITLE
fix(runtime): redact absolute runtime context paths

### DIFF
--- a/internal/analysis/service_test.go
+++ b/internal/analysis/service_test.go
@@ -629,7 +629,7 @@ func TestServiceAnalysePythonRuntimeTraceIntegration(t *testing.T) {
 	if len(requests.RuntimeUsage.Modules) != 1 || requests.RuntimeUsage.Modules[0].Module != "requests.sessions" {
 		t.Fatalf("expected Python runtime module detail, got %#v", requests.RuntimeUsage.Modules)
 	}
-	if len(requests.RuntimeUsage.ParentModules) != 1 || requests.RuntimeUsage.ParentModules[0].Module != "/repo/main.py" {
+	if len(requests.RuntimeUsage.ParentModules) != 1 || requests.RuntimeUsage.ParentModules[0].Module != "external:main.py" {
 		t.Fatalf("expected Python runtime parent detail, got %#v", requests.RuntimeUsage.ParentModules)
 	}
 

--- a/internal/runtime/trace_annotate.go
+++ b/internal/runtime/trace_annotate.go
@@ -236,9 +236,12 @@ func visibleRuntimeContextModule(value, repoPath string) string {
 	if value == "" {
 		return ""
 	}
-	value, fileURL := normalizeRuntimeContextValue(value)
+	value, fileURL, fileURLAuthority := normalizeRuntimeContextValue(value)
 	if value == "" {
 		return ""
+	}
+	if fileURLAuthority {
+		return safeRuntimeContextBase(value)
 	}
 	if !fileURL && strings.Contains(value, "://") && !runtimeContextWindowsDrivePath(value) {
 		return visibleRuntimeContextLiteral(value)
@@ -311,11 +314,15 @@ func runtimeContextRelativeToRoot(repoPath, candidate string) (string, bool) {
 	return filepath.ToSlash(relative), true
 }
 
-func normalizeRuntimeContextValue(value string) (string, bool) {
+func normalizeRuntimeContextValue(value string) (string, bool, bool) {
 	value = strings.ReplaceAll(value, `\`, "/")
 	fileURL := len(value) >= len(fileURLPrefix) && strings.EqualFold(value[:len(fileURLPrefix)], fileURLPrefix)
+	fileURLAuthority := false
 	if fileURL {
 		value = value[len(fileURLPrefix):]
+		fileURLAuthority = value != "" &&
+			!strings.HasPrefix(value, "/") &&
+			!runtimeContextWindowsDrivePath(value)
 		switch {
 		case strings.HasPrefix(strings.ToLower(value), "localhost/"):
 			value = value[len("localhost"):]
@@ -326,7 +333,7 @@ func normalizeRuntimeContextValue(value string) (string, bool) {
 	if len(value) >= 3 && value[0] == '/' && runtimeContextWindowsDrivePath(value[1:]) {
 		value = value[1:]
 	}
-	return value, fileURL
+	return value, fileURL, fileURLAuthority
 }
 
 func runtimeContextLooksLikePath(value string) bool {

--- a/internal/runtime/trace_annotate.go
+++ b/internal/runtime/trace_annotate.go
@@ -250,11 +250,14 @@ func visibleRuntimeContextModule(value, repoPath string) string {
 		return visibleRuntimeContextLiteral(value)
 	}
 	uncPath := strings.HasPrefix(value, "//")
+	if uncPath {
+		return safeRuntimeContextBase(value)
+	}
 	value = path.Clean(value)
 	if repoRelative, ok := runtimeContextRepoRelativePath(repoPath, value); ok {
 		return visibleRuntimeContextLiteral(repoRelative)
 	}
-	if fileURL || uncPath || path.IsAbs(value) || runtimeContextWindowsDrivePath(value) || runtimeContextEscapesRoot(value) {
+	if fileURL || path.IsAbs(value) || runtimeContextWindowsDrivePath(value) || runtimeContextEscapesRoot(value) {
 		return safeRuntimeContextBase(value)
 	}
 	return visibleRuntimeContextLiteral(value)

--- a/internal/runtime/trace_annotate.go
+++ b/internal/runtime/trace_annotate.go
@@ -1,10 +1,17 @@
 package runtime
 
 import (
+	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/report"
+)
+
+const (
+	externalRuntimeContextPrefix = "external:"
+	literalRuntimeContextPrefix  = "literal:"
 )
 
 func Annotate(rep report.Report, trace Trace, opts AnnotateOptions) report.Report {
@@ -27,12 +34,12 @@ func annotateExistingDependencies(rep *report.Report, trace Trace, supported map
 		}
 		key := DependencyKey{Language: language, Name: dep.Name}
 		seen[key] = struct{}{}
-		annotateDependency(dep, trace, key)
+		annotateDependency(dep, trace, key, rep.RepoPath)
 	}
 	return seen
 }
 
-func annotateDependency(dep *report.DependencyReport, trace Trace, key DependencyKey) {
+func annotateDependency(dep *report.DependencyReport, trace Trace, key DependencyKey, repoPath string) {
 	loads := runtimeLoadCount(trace, key)
 	hasStatic := hasStaticEvidence(*dep)
 	if loads == 0 && !hasStatic && dep.RuntimeUsage == nil {
@@ -44,8 +51,8 @@ func annotateDependency(dep *report.DependencyReport, trace Trace, key Dependenc
 		Correlation:   correlation,
 		RuntimeOnly:   correlation == report.RuntimeCorrelationRuntimeOnly,
 		Modules:       runtimeModules(runtimeModuleCounts(trace, key)),
-		ParentModules: runtimeModules(runtimeParentCounts(trace, key)),
-		Entrypoints:   runtimeModules(runtimeEntrypointCounts(trace, key)),
+		ParentModules: runtimeContextModules(runtimeParentCounts(trace, key), repoPath),
+		Entrypoints:   runtimeContextModules(runtimeEntrypointCounts(trace, key), repoPath),
 		TopSymbols:    runtimeSymbols(runtimeSymbolCounts(trace, key)),
 	}
 }
@@ -67,8 +74,8 @@ func appendRuntimeOnlyDependencies(rep *report.Report, trace Trace, seen map[Dep
 				Correlation:   report.RuntimeCorrelationRuntimeOnly,
 				RuntimeOnly:   true,
 				Modules:       runtimeModules(runtimeModuleCounts(trace, key)),
-				ParentModules: runtimeModules(runtimeParentCounts(trace, key)),
-				Entrypoints:   runtimeModules(runtimeEntrypointCounts(trace, key)),
+				ParentModules: runtimeContextModules(runtimeParentCounts(trace, key), rep.RepoPath),
+				Entrypoints:   runtimeContextModules(runtimeEntrypointCounts(trace, key), rep.RepoPath),
 				TopSymbols:    runtimeSymbols(runtimeSymbolCounts(trace, key)),
 			},
 		})
@@ -207,6 +214,147 @@ func runtimeModules(values map[string]int) []report.RuntimeModuleUsage {
 		return items[i].Count > items[j].Count
 	})
 	return items
+}
+
+func runtimeContextModules(values map[string]int, repoPath string) []report.RuntimeModuleUsage {
+	if len(values) == 0 {
+		return nil
+	}
+	redacted := make(map[string]int, len(values))
+	for module, count := range values {
+		visible := visibleRuntimeContextModule(module, repoPath)
+		if visible == "" {
+			continue
+		}
+		redacted[visible] += count
+	}
+	return runtimeModules(redacted)
+}
+
+func visibleRuntimeContextModule(value string, repoPath string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value, fileURL := normalizeRuntimeContextValue(value)
+	if value == "" {
+		return ""
+	}
+	if !fileURL && strings.Contains(value, "://") && !runtimeContextWindowsDrivePath(value) {
+		return visibleRuntimeContextLiteral(value)
+	}
+	if !fileURL && !runtimeContextLooksLikePath(value) {
+		return visibleRuntimeContextLiteral(value)
+	}
+	uncPath := strings.HasPrefix(value, "//")
+	value = path.Clean(value)
+	if repoRelative, ok := runtimeContextRepoRelativePath(repoPath, value); ok {
+		return visibleRuntimeContextLiteral(repoRelative)
+	}
+	if fileURL || uncPath || path.IsAbs(value) || runtimeContextWindowsDrivePath(value) || runtimeContextEscapesRoot(value) {
+		return safeRuntimeContextBase(value)
+	}
+	return visibleRuntimeContextLiteral(value)
+}
+
+func visibleRuntimeContextLiteral(value string) string {
+	if strings.HasPrefix(value, externalRuntimeContextPrefix) ||
+		strings.HasPrefix(value, literalRuntimeContextPrefix) {
+		return literalRuntimeContextPrefix + value
+	}
+	return value
+}
+
+func runtimeContextRepoRelativePath(repoPath, value string) (string, bool) {
+	repoPath = strings.TrimSpace(repoPath)
+	if repoPath == "" {
+		return "", false
+	}
+	repoPath = filepath.Clean(repoPath)
+	if !filepath.IsAbs(repoPath) {
+		return "", false
+	}
+
+	candidate := filepath.FromSlash(value)
+	if (path.IsAbs(value) || runtimeContextWindowsDrivePath(value)) && !filepath.IsAbs(candidate) {
+		return "", false
+	}
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(repoPath, candidate)
+	} else {
+		candidate = filepath.Clean(candidate)
+	}
+
+	resolvedRepoPath, repoErr := filepath.EvalSymlinks(repoPath)
+	resolvedCandidate, candidateErr := filepath.EvalSymlinks(candidate)
+	if repoErr == nil && candidateErr == nil {
+		return runtimeContextRelativeToRoot(resolvedRepoPath, resolvedCandidate)
+	}
+	if relative, ok := runtimeContextRelativeToRoot(repoPath, candidate); ok {
+		return relative, true
+	}
+	if repoErr == nil {
+		return runtimeContextRelativeToRoot(resolvedRepoPath, candidate)
+	}
+	return "", false
+}
+
+func runtimeContextRelativeToRoot(repoPath, candidate string) (string, bool) {
+	relative, err := filepath.Rel(repoPath, candidate)
+	if err != nil {
+		return "", false
+	}
+	relative = filepath.Clean(relative)
+	if relative == "." || filepath.IsAbs(relative) || runtimeContextEscapesRoot(filepath.ToSlash(relative)) {
+		return "", false
+	}
+	return filepath.ToSlash(relative), true
+}
+
+func normalizeRuntimeContextValue(value string) (string, bool) {
+	value = strings.ReplaceAll(value, `\`, "/")
+	fileURL := len(value) >= len(fileURLPrefix) && strings.EqualFold(value[:len(fileURLPrefix)], fileURLPrefix)
+	if fileURL {
+		value = value[len(fileURLPrefix):]
+		switch {
+		case strings.HasPrefix(strings.ToLower(value), "localhost/"):
+			value = value[len("localhost"):]
+		case value != "" && !strings.HasPrefix(value, "/") && !runtimeContextWindowsDrivePath(value):
+			value = "//" + value
+		}
+	}
+	if len(value) >= 3 && value[0] == '/' && runtimeContextWindowsDrivePath(value[1:]) {
+		value = value[1:]
+	}
+	return value, fileURL
+}
+
+func runtimeContextLooksLikePath(value string) bool {
+	return strings.Contains(value, "/") || strings.HasPrefix(value, ".") || runtimeContextWindowsDrivePath(value)
+}
+
+func runtimeContextWindowsDrivePath(value string) bool {
+	value = strings.TrimPrefix(value, "/")
+	return len(value) >= 2 &&
+		((value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')) &&
+		value[1] == ':'
+}
+
+func runtimeContextEscapesRoot(value string) bool {
+	return value == ".." || strings.HasPrefix(value, "../")
+}
+
+func safeRuntimeContextBase(value string) string {
+	value = strings.TrimRight(value, "/")
+	if runtimeContextWindowsDrivePath(value) {
+		value = strings.TrimPrefix(value, "/")
+		value = value[2:]
+	}
+	base := path.Base(value)
+	if base == "" || base == "." || base == ".." || base == "/" || runtimeContextWindowsDrivePath(base) {
+		return ""
+	}
+	return externalRuntimeContextPrefix + base
 }
 
 func runtimeSymbols(values map[string]int) []report.RuntimeSymbolUsage {

--- a/internal/runtime/trace_annotate.go
+++ b/internal/runtime/trace_annotate.go
@@ -231,7 +231,7 @@ func runtimeContextModules(values map[string]int, repoPath string) []report.Runt
 	return runtimeModules(redacted)
 }
 
-func visibleRuntimeContextModule(value string, repoPath string) string {
+func visibleRuntimeContextModule(value, repoPath string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return ""

--- a/internal/runtime/trace_annotate_test.go
+++ b/internal/runtime/trace_annotate_test.go
@@ -117,6 +117,26 @@ func TestAnnotateRuntimeContextRedactsUnsafeVisiblePaths(t *testing.T) {
 	})
 }
 
+func TestLoadAndAnnotateRuntimeContextRedactsFileURLAuthorities(t *testing.T) {
+	trace, err := loadTraceFromContent(t, `{"module":"`+lodashMapModule+`","parent":"file://server/share/private/main.js","entrypoint":"file://localhost/private/start.js"}`+"\n")
+	if err != nil {
+		t.Fatalf(loadTraceErrFmt, err)
+	}
+	rep := report.Report{
+		RepoPath: t.TempDir(),
+		Dependencies: []report.DependencyReport{
+			{Name: "lodash"},
+		},
+	}
+
+	usage := Annotate(rep, trace, AnnotateOptions{}).Dependencies[0].RuntimeUsage
+	if usage == nil {
+		t.Fatalf("expected runtime usage annotation")
+	}
+	assertRuntimeContextCounts(t, usage.ParentModules, map[string]int{"external:main.js": 1})
+	assertRuntimeContextCounts(t, usage.Entrypoints, map[string]int{"external:start.js": 1})
+}
+
 func TestAnnotateRuntimeContextPreservesIdentityThroughSymlinkedRepoRoot(t *testing.T) {
 	tempRoot := t.TempDir()
 	physicalRepo := filepath.Join(tempRoot, "physical")

--- a/internal/runtime/trace_annotate_test.go
+++ b/internal/runtime/trace_annotate_test.go
@@ -118,7 +118,10 @@ func TestAnnotateRuntimeContextRedactsUnsafeVisiblePaths(t *testing.T) {
 }
 
 func TestLoadAndAnnotateRuntimeContextRedactsFileURLAuthorities(t *testing.T) {
-	trace, err := loadTraceFromContent(t, `{"module":"`+lodashMapModule+`","parent":"file://server/share/private/main.js","entrypoint":"file://localhost/server/share/start.js"}`+"\n")
+	content :=
+		`{"module":"` + lodashMapModule + `","parent":"file://server/share/private/main.js","entrypoint":"file://localhost/server/share/start.js"}` + "\n" +
+			`{"module":"` + lodashMapModule + `","parent":"\\\\server\\share\\private\\unc.js","entrypoint":"file:////server/share/unc-start.js"}` + "\n"
+	trace, err := loadTraceFromContent(t, content)
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
 	}
@@ -133,8 +136,14 @@ func TestLoadAndAnnotateRuntimeContextRedactsFileURLAuthorities(t *testing.T) {
 	if usage == nil {
 		t.Fatalf("expected runtime usage annotation")
 	}
-	assertRuntimeContextCounts(t, usage.ParentModules, map[string]int{"external:main.js": 1})
-	assertRuntimeContextCounts(t, usage.Entrypoints, map[string]int{"external:start.js": 1})
+	assertRuntimeContextCounts(t, usage.ParentModules, map[string]int{
+		"external:main.js": 1,
+		"external:unc.js":  1,
+	})
+	assertRuntimeContextCounts(t, usage.Entrypoints, map[string]int{
+		"external:start.js":     1,
+		"external:unc-start.js": 1,
+	})
 }
 
 func TestAnnotateRuntimeContextPreservesIdentityThroughSymlinkedRepoRoot(t *testing.T) {

--- a/internal/runtime/trace_annotate_test.go
+++ b/internal/runtime/trace_annotate_test.go
@@ -118,12 +118,12 @@ func TestAnnotateRuntimeContextRedactsUnsafeVisiblePaths(t *testing.T) {
 }
 
 func TestLoadAndAnnotateRuntimeContextRedactsFileURLAuthorities(t *testing.T) {
-	trace, err := loadTraceFromContent(t, `{"module":"`+lodashMapModule+`","parent":"file://server/share/private/main.js","entrypoint":"file://localhost/private/start.js"}`+"\n")
+	trace, err := loadTraceFromContent(t, `{"module":"`+lodashMapModule+`","parent":"file://server/share/private/main.js","entrypoint":"file://localhost/server/share/start.js"}`+"\n")
 	if err != nil {
 		t.Fatalf(loadTraceErrFmt, err)
 	}
 	rep := report.Report{
-		RepoPath: t.TempDir(),
+		RepoPath: "/server/share",
 		Dependencies: []report.DependencyReport{
 			{Name: "lodash"},
 		},

--- a/internal/runtime/trace_annotate_test.go
+++ b/internal/runtime/trace_annotate_test.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/report"
@@ -8,6 +10,7 @@ import (
 
 func TestAnnotateRuntimeOnly(t *testing.T) {
 	rep := report.Report{
+		RepoPath: "/repo",
 		Dependencies: []report.DependencyReport{
 			{Name: "alpha"},
 			{
@@ -46,6 +49,178 @@ func TestAnnotateRuntimeOnly(t *testing.T) {
 	}
 	if annotated.Dependencies[1].RuntimeUsage.Correlation != report.RuntimeCorrelationOverlap {
 		t.Fatalf("expected beta overlap correlation, got %#v", annotated.Dependencies[1].RuntimeUsage)
+	}
+}
+
+func TestAnnotateRuntimeContextRedactsUnsafeVisiblePaths(t *testing.T) {
+	repoPath := t.TempDir()
+	repoParent := filepath.Join(repoPath, "src", "index.js")
+	repoRootParent := filepath.Join(repoPath, "outside.js")
+	repoReservedParent := filepath.Join(repoPath, "external:outside.js")
+	repoEntrypoint := filepath.Join(repoPath, "cmd", "main.js")
+	outsideParent := filepath.Join(t.TempDir(), "outside.js")
+	outsideEntrypoint := filepath.Join(t.TempDir(), "launch.js")
+	rep := report.Report{
+		RepoPath: repoPath,
+		Dependencies: []report.DependencyReport{
+			{Name: "alpha"},
+		},
+	}
+
+	trace := Trace{
+		DependencyLoads: map[string]int{"alpha": 4},
+		DependencyParents: map[string]map[string]int{
+			"alpha": {
+				fileURLPrefix + filepath.ToSlash(repoParent): 1,
+				repoParent:                         2,
+				repoRootParent:                     4,
+				repoReservedParent:                 5,
+				"../outside.js":                    1,
+				outsideParent:                      1,
+				`C:\Users\alice\project\secret.js`: 1,
+				"file:///C:/Users/alice/project/secret.js": 2,
+				`D:private\drive.js`:                       1,
+				"node:fs":                                  1,
+				"@scope/pkg":                               1,
+				"literal:marker":                           1,
+			},
+		},
+		DependencyEntrypoints: map[string]map[string]int{
+			"alpha": {
+				fileURLPrefix + filepath.ToSlash(repoEntrypoint): 3,
+				outsideEntrypoint: 1,
+				"file:///C:/Users/alice/project/win-launch.js": 1,
+			},
+		},
+	}
+
+	annotated := Annotate(rep, trace, AnnotateOptions{})
+	usage := annotated.Dependencies[0].RuntimeUsage
+	if usage == nil {
+		t.Fatalf("expected runtime usage annotation")
+	}
+	assertRuntimeContextCounts(t, usage.ParentModules, map[string]int{
+		"src/index.js":                3,
+		"outside.js":                  4,
+		"literal:external:outside.js": 5,
+		"external:outside.js":         2,
+		"external:secret.js":          3,
+		"external:drive.js":           1,
+		"node:fs":                     1,
+		"@scope/pkg":                  1,
+		"literal:literal:marker":      1,
+	})
+	assertRuntimeContextCounts(t, usage.Entrypoints, map[string]int{
+		"cmd/main.js":            3,
+		"external:launch.js":     1,
+		"external:win-launch.js": 1,
+	})
+}
+
+func TestAnnotateRuntimeContextPreservesIdentityThroughSymlinkedRepoRoot(t *testing.T) {
+	tempRoot := t.TempDir()
+	physicalRepo := filepath.Join(tempRoot, "physical")
+	physicalParent := filepath.Join(physicalRepo, "src", "index.js")
+	if err := os.MkdirAll(filepath.Dir(physicalParent), 0o750); err != nil {
+		t.Fatalf("create physical repo: %v", err)
+	}
+	if err := os.WriteFile(physicalParent, nil, 0o600); err != nil {
+		t.Fatalf("write physical parent module: %v", err)
+	}
+	linkedRepo := filepath.Join(tempRoot, "linked")
+	if err := os.Symlink(physicalRepo, linkedRepo); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	rep := report.Report{
+		RepoPath: linkedRepo,
+		Dependencies: []report.DependencyReport{
+			{Name: "alpha"},
+		},
+	}
+	trace := Trace{
+		DependencyLoads: map[string]int{"alpha": 3},
+		DependencyParents: map[string]map[string]int{
+			"alpha": {
+				physicalParent: 1,
+				filepath.Join(linkedRepo, "src", "index.js"): 2,
+			},
+		},
+	}
+
+	annotated := Annotate(rep, trace, AnnotateOptions{})
+	usage := annotated.Dependencies[0].RuntimeUsage
+	if usage == nil {
+		t.Fatalf("expected runtime usage annotation")
+	}
+	assertRuntimeContextCounts(t, usage.ParentModules, map[string]int{"src/index.js": 3})
+}
+
+func TestAnnotateRuntimeContextEdgeCases(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		value    string
+		repoPath string
+		want     string
+	}{
+		{name: "blank", value: "  "},
+		{name: "empty file URL", value: "file://"},
+		{name: "external root", value: "/"},
+		{name: "non-file URL", value: "https://example.test/entry.js", want: "https://example.test/entry.js"},
+		{name: "reserved URL prefix", value: "external://example.test/entry.js", want: "literal:external://example.test/entry.js"},
+		{name: "relative path without repo", value: "src/index.js", want: "src/index.js"},
+		{name: "relative repo root rejected", value: "/repo/main.js", repoPath: "repo", want: "external:main.js"},
+		{name: "localhost Windows file URL", value: "file://localhost/C:/Users/alice/main.js", want: "external:main.js"},
+		{name: "UNC file URL", value: "file://server/share/main.js", want: "external:main.js"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := annotateRuntimeParentModules(t, tt.value, tt.repoPath)
+			if tt.want == "" {
+				if len(got) != 0 {
+					t.Fatalf("expected %q to be omitted, got %#v", tt.value, got)
+				}
+				return
+			}
+			if len(got) != 1 || got[0].Module != tt.want || got[0].Count != 1 {
+				t.Fatalf("expected %q to render as %q, got %#v", tt.value, tt.want, got)
+			}
+		})
+	}
+}
+
+func annotateRuntimeParentModules(t *testing.T, value, repoPath string) []report.RuntimeModuleUsage {
+	t.Helper()
+	rep := report.Report{
+		RepoPath: repoPath,
+		Dependencies: []report.DependencyReport{
+			{Name: "alpha"},
+		},
+	}
+	trace := Trace{
+		DependencyLoads: map[string]int{"alpha": 1},
+		DependencyParents: map[string]map[string]int{
+			"alpha": {value: 1},
+		},
+	}
+	usage := Annotate(rep, trace, AnnotateOptions{}).Dependencies[0].RuntimeUsage
+	if usage == nil {
+		t.Fatalf("expected runtime usage for %q", value)
+	}
+	return usage.ParentModules
+}
+
+func assertRuntimeContextCounts(t *testing.T, got []report.RuntimeModuleUsage, want map[string]int) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("expected runtime context %#v, got %#v", want, got)
+	}
+	for _, item := range got {
+		if count, ok := want[item.Module]; !ok || count != item.Count {
+			t.Fatalf("expected runtime context %#v, got %#v", want, got)
+		}
 	}
 }
 

--- a/internal/runtime/trace_load.go
+++ b/internal/runtime/trace_load.go
@@ -177,6 +177,15 @@ func runtimeContextValue(value string) string {
 	if value == "" {
 		return ""
 	}
-	value = strings.TrimPrefix(value, fileURLPrefix)
-	return filepath.ToSlash(value)
+	value = filepath.ToSlash(value)
+	if !strings.HasPrefix(value, fileURLPrefix) {
+		return value
+	}
+	withoutPrefix := strings.TrimPrefix(value, fileURLPrefix)
+	if withoutPrefix != "" &&
+		!strings.HasPrefix(withoutPrefix, "/") &&
+		!runtimeContextWindowsDrivePath(withoutPrefix) {
+		return value
+	}
+	return withoutPrefix
 }


### PR DESCRIPTION
## Summary

Runtime parent-module and entrypoint metadata could expose absolute host paths through JSON, table, TUI, and SARIF reports.

This replacement for superseded #1416 stays within #1279: report-visible runtime context now preserves useful repo-relative identity while deterministically redacting paths outside the repository.

Closes #1279
Supersedes #1416

## Root cause

Runtime annotation copied normalized parent and entrypoint strings directly into the report model. Trace loading also removed lowercase `file://` syntax without preserving URL authority, so server and localhost paths could be mistaken for repo-relative values before they reached report renderers.

## Changes

- Render in-repository parent modules and entrypoints as repo-relative paths.
- Render external, traversal, Windows, UNC, and external `file://` paths as `external:<basename>`.
- Reserve and escape `external:` and `literal:` prefixes so redacted paths cannot collide with genuine visible values.
- Preserve non-path module identifiers such as `node:fs` and `@scope/pkg`.
- Merge counts only after deterministic visibility mapping, while keeping repo and external identities distinct.
- Preserve identity when the configured repository root is itself a symlink.
- Preserve and redact `file://` authority and UNC syntax before repository containment so server/share paths stay external.
- Add focused regressions for absolute paths, traversal, Windows/file URLs, symlinked roots, reserved-prefix collisions, and edge-case normalization.

## Validation

```bash
go test ./internal/runtime -run 'TestAnnotateRuntimeContext|TestLoadAndAnnotateRuntimeContextRedactsFileURLAuthorities' -count=1
go test ./internal/analysis -run '^TestServiceAnalysePythonRuntimeTraceIntegration$' -count=1
make ci
```

- Scoped diff: 4 files, 380 additions, 9 deletions.
- New-code duplication: 0.00%.
- Aggregate coverage: 98.3%; `internal/runtime` coverage: 98.3%.
- Security scan: 0 issues.
- Vulnerability scan: 0 vulnerabilities.
- Memory benchmark gate: passed.
- Independent scoped review: approved after collision-proof namespace tests.

Regression-Test: ./internal/runtime::TestAnnotateRuntimeContextRedactsUnsafeVisiblePaths
Regression-Test: ./internal/runtime::TestAnnotateRuntimeContextPreservesIdentityThroughSymlinkedRepoRoot
Regression-Test: ./internal/runtime::TestLoadAndAnnotateRuntimeContextRedactsFileURLAuthorities

## Risk and compatibility

- Breaking changes: report-visible absolute runtime context paths are intentionally replaced with repo-relative or redacted labels.
- Migration required: consumers matching raw absolute `parentModules` or `entrypoints` values must use the new stable labels.
- Performance impact: one bounded path-normalization pass over the existing parent/entrypoint count maps.
- Memory benchmark impact: none; the full memory benchmark gate passed.
- Runtime impact: capture remains unchanged; trace loading now preserves file-URL authority for safe downstream redaction.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
