### PR TITLE
fix(mcp): confine baseline store paths to repo

### DIFF
--- a/internal/app/app_mcp_mutations_test.go
+++ b/internal/app/app_mcp_mutations_test.go
@@ -134,6 +134,34 @@ func TestExecuteMCPSaveBaselineMutation(t *testing.T) {
 	}
 }
 
+func TestExecuteMCPSaveBaselineMutationRejectsOutOfRepoStorePath(t *testing.T) {
+	repo, _ := setupMCPGitLodashFixture(t)
+	outsideRoot := t.TempDir()
+
+	response := executeMCPTool(t, "lopper_save_baseline", map[string]any{
+		"repoPath":          repo,
+		"topN":              1,
+		"baselineStorePath": filepath.Join("..", filepath.Base(outsideRoot)),
+		"baselineLabel":     "nightly",
+		"confirmSave":       true,
+		"cacheEnabled":      false,
+		"timeoutMillis":     10000,
+	})
+	if response.Result == nil || !response.Result.IsError {
+		t.Fatalf("expected out-of-repo baseline store rejection, got %#v", response)
+	}
+	if !strings.Contains(response.Result.Content[0].Text, "must resolve within repoPath") {
+		t.Fatalf("expected repo boundary error, got %#v", response.Result.Content)
+	}
+	entries, err := os.ReadDir(outsideRoot)
+	if err != nil {
+		t.Fatalf("read outside store root: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no outside artifacts to be created, found %d entries", len(entries))
+	}
+}
+
 func TestExecuteMCPSaveDashboardBaselineMutation(t *testing.T) {
 	repo, _ := setupMCPGitLodashFixture(t)
 

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -469,6 +469,10 @@ func TestSmallHelperBranches(t *testing.T) {
 	if _, _, err := contextForTimeout(context.Background(), maxTimeoutMillis+1); err == nil {
 		t.Fatalf("expected invalid timeout")
 	}
+	repo := t.TempDir()
+	if got, err := validateRepoPath(repo); err != nil || got == "" {
+		t.Fatalf("expected valid repo path, got path=%q err=%v", got, err)
+	}
 	file := filepath.Join(t.TempDir(), "file")
 	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
 		t.Fatalf("write file: %v", err)
@@ -526,6 +530,15 @@ func TestSummarizeReportBranches(t *testing.T) {
 	withBaseline.BaselineComparison = &report.BaselineComparison{SummaryDelta: report.SummaryDelta{WastePercentDelta: 2.5}}
 	if got := summarizeReport(analysisToolKindCompare, withBaseline); !strings.Contains(got, "Waste delta") {
 		t.Fatalf("unexpected baseline summary: %q", got)
+	}
+	withRuntimeChanges := sampleReport(".")
+	withRuntimeChanges.BaselineComparison = &report.BaselineComparison{
+		SummaryDelta:        report.SummaryDelta{WastePercentDelta: 1.0},
+		RuntimeRegressions:  []report.DependencyDelta{{Name: "dep-a"}},
+		RuntimeImprovements: []report.DependencyDelta{{Name: "dep-b"}},
+	}
+	if got := summarizeReport(analysisToolKindCompare, withRuntimeChanges); !strings.Contains(got, "Runtime regressions: 1. Runtime improvements: 1.") {
+		t.Fatalf("unexpected runtime delta summary: %q", got)
 	}
 }
 

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -429,26 +429,10 @@ func TestResolveAnalysisRequestAdvisoryTrustBoundaries(t *testing.T) {
 
 func TestBaselineHelpers(t *testing.T) {
 	repo := t.TempDir()
-	if _, _, _, err := resolveBaselineComparison(repo, analysisToolArguments{BaselinePath: "a", BaselineStorePath: "b", BaselineKey: "k"}); err == nil {
-		t.Fatalf("expected baseline conflict")
-	}
-	if _, _, _, err := resolveBaselineComparison(repo, analysisToolArguments{BaselineStorePath: "store"}); err == nil {
-		t.Fatalf("expected missing baseline key")
-	}
-	directPath, directKey, directCurrent, err := resolveBaselineComparison(repo, analysisToolArguments{BaselinePath: "baseline.json", BaselineKey: "ignored"})
-	if err != nil {
-		t.Fatalf("resolve direct baseline: %v", err)
-	}
-	if directPath != "baseline.json" || directKey != "ignored" || directCurrent == "" {
-		t.Fatalf("unexpected direct baseline resolution: path=%q key=%q current=%q", directPath, directKey, directCurrent)
-	}
-	path, key, current, err := resolveBaselineComparison(repo, analysisToolArguments{BaselineStorePath: "store", BaselineKey: "release/1"})
-	if err != nil {
-		t.Fatalf("resolve baseline store: %v", err)
-	}
-	if !strings.Contains(path, "release_1") || key != "release/1" || current == "" {
-		t.Fatalf("unexpected baseline resolution: path=%q key=%q current=%q", path, key, current)
-	}
+	assertResolveBaselineComparisonError(t, repo, analysisToolArguments{BaselinePath: "a", BaselineStorePath: "b", BaselineKey: "k"}, "baseline conflict")
+	assertResolveBaselineComparisonError(t, repo, analysisToolArguments{BaselineStorePath: "store"}, "missing baseline key")
+	assertDirectBaselineResolution(t, repo)
+	assertBaselineStoreResolution(t, repo)
 
 	baselinePath := filepath.Join(repo, "baseline.json")
 	writeJSONFile(t, baselinePath, report.Report{SchemaVersion: report.SchemaVersion, Dependencies: []report.DependencyReport{{Name: "dep", UsedExportsCount: 1, TotalExportsCount: 2, UsedPercent: 50}}})
@@ -462,6 +446,35 @@ func TestBaselineHelpers(t *testing.T) {
 	}
 	if _, err := applyBaseline(currentReport, filepath.Join(repo, "missing.json"), "", "current"); err == nil {
 		t.Fatalf("expected missing baseline error")
+	}
+}
+
+func assertResolveBaselineComparisonError(t *testing.T, repo string, args analysisToolArguments, message string) {
+	t.Helper()
+	if _, _, _, err := resolveBaselineComparison(repo, args); err == nil {
+		t.Fatalf("expected %s", message)
+	}
+}
+
+func assertDirectBaselineResolution(t *testing.T, repo string) {
+	t.Helper()
+	path, key, current, err := resolveBaselineComparison(repo, analysisToolArguments{BaselinePath: "baseline.json", BaselineKey: "ignored"})
+	if err != nil {
+		t.Fatalf("resolve direct baseline: %v", err)
+	}
+	if path != "baseline.json" || key != "ignored" || current == "" {
+		t.Fatalf("unexpected direct baseline resolution: path=%q key=%q current=%q", path, key, current)
+	}
+}
+
+func assertBaselineStoreResolution(t *testing.T, repo string) {
+	t.Helper()
+	path, key, current, err := resolveBaselineComparison(repo, analysisToolArguments{BaselineStorePath: "store", BaselineKey: "release/1"})
+	if err != nil {
+		t.Fatalf("resolve baseline store: %v", err)
+	}
+	if !strings.Contains(path, "release_1") || key != "release/1" || current == "" {
+		t.Fatalf("unexpected baseline resolution: path=%q key=%q current=%q", path, key, current)
 	}
 }
 

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -479,10 +479,24 @@ func assertBaselineStoreResolution(t *testing.T, repo string) {
 }
 
 func TestSmallHelperBranches(t *testing.T) {
+	repo := t.TempDir()
+	assertContextForTimeoutRejectsInvalid(t)
+	assertValidateRepoPathBranches(t, repo)
+	assertParseScopeModeBranches(t)
+	assertCacheEnabledDefaults(t)
+	assertMergeStringOptionsBranches(t)
+	decorateReport(nil, defaultThresholdValues(), nil, nil, "")
+}
+
+func assertContextForTimeoutRejectsInvalid(t *testing.T) {
+	t.Helper()
 	if _, _, err := contextForTimeout(context.Background(), maxTimeoutMillis+1); err == nil {
 		t.Fatalf("expected invalid timeout")
 	}
-	repo := t.TempDir()
+}
+
+func assertValidateRepoPathBranches(t *testing.T, repo string) {
+	t.Helper()
 	if got, err := validateRepoPath(repo); err != nil || got == "" {
 		t.Fatalf("expected valid repo path, got path=%q err=%v", got, err)
 	}
@@ -495,6 +509,10 @@ func TestSmallHelperBranches(t *testing.T) {
 			t.Fatalf("expected validateRepoPath(%q) error", path)
 		}
 	}
+}
+
+func assertParseScopeModeBranches(t *testing.T) {
+	t.Helper()
 	for _, mode := range []string{"", analysis.ScopeModePackage, analysis.ScopeModeRepo, analysis.ScopeModeChangedPackages} {
 		if _, err := parseScopeMode(mode); err != nil {
 			t.Fatalf("parse scope %q: %v", mode, err)
@@ -503,9 +521,17 @@ func TestSmallHelperBranches(t *testing.T) {
 	if _, err := parseScopeMode("bad"); err == nil {
 		t.Fatalf("expected bad scope error")
 	}
+}
+
+func assertCacheEnabledDefaults(t *testing.T) {
+	t.Helper()
 	if !cacheEnabled(nil) || cacheEnabled(boolPtr(false)) {
 		t.Fatalf("unexpected cache enabled defaults")
 	}
+}
+
+func assertMergeStringOptionsBranches(t *testing.T) {
+	t.Helper()
 	if got := mergeStringOptions([]string{"config"}, nil); !slicesEqual(got, []string{"config"}) {
 		t.Fatalf("expected config patterns, got %#v", got)
 	}
@@ -515,7 +541,6 @@ func TestSmallHelperBranches(t *testing.T) {
 	if got := mergeStringOptions(nil, nil); len(got) != 0 {
 		t.Fatalf("expected nil patterns, got %#v", got)
 	}
-	decorateReport(nil, defaultThresholdValues(), nil, nil, "")
 }
 
 func TestDecodeStrictBranches(t *testing.T) {

--- a/internal/mcp/mutations.go
+++ b/internal/mcp/mutations.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -499,9 +500,53 @@ func resolveLocalMutationPath(repoPath, rawPath, field string) (string, error) {
 		return "", fmt.Errorf("%s contains an invalid NUL byte", field)
 	}
 	if filepath.IsAbs(trimmed) {
-		return filepath.Clean(trimmed), nil
+		return "", fmt.Errorf("%s must be a relative path within repoPath", field)
 	}
-	return filepath.Join(repoPath, trimmed), nil
+
+	repoRoot, err := filepath.EvalSymlinks(repoPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve repoPath: %w", err)
+	}
+	candidate := filepath.Clean(filepath.Join(repoRoot, trimmed))
+	if !pathWithinRoot(repoRoot, candidate) {
+		return "", fmt.Errorf("%s must resolve within repoPath", field)
+	}
+	ancestor, err := nearestExistingAncestor(candidate)
+	if err != nil {
+		return "", fmt.Errorf("inspect %s: %w", field, err)
+	}
+	resolvedAncestor, err := filepath.EvalSymlinks(ancestor)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", field, err)
+	}
+	if !pathWithinRoot(repoRoot, resolvedAncestor) {
+		return "", fmt.Errorf("%s must resolve within repoPath", field)
+	}
+	return candidate, nil
+}
+
+func nearestExistingAncestor(path string) (string, error) {
+	for current := filepath.Clean(path); ; current = filepath.Dir(current) {
+		_, err := os.Lstat(current)
+		if err == nil {
+			return current, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return current, nil
+		}
+	}
+}
+
+func pathWithinRoot(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func resolveMutationCurrentBaselineKey(repoPath string) string {

--- a/internal/mcp/mutations.go
+++ b/internal/mcp/mutations.go
@@ -499,30 +499,54 @@ func resolveLocalMutationPath(repoPath, rawPath, field string) (string, error) {
 	if strings.ContainsRune(trimmed, '\x00') {
 		return "", fmt.Errorf("%s contains an invalid NUL byte", field)
 	}
-	if filepath.IsAbs(trimmed) {
-		return "", fmt.Errorf("%s must be a relative path within repoPath", field)
-	}
-
 	repoRoot, err := filepath.EvalSymlinks(repoPath)
 	if err != nil {
 		return "", fmt.Errorf("resolve repoPath: %w", err)
 	}
 	candidate := filepath.Clean(filepath.Join(repoRoot, trimmed))
-	if !pathWithinRoot(repoRoot, candidate) {
+	if filepath.IsAbs(trimmed) {
+		candidate = filepath.Clean(trimmed)
+		repoAlias := filepath.Clean(repoPath)
+		if !pathWithinRoot(repoAlias, candidate) && !pathWithinRoot(repoRoot, candidate) {
+			return "", fmt.Errorf("%s must resolve within repoPath", field)
+		}
+	}
+
+	normalized, err := normalizeLocalMutationCandidate(repoRoot, candidate)
+	if err != nil {
+		if errors.Is(err, errMutationPathEscapesRepo) {
+			return "", fmt.Errorf("%s must resolve within repoPath", field)
+		}
+		return "", fmt.Errorf("inspect %s: %w", field, err)
+	}
+	if !pathWithinRoot(repoRoot, normalized) {
 		return "", fmt.Errorf("%s must resolve within repoPath", field)
 	}
+	return normalized, nil
+}
+
+var errMutationPathEscapesRepo = errors.New("mutation path escapes repoPath")
+
+func normalizeLocalMutationCandidate(repoRoot, candidate string) (string, error) {
 	ancestor, err := nearestExistingAncestor(candidate)
 	if err != nil {
-		return "", fmt.Errorf("inspect %s: %w", field, err)
+		return "", err
 	}
 	resolvedAncestor, err := filepath.EvalSymlinks(ancestor)
 	if err != nil {
-		return "", fmt.Errorf("resolve %s: %w", field, err)
+		return "", err
 	}
 	if !pathWithinRoot(repoRoot, resolvedAncestor) {
-		return "", fmt.Errorf("%s must resolve within repoPath", field)
+		return "", errMutationPathEscapesRepo
 	}
-	return candidate, nil
+	if ancestor == candidate {
+		return resolvedAncestor, nil
+	}
+	suffix, err := filepath.Rel(ancestor, candidate)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(filepath.Join(resolvedAncestor, suffix)), nil
 }
 
 func nearestExistingAncestor(path string) (string, error) {

--- a/internal/mcp/mutations_test.go
+++ b/internal/mcp/mutations_test.go
@@ -516,10 +516,18 @@ func TestResolveLocalMutationPath(t *testing.T) {
 	if err != nil || resolved != filepath.Join(resolvedRepo, "store") {
 		t.Fatalf("resolve relative path: path=%q err=%v", resolved, err)
 	}
-	for _, rawPath := range []string{"", "https://example.com/store", "bad\x00path", filepath.Join(repo, "store"), "../outside"} {
+	absoluteInside := filepath.Join(repo, "store")
+	resolved, err = resolveLocalMutationPath(repo, absoluteInside, "baselineStorePath")
+	if err != nil || resolved != filepath.Join(resolvedRepo, "store") {
+		t.Fatalf("resolve internal absolute path: path=%q err=%v", resolved, err)
+	}
+	for _, rawPath := range []string{"", "https://example.com/store", "bad\x00path", "../outside"} {
 		if _, err := resolveLocalMutationPath(repo, rawPath, "baselineStorePath"); err == nil {
 			t.Fatalf("expected local path validation error for %q", rawPath)
 		}
+	}
+	if _, err := resolveLocalMutationPath(repo, filepath.Join(t.TempDir(), "store"), "baselineStorePath"); err == nil || !strings.Contains(err.Error(), "must resolve within repoPath") {
+		t.Fatalf("expected outside absolute rejection, got %v", err)
 	}
 }
 
@@ -532,6 +540,72 @@ func TestResolveLocalMutationPathRejectsSymlinkEscape(t *testing.T) {
 
 	if _, err := resolveLocalMutationPath(repo, filepath.Join("escape", "store"), "baselineStorePath"); err == nil || !strings.Contains(err.Error(), "must resolve within repoPath") {
 		t.Fatalf("expected symlink escape rejection, got %v", err)
+	}
+}
+
+func TestResolveLocalMutationPathNormalizesAbsoluteRepoSymlink(t *testing.T) {
+	repo := t.TempDir()
+	repoAlias := filepath.Join(t.TempDir(), "repo-link")
+	if err := os.Symlink(repo, repoAlias); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	resolvedRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("resolve repo symlinks: %v", err)
+	}
+
+	resolved, err := resolveLocalMutationPath(repoAlias, filepath.Join(repoAlias, "store"), "baselineStorePath")
+	if err != nil || resolved != filepath.Join(resolvedRepo, "store") {
+		t.Fatalf("resolve absolute path within repo symlink: path=%q err=%v", resolved, err)
+	}
+
+	resolved, err = resolveLocalMutationPath(repoAlias, filepath.Join(resolvedRepo, "store"), "baselineStorePath")
+	if err != nil || resolved != filepath.Join(resolvedRepo, "store") {
+		t.Fatalf("resolve absolute path within resolved repo root: path=%q err=%v", resolved, err)
+	}
+}
+
+func TestNormalizeLocalMutationCandidate(t *testing.T) {
+	repo := t.TempDir()
+	resolvedRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("resolve repo symlinks: %v", err)
+	}
+	existing := filepath.Join(repo, "store")
+	if err := os.Mkdir(existing, 0o755); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+
+	normalized, err := normalizeLocalMutationCandidate(resolvedRepo, existing)
+	if err != nil || normalized != filepath.Join(resolvedRepo, "store") {
+		t.Fatalf("normalize existing candidate: path=%q err=%v", normalized, err)
+	}
+}
+
+func TestNormalizeLocalMutationCandidateRejectsEscape(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	resolvedRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("resolve repo symlinks: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(repo, "escape")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if _, err := normalizeLocalMutationCandidate(resolvedRepo, filepath.Join(repo, "escape", "store")); !errors.Is(err, errMutationPathEscapesRepo) {
+		t.Fatalf("expected mutation path escape error, got %v", err)
+	}
+}
+
+func TestResolveLocalMutationPathRejectsBrokenSymlinkPath(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Symlink(filepath.Join(t.TempDir(), "missing"), filepath.Join(repo, "broken")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if _, err := resolveLocalMutationPath(repo, filepath.Join("broken", "store"), "baselineStorePath"); err == nil || !strings.Contains(err.Error(), "inspect baselineStorePath") {
+		t.Fatalf("expected broken symlink inspection error, got %v", err)
 	}
 }
 
@@ -565,6 +639,12 @@ func TestPathWithinRoot(t *testing.T) {
 	}
 	if pathWithinRoot(root, filepath.Join(string(filepath.Separator), "tmp", "other")) {
 		t.Fatalf("expected sibling path outside root")
+	}
+	if pathWithinRoot("bad\x00root", filepath.Join(root, "nested")) {
+		t.Fatalf("expected invalid root to return false")
+	}
+	if pathWithinRoot(root, "bad\x00target") {
+		t.Fatalf("expected invalid target to return false")
 	}
 }
 

--- a/internal/mcp/mutations_test.go
+++ b/internal/mcp/mutations_test.go
@@ -72,6 +72,10 @@ func TestRunCodemodApplyToolReturnsStructuredPayload(t *testing.T) {
 
 func TestRunBaselineSaveToolReturnsStructuredPayload(t *testing.T) {
 	repo := t.TempDir()
+	resolvedRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("resolve repo symlinks: %v", err)
+	}
 	rep := sampleReport(repo)
 	runner := &fakeMutationRunner{baselineReport: rep}
 	server := NewServer(Options{Features: mustMutationFeatureSet(t, true), MutationRunner: runner})
@@ -102,7 +106,7 @@ func TestRunBaselineSaveToolReturnsStructuredPayload(t *testing.T) {
 	if !runner.baselineCalled {
 		t.Fatalf("expected baseline runner to be called")
 	}
-	wantStore := filepath.Join(repo, "baselines")
+	wantStore := filepath.Join(resolvedRepo, "baselines")
 	wantPath := report.BaselineSnapshotPath(wantStore, "label:nightly")
 	if runner.lastBaseline.TopN != 3 || runner.lastBaseline.BaselineStorePath != wantStore || runner.lastBaseline.BaselineKey != "label:nightly" {
 		t.Fatalf("unexpected baseline request: %#v", runner.lastBaseline)
@@ -123,7 +127,6 @@ func TestRunBaselineSaveToolReturnsStructuredPayload(t *testing.T) {
 func TestRunDashboardBaselineSaveToolReturnsStructuredPayload(t *testing.T) {
 	repo := t.TempDir()
 	childRepo := t.TempDir()
-	store := filepath.Join(repo, "dashboard-baselines")
 	runner := &fakeMutationRunner{
 		dashboardReport: dashboard.Report{
 			Summary: dashboard.Summary{
@@ -137,7 +140,7 @@ func TestRunDashboardBaselineSaveToolReturnsStructuredPayload(t *testing.T) {
 	result := callToolResult(t, server, toolSaveDashboardBaseline, map[string]any{
 		"repoPath":          repo,
 		"repos":             []map[string]any{{"name": "app", "path": childRepo, "language": "js-ts"}},
-		"baselineStorePath": store,
+		"baselineStorePath": "dashboard-baselines",
 		"baselineKey":       "release/1",
 		"confirmSave":       true,
 		"topN":              4,
@@ -149,8 +152,16 @@ func TestRunDashboardBaselineSaveToolReturnsStructuredPayload(t *testing.T) {
 	if !runner.dashboardCalled {
 		t.Fatalf("expected dashboard runner to be called")
 	}
+	resolvedRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("resolve repo symlinks: %v", err)
+	}
+	store := filepath.Join(resolvedRepo, "dashboard-baselines")
 	if runner.lastDashboard.TopN != 4 || runner.lastDashboard.DefaultLanguage != "js-ts" || len(runner.lastDashboard.Repos) != 1 {
 		t.Fatalf("unexpected dashboard request: %#v", runner.lastDashboard)
+	}
+	if runner.lastDashboard.BaselineStorePath != store {
+		t.Fatalf("unexpected dashboard store path: %#v", runner.lastDashboard)
 	}
 
 	payload, ok := result.StructuredContent.(dashboardBaselineSavePayload)
@@ -497,24 +508,76 @@ func TestResolveMutationRequestValidationBranches(t *testing.T) {
 
 func TestResolveLocalMutationPath(t *testing.T) {
 	repo := t.TempDir()
-	absStore := filepath.Join(repo, "store")
-	resolved, err := resolveLocalMutationPath(repo, absStore, "baselineStorePath")
-	if err != nil || resolved != absStore {
-		t.Fatalf("resolve absolute path: path=%q err=%v", resolved, err)
+	resolvedRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("resolve repo symlinks: %v", err)
 	}
-	for _, rawPath := range []string{"", "https://example.com/store", "bad\x00path"} {
+	resolved, err := resolveLocalMutationPath(repo, "store", "baselineStorePath")
+	if err != nil || resolved != filepath.Join(resolvedRepo, "store") {
+		t.Fatalf("resolve relative path: path=%q err=%v", resolved, err)
+	}
+	for _, rawPath := range []string{"", "https://example.com/store", "bad\x00path", filepath.Join(repo, "store"), "../outside"} {
 		if _, err := resolveLocalMutationPath(repo, rawPath, "baselineStorePath"); err == nil {
 			t.Fatalf("expected local path validation error for %q", rawPath)
 		}
 	}
 }
 
+func TestResolveLocalMutationPathRejectsSymlinkEscape(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(repo, "escape")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if _, err := resolveLocalMutationPath(repo, filepath.Join("escape", "store"), "baselineStorePath"); err == nil || !strings.Contains(err.Error(), "must resolve within repoPath") {
+		t.Fatalf("expected symlink escape rejection, got %v", err)
+	}
+}
+
+func TestNearestExistingAncestor(t *testing.T) {
+	repo := t.TempDir()
+	existing := filepath.Join(repo, "existing")
+	if err := os.Mkdir(existing, 0o755); err != nil {
+		t.Fatalf("mkdir existing: %v", err)
+	}
+
+	ancestor, err := nearestExistingAncestor(filepath.Join(existing, "child", "store"))
+	if err != nil || ancestor != existing {
+		t.Fatalf("expected nearest existing ancestor %q, got %q err=%v", existing, ancestor, err)
+	}
+	ancestor, err = nearestExistingAncestor(existing)
+	if err != nil || ancestor != existing {
+		t.Fatalf("expected existing path to resolve to itself, got %q err=%v", ancestor, err)
+	}
+	if _, err := nearestExistingAncestor("bad\x00path"); err == nil {
+		t.Fatalf("expected invalid path error")
+	}
+}
+
+func TestPathWithinRoot(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "tmp", "repo")
+	if !pathWithinRoot(root, root) {
+		t.Fatalf("expected root to be within itself")
+	}
+	if !pathWithinRoot(root, filepath.Join(root, "nested", "store")) {
+		t.Fatalf("expected nested path within root")
+	}
+	if pathWithinRoot(root, filepath.Join(string(filepath.Separator), "tmp", "other")) {
+		t.Fatalf("expected sibling path outside root")
+	}
+}
+
 func TestResolveBaselineMutationTarget(t *testing.T) {
 	repo := t.TempDir()
+	resolvedRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("resolve repo symlinks: %v", err)
+	}
 	if _, _, err := resolveBaselineMutationTarget(repo, "store", "key", "label", "baseline"); err == nil {
 		t.Fatalf("expected key/label conflict")
 	}
-	if store, key, err := resolveBaselineMutationTarget(repo, "store", "explicit", "", "baseline"); err != nil || store != filepath.Join(repo, "store") || key != "explicit" {
+	if store, key, err := resolveBaselineMutationTarget(repo, "store", "explicit", "", "baseline"); err != nil || store != filepath.Join(resolvedRepo, "store") || key != "explicit" {
 		t.Fatalf("unexpected explicit key resolution: store=%q key=%q err=%v", store, key, err)
 	}
 	if _, _, err := resolveBaselineMutationTarget(repo, "store", "", "", "baseline"); err == nil {
@@ -522,8 +585,12 @@ func TestResolveBaselineMutationTarget(t *testing.T) {
 	}
 	gitRepo := t.TempDir()
 	writeGitFixture(t, gitRepo)
+	resolvedGitRepo, err := filepath.EvalSymlinks(gitRepo)
+	if err != nil {
+		t.Fatalf("resolve git repo symlinks: %v", err)
+	}
 	store, key, err := resolveBaselineMutationTarget(gitRepo, "store", "", "", "baseline")
-	if err != nil || store != filepath.Join(gitRepo, "store") || !strings.HasPrefix(key, "commit:") {
+	if err != nil || store != filepath.Join(resolvedGitRepo, "store") || !strings.HasPrefix(key, "commit:") {
 		t.Fatalf("unexpected current commit key resolution: store=%q key=%q err=%v", store, key, err)
 	}
 }


### PR DESCRIPTION
## Summary

MCP baseline save tools accepted `baselineStorePath` values that could resolve outside the requested repository, including traversal and symlink escapes.

## Changes

- normalize mutation baseline store paths against the resolved repo root and reject paths that resolve outside `repoPath`
- add MCP app-level regression coverage for out-of-repo baseline save requests
- add mutation path unit coverage for traversal, symlink escapes, and resolved snapshot locations

## Validation

Commands and checks run:

```bash
go test ./internal/mcp ./internal/app
go test ./internal/mcp -run 'TestResolveLocalMutationPathRejectsSymlinkEscape|TestResolveLocalMutationPath|TestRunBaselineSaveToolReturnsStructuredPayload|TestRunDashboardBaselineSaveToolReturnsStructuredPayload'
go test ./internal/app -run TestExecuteMCPSaveBaselineMutationRejectsOutOfRepoStorePath
go run ./tools/prcheck --check-repo-policy --title 'fix(mcp): confine baseline store paths to repo' --head-ref 'bug/1215-mcp-baseline-store-boundary' --head-repo-full-name 'ben-ranford/lopper' --repo-full-name 'ben-ranford/lopper' --body-file /tmp/pr1215_body.md --regression-exempt-label false --allow-merge-commit false --allow-rebase-merge false --allow-squash-merge true --squash-merge-commit-title PR_TITLE
go run ./tools/regressionproof --title 'fix(mcp): confine baseline store paths to repo' --repo . --base-sha origin/main --body-file /tmp/pr1215_body.md --regression-exempt-label false
```

Additional manual validation:

- Confirmed `gh auth status`, branch `bug/1215-mcp-baseline-store-boundary`, head `4d578196742beda00863e4b249c2bb81e6cf5a60`, and a clean worktree before push.
- Verified traversal and symlink escape checks in `internal/mcp` with targeted `go test` coverage.

Regression-Test: ./internal/app::TestExecuteMCPSaveBaselineMutationRejectsOutOfRepoStorePath

## Risk and compatibility

- Breaking changes: rejects MCP baseline store paths that escape the target repo root
- Migration required: no
- Performance impact: negligible path normalization and ancestor checks on baseline-save requests
- Memory benchmark impact: none

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #1215
