### PR TITLE
fix(test): keep advisory RLIMIT test off Windows

### DIFF
--- a/internal/advisory/sync_test.go
+++ b/internal/advisory/sync_test.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
-	"syscall"
 	"testing"
 	"time"
 
@@ -26,7 +25,6 @@ import (
 )
 
 const (
-	downloadSnapshotWriteErrorChildEnv    = "LOPPER_DOWNLOAD_SNAPSHOT_WRITE_ERROR_CHILD"
 	publicationLockChildModeEnv           = "LOPPER_PUBLICATION_LOCK_CHILD_MODE"
 	publicationLockChildCacheEnv          = "LOPPER_PUBLICATION_LOCK_CHILD_CACHE"
 	publicationLockChildMarkerEnv         = "LOPPER_PUBLICATION_LOCK_CHILD_MARKER"
@@ -683,56 +681,6 @@ func TestDownloadSnapshotTempFileCreationErrors(t *testing.T) {
 	})}
 	if _, err := downloadSnapshot(context.Background(), "https://example.test/osv.json", closeErrClient, tempDirFile); err == nil || !strings.Contains(err.Error(), "close advisory response") {
 		t.Fatalf("expected temp file creation error with close detail, got %v", err)
-	}
-}
-
-func TestDownloadSnapshotWriteError(t *testing.T) {
-	if os.Getenv(downloadSnapshotWriteErrorChildEnv) == "1" {
-		runDownloadSnapshotWriteErrorChild(t)
-		return
-	}
-
-	cmd := exec.Command(os.Args[0], "-test.run=^TestDownloadSnapshotWriteError$")
-	cmd.Env = append(os.Environ(), downloadSnapshotWriteErrorChildEnv+"=1")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("run child test process: %v\n%s", err, output)
-	}
-}
-
-func runDownloadSnapshotWriteErrorChild(t *testing.T) {
-	var oldLimit syscall.Rlimit
-	if err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &oldLimit); err != nil {
-		t.Fatalf("get RLIMIT_FSIZE: %v", err)
-	}
-
-	defer func() {
-		if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &oldLimit); err != nil {
-			t.Fatalf("restore RLIMIT_FSIZE: %v", err)
-		}
-	}()
-	if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &syscall.Rlimit{Cur: 1, Max: oldLimit.Max}); err != nil {
-		t.Fatalf("set RLIMIT_FSIZE: %v", err)
-	}
-
-	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"vulns":[{"id":"OSV-1"}]}`)),
-		}, nil
-	})}
-	if _, err := downloadSnapshot(context.Background(), "https://example.test/osv.json", client, t.TempDir()); err == nil || !strings.Contains(err.Error(), "write advisory snapshot temp file") {
-		t.Fatalf("expected snapshot write error, got %v", err)
-	}
-
-	closeErrClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       &errCloseReadCloser{Reader: strings.NewReader(`{"vulns":[{"id":"OSV-2"}]}`)},
-		}, nil
-	})}
-	if _, err := downloadSnapshot(context.Background(), "https://example.test/osv.json", closeErrClient, t.TempDir()); err == nil || !strings.Contains(err.Error(), "write advisory snapshot temp file") || !strings.Contains(err.Error(), "close advisory response") {
-		t.Fatalf("expected snapshot write+close error, got %v", err)
 	}
 }
 

--- a/internal/advisory/sync_write_error_unix_test.go
+++ b/internal/advisory/sync_write_error_unix_test.go
@@ -1,0 +1,66 @@
+//go:build !windows
+
+package advisory
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+const downloadSnapshotWriteErrorChildEnv = "LOPPER_DOWNLOAD_SNAPSHOT_WRITE_ERROR_CHILD"
+
+func TestDownloadSnapshotWriteError(t *testing.T) {
+	if os.Getenv(downloadSnapshotWriteErrorChildEnv) == "1" {
+		runDownloadSnapshotWriteErrorChild(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestDownloadSnapshotWriteError$")
+	cmd.Env = append(os.Environ(), downloadSnapshotWriteErrorChildEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run child test process: %v\n%s", err, output)
+	}
+}
+
+func runDownloadSnapshotWriteErrorChild(t *testing.T) {
+	var oldLimit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &oldLimit); err != nil {
+		t.Fatalf("get RLIMIT_FSIZE: %v", err)
+	}
+
+	defer func() {
+		if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &oldLimit); err != nil {
+			t.Fatalf("restore RLIMIT_FSIZE: %v", err)
+		}
+	}()
+	if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &syscall.Rlimit{Cur: 1, Max: oldLimit.Max}); err != nil {
+		t.Fatalf("set RLIMIT_FSIZE: %v", err)
+	}
+
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"vulns":[{"id":"OSV-1"}]}`)),
+		}, nil
+	})}
+	if _, err := downloadSnapshot(context.Background(), "https://example.test/osv.json", client, t.TempDir()); err == nil || !strings.Contains(err.Error(), "write advisory snapshot temp file") {
+		t.Fatalf("expected snapshot write error, got %v", err)
+	}
+
+	closeErrClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       &errCloseReadCloser{Reader: strings.NewReader(`{"vulns":[{"id":"OSV-2"}]}`)},
+		}, nil
+	})}
+	if _, err := downloadSnapshot(context.Background(), "https://example.test/osv.json", closeErrClient, t.TempDir()); err == nil || !strings.Contains(err.Error(), "write advisory snapshot temp file") || !strings.Contains(err.Error(), "close advisory response") {
+		t.Fatalf("expected snapshot write+close error, got %v", err)
+	}
+}

--- a/internal/advisory/sync_write_error_windows_test.go
+++ b/internal/advisory/sync_write_error_windows_test.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package advisory
+
+import "testing"
+
+func TestDownloadSnapshotWriteError(t *testing.T) {
+	t.Skip("RLIMIT_FSIZE is unavailable on Windows")
+}

--- a/scripts/windows_compile_test.go
+++ b/scripts/windows_compile_test.go
@@ -1,0 +1,19 @@
+package scripts
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestAdvisoryTestsCompileForWindows(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "advisory.test.exe")
+	cmd := exec.Command("go", "test", "-c", "-o", outputPath, "./internal/advisory")
+	cmd.Dir = repoPath(t, "")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=windows", "GOARCH=amd64")
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-compile advisory tests for Windows: %v\n%s", err, output)
+	}
+}


### PR DESCRIPTION
## Summary

Keep the advisory snapshot write-error test out of Windows builds because its deterministic failure injection depends on Unix `RLIMIT_FSIZE` APIs. Closes #1449.

## Root cause

`internal/advisory/sync_test.go` was compiled on every platform but referenced `syscall.Rlimit`, `Getrlimit`, `Setrlimit`, and `RLIMIT_FSIZE`, which are unavailable when compiling tests for Windows.

## Changes

- Move the RLIMIT-backed write-error test and helper into a `!windows` test file.
- Add an explicit Windows skip documenting why the test cannot run there.
- Add a repository regression test that cross-compiles the advisory test binary for Windows.

## Validation

- `go test ./internal/advisory -run '^TestDownloadSnapshotWriteError$' -count=20`
- `go test ./scripts -run '^TestAdvisoryTestsCompileForWindows$' -count=3`
- `make ci` — 98.3% total coverage, 0 lint issues, 0 gosec issues, no vulnerabilities, race/leak/benchmark/build gates passed
- Independent implementation review: READY
- Independent test-adequacy review: APPROVE
- Regression proof: the declaration fails on base `6939fa3de42db738d5653a3ae4c7ada22e2535f2` and passes on head

Regression-Test: ./scripts::TestAdvisoryTestsCompileForWindows

## Risk and compatibility

- Breaking changes: none.
- Migration required: none.
- Performance impact: none; the new cross-compile runs only in tests.
- Memory benchmark impact: none; the benchmark gate passed without regression.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
