### PR TITLE
fix(workspace): support SHA-256 baseline keys

### DIFF
--- a/internal/app/app_save_baseline_test.go
+++ b/internal/app/app_save_baseline_test.go
@@ -118,6 +118,25 @@ func TestResolveCurrentBaselineKeyBranches(t *testing.T) {
 	}
 }
 
+func TestResolveCurrentBaselineKeySupportsSHA256Repository(t *testing.T) {
+	repo := t.TempDir()
+	sha := strings.Repeat("a", 64)
+	gitDir := filepath.Join(repo, ".git")
+	if err := os.MkdirAll(filepath.Join(gitDir, "refs", "heads"), 0o755); err != nil {
+		t.Fatalf("create SHA-256 git refs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o600); err != nil {
+		t.Fatalf("write SHA-256 HEAD: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "refs", "heads", "main"), []byte(sha+"\n"), 0o600); err != nil {
+		t.Fatalf("write SHA-256 ref: %v", err)
+	}
+
+	if got := resolveCurrentBaselineKey(repo); got != "commit:"+sha {
+		t.Fatalf("SHA-256 baseline key = %q, want %q", got, "commit:"+sha)
+	}
+}
+
 func TestSaveBaselineIfNeededAlreadyExistsError(t *testing.T) {
 	application := &App{Formatter: report.NewFormatter()}
 	base := report.Report{SchemaVersion: "0.1.0", RepoPath: "."}

--- a/internal/workspace/git_refs.go
+++ b/internal/workspace/git_refs.go
@@ -90,7 +90,7 @@ func candidateGitDirs(gitDir string) []string {
 }
 
 func validSHA(value string) bool {
-	if len(value) != 40 {
+	if len(value) != 40 && len(value) != 64 {
 		return false
 	}
 	for _, r := range value {

--- a/internal/workspace/workspace_commit_test.go
+++ b/internal/workspace/workspace_commit_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -76,6 +77,74 @@ func TestCurrentCommitSHADetachedHead(t *testing.T) {
 	}
 	if sha != shaTopic {
 		t.Fatalf(expectedGotFmt, shaTopic, sha)
+	}
+}
+
+func TestCurrentCommitSHASupportsSHA256References(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, gitDir string)
+	}{
+		{
+			name: "loose ref",
+			setup: func(t *testing.T, gitDir string) {
+				mustWrite(t, filepath.Join(gitDir, "HEAD"), "ref: "+mainRefPath+"\n")
+				mustWrite(t, filepath.Join(gitDir, "refs", "heads", "main"), sha256Main+"\n")
+			},
+		},
+		{
+			name: "packed ref",
+			setup: func(t *testing.T, gitDir string) {
+				mustWrite(t, filepath.Join(gitDir, "HEAD"), "ref: "+mainRefPath+"\n")
+				mustWrite(t, filepath.Join(gitDir, packedRefsFile), sha256Main+" "+mainRefPath+"\n")
+			},
+		},
+		{
+			name: "detached HEAD",
+			setup: func(t *testing.T, gitDir string) {
+				mustWrite(t, filepath.Join(gitDir, "HEAD"), sha256Main+"\n")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			gitDir := filepath.Join(repo, ".git")
+			tc.setup(t, gitDir)
+
+			sha, err := CurrentCommitSHA(repo)
+			if err != nil {
+				t.Fatalf("resolve SHA-256 commit: %v", err)
+			}
+			if sha != sha256Main {
+				t.Fatalf(expectedGotFmt, sha256Main, sha)
+			}
+		})
+	}
+}
+
+func TestCurrentCommitSHASupportsSHA256Repository(t *testing.T) {
+	repo := t.TempDir()
+	if output, err := exec.Command("git", "init", "--object-format=sha256", repo).CombinedOutput(); err != nil {
+		t.Skipf("Git does not support SHA-256 repositories: %v\n%s", err, output)
+	}
+	for _, args := range [][]string{
+		{"-C", repo, "config", "user.email", "test@example.com"},
+		{"-C", repo, "config", "user.name", "Lopper Test"},
+		{"-C", repo, "commit", "--allow-empty", "-m", "initial"},
+	} {
+		if output, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+
+	sha, err := CurrentCommitSHA(repo)
+	if err != nil {
+		t.Fatalf("resolve SHA-256 repository commit: %v", err)
+	}
+	if len(sha) != 64 || !validSHA(sha) {
+		t.Fatalf("SHA-256 repository commit = %q, want valid 64-character object ID", sha)
 	}
 }
 
@@ -232,5 +301,8 @@ func TestValidSHA(t *testing.T) {
 	}
 	if validSHA("abc123") {
 		t.Fatalf("expected short sha to be invalid")
+	}
+	if !validSHA(sha256Main) {
+		t.Fatalf("expected valid SHA-256 commit ID")
 	}
 }

--- a/internal/workspace/workspace_test_helpers_test.go
+++ b/internal/workspace/workspace_test_helpers_test.go
@@ -11,6 +11,7 @@ const (
 	shaMain        = "1111111111111111111111111111111111111111"
 	shaTopic       = "2222222222222222222222222222222222222222"
 	shaHex         = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	sha256Main     = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	expectedGotFmt = "expected %q, got %q"
 	packedRefsFile = "packed-refs"
 	mainRefPath    = "refs/heads/main"


### PR DESCRIPTION
## Summary

Closes #1355. Enables automatic commit-keyed baseline stores in SHA-256 Git repositories.

## Changes

- Accept full 40-character SHA-1 and 64-character SHA-256 commit IDs in the shared workspace ref resolver.
- Cover SHA-256 loose refs, packed refs, detached HEAD, a real SHA-256 Git repository, and automatic baseline-key generation.

## Validation

Commands and checks run:

```bash
go test ./internal/workspace ./internal/app -run "TestCurrentCommitSHASupportsSHA256|TestValidSHA|TestResolveCurrentBaselineKeySupportsSHA256Repository" -count=1
make ci
```

Additional manual validation:

- The real SHA-256 repository fixture resolves a valid 64-character current commit.

Regression-Test: ./internal/app::TestResolveCurrentBaselineKeySupportsSHA256Repository

## Risk and compatibility

- Breaking changes: No.
- Migration required: No.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review