### PR TITLE
fix(ci): reject invalid benchmark thresholds

### DIFF
--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -3591,6 +3591,44 @@ func BenchmarkConditional(b *testing.B) {
 	}
 }
 
+func TestMakefileBenchGatePreservesInvalidHelperThresholdExitWhenEnforcementDisabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		envKey   string
+		flagName string
+	}{
+		{name: "bytes", envKey: "MEMORY_BENCH_MAX_BYTES_PCT", flagName: "max-bytes-pct"},
+		{name: "allocs", envKey: "MEMORY_BENCH_MAX_ALLOCS_PCT", flagName: "max-allocs-pct"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, benchVars := newTempBenchGateGoRepo(t)
+			copyTree(t, repoPath(t, "tools/benchdelta"), filepath.Join(repo, "tools", "benchdelta"))
+			copyTree(t, repoPath(t, "internal/safeio"), filepath.Join(repo, "internal", "safeio"))
+			writeFile(t, filepath.Join(repo, "benchpkg", "bench_test.go"), benchmarkTestSource("benchpkg", "BenchmarkThresholdValidation"))
+			runGitCommand(t, repo, "add", "go.mod", "benchpkg/bench_test.go", "tools/benchdelta", "internal/safeio")
+			runGitCommand(t, repo, "commit", "-m", "add benchmark package")
+			benchVars["MEMORY_BENCH_ENFORCE"] = "0"
+			benchVars["MEMORY_BENCH_BASE"] = "HEAD"
+			benchVars["MEMORY_BENCH_PACKAGES"] = "./benchpkg"
+			benchVars[tc.envKey] = "NaN"
+			output, exitCode := runMakeTargetInDirExpectExitCode(t, repo, "bench-gate", benchVars, 2)
+			if exitCode != 2 {
+				t.Fatalf("bench-gate exit code = %d, want 2", exitCode)
+			}
+			want := `invalid threshold "` + tc.flagName + `": "NaN" (must be finite and >= 0)`
+			if !strings.Contains(output, want) {
+				t.Fatalf("bench-gate output missing invalid helper threshold diagnostic %q:\n%s", want, output)
+			}
+			assertMemoryBenchArtifacts(t, repo, "2\n", []string{"Comparison status: invalid", want}, []string{"Result: memory benchmark gate passed."})
+		})
+	}
+}
+
 func TestMakefileBenchGateFailsClosedWhenConfiguredPackageLosesAllHeadBenchmarks(t *testing.T) {
 	t.Parallel()
 

--- a/tools/benchdelta/main.go
+++ b/tools/benchdelta/main.go
@@ -33,6 +33,11 @@ type deltaThresholds struct {
 	allocsPct float64
 }
 
+type thresholdFlagValue struct {
+	raw   string
+	value float64
+}
+
 type comparisonRow struct {
 	name            string
 	baseBytes       float64
@@ -85,8 +90,10 @@ type comparisonSummary struct {
 func main() {
 	basePath := flag.String("base", "", "path to base benchmark output")
 	headPath := flag.String("head", "", "path to head benchmark output")
-	maxBytesPct := flag.Float64("max-bytes-pct", 15, "maximum allowed bytes/op increase percentage")
-	maxAllocsPct := flag.Float64("max-allocs-pct", 10, "maximum allowed allocs/op increase percentage")
+	maxBytesPct := newThresholdFlagValue(15)
+	maxAllocsPct := newThresholdFlagValue(10)
+	flag.Var(maxBytesPct, "max-bytes-pct", "maximum allowed bytes/op increase percentage")
+	flag.Var(maxAllocsPct, "max-allocs-pct", "maximum allowed allocs/op increase percentage")
 	summaryOut := flag.String("summary-out", "", "path to write markdown summary")
 	flag.Parse()
 
@@ -95,8 +102,14 @@ func main() {
 	}
 
 	limits := deltaThresholds{
-		bytesPct:  *maxBytesPct,
-		allocsPct: *maxAllocsPct,
+		bytesPct:  maxBytesPct.value,
+		allocsPct: maxAllocsPct.value,
+	}
+	if err := validateThresholdFlag("max-bytes-pct", maxBytesPct); err != nil {
+		exitWithSummary(*summaryOut, invalidInputSummary(limits, "unavailable", "unavailable", err.Error()))
+	}
+	if err := validateThresholdFlag("max-allocs-pct", maxAllocsPct); err != nil {
+		exitWithSummary(*summaryOut, invalidInputSummary(limits, "unavailable", "unavailable", err.Error()))
 	}
 
 	baseInput, err := parseBenchmarkFile(*basePath)
@@ -542,4 +555,38 @@ func percentDelta(base, head, limit float64) (string, bool) {
 		delta := ((head - base) / base) * 100
 		return fmt.Sprintf("%+.1f%%", delta), delta > limit
 	}
+}
+
+func newThresholdFlagValue(defaultValue float64) *thresholdFlagValue {
+	return &thresholdFlagValue{
+		raw:   strconv.FormatFloat(defaultValue, 'f', -1, 64),
+		value: defaultValue,
+	}
+}
+
+func (f *thresholdFlagValue) Set(raw string) error {
+	value, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return err
+	}
+	f.raw = raw
+	f.value = value
+	return nil
+}
+
+func (f *thresholdFlagValue) String() string {
+	if f == nil {
+		return ""
+	}
+	return f.raw
+}
+
+func validateThresholdFlag(name string, value *thresholdFlagValue) error {
+	if value == nil {
+		return nil
+	}
+	if !isFinite(value.value) || value.value < 0 {
+		return fmt.Errorf("invalid threshold %q: %q (must be finite and >= 0)", name, value.raw)
+	}
+	return nil
 }

--- a/tools/benchdelta/main_test.go
+++ b/tools/benchdelta/main_test.go
@@ -647,6 +647,88 @@ func TestMainSummaryWriteSuccess(t *testing.T) {
 	}
 }
 
+func TestMainRejectsInvalidThresholds(t *testing.T) {
+	if runBenchdeltaMainIfRequested(t) {
+		return
+	}
+
+	dir, basePath, headPath := writeMatchingBenchmarkFixtures(t)
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantOutput []string
+	}{
+		{
+			name:       "bytes nan",
+			args:       []string{"-base", basePath, "-head", headPath, "-max-bytes-pct", "NaN"},
+			wantOutput: []string{"Comparison status: invalid", "Result: benchmark input could not be read for a safe memory comparison.", `invalid threshold "max-bytes-pct": "NaN" (must be finite and >= 0)`},
+		},
+		{
+			name:       "bytes positive infinity",
+			args:       []string{"-base", basePath, "-head", headPath, "-max-bytes-pct", "+Inf"},
+			wantOutput: []string{"Comparison status: invalid", "Result: benchmark input could not be read for a safe memory comparison.", `invalid threshold "max-bytes-pct": "+Inf" (must be finite and >= 0)`},
+		},
+		{
+			name:       "bytes negative infinity",
+			args:       []string{"-base", basePath, "-head", headPath, "-max-bytes-pct", "-Inf"},
+			wantOutput: []string{"Comparison status: invalid", "Result: benchmark input could not be read for a safe memory comparison.", `invalid threshold "max-bytes-pct": "-Inf" (must be finite and >= 0)`},
+		},
+		{
+			name:       "bytes negative",
+			args:       []string{"-base", basePath, "-head", headPath, "-max-bytes-pct", "-0.1"},
+			wantOutput: []string{"Comparison status: invalid", "Result: benchmark input could not be read for a safe memory comparison.", `invalid threshold "max-bytes-pct": "-0.1" (must be finite and >= 0)`},
+		},
+		{
+			name:       "allocs nan",
+			args:       []string{"-base", basePath, "-head", headPath, "-max-allocs-pct", "NaN"},
+			wantOutput: []string{"Comparison status: invalid", "Result: benchmark input could not be read for a safe memory comparison.", `invalid threshold "max-allocs-pct": "NaN" (must be finite and >= 0)`},
+		},
+		{
+			name:       "allocs positive infinity",
+			args:       []string{"-base", basePath, "-head", headPath, "-max-allocs-pct", "+Inf"},
+			wantOutput: []string{"Comparison status: invalid", "Result: benchmark input could not be read for a safe memory comparison.", `invalid threshold "max-allocs-pct": "+Inf" (must be finite and >= 0)`},
+		},
+		{
+			name:       "allocs negative infinity",
+			args:       []string{"-base", basePath, "-head", headPath, "-max-allocs-pct", "-Inf"},
+			wantOutput: []string{"Comparison status: invalid", "Result: benchmark input could not be read for a safe memory comparison.", `invalid threshold "max-allocs-pct": "-Inf" (must be finite and >= 0)`},
+		},
+		{
+			name:       "allocs negative",
+			args:       []string{"-base", basePath, "-head", headPath, "-max-allocs-pct", "-0.1"},
+			wantOutput: []string{"Comparison status: invalid", "Result: benchmark input could not be read for a safe memory comparison.", `invalid threshold "max-allocs-pct": "-0.1" (must be finite and >= 0)`},
+		},
+		{
+			name:       "zero thresholds remain valid",
+			args:       []string{"-base", basePath, "-head", headPath, "-max-bytes-pct", "0", "-max-allocs-pct", "0"},
+			wantOutput: []string{"Result: memory benchmark gate passed.", "Thresholds: bytes/op <= +0.0%, allocs/op <= +0.0%"},
+		},
+		{
+			name:       "finite nonnegative thresholds remain valid",
+			args:       []string{"-base", basePath, "-head", headPath, "-max-bytes-pct", "1.5", "-max-allocs-pct", "2.5"},
+			wantOutput: []string{"Result: memory benchmark gate passed.", "Thresholds: bytes/op <= +1.5%, allocs/op <= +2.5%"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			summaryPath := filepath.Join(dir, strings.ReplaceAll(tc.name, " ", "-")+".md")
+			args := append(append([]string{}, tc.args...), "-summary-out", summaryPath)
+			output, exitCode := runBenchdeltaHelper(t, "TestMainRejectsInvalidThresholds", args...)
+			if strings.Contains(tc.name, "remain valid") {
+				assertBenchdeltaHelperExit(t, output, exitCode, exitCodePassed)
+			} else {
+				assertBenchdeltaHelperExit(t, output, exitCode, exitCodeInvalid)
+			}
+			for _, want := range tc.wantOutput {
+				assertBenchdeltaHelperOutput(t, output, want)
+			}
+			assertBenchdeltaSummaryArtifact(t, summaryPath, tc.wantOutput, nil)
+		})
+	}
+}
+
 func TestMainInvalidComparisonsStillWriteDeterministicSummaryArtifacts(t *testing.T) {
 	if runBenchdeltaMainIfRequested(t) {
 		return


### PR DESCRIPTION
## Summary

Reject non-finite and negative memory benchmark thresholds at the benchdelta input boundary so invalid configuration cannot turn a real regression into a passing result. Closes #1445.

## Changes

- Validate both bytes/op and allocs/op threshold flags before reading benchmark inputs.
- Preserve each raw flag value in the canonical invalid summary diagnostic.
- Keep zero and finite nonnegative thresholds valid.
- Prove `bench-gate` preserves helper exit 2 even when `MEMORY_BENCH_ENFORCE=0`.

## Validation

- `go test ./tools/benchdelta ./scripts -run '^(TestMainRejectsInvalidThresholds|TestMakefileBenchGatePreservesInvalidHelperThresholdExitWhenEnforcementDisabled)$' -count=10`
- `go test ./tools/benchdelta ./scripts`
- `make ci` — 98.3% total coverage, 0 lint issues, 0 gosec issues, no vulnerabilities, memory gate passed
- Independent code review: APPROVE
- Independent test-adequacy review: APPROVE
- Regression proof: both declarations fail on base `5382ce100140939c8038f955397acbeea537502a` and pass on head

Regression-Test: ./tools/benchdelta::TestMainRejectsInvalidThresholds
Regression-Test: ./scripts::TestMakefileBenchGatePreservesInvalidHelperThresholdExitWhenEnforcementDisabled

## Risk and compatibility

- Breaking changes: invalid threshold values that previously bypassed enforcement now fail closed with exit 2.
- Migration required: replace NaN, infinity, or negative thresholds with finite nonnegative values.
- Performance impact: negligible; validation occurs once at process startup.
- Memory benchmark impact: none; the benchmark gate passed without regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
