### PR TITLE
fix(analysis): bound scoped workspace copies

### DIFF
--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -41,7 +41,7 @@ func (s *Service) newAnalysisPipeline(ctx context.Context, req Request) (*analys
 	}
 
 	req.ScopeMode = normalizeScopeMode(req.ScopeMode)
-	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScope(ctx, repoPath, req.IncludePatterns, req.ExcludePatterns)
+	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScopeWithContext(ctx, repoPath, req.IncludePatterns, req.ExcludePatterns)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -41,7 +41,7 @@ func (s *Service) newAnalysisPipeline(ctx context.Context, req Request) (*analys
 	}
 
 	req.ScopeMode = normalizeScopeMode(req.ScopeMode)
-	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScope(repoPath, req.IncludePatterns, req.ExcludePatterns)
+	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScope(ctx, repoPath, req.IncludePatterns, req.ExcludePatterns)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/analysis/pipeline_setup_paths_test.go
+++ b/internal/analysis/pipeline_setup_paths_test.go
@@ -21,6 +21,19 @@ func TestAnalysisPipelineAdditionalSetupBranches(t *testing.T) {
 	}
 }
 
+func TestNewAnalysisPipelineStopsBeforeScopedCopyWhenCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	service := &Service{Registry: language.NewRegistry()}
+	if _, err := service.newAnalysisPipeline(ctx, Request{
+		RepoPath:        t.TempDir(),
+		IncludePatterns: []string{"**/*.js"},
+	}); err == nil {
+		t.Fatal("expected cancelled scoped pipeline setup to fail")
+	}
+}
+
 func TestScopedCandidateRootsChangedPackagesSuccessBranch(t *testing.T) {
 	repoRoot := t.TempDir()
 	rootA := filepath.Join(repoRoot, "packages", "a")

--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -149,61 +149,80 @@ func applyPathScope(ctx context.Context, repoPath string, includePatterns []stri
 
 func (w *scopeWalker) walkWithContext(ctx context.Context) fs.WalkDirFunc {
 	return func(currentPath string, entry fs.DirEntry, walkErr error) error {
-		if err := scopeContextErr(ctx); err != nil {
-			return err
+		return w.walk(ctx, currentPath, entry, walkErr)
+	}
+}
+
+func (w *scopeWalker) walk(ctx context.Context, currentPath string, entry fs.DirEntry, walkErr error) error {
+	if err := scopeContextErr(ctx); err != nil {
+		return err
+	}
+	if walkErr != nil {
+		return walkErr
+	}
+	if entry.IsDir() {
+		if entry.Name() == ".git" {
+			return filepath.SkipDir
 		}
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() {
-			if entry.Name() == ".git" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		w.stats.totalFiles++
-		relativePath, err := filepath.Rel(w.repoPath, currentPath)
-		if err != nil {
-			return err
-		}
-		slashed := filepath.ToSlash(filepath.Clean(relativePath))
-		includeMatched, includePattern := matchFirstCompiledPattern(slashed, w.includeCompiled)
-		excludeMatched, excludePattern := matchFirstCompiledPattern(slashed, w.excludeCompiled)
-		shouldSkip := (len(w.includePatterns) > 0 && !includeMatched) || excludeMatched
-		if shouldSkip {
-			recordScopeSkip(w.stats, slashed, includeMatched, includePattern, excludeMatched, excludePattern)
-			return nil
-		}
-		if entry.Type()&fs.ModeSymlink != 0 {
-			recordScopeSkipReason(w.stats, slashed, "is symlink (not copied)")
-			return nil
-		}
-		info, err := entry.Info()
-		if err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() {
+		return nil
+	}
+	return w.walkFile(ctx, currentPath, entry)
+}
+
+func (w *scopeWalker) walkFile(ctx context.Context, currentPath string, entry fs.DirEntry) error {
+	w.stats.totalFiles++
+	relativePath, err := filepath.Rel(w.repoPath, currentPath)
+	if err != nil {
+		return err
+	}
+	slashed := filepath.ToSlash(filepath.Clean(relativePath))
+	includeMatched, includePattern, skip := w.scopePathMatch(slashed)
+	if skip {
+		return nil
+	}
+	return w.copyScopedEntry(ctx, entry, relativePath, slashed, includeMatched, includePattern)
+}
+
+func (w *scopeWalker) scopePathMatch(slashed string) (bool, string, bool) {
+	includeMatched, includePattern := matchFirstCompiledPattern(slashed, w.includeCompiled)
+	excludeMatched, excludePattern := matchFirstCompiledPattern(slashed, w.excludeCompiled)
+	if (len(w.includePatterns) > 0 && !includeMatched) || excludeMatched {
+		recordScopeSkip(w.stats, slashed, includeMatched, includePattern, excludeMatched, excludePattern)
+		return false, "", true
+	}
+	return includeMatched, includePattern, false
+}
+
+func (w *scopeWalker) copyScopedEntry(ctx context.Context, entry fs.DirEntry, relativePath, slashed string, includeMatched bool, includePattern string) error {
+	if entry.Type()&fs.ModeSymlink != 0 {
+		recordScopeSkipReason(w.stats, slashed, "is symlink (not copied)")
+		return nil
+	}
+	info, err := entry.Info()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		recordScopeSkipReason(w.stats, slashed, "is not a regular file (not copied)")
+		return nil
+	}
+	if err := w.budget.reserve(slashed, info.Size()); err != nil {
+		return err
+	}
+	if includeMatched {
+		w.stats.includeMatches[includePattern]++
+	}
+	if err := copyFile(ctx, w.repoPath, w.scopedRoot, relativePath, info.Size()); err != nil {
+		if errors.Is(err, errScopedCopyNonRegularFile) {
+			w.budget.files--
+			w.budget.bytes -= info.Size()
 			recordScopeSkipReason(w.stats, slashed, "is not a regular file (not copied)")
 			return nil
 		}
-		if err := w.budget.reserve(slashed, info.Size()); err != nil {
-			return err
-		}
-		if includeMatched {
-			w.stats.includeMatches[includePattern]++
-		}
-		if err := copyFile(ctx, w.repoPath, w.scopedRoot, relativePath, info.Size()); err != nil {
-			if errors.Is(err, errScopedCopyNonRegularFile) {
-				w.budget.files--
-				w.budget.bytes -= info.Size()
-				recordScopeSkipReason(w.stats, slashed, "is not a regular file (not copied)")
-				return nil
-			}
-			return err
-		}
-		w.stats.keptFiles++
-		return nil
+		return err
 	}
+	w.stats.keptFiles++
+	return nil
 }
 
 func recordScopeSkip(stats *scopeStats, slashed string, includeMatched bool, includePattern string, excludeMatched bool, excludePattern string) {

--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -89,7 +89,11 @@ func (b *scopeCopyBudget) reserve(path string, size int64) error {
 	return nil
 }
 
-func applyPathScope(ctx context.Context, repoPath string, includePatterns []string, excludePatterns []string) (string, []string, func(), error) {
+func applyPathScope(repoPath string, includePatterns []string, excludePatterns []string) (string, []string, func(), error) {
+	return applyPathScopeWithContext(context.Background(), repoPath, includePatterns, excludePatterns)
+}
+
+func applyPathScopeWithContext(ctx context.Context, repoPath string, includePatterns []string, excludePatterns []string) (string, []string, func(), error) {
 	includePatterns = normalizePatterns(includePatterns)
 	excludePatterns = normalizePatterns(excludePatterns)
 	if len(includePatterns) == 0 && len(excludePatterns) == 0 {
@@ -149,11 +153,15 @@ func applyPathScope(ctx context.Context, repoPath string, includePatterns []stri
 
 func (w *scopeWalker) walkWithContext(ctx context.Context) fs.WalkDirFunc {
 	return func(currentPath string, entry fs.DirEntry, walkErr error) error {
-		return w.walk(ctx, currentPath, entry, walkErr)
+		return w.walkEntry(ctx, currentPath, entry, walkErr)
 	}
 }
 
-func (w *scopeWalker) walk(ctx context.Context, currentPath string, entry fs.DirEntry, walkErr error) error {
+func (w *scopeWalker) walk(currentPath string, entry fs.DirEntry, walkErr error) error {
+	return w.walkEntry(context.Background(), currentPath, entry, walkErr)
+}
+
+func (w *scopeWalker) walkEntry(ctx context.Context, currentPath string, entry fs.DirEntry, walkErr error) error {
 	if err := scopeContextErr(ctx); err != nil {
 		return err
 	}
@@ -212,7 +220,7 @@ func (w *scopeWalker) copyScopedEntry(ctx context.Context, entry fs.DirEntry, re
 	if includeMatched {
 		w.stats.includeMatches[includePattern]++
 	}
-	if err := copyFile(ctx, w.repoPath, w.scopedRoot, relativePath, info.Size()); err != nil {
+	if err := copyFileWithContext(ctx, w.repoPath, w.scopedRoot, relativePath, info.Size()); err != nil {
 		if errors.Is(err, errScopedCopyNonRegularFile) {
 			w.budget.files--
 			w.budget.bytes -= info.Size()

--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -255,8 +255,5 @@ func recordScopeSkipReason(stats *scopeStats, slashed string, reason string) {
 }
 
 func scopeContextErr(ctx context.Context) error {
-	if ctx == nil {
-		return nil
-	}
 	return ctx.Err()
 }

--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -79,8 +79,10 @@ func (b *scopeCopyBudget) reserve(path string, size int64) error {
 	if size < 0 {
 		return fmt.Errorf("analysis scope copy encountered negative file size for %q", path)
 	}
-	if b.maxBytes > 0 && b.bytes+size > b.maxBytes {
-		return fmt.Errorf("%w at %q (maximum bytes: %d)", errScopedCopyByteLimitExceeded, path, b.maxBytes)
+	if b.maxBytes > 0 {
+		if size > b.maxBytes || b.bytes > b.maxBytes-size {
+			return fmt.Errorf("%w at %q (maximum bytes: %d)", errScopedCopyByteLimitExceeded, path, b.maxBytes)
+		}
 	}
 	b.files++
 	b.bytes += size

--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -1,6 +1,8 @@
 package analysis
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -8,7 +10,17 @@ import (
 	"regexp"
 )
 
-const maxScopeDiagnostics = 5
+const (
+	maxScopeDiagnostics       = 5
+	maxScopedCopyFiles        = 4096
+	maxScopedCopyBytes  int64 = 256 << 20
+)
+
+var (
+	errScopedCopyFileLimitExceeded = errors.New("analysis scope copy file limit exceeded")
+	errScopedCopyByteLimitExceeded = errors.New("analysis scope copy size limit exceeded")
+	errScopedCopyNonRegularFile    = errors.New("analysis scope copy requires regular files")
+)
 
 func noOpCleanup() {
 	// Intentionally empty: when no scope patterns are configured, there is no temporary workspace to clean up.
@@ -38,6 +50,7 @@ type scopeWalker struct {
 	includeCompiled []compiledPattern
 	excludeCompiled []compiledPattern
 	stats           *scopeStats
+	budget          scopeCopyBudget
 }
 
 type compiledPattern struct {
@@ -45,7 +58,36 @@ type compiledPattern struct {
 	regex   *regexp.Regexp
 }
 
-func applyPathScope(repoPath string, includePatterns []string, excludePatterns []string) (string, []string, func(), error) {
+type scopeCopyBudget struct {
+	maxFiles int
+	maxBytes int64
+	files    int
+	bytes    int64
+}
+
+func newScopeCopyBudget() scopeCopyBudget {
+	return scopeCopyBudget{
+		maxFiles: maxScopedCopyFiles,
+		maxBytes: maxScopedCopyBytes,
+	}
+}
+
+func (b *scopeCopyBudget) reserve(path string, size int64) error {
+	if b.maxFiles > 0 && b.files+1 > b.maxFiles {
+		return fmt.Errorf("%w at %q (maximum files: %d)", errScopedCopyFileLimitExceeded, path, b.maxFiles)
+	}
+	if size < 0 {
+		return fmt.Errorf("analysis scope copy encountered negative file size for %q", path)
+	}
+	if b.maxBytes > 0 && b.bytes+size > b.maxBytes {
+		return fmt.Errorf("%w at %q (maximum bytes: %d)", errScopedCopyByteLimitExceeded, path, b.maxBytes)
+	}
+	b.files++
+	b.bytes += size
+	return nil
+}
+
+func applyPathScope(ctx context.Context, repoPath string, includePatterns []string, excludePatterns []string) (string, []string, func(), error) {
 	includePatterns = normalizePatterns(includePatterns)
 	excludePatterns = normalizePatterns(excludePatterns)
 	if len(includePatterns) == 0 && len(excludePatterns) == 0 {
@@ -79,9 +121,10 @@ func applyPathScope(repoPath string, includePatterns []string, excludePatterns [
 		includeCompiled: includeCompiled,
 		excludeCompiled: excludeCompiled,
 		stats:           stats,
+		budget:          newScopeCopyBudget(),
 	}
 
-	walkErr := filepath.WalkDir(repoPath, walker.walk)
+	walkErr := filepath.WalkDir(repoPath, walker.walkWithContext(ctx))
 	if walkErr != nil {
 		cleanup()
 		return "", nil, nil, fmt.Errorf("apply path scope: %w", walkErr)
@@ -102,41 +145,63 @@ func applyPathScope(repoPath string, includePatterns []string, excludePatterns [
 	return scopedRoot, warnings, cleanup, nil
 }
 
-func (w *scopeWalker) walk(currentPath string, entry fs.DirEntry, walkErr error) error {
-	if walkErr != nil {
-		return walkErr
-	}
-	if entry.IsDir() {
-		if entry.Name() == ".git" {
-			return filepath.SkipDir
+func (w *scopeWalker) walkWithContext(ctx context.Context) fs.WalkDirFunc {
+	return func(currentPath string, entry fs.DirEntry, walkErr error) error {
+		if err := scopeContextErr(ctx); err != nil {
+			return err
 		}
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		w.stats.totalFiles++
+		relativePath, err := filepath.Rel(w.repoPath, currentPath)
+		if err != nil {
+			return err
+		}
+		slashed := filepath.ToSlash(filepath.Clean(relativePath))
+		includeMatched, includePattern := matchFirstCompiledPattern(slashed, w.includeCompiled)
+		excludeMatched, excludePattern := matchFirstCompiledPattern(slashed, w.excludeCompiled)
+		shouldSkip := (len(w.includePatterns) > 0 && !includeMatched) || excludeMatched
+		if shouldSkip {
+			recordScopeSkip(w.stats, slashed, includeMatched, includePattern, excludeMatched, excludePattern)
+			return nil
+		}
+		if entry.Type()&fs.ModeSymlink != 0 {
+			recordScopeSkipReason(w.stats, slashed, "is symlink (not copied)")
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			recordScopeSkipReason(w.stats, slashed, "is not a regular file (not copied)")
+			return nil
+		}
+		if err := w.budget.reserve(slashed, info.Size()); err != nil {
+			return err
+		}
+		if includeMatched {
+			w.stats.includeMatches[includePattern]++
+		}
+		if err := copyFile(ctx, w.repoPath, w.scopedRoot, relativePath, info.Size()); err != nil {
+			if errors.Is(err, errScopedCopyNonRegularFile) {
+				w.budget.files--
+				w.budget.bytes -= info.Size()
+				recordScopeSkipReason(w.stats, slashed, "is not a regular file (not copied)")
+				return nil
+			}
+			return err
+		}
+		w.stats.keptFiles++
 		return nil
 	}
-	w.stats.totalFiles++
-	relativePath, err := filepath.Rel(w.repoPath, currentPath)
-	if err != nil {
-		return err
-	}
-	slashed := filepath.ToSlash(filepath.Clean(relativePath))
-	includeMatched, includePattern := matchFirstCompiledPattern(slashed, w.includeCompiled)
-	excludeMatched, excludePattern := matchFirstCompiledPattern(slashed, w.excludeCompiled)
-	shouldSkip := (len(w.includePatterns) > 0 && !includeMatched) || excludeMatched
-	if shouldSkip {
-		recordScopeSkip(w.stats, slashed, includeMatched, includePattern, excludeMatched, excludePattern)
-		return nil
-	}
-	if entry.Type()&fs.ModeSymlink != 0 {
-		recordScopeSkipReason(w.stats, slashed, "is symlink (not copied)")
-		return nil
-	}
-	if includeMatched {
-		w.stats.includeMatches[includePattern]++
-	}
-	if err := copyFile(w.repoPath, w.scopedRoot, relativePath); err != nil {
-		return err
-	}
-	w.stats.keptFiles++
-	return nil
 }
 
 func recordScopeSkip(stats *scopeStats, slashed string, includeMatched bool, includePattern string, excludeMatched bool, excludePattern string) {
@@ -158,4 +223,11 @@ func recordScopeSkipReason(stats *scopeStats, slashed string, reason string) {
 		return
 	}
 	stats.skippedDiagnostics = append(stats.skippedDiagnostics, slashed+" ("+reason+")")
+}
+
+func scopeContextErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
 }

--- a/internal/analysis/scope_copy.go
+++ b/internal/analysis/scope_copy.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -9,9 +10,14 @@ import (
 	"strings"
 )
 
-func copyFile(repoPath, scopedRoot, relativePath string) (err error) {
+const scopedCopyBufferSize = 32 * 1024
+
+func copyFile(ctx context.Context, repoPath, scopedRoot, relativePath string, expectedSize int64) (err error) {
 	if !isSafeRelativePath(relativePath) {
 		return fmt.Errorf("invalid relative path for scoped copy: %s", relativePath)
+	}
+	if err := scopeContextErr(ctx); err != nil {
+		return err
 	}
 	cleanRelativePath := filepath.Clean(relativePath)
 	sourcePath := filepath.Join(repoPath, cleanRelativePath)
@@ -37,6 +43,16 @@ func copyFile(repoPath, scopedRoot, relativePath string) (err error) {
 		return err
 	}
 	defer joinCloseError(&err, source.Close)
+	sourceInfo, err := source.Stat()
+	if err != nil {
+		return err
+	}
+	if !sourceInfo.Mode().IsRegular() {
+		return fmt.Errorf("%w: %s", errScopedCopyNonRegularFile, cleanRelativePath)
+	}
+	if sourceInfo.Size() > expectedSize {
+		return fmt.Errorf("analysis scope copy source grew while copying %q: expected at most %d bytes, got %d", cleanRelativePath, expectedSize, sourceInfo.Size())
+	}
 
 	targetRoot, err := os.OpenRoot(scopedRoot)
 	if err != nil {
@@ -49,10 +65,41 @@ func copyFile(repoPath, scopedRoot, relativePath string) (err error) {
 		return err
 	}
 	defer joinCloseError(&err, target.Close)
-	if _, err := io.Copy(target, source); err != nil {
+	written, err := copyScopedFileContents(ctx, target, io.LimitReader(source, expectedSize+1))
+	if err != nil {
 		return err
 	}
+	if written > expectedSize {
+		return fmt.Errorf("analysis scope copy source grew while copying %q: expected at most %d bytes", cleanRelativePath, expectedSize)
+	}
 	return nil
+}
+
+func copyScopedFileContents(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
+	buffer := make([]byte, scopedCopyBufferSize)
+	var written int64
+	for {
+		if err := scopeContextErr(ctx); err != nil {
+			return written, err
+		}
+		readBytes, readErr := src.Read(buffer)
+		if readBytes > 0 {
+			wroteBytes, writeErr := dst.Write(buffer[:readBytes])
+			written += int64(wroteBytes)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if wroteBytes != readBytes {
+				return written, io.ErrShortWrite
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			return written, nil
+		}
+		if readErr != nil {
+			return written, readErr
+		}
+	}
 }
 
 func joinCloseError(target *error, closeFn func() error) {

--- a/internal/analysis/scope_copy.go
+++ b/internal/analysis/scope_copy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,7 +13,11 @@ import (
 
 const scopedCopyBufferSize = 32 * 1024
 
-func copyFile(ctx context.Context, repoPath, scopedRoot, relativePath string, expectedSize int64) (err error) {
+func copyFile(repoPath, scopedRoot, relativePath string) error {
+	return copyFileWithContext(context.Background(), repoPath, scopedRoot, relativePath, math.MaxInt64-1)
+}
+
+func copyFileWithContext(ctx context.Context, repoPath, scopedRoot, relativePath string, expectedSize int64) (err error) {
 	if !isSafeRelativePath(relativePath) {
 		return fmt.Errorf("invalid relative path for scoped copy: %s", relativePath)
 	}

--- a/internal/analysis/scope_copy.go
+++ b/internal/analysis/scope_copy.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,25 +13,15 @@ import (
 const scopedCopyBufferSize = 32 * 1024
 
 func copyFile(repoPath, scopedRoot, relativePath string) error {
-	return copyFileWithContext(context.Background(), repoPath, scopedRoot, relativePath, math.MaxInt64-1)
+	return copyFileWithContext(context.Background(), repoPath, scopedRoot, relativePath, maxScopedCopyBytes)
 }
 
 func copyFileWithContext(ctx context.Context, repoPath, scopedRoot, relativePath string, expectedSize int64) (err error) {
 	if !isSafeRelativePath(relativePath) {
 		return fmt.Errorf("invalid relative path for scoped copy: %s", relativePath)
 	}
-	if err := scopeContextErr(ctx); err != nil {
-		return err
-	}
 	cleanRelativePath := filepath.Clean(relativePath)
-	sourcePath := filepath.Join(repoPath, cleanRelativePath)
 	targetPath := filepath.Join(scopedRoot, cleanRelativePath)
-	if !pathWithin(repoPath, sourcePath) {
-		return fmt.Errorf("source path escapes repository scope: %s", sourcePath)
-	}
-	if !pathWithin(scopedRoot, targetPath) {
-		return fmt.Errorf("target path escapes scoped workspace: %s", targetPath)
-	}
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o750); err != nil {
 		return err
 	}
@@ -81,30 +70,19 @@ func copyFileWithContext(ctx context.Context, repoPath, scopedRoot, relativePath
 }
 
 func copyScopedFileContents(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
-	buffer := make([]byte, scopedCopyBufferSize)
-	var written int64
-	for {
-		if err := scopeContextErr(ctx); err != nil {
-			return written, err
-		}
-		readBytes, readErr := src.Read(buffer)
-		if readBytes > 0 {
-			wroteBytes, writeErr := dst.Write(buffer[:readBytes])
-			written += int64(wroteBytes)
-			if writeErr != nil {
-				return written, writeErr
-			}
-			if wroteBytes != readBytes {
-				return written, io.ErrShortWrite
-			}
-		}
-		if errors.Is(readErr, io.EOF) {
-			return written, nil
-		}
-		if readErr != nil {
-			return written, readErr
-		}
+	return io.CopyBuffer(dst, scopeContextReader{ctx: ctx, source: src}, make([]byte, scopedCopyBufferSize))
+}
+
+type scopeContextReader struct {
+	ctx    context.Context
+	source io.Reader
+}
+
+func (r scopeContextReader) Read(buffer []byte) (int, error) {
+	if err := scopeContextErr(r.ctx); err != nil {
+		return 0, err
 	}
+	return r.source.Read(buffer)
 }
 
 func joinCloseError(target *error, closeFn func() error) {

--- a/internal/analysis/scope_copy.go
+++ b/internal/analysis/scope_copy.go
@@ -70,16 +70,20 @@ func copyFileWithContext(ctx context.Context, repoPath, scopedRoot, relativePath
 }
 
 func copyScopedFileContents(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
-	return io.CopyBuffer(dst, scopeContextReader{ctx: ctx, source: src}, make([]byte, scopedCopyBufferSize))
+	reader := scopeContextReader{
+		check:  func() error { return scopeContextErr(ctx) },
+		source: src,
+	}
+	return io.CopyBuffer(dst, &reader, make([]byte, scopedCopyBufferSize))
 }
 
 type scopeContextReader struct {
-	ctx    context.Context
+	check  func() error
 	source io.Reader
 }
 
-func (r scopeContextReader) Read(buffer []byte) (int, error) {
-	if err := scopeContextErr(r.ctx); err != nil {
+func (r *scopeContextReader) Read(buffer []byte) (int, error) {
+	if err := r.check(); err != nil {
 		return 0, err
 	}
 	return r.source.Read(buffer)

--- a/internal/analysis/scope_copy_errors_test.go
+++ b/internal/analysis/scope_copy_errors_test.go
@@ -18,7 +18,7 @@ func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 	repo := t.TempDir()
 	scopedRoot := t.TempDir()
 	sourcePath := filepath.Join(repo, "src", scopeKeepJS)
-	writeScopeFile(t, sourcePath, "export const keep = true\n")
+	writeFile(t, sourcePath, "export const keep = true\n")
 
 	targetDir := filepath.Join(scopedRoot, "src", scopeKeepJS)
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
@@ -51,7 +51,7 @@ func TestCopyFileHonorsCanceledContextBeforeOpen(t *testing.T) {
 	repo := t.TempDir()
 	scopedRoot := t.TempDir()
 	sourcePath := filepath.Join(repo, "src", scopeKeepJS)
-	writeScopeFile(t, sourcePath, "export const keep = true\n")
+	writeFile(t, sourcePath, "export const keep = true\n")
 
 	sourceInfo, err := os.Stat(sourcePath)
 	if err != nil {
@@ -67,7 +67,7 @@ func TestCopyFileRejectsSourceGrowthBeyondReservedSize(t *testing.T) {
 	scopedRoot := t.TempDir()
 	sourcePath := filepath.Join(repo, "src", scopeKeepJS)
 	content := "export const keep = true\n"
-	writeScopeFile(t, sourcePath, content)
+	writeFile(t, sourcePath, content)
 
 	if err := copyFile(context.Background(), repo, scopedRoot, filepath.Join("src", scopeKeepJS), int64(len(content)-1)); err == nil || !strings.Contains(err.Error(), "source grew while copying") {
 		t.Fatalf("expected source growth error, got %v", err)

--- a/internal/analysis/scope_copy_errors_test.go
+++ b/internal/analysis/scope_copy_errors_test.go
@@ -1,11 +1,15 @@
 package analysis
 
 import (
+	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 const scopeKeepJS = "keep.js"
@@ -20,7 +24,11 @@ func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		t.Fatalf("mkdir target dir: %v", err)
 	}
-	if err := copyFile(repo, scopedRoot, filepath.Join("src", scopeKeepJS)); err == nil {
+	sourceInfo, statErr := os.Stat(sourcePath)
+	if statErr != nil {
+		t.Fatalf("stat source path: %v", statErr)
+	}
+	if err := copyFile(context.Background(), repo, scopedRoot, filepath.Join("src", scopeKeepJS), sourceInfo.Size()); err == nil {
 		t.Fatalf("expected copyFile to fail when target path is a directory")
 	}
 
@@ -28,7 +36,7 @@ func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
 		t.Fatalf("mkdir source dir: %v", err)
 	}
-	if err := copyFile(repo, scopedRoot, filepath.Join("src", "nested")); err == nil {
+	if err := copyFile(context.Background(), repo, scopedRoot, filepath.Join("src", "nested"), 0); err == nil {
 		t.Fatalf("expected copyFile to fail when source path is a directory")
 	}
 
@@ -37,4 +45,97 @@ func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "close failed") {
 		t.Fatalf("expected joinCloseError to propagate close failure, got %v", err)
 	}
+}
+
+func TestCopyFileHonorsCanceledContextBeforeOpen(t *testing.T) {
+	repo := t.TempDir()
+	scopedRoot := t.TempDir()
+	sourcePath := filepath.Join(repo, "src", scopeKeepJS)
+	writeScopeFile(t, sourcePath, "export const keep = true\n")
+
+	sourceInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		t.Fatalf("stat source path: %v", err)
+	}
+	if err := copyFile(testutil.CanceledContext(), repo, scopedRoot, filepath.Join("src", scopeKeepJS), sourceInfo.Size()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled context error, got %v", err)
+	}
+}
+
+func TestCopyFileRejectsSourceGrowthBeyondReservedSize(t *testing.T) {
+	repo := t.TempDir()
+	scopedRoot := t.TempDir()
+	sourcePath := filepath.Join(repo, "src", scopeKeepJS)
+	content := "export const keep = true\n"
+	writeScopeFile(t, sourcePath, content)
+
+	if err := copyFile(context.Background(), repo, scopedRoot, filepath.Join("src", scopeKeepJS), int64(len(content)-1)); err == nil || !strings.Contains(err.Error(), "source grew while copying") {
+		t.Fatalf("expected source growth error, got %v", err)
+	}
+}
+
+func TestCopyScopedFileContentsErrorBranches(t *testing.T) {
+	readErr := errors.New("read failed")
+	if _, err := copyScopedFileContents(context.Background(), io.Discard, &errorReader{err: readErr}); !errors.Is(err, readErr) {
+		t.Fatalf("expected read error, got %v", err)
+	}
+
+	if _, err := copyScopedFileContents(context.Background(), &shortWriter{}, strings.NewReader("abc")); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("expected short write error, got %v", err)
+	}
+
+	writeErr := errors.New("write failed")
+	if _, err := copyScopedFileContents(context.Background(), &failingWriter{err: writeErr}, strings.NewReader("abc")); !errors.Is(err, writeErr) {
+		t.Fatalf("expected write error, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := cancelingReader{
+		cancel: cancel,
+		data:   []byte("abc"),
+	}
+	if _, err := copyScopedFileContents(ctx, io.Discard, &reader); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected mid-copy cancellation, got %v", err)
+	}
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r *errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+type shortWriter struct{}
+
+func (*shortWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return len(p) - 1, nil
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (w *failingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+type cancelingReader struct {
+	cancel func()
+	data   []byte
+	read   bool
+}
+
+func (r *cancelingReader) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+	r.read = true
+	copy(p, r.data)
+	r.cancel()
+	return len(r.data), nil
 }

--- a/internal/analysis/scope_copy_errors_test.go
+++ b/internal/analysis/scope_copy_errors_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 const scopeKeepJS = "keep.js"
+const scopeCopyTestByteLimit = 256 << 20
 
 func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 	repo := t.TempDir()
@@ -36,5 +37,27 @@ func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 	joinCloseError(&err, func() error { return errors.New("close failed") })
 	if err == nil || !strings.Contains(err.Error(), "close failed") {
 		t.Fatalf("expected joinCloseError to propagate close failure, got %v", err)
+	}
+}
+
+func TestCopyFileRejectsOversizedSource(t *testing.T) {
+	repo := t.TempDir()
+	filePath := filepath.Join(repo, scopeKeepJS)
+	file, err := os.Create(filePath)
+	if err != nil {
+		t.Fatalf("create oversized source: %v", err)
+	}
+	if err := file.Truncate(scopeCopyTestByteLimit + 1); err != nil {
+		if closeErr := file.Close(); closeErr != nil {
+			t.Fatalf("close oversized source after truncate error: %v", closeErr)
+		}
+		t.Fatalf("truncate oversized source: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close oversized source: %v", err)
+	}
+
+	if err := copyFile(repo, t.TempDir(), scopeKeepJS); err == nil {
+		t.Fatal("expected oversized source to be rejected")
 	}
 }

--- a/internal/analysis/scope_copy_errors_test.go
+++ b/internal/analysis/scope_copy_errors_test.go
@@ -1,15 +1,11 @@
 package analysis
 
 import (
-	"context"
 	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 const scopeKeepJS = "keep.js"
@@ -24,11 +20,7 @@ func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		t.Fatalf("mkdir target dir: %v", err)
 	}
-	sourceInfo, statErr := os.Stat(sourcePath)
-	if statErr != nil {
-		t.Fatalf("stat source path: %v", statErr)
-	}
-	if err := copyFile(context.Background(), repo, scopedRoot, filepath.Join("src", scopeKeepJS), sourceInfo.Size()); err == nil {
+	if err := copyFile(repo, scopedRoot, filepath.Join("src", scopeKeepJS)); err == nil {
 		t.Fatalf("expected copyFile to fail when target path is a directory")
 	}
 
@@ -36,7 +28,7 @@ func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
 		t.Fatalf("mkdir source dir: %v", err)
 	}
-	if err := copyFile(context.Background(), repo, scopedRoot, filepath.Join("src", "nested"), 0); err == nil {
+	if err := copyFile(repo, scopedRoot, filepath.Join("src", "nested")); err == nil {
 		t.Fatalf("expected copyFile to fail when source path is a directory")
 	}
 
@@ -45,97 +37,4 @@ func TestScopeCopyFileAdditionalErrorBranches(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "close failed") {
 		t.Fatalf("expected joinCloseError to propagate close failure, got %v", err)
 	}
-}
-
-func TestCopyFileHonorsCanceledContextBeforeOpen(t *testing.T) {
-	repo := t.TempDir()
-	scopedRoot := t.TempDir()
-	sourcePath := filepath.Join(repo, "src", scopeKeepJS)
-	writeFile(t, sourcePath, "export const keep = true\n")
-
-	sourceInfo, err := os.Stat(sourcePath)
-	if err != nil {
-		t.Fatalf("stat source path: %v", err)
-	}
-	if err := copyFile(testutil.CanceledContext(), repo, scopedRoot, filepath.Join("src", scopeKeepJS), sourceInfo.Size()); !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected canceled context error, got %v", err)
-	}
-}
-
-func TestCopyFileRejectsSourceGrowthBeyondReservedSize(t *testing.T) {
-	repo := t.TempDir()
-	scopedRoot := t.TempDir()
-	sourcePath := filepath.Join(repo, "src", scopeKeepJS)
-	content := "export const keep = true\n"
-	writeFile(t, sourcePath, content)
-
-	if err := copyFile(context.Background(), repo, scopedRoot, filepath.Join("src", scopeKeepJS), int64(len(content)-1)); err == nil || !strings.Contains(err.Error(), "source grew while copying") {
-		t.Fatalf("expected source growth error, got %v", err)
-	}
-}
-
-func TestCopyScopedFileContentsErrorBranches(t *testing.T) {
-	readErr := errors.New("read failed")
-	if _, err := copyScopedFileContents(context.Background(), io.Discard, &errorReader{err: readErr}); !errors.Is(err, readErr) {
-		t.Fatalf("expected read error, got %v", err)
-	}
-
-	if _, err := copyScopedFileContents(context.Background(), &shortWriter{}, strings.NewReader("abc")); !errors.Is(err, io.ErrShortWrite) {
-		t.Fatalf("expected short write error, got %v", err)
-	}
-
-	writeErr := errors.New("write failed")
-	if _, err := copyScopedFileContents(context.Background(), &failingWriter{err: writeErr}, strings.NewReader("abc")); !errors.Is(err, writeErr) {
-		t.Fatalf("expected write error, got %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	reader := cancelingReader{
-		cancel: cancel,
-		data:   []byte("abc"),
-	}
-	if _, err := copyScopedFileContents(ctx, io.Discard, &reader); !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected mid-copy cancellation, got %v", err)
-	}
-}
-
-type errorReader struct {
-	err error
-}
-
-func (r *errorReader) Read([]byte) (int, error) {
-	return 0, r.err
-}
-
-type shortWriter struct{}
-
-func (*shortWriter) Write(p []byte) (int, error) {
-	if len(p) == 0 {
-		return 0, nil
-	}
-	return len(p) - 1, nil
-}
-
-type failingWriter struct {
-	err error
-}
-
-func (w *failingWriter) Write([]byte) (int, error) {
-	return 0, w.err
-}
-
-type cancelingReader struct {
-	cancel func()
-	data   []byte
-	read   bool
-}
-
-func (r *cancelingReader) Read(p []byte) (int, error) {
-	if r.read {
-		return 0, io.EOF
-	}
-	r.read = true
-	copy(p, r.data)
-	r.cancel()
-	return len(r.data), nil
 }

--- a/internal/analysis/scope_path_guards_test.go
+++ b/internal/analysis/scope_path_guards_test.go
@@ -1,7 +1,6 @@
 package analysis
 
 import (
-	"context"
 	"errors"
 	"io/fs"
 	"os"
@@ -19,12 +18,12 @@ func TestPathWithinRejectsInvalidRoot(t *testing.T) {
 }
 
 func TestCopyFileAdditionalEscapeBranches(t *testing.T) {
-	if copyFile(context.Background(), "\x00", t.TempDir(), scopePathTextFile, 0) == nil {
+	if copyFile("\x00", t.TempDir(), scopePathTextFile) == nil {
 		t.Fatalf("expected invalid source root to be rejected")
 	}
 
 	repo := t.TempDir()
-	if copyFile(context.Background(), repo, "\x00", scopePathTextFile, 0) == nil {
+	if copyFile(repo, "\x00", scopePathTextFile) == nil {
 		t.Fatalf("expected invalid target root to be rejected")
 	}
 }
@@ -46,7 +45,7 @@ func TestScopeWalkerAdditionalBranches(t *testing.T) {
 		includeCompiled: []compiledPattern{includePattern},
 		stats:           newScopeStats([]string{"**/*"}, nil),
 	}
-	walk := walker.walkWithContext(context.Background())
+	walk := walker.walk
 	if walk(filePath, fileEntry, nil) == nil {
 		t.Fatalf("expected invalid repo root to fail relative-path resolution")
 	}
@@ -58,7 +57,7 @@ func TestScopeWalkerAdditionalBranches(t *testing.T) {
 		includeCompiled: []compiledPattern{includePattern},
 		stats:           newScopeStats([]string{"**/*"}, nil),
 	}
-	walk = walker.walkWithContext(context.Background())
+	walk = walker.walk
 	if walk(filePath, fileEntry, nil) == nil {
 		t.Fatalf("expected invalid scoped root to fail file copy")
 	}
@@ -76,7 +75,7 @@ func TestScopeWalkerAdditionalBranches(t *testing.T) {
 			continue
 		}
 		walker = &scopeWalker{}
-		if err := walker.walkWithContext(context.Background())(gitDir, entry, nil); !errors.Is(err, filepath.SkipDir) {
+		if err := walker.walk(gitDir, entry, nil); !errors.Is(err, filepath.SkipDir) {
 			t.Fatalf("expected .git directory to be skipped, got %v", err)
 		}
 		return
@@ -104,9 +103,8 @@ func TestScopeWalkerInfoFailureAndBudgetRollbackBranches(t *testing.T) {
 		includePatterns: []string{"**/*"},
 		includeCompiled: []compiledPattern{{pattern: "**/*", regex: regexp.MustCompile(".*")}},
 		stats:           newScopeStats([]string{"**/*"}, nil),
-		budget:          newScopeCopyBudget(),
 	}
-	walk := walker.walkWithContext(context.Background())
+	walk := walker.walk
 
 	infoErr := errors.New("info failed")
 	if err := walk(filepath.Join(repo, "src", "bad.js"), &fakeScopeDirEntry{name: "bad.js", infoErr: infoErr}, nil); !errors.Is(err, infoErr) {
@@ -119,9 +117,6 @@ func TestScopeWalkerInfoFailureAndBudgetRollbackBranches(t *testing.T) {
 	}
 	if err := walk(disguisedDirPath, &fakeScopeDirEntry{name: "disguised.js", info: regularInfo}, nil); err != nil {
 		t.Fatalf("expected non-regular source downgrade to be skipped, got %v", err)
-	}
-	if walker.budget.files != 0 || walker.budget.bytes != 0 {
-		t.Fatalf("expected scope budget rollback after non-regular source, got files=%d bytes=%d", walker.budget.files, walker.budget.bytes)
 	}
 	if !containsWarning(walker.stats.skippedDiagnostics, "disguised.js (is not a regular file (not copied))") {
 		t.Fatalf("expected non-regular rollback diagnostic, got %#v", walker.stats.skippedDiagnostics)

--- a/internal/analysis/scope_path_guards_test.go
+++ b/internal/analysis/scope_path_guards_test.go
@@ -36,7 +36,7 @@ func TestScopeWalkerAdditionalBranches(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	fileEntry := mustScopePathEntry(t, repo, scopePathTextFile)
+	fileEntry := mustScopeDirEntry(t, repo, scopePathTextFile)
 
 	includePattern := compiledPattern{pattern: "**/*", regex: regexp.MustCompile(".*")}
 	walker := &scopeWalker{
@@ -126,22 +126,6 @@ func TestScopeWalkerInfoFailureAndBudgetRollbackBranches(t *testing.T) {
 	if !containsWarning(walker.stats.skippedDiagnostics, "disguised.js (is not a regular file (not copied))") {
 		t.Fatalf("expected non-regular rollback diagnostic, got %#v", walker.stats.skippedDiagnostics)
 	}
-}
-
-func mustScopePathEntry(t *testing.T, dir, name string) os.DirEntry {
-	t.Helper()
-
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("readdir %s: %v", dir, err)
-	}
-	for _, entry := range entries {
-		if entry.Name() == name {
-			return entry
-		}
-	}
-	t.Fatalf("expected %s entry", name)
-	return nil
 }
 
 type fakeScopeDirEntry struct {

--- a/internal/analysis/scope_path_guards_test.go
+++ b/internal/analysis/scope_path_guards_test.go
@@ -1,7 +1,9 @@
 package analysis
 
 import (
+	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -17,12 +19,12 @@ func TestPathWithinRejectsInvalidRoot(t *testing.T) {
 }
 
 func TestCopyFileAdditionalEscapeBranches(t *testing.T) {
-	if copyFile("\x00", t.TempDir(), scopePathTextFile) == nil {
+	if copyFile(context.Background(), "\x00", t.TempDir(), scopePathTextFile, 0) == nil {
 		t.Fatalf("expected invalid source root to be rejected")
 	}
 
 	repo := t.TempDir()
-	if copyFile(repo, "\x00", scopePathTextFile) == nil {
+	if copyFile(context.Background(), repo, "\x00", scopePathTextFile, 0) == nil {
 		t.Fatalf("expected invalid target root to be rejected")
 	}
 }
@@ -44,7 +46,8 @@ func TestScopeWalkerAdditionalBranches(t *testing.T) {
 		includeCompiled: []compiledPattern{includePattern},
 		stats:           newScopeStats([]string{"**/*"}, nil),
 	}
-	if walker.walk(filePath, fileEntry, nil) == nil {
+	walk := walker.walkWithContext(context.Background())
+	if walk(filePath, fileEntry, nil) == nil {
 		t.Fatalf("expected invalid repo root to fail relative-path resolution")
 	}
 
@@ -55,7 +58,8 @@ func TestScopeWalkerAdditionalBranches(t *testing.T) {
 		includeCompiled: []compiledPattern{includePattern},
 		stats:           newScopeStats([]string{"**/*"}, nil),
 	}
-	if walker.walk(filePath, fileEntry, nil) == nil {
+	walk = walker.walkWithContext(context.Background())
+	if walk(filePath, fileEntry, nil) == nil {
 		t.Fatalf("expected invalid scoped root to fail file copy")
 	}
 
@@ -72,12 +76,56 @@ func TestScopeWalkerAdditionalBranches(t *testing.T) {
 			continue
 		}
 		walker = &scopeWalker{}
-		if err := walker.walk(gitDir, entry, nil); !errors.Is(err, filepath.SkipDir) {
+		if err := walker.walkWithContext(context.Background())(gitDir, entry, nil); !errors.Is(err, filepath.SkipDir) {
 			t.Fatalf("expected .git directory to be skipped, got %v", err)
 		}
 		return
 	}
 	t.Fatal("expected .git entry")
+}
+
+func TestScopeWalkerInfoFailureAndBudgetRollbackBranches(t *testing.T) {
+	repo := t.TempDir()
+	regularPath := filepath.Join(repo, "src", "template.js")
+	if err := os.MkdirAll(filepath.Dir(regularPath), 0o750); err != nil {
+		t.Fatalf("mkdir regular dir: %v", err)
+	}
+	if err := os.WriteFile(regularPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write regular file: %v", err)
+	}
+	regularInfo, err := os.Stat(regularPath)
+	if err != nil {
+		t.Fatalf("stat regular file: %v", err)
+	}
+
+	walker := &scopeWalker{
+		repoPath:        repo,
+		scopedRoot:      t.TempDir(),
+		includePatterns: []string{"**/*"},
+		includeCompiled: []compiledPattern{{pattern: "**/*", regex: regexp.MustCompile(".*")}},
+		stats:           newScopeStats([]string{"**/*"}, nil),
+		budget:          newScopeCopyBudget(),
+	}
+	walk := walker.walkWithContext(context.Background())
+
+	infoErr := errors.New("info failed")
+	if err := walk(filepath.Join(repo, "src", "bad.js"), &fakeScopeDirEntry{name: "bad.js", infoErr: infoErr}, nil); !errors.Is(err, infoErr) {
+		t.Fatalf("expected entry info error, got %v", err)
+	}
+
+	disguisedDirPath := filepath.Join(repo, "src", "disguised.js")
+	if err := os.MkdirAll(disguisedDirPath, 0o750); err != nil {
+		t.Fatalf("mkdir disguised dir: %v", err)
+	}
+	if err := walk(disguisedDirPath, &fakeScopeDirEntry{name: "disguised.js", info: regularInfo}, nil); err != nil {
+		t.Fatalf("expected non-regular source downgrade to be skipped, got %v", err)
+	}
+	if walker.budget.files != 0 || walker.budget.bytes != 0 {
+		t.Fatalf("expected scope budget rollback after non-regular source, got files=%d bytes=%d", walker.budget.files, walker.budget.bytes)
+	}
+	if !containsWarning(walker.stats.skippedDiagnostics, "disguised.js (is not a regular file (not copied))") {
+		t.Fatalf("expected non-regular rollback diagnostic, got %#v", walker.stats.skippedDiagnostics)
+	}
 }
 
 func mustScopePathEntry(t *testing.T, dir, name string) os.DirEntry {
@@ -95,3 +143,14 @@ func mustScopePathEntry(t *testing.T, dir, name string) os.DirEntry {
 	t.Fatalf("expected %s entry", name)
 	return nil
 }
+
+type fakeScopeDirEntry struct {
+	name    string
+	info    fs.FileInfo
+	infoErr error
+}
+
+func (e *fakeScopeDirEntry) Name() string               { return e.name }
+func (e *fakeScopeDirEntry) IsDir() bool                { return false }
+func (e *fakeScopeDirEntry) Type() fs.FileMode          { return 0 }
+func (e *fakeScopeDirEntry) Info() (fs.FileInfo, error) { return e.info, e.infoErr }

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -213,12 +213,7 @@ func TestApplyPathScopeRejectsOversizedScopedCopy(t *testing.T) {
 		t.Fatalf("close oversized file: %v", err)
 	}
 
-	if _, _, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil); err == nil {
-		if cleanup != nil {
-			cleanup()
-		}
-		t.Fatal("expected oversized scoped copy to fail")
-	}
+	expectScopedJSScopeFailure(t, repo, "expected oversized scoped copy to fail")
 }
 
 func TestApplyPathScopeRejectsTooManyCopiedFiles(t *testing.T) {
@@ -227,12 +222,7 @@ func TestApplyPathScopeRejectsTooManyCopiedFiles(t *testing.T) {
 		writeFile(t, filepath.Join(repo, "src", "pkg", fmt.Sprintf("f-%d.js", i)), "export const keep = true\n")
 	}
 
-	if _, _, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil); err == nil {
-		if cleanup != nil {
-			cleanup()
-		}
-		t.Fatal("expected scoped copy file limit to fail")
-	}
+	expectScopedJSScopeFailure(t, repo, "expected scoped copy file limit to fail")
 }
 
 func TestApplyPathScopeSkipsNonRegularFiles(t *testing.T) {
@@ -281,6 +271,17 @@ func applyScopedJSScope(t *testing.T, repo string) (string, []string) {
 	t.Cleanup(cleanup)
 
 	return scopedPath, warnings
+}
+
+func expectScopedJSScopeFailure(t *testing.T, repo, message string) {
+	t.Helper()
+
+	if _, _, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil); err == nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		t.Fatal(message)
+	}
 }
 
 func makeNamedPipe(path string) error {

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -20,9 +20,9 @@ const scopeKeepJSPath = "src/keep.js"
 
 func TestApplyPathScopeFiltersFilesAndReportsDiagnostics(t *testing.T) {
 	repo := t.TempDir()
-	writeScopeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
-	writeScopeFile(t, filepath.Join(repo, "src", "skip.test.js"), "export const skip = true\n")
-	writeScopeFile(t, filepath.Join(repo, "README.md"), "doc\n")
+	writeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
+	writeFile(t, filepath.Join(repo, "src", "skip.test.js"), "export const skip = true\n")
+	writeFile(t, filepath.Join(repo, "README.md"), "doc\n")
 
 	scopedPath, warnings, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, []string{"**/*.test.js"})
 	if err != nil {
@@ -107,9 +107,9 @@ func TestCopyFileFailsWhenSourceFileMissing(t *testing.T) {
 
 func TestApplyPathScopeSkipsSymlinkedFiles(t *testing.T) {
 	repo := t.TempDir()
-	writeScopeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
+	writeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
 	target := filepath.Join(repo, "outside.js")
-	writeScopeFile(t, target, "export const outside = true\n")
+	writeFile(t, target, "export const outside = true\n")
 	linkPath := filepath.Join(repo, "src", "linked.js")
 	if err := os.Symlink(target, linkPath); err != nil {
 		t.Skipf("symlink unsupported in test environment: %v", err)
@@ -240,7 +240,7 @@ func TestApplyPathScopeRejectsOversizedScopedCopy(t *testing.T) {
 func TestApplyPathScopeRejectsTooManyCopiedFiles(t *testing.T) {
 	repo := t.TempDir()
 	for i := 0; i <= maxScopedCopyFiles; i++ {
-		writeScopeFile(t, filepath.Join(repo, "src", "pkg", fmt.Sprintf("f-%d.js", i)), "export const keep = true\n")
+		writeFile(t, filepath.Join(repo, "src", "pkg", fmt.Sprintf("f-%d.js", i)), "export const keep = true\n")
 	}
 
 	_, _, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
@@ -254,7 +254,7 @@ func TestApplyPathScopeRejectsTooManyCopiedFiles(t *testing.T) {
 
 func TestApplyPathScopeHonorsCanceledContext(t *testing.T) {
 	repo := t.TempDir()
-	writeScopeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
+	writeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
 
 	_, _, cleanup, err := applyPathScope(testutil.CanceledContext(), repo, []string{scopeJSGlob}, nil)
 	if cleanup != nil {
@@ -267,7 +267,7 @@ func TestApplyPathScopeHonorsCanceledContext(t *testing.T) {
 
 func TestApplyPathScopeSkipsNonRegularFiles(t *testing.T) {
 	repo := t.TempDir()
-	writeScopeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
+	writeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
 	pipePath := filepath.Join(repo, "src", "pipe.js")
 	if err := os.MkdirAll(filepath.Dir(pipePath), 0o750); err != nil {
 		t.Fatalf("mkdir pipe dir: %v", err)
@@ -303,16 +303,6 @@ func containsWarning(warnings []string, expected string) bool {
 		}
 	}
 	return false
-}
-
-func writeScopeFile(t *testing.T, path string, content string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		t.Fatalf("mkdir %s: %v", path, err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
 }
 
 func makeNamedPipe(path string) error {

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -228,10 +228,7 @@ func TestApplyPathScopeRejectsOversizedScopedCopy(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWritePaddedFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n", maxScopedCopyBytes+1)
 
-	_, _, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
-	if cleanup != nil {
-		defer cleanup()
-	}
+	err := applyScopedCopyForTest(repo)
 	if !errors.Is(err, errScopedCopyByteLimitExceeded) {
 		t.Fatalf("expected scoped copy byte limit error, got %v", err)
 	}
@@ -243,10 +240,7 @@ func TestApplyPathScopeRejectsTooManyCopiedFiles(t *testing.T) {
 		writeFile(t, filepath.Join(repo, "src", "pkg", fmt.Sprintf("f-%d.js", i)), "export const keep = true\n")
 	}
 
-	_, _, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
-	if cleanup != nil {
-		defer cleanup()
-	}
+	err := applyScopedCopyForTest(repo)
 	if !errors.Is(err, errScopedCopyFileLimitExceeded) {
 		t.Fatalf("expected scoped copy file limit error, got %v", err)
 	}
@@ -303,6 +297,14 @@ func containsWarning(warnings []string, expected string) bool {
 		}
 	}
 	return false
+}
+
+func applyScopedCopyForTest(repo string) error {
+	_, _, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
+	if cleanup != nil {
+		cleanup()
+	}
+	return err
 }
 
 func makeNamedPipe(path string) error {

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -1,22 +1,19 @@
 package analysis
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
-
-	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 const scopeJSGlob = "src/**/*.js"
 const scopeGoGlob = "src/**/*.go"
 const scopeKeepJSPath = "src/keep.js"
+const scopeCopyFileLimit = 4096
+const scopeCopyByteLimit = 256 << 20
 
 func TestApplyPathScopeFiltersFilesAndReportsDiagnostics(t *testing.T) {
 	repo := t.TempDir()
@@ -24,7 +21,7 @@ func TestApplyPathScopeFiltersFilesAndReportsDiagnostics(t *testing.T) {
 	writeFile(t, filepath.Join(repo, "src", "skip.test.js"), "export const skip = true\n")
 	writeFile(t, filepath.Join(repo, "README.md"), "doc\n")
 
-	scopedPath, warnings, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, []string{"**/*.test.js"})
+	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, []string{"**/*.test.js"})
 	if err != nil {
 		t.Fatalf("apply path scope: %v", err)
 	}
@@ -58,7 +55,7 @@ func TestGlobMatchSupportsDoubleStar(t *testing.T) {
 
 func TestApplyPathScopeNoPatternsReturnsOriginalPath(t *testing.T) {
 	repo := t.TempDir()
-	scopedPath, warnings, cleanup, err := applyPathScope(context.Background(), repo, nil, nil)
+	scopedPath, warnings, cleanup, err := applyPathScope(repo, nil, nil)
 	if err != nil {
 		t.Fatalf("apply path scope without patterns: %v", err)
 	}
@@ -79,7 +76,7 @@ func TestNoOpCleanupDoesNothing(t *testing.T) {
 func TestCopyFileRejectsUnsafeRelativePath(t *testing.T) {
 	repo := t.TempDir()
 	scoped := t.TempDir()
-	if copyFile(context.Background(), repo, scoped, "../escape.txt", 0) == nil {
+	if copyFile(repo, scoped, "../escape.txt") == nil {
 		t.Fatalf("expected unsafe relative path rejection")
 	}
 }
@@ -89,7 +86,7 @@ func TestCopyFileFailsWhenSourceRootCannotOpen(t *testing.T) {
 	repo := filepath.Join(temp, "missing-repo")
 	scoped := t.TempDir()
 
-	err := copyFile(context.Background(), repo, scoped, "src/keep.js", 0)
+	err := copyFile(repo, scoped, "src/keep.js")
 	if err == nil {
 		t.Fatalf("expected source-root open failure for missing repository root")
 	}
@@ -99,7 +96,7 @@ func TestCopyFileFailsWhenSourceFileMissing(t *testing.T) {
 	repo := t.TempDir()
 	scoped := t.TempDir()
 
-	err := copyFile(context.Background(), repo, scoped, "src/missing.js", 0)
+	err := copyFile(repo, scoped, "src/missing.js")
 	if err == nil {
 		t.Fatalf("expected missing source file error")
 	}
@@ -115,7 +112,7 @@ func TestApplyPathScopeSkipsSymlinkedFiles(t *testing.T) {
 		t.Skipf("symlink unsupported in test environment: %v", err)
 	}
 
-	scopedPath, warnings, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
+	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil)
 	if err != nil {
 		t.Fatalf("apply path scope: %v", err)
 	}
@@ -200,62 +197,45 @@ func TestPathWithinAndSafeRelativePath(t *testing.T) {
 	}
 }
 
-func TestScopeCopyBudgetRejectsNegativeSize(t *testing.T) {
-	budget := newScopeCopyBudget()
-	if err := budget.reserve(scopeKeepJSPath, -1); err == nil || !strings.Contains(err.Error(), "negative file size") {
-		t.Fatalf("expected negative file size rejection, got %v", err)
-	}
-}
-
-func TestScopeCopyBudgetRejectsOverflowingByteReservation(t *testing.T) {
-	budget := scopeCopyBudget{
-		maxBytes: 32,
-		bytes:    31,
-	}
-	if err := budget.reserve(scopeKeepJSPath, math.MaxInt64); !errors.Is(err, errScopedCopyByteLimitExceeded) {
-		t.Fatalf("expected scoped copy byte limit error, got %v", err)
-	}
-}
-
-func TestScopeContextErrAllowsNilContext(t *testing.T) {
-	var nilCtx context.Context
-	if err := scopeContextErr(nilCtx); err != nil {
-		t.Fatalf("expected nil context to be allowed, got %v", err)
-	}
-}
-
 func TestApplyPathScopeRejectsOversizedScopedCopy(t *testing.T) {
 	repo := t.TempDir()
-	testutil.MustWritePaddedFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n", maxScopedCopyBytes+1)
+	oversizedPath := filepath.Join(repo, scopeKeepJSPath)
+	if err := os.MkdirAll(filepath.Dir(oversizedPath), 0o750); err != nil {
+		t.Fatalf("mkdir oversized file parent: %v", err)
+	}
+	file, err := os.Create(oversizedPath)
+	if err != nil {
+		t.Fatalf("create oversized file: %v", err)
+	}
+	if err := file.Truncate(scopeCopyByteLimit + 1); err != nil {
+		if closeErr := file.Close(); closeErr != nil {
+			t.Fatalf("close oversized file after truncate error: %v", closeErr)
+		}
+		t.Fatalf("truncate oversized file: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close oversized file: %v", err)
+	}
 
-	err := applyScopedCopyForTest(repo)
-	if !errors.Is(err, errScopedCopyByteLimitExceeded) {
-		t.Fatalf("expected scoped copy byte limit error, got %v", err)
+	if _, _, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil); err == nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		t.Fatal("expected oversized scoped copy to fail")
 	}
 }
 
 func TestApplyPathScopeRejectsTooManyCopiedFiles(t *testing.T) {
 	repo := t.TempDir()
-	for i := 0; i <= maxScopedCopyFiles; i++ {
+	for i := 0; i <= scopeCopyFileLimit; i++ {
 		writeFile(t, filepath.Join(repo, "src", "pkg", fmt.Sprintf("f-%d.js", i)), "export const keep = true\n")
 	}
 
-	err := applyScopedCopyForTest(repo)
-	if !errors.Is(err, errScopedCopyFileLimitExceeded) {
-		t.Fatalf("expected scoped copy file limit error, got %v", err)
-	}
-}
-
-func TestApplyPathScopeHonorsCanceledContext(t *testing.T) {
-	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
-
-	_, _, cleanup, err := applyPathScope(testutil.CanceledContext(), repo, []string{scopeJSGlob}, nil)
-	if cleanup != nil {
-		defer cleanup()
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected canceled context error, got %v", err)
+	if _, _, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil); err == nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		t.Fatal("expected scoped copy file limit to fail")
 	}
 }
 
@@ -273,7 +253,7 @@ func TestApplyPathScopeSkipsNonRegularFiles(t *testing.T) {
 		t.Skipf("named pipes unsupported in test environment: %v", err)
 	}
 
-	scopedPath, warnings, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
+	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil)
 	if err != nil {
 		t.Fatalf("apply path scope: %v", err)
 	}
@@ -297,14 +277,6 @@ func containsWarning(warnings []string, expected string) bool {
 		}
 	}
 	return false
-}
-
-func applyScopedCopyForTest(repo string) error {
-	_, _, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
-	if cleanup != nil {
-		cleanup()
-	}
-	return err
 }
 
 func makeNamedPipe(path string) error {

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -113,17 +114,9 @@ func TestApplyPathScopeSkipsSymlinkedFiles(t *testing.T) {
 
 	scopedPath, warnings := applyScopedJSScope(t, repo)
 
-	if _, err := os.Stat(filepath.Join(scopedPath, scopeKeepJSPath)); err != nil {
-		t.Fatalf("expected regular in-scope file to be copied: %v", err)
-	}
-	if _, err := os.Lstat(filepath.Join(scopedPath, "src", "linked.js")); !os.IsNotExist(err) {
-		t.Fatalf("expected symlinked file to be skipped, got err=%v", err)
-	}
+	assertScopedEntryIsSkipped(t, scopedPath, warnings, "src/linked.js", "is symlink (not copied)")
 	if !containsWarning(warnings, "analysis scope include matches: src/**/*.js=1") {
 		t.Fatalf("expected include summary to count only copied files, got %#v", warnings)
-	}
-	if !containsWarning(warnings, "analysis scope skipped file: src/linked.js (is symlink (not copied))") {
-		t.Fatalf("expected symlink skip diagnostic, got %#v", warnings)
 	}
 }
 
@@ -224,6 +217,21 @@ func TestApplyPathScopeRejectsTooManyCopiedFiles(t *testing.T) {
 	expectScopedJSScopeFailure(t, repo, "expected scoped copy file limit to fail")
 }
 
+func TestApplyPathScopeSkipsNonRegularFiles(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
+	pipePath := filepath.Join(repo, "src", "pipe.js")
+	if err := os.MkdirAll(filepath.Dir(pipePath), 0o750); err != nil {
+		t.Fatalf("mkdir pipe dir: %v", err)
+	}
+	if err := syscall.Mkfifo(pipePath, 0o600); err != nil {
+		t.Skipf("named pipes unsupported in test environment: %v", err)
+	}
+
+	scopedPath, warnings := applyScopedJSScope(t, repo)
+	assertScopedEntryIsSkipped(t, scopedPath, warnings, "src/pipe.js", "is not a regular file (not copied)")
+}
+
 func containsWarning(warnings []string, expected string) bool {
 	for _, warning := range warnings {
 		if strings.Contains(warning, expected) {
@@ -253,5 +261,19 @@ func expectScopedJSScopeFailure(t *testing.T, repo, message string) {
 			cleanup()
 		}
 		t.Fatal(message)
+	}
+}
+
+func assertScopedEntryIsSkipped(t *testing.T, scopedPath string, warnings []string, relativePath, reason string) {
+	t.Helper()
+
+	if _, err := os.Stat(filepath.Join(scopedPath, scopeKeepJSPath)); err != nil {
+		t.Fatalf("expected regular in-scope file to be copied: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(scopedPath, relativePath)); !os.IsNotExist(err) {
+		t.Fatalf("expected skipped scoped entry, got err=%v", err)
+	}
+	if !containsWarning(warnings, "analysis scope skipped file: "+relativePath+" ("+reason+")") {
+		t.Fatalf("expected skipped-entry diagnostic, got %#v", warnings)
 	}
 }

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -1,10 +1,16 @@
 package analysis
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+
+	"github.com/ben-ranford/lopper/internal/testutil"
 )
 
 const scopeJSGlob = "src/**/*.js"
@@ -17,7 +23,7 @@ func TestApplyPathScopeFiltersFilesAndReportsDiagnostics(t *testing.T) {
 	writeScopeFile(t, filepath.Join(repo, "src", "skip.test.js"), "export const skip = true\n")
 	writeScopeFile(t, filepath.Join(repo, "README.md"), "doc\n")
 
-	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, []string{"**/*.test.js"})
+	scopedPath, warnings, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, []string{"**/*.test.js"})
 	if err != nil {
 		t.Fatalf("apply path scope: %v", err)
 	}
@@ -51,7 +57,7 @@ func TestGlobMatchSupportsDoubleStar(t *testing.T) {
 
 func TestApplyPathScopeNoPatternsReturnsOriginalPath(t *testing.T) {
 	repo := t.TempDir()
-	scopedPath, warnings, cleanup, err := applyPathScope(repo, nil, nil)
+	scopedPath, warnings, cleanup, err := applyPathScope(context.Background(), repo, nil, nil)
 	if err != nil {
 		t.Fatalf("apply path scope without patterns: %v", err)
 	}
@@ -72,7 +78,7 @@ func TestNoOpCleanupDoesNothing(t *testing.T) {
 func TestCopyFileRejectsUnsafeRelativePath(t *testing.T) {
 	repo := t.TempDir()
 	scoped := t.TempDir()
-	if copyFile(repo, scoped, "../escape.txt") == nil {
+	if copyFile(context.Background(), repo, scoped, "../escape.txt", 0) == nil {
 		t.Fatalf("expected unsafe relative path rejection")
 	}
 }
@@ -82,7 +88,7 @@ func TestCopyFileFailsWhenSourceRootCannotOpen(t *testing.T) {
 	repo := filepath.Join(temp, "missing-repo")
 	scoped := t.TempDir()
 
-	err := copyFile(repo, scoped, "src/keep.js")
+	err := copyFile(context.Background(), repo, scoped, "src/keep.js", 0)
 	if err == nil {
 		t.Fatalf("expected source-root open failure for missing repository root")
 	}
@@ -92,7 +98,7 @@ func TestCopyFileFailsWhenSourceFileMissing(t *testing.T) {
 	repo := t.TempDir()
 	scoped := t.TempDir()
 
-	err := copyFile(repo, scoped, "src/missing.js")
+	err := copyFile(context.Background(), repo, scoped, "src/missing.js", 0)
 	if err == nil {
 		t.Fatalf("expected missing source file error")
 	}
@@ -108,7 +114,7 @@ func TestApplyPathScopeSkipsSymlinkedFiles(t *testing.T) {
 		t.Skipf("symlink unsupported in test environment: %v", err)
 	}
 
-	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil)
+	scopedPath, warnings, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
 	if err != nil {
 		t.Fatalf("apply path scope: %v", err)
 	}
@@ -193,6 +199,92 @@ func TestPathWithinAndSafeRelativePath(t *testing.T) {
 	}
 }
 
+func TestScopeCopyBudgetRejectsNegativeSize(t *testing.T) {
+	budget := newScopeCopyBudget()
+	if err := budget.reserve(scopeKeepJSPath, -1); err == nil || !strings.Contains(err.Error(), "negative file size") {
+		t.Fatalf("expected negative file size rejection, got %v", err)
+	}
+}
+
+func TestScopeContextErrAllowsNilContext(t *testing.T) {
+	var nilCtx context.Context
+	if err := scopeContextErr(nilCtx); err != nil {
+		t.Fatalf("expected nil context to be allowed, got %v", err)
+	}
+}
+
+func TestApplyPathScopeRejectsOversizedScopedCopy(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWritePaddedFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n", maxScopedCopyBytes+1)
+
+	_, _, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if !errors.Is(err, errScopedCopyByteLimitExceeded) {
+		t.Fatalf("expected scoped copy byte limit error, got %v", err)
+	}
+}
+
+func TestApplyPathScopeRejectsTooManyCopiedFiles(t *testing.T) {
+	repo := t.TempDir()
+	for i := 0; i <= maxScopedCopyFiles; i++ {
+		writeScopeFile(t, filepath.Join(repo, "src", "pkg", fmt.Sprintf("f-%d.js", i)), "export const keep = true\n")
+	}
+
+	_, _, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if !errors.Is(err, errScopedCopyFileLimitExceeded) {
+		t.Fatalf("expected scoped copy file limit error, got %v", err)
+	}
+}
+
+func TestApplyPathScopeHonorsCanceledContext(t *testing.T) {
+	repo := t.TempDir()
+	writeScopeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
+
+	_, _, cleanup, err := applyPathScope(testutil.CanceledContext(), repo, []string{scopeJSGlob}, nil)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled context error, got %v", err)
+	}
+}
+
+func TestApplyPathScopeSkipsNonRegularFiles(t *testing.T) {
+	repo := t.TempDir()
+	writeScopeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
+	pipePath := filepath.Join(repo, "src", "pipe.js")
+	if err := os.MkdirAll(filepath.Dir(pipePath), 0o750); err != nil {
+		t.Fatalf("mkdir pipe dir: %v", err)
+	}
+	if err := os.Remove(pipePath); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("clear pipe path: %v", err)
+	}
+	if err := makeNamedPipe(pipePath); err != nil {
+		t.Skipf("named pipes unsupported in test environment: %v", err)
+	}
+
+	scopedPath, warnings, cleanup, err := applyPathScope(context.Background(), repo, []string{scopeJSGlob}, nil)
+	if err != nil {
+		t.Fatalf("apply path scope: %v", err)
+	}
+	defer cleanup()
+
+	if _, err := os.Stat(filepath.Join(scopedPath, scopeKeepJSPath)); err != nil {
+		t.Fatalf("expected regular file to be copied: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(scopedPath, "src", "pipe.js")); !os.IsNotExist(err) {
+		t.Fatalf("expected non-regular file to be skipped, got err=%v", err)
+	}
+	if !containsWarning(warnings, "analysis scope skipped file: src/pipe.js (is not a regular file (not copied))") {
+		t.Fatalf("expected non-regular file skip diagnostic, got %#v", warnings)
+	}
+}
+
 func containsWarning(warnings []string, expected string) bool {
 	for _, warning := range warnings {
 		if strings.Contains(warning, expected) {
@@ -210,4 +302,8 @@ func writeScopeFile(t *testing.T, path string, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func makeNamedPipe(path string) error {
+	return syscall.Mkfifo(path, 0o600)
 }

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 )
 
@@ -225,33 +224,6 @@ func TestApplyPathScopeRejectsTooManyCopiedFiles(t *testing.T) {
 	expectScopedJSScopeFailure(t, repo, "expected scoped copy file limit to fail")
 }
 
-func TestApplyPathScopeSkipsNonRegularFiles(t *testing.T) {
-	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, scopeKeepJSPath), "export const keep = true\n")
-	pipePath := filepath.Join(repo, "src", "pipe.js")
-	if err := os.MkdirAll(filepath.Dir(pipePath), 0o750); err != nil {
-		t.Fatalf("mkdir pipe dir: %v", err)
-	}
-	if err := os.Remove(pipePath); err != nil && !os.IsNotExist(err) {
-		t.Fatalf("clear pipe path: %v", err)
-	}
-	if err := makeNamedPipe(pipePath); err != nil {
-		t.Skipf("named pipes unsupported in test environment: %v", err)
-	}
-
-	scopedPath, warnings := applyScopedJSScope(t, repo)
-
-	if _, err := os.Stat(filepath.Join(scopedPath, scopeKeepJSPath)); err != nil {
-		t.Fatalf("expected regular file to be copied: %v", err)
-	}
-	if _, err := os.Lstat(filepath.Join(scopedPath, "src", "pipe.js")); !os.IsNotExist(err) {
-		t.Fatalf("expected non-regular file to be skipped, got err=%v", err)
-	}
-	if !containsWarning(warnings, "analysis scope skipped file: src/pipe.js (is not a regular file (not copied))") {
-		t.Fatalf("expected non-regular file skip diagnostic, got %#v", warnings)
-	}
-}
-
 func containsWarning(warnings []string, expected string) bool {
 	for _, warning := range warnings {
 		if strings.Contains(warning, expected) {
@@ -282,8 +254,4 @@ func expectScopedJSScopeFailure(t *testing.T, repo, message string) {
 		}
 		t.Fatal(message)
 	}
-}
-
-func makeNamedPipe(path string) error {
-	return syscall.Mkfifo(path, 0o600)
 }

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -112,11 +112,7 @@ func TestApplyPathScopeSkipsSymlinkedFiles(t *testing.T) {
 		t.Skipf("symlink unsupported in test environment: %v", err)
 	}
 
-	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil)
-	if err != nil {
-		t.Fatalf("apply path scope: %v", err)
-	}
-	defer cleanup()
+	scopedPath, warnings := applyScopedJSScope(t, repo)
 
 	if _, err := os.Stat(filepath.Join(scopedPath, scopeKeepJSPath)); err != nil {
 		t.Fatalf("expected regular in-scope file to be copied: %v", err)
@@ -253,11 +249,7 @@ func TestApplyPathScopeSkipsNonRegularFiles(t *testing.T) {
 		t.Skipf("named pipes unsupported in test environment: %v", err)
 	}
 
-	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil)
-	if err != nil {
-		t.Fatalf("apply path scope: %v", err)
-	}
-	defer cleanup()
+	scopedPath, warnings := applyScopedJSScope(t, repo)
 
 	if _, err := os.Stat(filepath.Join(scopedPath, scopeKeepJSPath)); err != nil {
 		t.Fatalf("expected regular file to be copied: %v", err)
@@ -277,6 +269,18 @@ func containsWarning(warnings []string, expected string) bool {
 		}
 	}
 	return false
+}
+
+func applyScopedJSScope(t *testing.T, repo string) (string, []string) {
+	t.Helper()
+
+	scopedPath, warnings, cleanup, err := applyPathScope(repo, []string{scopeJSGlob}, nil)
+	if err != nil {
+		t.Fatalf("apply path scope: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	return scopedPath, warnings
 }
 
 func makeNamedPipe(path string) error {

--- a/internal/analysis/scope_test.go
+++ b/internal/analysis/scope_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -203,6 +204,16 @@ func TestScopeCopyBudgetRejectsNegativeSize(t *testing.T) {
 	budget := newScopeCopyBudget()
 	if err := budget.reserve(scopeKeepJSPath, -1); err == nil || !strings.Contains(err.Error(), "negative file size") {
 		t.Fatalf("expected negative file size rejection, got %v", err)
+	}
+}
+
+func TestScopeCopyBudgetRejectsOverflowingByteReservation(t *testing.T) {
+	budget := scopeCopyBudget{
+		maxBytes: 32,
+		bytes:    31,
+	}
+	if err := budget.reserve(scopeKeepJSPath, math.MaxInt64); !errors.Is(err, errScopedCopyByteLimitExceeded) {
+		t.Fatalf("expected scoped copy byte limit error, got %v", err)
 	}
 }
 

--- a/internal/analysis/scope_workspace_guards_test.go
+++ b/internal/analysis/scope_workspace_guards_test.go
@@ -1,7 +1,6 @@
 package analysis
 
 import (
-	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -18,7 +17,7 @@ func TestScopeNoOpCleanupIsCallable(t *testing.T) {
 }
 
 func TestScopeApplyPathScopeReturnsWalkErrorForMissingRepo(t *testing.T) {
-	_, _, _, err := applyPathScope(context.Background(), filepath.Join(t.TempDir(), "missing"), []string{scopeJSGlob}, nil)
+	_, _, _, err := applyPathScope(filepath.Join(t.TempDir(), "missing"), []string{scopeJSGlob}, nil)
 	if err == nil {
 		t.Fatalf("expected missing repo to fail applyPathScope")
 	}
@@ -33,7 +32,7 @@ func TestScopeWalkerGuardBranches(t *testing.T) {
 	gitEntry := mustScopeDirEntry(t, repo, ".git")
 
 	walker := &scopeWalker{repoPath: repo, scopedRoot: t.TempDir(), stats: newScopeStats(nil, nil)}
-	walk := walker.walkWithContext(context.Background())
+	walk := walker.walk
 	if walk("", nil, errors.New("walk failed")) == nil {
 		t.Fatalf("expected walkErr to be returned")
 	}
@@ -70,10 +69,10 @@ func TestScopePatternCompileAndTempWorkspaceFailures(t *testing.T) {
 	if _, err := compileGlobPatterns([]string{invalidPattern}); err == nil {
 		t.Fatalf("expected invalid utf-8 pattern to fail compilation")
 	}
-	if _, _, _, err := applyPathScope(context.Background(), t.TempDir(), []string{invalidPattern}, nil); err == nil {
+	if _, _, _, err := applyPathScope(t.TempDir(), []string{invalidPattern}, nil); err == nil {
 		t.Fatalf("expected include pattern compile error")
 	}
-	if _, _, _, err := applyPathScope(context.Background(), t.TempDir(), nil, []string{invalidPattern}); err == nil {
+	if _, _, _, err := applyPathScope(t.TempDir(), nil, []string{invalidPattern}); err == nil {
 		t.Fatalf("expected exclude pattern compile error")
 	}
 
@@ -83,7 +82,7 @@ func TestScopePatternCompileAndTempWorkspaceFailures(t *testing.T) {
 		t.Fatalf("write tmp file: %v", err)
 	}
 	t.Setenv("TMPDIR", tmpFile)
-	if _, _, _, err := applyPathScope(context.Background(), t.TempDir(), []string{scopeJSGlob}, nil); err == nil {
+	if _, _, _, err := applyPathScope(t.TempDir(), []string{scopeJSGlob}, nil); err == nil {
 		t.Fatalf("expected temp workspace creation to fail")
 	}
 }
@@ -92,12 +91,7 @@ func TestScopeCopyFileAndRelativePathGuards(t *testing.T) {
 	repo := t.TempDir()
 	sourcePath := filepath.Join(repo, "src", "keep.js")
 	writeFile(t, sourcePath, "export const keep = true\n")
-	sourceInfo, err := os.Stat(sourcePath)
-	if err != nil {
-		t.Fatalf("stat source path: %v", err)
-	}
-
-	if copyFile(context.Background(), repo, t.TempDir(), "..", 0) == nil {
+	if copyFile(repo, t.TempDir(), "..") == nil {
 		t.Fatalf("expected unsafe relative path to fail")
 	}
 
@@ -105,7 +99,7 @@ func TestScopeCopyFileAndRelativePathGuards(t *testing.T) {
 	if err := os.WriteFile(blockedRoot, []byte("x"), 0o644); err != nil {
 		t.Fatalf("write blocked root: %v", err)
 	}
-	if copyFile(context.Background(), repo, blockedRoot, filepath.Join("src", "keep.js"), sourceInfo.Size()) == nil {
+	if copyFile(repo, blockedRoot, filepath.Join("src", "keep.js")) == nil {
 		t.Fatalf("expected blocked scoped root to fail copy")
 	}
 }

--- a/internal/analysis/scope_workspace_guards_test.go
+++ b/internal/analysis/scope_workspace_guards_test.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -17,7 +18,7 @@ func TestScopeNoOpCleanupIsCallable(t *testing.T) {
 }
 
 func TestScopeApplyPathScopeReturnsWalkErrorForMissingRepo(t *testing.T) {
-	_, _, _, err := applyPathScope(filepath.Join(t.TempDir(), "missing"), []string{scopeJSGlob}, nil)
+	_, _, _, err := applyPathScope(context.Background(), filepath.Join(t.TempDir(), "missing"), []string{scopeJSGlob}, nil)
 	if err == nil {
 		t.Fatalf("expected missing repo to fail applyPathScope")
 	}
@@ -32,10 +33,11 @@ func TestScopeWalkerGuardBranches(t *testing.T) {
 	gitEntry := mustScopeDirEntry(t, repo, ".git")
 
 	walker := &scopeWalker{repoPath: repo, scopedRoot: t.TempDir(), stats: newScopeStats(nil, nil)}
-	if walker.walk("", nil, errors.New("walk failed")) == nil {
+	walk := walker.walkWithContext(context.Background())
+	if walk("", nil, errors.New("walk failed")) == nil {
 		t.Fatalf("expected walkErr to be returned")
 	}
-	if err := walker.walk(gitDir, gitEntry, nil); !errors.Is(err, filepath.SkipDir) {
+	if err := walk(gitDir, gitEntry, nil); !errors.Is(err, filepath.SkipDir) {
 		t.Fatalf("expected .git to return SkipDir, got %v", err)
 	}
 }
@@ -68,10 +70,10 @@ func TestScopePatternCompileAndTempWorkspaceFailures(t *testing.T) {
 	if _, err := compileGlobPatterns([]string{invalidPattern}); err == nil {
 		t.Fatalf("expected invalid utf-8 pattern to fail compilation")
 	}
-	if _, _, _, err := applyPathScope(t.TempDir(), []string{invalidPattern}, nil); err == nil {
+	if _, _, _, err := applyPathScope(context.Background(), t.TempDir(), []string{invalidPattern}, nil); err == nil {
 		t.Fatalf("expected include pattern compile error")
 	}
-	if _, _, _, err := applyPathScope(t.TempDir(), nil, []string{invalidPattern}); err == nil {
+	if _, _, _, err := applyPathScope(context.Background(), t.TempDir(), nil, []string{invalidPattern}); err == nil {
 		t.Fatalf("expected exclude pattern compile error")
 	}
 
@@ -81,7 +83,7 @@ func TestScopePatternCompileAndTempWorkspaceFailures(t *testing.T) {
 		t.Fatalf("write tmp file: %v", err)
 	}
 	t.Setenv("TMPDIR", tmpFile)
-	if _, _, _, err := applyPathScope(t.TempDir(), []string{scopeJSGlob}, nil); err == nil {
+	if _, _, _, err := applyPathScope(context.Background(), t.TempDir(), []string{scopeJSGlob}, nil); err == nil {
 		t.Fatalf("expected temp workspace creation to fail")
 	}
 }
@@ -90,8 +92,12 @@ func TestScopeCopyFileAndRelativePathGuards(t *testing.T) {
 	repo := t.TempDir()
 	sourcePath := filepath.Join(repo, "src", "keep.js")
 	writeScopeFile(t, sourcePath, "export const keep = true\n")
+	sourceInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		t.Fatalf("stat source path: %v", err)
+	}
 
-	if copyFile(repo, t.TempDir(), "..") == nil {
+	if copyFile(context.Background(), repo, t.TempDir(), "..", 0) == nil {
 		t.Fatalf("expected unsafe relative path to fail")
 	}
 
@@ -99,7 +105,7 @@ func TestScopeCopyFileAndRelativePathGuards(t *testing.T) {
 	if err := os.WriteFile(blockedRoot, []byte("x"), 0o644); err != nil {
 		t.Fatalf("write blocked root: %v", err)
 	}
-	if copyFile(repo, blockedRoot, filepath.Join("src", "keep.js")) == nil {
+	if copyFile(context.Background(), repo, blockedRoot, filepath.Join("src", "keep.js"), sourceInfo.Size()) == nil {
 		t.Fatalf("expected blocked scoped root to fail copy")
 	}
 }

--- a/internal/analysis/scope_workspace_guards_test.go
+++ b/internal/analysis/scope_workspace_guards_test.go
@@ -91,7 +91,7 @@ func TestScopePatternCompileAndTempWorkspaceFailures(t *testing.T) {
 func TestScopeCopyFileAndRelativePathGuards(t *testing.T) {
 	repo := t.TempDir()
 	sourcePath := filepath.Join(repo, "src", "keep.js")
-	writeScopeFile(t, sourcePath, "export const keep = true\n")
+	writeFile(t, sourcePath, "export const keep = true\n")
 	sourceInfo, err := os.Stat(sourcePath)
 	if err != nil {
 		t.Fatalf("stat source path: %v", err)

--- a/internal/analysis/service_helpers_test.go
+++ b/internal/analysis/service_helpers_test.go
@@ -108,6 +108,10 @@ func TestChangedRootsHandlesRelativeRootsAndNoChangedFiles(t *testing.T) {
 	if empty := changedRoots([]string{relativeRoot}, repo, nil); len(empty) != 0 {
 		t.Fatalf("expected no changed files to select no roots, got %#v", empty)
 	}
+
+	if empty := changedRoots(nil, repo, []string{"packages/a/src/index.ts"}); len(empty) != 0 {
+		t.Fatalf("expected no roots to select no changed roots, got %#v", empty)
+	}
 }
 
 func TestAppendChangedRootAncestorsDeduplicatesIndexedRoots(t *testing.T) {
@@ -173,6 +177,10 @@ func TestRootContainsFileAndUniqueSortedEdges(t *testing.T) {
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
 		t.Fatalf("unexpected uniqueSorted output: %#v", got)
 	}
+
+	if rootContainsFile(root, "\x00") {
+		t.Fatalf("expected invalid file path to be excluded")
+	}
 }
 
 func TestRemapAnalyzedRoots(t *testing.T) {
@@ -235,6 +243,19 @@ func TestAdjustImportLocationsSlashNormalizesWindowsPaths(t *testing.T) {
 	}
 	if got := imports[0].Locations[2].File; got != "C:/repo/pkg/abs.js" {
 		t.Fatalf("expected absolute windows import location to remain absolute and slash-normalized, got %q", got)
+	}
+}
+
+func TestAbsolutePathHelpersPreserveAbsoluteInputs(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	absoluteRoot := filepath.Join(repo, "packages", "a")
+	if got := absoluteRootPath(repo, absoluteRoot); got != absoluteRoot {
+		t.Fatalf("expected absolute root to be preserved, got %q", got)
+	}
+
+	absoluteFile := filepath.Join(repo, "packages", "a", "src", "index.ts")
+	if got := absoluteChangedPath(repo, absoluteFile); got != absoluteFile {
+		t.Fatalf("expected absolute changed path to be preserved, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Bound repository-controlled scoped workspace copies before they reach temporary storage, preventing large or unbounded copies from exhausting disk or extending analysis duration.

Closes #1257

## Changes

- Limit scoped copies to 4,096 regular files and 256 MiB.
- Reject source growth beyond the reserved size.
- Honor cancellation while walking and copying.
- Skip symlinked and non-regular inputs.

## Validation

Commands and checks run:

```bash
go test ./internal/analysis/...
make ci
```

Additional manual validation:

- Exercised oversized files, file-count limits, symlink and non-regular inputs, source growth, and cancelled scope contexts.

Regression-Test: ./internal/analysis::TestApplyPathScopeRejectsOversizedScopedCopy
Regression-Test: ./internal/analysis::TestApplyPathScopeRejectsTooManyCopiedFiles

## Risk and compatibility

- Breaking changes: Scoped analysis now fails safely when selected content exceeds fixed copy limits.
- Migration required: None.
- Performance impact: Limits untrusted workspace-copy work.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
