### PR TITLE
fix(profile): block symlink-followed output writes

### DIFF
--- a/internal/advisory/sync_test.go
+++ b/internal/advisory/sync_test.go
@@ -3397,6 +3397,7 @@ func TestUpdateManifestRootLocalWriteFailuresPreserveEvidenceAndCleanup(t *testi
 	now := time.Date(2026, time.July, 13, 0, 0, 0, 0, time.UTC)
 	cleanupWriteErr := errors.New("write failure")
 	cleanupErr := errors.New("cleanup failure")
+	tempInfo := advisoryTempFileInfo(t)
 	for _, tc := range []struct {
 		name   string
 		root   *advisoryFakeRoot
@@ -3432,6 +3433,7 @@ func TestUpdateManifestRootLocalWriteFailuresPreserveEvidenceAndCleanup(t *testi
 					return &advisoryFakeFile{
 						write: func(p []byte) (int, error) { return len(p), nil },
 						close: func() error { return errors.New("temp close failure") },
+						stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
 						chmod: func(os.FileMode) error { return nil },
 					}, nil
 				},
@@ -3446,6 +3448,7 @@ func TestUpdateManifestRootLocalWriteFailuresPreserveEvidenceAndCleanup(t *testi
 					return &advisoryFakeFile{
 						write: func(p []byte) (int, error) { return len(p), nil },
 						close: func() error { return nil },
+						stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
 						chmod: func(os.FileMode) error { return nil },
 					}, nil
 				},
@@ -3695,6 +3698,19 @@ func advisoryExpectAtomicTempCleanup(t *testing.T) func(string) error {
 		}
 		return nil
 	}
+}
+
+func advisoryTempFileInfo(t *testing.T) fs.FileInfo {
+	t.Helper()
+	tempPath := filepath.Join(t.TempDir(), "temp")
+	if err := os.WriteFile(tempPath, []byte("temp"), 0o600); err != nil {
+		t.Fatalf("write advisory temp fixture: %v", err)
+	}
+	tempInfo, err := os.Stat(tempPath)
+	if err != nil {
+		t.Fatalf("stat advisory temp fixture: %v", err)
+	}
+	return tempInfo
 }
 
 func advisoryOpenTestRoot(t *testing.T, rootDir string) safeio.Root {

--- a/internal/app/profile.go
+++ b/internal/app/profile.go
@@ -45,7 +45,7 @@ func persistProfileConfig(config, outputPath string, force bool) (result string,
 			}
 			return "", err
 		}
-	} else if err := writeCommandOutputFileFn(destination.root, destination.targetPath, []byte(config), 0o600, 0o750); err != nil {
+	} else if err := destination.root.WriteFileCreatingParentsWithPermissionFallback(destination.targetPath, []byte(config), 0o600, 0o750); err != nil {
 		return "", err
 	}
 	return "threshold profile config written to " + trimmedOutputPath, nil

--- a/internal/app/profile.go
+++ b/internal/app/profile.go
@@ -25,6 +25,9 @@ func persistProfileConfig(config, outputPath string, force bool) (result string,
 	if trimmedOutputPath == "" || trimmedOutputPath == "-" {
 		return config, nil
 	}
+	if hasDirectoryStyleOutputPath(trimmedOutputPath) {
+		return "", fmt.Errorf("output path must name a file: %s", trimmedOutputPath)
+	}
 	destination, err := openCommandOutputDestination(trimmedOutputPath)
 	if err != nil {
 		return "", err

--- a/internal/app/profile.go
+++ b/internal/app/profile.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/ben-ranford/lopper/internal/thresholds"
@@ -21,22 +20,29 @@ func (a *App) executeProfile(req Request) (string, error) {
 	return persistProfileConfig(config, req.Profile.OutputPath, req.Profile.Force)
 }
 
-func persistProfileConfig(config, outputPath string, force bool) (string, error) {
+func persistProfileConfig(config, outputPath string, force bool) (result string, returnErr error) {
 	trimmedOutputPath := strings.TrimSpace(outputPath)
 	if trimmedOutputPath == "" || trimmedOutputPath == "-" {
 		return config, nil
 	}
-	if !force {
-		if _, err := os.Stat(trimmedOutputPath); err == nil {
-			return "", fmt.Errorf("%s already exists; pass --force to overwrite", trimmedOutputPath)
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return "", err
-		}
-	}
-	if err := os.MkdirAll(filepath.Dir(trimmedOutputPath), 0o750); err != nil {
+	destination, err := openCommandOutputDestination(trimmedOutputPath)
+	if err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(trimmedOutputPath, []byte(config), 0o600); err != nil {
+	defer func() {
+		if closeErr := destination.root.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+
+	if !force {
+		if err := destination.root.WriteFileCreatingParentsIfAbsent(destination.targetPath, []byte(config), 0o600, 0o750); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				return "", fmt.Errorf("%s already exists; pass --force to overwrite", trimmedOutputPath)
+			}
+			return "", err
+		}
+	} else if err := writeCommandOutputFileFn(destination.root, destination.targetPath, []byte(config), 0o600, 0o750); err != nil {
 		return "", err
 	}
 	return "threshold profile config written to " + trimmedOutputPath, nil

--- a/internal/app/profile_other_test.go
+++ b/internal/app/profile_other_test.go
@@ -14,8 +14,24 @@ func TestPersistProfileConfigForceOverwritesWritableTargetWhenParentLacksWritePe
 		t.Skip("effective privileges bypass parent write permission checks")
 	}
 
-	workspace := t.TempDir()
-	parentDir := filepath.Join(workspace, "reports")
+	parentDir, outputPath := setupReadOnlyProfileParent(t)
+	requireParentWriteDenied(t, parentDir, ".profile-write-probe")
+	requireWritableTargetReopenable(t, outputPath)
+
+	status, err := persistProfileConfig("thresholds:\n  fail_on_increase_percent: 1\n", outputPath, true)
+	if err != nil {
+		t.Fatalf("persist forced profile output: %v", err)
+	}
+	if status != "threshold profile config written to "+outputPath {
+		t.Fatalf("unexpected status: %q", status)
+	}
+	assertProfileOutput(t, outputPath, "thresholds:\n  fail_on_increase_percent: 1\n", 0o600)
+}
+
+func setupReadOnlyProfileParent(t *testing.T) (string, string) {
+	t.Helper()
+
+	parentDir := filepath.Join(t.TempDir(), "reports")
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
 		t.Fatalf("mkdir reports: %v", err)
 	}
@@ -32,39 +48,52 @@ func TestPersistProfileConfigForceOverwritesWritableTargetWhenParentLacksWritePe
 		}
 	})
 
-	probePath := filepath.Join(parentDir, ".profile-write-probe")
-	if err := os.WriteFile(probePath, []byte("probe"), 0o600); err == nil {
+	return parentDir, outputPath
+}
+
+func requireParentWriteDenied(t *testing.T, parentDir, probeName string) {
+	t.Helper()
+
+	probePath := filepath.Join(parentDir, probeName)
+	err := os.WriteFile(probePath, []byte("probe"), 0o600)
+	switch {
+	case err == nil:
 		if removeErr := os.Remove(probePath); removeErr != nil {
 			t.Fatalf("remove write probe: %v", removeErr)
 		}
 		t.Skip("effective privileges bypass missing parent write permission")
-	} else if !os.IsPermission(err) {
+	case os.IsPermission(err):
+		return
+	default:
 		t.Skipf("parent write permission semantics are not testable: %v", err)
 	}
+}
 
-	probe, err := os.OpenFile(outputPath, os.O_WRONLY, 0)
-	if err != nil {
-		t.Skipf("existing writable target cannot be reopened without parent write permission: %v", err)
-	}
-	if err := probe.Close(); err != nil {
-		t.Fatalf("close writable target probe: %v", err)
-	}
+func assertProfileOutput(t *testing.T, outputPath, want string, wantPerm os.FileMode) {
+	t.Helper()
 
-	status, err := persistProfileConfig("thresholds:\n  fail_on_increase_percent: 1\n", outputPath, true)
-	if err != nil {
-		t.Fatalf("persist forced profile output: %v", err)
-	}
-	if status != "threshold profile config written to "+outputPath {
-		t.Fatalf("unexpected status: %q", status)
-	}
 	if got, err := os.ReadFile(outputPath); err != nil {
 		t.Fatalf("read forced profile output: %v", err)
-	} else if string(got) != "thresholds:\n  fail_on_increase_percent: 1\n" {
+	} else if string(got) != want {
 		t.Fatalf("unexpected forced profile output: %q", string(got))
 	}
 	if info, err := os.Stat(outputPath); err != nil {
 		t.Fatalf("stat forced profile output: %v", err)
-	} else if info.Mode().Perm() != 0o600 {
-		t.Fatalf("expected output mode 0600 to be preserved, got %#o", info.Mode().Perm())
+	} else if info.Mode().Perm() != wantPerm {
+		t.Fatalf("expected output mode %#o to be preserved, got %#o", wantPerm, info.Mode().Perm())
+	}
+}
+
+func requireWritableTargetReopenable(t *testing.T, outputPath string) {
+	t.Helper()
+
+	probe, err := os.OpenFile(outputPath, os.O_WRONLY, 0)
+	if err != nil {
+		t.Skipf("existing writable target cannot be reopened without parent write permission: %v", err)
+		return
+	}
+	closeErr := probe.Close()
+	if closeErr != nil {
+		t.Fatalf("close writable target probe: %v", closeErr)
 	}
 }

--- a/internal/app/profile_other_test.go
+++ b/internal/app/profile_other_test.go
@@ -1,0 +1,70 @@
+//go:build !windows
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestPersistProfileConfigForceOverwritesWritableTargetWhenParentLacksWritePermission(t *testing.T) {
+	if syscall.Geteuid() == 0 {
+		t.Skip("effective privileges bypass parent write permission checks")
+	}
+
+	workspace := t.TempDir()
+	parentDir := filepath.Join(workspace, "reports")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatalf("mkdir reports: %v", err)
+	}
+	outputPath := filepath.Join(parentDir, "profile.yaml")
+	if err := os.WriteFile(outputPath, []byte("thresholds:\n  fail_on_increase_percent: 5\n"), 0o600); err != nil {
+		t.Fatalf("seed profile output: %v", err)
+	}
+	if err := os.Chmod(parentDir, 0o555); err != nil {
+		t.Fatalf("chmod reports read-only: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(parentDir, 0o755); err != nil && !os.IsNotExist(err) {
+			t.Errorf("restore reports permissions: %v", err)
+		}
+	})
+
+	probePath := filepath.Join(parentDir, ".profile-write-probe")
+	if err := os.WriteFile(probePath, []byte("probe"), 0o600); err == nil {
+		if removeErr := os.Remove(probePath); removeErr != nil {
+			t.Fatalf("remove write probe: %v", removeErr)
+		}
+		t.Skip("effective privileges bypass missing parent write permission")
+	} else if !os.IsPermission(err) {
+		t.Skipf("parent write permission semantics are not testable: %v", err)
+	}
+
+	probe, err := os.OpenFile(outputPath, os.O_WRONLY, 0)
+	if err != nil {
+		t.Skipf("existing writable target cannot be reopened without parent write permission: %v", err)
+	}
+	if err := probe.Close(); err != nil {
+		t.Fatalf("close writable target probe: %v", err)
+	}
+
+	status, err := persistProfileConfig("thresholds:\n  fail_on_increase_percent: 1\n", outputPath, true)
+	if err != nil {
+		t.Fatalf("persist forced profile output: %v", err)
+	}
+	if status != "threshold profile config written to "+outputPath {
+		t.Fatalf("unexpected status: %q", status)
+	}
+	if got, err := os.ReadFile(outputPath); err != nil {
+		t.Fatalf("read forced profile output: %v", err)
+	} else if string(got) != "thresholds:\n  fail_on_increase_percent: 1\n" {
+		t.Fatalf("unexpected forced profile output: %q", string(got))
+	}
+	if info, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("stat forced profile output: %v", err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected output mode 0600 to be preserved, got %#o", info.Mode().Perm())
+	}
+}

--- a/internal/app/profile_other_test.go
+++ b/internal/app/profile_other_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/safeio"
 )
 
 func TestPersistProfileConfigForceOverwritesWritableTargetWhenParentLacksWritePermission(t *testing.T) {
@@ -17,6 +19,40 @@ func TestPersistProfileConfigForceOverwritesWritableTargetWhenParentLacksWritePe
 	parentDir, outputPath := setupReadOnlyProfileParent(t)
 	requireParentWriteDenied(t, parentDir, ".profile-write-probe")
 	requireWritableTargetReopenable(t, outputPath)
+
+	status, err := persistProfileConfig("thresholds:\n  fail_on_increase_percent: 1\n", outputPath, true)
+	if err != nil {
+		t.Fatalf("persist forced profile output: %v", err)
+	}
+	if status != "threshold profile config written to "+outputPath {
+		t.Fatalf("unexpected status: %q", status)
+	}
+	assertProfileOutput(t, outputPath, "thresholds:\n  fail_on_increase_percent: 1\n", 0o600)
+}
+
+func TestPersistProfileConfigForceIsOptInWhenParentLacksWritePermission(t *testing.T) {
+	if syscall.Geteuid() == 0 {
+		t.Skip("effective privileges bypass parent write permission checks")
+	}
+
+	parentDir, outputPath := setupReadOnlyProfileParent(t)
+	requireParentWriteDenied(t, parentDir, ".profile-write-probe")
+	requireWritableTargetReopenable(t, outputPath)
+
+	root, err := safeio.OpenCanonicalWriteRoot(parentDir)
+	if err != nil {
+		t.Fatalf("open canonical write root: %v", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Errorf("close canonical write root: %v", closeErr)
+		}
+	}()
+
+	if err := root.WriteFileCreatingParents(filepath.Base(outputPath), []byte("shared"), 0o600, 0o750); !os.IsPermission(err) {
+		t.Fatalf("expected shared writer permission error, got %v", err)
+	}
+	assertProfileOutput(t, outputPath, "thresholds:\n  fail_on_increase_percent: 5\n", 0o600)
 
 	status, err := persistProfileConfig("thresholds:\n  fail_on_increase_percent: 1\n", outputPath, true)
 	if err != nil {

--- a/internal/app/profile_test.go
+++ b/internal/app/profile_test.go
@@ -125,6 +125,12 @@ func TestExecuteProfileErrorPaths(t *testing.T) {
 	if _, err := application.Execute(context.Background(), req); err == nil {
 		t.Fatalf("expected write error when output path is a directory")
 	}
+
+	outputPath := filepath.Join(t.TempDir(), "reports") + string(os.PathSeparator)
+	req.Profile.OutputPath = outputPath
+	if _, err := application.Execute(context.Background(), req); err == nil || !strings.Contains(err.Error(), "output path must name a file") {
+		t.Fatalf("expected directory-style output rejection for %q, got %v", outputPath, err)
+	}
 }
 
 func TestPersistProfileConfigPropagatesParentError(t *testing.T) {

--- a/internal/app/profile_test.go
+++ b/internal/app/profile_test.go
@@ -51,17 +51,7 @@ func TestExecuteProfileWritesConfigWithOverwriteSafeguard(t *testing.T) {
 	req.Profile.OutputPath = outputPath
 	req.Profile.Features = mustProfileFeatureSet(t)
 
-	output, err := application.Execute(context.Background(), req)
-	if err != nil {
-		t.Fatalf("execute profile write: %v", err)
-	}
-	if !strings.Contains(output, outputPath) {
-		t.Fatalf("expected output confirmation to include path, got %q", output)
-	}
-	data, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatalf("read profile output: %v", err)
-	}
+	data := mustExecuteProfileToFile(t, application, req, outputPath)
 	if !strings.Contains(string(data), "fail_on_increase_percent: 5") {
 		t.Fatalf("expected noise-reduction config, got %q", string(data))
 	}
@@ -75,13 +65,30 @@ func TestExecuteProfileWritesConfigWithOverwriteSafeguard(t *testing.T) {
 	if _, err := application.Execute(context.Background(), req); err != nil {
 		t.Fatalf("execute profile force overwrite: %v", err)
 	}
-	data, err = os.ReadFile(outputPath)
+	data, err := os.ReadFile(outputPath)
 	if err != nil {
 		t.Fatalf("read forced profile output: %v", err)
 	}
 	if !strings.Contains(string(data), "fail_on_increase_percent: 1") {
 		t.Fatalf("expected strict config after force overwrite, got %q", string(data))
 	}
+}
+
+func mustExecuteProfileToFile(t *testing.T, application *App, req Request, outputPath string) []byte {
+	t.Helper()
+
+	output, err := application.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute profile write: %v", err)
+	}
+	if !strings.Contains(output, outputPath) {
+		t.Fatalf("expected output confirmation to include path, got %q", output)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read profile output: %v", err)
+	}
+	return data
 }
 
 func TestExecuteProfileStdoutOutputPath(t *testing.T) {

--- a/internal/app/profile_test.go
+++ b/internal/app/profile_test.go
@@ -127,17 +127,16 @@ func TestExecuteProfileErrorPaths(t *testing.T) {
 	}
 }
 
-func TestPersistProfileConfigPropagatesStatError(t *testing.T) {
+func TestPersistProfileConfigPropagatesParentError(t *testing.T) {
 	blocker := filepath.Join(t.TempDir(), "blocked")
 	writeBlockedFile(t, blocker)
 
 	_, err := persistProfileConfig("thresholds: {}", filepath.Join(blocker, "profile.yaml"), false)
 	if err == nil {
-		t.Fatal("expected stat error under regular file")
+		t.Fatal("expected non-directory parent error")
 	}
-	var pathErr *os.PathError
-	if !errors.As(err, &pathErr) || pathErr.Op != "stat" || pathErr.Path != filepath.Join(blocker, "profile.yaml") {
-		t.Fatalf("expected propagated stat path error, got %v", err)
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("expected non-directory parent rejection, got %v", err)
 	}
 }
 
@@ -147,6 +146,41 @@ func TestPersistProfileConfigPropagatesMkdirAllError(t *testing.T) {
 
 	if _, err := persistProfileConfig("thresholds: {}", filepath.Join(blocker, "profile.yaml"), true); err == nil {
 		t.Fatal("expected mkdir error under regular file")
+	}
+}
+
+func TestPersistProfileConfigRejectsParentSymlink(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(workspace, "reports")); err != nil {
+		t.Fatalf("create output parent symlink: %v", err)
+	}
+
+	outputPath := filepath.Join(workspace, "reports", "profile.yaml")
+	_, err := persistProfileConfig("thresholds: {}", outputPath, false)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected parent symlink rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "profile.yaml")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected outside file to remain absent, got err=%v", statErr)
+	}
+}
+
+func TestPersistProfileConfigRejectsDanglingTargetSymlinkWithForce(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	outputPath := filepath.Join(workspace, "profile.yaml")
+	outsideTarget := filepath.Join(outside, "missing", "profile.yaml")
+	if err := os.Symlink(outsideTarget, outputPath); err != nil {
+		t.Fatalf("create dangling output symlink: %v", err)
+	}
+
+	_, err := persistProfileConfig("thresholds: {}", outputPath, true)
+	if err == nil || !strings.Contains(err.Error(), "target path is a symlink") {
+		t.Fatalf("expected dangling symlink rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(outsideTarget); !os.IsNotExist(statErr) {
+		t.Fatalf("expected symlink target to remain absent, got err=%v", statErr)
 	}
 }
 

--- a/internal/safeio/atomic_write.go
+++ b/internal/safeio/atomic_write.go
@@ -93,6 +93,34 @@ func writeAtomicReplacement(root Root, targetRel string, data []byte, perm os.Fi
 	return nil
 }
 
+func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []byte, perm os.FileMode, replacementFile File) (returnErr error) {
+	session, err := newAtomicWriteSession(root, targetRel, perm)
+	if err != nil {
+		if pinnedOverwritePermissionFallbackAllowed(err, replacementFile) {
+			return overwritePinnedFile(root, targetRel, replacementFile, data, nil)
+		}
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, session.cleanup())
+	}()
+
+	if err := session.writeAndClose(data, perm); err != nil {
+		return err
+	}
+	if err := session.commit(); err != nil {
+		if pinnedOverwritePermissionFallbackAllowed(err, replacementFile) {
+			return overwritePinnedFile(root, targetRel, replacementFile, data, nil)
+		}
+		return err
+	}
+	return nil
+}
+
+func pinnedOverwritePermissionFallbackAllowed(err error, replacementFile File) bool {
+	return replacementFile != nil && os.IsPermission(err)
+}
+
 func openPinnedReplacementTarget(root Root, targetRel string, expectedInfo fs.FileInfo) (File, error) {
 	file, err := root.OpenFile(targetRel, os.O_WRONLY, 0)
 	if err != nil {

--- a/internal/safeio/atomic_write.go
+++ b/internal/safeio/atomic_write.go
@@ -13,6 +13,7 @@ type atomicWriteSession struct {
 	targetRel string
 	tempRel   string
 	tempFile  File
+	tempInfo  fs.FileInfo
 }
 
 type truncatingFile interface {
@@ -57,20 +58,37 @@ func (s *atomicWriteSession) commit() error {
 }
 
 func (s *atomicWriteSession) verifyCommittedTarget() error {
-	expectedInfo, err := s.tempFile.Stat()
-	if err != nil {
-		return err
+	if s.tempInfo == nil {
+		return fmt.Errorf("temporary file info unavailable after commit: %s", s.targetRel)
 	}
-	if !expectedInfo.Mode().IsRegular() {
+	if !s.tempInfo.Mode().IsRegular() {
 		return fmt.Errorf("temporary file is not regular after commit: %s", s.targetRel)
 	}
 	pathInfo, err := s.root.Lstat(s.targetRel)
 	if err != nil {
 		return fmt.Errorf("committed target changed before validation: %w", err)
 	}
-	if !pathInfo.Mode().IsRegular() || !os.SameFile(expectedInfo, pathInfo) {
+	if !pathInfo.Mode().IsRegular() || !os.SameFile(s.tempInfo, pathInfo) {
 		return fmt.Errorf("committed target changed before validation: %s", s.targetRel)
 	}
+	return nil
+}
+
+func (s *atomicWriteSession) snapshotAndCloseTempFile() error {
+	if s.tempFile == nil {
+		return nil
+	}
+	tempInfo, err := s.tempFile.Stat()
+	if err != nil {
+		return err
+	}
+	if !tempInfo.Mode().IsRegular() {
+		return fmt.Errorf("temporary file is not regular after commit: %s", s.targetRel)
+	}
+	if err := s.closeTempFile(); err != nil {
+		return err
+	}
+	s.tempInfo = tempInfo
 	return nil
 }
 
@@ -130,6 +148,9 @@ func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []
 	if err := session.writeAndPrepare(data, perm); err != nil {
 		return err
 	}
+	if err := session.snapshotAndCloseTempFile(); err != nil {
+		return err
+	}
 	if err := session.commit(); err != nil {
 		fallbackErr := fallbackAtomicReplacement(root, session.tempRel, targetRel, replacementFile, data, err)
 		if fallbackErr == nil {
@@ -140,10 +161,7 @@ func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []
 		}
 		return fallbackErr
 	}
-	if err := session.verifyCommittedTarget(); err != nil {
-		return err
-	}
-	return session.closeTempFile()
+	return session.verifyCommittedTarget()
 }
 
 func pinnedOverwritePermissionFallbackAllowed(err error, replacementFile File, allowPermissionFallback bool) bool {

--- a/internal/safeio/atomic_write.go
+++ b/internal/safeio/atomic_write.go
@@ -109,10 +109,14 @@ func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []
 		return err
 	}
 	if err := session.commit(); err != nil {
+		fallbackErr := fallbackAtomicReplacement(root, session.tempRel, targetRel, replacementFile, data, err)
+		if fallbackErr == nil {
+			return nil
+		}
 		if pinnedOverwritePermissionFallbackAllowed(err, replacementFile, allowPermissionFallback) {
 			return overwritePinnedFile(root, targetRel, replacementFile, data, nil)
 		}
-		return err
+		return fallbackErr
 	}
 	return nil
 }

--- a/internal/safeio/atomic_write.go
+++ b/internal/safeio/atomic_write.go
@@ -93,10 +93,10 @@ func writeAtomicReplacement(root Root, targetRel string, data []byte, perm os.Fi
 	return nil
 }
 
-func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []byte, perm os.FileMode, replacementFile File) (returnErr error) {
+func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []byte, perm os.FileMode, replacementFile File, allowPermissionFallback bool) (returnErr error) {
 	session, err := newAtomicWriteSession(root, targetRel, perm)
 	if err != nil {
-		if pinnedOverwritePermissionFallbackAllowed(err, replacementFile) {
+		if pinnedOverwritePermissionFallbackAllowed(err, replacementFile, allowPermissionFallback) {
 			return overwritePinnedFile(root, targetRel, replacementFile, data, nil)
 		}
 		return err
@@ -109,7 +109,7 @@ func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []
 		return err
 	}
 	if err := session.commit(); err != nil {
-		if pinnedOverwritePermissionFallbackAllowed(err, replacementFile) {
+		if pinnedOverwritePermissionFallbackAllowed(err, replacementFile, allowPermissionFallback) {
 			return overwritePinnedFile(root, targetRel, replacementFile, data, nil)
 		}
 		return err
@@ -117,8 +117,8 @@ func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []
 	return nil
 }
 
-func pinnedOverwritePermissionFallbackAllowed(err error, replacementFile File) bool {
-	return replacementFile != nil && os.IsPermission(err)
+func pinnedOverwritePermissionFallbackAllowed(err error, replacementFile File, allowPermissionFallback bool) bool {
+	return allowPermissionFallback && replacementFile != nil && os.IsPermission(err)
 }
 
 func openPinnedReplacementTarget(root Root, targetRel string, expectedInfo fs.FileInfo) (File, error) {

--- a/internal/safeio/atomic_write.go
+++ b/internal/safeio/atomic_write.go
@@ -35,13 +35,17 @@ func newAtomicWriteSession(root Root, targetRel string, perm os.FileMode) (*atom
 }
 
 func (s *atomicWriteSession) writeAndClose(data []byte, perm os.FileMode) error {
-	if _, err := s.tempFile.Write(data); err != nil {
-		return err
-	}
-	if err := s.tempFile.Chmod(perm); err != nil {
+	if err := s.writeAndPrepare(data, perm); err != nil {
 		return err
 	}
 	return s.closeTempFile()
+}
+
+func (s *atomicWriteSession) writeAndPrepare(data []byte, perm os.FileMode) error {
+	if _, err := s.tempFile.Write(data); err != nil {
+		return err
+	}
+	return s.tempFile.Chmod(perm)
 }
 
 func (s *atomicWriteSession) commit() error {
@@ -105,7 +109,7 @@ func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []
 		returnErr = errors.Join(returnErr, session.cleanup())
 	}()
 
-	if err := session.writeAndClose(data, perm); err != nil {
+	if err := session.writeAndPrepare(data, perm); err != nil {
 		return err
 	}
 	if err := session.commit(); err != nil {

--- a/internal/safeio/atomic_write.go
+++ b/internal/safeio/atomic_write.go
@@ -56,6 +56,24 @@ func (s *atomicWriteSession) commit() error {
 	return nil
 }
 
+func (s *atomicWriteSession) verifyCommittedTarget() error {
+	expectedInfo, err := s.tempFile.Stat()
+	if err != nil {
+		return err
+	}
+	if !expectedInfo.Mode().IsRegular() {
+		return fmt.Errorf("temporary file is not regular after commit: %s", s.targetRel)
+	}
+	pathInfo, err := s.root.Lstat(s.targetRel)
+	if err != nil {
+		return fmt.Errorf("committed target changed before validation: %w", err)
+	}
+	if !pathInfo.Mode().IsRegular() || !os.SameFile(expectedInfo, pathInfo) {
+		return fmt.Errorf("committed target changed before validation: %s", s.targetRel)
+	}
+	return nil
+}
+
 func (s *atomicWriteSession) closeTempFile() error {
 	if s.tempFile == nil {
 		return nil
@@ -122,7 +140,10 @@ func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []
 		}
 		return fallbackErr
 	}
-	return nil
+	if err := session.verifyCommittedTarget(); err != nil {
+		return err
+	}
+	return session.closeTempFile()
 }
 
 func pinnedOverwritePermissionFallbackAllowed(err error, replacementFile File, allowPermissionFallback bool) bool {

--- a/internal/safeio/atomic_write.go
+++ b/internal/safeio/atomic_write.go
@@ -124,13 +124,16 @@ func writeAtomicReplacement(root Root, targetRel string, data []byte, perm os.Fi
 		returnErr = errors.Join(returnErr, session.cleanup())
 	}()
 
-	if err := session.writeAndClose(data, perm); err != nil {
+	if err := session.writeAndPrepare(data, perm); err != nil {
+		return err
+	}
+	if err := session.snapshotAndCloseTempFile(); err != nil {
 		return err
 	}
 	if err := session.commit(); err != nil {
 		return fallbackAtomicReplacement(root, session.tempRel, targetRel, replacementFile, data, err)
 	}
-	return nil
+	return session.verifyCommittedTarget()
 }
 
 func writeAtomicReplacementWithPinnedTarget(root Root, targetRel string, data []byte, perm os.FileMode, replacementFile File, allowPermissionFallback bool) (returnErr error) {

--- a/internal/safeio/filesystem.go
+++ b/internal/safeio/filesystem.go
@@ -190,16 +190,16 @@ func trustedRootAliasTarget(requestedPath string) (string, bool) {
 	}
 }
 
-func openRootChildNoFollow(root Root, name, path string) (Root, error) {
-	info, err := root.Lstat(name)
+func openValidatedChildRoot(root Root, name, path string, infoFn func() (fs.FileInfo, error), symlinkMessage, notDirMessage, changedMessage string) (Root, error) {
+	info, err := infoFn()
 	if err != nil {
 		return nil, err
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("root contains symlink: %s", path)
+		return nil, fmt.Errorf("%s: %s", symlinkMessage, path)
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("root is not a directory: %s", path)
+		return nil, fmt.Errorf("%s: %s", notDirMessage, path)
 	}
 
 	next, err := root.OpenRoot(name)
@@ -211,9 +211,13 @@ func openRootChildNoFollow(root Root, name, path string) (Root, error) {
 		return nil, closeRootWithError(next, err)
 	}
 	if !os.SameFile(info, openedInfo) {
-		return nil, closeRootWithError(next, fmt.Errorf("root changed while opening: %s", path))
+		return nil, closeRootWithError(next, fmt.Errorf("%s: %s", changedMessage, path))
 	}
 	return next, nil
+}
+
+func openRootChildNoFollow(root Root, name, path string) (Root, error) {
+	return openValidatedChildRoot(root, name, path, func() (fs.FileInfo, error) { return root.Lstat(name) }, "root contains symlink", "root is not a directory", "root changed while opening")
 }
 
 func openRootExistingAncestorNoFollowWith(name string, absFn func(string) (string, error), relFn func(string, string) (string, error), openRootFn func(string) (Root, error), openRootChildFn func(Root, string, string) (Root, string, error)) (Root, string, []string, error) {

--- a/internal/safeio/filesystem.go
+++ b/internal/safeio/filesystem.go
@@ -52,6 +52,7 @@ type ReadDirFile interface {
 var ErrTargetPathSymlink = errors.New("target path is a symlink")
 
 var fileSystem FileSystem = &osFileSystem{}
+var runtimeGOOS = runtime.GOOS
 
 // OpenRoot opens a confined filesystem root.
 func OpenRoot(name string) (Root, error) {
@@ -175,7 +176,7 @@ func openPinnedRootAliasWith(targetPath string, requestedPath string, openRootNo
 }
 
 func trustedRootAliasTarget(requestedPath string) (string, bool) {
-	if runtime.GOOS != "darwin" {
+	if runtimeGOOS != "darwin" {
 		return "", false
 	}
 

--- a/internal/safeio/filesystem_branches_test.go
+++ b/internal/safeio/filesystem_branches_test.go
@@ -610,6 +610,16 @@ func TestSplitPinnedPathSkipsEmptyAndDotSegments(t *testing.T) {
 	}
 }
 
+func TestSplitPinnedPathReturnsNilPartsForRootDot(t *testing.T) {
+	cleanName, parts := splitPinnedPath(".")
+	if cleanName != "." {
+		t.Fatalf("unexpected clean name: %q", cleanName)
+	}
+	if len(parts) != 0 {
+		t.Fatalf("expected no parts for dot path, got %#v", parts)
+	}
+}
+
 func TestOpenRootExistingAncestorNoFollowWithPropagatesSetupErrors(t *testing.T) {
 	absErr := errors.New("resolve absolute ancestor path")
 	relErr := errors.New("resolve relative ancestor path")

--- a/internal/safeio/test_helpers_test.go
+++ b/internal/safeio/test_helpers_test.go
@@ -67,6 +67,15 @@ func withFileSystem(t *testing.T, fsys FileSystem) {
 	})
 }
 
+func withRuntimeGOOS(t *testing.T, goos string) {
+	t.Helper()
+	originalGOOS := runtimeGOOS
+	runtimeGOOS = goos
+	t.Cleanup(func() {
+		runtimeGOOS = originalGOOS
+	})
+}
+
 func openTestRoot(t *testing.T, rootDir string) Root {
 	t.Helper()
 	root, err := (&osFileSystem{}).OpenRoot(rootDir)

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -271,13 +271,16 @@ func createFileExclusivelyAtRoot(root Root, targetRel string, data []byte, perm 
 	defer func() {
 		if targetCreated {
 			returnErr = errors.Join(returnErr, cleanupAtomicTempFile(root, targetRel, file))
-			return
-		}
-		if file != nil {
-			returnErr = errors.Join(returnErr, closeFilePreservingPrimary(file, nil))
 		}
 	}()
 
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !openedInfo.Mode().IsRegular() {
+		return fmt.Errorf("exclusive-create target is not a regular file: %s", targetRel)
+	}
 	if _, err := file.Write(data); err != nil {
 		return err
 	}
@@ -287,8 +290,21 @@ func createFileExclusivelyAtRoot(root Root, targetRel string, data []byte, perm 
 	if err := file.Close(); err != nil {
 		return err
 	}
-	targetCreated = false
 	file = nil
+	pathInfo, err := root.Lstat(targetRel)
+	if err != nil {
+		targetCreated = false
+		return fmt.Errorf("exclusive-create target changed before validation: %w", err)
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 {
+		targetCreated = false
+		return fmt.Errorf("exclusive-create target became a symlink before validation: %s", targetRel)
+	}
+	if !pathInfo.Mode().IsRegular() || !os.SameFile(openedInfo, pathInfo) {
+		targetCreated = false
+		return fmt.Errorf("exclusive-create target changed before validation: %s", targetRel)
+	}
+	targetCreated = false
 	return nil
 }
 

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -275,7 +275,7 @@ func writeFileIfAbsentAtRoot(root Root, target rootedTarget, data []byte, perm o
 		if errors.Is(err, os.ErrExist) {
 			return os.ErrExist
 		}
-		if errors.Is(err, errors.ErrUnsupported) {
+		if errors.Is(err, errors.ErrUnsupported) || errors.Is(err, os.ErrPermission) {
 			return createFileExclusivelyAtRoot(root, target.rel, data, perm)
 		}
 		return err

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -298,7 +298,9 @@ func createFileExclusivelyAtRoot(root Root, targetRel string, data []byte, perm 
 			returnErr = errors.Join(returnErr, cleanupAtomicTempFile(root, targetRel, file))
 			return
 		}
-		returnErr = errors.Join(returnErr, closeFilePreservingPrimary(file, nil))
+		if file != nil {
+			returnErr = errors.Join(returnErr, closeFilePreservingPrimary(file, nil))
+		}
 	}()
 
 	if _, err := file.Write(data); err != nil {
@@ -307,7 +309,11 @@ func createFileExclusivelyAtRoot(root Root, targetRel string, data []byte, perm 
 	if err := file.Chmod(perm); err != nil {
 		return err
 	}
+	if err := file.Close(); err != nil {
+		return err
+	}
 	targetCreated = false
+	file = nil
 	return nil
 }
 

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -85,26 +85,18 @@ func (r *WriteRoot) resolveTarget(targetPath string) (rootedTarget, error) {
 }
 
 func (r *WriteRoot) writeFileAtTarget(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode) (returnErr error) {
-	parent, closeParent, err := r.openTargetParent(target, createParents, parentPerm)
-	if err != nil {
-		return err
-	}
-	if closeParent {
-		defer func() {
-			if closeErr := parent.Close(); closeErr != nil {
-				returnErr = errors.Join(returnErr, closeErr)
-			}
-		}()
-	}
-	if err := writeFileParentReadyFn(); err != nil {
-		return err
-	}
-	parentTarget := target
-	parentTarget.rel = filepath.Base(target.rel)
-	return writeFileAtRoot(parent, parentTarget, data, perm)
+	return r.withTargetParent(target, createParents, parentPerm, func(parent Root, parentTarget rootedTarget) error {
+		return writeFileAtRoot(parent, parentTarget, data, perm)
+	})
 }
 
 func (r *WriteRoot) writeFileIfAbsentAtTarget(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode) (returnErr error) {
+	return r.withTargetParent(target, createParents, parentPerm, func(parent Root, parentTarget rootedTarget) error {
+		return writeFileIfAbsentAtRoot(parent, parentTarget, data, perm)
+	})
+}
+
+func (r *WriteRoot) withTargetParent(target rootedTarget, createParents bool, parentPerm os.FileMode, write func(parent Root, parentTarget rootedTarget) error) (returnErr error) {
 	parent, closeParent, err := r.openTargetParent(target, createParents, parentPerm)
 	if err != nil {
 		return err
@@ -121,7 +113,7 @@ func (r *WriteRoot) writeFileIfAbsentAtTarget(target rootedTarget, data []byte, 
 	}
 	parentTarget := target
 	parentTarget.rel = filepath.Base(target.rel)
-	return writeFileIfAbsentAtRoot(parent, parentTarget, data, perm)
+	return write(parent, parentTarget)
 }
 
 func (r *WriteRoot) openTargetParent(target rootedTarget, create bool, perm os.FileMode) (Root, bool, error) {

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -275,8 +275,39 @@ func writeFileIfAbsentAtRoot(root Root, target rootedTarget, data []byte, perm o
 		if errors.Is(err, os.ErrExist) {
 			return os.ErrExist
 		}
+		if errors.Is(err, errors.ErrUnsupported) {
+			return createFileExclusivelyAtRoot(root, target.rel, data, perm)
+		}
 		return err
 	}
+	return nil
+}
+
+func createFileExclusivelyAtRoot(root Root, targetRel string, data []byte, perm os.FileMode) (returnErr error) {
+	file, err := root.OpenFile(targetRel, os.O_RDWR|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return os.ErrExist
+		}
+		return err
+	}
+
+	targetCreated := true
+	defer func() {
+		if targetCreated {
+			returnErr = errors.Join(returnErr, cleanupAtomicTempFile(root, targetRel, file))
+			return
+		}
+		returnErr = errors.Join(returnErr, closeFilePreservingPrimary(file, nil))
+	}()
+
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Chmod(perm); err != nil {
+		return err
+	}
+	targetCreated = false
 	return nil
 }
 

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -62,6 +62,17 @@ func (r *WriteRoot) WriteFileCreatingParents(targetPath string, data []byte, per
 	return r.writeFileAtTarget(target, data, perm, true, parentPerm)
 }
 
+// WriteFileCreatingParentsIfAbsent writes a root-relative file only when the
+// target path does not already exist, creating missing parent directories
+// inside the pinned root without following symlinks.
+func (r *WriteRoot) WriteFileCreatingParentsIfAbsent(targetPath string, data []byte, perm, parentPerm os.FileMode) error {
+	target, err := r.resolveTarget(targetPath)
+	if err != nil {
+		return err
+	}
+	return r.writeFileIfAbsentAtTarget(target, data, perm, true, parentPerm)
+}
+
 func (r *WriteRoot) resolveTarget(targetPath string) (rootedTarget, error) {
 	if filepath.IsAbs(targetPath) {
 		return rootedTarget{}, fmt.Errorf("target path must be relative to root: %s", targetPath)
@@ -91,6 +102,26 @@ func (r *WriteRoot) writeFileAtTarget(target rootedTarget, data []byte, perm os.
 	parentTarget := target
 	parentTarget.rel = filepath.Base(target.rel)
 	return writeFileAtRoot(parent, parentTarget, data, perm)
+}
+
+func (r *WriteRoot) writeFileIfAbsentAtTarget(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode) (returnErr error) {
+	parent, closeParent, err := r.openTargetParent(target, createParents, parentPerm)
+	if err != nil {
+		return err
+	}
+	if closeParent {
+		defer func() {
+			if closeErr := parent.Close(); closeErr != nil {
+				returnErr = errors.Join(returnErr, closeErr)
+			}
+		}()
+	}
+	if err := writeFileParentReadyFn(); err != nil {
+		return err
+	}
+	parentTarget := target
+	parentTarget.rel = filepath.Base(target.rel)
+	return writeFileIfAbsentAtRoot(parent, parentTarget, data, perm)
 }
 
 func (r *WriteRoot) openTargetParent(target rootedTarget, create bool, perm os.FileMode) (Root, bool, error) {
@@ -220,6 +251,41 @@ func writeFileAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMo
 		}
 	}
 	return writeAtomicReplacement(root, target.rel, data, writePerm, nil)
+}
+
+func writeFileIfAbsentAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {
+	if _, err := root.Lstat(target.rel); err == nil {
+		return os.ErrExist
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	tempRel, tempFile, err := CreateTempFileWithinRoot(root, filepath.Dir(target.rel), perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, CleanupTempFileWithinRoot(root, tempRel, tempFile))
+	}()
+
+	if _, err := tempFile.Write(data); err != nil {
+		return err
+	}
+	if err := tempFile.Chmod(perm); err != nil {
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	tempFile = nil
+
+	if err := root.Link(tempRel, target.rel); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return os.ErrExist
+		}
+		return err
+	}
+	return nil
 }
 
 func resolvedWriteFilePerm(root Root, target rootedTarget, requestedPerm os.FileMode) (os.FileMode, fs.FileInfo, error) {

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -277,36 +277,7 @@ func writeFileIfAbsentAtRoot(root Root, target rootedTarget, data []byte, perm o
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-
-	tempRel, tempFile, err := CreateTempFileWithinRoot(root, filepath.Dir(target.rel), perm)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		returnErr = errors.Join(returnErr, CleanupTempFileWithinRoot(root, tempRel, tempFile))
-	}()
-
-	if _, err := tempFile.Write(data); err != nil {
-		return err
-	}
-	if err := tempFile.Chmod(perm); err != nil {
-		return err
-	}
-	if err := tempFile.Close(); err != nil {
-		return err
-	}
-	tempFile = nil
-
-	if err := root.Link(tempRel, target.rel); err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return os.ErrExist
-		}
-		if errors.Is(err, errors.ErrUnsupported) || errors.Is(err, os.ErrPermission) {
-			return createFileExclusivelyAtRoot(root, target.rel, data, perm)
-		}
-		return err
-	}
-	return nil
+	return createFileExclusivelyAtRoot(root, target.rel, data, perm)
 }
 
 func createFileExclusivelyAtRoot(root Root, targetRel string, data []byte, perm os.FileMode) (returnErr error) {

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -233,16 +233,21 @@ func writeFileAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMo
 	if err != nil {
 		return err
 	}
-	if existingInfo != nil {
-		file, err := root.OpenFile(target.rel, os.O_WRONLY, 0)
-		if err != nil {
-			return err
-		}
-		if err := file.Close(); err != nil {
-			return err
-		}
+	if existingInfo == nil {
+		return writeAtomicReplacement(root, target.rel, data, writePerm, nil)
 	}
-	return writeAtomicReplacement(root, target.rel, data, writePerm, nil)
+
+	file, err := openPinnedReplacementTarget(root, target.rel, existingInfo)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+
+	return writeAtomicReplacementWithPinnedTarget(root, target.rel, data, writePerm, file)
 }
 
 func writeFileIfAbsentAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -62,6 +62,21 @@ func (r *WriteRoot) WriteFileCreatingParents(targetPath string, data []byte, per
 	return r.writeFileAtTarget(target, data, perm, true, parentPerm)
 }
 
+// WriteFileCreatingParentsWithPermissionFallback atomically writes a
+// root-relative file, creating missing parent directories inside the pinned
+// root. When an existing regular target is already open and writable, callers
+// may opt into an in-place overwrite fallback if parent directory permissions
+// reject the atomic temp-file path.
+func (r *WriteRoot) WriteFileCreatingParentsWithPermissionFallback(targetPath string, data []byte, perm, parentPerm os.FileMode) error {
+	target, err := r.resolveTarget(targetPath)
+	if err != nil {
+		return err
+	}
+	return r.withTargetParent(target, true, parentPerm, func(parent Root, parentTarget rootedTarget) error {
+		return writeFileAtRootWithPermissionFallback(parent, parentTarget, data, perm)
+	})
+}
+
 // WriteFileCreatingParentsIfAbsent writes a root-relative file only when the
 // target path does not already exist, creating missing parent directories
 // inside the pinned root without following symlinks.
@@ -247,7 +262,29 @@ func writeFileAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMo
 		}
 	}()
 
-	return writeAtomicReplacementWithPinnedTarget(root, target.rel, data, writePerm, file)
+	return writeAtomicReplacementWithPinnedTarget(root, target.rel, data, writePerm, file, false)
+}
+
+func writeFileAtRootWithPermissionFallback(root Root, target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {
+	writePerm, existingInfo, err := resolvedWriteFilePerm(root, target, perm)
+	if err != nil {
+		return err
+	}
+	if existingInfo == nil {
+		return writeAtomicReplacement(root, target.rel, data, writePerm, nil)
+	}
+
+	file, err := openPinnedReplacementTarget(root, target.rel, existingInfo)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, closeErr)
+		}
+	}()
+
+	return writeAtomicReplacementWithPinnedTarget(root, target.rel, data, writePerm, file, true)
 }
 
 func writeFileIfAbsentAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -160,29 +160,7 @@ func (r *WriteRoot) openTargetParent(target rootedTarget, create bool, perm os.F
 }
 
 func openTargetParentChild(root Root, name, path string, create bool, perm os.FileMode) (Root, error) {
-	info, err := lstatOrCreateDirectory(root, name, create, perm)
-	if err != nil {
-		return nil, err
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("output parent contains symlink: %s", path)
-	}
-	if !info.IsDir() {
-		return nil, fmt.Errorf("output parent is not a directory: %s", path)
-	}
-
-	next, err := root.OpenRoot(name)
-	if err != nil {
-		return nil, err
-	}
-	openedInfo, err := next.Lstat(".")
-	if err != nil {
-		return nil, closeRootWithError(next, err)
-	}
-	if !os.SameFile(info, openedInfo) {
-		return nil, closeRootWithError(next, fmt.Errorf("output parent changed while opening: %s", path))
-	}
-	return next, nil
+	return openValidatedChildRoot(root, name, path, func() (fs.FileInfo, error) { return lstatOrCreateDirectory(root, name, create, perm) }, "output parent contains symlink", "output parent is not a directory", "output parent changed while opening")
 }
 
 func lstatOrCreateDirectory(root Root, name string, create bool, perm os.FileMode) (fs.FileInfo, error) {

--- a/internal/safeio/write.go
+++ b/internal/safeio/write.go
@@ -59,7 +59,7 @@ func (r *WriteRoot) WriteFileCreatingParents(targetPath string, data []byte, per
 	if err != nil {
 		return err
 	}
-	return r.writeFileAtTarget(target, data, perm, true, parentPerm)
+	return r.writeFileToTargetParent(target, data, perm, true, parentPerm, writeFileAtRoot)
 }
 
 // WriteFileCreatingParentsWithPermissionFallback atomically writes a
@@ -85,7 +85,7 @@ func (r *WriteRoot) WriteFileCreatingParentsIfAbsent(targetPath string, data []b
 	if err != nil {
 		return err
 	}
-	return r.writeFileIfAbsentAtTarget(target, data, perm, true, parentPerm)
+	return r.writeFileToTargetParent(target, data, perm, true, parentPerm, writeFileIfAbsentAtRoot)
 }
 
 func (r *WriteRoot) resolveTarget(targetPath string) (rootedTarget, error) {
@@ -99,15 +99,13 @@ func (r *WriteRoot) resolveTarget(targetPath string) (rootedTarget, error) {
 	return rootedTarget{rootAbs: r.rootAbs, rel: rel, abs: filepath.Join(r.rootAbs, rel)}, nil
 }
 
-func (r *WriteRoot) writeFileAtTarget(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode) (returnErr error) {
-	return r.withTargetParent(target, createParents, parentPerm, func(parent Root, parentTarget rootedTarget) error {
-		return writeFileAtRoot(parent, parentTarget, data, perm)
-	})
+func (r *WriteRoot) writeFileAtTarget(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode) error {
+	return r.writeFileToTargetParent(target, data, perm, createParents, parentPerm, writeFileAtRoot)
 }
 
-func (r *WriteRoot) writeFileIfAbsentAtTarget(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode) (returnErr error) {
+func (r *WriteRoot) writeFileToTargetParent(target rootedTarget, data []byte, perm os.FileMode, createParents bool, parentPerm os.FileMode, write func(root Root, target rootedTarget, data []byte, perm os.FileMode) error) (returnErr error) {
 	return r.withTargetParent(target, createParents, parentPerm, func(parent Root, parentTarget rootedTarget) error {
-		return writeFileIfAbsentAtRoot(parent, parentTarget, data, perm)
+		return write(parent, parentTarget, data, perm)
 	})
 }
 
@@ -243,29 +241,15 @@ func WriteFileUnder(rootDir, targetPath string, data []byte, perm os.FileMode) (
 	return root.writeFileAtTarget(target, data, perm, false, 0)
 }
 
-func writeFileAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {
-	writePerm, existingInfo, err := resolvedWriteFilePerm(root, target, perm)
-	if err != nil {
-		return err
-	}
-	if existingInfo == nil {
-		return writeAtomicReplacement(root, target.rel, data, writePerm, nil)
-	}
-
-	file, err := openPinnedReplacementTarget(root, target.rel, existingInfo)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			returnErr = errors.Join(returnErr, closeErr)
-		}
-	}()
-
-	return writeAtomicReplacementWithPinnedTarget(root, target.rel, data, writePerm, file, false)
+func writeFileAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMode) error {
+	return writeFileAtRootWithOptions(root, target, data, perm, false)
 }
 
-func writeFileAtRootWithPermissionFallback(root Root, target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {
+func writeFileAtRootWithPermissionFallback(root Root, target rootedTarget, data []byte, perm os.FileMode) error {
+	return writeFileAtRootWithOptions(root, target, data, perm, true)
+}
+
+func writeFileAtRootWithOptions(root Root, target rootedTarget, data []byte, perm os.FileMode, allowPermissionFallback bool) (returnErr error) {
 	writePerm, existingInfo, err := resolvedWriteFilePerm(root, target, perm)
 	if err != nil {
 		return err
@@ -284,7 +268,7 @@ func writeFileAtRootWithPermissionFallback(root Root, target rootedTarget, data 
 		}
 	}()
 
-	return writeAtomicReplacementWithPinnedTarget(root, target.rel, data, writePerm, file, true)
+	return writeAtomicReplacementWithPinnedTarget(root, target.rel, data, writePerm, file, allowPermissionFallback)
 }
 
 func writeFileIfAbsentAtRoot(root Root, target rootedTarget, data []byte, perm os.FileMode) (returnErr error) {

--- a/internal/safeio/write_other_test.go
+++ b/internal/safeio/write_other_test.go
@@ -240,15 +240,16 @@ func newFallbackDeniedWriteRoot(t *testing.T, tempOpenErr error, rename func(str
 	t.Helper()
 
 	info, targetFile, targetData := newFallbackPinnedTarget(t)
+	tempInfo := newPinnedTargetInfo(t, "temp")
 	openTarget := func() (File, error) { return targetFile, nil }
 	root := &fakeRoot{
 		lstat: func(name string) (fs.FileInfo, error) {
-			if name != writeTestFileName {
-				return nil, os.ErrNotExist
+			if name == writeTestFileName {
+				return info, nil
 			}
-			return info, nil
+			return tempInfo, nil
 		},
-		openFile: openTargetOrTempFile(writeTestFileName, openTarget, tempOpenErr),
+		openFile: openTargetOrTempFile(writeTestFileName, openTarget, tempInfo, tempOpenErr),
 		rename:   rename,
 	}
 	return root, targetFile, targetData

--- a/internal/safeio/write_other_test.go
+++ b/internal/safeio/write_other_test.go
@@ -37,8 +37,68 @@ func TestOpenPinnedReplacementTargetIfNeededSkipsPinnedTargetOnNonWindows(t *tes
 
 func TestWriteFileReplacingUnderReplacesReadOnlyExistingRegularFileOnNonWindows(t *testing.T) {
 	rootDir := t.TempDir()
+	targetPath := seedReadOnlyTargetFile(t, rootDir, 0o444)
+	requireReadOnlyTarget(t, targetPath)
+
+	if err := WriteFileReplacingUnder(rootDir, targetPath, []byte("after"), 0o600); err != nil {
+		t.Fatalf("WriteFileReplacingUnder returned error: %v", err)
+	}
+
+	assertTargetContentAndMode(t, targetPath, "after", 0o444, "replaced")
+}
+
+func TestWriteRootFallsBackToPinnedOverwriteWhenParentLacksWritePermissionOnNonWindows(t *testing.T) {
+	if syscall.Geteuid() == 0 {
+		t.Skip("effective privileges bypass parent write permission checks")
+	}
+
+	rootDir, parentDir, targetPath := setupReadOnlyWriteParent(t)
+	requireParentWriteDeniedOnNonWindows(t, parentDir, ".safeio-write-probe")
+	requireWritableTargetReopenableOnNonWindows(t, targetPath)
+
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+	if err := root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750); err != nil {
+		t.Fatalf("WriteFileCreatingParents returned error: %v", err)
+	}
+
+	assertTargetContentAndMode(t, targetPath, "after", 0o640, "overwritten")
+	if entries, err := os.ReadDir(parentDir); err != nil {
+		t.Fatalf("read reports dir: %v", err)
+	} else if len(entries) != 1 || entries[0].Name() != writeTestFileName {
+		t.Fatalf("expected only target file to remain, got %v", entries)
+	}
+}
+
+func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenTempCreationDeniedOnNonWindows(t *testing.T) {
+	root, targetFile, targetData := newFallbackDeniedWriteRoot(t, os.ErrPermission, nil)
+
+	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile); err != nil {
+		t.Fatalf("writeAtomicReplacementWithPinnedTarget returned error: %v", err)
+	}
+	assertFallbackTargetData(t, targetData, "after")
+}
+
+func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenRenameDeniedOnNonWindows(t *testing.T) {
+	removeCalls := 0
+	root, targetFile, targetData := newFallbackRenameRoot(t, func(string) error {
+		removeCalls++
+		return nil
+	})
+
+	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile); err != nil {
+		t.Fatalf("writeAtomicReplacementWithPinnedTarget returned error: %v", err)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("expected temp cleanup after rename fallback, got %d removes", removeCalls)
+	}
+	assertFallbackTargetData(t, targetData, "after")
+}
+
+func seedReadOnlyTargetFile(t *testing.T, rootDir string, perm os.FileMode) string {
+	t.Helper()
+
 	targetPath := filepath.Join(rootDir, writeTestFileName)
-	if err := os.WriteFile(targetPath, []byte("before"), 0o444); err != nil {
+	if err := os.WriteFile(targetPath, []byte("before"), perm); err != nil {
 		t.Fatalf("seed target file: %v", err)
 	}
 	t.Cleanup(func() {
@@ -46,36 +106,39 @@ func TestWriteFileReplacingUnderReplacesReadOnlyExistingRegularFileOnNonWindows(
 			t.Errorf("restore target file permissions: %v", err)
 		}
 	})
+	return targetPath
+}
 
-	probe, probeErr := os.OpenFile(targetPath, os.O_WRONLY, 0)
-	if probeErr == nil {
-		if err := probe.Close(); err != nil {
-			t.Fatalf("close writability probe: %v", err)
+func requireReadOnlyTarget(t *testing.T, targetPath string) {
+	t.Helper()
+
+	probe, err := os.OpenFile(targetPath, os.O_WRONLY, 0)
+	if err == nil {
+		if closeErr := probe.Close(); closeErr != nil {
+			t.Fatalf("close writability probe: %v", closeErr)
 		}
 		t.Skip("effective privileges bypass read-only file permissions")
 	}
-	if !os.IsPermission(probeErr) {
-		t.Skipf("read-only file semantics are not testable: %v", probeErr)
-	}
-
-	if err := WriteFileReplacingUnder(rootDir, targetPath, []byte("after"), 0o600); err != nil {
-		t.Fatalf("WriteFileReplacingUnder returned error: %v", err)
-	}
-
-	assertFileContent(t, targetPath, "after")
-	info, err := os.Stat(targetPath)
-	if err != nil {
-		t.Fatalf("stat replaced file: %v", err)
-	}
-	if info.Mode().Perm() != 0o444 {
-		t.Fatalf("expected existing read-only mode 0444 to be preserved, got %#o", info.Mode().Perm())
+	if !os.IsPermission(err) {
+		t.Skipf("read-only file semantics are not testable: %v", err)
 	}
 }
 
-func TestWriteRootFallsBackToPinnedOverwriteWhenParentLacksWritePermissionOnNonWindows(t *testing.T) {
-	if syscall.Geteuid() == 0 {
-		t.Skip("effective privileges bypass parent write permission checks")
+func assertTargetContentAndMode(t *testing.T, targetPath, want string, wantPerm os.FileMode, label string) {
+	t.Helper()
+
+	assertFileContent(t, targetPath, want)
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatalf("stat %s file: %v", label, err)
 	}
+	if info.Mode().Perm() != wantPerm {
+		t.Fatalf("expected existing %s mode %#o to be preserved, got %#o", label, wantPerm, info.Mode().Perm())
+	}
+}
+
+func setupReadOnlyWriteParent(t *testing.T) (string, string, string) {
+	t.Helper()
 
 	rootDir := t.TempDir()
 	parentDir := filepath.Join(rootDir, "reports")
@@ -95,7 +158,13 @@ func TestWriteRootFallsBackToPinnedOverwriteWhenParentLacksWritePermissionOnNonW
 		}
 	})
 
-	probePath := filepath.Join(parentDir, ".safeio-write-probe")
+	return rootDir, parentDir, targetPath
+}
+
+func requireParentWriteDeniedOnNonWindows(t *testing.T, parentDir, probeName string) {
+	t.Helper()
+
+	probePath := filepath.Join(parentDir, probeName)
 	if err := os.WriteFile(probePath, []byte("probe"), 0o600); err == nil {
 		if removeErr := os.Remove(probePath); removeErr != nil {
 			t.Fatalf("remove write probe: %v", removeErr)
@@ -104,36 +173,11 @@ func TestWriteRootFallsBackToPinnedOverwriteWhenParentLacksWritePermissionOnNonW
 	} else if !os.IsPermission(err) {
 		t.Skipf("parent write permission semantics are not testable: %v", err)
 	}
-
-	probe, err := os.OpenFile(targetPath, os.O_WRONLY, 0)
-	if err != nil {
-		t.Skipf("existing writable target cannot be reopened without parent write permission: %v", err)
-	}
-	if err := probe.Close(); err != nil {
-		t.Fatalf("close writable target probe: %v", err)
-	}
-
-	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
-	if err := root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750); err != nil {
-		t.Fatalf("WriteFileCreatingParents returned error: %v", err)
-	}
-
-	assertFileContent(t, targetPath, "after")
-	info, err := os.Stat(targetPath)
-	if err != nil {
-		t.Fatalf("stat overwritten target: %v", err)
-	}
-	if info.Mode().Perm() != 0o640 {
-		t.Fatalf("expected target mode 0640 to be preserved, got %#o", info.Mode().Perm())
-	}
-	if entries, err := os.ReadDir(parentDir); err != nil {
-		t.Fatalf("read reports dir: %v", err)
-	} else if len(entries) != 1 || entries[0].Name() != writeTestFileName {
-		t.Fatalf("expected only target file to remain, got %v", entries)
-	}
 }
 
-func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenTempCreationDeniedOnNonWindows(t *testing.T) {
+func newFallbackPinnedTarget(t *testing.T) (fs.FileInfo, File, *[]byte) {
+	t.Helper()
+
 	targetPath := filepath.Join(t.TempDir(), writeTestFileName)
 	if err := os.WriteFile(targetPath, []byte("before"), 0o640); err != nil {
 		t.Fatalf("seed target info path: %v", err)
@@ -157,54 +201,13 @@ func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenTempCreationDeniedOn
 			return nil
 		},
 	}
-	root := &fakeRoot{
-		lstat: func(name string) (fs.FileInfo, error) {
-			if name != writeTestFileName {
-				return nil, os.ErrNotExist
-			}
-			return info, nil
-		},
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if name == writeTestFileName {
-				return targetFile, nil
-			}
-			return nil, os.ErrPermission
-		},
-	}
-
-	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile); err != nil {
-		t.Fatalf("writeAtomicReplacementWithPinnedTarget returned error: %v", err)
-	}
-	if string(targetData) != "after" {
-		t.Fatalf("expected fallback overwrite data, got %q", string(targetData))
-	}
+	return info, targetFile, &targetData
 }
 
-func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenRenameDeniedOnNonWindows(t *testing.T) {
-	targetPath := filepath.Join(t.TempDir(), writeTestFileName)
-	if err := os.WriteFile(targetPath, []byte("before"), 0o640); err != nil {
-		t.Fatalf("seed target info path: %v", err)
-	}
-	info := statTestPath(t, targetPath)
-	targetData := []byte("before")
-	targetFile := &truncatingFakeFile{
-		fakeFile: &fakeFile{
-			stat: func() (fs.FileInfo, error) { return info, nil },
-			write: func(p []byte) (int, error) {
-				targetData = append(targetData, p...)
-				return len(p), nil
-			},
-			close: closeWithoutError,
-		},
-		truncate: func(size int64) error {
-			if size != 0 {
-				t.Fatalf("unexpected truncate size: %d", size)
-			}
-			targetData = targetData[:0]
-			return nil
-		},
-	}
-	removeCalls := 0
+func newFallbackDeniedWriteRoot(t *testing.T, tempOpenErr error, rename func(string, string) error) (*fakeRoot, File, *[]byte) {
+	t.Helper()
+
+	info, targetFile, targetData := newFallbackPinnedTarget(t)
 	root := &fakeRoot{
 		lstat: func(name string) (fs.FileInfo, error) {
 			if name != writeTestFileName {
@@ -215,6 +218,9 @@ func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenRenameDeniedOnNonWin
 		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
 			if name == writeTestFileName {
 				return targetFile, nil
+			}
+			if tempOpenErr != nil {
+				return nil, tempOpenErr
 			}
 			return &fakeFile{
 				write: func(p []byte) (int, error) { return len(p), nil },
@@ -222,20 +228,35 @@ func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenRenameDeniedOnNonWin
 				close: closeWithoutError,
 			}, nil
 		},
-		rename: func(string, string) error { return os.ErrPermission },
-		remove: func(string) error {
-			removeCalls++
-			return nil
-		},
+		rename: rename,
 	}
+	return root, targetFile, targetData
+}
 
-	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile); err != nil {
-		t.Fatalf("writeAtomicReplacementWithPinnedTarget returned error: %v", err)
+func newFallbackRenameRoot(t *testing.T, remove func(string) error) (*fakeRoot, File, *[]byte) {
+	t.Helper()
+
+	root, targetFile, targetData := newFallbackDeniedWriteRoot(t, nil, func(string, string) error { return os.ErrPermission })
+	root.remove = remove
+	return root, targetFile, targetData
+}
+
+func assertFallbackTargetData(t *testing.T, targetData *[]byte, want string) {
+	t.Helper()
+
+	if string(*targetData) != want {
+		t.Fatalf("expected fallback overwrite data, got %q", string(*targetData))
 	}
-	if removeCalls != 1 {
-		t.Fatalf("expected temp cleanup after rename fallback, got %d removes", removeCalls)
+}
+
+func requireWritableTargetReopenableOnNonWindows(t *testing.T, targetPath string) {
+	t.Helper()
+
+	probe, err := os.OpenFile(targetPath, os.O_WRONLY, 0)
+	if err != nil {
+		t.Skipf("existing writable target cannot be reopened without parent write permission: %v", err)
 	}
-	if string(targetData) != "after" {
-		t.Fatalf("expected fallback overwrite data, got %q", string(targetData))
+	if err := probe.Close(); err != nil {
+		t.Fatalf("close writable target probe: %v", err)
 	}
 }

--- a/internal/safeio/write_other_test.go
+++ b/internal/safeio/write_other_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -47,7 +48,32 @@ func TestWriteFileReplacingUnderReplacesReadOnlyExistingRegularFileOnNonWindows(
 	assertTargetContentAndMode(t, targetPath, "after", 0o444, "replaced")
 }
 
-func TestWriteRootFallsBackToPinnedOverwriteWhenParentLacksWritePermissionOnNonWindows(t *testing.T) {
+func TestWriteRootPermissionFallbackCreatesMissingParentsOnNonWindows(t *testing.T) {
+	assertWriteRootCreatesMissingParentsAndWrites(t, "WriteFileCreatingParentsWithPermissionFallback", (*WriteRoot).WriteFileCreatingParentsWithPermissionFallback)
+}
+
+func TestWriteRootPermissionFallbackRejectsNonRelativeTargetsOnNonWindows(t *testing.T) {
+	assertWriteRootRejectsNonRelativeTargets(t, (*WriteRoot).WriteFileCreatingParentsWithPermissionFallback)
+}
+
+func TestWriteRootPermissionFallbackRejectsExistingDirectoryTargetOnNonWindows(t *testing.T) {
+	rootDir := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+	targetPath := filepath.Join("reports", writeTestFileName)
+	if err := os.MkdirAll(filepath.Join(rootDir, targetPath), 0o755); err != nil {
+		t.Fatalf("mkdir target directory: %v", err)
+	}
+
+	err := root.WriteFileCreatingParentsWithPermissionFallback(targetPath, []byte("hello"), 0o600, 0o750)
+	if err == nil {
+		t.Fatal("expected existing directory target to be rejected")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("expected non-regular target error, got %v", err)
+	}
+}
+
+func TestWriteRootReturnsErrorWithoutMutationWhenParentLacksWritePermissionOnNonWindows(t *testing.T) {
 	if syscall.Geteuid() == 0 {
 		t.Skip("effective privileges bypass parent write permission checks")
 	}
@@ -57,8 +83,31 @@ func TestWriteRootFallsBackToPinnedOverwriteWhenParentLacksWritePermissionOnNonW
 	requireWritableTargetReopenableOnNonWindows(t, targetPath)
 
 	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
-	if err := root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750); err != nil {
-		t.Fatalf("WriteFileCreatingParents returned error: %v", err)
+	err := root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750)
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Fatalf("expected permission error, got %v", err)
+	}
+
+	assertTargetContentAndMode(t, targetPath, "before", 0o640, "existing")
+	if entries, err := os.ReadDir(parentDir); err != nil {
+		t.Fatalf("read reports dir: %v", err)
+	} else if len(entries) != 1 || entries[0].Name() != writeTestFileName {
+		t.Fatalf("expected only target file to remain, got %v", entries)
+	}
+}
+
+func TestWriteRootPermissionFallbackOverwritesWhenParentLacksWritePermissionOnNonWindows(t *testing.T) {
+	if syscall.Geteuid() == 0 {
+		t.Skip("effective privileges bypass parent write permission checks")
+	}
+
+	rootDir, parentDir, targetPath := setupReadOnlyWriteParent(t)
+	requireParentWriteDeniedOnNonWindows(t, parentDir, ".safeio-write-probe")
+	requireWritableTargetReopenableOnNonWindows(t, targetPath)
+
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+	if err := root.WriteFileCreatingParentsWithPermissionFallback(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750); err != nil {
+		t.Fatalf("WriteFileCreatingParentsWithPermissionFallback returned error: %v", err)
 	}
 
 	assertTargetContentAndMode(t, targetPath, "after", 0o640, "overwritten")
@@ -72,7 +121,7 @@ func TestWriteRootFallsBackToPinnedOverwriteWhenParentLacksWritePermissionOnNonW
 func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenTempCreationDeniedOnNonWindows(t *testing.T) {
 	root, targetFile, targetData := newFallbackDeniedWriteRoot(t, os.ErrPermission, nil)
 
-	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile); err != nil {
+	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile, true); err != nil {
 		t.Fatalf("writeAtomicReplacementWithPinnedTarget returned error: %v", err)
 	}
 	assertFallbackTargetData(t, targetData, "after")
@@ -85,7 +134,7 @@ func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenRenameDeniedOnNonWin
 		return nil
 	})
 
-	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile); err != nil {
+	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile, true); err != nil {
 		t.Fatalf("writeAtomicReplacementWithPinnedTarget returned error: %v", err)
 	}
 	if removeCalls != 1 {

--- a/internal/safeio/write_other_test.go
+++ b/internal/safeio/write_other_test.go
@@ -232,31 +232,15 @@ func newFallbackPinnedTarget(t *testing.T) (fs.FileInfo, File, *[]byte) {
 		t.Fatalf("seed target info path: %v", err)
 	}
 	info := statTestPath(t, targetPath)
-	targetData := []byte("before")
-	targetFile := &truncatingFakeFile{
-		fakeFile: &fakeFile{
-			stat: func() (fs.FileInfo, error) { return info, nil },
-			write: func(p []byte) (int, error) {
-				targetData = append(targetData, p...)
-				return len(p), nil
-			},
-			close: closeWithoutError,
-		},
-		truncate: func(size int64) error {
-			if size != 0 {
-				t.Fatalf("unexpected truncate size: %d", size)
-			}
-			targetData = targetData[:0]
-			return nil
-		},
-	}
-	return info, targetFile, &targetData
+	targetFile, targetData := newPinnedFallbackTargetFile(t, info, "before")
+	return info, targetFile, targetData
 }
 
 func newFallbackDeniedWriteRoot(t *testing.T, tempOpenErr error, rename func(string, string) error) (*fakeRoot, File, *[]byte) {
 	t.Helper()
 
 	info, targetFile, targetData := newFallbackPinnedTarget(t)
+	openTarget := func() (File, error) { return targetFile, nil }
 	root := &fakeRoot{
 		lstat: func(name string) (fs.FileInfo, error) {
 			if name != writeTestFileName {
@@ -264,20 +248,8 @@ func newFallbackDeniedWriteRoot(t *testing.T, tempOpenErr error, rename func(str
 			}
 			return info, nil
 		},
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if name == writeTestFileName {
-				return targetFile, nil
-			}
-			if tempOpenErr != nil {
-				return nil, tempOpenErr
-			}
-			return &fakeFile{
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: chmodWithoutError,
-				close: closeWithoutError,
-			}, nil
-		},
-		rename: rename,
+		openFile: openTargetOrTempFile(writeTestFileName, openTarget, tempOpenErr),
+		rename:   rename,
 	}
 	return root, targetFile, targetData
 }

--- a/internal/safeio/write_other_test.go
+++ b/internal/safeio/write_other_test.go
@@ -4,8 +4,10 @@ package safeio
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -67,5 +69,173 @@ func TestWriteFileReplacingUnderReplacesReadOnlyExistingRegularFileOnNonWindows(
 	}
 	if info.Mode().Perm() != 0o444 {
 		t.Fatalf("expected existing read-only mode 0444 to be preserved, got %#o", info.Mode().Perm())
+	}
+}
+
+func TestWriteRootFallsBackToPinnedOverwriteWhenParentLacksWritePermissionOnNonWindows(t *testing.T) {
+	if syscall.Geteuid() == 0 {
+		t.Skip("effective privileges bypass parent write permission checks")
+	}
+
+	rootDir := t.TempDir()
+	parentDir := filepath.Join(rootDir, "reports")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatalf("mkdir reports: %v", err)
+	}
+	targetPath := filepath.Join(parentDir, writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("before"), 0o640); err != nil {
+		t.Fatalf("seed target file: %v", err)
+	}
+	if err := os.Chmod(parentDir, 0o555); err != nil {
+		t.Fatalf("chmod reports read-only: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(parentDir, 0o755); err != nil && !os.IsNotExist(err) {
+			t.Errorf("restore reports permissions: %v", err)
+		}
+	})
+
+	probePath := filepath.Join(parentDir, ".safeio-write-probe")
+	if err := os.WriteFile(probePath, []byte("probe"), 0o600); err == nil {
+		if removeErr := os.Remove(probePath); removeErr != nil {
+			t.Fatalf("remove write probe: %v", removeErr)
+		}
+		t.Skip("effective privileges bypass missing parent write permission")
+	} else if !os.IsPermission(err) {
+		t.Skipf("parent write permission semantics are not testable: %v", err)
+	}
+
+	probe, err := os.OpenFile(targetPath, os.O_WRONLY, 0)
+	if err != nil {
+		t.Skipf("existing writable target cannot be reopened without parent write permission: %v", err)
+	}
+	if err := probe.Close(); err != nil {
+		t.Fatalf("close writable target probe: %v", err)
+	}
+
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+	if err := root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("after"), 0o600, 0o750); err != nil {
+		t.Fatalf("WriteFileCreatingParents returned error: %v", err)
+	}
+
+	assertFileContent(t, targetPath, "after")
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatalf("stat overwritten target: %v", err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("expected target mode 0640 to be preserved, got %#o", info.Mode().Perm())
+	}
+	if entries, err := os.ReadDir(parentDir); err != nil {
+		t.Fatalf("read reports dir: %v", err)
+	} else if len(entries) != 1 || entries[0].Name() != writeTestFileName {
+		t.Fatalf("expected only target file to remain, got %v", entries)
+	}
+}
+
+func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenTempCreationDeniedOnNonWindows(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("before"), 0o640); err != nil {
+		t.Fatalf("seed target info path: %v", err)
+	}
+	info := statTestPath(t, targetPath)
+	targetData := []byte("before")
+	targetFile := &truncatingFakeFile{
+		fakeFile: &fakeFile{
+			stat: func() (fs.FileInfo, error) { return info, nil },
+			write: func(p []byte) (int, error) {
+				targetData = append(targetData, p...)
+				return len(p), nil
+			},
+			close: closeWithoutError,
+		},
+		truncate: func(size int64) error {
+			if size != 0 {
+				t.Fatalf("unexpected truncate size: %d", size)
+			}
+			targetData = targetData[:0]
+			return nil
+		},
+	}
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				return nil, os.ErrNotExist
+			}
+			return info, nil
+		},
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if name == writeTestFileName {
+				return targetFile, nil
+			}
+			return nil, os.ErrPermission
+		},
+	}
+
+	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile); err != nil {
+		t.Fatalf("writeAtomicReplacementWithPinnedTarget returned error: %v", err)
+	}
+	if string(targetData) != "after" {
+		t.Fatalf("expected fallback overwrite data, got %q", string(targetData))
+	}
+}
+
+func TestWriteAtomicReplacementWithPinnedTargetFallsBackWhenRenameDeniedOnNonWindows(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("before"), 0o640); err != nil {
+		t.Fatalf("seed target info path: %v", err)
+	}
+	info := statTestPath(t, targetPath)
+	targetData := []byte("before")
+	targetFile := &truncatingFakeFile{
+		fakeFile: &fakeFile{
+			stat: func() (fs.FileInfo, error) { return info, nil },
+			write: func(p []byte) (int, error) {
+				targetData = append(targetData, p...)
+				return len(p), nil
+			},
+			close: closeWithoutError,
+		},
+		truncate: func(size int64) error {
+			if size != 0 {
+				t.Fatalf("unexpected truncate size: %d", size)
+			}
+			targetData = targetData[:0]
+			return nil
+		},
+	}
+	removeCalls := 0
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				return nil, os.ErrNotExist
+			}
+			return info, nil
+		},
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if name == writeTestFileName {
+				return targetFile, nil
+			}
+			return &fakeFile{
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: closeWithoutError,
+			}, nil
+		},
+		rename: func(string, string) error { return os.ErrPermission },
+		remove: func(string) error {
+			removeCalls++
+			return nil
+		},
+	}
+
+	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile); err != nil {
+		t.Fatalf("writeAtomicReplacementWithPinnedTarget returned error: %v", err)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("expected temp cleanup after rename fallback, got %d removes", removeCalls)
+	}
+	if string(targetData) != "after" {
+		t.Fatalf("expected fallback overwrite data, got %q", string(targetData))
 	}
 }

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -846,21 +846,22 @@ func TestTrustedRootAliasTargetGuards(t *testing.T) {
 		t.Fatalf("expected nested alias path to be rejected, got target=%q ok=%v", untrustedTarget, ok)
 	}
 
+	withRuntimeGOOS(t, "darwin")
 	expectedTmpTarget := filepath.Join(string(os.PathSeparator), "private", "tmp")
 	tmpTarget, tmpOK := trustedRootAliasTarget(filepath.Join(string(os.PathSeparator), "tmp"))
-	if runtime.GOOS == "darwin" {
-		if !tmpOK || tmpTarget != expectedTmpTarget {
-			t.Fatalf("expected /tmp alias target %q, got target=%q ok=%v", expectedTmpTarget, tmpTarget, tmpOK)
-		}
-		expectedVarTarget := filepath.Join(string(os.PathSeparator), "private", "var")
-		varTarget, varOK := trustedRootAliasTarget(filepath.Join(string(os.PathSeparator), "var"))
-		if !varOK || varTarget != expectedVarTarget {
-			t.Fatalf("expected /var alias target %q, got target=%q ok=%v", expectedVarTarget, varTarget, varOK)
-		}
-		return
+	if !tmpOK || tmpTarget != expectedTmpTarget {
+		t.Fatalf("expected /tmp alias target %q, got target=%q ok=%v", expectedTmpTarget, tmpTarget, tmpOK)
 	}
+	expectedVarTarget := filepath.Join(string(os.PathSeparator), "private", "var")
+	varTarget, varOK := trustedRootAliasTarget(filepath.Join(string(os.PathSeparator), "var"))
+	if !varOK || varTarget != expectedVarTarget {
+		t.Fatalf("expected /var alias target %q, got target=%q ok=%v", expectedVarTarget, varTarget, varOK)
+	}
+
+	withRuntimeGOOS(t, "linux")
+	tmpTarget, tmpOK = trustedRootAliasTarget(filepath.Join(string(os.PathSeparator), "tmp"))
 	if tmpOK || tmpTarget != "" {
-		t.Fatalf("expected trusted aliases to be disabled on %s, got target=%q ok=%v", runtime.GOOS, tmpTarget, tmpOK)
+		t.Fatalf("expected trusted aliases to be disabled on linux, got target=%q ok=%v", tmpTarget, tmpOK)
 	}
 }
 
@@ -1213,6 +1214,16 @@ func TestWriteFileIfAbsentAtRootPropagatesLinkError(t *testing.T) {
 	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected link error, got %v", err)
+	}
+}
+
+func TestWriteFileIfAbsentAtRootNormalizesLinkExistsError(t *testing.T) {
+	root := makeFakeTempWriteRoot(nil)
+	root.link = func(string, string) error { return os.ErrExist }
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("expected os.ErrExist, got %v", err)
 	}
 }
 

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -2490,6 +2490,63 @@ func TestWriteAtomicReplacementWithPinnedTargetReturnsCommittedTargetStatError(t
 	}
 }
 
+func TestWriteAtomicReplacementWithPinnedTargetReturnsCloseErrorBeforeRename(t *testing.T) {
+	expectedErr := errors.New("close temp failure")
+	renameCalls := 0
+	lstatCalls := 0
+	removeCalls := 0
+	tempInfo := newPinnedTargetInfo(t, "temp")
+	targetPath := filepath.Join(t.TempDir(), writeTestFileName)
+	if err := os.WriteFile(targetPath, []byte("before"), 0o640); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	targetInfo := statTestPath(t, targetPath)
+	root := &fakeRoot{
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if !strings.HasPrefix(name, atomicTempPrefix) {
+				t.Fatalf("unexpected open path: %s", name)
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: func() error { return expectedErr },
+			}, nil
+		},
+		lstat: func(string) (fs.FileInfo, error) {
+			lstatCalls++
+			return targetInfo, nil
+		},
+		rename: func(string, string) error {
+			renameCalls++
+			return nil
+		},
+		remove: func(string) error {
+			removeCalls++
+			return nil
+		},
+	}
+	target := &fakeFile{
+		stat:  func() (fs.FileInfo, error) { return targetInfo, nil },
+		close: closeWithoutError,
+	}
+
+	err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, target, false)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected temp close error, got %v", err)
+	}
+	if renameCalls != 0 {
+		t.Fatalf("expected no rename after close failure, got %d", renameCalls)
+	}
+	if lstatCalls != 0 {
+		t.Fatalf("expected no committed target lstat after close failure, got %d", lstatCalls)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("expected temp cleanup after close failure, got %d removes", removeCalls)
+	}
+	assertFileContent(t, targetPath, "before")
+}
+
 func TestOpenPinnedReplacementTargetReturnsOpenError(t *testing.T) {
 	expectedErr := errors.New("open target failure")
 	root := &fakeRoot{

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -156,35 +156,20 @@ func openTargetOrTempFile(targetName string, openTarget func() (File, error), te
 func newCommittedTargetValidationRoot(t *testing.T, tempInfo fs.FileInfo, lstatTarget func() (fs.FileInfo, error), rename func() error, remove func(string) error, tempClosed *bool) *fakeRoot {
 	t.Helper()
 
-	return &fakeRoot{
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if !strings.HasPrefix(name, atomicTempPrefix) {
-				t.Fatalf("unexpected open path: %s", name)
-			}
-			return &fakeFile{
-				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: chmodWithoutError,
-				close: func() error {
-					*tempClosed = true
-					return nil
-				},
-			}, nil
-		},
-		lstat: func(name string) (fs.FileInfo, error) {
-			if name != writeTestFileName {
-				t.Fatalf("unexpected lstat path: %s", name)
-			}
-			return lstatTarget()
-		},
-		rename: func(string, string) error {
-			return rename()
-		},
-		remove: remove,
+	lstat := func(string) (fs.FileInfo, error) {
+		return lstatTarget()
 	}
+	renameFn := func(string, string) error {
+		return rename()
+	}
+	closeFn := func() error {
+		*tempClosed = true
+		return nil
+	}
+	return newCommittedTargetTestRoot(t, tempInfo, lstat, renameFn, remove, closeFn)
 }
 
-func newCommittedTargetLstatErrorRoot(t *testing.T, tempInfo fs.FileInfo, expectedErr error, tempClosed *bool) *fakeRoot {
+func newCommittedTargetTestRoot(t *testing.T, tempInfo fs.FileInfo, lstat func(string) (fs.FileInfo, error), rename func(string, string) error, remove func(string) error, closeFn func() error) *fakeRoot {
 	t.Helper()
 
 	return &fakeRoot{
@@ -192,24 +177,42 @@ func newCommittedTargetLstatErrorRoot(t *testing.T, tempInfo fs.FileInfo, expect
 			if !strings.HasPrefix(name, atomicTempPrefix) {
 				t.Fatalf("unexpected open path: %s", name)
 			}
-			return &fakeFile{
-				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: chmodWithoutError,
-				close: func() error {
-					*tempClosed = true
-					return nil
-				},
-			}, nil
+			return newCommittedTargetTempFile(t, tempInfo, closeFn), nil
 		},
 		lstat: func(name string) (fs.FileInfo, error) {
 			if name != writeTestFileName {
 				t.Fatalf("unexpected lstat path: %s", name)
 			}
-			return nil, expectedErr
+			return lstat(name)
 		},
-		rename: func(string, string) error { return nil },
-		remove: func(string) error { return nil },
+		rename: rename,
+		remove: remove,
+	}
+}
+
+func newCommittedTargetLstatErrorRoot(t *testing.T, tempInfo fs.FileInfo, expectedErr error, tempClosed *bool) *fakeRoot {
+	t.Helper()
+
+	lstatTarget := func() (fs.FileInfo, error) {
+		return nil, expectedErr
+	}
+	rename := func() error {
+		return nil
+	}
+	remove := func(string) error {
+		return nil
+	}
+	return newCommittedTargetValidationRoot(t, tempInfo, lstatTarget, rename, remove, tempClosed)
+}
+
+func newCommittedTargetTempFile(t *testing.T, tempInfo fs.FileInfo, closeFn func() error) *fakeFile {
+	t.Helper()
+
+	return &fakeFile{
+		stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
+		write: func(p []byte) (int, error) { return len(p), nil },
+		chmod: chmodWithoutError,
+		close: closeFn,
 	}
 }
 
@@ -2395,37 +2398,23 @@ func TestWriteAtomicReplacementVerifiesCommittedTarget(t *testing.T) {
 	renameCalls := 0
 	removeCalls := 0
 	lstatCalls := 0
-	root := &fakeRoot{
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if !strings.HasPrefix(name, atomicTempPrefix) {
-				t.Fatalf("unexpected open path: %s", name)
-			}
-			return &fakeFile{
-				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: chmodWithoutError,
-				close: func() error {
-					tempClosed = true
-					return nil
-				},
-			}, nil
-		},
-		lstat: func(name string) (fs.FileInfo, error) {
-			if name != writeTestFileName {
-				t.Fatalf("unexpected lstat path: %s", name)
-			}
-			lstatCalls++
-			return tempInfo, nil
-		},
-		rename: func(string, string) error {
-			renameCalls++
-			return nil
-		},
-		remove: func(string) error {
-			removeCalls++
-			return nil
-		},
+	lstat := func(string) (fs.FileInfo, error) {
+		lstatCalls++
+		return tempInfo, nil
 	}
+	rename := func(string, string) error {
+		renameCalls++
+		return nil
+	}
+	remove := func(string) error {
+		removeCalls++
+		return nil
+	}
+	closeFn := func() error {
+		tempClosed = true
+		return nil
+	}
+	root := newCommittedTargetTestRoot(t, tempInfo, lstat, rename, remove, closeFn)
 
 	err := writeAtomicReplacement(root, writeTestFileName, []byte("after"), 0o600, statTestPath(t, t.TempDir()))
 	if err != nil {
@@ -2450,36 +2439,22 @@ func TestWriteAtomicReplacementRejectsChangedCommittedTarget(t *testing.T) {
 	tempClosed := false
 	renameCalls := 0
 	removeCalls := 0
-	root := &fakeRoot{
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if !strings.HasPrefix(name, atomicTempPrefix) {
-				t.Fatalf("unexpected open path: %s", name)
-			}
-			return &fakeFile{
-				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: chmodWithoutError,
-				close: func() error {
-					tempClosed = true
-					return nil
-				},
-			}, nil
-		},
-		lstat: func(name string) (fs.FileInfo, error) {
-			if name != writeTestFileName {
-				t.Fatalf("unexpected lstat path: %s", name)
-			}
-			return changedInfo, nil
-		},
-		rename: func(string, string) error {
-			renameCalls++
-			return nil
-		},
-		remove: func(string) error {
-			removeCalls++
-			return nil
-		},
+	lstat := func(string) (fs.FileInfo, error) {
+		return changedInfo, nil
 	}
+	rename := func(string, string) error {
+		renameCalls++
+		return nil
+	}
+	remove := func(string) error {
+		removeCalls++
+		return nil
+	}
+	closeFn := func() error {
+		tempClosed = true
+		return nil
+	}
+	root := newCommittedTargetTestRoot(t, tempInfo, lstat, rename, remove, closeFn)
 
 	err := writeAtomicReplacement(root, writeTestFileName, []byte("after"), 0o600, statTestPath(t, t.TempDir()))
 	if err == nil || !strings.Contains(err.Error(), "committed target changed before validation") {
@@ -2501,31 +2476,20 @@ func TestWriteAtomicReplacementReturnsCloseErrorBeforeRename(t *testing.T) {
 	renameCalls := 0
 	lstatCalls := 0
 	removeCalls := 0
-	root := &fakeRoot{
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if !strings.HasPrefix(name, atomicTempPrefix) {
-				t.Fatalf("unexpected open path: %s", name)
-			}
-			return &fakeFile{
-				stat:  func() (fs.FileInfo, error) { return newPinnedTargetInfo(t, "temp"), nil },
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: chmodWithoutError,
-				close: func() error { return expectedErr },
-			}, nil
-		},
-		lstat: func(string) (fs.FileInfo, error) {
-			lstatCalls++
-			return newPinnedTargetInfo(t, "target"), nil
-		},
-		rename: func(string, string) error {
-			renameCalls++
-			return nil
-		},
-		remove: func(string) error {
-			removeCalls++
-			return nil
-		},
+	lstat := func(string) (fs.FileInfo, error) {
+		lstatCalls++
+		return newPinnedTargetInfo(t, "target"), nil
 	}
+	rename := func(string, string) error {
+		renameCalls++
+		return nil
+	}
+	remove := func(string) error {
+		removeCalls++
+		return nil
+	}
+	closeFn := func() error { return expectedErr }
+	root := newCommittedTargetTestRoot(t, newPinnedTargetInfo(t, "temp"), lstat, rename, remove, closeFn)
 
 	err := writeAtomicReplacement(root, writeTestFileName, []byte("after"), 0o600, statTestPath(t, t.TempDir()))
 	if !errors.Is(err, expectedErr) {

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -237,23 +237,6 @@ func assertWriteRootRejectsNonRelativeTargets(t *testing.T, invoke func(*WriteRo
 	}
 }
 
-func makeFakeTempWriteRoot(err error) *fakeRoot {
-	return &fakeRoot{
-		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
-		openFile: func(string, int, os.FileMode) (File, error) {
-			if err != nil {
-				return nil, err
-			}
-			return &fakeFile{
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: func(os.FileMode) error { return nil },
-				close: func() error { return nil },
-			}, nil
-		},
-		remove: func(string) error { return nil },
-	}
-}
-
 func makeFakeFallbackWriteRoot(targetFile func() File, remove func(string) error) *fakeRoot {
 	if remove == nil {
 		remove = func(string) error { return nil }
@@ -275,16 +258,13 @@ func makeFakeFallbackWriteRoot(targetFile func() File, remove func(string) error
 	}
 }
 
-func assertFallbackCleanupOrder(t *testing.T, removed []string) {
+func assertExclusiveCreateCleanup(t *testing.T, removed []string) {
 	t.Helper()
-	if len(removed) != 2 {
-		t.Fatalf("expected cleanup for fallback target and temp file, got %v", removed)
+	if len(removed) != 1 {
+		t.Fatalf("expected cleanup for incomplete exclusive-create target, got %v", removed)
 	}
 	if removed[0] != writeTestFileName {
-		t.Fatalf("expected fallback target cleanup first for %q, got %v", writeTestFileName, removed)
-	}
-	if !strings.HasPrefix(removed[1], atomicTempPrefix) {
-		t.Fatalf("expected temp cleanup second, got %v", removed)
+		t.Fatalf("expected exclusive-create target cleanup for %q, got %v", writeTestFileName, removed)
 	}
 }
 
@@ -1260,38 +1240,28 @@ func TestWriteFileIfAbsentAtRootPropagatesUnexpectedLookupError(t *testing.T) {
 	}
 }
 
-func TestWriteFileIfAbsentAtRootPropagatesCreateTempError(t *testing.T) {
-	expectedErr := errors.New("create temp failure")
-	root := makeFakeTempWriteRoot(expectedErr)
+func TestWriteFileIfAbsentAtRootPropagatesExclusiveCreateError(t *testing.T) {
+	expectedErr := errors.New("exclusive create failure")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if name != writeTestFileName {
+				t.Fatalf("unexpected create path: %s", name)
+			}
+			if flag != os.O_RDWR|os.O_CREATE|os.O_EXCL {
+				t.Fatalf("unexpected create flags: %#x", flag)
+			}
+			return nil, expectedErr
+		},
+	}
 
 	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
 	if !errors.Is(err, expectedErr) {
-		t.Fatalf("expected create temp error, got %v", err)
+		t.Fatalf("expected exclusive create error, got %v", err)
 	}
 }
 
-func TestWriteFileIfAbsentAtRootPropagatesLinkError(t *testing.T) {
-	expectedErr := errors.New("link failure")
-	root := makeFakeTempWriteRoot(nil)
-	root.link = func(string, string) error { return expectedErr }
-
-	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
-	if !errors.Is(err, expectedErr) {
-		t.Fatalf("expected link error, got %v", err)
-	}
-}
-
-func TestWriteFileIfAbsentAtRootNormalizesLinkExistsError(t *testing.T) {
-	root := makeFakeTempWriteRoot(nil)
-	root.link = func(string, string) error { return os.ErrExist }
-
-	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
-	if !errors.Is(err, os.ErrExist) {
-		t.Fatalf("expected os.ErrExist, got %v", err)
-	}
-}
-
-func TestWriteFileIfAbsentAtRootFallsBackWhenLinkUnsupported(t *testing.T) {
+func TestWriteFileIfAbsentAtRootCreatesTargetExclusivelyWithoutLinking(t *testing.T) {
 	var wroteTarget []byte
 	var chmodTarget os.FileMode
 	targetClosed := false
@@ -1321,19 +1291,18 @@ func TestWriteFileIfAbsentAtRootFallsBackWhenLinkUnsupported(t *testing.T) {
 					},
 				}, nil
 			}
-			return &fakeFile{
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: func(os.FileMode) error { return nil },
-				close: func() error { return nil },
-			}, nil
+			t.Fatalf("unexpected create path: %s", name)
+			return nil, nil
 		},
-		link:   func(string, string) error { return errors.ErrUnsupported },
-		remove: func(string) error { return nil },
+		link: func(string, string) error {
+			t.Fatal("write-if-absent should not link through a replaceable temp pathname")
+			return nil
+		},
 	}
 
 	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o640)
 	if err != nil {
-		t.Fatalf("expected fallback success, got %v", err)
+		t.Fatalf("expected exclusive create success, got %v", err)
 	}
 	if string(wroteTarget) != "hello" {
 		t.Fatalf("unexpected target content: %q", string(wroteTarget))
@@ -1342,56 +1311,25 @@ func TestWriteFileIfAbsentAtRootFallsBackWhenLinkUnsupported(t *testing.T) {
 		t.Fatalf("unexpected target chmod: %#o", chmodTarget)
 	}
 	if !targetClosed {
-		t.Fatal("expected fallback target file to close")
+		t.Fatal("expected exclusive-create target file to close")
 	}
 }
 
-func TestWriteFileIfAbsentAtRootFallsBackWhenLinkReturnsEPERM(t *testing.T) {
-	var wroteTarget []byte
+func TestWriteFileIfAbsentAtRootReturnsExistWhenTargetAppearsAfterLookup(t *testing.T) {
 	root := &fakeRoot{
 		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			return &fakeFile{
-				write: func(p []byte) (int, error) {
-					if name == writeTestFileName {
-						wroteTarget = append([]byte(nil), p...)
-					}
-					return len(p), nil
-				},
-				chmod: func(os.FileMode) error { return nil },
-				close: func() error { return nil },
-			}, nil
-		},
-		link:   func(string, string) error { return syscall.EPERM },
-		remove: func(string) error { return nil },
 	}
-
-	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o640)
-	if err != nil {
-		t.Fatalf("expected EPERM fallback success, got %v", err)
-	}
-	if string(wroteTarget) != "hello" {
-		t.Fatalf("unexpected target content: %q", string(wroteTarget))
-	}
-}
-
-func TestWriteFileIfAbsentAtRootReturnsExistWhenFallbackTargetExists(t *testing.T) {
-	root := makeFakeTempWriteRoot(nil)
-	root.link = func(string, string) error { return errors.ErrUnsupported }
 	root.openFile = func(name string, flag int, perm os.FileMode) (File, error) {
 		if name == writeTestFileName {
 			return nil, os.ErrExist
 		}
-		return &fakeFile{
-			write: func(p []byte) (int, error) { return len(p), nil },
-			chmod: func(os.FileMode) error { return nil },
-			close: func() error { return nil },
-		}, nil
+		t.Fatalf("unexpected create path: %s", name)
+		return nil, nil
 	}
 
 	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
 	if !errors.Is(err, os.ErrExist) {
-		t.Fatalf("expected os.ErrExist from fallback target create, got %v", err)
+		t.Fatalf("expected os.ErrExist from exclusive create, got %v", err)
 	}
 }
 
@@ -1420,7 +1358,7 @@ func TestWriteFileIfAbsentAtRootRemovesFallbackTargetOnWriteError(t *testing.T) 
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected fallback write error, got %v", err)
 	}
-	assertFallbackCleanupOrder(t, removed)
+	assertExclusiveCreateCleanup(t, removed)
 	if !targetClosed {
 		t.Fatal("expected fallback target file to close before cleanup")
 	}
@@ -1451,7 +1389,7 @@ func TestWriteFileIfAbsentAtRootRemovesFallbackTargetOnCloseError(t *testing.T) 
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected fallback close error, got %v", err)
 	}
-	assertFallbackCleanupOrder(t, removed)
+	assertExclusiveCreateCleanup(t, removed)
 	if !targetClosed {
 		t.Fatal("expected fallback target file close attempt before cleanup")
 	}

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -58,6 +58,16 @@ func moveFallbackFailureCases() []moveFallbackFailureCase {
 	}
 }
 
+func newPinnedTargetInfo(t *testing.T, contents string) fs.FileInfo {
+	t.Helper()
+
+	targetInfoPath := filepath.Join(t.TempDir(), writeTestFileName)
+	if err := os.WriteFile(targetInfoPath, []byte(contents), 0o640); err != nil {
+		t.Fatalf("seed target info path: %v", err)
+	}
+	return statTestPath(t, targetInfoPath)
+}
+
 func assertMovedFileResult(t *testing.T, sourcePath, targetPath, wantData, sourceAction string) {
 	t.Helper()
 
@@ -326,6 +336,28 @@ func assertExclusiveCreateCleanup(t *testing.T, removed []string) {
 	}
 	if removed[0] != writeTestFileName {
 		t.Fatalf("expected exclusive-create target cleanup for %q, got %v", writeTestFileName, removed)
+	}
+}
+
+func assertWriteIfAbsentFallbackCleanup(t *testing.T, expectedErr error, targetFile func(*bool) File) {
+	t.Helper()
+
+	var removed []string
+	targetClosed := false
+	remove := func(name string) error {
+		removed = append(removed, name)
+		return nil
+	}
+
+	root := makeFakeFallbackWriteRoot(func() File { return targetFile(&targetClosed) }, remove)
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected fallback error %v, got %v", expectedErr, err)
+	}
+	assertExclusiveCreateCleanup(t, removed)
+	if !targetClosed {
+		t.Fatal("expected fallback target file close attempt before cleanup")
 	}
 }
 
@@ -1396,64 +1428,30 @@ func TestWriteFileIfAbsentAtRootReturnsExistWhenTargetAppearsAfterLookup(t *test
 
 func TestWriteFileIfAbsentAtRootRemovesFallbackTargetOnWriteError(t *testing.T) {
 	expectedErr := errors.New("write target failure")
-	var removed []string
-	targetClosed := false
-	targetFile := func() File {
+	assertWriteIfAbsentFallbackCleanup(t, expectedErr, func(targetClosed *bool) File {
 		return &fakeFile{
 			write: func([]byte) (int, error) { return 0, expectedErr },
 			close: func() error {
-				targetClosed = true
+				*targetClosed = true
 				return nil
 			},
 			chmod: func(os.FileMode) error { return nil },
 		}
-	}
-	remove := func(name string) error {
-		removed = append(removed, name)
-		return nil
-	}
-
-	root := makeFakeFallbackWriteRoot(targetFile, remove)
-
-	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
-	if !errors.Is(err, expectedErr) {
-		t.Fatalf("expected fallback write error, got %v", err)
-	}
-	assertExclusiveCreateCleanup(t, removed)
-	if !targetClosed {
-		t.Fatal("expected fallback target file to close before cleanup")
-	}
+	})
 }
 
 func TestWriteFileIfAbsentAtRootRemovesFallbackTargetOnCloseError(t *testing.T) {
 	expectedErr := errors.New("close target failure")
-	var removed []string
-	targetClosed := false
-	targetFile := func() File {
+	assertWriteIfAbsentFallbackCleanup(t, expectedErr, func(targetClosed *bool) File {
 		return &fakeFile{
 			write: func(p []byte) (int, error) { return len(p), nil },
 			close: func() error {
-				targetClosed = true
+				*targetClosed = true
 				return expectedErr
 			},
 			chmod: func(os.FileMode) error { return nil },
 		}
-	}
-	remove := func(name string) error {
-		removed = append(removed, name)
-		return nil
-	}
-
-	root := makeFakeFallbackWriteRoot(targetFile, remove)
-
-	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
-	if !errors.Is(err, expectedErr) {
-		t.Fatalf("expected fallback close error, got %v", err)
-	}
-	assertExclusiveCreateCleanup(t, removed)
-	if !targetClosed {
-		t.Fatal("expected fallback target file close attempt before cleanup")
-	}
+	})
 }
 
 func TestWriteRootRejectsNonRelativeTargets(t *testing.T) {
@@ -2605,11 +2603,7 @@ func TestOverwritePinnedFileRejectsFileWithoutTruncate(t *testing.T) {
 }
 
 func TestOverwritePinnedFilePropagatesTruncateError(t *testing.T) {
-	targetInfoPath := filepath.Join(t.TempDir(), writeTestFileName)
-	if err := os.WriteFile(targetInfoPath, []byte("before"), 0o640); err != nil {
-		t.Fatalf("seed target info path: %v", err)
-	}
-	info := statTestPath(t, targetInfoPath)
+	info := newPinnedTargetInfo(t, "before")
 	expectedErr := errors.New("truncate target failure")
 	root := &fakeRoot{
 		lstat: func(string) (fs.FileInfo, error) { return info, nil },
@@ -2630,11 +2624,7 @@ func TestOverwritePinnedFilePropagatesTruncateError(t *testing.T) {
 }
 
 func TestOverwritePinnedFilePropagatesWriteError(t *testing.T) {
-	targetInfoPath := filepath.Join(t.TempDir(), writeTestFileName)
-	if err := os.WriteFile(targetInfoPath, []byte("before"), 0o640); err != nil {
-		t.Fatalf("seed target info path: %v", err)
-	}
-	info := statTestPath(t, targetInfoPath)
+	info := newPinnedTargetInfo(t, "before")
 	expectedErr := errors.New("write target failure")
 	root := &fakeRoot{
 		lstat: func(string) (fs.FileInfo, error) { return info, nil },

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -517,7 +517,7 @@ func TestWriteRootCreatesMissingParentsAndWritesAtomically(t *testing.T) {
 
 	rootDir := t.TempDir()
 	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
-	if err := root.WriteFileCreatingParents("reports/nested/"+writeTestFileName, []byte("hello"), 0o640, 0o750); err != nil {
+	if err := root.WriteFileCreatingParents(filepath.Join("reports", "nested", writeTestFileName), []byte("hello"), 0o640, 0o750); err != nil {
 		t.Fatalf("WriteFileCreatingParents returned error: %v", err)
 	}
 	info, err := os.Stat(filepath.Join(rootDir, "reports", "nested", writeTestFileName))

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -2547,6 +2547,44 @@ func TestWriteAtomicReplacementWithPinnedTargetReturnsCloseErrorBeforeRename(t *
 	assertFileContent(t, targetPath, "before")
 }
 
+func TestAtomicWriteSessionVerifyCommittedTargetRejectsMissingSnapshot(t *testing.T) {
+	session := &atomicWriteSession{
+		root:      &fakeRoot{},
+		targetRel: writeTestFileName,
+	}
+
+	err := session.verifyCommittedTarget()
+	if err == nil || !strings.Contains(err.Error(), "temporary file info unavailable after commit") {
+		t.Fatalf("expected missing temp snapshot error, got %v", err)
+	}
+}
+
+func TestAtomicWriteSessionSnapshotAndCloseTempFileRejectsNonRegularTemp(t *testing.T) {
+	session := &atomicWriteSession{
+		targetRel: writeTestFileName,
+		tempFile: &fakeFile{
+			stat: func() (fs.FileInfo, error) {
+				return &modeOverrideFileInfo{
+					FileInfo: newPinnedTargetInfo(t, "temp"),
+					mode:     os.ModeDir | 0o755,
+				}, nil
+			},
+			close: func() error {
+				t.Fatal("expected non-regular temp file to abort before close")
+				return nil
+			},
+		},
+	}
+
+	err := session.snapshotAndCloseTempFile()
+	if err == nil || !strings.Contains(err.Error(), "temporary file is not regular after commit") {
+		t.Fatalf("expected non-regular temp file error, got %v", err)
+	}
+	if session.tempInfo != nil {
+		t.Fatal("expected no temp snapshot after non-regular temp rejection")
+	}
+}
+
 func TestOpenPinnedReplacementTargetReturnsOpenError(t *testing.T) {
 	expectedErr := errors.New("open target failure")
 	root := &fakeRoot{

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -224,6 +224,40 @@ func makeFakeTempWriteRoot(err error) *fakeRoot {
 	}
 }
 
+func makeFakeFallbackWriteRoot(targetFile func() File, remove func(string) error) *fakeRoot {
+	if remove == nil {
+		remove = func(string) error { return nil }
+	}
+	return &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if name == writeTestFileName {
+				return targetFile(), nil
+			}
+			return &fakeFile{
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: func(os.FileMode) error { return nil },
+				close: func() error { return nil },
+			}, nil
+		},
+		link:   func(string, string) error { return errors.ErrUnsupported },
+		remove: remove,
+	}
+}
+
+func assertFallbackCleanupOrder(t *testing.T, removed []string) {
+	t.Helper()
+	if len(removed) != 2 {
+		t.Fatalf("expected cleanup for fallback target and temp file, got %v", removed)
+	}
+	if removed[0] != writeTestFileName {
+		t.Fatalf("expected fallback target cleanup first for %q, got %v", writeTestFileName, removed)
+	}
+	if !strings.HasPrefix(removed[1], atomicTempPrefix) {
+		t.Fatalf("expected temp cleanup second, got %v", removed)
+	}
+}
+
 func assertPreservedExistingRegularFileMode(t *testing.T, write func(rootDir, targetPath string, data []byte) error, writeName string) {
 	t.Helper()
 	rootDir := t.TempDir()
@@ -1335,46 +1369,28 @@ func TestWriteFileIfAbsentAtRootRemovesFallbackTargetOnWriteError(t *testing.T) 
 	expectedErr := errors.New("write target failure")
 	var removed []string
 	targetClosed := false
-
-	root := &fakeRoot{
-		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if name == writeTestFileName {
-				return &fakeFile{
-					write: func([]byte) (int, error) { return 0, expectedErr },
-					close: func() error {
-						targetClosed = true
-						return nil
-					},
-					chmod: func(os.FileMode) error { return nil },
-				}, nil
-			}
-			return &fakeFile{
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: func(os.FileMode) error { return nil },
-				close: func() error { return nil },
-			}, nil
-		},
-		link: func(string, string) error { return errors.ErrUnsupported },
-		remove: func(name string) error {
-			removed = append(removed, name)
-			return nil
-		},
+	targetFile := func() File {
+		return &fakeFile{
+			write: func([]byte) (int, error) { return 0, expectedErr },
+			close: func() error {
+				targetClosed = true
+				return nil
+			},
+			chmod: func(os.FileMode) error { return nil },
+		}
 	}
+	remove := func(name string) error {
+		removed = append(removed, name)
+		return nil
+	}
+
+	root := makeFakeFallbackWriteRoot(targetFile, remove)
 
 	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected fallback write error, got %v", err)
 	}
-	if len(removed) != 2 {
-		t.Fatalf("expected cleanup for fallback target and temp file, got %v", removed)
-	}
-	if removed[0] != writeTestFileName {
-		t.Fatalf("expected fallback target cleanup first for %q, got %v", writeTestFileName, removed)
-	}
-	if !strings.HasPrefix(removed[1], atomicTempPrefix) {
-		t.Fatalf("expected temp cleanup second, got %v", removed)
-	}
+	assertFallbackCleanupOrder(t, removed)
 	if !targetClosed {
 		t.Fatal("expected fallback target file to close before cleanup")
 	}
@@ -1384,46 +1400,28 @@ func TestWriteFileIfAbsentAtRootRemovesFallbackTargetOnCloseError(t *testing.T) 
 	expectedErr := errors.New("close target failure")
 	var removed []string
 	targetClosed := false
-
-	root := &fakeRoot{
-		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if name == writeTestFileName {
-				return &fakeFile{
-					write: func(p []byte) (int, error) { return len(p), nil },
-					close: func() error {
-						targetClosed = true
-						return expectedErr
-					},
-					chmod: func(os.FileMode) error { return nil },
-				}, nil
-			}
-			return &fakeFile{
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: func(os.FileMode) error { return nil },
-				close: func() error { return nil },
-			}, nil
-		},
-		link: func(string, string) error { return errors.ErrUnsupported },
-		remove: func(name string) error {
-			removed = append(removed, name)
-			return nil
-		},
+	targetFile := func() File {
+		return &fakeFile{
+			write: func(p []byte) (int, error) { return len(p), nil },
+			close: func() error {
+				targetClosed = true
+				return expectedErr
+			},
+			chmod: func(os.FileMode) error { return nil },
+		}
 	}
+	remove := func(name string) error {
+		removed = append(removed, name)
+		return nil
+	}
+
+	root := makeFakeFallbackWriteRoot(targetFile, remove)
 
 	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected fallback close error, got %v", err)
 	}
-	if len(removed) != 2 {
-		t.Fatalf("expected cleanup for fallback target and temp file, got %v", removed)
-	}
-	if removed[0] != writeTestFileName {
-		t.Fatalf("expected fallback target cleanup first for %q, got %v", writeTestFileName, removed)
-	}
-	if !strings.HasPrefix(removed[1], atomicTempPrefix) {
-		t.Fatalf("expected temp cleanup second, got %v", removed)
-	}
+	assertFallbackCleanupOrder(t, removed)
 	if !targetClosed {
 		t.Fatal("expected fallback target file close attempt before cleanup")
 	}

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -81,6 +81,45 @@ func writePinnedTargetInfoPair(t *testing.T) (fs.FileInfo, fs.FileInfo) {
 	return statTestPath(t, originalPath), statTestPath(t, changedPath)
 }
 
+func newPinnedFallbackTargetFile(t *testing.T, info fs.FileInfo, initial string) (File, *[]byte) {
+	t.Helper()
+	targetData := []byte(initial)
+	targetFile := &truncatingFakeFile{
+		fakeFile: &fakeFile{
+			stat: func() (fs.FileInfo, error) { return info, nil },
+			write: func(p []byte) (int, error) {
+				targetData = append(targetData, p...)
+				return len(p), nil
+			},
+			close: closeWithoutError,
+		},
+		truncate: func(size int64) error {
+			if size != 0 {
+				t.Fatalf("unexpected truncate size: %d", size)
+			}
+			targetData = targetData[:0]
+			return nil
+		},
+	}
+	return targetFile, &targetData
+}
+
+func openTargetOrTempFile(targetName string, openTarget func() (File, error), tempOpenErr error) func(string, int, os.FileMode) (File, error) {
+	return func(name string, flag int, perm os.FileMode) (File, error) {
+		if name == targetName {
+			return openTarget()
+		}
+		if tempOpenErr != nil {
+			return nil, tempOpenErr
+		}
+		return &fakeFile{
+			write: func(p []byte) (int, error) { return len(p), nil },
+			chmod: chmodWithoutError,
+			close: closeWithoutError,
+		}, nil
+	}
+}
+
 func assertOverwritePinnedFileRejectsBeforeMutation(t *testing.T, openedInfo fs.FileInfo, lstat func(*testing.T) func(string) (fs.FileInfo, error), beforeRevalidate func(*testing.T) func() error) {
 	t.Helper()
 
@@ -2218,19 +2257,11 @@ func TestWriteAtomicReplacementReturnsPinnedTargetCloseErrorAfterCommit(t *testi
 
 func TestWriteAtomicReplacementReturnsPinnedTargetOpenError(t *testing.T) {
 	expectedErr := errors.New("open pinned target failure")
+	openTarget := func() (File, error) { return nil, expectedErr }
 	root := &fakeRoot{
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if name == writeTestFileName {
-				return nil, expectedErr
-			}
-			return &fakeFile{
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: chmodWithoutError,
-				close: closeWithoutError,
-			}, nil
-		},
-		rename: func(string, string) error { return nil },
-		remove: func(string) error { return nil },
+		openFile: openTargetOrTempFile(writeTestFileName, openTarget, nil),
+		rename:   func(string, string) error { return nil },
+		remove:   func(string) error { return nil },
 	}
 
 	err := writeAtomicReplacement(root, writeTestFileName, []byte("after"), 0o600, statTestPath(t, t.TempDir()))

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -127,6 +127,34 @@ func assertWriteRootRejectsParent(t *testing.T, root *WriteRoot, wantError, fail
 	}
 }
 
+func assertWriteRootParentLookupError(t *testing.T, invoke func(*WriteRoot) error) {
+	t.Helper()
+	expectedErr := errors.New("parent lookup failure")
+	withFileSystem(t, &fakeFileSystem{openRoot: func(string) (Root, error) {
+		return &fakeRoot{
+			lstat: func(string) (fs.FileInfo, error) {
+				return nil, expectedErr
+			},
+			close: func() error { return nil },
+		}, nil
+	}})
+
+	root, err := OpenWriteRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenWriteRoot returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Errorf("close write root: %v", closeErr)
+		}
+	})
+
+	err = invoke(root)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected parent lookup error, got %v", err)
+	}
+}
+
 func assertPreservedExistingRegularFileMode(t *testing.T, write func(rootDir, targetPath string, data []byte) error, writeName string) {
 	t.Helper()
 	rootDir := t.TempDir()
@@ -446,6 +474,91 @@ func TestWriteRootCreatesMissingParentsAndWritesAtomically(t *testing.T) {
 		t.Fatalf("read root-level file: %v", err)
 	} else if string(data) != "root" {
 		t.Fatalf("unexpected root-level content: %q", string(data))
+	}
+}
+
+func TestWriteRootCreatesMissingParentsAndWritesIfAbsent(t *testing.T) {
+	rootDir := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	targetPath := filepath.Join("reports", "nested", writeTestFileName)
+	if err := root.WriteFileCreatingParentsIfAbsent(targetPath, []byte("hello"), 0o640, 0o750); err != nil {
+		t.Fatalf("WriteFileCreatingParentsIfAbsent returned error: %v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(rootDir, targetPath)); err != nil {
+		t.Fatalf("read written file: %v", err)
+	} else if string(data) != "hello" {
+		t.Fatalf("unexpected content: %q", string(data))
+	}
+}
+
+func TestWriteRootIfAbsentRejectsExistingTarget(t *testing.T) {
+	rootDir := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	targetPath := filepath.Join("reports", writeTestFileName)
+	if err := root.WriteFileCreatingParentsIfAbsent(targetPath, []byte("before"), 0o600, 0o750); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	err := root.WriteFileCreatingParentsIfAbsent(targetPath, []byte("after"), 0o600, 0o750)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("expected os.ErrExist, got %v", err)
+	}
+	if data, readErr := os.ReadFile(filepath.Join(rootDir, targetPath)); readErr != nil {
+		t.Fatalf("read existing target: %v", readErr)
+	} else if string(data) != "before" {
+		t.Fatalf("expected existing target to remain unchanged, got %q", string(data))
+	}
+}
+
+func TestWriteRootIfAbsentRejectsDanglingTargetSymlink(t *testing.T) {
+	rootDir := t.TempDir()
+	outside := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	targetPath := filepath.Join("reports", writeTestFileName)
+	if err := os.MkdirAll(filepath.Join(rootDir, "reports"), 0o755); err != nil {
+		t.Fatalf("mkdir reports: %v", err)
+	}
+	outsideTarget := filepath.Join(outside, "missing", writeTestFileName)
+	if err := os.Symlink(outsideTarget, filepath.Join(rootDir, targetPath)); err != nil {
+		t.Fatalf("create dangling target symlink: %v", err)
+	}
+
+	err := root.WriteFileCreatingParentsIfAbsent(targetPath, []byte("after"), 0o600, 0o750)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("expected dangling symlink target to be treated as existing, got %v", err)
+	}
+	if _, statErr := os.Stat(outsideTarget); !os.IsNotExist(statErr) {
+		t.Fatalf("expected symlink target to remain absent, got err=%v", statErr)
+	}
+}
+
+func TestWriteRootIfAbsentRejectsNonRelativeTargets(t *testing.T) {
+	rootDir := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	for _, targetPath := range []string{rootDir, "..", filepath.Join("..", writeTestFileName), "."} {
+		err := root.WriteFileCreatingParentsIfAbsent(targetPath, []byte("hello"), 0o600, 0o750)
+		if err == nil {
+			t.Fatalf("expected target %q to be rejected", targetPath)
+		}
+	}
+}
+
+func TestWriteRootIfAbsentPropagatesParentReadyError(t *testing.T) {
+	rootDir := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	original := writeFileParentReadyFn
+	writeFileParentReadyFn = func() error { return errors.New("parent not ready") }
+	t.Cleanup(func() {
+		writeFileParentReadyFn = original
+	})
+
+	err := root.WriteFileCreatingParentsIfAbsent("file.txt", []byte("hello"), 0o600, 0o750)
+	if err == nil || !strings.Contains(err.Error(), "parent not ready") {
+		t.Fatalf("expected parent ready error, got %v", err)
 	}
 }
 
@@ -1032,31 +1145,62 @@ func TestOSRootOpenRootReturnsMissingDirectoryError(t *testing.T) {
 }
 
 func TestWriteRootPropagatesParentLookupError(t *testing.T) {
-	expectedErr := errors.New("parent lookup failure")
-	withFileSystem(t, &fakeFileSystem{openRoot: func(string) (Root, error) {
-		return &fakeRoot{
-			lstat: func(string) (fs.FileInfo, error) {
-				return nil, expectedErr
-			},
-			close: func() error {
-				return nil
-			},
-		}, nil
-	}})
-
-	root, err := OpenWriteRoot(t.TempDir())
-	if err != nil {
-		t.Fatalf("OpenWriteRoot returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil {
-			t.Errorf("close write root: %v", closeErr)
-		}
+	assertWriteRootParentLookupError(t, func(root *WriteRoot) error {
+		return root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("hello"), 0o600, 0o750)
 	})
+}
 
-	err = root.WriteFileCreatingParents(filepath.Join("reports", writeTestFileName), []byte("hello"), 0o600, 0o750)
+func TestWriteRootIfAbsentPropagatesParentLookupError(t *testing.T) {
+	assertWriteRootParentLookupError(t, func(root *WriteRoot) error {
+		return root.WriteFileCreatingParentsIfAbsent(filepath.Join("reports", writeTestFileName), []byte("hello"), 0o600, 0o750)
+	})
+}
+
+func TestWriteFileIfAbsentAtRootPropagatesUnexpectedLookupError(t *testing.T) {
+	expectedErr := errors.New("lookup failure")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, expectedErr },
+	}
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
 	if !errors.Is(err, expectedErr) {
-		t.Fatalf("expected parent lookup error, got %v", err)
+		t.Fatalf("expected lookup error, got %v", err)
+	}
+}
+
+func TestWriteFileIfAbsentAtRootPropagatesCreateTempError(t *testing.T) {
+	expectedErr := errors.New("create temp failure")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		openFile: func(string, int, os.FileMode) (File, error) {
+			return nil, expectedErr
+		},
+	}
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected create temp error, got %v", err)
+	}
+}
+
+func TestWriteFileIfAbsentAtRootPropagatesLinkError(t *testing.T) {
+	expectedErr := errors.New("link failure")
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		openFile: func(string, int, os.FileMode) (File, error) {
+			return &fakeFile{
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: func(os.FileMode) error { return nil },
+				close: func() error { return nil },
+			}, nil
+		},
+		link:   func(string, string) error { return expectedErr },
+		remove: func(string) error { return nil },
+	}
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected link error, got %v", err)
 	}
 }
 

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -1707,9 +1707,21 @@ func TestWriteFileAtRootReturnsExistingTargetCloseError(t *testing.T) {
 	expectedErr := errors.New("existing target close failure")
 	root := &fakeRoot{
 		lstat: func(string) (fs.FileInfo, error) { return fileInfo, nil },
-		openFile: func(string, int, os.FileMode) (File, error) {
-			return &fakeFile{close: func() error { return expectedErr }}, nil
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if name != writeTestFileName {
+				return &fakeFile{
+					write: func(p []byte) (int, error) { return len(p), nil },
+					chmod: chmodWithoutError,
+					close: closeWithoutError,
+				}, nil
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return fileInfo, nil },
+				close: func() error { return expectedErr },
+			}, nil
 		},
+		rename: func(string, string) error { return nil },
+		remove: func(string) error { return nil },
 	}
 	target := rootedTarget{rel: writeTestFileName, abs: targetPath}
 

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -35,6 +35,22 @@ type moveFallbackFailureCase struct {
 	stage moveFallbackFailureStage
 }
 
+type exclusiveCreateState struct {
+	wroteTarget  []byte
+	chmodTarget  os.FileMode
+	targetClosed bool
+	lstatCalls   int
+}
+
+type exclusiveCreatedTargetCase struct {
+	name      string
+	fileInfo  fs.FileInfo
+	pathInfo  fs.FileInfo
+	lstatErr  error
+	wantError string
+	cleanup   bool
+}
+
 func (i *modeOverrideFileInfo) Mode() os.FileMode {
 	return i.mode
 }
@@ -111,6 +127,119 @@ func writePinnedTargetInfoPair(t *testing.T) (fs.FileInfo, fs.FileInfo) {
 		t.Fatalf("seed changed target: %v", err)
 	}
 	return statTestPath(t, originalPath), statTestPath(t, changedPath)
+}
+
+func newExclusiveCreateRoot(t *testing.T, targetInfo fs.FileInfo) (*fakeRoot, *exclusiveCreateState) {
+	t.Helper()
+
+	state := &exclusiveCreateState{}
+	return &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				t.Fatalf("unexpected target lookup: %s", name)
+			}
+			state.lstatCalls++
+			if state.lstatCalls == 1 {
+				return nil, os.ErrNotExist
+			}
+			return targetInfo, nil
+		},
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			assertExclusiveCreateOpen(t, name, flag, perm)
+			return &fakeFile{
+				stat: func() (fs.FileInfo, error) { return targetInfo, nil },
+				write: func(p []byte) (int, error) {
+					state.wroteTarget = append([]byte(nil), p...)
+					return len(p), nil
+				},
+				chmod: func(mode os.FileMode) error {
+					state.chmodTarget = mode
+					return nil
+				},
+				close: func() error {
+					state.targetClosed = true
+					return nil
+				},
+			}, nil
+		},
+		link: func(string, string) error {
+			t.Fatal("write-if-absent should not link through a replaceable temp pathname")
+			return nil
+		},
+	}, state
+}
+
+func assertExclusiveCreateOpen(t *testing.T, name string, flag int, perm os.FileMode) {
+	t.Helper()
+	if name != writeTestFileName {
+		t.Fatalf("unexpected create path: %s", name)
+	}
+	if flag != os.O_RDWR|os.O_CREATE|os.O_EXCL {
+		t.Fatalf("unexpected target open flags: %#x", flag)
+	}
+	if perm != 0o640 {
+		t.Fatalf("unexpected target perm: %#o", perm)
+	}
+}
+
+func assertExclusiveCreateSuccess(t *testing.T, state *exclusiveCreateState) {
+	t.Helper()
+	if string(state.wroteTarget) != "hello" {
+		t.Fatalf("unexpected target content: %q", string(state.wroteTarget))
+	}
+	if state.chmodTarget != 0o640 {
+		t.Fatalf("unexpected target chmod: %#o", state.chmodTarget)
+	}
+	if !state.targetClosed {
+		t.Fatal("expected exclusive-create target file to close")
+	}
+	if state.lstatCalls != 2 {
+		t.Fatalf("expected target revalidation after close, got %d lookups", state.lstatCalls)
+	}
+}
+
+func assertExclusiveCreatedTargetRejected(t *testing.T, tc exclusiveCreatedTargetCase) {
+	t.Helper()
+	closed := false
+	removed := false
+	lstatCalls := 0
+	root := &fakeRoot{
+		openFile: func(string, int, os.FileMode) (File, error) {
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return tc.fileInfo, nil },
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: func() error { closed = true; return nil },
+			}, nil
+		},
+		lstat: func(string) (fs.FileInfo, error) {
+			lstatCalls++
+			if lstatCalls == 1 {
+				return nil, os.ErrNotExist
+			}
+			return tc.pathInfo, tc.lstatErr
+		},
+		remove: func(string) error { removed = true; return nil },
+	}
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
+	if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+		t.Fatalf("expected %q, got %v", tc.wantError, err)
+	}
+	assertExclusiveCreatedTargetCleanup(t, tc.cleanup, closed, removed)
+}
+
+func assertExclusiveCreatedTargetCleanup(t *testing.T, cleanup, closed, removed bool) {
+	t.Helper()
+	if !closed {
+		t.Fatal("expected created target to close")
+	}
+	if cleanup && !removed {
+		t.Fatal("expected cleanup of rejected created target")
+	}
+	if !cleanup && removed {
+		t.Fatal("must not remove a target after failed post-close validation")
+	}
 }
 
 func newPinnedFallbackTargetFile(t *testing.T, info fs.FileInfo, initial string) (File, *[]byte) {
@@ -1429,132 +1558,30 @@ func TestWriteFileIfAbsentAtRootPropagatesExclusiveCreateError(t *testing.T) {
 }
 
 func TestWriteFileIfAbsentAtRootCreatesTargetExclusivelyWithoutLinking(t *testing.T) {
-	var wroteTarget []byte
-	var chmodTarget os.FileMode
-	targetClosed := false
 	targetInfo := newPinnedTargetInfo(t, "target")
-	lstatCalls := 0
-
-	root := &fakeRoot{
-		lstat: func(name string) (fs.FileInfo, error) {
-			if name != writeTestFileName {
-				t.Fatalf("unexpected target lookup: %s", name)
-			}
-			lstatCalls++
-			if lstatCalls == 1 {
-				return nil, os.ErrNotExist
-			}
-			return targetInfo, nil
-		},
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if name == writeTestFileName {
-				if flag != os.O_RDWR|os.O_CREATE|os.O_EXCL {
-					t.Fatalf("unexpected target open flags: %#x", flag)
-				}
-				if perm != 0o640 {
-					t.Fatalf("unexpected target perm: %#o", perm)
-				}
-				return &fakeFile{
-					stat: func() (fs.FileInfo, error) { return targetInfo, nil },
-					write: func(p []byte) (int, error) {
-						wroteTarget = append([]byte(nil), p...)
-						return len(p), nil
-					},
-					chmod: func(mode os.FileMode) error {
-						chmodTarget = mode
-						return nil
-					},
-					close: func() error {
-						targetClosed = true
-						return nil
-					},
-				}, nil
-			}
-			t.Fatalf("unexpected create path: %s", name)
-			return nil, nil
-		},
-		link: func(string, string) error {
-			t.Fatal("write-if-absent should not link through a replaceable temp pathname")
-			return nil
-		},
-	}
+	root, state := newExclusiveCreateRoot(t, targetInfo)
 
 	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o640)
 	if err != nil {
 		t.Fatalf("expected exclusive create success, got %v", err)
 	}
-	if string(wroteTarget) != "hello" {
-		t.Fatalf("unexpected target content: %q", string(wroteTarget))
-	}
-	if chmodTarget != 0o640 {
-		t.Fatalf("unexpected target chmod: %#o", chmodTarget)
-	}
-	if !targetClosed {
-		t.Fatal("expected exclusive-create target file to close")
-	}
-	if lstatCalls != 2 {
-		t.Fatalf("expected target revalidation after close, got %d lookups", lstatCalls)
-	}
+	assertExclusiveCreateSuccess(t, state)
 }
 
 func TestWriteFileIfAbsentAtRootRejectsInvalidCreatedTarget(t *testing.T) {
 	openedInfo, changedInfo := writePinnedTargetInfoPair(t)
 	cases := []struct {
-		name      string
-		fileInfo  fs.FileInfo
-		pathInfo  fs.FileInfo
-		lstatErr  error
-		wantError string
+		exclusiveCreatedTargetCase
 	}{
-		{name: "opened nonregular", fileInfo: &modeOverrideFileInfo{FileInfo: openedInfo, mode: os.ModeDir | 0o755}, wantError: "not a regular file"},
-		{name: "target symlink", fileInfo: openedInfo, pathInfo: &modeOverrideFileInfo{FileInfo: openedInfo, mode: os.ModeSymlink | 0o777}, wantError: "became a symlink"},
-		{name: "target replaced", fileInfo: openedInfo, pathInfo: changedInfo, wantError: "changed before validation"},
-		{name: "target lookup error", fileInfo: openedInfo, lstatErr: errors.New("target lookup failure"), wantError: "target lookup failure"},
+		{exclusiveCreatedTargetCase{name: "opened nonregular", fileInfo: &modeOverrideFileInfo{FileInfo: openedInfo, mode: os.ModeDir | 0o755}, wantError: "not a regular file", cleanup: true}},
+		{exclusiveCreatedTargetCase{name: "target symlink", fileInfo: openedInfo, pathInfo: &modeOverrideFileInfo{FileInfo: openedInfo, mode: os.ModeSymlink | 0o777}, wantError: "became a symlink"}},
+		{exclusiveCreatedTargetCase{name: "target replaced", fileInfo: openedInfo, pathInfo: changedInfo, wantError: "changed before validation"}},
+		{exclusiveCreatedTargetCase{name: "target lookup error", fileInfo: openedInfo, lstatErr: errors.New("target lookup failure"), wantError: "target lookup failure"}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			closed := false
-			removed := false
-			lstatCalls := 0
-			root := &fakeRoot{
-				openFile: func(string, int, os.FileMode) (File, error) {
-					return &fakeFile{
-						stat:  func() (fs.FileInfo, error) { return tc.fileInfo, nil },
-						write: func(p []byte) (int, error) { return len(p), nil },
-						chmod: chmodWithoutError,
-						close: func() error { closed = true; return nil },
-					}, nil
-				},
-				lstat: func(string) (fs.FileInfo, error) {
-					lstatCalls++
-					if lstatCalls == 1 {
-						return nil, os.ErrNotExist
-					}
-					return tc.pathInfo, tc.lstatErr
-				},
-				remove: func(string) error { removed = true; return nil },
-			}
-
-			err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
-			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
-				t.Fatalf("expected %q, got %v", tc.wantError, err)
-			}
-			if tc.name == "opened nonregular" {
-				if !closed {
-					t.Fatal("expected rejected created target cleanup to close the file")
-				}
-				if !removed {
-					t.Fatal("expected cleanup of rejected created target")
-				}
-				return
-			}
-			if !closed {
-				t.Fatal("expected created target to close before validation")
-			}
-			if removed {
-				t.Fatal("must not remove a target after failed post-close validation")
-			}
+			assertExclusiveCreatedTargetRejected(t, tc.exclusiveCreatedTargetCase)
 		})
 	}
 }

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -2733,6 +2733,71 @@ func TestAtomicWriteSessionSnapshotAndCloseTempFileRejectsNonRegularTemp(t *test
 	}
 }
 
+func TestAtomicWriteSessionVerifyCommittedTargetRejectsNonRegularSnapshot(t *testing.T) {
+	session := &atomicWriteSession{
+		targetRel: writeTestFileName,
+		tempInfo: &modeOverrideFileInfo{
+			FileInfo: newPinnedTargetInfo(t, "temp"),
+			mode:     os.ModeDir | 0o755,
+		},
+	}
+
+	err := session.verifyCommittedTarget()
+	if err == nil || !strings.Contains(err.Error(), "temporary file is not regular after commit") {
+		t.Fatalf("expected non-regular temp snapshot error, got %v", err)
+	}
+}
+
+func TestAtomicWriteSessionVerifyCommittedTargetRejectsNonRegularCommittedTarget(t *testing.T) {
+	tempInfo := newPinnedTargetInfo(t, "temp")
+	session := &atomicWriteSession{
+		root: &fakeRoot{
+			lstat: func(string) (fs.FileInfo, error) {
+				return &modeOverrideFileInfo{
+					FileInfo: tempInfo,
+					mode:     os.ModeDir | 0o755,
+				}, nil
+			},
+		},
+		targetRel: writeTestFileName,
+		tempInfo:  tempInfo,
+	}
+
+	err := session.verifyCommittedTarget()
+	if err == nil || !strings.Contains(err.Error(), "committed target changed before validation") {
+		t.Fatalf("expected non-regular committed target error, got %v", err)
+	}
+}
+
+func TestAtomicWriteSessionSnapshotAndCloseTempFileAllowsMissingTempFile(t *testing.T) {
+	session := &atomicWriteSession{}
+
+	if err := session.snapshotAndCloseTempFile(); err != nil {
+		t.Fatalf("expected nil snapshotAndCloseTempFile error, got %v", err)
+	}
+}
+
+func TestAtomicWriteSessionWriteAndCloseReturnsWriteError(t *testing.T) {
+	expectedErr := errors.New("write failure")
+	session := &atomicWriteSession{
+		tempFile: &fakeFile{
+			write: func([]byte) (int, error) { return 0, expectedErr },
+			close: func() error {
+				t.Fatal("expected writeAndClose to abort before close on write error")
+				return nil
+			},
+		},
+	}
+
+	err := session.writeAndClose([]byte("after"), 0o600)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected writeAndClose write error, got %v", err)
+	}
+	if session.tempFile == nil {
+		t.Fatal("expected temp file handle to remain when writeAndClose aborts before close")
+	}
+}
+
 func TestAtomicWriteSessionWriteAndClose(t *testing.T) {
 	tempClosed := false
 	session := &atomicWriteSession{

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -136,7 +136,7 @@ func newPinnedFallbackTargetFile(t *testing.T, info fs.FileInfo, initial string)
 	return targetFile, &targetData
 }
 
-func openTargetOrTempFile(targetName string, openTarget func() (File, error), tempOpenErr error) func(string, int, os.FileMode) (File, error) {
+func openTargetOrTempFile(targetName string, openTarget func() (File, error), tempInfo fs.FileInfo, tempOpenErr error) func(string, int, os.FileMode) (File, error) {
 	return func(name string, flag int, perm os.FileMode) (File, error) {
 		if name == targetName {
 			return openTarget()
@@ -145,10 +145,42 @@ func openTargetOrTempFile(targetName string, openTarget func() (File, error), te
 			return nil, tempOpenErr
 		}
 		return &fakeFile{
+			stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
 			write: func(p []byte) (int, error) { return len(p), nil },
 			chmod: chmodWithoutError,
 			close: closeWithoutError,
 		}, nil
+	}
+}
+
+func newCommittedTargetValidationRoot(t *testing.T, tempInfo fs.FileInfo, lstatTarget func() (fs.FileInfo, error), rename func() error, remove func(string) error, tempClosed *bool) *fakeRoot {
+	t.Helper()
+
+	return &fakeRoot{
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if !strings.HasPrefix(name, atomicTempPrefix) {
+				t.Fatalf("unexpected open path: %s", name)
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: func() error {
+					*tempClosed = true
+					return nil
+				},
+			}, nil
+		},
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				t.Fatalf("unexpected lstat path: %s", name)
+			}
+			return lstatTarget()
+		},
+		rename: func(string, string) error {
+			return rename()
+		},
+		remove: remove,
 	}
 }
 
@@ -358,55 +390,6 @@ func assertWriteIfAbsentFallbackCleanup(t *testing.T, expectedErr error, targetF
 	assertExclusiveCreateCleanup(t, removed)
 	if !targetClosed {
 		t.Fatal("expected fallback target file close attempt before cleanup")
-	}
-}
-
-func assertAtomicReplacementKeepsTempFileOpenUntilRename(t *testing.T, invoke func(Root) error) {
-	t.Helper()
-
-	tempClosed := false
-	renameCalls := 0
-	removeCalls := 0
-	expectedErr := errors.New("rename failure")
-	root := &fakeRoot{
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if !strings.HasPrefix(name, atomicTempPrefix) {
-				t.Fatalf("unexpected open path: %s", name)
-			}
-			return &fakeFile{
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: chmodWithoutError,
-				close: func() error {
-					tempClosed = true
-					return nil
-				},
-			}, nil
-		},
-		rename: func(string, string) error {
-			renameCalls++
-			if tempClosed {
-				t.Fatal("expected temp file to remain open during rename attempt")
-			}
-			return expectedErr
-		},
-		remove: func(string) error {
-			removeCalls++
-			return nil
-		},
-	}
-
-	err := invoke(root)
-	if !errors.Is(err, expectedErr) {
-		t.Fatalf("expected rename error, got %v", err)
-	}
-	if renameCalls != 1 {
-		t.Fatalf("expected one rename attempt, got %d", renameCalls)
-	}
-	if !tempClosed {
-		t.Fatal("expected cleanup to close temp file after rename failure")
-	}
-	if removeCalls != 1 {
-		t.Fatalf("expected one temp cleanup remove, got %d", removeCalls)
 	}
 }
 
@@ -1750,12 +1733,19 @@ func TestWriteFileAtRootReturnsExistingTargetCloseError(t *testing.T) {
 		t.Fatalf("seed existing target: %v", err)
 	}
 	fileInfo := statTestPath(t, targetPath)
+	tempInfo := newPinnedTargetInfo(t, "temp")
 	expectedErr := errors.New("existing target close failure")
 	root := &fakeRoot{
-		lstat: func(string) (fs.FileInfo, error) { return fileInfo, nil },
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name == writeTestFileName {
+				return fileInfo, nil
+			}
+			return tempInfo, nil
+		},
 		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
 			if name != writeTestFileName {
 				return &fakeFile{
+					stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
 					write: func(p []byte) (int, error) { return len(p), nil },
 					chmod: chmodWithoutError,
 					close: closeWithoutError,
@@ -2328,7 +2318,7 @@ func TestWriteAtomicReplacementReturnsPinnedTargetOpenError(t *testing.T) {
 	expectedErr := errors.New("open pinned target failure")
 	openTarget := func() (File, error) { return nil, expectedErr }
 	root := &fakeRoot{
-		openFile: openTargetOrTempFile(writeTestFileName, openTarget, nil),
+		openFile: openTargetOrTempFile(writeTestFileName, openTarget, newPinnedTargetInfo(t, "temp"), nil),
 		rename:   func(string, string) error { return nil },
 		remove:   func(string) error { return nil },
 	}
@@ -2345,14 +2335,159 @@ func TestWriteAtomicReplacementReturnsPinnedTargetOpenError(t *testing.T) {
 	}
 }
 
-func TestWriteAtomicReplacementWithPinnedTargetKeepsTempFileOpenUntilRename(t *testing.T) {
-	assertAtomicReplacementKeepsTempFileOpenUntilRename(t, func(root Root) error {
-		target := &fakeFile{
-			stat:  func() (fs.FileInfo, error) { return statTestPath(t, t.TempDir()), nil },
-			close: closeWithoutError,
-		}
-		return writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, target, false)
-	})
+func TestWriteAtomicReplacementWithPinnedTargetKeepsCommittedTargetIdentity(t *testing.T) {
+	tempInfo := newPinnedTargetInfo(t, "temp")
+	targetInfo := newPinnedTargetInfo(t, "target")
+	tempClosed := false
+	renameCalls := 0
+	removeCalls := 0
+	lstatTarget := func() (fs.FileInfo, error) { return tempInfo, nil }
+	rename := func() error {
+		renameCalls++
+		return nil
+	}
+	remove := func(string) error {
+		removeCalls++
+		return nil
+	}
+	root := newCommittedTargetValidationRoot(t, tempInfo, lstatTarget, rename, remove, &tempClosed)
+
+	target := &fakeFile{
+		stat:  func() (fs.FileInfo, error) { return targetInfo, nil },
+		close: closeWithoutError,
+	}
+	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, target, false); err != nil {
+		t.Fatalf("expected committed target validation success, got %v", err)
+	}
+	if renameCalls != 1 {
+		t.Fatalf("expected one rename attempt, got %d", renameCalls)
+	}
+	if !tempClosed {
+		t.Fatal("expected committed temp file to be closed")
+	}
+	if removeCalls != 0 {
+		t.Fatalf("expected no cleanup remove after successful rename, got %d", removeCalls)
+	}
+}
+
+func TestWriteAtomicReplacementWithPinnedTargetRejectsChangedCommittedTarget(t *testing.T) {
+	tempInfo, changedInfo := writePinnedTargetInfoPair(t)
+	tempClosed := false
+	renameCalls := 0
+	removeCalls := 0
+	target, targetData := newPinnedFallbackTargetFile(t, changedInfo, "before")
+	lstatTarget := func() (fs.FileInfo, error) { return changedInfo, nil }
+	rename := func() error {
+		renameCalls++
+		return nil
+	}
+	remove := func(string) error {
+		removeCalls++
+		return nil
+	}
+	root := newCommittedTargetValidationRoot(t, tempInfo, lstatTarget, rename, remove, &tempClosed)
+
+	err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, target, false)
+	if err == nil || !strings.Contains(err.Error(), "committed target changed before validation") {
+		t.Fatalf("expected committed target validation error, got %v", err)
+	}
+	if renameCalls != 1 {
+		t.Fatalf("expected one rename attempt, got %d", renameCalls)
+	}
+	if !tempClosed {
+		t.Fatal("expected temp file to be closed during cleanup")
+	}
+	if removeCalls != 0 {
+		t.Fatalf("expected no cleanup remove after committed target mismatch, got %d", removeCalls)
+	}
+	if string(*targetData) != "before" {
+		t.Fatalf("expected no fallback overwrite after committed target mismatch, got %q", string(*targetData))
+	}
+}
+
+func TestWriteAtomicReplacementWithPinnedTargetReturnsCommittedTargetLstatError(t *testing.T) {
+	tempInfo := newPinnedTargetInfo(t, "temp")
+	expectedErr := errors.New("lstat failure")
+	tempClosed := false
+	root := &fakeRoot{
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if !strings.HasPrefix(name, atomicTempPrefix) {
+				t.Fatalf("unexpected open path: %s", name)
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: func() error {
+					tempClosed = true
+					return nil
+				},
+			}, nil
+		},
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				t.Fatalf("unexpected lstat path: %s", name)
+			}
+			return nil, expectedErr
+		},
+		rename: func(string, string) error { return nil },
+		remove: func(string) error { return nil },
+	}
+
+	target := &fakeFile{
+		stat:  func() (fs.FileInfo, error) { return newPinnedTargetInfo(t, "target"), nil },
+		close: closeWithoutError,
+	}
+	err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, target, false)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected committed target lstat error, got %v", err)
+	}
+	if !tempClosed {
+		t.Fatal("expected temp file close during cleanup after lstat error")
+	}
+}
+
+func TestWriteAtomicReplacementWithPinnedTargetReturnsCommittedTargetStatError(t *testing.T) {
+	expectedErr := errors.New("stat failure")
+	tempClosed := false
+	lstatCalls := 0
+	root := &fakeRoot{
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if !strings.HasPrefix(name, atomicTempPrefix) {
+				t.Fatalf("unexpected open path: %s", name)
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return nil, expectedErr },
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: func() error {
+					tempClosed = true
+					return nil
+				},
+			}, nil
+		},
+		lstat: func(string) (fs.FileInfo, error) {
+			lstatCalls++
+			return newPinnedTargetInfo(t, "target"), nil
+		},
+		rename: func(string, string) error { return nil },
+		remove: func(string) error { return nil },
+	}
+
+	target := &fakeFile{
+		stat:  func() (fs.FileInfo, error) { return newPinnedTargetInfo(t, "target"), nil },
+		close: closeWithoutError,
+	}
+	err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, target, false)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected committed target stat error, got %v", err)
+	}
+	if lstatCalls != 0 {
+		t.Fatalf("expected no committed target lstat after stat error, got %d", lstatCalls)
+	}
+	if !tempClosed {
+		t.Fatal("expected temp file close during cleanup after stat error")
+	}
 }
 
 func TestOpenPinnedReplacementTargetReturnsOpenError(t *testing.T) {

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -1227,6 +1227,130 @@ func TestWriteFileIfAbsentAtRootNormalizesLinkExistsError(t *testing.T) {
 	}
 }
 
+func TestWriteFileIfAbsentAtRootFallsBackWhenLinkUnsupported(t *testing.T) {
+	var wroteTarget []byte
+	var chmodTarget os.FileMode
+	targetClosed := false
+
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if name == writeTestFileName {
+				if flag != os.O_RDWR|os.O_CREATE|os.O_EXCL {
+					t.Fatalf("unexpected target open flags: %#x", flag)
+				}
+				if perm != 0o640 {
+					t.Fatalf("unexpected target perm: %#o", perm)
+				}
+				return &fakeFile{
+					write: func(p []byte) (int, error) {
+						wroteTarget = append([]byte(nil), p...)
+						return len(p), nil
+					},
+					chmod: func(mode os.FileMode) error {
+						chmodTarget = mode
+						return nil
+					},
+					close: func() error {
+						targetClosed = true
+						return nil
+					},
+				}, nil
+			}
+			return &fakeFile{
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: func(os.FileMode) error { return nil },
+				close: func() error { return nil },
+			}, nil
+		},
+		link:   func(string, string) error { return errors.ErrUnsupported },
+		remove: func(string) error { return nil },
+	}
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o640)
+	if err != nil {
+		t.Fatalf("expected fallback success, got %v", err)
+	}
+	if string(wroteTarget) != "hello" {
+		t.Fatalf("unexpected target content: %q", string(wroteTarget))
+	}
+	if chmodTarget != 0o640 {
+		t.Fatalf("unexpected target chmod: %#o", chmodTarget)
+	}
+	if !targetClosed {
+		t.Fatal("expected fallback target file to close")
+	}
+}
+
+func TestWriteFileIfAbsentAtRootReturnsExistWhenFallbackTargetExists(t *testing.T) {
+	root := makeFakeTempWriteRoot(nil)
+	root.link = func(string, string) error { return errors.ErrUnsupported }
+	root.openFile = func(name string, flag int, perm os.FileMode) (File, error) {
+		if name == writeTestFileName {
+			return nil, os.ErrExist
+		}
+		return &fakeFile{
+			write: func(p []byte) (int, error) { return len(p), nil },
+			chmod: func(os.FileMode) error { return nil },
+			close: func() error { return nil },
+		}, nil
+	}
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("expected os.ErrExist from fallback target create, got %v", err)
+	}
+}
+
+func TestWriteFileIfAbsentAtRootRemovesFallbackTargetOnWriteError(t *testing.T) {
+	expectedErr := errors.New("write target failure")
+	var removed []string
+	targetClosed := false
+
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if name == writeTestFileName {
+				return &fakeFile{
+					write: func([]byte) (int, error) { return 0, expectedErr },
+					close: func() error {
+						targetClosed = true
+						return nil
+					},
+					chmod: func(os.FileMode) error { return nil },
+				}, nil
+			}
+			return &fakeFile{
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: func(os.FileMode) error { return nil },
+				close: func() error { return nil },
+			}, nil
+		},
+		link: func(string, string) error { return errors.ErrUnsupported },
+		remove: func(name string) error {
+			removed = append(removed, name)
+			return nil
+		},
+	}
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected fallback write error, got %v", err)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("expected cleanup for fallback target and temp file, got %v", removed)
+	}
+	if removed[0] != writeTestFileName {
+		t.Fatalf("expected fallback target cleanup first for %q, got %v", writeTestFileName, removed)
+	}
+	if !strings.HasPrefix(removed[1], atomicTempPrefix) {
+		t.Fatalf("expected temp cleanup second, got %v", removed)
+	}
+	if !targetClosed {
+		t.Fatal("expected fallback target file to close before cleanup")
+	}
+}
+
 func TestWriteRootRejectsNonRelativeTargets(t *testing.T) {
 	assertWriteRootRejectsNonRelativeTargets(t, (*WriteRoot).WriteFileCreatingParents)
 }

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -24,8 +24,38 @@ type modeOverrideFileInfo struct {
 	mode os.FileMode
 }
 
+type unsafeTargetModeCase struct {
+	name string
+	mode os.FileMode
+	want string
+}
+
+type moveFallbackFailureCase struct {
+	name  string
+	stage moveFallbackFailureStage
+}
+
 func (i *modeOverrideFileInfo) Mode() os.FileMode {
 	return i.mode
+}
+
+func unsafeTargetModeCases() []unsafeTargetModeCase {
+	return []unsafeTargetModeCase{
+		{name: "directory", mode: os.ModeDir | 0o755, want: "not a regular file"},
+		{name: "symlink", mode: os.ModeSymlink | 0o777, want: "became a symlink"},
+	}
+}
+
+func moveFallbackFailureCases() []moveFallbackFailureCase {
+	return []moveFallbackFailureCase{
+		{name: "open source", stage: moveFallbackFailSourceOpen},
+		{name: "read source", stage: moveFallbackFailSourceRead},
+		{name: "open temp", stage: moveFallbackFailTempOpen},
+		{name: "write temp", stage: moveFallbackFailTempWrite},
+		{name: "chmod temp", stage: moveFallbackFailTempChmod},
+		{name: "close temp", stage: moveFallbackFailTempClose},
+		{name: "rename temp", stage: moveFallbackFailTempRename},
+	}
 }
 
 type truncatingFakeFile struct {
@@ -2492,15 +2522,16 @@ func TestOverwritePinnedFileRejectsNonRegularPathBeforeMutation(t *testing.T) {
 	}
 	originalInfo := statTestPath(t, originalPath)
 
-	tests := []struct {
-		name     string
-		pathInfo fs.FileInfo
-		want     string
-	}{
-		{name: "directory", pathInfo: &modeOverrideFileInfo{FileInfo: originalInfo, mode: os.ModeDir | 0o755}, want: "not a regular file"},
-		{name: "symlink", pathInfo: &modeOverrideFileInfo{FileInfo: originalInfo, mode: os.ModeSymlink | 0o777}, want: "became a symlink"},
-	}
-	for _, tt := range tests {
+	for _, tc := range unsafeTargetModeCases() {
+		tt := struct {
+			name     string
+			pathInfo fs.FileInfo
+			want     string
+		}{
+			name:     tc.name,
+			pathInfo: &modeOverrideFileInfo{FileInfo: originalInfo, mode: tc.mode},
+			want:     tc.want,
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			statCalls := 0
 			target := &truncatingFakeFile{
@@ -3099,18 +3130,7 @@ func TestMoveFileWithinRootReturnsSourceRemovalErrorAfterCopyFallback(t *testing
 }
 
 func TestMoveFileWithinRootPreservesSourceWhenCopyFallbackFails(t *testing.T) {
-	for _, tc := range []struct {
-		name  string
-		stage moveFallbackFailureStage
-	}{
-		{name: "open source", stage: moveFallbackFailSourceOpen},
-		{name: "read source", stage: moveFallbackFailSourceRead},
-		{name: "open temp", stage: moveFallbackFailTempOpen},
-		{name: "write temp", stage: moveFallbackFailTempWrite},
-		{name: "chmod temp", stage: moveFallbackFailTempChmod},
-		{name: "close temp", stage: moveFallbackFailTempClose},
-		{name: "rename temp", stage: moveFallbackFailTempRename},
-	} {
+	for _, tc := range moveFallbackFailureCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			sentinel := errors.New(tc.name + " failure")
 			state := &moveFallbackState{}

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -1380,6 +1380,55 @@ func TestWriteFileIfAbsentAtRootRemovesFallbackTargetOnWriteError(t *testing.T) 
 	}
 }
 
+func TestWriteFileIfAbsentAtRootRemovesFallbackTargetOnCloseError(t *testing.T) {
+	expectedErr := errors.New("close target failure")
+	var removed []string
+	targetClosed := false
+
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if name == writeTestFileName {
+				return &fakeFile{
+					write: func(p []byte) (int, error) { return len(p), nil },
+					close: func() error {
+						targetClosed = true
+						return expectedErr
+					},
+					chmod: func(os.FileMode) error { return nil },
+				}, nil
+			}
+			return &fakeFile{
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: func(os.FileMode) error { return nil },
+				close: func() error { return nil },
+			}, nil
+		},
+		link: func(string, string) error { return errors.ErrUnsupported },
+		remove: func(name string) error {
+			removed = append(removed, name)
+			return nil
+		},
+	}
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected fallback close error, got %v", err)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("expected cleanup for fallback target and temp file, got %v", removed)
+	}
+	if removed[0] != writeTestFileName {
+		t.Fatalf("expected fallback target cleanup first for %q, got %v", writeTestFileName, removed)
+	}
+	if !strings.HasPrefix(removed[1], atomicTempPrefix) {
+		t.Fatalf("expected temp cleanup second, got %v", removed)
+	}
+	if !targetClosed {
+		t.Fatal("expected fallback target file close attempt before cleanup")
+	}
+}
+
 func TestWriteRootRejectsNonRelativeTargets(t *testing.T) {
 	assertWriteRootRejectsNonRelativeTargets(t, (*WriteRoot).WriteFileCreatingParents)
 }

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -58,6 +58,28 @@ func moveFallbackFailureCases() []moveFallbackFailureCase {
 	}
 }
 
+func assertMovedFileResult(t *testing.T, sourcePath, targetPath, wantData, sourceAction string) {
+	t.Helper()
+
+	if _, err := os.Stat(sourcePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected source file to %s, got %v", sourceAction, err)
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read moved file: %v", err)
+	}
+	if string(data) != wantData {
+		t.Fatalf("unexpected moved content %q", string(data))
+	}
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatalf("stat moved file: %v", err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("unexpected moved file mode: got %#o", info.Mode().Perm())
+	}
+}
+
 type truncatingFakeFile struct {
 	*fakeFile
 	truncate func(size int64) error
@@ -2856,24 +2878,7 @@ func TestMoveFileUnderRenamesWithinRootAndSetsMode(t *testing.T) {
 	if err := MoveFileUnder(rootDir, sourcePath, targetPath, 0o750, 0o640); err != nil {
 		t.Fatalf("MoveFileUnder returned error: %v", err)
 	}
-
-	if _, err := os.Stat(sourcePath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected source file to be moved away, got %v", err)
-	}
-	data, err := os.ReadFile(targetPath)
-	if err != nil {
-		t.Fatalf("read moved file: %v", err)
-	}
-	if string(data) != "hello" {
-		t.Fatalf("unexpected moved content %q", string(data))
-	}
-	info, err := os.Stat(targetPath)
-	if err != nil {
-		t.Fatalf("stat moved file: %v", err)
-	}
-	if info.Mode().Perm() != 0o640 {
-		t.Fatalf("unexpected moved file mode: got %#o", info.Mode().Perm())
-	}
+	assertMovedFileResult(t, sourcePath, targetPath, "hello", "be moved away")
 }
 
 func TestMoveFileUnderFallsBackToCopyAndSetsMode(t *testing.T) {
@@ -2906,24 +2911,7 @@ func TestMoveFileUnderFallsBackToCopyAndSetsMode(t *testing.T) {
 	if err := MoveFileUnder(rootDir, sourcePath, targetPath, 0o750, 0o640); err != nil {
 		t.Fatalf("MoveFileUnder returned error: %v", err)
 	}
-
-	if _, err := os.Stat(sourcePath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected source file to be removed after copy fallback, got %v", err)
-	}
-	data, err := os.ReadFile(targetPath)
-	if err != nil {
-		t.Fatalf("read copied file: %v", err)
-	}
-	if string(data) != "copied" {
-		t.Fatalf("unexpected copied content %q", string(data))
-	}
-	info, err := os.Stat(targetPath)
-	if err != nil {
-		t.Fatalf("stat copied file: %v", err)
-	}
-	if info.Mode().Perm() != 0o640 {
-		t.Fatalf("unexpected copied file mode: got %#o", info.Mode().Perm())
-	}
+	assertMovedFileResult(t, sourcePath, targetPath, "copied", "be removed after copy fallback")
 }
 
 func TestMoveFileUnderReturnsRenameErrorWithoutFallback(t *testing.T) {

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -1282,6 +1282,35 @@ func TestWriteFileIfAbsentAtRootFallsBackWhenLinkUnsupported(t *testing.T) {
 	}
 }
 
+func TestWriteFileIfAbsentAtRootFallsBackWhenLinkReturnsEPERM(t *testing.T) {
+	var wroteTarget []byte
+	root := &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			return &fakeFile{
+				write: func(p []byte) (int, error) {
+					if name == writeTestFileName {
+						wroteTarget = append([]byte(nil), p...)
+					}
+					return len(p), nil
+				},
+				chmod: func(os.FileMode) error { return nil },
+				close: func() error { return nil },
+			}, nil
+		},
+		link:   func(string, string) error { return syscall.EPERM },
+		remove: func(string) error { return nil },
+	}
+
+	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o640)
+	if err != nil {
+		t.Fatalf("expected EPERM fallback success, got %v", err)
+	}
+	if string(wroteTarget) != "hello" {
+		t.Fatalf("unexpected target content: %q", string(wroteTarget))
+	}
+}
+
 func TestWriteFileIfAbsentAtRootReturnsExistWhenFallbackTargetExists(t *testing.T) {
 	root := makeFakeTempWriteRoot(nil)
 	root.link = func(string, string) error { return errors.ErrUnsupported }

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -184,6 +184,35 @@ func newCommittedTargetValidationRoot(t *testing.T, tempInfo fs.FileInfo, lstatT
 	}
 }
 
+func newCommittedTargetLstatErrorRoot(t *testing.T, tempInfo fs.FileInfo, expectedErr error, tempClosed *bool) *fakeRoot {
+	t.Helper()
+
+	return &fakeRoot{
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if !strings.HasPrefix(name, atomicTempPrefix) {
+				t.Fatalf("unexpected open path: %s", name)
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: func() error {
+					*tempClosed = true
+					return nil
+				},
+			}, nil
+		},
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				t.Fatalf("unexpected lstat path: %s", name)
+			}
+			return nil, expectedErr
+		},
+		rename: func(string, string) error { return nil },
+		remove: func(string) error { return nil },
+	}
+}
+
 func assertOverwritePinnedFileRejectsBeforeMutation(t *testing.T, openedInfo fs.FileInfo, lstat func(*testing.T) func(string) (fs.FileInfo, error), beforeRevalidate func(*testing.T) func() error) {
 	t.Helper()
 
@@ -2131,6 +2160,12 @@ func withAtomicWriteFileSystem(t *testing.T, tempFile File, remove func(string) 
 			return nil
 		}
 	}
+	tempInfo := newPinnedTargetInfo(t, "temp")
+	if fakeTempFile, ok := tempFile.(*fakeFile); ok && fakeTempFile.stat == nil {
+		fakeTempFile.stat = func() (fs.FileInfo, error) {
+			return tempInfo, nil
+		}
+	}
 	withFileSystem(t, &fakeFileSystem{openRoot: func(string) (Root, error) {
 		return &fakeRoot{
 			lstat: func(string) (fs.FileInfo, error) {
@@ -2196,12 +2231,14 @@ func TestWriteFileUnderJoinsPrimaryErrorWithCleanupFailure(t *testing.T) {
 func TestWriteFileReplacingWithinRootJoinsRenameErrorWithCleanupFailure(t *testing.T) {
 	renameErr := errors.New("rename failure")
 	cleanupErr := errors.New("cleanup failure")
+	tempInfo := newPinnedTargetInfo(t, "temp")
 	root := &fakeRoot{
 		lstat: func(string) (fs.FileInfo, error) {
 			return nil, os.ErrNotExist
 		},
 		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
 			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
 				write: func(p []byte) (int, error) { return len(p), nil },
 				chmod: chmodWithoutError,
 				close: closeWithoutError,
@@ -2235,6 +2272,7 @@ func TestWriteFileReplacingWithinRootReturnsRenameErrorWithoutFallback(t *testin
 		t.Fatalf("seed target info path: %v", err)
 	}
 	info := statTestPath(t, targetInfoPath)
+	tempInfo := newPinnedTargetInfo(t, "temp")
 
 	targetOpened := false
 	root := &fakeRoot{
@@ -2253,6 +2291,7 @@ func TestWriteFileReplacingWithinRootReturnsRenameErrorWithoutFallback(t *testin
 				}, nil
 			}
 			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
 				write: func(p []byte) (int, error) { return len(p), nil },
 				chmod: chmodWithoutError,
 				close: closeWithoutError,
@@ -2282,9 +2321,16 @@ func TestWriteAtomicReplacementReturnsPinnedTargetCloseErrorAfterCommit(t *testi
 		t.Fatalf("seed target info path: %v", err)
 	}
 	info := statTestPath(t, targetInfoPath)
+	tempInfo := newPinnedTargetInfo(t, "temp")
 	closeErr := errors.New("pinned target close failure")
 
 	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				t.Fatalf("unexpected lstat path: %s", name)
+			}
+			return tempInfo, nil
+		},
 		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
 			if name == writeTestFileName {
 				return &fakeFile{
@@ -2293,6 +2339,7 @@ func TestWriteAtomicReplacementReturnsPinnedTargetCloseErrorAfterCommit(t *testi
 				}, nil
 			}
 			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
 				write: func(p []byte) (int, error) { return len(p), nil },
 				chmod: chmodWithoutError,
 				close: closeWithoutError,
@@ -2317,10 +2364,17 @@ func TestWriteAtomicReplacementReturnsPinnedTargetCloseErrorAfterCommit(t *testi
 func TestWriteAtomicReplacementReturnsPinnedTargetOpenError(t *testing.T) {
 	expectedErr := errors.New("open pinned target failure")
 	openTarget := func() (File, error) { return nil, expectedErr }
+	tempInfo := newPinnedTargetInfo(t, "temp")
 	root := &fakeRoot{
-		openFile: openTargetOrTempFile(writeTestFileName, openTarget, newPinnedTargetInfo(t, "temp"), nil),
-		rename:   func(string, string) error { return nil },
-		remove:   func(string) error { return nil },
+		openFile: openTargetOrTempFile(writeTestFileName, openTarget, tempInfo, nil),
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				t.Fatalf("unexpected lstat path: %s", name)
+			}
+			return tempInfo, nil
+		},
+		rename: func(string, string) error { return nil },
+		remove: func(string) error { return nil },
 	}
 
 	err := writeAtomicReplacement(root, writeTestFileName, []byte("after"), 0o600, statTestPath(t, t.TempDir()))
@@ -2332,6 +2386,159 @@ func TestWriteAtomicReplacementReturnsPinnedTargetOpenError(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf("expected non-Windows write to skip pinned target open, got %v", err)
+	}
+}
+
+func TestWriteAtomicReplacementVerifiesCommittedTarget(t *testing.T) {
+	tempInfo := newPinnedTargetInfo(t, "temp")
+	tempClosed := false
+	renameCalls := 0
+	removeCalls := 0
+	lstatCalls := 0
+	root := &fakeRoot{
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if !strings.HasPrefix(name, atomicTempPrefix) {
+				t.Fatalf("unexpected open path: %s", name)
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: func() error {
+					tempClosed = true
+					return nil
+				},
+			}, nil
+		},
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				t.Fatalf("unexpected lstat path: %s", name)
+			}
+			lstatCalls++
+			return tempInfo, nil
+		},
+		rename: func(string, string) error {
+			renameCalls++
+			return nil
+		},
+		remove: func(string) error {
+			removeCalls++
+			return nil
+		},
+	}
+
+	err := writeAtomicReplacement(root, writeTestFileName, []byte("after"), 0o600, statTestPath(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("expected committed target validation success, got %v", err)
+	}
+	if renameCalls != 1 {
+		t.Fatalf("expected one rename attempt, got %d", renameCalls)
+	}
+	if lstatCalls != 1 {
+		t.Fatalf("expected one committed target lstat, got %d", lstatCalls)
+	}
+	if !tempClosed {
+		t.Fatal("expected temp file close before rename validation")
+	}
+	if removeCalls != 0 {
+		t.Fatalf("expected no temp cleanup remove after successful rename, got %d", removeCalls)
+	}
+}
+
+func TestWriteAtomicReplacementRejectsChangedCommittedTarget(t *testing.T) {
+	tempInfo, changedInfo := writePinnedTargetInfoPair(t)
+	tempClosed := false
+	renameCalls := 0
+	removeCalls := 0
+	root := &fakeRoot{
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if !strings.HasPrefix(name, atomicTempPrefix) {
+				t.Fatalf("unexpected open path: %s", name)
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: func() error {
+					tempClosed = true
+					return nil
+				},
+			}, nil
+		},
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				t.Fatalf("unexpected lstat path: %s", name)
+			}
+			return changedInfo, nil
+		},
+		rename: func(string, string) error {
+			renameCalls++
+			return nil
+		},
+		remove: func(string) error {
+			removeCalls++
+			return nil
+		},
+	}
+
+	err := writeAtomicReplacement(root, writeTestFileName, []byte("after"), 0o600, statTestPath(t, t.TempDir()))
+	if err == nil || !strings.Contains(err.Error(), "committed target changed before validation") {
+		t.Fatalf("expected committed target validation error, got %v", err)
+	}
+	if renameCalls != 1 {
+		t.Fatalf("expected one rename attempt, got %d", renameCalls)
+	}
+	if !tempClosed {
+		t.Fatal("expected temp file close before committed target mismatch")
+	}
+	if removeCalls != 0 {
+		t.Fatalf("expected no cleanup remove after committed target mismatch, got %d", removeCalls)
+	}
+}
+
+func TestWriteAtomicReplacementReturnsCloseErrorBeforeRename(t *testing.T) {
+	expectedErr := errors.New("close temp failure")
+	renameCalls := 0
+	lstatCalls := 0
+	removeCalls := 0
+	root := &fakeRoot{
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if !strings.HasPrefix(name, atomicTempPrefix) {
+				t.Fatalf("unexpected open path: %s", name)
+			}
+			return &fakeFile{
+				stat:  func() (fs.FileInfo, error) { return newPinnedTargetInfo(t, "temp"), nil },
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: func() error { return expectedErr },
+			}, nil
+		},
+		lstat: func(string) (fs.FileInfo, error) {
+			lstatCalls++
+			return newPinnedTargetInfo(t, "target"), nil
+		},
+		rename: func(string, string) error {
+			renameCalls++
+			return nil
+		},
+		remove: func(string) error {
+			removeCalls++
+			return nil
+		},
+	}
+
+	err := writeAtomicReplacement(root, writeTestFileName, []byte("after"), 0o600, statTestPath(t, t.TempDir()))
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected temp close error, got %v", err)
+	}
+	if renameCalls != 0 {
+		t.Fatalf("expected no rename after close failure, got %d", renameCalls)
+	}
+	if lstatCalls != 0 {
+		t.Fatalf("expected no lstat after close failure, got %d", lstatCalls)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("expected temp cleanup after close failure, got %d removes", removeCalls)
 	}
 }
 
@@ -2409,30 +2616,7 @@ func TestWriteAtomicReplacementWithPinnedTargetReturnsCommittedTargetLstatError(
 	tempInfo := newPinnedTargetInfo(t, "temp")
 	expectedErr := errors.New("lstat failure")
 	tempClosed := false
-	root := &fakeRoot{
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if !strings.HasPrefix(name, atomicTempPrefix) {
-				t.Fatalf("unexpected open path: %s", name)
-			}
-			return &fakeFile{
-				stat:  func() (fs.FileInfo, error) { return tempInfo, nil },
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: chmodWithoutError,
-				close: func() error {
-					tempClosed = true
-					return nil
-				},
-			}, nil
-		},
-		lstat: func(name string) (fs.FileInfo, error) {
-			if name != writeTestFileName {
-				t.Fatalf("unexpected lstat path: %s", name)
-			}
-			return nil, expectedErr
-		},
-		rename: func(string, string) error { return nil },
-		remove: func(string) error { return nil },
-	}
+	root := newCommittedTargetLstatErrorRoot(t, tempInfo, expectedErr, &tempClosed)
 
 	target := &fakeFile{
 		stat:  func() (fs.FileInfo, error) { return newPinnedTargetInfo(t, "target"), nil },
@@ -2582,6 +2766,45 @@ func TestAtomicWriteSessionSnapshotAndCloseTempFileRejectsNonRegularTemp(t *test
 	}
 	if session.tempInfo != nil {
 		t.Fatal("expected no temp snapshot after non-regular temp rejection")
+	}
+}
+
+func TestAtomicWriteSessionWriteAndClose(t *testing.T) {
+	tempClosed := false
+	session := &atomicWriteSession{
+		tempFile: &fakeFile{
+			write: func(p []byte) (int, error) { return len(p), nil },
+			chmod: chmodWithoutError,
+			close: func() error {
+				tempClosed = true
+				return nil
+			},
+		},
+	}
+
+	if err := session.writeAndClose([]byte("after"), 0o600); err != nil {
+		t.Fatalf("expected writeAndClose success, got %v", err)
+	}
+	if !tempClosed {
+		t.Fatal("expected writeAndClose to close the temp file")
+	}
+	if session.tempFile != nil {
+		t.Fatal("expected writeAndClose to clear the temp file handle")
+	}
+}
+
+func TestWriteAtomicReplacementReturnsCommittedTargetLstatError(t *testing.T) {
+	expectedErr := errors.New("lstat failure")
+	tempInfo := newPinnedTargetInfo(t, "temp")
+	tempClosed := false
+	root := newCommittedTargetLstatErrorRoot(t, tempInfo, expectedErr, &tempClosed)
+
+	err := writeAtomicReplacement(root, writeTestFileName, []byte("after"), 0o600, statTestPath(t, t.TempDir()))
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected committed target lstat error, got %v", err)
+	}
+	if !tempClosed {
+		t.Fatal("expected temp file close during committed target lstat failure")
 	}
 }
 

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -361,6 +361,55 @@ func assertWriteIfAbsentFallbackCleanup(t *testing.T, expectedErr error, targetF
 	}
 }
 
+func assertAtomicReplacementKeepsTempFileOpenUntilRename(t *testing.T, invoke func(Root) error) {
+	t.Helper()
+
+	tempClosed := false
+	renameCalls := 0
+	removeCalls := 0
+	expectedErr := errors.New("rename failure")
+	root := &fakeRoot{
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if !strings.HasPrefix(name, atomicTempPrefix) {
+				t.Fatalf("unexpected open path: %s", name)
+			}
+			return &fakeFile{
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: func() error {
+					tempClosed = true
+					return nil
+				},
+			}, nil
+		},
+		rename: func(string, string) error {
+			renameCalls++
+			if tempClosed {
+				t.Fatal("expected temp file to remain open during rename attempt")
+			}
+			return expectedErr
+		},
+		remove: func(string) error {
+			removeCalls++
+			return nil
+		},
+	}
+
+	err := invoke(root)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected rename error, got %v", err)
+	}
+	if renameCalls != 1 {
+		t.Fatalf("expected one rename attempt, got %d", renameCalls)
+	}
+	if !tempClosed {
+		t.Fatal("expected cleanup to close temp file after rename failure")
+	}
+	if removeCalls != 1 {
+		t.Fatalf("expected one temp cleanup remove, got %d", removeCalls)
+	}
+}
+
 func assertPreservedExistingRegularFileMode(t *testing.T, write func(rootDir, targetPath string, data []byte) error, writeName string) {
 	t.Helper()
 	rootDir := t.TempDir()
@@ -2294,6 +2343,16 @@ func TestWriteAtomicReplacementReturnsPinnedTargetOpenError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected non-Windows write to skip pinned target open, got %v", err)
 	}
+}
+
+func TestWriteAtomicReplacementWithPinnedTargetKeepsTempFileOpenUntilRename(t *testing.T) {
+	assertAtomicReplacementKeepsTempFileOpenUntilRename(t, func(root Root) error {
+		target := &fakeFile{
+			stat:  func() (fs.FileInfo, error) { return statTestPath(t, t.TempDir()), nil },
+			close: closeWithoutError,
+		}
+		return writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, target, false)
+	})
 }
 
 func TestOpenPinnedReplacementTargetReturnsOpenError(t *testing.T) {

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -155,6 +155,75 @@ func assertWriteRootParentLookupError(t *testing.T, invoke func(*WriteRoot) erro
 	}
 }
 
+func assertWriteRootCreatesMissingParentsAndWrites(t *testing.T, writeName string, invoke func(*WriteRoot, string, []byte, os.FileMode, os.FileMode) error) {
+	t.Helper()
+	rootDir := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	targetPath := filepath.Join("reports", "nested", writeTestFileName)
+	if err := invoke(root, targetPath, []byte("hello"), 0o640, 0o750); err != nil {
+		t.Fatalf("%s returned error: %v", writeName, err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(rootDir, targetPath))
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("unexpected content: %q", string(data))
+	}
+}
+
+func assertWriteRootRejectsExistingTarget(t *testing.T, writeName string, invoke func(*WriteRoot, string, []byte, os.FileMode, os.FileMode) error) {
+	t.Helper()
+	rootDir := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	targetPath := filepath.Join("reports", writeTestFileName)
+	if err := invoke(root, targetPath, []byte("before"), 0o600, 0o750); err != nil {
+		t.Fatalf("seed target with %s: %v", writeName, err)
+	}
+	err := invoke(root, targetPath, []byte("after"), 0o600, 0o750)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("expected os.ErrExist, got %v", err)
+	}
+	if data, readErr := os.ReadFile(filepath.Join(rootDir, targetPath)); readErr != nil {
+		t.Fatalf("read existing target: %v", readErr)
+	} else if string(data) != "before" {
+		t.Fatalf("expected existing target to remain unchanged, got %q", string(data))
+	}
+}
+
+func assertWriteRootRejectsNonRelativeTargets(t *testing.T, invoke func(*WriteRoot, string, []byte, os.FileMode, os.FileMode) error) {
+	t.Helper()
+	rootDir := t.TempDir()
+	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
+
+	for _, targetPath := range []string{rootDir, "..", filepath.Join("..", writeTestFileName), "."} {
+		err := invoke(root, targetPath, []byte("hello"), 0o600, 0o750)
+		if err == nil {
+			t.Fatalf("expected target %q to be rejected", targetPath)
+		}
+	}
+}
+
+func makeFakeTempWriteRoot(err error) *fakeRoot {
+	return &fakeRoot{
+		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		openFile: func(string, int, os.FileMode) (File, error) {
+			if err != nil {
+				return nil, err
+			}
+			return &fakeFile{
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: func(os.FileMode) error { return nil },
+				close: func() error { return nil },
+			}, nil
+		},
+		remove: func(string) error { return nil },
+	}
+}
+
 func assertPreservedExistingRegularFileMode(t *testing.T, write func(rootDir, targetPath string, data []byte) error, writeName string) {
 	t.Helper()
 	rootDir := t.TempDir()
@@ -444,22 +513,14 @@ func TestWriteFileUnderReturnsErrorForMissingParentDir(t *testing.T) {
 }
 
 func TestWriteRootCreatesMissingParentsAndWritesAtomically(t *testing.T) {
+	assertWriteRootCreatesMissingParentsAndWrites(t, "WriteFileCreatingParents", (*WriteRoot).WriteFileCreatingParents)
+
 	rootDir := t.TempDir()
 	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
-
-	targetPath := filepath.Join("reports", "nested", writeTestFileName)
-	if err := root.WriteFileCreatingParents(targetPath, []byte("hello"), 0o640, 0o750); err != nil {
+	if err := root.WriteFileCreatingParents("reports/nested/"+writeTestFileName, []byte("hello"), 0o640, 0o750); err != nil {
 		t.Fatalf("WriteFileCreatingParents returned error: %v", err)
 	}
-
-	data, err := os.ReadFile(filepath.Join(rootDir, targetPath))
-	if err != nil {
-		t.Fatalf("read written file: %v", err)
-	}
-	if string(data) != "hello" {
-		t.Fatalf("unexpected content: %q", string(data))
-	}
-	info, err := os.Stat(filepath.Join(rootDir, targetPath))
+	info, err := os.Stat(filepath.Join(rootDir, "reports", "nested", writeTestFileName))
 	if err != nil {
 		t.Fatalf("stat written file: %v", err)
 	}
@@ -478,37 +539,11 @@ func TestWriteRootCreatesMissingParentsAndWritesAtomically(t *testing.T) {
 }
 
 func TestWriteRootCreatesMissingParentsAndWritesIfAbsent(t *testing.T) {
-	rootDir := t.TempDir()
-	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
-
-	targetPath := filepath.Join("reports", "nested", writeTestFileName)
-	if err := root.WriteFileCreatingParentsIfAbsent(targetPath, []byte("hello"), 0o640, 0o750); err != nil {
-		t.Fatalf("WriteFileCreatingParentsIfAbsent returned error: %v", err)
-	}
-	if data, err := os.ReadFile(filepath.Join(rootDir, targetPath)); err != nil {
-		t.Fatalf("read written file: %v", err)
-	} else if string(data) != "hello" {
-		t.Fatalf("unexpected content: %q", string(data))
-	}
+	assertWriteRootCreatesMissingParentsAndWrites(t, "WriteFileCreatingParentsIfAbsent", (*WriteRoot).WriteFileCreatingParentsIfAbsent)
 }
 
 func TestWriteRootIfAbsentRejectsExistingTarget(t *testing.T) {
-	rootDir := t.TempDir()
-	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
-
-	targetPath := filepath.Join("reports", writeTestFileName)
-	if err := root.WriteFileCreatingParentsIfAbsent(targetPath, []byte("before"), 0o600, 0o750); err != nil {
-		t.Fatalf("seed target: %v", err)
-	}
-	err := root.WriteFileCreatingParentsIfAbsent(targetPath, []byte("after"), 0o600, 0o750)
-	if !errors.Is(err, os.ErrExist) {
-		t.Fatalf("expected os.ErrExist, got %v", err)
-	}
-	if data, readErr := os.ReadFile(filepath.Join(rootDir, targetPath)); readErr != nil {
-		t.Fatalf("read existing target: %v", readErr)
-	} else if string(data) != "before" {
-		t.Fatalf("expected existing target to remain unchanged, got %q", string(data))
-	}
+	assertWriteRootRejectsExistingTarget(t, "WriteFileCreatingParentsIfAbsent", (*WriteRoot).WriteFileCreatingParentsIfAbsent)
 }
 
 func TestWriteRootIfAbsentRejectsDanglingTargetSymlink(t *testing.T) {
@@ -535,15 +570,7 @@ func TestWriteRootIfAbsentRejectsDanglingTargetSymlink(t *testing.T) {
 }
 
 func TestWriteRootIfAbsentRejectsNonRelativeTargets(t *testing.T) {
-	rootDir := t.TempDir()
-	root := openTestWriteRoot(t, rootDir, OpenWriteRoot)
-
-	for _, targetPath := range []string{rootDir, "..", filepath.Join("..", writeTestFileName), "."} {
-		err := root.WriteFileCreatingParentsIfAbsent(targetPath, []byte("hello"), 0o600, 0o750)
-		if err == nil {
-			t.Fatalf("expected target %q to be rejected", targetPath)
-		}
-	}
+	assertWriteRootRejectsNonRelativeTargets(t, (*WriteRoot).WriteFileCreatingParentsIfAbsent)
 }
 
 func TestWriteRootIfAbsentPropagatesParentReadyError(t *testing.T) {
@@ -1170,12 +1197,7 @@ func TestWriteFileIfAbsentAtRootPropagatesUnexpectedLookupError(t *testing.T) {
 
 func TestWriteFileIfAbsentAtRootPropagatesCreateTempError(t *testing.T) {
 	expectedErr := errors.New("create temp failure")
-	root := &fakeRoot{
-		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
-		openFile: func(string, int, os.FileMode) (File, error) {
-			return nil, expectedErr
-		},
-	}
+	root := makeFakeTempWriteRoot(expectedErr)
 
 	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
 	if !errors.Is(err, expectedErr) {
@@ -1185,18 +1207,8 @@ func TestWriteFileIfAbsentAtRootPropagatesCreateTempError(t *testing.T) {
 
 func TestWriteFileIfAbsentAtRootPropagatesLinkError(t *testing.T) {
 	expectedErr := errors.New("link failure")
-	root := &fakeRoot{
-		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
-		openFile: func(string, int, os.FileMode) (File, error) {
-			return &fakeFile{
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: func(os.FileMode) error { return nil },
-				close: func() error { return nil },
-			}, nil
-		},
-		link:   func(string, string) error { return expectedErr },
-		remove: func(string) error { return nil },
-	}
+	root := makeFakeTempWriteRoot(nil)
+	root.link = func(string, string) error { return expectedErr }
 
 	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
 	if !errors.Is(err, expectedErr) {
@@ -1205,23 +1217,7 @@ func TestWriteFileIfAbsentAtRootPropagatesLinkError(t *testing.T) {
 }
 
 func TestWriteRootRejectsNonRelativeTargets(t *testing.T) {
-	rootDir := t.TempDir()
-	root, err := OpenWriteRoot(rootDir)
-	if err != nil {
-		t.Fatalf("OpenWriteRoot returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		if closeErr := root.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
-			t.Errorf("close write root: %v", closeErr)
-		}
-	})
-
-	for _, targetPath := range []string{rootDir, "..", filepath.Join("..", writeTestFileName), "."} {
-		err := root.WriteFileCreatingParents(targetPath, []byte("hello"), 0o600, 0o750)
-		if err == nil {
-			t.Fatalf("expected target %q to be rejected", targetPath)
-		}
-	}
+	assertWriteRootRejectsNonRelativeTargets(t, (*WriteRoot).WriteFileCreatingParents)
 }
 
 func TestWriteRootRejectsSymlinkedParent(t *testing.T) {

--- a/internal/safeio/write_test.go
+++ b/internal/safeio/write_test.go
@@ -408,12 +408,22 @@ func assertWriteIfAbsentFallbackCleanup(t *testing.T, expectedErr error, targetF
 
 	var removed []string
 	targetClosed := false
+	targetInfo := newPinnedTargetInfo(t, "target")
 	remove := func(name string) error {
 		removed = append(removed, name)
 		return nil
 	}
 
-	root := makeFakeFallbackWriteRoot(func() File { return targetFile(&targetClosed) }, remove)
+	withTargetInfo := func() File {
+		file := targetFile(&targetClosed)
+		fake, ok := file.(*fakeFile)
+		if !ok {
+			t.Fatalf("expected fake file, got %T", file)
+		}
+		fake.stat = func() (fs.FileInfo, error) { return targetInfo, nil }
+		return fake
+	}
+	root := makeFakeFallbackWriteRoot(withTargetInfo, remove)
 
 	err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
 	if !errors.Is(err, expectedErr) {
@@ -1422,9 +1432,20 @@ func TestWriteFileIfAbsentAtRootCreatesTargetExclusivelyWithoutLinking(t *testin
 	var wroteTarget []byte
 	var chmodTarget os.FileMode
 	targetClosed := false
+	targetInfo := newPinnedTargetInfo(t, "target")
+	lstatCalls := 0
 
 	root := &fakeRoot{
-		lstat: func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				t.Fatalf("unexpected target lookup: %s", name)
+			}
+			lstatCalls++
+			if lstatCalls == 1 {
+				return nil, os.ErrNotExist
+			}
+			return targetInfo, nil
+		},
 		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
 			if name == writeTestFileName {
 				if flag != os.O_RDWR|os.O_CREATE|os.O_EXCL {
@@ -1434,6 +1455,7 @@ func TestWriteFileIfAbsentAtRootCreatesTargetExclusivelyWithoutLinking(t *testin
 					t.Fatalf("unexpected target perm: %#o", perm)
 				}
 				return &fakeFile{
+					stat: func() (fs.FileInfo, error) { return targetInfo, nil },
 					write: func(p []byte) (int, error) {
 						wroteTarget = append([]byte(nil), p...)
 						return len(p), nil
@@ -1469,6 +1491,111 @@ func TestWriteFileIfAbsentAtRootCreatesTargetExclusivelyWithoutLinking(t *testin
 	}
 	if !targetClosed {
 		t.Fatal("expected exclusive-create target file to close")
+	}
+	if lstatCalls != 2 {
+		t.Fatalf("expected target revalidation after close, got %d lookups", lstatCalls)
+	}
+}
+
+func TestWriteFileIfAbsentAtRootRejectsInvalidCreatedTarget(t *testing.T) {
+	openedInfo, changedInfo := writePinnedTargetInfoPair(t)
+	cases := []struct {
+		name      string
+		fileInfo  fs.FileInfo
+		pathInfo  fs.FileInfo
+		lstatErr  error
+		wantError string
+	}{
+		{name: "opened nonregular", fileInfo: &modeOverrideFileInfo{FileInfo: openedInfo, mode: os.ModeDir | 0o755}, wantError: "not a regular file"},
+		{name: "target symlink", fileInfo: openedInfo, pathInfo: &modeOverrideFileInfo{FileInfo: openedInfo, mode: os.ModeSymlink | 0o777}, wantError: "became a symlink"},
+		{name: "target replaced", fileInfo: openedInfo, pathInfo: changedInfo, wantError: "changed before validation"},
+		{name: "target lookup error", fileInfo: openedInfo, lstatErr: errors.New("target lookup failure"), wantError: "target lookup failure"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			closed := false
+			removed := false
+			lstatCalls := 0
+			root := &fakeRoot{
+				openFile: func(string, int, os.FileMode) (File, error) {
+					return &fakeFile{
+						stat:  func() (fs.FileInfo, error) { return tc.fileInfo, nil },
+						write: func(p []byte) (int, error) { return len(p), nil },
+						chmod: chmodWithoutError,
+						close: func() error { closed = true; return nil },
+					}, nil
+				},
+				lstat: func(string) (fs.FileInfo, error) {
+					lstatCalls++
+					if lstatCalls == 1 {
+						return nil, os.ErrNotExist
+					}
+					return tc.pathInfo, tc.lstatErr
+				},
+				remove: func(string) error { removed = true; return nil },
+			}
+
+			err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("expected %q, got %v", tc.wantError, err)
+			}
+			if tc.name == "opened nonregular" {
+				if !closed {
+					t.Fatal("expected rejected created target cleanup to close the file")
+				}
+				if !removed {
+					t.Fatal("expected cleanup of rejected created target")
+				}
+				return
+			}
+			if !closed {
+				t.Fatal("expected created target to close before validation")
+			}
+			if removed {
+				t.Fatal("must not remove a target after failed post-close validation")
+			}
+		})
+	}
+}
+
+func TestWriteFileIfAbsentAtRootCleansUpCreatedTargetPreparationErrors(t *testing.T) {
+	targetInfo := newPinnedTargetInfo(t, "target")
+	cases := []struct {
+		name     string
+		statErr  error
+		chmodErr error
+		wantErr  error
+	}{
+		{name: "stat", statErr: errors.New("target stat failure")},
+		{name: "chmod", chmodErr: errors.New("target chmod failure")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			closed := false
+			removed := false
+			root := &fakeRoot{
+				openFile: func(string, int, os.FileMode) (File, error) {
+					return &fakeFile{
+						stat:  func() (fs.FileInfo, error) { return targetInfo, tc.statErr },
+						write: func(p []byte) (int, error) { return len(p), nil },
+						chmod: func(os.FileMode) error { return tc.chmodErr },
+						close: func() error { closed = true; return nil },
+					}, nil
+				},
+				lstat:  func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist },
+				remove: func(string) error { removed = true; return nil },
+			}
+
+			err := writeFileIfAbsentAtRoot(root, rootedTarget{rel: writeTestFileName}, []byte("hello"), 0o600)
+			if !errors.Is(err, tc.statErr) && !errors.Is(err, tc.chmodErr) {
+				t.Fatalf("expected preparation error, got %v", err)
+			}
+			if !closed || !removed {
+				t.Fatalf("expected created target cleanup, closed=%t removed=%t", closed, removed)
+			}
+		})
 	}
 }
 

--- a/internal/safeio/write_windows_test.go
+++ b/internal/safeio/write_windows_test.go
@@ -141,6 +141,74 @@ func TestWriteFileReplacingWithinRootFallsBackForReplaceExistingRenameError(t *t
 	}
 }
 
+func TestWriteAtomicReplacementWithPinnedTargetFallsBackForReplaceExistingRenameErrorOnWindows(t *testing.T) {
+	infoPath := filepath.Join(t.TempDir(), writeTestFileName)
+	if err := os.WriteFile(infoPath, []byte("before"), 0o640); err != nil {
+		t.Fatalf("seed target info path: %v", err)
+	}
+	info := statTestPath(t, infoPath)
+
+	removeCalls := 0
+	targetData := []byte("before")
+	targetFile := &truncatingFakeFile{
+		fakeFile: &fakeFile{
+			stat: func() (fs.FileInfo, error) { return info, nil },
+			write: func(p []byte) (int, error) {
+				targetData = append(targetData, p...)
+				return len(p), nil
+			},
+			close: closeWithoutError,
+		},
+		truncate: func(size int64) error {
+			if size != 0 {
+				t.Fatalf("unexpected truncate size: %d", size)
+			}
+			targetData = targetData[:0]
+			return nil
+		},
+	}
+	root := &fakeRoot{
+		lstat: func(name string) (fs.FileInfo, error) {
+			if name != writeTestFileName {
+				return nil, os.ErrNotExist
+			}
+			return info, nil
+		},
+		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
+			if name == writeTestFileName {
+				return targetFile, nil
+			}
+			return &fakeFile{
+				write: func(p []byte) (int, error) { return len(p), nil },
+				chmod: chmodWithoutError,
+				close: closeWithoutError,
+			}, nil
+		},
+		rename: func(oldName, newName string) error {
+			return &os.LinkError{
+				Op:  "renameat",
+				Old: oldName,
+				New: newName,
+				Err: syscall.ERROR_ALREADY_EXISTS,
+			}
+		},
+		remove: func(string) error {
+			removeCalls++
+			return nil
+		},
+	}
+
+	if err := writeAtomicReplacementWithPinnedTarget(root, writeTestFileName, []byte("after"), 0o600, targetFile, true); err != nil {
+		t.Fatalf("writeAtomicReplacementWithPinnedTarget returned error: %v", err)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("expected one temp cleanup remove, got %d", removeCalls)
+	}
+	if string(targetData) != "after" {
+		t.Fatalf("expected fallback overwrite data, got %q", string(targetData))
+	}
+}
+
 func TestWriteFileReplacingWithinRootFallsBackWhenTargetAppearsBeforeRename(t *testing.T) {
 	targetInfoPath := filepath.Join(t.TempDir(), writeTestFileName)
 	if err := os.WriteFile(targetInfoPath, []byte("before"), 0o640); err != nil {

--- a/internal/safeio/write_windows_test.go
+++ b/internal/safeio/write_windows_test.go
@@ -149,24 +149,7 @@ func TestWriteAtomicReplacementWithPinnedTargetFallsBackForReplaceExistingRename
 	info := statTestPath(t, infoPath)
 
 	removeCalls := 0
-	targetData := []byte("before")
-	targetFile := &truncatingFakeFile{
-		fakeFile: &fakeFile{
-			stat: func() (fs.FileInfo, error) { return info, nil },
-			write: func(p []byte) (int, error) {
-				targetData = append(targetData, p...)
-				return len(p), nil
-			},
-			close: closeWithoutError,
-		},
-		truncate: func(size int64) error {
-			if size != 0 {
-				t.Fatalf("unexpected truncate size: %d", size)
-			}
-			targetData = targetData[:0]
-			return nil
-		},
-	}
+	targetFile, targetData := newPinnedFallbackTargetFile(t, info, "before")
 	root := &fakeRoot{
 		lstat: func(name string) (fs.FileInfo, error) {
 			if name != writeTestFileName {
@@ -174,16 +157,9 @@ func TestWriteAtomicReplacementWithPinnedTargetFallsBackForReplaceExistingRename
 			}
 			return info, nil
 		},
-		openFile: func(name string, flag int, perm os.FileMode) (File, error) {
-			if name == writeTestFileName {
-				return targetFile, nil
-			}
-			return &fakeFile{
-				write: func(p []byte) (int, error) { return len(p), nil },
-				chmod: chmodWithoutError,
-				close: closeWithoutError,
-			}, nil
-		},
+		openFile: openTargetOrTempFile(writeTestFileName, func() (File, error) {
+			return targetFile, nil
+		}, nil),
 		rename: func(oldName, newName string) error {
 			return &os.LinkError{
 				Op:  "renameat",

--- a/internal/safeio/write_windows_test.go
+++ b/internal/safeio/write_windows_test.go
@@ -210,23 +210,16 @@ func TestFallbackAtomicReplacementRejectsUnsafeTargetThatAppearsAfterRename(t *t
 	}
 	info := statTestPath(t, infoPath)
 
-	tests := []struct {
-		name string
-		info fs.FileInfo
-		want string
-	}{
-		{
-			name: "symlink",
-			info: &modeOverrideFileInfo{FileInfo: info, mode: os.ModeSymlink | 0o777},
-			want: "became a symlink",
-		},
-		{
-			name: "non-regular",
-			info: &modeOverrideFileInfo{FileInfo: info, mode: os.ModeDir | 0o755},
-			want: "not a regular file",
-		},
-	}
-	for _, tt := range tests {
+	for _, tc := range unsafeTargetModeCases() {
+		tt := struct {
+			name string
+			info fs.FileInfo
+			want string
+		}{
+			name: tc.name,
+			info: &modeOverrideFileInfo{FileInfo: info, mode: tc.mode},
+			want: tc.want,
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			targetOpened := false
 			root := &fakeRoot{

--- a/internal/safeio/write_windows_test.go
+++ b/internal/safeio/write_windows_test.go
@@ -150,16 +150,17 @@ func TestWriteAtomicReplacementWithPinnedTargetFallsBackForReplaceExistingRename
 
 	removeCalls := 0
 	targetFile, targetData := newPinnedFallbackTargetFile(t, info, "before")
+	tempInfo := newPinnedTargetInfo(t, "temp")
 	root := &fakeRoot{
 		lstat: func(name string) (fs.FileInfo, error) {
-			if name != writeTestFileName {
-				return nil, os.ErrNotExist
+			if name == writeTestFileName {
+				return info, nil
 			}
-			return info, nil
+			return tempInfo, nil
 		},
 		openFile: openTargetOrTempFile(writeTestFileName, func() (File, error) {
 			return targetFile, nil
-		}, nil),
+		}, tempInfo, nil),
 		rename: func(oldName, newName string) error {
 			return &os.LinkError{
 				Op:  "renameat",


### PR DESCRIPTION
## Summary

Profile config output writes could follow symlinked parent or target paths and write outside the intended destination when `--profile-output` was used.

## Changes

- route profile output writes through `safeio.WriteRoot` so parent creation and target writes stay pinned to the requested root
- add an if-absent safe-write path for non-`--force` profile writes that rejects existing or symlinked targets without following them
- extend profile and safeio regression coverage for parent symlink escapes, dangling target symlinks, and the new if-absent write path

## Validation

Commands and checks run:

```bash
go test ./internal/safeio ./internal/app
make ci
go run ./tools/prcheck --check-repo-policy --title 'fix(profile): block symlink-followed output writes' --head-ref 'bug/1217-profile-output-no-follow' --head-repo-full-name 'ben-ranford/lopper' --repo-full-name 'ben-ranford/lopper' --body-file /tmp/pr1217_body.md --regression-exempt-label false --allow-merge-commit false --allow-rebase-merge false --allow-squash-merge true --squash-merge-commit-title PR_TITLE
go run ./tools/regressionproof --title 'fix(profile): block symlink-followed output writes' --repo . --base-sha origin/main --body-file /tmp/pr1217_body.md --regression-exempt-label false
```

Additional manual validation:

- Verified `make ci` passed after rebasing onto `origin/main`, including duplication `2.98%`, race/goleak, memory benchmark, build, and coverage gates.
- Confirmed the branch worktree was clean before push and excluded generated `scripts/runtime/__pycache__/` residue.

Regression-Test: ./internal/app::TestPersistProfileConfigRejectsParentSymlink
Regression-Test: ./internal/app::TestPersistProfileConfigRejectsDanglingTargetSymlinkWithForce

## Risk and compatibility

- Breaking changes: profile output now rejects symlinked parent or target paths instead of following them
- Migration required: no
- Performance impact: negligible extra root-pinning and existence checks during profile writes
- Memory benchmark impact: none

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review

Closes #1217
