### PR TITLE
fix(baseline): reject malformed typed snapshot discriminators

### DIFF
--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -73,18 +73,16 @@ func LoadSnapshotFile[T any](path string, options SnapshotDecodeOptions[T]) (T, 
 }
 
 func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, string, error) {
-	var snapshot Snapshot[T]
-	if err := json.Unmarshal(data, &snapshot); err == nil && strings.TrimSpace(snapshot.BaselineSchemaVersion) != "" {
-		version := snapshot.BaselineSchemaVersion
-		if version != SnapshotSchemaVersion {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err == nil {
+		version, typed, err := typedSnapshotVersion(fields)
+		if err != nil {
 			var zero T
-			return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)
+			return zero, "", err
 		}
-		v := snapshot.Report
-		if options.Repair != nil {
-			v = options.Repair(v)
+		if typed {
+			return decodeTypedSnapshot(data, version, options)
 		}
-		return v, strings.TrimSpace(snapshot.Key), nil
 	}
 
 	v, err := decodeLegacySnapshot(data, options.DecodeLegacy)
@@ -96,6 +94,54 @@ func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, st
 		v = options.Repair(v)
 	}
 	return v, "", nil
+}
+
+func typedSnapshotVersion(fields map[string]json.RawMessage) (string, bool, error) {
+	rawVersion, ok := fields["baselineSchemaVersion"]
+	if !ok {
+		return "", false, nil
+	}
+
+	var version string
+	if err := json.Unmarshal(rawVersion, &version); err != nil {
+		return "", false, fmt.Errorf("invalid baseline schema version discriminator: %w", err)
+	}
+	if strings.TrimSpace(string(rawVersion)) == "null" {
+		return "", false, fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
+	}
+	if strings.TrimSpace(version) == "" {
+		if hasTypedSnapshotFields(fields) {
+			return "", false, fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
+		}
+		return "", false, nil
+	}
+	return version, true, nil
+}
+
+func decodeTypedSnapshot[T any](data []byte, version string, options SnapshotDecodeOptions[T]) (T, string, error) {
+	var snapshot Snapshot[T]
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		var zero T
+		return zero, "", fmt.Errorf("decode typed baseline snapshot: %w", err)
+	}
+	if version != SnapshotSchemaVersion {
+		var zero T
+		return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)
+	}
+	v := snapshot.Report
+	if options.Repair != nil {
+		v = options.Repair(v)
+	}
+	return v, strings.TrimSpace(snapshot.Key), nil
+}
+
+func hasTypedSnapshotFields(fields map[string]json.RawMessage) bool {
+	for _, field := range []string{"key", "savedAt", "report"} {
+		if _, ok := fields[field]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func LoadConfiguredSnapshot[T any](path string, store SnapshotStore[T]) (T, string, error) {

--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -80,12 +80,12 @@ func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, st
 			var zero T
 			return zero, "", err
 		}
-	if typed {
-		if version != SnapshotSchemaVersion {
-			var zero T
-			return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)
-		}
-		return decodeTypedSnapshot(data, version, options)
+		if typed {
+			if version != SnapshotSchemaVersion {
+				var zero T
+				return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)
+			}
+			return decodeTypedSnapshot(data, version, options)
 		}
 	}
 

--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -1,6 +1,7 @@
 package baseline
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -73,20 +74,17 @@ func LoadSnapshotFile[T any](path string, options SnapshotDecodeOptions[T]) (T, 
 }
 
 func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, string, error) {
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(data, &fields); err == nil {
-		version, typed, err := typedSnapshotVersion(fields)
-		if err != nil {
+	version, typed, err := inspectSnapshotEnvelope(data)
+	if err != nil {
+		var zero T
+		return zero, "", err
+	}
+	if typed {
+		if version != SnapshotSchemaVersion {
 			var zero T
-			return zero, "", err
+			return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)
 		}
-		if typed {
-			if version != SnapshotSchemaVersion {
-				var zero T
-				return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)
-			}
-			return decodeTypedSnapshot(data, version, options)
-		}
+		return decodeTypedSnapshot(data, options)
 	}
 
 	v, err := decodeLegacySnapshot(data, options.DecodeLegacy)
@@ -100,29 +98,7 @@ func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, st
 	return v, "", nil
 }
 
-func typedSnapshotVersion(fields map[string]json.RawMessage) (string, bool, error) {
-	rawVersion, ok := snapshotField(fields, "baselineSchemaVersion")
-	if !ok {
-		return "", false, nil
-	}
-
-	if strings.TrimSpace(string(rawVersion)) == "null" {
-		return "", false, fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
-	}
-	var version string
-	if err := json.Unmarshal(rawVersion, &version); err != nil {
-		return "", false, fmt.Errorf("invalid baseline schema version discriminator: %w", err)
-	}
-	if strings.TrimSpace(version) == "" {
-		if hasTypedSnapshotFields(fields) {
-			return "", false, fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
-		}
-		return "", false, nil
-	}
-	return version, true, nil
-}
-
-func decodeTypedSnapshot[T any](data []byte, version string, options SnapshotDecodeOptions[T]) (T, string, error) {
+func decodeTypedSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, string, error) {
 	var snapshot Snapshot[T]
 	if err := json.Unmarshal(data, &snapshot); err != nil {
 		var zero T
@@ -135,22 +111,118 @@ func decodeTypedSnapshot[T any](data []byte, version string, options SnapshotDec
 	return v, strings.TrimSpace(snapshot.Key), nil
 }
 
-func hasTypedSnapshotFields(fields map[string]json.RawMessage) bool {
-	for _, field := range []string{"key", "savedAt", "report"} {
-		if _, ok := snapshotField(fields, field); ok {
-			return true
+func inspectSnapshotEnvelope(data []byte) (version string, typed bool, returnErr error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	token, err := decoder.Token()
+	if err != nil {
+		return "", false, nil
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok || delimiter != '{' {
+		return "", false, nil
+	}
+
+	var hasVersion, hasTypedFields bool
+	for decoder.More() {
+		fieldToken, err := decoder.Token()
+		if err != nil {
+			return "", false, nil
+		}
+		field, ok := fieldToken.(string)
+		if !ok {
+			return "", false, nil
+		}
+		switch {
+		case strings.EqualFold(field, "baselineSchemaVersion"):
+			if hasVersion {
+				return "", false, fmt.Errorf("invalid baseline schema version discriminator: duplicate case-folded field")
+			}
+			hasVersion = true
+			version, err = decodeSnapshotVersionToken(decoder)
+			if err != nil {
+				return "", false, err
+			}
+		case isTypedSnapshotField(field):
+			hasTypedFields = true
+			if err := skipJSONValue(decoder); err != nil {
+				return "", false, nil
+			}
+		default:
+			if err := skipJSONValue(decoder); err != nil {
+				return "", false, nil
+			}
 		}
 	}
-	return false
+	if _, err := decoder.Token(); err != nil {
+		return "", false, nil
+	}
+	if !hasVersion {
+		if hasTypedFields {
+			return "", false, fmt.Errorf("invalid baseline schema version discriminator: typed envelope requires a version")
+		}
+		return "", false, nil
+	}
+	if strings.TrimSpace(version) == "" {
+		if hasTypedFields {
+			return "", false, fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
+		}
+		return "", false, nil
+	}
+	return version, true, nil
 }
 
-func snapshotField(fields map[string]json.RawMessage, name string) (json.RawMessage, bool) {
-	for field, value := range fields {
-		if strings.EqualFold(field, name) {
-			return value, true
+func decodeSnapshotVersionToken(decoder *json.Decoder) (string, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return "", err
+	}
+	if delimiter, ok := token.(json.Delim); ok {
+		if err := skipJSONDelimitedValue(decoder, delimiter); err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("invalid baseline schema version discriminator: must be a string")
+	}
+	if token == nil {
+		return "", fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
+	}
+	if _, ok := token.(float64); ok {
+		return "", fmt.Errorf("invalid baseline schema version discriminator: json: cannot unmarshal number into Go value of type string")
+	}
+	version, ok := token.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid baseline schema version discriminator: must be a string")
+	}
+	return version, nil
+}
+
+func isTypedSnapshotField(field string) bool {
+	return strings.EqualFold(field, "key") || strings.EqualFold(field, "savedAt") || strings.EqualFold(field, "report")
+}
+
+func skipJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	if delimiter, ok := token.(json.Delim); ok {
+		return skipJSONDelimitedValue(decoder, delimiter)
+	}
+	return nil
+}
+
+func skipJSONDelimitedValue(decoder *json.Decoder, delimiter json.Delim) error {
+	for decoder.More() {
+		if delimiter == '{' {
+			if _, err := decoder.Token(); err != nil {
+				return err
+			}
+		}
+		if err := skipJSONValue(decoder); err != nil {
+			return err
 		}
 	}
-	return nil, false
+	_, err := decoder.Token()
+	return err
 }
 
 func LoadConfiguredSnapshot[T any](path string, store SnapshotStore[T]) (T, string, error) {

--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -80,8 +80,12 @@ func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, st
 			var zero T
 			return zero, "", err
 		}
-		if typed {
-			return decodeTypedSnapshot(data, version, options)
+	if typed {
+		if version != SnapshotSchemaVersion {
+			var zero T
+			return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)
+		}
+		return decodeTypedSnapshot(data, version, options)
 		}
 	}
 
@@ -97,17 +101,17 @@ func DecodeSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (T, st
 }
 
 func typedSnapshotVersion(fields map[string]json.RawMessage) (string, bool, error) {
-	rawVersion, ok := fields["baselineSchemaVersion"]
+	rawVersion, ok := snapshotField(fields, "baselineSchemaVersion")
 	if !ok {
 		return "", false, nil
 	}
 
+	if strings.TrimSpace(string(rawVersion)) == "null" {
+		return "", false, fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
+	}
 	var version string
 	if err := json.Unmarshal(rawVersion, &version); err != nil {
 		return "", false, fmt.Errorf("invalid baseline schema version discriminator: %w", err)
-	}
-	if strings.TrimSpace(string(rawVersion)) == "null" {
-		return "", false, fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
 	}
 	if strings.TrimSpace(version) == "" {
 		if hasTypedSnapshotFields(fields) {
@@ -124,10 +128,6 @@ func decodeTypedSnapshot[T any](data []byte, version string, options SnapshotDec
 		var zero T
 		return zero, "", fmt.Errorf("decode typed baseline snapshot: %w", err)
 	}
-	if version != SnapshotSchemaVersion {
-		var zero T
-		return zero, "", snapshotSchemaError(version, options.UnsupportedSchema)
-	}
 	v := snapshot.Report
 	if options.Repair != nil {
 		v = options.Repair(v)
@@ -137,11 +137,20 @@ func decodeTypedSnapshot[T any](data []byte, version string, options SnapshotDec
 
 func hasTypedSnapshotFields(fields map[string]json.RawMessage) bool {
 	for _, field := range []string{"key", "savedAt", "report"} {
-		if _, ok := fields[field]; ok {
+		if _, ok := snapshotField(fields, field); ok {
 			return true
 		}
 	}
 	return false
+}
+
+func snapshotField(fields map[string]json.RawMessage, name string) (json.RawMessage, bool) {
+	for field, value := range fields {
+		if strings.EqualFold(field, name) {
+			return value, true
+		}
+	}
+	return nil, false
 }
 
 func LoadConfiguredSnapshot[T any](path string, store SnapshotStore[T]) (T, string, error) {

--- a/internal/baseline/snapshot.go
+++ b/internal/baseline/snapshot.go
@@ -1,7 +1,6 @@
 package baseline
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -112,117 +111,219 @@ func decodeTypedSnapshot[T any](data []byte, options SnapshotDecodeOptions[T]) (
 }
 
 func inspectSnapshotEnvelope(data []byte) (version string, typed bool, returnErr error) {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	token, err := decoder.Token()
-	if err != nil {
+	index := skipSnapshotJSONWhitespace(data, 0)
+	if index == len(data) || data[index] != '{' {
 		return "", false, nil
 	}
-	delimiter, ok := token.(json.Delim)
-	if !ok || delimiter != '{' {
-		return "", false, nil
-	}
-
-	var hasVersion, hasTypedFields bool
-	for decoder.More() {
-		fieldToken, err := decoder.Token()
+	state := snapshotEnvelopeState{}
+	index++
+	for {
+		next, done, err := inspectSnapshotEnvelopeField(data, index, &state)
 		if err != nil {
-			return "", false, nil
-		}
-		field, ok := fieldToken.(string)
-		if !ok {
-			return "", false, nil
-		}
-		switch {
-		case strings.EqualFold(field, "baselineSchemaVersion"):
-			if hasVersion {
-				return "", false, fmt.Errorf("invalid baseline schema version discriminator: duplicate case-folded field")
-			}
-			hasVersion = true
-			version, err = decodeSnapshotVersionToken(decoder)
-			if err != nil {
+			if strings.HasPrefix(err.Error(), "invalid baseline schema version discriminator:") {
 				return "", false, err
 			}
-		case isTypedSnapshotField(field):
-			hasTypedFields = true
-			if err := skipJSONValue(decoder); err != nil {
-				return "", false, nil
-			}
-		default:
-			if err := skipJSONValue(decoder); err != nil {
-				return "", false, nil
-			}
+			return snapshotEnvelopeInspectionError(state.hasVersion || state.hasTypedFields, err)
+		}
+		index = next
+		if done {
+			break
 		}
 	}
-	if _, err := decoder.Token(); err != nil {
-		return "", false, nil
+	if skipSnapshotJSONWhitespace(data, index) != len(data) {
+		return snapshotEnvelopeInspectionError(state.hasVersion || state.hasTypedFields, fmt.Errorf("unexpected trailing JSON data"))
 	}
-	if !hasVersion {
-		if hasTypedFields {
+	return snapshotEnvelopeResult(state)
+}
+
+func snapshotEnvelopeResult(state snapshotEnvelopeState) (string, bool, error) {
+	if !state.hasVersion {
+		if state.hasTypedFields {
 			return "", false, fmt.Errorf("invalid baseline schema version discriminator: typed envelope requires a version")
 		}
 		return "", false, nil
 	}
-	if strings.TrimSpace(version) == "" {
-		if hasTypedFields {
+	if strings.TrimSpace(state.version) == "" {
+		if state.hasTypedFields {
 			return "", false, fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
 		}
 		return "", false, nil
 	}
-	return version, true, nil
+	return state.version, true, nil
 }
 
-func decodeSnapshotVersionToken(decoder *json.Decoder) (string, error) {
-	token, err := decoder.Token()
+type snapshotEnvelopeState struct {
+	version        string
+	hasVersion     bool
+	hasTypedFields bool
+}
+
+func inspectSnapshotEnvelopeField(data []byte, index int, state *snapshotEnvelopeState) (int, bool, error) {
+	index = skipSnapshotJSONWhitespace(data, index)
+	if index >= len(data) {
+		return index, false, fmt.Errorf("unexpected end of JSON object")
+	}
+	if data[index] == '}' {
+		return index + 1, true, nil
+	}
+	field, next, err := decodeSnapshotJSONString(data, index)
 	if err != nil {
-		return "", err
+		return index, false, err
 	}
-	if delimiter, ok := token.(json.Delim); ok {
-		if err := skipJSONDelimitedValue(decoder, delimiter); err != nil {
-			return "", err
+	index = skipSnapshotJSONWhitespace(data, next)
+	if index >= len(data) || data[index] != ':' {
+		return index, false, fmt.Errorf("expected colon after field %q", field)
+	}
+	index++
+	if strings.EqualFold(field, "baselineSchemaVersion") {
+		if state.hasVersion {
+			return index, false, fmt.Errorf("invalid baseline schema version discriminator: duplicate case-folded field")
 		}
-		return "", fmt.Errorf("invalid baseline schema version discriminator: must be a string")
+		state.hasVersion = true
+		state.version, index, err = decodeSnapshotVersion(data, index)
+	} else {
+		state.hasTypedFields = state.hasTypedFields || isTypedSnapshotField(field)
+		index, err = skipSnapshotJSONValue(data, index)
 	}
-	if token == nil {
-		return "", fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
+	if err != nil {
+		return index, false, err
 	}
-	if _, ok := token.(float64); ok {
-		return "", fmt.Errorf("invalid baseline schema version discriminator: json: cannot unmarshal number into Go value of type string")
+	return finishSnapshotEnvelopeField(data, index)
+}
+
+func finishSnapshotEnvelopeField(data []byte, index int) (int, bool, error) {
+	index = skipSnapshotJSONWhitespace(data, index)
+	if index >= len(data) {
+		return index, false, fmt.Errorf("unexpected end of JSON object")
 	}
-	version, ok := token.(string)
-	if !ok {
-		return "", fmt.Errorf("invalid baseline schema version discriminator: must be a string")
+	if data[index] == ',' {
+		return index + 1, false, nil
 	}
-	return version, nil
+	if data[index] == '}' {
+		return index + 1, true, nil
+	}
+	return index, false, fmt.Errorf("expected comma or closing brace")
+}
+
+func snapshotEnvelopeInspectionError(typed bool, err error) (string, bool, error) {
+	if typed {
+		return "", false, fmt.Errorf("inspect typed baseline snapshot envelope: %w", err)
+	}
+	return "", false, nil
+}
+
+func decodeSnapshotVersion(data []byte, index int) (string, int, error) {
+	index = skipSnapshotJSONWhitespace(data, index)
+	if index >= len(data) {
+		return "", index, fmt.Errorf("invalid baseline schema version discriminator: unexpected end of JSON")
+	}
+	if len(data)-index >= len("null") && string(data[index:index+len("null")]) == "null" {
+		return "", index + len("null"), fmt.Errorf("invalid baseline schema version discriminator: must be a non-empty string")
+	}
+	if data[index] != '"' {
+		next, err := skipSnapshotJSONValue(data, index)
+		if err != nil {
+			return "", index, fmt.Errorf("invalid baseline schema version discriminator: %w", err)
+		}
+		if data[index] == '-' || (data[index] >= '0' && data[index] <= '9') {
+			return "", next, fmt.Errorf("invalid baseline schema version discriminator: json: cannot unmarshal number into Go value of type string")
+		}
+		return "", next, fmt.Errorf("invalid baseline schema version discriminator: must be a string")
+	}
+	version, next, err := decodeSnapshotJSONString(data, index)
+	if err != nil {
+		return "", index, fmt.Errorf("invalid baseline schema version discriminator: %w", err)
+	}
+	return version, next, nil
+}
+
+func skipSnapshotJSONWhitespace(data []byte, index int) int {
+	for index < len(data) && (data[index] == ' ' || data[index] == '\n' || data[index] == '\r' || data[index] == '\t') {
+		index++
+	}
+	return index
+}
+
+func decodeSnapshotJSONString(data []byte, index int) (string, int, error) {
+	next, err := skipSnapshotJSONString(data, index)
+	if err != nil {
+		return "", index, err
+	}
+	var value string
+	if err := json.Unmarshal(data[index:next], &value); err != nil {
+		return "", index, err
+	}
+	return value, next, nil
+}
+
+func skipSnapshotJSONString(data []byte, index int) (int, error) {
+	if index >= len(data) || data[index] != '"' {
+		return index, fmt.Errorf("expected JSON string")
+	}
+	for index++; index < len(data); index++ {
+		switch data[index] {
+		case '"':
+			return index + 1, nil
+		case '\\':
+			index++
+			if index >= len(data) {
+				return index, fmt.Errorf("unterminated JSON string escape")
+			}
+		case '\n', '\r':
+			return index, fmt.Errorf("invalid control character in JSON string")
+		}
+	}
+	return index, fmt.Errorf("unterminated JSON string")
+}
+
+func skipSnapshotJSONValue(data []byte, index int) (int, error) {
+	index = skipSnapshotJSONWhitespace(data, index)
+	if index >= len(data) {
+		return index, fmt.Errorf("unexpected end of JSON value")
+	}
+	depth := 0
+	for current := index; current < len(data); current++ {
+		if data[current] == '"' {
+			next, err := skipSnapshotJSONString(data, current)
+			if err != nil {
+				return next, err
+			}
+			current = next - 1
+			continue
+		}
+		next, done := skipSnapshotJSONValueDelimiter(data[current], current, &depth)
+		if done {
+			return next, nil
+		}
+	}
+	if depth != 0 {
+		return len(data), fmt.Errorf("unexpected end of JSON value")
+	}
+	return len(data), nil
+}
+
+func skipSnapshotJSONValueDelimiter(value byte, index int, depth *int) (int, bool) {
+	switch value {
+	case '{', '[':
+		*depth++
+	case '}', ']':
+		if *depth == 0 {
+			return index, true
+		}
+		*depth--
+		if *depth == 0 {
+			return index + 1, true
+		}
+	case ',', ' ', '\n', '\r', '\t':
+		if *depth == 0 {
+			return index, true
+		}
+	}
+	return 0, false
 }
 
 func isTypedSnapshotField(field string) bool {
 	return strings.EqualFold(field, "key") || strings.EqualFold(field, "savedAt") || strings.EqualFold(field, "report")
-}
-
-func skipJSONValue(decoder *json.Decoder) error {
-	token, err := decoder.Token()
-	if err != nil {
-		return err
-	}
-	if delimiter, ok := token.(json.Delim); ok {
-		return skipJSONDelimitedValue(decoder, delimiter)
-	}
-	return nil
-}
-
-func skipJSONDelimitedValue(decoder *json.Decoder, delimiter json.Delim) error {
-	for decoder.More() {
-		if delimiter == '{' {
-			if _, err := decoder.Token(); err != nil {
-				return err
-			}
-		}
-		if err := skipJSONValue(decoder); err != nil {
-			return err
-		}
-	}
-	_, err := decoder.Token()
-	return err
 }
 
 func LoadConfiguredSnapshot[T any](path string, store SnapshotStore[T]) (T, string, error) {

--- a/internal/baseline/snapshot_inspector_test.go
+++ b/internal/baseline/snapshot_inspector_test.go
@@ -1,0 +1,65 @@
+package baseline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeSnapshotSkipsLargeReportPayload(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{"baselineSchemaVersion":"1.0.0","report":{"payload":"` + strings.Repeat("x", 1<<20) + `"}}`)
+	_, _, err := DecodeSnapshot(data, normalizedSnapshotDecodeOptions())
+	if err != nil {
+		t.Fatalf("DecodeSnapshot() error = %v", err)
+	}
+}
+
+func TestDecodeSnapshotRejectsTypedSyntaxAfterRecognition(t *testing.T) {
+	t.Parallel()
+
+	for _, data := range []string{
+		`{"report":"unterminated}`,
+		`{"baselineSchemaVersion":"1.0.0"`,
+		`{"report":{},"\\q":true}`,
+		`{"baselineSchemaVersion":"1.0.0" "report":{"value":"snapshot"}}`,
+		`{"baselineSchemaVersion":"1.0.0","report":{"value":"snapshot"}} trailing`,
+	} {
+		if _, _, err := DecodeSnapshot([]byte(data), normalizedSnapshotDecodeOptions()); err == nil {
+			t.Fatalf("DecodeSnapshot(%q) returned nil error", data)
+		}
+	}
+}
+
+func TestDecodeSnapshotExercisesEnvelopeValueScanning(t *testing.T) {
+	t.Parallel()
+
+	for _, data := range []string{
+		`[]`,
+		`{"`,
+		`{"report"}`,
+		`{"baselineSchemaVersion":`,
+		`{"baselineSchemaVersion":{`,
+		`{"baselineSchemaVersion":true}`,
+		`{"baselineSchemaVersion":"\q"}`,
+		`{"\q":true}`,
+		`{"baselineSchemaVersion":"value\`,
+		"{\"baselineSchemaVersion\":\"value\n\"}",
+		`{}`,
+		`{"report":`,
+		`{"report":true`,
+		`{"report":"value\"quoted","baselineSchemaVersion":"1.0.0"}`,
+		`{"report":{"items":[1,"two",{"nested":true}]},"baselineSchemaVersion":"1.0.0"}`,
+		`{"report":1e1000,"baselineSchemaVersion":"1.0.0"}`,
+		`{"report":true,"baselineSchemaVersion":"1.0.0"}`,
+		`{"report":null,"baselineSchemaVersion":"1.0.0"}`,
+		`{"report": ["value"], "baselineSchemaVersion":"1.0.0"}`,
+		`{"report":"value\\","baselineSchemaVersion":"1.0.0"}`,
+		"{\"report\":\"value\n\",\"baselineSchemaVersion\":\"1.0.0\"}",
+		`{"report":{},"\q":true}`,
+	} {
+		if _, _, err := DecodeSnapshot([]byte(data), normalizedSnapshotDecodeOptions()); err != nil {
+			continue
+		}
+	}
+}

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -206,6 +206,41 @@ func TestDecodeSnapshotSchemaVersionCompatibility(t *testing.T) {
 	}
 }
 
+func TestDecodeSnapshotRejectsMalformedDiscriminatorsWithoutLegacyFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []snapshotDecodeCompatibilityCase{
+		{
+			name:    "number discriminator",
+			data:    `{"baselineSchemaVersion":1,"value":"legacy"}`,
+			wantErr: "invalid baseline schema version discriminator: json: cannot unmarshal number into Go value of type string",
+		},
+		{
+			name:    "null discriminator",
+			data:    `{"baselineSchemaVersion":null,"value":"legacy"}`,
+			wantErr: "invalid baseline schema version discriminator: must be a non-empty string",
+		},
+		{
+			name:    "blank typed discriminator",
+			data:    `{"baselineSchemaVersion":" ","report":{"value":"snapshot"}}`,
+			wantErr: "invalid baseline schema version discriminator: must be a non-empty string",
+		},
+		{
+			name:    "malformed typed envelope",
+			data:    `{"baselineSchemaVersion":"1.0.0","key":1,"value":"legacy"}`,
+			wantErr: "decode typed baseline snapshot: json: cannot unmarshal number into Go struct field Snapshot[github.com/ben-ranford/lopper/internal/baseline.testSnapshotReport].key of type string",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assertSnapshotDecodeCompatibility(t, tc)
+		})
+	}
+}
+
 func TestDecodeSnapshotRejectsUnsupportedSchemaWithCustomError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -232,6 +232,16 @@ func TestDecodeSnapshotRejectsMalformedDiscriminatorsWithoutLegacyFallback(t *te
 			wantKey:   "label:case",
 		},
 		{
+			name:    "duplicate case folded discriminator",
+			data:    `{"baselineSchemaVersion":"1.0.0","BaselineSchemaVersion":"9.9.9","report":{"value":"snapshot"}}`,
+			wantErr: "invalid baseline schema version discriminator: duplicate case-folded field",
+		},
+		{
+			name:    "typed envelope missing discriminator",
+			data:    `{"key":"label:missing","report":{"value":"snapshot"}}`,
+			wantErr: "invalid baseline schema version discriminator: typed envelope requires a version",
+		},
+		{
 			name:    "blank typed discriminator",
 			data:    `{"baselineSchemaVersion":" ","report":{"value":"snapshot"}}`,
 			wantErr: "invalid baseline schema version discriminator: must be a non-empty string",
@@ -248,6 +258,45 @@ func TestDecodeSnapshotRejectsMalformedDiscriminatorsWithoutLegacyFallback(t *te
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assertSnapshotDecodeCompatibility(t, tc)
+		})
+	}
+}
+
+func TestInspectSnapshotEnvelopeScansLargeReport(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{"baselineSchemaVersion":"1.0.0","report":{"payload":"` + strings.Repeat("x", 1<<20) + `"}}`)
+	version, typed, err := inspectSnapshotEnvelope(data)
+	if err != nil || !typed || version != SnapshotSchemaVersion {
+		t.Fatalf("inspectSnapshotEnvelope() = %q, %v, %v", version, typed, err)
+	}
+}
+
+func TestInspectSnapshotEnvelopeMalformedValueBranches(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name    string
+		data    string
+		wantErr bool
+	}{
+		{name: "empty input", data: ""},
+		{name: "top level array", data: "[]"},
+		{name: "incomplete object key", data: `{"`},
+		{name: "incomplete typed field", data: `{"report":`},
+		{name: "incomplete nested typed field key", data: `{"report":{"`},
+		{name: "incomplete ordinary field", data: `{"value":`},
+		{name: "incomplete discriminator", data: `{"baselineSchemaVersion":`, wantErr: true},
+		{name: "object discriminator", data: `{"baselineSchemaVersion":{"nested":true}}`, wantErr: true},
+		{name: "incomplete object discriminator", data: `{"baselineSchemaVersion":{`, wantErr: true},
+		{name: "boolean discriminator", data: `{"baselineSchemaVersion":true}`, wantErr: true},
+		{name: "nested report arrays", data: `{"baselineSchemaVersion":"1.0.0","report":{"items":[{"value":1}]}}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := inspectSnapshotEnvelope([]byte(test.data))
+			if (err != nil) != test.wantErr {
+				t.Fatalf("inspectSnapshotEnvelope(%q) error = %v, want error=%v", test.data, err, test.wantErr)
+			}
 		})
 	}
 }

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -251,6 +251,12 @@ func TestDecodeSnapshotRejectsMalformedDiscriminatorsWithoutLegacyFallback(t *te
 			data:    `{"baselineSchemaVersion":"1.0.0","key":1,"value":"legacy"}`,
 			wantErr: "decode typed baseline snapshot: json: cannot unmarshal number into Go struct field Snapshot[github.com/ben-ranford/lopper/internal/baseline.testSnapshotReport].key of type string",
 		},
+		{
+			name:      "large unknown number before typed envelope",
+			data:      `{"extension":1e1000,"baselineSchemaVersion":"1.0.0","key":"label:typed","report":{"value":"snapshot"}}`,
+			wantKey:   "label:typed",
+			wantValue: "SNAPSHOT",
+		},
 	}
 
 	for _, tc := range tests {
@@ -258,45 +264,6 @@ func TestDecodeSnapshotRejectsMalformedDiscriminatorsWithoutLegacyFallback(t *te
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assertSnapshotDecodeCompatibility(t, tc)
-		})
-	}
-}
-
-func TestInspectSnapshotEnvelopeScansLargeReport(t *testing.T) {
-	t.Parallel()
-
-	data := []byte(`{"baselineSchemaVersion":"1.0.0","report":{"payload":"` + strings.Repeat("x", 1<<20) + `"}}`)
-	version, typed, err := inspectSnapshotEnvelope(data)
-	if err != nil || !typed || version != SnapshotSchemaVersion {
-		t.Fatalf("inspectSnapshotEnvelope() = %q, %v, %v", version, typed, err)
-	}
-}
-
-func TestInspectSnapshotEnvelopeMalformedValueBranches(t *testing.T) {
-	t.Parallel()
-
-	for _, test := range []struct {
-		name    string
-		data    string
-		wantErr bool
-	}{
-		{name: "empty input", data: ""},
-		{name: "top level array", data: "[]"},
-		{name: "incomplete object key", data: `{"`},
-		{name: "incomplete typed field", data: `{"report":`},
-		{name: "incomplete nested typed field key", data: `{"report":{"`},
-		{name: "incomplete ordinary field", data: `{"value":`},
-		{name: "incomplete discriminator", data: `{"baselineSchemaVersion":`, wantErr: true},
-		{name: "object discriminator", data: `{"baselineSchemaVersion":{"nested":true}}`, wantErr: true},
-		{name: "incomplete object discriminator", data: `{"baselineSchemaVersion":{`, wantErr: true},
-		{name: "boolean discriminator", data: `{"baselineSchemaVersion":true}`, wantErr: true},
-		{name: "nested report arrays", data: `{"baselineSchemaVersion":"1.0.0","report":{"items":[{"value":1}]}}`},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			_, _, err := inspectSnapshotEnvelope([]byte(test.data))
-			if (err != nil) != test.wantErr {
-				t.Fatalf("inspectSnapshotEnvelope(%q) error = %v, want error=%v", test.data, err, test.wantErr)
-			}
 		})
 	}
 }

--- a/internal/baseline/snapshot_test.go
+++ b/internal/baseline/snapshot_test.go
@@ -221,6 +221,17 @@ func TestDecodeSnapshotRejectsMalformedDiscriminatorsWithoutLegacyFallback(t *te
 			wantErr: "invalid baseline schema version discriminator: must be a non-empty string",
 		},
 		{
+			name:    "case insensitive null discriminator",
+			data:    `{"BaselineSchemaVersion":null,"value":"legacy"}`,
+			wantErr: "invalid baseline schema version discriminator: must be a non-empty string",
+		},
+		{
+			name:      "case insensitive typed discriminator",
+			data:      `{"BaselineSchemaVersion":"1.0.0","Key":"label:case","Report":{"value":"snapshot"}}`,
+			wantValue: "SNAPSHOT",
+			wantKey:   "label:case",
+		},
+		{
 			name:    "blank typed discriminator",
 			data:    `{"baselineSchemaVersion":" ","report":{"value":"snapshot"}}`,
 			wantErr: "invalid baseline schema version discriminator: must be a non-empty string",
@@ -244,7 +255,7 @@ func TestDecodeSnapshotRejectsMalformedDiscriminatorsWithoutLegacyFallback(t *te
 func TestDecodeSnapshotRejectsUnsupportedSchemaWithCustomError(t *testing.T) {
 	t.Parallel()
 
-	_, _, err := DecodeSnapshot([]byte(`{"baselineSchemaVersion":"9.9.9","key":"label:bad","report":{"value":"x"}}`), SnapshotDecodeOptions[testSnapshotReport]{
+	_, _, err := DecodeSnapshot([]byte(`{"baselineSchemaVersion":"9.9.9","key":1,"report":{"value":"x"}}`), SnapshotDecodeOptions[testSnapshotReport]{
 		DecodeLegacy: decodeTestSnapshotReport,
 		UnsupportedSchema: func(version string) error {
 			return fmt.Errorf("unsupported custom baseline schema version: %s", version)


### PR DESCRIPTION
## Summary

Fixes #1452 by distinguishing a legacy snapshot without typed-envelope fields from a malformed typed snapshot. Malformed typed snapshots previously fell through to legacy decoding, which could accept them as legacy reports.

## Changes

- Detect `baselineSchemaVersion` presence before selecting the decode path.
- Reject null, non-string, and blank typed-envelope discriminators explicitly.
- Preserve legacy compatibility for an otherwise legacy payload with the historical whitespace discriminator field.
- Keep the full discriminator regression matrix in `internal/baseline`, outside the report benchmark package.

## Validation

Commands and checks run:

```bash
GOTOOLCHAIN=go1.26.5 go test ./internal/baseline ./internal/report ./internal/dashboard
```

Additional manual validation:

- Confirmed numeric and null discriminators never invoke legacy fallback.
- Confirmed a blank discriminator is rejected when typed envelope fields are present and legacy compatibility is retained when those fields are absent.

Regression-Test: ./internal/baseline::TestDecodeSnapshotRejectsMalformedDiscriminatorsWithoutLegacyFallback

## Risk and compatibility

- Breaking changes: Malformed typed snapshots that previously decoded through unintended legacy fallback now fail explicitly.
- Migration required: None; valid legacy snapshots remain supported.
- Performance impact: One small JSON-object discriminator inspection during snapshot decode.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
