### PR TITLE
fix(js): suppress removals for incomplete coverage

### DIFF
--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-const analysisCacheSchemaVersion = "v2"
+const analysisCacheSchemaVersion = "v3"
 
 type cacheEntryDescriptor struct {
 	KeyLabel    string

--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-const analysisCacheSchemaVersion = "v3"
+const analysisCacheSchemaVersion = "v4"
 
 type cacheEntryDescriptor struct {
 	KeyLabel    string

--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-const analysisCacheSchemaVersion = "v1"
+const analysisCacheSchemaVersion = "v2"
 
 type cacheEntryDescriptor struct {
 	KeyLabel    string
@@ -29,13 +29,17 @@ type cacheInputDigestMemoKey struct {
 }
 
 func (c *analysisCache) prepareEntry(req Request, adapterID, normalizedRoot string) (cacheEntryDescriptor, error) {
+	return c.prepareEntryWithSchemaVersion(req, adapterID, normalizedRoot, analysisCacheSchemaVersion)
+}
+
+func (c *analysisCache) prepareEntryWithSchemaVersion(req Request, adapterID, normalizedRoot, schemaVersion string) (cacheEntryDescriptor, error) {
 	if c == nil || !c.options.Enabled || !c.cacheable {
 		return cacheEntryDescriptor{}, nil
 	}
 	adapterID = strings.TrimSpace(adapterID)
 	normalizedRoot = filepath.Clean(normalizedRoot)
 	baseKey := map[string]any{
-		"schema":         analysisCacheSchemaVersion,
+		"schema":         schemaVersion,
 		"adapter":        adapterID,
 		"root":           normalizedRoot,
 		"dependency":     req.Dependency,

--- a/internal/analysis/cache_storage.go
+++ b/internal/analysis/cache_storage.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
+const cacheObjectCorruptReason = "object-corrupt"
+
 type cachePointer struct {
 	InputDigest  string `json:"inputDigest"`
 	ObjectDigest string `json:"objectDigest"`
@@ -68,17 +70,17 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 	var payload cachedPayload
 	if err = json.Unmarshal(objectData, &payload); err != nil {
 		c.metadata.Misses++
-		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: "object-corrupt"})
+		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: cacheObjectCorruptReason})
 		return report.Report{}, false, nil
 	}
 	if !payload.restoreUsageIncomplete() {
 		c.metadata.Misses++
-		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: "object-corrupt"})
+		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: cacheObjectCorruptReason})
 		return report.Report{}, false, nil
 	}
 	if !payload.restoreSuppressedUnusedImports() {
 		c.metadata.Misses++
-		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: "object-corrupt"})
+		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: cacheObjectCorruptReason})
 		return report.Report{}, false, nil
 	}
 	c.metadata.Hits++

--- a/internal/analysis/cache_storage.go
+++ b/internal/analysis/cache_storage.go
@@ -16,8 +16,9 @@ type cachePointer struct {
 }
 
 type cachedPayload struct {
-	Report                      report.Report `json:"report"`
-	UsageIncompleteDependencies []int         `json:"usageIncompleteDependencies,omitempty"`
+	Report                              report.Report              `json:"report"`
+	UsageIncompleteDependencies         []int                      `json:"usageIncompleteDependencies,omitempty"`
+	SuppressedUnusedImportsByDependency map[int][]report.ImportUse `json:"suppressedUnusedImportsByDependency,omitempty"`
 }
 
 func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool, error) {
@@ -71,6 +72,11 @@ func (c *analysisCache) lookup(entry cacheEntryDescriptor) (report.Report, bool,
 		return report.Report{}, false, nil
 	}
 	if !payload.restoreUsageIncomplete() {
+		c.metadata.Misses++
+		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: "object-corrupt"})
+		return report.Report{}, false, nil
+	}
+	if !payload.restoreSuppressedUnusedImports() {
 		c.metadata.Misses++
 		c.metadata.Invalidations = append(c.metadata.Invalidations, report.CacheInvalidation{Key: entry.KeyLabel, Reason: "object-corrupt"})
 		return report.Report{}, false, nil
@@ -152,6 +158,12 @@ func newCachedPayload(data report.Report) cachedPayload {
 		if data.Dependencies[index].UsageIncomplete {
 			payload.UsageIncompleteDependencies = append(payload.UsageIncompleteDependencies, index)
 		}
+		if data.Dependencies[index].UsageIncomplete && len(data.Dependencies[index].SuppressedUnusedImports) > 0 {
+			if payload.SuppressedUnusedImportsByDependency == nil {
+				payload.SuppressedUnusedImportsByDependency = make(map[int][]report.ImportUse)
+			}
+			payload.SuppressedUnusedImportsByDependency[index] = append([]report.ImportUse(nil), data.Dependencies[index].SuppressedUnusedImports...)
+		}
 	}
 	return payload
 }
@@ -162,6 +174,19 @@ func (p *cachedPayload) restoreUsageIncomplete() bool {
 			return false
 		}
 		p.Report.Dependencies[index].UsageIncomplete = true
+	}
+	return true
+}
+
+func (p *cachedPayload) restoreSuppressedUnusedImports() bool {
+	for index, imports := range p.SuppressedUnusedImportsByDependency {
+		if index < 0 || index >= len(p.Report.Dependencies) {
+			return false
+		}
+		if !p.Report.Dependencies[index].UsageIncomplete {
+			return false
+		}
+		p.Report.Dependencies[index].SuppressedUnusedImports = append([]report.ImportUse(nil), imports...)
 	}
 	return true
 }

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -26,6 +26,7 @@ type countingAdapter struct {
 	id              string
 	calls           int
 	usageIncomplete bool
+	hiddenImport    *report.ImportUse
 }
 
 func (a *countingAdapter) ID() string { return a.id }
@@ -62,6 +63,9 @@ func (a *countingAdapter) Analyse(_ context.Context, req language.Request) (repo
 	}
 	if a.usageIncomplete && !markUsageIncompleteForTest(&dependency) {
 		return report.Report{}, errors.New("usage-incomplete marker unavailable")
+	}
+	if a.hiddenImport != nil {
+		dependency.SuppressedUnusedImports = []report.ImportUse{*a.hiddenImport}
 	}
 	return report.Report{
 		Dependencies: []report.DependencyReport{dependency},
@@ -153,6 +157,14 @@ func TestAnalysisCachePreservesUsageIncomplete(t *testing.T) {
 
 	svc, adapter := newCacheTestService(t)
 	adapter.usageIncomplete = true
+	adapter.hiddenImport = &report.ImportUse{
+		Name:   "filter",
+		Module: "dep",
+		Locations: []report.Location{{
+			File: "src/hidden.js",
+			Line: 8,
+		}},
+	}
 	req := newCacheRequest(repo, filepath.Join(repo, cacheTestDirectoryName), false)
 
 	first, err := svc.Analyse(context.Background(), req)
@@ -161,6 +173,9 @@ func TestAnalysisCachePreservesUsageIncomplete(t *testing.T) {
 	}
 	if len(first.Dependencies) != 1 || first.Dependencies[0].RemovalCandidate != nil {
 		t.Fatalf("expected incomplete first analysis to suppress removal scoring, got %#v", first.Dependencies)
+	}
+	if !reflect.DeepEqual(first.Dependencies[0].SuppressedUnusedImports, []report.ImportUse{*adapter.hiddenImport}) {
+		t.Fatalf("expected first analysis to preserve hidden imports, got %#v", first.Dependencies[0].SuppressedUnusedImports)
 	}
 
 	second, err := svc.Analyse(context.Background(), req)
@@ -176,11 +191,14 @@ func TestAnalysisCachePreservesUsageIncomplete(t *testing.T) {
 	if len(second.Dependencies) != 1 || second.Dependencies[0].RemovalCandidate != nil {
 		t.Fatalf("expected cached incomplete analysis to suppress removal scoring, got %#v", second.Dependencies)
 	}
+	if !reflect.DeepEqual(second.Dependencies[0].SuppressedUnusedImports, []report.ImportUse{*adapter.hiddenImport}) {
+		t.Fatalf("expected cached analysis to preserve hidden imports, got %#v", second.Dependencies[0].SuppressedUnusedImports)
+	}
 	serialized, err := json.Marshal(second)
 	if err != nil {
 		t.Fatalf("marshal report: %v", err)
 	}
-	if strings.Contains(string(serialized), "usageIncomplete") {
+	if strings.Contains(string(serialized), "usageIncomplete") || strings.Contains(string(serialized), "SuppressedUnusedImports") || strings.Contains(string(serialized), "suppressedUnusedImports") || strings.Contains(string(serialized), "src/hidden.js") {
 		t.Fatalf("did not expect internal incomplete-usage state in report JSON: %s", serialized)
 	}
 }
@@ -799,6 +817,73 @@ func TestAnalysisCacheLookupInvalidationBranches(t *testing.T) {
 		t.Fatalf("write corrupt object: %v", err)
 	}
 	writePointerJSON(t, keyPath, entry.InputDigest, "obj-corrupt")
+	assertLookupMissWithReason(t, cache, entry, "object-corrupt")
+}
+
+func TestAnalysisCacheLookupRejectsSuppressedUnusedSidecarOutOfRangeIndex(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		index        int
+		objectDigest string
+	}{
+		{name: "negative", index: -1, objectDigest: "obj-sidecar-negative"},
+		{name: "past end", index: 1, objectDigest: "obj-sidecar-past-end"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repo := t.TempDir()
+			cachePath := filepath.Join(repo, "cache")
+			cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
+			if !cache.cacheable {
+				t.Fatalf("expected cacheable test setup")
+			}
+
+			entry := cacheEntryDescriptor{KeyLabel: "k", KeyDigest: "digest", InputDigest: "input-a"}
+			keyPath := filepath.Join(cachePath, "keys", entry.KeyDigest+".json")
+			payload, err := json.Marshal(cachedPayload{
+				Report: report.Report{Dependencies: []report.DependencyReport{{
+					Name: "dep",
+				}}},
+				UsageIncompleteDependencies: []int{0},
+				SuppressedUnusedImportsByDependency: map[int][]report.ImportUse{
+					test.index: []report.ImportUse{{Name: "hidden", Module: "dep"}},
+				},
+			})
+			if err != nil {
+				t.Fatalf("marshal payload: %v", err)
+			}
+			mustWriteFile(t, filepath.Join(cachePath, "objects", test.objectDigest+".json"), payload)
+			writePointerJSON(t, keyPath, entry.InputDigest, test.objectDigest)
+
+			assertLookupMissWithReason(t, cache, entry, "object-corrupt")
+		})
+	}
+}
+
+func TestAnalysisCacheLookupRejectsSuppressedUnusedSidecarOnCompleteDependency(t *testing.T) {
+	repo := t.TempDir()
+	cachePath := filepath.Join(repo, "cache")
+	cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
+	if !cache.cacheable {
+		t.Fatalf("expected cacheable test setup")
+	}
+
+	entry := cacheEntryDescriptor{KeyLabel: "k", KeyDigest: "digest", InputDigest: "input-a"}
+	keyPath := filepath.Join(cachePath, "keys", entry.KeyDigest+".json")
+	payload, err := json.Marshal(cachedPayload{
+		Report: report.Report{Dependencies: []report.DependencyReport{{
+			Name: "dep",
+		}}},
+		SuppressedUnusedImportsByDependency: map[int][]report.ImportUse{
+			0: []report.ImportUse{{Name: "hidden", Module: "dep"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	objectDigest := "obj-sidecar-complete"
+	mustWriteFile(t, filepath.Join(cachePath, "objects", objectDigest+".json"), payload)
+	writePointerJSON(t, keyPath, entry.InputDigest, objectDigest)
+
 	assertLookupMissWithReason(t, cache, entry, "object-corrupt")
 }
 

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -787,6 +787,24 @@ func assertLookupMissWithReason(t *testing.T, cache *analysisCache, entry cacheE
 	}
 }
 
+func cacheWithPayloadForLookupTest(t *testing.T, payload cachedPayload, objectDigest string) (*analysisCache, cacheEntryDescriptor) {
+	t.Helper()
+	repo := t.TempDir()
+	cachePath := filepath.Join(repo, "cache")
+	cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
+	if !cache.cacheable {
+		t.Fatalf("expected cacheable test setup")
+	}
+	entry := cacheEntryDescriptor{KeyLabel: "k", KeyDigest: "digest", InputDigest: "input-a"}
+	serialized, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(cachePath, "objects", objectDigest+".json"), serialized)
+	writePointerJSON(t, filepath.Join(cachePath, "keys", entry.KeyDigest+".json"), entry.InputDigest, objectDigest)
+	return cache, entry
+}
+
 func TestAnalysisCacheLookupInvalidationBranches(t *testing.T) {
 	repo := t.TempDir()
 	cachePath := filepath.Join(repo, "cache")
@@ -830,16 +848,7 @@ func TestAnalysisCacheLookupRejectsSuppressedUnusedSidecarOutOfRangeIndex(t *tes
 		{name: "past end", index: 1, objectDigest: "obj-sidecar-past-end"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			repo := t.TempDir()
-			cachePath := filepath.Join(repo, "cache")
-			cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
-			if !cache.cacheable {
-				t.Fatalf("expected cacheable test setup")
-			}
-
-			entry := cacheEntryDescriptor{KeyLabel: "k", KeyDigest: "digest", InputDigest: "input-a"}
-			keyPath := filepath.Join(cachePath, "keys", entry.KeyDigest+".json")
-			payload, err := json.Marshal(cachedPayload{
+			payload := cachedPayload{
 				Report: report.Report{Dependencies: []report.DependencyReport{{
 					Name: "dep",
 				}}},
@@ -847,44 +856,25 @@ func TestAnalysisCacheLookupRejectsSuppressedUnusedSidecarOutOfRangeIndex(t *tes
 				SuppressedUnusedImportsByDependency: map[int][]report.ImportUse{
 					test.index: []report.ImportUse{{Name: "hidden", Module: "dep"}},
 				},
-			})
-			if err != nil {
-				t.Fatalf("marshal payload: %v", err)
 			}
-			mustWriteFile(t, filepath.Join(cachePath, "objects", test.objectDigest+".json"), payload)
-			writePointerJSON(t, keyPath, entry.InputDigest, test.objectDigest)
-
-			assertLookupMissWithReason(t, cache, entry, "object-corrupt")
+			cache, entry := cacheWithPayloadForLookupTest(t, payload, test.objectDigest)
+			assertLookupMissWithReason(t, cache, entry, cacheObjectCorruptReason)
 		})
 	}
 }
 
 func TestAnalysisCacheLookupRejectsSuppressedUnusedSidecarOnCompleteDependency(t *testing.T) {
-	repo := t.TempDir()
-	cachePath := filepath.Join(repo, "cache")
-	cache := newAnalysisCache(Request{Cache: &CacheOptions{Enabled: true, Path: cachePath}}, repo)
-	if !cache.cacheable {
-		t.Fatalf("expected cacheable test setup")
-	}
-
-	entry := cacheEntryDescriptor{KeyLabel: "k", KeyDigest: "digest", InputDigest: "input-a"}
-	keyPath := filepath.Join(cachePath, "keys", entry.KeyDigest+".json")
-	payload, err := json.Marshal(cachedPayload{
+	payload := cachedPayload{
 		Report: report.Report{Dependencies: []report.DependencyReport{{
 			Name: "dep",
 		}}},
 		SuppressedUnusedImportsByDependency: map[int][]report.ImportUse{
 			0: []report.ImportUse{{Name: "hidden", Module: "dep"}},
 		},
-	})
-	if err != nil {
-		t.Fatalf("marshal payload: %v", err)
 	}
 	objectDigest := "obj-sidecar-complete"
-	mustWriteFile(t, filepath.Join(cachePath, "objects", objectDigest+".json"), payload)
-	writePointerJSON(t, keyPath, entry.InputDigest, objectDigest)
-
-	assertLookupMissWithReason(t, cache, entry, "object-corrupt")
+	cache, entry := cacheWithPayloadForLookupTest(t, payload, objectDigest)
+	assertLookupMissWithReason(t, cache, entry, cacheObjectCorruptReason)
 }
 
 func TestResolveCacheOptionsDefaultsAndOverrides(t *testing.T) {

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -185,6 +185,64 @@ func TestAnalysisCachePreservesUsageIncomplete(t *testing.T) {
 	}
 }
 
+func TestAnalysisCacheIgnoresLegacySchemaEntries(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "import dep from \"dep\"\n")
+
+	svc, adapter := newCacheTestService(t)
+	adapter.usageIncomplete = true
+	cacheDir := filepath.Join(repo, cacheTestDirectoryName)
+	req := newCacheRequest(repo, cacheDir, false)
+
+	cache := newAnalysisCache(req, repo)
+	if !cache.cacheable {
+		t.Fatalf("expected cacheable test setup, warnings=%#v", cache.takeWarnings())
+	}
+	entry, err := cache.prepareEntry(req, adapter.ID(), repo)
+	if err != nil {
+		t.Fatalf("prepare current cache entry: %v", err)
+	}
+	legacyEntry, err := cache.prepareEntryWithSchemaVersion(req, adapter.ID(), repo, "v1")
+	if err != nil {
+		t.Fatalf("prepare legacy cache entry: %v", err)
+	}
+	if legacyEntry.KeyDigest == entry.KeyDigest {
+		t.Fatalf("expected schema version to change cache key digest")
+	}
+
+	legacyReport := report.Report{
+		RepoPath: repo,
+		Dependencies: []report.DependencyReport{{
+			Name:              "dep",
+			UsedExportsCount:  1,
+			TotalExportsCount: 2,
+			UsedPercent:       50,
+			RemovalCandidate:  &report.RemovalCandidate{Score: 99},
+		}},
+	}
+	legacyPayload, err := json.Marshal(cachedPayload{Report: legacyReport})
+	if err != nil {
+		t.Fatalf("marshal legacy payload: %v", err)
+	}
+	legacyObjectDigest := sha256Hex(legacyPayload)
+	mustWriteFile(t, filepath.Join(cacheDir, "objects", legacyObjectDigest+".json"), legacyPayload)
+	writePointerJSON(t, filepath.Join(cacheDir, "keys", legacyEntry.KeyDigest+".json"), legacyEntry.InputDigest, legacyObjectDigest)
+
+	got, err := svc.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("analyse with legacy cache entry: %v", err)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("expected legacy schema cache entry to miss and rerun analysis, calls=%d", adapter.calls)
+	}
+	if got.Cache == nil || got.Cache.Hits != 0 || got.Cache.Misses != 1 || got.Cache.Writes != 1 {
+		t.Fatalf("unexpected cache metadata for legacy schema miss: %#v", got.Cache)
+	}
+	if len(got.Dependencies) != 1 || got.Dependencies[0].RemovalCandidate != nil {
+		t.Fatalf("expected rerun analysis to suppress removal scoring, got %#v", got.Dependencies)
+	}
+}
+
 func TestAnalysisCacheSeparatesSuggestOnlyEntries(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "import dep from \"dep\"\n")

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -220,7 +220,7 @@ func TestAnalysisCacheIgnoresLegacySchemaEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare current cache entry: %v", err)
 	}
-	legacyEntry, err := cache.prepareEntryWithSchemaVersion(req, adapter.ID(), repo, "v1")
+	legacyEntry, err := cache.prepareEntryWithSchemaVersion(req, adapter.ID(), repo, "v2")
 	if err != nil {
 		t.Fatalf("prepare legacy cache entry: %v", err)
 	}

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -220,7 +220,7 @@ func TestAnalysisCacheIgnoresLegacySchemaEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare current cache entry: %v", err)
 	}
-	legacyEntry, err := cache.prepareEntryWithSchemaVersion(req, adapter.ID(), repo, "v2")
+	legacyEntry, err := cache.prepareEntryWithSchemaVersion(req, adapter.ID(), repo, "v3")
 	if err != nil {
 		t.Fatalf("prepare legacy cache entry: %v", err)
 	}

--- a/internal/analysis/execution.go
+++ b/internal/analysis/execution.go
@@ -136,6 +136,7 @@ func adjustRelativeLocations(repoPath string, analyzedRoot string, dependencies 
 	for i := range dependencies {
 		adjustImportLocations(prefix, dependencies[i].UsedImports)
 		adjustImportLocations(prefix, dependencies[i].UnusedImports)
+		adjustImportLocations(prefix, dependencies[i].SuppressedUnusedImports)
 	}
 }
 

--- a/internal/analysis/merge.go
+++ b/internal/analysis/merge.go
@@ -117,6 +117,7 @@ func mergeDependencyMetadataFamily(merged *report.DependencyReport, _ report.Dep
 func mergeDependencyUsageCompletenessFamily(merged *report.DependencyReport, left, right report.DependencyReport) {
 	merged.UsageIncomplete = left.UsageIncomplete || right.UsageIncomplete
 	if !merged.UsageIncomplete {
+		merged.SuppressedUnusedImports = nil
 		return
 	}
 
@@ -124,11 +125,22 @@ func mergeDependencyUsageCompletenessFamily(merged *report.DependencyReport, lef
 	merged.TotalExportsCount = 0
 	merged.UsedPercent = 0
 	merged.EstimatedUnusedBytes = 0
+	merged.SuppressedUnusedImports = mergeIncompletePathEvidence(left, right)
 	merged.UnusedImports = nil
 	merged.UnusedExports = nil
 	merged.Recommendations = nil
 	merged.Codemod = nil
 	merged.RemovalCandidate = nil
+}
+
+func mergeIncompletePathEvidence(left, right report.DependencyReport) []report.ImportUse {
+	hidden := mergeImportUses(left.SuppressedUnusedImports, right.SuppressedUnusedImports)
+	hidden = mergeImportUses(hidden, left.UnusedImports)
+	hidden = mergeImportUses(hidden, right.UnusedImports)
+	if len(hidden) == 0 {
+		return nil
+	}
+	return hidden
 }
 
 func filterUsedOverlaps(unused, used []report.ImportUse) []report.ImportUse {

--- a/internal/analysis/merge.go
+++ b/internal/analysis/merge.go
@@ -124,6 +124,7 @@ func mergeDependencyUsageCompletenessFamily(merged *report.DependencyReport, lef
 	merged.TotalExportsCount = 0
 	merged.UsedPercent = 0
 	merged.EstimatedUnusedBytes = 0
+	merged.UnusedImports = nil
 	merged.UnusedExports = nil
 	merged.Recommendations = nil
 	merged.Codemod = nil

--- a/internal/analysis/merge_report_families_test.go
+++ b/internal/analysis/merge_report_families_test.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -111,7 +112,7 @@ func TestMergeDependencySuppressesRemovalSignalsWhenUsageIsIncomplete(t *testing
 	}
 }
 
-func TestSuppressedUnusedImportsProvidePathEvidenceWithoutAffectingVulnerabilityScoring(t *testing.T) {
+func TestSuppressedUnusedImportsPreserveVulnerabilityScoringAndPathEvidence(t *testing.T) {
 	reportData := report.Report{Dependencies: []report.DependencyReport{{
 		Name: "example-lib",
 		SuppressedUnusedImports: []report.ImportUse{{
@@ -119,25 +120,43 @@ func TestSuppressedUnusedImportsProvidePathEvidenceWithoutAffectingVulnerability
 			Module:    "example-lib",
 			Locations: []report.Location{{File: "src/hidden.js", Line: 12}},
 		}},
+		RiskCues: []report.RiskCue{{
+			Code:     "dynamic-loader",
+			Severity: "medium",
+		}},
 	}}}
+	report.AnnotateReachabilityConfidence(&reportData)
 	report.AnnotateVulnerabilities(&reportData, []report.VulnerabilityAdvisory{{
 		ID:       "GHSA-hidden",
 		Package:  "example-lib",
-		Severity: "low",
+		Severity: "critical",
 	}})
 
 	if len(reportData.Dependencies[0].Vulnerabilities) != 1 {
 		t.Fatalf("expected one matching vulnerability, got %#v", reportData.Dependencies[0].Vulnerabilities)
 	}
 	finding := reportData.Dependencies[0].Vulnerabilities[0]
-	if finding.Reachable || finding.Priority != report.VulnerabilityPriorityLow || finding.PriorityScore != 12.5 {
-		t.Fatalf("expected hidden path evidence to leave vulnerability scoring unchanged, got %#v", finding)
+	if !finding.Reachable || finding.Priority != report.VulnerabilityPriorityHigh || finding.PriorityScore != 74.1 {
+		t.Fatalf("expected suppressed static evidence to preserve vulnerability scoring, got %#v", finding)
 	}
-	if !slices.Contains(finding.Evidence, "static_imports: none observed") {
-		t.Fatalf("expected hidden path evidence to stay out of static evidence, got %#v", finding.Evidence)
+	if !slices.Contains(finding.Evidence, "static_imports: conservative evidence retained internally because usage coverage is incomplete") {
+		t.Fatalf("expected suppressed imports to remain redacted security evidence, got %#v", finding.Evidence)
 	}
 	if slices.Contains(finding.Evidence, "static_location: src/hidden.js:12") {
-		t.Fatalf("expected hidden path evidence to stay out of static location evidence, got %#v", finding.Evidence)
+		t.Fatalf("expected suppressed import locations to stay internal, got %#v", finding.Evidence)
+	}
+
+	sarifOutput, err := report.NewFormatter().Format(reportData, report.FormatSARIF)
+	if err != nil {
+		t.Fatalf("format vulnerability SARIF: %v", err)
+	}
+	if !strings.Contains(sarifOutput, `"ruleId": "lopper/vulnerability/ghsa-hidden"`) {
+		t.Fatalf("expected vulnerability result in SARIF, got %s", sarifOutput)
+	}
+	for _, forbidden := range []string{`"ruleId": "lopper/waste/unused-import"`, `"ruleId": "lopper/waste/unused-export"`, "src/hidden.js"} {
+		if strings.Contains(sarifOutput, forbidden) {
+			t.Fatalf("expected suppressed removal details to stay out of SARIF, found %q in %s", forbidden, sarifOutput)
+		}
 	}
 
 	exception := report.VulnerabilityException{

--- a/internal/analysis/merge_report_families_test.go
+++ b/internal/analysis/merge_report_families_test.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -49,24 +50,51 @@ func TestMergeDependencySuppressesRemovalSignalsWhenUsageIsIncomplete(t *testing
 		TotalExportsCount:    3,
 		UsedPercent:          100.0 / 3.0,
 		EstimatedUnusedBytes: 256,
-		UsedImports:          []report.ImportUse{{Module: "lodash", Name: "map"}},
-		UnusedImports:        []report.ImportUse{{Module: "lodash", Name: "filter"}},
-		UnusedExports:        []report.SymbolRef{{Name: "unused"}},
-		Recommendations:      []report.Recommendation{{Code: "remove-unused"}},
-		Codemod:              &report.CodemodReport{},
-		RemovalCandidate:     &report.RemovalCandidate{Score: 80},
+		UsedImports: []report.ImportUse{{
+			Module:    "lodash",
+			Name:      "map",
+			Locations: []report.Location{{File: "src/confirmed.js", Line: 3, Column: 5}},
+		}, {
+			Module:    "lodash",
+			Name:      "filter",
+			Locations: []report.Location{{File: "src/used-filter.js", Line: 5, Column: 4}},
+		}},
+		UnusedImports: []report.ImportUse{{
+			Module:    "lodash",
+			Name:      "chunk",
+			Locations: []report.Location{{File: "src/promoted.js", Line: 9, Column: 2}},
+		}},
+		UnusedExports:    []report.SymbolRef{{Name: "unused"}},
+		Recommendations:  []report.Recommendation{{Code: "remove-unused"}},
+		Codemod:          &report.CodemodReport{},
+		RemovalCandidate: &report.RemovalCandidate{Score: 80},
+		Vulnerabilities:  []report.VulnerabilityFinding{{AdvisoryID: "GHSA-1"}},
 	}
 	incomplete := report.DependencyReport{
-		Name:          "lodash",
-		UsedImports:   []report.ImportUse{{Module: "lodash", Name: "flatten"}},
-		UnusedImports: []report.ImportUse{{Module: "lodash", Name: "chunk"}},
+		Name: "lodash",
+		UsedImports: []report.ImportUse{{
+			Module:    "lodash",
+			Name:      "flatten",
+			Locations: []report.Location{{File: "src/incomplete-used.js", Line: 4, Column: 7}},
+		}},
+		SuppressedUnusedImports: []report.ImportUse{{
+			Module:    "lodash",
+			Name:      "filter",
+			Locations: []report.Location{{File: "src/promoted.js", Line: 7, Column: 11}},
+		}},
+		Vulnerabilities: []report.VulnerabilityFinding{{AdvisoryID: "GHSA-1"}},
 	}
 	if !setUsageIncompleteForMergeTest(&incomplete) {
 		t.Fatal("expected usage-incomplete marker to be available")
 	}
 	wantUsedImports := []report.ImportUse{
-		{Module: "lodash", Name: "flatten"},
-		{Module: "lodash", Name: "map"},
+		{Module: "lodash", Name: "filter", Locations: []report.Location{{File: "src/used-filter.js", Line: 5, Column: 4}}},
+		{Module: "lodash", Name: "flatten", Locations: []report.Location{{File: "src/incomplete-used.js", Line: 4, Column: 7}}},
+		{Module: "lodash", Name: "map", Locations: []report.Location{{File: "src/confirmed.js", Line: 3, Column: 5}}},
+	}
+	wantSuppressedUnused := []report.ImportUse{
+		{Module: "lodash", Name: "chunk", Locations: []report.Location{{File: "src/promoted.js", Line: 9, Column: 2}}},
+		{Module: "lodash", Name: "filter", Locations: []report.Location{{File: "src/promoted.js", Line: 7, Column: 11}}},
 	}
 
 	for _, test := range []struct {
@@ -78,12 +106,55 @@ func TestMergeDependencySuppressesRemovalSignalsWhenUsageIsIncomplete(t *testing
 		{name: "incomplete right", left: complete, right: incomplete},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			assertIncompleteRemovalSignalsSuppressedAfterMerge(t, mergeDependency(test.left, test.right), wantUsedImports)
+			assertIncompleteRemovalSignalsSuppressedAfterMerge(t, mergeDependency(test.left, test.right), wantUsedImports, wantSuppressedUnused)
 		})
 	}
 }
 
-func assertIncompleteRemovalSignalsSuppressedAfterMerge(t *testing.T, merged report.DependencyReport, wantUsedImports []report.ImportUse) {
+func TestSuppressedUnusedImportsProvidePathEvidenceWithoutAffectingVulnerabilityScoring(t *testing.T) {
+	reportData := report.Report{Dependencies: []report.DependencyReport{{
+		Name: "example-lib",
+		SuppressedUnusedImports: []report.ImportUse{{
+			Name:      "hidden",
+			Module:    "example-lib",
+			Locations: []report.Location{{File: "src/hidden.js", Line: 12}},
+		}},
+	}}}
+	report.AnnotateVulnerabilities(&reportData, []report.VulnerabilityAdvisory{{
+		ID:       "GHSA-hidden",
+		Package:  "example-lib",
+		Severity: "low",
+	}})
+
+	if len(reportData.Dependencies[0].Vulnerabilities) != 1 {
+		t.Fatalf("expected one matching vulnerability, got %#v", reportData.Dependencies[0].Vulnerabilities)
+	}
+	finding := reportData.Dependencies[0].Vulnerabilities[0]
+	if finding.Reachable || finding.Priority != report.VulnerabilityPriorityLow || finding.PriorityScore != 12.5 {
+		t.Fatalf("expected hidden path evidence to leave vulnerability scoring unchanged, got %#v", finding)
+	}
+	if !slices.Contains(finding.Evidence, "static_imports: none observed") {
+		t.Fatalf("expected hidden path evidence to stay out of static evidence, got %#v", finding.Evidence)
+	}
+	if slices.Contains(finding.Evidence, "static_location: src/hidden.js:12") {
+		t.Fatalf("expected hidden path evidence to stay out of static location evidence, got %#v", finding.Evidence)
+	}
+
+	exception := report.VulnerabilityException{
+		VulnerabilityID: "GHSA-hidden",
+		Path:            "src/hidden.js",
+		Status:          "not-affected",
+		Expires:         "2026-12-31",
+	}
+	now := time.Date(2026, time.July, 30, 0, 0, 0, 0, time.UTC)
+	report.ApplyVulnerabilityExceptions(&reportData, []report.VulnerabilityException{exception}, now)
+	decision := reportData.Dependencies[0].Vulnerabilities[0].Decision
+	if decision == nil || decision.Status != "not-affected" {
+		t.Fatalf("expected hidden path evidence to match vulnerability exception, got %#v", decision)
+	}
+}
+
+func assertIncompleteRemovalSignalsSuppressedAfterMerge(t *testing.T, merged report.DependencyReport, wantUsedImports []report.ImportUse, wantSuppressedUnused []report.ImportUse) {
 	t.Helper()
 
 	if !usageIncompleteForMergeTest(merged) {
@@ -101,8 +172,23 @@ func assertIncompleteRemovalSignalsSuppressedAfterMerge(t *testing.T, merged rep
 	if !reflect.DeepEqual(merged.UsedImports, wantUsedImports) {
 		t.Fatalf("expected confirmed used imports to remain after incomplete merge, got %#v want %#v", merged.UsedImports, wantUsedImports)
 	}
+	if !reflect.DeepEqual(merged.SuppressedUnusedImports, wantSuppressedUnused) {
+		t.Fatalf("expected hidden unused-import path evidence to be preserved, got %#v want %#v", merged.SuppressedUnusedImports, wantSuppressedUnused)
+	}
 	if len(merged.Recommendations) != 0 || merged.Codemod != nil || merged.RemovalCandidate != nil {
 		t.Fatalf("expected incomplete removal advice to be suppressed, got %#v", merged)
+	}
+
+	reportData := report.Report{Dependencies: []report.DependencyReport{merged}}
+	exceptions := []report.VulnerabilityException{{
+		VulnerabilityID: "GHSA-1",
+		Path:            "src/promoted.js",
+		Status:          "not-affected",
+	}}
+	report.ApplyVulnerabilityExceptions(&reportData, exceptions, time.Date(2026, time.July, 13, 0, 0, 0, 0, time.UTC))
+	decision := reportData.Dependencies[0].Vulnerabilities[0].Decision
+	if decision == nil || decision.Status != "not-affected" {
+		t.Fatalf("expected promoted import location to satisfy path-scoped vulnerability exception, got %#v", decision)
 	}
 }
 

--- a/internal/analysis/merge_report_families_test.go
+++ b/internal/analysis/merge_report_families_test.go
@@ -49,16 +49,24 @@ func TestMergeDependencySuppressesRemovalSignalsWhenUsageIsIncomplete(t *testing
 		TotalExportsCount:    3,
 		UsedPercent:          100.0 / 3.0,
 		EstimatedUnusedBytes: 256,
+		UsedImports:          []report.ImportUse{{Module: "lodash", Name: "map"}},
+		UnusedImports:        []report.ImportUse{{Module: "lodash", Name: "filter"}},
 		UnusedExports:        []report.SymbolRef{{Name: "unused"}},
 		Recommendations:      []report.Recommendation{{Code: "remove-unused"}},
 		Codemod:              &report.CodemodReport{},
 		RemovalCandidate:     &report.RemovalCandidate{Score: 80},
 	}
 	incomplete := report.DependencyReport{
-		Name: "lodash",
+		Name:          "lodash",
+		UsedImports:   []report.ImportUse{{Module: "lodash", Name: "flatten"}},
+		UnusedImports: []report.ImportUse{{Module: "lodash", Name: "chunk"}},
 	}
 	if !setUsageIncompleteForMergeTest(&incomplete) {
 		t.Fatal("expected usage-incomplete marker to be available")
+	}
+	wantUsedImports := []report.ImportUse{
+		{Module: "lodash", Name: "flatten"},
+		{Module: "lodash", Name: "map"},
 	}
 
 	for _, test := range []struct {
@@ -70,12 +78,12 @@ func TestMergeDependencySuppressesRemovalSignalsWhenUsageIsIncomplete(t *testing
 		{name: "incomplete right", left: complete, right: incomplete},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			assertIncompleteRemovalSignalsSuppressedAfterMerge(t, mergeDependency(test.left, test.right))
+			assertIncompleteRemovalSignalsSuppressedAfterMerge(t, mergeDependency(test.left, test.right), wantUsedImports)
 		})
 	}
 }
 
-func assertIncompleteRemovalSignalsSuppressedAfterMerge(t *testing.T, merged report.DependencyReport) {
+func assertIncompleteRemovalSignalsSuppressedAfterMerge(t *testing.T, merged report.DependencyReport, wantUsedImports []report.ImportUse) {
 	t.Helper()
 
 	if !usageIncompleteForMergeTest(merged) {
@@ -86,6 +94,12 @@ func assertIncompleteRemovalSignalsSuppressedAfterMerge(t *testing.T, merged rep
 	}
 	if merged.EstimatedUnusedBytes != 0 || len(merged.UnusedExports) != 0 {
 		t.Fatalf("expected incomplete unused-export signals to be suppressed, got %#v", merged)
+	}
+	if len(merged.UnusedImports) != 0 {
+		t.Fatalf("expected incomplete unused-import signals to be suppressed, got %#v", merged.UnusedImports)
+	}
+	if !reflect.DeepEqual(merged.UsedImports, wantUsedImports) {
+		t.Fatalf("expected confirmed used imports to remain after incomplete merge, got %#v want %#v", merged.UsedImports, wantUsedImports)
 	}
 	if len(merged.Recommendations) != 0 || merged.Codemod != nil || merged.RemovalCandidate != nil {
 		t.Fatalf("expected incomplete removal advice to be suppressed, got %#v", merged)

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -193,8 +193,9 @@ func TestRemapAnalyzedRoots(t *testing.T) {
 
 func TestAdjustRelativeLocationsAndLanguage(t *testing.T) {
 	deps := []report.DependencyReport{{
-		UsedImports:   []report.ImportUse{{Locations: []report.Location{{File: "src/main.js", Line: 1}}}},
-		UnusedImports: []report.ImportUse{{Locations: []report.Location{{File: "/abs/file.js", Line: 2}}}},
+		UsedImports:             []report.ImportUse{{Locations: []report.Location{{File: "src/main.js", Line: 1}}}},
+		UnusedImports:           []report.ImportUse{{Locations: []report.Location{{File: "/abs/file.js", Line: 2}}}},
+		SuppressedUnusedImports: []report.ImportUse{{Locations: []report.Location{{File: "src/hidden.js", Line: 3}, {File: "/abs/hidden.js", Line: 4}}}},
 	}}
 	applyLanguageID(deps, "js-ts")
 	if deps[0].Language != "js-ts" {
@@ -206,6 +207,12 @@ func TestAdjustRelativeLocationsAndLanguage(t *testing.T) {
 	}
 	if deps[0].UnusedImports[0].Locations[0].File != "/abs/file.js" {
 		t.Fatalf("expected absolute file path unchanged")
+	}
+	if deps[0].SuppressedUnusedImports[0].Locations[0].File != "packages/a/src/hidden.js" {
+		t.Fatalf("expected hidden relative file adjustment, got %q", deps[0].SuppressedUnusedImports[0].Locations[0].File)
+	}
+	if deps[0].SuppressedUnusedImports[0].Locations[1].File != "/abs/hidden.js" {
+		t.Fatalf("expected hidden absolute file path unchanged")
 	}
 }
 

--- a/internal/lang/js/adapter_test.go
+++ b/internal/lang/js/adapter_test.go
@@ -157,6 +157,9 @@ func TestAdapterAnalyseTopN(t *testing.T) {
 
 func TestAdapterAnalyseSuppressesSignalsForSyntaxRecoveryScan(t *testing.T) {
 	repo, _, _ := setupLodashFixture(t, "import { map, filter } from \"lodash\";\nmap([1], (x) => x)\nconst broken = {\nfilter([1], Boolean)\n")
+	if err := os.WriteFile(filepath.Join(repo, "unused.js"), []byte("import { map } from \"lodash\";\n"), 0o644); err != nil {
+		t.Fatalf("write same-symbol unused import: %v", err)
+	}
 
 	reportData := analyseSuggestOnly(t, repo)
 	if len(reportData.Dependencies) != 1 {
@@ -173,8 +176,26 @@ func TestAdapterAnalyseSuppressesSignalsForSyntaxRecoveryScan(t *testing.T) {
 	if len(dependency.Recommendations) != 0 {
 		t.Fatalf("expected syntax-recovery scan to suppress recommendations, got %#v", dependency.Recommendations)
 	}
-	if len(dependency.UsedImports) != 1 || dependency.UsedImports[0].Name != "map" || dependency.UsedImports[0].Module != "lodash" {
-		t.Fatalf("expected syntax-recovery scan to preserve confirmed import evidence, got %#v", dependency.UsedImports)
+	if len(dependency.UsedImports) != 1 {
+		t.Fatalf("expected syntax-recovery scan to preserve only confirmed import evidence, got %#v", dependency.UsedImports)
+	}
+	if len(dependency.UnusedImports) != 0 {
+		t.Fatalf("expected syntax-recovery scan to clear public unused imports, got %#v", dependency.UnusedImports)
+	}
+	mapImport := dependency.UsedImports[0]
+	if mapImport.Name != "map" || mapImport.Module != "lodash" || len(mapImport.Locations) != 1 || mapImport.Locations[0].File != testIndexJS || mapImport.Locations[0].Line != 1 {
+		t.Fatalf("expected syntax-recovery scan to preserve confirmed import location evidence, got %#v", dependency.UsedImports)
+	}
+	if len(dependency.SuppressedUnusedImports) != 2 {
+		t.Fatalf("expected syntax-recovery scan to retain both hidden unused imports, got %#v", dependency.SuppressedUnusedImports)
+	}
+	filterImport := dependency.SuppressedUnusedImports[0]
+	if filterImport.Name != "filter" || filterImport.Module != "lodash" || len(filterImport.Locations) != 1 || filterImport.Locations[0].File != testIndexJS || filterImport.Locations[0].Line != 1 {
+		t.Fatalf("expected syntax-recovery scan to retain suppressed unused import location evidence, got %#v", dependency.SuppressedUnusedImports)
+	}
+	mapUnusedImport := dependency.SuppressedUnusedImports[1]
+	if mapUnusedImport.Name != "map" || mapUnusedImport.Module != "lodash" || len(mapUnusedImport.Locations) != 1 || mapUnusedImport.Locations[0].File != "unused.js" || mapUnusedImport.Locations[0].Line != 1 {
+		t.Fatalf("expected syntax-recovery scan to retain same-symbol unused location evidence, got %#v", dependency.SuppressedUnusedImports)
 	}
 	assertRemovalSignalsSuppressed(t, dependency, reportData.Warnings)
 

--- a/internal/lang/js/adapter_test.go
+++ b/internal/lang/js/adapter_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
-	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
@@ -157,7 +156,7 @@ func TestAdapterAnalyseTopN(t *testing.T) {
 }
 
 func TestAdapterAnalyseSuppressesSignalsForSyntaxRecoveryScan(t *testing.T) {
-	repo, _, _ := setupLodashFixture(t, "import { map } from \"lodash\";\nconst broken =\n")
+	repo, _, _ := setupLodashFixture(t, "import { map, filter } from \"lodash\";\nmap([1], (x) => x)\nconst broken = {\nfilter([1], Boolean)\n")
 
 	reportData := analyseSuggestOnly(t, repo)
 	if len(reportData.Dependencies) != 1 {
@@ -174,52 +173,42 @@ func TestAdapterAnalyseSuppressesSignalsForSyntaxRecoveryScan(t *testing.T) {
 	if len(dependency.Recommendations) != 0 {
 		t.Fatalf("expected syntax-recovery scan to suppress recommendations, got %#v", dependency.Recommendations)
 	}
-	if dependency.Codemod != nil {
-		t.Fatalf("expected syntax-recovery scan to suppress codemod output, got %#v", dependency.Codemod)
+	if len(dependency.UsedImports) != 1 || dependency.UsedImports[0].Name != "map" || dependency.UsedImports[0].Module != "lodash" {
+		t.Fatalf("expected syntax-recovery scan to preserve confirmed import evidence, got %#v", dependency.UsedImports)
 	}
-
-	scored := []report.DependencyReport{dependency}
-	report.AnnotateRemovalCandidateScores(scored)
-	if scored[0].RemovalCandidate != nil {
-		t.Fatalf("expected syntax-recovery scan to suppress removal score, got %#v", scored[0].RemovalCandidate)
-	}
+	assertRemovalSignalsSuppressed(t, dependency, reportData.Warnings)
 
 	warnings := strings.Join(reportData.Warnings, "\n")
 	if !strings.Contains(warnings, "parse errors in 1 file(s)") {
 		t.Fatalf("expected parse-error warning to remain visible, got %#v", reportData.Warnings)
 	}
-	if !strings.Contains(warnings, "removal signals suppressed") {
-		t.Fatalf("expected incomplete-coverage suppression warning, got %#v", reportData.Warnings)
-	}
 }
 
-func TestAdapterDetectWithPackageJSON(t *testing.T) {
-	repo := t.TempDir()
-	if err := os.WriteFile(filepath.Join(repo, testPackageJSONName), []byte("{\"name\":\"fixture\"}\n"), 0o644); err != nil {
-		t.Fatalf("write package.json: %v", err)
+func TestAdapterDetectSignals(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content string
+	}{
+		{name: "package_json", path: testPackageJSONName, content: "{\"name\":\"fixture\"}\n"},
+		{name: "js_source", path: testIndexJS, content: "export const x = 1\n"},
 	}
 
-	ok, err := NewAdapter().Detect(context.Background(), repo)
-	if err != nil {
-		t.Fatalf(testDetectErrFmt, err)
-	}
-	if !ok {
-		t.Fatalf("expected detect=true when package.json exists")
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := t.TempDir()
+			if err := os.WriteFile(filepath.Join(repo, tt.path), []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("write %s: %v", tt.path, err)
+			}
 
-func TestAdapterDetectWithJSSource(t *testing.T) {
-	repo := t.TempDir()
-	if err := os.WriteFile(filepath.Join(repo, testIndexJS), []byte("export const x = 1\n"), 0o644); err != nil {
-		t.Fatalf("write index.js: %v", err)
-	}
-
-	ok, err := NewAdapter().Detect(context.Background(), repo)
-	if err != nil {
-		t.Fatalf(testDetectErrFmt, err)
-	}
-	if !ok {
-		t.Fatalf("expected detect=true when JS sources exist")
+			ok, err := NewAdapter().Detect(context.Background(), repo)
+			if err != nil {
+				t.Fatalf(testDetectErrFmt, err)
+			}
+			if !ok {
+				t.Fatalf("expected detect=true when %s exists", tt.path)
+			}
+		})
 	}
 }
 

--- a/internal/lang/js/adapter_test.go
+++ b/internal/lang/js/adapter_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
+	reportmodel "github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
@@ -186,16 +188,17 @@ func TestAdapterAnalyseSuppressesSignalsForSyntaxRecoveryScan(t *testing.T) {
 	if mapImport.Name != "map" || mapImport.Module != "lodash" || len(mapImport.Locations) != 1 || mapImport.Locations[0].File != testIndexJS || mapImport.Locations[0].Line != 1 {
 		t.Fatalf("expected syntax-recovery scan to preserve confirmed import location evidence, got %#v", dependency.UsedImports)
 	}
-	if len(dependency.SuppressedUnusedImports) != 2 {
-		t.Fatalf("expected syntax-recovery scan to retain both hidden unused imports, got %#v", dependency.SuppressedUnusedImports)
+	suppressedUnusedImports := suppressedUnusedImportsForTest(t, dependency)
+	if len(suppressedUnusedImports) != 2 {
+		t.Fatalf("expected syntax-recovery scan to retain both hidden unused imports, got %#v", suppressedUnusedImports)
 	}
-	filterImport := dependency.SuppressedUnusedImports[0]
+	filterImport := suppressedUnusedImports[0]
 	if filterImport.Name != "filter" || filterImport.Module != "lodash" || len(filterImport.Locations) != 1 || filterImport.Locations[0].File != testIndexJS || filterImport.Locations[0].Line != 1 {
-		t.Fatalf("expected syntax-recovery scan to retain suppressed unused import location evidence, got %#v", dependency.SuppressedUnusedImports)
+		t.Fatalf("expected syntax-recovery scan to retain suppressed unused import location evidence, got %#v", suppressedUnusedImports)
 	}
-	mapUnusedImport := dependency.SuppressedUnusedImports[1]
+	mapUnusedImport := suppressedUnusedImports[1]
 	if mapUnusedImport.Name != "map" || mapUnusedImport.Module != "lodash" || len(mapUnusedImport.Locations) != 1 || mapUnusedImport.Locations[0].File != "unused.js" || mapUnusedImport.Locations[0].Line != 1 {
-		t.Fatalf("expected syntax-recovery scan to retain same-symbol unused location evidence, got %#v", dependency.SuppressedUnusedImports)
+		t.Fatalf("expected syntax-recovery scan to retain same-symbol unused location evidence, got %#v", suppressedUnusedImports)
 	}
 	assertRemovalSignalsSuppressed(t, dependency, reportData.Warnings)
 
@@ -203,6 +206,20 @@ func TestAdapterAnalyseSuppressesSignalsForSyntaxRecoveryScan(t *testing.T) {
 	if !strings.Contains(warnings, "parse errors in 1 file(s)") {
 		t.Fatalf("expected parse-error warning to remain visible, got %#v", reportData.Warnings)
 	}
+}
+
+func suppressedUnusedImportsForTest(t *testing.T, dependency any) []reportmodel.ImportUse {
+	t.Helper()
+
+	field := reflect.ValueOf(dependency).FieldByName("SuppressedUnusedImports")
+	if !field.IsValid() {
+		t.Fatal("expected dependency report to expose suppressed unused import evidence")
+	}
+	imports, ok := field.Interface().([]reportmodel.ImportUse)
+	if !ok {
+		t.Fatalf("expected suppressed unused import evidence type, got %T", field.Interface())
+	}
+	return imports
 }
 
 func TestAdapterDetectSignals(t *testing.T) {

--- a/internal/lang/js/adapter_test.go
+++ b/internal/lang/js/adapter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
+	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
@@ -152,6 +153,43 @@ func TestAdapterAnalyseTopN(t *testing.T) {
 	}
 	if report.Dependencies[0].Name != "beta" {
 		t.Fatalf("expected top dependency to be beta, got %q", report.Dependencies[0].Name)
+	}
+}
+
+func TestAdapterAnalyseSuppressesSignalsForSyntaxRecoveryScan(t *testing.T) {
+	repo, _, _ := setupLodashFixture(t, "import { map } from \"lodash\";\nconst broken =\n")
+
+	reportData := analyseSuggestOnly(t, repo)
+	if len(reportData.Dependencies) != 1 {
+		t.Fatalf(testExpectedOneDepFmt, len(reportData.Dependencies))
+	}
+
+	dependency := reportData.Dependencies[0]
+	if !dependency.UsageIncomplete {
+		t.Fatalf("expected syntax-recovery scan to mark dependency usage incomplete, got %#v", dependency)
+	}
+	if len(dependency.UnusedExports) != 0 {
+		t.Fatalf("expected syntax-recovery scan to suppress unused exports, got %#v", dependency.UnusedExports)
+	}
+	if len(dependency.Recommendations) != 0 {
+		t.Fatalf("expected syntax-recovery scan to suppress recommendations, got %#v", dependency.Recommendations)
+	}
+	if dependency.Codemod != nil {
+		t.Fatalf("expected syntax-recovery scan to suppress codemod output, got %#v", dependency.Codemod)
+	}
+
+	scored := []report.DependencyReport{dependency}
+	report.AnnotateRemovalCandidateScores(scored)
+	if scored[0].RemovalCandidate != nil {
+		t.Fatalf("expected syntax-recovery scan to suppress removal score, got %#v", scored[0].RemovalCandidate)
+	}
+
+	warnings := strings.Join(reportData.Warnings, "\n")
+	if !strings.Contains(warnings, "parse errors in 1 file(s)") {
+		t.Fatalf("expected parse-error warning to remain visible, got %#v", reportData.Warnings)
+	}
+	if !strings.Contains(warnings, "removal signals suppressed") {
+		t.Fatalf("expected incomplete-coverage suppression warning, got %#v", reportData.Warnings)
 	}
 }
 

--- a/internal/lang/js/exports.go
+++ b/internal/lang/js/exports.go
@@ -106,6 +106,7 @@ func resolveDependencyExports(req dependencyExportRequest) (ExportSurface, error
 
 	pkg, warnings, err := loadPackageJSONForSurface(depPath)
 	if err != nil {
+		surface.CoverageIncomplete = true
 		surface.Warnings = append(surface.Warnings, warnings...)
 		return surface, nil
 	}

--- a/internal/lang/js/exports_helpers_test.go
+++ b/internal/lang/js/exports_helpers_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
-
-	"github.com/ben-ranford/lopper/internal/report"
 )
 
 const indexJSName = "index.js"
@@ -299,18 +297,7 @@ func TestBuildDependencyReportSuppressesIncompleteExportSurface(t *testing.T) {
 	if len(dependency.UnusedExports) != 0 || len(dependency.Recommendations) != 0 {
 		t.Fatalf("expected partial export removal advice to be suppressed, got %#v", dependency)
 	}
-	if dependency.Codemod != nil {
-		t.Fatalf("expected partial export coverage to suppress codemods, got %#v", dependency.Codemod)
-	}
-	if !strings.Contains(strings.Join(warnings, "\n"), "removal signals suppressed") {
-		t.Fatalf("expected incomplete-export warning, got %#v", warnings)
-	}
-
-	scored := []report.DependencyReport{dependency}
-	report.AnnotateRemovalCandidateScores(scored)
-	if scored[0].RemovalCandidate != nil {
-		t.Fatalf("expected incomplete export surface to suppress removal scoring, got %#v", scored[0].RemovalCandidate)
-	}
+	assertRemovalSignalsSuppressed(t, dependency, warnings)
 }
 
 func TestBuildDependencyReportSuppressesSignalsForMalformedPackageMetadata(t *testing.T) {
@@ -349,22 +336,11 @@ func TestBuildDependencyReportSuppressesSignalsForMalformedPackageMetadata(t *te
 	if len(dependency.Recommendations) != 0 {
 		t.Fatalf("expected malformed package metadata to suppress recommendations, got %#v", dependency.Recommendations)
 	}
-	if dependency.Codemod != nil {
-		t.Fatalf("expected malformed package metadata to suppress codemod output, got %#v", dependency.Codemod)
-	}
-
-	scored := []report.DependencyReport{dependency}
-	report.AnnotateRemovalCandidateScores(scored)
-	if scored[0].RemovalCandidate != nil {
-		t.Fatalf("expected malformed package metadata to suppress removal scoring, got %#v", scored[0].RemovalCandidate)
-	}
+	assertRemovalSignalsSuppressed(t, dependency, warnings)
 
 	joinedWarnings := strings.Join(warnings, "\n")
 	if !strings.Contains(joinedWarnings, "failed to parse dependency package.json") {
 		t.Fatalf("expected malformed package metadata warning to remain visible, got %#v", warnings)
-	}
-	if !strings.Contains(joinedWarnings, "removal signals suppressed") {
-		t.Fatalf("expected incomplete-coverage suppression warning, got %#v", warnings)
 	}
 }
 

--- a/internal/lang/js/exports_helpers_test.go
+++ b/internal/lang/js/exports_helpers_test.go
@@ -313,6 +313,61 @@ func TestBuildDependencyReportSuppressesIncompleteExportSurface(t *testing.T) {
 	}
 }
 
+func TestBuildDependencyReportSuppressesSignalsForMalformedPackageMetadata(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, indexJSName), []byte("import { broken } from \"broken\"\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	depRoot := filepath.Join(repo, "node_modules", "broken")
+	if err := os.MkdirAll(depRoot, 0o755); err != nil {
+		t.Fatalf("mkdir dependency root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(depRoot, "package.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write malformed package.json: %v", err)
+	}
+
+	scanResult, err := ScanRepo(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("scan repo: %v", err)
+	}
+	dependency, warnings := buildDependencyReport(dependencyReportOptions{
+		RepoPath:                          repo,
+		Dependency:                        "broken",
+		DependencyRootPath:                depRoot,
+		ScanResult:                        scanResult,
+		MinUsagePercentForRecommendations: 1,
+		SuggestOnly:                       true,
+	})
+
+	if !dependency.UsageIncomplete {
+		t.Fatalf("expected malformed package metadata to mark dependency usage incomplete, got %#v", dependency)
+	}
+	if len(dependency.UnusedExports) != 0 {
+		t.Fatalf("expected malformed package metadata to suppress unused exports, got %#v", dependency.UnusedExports)
+	}
+	if len(dependency.Recommendations) != 0 {
+		t.Fatalf("expected malformed package metadata to suppress recommendations, got %#v", dependency.Recommendations)
+	}
+	if dependency.Codemod != nil {
+		t.Fatalf("expected malformed package metadata to suppress codemod output, got %#v", dependency.Codemod)
+	}
+
+	scored := []report.DependencyReport{dependency}
+	report.AnnotateRemovalCandidateScores(scored)
+	if scored[0].RemovalCandidate != nil {
+		t.Fatalf("expected malformed package metadata to suppress removal scoring, got %#v", scored[0].RemovalCandidate)
+	}
+
+	joinedWarnings := strings.Join(warnings, "\n")
+	if !strings.Contains(joinedWarnings, "failed to parse dependency package.json") {
+		t.Fatalf("expected malformed package metadata warning to remain visible, got %#v", warnings)
+	}
+	if !strings.Contains(joinedWarnings, "removal signals suppressed") {
+		t.Fatalf("expected incomplete-coverage suppression warning, got %#v", warnings)
+	}
+}
+
 func boolFieldForTest(value any, name string) bool {
 	field := reflect.ValueOf(value).FieldByName(name)
 	return field.IsValid() && field.Kind() == reflect.Bool && field.Bool()

--- a/internal/lang/js/reporting.go
+++ b/internal/lang/js/reporting.go
@@ -468,11 +468,13 @@ func buildTopDependencies(repoPath string, scanResult ScanResult, topN int, runt
 		warnings = append(warnings, depWarnings...)
 	}
 
-	if scanResult.UsageIncomplete {
+	if scanResult.UsageIncomplete || slices.ContainsFunc(reports, func(dependency report.DependencyReport) bool {
+		return dependency.UsageIncomplete
+	}) {
 		sort.Slice(reports, func(i, j int) bool {
 			return reports[i].Name < reports[j].Name
 		})
-		warnings = append(warnings, "top-N removal ranking disabled because JS/TS usage coverage is incomplete")
+		warnings = append(warnings, "top-N removal ranking disabled because JS/TS dependency coverage is incomplete")
 		return reports, warnings
 	}
 

--- a/internal/lang/js/reporting.go
+++ b/internal/lang/js/reporting.go
@@ -85,6 +85,7 @@ func buildDependencyReport(opts dependencyReportOptions) (report.DependencyRepor
 		depReport.UsedExportsCount = 0
 		depReport.TotalExportsCount = 0
 		depReport.UsedPercent = 0
+		depReport.UnusedImports = nil
 		depReport.UnusedExports = nil
 		warnings = append(warnings, fmt.Sprintf("usage or export coverage incomplete for %s; removal signals suppressed", opts.Dependency))
 	} else {

--- a/internal/lang/js/reporting.go
+++ b/internal/lang/js/reporting.go
@@ -82,6 +82,7 @@ func buildDependencyReport(opts dependencyReportOptions) (report.DependencyRepor
 	}
 	if coverageIncomplete {
 		depReport.UsageIncomplete = true
+		depReport.SuppressedUnusedImports = usage.unfilteredUnusedImports
 		depReport.UsedExportsCount = 0
 		depReport.TotalExportsCount = 0
 		depReport.UsedPercent = 0
@@ -101,11 +102,12 @@ func buildDependencyReport(opts dependencyReportOptions) (report.DependencyRepor
 
 // dependencyUsageSummary captures intermediate usage aggregates for dependency report assembly.
 type dependencyUsageSummary struct {
-	usedExports   map[string]struct{}
-	counts        map[string]int
-	usedImports   []report.ImportUse
-	unusedImports []report.ImportUse
-	warnings      []string
+	usedExports             map[string]struct{}
+	counts                  map[string]int
+	usedImports             []report.ImportUse
+	unusedImports           []report.ImportUse
+	unfilteredUnusedImports []report.ImportUse
+	warnings                []string
 }
 
 type dependencyImportUsage struct {
@@ -124,11 +126,12 @@ func collectDependencyUsageSummary(scanResult ScanResult, dependency string) dep
 	warnings := dependencyUsageWarnings(dependency, usage.UsedExports, usage.HasAmbiguousWildcard)
 	warnings = append(warnings, usage.Warnings...)
 	return dependencyUsageSummary{
-		usedExports:   usage.UsedExports,
-		counts:        usage.Counts,
-		usedImports:   usedImportList,
-		unusedImports: unusedImportList,
-		warnings:      warnings,
+		usedExports:             usage.UsedExports,
+		counts:                  usage.Counts,
+		usedImports:             usedImportList,
+		unusedImports:           unusedImportList,
+		unfilteredUnusedImports: flattenImportUses(usage.UnusedImports),
+		warnings:                warnings,
 	}
 }
 

--- a/internal/lang/js/scan.go
+++ b/internal/lang/js/scan.go
@@ -113,6 +113,7 @@ func ScanRepo(ctx context.Context, repoPath string) (ScanResult, error) {
 	}
 
 	if state.parseErrorCount > 0 {
+		result.UsageIncomplete = true
 		warning := fmt.Sprintf("parse errors in %d file(s)", state.parseErrorCount)
 		if len(state.parseErrorFiles) > 0 {
 			warning = fmt.Sprintf("%s: %s", warning, strings.Join(state.parseErrorFiles, ", "))

--- a/internal/lang/js/scan_repo_usage_paths_test.go
+++ b/internal/lang/js/scan_repo_usage_paths_test.go
@@ -135,6 +135,48 @@ func TestJSIncompleteScanDisablesTopNRemovalRanking(t *testing.T) {
 	}
 }
 
+func TestJSIncompleteDependencySurfaceDisablesTopNRemovalRanking(t *testing.T) {
+	repo := t.TempDir()
+	source := "import { broken } from \"alpha\"\nimport { used } from \"beta\"\nused()\n"
+	if err := os.WriteFile(filepath.Join(repo, "index.js"), []byte(source), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	alphaRoot := filepath.Join(repo, "node_modules", "alpha")
+	if err := os.MkdirAll(alphaRoot, 0o755); err != nil {
+		t.Fatalf("mkdir alpha dependency: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(alphaRoot, "package.json"), []byte("{"), 0o644); err != nil {
+		t.Fatalf("write malformed alpha package metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(alphaRoot, "index.js"), []byte("export const broken = 1\n"), 0o644); err != nil {
+		t.Fatalf("write alpha entrypoint: %v", err)
+	}
+	if err := writeDependency(repo, "beta", "export const used = 1\n"); err != nil {
+		t.Fatalf("write beta dependency: %v", err)
+	}
+
+	result, err := ScanRepo(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("scan repo: %v", err)
+	}
+	topReports, topWarnings := buildTopDependencies(repo, result, 1, "", 1, report.DefaultRemovalCandidateWeights(), false)
+	if len(topReports) != 2 || topReports[0].Name != "alpha" || topReports[1].Name != "beta" {
+		t.Fatalf("expected deterministic unranked reports from incomplete dependency coverage, got %#v", topReports)
+	}
+	if !topReports[0].UsageIncomplete {
+		t.Fatalf("expected malformed alpha metadata to mark its report incomplete, got %#v", topReports[0])
+	}
+	for _, topReport := range topReports {
+		if topReport.RemovalCandidate != nil {
+			t.Fatalf("did not expect incomplete top-N report to be scored, got %#v", topReport)
+		}
+	}
+	if !strings.Contains(strings.Join(topWarnings, "\n"), "top-N removal ranking disabled") {
+		t.Fatalf("expected incomplete top-N warning, got %#v", topWarnings)
+	}
+}
+
 func setupOversizedSourceRepo(t *testing.T) (string, string) {
 	t.Helper()
 	repo := t.TempDir()

--- a/internal/lang/js/scan_repo_usage_paths_test.go
+++ b/internal/lang/js/scan_repo_usage_paths_test.go
@@ -171,6 +171,14 @@ func assertIncompleteRemovalSignalsSuppressed(t *testing.T, repo string, result 
 		ScanResult:                        result,
 		MinUsagePercentForRecommendations: 1,
 	})
+	assertRemovalSignalsSuppressed(t, dependencyReport, dependencyWarnings)
+}
+
+func assertRemovalSignalsSuppressed(t *testing.T, dependencyReport report.DependencyReport, warnings []string) {
+	t.Helper()
+	if len(dependencyReport.UnusedImports) != 0 {
+		t.Fatalf("did not expect unused imports from an incomplete scan, got %#v", dependencyReport.UnusedImports)
+	}
 	if len(dependencyReport.UnusedExports) != 0 {
 		t.Fatalf("did not expect unused exports from an incomplete scan, got %#v", dependencyReport.UnusedExports)
 	}
@@ -180,8 +188,11 @@ func assertIncompleteRemovalSignalsSuppressed(t *testing.T, repo string, result 
 	if len(dependencyReport.Recommendations) != 0 {
 		t.Fatalf("did not expect recommendations from an incomplete scan, got %#v", dependencyReport.Recommendations)
 	}
-	if !strings.Contains(strings.Join(dependencyWarnings, "\n"), "removal signals suppressed") {
-		t.Fatalf("expected incomplete-usage suppression warning, got %#v", dependencyWarnings)
+	if dependencyReport.Codemod != nil {
+		t.Fatalf("did not expect codemod output from an incomplete scan, got %#v", dependencyReport.Codemod)
+	}
+	if !strings.Contains(strings.Join(warnings, "\n"), "removal signals suppressed") {
+		t.Fatalf("expected incomplete-coverage suppression warning, got %#v", warnings)
 	}
 	scored := []report.DependencyReport{dependencyReport}
 	report.AnnotateRemovalCandidateScores(scored)

--- a/internal/report/model/dependency.go
+++ b/internal/report/model/dependency.go
@@ -22,7 +22,8 @@ type DependencyReport struct {
 	Vulnerabilities        []VulnerabilityFinding  `json:"vulnerabilities,omitempty"`
 	License                *DependencyLicense      `json:"license,omitempty"`
 	Provenance             *DependencyProvenance   `json:"provenance,omitempty"`
-	// SuppressedUnusedImports is path-only evidence for unused findings suppressed by incomplete coverage.
+	// SuppressedUnusedImports is conservative static and path evidence for unused findings suppressed by incomplete coverage.
+	// It must not be emitted as removal advice.
 	SuppressedUnusedImports []ImportUse `json:"-"`
 }
 

--- a/internal/report/model/dependency.go
+++ b/internal/report/model/dependency.go
@@ -22,6 +22,8 @@ type DependencyReport struct {
 	Vulnerabilities        []VulnerabilityFinding  `json:"vulnerabilities,omitempty"`
 	License                *DependencyLicense      `json:"license,omitempty"`
 	Provenance             *DependencyProvenance   `json:"provenance,omitempty"`
+	// SuppressedUnusedImports is path-only evidence for unused findings suppressed by incomplete coverage.
+	SuppressedUnusedImports []ImportUse `json:"-"`
 }
 
 type DependencyIdentity struct {

--- a/internal/report/scoring_reachability.go
+++ b/internal/report/scoring_reachability.go
@@ -194,7 +194,7 @@ func exportInventoryConfidenceSignal(dep DependencyReport) evaluatedReachability
 
 func importPrecisionConfidenceSignal(dep DependencyReport) evaluatedReachabilitySignal {
 	switch {
-	case hasWildcardImport(dep.UsedImports) || hasWildcardImport(dep.UnusedImports):
+	case hasWildcardImport(dep.UsedImports) || hasWildcardImport(dep.UnusedImports) || hasWildcardImport(dep.SuppressedUnusedImports):
 		return evaluatedReachabilitySignal{
 			signal: ReachabilitySignal{
 				Code:      confidenceReasonWildcardImport,
@@ -340,7 +340,7 @@ func runtimeUsageCorrelation(usage *RuntimeUsage) RuntimeCorrelation {
 }
 
 func hasStaticImportEvidence(dep DependencyReport) bool {
-	return len(dep.UsedImports)+len(dep.UnusedImports) > 0
+	return len(dep.UsedImports)+len(dep.UnusedImports)+len(dep.SuppressedUnusedImports) > 0
 }
 
 func hasRiskCode(cues []RiskCue, code string) bool {

--- a/internal/report/vulnerability.go
+++ b/internal/report/vulnerability.go
@@ -569,6 +569,8 @@ func staticImportEvidenceScore(dep DependencyReport) float64 {
 		return 80
 	case len(dep.UnusedImports) > 0:
 		return 45
+	case len(dep.SuppressedUnusedImports) > 0:
+		return 45
 	default:
 		return 0
 	}
@@ -662,6 +664,9 @@ func staticImportEvidence(dep DependencyReport) []string {
 	}
 	if len(dep.UnusedImports) > 0 {
 		return []string{fmt.Sprintf("static_imports: %d unused import reference(s)", len(dep.UnusedImports))}
+	}
+	if len(dep.SuppressedUnusedImports) > 0 {
+		return []string{"static_imports: conservative evidence retained internally because usage coverage is incomplete"}
 	}
 	return []string{"static_imports: none observed"}
 }

--- a/internal/report/vulnerability.go
+++ b/internal/report/vulnerability.go
@@ -258,7 +258,7 @@ func dependencyHasPathEvidence(dep DependencyReport, path string) bool {
 	if needle == "" {
 		return true
 	}
-	for _, imports := range [][]ImportUse{dep.UsedImports, dep.UnusedImports} {
+	for _, imports := range [][]ImportUse{dep.UsedImports, dep.UnusedImports, dep.SuppressedUnusedImports} {
 		for _, item := range imports {
 			for _, location := range item.Locations {
 				candidate := normalizeVulnerabilityPathEvidence(location.File)

--- a/internal/runtime/trace_annotate.go
+++ b/internal/runtime/trace_annotate.go
@@ -185,7 +185,7 @@ func sortDependencies(dependencies []report.DependencyReport) {
 }
 
 func hasStaticEvidence(dep report.DependencyReport) bool {
-	return len(dep.UsedImports)+len(dep.UnusedImports) > 0
+	return len(dep.UsedImports)+len(dep.UnusedImports)+len(dep.SuppressedUnusedImports) > 0
 }
 
 func runtimeCorrelation(hasStatic, hasRuntime bool) report.RuntimeCorrelation {

--- a/internal/runtime/trace_annotate_test.go
+++ b/internal/runtime/trace_annotate_test.go
@@ -262,21 +262,29 @@ func TestAnnotateStaticOnly(t *testing.T) {
 					{Name: "map", Module: "alpha"},
 				},
 			},
+			{
+				Name: "beta",
+				SuppressedUnusedImports: []report.ImportUse{
+					{Name: "filter", Module: "beta"},
+				},
+			},
 		},
 	}
 
 	annotated := Annotate(rep, Trace{DependencyLoads: map[string]int{}}, AnnotateOptions{})
-	if annotated.Dependencies[0].RuntimeUsage == nil {
-		t.Fatalf("expected static-only runtime usage annotation")
-	}
-	if annotated.Dependencies[0].RuntimeUsage.Correlation != report.RuntimeCorrelationStaticOnly {
-		t.Fatalf("expected static-only correlation, got %#v", annotated.Dependencies[0].RuntimeUsage)
-	}
-	if annotated.Dependencies[0].RuntimeUsage.LoadCount != 0 {
-		t.Fatalf("expected zero load count for static-only annotation, got %d", annotated.Dependencies[0].RuntimeUsage.LoadCount)
-	}
-	if annotated.Dependencies[0].RuntimeUsage.RuntimeOnly {
-		t.Fatalf("did not expect runtime-only=true for static-only annotation")
+	for _, dependency := range annotated.Dependencies {
+		if dependency.RuntimeUsage == nil {
+			t.Fatalf("expected static-only runtime usage annotation for %q", dependency.Name)
+		}
+		if dependency.RuntimeUsage.Correlation != report.RuntimeCorrelationStaticOnly {
+			t.Fatalf("expected static-only correlation for %q, got %#v", dependency.Name, dependency.RuntimeUsage)
+		}
+		if dependency.RuntimeUsage.LoadCount != 0 {
+			t.Fatalf("expected zero load count for %q, got %d", dependency.Name, dependency.RuntimeUsage.LoadCount)
+		}
+		if dependency.RuntimeUsage.RuntimeOnly {
+			t.Fatalf("did not expect runtime-only=true for %q", dependency.Name)
+		}
 	}
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -5507,6 +5507,15 @@ func workflowStepWithString(t *testing.T, step workflowStepConfig, key string) s
 	return value
 }
 
+func TestAnalysisCacheSchemaInvalidatesV3TopNEntries(t *testing.T) {
+	const expectedDeclaration = `const analysisCacheSchemaVersion = "v4"`
+
+	source := readConfig(t, "internal/analysis/cache_entry.go")
+	if !strings.Contains(source, expectedDeclaration) {
+		t.Fatalf("analysis cache schema must invalidate v3 top-N entries; expected %q", expectedDeclaration)
+	}
+}
+
 func readJSONConfig(t *testing.T, path string, target any) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Fail closed when JS/TS source parsing or dependency package metadata is incomplete, so partial coverage cannot emit dependency-removal signals. Closes #1444.

## Changes

- Mark syntax-error/recovery source scans as usage-incomplete.
- Mark unreadable or malformed dependency package metadata as export-coverage-incomplete.
- Reuse the existing suppression path for recommendations, codemods, unused exports, and removal-candidate scores.
- Add focused regressions for both architect-reproduced fail-open inputs.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/js -run "TestAdapterAnalyseSuppressesSignalsForSyntaxRecoveryScan|TestBuildDependencyReportSuppressesSignalsForMalformedPackageMetadata"
go test ./internal/lang/js
go test ./internal/lang/js ./internal/report
make ci
```

Additional manual validation:

- Both new tests failed before the production markers were added and passed afterward.
- Independent pre-publish code review returned APPROVE with zero findings.
- Documentation and `memory-approved` are not otherwise applicable to this internal fail-safe change.

Regression-Test: ./internal/lang/js::TestAdapterAnalyseSuppressesSignalsForSyntaxRecoveryScan
Regression-Test: ./internal/lang/js::TestBuildDependencyReportSuppressesSignalsForMalformedPackageMetadata

## Risk and compatibility

- Breaking changes: None.
- Migration required: No.
- Performance impact: Negligible; two existing completeness flags are set on already-detected error paths.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Regression-Test: ./internal/lang/js::TestJSIncompleteDependencySurfaceDisablesTopNRemovalRanking
Regression-Test: ./scripts::TestAnalysisCacheSchemaInvalidatesV3TopNEntries