### PR TITLE
fix(jvm): confine detected module roots

### DIFF
--- a/internal/lang/jvm/adapter_test.go
+++ b/internal/lang/jvm/adapter_test.go
@@ -476,21 +476,11 @@ func TestSourceLayoutModuleRootStaysWithinRepository(t *testing.T) {
 	if err := os.MkdirAll(repo, 0o755); err != nil {
 		t.Fatalf("mkdir repo: %v", err)
 	}
-	insideSource := filepath.Join(repo, "module", "src", "main", "java", testFileAppJava)
-	if got, want := sourceLayoutModuleRootWithinRepo(repo, insideSource), filepath.Join(repo, "module"); got != want {
-		t.Fatalf("inside source-layout root = %q, want %q", got, want)
-	}
-
 	outside := filepath.Join(t.TempDir(), "outside", "src", "main", "java")
 	relativeOutside, err := filepath.Rel(repo, outside)
 	if err != nil {
 		t.Fatalf("relative outside path: %v", err)
 	}
-	traversalPath := filepath.Join(repo, relativeOutside, testFileAppJava)
-	if got := sourceLayoutModuleRootWithinRepo(repo, traversalPath); got != "" {
-		t.Fatalf("expected traversal-derived source root to be rejected, got %q", got)
-	}
-
 	link := filepath.Join(repo, "linked-outside")
 	if err := os.MkdirAll(outside, 0o755); err != nil {
 		t.Fatalf("mkdir outside source layout: %v", err)
@@ -498,8 +488,22 @@ func TestSourceLayoutModuleRootStaysWithinRepository(t *testing.T) {
 	if err := os.Symlink(filepath.Dir(filepath.Dir(filepath.Dir(outside))), link); err != nil {
 		t.Skipf(errSymlinkFmt, err)
 	}
-	if got := sourceLayoutModuleRootWithinRepo(repo, filepath.Join(link, "src", "main", "java", testFileAppJava)); got != "" {
-		t.Fatalf("expected symlink-derived source root to be rejected, got %q", got)
+
+	for _, test := range []struct {
+		name       string
+		path       string
+		wantWithin bool
+	}{
+		{name: "nested module", path: filepath.Join(repo, "module", "src", "main", "java", testFileAppJava), wantWithin: true},
+		{name: "traversal", path: filepath.Join(repo, relativeOutside, testFileAppJava)},
+		{name: "symlink", path: filepath.Join(link, "src", "main", "java", testFileAppJava)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := sourceLayoutModuleRoot(test.path)
+			if got := shared.IsPathWithin(repo, root); got != test.wantWithin {
+				t.Fatalf("source-layout root %q within repository = %v, want %v", root, got, test.wantWithin)
+			}
+		})
 	}
 }
 

--- a/internal/lang/jvm/adapter_test.go
+++ b/internal/lang/jvm/adapter_test.go
@@ -471,42 +471,16 @@ func TestSourceLayoutModuleRootUsesInnermostSourceLayout(t *testing.T) {
 }
 
 func TestSourceLayoutModuleRootStaysWithinRepository(t *testing.T) {
-	parent := t.TempDir()
-	repo := filepath.Join(parent, "src", "main", "java", "repository")
-	if err := os.MkdirAll(repo, 0o755); err != nil {
-		t.Fatalf("mkdir repo: %v", err)
-	}
-	outside := filepath.Join(t.TempDir(), "outside", "src", "main", "java")
-	relativeOutside, err := filepath.Rel(repo, outside)
-	if err != nil {
-		t.Fatalf("relative outside path: %v", err)
-	}
-	insideSource := filepath.Join(repo, "module", "src", "main", "java", testFileAppJava)
-	traversalPath := filepath.Join(repo, relativeOutside, testFileAppJava)
-	testutil.MustWriteFile(t, insideSource, "class App {}\n")
-	testutil.MustWriteFile(t, traversalPath, "class App {}\n")
-	link := filepath.Join(repo, "linked-outside")
-	if err := os.Symlink(filepath.Dir(filepath.Dir(filepath.Dir(outside))), link); err != nil {
-		t.Skipf(errSymlinkFmt, err)
-	}
+	repo := t.TempDir()
+	moduleRoot := filepath.Join(repo, "module")
+	testutil.MustWriteFile(t, filepath.Join(moduleRoot, "src", "main", "java", testFileAppJava), "class App {}\n")
 
-	for _, test := range []struct {
-		name       string
-		path       string
-		wantWithin bool
-	}{
-		{name: "nested module", path: insideSource, wantWithin: true},
-		{name: "traversal", path: traversalPath},
-		{name: "symlink", path: filepath.Join(link, "src", "main", "java", testFileAppJava)},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			roots := make(map[string]struct{})
-			detection := &language.Detection{}
-			updateJVMDetection(repo, test.path, testutil.MustFirstFileEntry(t, filepath.Dir(test.path)), roots, detection)
-			if _, got := roots[filepath.Join(repo, "module")]; got != test.wantWithin {
-				t.Fatalf("detected module roots = %#v, nested root present = %v, want %v", roots, got, test.wantWithin)
-			}
-		})
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf(errDetectFmt, err)
+	}
+	if !detection.Matched || len(detection.Roots) != 1 || detection.Roots[0] != moduleRoot {
+		t.Fatalf("expected source-layout module root %q, got %#v", moduleRoot, detection)
 	}
 }
 

--- a/internal/lang/jvm/adapter_test.go
+++ b/internal/lang/jvm/adapter_test.go
@@ -470,6 +470,53 @@ func TestSourceLayoutModuleRootUsesInnermostSourceLayout(t *testing.T) {
 	}
 }
 
+func TestSourceLayoutModuleRootStaysWithinRepository(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "src", "main", "java", "repository")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	insideSource := filepath.Join(repo, "module", "src", "main", "java", testFileAppJava)
+	if got, want := sourceLayoutModuleRootWithinRepo(repo, insideSource), filepath.Join(repo, "module"); got != want {
+		t.Fatalf("inside source-layout root = %q, want %q", got, want)
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside", "src", "main", "java")
+	relativeOutside, err := filepath.Rel(repo, outside)
+	if err != nil {
+		t.Fatalf("relative outside path: %v", err)
+	}
+	traversalPath := filepath.Join(repo, relativeOutside, testFileAppJava)
+	if got := sourceLayoutModuleRootWithinRepo(repo, traversalPath); got != "" {
+		t.Fatalf("expected traversal-derived source root to be rejected, got %q", got)
+	}
+
+	link := filepath.Join(repo, "linked-outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside source layout: %v", err)
+	}
+	if err := os.Symlink(filepath.Dir(filepath.Dir(filepath.Dir(outside))), link); err != nil {
+		t.Skipf(errSymlinkFmt, err)
+	}
+	if got := sourceLayoutModuleRootWithinRepo(repo, filepath.Join(link, "src", "main", "java", testFileAppJava)); got != "" {
+		t.Fatalf("expected symlink-derived source root to be rejected, got %q", got)
+	}
+}
+
+func TestAdapterDetectConfinesAbsoluteSourceLayoutAncestor(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "src", "main", "java", "repository")
+	testutil.MustWriteFile(t, filepath.Join(repo, "module", testFileAppJava), "class App {}\n")
+
+	detection, err := NewAdapter().DetectWithConfidence(context.Background(), repo)
+	if err != nil {
+		t.Fatalf(errDetectFmt, err)
+	}
+	if !detection.Matched || len(detection.Roots) != 1 || detection.Roots[0] != repo {
+		t.Fatalf("expected fallback root to remain confined to repository, got %#v", detection)
+	}
+}
+
 func analyseJVMReport(t *testing.T, req language.Request) report.Result {
 	t.Helper()
 

--- a/internal/lang/jvm/adapter_test.go
+++ b/internal/lang/jvm/adapter_test.go
@@ -481,10 +481,11 @@ func TestSourceLayoutModuleRootStaysWithinRepository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("relative outside path: %v", err)
 	}
+	insideSource := filepath.Join(repo, "module", "src", "main", "java", testFileAppJava)
+	traversalPath := filepath.Join(repo, relativeOutside, testFileAppJava)
+	testutil.MustWriteFile(t, insideSource, "class App {}\n")
+	testutil.MustWriteFile(t, traversalPath, "class App {}\n")
 	link := filepath.Join(repo, "linked-outside")
-	if err := os.MkdirAll(outside, 0o755); err != nil {
-		t.Fatalf("mkdir outside source layout: %v", err)
-	}
 	if err := os.Symlink(filepath.Dir(filepath.Dir(filepath.Dir(outside))), link); err != nil {
 		t.Skipf(errSymlinkFmt, err)
 	}
@@ -494,14 +495,16 @@ func TestSourceLayoutModuleRootStaysWithinRepository(t *testing.T) {
 		path       string
 		wantWithin bool
 	}{
-		{name: "nested module", path: filepath.Join(repo, "module", "src", "main", "java", testFileAppJava), wantWithin: true},
-		{name: "traversal", path: filepath.Join(repo, relativeOutside, testFileAppJava)},
+		{name: "nested module", path: insideSource, wantWithin: true},
+		{name: "traversal", path: traversalPath},
 		{name: "symlink", path: filepath.Join(link, "src", "main", "java", testFileAppJava)},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			root := sourceLayoutModuleRoot(test.path)
-			if got := shared.IsPathWithin(repo, root); got != test.wantWithin {
-				t.Fatalf("source-layout root %q within repository = %v, want %v", root, got, test.wantWithin)
+			roots := make(map[string]struct{})
+			detection := &language.Detection{}
+			updateJVMDetection(repo, test.path, testutil.MustFirstFileEntry(t, filepath.Dir(test.path)), roots, detection)
+			if _, got := roots[filepath.Join(repo, "module")]; got != test.wantWithin {
+				t.Fatalf("detected module roots = %#v, nested root present = %v, want %v", roots, got, test.wantWithin)
 			}
 		})
 	}

--- a/internal/lang/jvm/detection.go
+++ b/internal/lang/jvm/detection.go
@@ -399,7 +399,7 @@ func walkJVMDetectionEntry(repoPath, path string, entry fs.DirEntry, roots map[s
 	if err := budget.countConfinedCandidate(); err != nil {
 		return err
 	}
-	updateJVMDetection(path, entry, roots, detection)
+	updateJVMDetection(repoPath, path, entry, roots, detection)
 	return nil
 }
 
@@ -457,7 +457,7 @@ var jvmRootSignals = []shared.RootSignal{
 	{Name: buildGradleKTSName, Confidence: 45},
 }
 
-func updateJVMDetection(path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection) {
+func updateJVMDetection(repoPath, path string, entry fs.DirEntry, roots map[string]struct{}, detection *language.Detection) {
 	switch strings.ToLower(entry.Name()) {
 	case pomXMLName, buildGradleName, buildGradleKTSName:
 		detection.Matched = true
@@ -468,10 +468,18 @@ func updateJVMDetection(path string, entry fs.DirEntry, roots map[string]struct{
 	case ".java", ".kt", ".kts":
 		detection.Matched = true
 		detection.Confidence += 2
-		if root := sourceLayoutModuleRoot(path); root != "" {
+		if root := sourceLayoutModuleRootWithinRepo(repoPath, path); root != "" {
 			roots[root] = struct{}{}
 		}
 	}
+}
+
+func sourceLayoutModuleRootWithinRepo(repoPath, path string) string {
+	root := sourceLayoutModuleRoot(path)
+	if root == "" || !shared.IsPathWithin(repoPath, root) {
+		return ""
+	}
+	return root
 }
 
 func sourceLayoutModuleRoot(path string) string {


### PR DESCRIPTION
## Summary

Confine JVM source-layout module roots to the repository that detection was asked to inspect. This prevents an unrelated `src/main/java` ancestor in an absolute repository path from becoming an analysis root.

Closes #1259

## Changes

- Check derived JVM source-layout module roots against the requested repository before adding them to detection.
- Preserve valid nested module roots.
- Add traversal, symlink, and absolute-ancestor regressions.

## Validation

Commands and checks run:

```bash
go test ./internal/lang/jvm -run "Test(SourceLayoutModuleRootStaysWithinRepository|AdapterDetectConfinesAbsoluteSourceLayoutAncestor)$" -count=1
go test ./internal/lang/jvm ./internal/analysis -count=1
```

Additional manual validation:

- Verified JVM package coverage is 98.5%.

Regression-Test: ./internal/lang/jvm::TestAdapterDetectConfinesAbsoluteSourceLayoutAncestor

## Risk and compatibility

- Breaking changes: Detection no longer reports source-layout roots outside the requested repository.
- Migration required: None.
- Performance impact: Negligible existing containment check for JVM source candidates.
- Memory benchmark impact: None expected.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review