### PR TITLE
fix(python): reject symlinked src roots

### DIFF
--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -398,11 +398,15 @@ func dependencyFromModule(repoPath, moduleName string) string {
 
 func isLocalModule(repoPath, root string) bool {
 	for _, searchRoot := range localModuleSearchRoots(repoPath) {
-		if _, err := os.Stat(filepath.Join(searchRoot, root+".py")); err == nil {
+		// Use Lstat to avoid following symlinks that could escape the repo boundary.
+		if info, err := os.Lstat(filepath.Join(searchRoot, root+".py")); err == nil && info.Mode()&os.ModeSymlink == 0 {
 			return true
 		}
-		if _, err := os.Stat(filepath.Join(searchRoot, root, "__init__.py")); err == nil {
-			return true
+		pkgDir := filepath.Join(searchRoot, root)
+		if info, err := os.Lstat(pkgDir); err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+			if _, err := os.Lstat(filepath.Join(pkgDir, "__init__.py")); err == nil {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -404,7 +404,7 @@ func isLocalModule(repoPath, root string) bool {
 		}
 		pkgDir := filepath.Join(searchRoot, root)
 		if info, err := os.Lstat(pkgDir); err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
-			if _, err := os.Lstat(filepath.Join(pkgDir, "__init__.py")); err == nil {
+			if marker, err := os.Lstat(filepath.Join(pkgDir, "__init__.py")); err == nil && marker.Mode()&os.ModeSymlink == 0 {
 				return true
 			}
 		}

--- a/internal/lang/python/adapter.go
+++ b/internal/lang/python/adapter.go
@@ -412,7 +412,7 @@ func localModuleSearchRoots(repoPath string) []string {
 	roots := []string{repoPath}
 
 	srcRoot := filepath.Join(repoPath, "src")
-	if info, err := os.Stat(srcRoot); err == nil && info.IsDir() {
+	if info, err := os.Lstat(srcRoot); err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
 		roots = append(roots, srcRoot)
 	}
 

--- a/internal/lang/python/adapter_test.go
+++ b/internal/lang/python/adapter_test.go
@@ -366,6 +366,34 @@ func TestAdapterAnalyseTopNIgnoresSrcLayoutLocalPackages(t *testing.T) {
 	}
 }
 
+func TestAdapterAnalyseTopNDoesNotFollowSymlinkedSrcOutsideRepo(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "pyproject.toml"), "[project]\nname='demo'\nversion='0.1.0'\ndependencies=['requests>=2.0']\n")
+	testutil.MustWriteFile(t, filepath.Join(outside, "app", "__init__.py"), localModuleContent)
+	testutil.MustWriteFile(t, filepath.Join(repo, testMainPy), "import app\nimport requests\n")
+
+	if err := os.Symlink(outside, filepath.Join(repo, "src")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	reportData, err := NewAdapter().Analyse(context.Background(), language.Request{
+		RepoPath: repo,
+		TopN:     10,
+	})
+	if err != nil {
+		t.Fatalf("analyse symlinked src repo: %v", err)
+	}
+
+	names := dependencyNames(reportData)
+	if !slices.Contains(names, "app") {
+		t.Fatalf("expected escaping symlinked src package to stay external, got %#v", names)
+	}
+	if !slices.Contains(names, "requests") {
+		t.Fatalf("expected external dependency to remain present, got %#v", names)
+	}
+}
+
 func TestAdapterMetadataAndDetect(t *testing.T) {
 	adapter := NewAdapter()
 	if adapter.ID() != "python" {

--- a/internal/lang/python/helpers_test.go
+++ b/internal/lang/python/helpers_test.go
@@ -116,6 +116,25 @@ func TestPythonLocalModuleSearchRootsKeepRealSrc(t *testing.T) {
 	}
 }
 
+func TestPythonIsLocalModuleSkipsSymlinkedPkgInsideRealSrc(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(outside, "__init__.py"), localModuleContent)
+
+	// repo/src is a real directory; repo/src/app is a symlink to outside.
+	srcPath := filepath.Join(repo, "src")
+	if err := os.MkdirAll(srcPath, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(srcPath, "app")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if isLocalModule(repo, "app") {
+		t.Fatalf("expected symlinked package dir inside real src to not be treated as local")
+	}
+}
+
 func TestPythonDependencyFromModuleStdlibCoverage(t *testing.T) {
 	repo := t.TempDir()
 	modules := []string{

--- a/internal/lang/python/helpers_test.go
+++ b/internal/lang/python/helpers_test.go
@@ -135,6 +135,24 @@ func TestPythonIsLocalModuleSkipsSymlinkedPkgInsideRealSrc(t *testing.T) {
 	}
 }
 
+func TestPythonIsLocalModuleSkipsSymlinkedPackageMarker(t *testing.T) {
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "__init__.py")
+	testutil.MustWriteFile(t, outside, localModuleContent)
+
+	pkgDir := filepath.Join(repo, "app")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("mkdir package: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(pkgDir, "__init__.py")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if isLocalModule(repo, "app") {
+		t.Fatalf("expected package with a symlinked marker to not be treated as local")
+	}
+}
+
 func TestPythonDependencyFromModuleStdlibCoverage(t *testing.T) {
 	repo := t.TempDir()
 	modules := []string{

--- a/internal/lang/python/helpers_test.go
+++ b/internal/lang/python/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -81,6 +82,37 @@ func TestPythonModuleResolutionHelpers(t *testing.T) {
 		if got := isLocalModule(repo, tc.module); got != tc.want {
 			t.Fatalf("isLocalModule(%q): expected %v, got %v", tc.module, tc.want, got)
 		}
+	}
+}
+
+func TestPythonLocalModuleSearchRootsSkipSymlinkedSrc(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(outside, "app", "__init__.py"), localModuleContent)
+
+	srcPath := filepath.Join(repo, "src")
+	if err := os.Symlink(outside, srcPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if got := localModuleSearchRoots(repo); !slices.Equal(got, []string{repo}) {
+		t.Fatalf("expected symlinked src root to be ignored, got %#v", got)
+	}
+	if isLocalModule(repo, "app") {
+		t.Fatalf("expected symlinked src root outside repo not to be treated as local")
+	}
+}
+
+func TestPythonLocalModuleSearchRootsKeepRealSrc(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", "app", "__init__.py"), localModuleContent)
+
+	wantRoots := []string{repo, filepath.Join(repo, "src")}
+	if got := localModuleSearchRoots(repo); !slices.Equal(got, wantRoots) {
+		t.Fatalf("expected real src root to be included, got %#v", got)
+	}
+	if !isLocalModule(repo, "app") {
+		t.Fatalf("expected real src root package to stay local")
 	}
 }
 


### PR DESCRIPTION
## Summary

Reject a repository `src` symlink as a Python local-module search root so static analysis does not inspect local metadata outside the trusted repository boundary.

Closes #1281

## Changes

- Use `os.Lstat` when evaluating the optional Python `src` root.
- Keep real `src` layouts supported.
- Add unit and adapter regressions for an escaping `src` symlink.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/python/...
make ci
```

Additional manual validation:

- Exercised a real `src` layout and a `src` symlink that targets a separate temporary directory.

Regression-Test: ./internal/lang/python::TestPythonLocalModuleSearchRootsSkipSymlinkedSrc
Regression-Test: ./internal/lang/python::TestAdapterAnalyseTopNDoesNotFollowSymlinkedSrcOutsideRepo

## Risk and compatibility

- Breaking changes: Symlinked `src` directories are no longer considered local Python module roots.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review