### PR TITLE
fix(js): bound untrusted source reads

### DIFF
--- a/internal/analysis/cache_storage.go
+++ b/internal/analysis/cache_storage.go
@@ -15,7 +15,8 @@ type cachePointer struct {
 }
 
 type cachedPayload struct {
-	Report report.Report `json:"report"`
+	Report                      report.Report `json:"report"`
+	UsageIncompleteDependencies []int         `json:"usageIncompleteDependencies,omitempty"`
 }
 
 func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool, error) {
@@ -61,6 +62,11 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: "object-corrupt"})
 		return report.Report{}, false, nil
 	}
+	if !payload.restoreUsageIncomplete() {
+		c.metadata.Misses++
+		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: "object-corrupt"})
+		return report.Report{}, false, nil
+	}
 	c.metadata.Hits++
 	return payload.Report, true, nil
 }
@@ -69,7 +75,7 @@ func (c *analysisCache) store(entry cacheEntryDescriptor, data report.Report) er
 	if c == nil || !c.options.Enabled || !c.cacheable || c.options.ReadOnly {
 		return nil
 	}
-	payload := cachedPayload{Report: data}
+	payload := newCachedPayload(data)
 	serializedPayload, err := json.Marshal(payload)
 	if err != nil {
 		return err
@@ -96,4 +102,24 @@ func (c *analysisCache) store(entry cacheEntryDescriptor, data report.Report) er
 	}
 	c.metadata.Writes++
 	return nil
+}
+
+func newCachedPayload(data report.Report) cachedPayload {
+	payload := cachedPayload{Report: data}
+	for index := range data.Dependencies {
+		if data.Dependencies[index].UsageIncomplete {
+			payload.UsageIncompleteDependencies = append(payload.UsageIncompleteDependencies, index)
+		}
+	}
+	return payload
+}
+
+func (p *cachedPayload) restoreUsageIncomplete() bool {
+	for _, index := range p.UsageIncompleteDependencies {
+		if index < 0 || index >= len(p.Report.Dependencies) {
+			return false
+		}
+		p.Report.Dependencies[index].UsageIncomplete = true
+	}
+	return true
 }

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -3,8 +3,10 @@ package analysis
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -21,8 +23,9 @@ const (
 )
 
 type countingAdapter struct {
-	id    string
-	calls int
+	id              string
+	calls           int
+	usageIncomplete bool
 }
 
 func (a *countingAdapter) ID() string { return a.id }
@@ -57,9 +60,21 @@ func (a *countingAdapter) Analyse(_ context.Context, req language.Request) (repo
 			},
 		}
 	}
+	if a.usageIncomplete && !markUsageIncompleteForTest(&dependency) {
+		return report.Report{}, errors.New("usage-incomplete marker unavailable")
+	}
 	return report.Report{
 		Dependencies: []report.DependencyReport{dependency},
 	}, nil
+}
+
+func markUsageIncompleteForTest(dependency *report.DependencyReport) bool {
+	field := reflect.ValueOf(dependency).Elem().FieldByName("UsageIncomplete")
+	if !field.IsValid() || !field.CanSet() {
+		return false
+	}
+	field.SetBool(true)
+	return true
 }
 
 func newCacheTestService(t *testing.T) (*Service, *countingAdapter) {
@@ -129,6 +144,44 @@ func TestAnalysisCacheHitAndInvalidation(t *testing.T) {
 	}
 	if len(third.Cache.Invalidations) == 0 || !strings.Contains(third.Cache.Invalidations[0].Reason, "input-changed") {
 		t.Fatalf("expected input-changed invalidation, got %#v", third.Cache.Invalidations)
+	}
+}
+
+func TestAnalysisCachePreservesUsageIncomplete(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "import dep from \"dep\"\n")
+
+	svc, adapter := newCacheTestService(t)
+	adapter.usageIncomplete = true
+	req := newCacheRequest(repo, filepath.Join(repo, cacheTestDirectoryName), false)
+
+	first, err := svc.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first analyse: %v", err)
+	}
+	if len(first.Dependencies) != 1 || first.Dependencies[0].RemovalCandidate != nil {
+		t.Fatalf("expected incomplete first analysis to suppress removal scoring, got %#v", first.Dependencies)
+	}
+
+	second, err := svc.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second analyse: %v", err)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("expected second analysis to use cache, adapter calls=%d", adapter.calls)
+	}
+	if second.Cache == nil || second.Cache.Hits != 1 {
+		t.Fatalf("expected cache hit metadata, got %#v", second.Cache)
+	}
+	if len(second.Dependencies) != 1 || second.Dependencies[0].RemovalCandidate != nil {
+		t.Fatalf("expected cached incomplete analysis to suppress removal scoring, got %#v", second.Dependencies)
+	}
+	serialized, err := json.Marshal(second)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	if strings.Contains(string(serialized), "usageIncomplete") {
+		t.Fatalf("did not expect internal incomplete-usage state in report JSON: %s", serialized)
 	}
 }
 

--- a/internal/analysis/merge.go
+++ b/internal/analysis/merge.go
@@ -63,6 +63,7 @@ var dependencyFamilyMergeOrder = []dependencyFamilyMergeFn{
 	mergeDependencyCodemodFamily,
 	mergeDependencyRuntimeFamily,
 	mergeDependencyMetadataFamily,
+	mergeDependencyUsageCompletenessFamily,
 }
 
 func mergeDependencyExportFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
@@ -111,6 +112,22 @@ func mergeDependencyMetadataFamily(merged *report.DependencyReport, _ report.Dep
 	if merged.Provenance == nil {
 		merged.Provenance = right.Provenance
 	}
+}
+
+func mergeDependencyUsageCompletenessFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
+	merged.UsageIncomplete = left.UsageIncomplete || right.UsageIncomplete
+	if !merged.UsageIncomplete {
+		return
+	}
+
+	merged.UsedExportsCount = 0
+	merged.TotalExportsCount = 0
+	merged.UsedPercent = 0
+	merged.EstimatedUnusedBytes = 0
+	merged.UnusedExports = nil
+	merged.Recommendations = nil
+	merged.Codemod = nil
+	merged.RemovalCandidate = nil
 }
 
 func filterUsedOverlaps(unused, used []report.ImportUse) []report.ImportUse {

--- a/internal/analysis/merge_report_families_test.go
+++ b/internal/analysis/merge_report_families_test.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -54,8 +55,10 @@ func TestMergeDependencySuppressesRemovalSignalsWhenUsageIsIncomplete(t *testing
 		RemovalCandidate:     &report.RemovalCandidate{Score: 80},
 	}
 	incomplete := report.DependencyReport{
-		Name:            "lodash",
-		UsageIncomplete: true,
+		Name: "lodash",
+	}
+	if !setUsageIncompleteForMergeTest(&incomplete) {
+		t.Fatal("expected usage-incomplete marker to be available")
 	}
 
 	for _, test := range []struct {
@@ -67,22 +70,40 @@ func TestMergeDependencySuppressesRemovalSignalsWhenUsageIsIncomplete(t *testing
 		{name: "incomplete right", left: complete, right: incomplete},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			merged := mergeDependency(test.left, test.right)
-
-			if !merged.UsageIncomplete {
-				t.Fatal("expected merged dependency usage to remain incomplete")
-			}
-			if merged.UsedExportsCount != 0 || merged.TotalExportsCount != 0 || merged.UsedPercent != 0 {
-				t.Fatalf("expected incomplete usage aggregates to be suppressed, got %#v", merged)
-			}
-			if merged.EstimatedUnusedBytes != 0 || len(merged.UnusedExports) != 0 {
-				t.Fatalf("expected incomplete unused-export signals to be suppressed, got %#v", merged)
-			}
-			if len(merged.Recommendations) != 0 || merged.Codemod != nil || merged.RemovalCandidate != nil {
-				t.Fatalf("expected incomplete removal advice to be suppressed, got %#v", merged)
-			}
+			assertIncompleteRemovalSignalsSuppressedAfterMerge(t, mergeDependency(test.left, test.right))
 		})
 	}
+}
+
+func assertIncompleteRemovalSignalsSuppressedAfterMerge(t *testing.T, merged report.DependencyReport) {
+	t.Helper()
+
+	if !usageIncompleteForMergeTest(merged) {
+		t.Fatal("expected merged dependency usage to remain incomplete")
+	}
+	if merged.UsedExportsCount != 0 || merged.TotalExportsCount != 0 || merged.UsedPercent != 0 {
+		t.Fatalf("expected incomplete usage aggregates to be suppressed, got %#v", merged)
+	}
+	if merged.EstimatedUnusedBytes != 0 || len(merged.UnusedExports) != 0 {
+		t.Fatalf("expected incomplete unused-export signals to be suppressed, got %#v", merged)
+	}
+	if len(merged.Recommendations) != 0 || merged.Codemod != nil || merged.RemovalCandidate != nil {
+		t.Fatalf("expected incomplete removal advice to be suppressed, got %#v", merged)
+	}
+}
+
+func setUsageIncompleteForMergeTest(dependency *report.DependencyReport) bool {
+	field := reflect.ValueOf(dependency).Elem().FieldByName("UsageIncomplete")
+	if !field.IsValid() || !field.CanSet() {
+		return false
+	}
+	field.SetBool(true)
+	return true
+}
+
+func usageIncompleteForMergeTest(dependency report.DependencyReport) bool {
+	field := reflect.ValueOf(dependency).FieldByName("UsageIncomplete")
+	return field.IsValid() && field.Kind() == reflect.Bool && field.Bool()
 }
 
 func mergeFamilyReport(generatedAt time.Time, warning string, confirmed, uncertain int, samples []string, dependencies ...report.DependencyReport) report.Report {

--- a/internal/analysis/merge_report_families_test.go
+++ b/internal/analysis/merge_report_families_test.go
@@ -41,6 +41,50 @@ func TestMergeReportsCoordinatesFamiliesInStableOrder(t *testing.T) {
 	assertMergedDependencies(t, merged)
 }
 
+func TestMergeDependencySuppressesRemovalSignalsWhenUsageIsIncomplete(t *testing.T) {
+	complete := report.DependencyReport{
+		Name:                 "lodash",
+		UsedExportsCount:     1,
+		TotalExportsCount:    3,
+		UsedPercent:          100.0 / 3.0,
+		EstimatedUnusedBytes: 256,
+		UnusedExports:        []report.SymbolRef{{Name: "unused"}},
+		Recommendations:      []report.Recommendation{{Code: "remove-unused"}},
+		Codemod:              &report.CodemodReport{},
+		RemovalCandidate:     &report.RemovalCandidate{Score: 80},
+	}
+	incomplete := report.DependencyReport{
+		Name:            "lodash",
+		UsageIncomplete: true,
+	}
+
+	for _, test := range []struct {
+		name  string
+		left  report.DependencyReport
+		right report.DependencyReport
+	}{
+		{name: "incomplete left", left: incomplete, right: complete},
+		{name: "incomplete right", left: complete, right: incomplete},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			merged := mergeDependency(test.left, test.right)
+
+			if !merged.UsageIncomplete {
+				t.Fatal("expected merged dependency usage to remain incomplete")
+			}
+			if merged.UsedExportsCount != 0 || merged.TotalExportsCount != 0 || merged.UsedPercent != 0 {
+				t.Fatalf("expected incomplete usage aggregates to be suppressed, got %#v", merged)
+			}
+			if merged.EstimatedUnusedBytes != 0 || len(merged.UnusedExports) != 0 {
+				t.Fatalf("expected incomplete unused-export signals to be suppressed, got %#v", merged)
+			}
+			if len(merged.Recommendations) != 0 || merged.Codemod != nil || merged.RemovalCandidate != nil {
+				t.Fatalf("expected incomplete removal advice to be suppressed, got %#v", merged)
+			}
+		})
+	}
+}
+
 func mergeFamilyReport(generatedAt time.Time, warning string, confirmed, uncertain int, samples []string, dependencies ...report.DependencyReport) report.Report {
 	return report.Report{
 		GeneratedAt:      generatedAt,

--- a/internal/lang/js/export_surface_resolution.go
+++ b/internal/lang/js/export_surface_resolution.go
@@ -69,7 +69,7 @@ func parseEntrypointsIntoSurface(depPath string, resolved []string, surface *Exp
 		}
 		seenEntries[entry] = struct{}{}
 
-		content, err := safeio.ReadFileUnder(depPath, entry)
+		content, err := safeio.ReadFileUnderLimit(depPath, entry, maxScannableJSFile)
 		if err != nil {
 			surface.Warnings = append(surface.Warnings, fmt.Sprintf("failed to read entrypoint: %s", entry))
 			continue

--- a/internal/lang/js/export_surface_resolution.go
+++ b/internal/lang/js/export_surface_resolution.go
@@ -77,14 +77,12 @@ func parseEntrypointsIntoSurface(depPath string, resolved []string, surface *Exp
 			continue
 		}
 		tree, err := parser.Parse(context.Background(), entry, content)
-		if err != nil {
+		if err != nil || tree == nil || tree.RootNode().HasError() {
 			surface.CoverageIncomplete = true
 			surface.Warnings = append(surface.Warnings, fmt.Sprintf("failed to parse entrypoint: %s", entry))
 			continue
 		}
-		if tree != nil {
-			addCollectedExports(surface, collectExportNames(tree, content))
-		}
+		addCollectedExports(surface, collectExportNames(tree, content))
 	}
 	for entry := range seenEntries {
 		surface.EntryPoints = append(surface.EntryPoints, entry)

--- a/internal/lang/js/export_surface_resolution.go
+++ b/internal/lang/js/export_surface_resolution.go
@@ -52,6 +52,7 @@ func resolveEntrypoints(depPath string, entrypoints map[string]struct{}, surface
 	for entry := range entrypoints {
 		path, ok := resolveEntrypoint(depPath, entry)
 		if !ok {
+			surface.CoverageIncomplete = true
 			surface.Warnings = append(surface.Warnings, fmt.Sprintf("entrypoint not found: %s", entry))
 			continue
 		}
@@ -71,11 +72,13 @@ func parseEntrypointsIntoSurface(depPath string, resolved []string, surface *Exp
 
 		content, err := safeio.ReadFileUnderLimit(depPath, entry, maxScannableJSFile)
 		if err != nil {
+			surface.CoverageIncomplete = true
 			surface.Warnings = append(surface.Warnings, fmt.Sprintf("failed to read entrypoint: %s", entry))
 			continue
 		}
 		tree, err := parser.Parse(context.Background(), entry, content)
 		if err != nil {
+			surface.CoverageIncomplete = true
 			surface.Warnings = append(surface.Warnings, fmt.Sprintf("failed to parse entrypoint: %s", entry))
 			continue
 		}

--- a/internal/lang/js/exports.go
+++ b/internal/lang/js/exports.go
@@ -6,10 +6,11 @@ import (
 )
 
 type ExportSurface struct {
-	Names            map[string]struct{}
-	IncludesWildcard bool
-	EntryPoints      []string
-	Warnings         []string
+	Names              map[string]struct{}
+	IncludesWildcard   bool
+	EntryPoints        []string
+	Warnings           []string
+	CoverageIncomplete bool
 }
 
 type packageJSON struct {

--- a/internal/lang/js/exports_helpers_test.go
+++ b/internal/lang/js/exports_helpers_test.go
@@ -193,6 +193,10 @@ func TestParseEntrypointsIntoSurfaceReadAndParseWarnings(t *testing.T) {
 	if err := os.WriteFile(jsFile, []byte("export const value = 1\n"), 0o600); err != nil {
 		t.Fatalf("write index.js: %v", err)
 	}
+	largeFile := filepath.Join(repo, "large.js")
+	if err := os.WriteFile(largeFile, []byte(strings.Repeat("a", oversizedJSFileSize)), 0o600); err != nil {
+		t.Fatalf("write large.js: %v", err)
+	}
 	badFile := filepath.Join(repo, "index.txt")
 	if err := os.WriteFile(badFile, []byte("export const nope = 1\n"), 0o600); err != nil {
 		t.Fatalf("write index.txt: %v", err)
@@ -200,7 +204,7 @@ func TestParseEntrypointsIntoSurfaceReadAndParseWarnings(t *testing.T) {
 	missingFile := filepath.Join(repo, "missing.js")
 
 	surface := &ExportSurface{Names: map[string]struct{}{}}
-	parseEntrypointsIntoSurface(repo, []string{jsFile, jsFile, badFile, missingFile}, surface)
+	parseEntrypointsIntoSurface(repo, []string{jsFile, jsFile, largeFile, badFile, missingFile}, surface)
 
 	if _, ok := surface.Names["value"]; !ok {
 		t.Fatalf("expected parsed export name from valid entrypoint")
@@ -211,6 +215,31 @@ func TestParseEntrypointsIntoSurfaceReadAndParseWarnings(t *testing.T) {
 	warnings := strings.Join(surface.Warnings, "\n")
 	if !strings.Contains(warnings, "failed to parse entrypoint") || !strings.Contains(warnings, "failed to read entrypoint") {
 		t.Fatalf("expected parse/read warnings, got %#v", surface.Warnings)
+	}
+	if !slices.Contains(surface.Warnings, "failed to read entrypoint: "+largeFile) {
+		t.Fatalf("expected oversized entrypoint warning for large.js, got %#v", surface.Warnings)
+	}
+}
+
+func TestParseEntrypointsIntoSurfaceRejectsSymlinkedEntrypoint(t *testing.T) {
+	depPath := t.TempDir()
+	outsidePath := filepath.Join(t.TempDir(), "outside.js")
+	if err := os.WriteFile(outsidePath, []byte("export const outside = 1\n"), 0o600); err != nil {
+		t.Fatalf("write outside entrypoint: %v", err)
+	}
+	entrypoint := filepath.Join(depPath, indexJSName)
+	if err := os.Symlink(outsidePath, entrypoint); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	surface := &ExportSurface{Names: map[string]struct{}{}}
+	parseEntrypointsIntoSurface(depPath, []string{entrypoint}, surface)
+
+	if !slices.Contains(surface.Warnings, "failed to read entrypoint: "+entrypoint) {
+		t.Fatalf("expected symlinked entrypoint warning, got %#v", surface.Warnings)
+	}
+	if len(surface.Names) != 0 {
+		t.Fatalf("expected no exports from outside target, got %#v", surface.Names)
 	}
 }
 

--- a/internal/lang/js/exports_helpers_test.go
+++ b/internal/lang/js/exports_helpers_test.go
@@ -248,6 +248,31 @@ func TestParseEntrypointsIntoSurfaceReadAndParseWarnings(t *testing.T) {
 	}
 }
 
+func TestParseEntrypointsIntoSurfaceMarksRecoveryTreesIncomplete(t *testing.T) {
+	depRoot := t.TempDir()
+	validFile := filepath.Join(depRoot, indexJSName)
+	if err := os.WriteFile(validFile, []byte("export const safe = 1\n"), 0o600); err != nil {
+		t.Fatalf("write valid entrypoint: %v", err)
+	}
+	brokenFile := filepath.Join(depRoot, "broken.js")
+	if err := os.WriteFile(brokenFile, []byte("export const partial = ;\n"), 0o600); err != nil {
+		t.Fatalf("write broken entrypoint: %v", err)
+	}
+
+	surface := &ExportSurface{Names: map[string]struct{}{}}
+	parseEntrypointsIntoSurface(depRoot, []string{validFile, brokenFile}, surface)
+
+	if _, ok := surface.Names["safe"]; !ok {
+		t.Fatal("expected valid entrypoint export to remain available")
+	}
+	if !boolFieldForTest(*surface, "CoverageIncomplete") {
+		t.Fatal("expected syntax-recovery tree to mark export coverage incomplete")
+	}
+	if !slices.Contains(surface.Warnings, "failed to parse entrypoint: "+brokenFile) {
+		t.Fatalf("expected syntax-recovery warning, got %#v", surface.Warnings)
+	}
+}
+
 func TestBuildDependencyReportSuppressesIncompleteExportSurface(t *testing.T) {
 	depRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(depRoot, "package.json"), []byte(`{"name":"dep","exports":{".":"./index.js","./large":"./large.js"}}`), 0o600); err != nil {

--- a/internal/lang/js/exports_helpers_test.go
+++ b/internal/lang/js/exports_helpers_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/ben-ranford/lopper/internal/report"
 )
 
 const indexJSName = "index.js"
@@ -85,6 +88,27 @@ func TestEntrypointAndPathHelpers(t *testing.T) {
 	}
 	if got, err := dependencyRoot(repo, testMalformedDependency+"/pkg"); err != nil || got != filepath.Join(repo, "node_modules", testMalformedDependency, "pkg") {
 		t.Fatalf("unexpected scoped root: %q err=%v", got, err)
+	}
+}
+
+func TestResolveEntrypointsMarksMissingCoverageIncomplete(t *testing.T) {
+	depRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(depRoot, indexJSName), []byte("export const safe = 1\n"), 0o600); err != nil {
+		t.Fatalf("write index.js: %v", err)
+	}
+
+	surface := &ExportSurface{Names: map[string]struct{}{}}
+	entrypoints := map[string]struct{}{
+		indexJSName:    {},
+		"./missing.js": {},
+	}
+	resolved := resolveEntrypoints(depRoot, entrypoints, surface)
+
+	if len(resolved) != 1 {
+		t.Fatalf("expected valid entrypoint to remain resolved, got %#v", resolved)
+	}
+	if !boolFieldForTest(*surface, "CoverageIncomplete") {
+		t.Fatal("expected unresolved declared entrypoint to mark export coverage incomplete")
 	}
 }
 
@@ -219,6 +243,54 @@ func TestParseEntrypointsIntoSurfaceReadAndParseWarnings(t *testing.T) {
 	if !slices.Contains(surface.Warnings, "failed to read entrypoint: "+largeFile) {
 		t.Fatalf("expected oversized entrypoint warning for large.js, got %#v", surface.Warnings)
 	}
+	if !boolFieldForTest(*surface, "CoverageIncomplete") {
+		t.Fatal("expected skipped entrypoints to mark export coverage incomplete")
+	}
+}
+
+func TestBuildDependencyReportSuppressesIncompleteExportSurface(t *testing.T) {
+	depRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(depRoot, "package.json"), []byte(`{"name":"dep","exports":{".":"./index.js","./large":"./large.js"}}`), 0o600); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(depRoot, indexJSName), []byte("export const safe = 1\n"), 0o600); err != nil {
+		t.Fatalf("write index.js: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(depRoot, "large.js"), []byte(strings.Repeat("a", oversizedJSFileSize)), 0o600); err != nil {
+		t.Fatalf("write oversized entrypoint: %v", err)
+	}
+
+	dependency, warnings := buildDependencyReport(dependencyReportOptions{
+		Dependency:                        "dep",
+		DependencyRootPath:                depRoot,
+		ScanResult:                        ScanResult{},
+		MinUsagePercentForRecommendations: 100,
+		SuggestOnly:                       true,
+	})
+
+	if dependency.UsedExportsCount != 0 || dependency.TotalExportsCount != 0 || dependency.UsedPercent != 0 {
+		t.Fatalf("expected partial export metrics to be suppressed, got %#v", dependency)
+	}
+	if len(dependency.UnusedExports) != 0 || len(dependency.Recommendations) != 0 {
+		t.Fatalf("expected partial export removal advice to be suppressed, got %#v", dependency)
+	}
+	if dependency.Codemod != nil {
+		t.Fatalf("expected partial export coverage to suppress codemods, got %#v", dependency.Codemod)
+	}
+	if !strings.Contains(strings.Join(warnings, "\n"), "removal signals suppressed") {
+		t.Fatalf("expected incomplete-export warning, got %#v", warnings)
+	}
+
+	scored := []report.DependencyReport{dependency}
+	report.AnnotateRemovalCandidateScores(scored)
+	if scored[0].RemovalCandidate != nil {
+		t.Fatalf("expected incomplete export surface to suppress removal scoring, got %#v", scored[0].RemovalCandidate)
+	}
+}
+
+func boolFieldForTest(value any, name string) bool {
+	field := reflect.ValueOf(value).FieldByName(name)
+	return field.IsValid() && field.Kind() == reflect.Bool && field.Bool()
 }
 
 func TestParseEntrypointsIntoSurfaceRejectsSymlinkedEntrypoint(t *testing.T) {

--- a/internal/lang/js/reporting.go
+++ b/internal/lang/js/reporting.go
@@ -79,13 +79,17 @@ func buildDependencyReport(opts dependencyReportOptions) (report.DependencyRepor
 		License:              license,
 		Provenance:           provenance,
 	}
-	depReport.Recommendations = buildRecommendations(opts.Dependency, depReport, opts.MinUsagePercentForRecommendations)
 	if opts.ScanResult.UsageIncomplete {
-		depReport.Recommendations = slices.DeleteFunc(depReport.Recommendations, func(recommendation report.Recommendation) bool {
-			return recommendation.Code == "remove-unused-dependency"
-		})
+		depReport.UsageIncomplete = true
+		depReport.UsedExportsCount = 0
+		depReport.TotalExportsCount = 0
+		depReport.UsedPercent = 0
+		depReport.UnusedExports = nil
+		warnings = append(warnings, fmt.Sprintf("usage coverage incomplete for %s; removal signals suppressed", opts.Dependency))
+	} else {
+		depReport.Recommendations = buildRecommendations(opts.Dependency, depReport, opts.MinUsagePercentForRecommendations)
 	}
-	if opts.SuggestOnly {
+	if opts.SuggestOnly && !opts.ScanResult.UsageIncomplete {
 		codemod, codemodWarnings := BuildSubpathCodemodReport(opts.RepoPath, opts.Dependency, opts.DependencyRootPath, opts.ScanResult)
 		depReport.Codemod = codemod
 		warnings = append(warnings, codemodWarnings...)
@@ -457,6 +461,14 @@ func buildTopDependencies(repoPath string, scanResult ScanResult, topN int, runt
 		})
 		reports = append(reports, depReport)
 		warnings = append(warnings, depWarnings...)
+	}
+
+	if scanResult.UsageIncomplete {
+		sort.Slice(reports, func(i, j int) bool {
+			return reports[i].Name < reports[j].Name
+		})
+		warnings = append(warnings, "top-N removal ranking disabled because JS/TS usage coverage is incomplete")
+		return reports, warnings
 	}
 
 	shared.SortReportsByWaste(reports, weights)

--- a/internal/lang/js/reporting.go
+++ b/internal/lang/js/reporting.go
@@ -80,6 +80,11 @@ func buildDependencyReport(opts dependencyReportOptions) (report.DependencyRepor
 		Provenance:           provenance,
 	}
 	depReport.Recommendations = buildRecommendations(opts.Dependency, depReport, opts.MinUsagePercentForRecommendations)
+	if opts.ScanResult.UsageIncomplete {
+		depReport.Recommendations = slices.DeleteFunc(depReport.Recommendations, func(recommendation report.Recommendation) bool {
+			return recommendation.Code == "remove-unused-dependency"
+		})
+	}
 	if opts.SuggestOnly {
 		codemod, codemodWarnings := BuildSubpathCodemodReport(opts.RepoPath, opts.Dependency, opts.DependencyRootPath, opts.ScanResult)
 		depReport.Codemod = codemod

--- a/internal/lang/js/reporting.go
+++ b/internal/lang/js/reporting.go
@@ -63,6 +63,7 @@ func buildDependencyReport(opts dependencyReportOptions) (report.DependencyRepor
 	warnings = append(warnings, riskWarnings...)
 	license, provenance, licenseWarnings := detectLicenseAndProvenance(opts.DependencyRootPath, opts.IncludeRegistryProvenance)
 	warnings = append(warnings, licenseWarnings...)
+	coverageIncomplete := opts.ScanResult.UsageIncomplete || surface.CoverageIncomplete
 
 	depReport := report.DependencyReport{
 		Language:             "js-ts",
@@ -79,17 +80,17 @@ func buildDependencyReport(opts dependencyReportOptions) (report.DependencyRepor
 		License:              license,
 		Provenance:           provenance,
 	}
-	if opts.ScanResult.UsageIncomplete {
+	if coverageIncomplete {
 		depReport.UsageIncomplete = true
 		depReport.UsedExportsCount = 0
 		depReport.TotalExportsCount = 0
 		depReport.UsedPercent = 0
 		depReport.UnusedExports = nil
-		warnings = append(warnings, fmt.Sprintf("usage coverage incomplete for %s; removal signals suppressed", opts.Dependency))
+		warnings = append(warnings, fmt.Sprintf("usage or export coverage incomplete for %s; removal signals suppressed", opts.Dependency))
 	} else {
 		depReport.Recommendations = buildRecommendations(opts.Dependency, depReport, opts.MinUsagePercentForRecommendations)
 	}
-	if opts.SuggestOnly && !opts.ScanResult.UsageIncomplete {
+	if opts.SuggestOnly && !coverageIncomplete {
 		codemod, codemodWarnings := BuildSubpathCodemodReport(opts.RepoPath, opts.Dependency, opts.DependencyRootPath, opts.ScanResult)
 		depReport.Codemod = codemod
 		warnings = append(warnings, codemodWarnings...)

--- a/internal/lang/js/risk_dynamic.go
+++ b/internal/lang/js/risk_dynamic.go
@@ -36,27 +36,43 @@ func detectDynamicLoaderUsage(depRoot string, entrypoints []string) (int, []stri
 	samples := make([]string, 0, 3)
 
 	for _, entry := range entrypoints {
-		if !isLikelyCodeAsset(entry) {
-			continue
-		}
-		content, err := safeio.ReadFileUnderLimit(depRoot, entry, maxScannableJSFile)
+		entryCount, entrySamples, err := detectDynamicLoaderUsageInEntrypoint(depRoot, entry)
 		if err != nil {
-			if errors.Is(err, safeio.ErrFileTooLarge) {
-				continue
-			}
 			return 0, nil, err
 		}
-		lines := strings.Split(string(content), "\n")
-		for idx, line := range lines {
-			if hasDynamicCall(line, "require(") || hasDynamicCall(line, "import(") {
-				count++
-				if len(samples) < 3 {
-					samples = append(samples, fmt.Sprintf("%s:%d", filepath.Base(entry), idx+1))
-				}
+		count += entryCount
+		remaining := 3 - len(samples)
+		if remaining > len(entrySamples) {
+			remaining = len(entrySamples)
+		}
+		samples = append(samples, entrySamples[:remaining]...)
+	}
+
+	return count, samples, nil
+}
+
+func detectDynamicLoaderUsageInEntrypoint(depRoot, entry string) (int, []string, error) {
+	if !isLikelyCodeAsset(entry) {
+		return 0, nil, nil
+	}
+	content, err := safeio.ReadFileUnderLimit(depRoot, entry, maxScannableJSFile)
+	if err != nil {
+		if errors.Is(err, safeio.ErrFileTooLarge) {
+			return 0, nil, nil
+		}
+		return 0, nil, err
+	}
+
+	count := 0
+	samples := make([]string, 0, 3)
+	for idx, line := range strings.Split(string(content), "\n") {
+		if hasDynamicCall(line, "require(") || hasDynamicCall(line, "import(") {
+			count++
+			if len(samples) < 3 {
+				samples = append(samples, fmt.Sprintf("%s:%d", filepath.Base(entry), idx+1))
 			}
 		}
 	}
-
 	return count, samples, nil
 }
 

--- a/internal/lang/js/risk_dynamic.go
+++ b/internal/lang/js/risk_dynamic.go
@@ -38,7 +38,7 @@ func detectDynamicLoaderUsage(depRoot string, entrypoints []string) (int, []stri
 		if !isLikelyCodeAsset(entry) {
 			continue
 		}
-		content, err := safeio.ReadFileUnder(depRoot, entry)
+		content, err := safeio.ReadFileUnderLimit(depRoot, entry, maxScannableJSFile)
 		if err != nil {
 			return 0, nil, err
 		}

--- a/internal/lang/js/risk_dynamic.go
+++ b/internal/lang/js/risk_dynamic.go
@@ -1,6 +1,7 @@
 package js
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -40,6 +41,9 @@ func detectDynamicLoaderUsage(depRoot string, entrypoints []string) (int, []stri
 		}
 		content, err := safeio.ReadFileUnderLimit(depRoot, entry, maxScannableJSFile)
 		if err != nil {
+			if errors.Is(err, safeio.ErrFileTooLarge) {
+				continue
+			}
 			return 0, nil, err
 		}
 		lines := strings.Split(string(content), "\n")

--- a/internal/lang/js/risk_dynamic.go
+++ b/internal/lang/js/risk_dynamic.go
@@ -11,69 +11,91 @@ import (
 )
 
 func buildDynamicLoaderRiskCue(depRoot string, entrypoints []string) (*report.RiskCue, error) {
-	dynamicCount, samples, err := detectDynamicLoaderUsage(depRoot, entrypoints)
+	scan, err := scanDynamicLoaderUsage(depRoot, entrypoints)
 	if err != nil {
 		return nil, err
 	}
-	if dynamicCount == 0 {
+	if scan.count == 0 && scan.skippedOversized == 0 {
 		return nil, nil
-	}
-
-	msg := fmt.Sprintf("dynamic require/import usage found in %d dependency entrypoint location(s)", dynamicCount)
-	if len(samples) > 0 {
-		msg = fmt.Sprintf("%s (%s)", msg, strings.Join(samples, ", "))
 	}
 
 	return &report.RiskCue{
 		Code:     riskCodeDynamicLoader,
 		Severity: "medium",
-		Message:  msg,
+		Message:  dynamicLoaderRiskMessage(scan),
 	}, nil
 }
 
 func detectDynamicLoaderUsage(depRoot string, entrypoints []string) (int, []string, error) {
-	count := 0
-	samples := make([]string, 0, 3)
-
-	for _, entry := range entrypoints {
-		entryCount, entrySamples, err := detectDynamicLoaderUsageInEntrypoint(depRoot, entry)
-		if err != nil {
-			return 0, nil, err
-		}
-		count += entryCount
-		remaining := 3 - len(samples)
-		if remaining > len(entrySamples) {
-			remaining = len(entrySamples)
-		}
-		samples = append(samples, entrySamples[:remaining]...)
+	scan, err := scanDynamicLoaderUsage(depRoot, entrypoints)
+	if err != nil {
+		return 0, nil, err
 	}
-
-	return count, samples, nil
+	return scan.count, scan.samples, nil
 }
 
-func detectDynamicLoaderUsageInEntrypoint(depRoot, entry string) (int, []string, error) {
+type dynamicLoaderScanResult struct {
+	count            int
+	samples          []string
+	skippedOversized int
+}
+
+func scanDynamicLoaderUsage(depRoot string, entrypoints []string) (dynamicLoaderScanResult, error) {
+	result := dynamicLoaderScanResult{samples: make([]string, 0, 3)}
+	for _, entry := range entrypoints {
+		entryScan, err := scanDynamicLoaderUsageInEntrypoint(depRoot, entry)
+		if err != nil {
+			return dynamicLoaderScanResult{}, err
+		}
+		result.count += entryScan.count
+		result.skippedOversized += entryScan.skippedOversized
+		remaining := 3 - len(result.samples)
+		if remaining > len(entryScan.samples) {
+			remaining = len(entryScan.samples)
+		}
+		result.samples = append(result.samples, entryScan.samples[:remaining]...)
+	}
+
+	return result, nil
+}
+
+func dynamicLoaderRiskMessage(scan dynamicLoaderScanResult) string {
+	if scan.count == 0 {
+		return fmt.Sprintf("dynamic loader usage could not be verified in %d oversized dependency entrypoint(s)", scan.skippedOversized)
+	}
+
+	msg := fmt.Sprintf("dynamic require/import usage found in %d dependency entrypoint location(s)", scan.count)
+	if len(scan.samples) > 0 {
+		msg = fmt.Sprintf("%s (%s)", msg, strings.Join(scan.samples, ", "))
+	}
+	if scan.skippedOversized > 0 {
+		msg = fmt.Sprintf("%s; dynamic loader usage could not be verified in %d oversized dependency entrypoint(s)", msg, scan.skippedOversized)
+	}
+	return msg
+}
+
+func scanDynamicLoaderUsageInEntrypoint(depRoot, entry string) (dynamicLoaderScanResult, error) {
 	if !isLikelyCodeAsset(entry) {
-		return 0, nil, nil
+		return dynamicLoaderScanResult{}, nil
 	}
 	content, err := safeio.ReadFileUnderLimit(depRoot, entry, maxScannableJSFile)
 	if err != nil {
 		if errors.Is(err, safeio.ErrFileTooLarge) {
-			return 0, nil, nil
+			return dynamicLoaderScanResult{skippedOversized: 1}, nil
 		}
-		return 0, nil, err
+		return dynamicLoaderScanResult{}, err
 	}
 
-	count := 0
-	samples := make([]string, 0, 3)
+	result := dynamicLoaderScanResult{samples: make([]string, 0, 3)}
 	for idx, line := range strings.Split(string(content), "\n") {
 		if hasDynamicCall(line, "require(") || hasDynamicCall(line, "import(") {
-			count++
-			if len(samples) < 3 {
-				samples = append(samples, fmt.Sprintf("%s:%d", filepath.Base(entry), idx+1))
+			result.count++
+			if len(result.samples) < 3 {
+				result.samples = append(result.samples, fmt.Sprintf("%s:%d", filepath.Base(entry), idx+1))
 			}
 		}
 	}
-	return count, samples, nil
+	return result, nil
 }
 
 func hasDynamicCall(line, token string) bool {

--- a/internal/lang/js/risk_recommendation_branches_test.go
+++ b/internal/lang/js/risk_recommendation_branches_test.go
@@ -1,12 +1,15 @@
 package js
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 const requireToken = "require("
@@ -131,6 +134,19 @@ func TestDetectDynamicLoaderUsageAndErrors(t *testing.T) {
 
 	if _, _, err := detectDynamicLoaderUsage(depRoot, []string{filepath.Join(depRoot, "missing.js")}); err == nil {
 		t.Fatalf("expected read error for missing dynamic-loader entrypoint")
+	}
+}
+
+func TestDetectDynamicLoaderUsageRejectsOversizedEntrypoint(t *testing.T) {
+	depRoot := t.TempDir()
+	entry := filepath.Join(depRoot, "index.js")
+	if err := os.WriteFile(entry, []byte(strings.Repeat("a", oversizedJSFileSize)), 0o600); err != nil {
+		t.Fatalf("write oversized entrypoint: %v", err)
+	}
+
+	_, _, err := detectDynamicLoaderUsage(depRoot, []string{entry})
+	if !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected oversized entrypoint error %v, got %v", safeio.ErrFileTooLarge, err)
 	}
 }
 

--- a/internal/lang/js/risk_recommendation_branches_test.go
+++ b/internal/lang/js/risk_recommendation_branches_test.go
@@ -156,6 +156,48 @@ func TestDetectDynamicLoaderUsageRejectsOversizedEntrypoint(t *testing.T) {
 	}
 }
 
+func TestBuildDynamicLoaderRiskCueMarksOversizedEntrypointIncomplete(t *testing.T) {
+	depRoot := t.TempDir()
+	oversizedEntry := filepath.Join(depRoot, "oversized.js")
+	oversizedContent := "require(oversizedTarget)\n" + strings.Repeat("a", oversizedJSFileSize)
+	if err := os.WriteFile(oversizedEntry, []byte(oversizedContent), 0o600); err != nil {
+		t.Fatalf("write oversized entrypoint: %v", err)
+	}
+
+	cue, err := buildDynamicLoaderRiskCue(depRoot, []string{oversizedEntry})
+	if err != nil {
+		t.Fatalf("build dynamic-loader risk cue: %v", err)
+	}
+	if cue == nil || cue.Code != riskCodeDynamicLoader {
+		t.Fatalf("expected oversized entrypoint to emit a dynamic-loader uncertainty cue, got %#v", cue)
+	}
+	if !strings.Contains(cue.Message, "could not be verified") || !strings.Contains(cue.Message, "oversized") {
+		t.Fatalf("expected bounded-scan uncertainty in cue message, got %q", cue.Message)
+	}
+
+	reportData := report.Report{
+		Dependencies: []report.DependencyReport{{Name: "oversized", RiskCues: []report.RiskCue{*cue}}},
+	}
+	report.AnnotateReachabilityConfidence(&reportData)
+	reasons := strings.Join(reportData.Dependencies[0].ReachabilityConfidence.RationaleCodes, "\n")
+	if !strings.Contains(reasons, "dependency-dynamic-loader") || strings.Contains(reasons, "dependency-entrypoints-static") {
+		t.Fatalf("expected incomplete entrypoint scan to reduce dynamic-loader confidence, got %q", reasons)
+	}
+
+	validEntry := filepath.Join(depRoot, "valid.js")
+	if err := os.WriteFile(validEntry, []byte("require(validTarget)\n"), 0o600); err != nil {
+		t.Fatalf("write valid entrypoint: %v", err)
+	}
+	mixedCue, err := buildDynamicLoaderRiskCue(depRoot, []string{oversizedEntry, validEntry})
+	if err != nil {
+		t.Fatalf("build mixed dynamic-loader risk cue: %v", err)
+	}
+	if mixedCue == nil || !strings.Contains(mixedCue.Message, "dynamic require/import usage found") ||
+		!strings.Contains(mixedCue.Message, "could not be verified") {
+		t.Fatalf("expected mixed dynamic and incomplete evidence, got %#v", mixedCue)
+	}
+}
+
 func TestDetectNodeBinaryBoundedWalk(t *testing.T) {
 	depRoot := t.TempDir()
 	filesRoot := filepath.Join(depRoot, "files")

--- a/internal/lang/js/risk_recommendation_branches_test.go
+++ b/internal/lang/js/risk_recommendation_branches_test.go
@@ -1,7 +1,6 @@
 package js
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -9,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/report"
-	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 const requireToken = "require("
@@ -139,14 +137,22 @@ func TestDetectDynamicLoaderUsageAndErrors(t *testing.T) {
 
 func TestDetectDynamicLoaderUsageRejectsOversizedEntrypoint(t *testing.T) {
 	depRoot := t.TempDir()
-	entry := filepath.Join(depRoot, "index.js")
-	if err := os.WriteFile(entry, []byte(strings.Repeat("a", oversizedJSFileSize)), 0o600); err != nil {
+	oversizedEntry := filepath.Join(depRoot, "oversized.js")
+	oversizedContent := "require(oversizedTarget)\n" + strings.Repeat("a", oversizedJSFileSize)
+	if err := os.WriteFile(oversizedEntry, []byte(oversizedContent), 0o600); err != nil {
 		t.Fatalf("write oversized entrypoint: %v", err)
 	}
+	validEntry := filepath.Join(depRoot, "valid.js")
+	if err := os.WriteFile(validEntry, []byte("require(validTarget)\n"), 0o600); err != nil {
+		t.Fatalf("write valid entrypoint: %v", err)
+	}
 
-	_, _, err := detectDynamicLoaderUsage(depRoot, []string{entry})
-	if !errors.Is(err, safeio.ErrFileTooLarge) {
-		t.Fatalf("expected oversized entrypoint error %v, got %v", safeio.ErrFileTooLarge, err)
+	count, samples, err := detectDynamicLoaderUsage(depRoot, []string{oversizedEntry, validEntry})
+	if err != nil {
+		t.Fatalf("expected oversized entrypoint to be skipped, got %v", err)
+	}
+	if count != 1 || len(samples) != 1 || samples[0] != "valid.js:1" {
+		t.Fatalf("expected only bounded entrypoint dynamic usage, got count=%d samples=%#v", count, samples)
 	}
 }
 

--- a/internal/lang/js/scan.go
+++ b/internal/lang/js/scan.go
@@ -102,6 +102,14 @@ func ScanRepo(ctx context.Context, repoPath string) (ScanResult, error) {
 		result.Warnings = append(result.Warnings, "no JS/TS files found for analysis")
 	}
 
+	if state.oversizedCount > 0 {
+		warning := fmt.Sprintf("skipped %d oversized JS/TS file(s) exceeding the %d-byte limit", state.oversizedCount, maxScannableJSFile)
+		if len(state.oversizedFiles) > 0 {
+			warning = fmt.Sprintf("%s: %s", warning, strings.Join(state.oversizedFiles, ", "))
+		}
+		result.Warnings = append(result.Warnings, warning)
+	}
+
 	if state.parseErrorCount > 0 {
 		warning := fmt.Sprintf("parse errors in %d file(s)", state.parseErrorCount)
 		if len(state.parseErrorFiles) > 0 {

--- a/internal/lang/js/scan.go
+++ b/internal/lang/js/scan.go
@@ -49,8 +49,9 @@ type FileScan struct {
 }
 
 type ScanResult struct {
-	Files    []FileScan
-	Warnings []string
+	Files           []FileScan
+	Warnings        []string
+	UsageIncomplete bool
 }
 
 var supportedExtensions = map[string]bool{
@@ -103,6 +104,7 @@ func ScanRepo(ctx context.Context, repoPath string) (ScanResult, error) {
 	}
 
 	if state.oversizedCount > 0 {
+		result.UsageIncomplete = true
 		warning := fmt.Sprintf("skipped %d oversized JS/TS file(s) exceeding the %d-byte limit", state.oversizedCount, maxScannableJSFile)
 		if len(state.oversizedFiles) > 0 {
 			warning = fmt.Sprintf("%s: %s", warning, strings.Join(state.oversizedFiles, ", "))

--- a/internal/lang/js/scan_parser.go
+++ b/internal/lang/js/scan_parser.go
@@ -19,6 +19,8 @@ type sourceParser struct {
 	tsx *sitter.Language
 }
 
+const maxScannableJSFile = 2 * 1024 * 1024
+
 func newSourceParser() *sourceParser {
 	return &sourceParser{
 		js:  javascript.GetLanguage(),
@@ -59,9 +61,9 @@ func readAndParseFile(ctx context.Context, parser *sourceParser, repoPath string
 		readErr error
 	)
 	if strings.TrimSpace(repoPath) == "" {
-		content, readErr = safeio.ReadFile(path)
+		content, readErr = safeio.ReadFileLimit(path, maxScannableJSFile)
 	} else {
-		content, readErr = safeio.ReadFileUnder(repoPath, path)
+		content, readErr = safeio.ReadFileUnderLimit(repoPath, path, maxScannableJSFile)
 	}
 	if readErr != nil {
 		return nil, nil, "", readErr

--- a/internal/lang/js/scan_repo.go
+++ b/internal/lang/js/scan_repo.go
@@ -2,9 +2,12 @@ package js
 
 import (
 	"context"
+	"errors"
 	"io/fs"
+	"path/filepath"
 
 	"github.com/ben-ranford/lopper/internal/lang/shared"
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 type scanRepoState struct {
@@ -13,6 +16,8 @@ type scanRepoState struct {
 	result          *ScanResult
 	parseErrorCount int
 	parseErrorFiles []string
+	oversizedCount  int
+	oversizedFiles  []string
 }
 
 func scanRepoEntry(ctx context.Context, state *scanRepoState, path string, entry fs.DirEntry) error {
@@ -28,6 +33,17 @@ func scanRepoEntry(ctx context.Context, state *scanRepoState, path string, entry
 
 	content, tree, relPath, err := readAndParseFile(ctx, state.parser, state.repoPath, path)
 	if err != nil {
+		if errors.Is(err, safeio.ErrFileTooLarge) {
+			state.oversizedCount++
+			oversizedPath := path
+			if relPath, relErr := filepath.Rel(state.repoPath, path); relErr == nil {
+				oversizedPath = relPath
+			}
+			if len(state.oversizedFiles) < 5 {
+				state.oversizedFiles = append(state.oversizedFiles, oversizedPath)
+			}
+			return nil
+		}
 		return err
 	}
 	if tree.RootNode().HasError() {

--- a/internal/lang/js/scan_repo_usage_paths_test.go
+++ b/internal/lang/js/scan_repo_usage_paths_test.go
@@ -6,10 +6,14 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/safeio"
 	sitter "github.com/smacker/go-tree-sitter"
 )
+
+const oversizedJSFileSize = 2*1024*1024 + 1
 
 func TestJSScanRepoAndReadHelpers(t *testing.T) {
 	if _, err := ScanRepo(context.Background(), filepath.Join(t.TempDir(), "missing")); err == nil {
@@ -85,6 +89,37 @@ class Widget {}
 	assertIdentifierUsageState(t, tree, source, "util", "member_expression", false)
 	assertIdentifierUsageState(t, tree, source, "list", "subscript_expression", false)
 	assertIdentifierUsageState(t, tree, source, "index", "subscript_expression", true)
+}
+
+func TestJSScanRepoRejectsOversizedSource(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "index.js"), []byte(strings.Repeat("a", oversizedJSFileSize)), 0o644); err != nil {
+		t.Fatalf("write oversized source: %v", err)
+	}
+
+	_, err := ScanRepo(context.Background(), repo)
+	if !errors.Is(err, safeio.ErrFileTooLarge) {
+		t.Fatalf("expected oversized source error %v, got %v", safeio.ErrFileTooLarge, err)
+	}
+}
+
+func TestJSScanRepoRejectsSymlinkedSource(t *testing.T) {
+	repo := t.TempDir()
+	outsidePath := filepath.Join(t.TempDir(), "outside.js")
+	if err := os.WriteFile(outsidePath, []byte("export const outside = 1\n"), 0o644); err != nil {
+		t.Fatalf("write outside source: %v", err)
+	}
+	if err := os.Symlink(outsidePath, filepath.Join(repo, "index.js")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	result, err := ScanRepo(context.Background(), repo)
+	if !errors.Is(err, safeio.ErrTargetPathSymlink) {
+		t.Fatalf("expected symlink source error %v, got %v", safeio.ErrTargetPathSymlink, err)
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("expected outside target not to be parsed, got %#v", result.Files)
+	}
 }
 
 func assertIdentifierUsageState(t *testing.T, tree *sitter.Tree, source []byte, name string, parentType string, want bool) {

--- a/internal/lang/js/scan_repo_usage_paths_test.go
+++ b/internal/lang/js/scan_repo_usage_paths_test.go
@@ -93,13 +93,24 @@ class Widget {}
 
 func TestJSScanRepoRejectsOversizedSource(t *testing.T) {
 	repo := t.TempDir()
-	if err := os.WriteFile(filepath.Join(repo, "index.js"), []byte(strings.Repeat("a", oversizedJSFileSize)), 0o644); err != nil {
+	oversizedPath := filepath.Join(repo, "index.js")
+	if err := os.WriteFile(oversizedPath, []byte(strings.Repeat("a", oversizedJSFileSize)), 0o644); err != nil {
 		t.Fatalf("write oversized source: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(repo, "valid.js"), []byte("export const valid = 1\n"), 0o644); err != nil {
+		t.Fatalf("write valid source: %v", err)
+	}
 
-	_, err := ScanRepo(context.Background(), repo)
-	if !errors.Is(err, safeio.ErrFileTooLarge) {
-		t.Fatalf("expected oversized source error %v, got %v", safeio.ErrFileTooLarge, err)
+	result, err := ScanRepo(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("expected oversized source to be skipped, got %v", err)
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != "valid.js" {
+		t.Fatalf("expected valid source analysis to continue, got %#v", result.Files)
+	}
+	warnings := strings.Join(result.Warnings, "\n")
+	if !strings.Contains(warnings, "skipped 1 oversized JS/TS file") || !strings.Contains(warnings, filepath.Base(oversizedPath)) {
+		t.Fatalf("expected oversized source warning, got %#v", result.Warnings)
 	}
 }
 

--- a/internal/lang/js/scan_repo_usage_paths_test.go
+++ b/internal/lang/js/scan_repo_usage_paths_test.go
@@ -112,6 +112,18 @@ func TestJSScanRepoRejectsOversizedSource(t *testing.T) {
 	if !strings.Contains(warnings, "skipped 1 oversized JS/TS file") || !strings.Contains(warnings, filepath.Base(oversizedPath)) {
 		t.Fatalf("expected oversized source warning, got %#v", result.Warnings)
 	}
+
+	dependencyReport, _ := buildDependencyReport(dependencyReportOptions{
+		RepoPath:                          repo,
+		Dependency:                        "oversized-only",
+		ScanResult:                        result,
+		MinUsagePercentForRecommendations: 1,
+	})
+	for _, recommendation := range dependencyReport.Recommendations {
+		if recommendation.Code == "remove-unused-dependency" {
+			t.Fatalf("did not expect removal advice from an incomplete scan, got %#v", dependencyReport.Recommendations)
+		}
+	}
 }
 
 func TestJSScanRepoRejectsSymlinkedSource(t *testing.T) {

--- a/internal/lang/js/scan_repo_usage_paths_test.go
+++ b/internal/lang/js/scan_repo_usage_paths_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/safeio"
 	sitter "github.com/smacker/go-tree-sitter"
 )
@@ -100,6 +101,9 @@ func TestJSScanRepoRejectsOversizedSource(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "valid.js"), []byte("export const valid = 1\n"), 0o644); err != nil {
 		t.Fatalf("write valid source: %v", err)
 	}
+	if err := writeDependency(repo, "oversized-only", "export const only = 1\n"); err != nil {
+		t.Fatalf("write dependency: %v", err)
+	}
 
 	result, err := ScanRepo(context.Background(), repo)
 	if err != nil {
@@ -113,16 +117,54 @@ func TestJSScanRepoRejectsOversizedSource(t *testing.T) {
 		t.Fatalf("expected oversized source warning, got %#v", result.Warnings)
 	}
 
-	dependencyReport, _ := buildDependencyReport(dependencyReportOptions{
+	dependencyReport, dependencyWarnings := buildDependencyReport(dependencyReportOptions{
 		RepoPath:                          repo,
 		Dependency:                        "oversized-only",
+		DependencyRootPath:                filepath.Join(repo, "node_modules", "oversized-only"),
 		ScanResult:                        result,
 		MinUsagePercentForRecommendations: 1,
 	})
-	for _, recommendation := range dependencyReport.Recommendations {
-		if recommendation.Code == "remove-unused-dependency" {
-			t.Fatalf("did not expect removal advice from an incomplete scan, got %#v", dependencyReport.Recommendations)
+	if len(dependencyReport.UnusedExports) != 0 {
+		t.Fatalf("did not expect unused exports from an incomplete scan, got %#v", dependencyReport.UnusedExports)
+	}
+	if dependencyReport.UsedExportsCount != 0 || dependencyReport.TotalExportsCount != 0 || dependencyReport.UsedPercent != 0 {
+		t.Fatalf("did not expect usage percentages from an incomplete scan, got %#v", dependencyReport)
+	}
+	if len(dependencyReport.Recommendations) != 0 {
+		t.Fatalf("did not expect recommendations from an incomplete scan, got %#v", dependencyReport.Recommendations)
+	}
+	if !strings.Contains(strings.Join(dependencyWarnings, "\n"), "removal signals suppressed") {
+		t.Fatalf("expected incomplete-usage suppression warning, got %#v", dependencyWarnings)
+	}
+	scored := []report.DependencyReport{dependencyReport}
+	report.AnnotateRemovalCandidateScores(scored)
+	if scored[0].RemovalCandidate != nil {
+		t.Fatalf("did not expect a removal score from an incomplete scan, got %#v", scored[0].RemovalCandidate)
+	}
+
+	for _, dependency := range []string{"alpha", "beta"} {
+		if err := writeDependency(repo, dependency, "export const value = 1\n"); err != nil {
+			t.Fatalf("write %s dependency: %v", dependency, err)
 		}
+	}
+	result.Files = []FileScan{{
+		Path: "valid.js",
+		Imports: []ImportBinding{
+			{Module: "beta"},
+			{Module: "alpha"},
+		},
+	}}
+	topReports, topWarnings := buildTopDependencies(repo, result, 1, "", 1, report.DefaultRemovalCandidateWeights(), false)
+	if len(topReports) != 2 || topReports[0].Name != "alpha" || topReports[1].Name != "beta" {
+		t.Fatalf("expected deterministic unranked reports from incomplete usage, got %#v", topReports)
+	}
+	for _, topReport := range topReports {
+		if topReport.RemovalCandidate != nil {
+			t.Fatalf("did not expect incomplete top-N report to be scored, got %#v", topReport)
+		}
+	}
+	if !strings.Contains(strings.Join(topWarnings, "\n"), "top-N removal ranking disabled") {
+		t.Fatalf("expected incomplete top-N warning, got %#v", topWarnings)
 	}
 }
 

--- a/internal/lang/js/scan_repo_usage_paths_test.go
+++ b/internal/lang/js/scan_repo_usage_paths_test.go
@@ -93,6 +93,50 @@ class Widget {}
 }
 
 func TestJSScanRepoRejectsOversizedSource(t *testing.T) {
+	repo, oversizedPath := setupOversizedSourceRepo(t)
+	result, err := ScanRepo(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("expected oversized source to be skipped, got %v", err)
+	}
+	assertOversizedSourceSkipped(t, result, oversizedPath)
+	assertIncompleteRemovalSignalsSuppressed(t, repo, result)
+}
+
+func TestJSIncompleteScanDisablesTopNRemovalRanking(t *testing.T) {
+	repo, _ := setupOversizedSourceRepo(t)
+	result, err := ScanRepo(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("expected oversized source to be skipped, got %v", err)
+	}
+	for _, dependency := range []string{"alpha", "beta"} {
+		if err := writeDependency(repo, dependency, "export const value = 1\n"); err != nil {
+			t.Fatalf("write %s dependency: %v", dependency, err)
+		}
+	}
+	result.Files = []FileScan{{
+		Path: "valid.js",
+		Imports: []ImportBinding{
+			{Module: "beta"},
+			{Module: "alpha"},
+		},
+	}}
+
+	topReports, topWarnings := buildTopDependencies(repo, result, 1, "", 1, report.DefaultRemovalCandidateWeights(), false)
+	if len(topReports) != 2 || topReports[0].Name != "alpha" || topReports[1].Name != "beta" {
+		t.Fatalf("expected deterministic unranked reports from incomplete usage, got %#v", topReports)
+	}
+	for _, topReport := range topReports {
+		if topReport.RemovalCandidate != nil {
+			t.Fatalf("did not expect incomplete top-N report to be scored, got %#v", topReport)
+		}
+	}
+	if !strings.Contains(strings.Join(topWarnings, "\n"), "top-N removal ranking disabled") {
+		t.Fatalf("expected incomplete top-N warning, got %#v", topWarnings)
+	}
+}
+
+func setupOversizedSourceRepo(t *testing.T) (string, string) {
+	t.Helper()
 	repo := t.TempDir()
 	oversizedPath := filepath.Join(repo, "index.js")
 	if err := os.WriteFile(oversizedPath, []byte(strings.Repeat("a", oversizedJSFileSize)), 0o644); err != nil {
@@ -104,11 +148,11 @@ func TestJSScanRepoRejectsOversizedSource(t *testing.T) {
 	if err := writeDependency(repo, "oversized-only", "export const only = 1\n"); err != nil {
 		t.Fatalf("write dependency: %v", err)
 	}
+	return repo, oversizedPath
+}
 
-	result, err := ScanRepo(context.Background(), repo)
-	if err != nil {
-		t.Fatalf("expected oversized source to be skipped, got %v", err)
-	}
+func assertOversizedSourceSkipped(t *testing.T, result ScanResult, oversizedPath string) {
+	t.Helper()
 	if len(result.Files) != 1 || result.Files[0].Path != "valid.js" {
 		t.Fatalf("expected valid source analysis to continue, got %#v", result.Files)
 	}
@@ -116,7 +160,10 @@ func TestJSScanRepoRejectsOversizedSource(t *testing.T) {
 	if !strings.Contains(warnings, "skipped 1 oversized JS/TS file") || !strings.Contains(warnings, filepath.Base(oversizedPath)) {
 		t.Fatalf("expected oversized source warning, got %#v", result.Warnings)
 	}
+}
 
+func assertIncompleteRemovalSignalsSuppressed(t *testing.T, repo string, result ScanResult) {
+	t.Helper()
 	dependencyReport, dependencyWarnings := buildDependencyReport(dependencyReportOptions{
 		RepoPath:                          repo,
 		Dependency:                        "oversized-only",
@@ -140,31 +187,6 @@ func TestJSScanRepoRejectsOversizedSource(t *testing.T) {
 	report.AnnotateRemovalCandidateScores(scored)
 	if scored[0].RemovalCandidate != nil {
 		t.Fatalf("did not expect a removal score from an incomplete scan, got %#v", scored[0].RemovalCandidate)
-	}
-
-	for _, dependency := range []string{"alpha", "beta"} {
-		if err := writeDependency(repo, dependency, "export const value = 1\n"); err != nil {
-			t.Fatalf("write %s dependency: %v", dependency, err)
-		}
-	}
-	result.Files = []FileScan{{
-		Path: "valid.js",
-		Imports: []ImportBinding{
-			{Module: "beta"},
-			{Module: "alpha"},
-		},
-	}}
-	topReports, topWarnings := buildTopDependencies(repo, result, 1, "", 1, report.DefaultRemovalCandidateWeights(), false)
-	if len(topReports) != 2 || topReports[0].Name != "alpha" || topReports[1].Name != "beta" {
-		t.Fatalf("expected deterministic unranked reports from incomplete usage, got %#v", topReports)
-	}
-	for _, topReport := range topReports {
-		if topReport.RemovalCandidate != nil {
-			t.Fatalf("did not expect incomplete top-N report to be scored, got %#v", topReport)
-		}
-	}
-	if !strings.Contains(strings.Join(topWarnings, "\n"), "top-N removal ranking disabled") {
-		t.Fatalf("expected incomplete top-N warning, got %#v", topWarnings)
 	}
 }
 

--- a/internal/report/model/dependency.go
+++ b/internal/report/model/dependency.go
@@ -18,6 +18,7 @@ type DependencyReport struct {
 	RuntimeUsage           *RuntimeUsage           `json:"runtimeUsage,omitempty"`
 	ReachabilityConfidence *ReachabilityConfidence `json:"reachabilityConfidence,omitempty"`
 	RemovalCandidate       *RemovalCandidate       `json:"removalCandidate,omitempty"`
+	UsageIncomplete        bool                    `json:"-"`
 	Vulnerabilities        []VulnerabilityFinding  `json:"vulnerabilities,omitempty"`
 	License                *DependencyLicense      `json:"license,omitempty"`
 	Provenance             *DependencyProvenance   `json:"provenance,omitempty"`

--- a/internal/report/scoring.go
+++ b/internal/report/scoring.go
@@ -30,6 +30,10 @@ func AnnotateRemovalCandidateScoresWithWeights(dependencies []DependencyReport, 
 	weights = NormalizeRemovalCandidateWeights(weights)
 
 	for i := range dependencies {
+		if dependencies[i].UsageIncomplete {
+			dependencies[i].RemovalCandidate = nil
+			continue
+		}
 		dependencies[i].RemovalCandidate = buildRemovalCandidate(dependencies[i], weights)
 	}
 }

--- a/internal/report/scoring_test.go
+++ b/internal/report/scoring_test.go
@@ -15,6 +15,7 @@ func TestAnnotateRemovalCandidateScoresDeterministic(t *testing.T) {
 	deps := []DependencyReport{
 		{Name: "alpha", UsedExportsCount: 5, TotalExportsCount: 10, UsedPercent: 50},
 		{Name: "beta", UsedExportsCount: 1, TotalExportsCount: 10, UsedPercent: 10},
+		{Name: "incomplete", UsageIncomplete: true},
 	}
 
 	AnnotateRemovalCandidateScores(deps)
@@ -24,6 +25,9 @@ func TestAnnotateRemovalCandidateScoresDeterministic(t *testing.T) {
 	}
 	if deps[1].RemovalCandidate.Score <= deps[0].RemovalCandidate.Score {
 		t.Fatalf("expected lower-usage dependency to score higher, alpha=%f beta=%f", deps[0].RemovalCandidate.Score, deps[1].RemovalCandidate.Score)
+	}
+	if deps[2].RemovalCandidate != nil {
+		t.Fatalf("expected incomplete usage to suppress removal scoring, got %#v", deps[2].RemovalCandidate)
 	}
 }
 


### PR DESCRIPTION
## Summary

JavaScript and TypeScript analysis must not follow repository symlinks outside the trusted root or read attacker-controlled files without a deterministic size bound.

This replacement for superseded #1421 stays within #1288: the existing rooted read boundary now enforces a 2 MiB limit for repository source files and every dependency-entrypoint read path, while bounded warning behavior keeps valid analysis available when oversized files are skipped.

Closes #1288
Supersedes #1421

## Root cause

The JS scanner selected candidate files from untrusted repositories and parsed their full contents. Dependency entrypoints were also reread without a bound during dynamic-loader risk detection. Rooted reads already provided the intended symlink confinement on the current base, but these source boundaries remained unbounded and the confinement behavior lacked issue-specific regression coverage.

## Changes

- Bound repository JS/TS source reads to 2 MiB before parsing.
- Skip oversized repository sources with a bounded warning sample so other valid files remain analyzable.
- Apply the same bound to dependency entrypoint reads used for export-surface resolution.
- Treat unreadable or unparseable dependency entrypoints as incomplete export coverage and suppress partial-surface removal metrics.
- Apply the bound to the downstream dynamic-loader risk scan, recording uncertainty for oversized entries while continuing across remaining bounded entrypoints.
- Mark skipped repository sources as incomplete usage data and suppress every absence-based signal: unused exports, usage percentages, recommendations, codemods, generic removal scores, and top-N removal ranking.
- Preserve the internal incomplete-usage marker across analysis-cache writes and hits without exposing it in user-facing report JSON.
- Preserve incomplete usage across workspace report merges and suppress merged removal advice whenever any contributing scan was incomplete.
- Emit a dynamic-loader uncertainty cue for oversized dependency entrypoints so unscanned code cannot receive static-entrypoint confidence.
- Keep the bounded entrypoint scanner and its regression assertions below the repository's cognitive-complexity threshold without changing behavior.
- Preserve existing error behavior for repository scans and warning behavior for unreadable dependency entrypoints.
- Prove oversized repository files are skipped while bounded analysis continues.
- Prove symlinked repository sources and dependency entrypoints are rejected without parsing outside targets.

## Validation

```bash
go test ./internal/analysis -run 'TestMergeDependencySuppressesRemovalSignalsWhenUsageIsIncomplete' -count=10
go test ./internal/lang/js -run 'TestBuildDependencyReportSuppressesIncompleteExportSurface|TestBuildDynamicLoaderRiskCueMarksOversizedEntrypointIncomplete|TestDetectDynamicLoaderUsageRejectsOversizedEntrypoint|TestJSScanRepoRejects|TestParseEntrypointsIntoSurface(ReadAndParseWarnings|RejectsSymlinkedEntrypoint)' -count=10
go test ./internal/analysis ./internal/lang/js ./internal/report
gocognit -over 15 internal/analysis/merge.go internal/lang/js/risk_dynamic.go internal/lang/js/scan_repo_usage_paths_test.go
make ci
```

- Scoped diff: 17 files, 616 additions, 44 deletions.
- No new dependency or cross-cutting abstraction.

Regression-Test: ./internal/lang/js::TestJSScanRepoRejectsOversizedSource
Regression-Test: ./internal/lang/js::TestParseEntrypointsIntoSurfaceReadAndParseWarnings
Regression-Test: ./internal/lang/js::TestParseEntrypointsIntoSurfaceMarksRecoveryTreesIncomplete
Regression-Test: ./internal/lang/js::TestDetectDynamicLoaderUsageRejectsOversizedEntrypoint
Regression-Test: ./internal/lang/js::TestBuildDynamicLoaderRiskCueMarksOversizedEntrypointIncomplete
Regression-Test: ./internal/lang/js::TestBuildDependencyReportSuppressesIncompleteExportSurface
Regression-Test: ./internal/lang/js::TestResolveEntrypointsMarksMissingCoverageIncomplete
Regression-Test: ./internal/analysis::TestAnalysisCachePreservesUsageIncomplete

## Risk and compatibility

- Breaking changes: JS/TS files larger than 2 MiB are now skipped at the untrusted-input boundary instead of being read in full.
- Migration required: none for repositories whose source and dependency entrypoint files are within the bound.
- Performance impact: bounded reads avoid unbounded allocation while preserving the existing parse path for accepted files.
- Memory benchmark impact: none; the full memory benchmark gate passed.
- Security impact: repository symlinks remain confined to the trusted root and now have focused regression proof.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
