### PR TITLE
fix(analysis): confine Kotlin Android candidate roots

### DIFF
--- a/internal/analysis/execution.go
+++ b/internal/analysis/execution.go
@@ -47,6 +47,10 @@ func (s *Service) runCandidateOnRoots(ctx context.Context, req Request, repoPath
 	warnings = append(warnings, rootWarnings...)
 	for _, root := range roots {
 		normalizedRoot := normalizeCandidateRoot(repoPath, root)
+		if normalizedRoot == "" {
+			warnings = append(warnings, "skipping candidate root outside repo boundary: "+root)
+			continue
+		}
 		if alreadySeenRoot(rootSeen, normalizedRoot) {
 			continue
 		}

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ben-ranford/lopper/internal/lang/shared"
 	"github.com/ben-ranford/lopper/internal/language"
 	"github.com/ben-ranford/lopper/internal/report"
 	"github.com/ben-ranford/lopper/internal/runtime"
@@ -306,10 +307,15 @@ func uniqueSorted(values []string) []string {
 }
 
 func normalizeCandidateRoot(repoPath, root string) string {
-	if filepath.IsAbs(root) {
-		return root
+	normalized := root
+	if !filepath.IsAbs(normalized) {
+		normalized = filepath.Join(repoPath, normalized)
 	}
-	return filepath.Join(repoPath, root)
+	normalized = filepath.Clean(normalized)
+	if !shared.IsPathWithin(repoPath, normalized) {
+		return ""
+	}
+	return normalized
 }
 
 func remapAnalyzedRoots(roots []string, fromRepoPath, toRepoPath string) []string {

--- a/internal/analysis/service_errors_test.go
+++ b/internal/analysis/service_errors_test.go
@@ -18,10 +18,11 @@ const (
 )
 
 type testServiceAdapter struct {
-	id      string
-	detect  language.Detection
-	analyse report.Report
-	err     error
+	id        string
+	detect    language.Detection
+	analyse   report.Report
+	analyseFn func(context.Context, language.Request) (report.Report, error)
+	err       error
 }
 
 func (a *testServiceAdapter) ID() string        { return a.id }
@@ -32,7 +33,10 @@ func (a *testServiceAdapter) Detect(context.Context, string) (bool, error) {
 func (a *testServiceAdapter) DetectWithConfidence(context.Context, string) (language.Detection, error) {
 	return a.detect, nil
 }
-func (a *testServiceAdapter) Analyse(context.Context, language.Request) (report.Report, error) {
+func (a *testServiceAdapter) Analyse(ctx context.Context, req language.Request) (report.Report, error) {
+	if a.analyseFn != nil {
+		return a.analyseFn(ctx, req)
+	}
 	if a.err != nil {
 		return report.Report{}, a.err
 	}

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ben-ranford/lopper/internal/language"
@@ -39,6 +40,101 @@ func TestHelperFunctions(t *testing.T) {
 	}
 	if normalizeScopeMode("REPO") != ScopeModeRepo {
 		t.Fatalf("expected repo scope mode normalization")
+	}
+}
+
+func TestNormalizeCandidateRootConfinesPathsToRepo(t *testing.T) {
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	outside := filepath.Join(base, "outside")
+	valid := filepath.Join(repo, "app")
+	if err := os.MkdirAll(valid, 0o755); err != nil {
+		t.Fatalf("mkdir valid root: %v", err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside root: %v", err)
+	}
+
+	if got := normalizeCandidateRoot(repo, valid); got != valid {
+		t.Fatalf("expected in-repo absolute root preserved, got %q want %q", got, valid)
+	}
+	if got := normalizeCandidateRoot(repo, filepath.Join("app", "..", "app")); got != valid {
+		t.Fatalf("expected in-repo relative root cleaned, got %q want %q", got, valid)
+	}
+	if got := normalizeCandidateRoot(repo, filepath.Join("..", "outside")); got != "" {
+		t.Fatalf("expected traversal candidate root rejection, got %q", got)
+	}
+	if got := normalizeCandidateRoot(repo, outside); got != "" {
+		t.Fatalf("expected outside absolute root rejection, got %q", got)
+	}
+
+	link := filepath.Join(repo, "linked-outside")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink linked-outside: %v", err)
+	}
+	if got := normalizeCandidateRoot(repo, link); got != "" {
+		t.Fatalf("expected symlink escape root rejection, got %q", got)
+	}
+}
+
+func TestRunCandidateOnRootsConfinesKotlinAndroidRootsToRepo(t *testing.T) {
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	validRoot := filepath.Join(repo, "app")
+	outsideRoot := filepath.Join(base, "outside")
+	if err := os.MkdirAll(validRoot, 0o755); err != nil {
+		t.Fatalf("mkdir valid root: %v", err)
+	}
+	if err := os.MkdirAll(outsideRoot, 0o755); err != nil {
+		t.Fatalf("mkdir outside root: %v", err)
+	}
+	linkedOutside := filepath.Join(repo, "linked-outside")
+	if err := os.Symlink(outsideRoot, linkedOutside); err != nil {
+		t.Fatalf("symlink linked-outside: %v", err)
+	}
+
+	calledRoots := make([]string, 0, 1)
+	candidate := language.Candidate{
+		Adapter: &testServiceAdapter{
+			id: kotlinAndroidLanguageID,
+			analyseFn: func(_ context.Context, req language.Request) (report.Report, error) {
+				calledRoots = append(calledRoots, req.RepoPath)
+				return report.Report{
+					Dependencies: []report.DependencyReport{{Name: "core-ktx"}},
+				}, nil
+			},
+		},
+		Detection: language.Detection{
+			Matched: true,
+			Roots: []string{
+				validRoot,
+				outsideRoot,
+				filepath.Join("..", "outside"),
+				linkedOutside,
+			},
+		},
+	}
+
+	reports, warnings, analyzedRoots, err := (&Service{}).runCandidateOnRoots(context.Background(), Request{RepoPath: repo, Language: kotlinAndroidLanguageID}, repo, candidate, nil)
+	if err != nil {
+		t.Fatalf("runCandidateOnRoots: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("expected one report from in-repo Kotlin Android root, got %d", len(reports))
+	}
+	if len(calledRoots) != 1 || calledRoots[0] != validRoot {
+		t.Fatalf("expected only in-repo Kotlin Android root analysed, got %#v", calledRoots)
+	}
+	if len(analyzedRoots) != 1 || analyzedRoots[0] != validRoot {
+		t.Fatalf("expected only trusted analyzed root, got %#v", analyzedRoots)
+	}
+	if len(warnings) != 3 {
+		t.Fatalf("expected three candidate-root boundary warnings, got %#v", warnings)
+	}
+	for _, warning := range warnings {
+		if !strings.Contains(warning, "outside repo boundary") {
+			t.Fatalf("expected repo-boundary warning, got %q", warning)
+		}
 	}
 }
 

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -70,7 +70,7 @@ func TestNormalizeCandidateRootConfinesPathsToRepo(t *testing.T) {
 
 	link := filepath.Join(repo, "linked-outside")
 	if err := os.Symlink(outside, link); err != nil {
-		t.Fatalf("symlink linked-outside: %v", err)
+		t.Skipf("symlink unavailable: %v", err)
 	}
 	if got := normalizeCandidateRoot(repo, link); got != "" {
 		t.Fatalf("expected symlink escape root rejection, got %q", got)

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -90,7 +90,7 @@ func TestRunCandidateOnRootsConfinesKotlinAndroidRootsToRepo(t *testing.T) {
 	}
 	linkedOutside := filepath.Join(repo, "linked-outside")
 	if err := os.Symlink(outsideRoot, linkedOutside); err != nil {
-		t.Fatalf("symlink linked-outside: %v", err)
+		t.Skipf("symlink unavailable: %v", err)
 	}
 
 	calledRoots := make([]string, 0, 1)


### PR DESCRIPTION
## Summary

Confine adapter-selected Kotlin/Android candidate roots to the requested repository before analysis, preventing traversal, absolute-path, and symlink escapes from scanning outside the trusted root.

Closes #1250

## Changes

- Reject candidate roots that resolve outside the repository boundary.
- Skip rejected roots with a boundary warning rather than analysing them.
- Add traversal, absolute-path, symlink, and Kotlin/Android execution regressions.

## Validation

Commands and checks run:

```bash
go test ./internal/analysis/...
make ci
```

Additional manual validation:

- Exercised in-repository, traversal, external absolute, and symlinked-outside roots through the service candidate runner.

Regression-Test: ./internal/analysis::TestRunCandidateOnRootsConfinesKotlinAndroidRootsToRepo

## Risk and compatibility

- Breaking changes: Candidate roots outside the requested repository are now rejected.
- Migration required: None.
- Performance impact: Avoids unintended parent-tree scans.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review