### PR TITLE
fix(ci): pin memory benchmark Go toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,12 +225,14 @@ bench-gate:
 		exit 2; \
 	}; \
 	if [ -z "$$requested_go_bin" ]; then \
-		go_env_output="$$(GOTOOLCHAIN=$$requested_go_toolchain $(GO) env GOROOT GOEXE 2>/dev/null || true)"; \
+		go_env_output="$$(GOTOOLCHAIN=$$requested_go_toolchain $(GO) env GOROOT GOHOSTOS 2>/dev/null || true)"; \
 		derived_go_root="$$(printf '%s\n' "$$go_env_output" | sed -n '1p')"; \
-		derived_go_exe="$$(printf '%s\n' "$$go_env_output" | sed -n '2p')"; \
+		derived_go_host_os="$$(printf '%s\n' "$$go_env_output" | sed -n '2p')"; \
 		if [ -z "$$derived_go_root" ]; then \
 			fail_invalid_memory_gate "configured GO command could not resolve GOROOT; set GO_BIN explicitly."; \
 		fi; \
+		derived_go_exe=""; \
+		if [ "$$derived_go_host_os" = "windows" ]; then derived_go_exe=".exe"; fi; \
 		requested_go_bin="$$derived_go_root/bin/go$$derived_go_exe"; \
 	fi; \
 	resolve_go_bin_reference() { \

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ COVERAGE_PACKAGE_MIN ?= $(COVERAGE_MIN)
 LOCKFILEDRIFT_HEAD_TAG ?= lockfiledrift_head
 LOCKFILEDRIFT_HEAD_PACKAGE ?= ./internal/app
 GO ?= go
+GO_BIN ?= $(GO)
 GO_TOOLCHAIN ?= go1.26.5
 GO_CMD := GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO)
 MANPAGE_OUT ?= docs/man/lopper.1
@@ -208,25 +209,150 @@ bench-gate:
 	@set -eu; \
 	requested_base_ref="$(MEMORY_BENCH_BASE)"; \
 	base_ref="$$requested_base_ref"; \
+	requested_go_bin="$(GO_BIN)"; \
+	requested_go_toolchain="$(GO_TOOLCHAIN)"; \
 	mkdir -p $$(dirname "$(BENCH_BASE_OUTPUT)") $$(dirname "$(BENCH_HEAD_OUTPUT)") $$(dirname "$(MEMORY_BENCH_SUMMARY)") $$(dirname "$(MEMORY_BENCH_STATUS)"); \
 	write_invalid_memory_summary() { \
 		printf "## Memory Benchmarks\n\nThresholds: bytes/op <= +%s%%, allocs/op <= +%s%%\n\nBase benchmarks: unavailable\nHead benchmarks: unavailable\n\nInput errors:\n- %s\n\nComparison status: invalid\nResult: benchmark input could not be read for a safe memory comparison.\n" "$(MEMORY_BENCH_MAX_BYTES_PCT)" "$(MEMORY_BENCH_MAX_ALLOCS_PCT)" "$$1" > "$(MEMORY_BENCH_SUMMARY)"; \
 		printf "2\n" > "$(MEMORY_BENCH_STATUS)"; \
 	}; \
 	fail_invalid_memory_gate() { \
-		printf "Memory benchmark gate invalid: %s\n" "$$1" >&2; \
-		write_invalid_memory_summary "$$1"; \
+		diagnostic="$$1"; \
+		summary_error="$$diagnostic"; \
+		if [ "$$#" -gt 1 ]; then summary_error="$$2"; fi; \
+		printf "Memory benchmark gate invalid: %s\n" "$$diagnostic" >&2; \
+		write_invalid_memory_summary "$$summary_error"; \
 		exit 2; \
 	}; \
+	resolve_go_bin_reference() { \
+		candidate="$$1"; \
+		case "$$candidate" in \
+			*/*) resolved="$$candidate" ;; \
+			*) resolved="$$(command -v "$$candidate" 2>/dev/null || true)" ;; \
+		esac; \
+		if [ -z "$$resolved" ]; then return 1; fi; \
+		case "$$resolved" in \
+			/*) ;; \
+			*) resolved="$$PWD/$$resolved" ;; \
+		esac; \
+		if [ ! -e "$$resolved" ]; then return 1; fi; \
+		printf "%s\n" "$$resolved"; \
+	}; \
+	resolve_go_bin() { \
+		reference_path="$$1"; \
+		resolved_go_bin=""; \
+		resolve_go_bin_error=""; \
+		if [ -z "$$reference_path" ] || [ ! -e "$$reference_path" ]; then return 1; fi; \
+		target_path="$$reference_path"; \
+		case "$$target_path" in \
+			/*) ;; \
+			*) target_path="$$PWD/$$target_path" ;; \
+		esac; \
+		symlink_depth=0; \
+		while [ -L "$$target_path" ]; do \
+			link_parent="$$(CDPATH= cd -P "$$(dirname "$$target_path")" 2>/dev/null && pwd -P)" || { \
+				resolve_go_bin_error="could not canonicalize symlink parent '$$target_path'."; \
+				return 2; \
+			}; \
+			link_target="$$(readlink "$$target_path" 2>/dev/null)" || { \
+				resolve_go_bin_error="could not read symbolic link '$$target_path'."; \
+				return 2; \
+			}; \
+			case "$$link_target" in \
+				/*) target_path="$$link_target" ;; \
+				*) target_path="$$link_parent/$$link_target" ;; \
+			esac; \
+			symlink_depth=$$((symlink_depth + 1)); \
+			if [ "$$symlink_depth" -gt 40 ]; then \
+				resolve_go_bin_error="exceeded symlink resolution depth for '$$reference_path'."; \
+				return 2; \
+			fi; \
+		done; \
+		canonical_parent="$$(CDPATH= cd -P "$$(dirname "$$target_path")" 2>/dev/null && pwd -P)" || { \
+			resolve_go_bin_error="could not canonicalize parent directory '$$target_path'."; \
+			return 2; \
+		}; \
+		canonical_name="$$(basename "$$target_path")" || { \
+			resolve_go_bin_error="could not determine executable name for '$$target_path'."; \
+			return 2; \
+		}; \
+		resolved_go_bin="$$canonical_parent/$$canonical_name"; \
+		return 0; \
+	}; \
+	fingerprint_go_bin() { \
+		cksum "$$1" 2>/dev/null; \
+	}; \
+	go_bin_reference_path="$$(resolve_go_bin_reference "$$requested_go_bin" || true)"; \
+	if resolve_go_bin "$$go_bin_reference_path"; then \
+		go_bin_path="$$resolved_go_bin"; \
+	else \
+		go_bin_status=$$?; \
+		if [ "$$go_bin_status" -eq 1 ]; then \
+			fail_invalid_memory_gate "configured GO_BIN '$$requested_go_bin' is missing or not found." "base benchmark input could not be read: configured GO_BIN '$$requested_go_bin' is missing or not found."; \
+		fi; \
+		fail_invalid_memory_gate "configured GO_BIN '$$requested_go_bin' could not be canonicalized: $$resolve_go_bin_error" "base benchmark input could not be read: configured GO_BIN '$$requested_go_bin' could not be canonicalized: $$resolve_go_bin_error"; \
+	fi; \
+	if [ ! -x "$$go_bin_path" ]; then \
+		fail_invalid_memory_gate "configured GO_BIN '$$go_bin_path' is not executable." "base benchmark input could not be read: configured GO_BIN '$$go_bin_path' is not executable."; \
+	fi; \
+	expected_go_bin_fingerprint="$$(fingerprint_go_bin "$$go_bin_path" || true)"; \
+	if [ -z "$$expected_go_bin_fingerprint" ]; then \
+		fail_invalid_memory_gate "configured GO_BIN '$$go_bin_path' could not be fingerprinted." "base benchmark input could not be read: configured GO_BIN '$$go_bin_path' could not be fingerprinted."; \
+	fi; \
+	validate_go_bin_identity() { \
+		phase="$$1"; \
+		if resolve_go_bin "$$go_bin_reference_path"; then \
+			current_go_bin_path="$$resolved_go_bin"; \
+		else \
+			fail_invalid_memory_gate "configured GO_BIN '$$requested_go_bin' disappeared or became invalid before $$phase." "base benchmark input could not be read: configured GO_BIN '$$requested_go_bin' disappeared or became invalid before $$phase."; \
+		fi; \
+		if [ "$$current_go_bin_path" != "$$go_bin_path" ]; then \
+			fail_invalid_memory_gate "configured GO_BIN '$$requested_go_bin' resolved to '$$current_go_bin_path' during $$phase after validating '$$go_bin_path'." "base benchmark input could not be read: configured GO_BIN '$$requested_go_bin' was substituted during $$phase."; \
+		fi; \
+		if [ ! -x "$$current_go_bin_path" ]; then \
+			fail_invalid_memory_gate "configured GO_BIN '$$current_go_bin_path' is not executable during $$phase." "base benchmark input could not be read: configured GO_BIN '$$current_go_bin_path' is not executable during $$phase."; \
+		fi; \
+		current_go_bin_fingerprint="$$(fingerprint_go_bin "$$current_go_bin_path" || true)"; \
+		if [ -z "$$current_go_bin_fingerprint" ] || [ "$$current_go_bin_fingerprint" != "$$expected_go_bin_fingerprint" ]; then \
+			fail_invalid_memory_gate "configured GO_BIN '$$current_go_bin_path' changed in place before $$phase." "base benchmark input could not be read: configured GO_BIN '$$current_go_bin_path' changed in place before $$phase."; \
+		fi; \
+	}; \
+	validate_go_bin_identity "Go toolchain discovery"; \
+	expected_go_version="$$(GOTOOLCHAIN=$$requested_go_toolchain "$$go_bin_path" env GOVERSION 2>/dev/null || true)"; \
+	if [ -z "$$expected_go_version" ]; then \
+		fail_invalid_memory_gate "configured GO_BIN '$$go_bin_path' could not resolve GOVERSION for GOTOOLCHAIN='$$requested_go_toolchain'." "base benchmark input could not be read: configured GO_BIN '$$go_bin_path' could not resolve GOVERSION for GOTOOLCHAIN='$$requested_go_toolchain'."; \
+	fi; \
+	validate_go_toolchain() { \
+		phase="$$1"; \
+		validate_go_bin_identity "$$phase"; \
+		resolved_go_version="$$(GOTOOLCHAIN=$$requested_go_toolchain "$$go_bin_path" env GOVERSION 2>/dev/null || true)"; \
+		if [ "$$resolved_go_version" != "$$expected_go_version" ]; then \
+			fail_invalid_memory_gate "configured GO_BIN '$$go_bin_path' reported GOVERSION '$$resolved_go_version' during $$phase; expected '$$expected_go_version'." "base benchmark input could not be read: configured GO_BIN '$$go_bin_path' reported GOVERSION '$$resolved_go_version' during $$phase; expected '$$expected_go_version'."; \
+		fi; \
+	}; \
+	run_validated_go() { \
+		phase="$$1"; \
+		shift; \
+		validate_go_toolchain "$$phase"; \
+		GOTOOLCHAIN=$$requested_go_toolchain "$$go_bin_path" "$$@"; \
+	}; \
+	validate_go_toolchain "initial validation"; \
+	go_version_log="$$(GOTOOLCHAIN=$$requested_go_toolchain "$$go_bin_path" version 2>/dev/null || true)"; \
+	reported_go_version="$$(printf '%s\n' "$$go_version_log" | awk 'NR == 1 { print $$3 }')"; \
+	if [ -z "$$go_version_log" ] || [ "$$reported_go_version" != "$$expected_go_version" ]; then \
+		fail_invalid_memory_gate "configured GO_BIN '$$go_bin_path' reported version '$$reported_go_version' for GOTOOLCHAIN='$$requested_go_toolchain'; expected '$$expected_go_version'." "base benchmark input could not be read: configured GO_BIN '$$go_bin_path' reported version '$$reported_go_version' for GOTOOLCHAIN='$$requested_go_toolchain'; expected '$$expected_go_version'."; \
+	fi; \
+	echo "Memory benchmark GO_BIN: $$go_bin_path"; \
+	echo "Memory benchmark Go toolchain: $$expected_go_version"; \
 	benchmark_harness_fingerprint() { \
 		fingerprint_pkg="$$1"; \
 		fingerprint_files_tmp=$$(mktemp) || return 1; \
 		fingerprint_manifest_tmp=$$(mktemp) || { rm -f "$$fingerprint_files_tmp"; return 1; }; \
-		if ! fingerprint_dir=$$(GOFLAGS=-buildvcs=false $(GO_CMD) list -f '{{.Dir}}' "$$fingerprint_pkg" 2>/dev/null); then \
+		if ! fingerprint_dir=$$(GOFLAGS=-buildvcs=false run_validated_go "benchmark harness directory resolution for '$$fingerprint_pkg'" list -f '{{.Dir}}' "$$fingerprint_pkg" 2>/dev/null); then \
 			rm -f "$$fingerprint_files_tmp" "$$fingerprint_manifest_tmp"; \
 			return 1; \
 		fi; \
-		if ! GOFLAGS=-buildvcs=false $(GO_CMD) list -f '{{range .TestGoFiles}}{{printf "test\t%s\n" .}}{{end}}{{range .TestEmbedFiles}}{{printf "test-embed\t%s\n" .}}{{end}}{{range .XTestGoFiles}}{{printf "xtest\t%s\n" .}}{{end}}{{range .XTestEmbedFiles}}{{printf "xtest-embed\t%s\n" .}}{{end}}' "$$fingerprint_pkg" > "$$fingerprint_files_tmp" 2>/dev/null; then \
+		if ! GOFLAGS=-buildvcs=false run_validated_go "benchmark harness file resolution for '$$fingerprint_pkg'" list -f '{{range .TestGoFiles}}{{printf "test\t%s\n" .}}{{end}}{{range .TestEmbedFiles}}{{printf "test-embed\t%s\n" .}}{{end}}{{range .XTestGoFiles}}{{printf "xtest\t%s\n" .}}{{end}}{{range .XTestEmbedFiles}}{{printf "xtest-embed\t%s\n" .}}{{end}}' "$$fingerprint_pkg" > "$$fingerprint_files_tmp" 2>/dev/null; then \
 			rm -f "$$fingerprint_files_tmp" "$$fingerprint_manifest_tmp"; \
 			return 1; \
 		fi; \
@@ -258,7 +384,7 @@ bench-gate:
 		invocation_pkg="$$1"; \
 		invocation_selection="$$2"; \
 		invocation_fingerprint="$$3"; \
-		printf "package=%s selection=%s -run '^$$' GO_TEST_LDFLAGS_ARGS=%s flags=-benchmem -count=%s -benchtime=%s harness-files=TestGoFiles,TestEmbedFiles,XTestGoFiles,XTestEmbedFiles harness-fingerprint=%s invocation=GOFLAGS=-buildvcs=false %s test %s -run '^$$' -bench '%s' -benchmem -count=%s -benchtime=%s '%s'" "$$invocation_pkg" "$$invocation_selection" "$(subst ",\",$(GO_TEST_LDFLAGS_ARGS))" "$(BENCH_COUNT)" "$(BENCH_TIME)" "$$invocation_fingerprint" "$(GO_CMD)" "$(subst ",\",$(GO_TEST_LDFLAGS_ARGS))" "$$invocation_selection" "$(BENCH_COUNT)" "$(BENCH_TIME)" "$$invocation_pkg"; \
+		printf "package=%s selection=%s -run '^$$' GO_TEST_LDFLAGS_ARGS=%s flags=-benchmem -count=%s -benchtime=%s harness-files=TestGoFiles,TestEmbedFiles,XTestGoFiles,XTestEmbedFiles harness-fingerprint=%s invocation=GOFLAGS=-buildvcs=false GOTOOLCHAIN=%s %s test %s -run '^$$' -bench '%s' -benchmem -count=%s -benchtime=%s '%s'" "$$invocation_pkg" "$$invocation_selection" "$(subst ",\",$(GO_TEST_LDFLAGS_ARGS))" "$(BENCH_COUNT)" "$(BENCH_TIME)" "$$invocation_fingerprint" "$$requested_go_toolchain" "$$go_bin_path" "$(subst ",\",$(GO_TEST_LDFLAGS_ARGS))" "$$invocation_selection" "$(BENCH_COUNT)" "$(BENCH_TIME)" "$$invocation_pkg"; \
 	}; \
 	if ! git rev-parse --verify -q "$$base_ref^{commit}" >/dev/null; then \
 		echo "Memory benchmark base ref '$$base_ref' is missing or invalid; failing closed."; \
@@ -280,7 +406,9 @@ bench-gate:
 	: > "$$base_output_tmp"; \
 	: > "$$head_output_tmp"; \
 	: > "$$bench_definitions_tmp"; \
-	if ! GOFLAGS=-buildvcs=false $(GO_CMD) list $(MEMORY_BENCH_PACKAGES) > "$$bench_packages_tmp" 2>&1; then \
+	printf "Memory benchmark GO_BIN: %s\nMemory benchmark Go toolchain: %s\n" "$$go_bin_path" "$$expected_go_version" >> "$$base_output_tmp"; \
+	printf "Memory benchmark GO_BIN: %s\nMemory benchmark Go toolchain: %s\n" "$$go_bin_path" "$$expected_go_version" >> "$$head_output_tmp"; \
+	if ! GOFLAGS=-buildvcs=false run_validated_go "head benchmark package resolution" list $(MEMORY_BENCH_PACKAGES) > "$$bench_packages_tmp" 2>&1; then \
 		cat "$$bench_packages_tmp"; \
 		fail_invalid_memory_gate "head benchmark package targets could not be resolved."; \
 	fi; \
@@ -289,7 +417,7 @@ bench-gate:
 		[ -n "$$bench_pkg" ] || continue; \
 		pkg_bench_tmp=$$(mktemp); \
 		pkg_names_tmp=$$(mktemp); \
-		if ! GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -list '^Benchmark' "$$bench_pkg" > "$$pkg_bench_tmp" 2>&1; then \
+		if ! GOFLAGS=-buildvcs=false run_validated_go "head benchmark discovery for '$$bench_pkg'" test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -list '^Benchmark' "$$bench_pkg" > "$$pkg_bench_tmp" 2>&1; then \
 			cat "$$pkg_bench_tmp"; \
 			rm -f "$$pkg_bench_tmp" "$$pkg_names_tmp"; \
 			fail_invalid_memory_gate "head benchmark definition could not be resolved from package '$$bench_pkg'."; \
@@ -329,7 +457,7 @@ bench-gate:
 		printf "Applied base benchmark definition: %s\n" "$$definition_metadata"; \
 		printf "Applied base benchmark definition: %s\n" "$$definition_metadata" >> "$$base_output_tmp"; \
 		bench_run_output_tmp=$$(mktemp); \
-		if ! (cd "$$base_tree" && GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench "$$bench_selection" -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) "$$bench_pkg") > "$$bench_run_output_tmp" 2>&1; then \
+		if ! (cd "$$base_tree" && GOFLAGS=-buildvcs=false run_validated_go "base benchmark execution for '$$bench_pkg'" test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench "$$bench_selection" -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) "$$bench_pkg") > "$$bench_run_output_tmp" 2>&1; then \
 			cat "$$bench_run_output_tmp"; \
 			rm -f "$$bench_run_output_tmp"; \
 			fail_invalid_memory_gate "base benchmark definition for package '$$bench_pkg' with selection '$$bench_selection' could not be applied unchanged."; \
@@ -344,7 +472,7 @@ bench-gate:
 		printf "Applied head benchmark definition: %s\n" "$$definition_metadata"; \
 		printf "Applied head benchmark definition: %s\n" "$$definition_metadata" >> "$$head_output_tmp"; \
 		bench_run_output_tmp=$$(mktemp); \
-		if ! GOFLAGS=-buildvcs=false $(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench "$$bench_selection" -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) "$$bench_pkg" > "$$bench_run_output_tmp" 2>&1; then \
+		if ! GOFLAGS=-buildvcs=false run_validated_go "head benchmark execution for '$$bench_pkg'" test $(GO_TEST_LDFLAGS_ARGS) -run '^$$' -bench "$$bench_selection" -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) "$$bench_pkg" > "$$bench_run_output_tmp" 2>&1; then \
 			cat "$$bench_run_output_tmp"; \
 			rm -f "$$bench_run_output_tmp"; \
 			fail_invalid_memory_gate "head benchmark definition for package '$$bench_pkg' with selection '$$bench_selection' could not be applied unchanged."; \
@@ -355,7 +483,7 @@ bench-gate:
 	done < "$$bench_definitions_tmp"; \
 	cp "$$head_output_tmp" "$(BENCH_HEAD_OUTPUT)"; \
 	benchdelta_bin="$$bench_dir/benchdelta"; \
-	GOFLAGS=-buildvcs=false $(GO_CMD) build -o "$$benchdelta_bin" ./tools/benchdelta; \
+	GOFLAGS=-buildvcs=false run_validated_go "benchdelta helper build" build -o "$$benchdelta_bin" ./tools/benchdelta; \
 	set +e; \
 	"$$benchdelta_bin" -base "$(BENCH_BASE_OUTPUT)" -head "$(BENCH_HEAD_OUTPUT)" -max-bytes-pct "$(MEMORY_BENCH_MAX_BYTES_PCT)" -max-allocs-pct "$(MEMORY_BENCH_MAX_ALLOCS_PCT)" -summary-out "$(MEMORY_BENCH_SUMMARY)"; \
 	status=$$?; \

--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,12 @@ bench-gate:
 	}; \
 	validate_go_toolchain "initial validation"; \
 	go_version_log="$$(GOTOOLCHAIN=$$requested_go_toolchain "$$go_bin_path" version 2>/dev/null || true)"; \
-	reported_go_version="$$(printf '%s\n' "$$go_version_log" | awk 'NR == 1 { print $$3 }')"; \
+	reported_go_version="$${go_version_log#go version }"; \
+	if [ "$$reported_go_version" = "$$go_version_log" ]; then \
+		reported_go_version=""; \
+	else \
+		reported_go_version="$${reported_go_version% *}"; \
+	fi; \
 	if [ -z "$$go_version_log" ] || [ "$$reported_go_version" != "$$expected_go_version" ]; then \
 		fail_invalid_memory_gate "configured GO_BIN '$$go_bin_path' reported version '$$reported_go_version' for GOTOOLCHAIN='$$requested_go_toolchain'; expected '$$expected_go_version'." "base benchmark input could not be read: configured GO_BIN '$$go_bin_path' reported version '$$reported_go_version' for GOTOOLCHAIN='$$requested_go_toolchain'; expected '$$expected_go_version'."; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ COVERAGE_PACKAGE_MIN ?= $(COVERAGE_MIN)
 LOCKFILEDRIFT_HEAD_TAG ?= lockfiledrift_head
 LOCKFILEDRIFT_HEAD_PACKAGE ?= ./internal/app
 GO ?= go
-GO_BIN ?= $(GO)
+GO_BIN ?=
 GO_TOOLCHAIN ?= go1.26.5
 GO_CMD := GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO)
 MANPAGE_OUT ?= docs/man/lopper.1
@@ -224,6 +224,15 @@ bench-gate:
 		write_invalid_memory_summary "$$summary_error"; \
 		exit 2; \
 	}; \
+	if [ -z "$$requested_go_bin" ]; then \
+		go_env_output="$$(GOTOOLCHAIN=$$requested_go_toolchain $(GO) env GOROOT GOEXE 2>/dev/null || true)"; \
+		derived_go_root="$$(printf '%s\n' "$$go_env_output" | sed -n '1p')"; \
+		derived_go_exe="$$(printf '%s\n' "$$go_env_output" | sed -n '2p')"; \
+		if [ -z "$$derived_go_root" ]; then \
+			fail_invalid_memory_gate "configured GO command could not resolve GOROOT; set GO_BIN explicitly."; \
+		fi; \
+		requested_go_bin="$$derived_go_root/bin/go$$derived_go_exe"; \
+	fi; \
 	resolve_go_bin_reference() { \
 		candidate="$$1"; \
 		case "$$candidate" in \

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3099,7 +3099,8 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 		`printf "2\n" > "$(MEMORY_BENCH_STATUS)"`,
 		`requested_go_bin="$(GO_BIN)"`,
 		`requested_go_toolchain="$(GO_TOOLCHAIN)"`,
-		`go_env_output="$$(GOTOOLCHAIN=$$requested_go_toolchain $(GO) env GOROOT GOEXE`,
+		`go_env_output="$$(GOTOOLCHAIN=$$requested_go_toolchain $(GO) env GOROOT GOHOSTOS`,
+		`if [ "$$derived_go_host_os" = "windows" ]; then derived_go_exe=".exe"; fi`,
 		`requested_go_bin="$$derived_go_root/bin/go$$derived_go_exe"`,
 		`resolve_go_bin_reference() { \`,
 		`resolve_go_bin() { \`,
@@ -3214,6 +3215,7 @@ func TestMakefileBenchGateKeepsGoBinIndependentFromMultiwordGo(t *testing.T) {
 	}
 	vars := map[string]string{
 		"GO":                "env " + hostGo,
+		"GOOS":              "windows",
 		"GO_TOOLCHAIN":      "local",
 		"MEMORY_BENCH_BASE": "refs/heads/does-not-exist",
 	}

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3457,33 +3457,7 @@ func TestMakefileBenchGateAppliesOneDefinitionAcrossRevisions(t *testing.T) {
 		"harness-fingerprint=git-hash-object:",
 	})
 
-	logBytes, err := os.ReadFile(goBinLog)
-	if err != nil {
-		t.Fatalf("read GO_BIN invocation log: %v", err)
-	}
-	benchmarkDirs := map[string]struct{}{}
-	sawHelperBuild := false
-	for _, line := range strings.Split(strings.TrimSpace(string(logBytes)), "\n") {
-		fields := strings.SplitN(line, "\t", 3)
-		if len(fields) != 3 {
-			t.Fatalf("invalid GO_BIN invocation log line %q", line)
-		}
-		if fields[0] != resolvedGoBin {
-			t.Fatalf("GO_BIN invocation path = %q, want canonical path %q", fields[0], resolvedGoBin)
-		}
-		if strings.HasPrefix(fields[2], "test ") && strings.Contains(fields[2], " -bench ") {
-			benchmarkDirs[fields[1]] = struct{}{}
-		}
-		if strings.HasPrefix(fields[2], "build -o ") && strings.HasSuffix(fields[2], " ./tools/benchdelta") {
-			sawHelperBuild = true
-		}
-	}
-	if len(benchmarkDirs) != 2 {
-		t.Fatalf("canonical GO_BIN must benchmark distinct base and head directories, got %v from:\n%s", benchmarkDirs, logBytes)
-	}
-	if !sawHelperBuild {
-		t.Fatalf("canonical GO_BIN did not build the benchmark helper:\n%s", logBytes)
-	}
+	assertPinnedGoBinInvocations(t, goBinLog, resolvedGoBin)
 }
 
 func TestMakefileBenchGateApplicationFailuresExitInvalid(t *testing.T) {
@@ -5607,6 +5581,38 @@ func writeExecutableFile(t *testing.T, path string, contents string) {
 
 	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
 		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+func assertPinnedGoBinInvocations(t *testing.T, logPath string, resolvedGoBin string) {
+	t.Helper()
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read GO_BIN invocation log: %v", err)
+	}
+	benchmarkDirs := map[string]struct{}{}
+	sawHelperBuild := false
+	for _, line := range strings.Split(strings.TrimSpace(string(logBytes)), "\n") {
+		fields := strings.SplitN(line, "\t", 3)
+		if len(fields) != 3 {
+			t.Fatalf("invalid GO_BIN invocation log line %q", line)
+		}
+		if fields[0] != resolvedGoBin {
+			t.Fatalf("GO_BIN invocation path = %q, want canonical path %q", fields[0], resolvedGoBin)
+		}
+		if strings.HasPrefix(fields[2], "test ") && strings.Contains(fields[2], " -bench ") {
+			benchmarkDirs[fields[1]] = struct{}{}
+		}
+		if strings.HasPrefix(fields[2], "build -o ") && strings.HasSuffix(fields[2], " ./tools/benchdelta") {
+			sawHelperBuild = true
+		}
+	}
+	if len(benchmarkDirs) != 2 {
+		t.Fatalf("canonical GO_BIN must benchmark distinct base and head directories, got %v from:\n%s", benchmarkDirs, logBytes)
+	}
+	if !sawHelperBuild {
+		t.Fatalf("canonical GO_BIN did not build the benchmark helper:\n%s", logBytes)
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3089,8 +3089,8 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 	if target == "" {
 		t.Fatal("Makefile must define the bench-gate target")
 	}
-	if !strings.Contains(makefile, "GO_BIN ?= $(GO)") {
-		t.Fatal("Makefile must default GO_BIN to the configured Go command")
+	if !strings.Contains(makefile, "GO_BIN ?=\n") {
+		t.Fatal("Makefile must allow bench-gate to derive GO_BIN independently from the potentially multiword GO command")
 	}
 
 	for _, want := range []string{
@@ -3099,6 +3099,8 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 		`printf "2\n" > "$(MEMORY_BENCH_STATUS)"`,
 		`requested_go_bin="$(GO_BIN)"`,
 		`requested_go_toolchain="$(GO_TOOLCHAIN)"`,
+		`go_env_output="$$(GOTOOLCHAIN=$$requested_go_toolchain $(GO) env GOROOT GOEXE`,
+		`requested_go_bin="$$derived_go_root/bin/go$$derived_go_exe"`,
 		`resolve_go_bin_reference() { \`,
 		`resolve_go_bin() { \`,
 		`expected_go_bin_fingerprint="$$(fingerprint_go_bin "$$go_bin_path" || true)"`,
@@ -3199,6 +3201,34 @@ func TestMakefileBenchGateRejectsMissingOrNonExecutableGoBin(t *testing.T) {
 			}
 			assertMemoryBenchArtifacts(t, repo, "2\n", wantContains, []string{"Result: memory benchmark gate passed."})
 		})
+	}
+}
+
+func TestMakefileBenchGateKeepsGoBinIndependentFromMultiwordGo(t *testing.T) {
+	t.Parallel()
+
+	repo := newTempBenchGateRepo(t)
+	hostGo, err := exec.LookPath("go")
+	if err != nil {
+		t.Fatalf("resolve host go binary: %v", err)
+	}
+	vars := map[string]string{
+		"GO":                "env " + hostGo,
+		"GO_TOOLCHAIN":      "local",
+		"MEMORY_BENCH_BASE": "refs/heads/does-not-exist",
+	}
+	output, _ := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", vars, 2)
+	if strings.Contains(output, "configured GO_BIN 'env ") {
+		t.Fatalf("bench-gate treated the multiword GO command as GO_BIN:\n%s", output)
+	}
+	for _, want := range []string{
+		"Memory benchmark GO_BIN:",
+		"Memory benchmark Go toolchain:",
+		"requested base ref 'refs/heads/does-not-exist' is missing or invalid",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("bench-gate output missing %q:\n%s", want, output)
+		}
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3089,11 +3089,24 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 	if target == "" {
 		t.Fatal("Makefile must define the bench-gate target")
 	}
+	if !strings.Contains(makefile, "GO_BIN ?= $(GO)") {
+		t.Fatal("Makefile must default GO_BIN to the configured Go command")
+	}
 
 	for _, want := range []string{
 		`write_invalid_memory_summary() { \`,
 		`fail_invalid_memory_gate() { \`,
 		`printf "2\n" > "$(MEMORY_BENCH_STATUS)"`,
+		`requested_go_bin="$(GO_BIN)"`,
+		`requested_go_toolchain="$(GO_TOOLCHAIN)"`,
+		`resolve_go_bin_reference() { \`,
+		`resolve_go_bin() { \`,
+		`expected_go_bin_fingerprint="$$(fingerprint_go_bin "$$go_bin_path" || true)"`,
+		`validate_go_bin_identity "Go toolchain discovery"`,
+		`expected_go_version="$$(GOTOOLCHAIN=$$requested_go_toolchain "$$go_bin_path" env GOVERSION`,
+		`run_validated_go() { \`,
+		`echo "Memory benchmark GO_BIN: $$go_bin_path"`,
+		`echo "Memory benchmark Go toolchain: $$expected_go_version"`,
 		`requested base ref '$$base_ref' is missing or invalid`,
 		`requested base ref '$$base_ref' is not related to HEAD`,
 		`benchmark_harness_fingerprint() { \`,
@@ -3109,6 +3122,7 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 		`printf "Applied head benchmark definition: %s\n" "$$definition_metadata" >> "$$head_output_tmp"`,
 		`-bench "$$bench_selection" -benchmem -count=$(BENCH_COUNT) -benchtime=$(BENCH_TIME) "$$bench_pkg"`,
 		`benchdelta_bin="$$bench_dir/benchdelta"`,
+		`run_validated_go "benchdelta helper build" build -o "$$benchdelta_bin" ./tools/benchdelta`,
 		`if [ "$(MEMORY_BENCH_ENFORCE)" = "0" ]; then`,
 		`exit "$$status"`,
 	} {
@@ -3118,6 +3132,7 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 	}
 
 	for _, omit := range []string{
+		`$(GO_CMD)`,
 		`$(GO_CMD) run ./tools/benchdelta`,
 		`if [ "$$status" -eq 2 ]; then`,
 		`falling back to 'HEAD~1'`,
@@ -3133,16 +3148,165 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 	}
 
 	assertTextAppearsBefore(t, target, `if [ "$$base_harness_fingerprint" != "$$harness_fingerprint" ]; then`, `printf "Applied base benchmark definition: %s\n" "$$definition_metadata"`, "bench-gate must verify every base harness fingerprint before executing benchmarks")
+	assertTextAppearsBefore(t, target, `validate_go_toolchain "initial validation"`, `if ! git rev-parse --verify -q "$$base_ref^{commit}"`, "bench-gate must pin the Go executable and toolchain before resolving revisions")
+}
+
+func TestMakefileBenchGateRejectsMissingOrNonExecutableGoBin(t *testing.T) {
+	t.Parallel()
+
+	hostGo, err := exec.LookPath("go")
+	if err != nil {
+		t.Fatalf("resolve host go binary: %v", err)
+	}
+	tests := []struct {
+		name       string
+		create     bool
+		wantOutput string
+	}{
+		{name: "missing", wantOutput: "is missing or not found."},
+		{name: "non-executable", create: true, wantOutput: "is not executable."},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := newTempBenchGateRepo(t)
+			goBin := filepath.Join(t.TempDir(), "go")
+			diagnosticPath := goBin
+			if tc.create {
+				writeFile(t, goBin, "#!/bin/sh\nexit 0\n")
+				resolved, err := filepath.EvalSymlinks(goBin)
+				if err != nil {
+					t.Fatalf("resolve non-executable GO_BIN: %v", err)
+				}
+				diagnosticPath = resolved
+			} else {
+				assertPathAbsent(t, goBin)
+			}
+			vars := map[string]string{
+				"GO":                hostGo,
+				"GO_BIN":            goBin,
+				"GO_TOOLCHAIN":      "local",
+				"MEMORY_BENCH_BASE": "main",
+			}
+			output, _ := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", vars, 2)
+			if !strings.Contains(output, "configured GO_BIN '"+diagnosticPath+"' "+tc.wantOutput) {
+				t.Fatalf("bench-gate output missing GO_BIN diagnostic for %s:\n%s", tc.name, output)
+			}
+			wantContains := []string{
+				"Comparison status: invalid",
+				"configured GO_BIN '" + diagnosticPath + "' " + tc.wantOutput,
+			}
+			assertMemoryBenchArtifacts(t, repo, "2\n", wantContains, []string{"Result: memory benchmark gate passed."})
+		})
+	}
+}
+
+func TestMakefileBenchGateRejectsMismatchedGoVersion(t *testing.T) {
+	t.Parallel()
+
+	repo := newTempBenchGateRepo(t)
+	hostGo, err := exec.LookPath("go")
+	if err != nil {
+		t.Fatalf("resolve host go binary: %v", err)
+	}
+	goBin := filepath.Join(t.TempDir(), "go")
+	writeExecutableFile(t, goBin, `#!/bin/sh
+set -eu
+case "${1:-}" in
+  env)
+    [ "${2:-}" = "GOVERSION" ] || exit 9
+    printf 'go1.26.5\n'
+    ;;
+  version)
+    printf 'go version go1.26.4 fake/mismatch\n'
+    ;;
+  *)
+    exit 9
+    ;;
+esac
+	`)
+	vars := map[string]string{
+		"GO":                hostGo,
+		"GO_BIN":            goBin,
+		"GO_TOOLCHAIN":      "local",
+		"MEMORY_BENCH_BASE": "main",
+	}
+	output, _ := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", vars, 2)
+	want := "reported version 'go1.26.4' for GOTOOLCHAIN='local'; expected 'go1.26.5'."
+	if !strings.Contains(output, want) {
+		t.Fatalf("bench-gate output missing exact version mismatch %q:\n%s", want, output)
+	}
+	assertMemoryBenchArtifacts(t, repo, "2\n", []string{"Comparison status: invalid", want}, []string{"Result: memory benchmark gate passed."})
+}
+
+func TestMakefileBenchGateRejectsSubstitutedGoBin(t *testing.T) {
+	t.Parallel()
+
+	repo := newTempBenchGateRepo(t)
+	hostGo, err := exec.LookPath("go")
+	if err != nil {
+		t.Fatalf("resolve host go binary: %v", err)
+	}
+	goDir := t.TempDir()
+	primary := filepath.Join(goDir, "go-primary")
+	replacement := filepath.Join(goDir, "go-replacement")
+	goBin := filepath.Join(goDir, "go")
+	writeExecutableFile(t, replacement, "#!/bin/sh\nexit 9\n")
+	writeExecutableFile(t, primary, `#!/bin/sh
+set -eu
+case "${1:-}" in
+  env)
+    [ "${2:-}" = "GOVERSION" ] || exit 9
+    ln -sf `+strconv.Quote(replacement)+` `+strconv.Quote(goBin)+`
+    printf 'go1.26.5\n'
+    ;;
+  *)
+    exit 9
+    ;;
+esac
+`)
+	if err := os.Symlink(primary, goBin); err != nil {
+		t.Fatalf("create GO_BIN symlink: %v", err)
+	}
+	resolvedPrimary, err := filepath.EvalSymlinks(primary)
+	if err != nil {
+		t.Fatalf("resolve primary GO_BIN: %v", err)
+	}
+	resolvedReplacement, err := filepath.EvalSymlinks(replacement)
+	if err != nil {
+		t.Fatalf("resolve replacement GO_BIN: %v", err)
+	}
+	vars := map[string]string{
+		"GO":                hostGo,
+		"GO_BIN":            goBin,
+		"GO_TOOLCHAIN":      "local",
+		"MEMORY_BENCH_BASE": "main",
+	}
+	output, _ := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", vars, 2)
+	wantOutput := "resolved to '" + resolvedReplacement + "' during initial validation after validating '" + resolvedPrimary + "'."
+	if !strings.Contains(output, wantOutput) {
+		t.Fatalf("bench-gate output missing substitution diagnostic %q:\n%s", wantOutput, output)
+	}
+	wantSummary := "configured GO_BIN '" + goBin + "' was substituted during initial validation."
+	assertMemoryBenchArtifacts(t, repo, "2\n", []string{"Comparison status: invalid", wantSummary}, []string{"Result: memory benchmark gate passed."})
 }
 
 func TestMakefileBenchGateFailsClosedForInvalidRequestedBase(t *testing.T) {
 	t.Parallel()
 
 	repo := newTempBenchGateRepo(t)
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		t.Fatalf("resolve go binary: %v", err)
+	}
 	summaryPath := filepath.Join("nested", "summary", "memory-bench-summary.md")
 	statusPath := filepath.Join("nested", "status", "memory-bench-status.txt")
 	baseOutputPath := filepath.Join("nested", "base", "bench-base.out")
 	vars := map[string]string{
+		"GO":                   goPath,
+		"GO_BIN":               goPath,
+		"GO_TOOLCHAIN":         "local",
 		"MEMORY_BENCH_BASE":    "refs/heads/does-not-exist",
 		"MEMORY_BENCH_SUMMARY": summaryPath,
 		"MEMORY_BENCH_STATUS":  statusPath,
@@ -3168,6 +3332,10 @@ func TestMakefileBenchGateFailsClosedForUnrelatedRequestedBase(t *testing.T) {
 	t.Parallel()
 
 	repo := newTempBenchGateRepo(t)
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		t.Fatalf("resolve go binary: %v", err)
+	}
 	runGitCommand(t, repo, "checkout", "--orphan", "unrelated-base")
 	writeFile(t, filepath.Join(repo, "unrelated.txt"), "unrelated\n")
 	runGitCommand(t, repo, "add", "unrelated.txt")
@@ -3175,6 +3343,9 @@ func TestMakefileBenchGateFailsClosedForUnrelatedRequestedBase(t *testing.T) {
 	runGitCommand(t, repo, "checkout", "main")
 
 	vars := map[string]string{
+		"GO":                   goPath,
+		"GO_BIN":               goPath,
+		"GO_TOOLCHAIN":         "local",
 		"MEMORY_BENCH_BASE":    "unrelated-base",
 		"MEMORY_BENCH_SUMMARY": ".artifacts/memory-bench-summary.md",
 		"MEMORY_BENCH_STATUS":  ".artifacts/memory-bench-status.txt",
@@ -3198,6 +3369,26 @@ func TestMakefileBenchGateAppliesOneDefinitionAcrossRevisions(t *testing.T) {
 	t.Parallel()
 
 	repo, benchVars := newTempBenchGateGoRepo(t)
+	realGo := benchVars["GO"]
+	goBinDir := filepath.Join(repo, "toolchain")
+	if err := os.MkdirAll(goBinDir, 0o755); err != nil {
+		t.Fatalf("create GO_BIN directory: %v", err)
+	}
+	goBinLog := filepath.Join(goBinDir, "invocations.log")
+	goBin := filepath.Join(goBinDir, "go-wrapper")
+	writeExecutableFile(t, goBin, "#!/bin/sh\nset -eu\nprintf '%s\\t%s\\t%s\\n' \"$0\" \"$PWD\" \"$*\" >> "+strconv.Quote(goBinLog)+"\nexec "+strconv.Quote(realGo)+" \"$@\"\n")
+	resolvedGoBin, err := filepath.EvalSymlinks(goBin)
+	if err != nil {
+		t.Fatalf("resolve canonical GO_BIN: %v", err)
+	}
+	versionCmd := exec.Command(realGo, "env", "GOVERSION")
+	versionCmd.Env = append(gitexec.SanitizedEnv(), "GOTOOLCHAIN=local")
+	versionOutput, err := versionCmd.Output()
+	if err != nil {
+		t.Fatalf("resolve expected Go version: %v", err)
+	}
+	expectedGoVersion := strings.TrimSpace(string(versionOutput))
+	benchVars["GO_BIN"] = filepath.Join("toolchain", "go-wrapper")
 	copyTree(t, repoPath(t, "tools/benchdelta"), filepath.Join(repo, "tools", "benchdelta"))
 	copyTree(t, repoPath(t, "internal/safeio"), filepath.Join(repo, "internal", "safeio"))
 	basePkgOneSource := "package benchpkgone\n\nfunc benchmarkInput() int { return 1 }\n"
@@ -3229,6 +3420,9 @@ func TestMakefileBenchGateAppliesOneDefinitionAcrossRevisions(t *testing.T) {
 		"harness-fingerprint=git-hash-object:",
 		"Applied base benchmark definition:",
 		"Applied head benchmark definition:",
+		"Memory benchmark GO_BIN: " + resolvedGoBin,
+		"Memory benchmark Go toolchain: " + expectedGoVersion,
+		"invocation=GOFLAGS=-buildvcs=false GOTOOLCHAIN=local " + resolvedGoBin + " test",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("bench-gate output missing %q:\n%s", want, output)
@@ -3247,17 +3441,49 @@ func TestMakefileBenchGateAppliesOneDefinitionAcrossRevisions(t *testing.T) {
 	}
 	assertMemoryBenchArtifacts(t, repo, "0\n", wantContains, wantOmit)
 	assertFileContainsAll(t, filepath.Join(repo, ".artifacts", "bench-base.out"), []string{
+		"Memory benchmark GO_BIN: " + resolvedGoBin,
+		"Memory benchmark Go toolchain: " + expectedGoVersion,
 		"Applied base benchmark definition:",
 		"selection=^(BenchmarkPkgOneOnly|BenchmarkShared)$",
 		"selection=^(BenchmarkPkgTwoOnly|BenchmarkShared)$",
 		"harness-fingerprint=git-hash-object:",
 	})
 	assertFileContainsAll(t, filepath.Join(repo, ".artifacts", "bench-head.out"), []string{
+		"Memory benchmark GO_BIN: " + resolvedGoBin,
+		"Memory benchmark Go toolchain: " + expectedGoVersion,
 		"Applied head benchmark definition:",
 		"selection=^(BenchmarkPkgOneOnly|BenchmarkShared)$",
 		"selection=^(BenchmarkPkgTwoOnly|BenchmarkShared)$",
 		"harness-fingerprint=git-hash-object:",
 	})
+
+	logBytes, err := os.ReadFile(goBinLog)
+	if err != nil {
+		t.Fatalf("read GO_BIN invocation log: %v", err)
+	}
+	benchmarkDirs := map[string]struct{}{}
+	sawHelperBuild := false
+	for _, line := range strings.Split(strings.TrimSpace(string(logBytes)), "\n") {
+		fields := strings.SplitN(line, "\t", 3)
+		if len(fields) != 3 {
+			t.Fatalf("invalid GO_BIN invocation log line %q", line)
+		}
+		if fields[0] != resolvedGoBin {
+			t.Fatalf("GO_BIN invocation path = %q, want canonical path %q", fields[0], resolvedGoBin)
+		}
+		if strings.HasPrefix(fields[2], "test ") && strings.Contains(fields[2], " -bench ") {
+			benchmarkDirs[fields[1]] = struct{}{}
+		}
+		if strings.HasPrefix(fields[2], "build -o ") && strings.HasSuffix(fields[2], " ./tools/benchdelta") {
+			sawHelperBuild = true
+		}
+	}
+	if len(benchmarkDirs) != 2 {
+		t.Fatalf("canonical GO_BIN must benchmark distinct base and head directories, got %v from:\n%s", benchmarkDirs, logBytes)
+	}
+	if !sawHelperBuild {
+		t.Fatalf("canonical GO_BIN did not build the benchmark helper:\n%s", logBytes)
+	}
 }
 
 func TestMakefileBenchGateApplicationFailuresExitInvalid(t *testing.T) {
@@ -5365,6 +5591,7 @@ func newTempBenchGateGoRepo(t *testing.T) (string, map[string]string) {
 	writeFile(t, filepath.Join(repo, "go.mod"), "module github.com/ben-ranford/lopper\n\ngo 1.26.0\n")
 	return repo, map[string]string{
 		"GO":                          goPath,
+		"GO_BIN":                      goPath,
 		"GO_TOOLCHAIN":                "local",
 		"HOME":                        homeDir,
 		"GOCACHE":                     cacheDir,
@@ -5372,6 +5599,14 @@ func newTempBenchGateGoRepo(t *testing.T) (string, map[string]string) {
 		"BENCH_TIME":                  "1x",
 		"MEMORY_BENCH_MAX_BYTES_PCT":  "100000",
 		"MEMORY_BENCH_MAX_ALLOCS_PCT": "100000",
+	}
+}
+
+func writeExecutableFile(t *testing.T, path string, contents string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3108,6 +3108,8 @@ func TestMakefileBenchGatePreservesInvalidExitCodes(t *testing.T) {
 		`validate_go_bin_identity "Go toolchain discovery"`,
 		`expected_go_version="$$(GOTOOLCHAIN=$$requested_go_toolchain "$$go_bin_path" env GOVERSION`,
 		`run_validated_go() { \`,
+		`reported_go_version="$${go_version_log#go version }"`,
+		`reported_go_version="$${reported_go_version% *}"`,
 		`echo "Memory benchmark GO_BIN: $$go_bin_path"`,
 		`echo "Memory benchmark Go toolchain: $$expected_go_version"`,
 		`requested base ref '$$base_ref' is missing or invalid`,
@@ -3270,6 +3272,45 @@ esac
 		t.Fatalf("bench-gate output missing exact version mismatch %q:\n%s", want, output)
 	}
 	assertMemoryBenchArtifacts(t, repo, "2\n", []string{"Comparison status: invalid", want}, []string{"Result: memory benchmark gate passed."})
+}
+
+func TestMakefileBenchGateAcceptsDevelopmentGoVersion(t *testing.T) {
+	t.Parallel()
+
+	repo := newTempBenchGateRepo(t)
+	goBin := filepath.Join(t.TempDir(), "go")
+	writeExecutableFile(t, goBin, `#!/bin/sh
+set -eu
+case "${1:-}" in
+  env)
+    [ "${2:-}" = "GOVERSION" ] || exit 9
+    printf 'devel go1.27-abcdef\n'
+    ;;
+  version)
+    printf 'go version devel go1.27-abcdef fake/host\n'
+    ;;
+  *)
+    exit 9
+    ;;
+esac
+`)
+	vars := map[string]string{
+		"GO_BIN":            goBin,
+		"GO_TOOLCHAIN":      "local",
+		"MEMORY_BENCH_BASE": "refs/heads/does-not-exist",
+	}
+	output, _ := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", vars, 2)
+	for _, want := range []string{
+		"Memory benchmark Go toolchain: devel go1.27-abcdef",
+		"requested base ref 'refs/heads/does-not-exist' is missing or invalid",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("bench-gate output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "reported version 'devel'") {
+		t.Fatalf("bench-gate truncated the development Go version:\n%s", output)
+	}
 }
 
 func TestMakefileBenchGateRejectsSubstitutedGoBin(t *testing.T) {


### PR DESCRIPTION
## Summary

The memory benchmark gate trusted the ambient Go command independently across discovery, base, head, and helper-build phases, so a changed executable or toolchain could invalidate the comparison.

Closes #1404

## Changes

- Resolve `GO_BIN` once to a canonical executable path before revision or benchmark work begins.
- Fingerprint the executable and pin its exact `GOVERSION` for the configured `GO_TOOLCHAIN`.
- Revalidate the executable identity, fingerprint, and version before every Go-backed discovery, base, head, and helper-build phase.
- Record the canonical executable and exact Go version in logs and base/head artifacts.
- Fail missing, non-executable, version-mismatched, or substituted executables with status 2.
- Preserve #1402's single benchmark definition across both revisions.

## Validation

Commands and checks run:

```bash
go test ./scripts -run '^TestMakefileBenchGate' -count=1
go test ./scripts -run '^(TestMakefileBenchGateRejectsMissingOrNonExecutableGoBin|TestMakefileBenchGateRejectsMismatchedGoVersion|TestMakefileBenchGateRejectsSubstitutedGoBin|TestMakefileBenchGateAppliesOneDefinitionAcrossRevisions)$' -count=5
go test ./scripts -count=1
make bench-gate
make ci
```

Independent local code review: APPROVE, 0 scoped issues.

Regression-Test: ./scripts::TestMakefileBenchGateRejectsSubstitutedGoBin

## Risk and compatibility

- Breaking changes: Invalid or changing `GO_BIN`/toolchain configurations now fail the memory gate with status 2.
- Migration required: Set `GO_BIN` to a stable executable and `GO_TOOLCHAIN` to the intended toolchain version.
- Performance impact: Lightweight path, checksum, and version checks run before each Go-backed benchmark phase.
- Memory benchmark impact: The real four-benchmark base/head gate passed with the same canonical Go 1.26.5 executable.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
