### PR TITLE
fix(analysis): preserve duplicate import provenance

### DIFF
--- a/internal/analysis/merge.go
+++ b/internal/analysis/merge.go
@@ -457,8 +457,8 @@ func mergeImportUses(left, right []report.ImportUse) []report.ImportUse {
 			current.Locations = append(current.Locations, item.Locations...)
 			current.Provenance = append(current.Provenance, item.Provenance...)
 			current.ConfidenceReasonCodes = append(current.ConfidenceReasonCodes, item.ConfidenceReasonCodes...)
-			// A merged import is only as certain as its least-certain contributing root.
-			if current.ConfidenceScore == 0 || item.ConfidenceScore > 0 && item.ConfidenceScore < current.ConfidenceScore {
+			// Zero is unset; otherwise preserve the lowest non-zero contributing score.
+			if current.ConfidenceScore == 0 || (item.ConfidenceScore > 0 && item.ConfidenceScore < current.ConfidenceScore) {
 				current.ConfidenceScore = item.ConfidenceScore
 			}
 			merged[key] = current

--- a/internal/analysis/merge.go
+++ b/internal/analysis/merge.go
@@ -455,6 +455,12 @@ func mergeImportUses(left, right []report.ImportUse) []report.ImportUse {
 		key := item.Module + "\x00" + item.Name
 		if current, ok := merged[key]; ok {
 			current.Locations = append(current.Locations, item.Locations...)
+			current.Provenance = append(current.Provenance, item.Provenance...)
+			current.ConfidenceReasonCodes = append(current.ConfidenceReasonCodes, item.ConfidenceReasonCodes...)
+			// A merged import is only as certain as its least-certain contributing root.
+			if current.ConfidenceScore == 0 || item.ConfidenceScore > 0 && item.ConfidenceScore < current.ConfidenceScore {
+				current.ConfidenceScore = item.ConfidenceScore
+			}
 			merged[key] = current
 			continue
 		}
@@ -462,6 +468,9 @@ func mergeImportUses(left, right []report.ImportUse) []report.ImportUse {
 	}
 	items := make([]report.ImportUse, 0, len(merged))
 	for _, item := range merged {
+		item.Locations = sortedImportUseLocations(item.Locations)
+		item.Provenance = uniqueSorted(item.Provenance)
+		item.ConfidenceReasonCodes = uniqueSorted(item.ConfidenceReasonCodes)
 		items = append(items, item)
 	}
 	sort.Slice(items, func(i, j int) bool {
@@ -469,6 +478,20 @@ func mergeImportUses(left, right []report.ImportUse) []report.ImportUse {
 			return items[i].Name < items[j].Name
 		}
 		return items[i].Module < items[j].Module
+	})
+	return items
+}
+
+func sortedImportUseLocations(locations []report.Location) []report.Location {
+	items := append([]report.Location(nil), locations...)
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].File != items[j].File {
+			return items[i].File < items[j].File
+		}
+		if items[i].Line != items[j].Line {
+			return items[i].Line < items[j].Line
+		}
+		return items[i].Column < items[j].Column
 	})
 	return items
 }

--- a/internal/analysis/merge_report_families_test.go
+++ b/internal/analysis/merge_report_families_test.go
@@ -44,6 +44,55 @@ func TestMergeReportsCoordinatesFamiliesInStableOrder(t *testing.T) {
 	assertMergedDependencies(t, merged)
 }
 
+func TestMergeImportUsesPreservesProvenanceDeterministically(t *testing.T) {
+	left := []report.ImportUse{{
+		Module:    "lodash",
+		Name:      "map",
+		Locations: []report.Location{{File: "src/z.ts", Line: 3, Column: 1}, {File: "src/a.ts", Line: 9, Column: 2}},
+		Provenance: []string{
+			"workspace/root-b",
+			"shared/barrel",
+		},
+		ConfidenceScore:       82.5,
+		ConfidenceReasonCodes: []string{"static-import", "shared-evidence"},
+	}}
+	right := []report.ImportUse{{
+		Module:    "lodash",
+		Name:      "map",
+		Locations: []report.Location{{File: "src/m.ts", Line: 5, Column: 4}, {File: "src/a.ts", Line: 1, Column: 8}, {File: "src/a.ts", Line: 1, Column: 7}},
+		Provenance: []string{
+			"workspace/root-a",
+			"shared/barrel",
+			"workspace/root-a",
+		},
+		ConfidenceScore:       61.4,
+		ConfidenceReasonCodes: []string{"runtime-evidence", "shared-evidence", "runtime-evidence"},
+	}}
+	want := []report.ImportUse{{
+		Module:                "lodash",
+		Name:                  "map",
+		Locations:             []report.Location{{File: "src/a.ts", Line: 1, Column: 7}, {File: "src/a.ts", Line: 1, Column: 8}, {File: "src/a.ts", Line: 9, Column: 2}, {File: "src/m.ts", Line: 5, Column: 4}, {File: "src/z.ts", Line: 3, Column: 1}},
+		Provenance:            []string{"shared/barrel", "workspace/root-a", "workspace/root-b"},
+		ConfidenceScore:       61.4,
+		ConfidenceReasonCodes: []string{"runtime-evidence", "shared-evidence", "static-import"},
+	}}
+
+	for _, test := range []struct {
+		name  string
+		left  []report.ImportUse
+		right []report.ImportUse
+	}{
+		{name: "left then right", left: left, right: right},
+		{name: "right then left", left: right, right: left},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := mergeImportUses(test.left, test.right); !reflect.DeepEqual(got, want) {
+				t.Fatalf("mergeImportUses() = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
 func TestMergeDependencySuppressesRemovalSignalsWhenUsageIsIncomplete(t *testing.T) {
 	complete := report.DependencyReport{
 		Name:                 "lodash",


### PR DESCRIPTION
## Summary

Preserve import provenance when duplicate module/name records from separate analysis roots are merged. This prevents a later root’s attribution from being discarded while its locations remain.

## Changes

- Union, deduplicate, and sort duplicate import provenance and confidence reason codes.
- Sort merged import locations by file, line, and column so merge output is independent of root order.
- Keep the conservative lower nonzero import confidence score when duplicate records disagree.
- Add a regression covering both input orders and duplicate provenance values.

## Validation

Commands and checks run:

```bash
go test ./internal/analysis -run '^TestMergeImportUsesPreservesProvenanceDeterministically$' -count=1
go test ./internal/analysis -cover -count=1
make ci
```

Additional manual validation:

- Confirmed the regression produces an identical merged record when the two roots are reversed.
- Commit hook completed the repository CI successfully after the coverage regression.

Regression-Test: ./internal/analysis::TestMergeImportUsesPreservesProvenanceDeterministically

## Risk and compatibility

- Breaking changes: None.
- Migration required: No.
- Performance impact: Negligible; only duplicate import records perform small deterministic normalization work.
- Memory benchmark impact: None observed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
