### PR TITLE
fix(cache): preserve scoped CLI cache roots

### DIFF
--- a/internal/analysis/cache.go
+++ b/internal/analysis/cache.go
@@ -16,15 +16,17 @@ type resolvedCacheOptions struct {
 }
 
 type analysisCache struct {
-	options         resolvedCacheOptions
-	metadata        report.CacheMetadata
-	warnings        []string
-	cacheable       bool
-	rejectReadHits  bool
-	inputDigestMemo map[cacheInputDigestMemoKey]string
+	options          resolvedCacheOptions
+	metadata         report.CacheMetadata
+	warnings         []string
+	cacheable        bool
+	rejectReadHits   bool
+	inputDigestMemo  map[cacheInputDigestMemoKey]string
+	stableRepoPath   string
+	analysisRepoPath string
 }
 
-func newAnalysisCache(req Request, repoPath string) *analysisCache {
+func newAnalysisCache(req Request, repoPath string, analysisRepoPaths ...string) *analysisCache {
 	options := resolveCacheOptions(req.Cache, repoPath)
 	metadata := report.CacheMetadata{
 		Enabled:  options.Enabled,
@@ -32,10 +34,15 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 		ReadOnly: options.ReadOnly,
 	}
 	cache := &analysisCache{
-		options:        options,
-		metadata:       metadata,
-		warnings:       make([]string, 0),
-		rejectReadHits: !options.ExplicitPath,
+		options:          options,
+		metadata:         metadata,
+		warnings:         make([]string, 0),
+		rejectReadHits:   !options.ExplicitPath,
+		stableRepoPath:   filepath.Clean(repoPath),
+		analysisRepoPath: filepath.Clean(repoPath),
+	}
+	if len(analysisRepoPaths) > 0 && strings.TrimSpace(analysisRepoPaths[0]) != "" {
+		cache.analysisRepoPath = filepath.Clean(analysisRepoPaths[0])
 	}
 	if !options.Enabled {
 		cache.cacheable = false
@@ -60,6 +67,18 @@ func newAnalysisCache(req Request, repoPath string) *analysisCache {
 	}
 	cache.cacheable = true
 	return cache
+}
+
+func (c *analysisCache) stableCacheRoot(rootPath string) string {
+	if c == nil {
+		return rootPath
+	}
+	rootPath = filepath.Clean(rootPath)
+	rel, err := filepath.Rel(c.analysisRepoPath, rootPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return rootPath
+	}
+	return filepath.Join(c.stableRepoPath, rel)
 }
 
 func cachePathEscapesRepo(cachePath, repoPath string) bool {
@@ -100,6 +119,31 @@ func resolveCacheOptions(req *CacheOptions, repoPath string) resolvedCacheOption
 	}
 	options.ReadOnly = req.ReadOnly
 	return options
+}
+
+func normalizeCacheOptionsForRepository(req *CacheOptions, repoPath string) *CacheOptions {
+	if req == nil {
+		return nil
+	}
+
+	options := *req
+	options.Path = strings.TrimSpace(options.Path)
+	options.ResolvedPath = resolveCachePathForRepository(repoPath, options.ResolvedPath)
+	if options.ResolvedPath == "" {
+		options.ResolvedPath = resolveCachePathForRepository(repoPath, options.Path)
+	}
+	return &options
+}
+
+func resolveCachePathForRepository(repoPath, path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(repoPath, path)
 }
 
 func (c *analysisCache) warn(message string) {

--- a/internal/analysis/cache_entry.go
+++ b/internal/analysis/cache_entry.go
@@ -38,10 +38,11 @@ func (c *analysisCache) prepareEntryWithSchemaVersion(req Request, adapterID, no
 	}
 	adapterID = strings.TrimSpace(adapterID)
 	normalizedRoot = filepath.Clean(normalizedRoot)
+	stableRoot := c.stableCacheRoot(normalizedRoot)
 	baseKey := map[string]any{
 		"schema":         schemaVersion,
 		"adapter":        adapterID,
-		"root":           normalizedRoot,
+		"root":           stableRoot,
 		"dependency":     req.Dependency,
 		"language":       normalizeCacheLanguage(req.Language),
 		"topN":           req.TopN,
@@ -71,6 +72,9 @@ func (c *analysisCache) prepareEntryWithSchemaVersion(req Request, adapterID, no
 	if len(req.LicenseDenyList) > 0 {
 		baseKey["licenseDeny"] = req.LicenseDenyList
 	}
+	if scopeIdentity := normalizedScopeCacheIdentity(req); scopeIdentity != nil {
+		baseKey["pathScope"] = scopeIdentity
+	}
 	baseKey["includeRegistryProvenance"] = req.IncludeRegistryProvenance
 	baseDigest, err := hashJSON(baseKey)
 	if err != nil {
@@ -81,10 +85,26 @@ func (c *analysisCache) prepareEntryWithSchemaVersion(req Request, adapterID, no
 		return cacheEntryDescriptor{}, err
 	}
 	return cacheEntryDescriptor{
-		KeyLabel:    adapterID + ":" + normalizedRoot,
+		KeyLabel:    adapterID + ":" + stableRoot,
 		KeyDigest:   baseDigest,
 		InputDigest: inputDigest,
 	}, nil
+}
+
+type scopeCacheIdentity struct {
+	Include []string `json:"include,omitempty"`
+	Exclude []string `json:"exclude,omitempty"`
+}
+
+func normalizedScopeCacheIdentity(req Request) *scopeCacheIdentity {
+	identity := &scopeCacheIdentity{
+		Include: normalizePatterns(req.IncludePatterns),
+		Exclude: normalizePatterns(req.ExcludePatterns),
+	}
+	if len(identity.Include) == 0 && len(identity.Exclude) == 0 {
+		return nil
+	}
+	return identity
 }
 
 func (c *analysisCache) memoizedInputDigest(rootPath, configPath string) (string, error) {

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -151,6 +151,34 @@ func TestAnalysisCacheHitAndInvalidation(t *testing.T) {
 	}
 }
 
+func TestScopedAnalysisReusesRepositoryRelativeCache(t *testing.T) {
+	repo := t.TempDir()
+	testutil.MustWriteFile(t, filepath.Join(repo, "src", cacheTestJSIndexFileName), "export const value = 1\n")
+
+	service, adapter := newCacheTestService(t)
+	req := newCacheRequest(repo, "  .cache/lopper  ", false)
+	req.IncludePatterns = []string{"**"}
+
+	first, err := service.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first scoped analysis: %v", err)
+	}
+	if first.Cache == nil || first.Cache.Path != filepath.Join(repo, ".cache", "lopper") || first.Cache.Misses != 1 || first.Cache.Writes != 1 {
+		t.Fatalf("unexpected first scoped cache metadata: %#v", first.Cache)
+	}
+
+	second, err := service.Analyse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second scoped analysis: %v", err)
+	}
+	if second.Cache == nil || second.Cache.Hits != 1 || second.Cache.Misses != 0 || second.Cache.Writes != 0 {
+		t.Fatalf("expected second scoped analysis to reuse the cache, got %#v", second.Cache)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("expected cached scoped analysis to call adapter once, got %d", adapter.calls)
+	}
+}
+
 func TestAnalysisCachePreservesUsageIncomplete(t *testing.T) {
 	repo := t.TempDir()
 	testutil.MustWriteFile(t, filepath.Join(repo, cacheTestJSIndexFileName), "import dep from \"dep\"\n")
@@ -891,6 +919,27 @@ func TestResolveCacheOptionsDefaultsAndOverrides(t *testing.T) {
 	overrides := resolveCacheOptions(requested, "/repo")
 	if overrides.Enabled || overrides.Path != "/tmp/cache" || !overrides.ReadOnly {
 		t.Fatalf("unexpected override cache options: %#v", overrides)
+	}
+}
+
+func TestNormalizeCacheOptionsForRepositoryNormalizesRelativeAndWhitespacePaths(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	for _, tc := range []struct {
+		name         string
+		options      *CacheOptions
+		wantPath     string
+		wantResolved string
+	}{
+		{name: "whitespace only", options: &CacheOptions{Enabled: true, Path: "  ", ResolvedPath: "  "}},
+		{name: "relative configured path", options: &CacheOptions{Enabled: true, Path: "  .cache/lopper  "}, wantPath: ".cache/lopper", wantResolved: filepath.Join(repo, ".cache", "lopper")},
+		{name: "relative pinned path", options: &CacheOptions{Enabled: true, ResolvedPath: "  .cache/pinned  "}, wantResolved: filepath.Join(repo, ".cache", "pinned")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeCacheOptionsForRepository(tc.options, repo)
+			if got.Path != tc.wantPath || got.ResolvedPath != tc.wantResolved {
+				t.Fatalf("normalized options = %#v, want path=%q resolved=%q", got, tc.wantPath, tc.wantResolved)
+			}
+		})
 	}
 }
 

--- a/internal/analysis/cache_test.go
+++ b/internal/analysis/cache_test.go
@@ -922,27 +922,6 @@ func TestResolveCacheOptionsDefaultsAndOverrides(t *testing.T) {
 	}
 }
 
-func TestNormalizeCacheOptionsForRepositoryNormalizesRelativeAndWhitespacePaths(t *testing.T) {
-	repo := filepath.Join(t.TempDir(), "repo")
-	for _, tc := range []struct {
-		name         string
-		options      *CacheOptions
-		wantPath     string
-		wantResolved string
-	}{
-		{name: "whitespace only", options: &CacheOptions{Enabled: true, Path: "  ", ResolvedPath: "  "}},
-		{name: "relative configured path", options: &CacheOptions{Enabled: true, Path: "  .cache/lopper  "}, wantPath: ".cache/lopper", wantResolved: filepath.Join(repo, ".cache", "lopper")},
-		{name: "relative pinned path", options: &CacheOptions{Enabled: true, ResolvedPath: "  .cache/pinned  "}, wantResolved: filepath.Join(repo, ".cache", "pinned")},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			got := normalizeCacheOptionsForRepository(tc.options, repo)
-			if got.Path != tc.wantPath || got.ResolvedPath != tc.wantResolved {
-				t.Fatalf("normalized options = %#v, want path=%q resolved=%q", got, tc.wantPath, tc.wantResolved)
-			}
-		})
-	}
-}
-
 func TestAnalysisCachePrepareEntryBypassBranches(t *testing.T) {
 	entry, err := (*analysisCache)(nil).prepareEntry(Request{}, "adapter", "/repo")
 	if err != nil || entry != (cacheEntryDescriptor{}) {

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -43,7 +43,11 @@ func (s *Service) newAnalysisPipeline(ctx context.Context, req Request) (*analys
 
 	req.ScopeMode = normalizeScopeMode(req.ScopeMode)
 	req.Cache = normalizeCacheOptionsForRepository(req.Cache, repoPath)
-	cacheRoot := resolveCacheOptions(req.Cache, repoPath).Path
+	cacheOptions := resolveCacheOptions(req.Cache, repoPath)
+	cacheRoot := ""
+	if cacheOptions.Enabled {
+		cacheRoot = cacheOptions.Path
+	}
 	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScopeWithContext(ctx, repoPath, req.IncludePatterns, req.ExcludePatterns, cacheRoot)
 	if err != nil {
 		return nil, err

--- a/internal/analysis/pipeline.go
+++ b/internal/analysis/pipeline.go
@@ -42,7 +42,9 @@ func (s *Service) newAnalysisPipeline(ctx context.Context, req Request) (*analys
 	}
 
 	req.ScopeMode = normalizeScopeMode(req.ScopeMode)
-	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScopeWithContext(ctx, repoPath, req.IncludePatterns, req.ExcludePatterns)
+	req.Cache = normalizeCacheOptionsForRepository(req.Cache, repoPath)
+	cacheRoot := resolveCacheOptions(req.Cache, repoPath).Path
+	analysisRepoPath, scopeWarnings, cleanupFn, err := applyPathScopeWithContext(ctx, repoPath, req.IncludePatterns, req.ExcludePatterns, cacheRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +62,7 @@ func (s *Service) newAnalysisPipeline(ctx context.Context, req Request) (*analys
 		scopeWarnings:    scopeWarnings,
 		cleanupFn:        cleanupFn,
 		candidates:       candidates,
-		cache:            newAnalysisCache(req, analysisRepoPath),
+		cache:            newAnalysisCache(req, repoPath, analysisRepoPath),
 	}, nil
 }
 

--- a/internal/analysis/pipeline_setup_paths_test.go
+++ b/internal/analysis/pipeline_setup_paths_test.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,6 +19,45 @@ func TestAnalysisPipelineAdditionalSetupBranches(t *testing.T) {
 		IncludePatterns: []string{invalidPattern},
 	}); err == nil {
 		t.Fatalf("expected newAnalysisPipeline to surface applyPathScope failures")
+	}
+}
+
+func TestNewAnalysisPipelineExcludesRepositoryCacheFromScopedWorkspace(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		cachePath string
+		include   []string
+		exclude   []string
+		cacheDir  string
+	}{
+		{name: "default cache with broad include", include: []string{"**"}, cacheDir: cacheDirName},
+		{name: "configured relative cache with exclude-only scope", cachePath: "  .cache/lopper  ", exclude: []string{"ignored/**"}, cacheDir: filepath.Join(".cache", "lopper")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, filepath.Join(repo, "src", "index.js"), "export const value = 1\n")
+			writeFile(t, filepath.Join(repo, tc.cacheDir, "objects", "seed.js"), "export const cached = true\n")
+
+			service, _ := newCacheTestService(t)
+			pipeline, err := service.newAnalysisPipeline(context.Background(), Request{
+				RepoPath:        filepath.Join(repo, "."),
+				Language:        "cachelang",
+				IncludePatterns: tc.include,
+				ExcludePatterns: tc.exclude,
+				Cache:           &CacheOptions{Enabled: true, Path: tc.cachePath},
+			})
+			if err != nil {
+				t.Fatalf("create scoped pipeline: %v", err)
+			}
+			defer pipeline.cleanup()
+
+			if got, want := pipeline.cache.options.Path, filepath.Join(repo, tc.cacheDir); got != want {
+				t.Fatalf("cache root = %q, want %q", got, want)
+			}
+			if _, err := os.Stat(filepath.Join(pipeline.analysisRepoPath, tc.cacheDir)); !os.IsNotExist(err) {
+				t.Fatalf("expected scoped workspace to omit configured cache root, stat err=%v", err)
+			}
+		})
 	}
 }
 

--- a/internal/analysis/pipeline_setup_paths_test.go
+++ b/internal/analysis/pipeline_setup_paths_test.go
@@ -61,6 +61,28 @@ func TestNewAnalysisPipelineExcludesRepositoryCacheFromScopedWorkspace(t *testin
 	}
 }
 
+func TestNewAnalysisPipelineIncludesConfiguredCachePathWhenCachingIsDisabled(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "src", "index.js"), "export const value = 1\n")
+	writeFile(t, filepath.Join(repo, "src", "generated", "cached.js"), "export const cached = true\n")
+
+	service, _ := newCacheTestService(t)
+	pipeline, err := service.newAnalysisPipeline(context.Background(), Request{
+		RepoPath:        repo,
+		Language:        "cachelang",
+		IncludePatterns: []string{"**"},
+		Cache:           &CacheOptions{Enabled: false, Path: filepath.Join("src", "generated")},
+	})
+	if err != nil {
+		t.Fatalf("create scoped pipeline: %v", err)
+	}
+	defer pipeline.cleanup()
+
+	if _, err := os.Stat(filepath.Join(pipeline.analysisRepoPath, "src", "generated", "cached.js")); err != nil {
+		t.Fatalf("expected configured cache path to remain in scoped workspace when caching is disabled: %v", err)
+	}
+}
+
 func TestNewAnalysisPipelineStopsBeforeScopedCopyWhenCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/analysis/scope.go
+++ b/internal/analysis/scope.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -51,6 +52,7 @@ type scopeWalker struct {
 	excludeCompiled []compiledPattern
 	stats           *scopeStats
 	budget          scopeCopyBudget
+	skippedDirs     map[string]struct{}
 }
 
 type compiledPattern struct {
@@ -93,7 +95,7 @@ func applyPathScope(repoPath string, includePatterns []string, excludePatterns [
 	return applyPathScopeWithContext(context.Background(), repoPath, includePatterns, excludePatterns)
 }
 
-func applyPathScopeWithContext(ctx context.Context, repoPath string, includePatterns []string, excludePatterns []string) (string, []string, func(), error) {
+func applyPathScopeWithContext(ctx context.Context, repoPath string, includePatterns []string, excludePatterns []string, skippedDirs ...string) (string, []string, func(), error) {
 	includePatterns = normalizePatterns(includePatterns)
 	excludePatterns = normalizePatterns(excludePatterns)
 	if len(includePatterns) == 0 && len(excludePatterns) == 0 {
@@ -128,6 +130,7 @@ func applyPathScopeWithContext(ctx context.Context, repoPath string, includePatt
 		excludeCompiled: excludeCompiled,
 		stats:           stats,
 		budget:          newScopeCopyBudget(),
+		skippedDirs:     scopedCopySkippedDirs(repoPath, skippedDirs),
 	}
 
 	walkErr := filepath.WalkDir(repoPath, walker.walkWithContext(ctx))
@@ -172,9 +175,30 @@ func (w *scopeWalker) walkEntry(ctx context.Context, currentPath string, entry f
 		if entry.Name() == ".git" {
 			return filepath.SkipDir
 		}
+		if _, skip := w.skippedDirs[filepath.Clean(currentPath)]; skip {
+			return filepath.SkipDir
+		}
 		return nil
 	}
 	return w.walkFile(ctx, currentPath, entry)
+}
+
+func scopedCopySkippedDirs(repoPath string, paths []string) map[string]struct{} {
+	skipped := make(map[string]struct{}, len(paths))
+	repoPath = filepath.Clean(repoPath)
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		path = filepath.Clean(path)
+		rel, err := filepath.Rel(repoPath, path)
+		if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		skipped[path] = struct{}{}
+	}
+	return skipped
 }
 
 func (w *scopeWalker) walkFile(ctx context.Context, currentPath string, entry fs.DirEntry) error {


### PR DESCRIPTION
## Summary

Keep CLI analysis cache roots stable when path scopes create a temporary workspace. Relative cache paths now resolve from the normalized repository, and the resolved cache directory is excluded from scoped copies.

Closes #1429

## Changes

- Resolve configured and pinned cache paths against the normalized repository before scope creation.
- Keep cache storage and cache entry identities rooted at the original repository.
- Exclude the resolved in-repository cache root during scoped copies.
- Separate scoped and unscoped cache entries by normalized scope patterns.

## Validation

Commands and checks run:

```bash
go test ./internal/analysis -count=1
go test -race ./internal/analysis -run 'Test(NewAnalysisPipelineExcludesRepositoryCacheFromScopedWorkspace|ScopedAnalysisReusesRepositoryRelativeCache|NormalizeCacheOptionsForRepositoryNormalizesRelativeAndWhitespacePaths)$' -count=1
```

Additional manual validation:

- The standalone local CI gate completed its module, lint, formatting, workflow, duplication, and inline-suppression phases before the desktop runner stopped it during gosec; exact-head GitHub CI is pending.

Regression-Test: ./internal/analysis::TestNewAnalysisPipelineExcludesRepositoryCacheFromScopedWorkspace
Regression-Test: ./internal/analysis::TestScopedAnalysisReusesRepositoryRelativeCache

## Risk and compatibility

- Breaking changes: None; relative CLI cache paths now consistently resolve from the repository.
- Migration required: None.
- Performance impact: Negligible path normalization during pipeline setup.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
