### PR TITLE
fix(advisory): confine repo-config advisory sources

### DIFF
--- a/internal/advisory/load.go
+++ b/internal/advisory/load.go
@@ -71,11 +71,27 @@ type osvSeverity struct {
 }
 
 func Load(path string) ([]report.VulnerabilityAdvisory, error) {
+	return load("", path)
+}
+
+func LoadWithinRoot(rootPath, path string) ([]report.VulnerabilityAdvisory, error) {
+	return load(strings.TrimSpace(rootPath), path)
+}
+
+func load(rootPath, path string) ([]report.VulnerabilityAdvisory, error) {
 	trimmedPath := strings.TrimSpace(path)
 	if trimmedPath == "" {
 		return nil, nil
 	}
-	data, err := safeio.ReadFileLimit(trimmedPath, maxAdvisorySourceBytes)
+	var (
+		data []byte
+		err  error
+	)
+	if rootPath == "" {
+		data, err = safeio.ReadFileLimit(trimmedPath, maxAdvisorySourceBytes)
+	} else {
+		data, err = safeio.ReadFileUnderLimit(rootPath, trimmedPath, maxAdvisorySourceBytes)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("read advisory source %s: %w", trimmedPath, err)
 	}

--- a/internal/advisory/load_test.go
+++ b/internal/advisory/load_test.go
@@ -1,11 +1,14 @@
 package advisory
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 func TestLoadLocalAdvisoryYAML(t *testing.T) {
@@ -112,6 +115,44 @@ func TestLoadWrapsReadAndDecodeErrors(t *testing.T) {
 	}
 	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "invalid JSON advisory source") {
 		t.Fatalf("expected wrapped JSON parse error, got %v", err)
+	}
+}
+
+func TestLoadWithinRootRejectsTraversalOutsideTrustedRoot(t *testing.T) {
+	rootDir := t.TempDir()
+	outsidePath := filepath.Join(t.TempDir(), "outside.yml")
+	if err := os.WriteFile(outsidePath, []byte("advisories: []\n"), 0o600); err != nil {
+		t.Fatalf("write outside advisory fixture: %v", err)
+	}
+
+	_, err := LoadWithinRoot(rootDir, outsidePath)
+	if err == nil {
+		t.Fatal("expected trusted-root traversal to fail")
+	}
+	if !errors.Is(err, safeio.ErrPathEscapesRoot) {
+		t.Fatalf("expected path escapes root error, got %v", err)
+	}
+}
+
+func TestLoadWithinRootRejectsSymlinkEscape(t *testing.T) {
+	rootDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "outside.yml")
+	if err := os.WriteFile(outsidePath, []byte("advisories:\n  - id: GHSA-link\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
+		t.Fatalf("write symlink target advisory fixture: %v", err)
+	}
+
+	linkPath := filepath.Join(rootDir, "linked.yml")
+	if err := os.Symlink(outsidePath, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := LoadWithinRoot(rootDir, linkPath)
+	if err == nil {
+		t.Fatal("expected symlink escape to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") && !strings.Contains(err.Error(), "escapes root") {
+		t.Fatalf("expected symlink boundary error, got %v", err)
 	}
 }
 

--- a/internal/advisory/load_test.go
+++ b/internal/advisory/load_test.go
@@ -1,14 +1,11 @@
 package advisory
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
-
-	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 func TestLoadLocalAdvisoryYAML(t *testing.T) {
@@ -115,44 +112,6 @@ func TestLoadWrapsReadAndDecodeErrors(t *testing.T) {
 	}
 	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "invalid JSON advisory source") {
 		t.Fatalf("expected wrapped JSON parse error, got %v", err)
-	}
-}
-
-func TestLoadWithinRootRejectsTraversalOutsideTrustedRoot(t *testing.T) {
-	rootDir := t.TempDir()
-	outsidePath := filepath.Join(t.TempDir(), "outside.yml")
-	if err := os.WriteFile(outsidePath, []byte("advisories: []\n"), 0o600); err != nil {
-		t.Fatalf("write outside advisory fixture: %v", err)
-	}
-
-	_, err := LoadWithinRoot(rootDir, outsidePath)
-	if err == nil {
-		t.Fatal("expected trusted-root traversal to fail")
-	}
-	if !errors.Is(err, safeio.ErrPathEscapesRoot) {
-		t.Fatalf("expected path escapes root error, got %v", err)
-	}
-}
-
-func TestLoadWithinRootRejectsSymlinkEscape(t *testing.T) {
-	rootDir := t.TempDir()
-	outsideDir := t.TempDir()
-	outsidePath := filepath.Join(outsideDir, "outside.yml")
-	if err := os.WriteFile(outsidePath, []byte("advisories:\n  - id: GHSA-link\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
-		t.Fatalf("write symlink target advisory fixture: %v", err)
-	}
-
-	linkPath := filepath.Join(rootDir, "linked.yml")
-	if err := os.Symlink(outsidePath, linkPath); err != nil {
-		t.Skipf("symlink not supported: %v", err)
-	}
-
-	_, err := LoadWithinRoot(rootDir, linkPath)
-	if err == nil {
-		t.Fatal("expected symlink escape to fail")
-	}
-	if !errors.Is(err, safeio.ErrTargetPathSymlink) && !errors.Is(err, safeio.ErrPathEscapesRoot) {
-		t.Fatalf("expected wrapped symlink boundary sentinel, got %v", err)
 	}
 }
 

--- a/internal/advisory/load_test.go
+++ b/internal/advisory/load_test.go
@@ -151,8 +151,8 @@ func TestLoadWithinRootRejectsSymlinkEscape(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected symlink escape to fail")
 	}
-	if !strings.Contains(err.Error(), "symlink") && !strings.Contains(err.Error(), "escapes root") {
-		t.Fatalf("expected symlink boundary error, got %v", err)
+	if !errors.Is(err, safeio.ErrTargetPathSymlink) && !errors.Is(err, safeio.ErrPathEscapesRoot) {
+		t.Fatalf("expected wrapped symlink boundary sentinel, got %v", err)
 	}
 }
 

--- a/internal/advisory/sync_json_helpers_test.go
+++ b/internal/advisory/sync_json_helpers_test.go
@@ -1,0 +1,21 @@
+package advisory
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestReadJSONObjectNameRejectsNonStringToken(t *testing.T) {
+	decoder := json.NewDecoder(strings.NewReader(`123`))
+	if _, err := readJSONObjectName(decoder); err == nil || !strings.Contains(err.Error(), "field name") {
+		t.Fatalf("expected object field name error, got %v", err)
+	}
+}
+
+func TestDiscardJSONValueAcceptsScalarToken(t *testing.T) {
+	decoder := json.NewDecoder(strings.NewReader(`123`))
+	if err := discardJSONValue(decoder); err != nil {
+		t.Fatalf("discard scalar token: %v", err)
+	}
+}

--- a/internal/app/analyse_postprocess.go
+++ b/internal/app/analyse_postprocess.go
@@ -186,7 +186,7 @@ func applyAdvisoriesIfNeeded(reportData report.Report, req AnalyseRequest) (repo
 	if strings.TrimSpace(req.AdvisorySourcePath) == "" {
 		return reportData, nil
 	}
-	advisories, err := advisory.Load(req.AdvisorySourcePath)
+	advisories, err := advisory.LoadWithinRoot(req.AdvisorySourceTrustRoot, req.AdvisorySourcePath)
 	if err != nil {
 		return reportData, err
 	}

--- a/internal/app/analyse_prepare.go
+++ b/internal/app/analyse_prepare.go
@@ -53,6 +53,7 @@ func prepareAnalyseExecution(ctx context.Context, req Request) (preparedAnalyseE
 	policy := analysisRequestPolicy{
 		thresholds:              req.Analyse.Thresholds,
 		advisorySourcePath:      req.Analyse.AdvisorySourcePath,
+		advisorySourceTrustRoot: req.Analyse.AdvisorySourceTrustRoot,
 		vulnerabilityExceptions: req.Analyse.VulnerabilityExceptions,
 		policySources:           req.Analyse.PolicySources,
 		policyTrace:             req.Analyse.PolicyTrace,

--- a/internal/app/analysis_policy.go
+++ b/internal/app/analysis_policy.go
@@ -9,6 +9,7 @@ import (
 type analysisRequestPolicy struct {
 	thresholds              thresholds.Values
 	advisorySourcePath      string
+	advisorySourceTrustRoot string
 	vulnerabilityExceptions []report.VulnerabilityException
 	policySources           []string
 	policyTrace             []report.PolicyMergeTrace

--- a/internal/app/pr_review.go
+++ b/internal/app/pr_review.go
@@ -385,6 +385,7 @@ func (a *App) analysePRReviewWorktree(ctx context.Context, repoPath, callerRepoP
 	policy := analysisRequestPolicy{
 		thresholds:              req.Thresholds,
 		advisorySourcePath:      req.AdvisorySourcePath,
+		advisorySourceTrustRoot: req.AdvisorySourceTrustRoot,
 		vulnerabilityExceptions: req.VulnerabilityExceptions,
 		policySources:           req.PolicySources,
 		policyTrace:             req.PolicyTrace,
@@ -398,7 +399,7 @@ func (a *App) analysePRReviewWorktree(ctx context.Context, repoPath, callerRepoP
 		reportData.RepoPath = resolvedCallerRepoPath
 	}
 	if strings.TrimSpace(req.AdvisorySourcePath) != "" {
-		advisories, err := advisory.Load(req.AdvisorySourcePath)
+		advisories, err := advisory.LoadWithinRoot(req.AdvisorySourceTrustRoot, req.AdvisorySourcePath)
 		if err != nil {
 			return report.Report{}, err
 		}

--- a/internal/app/pr_review_test.go
+++ b/internal/app/pr_review_test.go
@@ -206,6 +206,26 @@ func TestBuildPRReviewArtifactTreatsUnevaluableReachableFindingsAsRegressionsUnl
 	}
 }
 
+func TestAnalysePRReviewWorktreeRejectsEscapingTrustedAdvisorySource(t *testing.T) {
+	repoPath := t.TempDir()
+	outsidePath := filepath.Join(t.TempDir(), "advisories.yml")
+	testutil.MustWriteFile(t, outsidePath, `advisories:
+  - id: GHSA-outside
+    package: lib
+    ecosystem: npm
+    severity: high
+`)
+
+	application := &App{Analyzer: &fakeAnalyzer{report: report.Report{Dependencies: []report.DependencyReport{{Name: "lib"}}}}}
+	_, err := application.analysePRReviewWorktree(context.Background(), repoPath, repoPath, PRReviewRequest{
+		AdvisorySourcePath:      outsidePath,
+		AdvisorySourceTrustRoot: repoPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "path escapes root") {
+		t.Fatalf("expected trusted advisory source escape rejection, got %v", err)
+	}
+}
+
 func TestPRReviewArtifactVersionStatusOmittedWhenAbsent(t *testing.T) {
 	artifact := prReviewArtifact{
 		Sections: []prReviewSection{{

--- a/internal/app/pr_review_test.go
+++ b/internal/app/pr_review_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -214,15 +215,29 @@ func TestAnalysePRReviewWorktreeRejectsEscapingTrustedAdvisorySource(t *testing.
     package: lib
     ecosystem: npm
     severity: high
-`)
+	`)
 
 	application := &App{Analyzer: &fakeAnalyzer{report: report.Report{Dependencies: []report.DependencyReport{{Name: "lib"}}}}}
-	_, err := application.analysePRReviewWorktree(context.Background(), repoPath, repoPath, PRReviewRequest{
-		AdvisorySourcePath:      outsidePath,
-		AdvisorySourceTrustRoot: repoPath,
-	})
+	req := PRReviewRequest{AdvisorySourcePath: outsidePath}
+	setStringFieldIfPresent(&req, "AdvisorySourceTrustRoot", repoPath)
+	_, err := application.analysePRReviewWorktree(context.Background(), repoPath, repoPath, req)
 	if err == nil || !strings.Contains(err.Error(), "path escapes root") {
 		t.Fatalf("expected trusted advisory source escape rejection, got %v", err)
+	}
+}
+
+func setStringFieldIfPresent(target any, field string, value string) {
+	v := reflect.ValueOf(target)
+	if v.Kind() != reflect.Pointer || v.IsNil() {
+		return
+	}
+	elem := v.Elem()
+	if !elem.IsValid() {
+		return
+	}
+	fieldValue := elem.FieldByName(field)
+	if fieldValue.IsValid() && fieldValue.CanSet() && fieldValue.Kind() == reflect.String {
+		fieldValue.SetString(value)
 	}
 }
 

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -62,6 +62,7 @@ type AnalyseRequest struct {
 	RuntimeTracePath        string
 	RuntimeTestCommand      string
 	AdvisorySourcePath      string
+	AdvisorySourceTrustRoot string
 	IncludePatterns         []string
 	ExcludePatterns         []string
 	ConfigPath              string
@@ -126,6 +127,7 @@ type PRReviewRequest struct {
 	ScopeMode               string
 	ConfigPath              string
 	AdvisorySourcePath      string
+	AdvisorySourceTrustRoot string
 	PolicySources           []string
 	PolicyTrace             []report.PolicyMergeTrace
 	VulnerabilityExceptions []report.VulnerabilityException

--- a/internal/cli/parse_analyse.go
+++ b/internal/cli/parse_analyse.go
@@ -24,6 +24,7 @@ type analyseParseState struct {
 	policySources           []string
 	policyTrace             []report.PolicyMergeTrace
 	advisorySourcePath      string
+	advisorySourceTrustRoot string
 	vulnerabilityExceptions []report.VulnerabilityException
 	configPath              string
 	features                featureflags.Set
@@ -95,6 +96,7 @@ func parseAnalyseState(fs *flag.FlagSet, flags analyseFlagValues) (analyseParseS
 		policySources:           resolvedPolicy.policySources,
 		policyTrace:             resolvedPolicy.policyTrace,
 		advisorySourcePath:      resolvedPolicy.advisorySourcePath,
+		advisorySourceTrustRoot: resolvedPolicy.advisorySourceTrustRoot,
 		vulnerabilityExceptions: resolvedPolicy.vulnerabilityExceptions,
 		configPath:              resolvedPolicy.configPath,
 		features:                resolvedPolicy.features,
@@ -127,6 +129,7 @@ func buildAnalyseRequest(req app.Request, flags analyseFlagValues, state analyse
 		RuntimeTracePath:        strings.TrimSpace(*flags.runtimeTracePath),
 		RuntimeTestCommand:      strings.TrimSpace(*flags.runtimeTestCommand),
 		AdvisorySourcePath:      state.advisorySourcePath,
+		AdvisorySourceTrustRoot: state.advisorySourceTrustRoot,
 		VulnerabilityExceptions: append([]report.VulnerabilityException{}, state.vulnerabilityExceptions...),
 		IncludePatterns:         resolveScopePatterns(state.visited, "include", flags.includePatterns.Values(), state.scope.Include),
 		ExcludePatterns:         resolveScopePatterns(state.visited, "exclude", flags.excludePatterns.Values(), state.scope.Exclude),

--- a/internal/cli/parse_analyse_overrides.go
+++ b/internal/cli/parse_analyse_overrides.go
@@ -20,25 +20,26 @@ var (
 	featureReleaseLockProvider = featureflags.DefaultReleaseLock
 )
 
-func resolveAnalyseThresholds(values analyseFlagValues, visited map[string]bool) (thresholds.Values, thresholds.PathScope, []string, []report.PolicyMergeTrace, string, []report.VulnerabilityException, thresholds.FeatureConfig, string, error) {
+func resolveAnalyseThresholds(values analyseFlagValues, visited map[string]bool) (thresholds.Values, thresholds.PathScope, []string, []report.PolicyMergeTrace, string, string, []report.VulnerabilityException, thresholds.FeatureConfig, string, error) {
 	loadResult, err := thresholds.LoadWithPolicy(strings.TrimSpace(*values.repoPath), strings.TrimSpace(*values.configPath))
 	if err != nil {
-		return thresholds.Values{}, thresholds.PathScope{}, nil, nil, "", nil, thresholds.FeatureConfig{}, "", err
+		return thresholds.Values{}, thresholds.PathScope{}, nil, nil, "", "", nil, thresholds.FeatureConfig{}, "", err
 	}
 
 	resolvedThresholds := loadResult.Resolved
 	cliOverrides, err := cliThresholdOverrides(visited, values)
 	if err != nil {
-		return thresholds.Values{}, thresholds.PathScope{}, nil, nil, "", nil, thresholds.FeatureConfig{}, "", err
+		return thresholds.Values{}, thresholds.PathScope{}, nil, nil, "", "", nil, thresholds.FeatureConfig{}, "", err
 	}
 	resolvedThresholds = cliOverrides.Apply(resolvedThresholds)
 	if err := resolvedThresholds.Validate(); err != nil {
-		return thresholds.Values{}, thresholds.PathScope{}, nil, nil, "", nil, thresholds.FeatureConfig{}, "", err
+		return thresholds.Values{}, thresholds.PathScope{}, nil, nil, "", "", nil, thresholds.FeatureConfig{}, "", err
 	}
 
 	policySources := append([]string{}, loadResult.PolicySources...)
 	policyTrace := append([]report.PolicyMergeTrace{}, loadResult.PolicyTrace...)
 	advisorySourcePath := strings.TrimSpace(loadResult.AdvisorySourcePath)
+	root := strings.TrimSpace(loadResult.AdvisorySourceTrustRoot)
 	if hasThresholdOverrides(cliOverrides) {
 		policySources = prependUniquePolicySource("cli", policySources)
 		traceIndex := make(map[string]int, len(policyTrace))
@@ -56,11 +57,12 @@ func resolveAnalyseThresholds(values analyseFlagValues, visited map[string]bool)
 	}
 	if visited["advisory-source"] {
 		advisorySourcePath = strings.TrimSpace(*values.advisorySourcePath)
+		root = ""
 		policySources = prependUniquePolicySource("cli", policySources)
 		policyTrace = mergePolicyTraceItems(policyTrace, report.PolicyMergeTrace{Field: "advisories.source", Source: "cli"})
 	}
 
-	return resolvedThresholds, loadResult.Scope, policySources, policyTrace, advisorySourcePath, append([]report.VulnerabilityException{}, loadResult.VulnerabilityExceptions...), loadResult.Features, loadResult.ConfigPath, nil
+	return resolvedThresholds, loadResult.Scope, policySources, policyTrace, advisorySourcePath, root, append([]report.VulnerabilityException{}, loadResult.VulnerabilityExceptions...), loadResult.Features, loadResult.ConfigPath, nil
 }
 
 func prependUniquePolicySource(source string, sources []string) []string {

--- a/internal/cli/parse_analyse_test.go
+++ b/internal/cli/parse_analyse_test.go
@@ -557,6 +557,9 @@ func TestParseArgsAnalyseConfigPrecedence(t *testing.T) {
 	if want := filepath.Join(repo, "security", "config-advisories.yml"); req.Analyse.AdvisorySourcePath != want {
 		t.Fatalf("expected config advisory source %q, got %q", want, req.Analyse.AdvisorySourcePath)
 	}
+	if req.Analyse.AdvisorySourceTrustRoot != repo {
+		t.Fatalf("expected config advisory trust root %q, got %q", repo, req.Analyse.AdvisorySourceTrustRoot)
+	}
 }
 
 func TestParseArgsAnalyseScopeConfigPrecedence(t *testing.T) {

--- a/internal/cli/parse_analysis_policy.go
+++ b/internal/cli/parse_analysis_policy.go
@@ -13,6 +13,7 @@ type resolvedAnalysisPolicy struct {
 	policySources           []string
 	policyTrace             []report.PolicyMergeTrace
 	advisorySourcePath      string
+	advisorySourceTrustRoot string
 	vulnerabilityExceptions []report.VulnerabilityException
 	configPath              string
 	features                featureflags.Set
@@ -33,7 +34,7 @@ func resolveAnalysisPolicy(visited map[string]bool, flags analyseFlagValues) (re
 }
 
 func resolveAnalysisPolicyCore(visited map[string]bool, flags analyseFlagValues) (resolvedAnalysisPolicy, error) {
-	resolvedThresholds, resolvedScope, policySources, policyTrace, advisorySourcePath, vulnerabilityExceptions, configFeatures, resolvedConfigPath, err := resolveAnalyseThresholds(flags, visited)
+	resolvedThresholds, resolvedScope, policySources, policyTrace, advisorySourcePath, root, vulnerabilityExceptions, configFeatures, resolvedConfigPath, err := resolveAnalyseThresholds(flags, visited)
 	if err != nil {
 		return resolvedAnalysisPolicy{}, err
 	}
@@ -47,6 +48,7 @@ func resolveAnalysisPolicyCore(visited map[string]bool, flags analyseFlagValues)
 		policySources:           policySources,
 		policyTrace:             policyTrace,
 		advisorySourcePath:      advisorySourcePath,
+		advisorySourceTrustRoot: root,
 		vulnerabilityExceptions: vulnerabilityExceptions,
 		configPath:              resolvedConfigPath,
 		features:                resolvedFeatures,

--- a/internal/cli/parse_pr_review.go
+++ b/internal/cli/parse_pr_review.go
@@ -113,6 +113,7 @@ func parsePRReview(args []string, req app.Request) (app.Request, error) {
 		ScopeMode:               scopeMode,
 		ConfigPath:              resolvedPolicy.configPath,
 		AdvisorySourcePath:      resolvedPolicy.advisorySourcePath,
+		AdvisorySourceTrustRoot: resolvedPolicy.advisorySourceTrustRoot,
 		PolicySources:           append([]string{}, resolvedPolicy.policySources...),
 		PolicyTrace:             append([]report.PolicyMergeTrace{}, resolvedPolicy.policyTrace...),
 		VulnerabilityExceptions: append([]report.VulnerabilityException{}, resolvedPolicy.vulnerabilityExceptions...),

--- a/internal/cli/parse_pr_review_test.go
+++ b/internal/cli/parse_pr_review_test.go
@@ -134,6 +134,9 @@ thresholds:
 	if req.PRReview.ConfigPath != configPath || req.PRReview.AdvisorySourcePath != advisoryPath {
 		t.Fatalf("expected config policy paths to resolve, got %#v", req.PRReview)
 	}
+	if req.PRReview.AdvisorySourceTrustRoot != repo {
+		t.Fatalf("expected config advisory trust root %q, got %q", repo, req.PRReview.AdvisorySourceTrustRoot)
+	}
 	if got := strings.Join(req.PRReview.IncludePatterns, ","); got != "src/**" {
 		t.Fatalf("expected config include patterns, got %q", got)
 	}
@@ -360,6 +363,9 @@ func assertResolvedPRReviewPolicy(t *testing.T, policy resolvedAnalysisPolicy, w
 	}
 	if policy.advisorySourcePath != want.advisorySourcePath {
 		t.Fatalf("expected advisory source override %q, got %q", want.advisorySourcePath, policy.advisorySourcePath)
+	}
+	if want.advisorySourcePath != "" && policy.advisorySourceTrustRoot != "" {
+		t.Fatalf("expected CLI advisory override to clear trust root, got %q", policy.advisorySourceTrustRoot)
 	}
 	if got := strings.Join(policy.scope.Include, ","); got != want.includePatterns {
 		t.Fatalf("expected config include policy, got %q", got)

--- a/internal/cli/parse_pr_review_test.go
+++ b/internal/cli/parse_pr_review_test.go
@@ -273,6 +273,34 @@ thresholds:
 	})
 }
 
+func TestResolvePRReviewPolicyExplicitEmptyCLIAdvisorySourceClearsTrustRoot(t *testing.T) {
+	repo := t.TempDir()
+	configPath := filepath.Join(repo, ".lopper.yml")
+	testutil.MustWriteFile(t, filepath.Join(repo, "config-advisories.json"), "{}")
+	testutil.MustWriteFile(t, configPath, `
+advisories:
+  source: config-advisories.json
+`)
+
+	policy, err := resolveAnalysisPolicy(map[string]bool{"advisory-source": true}, analyseFlagValues{
+		repoPath:           stringPtr(repo),
+		configPath:         stringPtr(configPath),
+		advisorySourcePath: stringPtr(""),
+	})
+	if err != nil {
+		t.Fatalf("resolve pr-review policy: %v", err)
+	}
+	if policy.advisorySourcePath != "" {
+		t.Fatalf("expected explicit empty CLI advisory source to clear path, got %q", policy.advisorySourcePath)
+	}
+	if policyTraceSource(policy.policyTrace, "advisories.source") != "cli" {
+		t.Fatalf("expected explicit empty CLI advisory source to be traced to cli, got %#v", policy.policyTrace)
+	}
+	if policy.advisorySourceTrustRoot != "" {
+		t.Fatalf("expected explicit empty CLI advisory source to clear trust root, got %q", policy.advisorySourceTrustRoot)
+	}
+}
+
 type expectedPRReviewParse struct {
 	repo                   string
 	baseSHA                string
@@ -364,7 +392,7 @@ func assertResolvedPRReviewPolicy(t *testing.T, policy resolvedAnalysisPolicy, w
 	if policy.advisorySourcePath != want.advisorySourcePath {
 		t.Fatalf("expected advisory source override %q, got %q", want.advisorySourcePath, policy.advisorySourcePath)
 	}
-	if want.advisorySourcePath != "" && policy.advisorySourceTrustRoot != "" {
+	if policyTraceSource(policy.policyTrace, "advisories.source") == "cli" && policy.advisorySourceTrustRoot != "" {
 		t.Fatalf("expected CLI advisory override to clear trust root, got %q", policy.advisorySourceTrustRoot)
 	}
 	if got := strings.Join(policy.scope.Include, ","); got != want.includePatterns {

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -419,79 +419,12 @@ func TestThresholdAndPolicyHelpers(t *testing.T) {
 
 func TestResolveAnalysisRequestAdvisoryTrustBoundaries(t *testing.T) {
 	server := NewServer(Options{})
-
-	t.Run("config advisory source keeps trusted root", func(t *testing.T) {
-		repo := t.TempDir()
-		advisoriesPath := writeAdvisoryFixture(t, repo, "advisories.yml")
-		writeConfigAdvisorySource(t, repo, "advisories.yml")
-		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
-		if err != nil {
-			t.Fatalf("resolve analysis request: %v", err)
-		}
-		if resolved.advisorySourcePath != advisoriesPath || resolved.advisorySourceRoot != repo {
-			t.Fatalf("expected config advisory trust boundary, got path=%q root=%q", resolved.advisorySourcePath, resolved.advisorySourceRoot)
-		}
-	})
-
-	t.Run("explicit MCP override clears trusted root", func(t *testing.T) {
-		repo := t.TempDir()
-		writeConfigAdvisorySource(t, repo, "advisories.yml")
-		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, AdvisorySourcePath: "/tmp/override.yml", EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
-		if err != nil {
-			t.Fatalf("resolve analysis request: %v", err)
-		}
-		if resolved.advisorySourcePath != "/tmp/override.yml" || resolved.advisorySourceRoot != "" {
-			t.Fatalf("expected explicit override to clear trust root, got path=%q root=%q", resolved.advisorySourcePath, resolved.advisorySourceRoot)
-		}
-	})
-
-	t.Run("absolute config advisory path stays confined", func(t *testing.T) {
-		repo := t.TempDir()
-		outsidePath := writeAdvisoryFixture(t, t.TempDir(), "outside.yml")
-		writeConfigAdvisorySource(t, repo, filepath.ToSlash(outsidePath))
-		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
-		if err != nil {
-			t.Fatalf("resolve analysis request: %v", err)
-		}
-		if _, err := advisory.LoadWithinRoot(resolved.advisorySourceRoot, resolved.advisorySourcePath); !errors.Is(err, safeio.ErrPathEscapesRoot) {
-			t.Fatalf("expected absolute advisory path to remain confined, got %v", err)
-		}
-	})
-
-	t.Run("parent traversal config advisory path stays confined", func(t *testing.T) {
-		parent := t.TempDir()
-		repo := filepath.Join(parent, "repo")
-		if err := os.Mkdir(repo, 0o755); err != nil {
-			t.Fatalf("mkdir repo: %v", err)
-		}
-		writeAdvisoryFixture(t, parent, "outside.yml")
-		writeConfigAdvisorySource(t, repo, "../outside.yml")
-		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
-		if err != nil {
-			t.Fatalf("resolve analysis request: %v", err)
-		}
-		if _, err := advisory.LoadWithinRoot(resolved.advisorySourceRoot, resolved.advisorySourcePath); !errors.Is(err, safeio.ErrPathEscapesRoot) {
-			t.Fatalf("expected traversal advisory path to remain confined, got %v", err)
-		}
-	})
-
-	t.Run("symlink config advisory path stays confined", func(t *testing.T) {
-		repo := t.TempDir()
-		outsideDir := t.TempDir()
-		outsidePath := writeAdvisoryFixture(t, outsideDir, "outside.yml")
-		linkPath := filepath.Join(repo, "linked.yml")
-		if err := os.Symlink(outsidePath, linkPath); err != nil {
-			t.Skipf("symlink not supported: %v", err)
-		}
-		writeConfigAdvisorySource(t, repo, "linked.yml")
-		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
-		if err != nil {
-			t.Fatalf("resolve analysis request: %v", err)
-		}
-		if _, err := advisory.LoadWithinRoot(resolved.advisorySourceRoot, resolved.advisorySourcePath); !errors.Is(err, safeio.ErrTargetPathSymlink) {
-			t.Fatalf("expected symlink advisory path to remain confined, got %v", err)
-		}
-	})
+	for _, tc := range advisoryTrustBoundaryCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, args, assertResolved := tc.prepare(t)
+			assertAdvisoryTrustBoundary(t, server, repo, args, assertResolved)
+		})
+	}
 }
 
 func TestBaselineHelpers(t *testing.T) {
@@ -700,6 +633,106 @@ func writeConfigAdvisorySource(t *testing.T, repo string, source string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: "+source+"\n"), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
+	}
+}
+
+type advisoryTrustBoundaryCase struct {
+	name    string
+	prepare func(t *testing.T) (string, analysisToolArguments, func(*testing.T, resolvedToolRequest))
+}
+
+func advisoryTrustBoundaryCases() []advisoryTrustBoundaryCase {
+	return []advisoryTrustBoundaryCase{
+		{
+			name: "config advisory source keeps trusted root",
+			prepare: func(t *testing.T) (string, analysisToolArguments, func(*testing.T, resolvedToolRequest)) {
+				repo := t.TempDir()
+				advisoriesPath := writeAdvisoryFixture(t, repo, "advisories.yml")
+				writeConfigAdvisorySource(t, repo, "advisories.yml")
+				return repo, advisoryFeatureArgs(repo), func(t *testing.T, resolved resolvedToolRequest) {
+					t.Helper()
+					if resolved.advisorySourcePath != advisoriesPath || resolved.advisorySourceRoot != repo {
+						t.Fatalf("expected config advisory trust boundary, got path=%q root=%q", resolved.advisorySourcePath, resolved.advisorySourceRoot)
+					}
+				}
+			},
+		},
+		{
+			name: "explicit MCP override clears trusted root",
+			prepare: func(t *testing.T) (string, analysisToolArguments, func(*testing.T, resolvedToolRequest)) {
+				repo := t.TempDir()
+				writeConfigAdvisorySource(t, repo, "advisories.yml")
+				args := advisoryFeatureArgs(repo)
+				args.AdvisorySourcePath = "/tmp/override.yml"
+				return repo, args, func(t *testing.T, resolved resolvedToolRequest) {
+					t.Helper()
+					if resolved.advisorySourcePath != "/tmp/override.yml" || resolved.advisorySourceRoot != "" {
+						t.Fatalf("expected explicit override to clear trust root, got path=%q root=%q", resolved.advisorySourcePath, resolved.advisorySourceRoot)
+					}
+				}
+			},
+		},
+		{
+			name: "absolute config advisory path stays confined",
+			prepare: func(t *testing.T) (string, analysisToolArguments, func(*testing.T, resolvedToolRequest)) {
+				repo := t.TempDir()
+				outsidePath := writeAdvisoryFixture(t, t.TempDir(), "outside.yml")
+				writeConfigAdvisorySource(t, repo, filepath.ToSlash(outsidePath))
+				return repo, advisoryFeatureArgs(repo), assertAdvisoryLoadError(safeio.ErrPathEscapesRoot)
+			},
+		},
+		{
+			name: "parent traversal config advisory path stays confined",
+			prepare: func(t *testing.T) (string, analysisToolArguments, func(*testing.T, resolvedToolRequest)) {
+				parent := t.TempDir()
+				repo := filepath.Join(parent, "repo")
+				if err := os.Mkdir(repo, 0o755); err != nil {
+					t.Fatalf("mkdir repo: %v", err)
+				}
+				writeAdvisoryFixture(t, parent, "outside.yml")
+				writeConfigAdvisorySource(t, repo, "../outside.yml")
+				return repo, advisoryFeatureArgs(repo), assertAdvisoryLoadError(safeio.ErrPathEscapesRoot)
+			},
+		},
+		{
+			name: "symlink config advisory path stays confined",
+			prepare: func(t *testing.T) (string, analysisToolArguments, func(*testing.T, resolvedToolRequest)) {
+				repo := t.TempDir()
+				outsideDir := t.TempDir()
+				outsidePath := writeAdvisoryFixture(t, outsideDir, "outside.yml")
+				linkPath := filepath.Join(repo, "linked.yml")
+				if err := os.Symlink(outsidePath, linkPath); err != nil {
+					t.Skipf("symlink not supported: %v", err)
+				}
+				writeConfigAdvisorySource(t, repo, "linked.yml")
+				return repo, advisoryFeatureArgs(repo), assertAdvisoryLoadError(safeio.ErrTargetPathSymlink)
+			},
+		},
+	}
+}
+
+func advisoryFeatureArgs(repo string) analysisToolArguments {
+	return analysisToolArguments{
+		RepoPath:       repo,
+		EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature},
+	}
+}
+
+func assertAdvisoryTrustBoundary(t *testing.T, server *Server, repo string, args analysisToolArguments, assertResolved func(*testing.T, resolvedToolRequest)) {
+	t.Helper()
+	resolved, err := server.resolveAnalysisRequest(context.Background(), args, analysisToolKindTop)
+	if err != nil {
+		t.Fatalf("resolve analysis request: %v", err)
+	}
+	assertResolved(t, resolved)
+}
+
+func assertAdvisoryLoadError(want error) func(*testing.T, resolvedToolRequest) {
+	return func(t *testing.T, resolved resolvedToolRequest) {
+		t.Helper()
+		if _, err := advisory.LoadWithinRoot(resolved.advisorySourceRoot, resolved.advisorySourcePath); !errors.Is(err, want) {
+			t.Fatalf("expected advisory path to remain confined, got %v", err)
+		}
 	}
 }
 

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -12,9 +12,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ben-ranford/lopper/internal/advisory"
 	"github.com/ben-ranford/lopper/internal/analysis"
 	"github.com/ben-ranford/lopper/internal/featureflags"
 	"github.com/ben-ranford/lopper/internal/report"
+	"github.com/ben-ranford/lopper/internal/safeio"
 	"github.com/ben-ranford/lopper/internal/thresholds"
 	"github.com/ben-ranford/lopper/internal/version"
 )
@@ -440,11 +442,11 @@ func TestThresholdAndPolicyHelpers(t *testing.T) {
 	if !values.LicenseFailOnDeny || !values.LicenseIncludeRegistryProvenance || values.ReachableVulnerabilityPriority != report.VulnerabilityPriorityHigh {
 		t.Fatalf("expected license policy values, got %#v", values)
 	}
-	if got := resolveAdvisorySourcePath(thresholds.LoadResult{AdvisorySourcePath: "config.yml"}, analysisToolArguments{}); got != "config.yml" {
-		t.Fatalf("expected config advisory source, got %q", got)
+	if gotPath, gotRoot := resolveAdvisorySource(thresholds.LoadResult{AdvisorySourcePath: "config.yml", AdvisorySourceTrustRoot: repo}, analysisToolArguments{}); gotPath != "config.yml" || gotRoot != repo {
+		t.Fatalf("expected config advisory source and trust root, got path=%q root=%q", gotPath, gotRoot)
 	}
-	if got := resolveAdvisorySourcePath(thresholds.LoadResult{AdvisorySourcePath: "config.yml"}, analysisToolArguments{AdvisorySourcePath: "cli.yml"}); got != "cli.yml" {
-		t.Fatalf("expected argument advisory source, got %q", got)
+	if gotPath, gotRoot := resolveAdvisorySource(thresholds.LoadResult{AdvisorySourcePath: "config.yml", AdvisorySourceTrustRoot: repo}, analysisToolArguments{AdvisorySourcePath: "cli.yml"}); gotPath != "cli.yml" || gotRoot != "" {
+		t.Fatalf("expected argument advisory source to clear trust root, got path=%q root=%q", gotPath, gotRoot)
 	}
 	if got := prependPolicySource("mcp", []string{"mcp", "defaults"}); !slicesEqual(got, []string{"mcp", "defaults"}) {
 		t.Fatalf("unexpected deduped sources: %#v", got)
@@ -455,6 +457,110 @@ func TestThresholdAndPolicyHelpers(t *testing.T) {
 	if got := mergeMCPPolicyTrace(nil, analysisToolArguments{LowConfidenceWarningPercent: intPtr(35)}); len(got) != 1 || got[0].Source != "mcp" {
 		t.Fatalf("unexpected appended trace merge: %#v", got)
 	}
+}
+
+func TestResolveAnalysisRequestAdvisoryTrustBoundaries(t *testing.T) {
+	server := NewServer(Options{})
+
+	t.Run("config advisory source keeps trusted root", func(t *testing.T) {
+		repo := t.TempDir()
+		advisoriesPath := filepath.Join(repo, "advisories.yml")
+		if err := os.WriteFile(advisoriesPath, []byte("advisories:\n  - id: GHSA-config\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
+			t.Fatalf("write advisories: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: advisories.yml\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
+		if err != nil {
+			t.Fatalf("resolve analysis request: %v", err)
+		}
+		if resolved.advisorySourcePath != advisoriesPath || resolved.advisorySourceRoot != repo {
+			t.Fatalf("expected config advisory trust boundary, got path=%q root=%q", resolved.advisorySourcePath, resolved.advisorySourceRoot)
+		}
+	})
+
+	t.Run("explicit MCP override clears trusted root", func(t *testing.T) {
+		repo := t.TempDir()
+		if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: advisories.yml\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, AdvisorySourcePath: "/tmp/override.yml", EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
+		if err != nil {
+			t.Fatalf("resolve analysis request: %v", err)
+		}
+		if resolved.advisorySourcePath != "/tmp/override.yml" || resolved.advisorySourceRoot != "" {
+			t.Fatalf("expected explicit override to clear trust root, got path=%q root=%q", resolved.advisorySourcePath, resolved.advisorySourceRoot)
+		}
+	})
+
+	t.Run("absolute config advisory path stays confined", func(t *testing.T) {
+		repo := t.TempDir()
+		outsidePath := filepath.Join(t.TempDir(), "outside.yml")
+		if err := os.WriteFile(outsidePath, []byte("advisories:\n  - id: GHSA-outside\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
+			t.Fatalf("write outside advisories: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: "+filepath.ToSlash(outsidePath)+"\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
+		if err != nil {
+			t.Fatalf("resolve analysis request: %v", err)
+		}
+		if _, err := advisory.LoadWithinRoot(resolved.advisorySourceRoot, resolved.advisorySourcePath); !errors.Is(err, safeio.ErrPathEscapesRoot) {
+			t.Fatalf("expected absolute advisory path to remain confined, got %v", err)
+		}
+	})
+
+	t.Run("parent traversal config advisory path stays confined", func(t *testing.T) {
+		parent := t.TempDir()
+		repo := filepath.Join(parent, "repo")
+		if err := os.Mkdir(repo, 0o755); err != nil {
+			t.Fatalf("mkdir repo: %v", err)
+		}
+		outsidePath := filepath.Join(parent, "outside.yml")
+		if err := os.WriteFile(outsidePath, []byte("advisories:\n  - id: GHSA-outside\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
+			t.Fatalf("write outside advisories: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: ../outside.yml\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
+		if err != nil {
+			t.Fatalf("resolve analysis request: %v", err)
+		}
+		if _, err := advisory.LoadWithinRoot(resolved.advisorySourceRoot, resolved.advisorySourcePath); !errors.Is(err, safeio.ErrPathEscapesRoot) {
+			t.Fatalf("expected traversal advisory path to remain confined, got %v", err)
+		}
+	})
+
+	t.Run("symlink config advisory path stays confined", func(t *testing.T) {
+		repo := t.TempDir()
+		outsideDir := t.TempDir()
+		outsidePath := filepath.Join(outsideDir, "outside.yml")
+		if err := os.WriteFile(outsidePath, []byte("advisories:\n  - id: GHSA-outside\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
+			t.Fatalf("write outside advisories: %v", err)
+		}
+		linkPath := filepath.Join(repo, "linked.yml")
+		if err := os.Symlink(outsidePath, linkPath); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: linked.yml\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
+		if err != nil {
+			t.Fatalf("resolve analysis request: %v", err)
+		}
+		if _, err := advisory.LoadWithinRoot(resolved.advisorySourceRoot, resolved.advisorySourcePath); !errors.Is(err, safeio.ErrTargetPathSymlink) {
+			t.Fatalf("expected symlink advisory path to remain confined, got %v", err)
+		}
+	})
 }
 
 func TestBaselineHelpers(t *testing.T) {

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -411,52 +411,10 @@ func TestDefaultServerFeatureBranches(t *testing.T) {
 
 func TestThresholdAndPolicyHelpers(t *testing.T) {
 	repo := t.TempDir()
-	bad := analysisToolArguments{LowConfidenceWarningPercent: intPtr(101)}
-	if _, _, _, _, err := resolveThresholds(repo, bad); err == nil {
-		t.Fatalf("expected threshold override validation error")
-	}
-	if _, _, _, _, err := resolveThresholds(repo, analysisToolArguments{ConfigPath: "missing.yml"}); err == nil {
-		t.Fatalf("expected missing config error")
-	}
-
-	args := analysisToolArguments{
-		LowConfidenceWarningPercent:       intPtr(35),
-		MinUsagePercentForRecommendations: intPtr(45),
-		MaxUncertainImportCount:           intPtr(3),
-		ScoreWeightUsage:                  floatPtr(0.5),
-		ScoreWeightImpact:                 floatPtr(0.3),
-		ScoreWeightConfidence:             floatPtr(0.2),
-		LicenseDeny:                       []string{"MIT"},
-		LicenseFailOnDeny:                 boolPtr(true),
-		LicenseProvenanceRegistry:         boolPtr(true),
-		ReachableVulnerabilityPriority:    stringPtr(report.VulnerabilityPriorityHigh),
-		AdvisorySourcePath:                "advisories.yml",
-	}
-	_, values, sources, trace, err := resolveThresholds(repo, args)
-	if err != nil {
-		t.Fatalf("resolve thresholds: %v", err)
-	}
-	if sources[0] != "mcp" || policyTraceSource(trace, "license.fail_on_deny") != "mcp" || policyTraceSource(trace, "advisories.source") != "mcp" {
-		t.Fatalf("expected mcp policy metadata, sources=%#v trace=%#v", sources, trace)
-	}
-	if !values.LicenseFailOnDeny || !values.LicenseIncludeRegistryProvenance || values.ReachableVulnerabilityPriority != report.VulnerabilityPriorityHigh {
-		t.Fatalf("expected license policy values, got %#v", values)
-	}
-	if gotPath, gotRoot := resolveAdvisorySource(thresholds.LoadResult{AdvisorySourcePath: "config.yml", AdvisorySourceTrustRoot: repo}, analysisToolArguments{}); gotPath != "config.yml" || gotRoot != repo {
-		t.Fatalf("expected config advisory source and trust root, got path=%q root=%q", gotPath, gotRoot)
-	}
-	if gotPath, gotRoot := resolveAdvisorySource(thresholds.LoadResult{AdvisorySourcePath: "config.yml", AdvisorySourceTrustRoot: repo}, analysisToolArguments{AdvisorySourcePath: "cli.yml"}); gotPath != "cli.yml" || gotRoot != "" {
-		t.Fatalf("expected argument advisory source to clear trust root, got path=%q root=%q", gotPath, gotRoot)
-	}
-	if got := prependPolicySource("mcp", []string{"mcp", "defaults"}); !slicesEqual(got, []string{"mcp", "defaults"}) {
-		t.Fatalf("unexpected deduped sources: %#v", got)
-	}
-	if got := mergeMCPPolicyTrace([]report.PolicyMergeTrace{{Field: "existing", Source: "defaults"}}, analysisToolArguments{}); len(got) != 1 || got[0].Source != "defaults" {
-		t.Fatalf("unexpected no-op trace merge: %#v", got)
-	}
-	if got := mergeMCPPolicyTrace(nil, analysisToolArguments{LowConfidenceWarningPercent: intPtr(35)}); len(got) != 1 || got[0].Source != "mcp" {
-		t.Fatalf("unexpected appended trace merge: %#v", got)
-	}
+	assertResolveThresholdsErrors(t, repo)
+	assertResolvedThresholdPolicyValues(t, repo)
+	assertAdvisorySourceResolution(t, repo)
+	assertMCPPolicyTraceHelpers(t)
 }
 
 func TestResolveAnalysisRequestAdvisoryTrustBoundaries(t *testing.T) {
@@ -464,14 +422,8 @@ func TestResolveAnalysisRequestAdvisoryTrustBoundaries(t *testing.T) {
 
 	t.Run("config advisory source keeps trusted root", func(t *testing.T) {
 		repo := t.TempDir()
-		advisoriesPath := filepath.Join(repo, "advisories.yml")
-		if err := os.WriteFile(advisoriesPath, []byte("advisories:\n  - id: GHSA-config\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
-			t.Fatalf("write advisories: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: advisories.yml\n"), 0o600); err != nil {
-			t.Fatalf("write config: %v", err)
-		}
-
+		advisoriesPath := writeAdvisoryFixture(t, repo, "advisories.yml")
+		writeConfigAdvisorySource(t, repo, "advisories.yml")
 		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
 		if err != nil {
 			t.Fatalf("resolve analysis request: %v", err)
@@ -483,10 +435,7 @@ func TestResolveAnalysisRequestAdvisoryTrustBoundaries(t *testing.T) {
 
 	t.Run("explicit MCP override clears trusted root", func(t *testing.T) {
 		repo := t.TempDir()
-		if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: advisories.yml\n"), 0o600); err != nil {
-			t.Fatalf("write config: %v", err)
-		}
-
+		writeConfigAdvisorySource(t, repo, "advisories.yml")
 		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, AdvisorySourcePath: "/tmp/override.yml", EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
 		if err != nil {
 			t.Fatalf("resolve analysis request: %v", err)
@@ -498,14 +447,8 @@ func TestResolveAnalysisRequestAdvisoryTrustBoundaries(t *testing.T) {
 
 	t.Run("absolute config advisory path stays confined", func(t *testing.T) {
 		repo := t.TempDir()
-		outsidePath := filepath.Join(t.TempDir(), "outside.yml")
-		if err := os.WriteFile(outsidePath, []byte("advisories:\n  - id: GHSA-outside\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
-			t.Fatalf("write outside advisories: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: "+filepath.ToSlash(outsidePath)+"\n"), 0o600); err != nil {
-			t.Fatalf("write config: %v", err)
-		}
-
+		outsidePath := writeAdvisoryFixture(t, t.TempDir(), "outside.yml")
+		writeConfigAdvisorySource(t, repo, filepath.ToSlash(outsidePath))
 		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
 		if err != nil {
 			t.Fatalf("resolve analysis request: %v", err)
@@ -521,14 +464,8 @@ func TestResolveAnalysisRequestAdvisoryTrustBoundaries(t *testing.T) {
 		if err := os.Mkdir(repo, 0o755); err != nil {
 			t.Fatalf("mkdir repo: %v", err)
 		}
-		outsidePath := filepath.Join(parent, "outside.yml")
-		if err := os.WriteFile(outsidePath, []byte("advisories:\n  - id: GHSA-outside\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
-			t.Fatalf("write outside advisories: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: ../outside.yml\n"), 0o600); err != nil {
-			t.Fatalf("write config: %v", err)
-		}
-
+		writeAdvisoryFixture(t, parent, "outside.yml")
+		writeConfigAdvisorySource(t, repo, "../outside.yml")
 		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
 		if err != nil {
 			t.Fatalf("resolve analysis request: %v", err)
@@ -541,18 +478,12 @@ func TestResolveAnalysisRequestAdvisoryTrustBoundaries(t *testing.T) {
 	t.Run("symlink config advisory path stays confined", func(t *testing.T) {
 		repo := t.TempDir()
 		outsideDir := t.TempDir()
-		outsidePath := filepath.Join(outsideDir, "outside.yml")
-		if err := os.WriteFile(outsidePath, []byte("advisories:\n  - id: GHSA-outside\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
-			t.Fatalf("write outside advisories: %v", err)
-		}
+		outsidePath := writeAdvisoryFixture(t, outsideDir, "outside.yml")
 		linkPath := filepath.Join(repo, "linked.yml")
 		if err := os.Symlink(outsidePath, linkPath); err != nil {
 			t.Skipf("symlink not supported: %v", err)
 		}
-		if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: linked.yml\n"), 0o600); err != nil {
-			t.Fatalf("write config: %v", err)
-		}
-
+		writeConfigAdvisorySource(t, repo, "linked.yml")
 		resolved, err := server.resolveAnalysisRequest(context.Background(), analysisToolArguments{RepoPath: repo, EnableFeatures: []string{report.ReachabilityVulnerabilityPrioritizationPreviewFeature}}, analysisToolKindTop)
 		if err != nil {
 			t.Fatalf("resolve analysis request: %v", err)
@@ -693,6 +624,83 @@ func stringPtr(value string) *string {
 
 func boolPtr(value bool) *bool {
 	return &value
+}
+
+func assertResolveThresholdsErrors(t *testing.T, repo string) {
+	t.Helper()
+	bad := analysisToolArguments{LowConfidenceWarningPercent: intPtr(101)}
+	if _, _, _, _, err := resolveThresholds(repo, bad); err == nil {
+		t.Fatalf("expected threshold override validation error")
+	}
+	if _, _, _, _, err := resolveThresholds(repo, analysisToolArguments{ConfigPath: "missing.yml"}); err == nil {
+		t.Fatalf("expected missing config error")
+	}
+}
+
+func assertResolvedThresholdPolicyValues(t *testing.T, repo string) {
+	t.Helper()
+	args := analysisToolArguments{
+		LowConfidenceWarningPercent:       intPtr(35),
+		MinUsagePercentForRecommendations: intPtr(45),
+		MaxUncertainImportCount:           intPtr(3),
+		ScoreWeightUsage:                  floatPtr(0.5),
+		ScoreWeightImpact:                 floatPtr(0.3),
+		ScoreWeightConfidence:             floatPtr(0.2),
+		LicenseDeny:                       []string{"MIT"},
+		LicenseFailOnDeny:                 boolPtr(true),
+		LicenseProvenanceRegistry:         boolPtr(true),
+		ReachableVulnerabilityPriority:    stringPtr(report.VulnerabilityPriorityHigh),
+		AdvisorySourcePath:                "advisories.yml",
+	}
+	_, values, sources, trace, err := resolveThresholds(repo, args)
+	if err != nil {
+		t.Fatalf("resolve thresholds: %v", err)
+	}
+	if sources[0] != "mcp" || policyTraceSource(trace, "license.fail_on_deny") != "mcp" || policyTraceSource(trace, "advisories.source") != "mcp" {
+		t.Fatalf("expected mcp policy metadata, sources=%#v trace=%#v", sources, trace)
+	}
+	if !values.LicenseFailOnDeny || !values.LicenseIncludeRegistryProvenance || values.ReachableVulnerabilityPriority != report.VulnerabilityPriorityHigh {
+		t.Fatalf("expected license policy values, got %#v", values)
+	}
+}
+
+func assertAdvisorySourceResolution(t *testing.T, repo string) {
+	t.Helper()
+	if gotPath, gotRoot := resolveAdvisorySource(thresholds.LoadResult{AdvisorySourcePath: "config.yml", AdvisorySourceTrustRoot: repo}, analysisToolArguments{}); gotPath != "config.yml" || gotRoot != repo {
+		t.Fatalf("expected config advisory source and trust root, got path=%q root=%q", gotPath, gotRoot)
+	}
+	if gotPath, gotRoot := resolveAdvisorySource(thresholds.LoadResult{AdvisorySourcePath: "config.yml", AdvisorySourceTrustRoot: repo}, analysisToolArguments{AdvisorySourcePath: "cli.yml"}); gotPath != "cli.yml" || gotRoot != "" {
+		t.Fatalf("expected argument advisory source to clear trust root, got path=%q root=%q", gotPath, gotRoot)
+	}
+}
+
+func assertMCPPolicyTraceHelpers(t *testing.T) {
+	t.Helper()
+	if got := prependPolicySource("mcp", []string{"mcp", "defaults"}); !slicesEqual(got, []string{"mcp", "defaults"}) {
+		t.Fatalf("unexpected deduped sources: %#v", got)
+	}
+	if got := mergeMCPPolicyTrace([]report.PolicyMergeTrace{{Field: "existing", Source: "defaults"}}, analysisToolArguments{}); len(got) != 1 || got[0].Source != "defaults" {
+		t.Fatalf("unexpected no-op trace merge: %#v", got)
+	}
+	if got := mergeMCPPolicyTrace(nil, analysisToolArguments{LowConfidenceWarningPercent: intPtr(35)}); len(got) != 1 || got[0].Source != "mcp" {
+		t.Fatalf("unexpected appended trace merge: %#v", got)
+	}
+}
+
+func writeAdvisoryFixture(t *testing.T, dir string, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("advisories:\n  - id: GHSA-outside\n    package: lib\n    ecosystem: npm\n    severity: high\n"), 0o600); err != nil {
+		t.Fatalf("write advisories: %v", err)
+	}
+	return path
+}
+
+func writeConfigAdvisorySource(t *testing.T, repo string, source string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, ".lopper.yml"), []byte("advisories:\n  source: "+source+"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 }
 
 func slicesEqual(left, right []string) bool {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -130,6 +130,7 @@ type resolvedToolRequest struct {
 	policySources      []string
 	policyTrace        []report.PolicyMergeTrace
 	advisorySourcePath string
+	advisorySourceRoot string
 	baselinePath       string
 	baselineKey        string
 	currentKey         string
@@ -248,7 +249,7 @@ func (s *Server) runAnalysisTool(ctx context.Context, rawArgs json.RawMessage, k
 		return analysisErrorResult(err)
 	}
 	if resolved.advisorySourcePath != "" {
-		advisories, err := advisory.Load(resolved.advisorySourcePath)
+		advisories, err := advisory.LoadWithinRoot(resolved.advisorySourceRoot, resolved.advisorySourcePath)
 		if err != nil {
 			return analysisErrorResult(err)
 		}
@@ -309,7 +310,7 @@ func (s *Server) resolveAnalysisRequest(ctx context.Context, args analysisToolAr
 	if err != nil {
 		return resolvedToolRequest{}, err
 	}
-	advisorySourcePath := resolveAdvisorySourcePath(loadResult, args)
+	advisorySourcePath, advisorySourceRoot := resolveAdvisorySource(loadResult, args)
 	if err := validateAnalysisVulnerabilityFeature(features, thresholdsValue, advisorySourcePath); err != nil {
 		return resolvedToolRequest{}, err
 	}
@@ -320,6 +321,7 @@ func (s *Server) resolveAnalysisRequest(ctx context.Context, args analysisToolAr
 		policySources:      policySources,
 		policyTrace:        policyTrace,
 		advisorySourcePath: advisorySourcePath,
+		advisorySourceRoot: advisorySourceRoot,
 		baselinePath:       baselinePath,
 		baselineKey:        baselineKey,
 		currentKey:         currentKey,
@@ -702,11 +704,11 @@ func mcpPolicyTrace(args analysisToolArguments) []report.PolicyMergeTrace {
 	return trace
 }
 
-func resolveAdvisorySourcePath(loadResult thresholds.LoadResult, args analysisToolArguments) string {
+func resolveAdvisorySource(loadResult thresholds.LoadResult, args analysisToolArguments) (string, string) {
 	if path := strings.TrimSpace(args.AdvisorySourcePath); path != "" {
-		return path
+		return path, ""
 	}
-	return strings.TrimSpace(loadResult.AdvisorySourcePath)
+	return strings.TrimSpace(loadResult.AdvisorySourcePath), strings.TrimSpace(loadResult.AdvisorySourceTrustRoot)
 }
 
 func validateAnalysisVulnerabilityFeature(features featureflags.Set, values thresholds.Values, advisorySourcePath string) error {

--- a/internal/thresholds/config.go
+++ b/internal/thresholds/config.go
@@ -20,6 +20,7 @@ type LoadResult struct {
 	Scope                   PathScope
 	Features                FeatureConfig
 	AdvisorySourcePath      string
+	AdvisorySourceTrustRoot string
 	VulnerabilityExceptions []report.VulnerabilityException
 	ConfigPath              string
 	PolicySources           []string
@@ -65,6 +66,7 @@ func LoadWithPolicy(repoPath, explicitPath string) (LoadResult, error) {
 			Scope:                   normalizePathScope(PathScope{}),
 			Features:                normalizeFeatureConfig(FeatureConfig{}),
 			AdvisorySourcePath:      "",
+			AdvisorySourceTrustRoot: "",
 			VulnerabilityExceptions: nil,
 			PolicySources:           []string{defaultPolicySource},
 			PolicyTrace:             policyTraceFromMap(defaultPolicyTrace()),
@@ -91,6 +93,7 @@ func LoadWithPolicy(repoPath, explicitPath string) (LoadResult, error) {
 		Scope:                   normalizePathScope(mergeResult.scope),
 		Features:                normalizeFeatureConfig(mergeResult.features),
 		AdvisorySourcePath:      mergeResult.advisorySource.source,
+		AdvisorySourceTrustRoot: mergeResult.advisorySource.trustRoot,
 		VulnerabilityExceptions: append([]report.VulnerabilityException{}, mergeResult.vulnerabilityExceptions.exceptions...),
 		ConfigPath:              configPath,
 		PolicySources:           mergeResult.policySourcesHighToLow(),

--- a/internal/thresholds/config_overrides.go
+++ b/internal/thresholds/config_overrides.go
@@ -60,7 +60,7 @@ func (c *rawConfig) toOverrides() (Overrides, error) {
 	if err := applyNestedStringOverride("lockfile_drift_policy", &overrides.LockfileDriftPolicy, c.Thresholds.LockfileDriftPolicy); err != nil {
 		return Overrides{}, err
 	}
-	if err := applyNestedListOverride("license_deny", &overrides.LicenseDenyList, &overrides.licenseDenyListSet, c.Thresholds.LicenseDeny); err != nil {
+	if err := applyNestedListOverride("license_deny", &overrides.LicenseDenyList, c.Thresholds.LicenseDeny, &overrides.licenseDenyListSet); err != nil {
 		return Overrides{}, err
 	}
 	if err := applyNestedBoolOverride("license_fail_on_deny", &overrides.LicenseFailOnDeny, c.Thresholds.LicenseFailOnDeny); err != nil {
@@ -108,7 +108,7 @@ func applyNestedStringOverride(name string, target **string, nested *string) err
 	return nil
 }
 
-func applyNestedListOverride(name string, target *[]string, targetSet *bool, nested *[]string) error {
+func applyNestedListOverride(name string, target *[]string, nested *[]string, targetSet *bool) error {
 	if nested == nil {
 		return nil
 	}

--- a/internal/thresholds/config_overrides.go
+++ b/internal/thresholds/config_overrides.go
@@ -206,8 +206,9 @@ func mergeFeatures(base, higher FeatureConfig) FeatureConfig {
 }
 
 type advisorySourceConfig struct {
-	source string
-	set    bool
+	source    string
+	trustRoot string
+	set       bool
 }
 
 type vulnerabilityExceptionConfig struct {
@@ -215,7 +216,7 @@ type vulnerabilityExceptionConfig struct {
 	set        bool
 }
 
-func (a *rawAdvisories) toAdvisorySourceConfig(configPath string) advisorySourceConfig {
+func (a *rawAdvisories) toAdvisorySourceConfig(configPath string, trustRoot string) advisorySourceConfig {
 	if a == nil || a.Source == nil {
 		return advisorySourceConfig{}
 	}
@@ -224,9 +225,13 @@ func (a *rawAdvisories) toAdvisorySourceConfig(configPath string) advisorySource
 		return advisorySourceConfig{set: true}
 	}
 	if filepath.IsAbs(source) {
-		return advisorySourceConfig{source: filepath.Clean(source), set: true}
+		return advisorySourceConfig{source: filepath.Clean(source), trustRoot: strings.TrimSpace(trustRoot), set: true}
 	}
-	return advisorySourceConfig{source: filepath.Clean(filepath.Join(filepath.Dir(configPath), source)), set: true}
+	return advisorySourceConfig{
+		source:    filepath.Clean(filepath.Join(filepath.Dir(configPath), source)),
+		trustRoot: strings.TrimSpace(trustRoot),
+		set:       true,
+	}
 }
 
 func (a *rawAdvisories) toVulnerabilityExceptionConfig(configPath string) (vulnerabilityExceptionConfig, error) {

--- a/internal/thresholds/config_overrides.go
+++ b/internal/thresholds/config_overrides.go
@@ -216,7 +216,7 @@ type vulnerabilityExceptionConfig struct {
 	set        bool
 }
 
-func (a *rawAdvisories) toAdvisorySourceConfig(configPath string, trustRoot string) advisorySourceConfig {
+func (a *rawAdvisories) toAdvisorySourceConfig(configPath, trustRoot string) advisorySourceConfig {
 	if a == nil || a.Source == nil {
 		return advisorySourceConfig{}
 	}

--- a/internal/thresholds/config_packs.go
+++ b/internal/thresholds/config_packs.go
@@ -118,7 +118,7 @@ func (r *packResolver) resolveFile(path string, trust packTrust) (resolveMergeRe
 	merged = mergeOverrides(merged, selfOverrides)
 	mergedScope = mergeScope(mergedScope, cfg.Scope.toPathScope())
 	mergedFeatures = mergeFeatures(mergedFeatures, cfg.Features.toFeatureConfig())
-	selfAdvisorySource := cfg.Advisories.toAdvisorySourceConfig(canonical)
+	selfAdvisorySource := cfg.Advisories.toAdvisorySourceConfig(canonical, trust.localRoot)
 	mergedAdvisorySource = mergeAdvisorySource(mergedAdvisorySource, selfAdvisorySource)
 	selfVulnerabilityExceptions, err := cfg.Advisories.toVulnerabilityExceptionConfig(canonical)
 	if err != nil {

--- a/internal/thresholds/config_test.go
+++ b/internal/thresholds/config_test.go
@@ -79,6 +79,9 @@ func TestLoadYAMLConfig(t *testing.T) {
 	if want := filepath.Join(repo, "security", "advisories.yml"); result.AdvisorySourcePath != want {
 		t.Fatalf("expected advisory source path %q, got %q", want, result.AdvisorySourcePath)
 	}
+	if result.AdvisorySourceTrustRoot != repo {
+		t.Fatalf("expected advisory trust root %q, got %q", repo, result.AdvisorySourceTrustRoot)
+	}
 }
 
 func TestLoadYAMLConfigAllowsDisabledSentinelThresholds(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #1214

Repo-scoped config loading allowed `.lopper.yml` to point `advisories.source` at an absolute path or a relative path that resolved outside the trusted repository root, so analysing an untrusted repository could read advisory content from elsewhere on disk.

## Changes

- Added `advisory.LoadWithinRoot` so advisory files loaded from repository config are read through the trusted root boundary instead of unrestricted filesystem reads.
- Threaded `AdvisorySourceTrustRoot` from threshold/config resolution through analyse and PR review request handling, and clear that trust root when a CLI advisory override is used.
- Added request/config propagation and trusted-boundary regression coverage in base-compilable `internal/app`, plus propagation tests in `internal/cli` and `internal/thresholds`, while keeping head-only advisory boundary coverage out of regressionproof-selected packages.

## Validation

Commands and checks run:

```bash
go test ./internal/app -run '^TestAnalysePRReviewWorktreeRejectsEscapingTrustedAdvisorySource$'
go test ./internal/advisory ./internal/app ./internal/cli ./internal/thresholds
make ci
```

Additional manual validation:

- Confirmed the branch contains one unique commit and both author and committer are `Ben Ranford <84072202+ben-ranford@users.noreply.github.com>`.
- Confirmed the working tree was clean before push apart from transient local `__pycache__` artifacts removed before publication.

Regression-Test: ./internal/app::TestAnalysePRReviewWorktreeRejectsEscapingTrustedAdvisorySource

## Risk and compatibility

- Breaking changes: No.
- Migration required: No.
- Performance impact: None expected; `make ci` memory benchmark gate passed.
- Memory benchmark impact: None observed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

