### PR TITLE
fix(ci): pin benchmark definitions across revisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,41 +208,151 @@ bench-gate:
 	@set -eu; \
 	requested_base_ref="$(MEMORY_BENCH_BASE)"; \
 	base_ref="$$requested_base_ref"; \
-	mkdir -p $$(dirname "$(BENCH_BASE_OUTPUT)"); \
+	mkdir -p $$(dirname "$(BENCH_BASE_OUTPUT)") $$(dirname "$(BENCH_HEAD_OUTPUT)") $$(dirname "$(MEMORY_BENCH_SUMMARY)") $$(dirname "$(MEMORY_BENCH_STATUS)"); \
 	write_invalid_memory_summary() { \
-		mkdir -p $$(dirname "$(MEMORY_BENCH_SUMMARY)") $$(dirname "$(MEMORY_BENCH_STATUS)"); \
 		printf "## Memory Benchmarks\n\nThresholds: bytes/op <= +%s%%, allocs/op <= +%s%%\n\nBase benchmarks: unavailable\nHead benchmarks: unavailable\n\nInput errors:\n- %s\n\nComparison status: invalid\nResult: benchmark input could not be read for a safe memory comparison.\n" "$(MEMORY_BENCH_MAX_BYTES_PCT)" "$(MEMORY_BENCH_MAX_ALLOCS_PCT)" "$$1" > "$(MEMORY_BENCH_SUMMARY)"; \
 		printf "2\n" > "$(MEMORY_BENCH_STATUS)"; \
 	}; \
+	fail_invalid_memory_gate() { \
+		printf "Memory benchmark gate invalid: %s\n" "$$1" >&2; \
+		write_invalid_memory_summary "$$1"; \
+		exit 2; \
+	}; \
+	benchmark_harness_fingerprint() { \
+		fingerprint_pkg="$$1"; \
+		fingerprint_files_tmp=$$(mktemp) || return 1; \
+		fingerprint_manifest_tmp=$$(mktemp) || { rm -f "$$fingerprint_files_tmp"; return 1; }; \
+		if ! fingerprint_dir=$$(GOFLAGS=-buildvcs=false $(GO_CMD) list -f '{{.Dir}}' "$$fingerprint_pkg" 2>/dev/null); then \
+			rm -f "$$fingerprint_files_tmp" "$$fingerprint_manifest_tmp"; \
+			return 1; \
+		fi; \
+		if ! GOFLAGS=-buildvcs=false $(GO_CMD) list -f '{{range .TestGoFiles}}{{printf "test\t%s\n" .}}{{end}}{{range .TestEmbedFiles}}{{printf "test-embed\t%s\n" .}}{{end}}{{range .XTestGoFiles}}{{printf "xtest\t%s\n" .}}{{end}}{{range .XTestEmbedFiles}}{{printf "xtest-embed\t%s\n" .}}{{end}}' "$$fingerprint_pkg" > "$$fingerprint_files_tmp" 2>/dev/null; then \
+			rm -f "$$fingerprint_files_tmp" "$$fingerprint_manifest_tmp"; \
+			return 1; \
+		fi; \
+		if ! LC_ALL=C sort -u -o "$$fingerprint_files_tmp" "$$fingerprint_files_tmp"; then \
+			rm -f "$$fingerprint_files_tmp" "$$fingerprint_manifest_tmp"; \
+			return 1; \
+		fi; \
+		: > "$$fingerprint_manifest_tmp"; \
+		fingerprint_failed=0; \
+		while IFS=$$(printf '\t') read -r fingerprint_kind fingerprint_file; do \
+			[ -n "$$fingerprint_file" ] || continue; \
+			if ! fingerprint_blob=$$(git hash-object "$$fingerprint_dir/$$fingerprint_file" 2>/dev/null); then \
+				fingerprint_failed=1; \
+				break; \
+			fi; \
+			if ! printf "%s\t%s\t%s\n" "$$fingerprint_kind" "$$fingerprint_file" "$$fingerprint_blob" >> "$$fingerprint_manifest_tmp"; then \
+				fingerprint_failed=1; \
+				break; \
+			fi; \
+		done < "$$fingerprint_files_tmp"; \
+		if [ "$$fingerprint_failed" -ne 0 ] || ! fingerprint_value=$$(git hash-object "$$fingerprint_manifest_tmp" 2>/dev/null); then \
+			rm -f "$$fingerprint_files_tmp" "$$fingerprint_manifest_tmp"; \
+			return 1; \
+		fi; \
+		rm -f "$$fingerprint_files_tmp" "$$fingerprint_manifest_tmp"; \
+		printf "git-hash-object:%s\n" "$$fingerprint_value"; \
+	}; \
+	format_benchmark_definition() { \
+		invocation_pkg="$$1"; \
+		invocation_selection="$$2"; \
+		invocation_fingerprint="$$3"; \
+		printf "package=%s selection=%s -run '^$$' GO_TEST_LDFLAGS_ARGS=%s flags=-benchmem -count=%s -benchtime=%s harness-files=TestGoFiles,TestEmbedFiles,XTestGoFiles,XTestEmbedFiles harness-fingerprint=%s invocation=GOFLAGS=-buildvcs=false %s test %s -run '^$$' -bench '%s' -benchmem -count=%s -benchtime=%s '%s'" "$$invocation_pkg" "$$invocation_selection" "$(subst ",\",$(GO_TEST_LDFLAGS_ARGS))" "$(BENCH_COUNT)" "$(BENCH_TIME)" "$$invocation_fingerprint" "$(GO_CMD)" "$(subst ",\",$(GO_TEST_LDFLAGS_ARGS))" "$$invocation_selection" "$(BENCH_COUNT)" "$(BENCH_TIME)" "$$invocation_pkg"; \
+	}; \
 	if ! git rev-parse --verify -q "$$base_ref^{commit}" >/dev/null; then \
 		echo "Memory benchmark base ref '$$base_ref' is missing or invalid; failing closed."; \
-		write_invalid_memory_summary "base benchmark input could not be read: requested base ref '$$base_ref' is missing or invalid."; \
-		exit 2; \
+		fail_invalid_memory_gate "base benchmark input could not be read: requested base ref '$$base_ref' is missing or invalid."; \
 	fi; \
 	if ! base_commit=$$(git merge-base "$$base_ref" HEAD 2>/dev/null); then \
 		echo "Memory benchmark base ref '$$base_ref' is not related to HEAD; failing closed."; \
-		write_invalid_memory_summary "base benchmark input could not be read: requested base ref '$$base_ref' is not related to HEAD."; \
-		exit 2; \
+		fail_invalid_memory_gate "base benchmark input could not be read: requested base ref '$$base_ref' is not related to HEAD."; \
 	fi; \
 	bench_dir=$$(mktemp -d); \
 	base_tree="$$bench_dir/base"; \
 	base_output_tmp=$$(mktemp); \
 	head_output_tmp=$$(mktemp); \
-	cleanup() { (unset GIT_INDEX_FILE; git worktree remove --force "$$base_tree" >/dev/null 2>&1 || true); rm -rf "$$bench_dir"; rm -f "$$base_output_tmp" "$$head_output_tmp"; }; \
+	bench_packages_tmp=$$(mktemp); \
+	bench_definitions_tmp=$$(mktemp); \
+	cleanup() { (unset GIT_INDEX_FILE; git worktree remove --force "$$base_tree" >/dev/null 2>&1 || true); rm -rf "$$bench_dir"; rm -f "$$base_output_tmp" "$$head_output_tmp" "$$bench_packages_tmp" "$$bench_definitions_tmp"; }; \
 	trap cleanup EXIT INT TERM; \
 	echo "Running memory benchmark delta against $$base_ref."; \
-	(unset GIT_INDEX_FILE; git worktree add --detach "$$base_tree" "$$base_commit" >/dev/null); \
-	if ! (cd "$$base_tree" && GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES)) > "$$base_output_tmp" 2>&1; then \
-		cat "$$base_output_tmp"; \
-		exit 1; \
+	: > "$$base_output_tmp"; \
+	: > "$$head_output_tmp"; \
+	: > "$$bench_definitions_tmp"; \
+	if ! GOFLAGS=-buildvcs=false $(GO_CMD) list $(MEMORY_BENCH_PACKAGES) > "$$bench_packages_tmp" 2>&1; then \
+		cat "$$bench_packages_tmp"; \
+		fail_invalid_memory_gate "head benchmark package targets could not be resolved."; \
 	fi; \
-	cat "$$base_output_tmp"; \
+	LC_ALL=C sort -u -o "$$bench_packages_tmp" "$$bench_packages_tmp"; \
+	while IFS= read -r bench_pkg; do \
+		[ -n "$$bench_pkg" ] || continue; \
+		pkg_bench_tmp=$$(mktemp); \
+		pkg_names_tmp=$$(mktemp); \
+		if ! GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -list '^Benchmark' "$$bench_pkg" > "$$pkg_bench_tmp" 2>&1; then \
+			cat "$$pkg_bench_tmp"; \
+			rm -f "$$pkg_bench_tmp" "$$pkg_names_tmp"; \
+			fail_invalid_memory_gate "head benchmark definition could not be resolved from package '$$bench_pkg'."; \
+		fi; \
+		awk '/^Benchmark/ { print $$1 }' "$$pkg_bench_tmp" | LC_ALL=C sort -u > "$$pkg_names_tmp"; \
+		if [ ! -s "$$pkg_names_tmp" ]; then \
+			rm -f "$$pkg_bench_tmp" "$$pkg_names_tmp"; \
+			fail_invalid_memory_gate "configured head benchmark package target '$$bench_pkg' resolved zero selected benchmarks."; \
+		fi; \
+		if ! harness_fingerprint=$$(benchmark_harness_fingerprint "$$bench_pkg"); then \
+			rm -f "$$pkg_bench_tmp" "$$pkg_names_tmp"; \
+			fail_invalid_memory_gate "head benchmark harness fingerprint could not be resolved from package '$$bench_pkg'."; \
+		fi; \
+		bench_selection=$$(awk 'BEGIN { separator = "^(" } { printf "%s%s", separator, $$1; separator = "|" } END { print ")$$" }' "$$pkg_names_tmp"); \
+		printf "%s\t%s\t%s\n" "$$bench_pkg" "$$bench_selection" "$$harness_fingerprint" >> "$$bench_definitions_tmp"; \
+		rm -f "$$pkg_bench_tmp" "$$pkg_names_tmp"; \
+	done < "$$bench_packages_tmp"; \
+	LC_ALL=C sort -u "$$bench_definitions_tmp" -o "$$bench_definitions_tmp"; \
+	echo "Resolved head benchmark definitions:"; \
+	while IFS=$$(printf '\t') read -r bench_pkg bench_selection harness_fingerprint; do \
+		definition_metadata=$$(format_benchmark_definition "$$bench_pkg" "$$bench_selection" "$$harness_fingerprint"); \
+		printf "  %s\n" "$$definition_metadata"; \
+	done < "$$bench_definitions_tmp"; \
+	if ! (unset GIT_INDEX_FILE; git worktree add --detach "$$base_tree" "$$base_commit" >/dev/null); then \
+		fail_invalid_memory_gate "base benchmark revision '$$base_commit' could not be prepared."; \
+	fi; \
+	while IFS=$$(printf '\t') read -r bench_pkg bench_selection harness_fingerprint; do \
+		if ! base_harness_fingerprint=$$(cd "$$base_tree" && benchmark_harness_fingerprint "$$bench_pkg"); then \
+			fail_invalid_memory_gate "base benchmark harness fingerprint could not be resolved for package '$$bench_pkg'."; \
+		fi; \
+		if [ "$$base_harness_fingerprint" != "$$harness_fingerprint" ]; then \
+			fail_invalid_memory_gate "base benchmark definition for package '$$bench_pkg' does not match the resolved head harness fingerprint."; \
+		fi; \
+	done < "$$bench_definitions_tmp"; \
+	while IFS=$$(printf '\t') read -r bench_pkg bench_selection harness_fingerprint; do \
+		definition_metadata=$$(format_benchmark_definition "$$bench_pkg" "$$bench_selection" "$$harness_fingerprint"); \
+		printf "Applied base benchmark definition: %s\n" "$$definition_metadata"; \
+		printf "Applied base benchmark definition: %s\n" "$$definition_metadata" >> "$$base_output_tmp"; \
+		bench_run_output_tmp=$$(mktemp); \
+		if ! (cd "$$base_tree" && GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench "$$bench_selection" -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) "$$bench_pkg") > "$$bench_run_output_tmp" 2>&1; then \
+			cat "$$bench_run_output_tmp"; \
+			rm -f "$$bench_run_output_tmp"; \
+			fail_invalid_memory_gate "base benchmark definition for package '$$bench_pkg' with selection '$$bench_selection' could not be applied unchanged."; \
+		fi; \
+		cat "$$bench_run_output_tmp"; \
+		cat "$$bench_run_output_tmp" >> "$$base_output_tmp"; \
+		rm -f "$$bench_run_output_tmp"; \
+	done < "$$bench_definitions_tmp"; \
 	cp "$$base_output_tmp" "$(BENCH_BASE_OUTPUT)"; \
-	if ! GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench . -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) $(MEMORY_BENCH_PACKAGES) > "$$head_output_tmp" 2>&1; then \
-		cat "$$head_output_tmp"; \
-		exit 1; \
-	fi; \
-	cat "$$head_output_tmp"; \
+	while IFS=$$(printf '\t') read -r bench_pkg bench_selection harness_fingerprint; do \
+		definition_metadata=$$(format_benchmark_definition "$$bench_pkg" "$$bench_selection" "$$harness_fingerprint"); \
+		printf "Applied head benchmark definition: %s\n" "$$definition_metadata"; \
+		printf "Applied head benchmark definition: %s\n" "$$definition_metadata" >> "$$head_output_tmp"; \
+		bench_run_output_tmp=$$(mktemp); \
+		if ! GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench "$$bench_selection" -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) "$$bench_pkg" > "$$bench_run_output_tmp" 2>&1; then \
+			cat "$$bench_run_output_tmp"; \
+			rm -f "$$bench_run_output_tmp"; \
+			fail_invalid_memory_gate "head benchmark definition for package '$$bench_pkg' with selection '$$bench_selection' could not be applied unchanged."; \
+		fi; \
+		cat "$$bench_run_output_tmp"; \
+		cat "$$bench_run_output_tmp" >> "$$head_output_tmp"; \
+		rm -f "$$bench_run_output_tmp"; \
+	done < "$$bench_definitions_tmp"; \
 	cp "$$head_output_tmp" "$(BENCH_HEAD_OUTPUT)"; \
 	benchdelta_bin="$$bench_dir/benchdelta"; \
 	GOFLAGS=-buildvcs=false $(GO_CMD) build -o "$$benchdelta_bin" ./tools/benchdelta; \

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3092,15 +3092,24 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 
 	for _, want := range []string{
 		`write_invalid_memory_summary() { \`,
+		`fail_invalid_memory_gate() { \`,
 		`printf "2\n" > "$(MEMORY_BENCH_STATUS)"`,
 		`requested base ref '$$base_ref' is missing or invalid`,
 		`requested base ref '$$base_ref' is not related to HEAD`,
+		`benchmark_harness_fingerprint() { \`,
+		`{{range .TestGoFiles}}{{printf "test\t%s\n" .}}{{end}}`,
+		`{{range .XTestGoFiles}}{{printf "xtest\t%s\n" .}}{{end}}`,
+		`-list '^Benchmark' "$$bench_pkg"`,
+		`configured head benchmark package target '$$bench_pkg' resolved zero selected benchmarks.`,
+		`echo "Resolved head benchmark definitions:"`,
+		`harness-files=TestGoFiles,TestEmbedFiles,XTestGoFiles,XTestEmbedFiles harness-fingerprint=%s`,
+		`base_harness_fingerprint=$$(cd "$$base_tree" && benchmark_harness_fingerprint "$$bench_pkg")`,
+		`does not match the resolved head harness fingerprint.`,
+		`printf "Applied base benchmark definition: %s\n" "$$definition_metadata" >> "$$base_output_tmp"`,
+		`printf "Applied head benchmark definition: %s\n" "$$definition_metadata" >> "$$head_output_tmp"`,
+		`-bench "$$bench_selection" -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) "$$bench_pkg"`,
 		`benchdelta_bin="$$bench_dir/benchdelta"`,
-		`$(GO_CMD) build -o "$$benchdelta_bin" ./tools/benchdelta`,
-		`"$$benchdelta_bin" -base "$(BENCH_BASE_OUTPUT)" -head "$(BENCH_HEAD_OUTPUT)"`,
-		`printf "%s\n" "$$status" > "$(MEMORY_BENCH_STATUS)"`,
 		`if [ "$(MEMORY_BENCH_ENFORCE)" = "0" ]; then`,
-		`if [ "$$status" -eq 1 ]; then`,
 		`exit "$$status"`,
 	} {
 		if !strings.Contains(target, want) {
@@ -3114,11 +3123,16 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 		`falling back to 'HEAD~1'`,
 		`No valid memory benchmark base ref found; skipping memory benchmark gate.`,
 		`is not related to HEAD; skipping memory benchmark gate.`,
+		`head benchmark selection is ambiguous across packages`,
+		`{{range .GoFiles}}`,
+		`prepare_artifact_parent`,
 	} {
 		if strings.Contains(target, omit) {
 			t.Fatalf("bench-gate target must not contain %q", omit)
 		}
 	}
+
+	assertTextAppearsBefore(t, target, `if [ "$$base_harness_fingerprint" != "$$harness_fingerprint" ]; then`, `printf "Applied base benchmark definition: %s\n" "$$definition_metadata"`, "bench-gate must verify every base harness fingerprint before executing benchmarks")
 }
 
 func TestMakefileBenchGateFailsClosedForInvalidRequestedBase(t *testing.T) {
@@ -3178,6 +3192,217 @@ func TestMakefileBenchGateFailsClosedForUnrelatedRequestedBase(t *testing.T) {
 		"Result: memory benchmark regression detected.",
 	}
 	assertMemoryBenchArtifacts(t, repo, "2\n", wantContains, wantOmit)
+}
+
+func TestMakefileBenchGateAppliesOneDefinitionAcrossRevisions(t *testing.T) {
+	t.Parallel()
+
+	repo, benchVars := newTempBenchGateGoRepo(t)
+	copyTree(t, repoPath(t, "tools/benchdelta"), filepath.Join(repo, "tools", "benchdelta"))
+	copyTree(t, repoPath(t, "internal/safeio"), filepath.Join(repo, "internal", "safeio"))
+	basePkgOneSource := "package benchpkgone\n\nfunc benchmarkInput() int { return 1 }\n"
+	writeFile(t, filepath.Join(repo, "benchpkgone", "bench_test.go"), benchmarkTestSource("benchpkgone", "BenchmarkPkgOneOnly", "BenchmarkShared"))
+	writeFile(t, filepath.Join(repo, "benchpkgone", "work.go"), basePkgOneSource)
+	writeFile(t, filepath.Join(repo, "benchpkgtwo", "bench_test.go"), benchmarkTestSource("benchpkgtwo", "BenchmarkPkgTwoOnly", "BenchmarkShared"))
+	runGitCommand(t, repo, "add", "go.mod", "benchpkgone/bench_test.go", "benchpkgone/work.go", "benchpkgtwo/bench_test.go")
+	runGitCommand(t, repo, "commit", "-m", "add base benchmarks")
+
+	headPkgOneSource := "package benchpkgone\n\nfunc benchmarkInput() int { return 2 }\n"
+	writeFile(t, filepath.Join(repo, "benchpkgone", "work.go"), headPkgOneSource)
+	runGitCommand(t, repo, "add", "benchpkgone/work.go")
+	runGitCommand(t, repo, "commit", "-m", "change production code without changing benchmark harnesses")
+
+	benchVars["MEMORY_BENCH_BASE"] = "HEAD~1"
+	benchVars["MEMORY_BENCH_PACKAGES"] = "./benchpkgone ./benchpkgtwo"
+	output, exitCode := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", benchVars, 0)
+	if exitCode != 0 {
+		t.Fatalf("bench-gate exit code = %d, want 0", exitCode)
+	}
+	for _, want := range []string{
+		"Resolved head benchmark definitions:",
+		"package=github.com/ben-ranford/lopper/benchpkgone selection=^(BenchmarkPkgOneOnly|BenchmarkShared)$",
+		"package=github.com/ben-ranford/lopper/benchpkgtwo selection=^(BenchmarkPkgTwoOnly|BenchmarkShared)$",
+		"-run '^$'",
+		"GO_TEST_LDFLAGS_ARGS=",
+		"-benchmem -count=1 -benchtime=1x",
+		"harness-files=TestGoFiles,TestEmbedFiles,XTestGoFiles,XTestEmbedFiles",
+		"harness-fingerprint=git-hash-object:",
+		"Applied base benchmark definition:",
+		"Applied head benchmark definition:",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("bench-gate output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "ambiguous across packages") {
+		t.Fatalf("bench-gate output unexpectedly rejected same-named benchmarks across packages:\n%s", output)
+	}
+
+	wantContains := []string{
+		"Result: memory benchmark gate passed.",
+	}
+	wantOmit := []string{
+		"Result: memory benchmark regression detected.",
+		"Comparison status: invalid",
+	}
+	assertMemoryBenchArtifacts(t, repo, "0\n", wantContains, wantOmit)
+	assertFileContainsAll(t, filepath.Join(repo, ".artifacts", "bench-base.out"), []string{
+		"Applied base benchmark definition:",
+		"selection=^(BenchmarkPkgOneOnly|BenchmarkShared)$",
+		"selection=^(BenchmarkPkgTwoOnly|BenchmarkShared)$",
+		"harness-fingerprint=git-hash-object:",
+	})
+	assertFileContainsAll(t, filepath.Join(repo, ".artifacts", "bench-head.out"), []string{
+		"Applied head benchmark definition:",
+		"selection=^(BenchmarkPkgOneOnly|BenchmarkShared)$",
+		"selection=^(BenchmarkPkgTwoOnly|BenchmarkShared)$",
+		"harness-fingerprint=git-hash-object:",
+	})
+}
+
+func TestMakefileBenchGateApplicationFailuresExitInvalid(t *testing.T) {
+	t.Parallel()
+
+	const benchmarkSource = `package benchpkg
+
+import "testing"
+
+func BenchmarkConditional(b *testing.B) {
+	if benchmarkShouldFail() {
+		b.Fatal("configured application failure")
+	}
+}
+`
+	tests := []struct {
+		name             string
+		baseFails        bool
+		headFails        bool
+		failingRevision  string
+		wantBaseArtifact bool
+	}{
+		{name: "base", baseFails: true, failingRevision: "base"},
+		{name: "head", headFails: true, failingRevision: "head", wantBaseArtifact: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, benchVars := newTempBenchGateGoRepo(t)
+			writeFile(t, filepath.Join(repo, "benchpkg", "bench_test.go"), benchmarkSource)
+			writeFile(t, filepath.Join(repo, "benchpkg", "work.go"), "package benchpkg\n\nfunc benchmarkShouldFail() bool { return "+strconv.FormatBool(tc.baseFails)+" }\n")
+			runGitCommand(t, repo, "add", "go.mod", "benchpkg/bench_test.go", "benchpkg/work.go")
+			runGitCommand(t, repo, "commit", "-m", "add conditional benchmark")
+
+			writeFile(t, filepath.Join(repo, "benchpkg", "work.go"), "package benchpkg\n\nfunc benchmarkShouldFail() bool { return "+strconv.FormatBool(tc.headFails)+" }\n")
+			runGitCommand(t, repo, "add", "benchpkg/work.go")
+			runGitCommand(t, repo, "commit", "-m", "configure head benchmark")
+
+			benchVars["MEMORY_BENCH_BASE"] = "HEAD~1"
+			benchVars["MEMORY_BENCH_PACKAGES"] = "./benchpkg"
+			output, _ := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", benchVars, 2)
+			diagnostic := tc.failingRevision + " benchmark definition for package 'github.com/ben-ranford/lopper/benchpkg' with selection '^(BenchmarkConditional)$' could not be applied unchanged."
+			if !strings.Contains(output, diagnostic) {
+				t.Fatalf("bench-gate output missing application failure %q:\n%s", diagnostic, output)
+			}
+			assertMemoryBenchArtifacts(t, repo, "2\n", []string{"Comparison status: invalid", diagnostic}, []string{"Result: memory benchmark gate passed."})
+
+			baseOutput := filepath.Join(repo, ".artifacts", "bench-base.out")
+			if tc.wantBaseArtifact {
+				assertFileExists(t, baseOutput)
+			} else {
+				assertPathAbsent(t, baseOutput)
+			}
+			assertPathAbsent(t, filepath.Join(repo, ".artifacts", "bench-head.out"))
+		})
+	}
+}
+
+func TestMakefileBenchGateFailsClosedWhenConfiguredPackageLosesAllHeadBenchmarks(t *testing.T) {
+	t.Parallel()
+
+	repo, benchVars := newTempBenchGateGoRepo(t)
+	writeFile(t, filepath.Join(repo, "benchpkgone", "bench_test.go"), benchmarkTestSource("benchpkgone", "BenchmarkRemovedFromHead"))
+	writeFile(t, filepath.Join(repo, "benchpkgtwo", "bench_test.go"), benchmarkTestSource("benchpkgtwo", "BenchmarkStillPresent"))
+	runGitCommand(t, repo, "add", "go.mod", "benchpkgone/bench_test.go", "benchpkgtwo/bench_test.go")
+	runGitCommand(t, repo, "commit", "-m", "add configured benchmark packages")
+
+	writeFile(t, filepath.Join(repo, "benchpkgone", "bench_test.go"), "package benchpkgone\n")
+	runGitCommand(t, repo, "add", "benchpkgone/bench_test.go")
+	runGitCommand(t, repo, "commit", "-m", "remove benchmarks from one configured package")
+
+	benchVars["MEMORY_BENCH_BASE"] = "HEAD~1"
+	benchVars["MEMORY_BENCH_PACKAGES"] = "./benchpkgone ./benchpkgtwo"
+	output, exitCode := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", benchVars, 2)
+	if exitCode != 2 {
+		t.Fatalf("bench-gate exit code = %d, want 2", exitCode)
+	}
+	if !strings.Contains(output, "configured head benchmark package target 'github.com/ben-ranford/lopper/benchpkgone' resolved zero selected benchmarks.") {
+		t.Fatalf("bench-gate output missing zero-selected-benchmark diagnostic:\n%s", output)
+	}
+	for _, omit := range []string{"Resolved head benchmark definitions:", "Applied base benchmark definition:", "Applied head benchmark definition:"} {
+		if strings.Contains(output, omit) {
+			t.Fatalf("bench-gate must fail before benchmark execution, found %q:\n%s", omit, output)
+		}
+	}
+
+	wantContains := []string{
+		"Comparison status: invalid",
+		"configured head benchmark package target 'github.com/ben-ranford/lopper/benchpkgone' resolved zero selected benchmarks.",
+	}
+	wantOmit := []string{
+		"Result: memory benchmark gate passed.",
+		"Result: memory benchmark regression detected.",
+		"BenchmarkStillPresent-",
+	}
+	assertMemoryBenchArtifacts(t, repo, "2\n", wantContains, wantOmit)
+	assertPathAbsent(t, filepath.Join(repo, ".artifacts", "bench-base.out"))
+	assertPathAbsent(t, filepath.Join(repo, ".artifacts", "bench-head.out"))
+}
+
+func TestMakefileBenchGateRejectsChangedBenchmarkHarnessBeforeExecution(t *testing.T) {
+	t.Parallel()
+
+	repo, benchVars := newTempBenchGateGoRepo(t)
+	baseHarness := "package benchpkg\n\nfunc benchmarkHarnessValue() int { return 1 }\n"
+	writeFile(t, filepath.Join(repo, "benchpkg", "bench_test.go"), benchmarkTestSource("benchpkg", "BenchmarkShared"))
+	writeFile(t, filepath.Join(repo, "benchpkg", "harness_test.go"), baseHarness)
+	runGitCommand(t, repo, "add", "go.mod", "benchpkg/bench_test.go", "benchpkg/harness_test.go")
+	runGitCommand(t, repo, "commit", "-m", "add benchmark harness")
+
+	headHarness := "package benchpkg\n\nfunc benchmarkHarnessValue() int { return 2 }\n"
+	writeFile(t, filepath.Join(repo, "benchpkg", "harness_test.go"), headHarness)
+	runGitCommand(t, repo, "add", "benchpkg/harness_test.go")
+	runGitCommand(t, repo, "commit", "-m", "change benchmark harness")
+
+	benchVars["MEMORY_BENCH_BASE"] = "HEAD~1"
+	benchVars["MEMORY_BENCH_PACKAGES"] = "./benchpkg"
+	output, exitCode := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", benchVars, 2)
+	if exitCode != 2 {
+		t.Fatalf("bench-gate exit code = %d, want 2", exitCode)
+	}
+	if !strings.Contains(output, "package=github.com/ben-ranford/lopper/benchpkg selection=^(BenchmarkShared)$") ||
+		!strings.Contains(output, "harness-fingerprint=git-hash-object:") {
+		t.Fatalf("bench-gate output missing resolved head definition:\n%s", output)
+	}
+	for _, omit := range []string{"Applied base benchmark definition:", "Applied head benchmark definition:"} {
+		if strings.Contains(output, omit) {
+			t.Fatalf("bench-gate must reject changed harness before execution, found %q:\n%s", omit, output)
+		}
+	}
+
+	wantContains := []string{
+		"Comparison status: invalid",
+		"base benchmark definition for package 'github.com/ben-ranford/lopper/benchpkg' does not match the resolved head harness fingerprint.",
+	}
+	wantOmit := []string{
+		"Result: memory benchmark gate passed.",
+		"Result: memory benchmark regression detected.",
+		"BenchmarkShared-",
+	}
+	assertMemoryBenchArtifacts(t, repo, "2\n", wantContains, wantOmit)
+	assertPathAbsent(t, filepath.Join(repo, ".artifacts", "bench-base.out"))
+	assertPathAbsent(t, filepath.Join(repo, ".artifacts", "bench-head.out"))
 }
 
 func TestMakefileLockfiledriftHeadContract(t *testing.T) {
@@ -5122,6 +5347,43 @@ func newTempBenchGateRepo(t *testing.T) string {
 	return root
 }
 
+func newTempBenchGateGoRepo(t *testing.T) (string, map[string]string) {
+	t.Helper()
+
+	repo := newTempBenchGateRepo(t)
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		t.Fatalf("resolve go binary: %v", err)
+	}
+	homeDir := filepath.Join(t.TempDir(), "home")
+	cacheDir := filepath.Join(t.TempDir(), "gocache")
+	for _, dir := range []string{homeDir, cacheDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create Go environment directory: %v", err)
+		}
+	}
+	writeFile(t, filepath.Join(repo, "go.mod"), "module github.com/ben-ranford/lopper\n\ngo 1.26.0\n")
+	return repo, map[string]string{
+		"GO":                          goPath,
+		"GO_TOOLCHAIN":                "local",
+		"HOME":                        homeDir,
+		"GOCACHE":                     cacheDir,
+		"BENCH_COUNT":                 "1",
+		"BENCH_TIME":                  "1x",
+		"MEMORY_BENCH_MAX_BYTES_PCT":  "100000",
+		"MEMORY_BENCH_MAX_ALLOCS_PCT": "100000",
+	}
+}
+
+func benchmarkTestSource(packageName string, benchmarkNames ...string) string {
+	var source strings.Builder
+	source.WriteString("package " + packageName + "\n\nimport \"testing\"\n\nvar benchmarkSink []byte\n\n")
+	for _, benchmarkName := range benchmarkNames {
+		source.WriteString("func " + benchmarkName + "(b *testing.B) { for i := 0; i < b.N; i++ { benchmarkSink = make([]byte, 1) } }\n")
+	}
+	return source.String()
+}
+
 func newCoverageFakeGo(t *testing.T) string {
 	t.Helper()
 
@@ -5131,6 +5393,40 @@ func newCoverageFakeGo(t *testing.T) string {
 		t.Fatalf("write fake go: %v", err)
 	}
 	return path
+}
+
+func copyTree(t *testing.T, src, dst string) {
+	t.Helper()
+
+	info, err := os.Stat(src)
+	if err != nil {
+		t.Fatalf("stat source tree %s: %v", src, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("source tree %s is not a directory", src)
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("create destination tree %s: %v", dst, err)
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		t.Fatalf("read source tree %s: %v", src, err)
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if entry.IsDir() {
+			copyTree(t, srcPath, dstPath)
+			continue
+		}
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			t.Fatalf("read source file %s: %v", srcPath, err)
+		}
+		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+			t.Fatalf("write destination file %s: %v", dstPath, err)
+		}
+	}
 }
 
 func assertPathAbsent(t *testing.T, path string) {
@@ -5158,6 +5454,21 @@ func assertFileExists(t *testing.T, path string) {
 
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected %s to exist, err=%v", path, err)
+	}
+}
+
+func assertFileContainsAll(t *testing.T, path string, want []string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %s: %v", path, err)
+	}
+	content := string(data)
+	for _, needle := range want {
+		if !strings.Contains(content, needle) {
+			t.Fatalf("expected %s to contain %q, got:\n%s", path, needle, content)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The memory benchmark gate could discover benchmark names independently in the base and head revisions, allowing the compared benchmark set to drift between revisions.

Closes #1402

## Changes

- Resolve one explicit benchmark definition from the head revision, including canonical package targets, exact benchmark selectors, relevant flags, and benchmark harness files.
- Apply that unchanged definition to both base and head benchmark runs.
- Fingerprint benchmark harness files and reject a base revision whose harness differs before any benchmark executes.
- Fail definition resolution or application with exit status 2.
- Record the exact resolved definition in logs and benchmark artifacts.

## Validation

Commands and checks run:

```bash
go test ./scripts -run 'TestMakefileBenchGate' -count=1
go test ./scripts -run '^TestMakefileBenchGateAppliesOneDefinitionAcrossRevisions$' -count=5
go test ./scripts -count=1
make bench-gate
make ci
```

Regression-Test: ./scripts::TestMakefileBenchGateAppliesOneDefinitionAcrossRevisions

## Risk and compatibility

- Breaking changes: The benchmark gate now rejects revisions where the requested benchmark definition cannot be applied unchanged.
- Migration required: Keep benchmark package targets and harness files aligned across the compared revisions.
- Performance impact: The gate performs bounded benchmark discovery and harness fingerprint checks before running the existing benchmark workload.
- Memory benchmark impact: The repository memory benchmark gate passed with four identical base/head definitions.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
