### PR TITLE
refactor(dashboard): share path containment guards

### DIFF
--- a/internal/app/dashboard_materialize.go
+++ b/internal/app/dashboard_materialize.go
@@ -248,7 +248,7 @@ func trustedCommandOutputRootBoundary(outputAbs string) (commandOutputRootBounda
 	if err != nil {
 		return commandOutputRootBoundary{}, fmt.Errorf("resolve output workspace: %w", err)
 	}
-	withinWorkspace, err := pathWithinRoot(workspaceRoot, outputAbs)
+	withinWorkspace, err := dashboardPathWithinRoot(workspaceRoot, outputAbs)
 	if err != nil {
 		return commandOutputRootBoundary{}, err
 	}
@@ -297,7 +297,7 @@ func trustedCommandOutputRootBoundaryForRoot(outputAbs, root string) (commandOut
 		}
 		return commandOutputRootBoundary{}, fmt.Errorf("resolve trusted output workspace: %w", err)
 	}
-	withinWorkspace, err := pathWithinRoot(rootAbs, outputAbs)
+	withinWorkspace, err := dashboardPathWithinRoot(rootAbs, outputAbs)
 	if err != nil {
 		return commandOutputRootBoundary{}, err
 	}
@@ -373,7 +373,7 @@ func resolveAliasedWorkspaceRootBoundary(outputAbs, workspaceRoot string) (comma
 			if err != nil {
 				return commandOutputRootBoundary{}, err
 			}
-			withinWorkspace, err := pathWithinRoot(workspaceRoot, resolvedCurrent)
+			withinWorkspace, err := dashboardPathWithinRoot(workspaceRoot, resolvedCurrent)
 			if err != nil {
 				return commandOutputRootBoundary{}, err
 			}
@@ -392,17 +392,6 @@ func resolveAliasedWorkspaceRootBoundary(outputAbs, workspaceRoot string) (comma
 	}
 }
 
-func pathWithinRoot(rootAbs, targetAbs string) (bool, error) {
-	if pathsUseDifferentWindowsVolumes(rootAbs, targetAbs) {
-		return false, nil
-	}
-	rel, err := filepath.Rel(rootAbs, targetAbs)
-	if err != nil {
-		return false, fmt.Errorf("compute output path: %w", err)
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))), nil
-}
-
 func isRootLevelSystemAlias(path string) bool {
 	cleanPath := filepath.Clean(path)
 	if !filepath.IsAbs(cleanPath) {
@@ -418,23 +407,6 @@ func isRootLevelSystemAlias(path string) bool {
 	}
 	targetInfo, err := os.Stat(cleanPath)
 	return err == nil && targetInfo.IsDir()
-}
-
-func pathsUseDifferentWindowsVolumes(rootAbs, targetAbs string) bool {
-	rootVolume := pathVolumeName(rootAbs)
-	targetVolume := pathVolumeName(targetAbs)
-	return rootVolume != "" && targetVolume != "" && rootVolume != targetVolume
-}
-
-func pathVolumeName(path string) string {
-	volume := filepath.VolumeName(path)
-	if volume == "" && len(path) >= 2 && path[1] == ':' {
-		drive := path[0]
-		if ('a' <= drive && drive <= 'z') || ('A' <= drive && drive <= 'Z') {
-			volume = path[:2]
-		}
-	}
-	return strings.ToLower(volume)
 }
 
 func hasTrailingOutputPathSeparator(path string) bool {

--- a/internal/app/dashboard_materialize_test.go
+++ b/internal/app/dashboard_materialize_test.go
@@ -1077,17 +1077,17 @@ func TestPathWithinRoot(t *testing.T) {
 		t.Fatalf("mkdir root: %v", err)
 	}
 
-	within, err := pathWithinRoot(root, filepath.Join(root, "nested", "report.json"))
+	within, err := dashboardPathWithinRoot(root, filepath.Join(root, "nested", "report.json"))
 	if err != nil {
-		t.Fatalf("pathWithinRoot within root: %v", err)
+		t.Fatalf("dashboardPathWithinRoot within root: %v", err)
 	}
 	if !within {
 		t.Fatal("expected nested path to remain within root")
 	}
 
-	within, err = pathWithinRoot(root, filepath.Join(filepath.Dir(root), "outside", "report.json"))
+	within, err = dashboardPathWithinRoot(root, filepath.Join(filepath.Dir(root), "outside", "report.json"))
 	if err != nil {
-		t.Fatalf("pathWithinRoot outside root: %v", err)
+		t.Fatalf("dashboardPathWithinRoot outside root: %v", err)
 	}
 	if within {
 		t.Fatal("expected sibling path to escape root")
@@ -1100,9 +1100,9 @@ func TestPathWithinRootAllowsRootPath(t *testing.T) {
 		t.Fatalf("mkdir root: %v", err)
 	}
 
-	within, err := pathWithinRoot(root, root)
+	within, err := dashboardPathWithinRoot(root, root)
 	if err != nil {
-		t.Fatalf("pathWithinRoot root path: %v", err)
+		t.Fatalf("dashboardPathWithinRoot root path: %v", err)
 	}
 	if !within {
 		t.Fatal("expected root path to remain within root")
@@ -1110,7 +1110,7 @@ func TestPathWithinRootAllowsRootPath(t *testing.T) {
 }
 
 func TestPathWithinRootTreatsDifferentWindowsVolumesAsOutside(t *testing.T) {
-	within, err := pathWithinRoot(`C:\repo`, `D:\reports\output.json`)
+	within, err := dashboardPathWithinRoot(`C:\repo`, `D:\reports\output.json`)
 	if err != nil {
 		t.Fatalf("pathWithinRoot different volumes: %v", err)
 	}
@@ -1120,10 +1120,10 @@ func TestPathWithinRootTreatsDifferentWindowsVolumesAsOutside(t *testing.T) {
 }
 
 func TestPathVolumeNameFallsBackToWindowsDrivePrefix(t *testing.T) {
-	if got := pathVolumeName(`D:\reports\output.json`); got != "d:" {
+	if got := dashboardPathVolumeName(`D:\reports\output.json`); got != "d:" {
 		t.Fatalf("expected windows drive prefix, got %q", got)
 	}
-	if got := pathVolumeName("/tmp/report.json"); got != "" {
+	if got := dashboardPathVolumeName("/tmp/report.json"); got != "" {
 		t.Fatalf("expected no volume for posix path, got %q", got)
 	}
 }

--- a/internal/app/dashboard_paths.go
+++ b/internal/app/dashboard_paths.go
@@ -15,7 +15,7 @@ func dashboardPathWithinRoot(rootAbs, targetAbs string) (bool, error) {
 	}
 	rel, err := filepath.Rel(rootAbs, targetAbs)
 	if err != nil {
-		return false, fmt.Errorf("compute dashboard path: %w", err)
+		return false, fmt.Errorf("compute relative dashboard path: %w", err)
 	}
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))), nil
 }

--- a/internal/app/dashboard_paths.go
+++ b/internal/app/dashboard_paths.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// dashboardPathWithinRoot applies the same volume-aware containment rule to
+// dashboard output roots and remote checkout roots.
+func dashboardPathWithinRoot(rootAbs, targetAbs string) (bool, error) {
+	if dashboardPathsUseDifferentWindowsVolumes(rootAbs, targetAbs) {
+		return false, nil
+	}
+	rel, err := filepath.Rel(rootAbs, targetAbs)
+	if err != nil {
+		return false, fmt.Errorf("compute dashboard path: %w", err)
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))), nil
+}
+
+func dashboardPathWithinDir(rootAbs, targetAbs string) bool {
+	within, err := dashboardPathWithinRoot(rootAbs, targetAbs)
+	return err == nil && within
+}
+
+func dashboardPathsUseDifferentWindowsVolumes(rootAbs, targetAbs string) bool {
+	rootVolume := dashboardPathVolumeName(rootAbs)
+	targetVolume := dashboardPathVolumeName(targetAbs)
+	return rootVolume != "" && targetVolume != "" && rootVolume != targetVolume
+}
+
+func dashboardPathVolumeName(path string) string {
+	volume := filepath.VolumeName(path)
+	if volume == "" && len(path) >= 2 && path[1] == ':' {
+		drive := path[0]
+		if ('a' <= drive && drive <= 'z') || ('A' <= drive && drive <= 'Z') {
+			volume = path[:2]
+		}
+	}
+	return strings.ToLower(volume)
+}

--- a/internal/app/dashboard_remote.go
+++ b/internal/app/dashboard_remote.go
@@ -486,7 +486,7 @@ func dashboardCheckoutPath(cacheRoot string, spec dashboardRepoURLSpec, revision
 	sum := sha256.Sum256([]byte(hashInput))
 	hash := hex.EncodeToString(sum[:])[:dashboardRepoCacheHashLength]
 	checkoutPath := filepath.Join(root, checkoutName+"-"+hash)
-	if !pathWithinDir(root, checkoutPath) {
+	if !dashboardPathWithinDir(root, checkoutPath) {
 		return "", fmt.Errorf("dashboard repo checkout path escapes cache root")
 	}
 	return checkoutPath, nil
@@ -513,12 +513,4 @@ func sanitizeDashboardCheckoutName(value string) string {
 		return "repo"
 	}
 	return sanitized
-}
-
-func pathWithinDir(root, child string) bool {
-	rel, err := filepath.Rel(root, child)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }

--- a/internal/app/dashboard_remote_test.go
+++ b/internal/app/dashboard_remote_test.go
@@ -833,8 +833,8 @@ func assertDashboardCheckoutName(t *testing.T, input, want string) {
 
 func assertPathWithinDir(t *testing.T, root, candidate string, want bool, message string) {
 	t.Helper()
-	if got := pathWithinDir(root, candidate); got != want {
-		t.Fatalf("%s: pathWithinDir(%q, %q) = %t", message, root, candidate, got)
+	if got := dashboardPathWithinDir(root, candidate); got != want {
+		t.Fatalf("%s: dashboardPathWithinDir(%q, %q) = %t", message, root, candidate, got)
 	}
 }
 

--- a/internal/app/dashboard_request.go
+++ b/internal/app/dashboard_request.go
@@ -32,7 +32,7 @@ func resolveDashboardRequest(req DashboardRequest) (resolvedDashboardRequest, er
 		configFormat = loadedConfig.Dashboard.Output
 		configOwnership = loadedConfig.Dashboard.Ownership
 		if strings.TrimSpace(req.BaselineStorePath) == "" {
-			req.BaselineStorePath = resolveDashboardConfigPath(loadedConfig.ConfigDir, loadedConfig.Dashboard.BaselineStore)
+			req.BaselineStorePath = dashboard.ResolveConfigPath(loadedConfig.ConfigDir, loadedConfig.Dashboard.BaselineStore)
 		}
 		if len(repos) == 0 {
 			repos, err = reposFromDashboardConfig(loadedConfig, &req.Features)
@@ -208,15 +208,4 @@ func inferDashboardRepoName(path string) string {
 		return strings.TrimSpace(path)
 	}
 	return base
-}
-
-func resolveDashboardConfigPath(configDir, value string) string {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return ""
-	}
-	if filepath.IsAbs(trimmed) {
-		return trimmed
-	}
-	return filepath.Join(configDir, trimmed)
 }

--- a/internal/app/dashboard_request_output_test.go
+++ b/internal/app/dashboard_request_output_test.go
@@ -48,7 +48,7 @@ func TestDashboardRequestAdditionalBranches(t *testing.T) {
 	}
 
 	absoluteBaselineStore := filepath.Join(t.TempDir(), "baselines")
-	if got := resolveDashboardConfigPath(configDir, absoluteBaselineStore); got != absoluteBaselineStore {
+	if got := dashboard.ResolveConfigPath(configDir, absoluteBaselineStore); got != absoluteBaselineStore {
 		t.Fatalf("expected absolute dashboard config path to pass through, got %q", got)
 	}
 }

--- a/internal/dashboard/config.go
+++ b/internal/dashboard/config.go
@@ -55,6 +55,16 @@ type LoadedConfig struct {
 	Dashboard ConfigDashboard
 }
 
+// ResolveConfigPath resolves a non-empty config-relative path without changing
+// the configured absolute path.
+func ResolveConfigPath(configDir, value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || filepath.IsAbs(trimmed) {
+		return trimmed
+	}
+	return filepath.Join(configDir, trimmed)
+}
+
 func LoadConfig(path string) (LoadedConfig, error) {
 	trimmedPath := strings.TrimSpace(path)
 	if trimmedPath == "" {

--- a/internal/dashboard/config.go
+++ b/internal/dashboard/config.go
@@ -55,8 +55,8 @@ type LoadedConfig struct {
 	Dashboard ConfigDashboard
 }
 
-// ResolveConfigPath resolves a non-empty config-relative path without changing
-// the configured absolute path.
+// ResolveConfigPath trims a configured path and resolves relative paths against
+// the config directory.
 func ResolveConfigPath(configDir, value string) string {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" || filepath.IsAbs(trimmed) {

--- a/internal/dashboard/dashboard_config_helpers_test.go
+++ b/internal/dashboard/dashboard_config_helpers_test.go
@@ -36,6 +36,20 @@ func TestDashboardAdditionalHelperBranches(t *testing.T) {
 	}
 }
 
+func TestResolveConfigPath(t *testing.T) {
+	configDir := t.TempDir()
+	if got := ResolveConfigPath(configDir, "  nested/baselines  "); got != filepath.Join(configDir, "nested", "baselines") {
+		t.Fatalf("expected config-relative path, got %q", got)
+	}
+	absolutePath := filepath.Join(t.TempDir(), "baselines")
+	if got := ResolveConfigPath(configDir, absolutePath); got != absolutePath {
+		t.Fatalf("expected absolute path unchanged, got %q", got)
+	}
+	if got := ResolveConfigPath(configDir, " "); got != "" {
+		t.Fatalf("expected blank path to remain blank, got %q", got)
+	}
+}
+
 func TestLoadConfigMissingFile(t *testing.T) {
 	_, err := LoadConfig(filepath.Join(t.TempDir(), "missing-dashboard.yml"))
 	if !errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
## Summary

Centralize dashboard path-containment rules so output writes and remote checkout materialization apply the same volume-aware boundary semantics. Config-relative dashboard paths now resolve in the dashboard package.

Closes #1333

## Changes

- Add a shared dashboard path guard for containment and cross-volume handling.
- Reuse the guard for dashboard output roots and remote checkout cache paths.
- Move config-relative path resolution into `internal/dashboard`.
- Preserve existing behavior with focused regression coverage.

## Validation

Commands and checks run:

```bash
go test ./internal/app -run "Test(PathWithinRoot|DashboardCheckoutHelpers|DashboardRequestAdditionalBranches)$" -count=1
go test ./internal/dashboard -run TestResolveConfigPath -count=1
```

Additional manual validation:

- Verified shared containment rejects outside paths and different Windows volumes while retaining valid output and checkout roots.

## Risk and compatibility

- Breaking changes: None; this preserves established guard behavior behind a shared implementation.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review