### PR TITLE
fix(portability): define Windows test compilation boundary

### DIFF
--- a/internal/runtime/capture_cov_branches_test.go
+++ b/internal/runtime/capture_cov_branches_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 )
 
@@ -137,26 +136,6 @@ func restoreRuntimeHookState(t *testing.T) {
 			runtimeHookPathsErr = originalErr
 		})
 	})
-}
-
-func TestConfigureRuntimeCommandCancelMapsESRCHToProcessDone(t *testing.T) {
-	cmd := shellCommand(context.Background(), "-c", "sleep 5")
-	configureRuntimeCommand(cmd)
-
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start process: %v", err)
-	}
-	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
-		t.Fatalf("kill process group: %v", err)
-	}
-	if err := cmd.Wait(); err != nil && !errors.Is(err, os.ErrProcessDone) && !strings.Contains(err.Error(), "signal: killed") {
-		t.Fatalf("wait process: %v", err)
-	}
-
-	err := cmd.Cancel()
-	if !errors.Is(err, os.ErrProcessDone) {
-		t.Fatalf("expected ESRCH to map to os.ErrProcessDone, got %v", err)
-	}
 }
 
 func shellCommand(ctx context.Context, args ...string) *exec.Cmd {

--- a/internal/runtime/capture_cov_branches_unix_test.go
+++ b/internal/runtime/capture_cov_branches_unix_test.go
@@ -1,0 +1,33 @@
+//go:build unix
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// Windows has no process-group signal equivalent, so this test remains Unix-only.
+func TestConfigureRuntimeCommandCancelMapsESRCHToProcessDone(t *testing.T) {
+	cmd := shellCommand(context.Background(), "-c", "sleep 5")
+	configureRuntimeCommand(cmd)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start process: %v", err)
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		t.Fatalf("kill process group: %v", err)
+	}
+	if err := cmd.Wait(); err != nil && !errors.Is(err, os.ErrProcessDone) && !strings.Contains(err.Error(), "signal: killed") {
+		t.Fatalf("wait process: %v", err)
+	}
+
+	err := cmd.Cancel()
+	if !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("expected ESRCH to map to os.ErrProcessDone, got %v", err)
+	}
+}

--- a/internal/safeio/write_windows_test.go
+++ b/internal/safeio/write_windows_test.go
@@ -181,8 +181,8 @@ func TestWriteAtomicReplacementWithPinnedTargetFallsBackForReplaceExistingRename
 	if removeCalls != 1 {
 		t.Fatalf("expected one temp cleanup remove, got %d", removeCalls)
 	}
-	if string(targetData) != "after" {
-		t.Fatalf("expected fallback overwrite data, got %q", string(targetData))
+	if string(*targetData) != "after" {
+		t.Fatalf("expected fallback overwrite data, got %q", string(*targetData))
 	}
 }
 

--- a/scripts/windows_compile_test.go
+++ b/scripts/windows_compile_test.go
@@ -4,16 +4,53 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
-func TestAdvisoryTestsCompileForWindows(t *testing.T) {
-	outputPath := filepath.Join(t.TempDir(), "advisory.test.exe")
-	cmd := exec.Command("go", "test", "-c", "-o", outputPath, "./internal/advisory")
-	cmd.Dir = repoPath(t, "")
-	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=windows", "GOARCH=amd64")
+var windowsTestCompilePackages = []string{
+	"./internal/advisory",
+	"./internal/baseline",
+	"./internal/csvsanitize",
+	"./internal/dashboard",
+	"./internal/featureflags",
+	"./internal/gitexec",
+	"./internal/githubaction",
+	"./internal/language",
+	"./internal/notify",
+	"./internal/prmetadata",
+	"./internal/report",
+	"./internal/report/model",
+	"./internal/runtime",
+	"./internal/safeio",
+	"./internal/terminal",
+	"./internal/testsupport",
+	"./internal/testutil",
+	"./internal/thresholds",
+	"./internal/version",
+	"./internal/workspace",
+	"./tools/benchdelta",
+	"./tools/coveragegate",
+	"./tools/featureflag",
+	"./tools/prcheck",
+	"./tools/regressionproof",
+}
 
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("cross-compile advisory tests for Windows: %v\n%s", err, output)
+// Packages that transitively depend on cgo/tree-sitter parsers are deliberately
+// outside this CGO-disabled contract: cmd/lopper, internal/analysis,
+// internal/app, internal/cli, internal/mcp, internal/ui, internal/lang/*, and
+// scripts (whose JVM regression test imports internal/lang/jvm).
+func TestWindowsCompatibleTestsCompile(t *testing.T) {
+	for index, packagePath := range windowsTestCompilePackages {
+		t.Run(packagePath, func(t *testing.T) {
+			outputPath := filepath.Join(t.TempDir(), "windows-"+strconv.Itoa(index)+".test.exe")
+			cmd := exec.Command("go", "test", "-c", "-o", outputPath, packagePath)
+			cmd.Dir = repoPath(t, "")
+			cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=windows", "GOARCH=amd64")
+
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("cross-compile Windows tests: %v\n%s", err, output)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Define and enforce the CGO-disabled Windows test-compilation boundary for packages that do not depend on tree-sitter parser surfaces. This exposes Unix-only test code during cross-compilation without claiming Windows support for excluded cgo packages.

## Changes

- Cross-compile the explicit Windows-compatible package set in a deterministic scripts regression.
- Keep cgo/tree-sitter-dependent command, analysis, app, CLI, MCP, UI, language, and scripts surfaces explicitly outside the contract.
- Move the Unix process-group signal assertion behind a narrow `unix` build constraint.
- Correct the Windows-only safeio fallback test’s pointer assertion so its test binary compiles.

## Validation

Commands and checks run:

```bash
go test ./scripts -run '^TestWindowsCompatibleTestsCompile$' -count=1
go test ./internal/runtime ./internal/safeio
go test ./internal/runtime ./internal/safeio -cover -count=1
make ci
```

Additional manual validation:

- Verified each declared package cross-compiles with `CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go test -c`.
- Confirmed tree-sitter-dependent surfaces fail under that configuration and remain documented exclusions rather than silent skips.

Regression-Test: ./scripts::TestWindowsCompatibleTestsCompile

## Risk and compatibility

- Breaking changes: None.
- Migration required: No.
- Performance impact: CI compiles 25 cached Windows test binaries; no runtime behavior changes.
- Memory benchmark impact: None observed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
