### PR TITLE
fix(release): scope release notes push credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,10 +113,12 @@ jobs:
         run: |
           set -euo pipefail
           git_bin=/usr/bin/git
+          bash_bin=/bin/bash
+          env_bin=/usr/bin/env
           base64_bin=/usr/bin/base64
           tr_bin=/usr/bin/tr
           mktemp_bin=/usr/bin/mktemp
-          if [ ! -x "${git_bin}" ] || [ ! -x "${base64_bin}" ] || [ ! -x "${tr_bin}" ] || [ ! -x "${mktemp_bin}" ]; then
+          if [ ! -x "${git_bin}" ] || [ ! -x "${bash_bin}" ] || [ ! -x "${env_bin}" ] || [ ! -x "${base64_bin}" ] || [ ! -x "${tr_bin}" ] || [ ! -x "${mktemp_bin}" ]; then
             echo "::error::Trusted binaries are unavailable for the release-notes push step." >&2
             exit 1
           fi
@@ -124,15 +126,31 @@ jobs:
           trap '/bin/rm -rf "${git_home}"' EXIT
 
           git_network() (
-            export HOME="${git_home}" PATH=/usr/bin:/bin GIT_TERMINAL_PROMPT=0
-            export GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_COUNT=5
-            export GIT_CONFIG_KEY_0=core.hooksPath GIT_CONFIG_VALUE_0=/dev/null
-            export GIT_CONFIG_KEY_1=credential.helper GIT_CONFIG_VALUE_1=
-            export GIT_CONFIG_KEY_2=protocol.file.allow GIT_CONFIG_VALUE_2=never
-            export GIT_CONFIG_KEY_3=protocol.ext.allow GIT_CONFIG_VALUE_3=never
-            export GIT_CONFIG_KEY_4=http.https://github.com/.extraheader
-            export GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"
-            exec "${git_bin}" "$@"
+            exec 3<<<"${auth_header}"
+            # shellcheck disable=SC2016 # expand the authorization header only in the clean child shell.
+            "${env_bin}" -i \
+              HOME="${git_home}" \
+              PATH=/usr/bin:/bin \
+              GIT_TERMINAL_PROMPT=0 \
+              GIT_CONFIG_NOSYSTEM=1 \
+              GIT_CONFIG_GLOBAL=/dev/null \
+              GIT_CONFIG_COUNT=5 \
+              GIT_CONFIG_KEY_0=core.hooksPath \
+              GIT_CONFIG_VALUE_0=/dev/null \
+              GIT_CONFIG_KEY_1=credential.helper \
+              GIT_CONFIG_VALUE_1= \
+              GIT_CONFIG_KEY_2=protocol.file.allow \
+              GIT_CONFIG_VALUE_2=never \
+              GIT_CONFIG_KEY_3=protocol.ext.allow \
+              GIT_CONFIG_VALUE_3=never \
+              GIT_CONFIG_KEY_4=http.https://github.com/.extraheader \
+              "${bash_bin}" -c '
+                IFS= read -r auth_header <&3
+                exec 3<&-
+                export GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"
+                unset auth_header
+                exec /usr/bin/git "$@"
+              ' git_network "$@"
           )
 
           release_pr_branch="$(jq -er '.[0].headBranchName' <<<"${RELEASE_PLEASE_PRS}")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,8 +112,50 @@ jobs:
           RELEASE_PLEASE_PRS: ${{ steps.release.outputs.prs }}
         run: |
           set -euo pipefail
+          git_bin=/usr/bin/git
+          env_bin=/usr/bin/env
+          base64_bin=/usr/bin/base64
+          tr_bin=/usr/bin/tr
+          mktemp_bin=/usr/bin/mktemp
+          if [ ! -x "${git_bin}" ] || [ ! -x "${env_bin}" ] || [ ! -x "${base64_bin}" ] || [ ! -x "${tr_bin}" ] || [ ! -x "${mktemp_bin}" ]; then
+            echo "::error::Trusted binaries are unavailable for the release-notes push step." >&2
+            exit 1
+          fi
+          git_home="$("${mktemp_bin}" -d)"
+          trap '/bin/rm -rf "${git_home}"' EXIT
+
+          git_network() {
+            "${env_bin}" -i \
+              HOME="${git_home}" \
+              PATH=/usr/bin:/bin \
+              GIT_TERMINAL_PROMPT=0 \
+              GIT_CONFIG_NOSYSTEM=1 \
+              GIT_CONFIG_GLOBAL=/dev/null \
+              GIT_CONFIG_COUNT=5 \
+              GIT_CONFIG_KEY_0=core.hooksPath \
+              GIT_CONFIG_VALUE_0=/dev/null \
+              GIT_CONFIG_KEY_1=credential.helper \
+              GIT_CONFIG_VALUE_1= \
+              GIT_CONFIG_KEY_2=protocol.file.allow \
+              GIT_CONFIG_VALUE_2=never \
+              GIT_CONFIG_KEY_3=protocol.ext.allow \
+              GIT_CONFIG_VALUE_3=never \
+              GIT_CONFIG_KEY_4=http.https://github.com/.extraheader \
+              GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}" \
+              "${git_bin}" \
+              "$@"
+          }
+
           release_pr_branch="$(jq -er '.[0].headBranchName' <<<"${RELEASE_PLEASE_PRS}")"
-          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${release_pr_branch}"
+          push_token="${PUSH_TOKEN}"
+          unset PUSH_TOKEN
+          if [ -z "${push_token}" ]; then
+            echo "::error::No token is available to push refreshed VS Code extension release notes." >&2
+            exit 1
+          fi
+          auth_header="$(printf 'x-access-token:%s' "${push_token}" | "${base64_bin}" | "${tr_bin}" -d '\n')"
+          unset push_token
+          git_network push origin "HEAD:${release_pr_branch}"
 
       - name: Checkout release metadata
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,38 +113,27 @@ jobs:
         run: |
           set -euo pipefail
           git_bin=/usr/bin/git
-          env_bin=/usr/bin/env
           base64_bin=/usr/bin/base64
           tr_bin=/usr/bin/tr
           mktemp_bin=/usr/bin/mktemp
-          if [ ! -x "${git_bin}" ] || [ ! -x "${env_bin}" ] || [ ! -x "${base64_bin}" ] || [ ! -x "${tr_bin}" ] || [ ! -x "${mktemp_bin}" ]; then
+          if [ ! -x "${git_bin}" ] || [ ! -x "${base64_bin}" ] || [ ! -x "${tr_bin}" ] || [ ! -x "${mktemp_bin}" ]; then
             echo "::error::Trusted binaries are unavailable for the release-notes push step." >&2
             exit 1
           fi
           git_home="$("${mktemp_bin}" -d)"
           trap '/bin/rm -rf "${git_home}"' EXIT
 
-          git_network() {
-            "${env_bin}" -i \
-              HOME="${git_home}" \
-              PATH=/usr/bin:/bin \
-              GIT_TERMINAL_PROMPT=0 \
-              GIT_CONFIG_NOSYSTEM=1 \
-              GIT_CONFIG_GLOBAL=/dev/null \
-              GIT_CONFIG_COUNT=5 \
-              GIT_CONFIG_KEY_0=core.hooksPath \
-              GIT_CONFIG_VALUE_0=/dev/null \
-              GIT_CONFIG_KEY_1=credential.helper \
-              GIT_CONFIG_VALUE_1= \
-              GIT_CONFIG_KEY_2=protocol.file.allow \
-              GIT_CONFIG_VALUE_2=never \
-              GIT_CONFIG_KEY_3=protocol.ext.allow \
-              GIT_CONFIG_VALUE_3=never \
-              GIT_CONFIG_KEY_4=http.https://github.com/.extraheader \
-              GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}" \
-              "${git_bin}" \
-              "$@"
-          }
+          git_network() (
+            export HOME="${git_home}" PATH=/usr/bin:/bin GIT_TERMINAL_PROMPT=0
+            export GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_COUNT=5
+            export GIT_CONFIG_KEY_0=core.hooksPath GIT_CONFIG_VALUE_0=/dev/null
+            export GIT_CONFIG_KEY_1=credential.helper GIT_CONFIG_VALUE_1=
+            export GIT_CONFIG_KEY_2=protocol.file.allow GIT_CONFIG_VALUE_2=never
+            export GIT_CONFIG_KEY_3=protocol.ext.allow GIT_CONFIG_VALUE_3=never
+            export GIT_CONFIG_KEY_4=http.https://github.com/.extraheader
+            export GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"
+            exec "${git_bin}" "$@"
+          )
 
           release_pr_branch="$(jq -er '.[0].headBranchName' <<<"${RELEASE_PLEASE_PRS}")"
           push_token="${PUSH_TOKEN}"

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -223,13 +223,15 @@ func TestReleaseWorkflowRefreshesVSCodeReleaseNotesOnReleasePleasePR(t *testing.
 	assertWorkflowStepRunContainsAll(t, push, "release notes push", []string{
 		`push_token="${PUSH_TOKEN}"`,
 		`unset PUSH_TOKEN`,
+		`exec 3<<<"${auth_header}"`,
+		`"${env_bin}" -i`,
 		`GIT_CONFIG_KEY_4=http.https://github.com/.extraheader`,
 		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
-		`exec "${git_bin}" "$@"`,
+		`exec /usr/bin/git "$@"`,
 		`git_network push origin "HEAD:${release_pr_branch}"`,
 	})
 	assertWorkflowStepKeepsGitCredentialsCommandScoped(t, push, "release notes push")
-	if strings.Contains(push.Run, `"${env_bin}" -i`) {
+	if strings.Contains(push.Run, `GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}" \\`) {
 		t.Fatal("release notes push must not pass its authorization header through env argv")
 	}
 	assertWorkflowStepOrder(t, preparation, "Run release-please", "Checkout release-please PR", "Checkout trusted release-notes tooling", "Refresh VS Code extension release notes", "Push refreshed VS Code extension release notes", "Checkout release metadata")

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -225,9 +225,13 @@ func TestReleaseWorkflowRefreshesVSCodeReleaseNotesOnReleasePleasePR(t *testing.
 		`unset PUSH_TOKEN`,
 		`GIT_CONFIG_KEY_4=http.https://github.com/.extraheader`,
 		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
+		`exec "${git_bin}" "$@"`,
 		`git_network push origin "HEAD:${release_pr_branch}"`,
 	})
 	assertWorkflowStepKeepsGitCredentialsCommandScoped(t, push, "release notes push")
+	if strings.Contains(push.Run, `"${env_bin}" -i`) {
+		t.Fatal("release notes push must not pass its authorization header through env argv")
+	}
 	assertWorkflowStepOrder(t, preparation, "Run release-please", "Checkout release-please PR", "Checkout trusted release-notes tooling", "Refresh VS Code extension release notes", "Push refreshed VS Code extension release notes", "Checkout release metadata")
 }
 

--- a/scripts/release_workflow_config_test.go
+++ b/scripts/release_workflow_config_test.go
@@ -220,7 +220,14 @@ func TestReleaseWorkflowRefreshesVSCodeReleaseNotesOnReleasePleasePR(t *testing.
 		`git commit -m "docs(vscode): refresh release notes"`,
 	})
 	assertWorkflowStepEnv(t, push, "release notes push", map[string]string{"PUSH_TOKEN": "${{ secrets.RELEASE_PLEASE_TOKEN || secrets.MAIN_SYNC_PAT || secrets.GITHUB_TOKEN }}", "RELEASE_PLEASE_PRS": "${{ steps.release.outputs.prs }}"})
-	assertWorkflowStepRunContainsAll(t, push, "release notes push", []string{`git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${release_pr_branch}"`})
+	assertWorkflowStepRunContainsAll(t, push, "release notes push", []string{
+		`push_token="${PUSH_TOKEN}"`,
+		`unset PUSH_TOKEN`,
+		`GIT_CONFIG_KEY_4=http.https://github.com/.extraheader`,
+		`GIT_CONFIG_VALUE_4="AUTHORIZATION: basic ${auth_header}"`,
+		`git_network push origin "HEAD:${release_pr_branch}"`,
+	})
+	assertWorkflowStepKeepsGitCredentialsCommandScoped(t, push, "release notes push")
 	assertWorkflowStepOrder(t, preparation, "Run release-please", "Checkout release-please PR", "Checkout trusted release-notes tooling", "Refresh VS Code extension release notes", "Push refreshed VS Code extension release notes", "Checkout release metadata")
 }
 


### PR DESCRIPTION
## Summary

Fixes #1497. The release-notes refresh used an authenticated remote URL, which placed its write token in the `git push` process arguments and could expose it through diagnostics.

## Changes

- Replace the authenticated remote URL with the repository's isolated `git_network` pattern.
- Scope the authorization header to the Git child environment and unset `PUSH_TOKEN` before invoking Git.
- Lock the credential boundary with the existing workflow-contract assertion.

## Validation

Commands and checks run:

```bash
GOTOOLCHAIN=go1.26.5 make ci
GOTOOLCHAIN=go1.26.5 go test ./scripts -run '^TestReleaseWorkflowRefreshesVSCodeReleaseNotesOnReleasePleasePR$' -count=1
make actionlint
```

Additional manual validation:

- Confirmed the push command now uses `origin` and a branch ref only; it contains no credential-bearing URL.

Regression-Test: ./scripts::TestReleaseWorkflowRefreshesVSCodeReleaseNotesOnReleasePleasePR

## Risk and compatibility

- Breaking changes: None.
- Migration required: None.
- Performance impact: None.
- Memory benchmark impact: None; the memory gate passed.

## Checklist

- [x] Tests added/updated for behavior changes
- [x] Docs updated (README/docs/schema) if needed
- [x] `memory-approved` requested/applied if intentional memory benchmark regressions exceed CI thresholds
- [x] No unrelated changes included
- [x] Ready for review
