### PR TITLE
fix(mcp): reuse trusted read-only cache aliases

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -735,6 +736,35 @@ func TestReadOnlyMCPAnalysisCacheOptionsPreservesImplicitDefaultIntent(t *testin
 	options := readOnlyMCPAnalysisCacheOptions(repo, nil, "")
 	if options == nil || !options.Enabled || options.Path != "" || options.ResolvedPath != cachePath || !options.ReadOnly {
 		t.Fatalf("unexpected implicit default cache options: %#v", options)
+	}
+}
+
+func TestTrustedReadOnlyCacheAliasAllowsOnlyMacOSTempAlias(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS filesystem aliases are not available")
+	}
+	cachePath := filepath.Join("/tmp", filepath.Base(t.TempDir()), ".lopper-cache")
+	for _, dirName := range []string{"keys", "objects"} {
+		if err := os.MkdirAll(filepath.Join(cachePath, dirName), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dirName, err)
+		}
+	}
+	defer func() {
+		if err := os.RemoveAll(filepath.Dir(cachePath)); err != nil {
+			t.Errorf("remove alias fixture: %v", err)
+		}
+	}()
+	if !trustedReadOnlyCacheAlias(cachePath) {
+		t.Fatal("expected macOS /tmp alias to be trusted")
+	}
+	if !cachePathReadyForReadOnly(cachePath) {
+		t.Fatal("expected initialized cache through macOS /tmp alias to be reusable")
+	}
+}
+
+func TestTrustedReadOnlyCacheAliasRejectsNonTempPaths(t *testing.T) {
+	if trustedReadOnlyCacheAlias(t.TempDir()) {
+		t.Fatal("unexpected trusted alias outside the fixed macOS temp path")
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -784,7 +784,7 @@ func TestTrustedReadOnlyCacheAliasForGOOS(t *testing.T) {
 	}{
 		"non-Darwin":    {goos: "linux", path: "/tmp/.lopper-cache"},
 		"relative path": {goos: "darwin", path: "tmp/.lopper-cache"},
-		"outside temp":  {goos: "darwin", path: t.TempDir()},
+		"outside temp":  {goos: "darwin", path: "/var/empty/lopper-cache"},
 		"missing cache": {goos: "darwin", path: "/tmp/lopper-cache-does-not-exist"},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -768,6 +768,38 @@ func TestTrustedReadOnlyCacheAliasRejectsNonTempPaths(t *testing.T) {
 	}
 }
 
+func TestTrustedReadOnlyCacheAliasForGOOS(t *testing.T) {
+	cachePath := filepath.Join("/tmp", filepath.Base(t.TempDir()), ".lopper-cache")
+	for _, dirName := range []string{"keys", "objects"} {
+		if err := os.MkdirAll(filepath.Join(cachePath, dirName), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dirName, err)
+		}
+	}
+	defer func() {
+		if err := os.RemoveAll(filepath.Dir(cachePath)); err != nil {
+			t.Errorf("remove alias fixture: %v", err)
+		}
+	}()
+
+	for name, test := range map[string]struct {
+		goos string
+		path string
+		want bool
+	}{
+		"non-Darwin":       {goos: "linux", path: cachePath},
+		"relative path":    {goos: "darwin", path: "tmp/.lopper-cache"},
+		"outside temp":     {goos: "darwin", path: t.TempDir()},
+		"missing cache":    {goos: "darwin", path: filepath.Join(cachePath, "missing")},
+		"macOS temp alias": {goos: "darwin", path: cachePath, want: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := trustedReadOnlyCacheAliasForGOOS(test.goos, test.path); got != test.want {
+				t.Fatalf("trustedReadOnlyCacheAliasForGOOS(%q, %q) = %v, want %v", test.goos, test.path, got, test.want)
+			}
+		})
+	}
+}
+
 func assertAnalysisRequestThresholds(t *testing.T, req analysis.Request) {
 	t.Helper()
 	if req.LowConfidenceWarningPercent == nil || *req.LowConfidenceWarningPercent != 33 {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -778,17 +778,27 @@ func TestTrustedReadOnlyCacheAliasRejectsNonTempPaths(t *testing.T) {
 
 func TestTrustedReadOnlyCacheAliasForGOOS(t *testing.T) {
 	for name, test := range map[string]struct {
-		goos string
-		path string
-		want bool
+		goos            string
+		path            string
+		want            bool
+		resolveSymlinks func(string) (string, error)
 	}{
 		"non-Darwin":    {goos: "linux", path: "/tmp/.lopper-cache"},
 		"relative path": {goos: "darwin", path: "tmp/.lopper-cache"},
 		"outside temp":  {goos: "darwin", path: "/var/empty/lopper-cache"},
-		"missing cache": {goos: "darwin", path: "/tmp/lopper-cache-does-not-exist"},
+		"missing cache": {
+			goos: "darwin", path: "/tmp/lopper-cache-missing",
+			resolveSymlinks: func(string) (string, error) {
+				return "", os.ErrNotExist
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if got := trustedReadOnlyCacheAliasForGOOS(test.goos, test.path); got != test.want {
+			got := trustedReadOnlyCacheAliasForGOOS(test.goos, test.path)
+			if test.resolveSymlinks != nil {
+				got = trustedReadOnlyCacheAliasForGOOSWithResolver(test.goos, test.path, test.resolveSymlinks)
+			}
+			if got != test.want {
 				t.Fatalf("trustedReadOnlyCacheAliasForGOOS(%q, %q) = %v, want %v", test.goos, test.path, got, test.want)
 			}
 		})

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -743,17 +743,25 @@ func TestTrustedReadOnlyCacheAliasAllowsOnlyMacOSTempAlias(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("macOS filesystem aliases are not available")
 	}
-	cachePath := filepath.Join("/tmp", filepath.Base(t.TempDir()), ".lopper-cache")
+	fixtureDir, err := os.MkdirTemp("/tmp", "lopper-cache-alias-")
+	if err != nil {
+		t.Fatalf("create alias fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(fixtureDir); err != nil {
+			t.Errorf("remove alias fixture: %v", err)
+		}
+	})
+	resolvedPath, err := filepath.EvalSymlinks(fixtureDir)
+	if err != nil || resolvedPath != "/private"+fixtureDir {
+		t.Skip("macOS /tmp is not a /private/tmp alias")
+	}
+	cachePath := filepath.Join(fixtureDir, ".lopper-cache")
 	for _, dirName := range []string{"keys", "objects"} {
 		if err := os.MkdirAll(filepath.Join(cachePath, dirName), 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", dirName, err)
 		}
 	}
-	defer func() {
-		if err := os.RemoveAll(filepath.Dir(cachePath)); err != nil {
-			t.Errorf("remove alias fixture: %v", err)
-		}
-	}()
 	if !trustedReadOnlyCacheAlias(cachePath) {
 		t.Fatal("expected macOS /tmp alias to be trusted")
 	}
@@ -769,28 +777,15 @@ func TestTrustedReadOnlyCacheAliasRejectsNonTempPaths(t *testing.T) {
 }
 
 func TestTrustedReadOnlyCacheAliasForGOOS(t *testing.T) {
-	cachePath := filepath.Join("/tmp", filepath.Base(t.TempDir()), ".lopper-cache")
-	for _, dirName := range []string{"keys", "objects"} {
-		if err := os.MkdirAll(filepath.Join(cachePath, dirName), 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", dirName, err)
-		}
-	}
-	defer func() {
-		if err := os.RemoveAll(filepath.Dir(cachePath)); err != nil {
-			t.Errorf("remove alias fixture: %v", err)
-		}
-	}()
-
 	for name, test := range map[string]struct {
 		goos string
 		path string
 		want bool
 	}{
-		"non-Darwin":       {goos: "linux", path: cachePath},
-		"relative path":    {goos: "darwin", path: "tmp/.lopper-cache"},
-		"outside temp":     {goos: "darwin", path: t.TempDir()},
-		"missing cache":    {goos: "darwin", path: filepath.Join(cachePath, "missing")},
-		"macOS temp alias": {goos: "darwin", path: cachePath, want: true},
+		"non-Darwin":    {goos: "linux", path: "/tmp/.lopper-cache"},
+		"relative path": {goos: "darwin", path: "tmp/.lopper-cache"},
+		"outside temp":  {goos: "darwin", path: t.TempDir()},
+		"missing cache": {goos: "darwin", path: "/tmp/lopper-cache-does-not-exist"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if got := trustedReadOnlyCacheAliasForGOOS(test.goos, test.path); got != test.want {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -771,7 +771,7 @@ func TestTrustedReadOnlyCacheAliasAllowsOnlyMacOSTempAlias(t *testing.T) {
 }
 
 func TestTrustedReadOnlyCacheAliasRejectsNonTempPaths(t *testing.T) {
-	if trustedReadOnlyCacheAlias(t.TempDir()) {
+	if trustedReadOnlyCacheAlias("/var/empty/lopper-cache") {
 		t.Fatal("unexpected trusted alias outside the fixed macOS temp path")
 	}
 }
@@ -792,6 +792,20 @@ func TestTrustedReadOnlyCacheAliasForGOOS(t *testing.T) {
 				t.Fatalf("trustedReadOnlyCacheAliasForGOOS(%q, %q) = %v, want %v", test.goos, test.path, got, test.want)
 			}
 		})
+	}
+}
+
+func TestTrustedReadOnlyCacheAliasForGOOSAcceptsMacOSTempAlias(t *testing.T) {
+	const cachePath = "/tmp/lopper-cache"
+	resolver := func(path string) (string, error) {
+		if path != cachePath {
+			t.Fatalf("resolver path = %q, want %q", path, cachePath)
+		}
+		return "/private" + path, nil
+	}
+
+	if !trustedReadOnlyCacheAliasForGOOSWithResolver("darwin", cachePath, resolver) {
+		t.Fatal("expected trusted macOS /tmp alias")
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -443,6 +443,10 @@ func trustedReadOnlyCacheAlias(cachePath string) bool {
 }
 
 func trustedReadOnlyCacheAliasForGOOS(goos, cachePath string) bool {
+	return trustedReadOnlyCacheAliasForGOOSWithResolver(goos, cachePath, filepath.EvalSymlinks)
+}
+
+func trustedReadOnlyCacheAliasForGOOSWithResolver(goos, cachePath string, resolveSymlinks func(string) (string, error)) bool {
 	if goos != "darwin" || !filepath.IsAbs(cachePath) {
 		return false
 	}
@@ -450,7 +454,7 @@ func trustedReadOnlyCacheAliasForGOOS(goos, cachePath string) bool {
 	if absPath != "/tmp" && !strings.HasPrefix(absPath, "/tmp/") {
 		return false
 	}
-	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	resolvedPath, err := resolveSymlinks(absPath)
 	if err != nil {
 		return false
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -439,14 +439,14 @@ func cachePathReadyForReadOnly(cachePath string) bool {
 }
 
 func trustedReadOnlyCacheAlias(cachePath string) bool {
-	if runtime.GOOS != "darwin" {
+	return trustedReadOnlyCacheAliasForGOOS(runtime.GOOS, cachePath)
+}
+
+func trustedReadOnlyCacheAliasForGOOS(goos, cachePath string) bool {
+	if goos != "darwin" || !filepath.IsAbs(cachePath) {
 		return false
 	}
-	absPath, err := filepath.Abs(cachePath)
-	if err != nil {
-		return false
-	}
-	absPath = filepath.Clean(absPath)
+	absPath := filepath.Clean(cachePath)
 	if absPath != "/tmp" && !strings.HasPrefix(absPath, "/tmp/") {
 		return false
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -425,7 +426,7 @@ func readOnlyMCPAnalysisCacheOptions(repoPath string, enabled *bool, cachePath s
 }
 
 func cachePathReadyForReadOnly(cachePath string) bool {
-	if pathContainsSymlink(cachePath) {
+	if pathContainsSymlink(cachePath) && !trustedReadOnlyCacheAlias(cachePath) {
 		return false
 	}
 	for _, dirName := range []string{"keys", "objects"} {
@@ -435,6 +436,25 @@ func cachePathReadyForReadOnly(cachePath string) bool {
 		}
 	}
 	return true
+}
+
+func trustedReadOnlyCacheAlias(cachePath string) bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	absPath, err := filepath.Abs(cachePath)
+	if err != nil {
+		return false
+	}
+	absPath = filepath.Clean(absPath)
+	if absPath != "/tmp" && !strings.HasPrefix(absPath, "/tmp/") {
+		return false
+	}
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return false
+	}
+	return resolvedPath == "/private"+absPath
 }
 
 func pathContainsSymlink(path string) bool {


### PR DESCRIPTION
## Summary

Fixes #1430. MCP read-only cache reuse rejected macOS's fixed `/tmp` filesystem alias even when the initialized cache was safe to read.

## Changes

- Allow only the fixed macOS `/tmp` to `/private/tmp` alias for initialized read-only MCP caches.
- Keep traversal, missing paths, and arbitrary symlink ancestry fail-closed.
- Add focused alias and hostile-path regressions.

## Validation

Commands and checks run:

```bash
GOTOOLCHAIN=go1.26.5 go test ./internal/mcp -run '^(TestTrustedReadOnlyCacheAliasAllowsOnlyMacOSTempAlias|TestTrustedReadOnlyCacheAliasRejectsNonTempPaths|TestCallAnalyseTopLeavesSymlinkedOutsideCachePathUnmodified|TestReadOnlyMCPAnalysisCacheOptionsPreservesImplicitDefaultIntent)$' -count=1
make ci
```

Additional manual validation:

- Verified the alias is limited to the canonical macOS temporary-directory mapping.

Regression-Test-Exemption: The defect depends on Darwin kernel /tmp-to-/private/tmp aliasing; the Linux proof runner cannot reproduce it through the base-compatible public API. The PR retains a Darwin integration test and host-independent injected-resolver regression.

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
