### PR TITLE
fix(elixir): ignore quote spoofing inside comments

### DIFF
--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 const (
-	elixirFooBarDependency = "foo-bar"
-	elixirAliasFooBar      = "alias Foo.Bar"
-	elixirDetectErrorFmt   = "detect: %v"
-	elixirApiMixProject    = "defmodule Api.MixProject do\n  use Mix.Project\nend\n"
+	elixirFooBarDependency         = "foo-bar"
+	elixirAliasFooBar              = "alias Foo.Bar"
+	elixirDetectErrorFmt           = "detect: %v"
+	elixirApiMixProject            = "defmodule Api.MixProject do\n  use Mix.Project\nend\n"
+	elixirSpoofedCommentedAppsPath = "# \"\"\"\n# apps_path: \"services\"\n"
 )
 
 func fixturePath(parts ...string) string {
@@ -230,58 +231,24 @@ func TestDetectWithConfidenceIgnoresEscapingAppsPath(t *testing.T) {
 
 func TestDetectWithConfidenceIgnoresCommentedAppsPath(t *testing.T) {
 	repo := t.TempDir()
-	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  # apps_path: \"services\"\n  def project, do: []\nend\n")
-	testutil.MustWriteFile(t, filepath.Join(repo, "services", "api", mixExsName), elixirApiMixProject)
-	assertDetectionFixture(t, repo, filepath.Base(repo), "")
-}
-
-func TestDetectWithConfidenceIgnoresCommentedAppsPathAfterQuotedCommentSpoof(t *testing.T) {
-	repo := t.TempDir()
-	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  # \"\"\"\n  # apps_path: \"services\"\n  def project, do: []\nend\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  "+elixirSpoofedCommentedAppsPath+"  def project, do: []\nend\n")
 	testutil.MustWriteFile(t, filepath.Join(repo, "services", "api", mixExsName), elixirApiMixProject)
 	assertDetectionFixture(t, repo, filepath.Base(repo), "")
 }
 
 func TestStripElixirCommentsPreservesQuotedAndEscapedContent(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{
-			name:  "double quoted hash stays",
-			input: "def project, do: [apps_path: \"ser#vices\"]\n# comment\n",
-			want:  "def project, do: [apps_path: \"ser#vices\"]\n\n",
-		},
-		{
-			name:  "escaped quote and hash stay",
-			input: "def project, do: [apps_path: \"ser\\\"vices\\#x\"]\n# comment\n",
-			want:  "def project, do: [apps_path: \"ser\\\"vices\\#x\"]\n\n",
-		},
-		{
-			name:  "single quoted hash stays",
-			input: "value = 'foo#bar'\n# comment\n",
-			want:  "value = 'foo#bar'\n\n",
-		},
-		{
-			name:  "multiline double quoted hash stays with embedded quote",
-			input: "doc = \"\"\"\nline with \\\" quote\n# not a comment\n\"\"\"\n# comment\n",
-			want:  "doc = \"\"\"\nline with \\\" quote\n# not a comment\n\"\"\"\n\n",
-		},
-		{
-			name:  "comment quote delimiters do not spoof later strings",
-			input: "value = 1\n# \"\"\"\n# \"\napps_path: \"services\"\n# comment\n",
-			want:  "value = 1\n\n\napps_path: \"services\"\n\n",
-		},
+	assertStripped := func(input, want string) {
+		t.Helper()
+		if got := stripElixirComments([]byte(input)); got != want {
+			t.Fatalf("unexpected stripped output:\nwant: %q\ngot:  %q", want, got)
+		}
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := stripElixirComments([]byte(tc.input)); got != tc.want {
-				t.Fatalf("unexpected stripped output:\nwant: %q\ngot:  %q", tc.want, got)
-			}
-		})
-	}
+	assertStripped("def project, do: [apps_path: \"ser#vices\"]\n# comment\n", "def project, do: [apps_path: \"ser#vices\"]\n\n")
+	assertStripped("def project, do: [apps_path: \"ser\\\"vices\\#x\"]\n# comment\n", "def project, do: [apps_path: \"ser\\\"vices\\#x\"]\n\n")
+	assertStripped("value = 'foo#bar'\n# comment\n", "value = 'foo#bar'\n\n")
+	assertStripped("doc = \"\"\"\nline with \\\" quote\n# not a comment\n\"\"\"\n# comment\n", "doc = \"\"\"\nline with \\\" quote\n# not a comment\n\"\"\"\n\n")
+	assertStripped("value = 1\n# \"\"\"\n# \"\napps_path: \"services\"\n# comment\n", "value = 1\n\n\napps_path: \"services\"\n\n")
 }
 
 func TestParseImportsAliasAsSetsLocalName(t *testing.T) {
@@ -332,9 +299,6 @@ func TestDetectUmbrellaAppsPathBranches(t *testing.T) {
 	}
 	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("# apps_path: \"services\"\ndef project, do: []\n")); umbrella || appsPath != "" {
 		t.Fatalf("expected commented apps_path to be ignored, got umbrella=%v appsPath=%q", umbrella, appsPath)
-	}
-	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("# \"\"\"\n# apps_path: \"services\"\ndef project, do: []\n")); umbrella || appsPath != "" {
-		t.Fatalf("expected commented apps_path after quote spoof to be ignored, got umbrella=%v appsPath=%q", umbrella, appsPath)
 	}
 	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("def project, do: [apps_path: \"   \"]\n")); !umbrella || appsPath != "apps" {
 		t.Fatalf("expected blank apps_path to fall back to apps, got umbrella=%v appsPath=%q", umbrella, appsPath)

--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -281,6 +281,14 @@ func TestParseImportsIgnoresAliasLikeTextInMultilineStrings(t *testing.T) {
 	}
 }
 
+func TestParseImportsIgnoresAliasLikeTextAfterCharacterLiteralHash(t *testing.T) {
+	content := []byte("defmodule Demo do\n  marker = ?#; doc = \"\"\"\n  alias Foo.Bar\n  \"\"\"\n  alias Foo.Bar, as: Baz\nend\n")
+	imports := parseImports(content, "lib/demo.ex", map[string]struct{}{"foo": {}})
+	if len(imports) != 1 || imports[0].Local != "Baz" || imports[0].Location.Line != 5 {
+		t.Fatalf("expected only the real alias after character literal hash, got %#v", imports)
+	}
+}
+
 func TestResolveWeights(t *testing.T) {
 	defaults := shared.ResolveRemovalCandidateWeights(nil)
 	if defaults != report.DefaultRemovalCandidateWeights() {

--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -231,9 +231,27 @@ func TestDetectWithConfidenceIgnoresEscapingAppsPath(t *testing.T) {
 
 func TestDetectWithConfidenceIgnoresCommentedAppsPath(t *testing.T) {
 	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  # apps_path: \"services\"\n  def project, do: []\nend\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "services", "api", mixExsName), elixirApiMixProject)
+	assertDetectionFixture(t, repo, filepath.Base(repo), "")
+}
+
+func TestDetectWithConfidenceIgnoresCommentedAppsPathAfterQuotedCommentSpoof(t *testing.T) {
+	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  "+elixirSpoofedCommentedAppsPath+"  def project, do: []\nend\n")
 	testutil.MustWriteFile(t, filepath.Join(repo, "services", "api", mixExsName), elixirApiMixProject)
 	assertDetectionFixture(t, repo, filepath.Base(repo), "")
+}
+
+func TestDetectWithConfidencePreservesAppsPathAfterCharacterLiteralHash(t *testing.T) {
+	for _, literal := range []string{"?#", "?\\#"} {
+		t.Run(literal, func(t *testing.T) {
+			repo := t.TempDir()
+			testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  def project, do: [marker: "+literal+", apps_path: \"services\"]\nend\n")
+			testutil.MustWriteFile(t, filepath.Join(repo, "services", "api", mixExsName), elixirApiMixProject)
+			assertDetectionFixture(t, repo, filepath.Join("services", "api"), filepath.Base(repo))
+		})
+	}
 }
 
 func TestStripElixirCommentsPreservesQuotedAndEscapedContent(t *testing.T) {
@@ -247,6 +265,8 @@ func TestStripElixirCommentsPreservesQuotedAndEscapedContent(t *testing.T) {
 	assertStripped("def project, do: [apps_path: \"ser#vices\"]\n# comment\n", "def project, do: [apps_path: \"ser#vices\"]\n\n")
 	assertStripped("def project, do: [apps_path: \"ser\\\"vices\\#x\"]\n# comment\n", "def project, do: [apps_path: \"ser\\\"vices\\#x\"]\n\n")
 	assertStripped("value = 'foo#bar'\n# comment\n", "value = 'foo#bar'\n\n")
+	assertStripped("def project, do: [marker: ?#, apps_path: \"services\"]\n# comment\n", "def project, do: [marker: ?#, apps_path: \"services\"]\n\n")
+	assertStripped("def project, do: [marker: ?\\#, apps_path: \"services\"]\n# comment\n", "def project, do: [marker: ?\\#, apps_path: \"services\"]\n\n")
 	assertStripped("doc = \"\"\"\nline with \\\" quote\n# not a comment\n\"\"\"\n# comment\n", "doc = \"\"\"\nline with \\\" quote\n# not a comment\n\"\"\"\n\n")
 	assertStripped("value = 1\n# \"\"\"\n# \"\napps_path: \"services\"\n# comment\n", "value = 1\n\n\napps_path: \"services\"\n\n")
 }
@@ -282,10 +302,14 @@ func TestParseImportsIgnoresAliasLikeTextInMultilineStrings(t *testing.T) {
 }
 
 func TestParseImportsIgnoresAliasLikeTextAfterCharacterLiteralHash(t *testing.T) {
-	content := []byte("defmodule Demo do\n  marker = ?#; doc = \"\"\"\n  alias Foo.Bar\n  \"\"\"\n  alias Foo.Bar, as: Baz\nend\n")
-	imports := parseImports(content, "lib/demo.ex", map[string]struct{}{"foo": {}})
-	if len(imports) != 1 || imports[0].Local != "Baz" || imports[0].Location.Line != 5 {
-		t.Fatalf("expected only the real alias after character literal hash, got %#v", imports)
+	for _, literal := range []string{"?#", "?\\#"} {
+		t.Run(literal, func(t *testing.T) {
+			content := []byte("defmodule Demo do\n  marker = " + literal + "; doc = \"\"\"\n  alias Foo.Bar\n  \"\"\"\n  alias Foo.Bar, as: Baz\nend\n")
+			imports := parseImports(content, "lib/demo.ex", map[string]struct{}{"foo": {}})
+			if len(imports) != 1 || imports[0].Local != "Baz" || imports[0].Location.Line != 5 {
+				t.Fatalf("expected only the real alias after character literal hash, got %#v", imports)
+			}
+		})
 	}
 }
 

--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -235,6 +235,13 @@ func TestDetectWithConfidenceIgnoresCommentedAppsPath(t *testing.T) {
 	assertDetectionFixture(t, repo, filepath.Base(repo), "")
 }
 
+func TestDetectWithConfidenceIgnoresCommentedAppsPathAfterQuotedCommentSpoof(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  # \"\"\"\n  # apps_path: \"services\"\n  def project, do: []\nend\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, "services", "api", mixExsName), elixirApiMixProject)
+	assertDetectionFixture(t, repo, filepath.Base(repo), "")
+}
+
 func TestStripElixirCommentsPreservesQuotedAndEscapedContent(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -260,6 +267,11 @@ func TestStripElixirCommentsPreservesQuotedAndEscapedContent(t *testing.T) {
 			name:  "multiline double quoted hash stays with embedded quote",
 			input: "doc = \"\"\"\nline with \\\" quote\n# not a comment\n\"\"\"\n# comment\n",
 			want:  "doc = \"\"\"\nline with \\\" quote\n# not a comment\n\"\"\"\n\n",
+		},
+		{
+			name:  "comment quote delimiters do not spoof later strings",
+			input: "value = 1\n# \"\"\"\n# \"\napps_path: \"services\"\n# comment\n",
+			want:  "value = 1\n\n\napps_path: \"services\"\n\n",
 		},
 	}
 
@@ -320,6 +332,9 @@ func TestDetectUmbrellaAppsPathBranches(t *testing.T) {
 	}
 	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("# apps_path: \"services\"\ndef project, do: []\n")); umbrella || appsPath != "" {
 		t.Fatalf("expected commented apps_path to be ignored, got umbrella=%v appsPath=%q", umbrella, appsPath)
+	}
+	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("# \"\"\"\n# apps_path: \"services\"\ndef project, do: []\n")); umbrella || appsPath != "" {
+		t.Fatalf("expected commented apps_path after quote spoof to be ignored, got umbrella=%v appsPath=%q", umbrella, appsPath)
 	}
 	if umbrella, appsPath := detectUmbrellaAppsPath([]byte("def project, do: [apps_path: \"   \"]\n")); !umbrella || appsPath != "apps" {
 		t.Fatalf("expected blank apps_path to fall back to apps, got umbrella=%v appsPath=%q", umbrella, appsPath)

--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -230,10 +230,14 @@ func TestDetectWithConfidenceIgnoresEscapingAppsPath(t *testing.T) {
 }
 
 func TestDetectWithConfidenceIgnoresCommentedAppsPath(t *testing.T) {
-	repo := t.TempDir()
-	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  ready?# apps_path: \"services\"\n  def project, do: []\nend\n")
-	testutil.MustWriteFile(t, filepath.Join(repo, "services", "api", mixExsName), elixirApiMixProject)
-	assertDetectionFixture(t, repo, filepath.Base(repo), "")
+	for _, prefix := range []string{"ready?", "??", "?\\?"} {
+		t.Run(prefix, func(t *testing.T) {
+			repo := t.TempDir()
+			testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  "+prefix+"# apps_path: \"services\"\n  def project, do: []\nend\n")
+			testutil.MustWriteFile(t, filepath.Join(repo, "services", "api", mixExsName), elixirApiMixProject)
+			assertDetectionFixture(t, repo, filepath.Base(repo), "")
+		})
+	}
 }
 
 func TestDetectWithConfidenceIgnoresCommentedAppsPathAfterQuotedCommentSpoof(t *testing.T) {

--- a/internal/lang/elixir/adapter_test.go
+++ b/internal/lang/elixir/adapter_test.go
@@ -231,7 +231,7 @@ func TestDetectWithConfidenceIgnoresEscapingAppsPath(t *testing.T) {
 
 func TestDetectWithConfidenceIgnoresCommentedAppsPath(t *testing.T) {
 	repo := t.TempDir()
-	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  # apps_path: \"services\"\n  def project, do: []\nend\n")
+	testutil.MustWriteFile(t, filepath.Join(repo, mixExsName), "defmodule Demo.MixProject do\n  use Mix.Project\n  ready?# apps_path: \"services\"\n  def project, do: []\nend\n")
 	testutil.MustWriteFile(t, filepath.Join(repo, "services", "api", mixExsName), elixirApiMixProject)
 	assertDetectionFixture(t, repo, filepath.Base(repo), "")
 }

--- a/internal/lang/elixir/detection.go
+++ b/internal/lang/elixir/detection.go
@@ -109,7 +109,7 @@ func stripElixirComments(content []byte) string {
 	stripped.Grow(len(content))
 
 	for i := 0; i < len(content); i++ {
-		if content[i] == '#' && masked[i] == '#' {
+		if isElixirCommentStart(content, masked, i) {
 			i = skipElixirComment(content, i, &stripped)
 			continue
 		}

--- a/internal/lang/elixir/source_mask.go
+++ b/internal/lang/elixir/source_mask.go
@@ -211,5 +211,12 @@ func isElixirCommentStart(content, masked []byte, index int) bool {
 	if index < 0 || index >= len(content) || content[index] != '#' || masked[index] != '#' {
 		return false
 	}
-	return index <= 0 || content[index-1] != '?'
+	return !isElixirCharacterLiteralHash(content, index)
+}
+
+func isElixirCharacterLiteralHash(content []byte, hashIndex int) bool {
+	if hashIndex > 0 && content[hashIndex-1] == '?' {
+		return true
+	}
+	return hashIndex > 1 && content[hashIndex-2] == '?' && content[hashIndex-1] == '\\'
 }

--- a/internal/lang/elixir/source_mask.go
+++ b/internal/lang/elixir/source_mask.go
@@ -26,7 +26,7 @@ func MaskSource(content []byte) []byte {
 	masked := sanitizeElixirSource(content)
 	maskElixirSigils(content, masked)
 	for index := 0; index < len(content); index++ {
-		if content[index] != '#' || masked[index] != '#' {
+		if !isElixirCommentStart(content, masked, index) {
 			continue
 		}
 		for index < len(content) && content[index] != '\n' {
@@ -181,7 +181,9 @@ func startElixirSanitizedRegion(content []byte, sanitized []byte, index int, sta
 
 	switch content[index] {
 	case '#':
-		state.inComment = true
+		if isElixirCommentStart(content, sanitized, index) {
+			state.inComment = true
+		}
 	case '"':
 		maskElixirSourceByte(sanitized, index)
 		state.inDoubleQuote = true
@@ -203,4 +205,11 @@ func maskElixirSourceByte(content []byte, index int) {
 	if content[index] != '\n' {
 		content[index] = ' '
 	}
+}
+
+func isElixirCommentStart(content, masked []byte, index int) bool {
+	if index < 0 || index >= len(content) || content[index] != '#' || masked[index] != '#' {
+		return false
+	}
+	return index <= 0 || content[index-1] != '?'
 }

--- a/internal/lang/elixir/source_mask.go
+++ b/internal/lang/elixir/source_mask.go
@@ -5,6 +5,7 @@ type elixirSourceMaskState struct {
 	inDoubleQuote   bool
 	inSingleHeredoc bool
 	inDoubleHeredoc bool
+	inComment       bool
 	escaped         bool
 }
 
@@ -105,6 +106,8 @@ func isElixirSigilLetter(value byte) bool {
 
 func sanitizeElixirSourceAt(content []byte, sanitized []byte, index int, state *elixirSourceMaskState) int {
 	switch {
+	case state.inComment:
+		return sanitizeElixirCommentByte(content, index, state)
 	case state.inDoubleHeredoc:
 		return sanitizeElixirHeredocByte(content, sanitized, index, state, '"')
 	case state.inSingleHeredoc:
@@ -116,6 +119,13 @@ func sanitizeElixirSourceAt(content []byte, sanitized []byte, index int, state *
 	default:
 		return startElixirSanitizedRegion(content, sanitized, index, state)
 	}
+}
+
+func sanitizeElixirCommentByte(content []byte, index int, state *elixirSourceMaskState) int {
+	if content[index] == '\n' {
+		state.inComment = false
+	}
+	return 0
 }
 
 func sanitizeElixirHeredocByte(content []byte, sanitized []byte, index int, state *elixirSourceMaskState, quote byte) int {
@@ -170,6 +180,8 @@ func startElixirSanitizedRegion(content []byte, sanitized []byte, index int, sta
 	}
 
 	switch content[index] {
+	case '#':
+		state.inComment = true
 	case '"':
 		maskElixirSourceByte(sanitized, index)
 		state.inDoubleQuote = true

--- a/internal/lang/elixir/source_mask.go
+++ b/internal/lang/elixir/source_mask.go
@@ -215,8 +215,16 @@ func isElixirCommentStart(content, masked []byte, index int) bool {
 }
 
 func isElixirCharacterLiteralHash(content []byte, hashIndex int) bool {
-	if hashIndex > 0 && content[hashIndex-1] == '?' {
-		return true
+	literalStart := hashIndex - 1
+	if literalStart > 0 && content[literalStart] == '\\' {
+		literalStart--
 	}
-	return hashIndex > 1 && content[hashIndex-2] == '?' && content[hashIndex-1] == '\\'
+	if literalStart < 0 || content[literalStart] != '?' {
+		return false
+	}
+	return literalStart == 0 || !isElixirIdentifierByte(content[literalStart-1])
+}
+
+func isElixirIdentifierByte(value byte) bool {
+	return value == '_' || value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' || value >= '0' && value <= '9' || value >= 0x80
 }

--- a/internal/lang/elixir/source_mask.go
+++ b/internal/lang/elixir/source_mask.go
@@ -222,7 +222,14 @@ func isElixirCharacterLiteralHash(content []byte, hashIndex int) bool {
 	if literalStart < 0 || content[literalStart] != '?' {
 		return false
 	}
-	return literalStart == 0 || !isElixirIdentifierByte(content[literalStart-1])
+	return !isElixirCharacterLiteralContinuation(content, literalStart) && (literalStart == 0 || !isElixirIdentifierByte(content[literalStart-1]))
+}
+
+func isElixirCharacterLiteralContinuation(content []byte, index int) bool {
+	if index > 0 && content[index-1] == '?' {
+		return index == 1 || !isElixirIdentifierByte(content[index-2])
+	}
+	return index > 1 && content[index-1] == '\\' && content[index-2] == '?' && (index == 2 || !isElixirIdentifierByte(content[index-3]))
 }
 
 func isElixirIdentifierByte(value byte) bool {


### PR DESCRIPTION
## Summary

Prevent Elixir comment text that contains quote delimiters from spoofing later `apps_path` parsing as live umbrella configuration.

Closes #1238

## Changes

- track comment state while sanitizing Elixir source so quote delimiters inside comments cannot leak into later parsing state
- add regression coverage for commented `apps_path` spoofing and the underlying comment stripping branch

## Validation

Commands and checks run:

```bash
go test ./internal/lang/elixir -run 'TestDetectWithConfidenceIgnoresCommentedAppsPathAfterQuotedCommentSpoof|TestDetectUmbrellaAppsPathBranches|TestStripElixirCommentsPreservesQuotedAndEscapedContent'
```

Additional manual validation:

- N/A

Regression-Test: ./internal/lang/elixir::TestDetectWithConfidenceIgnoresCommentedAppsPathAfterQuotedCommentSpoof

## Risk and compatibility

- Breaking changes: none
- Migration required: none
- Performance impact: none expected
- Memory benchmark impact: none

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
