### PR TITLE
fix(runtime): refresh traces on cache hits

### DIFF
--- a/internal/analysis/runtime_capture.go
+++ b/internal/analysis/runtime_capture.go
@@ -11,6 +11,7 @@ import (
 const runtimeTraceCommandWarningPrefix = "runtime trace command failed; continuing with static analysis: "
 
 func captureRuntimeTraceIfNeeded(ctx context.Context, req Request, repoPath string, cache *analysisCache, candidates []language.Candidate) ([]string, string, bool) {
+	_ = cache
 	tracePath := strings.TrimSpace(req.RuntimeTracePath)
 	command := strings.TrimSpace(req.RuntimeTestCommand)
 	if command == "" {
@@ -27,7 +28,6 @@ func captureRuntimeTraceIfNeeded(ctx context.Context, req Request, repoPath stri
 		TracePath:            tracePath,
 		Command:              command,
 		Provider:             provider,
-		ReuseIfUnchanged:     shouldReuseRuntimeTrace(cache),
 		PythonRunnerProfiles: pythonRunnerProfiles,
 	}); err != nil {
 		warning := runtimeTraceCommandWarningPrefix + err.Error()
@@ -76,15 +76,4 @@ func isExplicitPythonLanguage(languageID string) bool {
 	default:
 		return false
 	}
-}
-
-func shouldReuseRuntimeTrace(cache *analysisCache) bool {
-	if cache == nil {
-		return false
-	}
-	metadata := cache.metadataSnapshot()
-	if metadata == nil {
-		return false
-	}
-	return metadata.Enabled && metadata.Hits > 0 && metadata.Misses == 0
 }

--- a/internal/analysis/runtime_capture_test.go
+++ b/internal/analysis/runtime_capture_test.go
@@ -73,7 +73,7 @@ func TestServicePythonRuntimeCaptureIndependentOfTraceFeature(t *testing.T) {
 	}
 }
 
-func TestServiceRuntimeCaptureReusesTraceOnCacheHit(t *testing.T) {
+func TestServiceRuntimeCaptureRefreshesTraceOnCacheHit(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "console.log('hello')\n")
 	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestPackageJSONFileName), "{\n  \"name\": \"demo\"\n}\n")
@@ -107,8 +107,8 @@ func TestServiceRuntimeCaptureReusesTraceOnCacheHit(t *testing.T) {
 	if adapter.calls != 1 {
 		t.Fatalf("expected second run to be cache hit, adapter calls=%d", adapter.calls)
 	}
-	if got := readRuntimeCounter(t, counterPath); got != 1 {
-		t.Fatalf("expected runtime capture reuse on cache hit, got %d", got)
+	if got := readRuntimeCounter(t, counterPath); got != 2 {
+		t.Fatalf("expected runtime capture refresh on cache hit, got %d", got)
 	}
 	if second.Cache == nil || second.Cache.Hits != 1 || second.Cache.Misses != 0 {
 		t.Fatalf("expected second run cache hit metadata, got %#v", second.Cache)
@@ -149,22 +149,6 @@ func TestCaptureRuntimeTraceIfNeededWarningAndReuseBranches(t *testing.T) {
 
 	if warnings, tracePath, captured = captureRuntimeTraceIfNeeded(context.Background(), Request{}, repo, nil, nil); len(warnings) != 0 || tracePath != "" || captured {
 		t.Fatalf("expected empty runtime command to skip capture, got warnings=%#v tracePath=%q captured=%v", warnings, tracePath, captured)
-	}
-
-	reuseCases := []struct {
-		name  string
-		cache *analysisCache
-		want  bool
-	}{
-		{name: "nil cache", cache: nil, want: false},
-		{name: "disabled cache", cache: &analysisCache{metadata: report.CacheMetadata{}}, want: false},
-		{name: "cache miss", cache: &analysisCache{metadata: report.CacheMetadata{Enabled: true, Misses: 1}}, want: false},
-		{name: "cache hit", cache: &analysisCache{metadata: report.CacheMetadata{Enabled: true, Hits: 1}}, want: true},
-	}
-	for _, testCase := range reuseCases {
-		if got := shouldReuseRuntimeTrace(testCase.cache); got != testCase.want {
-			t.Fatalf("%s: expected shouldReuseRuntimeTrace=%v, got %v", testCase.name, testCase.want, got)
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Analysis cache hits must not let repository-controlled runtime trace or state files suppress a fresh runtime capture.

Closes #1232
Supersedes #1422

## Root cause

The analysis layer translated a cache-hit result into `ReuseIfUnchanged`. That allowed an existing repo-local `.artifacts` trace and state pair to bypass recapture even though those files are controlled by the repository being analysed.

## Changes

- Remove the analysis-cache-derived runtime reuse shortcut.
- Capture a fresh runtime trace whenever a runtime command is configured.
- Preserve explicit runtime reuse for other callers that deliberately opt into it.
- Assert that a second analysis call can be an analysis-cache hit while runtime capture still runs again.

## Validation

Commands and checks run:

```bash
go test ./internal/analysis -run '^TestServiceRuntimeCaptureRefreshesTraceOnCacheHit$' -count=10
go test ./internal/analysis ./internal/runtime
make ci
```

Regression-Test: ./internal/analysis::TestServiceRuntimeCaptureRefreshesTraceOnCacheHit

## Scope

- 2 files changed
- 4 additions, 31 deletions
- No new dependencies or abstractions

## Risk and compatibility

- Breaking changes: None
- Migration required: None
- Performance impact: Runtime capture now runs on analysis cache hits when configured, closing the unsafe reuse path.
- Memory benchmark impact: None; the memory benchmark gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
