### PR TITLE
fix(cache): distrust default repo-local hits

### DIFF
--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -9,9 +9,10 @@ import (
 )
 
 type resolvedCacheOptions struct {
-	Enabled  bool
-	Path     string
-	ReadOnly bool
+	Enabled      bool
+	Path         string
+	ReadOnly     bool
+	ExplicitPath bool
 }
 
 type analysisCache struct {
@@ -19,6 +20,7 @@ type analysisCache struct {
 	metadata        report.CacheMetadata
 	warnings        []string
 	cacheable       bool
+	rejectReadHits  bool
 	inputDigestMemo map[cacheInputDigestMemoKey]string
 }
 
@@ -30,9 +32,10 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 		ReadOnly: options.ReadOnly,
 	}
 	cache := &analysisCache{
-		options:  options,
-		metadata: metadata,
-		warnings: make([]string, 0),
+		options:        options,
+		metadata:       metadata,
+		warnings:       make([]string, 0),
+		rejectReadHits: !options.ExplicitPath,
 	}
 	if !options.Enabled {
 		cache.cacheable = false
@@ -90,6 +93,10 @@ func resolveCacheOptions(req *CacheOptions, repoPath string) resolvedCacheOption
 	options.Enabled = req.Enabled
 	if strings.TrimSpace(req.Path) != "" {
 		options.Path = strings.TrimSpace(req.Path)
+		options.ExplicitPath = true
+	}
+	if strings.TrimSpace(req.ResolvedPath) != "" {
+		options.Path = strings.TrimSpace(req.ResolvedPath)
 	}
 	options.ReadOnly = req.ReadOnly
 	return options

--- a/internal/analysis/cache_storage.go
+++ b/internal/analysis/cache_storage.go
@@ -25,15 +25,11 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 		return report.Report{}, false, nil
 	}
 	pointerPath := filepath.Join(c.options.Path, "keys", entry.KeyDigest+".json")
-	if c.rejectReadHits {
-		pointerExists, err := cachePointerExists(c.options.Path, entry.KeyDigest)
-		if err != nil {
-			return report.Report{}, false, err
-		}
-		c.metadata.Misses++
-		if pointerExists {
-			c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: "default-local-untrusted"})
-		}
+	rejected, err := c.rejectDefaultCacheRead(entry)
+	if err != nil {
+		return report.Report{}, false, err
+	}
+	if rejected {
 		return report.Report{}, false, nil
 	}
 	pointerData, err := safeio.ReadFileUnder(c.options.Path, pointerPath)
@@ -81,6 +77,21 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 	}
 	c.metadata.Hits++
 	return payload.Report, true, nil
+}
+
+func (c *analysisCache) rejectDefaultCacheRead(entry cacheEntryDescriptor) (bool, error) {
+	if !c.rejectReadHits {
+		return false, nil
+	}
+	pointerExists, err := cachePointerExists(c.options.Path, entry.KeyDigest)
+	if err != nil {
+		return false, err
+	}
+	c.metadata.Misses++
+	if pointerExists {
+		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: "default-local-untrusted"})
+	}
+	return true, nil
 }
 
 func cachePointerExists(cachePath, keyDigest string) (_ bool, err error) {

--- a/internal/analysis/cache_storage.go
+++ b/internal/analysis/cache_storage.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -24,6 +25,17 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 		return report.Report{}, false, nil
 	}
 	pointerPath := filepath.Join(c.options.Path, "keys", entry.KeyDigest+".json")
+	if c.rejectReadHits {
+		pointerExists, err := cachePointerExists(c.options.Path, entry.KeyDigest)
+		if err != nil {
+			return report.Report{}, false, err
+		}
+		c.metadata.Misses++
+		if pointerExists {
+			c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: "default-local-untrusted"})
+		}
+		return report.Report{}, false, nil
+	}
 	pointerData, err := safeio.ReadFileUnder(c.options.Path, pointerPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -69,6 +81,25 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 	}
 	c.metadata.Hits++
 	return payload.Report, true, nil
+}
+
+func cachePointerExists(cachePath, keyDigest string) (_ bool, err error) {
+	root, err := safeio.OpenRootNoFollow(cachePath)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		err = errors.Join(err, root.Close())
+	}()
+
+	_, err = root.Lstat(filepath.Join("keys", keyDigest+".json"))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (c *analysisCache) store(entry cacheEntryDescriptor, data report.Report) error {

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -265,6 +265,78 @@ func TestAnalysisCacheReadOnlySkipsWrites(t *testing.T) {
 	}
 }
 
+func TestDefaultRepoLocalCacheForgedEntryMisses(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "console.log('hello')\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestPackageJSONFileName), "{\n  \"name\": \"demo\"\n}\n")
+
+	svc, adapter := newCacheTestService(t)
+	cachePath := filepath.Join(repo, ".lopper-cache")
+	req := Request{
+		RepoPath: repo,
+		Language: "cachelang",
+		TopN:     1,
+		Cache: &CacheOptions{
+			Enabled: true,
+		},
+	}
+
+	cache := newAnalysisCache(req, repo)
+	if !cache.cacheable {
+		t.Fatalf("expected resolved default repo-local cache test setup to be cacheable, warnings=%#v", cache.takeWarnings())
+	}
+
+	entry, err := cache.prepareEntry(req, adapter.ID(), repo)
+	if err != nil {
+		t.Fatalf("prepare forged cache entry: %v", err)
+	}
+	objectDigest := "forged-object"
+	mustWriteFile(t, filepath.Join(cachePath, "objects", objectDigest+".json"), []byte(`{"report":{"repoPath":"forged-repo"}}`))
+	writePointerJSON(t, filepath.Join(cachePath, "keys", entry.KeyDigest+".json"), entry.InputDigest, objectDigest)
+
+	got, err := svc.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("analyse with forged default cache entry: %v", err)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("expected forged default cache entry to miss and run adapter, calls=%d", adapter.calls)
+	}
+	if got.Cache == nil || got.Cache.Hits != 0 || got.Cache.Misses != 1 || got.Cache.Writes != 1 {
+		t.Fatalf("unexpected cache metadata for forged default cache entry: %#v", got.Cache)
+	}
+	if len(got.Cache.Invalidations) == 0 || got.Cache.Invalidations[0].Reason != "default-local-untrusted" {
+		t.Fatalf("expected default-local-untrusted invalidation, got %#v", got.Cache.Invalidations)
+	}
+}
+
+func TestDefaultRepoLocalCacheColdMissHasNoUntrustedInvalidation(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "console.log('hello')\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestPackageJSONFileName), "{\n  \"name\": \"demo\"\n}\n")
+
+	svc, adapter := newCacheTestService(t)
+	got, err := svc.Analyse(context.Background(), Request{
+		RepoPath: repo,
+		Language: "cachelang",
+		TopN:     1,
+		Cache: &CacheOptions{
+			Enabled: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("analyse with empty default cache: %v", err)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("expected empty default cache to run adapter, calls=%d", adapter.calls)
+	}
+	if got.Cache == nil || got.Cache.Hits != 0 || got.Cache.Misses != 1 || got.Cache.Writes != 1 {
+		t.Fatalf("unexpected cold-miss cache metadata: %#v", got.Cache)
+	}
+	if len(got.Cache.Invalidations) != 0 {
+		t.Fatalf("expected empty default cache to have no invalidations, got %#v", got.Cache.Invalidations)
+	}
+}
+
 func TestAnalysisCachePrepareEntryIncludesLicensePolicyInputs(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "console.log('hello')\n")

--- a/internal/analysis/request.go
+++ b/internal/analysis/request.go
@@ -12,9 +12,10 @@ const (
 )
 
 type CacheOptions struct {
-	Enabled  bool
-	Path     string
-	ReadOnly bool
+	Enabled      bool
+	Path         string
+	ResolvedPath string
+	ReadOnly     bool
 }
 
 type Request struct {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -443,7 +443,6 @@ func TestCallAnalyseTopUsesInitializedCacheReadOnly(t *testing.T) {
 		"repoPath":      repo,
 		"topN":          1,
 		"language":      "js-ts",
-		"include":       []string{"**/*.js"},
 		"cacheReadOnly": false,
 	})
 	if result.IsError {
@@ -713,11 +712,29 @@ func assertAnalysisRequestBasics(t *testing.T, req analysis.Request) {
 
 func assertAnalysisRequestOptions(t *testing.T, req analysis.Request) {
 	t.Helper()
-	if req.Cache == nil || req.Cache.Enabled || req.Cache.Path != ".cache/lopper" || !req.Cache.ReadOnly {
+	if req.Cache == nil || req.Cache.Enabled || req.Cache.Path != ".cache/lopper" || req.Cache.ResolvedPath != "" || !req.Cache.ReadOnly {
 		t.Fatalf("unexpected cache options: %#v", req.Cache)
 	}
 	if req.RuntimeProfile != "browser-import" || req.RuntimeTracePath != "trace.ndjson" || !req.RuntimeTracePathExplicit {
 		t.Fatalf("unexpected runtime options: %#v", req)
+	}
+}
+
+func TestReadOnlyMCPAnalysisCacheOptionsPreservesImplicitDefaultIntent(t *testing.T) {
+	repo, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp root: %v", err)
+	}
+	cachePath := filepath.Join(repo, ".lopper-cache")
+	for _, dirName := range []string{"keys", "objects"} {
+		if err := os.MkdirAll(filepath.Join(cachePath, dirName), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dirName, err)
+		}
+	}
+
+	options := readOnlyMCPAnalysisCacheOptions(repo, nil, "")
+	if options == nil || !options.Enabled || options.Path != "" || options.ResolvedPath != cachePath || !options.ReadOnly {
+		t.Fatalf("unexpected implicit default cache options: %#v", options)
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -415,7 +415,7 @@ func readOnlyMCPAnalysisCacheOptions(repoPath string, enabled *bool, cachePath s
 	if resolvedPath == "" {
 		resolvedPath = filepath.Join(repoPath, ".lopper-cache")
 	}
-	options.Path = resolvedPath
+	options.ResolvedPath = resolvedPath
 	if !cachePathReadyForReadOnly(resolvedPath) {
 		options.Enabled = false
 	}


### PR DESCRIPTION
## Summary

Default repository-local analysis caches are writable by the repository being analysed, so their contents must not be trusted as authoritative analysis results.

Closes #1262
Supersedes #1425

## Changes

- Distinguish an explicitly configured cache path from an internally resolved default path.
- Treat existing entries in the default repo-local cache as misses and record a `default-local-untrusted` invalidation.
- Preserve ordinary cold-miss metadata when no default cache pointer exists.
- Continue writing refreshed results so the output and cache metadata contracts remain intact.
- Preserve cache-hit behavior for callers that explicitly choose a cache path.
- Preserve the implicit-default trust decision when MCP resolves the path for read-only analysis.
- Add focused analysis and MCP regressions for forged default cache entries and intent propagation.

## Validation

Commands and checks run:

```bash
go test ./internal/analysis -run '^(TestDefaultRepoLocalCacheForgedEntryMisses|TestDefaultRepoLocalCacheColdMissHasNoUntrustedInvalidation|TestAnalysisCacheReadOnlySkipsWrites|TestResolveCacheOptionsDefaultsAndOverrides)$' -count=10
go test ./internal/mcp -run '^(TestReadOnlyMCPAnalysisCacheOptionsPreservesImplicitDefaultIntent|TestCallAnalyseTopUsesInitializedCacheReadOnly)$' -count=10
go test ./internal/analysis ./internal/mcp
make ci
```

Regression-Test: ./internal/analysis::TestDefaultRepoLocalCacheForgedEntryMisses

## Risk and compatibility

- Breaking changes: Default repo-local cache entries are no longer reused; explicit cache paths retain reuse behavior.
- Migration required: None.
- Performance impact: Default cache users rerun adapters instead of trusting repository-controlled cached reports.
- Memory benchmark impact: None; the memory benchmark gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
