### PR TITLE
fix(vscode): short-circuit untrusted local binary checks

### DIFF
--- a/extensions/vscode-lopper/src/managedBinary.ts
+++ b/extensions/vscode-lopper/src/managedBinary.ts
@@ -284,13 +284,13 @@ export class LopperBinaryLifecycleManager implements BinaryLifecycleManager {
 
   private async resolveLocalBinaryPath(request: BinaryResolutionRequest): Promise<string | undefined> {
     const localBinary = path.join(request.workspaceRoot, "bin", binaryFileName(this.platform));
-    const localBinaryStats = await this.localBinaryStats(localBinary);
-    if (!localBinaryStats) {
+    if (!request.workspaceTrusted) {
+      this.output.appendLine(`skipping workspace-local lopper binary in untrusted workspace: ${localBinary}`);
       return this.resolvePathBinary(request);
     }
 
-    if (!request.workspaceTrusted) {
-      this.output.appendLine(`skipping workspace-local lopper binary in untrusted workspace: ${localBinary}`);
+    const localBinaryStats = await this.localBinaryStats(localBinary);
+    if (!localBinaryStats) {
       return this.resolvePathBinary(request);
     }
 

--- a/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
+++ b/extensions/vscode-lopper/src/test/suite/managedBinary.test.ts
@@ -324,6 +324,30 @@ suite("managed binary installer", () => {
     });
   });
 
+  test("skips inaccessible workspace-local bin paths in untrusted workspaces", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    await withPathFallbackFixture("inaccessible-untrusted", async ({ workspaceRoot, fallbackBinary, lifecycle }) => {
+      const localBinaryDir = path.join(workspaceRoot, "bin");
+      await mkdir(localBinaryDir, { recursive: true });
+      await chmod(localBinaryDir, 0o000);
+
+      try {
+        const resolvedPath = await lifecycle.resolveBinaryPath({
+          workspaceRoot,
+          workspaceTrusted: false,
+          autoDownloadBinary: false,
+        });
+
+        assert.equal(resolvedPath, fallbackBinary);
+      } finally {
+        await chmod(localBinaryDir, 0o755);
+      }
+    });
+  });
+
   test("forwards progress cancellation signals to managed installer", async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), "lopper-managed-lifecycle-signal-"));
     const controller = new AbortController();


### PR DESCRIPTION
## Summary

Check VS Code workspace trust before inspecting a workspace-local `bin/lopper` path, so malformed or inaccessible untrusted paths cannot block safe PATH or managed-binary fallback.

Closes #1282

## Changes

- Short-circuit untrusted workspaces before statting the local binary path.
- Preserve trusted-workspace validation and PATH fallback behavior.
- Add a regression for an inaccessible local binary directory in an untrusted workspace.

## Validation

Commands and checks run:

```bash
npm run compile
make ci
```

Additional manual validation:

- Started the VS Code extension e2e runner; its VS Code runtime download was still in progress when the local command window elapsed.

Regression-Test-Exemption: deterministic coverage runs in the VS Code TypeScript integration harness, which the Go-only regression proof runner cannot execute

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: Avoids local filesystem work in untrusted workspaces.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
