### PR TITLE
fix(release): generate VS Code extension release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,63 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Checkout release-please PR
+        if: ${{ github.event_name != 'workflow_dispatch' && steps.release.outputs.prs_created == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ fromJSON(steps.release.outputs.prs)[0].headBranchName }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Checkout trusted release-notes tooling
+        if: ${{ github.event_name != 'workflow_dispatch' && steps.release.outputs.prs_created == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          ref: ${{ steps.trusted_main.outputs.trusted_main_sha }}
+          path: .trusted-release-notes-tooling
+
+      - name: Refresh VS Code extension release notes
+        if: ${{ github.event_name != 'workflow_dispatch' && steps.release.outputs.prs_created == 'true' }}
+        id: refresh_release_notes
+        env:
+          RELEASE_PLEASE_PRS: ${{ steps.release.outputs.prs }}
+        run: |
+          set -euo pipefail
+          release_pr_branch="$(jq -er '.[0].headBranchName' <<<"${RELEASE_PLEASE_PRS}")"
+          expected_branch="release-please--branches--${GITHUB_REF_NAME}"
+          if [ "${release_pr_branch}" != "${expected_branch}" ]; then
+            echo "::error::Refusing to update unexpected release-please branch ${release_pr_branch}." >&2
+            exit 1
+          fi
+          previous_tag="$(git tag --merged HEAD --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)"
+          if [ -z "${previous_tag}" ]; then
+            echo "::error::No previous stable tag is reachable from the release-please PR." >&2
+            exit 1
+          fi
+          python3 .trusted-release-notes-tooling/scripts/vscode_release_notes.py --repo "$GITHUB_WORKSPACE" --previous-tag "${previous_tag}" --date "$(date -u +%F)"
+          python3 .trusted-release-notes-tooling/scripts/vscode_release_notes.py --repo "$GITHUB_WORKSPACE" --check
+          if git diff --quiet -- extensions/vscode-lopper/CHANGELOG.md; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add extensions/vscode-lopper/CHANGELOG.md
+          git commit -m "docs(vscode): refresh release notes"
+          echo 'changed=true' >> "$GITHUB_OUTPUT"
+
+      - name: Push refreshed VS Code extension release notes
+        if: ${{ github.event_name != 'workflow_dispatch' && steps.release.outputs.prs_created == 'true' && steps.refresh_release_notes.outputs.changed == 'true' }}
+        env:
+          PUSH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}
+          RELEASE_PLEASE_PRS: ${{ steps.release.outputs.prs }}
+        run: |
+          set -euo pipefail
+          release_pr_branch="$(jq -er '.[0].headBranchName' <<<"${RELEASE_PLEASE_PRS}")"
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${release_pr_branch}"
+
       - name: Checkout release metadata
         if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format fmt format-check gostyle lint actionlint shellcheck mod-check feature-flag feature-flag-graduate feature-flag-check dup-check suppression-check security vuln-check test test-lockfiledrift-head cyclonedx-schema-check test-leaks test-leaks-lockfiledrift-head test-race test-race-lockfiledrift-head bench-mem bench-delta bench-gate cov cov-lockfiledrift-head benchdelta-cov build manpage ci smoke demos demos-check mem-profiles release clean toolchain-check toolchain-install toolchain-install-macos toolchain-install-linux print-gosec-version tools-install setup hooks-install hooks-uninstall sync-version vscode-extension-install vscode-extension-compile vscode-extension-test vscode-extension-package
+.PHONY: format fmt format-check gostyle lint actionlint shellcheck mod-check feature-flag feature-flag-graduate feature-flag-check dup-check suppression-check security vuln-check test test-lockfiledrift-head vscode-release-notes-check cyclonedx-schema-check test-leaks test-leaks-lockfiledrift-head test-race test-race-lockfiledrift-head bench-mem bench-delta bench-gate cov cov-lockfiledrift-head benchdelta-cov build manpage ci smoke demos demos-check mem-profiles release clean toolchain-check toolchain-install toolchain-install-macos toolchain-install-linux print-gosec-version tools-install setup hooks-install hooks-uninstall sync-version vscode-extension-install vscode-extension-compile vscode-extension-test vscode-extension-package
 
 BINARY_NAME ?= lopper
 CMD_PATH ?= ./cmd/lopper
@@ -162,6 +162,11 @@ test:
 	@pkgs=$$(GOFLAGS=-buildvcs=false $(GO_CMD) list ./... | grep -Ev '/internal/app$$'); \
 		$(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) $$pkgs
 	@$(MAKE) test-lockfiledrift-head
+	@python3 -m unittest scripts/vscode_release_notes_test.py
+	@$(MAKE) vscode-release-notes-check
+
+vscode-release-notes-check:
+	@python3 scripts/vscode_release_notes.py --check
 
 test-lockfiledrift-head:
 	$(GO_CMD) test $(GO_TEST_LDFLAGS_ARGS) -tags "$(LOCKFILEDRIFT_HEAD_TAG)" $(LOCKFILEDRIFT_HEAD_PACKAGE)

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -185,6 +185,45 @@ func TestReleasePleaseWritesRootChangelog(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowRefreshesVSCodeReleaseNotesOnReleasePleasePR(t *testing.T) {
+	t.Parallel()
+
+	var workflow workflowConfig
+	readYAMLConfig(t, ".github/workflows/release.yml", &workflow)
+	preparation := workflowJobByName(t, workflow.Jobs, "prepare-release")
+	checkout := workflowStepByName(t, workflow.Jobs, "prepare-release", "Checkout release-please PR")
+	trustedTooling := workflowStepByName(t, workflow.Jobs, "prepare-release", "Checkout trusted release-notes tooling")
+	refresh := workflowStepByName(t, workflow.Jobs, "prepare-release", "Refresh VS Code extension release notes")
+	push := workflowStepByName(t, workflow.Jobs, "prepare-release", "Push refreshed VS Code extension release notes")
+
+	assertWorkflowStringValues(t, []workflowStringValue{
+		{label: "release notes checkout action", got: checkout.Uses, want: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"},
+		{label: "release notes checkout depth", got: checkout.With["fetch-depth"], want: "0"},
+		{label: "release notes checkout ref", got: checkout.With["ref"], want: "${{ fromJSON(steps.release.outputs.prs)[0].headBranchName }}"},
+		{label: "release notes checkout token", got: checkout.With["token"], want: "${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}"},
+		{label: "release notes checkout credential persistence", got: checkout.With["persist-credentials"], want: "false"},
+		{label: "trusted tooling ref", got: trustedTooling.With["ref"], want: "${{ steps.trusted_main.outputs.trusted_main_sha }}"},
+		{label: "trusted tooling path", got: trustedTooling.With["path"], want: ".trusted-release-notes-tooling"},
+		{label: "trusted tooling credential persistence", got: trustedTooling.With["persist-credentials"], want: "false"},
+		{label: "release notes refresh condition", got: refresh.If, want: "${{ github.event_name != 'workflow_dispatch' && steps.release.outputs.prs_created == 'true' }}"},
+	})
+	assertWorkflowStepEnv(t, refresh, "release notes refresh", map[string]string{"RELEASE_PLEASE_PRS": "${{ steps.release.outputs.prs }}"})
+	assertWorkflowStepRunContainsAll(t, refresh, "release notes refresh", []string{
+		`jq -er '.[0].headBranchName' <<<"${RELEASE_PLEASE_PRS}"`,
+		`expected_branch="release-please--branches--${GITHUB_REF_NAME}"`,
+		`git tag --merged HEAD --sort=-version:refname`,
+		`grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'`,
+		`python3 .trusted-release-notes-tooling/scripts/vscode_release_notes.py --repo "$GITHUB_WORKSPACE" --previous-tag "${previous_tag}" --date "$(date -u +%F)"`,
+		`python3 .trusted-release-notes-tooling/scripts/vscode_release_notes.py --repo "$GITHUB_WORKSPACE" --check`,
+		`git diff --quiet -- extensions/vscode-lopper/CHANGELOG.md`,
+		`git add extensions/vscode-lopper/CHANGELOG.md`,
+		`git commit -m "docs(vscode): refresh release notes"`,
+	})
+	assertWorkflowStepEnv(t, push, "release notes push", map[string]string{"PUSH_TOKEN": "${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}", "RELEASE_PLEASE_PRS": "${{ steps.release.outputs.prs }}"})
+	assertWorkflowStepRunContainsAll(t, push, "release notes push", []string{`git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${release_pr_branch}"`})
+	assertWorkflowStepOrder(t, preparation, "Run release-please", "Checkout release-please PR", "Checkout trusted release-notes tooling", "Refresh VS Code extension release notes", "Push refreshed VS Code extension release notes", "Checkout release metadata")
+}
+
 func assertPreviewChangelogSection(t *testing.T, sections []releasePleaseChangelogSection) {
 	t.Helper()
 
@@ -562,8 +601,8 @@ func TestReleaseWorkflowConfinesMainSyncPATToReleasePleaseAndTrustedFeatureHisto
 	}
 
 	workflowText := readConfig(t, ".github/workflows/release.yml")
-	if got := strings.Count(workflowText, "secrets.MAIN_SYNC_PAT"); got != 2 {
-		t.Fatalf("release workflow MAIN_SYNC_PAT references = %d, want release-please and trusted feature history push fallbacks only", got)
+	if got := strings.Count(workflowText, "secrets.MAIN_SYNC_PAT"); got != 4 {
+		t.Fatalf("release workflow MAIN_SYNC_PAT references = %d, want release-please, release-notes checkout and push, and trusted feature history push fallbacks only", got)
 	}
 	if !strings.Contains(workflowText, "PUSH_TOKEN: ${{ secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}") {
 		t.Fatal("trusted feature history push must retain MAIN_SYNC_PAT fallback to GITHUB_TOKEN")
@@ -1221,6 +1260,8 @@ func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
 
 	want := []string{
 		"jobs.prepare-release.steps.Run release-please#1.with.token=${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}",
+		"jobs.prepare-release.steps.Checkout release-please PR#1.with.token=${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}",
+		"jobs.prepare-release.steps.Push refreshed VS Code extension release notes#1.env.PUSH_TOKEN=${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}",
 		"jobs.prepare-release.steps.Checkout release metadata#1.with.token=${{ secrets.GITHUB_TOKEN }}",
 		"jobs.prepare-release.steps.Prepare manual release#1.env.GH_TOKEN=${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}",
 		"jobs.prepare-marketplace-toolchain.steps.Detect Marketplace token#1.env.VSCE_PUBLISH=${{ secrets.VSCE_PUBLISH }}",
@@ -1262,6 +1303,8 @@ func TestReleaseWorkflowScopesPublicationSecretsToNamedSteps(t *testing.T) {
 		"jobs.prepare-release-publication.steps.Download feature flag release report#1.uses",
 		"jobs.prepare-release-publication.steps.Upload release publication inputs#1.uses",
 		"jobs.prepare-release.steps.Checkout release metadata#1.uses",
+		"jobs.prepare-release.steps.Checkout release-please PR#1.uses",
+		"jobs.prepare-release.steps.Checkout trusted release-notes tooling#1.uses",
 		"jobs.prepare-release.steps.Run release-please#1.uses",
 		"jobs.publish-marketplace.steps.Download Marketplace toolchain#1.uses",
 		"jobs.publish-marketplace.steps.Download release publication inputs#1.uses",

--- a/scripts/vscode_release_notes.py
+++ b/scripts/vscode_release_notes.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Generate and validate the VS Code extension release-notes contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path, PurePosixPath
+
+
+EXTENSION_DIR = Path("extensions/vscode-lopper")
+CHANGELOG_FILE_NAME = "CHANGELOG.md"
+CHANGELOG_PATH = EXTENSION_DIR / CHANGELOG_FILE_NAME
+PACKAGE_PATH = EXTENSION_DIR / "package.json"
+LOCKFILE_PATH = EXTENSION_DIR / "package-lock.json"
+ROOT_CHANGELOG_PATH = Path(CHANGELOG_FILE_NAME)
+VERSION_HEADER = re.compile(
+    r"^## (?:\[(?P<linked_version>\d{1,9}\.\d{1,9}\.\d{1,9})\]\([^)]+\)|(?P<version>\d{1,9}\.\d{1,9}\.\d{1,9})) \((?P<date>\d{4}-\d{2}-\d{2})\)$",
+    re.MULTILINE,
+)
+STABLE_TAG = re.compile(r"v\d{1,9}\.\d{1,9}\.\d{1,9}\Z")
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def release_entries(changelog: str) -> list[re.Match[str]]:
+    return list(VERSION_HEADER.finditer(changelog))
+
+
+def entry_version(entry: re.Match[str]) -> str:
+    return entry.group("linked_version") or entry.group("version")
+
+
+def trusted_extension_changelog(repo: Path) -> Path:
+    repo_root = repo.resolve()
+    changelog = (repo / CHANGELOG_PATH).resolve()
+    try:
+        changelog.relative_to(repo_root)
+    except ValueError as exc:
+        raise ValueError("VS Code changelog must not resolve outside the repository") from exc
+    return changelog
+
+
+def write_extension_changelog(repo: Path, content: str) -> None:
+    repo_root = repo.resolve()
+    changelog = repo_root / EXTENSION_DIR / CHANGELOG_FILE_NAME
+    resolved_changelog = changelog.resolve()
+    if not resolved_changelog.is_relative_to(repo_root) or resolved_changelog != changelog:
+        raise ValueError("VS Code changelog must not resolve outside the repository")
+    changelog.write_text(content, encoding="utf-8")
+
+
+def validate(repo: Path) -> list[str]:
+    package = read_json(repo / PACKAGE_PATH)
+    lockfile = read_json(repo / LOCKFILE_PATH)
+    version = package.get("version")
+    lock_version = lockfile.get("version")
+    root_lock_version = lockfile.get("packages", {}).get("", {}).get("version")
+    errors: list[str] = []
+    if not isinstance(version, str) or not version:
+        errors.append("VS Code package.json must contain a version")
+        return errors
+    if lock_version != version or root_lock_version != version:
+        errors.append("VS Code package.json and package-lock.json versions must match")
+
+    entries = release_entries(trusted_extension_changelog(repo).read_text(encoding="utf-8"))
+    matching = [entry for entry in entries if entry_version(entry) == version]
+    if len(matching) != 1:
+        errors.append(f"VS Code changelog must contain exactly one {version} entry")
+    if not entries or entry_version(entries[0]) != version:
+        errors.append("VS Code changelog newest entry must match the extension version")
+    return errors
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+def old_lockfile(repo: Path, previous_tag: str) -> dict:
+    if not STABLE_TAG.fullmatch(previous_tag):
+        raise ValueError("previous tag must be a stable vMAJOR.MINOR.PATCH tag")
+    raw = git(repo, "show", f"{previous_tag}:{LOCKFILE_PATH.as_posix()}")
+    return json.loads(raw)
+
+
+def changed_dependency_notes(old: dict, current: dict) -> list[str]:
+    old_packages = old.get("packages", {})
+    current_packages = current.get("packages", {})
+    old_production = old_packages.get("", {}).get("dependencies", {})
+    production = current_packages.get("", {}).get("dependencies", {})
+    notes: list[str] = []
+    for name in sorted(set(old_production) | set(production)):
+        package_path = f"node_modules/{name}"
+        before = old_packages.get(package_path, {}).get("version")
+        after = current_packages.get(package_path, {}).get("version")
+        was_production = name in old_production
+        is_production = name in production
+        if not was_production and is_production and isinstance(after, str):
+            notes.append(f"Added the bundled `{name}` dependency at {after}.")
+        elif was_production and not is_production and isinstance(before, str):
+            notes.append(f"Removed the bundled `{name}` dependency previously at {before}.")
+        elif was_production and is_production and isinstance(before, str) and isinstance(after, str) and before != after:
+            notes.append(f"Updated the bundled `{name}` dependency from {before} to {after}.")
+    return notes
+
+
+def root_release_block(changelog: str) -> str:
+    starts = list(re.finditer(r"^## \[?\d{1,9}\.\d{1,9}\.\d{1,9}", changelog, re.MULTILINE))
+    if not starts:
+        return ""
+    start = starts[0].start()
+    next_start = changelog.find("\n## ", start + 1)
+    return changelog[start:] if next_start < 0 else changelog[start:next_start]
+
+
+def clean_root_note(line: str) -> str:
+    line = line.removeprefix("* ").lstrip()
+    while line.endswith(")"):
+        reference_start = line.rfind(" (")
+        if reference_start < 0 or "[" not in line[reference_start:]:
+            break
+        line = line[:reference_start]
+    line = line.replace("**", "")
+    if line.startswith("vscode: "):
+        return "Updated VS Code behavior: " + line.removeprefix("vscode: ")
+    return line
+
+
+def visible_extension_commits(repo: Path, previous_tag: str) -> list[tuple[str, str]]:
+    commits: list[tuple[str, str]] = []
+    raw = git(repo, "log", "--format=%H%x00%s", f"{previous_tag}..HEAD", "--", EXTENSION_DIR.as_posix())
+    for row in filter(None, raw.splitlines()):
+        sha, subject = row.split("\x00", 1)
+        paths = git(repo, "diff-tree", "--no-commit-id", "--name-only", "-r", sha).splitlines()
+        source_paths = [
+            path for path in paths
+            if (path.startswith(f"{EXTENSION_DIR.as_posix()}/src/") and "/src/test/" not in path)
+        ]
+        manifest_changed = PACKAGE_PATH.as_posix() in paths and user_visible_manifest_change(repo, sha)
+        marketplace_document_changed = marketplace_visible_package_document_changed(repo, sha, paths)
+        if source_paths or manifest_changed or marketplace_document_changed:
+            commits.append((sha, subject))
+    return commits
+
+
+def marketplace_visible_package_document_changed(repo: Path, sha: str, paths: list[str]) -> bool:
+    marketplace_paths = {(EXTENSION_DIR / "README.md").as_posix()}
+    icon_path = configured_marketplace_icon_path(repo, sha)
+    if icon_path is not None:
+        marketplace_paths.add(icon_path)
+    return bool(marketplace_paths.intersection(paths))
+
+
+def configured_marketplace_icon_path(repo: Path, sha: str) -> str | None:
+    try:
+        package = json.loads(git(repo, "show", f"{sha}:{PACKAGE_PATH.as_posix()}"))
+    except (json.JSONDecodeError, subprocess.CalledProcessError):
+        return None
+    if not isinstance(package, dict):
+        return None
+    icon = package.get("icon")
+    if not isinstance(icon, str) or not icon or "\\" in icon:
+        return None
+    icon_path = PurePosixPath(icon)
+    if icon_path.is_absolute() or not icon_path.parts or ".." in icon_path.parts:
+        return None
+    return (EXTENSION_DIR / Path(*icon_path.parts)).as_posix()
+
+
+def user_visible_manifest_change(repo: Path, sha: str) -> bool:
+    try:
+        previous = json.loads(git(repo, "show", f"{sha}^:{PACKAGE_PATH.as_posix()}"))
+        current = json.loads(git(repo, "show", f"{sha}:{PACKAGE_PATH.as_posix()}"))
+    except (json.JSONDecodeError, subprocess.CalledProcessError):
+        return False
+    for manifest in (previous, current):
+        for key in ("version", "dependencies", "devDependencies"):
+            manifest.pop(key, None)
+    return previous != current
+
+
+def source_notes(repo: Path, previous_tag: str) -> list[str]:
+    root_block = root_release_block((repo / ROOT_CHANGELOG_PATH).read_text(encoding="utf-8"))
+    notes: list[str] = []
+    for sha, subject in visible_extension_commits(repo, previous_tag):
+        matched = [clean_root_note(line) for line in root_block.splitlines() if line.startswith("*") and sha[:7] in line]
+        notes.extend(matched or [f"Updated VS Code behavior: {subject}."])
+    return list(dict.fromkeys(notes))
+
+
+def render_entry(version: str, entry_date: str, notes: list[str]) -> str:
+    body = "\n".join(f"- {note}" for note in notes) or "- No user-visible VS Code extension changes."
+    return f"## {version} ({entry_date})\n\n{body}\n\n"
+
+
+def generate(repo: Path, previous_tag: str, entry_date: str) -> None:
+    if not STABLE_TAG.fullmatch(previous_tag):
+        raise ValueError("previous tag must be a stable vMAJOR.MINOR.PATCH tag")
+    errors = validate_versions(repo)
+    if errors:
+        raise ValueError("; ".join(errors))
+    package = read_json(repo / PACKAGE_PATH)
+    version = package["version"]
+    notes = source_notes(repo, previous_tag)
+    notes.extend(changed_dependency_notes(old_lockfile(repo, previous_tag), read_json(repo / LOCKFILE_PATH)))
+    notes = list(dict.fromkeys(notes))
+    changelog_path = trusted_extension_changelog(repo)
+    changelog = changelog_path.read_text(encoding="utf-8")
+    entries = release_entries(changelog)
+    without_version = ""
+    cursor = 0
+    for index, entry in enumerate(entries):
+        if entry_version(entry) != version:
+            continue
+        end = entries[index + 1].start() if index + 1 < len(entries) else len(changelog)
+        without_version += changelog[cursor:entry.start()]
+        cursor = end
+    without_version += changelog[cursor:]
+    marker = "# Changelog\n\n"
+    if not without_version.startswith(marker):
+        raise ValueError("VS Code changelog must start with '# Changelog'")
+    write_extension_changelog(
+        repo,
+        marker + render_entry(version, entry_date, notes) + without_version[len(marker):],
+    )
+
+
+def validate_versions(repo: Path) -> list[str]:
+    package = read_json(repo / PACKAGE_PATH)
+    lockfile = read_json(repo / LOCKFILE_PATH)
+    version = package.get("version")
+    if not isinstance(version, str) or not version:
+        return ["VS Code package.json must contain a version"]
+    if lockfile.get("version") != version or lockfile.get("packages", {}).get("", {}).get("version") != version:
+        return ["VS Code package.json and package-lock.json versions must match"]
+    return []
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--previous-tag")
+    parser.add_argument("--date", default=date.today().isoformat())
+    parser.add_argument("--repo", type=Path)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+    repo = args.repo.resolve() if args.repo else Path(__file__).resolve().parent.parent
+    try:
+        if args.check:
+            errors = validate(repo)
+            if errors:
+                raise ValueError("; ".join(errors))
+        else:
+            if not args.previous_tag:
+                raise ValueError("--previous-tag is required when generating release notes")
+            generate(repo, args.previous_tag, args.date)
+    except (OSError, ValueError, subprocess.CalledProcessError) as exc:
+        print(f"VS Code release notes: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/vscode_release_notes_test.py
+++ b/scripts/vscode_release_notes_test.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import vscode_release_notes
+
+
+class VSCodeReleaseNotesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temp.name)
+        subprocess.run(["git", "init", "-q", self.repo], check=True)
+        subprocess.run(["git", "-C", self.repo, "config", "user.name", "Test"], check=True)
+        subprocess.run(["git", "-C", self.repo, "config", "user.email", "test@example.com"], check=True)
+        self.write_release("1.0.0", "# Changelog\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n")
+        self.commit("initial release")
+        subprocess.run(["git", "-C", self.repo, "tag", "v1.0.0"], check=True)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def write_release(self, version: str, changelog: str, *, production=None, dev=None) -> None:
+        extension = self.repo / "extensions/vscode-lopper"
+        extension.mkdir(parents=True, exist_ok=True)
+        if production is None:
+            production = {"tar": "^1.0.0"}
+        if dev is None:
+            dev = {"mocha": "^1.0.0"}
+        package = {"name": "vscode-lopper", "version": version, "dependencies": production, "devDependencies": dev}
+        packages = {"": {"name": "vscode-lopper", "version": version, "dependencies": production, "devDependencies": dev}}
+        for name, constraint in production.items():
+            packages[f"node_modules/{name}"] = {"version": constraint.lstrip("^")}
+        for name, constraint in dev.items():
+            packages[f"node_modules/{name}"] = {"version": constraint.lstrip("^")}
+        (extension / "package.json").write_text(json.dumps(package), encoding="utf-8")
+        (extension / "package-lock.json").write_text(json.dumps({"name": "vscode-lopper", "version": version, "packages": packages}), encoding="utf-8")
+        (extension / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+        (self.repo / "CHANGELOG.md").write_text("# Changelog\n\n## [1.0.1](x) (2026-02-02)\n\n* **vscode:** show dependency findings ([abcdef0](x))\n", encoding="utf-8")
+
+    def commit(self, subject: str) -> str:
+        subprocess.run(["git", "-C", self.repo, "add", "."], check=True)
+        subprocess.run(["git", "-C", self.repo, "commit", "-qm", subject], check=True)
+        return subprocess.check_output(["git", "-C", self.repo, "rev-parse", "HEAD"], text=True).strip()
+
+    def test_generates_user_visible_source_note_from_root_release_changelog(self) -> None:
+        source = self.repo / "extensions/vscode-lopper/src/extension.ts"
+        source.parent.mkdir(parents=True)
+        source.write_text("export const findings = true;\n", encoding="utf-8")
+        sha = self.commit("fix(vscode): show dependency findings")
+        self.write_release("1.0.1", "# Changelog\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n")
+        root = self.repo / "CHANGELOG.md"
+        root.write_text(f"# Changelog\n\n## [1.0.1](x) (2026-02-02)\n\n* **vscode:** show dependency findings ([{sha[:7]}](x))\n", encoding="utf-8")
+        vscode_release_notes.generate(self.repo, "v1.0.0", "2026-02-02")
+        self.assertIn("Updated VS Code behavior: show dependency findings", (self.repo / vscode_release_notes.CHANGELOG_PATH).read_text())
+
+    def test_generates_note_for_user_visible_extension_manifest_change(self) -> None:
+        package = self.repo / vscode_release_notes.PACKAGE_PATH
+        package.write_text('{"name":"vscode-lopper","version":"1.0.0","contributes":{"commands":[{"command":"lopper.run"}]}}', encoding="utf-8")
+        sha = self.commit("feat(vscode): add command")
+        self.write_release("1.0.1", "# Changelog\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n")
+        root = self.repo / "CHANGELOG.md"
+        root.write_text(f"# Changelog\n\n## [1.0.1](x) (2026-02-02)\n\n* **vscode:** add command ([{sha[:7]}](x))\n", encoding="utf-8")
+        vscode_release_notes.generate(self.repo, "v1.0.0", "2026-02-02")
+        self.assertIn("Updated VS Code behavior: add command", (self.repo / vscode_release_notes.CHANGELOG_PATH).read_text())
+
+    def test_generates_note_for_marketplace_visible_extension_readme_change(self) -> None:
+        readme = self.repo / vscode_release_notes.EXTENSION_DIR / "README.md"
+        readme.write_text("# VS Code Lopper\n\nNew Marketplace instructions.\n", encoding="utf-8")
+        sha = self.commit("docs(vscode): update Marketplace instructions")
+        self.write_release("1.0.1", "# Changelog\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n")
+        root = self.repo / "CHANGELOG.md"
+        root.write_text(f"# Changelog\n\n## [1.0.1](x) (2026-02-02)\n\n* **vscode:** update Marketplace instructions ([{sha[:7]}](x))\n", encoding="utf-8")
+        vscode_release_notes.generate(self.repo, "v1.0.0", "2026-02-02")
+        self.assertIn("Updated VS Code behavior: update Marketplace instructions", (self.repo / vscode_release_notes.CHANGELOG_PATH).read_text())
+
+    def test_generates_note_for_configured_marketplace_icon_change_only(self) -> None:
+        package = self.repo / vscode_release_notes.PACKAGE_PATH
+        package_data = json.loads(package.read_text(encoding="utf-8"))
+        package_data["icon"] = "images/lopper-icon.png"
+        package.write_text(json.dumps(package_data), encoding="utf-8")
+        icon = self.repo / vscode_release_notes.EXTENSION_DIR / "images/lopper-icon.png"
+        icon.parent.mkdir(parents=True)
+        icon.write_bytes(b"new icon")
+        sha = self.commit("docs(vscode): update Marketplace icon")
+        self.assertFalse(vscode_release_notes.marketplace_visible_package_document_changed(
+            self.repo,
+            sha,
+            [(vscode_release_notes.EXTENSION_DIR / "images/not-the-icon.png").as_posix()],
+        ))
+        self.write_release("1.0.1", "# Changelog\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n")
+        root = self.repo / "CHANGELOG.md"
+        root.write_text(f"# Changelog\n\n## [1.0.1](x) (2026-02-02)\n\n* **vscode:** update Marketplace icon ([{sha[:7]}](x))\n", encoding="utf-8")
+        vscode_release_notes.generate(self.repo, "v1.0.0", "2026-02-02")
+        self.assertIn("Updated VS Code behavior: update Marketplace icon", (self.repo / vscode_release_notes.CHANGELOG_PATH).read_text())
+
+    def test_rejects_unsafe_configured_marketplace_icon_path(self) -> None:
+        package = self.repo / vscode_release_notes.PACKAGE_PATH
+        package_data = json.loads(package.read_text(encoding="utf-8"))
+        package_data["icon"] = "../README.md"
+        package.write_text(json.dumps(package_data), encoding="utf-8")
+        sha = self.commit("test: configure unsafe Marketplace icon")
+        self.assertIsNone(vscode_release_notes.configured_marketplace_icon_path(self.repo, sha))
+
+    def test_includes_shipped_dependency_and_omits_dev_only_dependency(self) -> None:
+        self.write_release("1.0.1", "# Changelog\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n", production={"tar": "^2.0.0"}, dev={"mocha": "^2.0.0"})
+        self.commit("chore(deps): refresh packages")
+        vscode_release_notes.generate(self.repo, "v1.0.0", "2026-02-02")
+        output = (self.repo / vscode_release_notes.CHANGELOG_PATH).read_text()
+        self.assertIn("bundled `tar` dependency from 1.0.0 to 2.0.0", output)
+        self.assertNotIn("mocha", output)
+
+    def test_reports_production_dependency_removal(self) -> None:
+        self.write_release("1.0.1", "# Changelog\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n", production={}, dev={"tar": "^1.0.0"})
+        self.commit("chore(deps): remove bundled package")
+        vscode_release_notes.generate(self.repo, "v1.0.0", "2026-02-02")
+        output = (self.repo / vscode_release_notes.CHANGELOG_PATH).read_text()
+        self.assertIn("Removed the bundled `tar` dependency previously at 1.0.0", output)
+
+    def test_reports_dependency_promoted_from_dev_to_production(self) -> None:
+        old = {"packages": {"": {"devDependencies": {"tar": "^1.0.0"}}, "node_modules/tar": {"version": "1.0.0"}}}
+        current = {"packages": {"": {"dependencies": {"tar": "^1.0.0"}}, "node_modules/tar": {"version": "1.0.0"}}}
+        self.assertEqual(vscode_release_notes.changed_dependency_notes(old, current), ["Added the bundled `tar` dependency at 1.0.0."])
+
+    def test_no_extension_delta_has_explicit_empty_note(self) -> None:
+        self.write_release("1.0.1", "# Changelog\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n")
+        self.commit("chore: release")
+        vscode_release_notes.generate(self.repo, "v1.0.0", "2026-02-02")
+        self.assertIn("No user-visible VS Code extension changes.", (self.repo / vscode_release_notes.CHANGELOG_PATH).read_text())
+
+    def test_refresh_replaces_existing_entry_without_duplicates_or_stale_date(self) -> None:
+        self.write_release("1.0.1", "# Changelog\n\n## 1.0.1 (2025-01-01)\n\n- Stale.\n\n## 1.0.1 (2025-01-02)\n\n- Duplicate.\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n")
+        self.commit("chore: release")
+        vscode_release_notes.generate(self.repo, "v1.0.0", "2026-02-02")
+        output = (self.repo / vscode_release_notes.CHANGELOG_PATH).read_text()
+        self.assertEqual(output.count("## 1.0.1"), 1)
+        self.assertIn("## 1.0.1 (2026-02-02)", output)
+
+    def test_validation_rejects_mismatched_or_duplicate_versions(self) -> None:
+        self.write_release("1.0.1", "# Changelog\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n")
+        errors = vscode_release_notes.validate(self.repo)
+        self.assertTrue(any("newest entry" in error for error in errors))
+        self.assertTrue(any("exactly one" in error for error in errors))
+
+    def test_validation_accepts_linked_changelog_headings(self) -> None:
+        self.write_release("1.0.1", "# Changelog\n\n## [1.0.1](https://example.invalid) (2026-02-02)\n\n- Current release.\n\n## 1.0.0 (2026-01-01)\n\n- Previous release.\n")
+        self.assertEqual(vscode_release_notes.validate(self.repo), [])
+
+    def test_validation_rejects_changelog_symlink_outside_repo(self) -> None:
+        outside = self.repo.parent / "outside-changelog.md"
+        outside.write_text("# Changelog\n", encoding="utf-8")
+        changelog = self.repo / vscode_release_notes.CHANGELOG_PATH
+        changelog.unlink()
+        changelog.symlink_to(outside)
+        with self.assertRaisesRegex(ValueError, "outside the repository"):
+            vscode_release_notes.validate(self.repo)
+
+    def test_write_rejects_extension_changelog_symlink_outside_repo(self) -> None:
+        outside = self.repo.parent / "outside-changelog.md"
+        outside.write_text("# Changelog\n", encoding="utf-8")
+        changelog = self.repo / vscode_release_notes.CHANGELOG_PATH
+        changelog.unlink()
+        changelog.symlink_to(outside)
+        with self.assertRaisesRegex(ValueError, "outside the repository"):
+            vscode_release_notes.write_extension_changelog(self.repo, "unsafe\n")
+        self.assertEqual(outside.read_text(encoding="utf-8"), "# Changelog\n")
+
+    def test_write_targets_fixed_extension_changelog_in_temp_repo(self) -> None:
+        vscode_release_notes.write_extension_changelog(self.repo, "# Changelog\n\n- Updated.\n")
+        changelog = self.repo / vscode_release_notes.CHANGELOG_PATH
+        self.assertEqual(changelog.read_text(encoding="utf-8"), "# Changelog\n\n- Updated.\n")
+
+    def test_generation_rejects_non_stable_tag_before_running_git(self) -> None:
+        with self.assertRaises(ValueError):
+            vscode_release_notes.generate(self.repo, "v1.0.0; touch unsafe", "2026-02-02")
+
+    def test_clean_root_note_removes_trailing_release_links_without_regex(self) -> None:
+        note = vscode_release_notes.clean_root_note("* **vscode:** show findings ([#1](x)) ([abcdef0](x))")
+        self.assertEqual(note, "Updated VS Code behavior: show findings")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1454. Release-please previously synchronized the VS Code extension version files but left its changelog entry to a manual follow-up, so Marketplace-facing behavior and shipped dependency changes could be absent from the release PR.

## Changes

- Add a deterministic extension release-notes generator that compares the proposed release head with the previous stable tag.
- Derive user-visible VS Code notes from generated root release entries and extension source changes; include production dependency updates while excluding dev-only updates.
- Refresh the managed release-please PR idempotently, validate matching package/lockfile/changelog versions, and commit only the extension changelog.
- Enforce the release-note contract in the standard test target and retain the root-versus-extension changelog boundary.

## Validation

Commands and checks run:

```bash
make ci
GOTOOLCHAIN=go1.26.5 go test ./scripts -count=1
python3 -m unittest scripts/vscode_release_notes_test.py
```

Additional manual validation:

- Verified production dependency updates are included, dev-only updates are omitted, no-change releases get an explicit note, and refreshes remove duplicate/stale entries.

Regression-Test: ./scripts::TestReleaseWorkflowRefreshesVSCodeReleaseNotesOnReleasePleasePR

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None; the memory gate passed with zero deltas.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
