### PR TITLE
fix(runtime): bound trace loading work

### DIFF
--- a/internal/runtime/trace_load.go
+++ b/internal/runtime/trace_load.go
@@ -2,10 +2,10 @@ package runtime
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"path/filepath"
 	"strings"
 
@@ -13,21 +13,20 @@ import (
 )
 
 const maxRuntimeTraceBytes int64 = 8 * 1024 * 1024
+const maxRuntimeTraceEvents = 300000
+
+var errRuntimeTraceTooManyEvents = errors.New("runtime trace contains too many events")
 
 func Load(path string) (_ Trace, err error) {
-	file, err := safeio.OpenFile(path)
+	data, err := safeio.ReadFileLimit(path, maxRuntimeTraceBytes)
 	if err != nil {
 		return Trace{}, err
 	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			err = errors.Join(err, closeErr)
-		}
-	}()
 
 	trace := newTrace()
-	scanner := bufio.NewScanner(newRuntimeTraceByteLimitReader(file, maxRuntimeTraceBytes))
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 	line := 0
+	eventCount := 0
 	for scanner.Scan() {
 		if err := scanner.Err(); err != nil {
 			return Trace{}, err
@@ -36,6 +35,10 @@ func Load(path string) (_ Trace, err error) {
 		text := strings.TrimSpace(scanner.Text())
 		if text == "" {
 			continue
+		}
+		eventCount++
+		if eventCount > maxRuntimeTraceEvents {
+			return Trace{}, errRuntimeTraceTooManyEvents
 		}
 		var event Event
 		if err := json.Unmarshal([]byte(text), &event); err != nil {
@@ -55,41 +58,6 @@ func Load(path string) (_ Trace, err error) {
 	}
 
 	return trace, nil
-}
-
-type runtimeTraceByteLimitReader struct {
-	reader    io.Reader
-	remaining int64
-}
-
-func newRuntimeTraceByteLimitReader(reader io.Reader, maxBytes int64) io.Reader {
-	return &runtimeTraceByteLimitReader{reader: reader, remaining: maxBytes}
-}
-
-func (r *runtimeTraceByteLimitReader) Read(p []byte) (int, error) {
-	if len(p) == 0 {
-		return 0, nil
-	}
-	limit := r.remaining + 1
-	if limit <= 0 {
-		limit = 1
-	}
-	if int64(len(p)) > limit {
-		p = p[:limit]
-	}
-
-	n, err := r.reader.Read(p)
-	if int64(n) <= r.remaining {
-		r.remaining -= int64(n)
-		return n, err
-	}
-
-	allowed := int(r.remaining)
-	if allowed < 0 {
-		allowed = 0
-	}
-	r.remaining = 0
-	return allowed, safeio.ErrFileTooLarge
 }
 
 func newTrace() Trace {

--- a/internal/runtime/trace_load_test.go
+++ b/internal/runtime/trace_load_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,6 +109,23 @@ func TestLoadTraceOversizedFile(t *testing.T) {
 	_, err := loadTraceFromContent(t, oversizedRuntimeTraceContent())
 	if !errors.Is(err, safeio.ErrFileTooLarge) {
 		t.Fatalf("expected oversized trace to fail with ErrFileTooLarge, got %v", err)
+	}
+}
+
+func TestLoadTraceTooManyEvents(t *testing.T) {
+	const maxRuntimeTraceEventsForTest = 300000
+
+	var content strings.Builder
+	for i := 0; i <= maxRuntimeTraceEventsForTest; i++ {
+		fmt.Fprintf(&content, "{\"dependency\":\"pkg-%x\"}\n", i)
+	}
+
+	_, err := loadTraceFromContent(t, content.String())
+	if err == nil {
+		t.Fatalf("expected too-many-events error")
+	}
+	if err.Error() != "runtime trace contains too many events" {
+		t.Fatalf("expected stable too-many-events error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Runtime traces are untrusted NDJSON input. Their byte size was bounded, but the loader could still process every event and grow dependency maps without an explicit work cap.

Closes #1274
Supersedes #1427

## Changes

- Read runtime traces through the repository's bounded, symlink-safe exact-file helper with the existing 8 MiB limit.
- Reject traces containing more than 300,000 non-empty events before unmarshalling or mutating dependency maps for the excess event.
- Return a stable `runtime trace contains too many events` error at the untrusted-input boundary.
- Add a focused regression that exercises the event cap with distinct dependency names.

## Validation

Commands and checks run:

```bash
go test ./internal/runtime -run '^TestLoadTraceTooManyEvents$' -count=3
go test ./internal/runtime
go test ./internal/analysis
make ci
```

Regression-Test: ./internal/runtime::TestLoadTraceTooManyEvents

## Risk and compatibility

- Breaking changes: Runtime traces with more than 300,000 non-empty events now fail with a bounded-work error.
- Migration required: Split or reduce traces that exceed the explicit event cap.
- Performance impact: Input buffering is capped at 8 MiB and event-driven map growth is capped; valid traces retain the same output contract.
- Memory benchmark impact: None expected; the repository memory benchmark gate is included in `make ci`.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
